### PR TITLE
chore: update pi-coding-agent repo links to github.com/badlogic/pi-mono

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # PizzaPi — Agent Guide
 
-PizzaPi is a self-hosted web interface and relay server for the [`pi` coding agent](https://github.com/mariozechner/pi). It streams live agent sessions to any browser and allows remote interaction from mobile or desktop without needing terminal access.
+PizzaPi is a self-hosted web interface and relay server for the [`pi` coding agent](https://github.com/badlogic/pi-mono). It streams live agent sessions to any browser and allows remote interaction from mobile or desktop without needing terminal access.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # PizzaPi
 
-A self-hosted web interface and relay server for the [pi coding agent](https://github.com/mariozechner/pi). Stream live AI coding sessions to any browser and interact remotely from mobile or desktop — no terminal required.
+A self-hosted web interface and relay server for the [pi coding agent](https://github.com/badlogic/pi-mono). Stream live AI coding sessions to any browser and interact remotely from mobile or desktop — no terminal required.
 
 ---
 

--- a/packages/docs/src/content/docs/guides/skills.mdx
+++ b/packages/docs/src/content/docs/guides/skills.mdx
@@ -85,7 +85,7 @@ PizzaPi supports connecting **MCP servers** to the agent, giving it access to ad
 
 ### Configuration
 
-MCP servers are configured in your `pi` configuration (not PizzaPi config). Refer to the [pi documentation](https://github.com/mariozechner/pi) for MCP setup details.
+MCP servers are configured in your `pi` configuration (not PizzaPi config). Refer to the [pi documentation](https://github.com/badlogic/pi-mono) for MCP setup details.
 
 PizzaPi's `mcp-extension` automatically bridges any configured MCP servers into the agent's tool set for every session.
 

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -21,7 +21,7 @@ import { Card, CardGrid, LinkButton, Aside, Steps } from "@astrojs/starlight/com
 
 ## What is PizzaPi?
 
-**PizzaPi** is a self-hosted relay server and web UI that wraps the [`pi` coding agent](https://github.com/mariozechner/pi). It streams every event from your local agent session to a browser in real time — so you can monitor, interact, and review code changes from your phone, tablet, or another computer.
+**PizzaPi** is a self-hosted relay server and web UI that wraps the [`pi` coding agent](https://github.com/badlogic/pi-mono). It streams every event from your local agent session to a browser in real time — so you can monitor, interact, and review code changes from your phone, tablet, or another computer.
 
 <svg viewBox="0 0 600 350" xmlns="http://www.w3.org/2000/svg">
   <rect width="600" height="350" fill="#1e1e1e" rx="8"/>
@@ -134,7 +134,7 @@ pizzapi
 
 | Layer | Technology |
 |-------|------------|
-| Agent Core | [`pi` coding agent](https://github.com/mariozechner/pi) by Mario Zechner |
+| Agent Core | [`pi` coding agent](https://github.com/badlogic/pi-mono) by Mario Zechner |
 | Runtime | [Bun](https://bun.sh) |
 | Server | Bun.serve, [better-auth](https://www.better-auth.com/), Kysely + SQLite, Redis |
 | Web UI | React 19, Vite 6, TailwindCSS v4, Radix UI / shadcn/ui |

--- a/packages/npm/README.md
+++ b/packages/npm/README.md
@@ -1,6 +1,6 @@
 # PizzaPi
 
-A self-hosted web interface and relay server for the [pi coding agent](https://github.com/mariozechner/pi). Stream live AI coding sessions to any browser and interact remotely from mobile or desktop.
+A self-hosted web interface and relay server for the [pi coding agent](https://github.com/badlogic/pi-mono). Stream live AI coding sessions to any browser and interact remotely from mobile or desktop.
 
 ## Quick Start
 


### PR DESCRIPTION
Replace all references from `github.com/mariozechner/pi` to `github.com/badlogic/pi-mono` across:

- `README.md`
- `AGENTS.md`
- `packages/npm/README.md`
- `packages/docs/src/content/docs/index.mdx` (2 occurrences)
- `packages/docs/src/content/docs/guides/skills.mdx`

Skipped auto-generated files (`data-store.json`, `auth.db`).