### PR TITLE
🔒 Security Fix: Restrict development origins from trustedOrigins in production

### DIFF
--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -172,9 +172,20 @@ const extraOrigins: string[] = process.env.PIZZAPI_EXTRA_ORIGINS
     ? process.env.PIZZAPI_EXTRA_ORIGINS.split(",").map((o) => o.trim()).filter(Boolean)
     : [];
 
+const isProduction = process.env.NODE_ENV === "production";
+if (isProduction && !process.env.PIZZAPI_BASE_URL) {
+    console.warn("WARNING: PIZZAPI_BASE_URL is not set in production. This may cause CORS or WebSocket connection issues.");
+}
+
+const baseOrigins: string[] = [];
+if (process.env.PIZZAPI_BASE_URL) {
+    baseOrigins.push(process.env.PIZZAPI_BASE_URL);
+} else if (!isProduction) {
+    baseOrigins.push("http://localhost:5173", "http://127.0.0.1:5173");
+}
+
 export const trustedOrigins: string[] = [
-    process.env.PIZZAPI_BASE_URL ?? "http://localhost:5173",
-    "http://127.0.0.1:5173",
+    ...baseOrigins,
     ...extraOrigins,
 ];
 


### PR DESCRIPTION
🎯 **What:** Hardcoded development origins (`http://localhost:5173`, `http://127.0.0.1:5173`) in `trustedOrigins` have been restricted to only apply when `NODE_ENV !== 'production'`.
⚠️ **Risk:** Including `localhost` origins unconditionally in production can allow an attacker to exploit SSRF/CORS configurations or spoof WebSocket connections if they can manipulate the resolution or access the service from specific network positions. 
🛡️ **Solution:** The `trustedOrigins` configuration now strictly enforces `process.env.PIZZAPI_BASE_URL` and `process.env.PIZZAPI_EXTRA_ORIGINS` in production. A helpful warning logs if the base URL is unset, assisting in deployment debugging without compromising security.

---
*PR created automatically by Jules for task [2484427315515859790](https://jules.google.com/task/2484427315515859790) started by @Pizzaface*