### PR TITLE
⚡ Bolt: Resolve N+1 query in cleanStaleIndexEntries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Resolving N+1 queries in node-redis
+**Learning:** Sequential calls to `r.exists()` within loops created significant performance bottlenecks when interacting with a remote Redis server, specifically in functions executing N+1 queries like `cleanStaleIndexEntries`.
+**Action:** Always batch repeated, independent read operations using Redis pipelining (`r.multi()`). Use a single pipeline to buffer `exists()` checks, run `multi.exec()`, map the boolean results to the corresponding IDs, and batch deletions into a single `sRem` call, reducing round-trips from `O(N)` to `O(1)`.


### PR DESCRIPTION
💡 **What:** Refactored `cleanStaleIndexEntries` in `packages/server/src/ws/sio-state.ts` to replace sequential `r.exists()` calls within loops with a single Redis pipeline (`multi()`). Stale IDs are now collected and removed in a single `r.sRem()` bulk operation.
🎯 **Why:** To eliminate an N+1 query bottleneck. In the previous implementation, checking N sessions and M runners required N+M separate round trips to the remote Redis instance.
📊 **Impact:** Reduces network round trips from O(N) to O(1), significantly improving the execution time of index cleanup and lowering CPU/network load when handling large numbers of concurrent sessions or runners.
🔬 **Measurement:** Verify by running the backend build (`bun run build:server`) and test suite (`bun test packages/server`). The `tests/redis_perf.test.ts` or general application profiling will reflect a drop in command execution latency.

---
*PR created automatically by Jules for task [1238462765011382821](https://jules.google.com/task/1238462765011382821) started by @Pizzaface*