### PR TITLE
🎨 Palette: Improve WebTerminal accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2026-02-21 - Improving Auth Tabs Accessibility
 **Learning:** Custom tab implementations must support keyboard navigation (Arrow keys, Home/End) alongside ARIA roles. Simply adding `role="tab"` without focus management creates a broken experience for keyboard users.
 **Action:** When adding ARIA roles to interactive components, always implement the corresponding keyboard interaction patterns defined in the WAI-ARIA APG.
+
+## 2026-02-21 - Icon-Only Button Accessibility
+**Learning:** Several icon-only buttons (e.g., in WebTerminal, SessionViewer) were implemented without `aria-label` or `title` attributes, making them inaccessible to screen readers and confusing for mouse users (no tooltip).
+**Action:** Always verify icon-only buttons have an `aria-label` describing the action, and preferably a `title` for a native tooltip.

--- a/packages/ui/src/components/WebTerminal.tsx
+++ b/packages/ui/src/components/WebTerminal.tsx
@@ -261,6 +261,8 @@ export function WebTerminal({ terminalId, onClose, className }: WebTerminalProps
             size="icon"
             className="size-8 md:size-5 text-zinc-500 hover:text-zinc-100 hover:bg-zinc-800"
             onClick={() => setIsMaximized((v) => !v)}
+            aria-label={isMaximized ? "Restore terminal size" : "Maximize terminal"}
+            title={isMaximized ? "Restore terminal size" : "Maximize terminal"}
           >
             {isMaximized ? <Minimize2 size={12} /> : <Maximize2 size={12} />}
           </Button>
@@ -269,6 +271,8 @@ export function WebTerminal({ terminalId, onClose, className }: WebTerminalProps
             size="icon"
             className="size-8 md:size-5 text-zinc-500 hover:text-red-400 hover:bg-zinc-800"
             onClick={handleClose}
+            aria-label="Close terminal"
+            title="Close terminal"
           >
             <X size={12} />
           </Button>


### PR DESCRIPTION
💡 What: Added `aria-label` and `title` to `WebTerminal` control buttons.
🎯 Why: Icon-only buttons were inaccessible to screen readers and lacked tooltips.
♿ Accessibility: Improved button semantics for screen readers and added native tooltips.

---
*PR created automatically by Jules for task [12996069115418860522](https://jules.google.com/task/12996069115418860522) started by @Pizzaface*