### PR TITLE
🛡️ Sentinel: [HIGH] Fix path traversal in runner CWD validation

### DIFF
--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-02-24 - Path Traversal in Runner CWD
+**Vulnerability:** The server allowed `..` path segments in `cwd` parameters, enabling path traversal outside allowed runner roots.
+**Learning:** `normalizePath` helper only converted slashes but did not resolve `..` segments, creating a false sense of security.
+**Prevention:** Always use `path.resolve` or `path.normalize` (specifically `path.posix.normalize` for consistent server-side handling) to canonicalize paths before validating them against allowlists.

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -30,7 +30,7 @@ import {
     getSubscriptionsForUser,
     updateEnabledEvents,
 } from "../push.js";
-import { RateLimiter, isValidEmail, isValidPassword } from "../security.js";
+import { RateLimiter, isValidEmail, isValidPassword, cwdMatchesRoots } from "../security.js";
 import { isValidSkillName } from "../validation.js";
 
 // 5 requests per 15 minutes
@@ -820,11 +820,6 @@ export async function handleApi(req: Request, url: URL): Promise<Response | unde
     return undefined;
 }
 
-function normalizePath(value: string): string {
-    const trimmed = value.trim().replace(/\\/g, "/");
-    return trimmed.length > 1 ? trimmed.replace(/\/+$/, "") : trimmed;
-}
-
 /** Safely parse a JSON string that should be an array. Returns [] on failure. */
 function parseJsonArray(value: string | null | undefined): any[] {
     if (!value) return [];
@@ -834,15 +829,6 @@ function parseJsonArray(value: string | null | undefined): any[] {
     } catch {
         return [];
     }
-}
-
-/** Check whether a cwd is inside one of the allowed roots. */
-function cwdMatchesRoots(roots: string[], cwd: string): boolean {
-    const nCwd = normalizePath(cwd);
-    return roots.some((root) => {
-        const r = normalizePath(root);
-        return nCwd === r || nCwd.startsWith(r + "/");
-    });
 }
 
 async function pickRunnerIdLeastLoaded(): Promise<string | null> {
@@ -860,15 +846,10 @@ async function pickRunnerIdForCwd(requestedCwd?: string): Promise<string | null>
         roots: r.roots as string[] | undefined,
     }));
 
-    const nCwd = normalizePath(cwd);
-
     // 1) Prefer runners that declare roots AND match the cwd.
     const rootMatched = all
         .filter((r) => Array.isArray(r.roots) && r.roots.length > 0)
-        .filter((r) => (r.roots ?? []).some((root) => {
-            const nRoot = normalizePath(root);
-            return nCwd === nRoot || nCwd.startsWith(nRoot + "/");
-        }))
+        .filter((r) => cwdMatchesRoots(r.roots ?? [], cwd))
         .sort((a, b) => a.sessionCount - b.sessionCount);
 
     if (rootMatched.length > 0) return rootMatched[0].runnerId;

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { RateLimiter, isValidEmail, isValidPassword } from "./security";
+import { RateLimiter, isValidEmail, isValidPassword, cwdMatchesRoots } from "./security";
 
 describe("RateLimiter", () => {
     test("allows requests within limit", () => {
@@ -47,5 +47,29 @@ describe("Validation", () => {
     test("isValidPassword", () => {
         expect(isValidPassword("12345678")).toBe(true);
         expect(isValidPassword("short")).toBe(false);
+    });
+
+    test("cwdMatchesRoots", () => {
+        const root = "/home/user/project";
+        // Exact match
+        expect(cwdMatchesRoots([root], "/home/user/project")).toBe(true);
+        // Child directory
+        expect(cwdMatchesRoots([root], "/home/user/project/src")).toBe(true);
+
+        // Path traversal attempts
+        expect(cwdMatchesRoots([root], "/home/user/project/../../etc/passwd")).toBe(false);
+        expect(cwdMatchesRoots([root], "/home/user/project/src/../../../etc/passwd")).toBe(false);
+
+        // Partial folder name match (should fail)
+        expect(cwdMatchesRoots([root], "/home/user/project-secret")).toBe(false);
+
+        // Outside directory
+        expect(cwdMatchesRoots([root], "/etc/passwd")).toBe(false);
+
+        // Multiple roots
+        const roots = ["/app/data", "/tmp"];
+        expect(cwdMatchesRoots(roots, "/app/data/file.txt")).toBe(true);
+        expect(cwdMatchesRoots(roots, "/tmp/temp.txt")).toBe(true);
+        expect(cwdMatchesRoots(roots, "/app/config")).toBe(false);
     });
 });

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -1,3 +1,5 @@
+import { posix as path } from "path";
+
 export class RateLimiter {
     private hits = new Map<string, { count: number; resetTime: number }>();
     private cleanupInterval: ReturnType<typeof setInterval>;
@@ -60,4 +62,30 @@ export function isValidEmail(email: string): boolean {
 
 export function isValidPassword(password: string): boolean {
     return password.length >= 8;
+}
+
+function normalizePath(value: string): string {
+    const trimmed = value.trim().replace(/\\/g, "/");
+    return trimmed.length > 1 ? trimmed.replace(/\/+$/, "") : trimmed;
+}
+
+/** Check whether a cwd is inside one of the allowed roots. */
+export function cwdMatchesRoots(roots: string[], cwd: string): boolean {
+    // 1. Normalize slashes first
+    const nCwd = normalizePath(cwd);
+
+    // 2. Resolve '..' segments using path.posix.normalize
+    const resolvedCwd = path.normalize(nCwd);
+
+    return roots.some((root) => {
+        const nRoot = normalizePath(root);
+        const resolvedRoot = path.normalize(nRoot);
+
+        // Check if resolvedCwd starts with resolvedRoot
+        // Important: Append '/' to ensure we don't match partial folder names
+        // e.g. /home/admin matches /home/admin-secret
+
+        if (resolvedCwd === resolvedRoot) return true;
+        return resolvedCwd.startsWith(resolvedRoot + "/");
+    });
 }


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The server allowed `..` path segments in `cwd` parameters, enabling path traversal outside allowed runner roots.
🎯 Impact: Attackers could potentially access files outside the restricted runner workspace.
🔧 Fix: Updated `cwdMatchesRoots` to use `path.posix.normalize` to resolve paths before checking against roots. Moved path validation logic to `packages/server/src/security.ts`.
✅ Verification: Added unit tests in `packages/server/src/security.test.ts` verifying that traversal attempts are blocked.

---
*PR created automatically by Jules for task [17475924392326061099](https://jules.google.com/task/17475924392326061099) started by @Pizzaface*