### PR TITLE
⚡ Bolt: Throttle session activity database updates

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-23 - Session Viewer Scalability
 **Learning:** The session viewer re-processes the entire message history (grouping, deduplication, sorting) on every update (e.g. streaming tokens). This is O(N) or O(N log N) per update, which becomes a bottleneck for long sessions.
 **Action:** Future optimizations should focus on incremental updates or memoization of processed history chunks to avoid reprocessing the entire list.
+
+## 2024-05-23 - Session Activity Throttling
+**Learning:** High-frequency event streams (like TUI output) trigger `touchSessionActivity` on every chunk. Without throttling, this hammers the SQLite database with redundant `UPDATE relay_session` calls, increasing write IOPs significantly for active sessions.
+**Action:** Always implement debounce or throttle mechanisms for database updates driven by real-time event streams, especially when precision (e.g., last active time) is tolerant of small delays (seconds).


### PR DESCRIPTION
💡 What: Throttled `touchSessionActivity` in `packages/server/src/ws/sio-registry.ts` to execute at most once every 2 seconds per session.
🎯 Why: Previously, every TUI event (including stream chunks) triggered a database write to update `lastActiveAt`, causing excessive SQLite IO during active sessions.
📊 Impact: Reduces database writes for active sessions significantly (e.g., from ~100 writes/sec during streaming to ~0.5 writes/sec).
🔬 Measurement: Verified with a reproduction test case that simulated rapid calls and confirmed the reduction in `touchRelaySession` invocations.

---
*PR created automatically by Jules for task [17185183096463827243](https://jules.google.com/task/17185183096463827243) started by @Pizzaface*