### PR TITLE
🧪 test: add coverage for attachmentMaxFileSizeBytes

### DIFF
--- a/packages/server/src/attachments/store.test.ts
+++ b/packages/server/src/attachments/store.test.ts
@@ -54,4 +54,48 @@ describe("attachmentMaxFileSizeBytes", () => {
             delete process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES;
         }
     });
+
+    test("returns the configured size for a valid env var", () => {
+        const original = process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES;
+        process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES = "10485760"; // 10MB
+        expect(attachmentMaxFileSizeBytes()).toBe(10 * 1024 * 1024);
+        if (original !== undefined) {
+            process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES = original;
+        } else {
+            delete process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES;
+        }
+    });
+
+    test("returns default for a zero size", () => {
+        const original = process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES;
+        process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES = "0";
+        expect(attachmentMaxFileSizeBytes()).toBe(20 * 1024 * 1024);
+        if (original !== undefined) {
+            process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES = original;
+        } else {
+            delete process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES;
+        }
+    });
+
+    test("returns default for a negative size", () => {
+        const original = process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES;
+        process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES = "-500000";
+        expect(attachmentMaxFileSizeBytes()).toBe(20 * 1024 * 1024);
+        if (original !== undefined) {
+            process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES = original;
+        } else {
+            delete process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES;
+        }
+    });
+
+    test("returns default for an empty string", () => {
+        const original = process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES;
+        process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES = "";
+        expect(attachmentMaxFileSizeBytes()).toBe(20 * 1024 * 1024);
+        if (original !== undefined) {
+            process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES = original;
+        } else {
+            delete process.env.PIZZAPI_ATTACHMENT_MAX_FILE_SIZE_BYTES;
+        }
+    });
 });


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was in `attachmentMaxFileSizeBytes` to ensure environment variables are correctly parsed and fall back to defaults under various edge cases.
📊 **Coverage:** Now tests for valid integer sizes, zero size, negative size, and empty strings.
✨ **Result:** Improved test coverage and reliability for attachment size limits logic.

---
*PR created automatically by Jules for task [3592692789084206017](https://jules.google.com/task/3592692789084206017) started by @Pizzaface*