### PR TITLE
feat(server): enforce stronger password policy

### DIFF
--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -58,7 +58,7 @@ export async function handleApi(req: Request, url: URL): Promise<Response | unde
         }
 
         if (!isValidPassword(password)) {
-            return Response.json({ error: "Password must be at least 8 characters long" }, { status: 400 });
+            return Response.json({ error: "Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number" }, { status: 400 });
         }
 
         const existing = await kysely

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -101,20 +101,24 @@ describe("isValidEmail", () => {
 });
 
 describe("isValidPassword", () => {
-    test("accepts passwords >= 8 characters", () => {
-        expect(isValidPassword("12345678")).toBe(true);
-        expect(isValidPassword("a very long password with spaces")).toBe(true);
-        expect(isValidPassword("abcdefgh")).toBe(true);
+    test("accepts valid passwords (>=8 chars, 1 upper, 1 lower, 1 number)", () => {
+        expect(isValidPassword("Abc12345")).toBe(true);
+        expect(isValidPassword("ComplexPass1")).toBe(true);
+        expect(isValidPassword("1234Abcd")).toBe(true);
     });
 
     test("rejects passwords < 8 characters", () => {
-        expect(isValidPassword("short")).toBe(false);
+        expect(isValidPassword("Short1A")).toBe(false);
         expect(isValidPassword("1234567")).toBe(false);
         expect(isValidPassword("")).toBe(false);
     });
 
-    test("boundary: exactly 8 characters", () => {
-        expect(isValidPassword("12345678")).toBe(true);
-        expect(isValidPassword("1234567")).toBe(false);
+    test("rejects passwords missing required character types", () => {
+        // No uppercase
+        expect(isValidPassword("abcdefg1")).toBe(false);
+        // No lowercase
+        expect(isValidPassword("ABCDEFG1")).toBe(false);
+        // No number
+        expect(isValidPassword("Abcdefgh")).toBe(false);
     });
 });

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -59,5 +59,9 @@ export function isValidEmail(email: string): boolean {
 }
 
 export function isValidPassword(password: string): boolean {
-    return password.length >= 8;
+    if (password.length < 8) return false;
+    const hasUpperCase = /[A-Z]/.test(password);
+    const hasLowerCase = /[a-z]/.test(password);
+    const hasNumber = /[0-9]/.test(password);
+    return hasUpperCase && hasLowerCase && hasNumber;
 }


### PR DESCRIPTION
Enforces a stronger password policy for user registration. Passwords must now be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number. This change updates the `isValidPassword` utility, the `/api/register` endpoint's error message, and the corresponding unit tests.

---
*PR created automatically by Jules for task [15604489062086305051](https://jules.google.com/task/15604489062086305051) started by @Pizzaface*