### PR TITLE
🧪 [testing] Add tests for getEphemeralSweepIntervalMs in store.ts

### DIFF
--- a/packages/server/src/sessions/store.test.ts
+++ b/packages/server/src/sessions/store.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, afterEach } from "bun:test";
+import { getEphemeralSweepIntervalMs, getEphemeralTtlMs } from "./store.js";
+
+describe("store.ts", () => {
+    describe("getEphemeralSweepIntervalMs", () => {
+        const ORIGINAL_ENV = process.env.PIZZAPI_EPHEMERAL_SWEEP_MS;
+
+        afterEach(() => {
+            if (ORIGINAL_ENV === undefined) {
+                delete process.env.PIZZAPI_EPHEMERAL_SWEEP_MS;
+            } else {
+                process.env.PIZZAPI_EPHEMERAL_SWEEP_MS = ORIGINAL_ENV;
+            }
+        });
+
+        it("should return the default value when env var is not set", () => {
+            delete process.env.PIZZAPI_EPHEMERAL_SWEEP_MS;
+            expect(getEphemeralSweepIntervalMs()).toBe(60 * 1000);
+        });
+
+        it("should return the parsed value when env var is a valid positive integer", () => {
+            process.env.PIZZAPI_EPHEMERAL_SWEEP_MS = "120000";
+            expect(getEphemeralSweepIntervalMs()).toBe(120000);
+        });
+
+        it("should return the default value when env var is zero", () => {
+            process.env.PIZZAPI_EPHEMERAL_SWEEP_MS = "0";
+            expect(getEphemeralSweepIntervalMs()).toBe(60 * 1000);
+        });
+
+        it("should return the default value when env var is a negative integer", () => {
+            process.env.PIZZAPI_EPHEMERAL_SWEEP_MS = "-5000";
+            expect(getEphemeralSweepIntervalMs()).toBe(60 * 1000);
+        });
+
+        it("should return the default value when env var is not a number", () => {
+            process.env.PIZZAPI_EPHEMERAL_SWEEP_MS = "abc";
+            expect(getEphemeralSweepIntervalMs()).toBe(60 * 1000);
+        });
+
+        it("should return the default value when env var is an empty string", () => {
+            process.env.PIZZAPI_EPHEMERAL_SWEEP_MS = "";
+            expect(getEphemeralSweepIntervalMs()).toBe(60 * 1000);
+        });
+    });
+
+    describe("getEphemeralTtlMs", () => {
+        const ORIGINAL_ENV = process.env.PIZZAPI_EPHEMERAL_TTL_MS;
+
+        afterEach(() => {
+            if (ORIGINAL_ENV === undefined) {
+                delete process.env.PIZZAPI_EPHEMERAL_TTL_MS;
+            } else {
+                process.env.PIZZAPI_EPHEMERAL_TTL_MS = ORIGINAL_ENV;
+            }
+        });
+
+        it("should return the default value when env var is not set", () => {
+            delete process.env.PIZZAPI_EPHEMERAL_TTL_MS;
+            expect(getEphemeralTtlMs()).toBe(10 * 60 * 1000);
+        });
+
+        it("should return the parsed value when env var is a valid positive integer", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "300000";
+            expect(getEphemeralTtlMs()).toBe(300000);
+        });
+
+        it("should return the default value when env var is zero", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "0";
+            expect(getEphemeralTtlMs()).toBe(10 * 60 * 1000);
+        });
+
+        it("should return the default value when env var is a negative integer", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "-10000";
+            expect(getEphemeralTtlMs()).toBe(10 * 60 * 1000);
+        });
+
+        it("should return the default value when env var is not a number", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "invalid";
+            expect(getEphemeralTtlMs()).toBe(10 * 60 * 1000);
+        });
+
+        it("should return the default value when env var is an empty string", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "";
+            expect(getEphemeralTtlMs()).toBe(10 * 60 * 1000);
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** This PR addresses a gap in test coverage by adding robust unit tests for `getEphemeralSweepIntervalMs` and `getEphemeralTtlMs` in `packages/server/src/sessions/store.ts`. These functions handle environment variable parsing to set default ephemeral session limits and sweep intervals.

📊 **Coverage:** The new tests cover:
- Happy paths (valid positive integers).
- Expected defaults when the `process.env` variable is completely absent.
- Edge cases including zeros, negative integers, completely invalid non-numeric strings, and empty string evaluations.
- Preserves test purity by recording and restoring the state of the modified `process.env` variables in `afterEach` hooks.

✨ **Result:** Enhanced test coverage and assurance that `process.env` configuration fallbacks remain reliable. Improved developer confidence to refactor in the future.

---
*PR created automatically by Jules for task [7505138483731485869](https://jules.google.com/task/7505138483731485869) started by @Pizzaface*