### PR TITLE
🧪 Add tests for getEphemeralTtlMs in sessions/store.ts

### DIFF
--- a/packages/server/src/sessions/store.test.ts
+++ b/packages/server/src/sessions/store.test.ts
@@ -1,0 +1,57 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { getEphemeralTtlMs } from "./store.js";
+
+const DEFAULT_EPHEMERAL_TTL_MS = 10 * 60 * 1000;
+
+describe("sessions/store", () => {
+    describe("getEphemeralTtlMs", () => {
+        let originalEnvVar: string | undefined;
+
+        beforeEach(() => {
+            originalEnvVar = process.env.PIZZAPI_EPHEMERAL_TTL_MS;
+        });
+
+        afterEach(() => {
+            if (originalEnvVar === undefined) {
+                delete process.env.PIZZAPI_EPHEMERAL_TTL_MS;
+            } else {
+                process.env.PIZZAPI_EPHEMERAL_TTL_MS = originalEnvVar;
+            }
+        });
+
+        test("returns default value when env var is not set", () => {
+            delete process.env.PIZZAPI_EPHEMERAL_TTL_MS;
+            expect(getEphemeralTtlMs()).toBe(DEFAULT_EPHEMERAL_TTL_MS);
+        });
+
+        test("returns parsed value when env var is a valid positive integer", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "5000";
+            expect(getEphemeralTtlMs()).toBe(5000);
+        });
+
+        test("returns default value when env var is zero", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "0";
+            expect(getEphemeralTtlMs()).toBe(DEFAULT_EPHEMERAL_TTL_MS);
+        });
+
+        test("returns default value when env var is a negative number", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "-1000";
+            expect(getEphemeralTtlMs()).toBe(DEFAULT_EPHEMERAL_TTL_MS);
+        });
+
+        test("returns default value when env var is a non-numeric string", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "abc";
+            expect(getEphemeralTtlMs()).toBe(DEFAULT_EPHEMERAL_TTL_MS);
+        });
+
+        test("returns parsed value when env var is a float (truncates to int)", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "5000.5";
+            expect(getEphemeralTtlMs()).toBe(5000);
+        });
+
+        test("returns default value when env var is an empty string", () => {
+            process.env.PIZZAPI_EPHEMERAL_TTL_MS = "";
+            expect(getEphemeralTtlMs()).toBe(DEFAULT_EPHEMERAL_TTL_MS);
+        });
+    });
+});


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
The `getEphemeralTtlMs` function in `packages/server/src/sessions/store.ts`, which parses the `PIZZAPI_EPHEMERAL_TTL_MS` environment variable, lacked unit tests.

📊 **Coverage:** What scenarios are now tested
- Environment variable is not set (returns default)
- Environment variable is a valid positive integer (returns parsed value)
- Environment variable is zero (returns default)
- Environment variable is a negative number (returns default)
- Environment variable is a non-numeric string (returns default)
- Environment variable is a float (truncates to int)
- Environment variable is an empty string (returns default)

✨ **Result:** The improvement in test coverage
We now have full confidence that the `getEphemeralTtlMs` function will behave predictably and safely regardless of what the user supplies in the environment variables, falling back to a sane default when given invalid input.

---
*PR created automatically by Jules for task [9100197668908134190](https://jules.google.com/task/9100197668908134190) started by @Pizzaface*