### PR TITLE
🎨 Palette: Add aria-label to drag handles

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -13,3 +13,7 @@
 ## 2025-05-20 - Title Attribute Insufficiency
 **Learning:** Icon-only buttons in `SessionViewer` relied solely on `title` for accessibility. While `title` provides a tooltip, it is not reliably announced by all screen readers and does not replace `aria-label` for providing an accessible name.
 **Action:** Ensure all icon-only buttons have an explicit `aria-label`, even if they already have a `title`.
+
+## 2026-02-28 - ARIA Labels on Non-Interactive Drag Handles
+**Learning:** Adding `aria-label` to purely pointer-driven elements (like `onPointerDown` drag handles) that lack full keyboard support should NOT be accompanied by `role="button"` or `tabIndex={0}`. Doing so creates a keyboard trap/broken focus element that screen readers announce but users cannot activate with Space or Enter.
+**Action:** When adding accessibility labels to visually interactive but non-keyboard-operable elements, use `aria-label` or `aria-roledescription` without making them focusable unless full keyboard interaction (e.g., Space/Enter handlers) is also implemented.

--- a/packages/ui/src/components/CombinedPanel.tsx
+++ b/packages/ui/src/components/CombinedPanel.tsx
@@ -296,6 +296,7 @@ export function CombinedPanel({
               className="flex items-center justify-center size-7 rounded cursor-grab active:cursor-grabbing text-muted-foreground/60 hover:text-muted-foreground hover:bg-accent transition-colors touch-none select-none"
               onPointerDown={onDragStart}
               title="Drag to reposition panel"
+              aria-label="Drag to reposition panel"
             >
               <GripHorizontal size={13} />
             </div>

--- a/packages/ui/src/components/TerminalManager.tsx
+++ b/packages/ui/src/components/TerminalManager.tsx
@@ -326,6 +326,7 @@ export function TerminalManager({
               className="flex items-center justify-center size-7 rounded cursor-grab active:cursor-grabbing text-muted-foreground/60 hover:text-muted-foreground hover:bg-accent transition-colors touch-none select-none"
               onPointerDown={onDragStart}
               title="Drag to reposition panel"
+              aria-label="Drag to reposition panel"
             >
               <GripHorizontal size={13} />
             </div>


### PR DESCRIPTION
This commit adds `aria-label="Drag to reposition panel"` to the drag handles in `CombinedPanel.tsx` and `TerminalManager.tsx` to improve accessibility for screen readers. This ensures these components are aligned with the existing handle in `FileExplorer.tsx`. Note that `role="button"` and `tabIndex={0}` were intentionally omitted because the drag functionality is purely mouse/pointer-driven, and making the handle focusable without keyboard action handlers would create a broken focus element.

---
*PR created automatically by Jules for task [13654126376070700932](https://jules.google.com/task/13654126376070700932) started by @Pizzaface*