### PR TITLE
feat: disable signups after first user registration

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -17,6 +17,9 @@ services:
     environment:
       - PORT=7492
       - PIZZAPI_REDIS_URL=redis://redis:6379
+      # Disable new signups after the first user has registered (default: true)
+      # Set to false to allow unlimited registrations.
+      # - PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER=true
     volumes:
       - pizzapi-data:/app/data
     depends_on:

--- a/packages/server/src/auth.test.ts
+++ b/packages/server/src/auth.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test, beforeAll } from "bun:test";
+import { disableSignupAfterFirstUser, isSignupAllowed, kysely } from "./auth";
+import { sql } from "kysely";
+
+// Ensure the user table exists for testing (better-auth normally creates it via migrations)
+beforeAll(async () => {
+    await sql`
+        CREATE TABLE IF NOT EXISTS user (
+            id TEXT PRIMARY KEY,
+            name TEXT NOT NULL,
+            email TEXT NOT NULL UNIQUE,
+            emailVerified INTEGER NOT NULL DEFAULT 0,
+            image TEXT,
+            createdAt TEXT NOT NULL,
+            updatedAt TEXT NOT NULL
+        )
+    `.execute(kysely);
+});
+
+describe("signup gating", () => {
+    test("disableSignupAfterFirstUser defaults to true", () => {
+        // The env var PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER is not set in
+        // the test environment, so it should fall back to the default (true).
+        expect(disableSignupAfterFirstUser).toBe(true);
+    });
+
+    test("isSignupAllowed returns true when no users exist", async () => {
+        // Clean the table for a deterministic test
+        await kysely.deleteFrom("user").execute();
+
+        const allowed = await isSignupAllowed();
+        expect(allowed).toBe(true);
+    });
+
+    test("isSignupAllowed returns false when users exist", async () => {
+        // Insert a test user
+        await kysely.deleteFrom("user").execute();
+        const now = new Date().toISOString();
+        await kysely
+            .insertInto("user")
+            .values({
+                id: "test-user-1",
+                name: "Test User",
+                email: "test@example.com",
+                emailVerified: 0,
+                image: null,
+                createdAt: now,
+                updatedAt: now,
+            })
+            .execute();
+
+        const allowed = await isSignupAllowed();
+        expect(allowed).toBe(false);
+
+        // Clean up
+        await kysely.deleteFrom("user").execute();
+    });
+});

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -219,3 +219,30 @@ export const auth = betterAuth({
 });
 
 export type Auth = typeof auth;
