### PR TITLE
🎨 Palette: Add accessible labels to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2026-02-25 - Tree View Accessibility in File Explorer
 **Learning:** The File Explorer tree view used generic `div` and `button` elements without `aria-expanded` state, making it impossible for screen reader users to know if a folder is open or closed.
 **Action:** When implementing custom tree views, always ensure `aria-expanded` is present on the toggle control, and use `aria-label` to provide context (e.g., "Folder [name]").
+
+## 2025-05-20 - Title Attribute Insufficiency
+**Learning:** Icon-only buttons in `SessionViewer` relied solely on `title` for accessibility. While `title` provides a tooltip, it is not reliably announced by all screen readers and does not replace `aria-label` for providing an accessible name.
+**Action:** Ensure all icon-only buttons have an explicit `aria-label`, even if they already have a `title`.

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -249,6 +249,7 @@ function ComposerAttachmentButton() {
       className="size-8 shrink-0 text-muted-foreground"
       onClick={() => attachments.openFileDialog()}
       title="Add attachments"
+      aria-label="Add attachments"
     >
       <PaperclipIcon className="size-4" />
     </Button>
@@ -892,6 +893,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                   }
                 }}
                 title="Click to cycle effort level"
+                aria-label={`Cycle reasoning effort level (current: ${effortLevel && effortLevel !== "off" ? effortLevel : "off"})`}
                 type="button"
               >
                 {effortLevel && effortLevel !== "off" ? effortLevel : "off"}
@@ -916,6 +918,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                 type="button"
                 variant="outline"
                 title="Toggle terminal"
+                aria-label="Toggle terminal"
               >
                 <TerminalIcon className="size-3.5" />
                 <span className="hidden sm:inline ml-1">Terminal</span>
@@ -929,6 +932,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                 type="button"
                 variant="outline"
                 title="Toggle file explorer"
+                aria-label="Toggle file explorer"
               >
                 <FolderTree className="size-3.5" />
                 <span className="hidden sm:inline ml-1">Files</span>
@@ -947,6 +951,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               variant="outline"
               size="icon"
               title="Download conversation markdown"
+              aria-label="Download conversation"
             >
               <DownloadIcon className="size-3.5" />
               <span className="hidden sm:inline ml-1">Save</span>
@@ -966,6 +971,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               type="button"
               variant="destructive"
               title="End Session"
+              aria-label="End session"
             >
               <OctagonX className="size-3.5" />
               <span className="hidden sm:inline ml-1">End</span>
@@ -985,6 +991,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               type="button"
               variant="outline"
               title="New conversation (/new)"
+              aria-label="Clear conversation"
             >
               <Plus className="size-3.5" />
               <span className="hidden sm:inline ml-1">Clear</span>
@@ -1048,6 +1055,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                 size="icon"
                 type="button"
                 variant="outline"
+                aria-label="Scroll to bottom"
               >
                 <ArrowDownIcon className="size-4" />
               </Button>
@@ -1100,6 +1108,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                       onClick={() => onRemoveQueuedMessage(qm.id)}
                       className="opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-all flex-shrink-0 mt-0.5"
                       title="Remove queued message"
+                      aria-label="Remove queued message"
                     >
                       <X className="size-3" />
                     </button>


### PR DESCRIPTION
I have improved the accessibility of the `SessionViewer` component by adding `aria-label` attributes to several icon-only buttons. This ensures that screen reader users can understand the purpose of these buttons, even on devices where hover tooltips (via `title`) are not available.

Changes include:
- Added `aria-label="Toggle terminal"` to the terminal toggle button.
- Added `aria-label="Toggle file explorer"` to the file explorer toggle button.
- Added `aria-label="Download conversation"` to the conversation download button.
- Added `aria-label="End session"` to the end session button.
- Added `aria-label="Clear conversation"` to the clear conversation button.
- Added `aria-label="Scroll to bottom"` to the scroll-to-bottom button.
- Added `aria-label="Remove queued message"` to the remove queued message button.
- Added `aria-label="Add attachments"` to the attachment button.
- Enhanced the "Cycle reasoning effort level" button with a dynamic `aria-label` that reflects the current state (e.g., "Cycle reasoning effort level (current: medium)").

I verified these changes by:
1.  Running `bun run build:ui` to ensure no build regressions.
2.  Temporarily mocking the `App` component to bypass authentication and backend dependencies.
3.  Using a Playwright script to render the UI and verify that the `aria-label` attributes are correctly present on the DOM elements.

---
*PR created automatically by Jules for task [14174020801831285980](https://jules.google.com/task/14174020801831285980) started by @Pizzaface*