### PR TITLE
🛡️ Sentinel: Enforce skill name validation and sanitize error messages

### DIFF
--- a/packages/server/src/validation.ts
+++ b/packages/server/src/validation.ts
@@ -1,0 +1,18 @@
+/**
+ * Validates a skill name to prevent path traversal and enforce safe identifiers.
+ * Allowed characters: a-z, A-Z, 0-9, -, _, .
+ * Must not start or end with a dot, and must not contain consecutive dots.
+ * Length: 1-64 characters
+ *
+ * @param name The skill name to validate
+ * @returns true if the name is valid, false otherwise
+ */
+export function isValidSkillName(name: string): boolean {
+    if (!name || typeof name !== "string") return false;
+    if (name.length > 64) return false;
+
+    // Allow alphanumeric, dash, underscore, dot.
+    // Must start and end with alphanumeric/dash/underscore.
+    // Dots must be separated by other characters (no consecutive dots).
+    return /^[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)*$/.test(name);
+}

--- a/packages/server/tests/validation.test.ts
+++ b/packages/server/tests/validation.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { isValidSkillName } from "../src/validation.js";
+
+describe("isValidSkillName", () => {
+    it("should accept valid skill names", () => {
+        expect(isValidSkillName("my-skill")).toBe(true);
+        expect(isValidSkillName("my_skill")).toBe(true);
+        expect(isValidSkillName("Skill123")).toBe(true);
+        expect(isValidSkillName("a")).toBe(true);
+        expect(isValidSkillName("123")).toBe(true);
+        expect(isValidSkillName("script.py")).toBe(true);
+        expect(isValidSkillName("my.cool.script")).toBe(true);
+    });
+
+    it("should reject invalid characters", () => {
+        expect(isValidSkillName("my skill")).toBe(false); // space
+        expect(isValidSkillName("my/skill")).toBe(false); // slash
+        expect(isValidSkillName("my\\skill")).toBe(false); // backslash
+        expect(isValidSkillName("skill!")).toBe(false); // special char
+        expect(isValidSkillName("../skill")).toBe(false); // path traversal
+    });
+
+    it("should reject invalid dot usage", () => {
+        expect(isValidSkillName(".config")).toBe(false); // starts with dot
+        expect(isValidSkillName("config.")).toBe(false); // ends with dot
+        expect(isValidSkillName("foo..bar")).toBe(false); // consecutive dots
+        expect(isValidSkillName("..")).toBe(false); // just dots
+    });
+
+    it("should reject names that are too long", () => {
+        const longName = "a".repeat(65);
+        expect(isValidSkillName(longName)).toBe(false);
+        const maxLengthName = "a".repeat(64);
+        expect(isValidSkillName(maxLengthName)).toBe(true);
+    });
+
+    it("should reject empty or non-string inputs", () => {
+        expect(isValidSkillName("")).toBe(false);
+        // @ts-ignore
+        expect(isValidSkillName(null)).toBe(false);
+        // @ts-ignore
+        expect(isValidSkillName(undefined)).toBe(false);
+        // @ts-ignore
+        expect(isValidSkillName(123)).toBe(false);
+    });
+});


### PR DESCRIPTION
This PR enhances the security of the runner skills API by implementing strict validation for skill names.

Changes:
- Introduced `isValidSkillName` utility in `packages/server/src/validation.ts`.
- Validates that skill names are alphanumeric (plus `_`, `-`, `.`) and do not contain path traversal sequences (`..`).
- Ensures skill names do not start or end with a dot.
- Updates `packages/server/src/routes/api.ts` to enforce this validation on GET, POST, PUT, and DELETE endpoints for skills.
- Wraps runner communication in try/catch blocks that log the actual error server-side but return a generic 502 error to the client, preventing information leakage.

This prevents potential path traversal attacks if the runner implementation were to use the skill name directly in file paths, and improves overall API robustness.

---
*PR created automatically by Jules for task [16432155274749102432](https://jules.google.com/task/16432155274749102432) started by @Pizzaface*