+
+// ── Signup gating ──────────────────────────────────────────────────────────────
+// When PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER is true (default), new account
+// creation is blocked once at least one user exists in the database.
+
+export const disableSignupAfterFirstUser = parseBooleanEnv(
+    process.env.PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER,
+    true,
+);
+
+/**
+ * Returns `true` when new user signups are currently allowed.
+ *
+ * Signups are allowed when:
+ * - `PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER` is false, OR
+ * - no users have been created yet (first registration).
+ */
+export async function isSignupAllowed(): Promise<boolean> {
+    if (!disableSignupAfterFirstUser) return true;
+
+    const row = await kysely
+        .selectFrom("user")
+        .select(kysely.fn.countAll<number>().as("cnt"))
+        .executeTakeFirst();
+
+    return (row?.cnt ?? 0) === 0;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -1,4 +1,4 @@
-import { auth, trustedOrigins } from "./auth.js";
+import { auth, trustedOrigins, isSignupAllowed } from "./auth.js";
 import { handleApi } from "./routes/api.js";
 import { serveStaticFile } from "./static.js";
 import {
@@ -103,6 +103,16 @@ async function handleFetch(req: Request): Promise<Response> {
 
     // ── better-auth handler ────────────────────────────────────────────────
     if (url.pathname.startsWith("/api/auth")) {
+        // Block signup when signups are disabled (after first user).
+        if (url.pathname === "/api/auth/sign-up/email" && req.method === "POST") {
+            const allowed = await isSignupAllowed();
+            if (!allowed) {
+                return Response.json(
+                    { error: "Signups are disabled. Contact the administrator." },
+                    { status: 403 },
+                );
+            }
+        }
         try {
             return await auth.handler(req);
         } catch (e) {

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -33,6 +33,7 @@ import {
 } from "../push.js";
 import { RateLimiter, isValidEmail, isValidPassword, cwdMatchesRoots } from "../security.js";
 import { isValidSkillName } from "../validation.js";
+import { isSignupAllowed } from "../auth.js";
 
 // 5 requests per 15 minutes
 const registerRateLimiter = new RateLimiter(5, 15 * 60 * 1000);
@@ -40,6 +41,12 @@ const registerRateLimiter = new RateLimiter(5, 15 * 60 * 1000);
 export async function handleApi(req: Request, url: URL): Promise<Response | undefined> {
     if (url.pathname === "/health") {
         return Response.json({ status: "ok" });
+    }
+
+    // ── Public endpoint: signup status ───────────────────────────────────
+    if (url.pathname === "/api/signup-status" && req.method === "GET") {
+        const allowed = await isSignupAllowed();
+        return Response.json({ signupEnabled: allowed });
     }
 
     if (url.pathname === "/api/register" && req.method === "POST") {
@@ -79,6 +86,11 @@ export async function handleApi(req: Request, url: URL): Promise<Response | unde
             }
             userId = signIn.user.id;
         } else {
+            // Block new account creation when signups are disabled.
+            const allowed = await isSignupAllowed();
+            if (!allowed) {
+                return Response.json({ error: "Signups are disabled. Contact the administrator." }, { status: 403 });
+            }
             if (!name) {
                 return Response.json({ error: "Missing required field: name (required for new accounts)" }, { status: 400 });
             }

--- a/packages/ui/src/components/AuthPage.tsx
+++ b/packages/ui/src/components/AuthPage.tsx
@@ -20,9 +20,28 @@ export function AuthPage({ onAuthenticated }: AuthPageProps) {
     const [password, setPassword] = React.useState("");
     const [error, setError] = React.useState<string | null>(null);
     const [loading, setLoading] = React.useState(false);
+    const [signupEnabled, setSignupEnabled] = React.useState<boolean | null>(null);
 
     const signinRef = React.useRef<HTMLButtonElement>(null);
     const signupRef = React.useRef<HTMLButtonElement>(null);
+
+    // Fetch signup status on mount
+    React.useEffect(() => {
+        let cancelled = false;
+        void fetch("/api/signup-status")
+            .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
+            .then((data) => {
+                if (cancelled) return;
+                setSignupEnabled((data as any)?.signupEnabled === true);
+            })
+            .catch(() => {
+                if (cancelled) return;
+                // Default to showing signup tab on network errors so the first
+                // user can still register.
+                setSignupEnabled(true);
+            });
+        return () => { cancelled = true; };
+    }, []);
 
     async function handleSubmit(e: React.FormEvent) {
         e.preventDefault();
@@ -51,12 +70,13 @@ export function AuthPage({ onAuthenticated }: AuthPageProps) {
     }
 
     function switchTab(next: Tab) {
+        if (next === "signup" && signupEnabled === false) return;
         setTab(next);
         setError(null);
     }
 
     function handleKeyDown(e: React.KeyboardEvent) {
-        if (e.key === "ArrowRight") {
+        if (e.key === "ArrowRight" && signupEnabled !== false) {
             e.preventDefault();
             switchTab("signup");
             signupRef.current?.focus();
@@ -68,12 +88,21 @@ export function AuthPage({ onAuthenticated }: AuthPageProps) {
             e.preventDefault();
             switchTab("signin");
             signinRef.current?.focus();
-        } else if (e.key === "End") {
+        } else if (e.key === "End" && signupEnabled !== false) {
             e.preventDefault();
             switchTab("signup");
             signupRef.current?.focus();
         }
     }
+
+    // If signup is disabled and user somehow switched to signup tab, force back
+    React.useEffect(() => {
+        if (signupEnabled === false && tab === "signup") {
+            setTab("signin");
+        }
+    }, [signupEnabled, tab]);
+
+    const showSignupTab = signupEnabled !== false;
 
     return (
         <div className="flex min-h-[100dvh] w-full items-start justify-center bg-background p-4 overflow-y-auto pp-safe-top pp-safe-bottom sm:items-center">
@@ -106,19 +135,21 @@ export function AuthPage({ onAuthenticated }: AuthPageProps) {
                         >
                             Sign in
                         </button>
-                        <button
-                            ref={signupRef}
-                            id="tab-signup"
-                            role="tab"
-                            aria-selected={tab === "signup"}
-                            aria-controls="auth-panel"
-                            tabIndex={tab === "signup" ? 0 : -1}
-                            type="button"
-                            className={`px-3 py-1.5 text-sm font-medium transition-colors border-b-2 -mb-px ${tab === "signup" ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}
-                            onClick={() => switchTab("signup")}
-                        >
-                            Sign up
-                        </button>
+                        {showSignupTab && (
+                            <button
+                                ref={signupRef}
+                                id="tab-signup"
+                                role="tab"
+                                aria-selected={tab === "signup"}
+                                aria-controls="auth-panel"
+                                tabIndex={tab === "signup" ? 0 : -1}
+                                type="button"
+                                className={`px-3 py-1.5 text-sm font-medium transition-colors border-b-2 -mb-px ${tab === "signup" ? "border-foreground text-foreground" : "border-transparent text-muted-foreground hover:text-foreground"}`}
+                                onClick={() => switchTab("signup")}
+                            >
+                                Sign up
+                            </button>
+                        )}
                     </div>
                 </CardHeader>
                 <div


### PR DESCRIPTION
## Summary

Adds `PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER` env var (default: `true`). When enabled, new account creation is blocked once at least one user exists in the database. The first registration always succeeds.

## Changes

### Backend
- **`auth.ts`**: New `isSignupAllowed()` function checks user count when gating is enabled; exports `disableSignupAfterFirstUser` config
- **`index.ts`**: Intercepts `/api/auth/sign-up/email` before better-auth handler to block signups when disabled
- **`api.ts`**: Blocks new user creation in `/api/register` endpoint (existing user sign-in still works); adds public `GET /api/signup-status` endpoint returning `{ signupEnabled: boolean }`

### Frontend
- **`AuthPage.tsx`**: Fetches `/api/signup-status` on mount; hides the Sign up tab when signups are disabled

### Docker
- **`compose.yml`**: Documents the new env var (commented out since default is `true`)

### Tests
- **`auth.test.ts`**: Tests default config value, and `isSignupAllowed()` with 0 users and 1+ users

## How to disable this feature

Set `PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER=false` in your environment to allow unlimited registrations.