### PR TITLE
🧹 Remove hardcoded trusted origins in favor of env configurations

### DIFF
--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -7,121 +7,121 @@ import { Database } from "bun:sqlite";
 // ── DB schema types ───────────────────────────────────────────────────────────
 
 export interface UserTable {
-    id: string;
-    name: string;
-    email: string;
-    emailVerified: number;
-    image: string | null;
-    createdAt: string;
-    updatedAt: string;
+  id: string;
+  name: string;
+  email: string;
+  emailVerified: number;
+  image: string | null;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface SessionTable {
-    id: string;
-    expiresAt: string;
-    token: string;
-    createdAt: string;
-    updatedAt: string;
-    ipAddress: string | null;
-    userAgent: string | null;
-    userId: string;
+  id: string;
+  expiresAt: string;
+  token: string;
+  createdAt: string;
+  updatedAt: string;
+  ipAddress: string | null;
+  userAgent: string | null;
+  userId: string;
 }
 
 export interface AccountTable {
-    id: string;
-    accountId: string;
-    providerId: string;
-    userId: string;
-    accessToken: string | null;
-    refreshToken: string | null;
-    idToken: string | null;
-    accessTokenExpiresAt: string | null;
-    refreshTokenExpiresAt: string | null;
-    scope: string | null;
-    password: string | null;
-    createdAt: string;
-    updatedAt: string;
+  id: string;
+  accountId: string;
+  providerId: string;
+  userId: string;
+  accessToken: string | null;
+  refreshToken: string | null;
+  idToken: string | null;
+  accessTokenExpiresAt: string | null;
+  refreshTokenExpiresAt: string | null;
+  scope: string | null;
+  password: string | null;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface VerificationTable {
-    id: string;
-    identifier: string;
-    value: string;
-    expiresAt: string;
-    createdAt: string;
-    updatedAt: string;
+  id: string;
+  identifier: string;
+  value: string;
+  expiresAt: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface ApiKeyTable {
-    id: string;
-    name: string | null;
-    start: string | null;
-    prefix: string | null;
-    key: string;
-    userId: string;
-    refillInterval: number | null;
-    refillAmount: number | null;
-    lastRefillAt: string | null;
-    enabled: number;
-    rateLimitEnabled: number;
-    rateLimitTimeWindow: number | null;
-    rateLimitMax: number | null;
-    requestCount: number;
-    remaining: number | null;
-    lastRequest: string | null;
-    expiresAt: string | null;
-    createdAt: string;
-    updatedAt: string;
-    permissions: string | null;
-    metadata: string | null;
+  id: string;
+  name: string | null;
+  start: string | null;
+  prefix: string | null;
+  key: string;
+  userId: string;
+  refillInterval: number | null;
+  refillAmount: number | null;
+  lastRefillAt: string | null;
+  enabled: number;
+  rateLimitEnabled: number;
+  rateLimitTimeWindow: number | null;
+  rateLimitMax: number | null;
+  requestCount: number;
+  remaining: number | null;
+  lastRequest: string | null;
+  expiresAt: string | null;
+  createdAt: string;
+  updatedAt: string;
+  permissions: string | null;
+  metadata: string | null;
 }
 
 export interface RelaySessionTable {
-    id: string;
-    userId: string | null;
-    userName: string | null;
-    cwd: string;
-    shareUrl: string;
-    startedAt: string;
-    lastActiveAt: string;
-    endedAt: string | null;
-    isEphemeral: number;
-    expiresAt: string | null;
+  id: string;
+  userId: string | null;
+  userName: string | null;
+  cwd: string;
+  shareUrl: string;
+  startedAt: string;
+  lastActiveAt: string;
+  endedAt: string | null;
+  isEphemeral: number;
+  expiresAt: string | null;
 }
 
 export interface RelaySessionStateTable {
-    sessionId: string;
-    state: string;
-    updatedAt: string;
+  sessionId: string;
+  state: string;
+  updatedAt: string;
 }
 
 export interface PushSubscriptionTable {
-    id: string;
-    userId: string;
-    endpoint: string;
-    keys: string;
-    createdAt: string;
-    enabledEvents: string;
+  id: string;
+  userId: string;
+  endpoint: string;
+  keys: string;
+  createdAt: string;
+  enabledEvents: string;
 }
 
 export interface RunnerRecentFolderTable {
-    id: string;
-    userId: string;
-    runnerId: string;
-    path: string;
-    lastUsedAt: string;
+  id: string;
+  userId: string;
+  runnerId: string;
+  path: string;
+  lastUsedAt: string;
 }
 
 export interface DB {
-    user: UserTable;
-    session: SessionTable;
-    account: AccountTable;
-    verification: VerificationTable;
-    apikey: ApiKeyTable;
-    relay_session: RelaySessionTable;
-    relay_session_state: RelaySessionStateTable;
-    push_subscription: PushSubscriptionTable;
-    runner_recent_folder: RunnerRecentFolderTable;
+  user: UserTable;
+  session: SessionTable;
+  account: AccountTable;
+  verification: VerificationTable;
+  apikey: ApiKeyTable;
+  relay_session: RelaySessionTable;
+  relay_session_state: RelaySessionStateTable;
+  push_subscription: PushSubscriptionTable;
+  runner_recent_folder: RunnerRecentFolderTable;
 }
 
 // ── Instances ─────────────────────────────────────────────────────────────────
@@ -134,30 +134,39 @@ export const kysely = new Kysely<DB>({ dialect });
 const DEFAULT_API_KEY_RATE_LIMIT_TIME_WINDOW_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_API_KEY_RATE_LIMIT_MAX_REQUESTS = 10;
 
-function parseBooleanEnv(value: string | undefined, fallback: boolean): boolean {
-    if (!value) return fallback;
-    const normalized = value.trim().toLowerCase();
-    if (["1", "true", "yes", "on"].includes(normalized)) return true;
-    if (["0", "false", "no", "off"].includes(normalized)) return false;
-    return fallback;
+function parseBooleanEnv(
+  value: string | undefined,
+  fallback: boolean,
+): boolean {
+  if (!value) return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return fallback;
 }
 
-function parsePositiveIntEnv(value: string | undefined, fallback: number): number {
-    if (!value) return fallback;
-    const parsed = Number.parseInt(value, 10);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+function parsePositiveIntEnv(
+  value: string | undefined,
+  fallback: number,
+): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
 export const apiKeyRateLimitConfig = {
-    enabled: parseBooleanEnv(process.env.PIZZAPI_API_KEY_RATE_LIMIT_ENABLED, false),
-    timeWindow: parsePositiveIntEnv(
-        process.env.PIZZAPI_API_KEY_RATE_LIMIT_TIME_WINDOW_MS,
-        DEFAULT_API_KEY_RATE_LIMIT_TIME_WINDOW_MS,
-    ),
-    maxRequests: parsePositiveIntEnv(
-        process.env.PIZZAPI_API_KEY_RATE_LIMIT_MAX_REQUESTS,
-        DEFAULT_API_KEY_RATE_LIMIT_MAX_REQUESTS,
-    ),
+  enabled: parseBooleanEnv(
+    process.env.PIZZAPI_API_KEY_RATE_LIMIT_ENABLED,
+    false,
+  ),
+  timeWindow: parsePositiveIntEnv(
+    process.env.PIZZAPI_API_KEY_RATE_LIMIT_TIME_WINDOW_MS,
+    DEFAULT_API_KEY_RATE_LIMIT_TIME_WINDOW_MS,
+  ),
+  maxRequests: parsePositiveIntEnv(
+    process.env.PIZZAPI_API_KEY_RATE_LIMIT_MAX_REQUESTS,
+    DEFAULT_API_KEY_RATE_LIMIT_MAX_REQUESTS,
+  ),
 };
 
 /**
@@ -169,33 +178,46 @@ export const apiKeyRateLimitConfig = {
  *   PIZZAPI_EXTRA_ORIGINS=https://myhost.ts.net,http://myhost.ts.net:5173
  */
 const extraOrigins: string[] = process.env.PIZZAPI_EXTRA_ORIGINS
-    ? process.env.PIZZAPI_EXTRA_ORIGINS.split(",").map((o) => o.trim()).filter(Boolean)
-    : [];
+  ? process.env.PIZZAPI_EXTRA_ORIGINS.split(",")
+      .map((o) => o.trim())
+      .filter(Boolean)
+  : [];
 
-export const trustedOrigins: string[] = [
-    process.env.PIZZAPI_BASE_URL ?? "http://localhost:5173",
-    "http://127.0.0.1:5173",
-    ...extraOrigins,
-];
+const baseOrigins: string[] = [];
+
+if (process.env.PIZZAPI_BASE_URL) {
+  baseOrigins.push(process.env.PIZZAPI_BASE_URL);
+}
+
+if (process.env.NODE_ENV !== "production") {
+  if (!process.env.PIZZAPI_BASE_URL) {
+    baseOrigins.push("http://localhost:5173");
+  }
+  baseOrigins.push("http://127.0.0.1:5173");
+}
+
+export const trustedOrigins: string[] = [...baseOrigins, ...extraOrigins];
 
 export const auth = betterAuth({
-    baseURL: process.env.BETTER_AUTH_BASE_URL ?? `http://localhost:${process.env.PORT ?? "3000"}`,
-    secret: process.env.BETTER_AUTH_SECRET,
-    database: { dialect, type: "sqlite", transaction: true },
-    trustedOrigins,
-    emailAndPassword: {
-        enabled: true,
-    },
-    plugins: [
-        apiKey({
-            enableSessionForAPIKeys: true,
-            rateLimit: {
-                enabled: apiKeyRateLimitConfig.enabled,
-                timeWindow: apiKeyRateLimitConfig.timeWindow,
-                maxRequests: apiKeyRateLimitConfig.maxRequests,
-            },
-        }),
-    ],
+  baseURL:
+    process.env.BETTER_AUTH_BASE_URL ??
+    `http://localhost:${process.env.PORT ?? "3000"}`,
+  secret: process.env.BETTER_AUTH_SECRET,
+  database: { dialect, type: "sqlite", transaction: true },
+  trustedOrigins,
+  emailAndPassword: {
+    enabled: true,
+  },
+  plugins: [
+    apiKey({
+      enableSessionForAPIKeys: true,
+      rateLimit: {
+        enabled: apiKeyRateLimitConfig.enabled,
+        timeWindow: apiKeyRateLimitConfig.timeWindow,
+        maxRequests: apiKeyRateLimitConfig.maxRequests,
+      },
+    }),
+  ],
 });
 
 export type Auth = typeof auth;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Hardcoded trusted development origins (`http://localhost:5173` and `http://127.0.0.1:5173`) in `packages/server/src/auth.ts` were removed from production scope. The configuration now intelligently relies on the `NODE_ENV` configuration to conditionally inject local hostnames and prioritizes environment variables (`PIZZAPI_BASE_URL` and `PIZZAPI_EXTRA_ORIGINS`).

💡 **Why:** How this improves maintainability
This eliminates the risk of inadvertently trusting development-oriented local origins on production environments while preserving developer convenience. It centralizes configuration logic into easily manipulable environment variables.

✅ **Verification:** How you confirmed the change is safe
Ran unit tests in `packages/server` which successfully passed. Verified the compilation correctness of `auth.ts` via bun build targeting node, formatted code with Prettier, and completed an internal Code Review.

✨ **Result:** The improvement achieved
A cleaner `auth.ts` configuration fully resilient against misconfiguration in deployed environments, improving security defaults.

---
*PR created automatically by Jules for task [10286560347221308808](https://jules.google.com/task/10286560347221308808) started by @Pizzaface*