### PR TITLE
feat: extract skill utilities with tests, fix command popover with args

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,29 +10,8 @@ import { existsSync } from "fs";
 import { readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
-import { defaultAgentDir, expandHome, loadConfig } from "./config.js";
-
-/**
- * Build the list of additional skill paths for DefaultResourceLoader.
- * Always includes:
- *   - ~/.pizzapi/skills/  (global PizzaPi skills)
- *   - <cwd>/.pizzapi/skills/  (project-local PizzaPi skills)
- * Plus any paths declared in config.skills.
- */
-function buildSkillPaths(cwd: string, _agentDir: string, configSkills?: string[]): string[] {
-    const paths: string[] = [
-        join(homedir(), ".pizzapi", "skills"),
-        join(cwd, ".pizzapi", "skills"),
-    ];
-    if (Array.isArray(configSkills)) {
-        for (const p of configSkills) {
-            if (typeof p === "string" && p.trim()) {
-                paths.push(expandHome(p.trim()));
-            }
-        }
-    }
-    return paths;
-}
+import { defaultAgentDir, loadConfig } from "./config.js";
+import { buildInteractiveSkillPaths } from "./skills.js";
 import { remoteExtension } from "./extensions/remote.js";
 import { mcpExtension } from "./extensions/mcp-extension.js";
 import { restartExtension } from "./extensions/restart.js";
@@ -397,7 +376,7 @@ async function main() {
         cwd,
         agentDir,
         extensionFactories: [remoteExtension, mcpExtension, restartExtension, setSessionNameExtension, updateTodoExtension, spawnSessionExtension, sessionMessagingExtension],
-        additionalSkillPaths: buildSkillPaths(cwd, agentDir, config.skills),
+        additionalSkillPaths: buildInteractiveSkillPaths(cwd, config.skills),
         ...(config.systemPrompt !== undefined && {
             systemPromptOverride: () => config.systemPrompt,
         }),

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -149,149 +149,15 @@ function releaseStateLock(statePath: string) {
     }
 }
 
-// ── Skill helpers ─────────────────────────────────────────────────────────────
+// ── Skill helpers (re-exported from shared module) ────────────────────────────
 
-/** Default global skills directory for PizzaPi. */
-function globalSkillsDir(): string {
-    return join(homedir(), ".pizzapi", "skills");
-}
-
-interface SkillMeta {
-    name: string;
-    description: string;
-    filePath: string;
-}
-
-/**
- * Scan the global PizzaPi skills directory and return basic metadata.
- * Mirrors the discovery rules from the Agent Skills standard:
- *   - Direct .md files in the root → name = basename without extension
- *   - SKILL.md files under subdirectories → name = directory name
- */
-function scanGlobalSkills(): SkillMeta[] {
-    const dir = globalSkillsDir();
-    if (!existsSync(dir)) return [];
-
-    const skills: SkillMeta[] = [];
-
-    let entries: string[];
-    try {
-        entries = readdirSync(dir);
-    } catch {
-        return [];
-    }
-
-    for (const entry of entries) {
-        const fullPath = join(dir, entry);
-        let st: ReturnType<typeof statSync>;
-        try {
-            st = statSync(fullPath);
-        } catch {
-            continue;
-        }
-
-        if (st.isFile() && entry.toLowerCase().endsWith(".md")) {
-            // Direct .md file in root
-            const name = entry.slice(0, -3);
-            const { description } = parseSkillFrontmatter(fullPath);
-            skills.push({ name, description, filePath: fullPath });
-        } else if (st.isDirectory()) {
-            // Look for SKILL.md inside
-            const skillMd = join(fullPath, "SKILL.md");
-            if (existsSync(skillMd)) {
-                const { description } = parseSkillFrontmatter(skillMd);
-                skills.push({ name: entry, description, filePath: skillMd });
-            }
-        }
-    }
-
-    return skills;
-}
-
-/**
- * Parse the `description` field out of a SKILL.md frontmatter block.
- * Returns empty string if not found or file is unreadable.
- */
-function parseSkillFrontmatter(filePath: string): { description: string } {
-    let content: string;
-    try {
-        content = readFileSync(filePath, "utf-8");
-    } catch {
-        return { description: "" };
-    }
-
-    // Frontmatter is between the first and second `---` lines.
-    if (!content.startsWith("---")) return { description: "" };
-    const end = content.indexOf("\n---", 3);
-    if (end === -1) return { description: "" };
-
-    const block = content.slice(3, end);
-    const match = block.match(/^description:\s*(.+)$/m);
-    return { description: match ? match[1].trim().replace(/^["']|["']$/g, "") : "" };
-}
-
-/**
- * Read the full content of a skill file.
- * For subdirectory skills (SKILL.md), returns the file content.
- * Returns null if not found.
- */
-function readSkillContent(name: string): string | null {
-    const dir = globalSkillsDir();
-
-    // Try subdirectory first: <dir>/<name>/SKILL.md
-    const subPath = join(dir, name, "SKILL.md");
-    if (existsSync(subPath)) {
-        try { return readFileSync(subPath, "utf-8"); } catch { return null; }
-    }
-
-    // Try direct file: <dir>/<name>.md
-    const filePath = join(dir, `${name}.md`);
-    if (existsSync(filePath)) {
-        try { return readFileSync(filePath, "utf-8"); } catch { return null; }
-    }
-
-    return null;
-}
-
-/**
- * Write (create or update) a skill.
- * Uses the subdirectory layout: ~/.pizzapi/skills/<name>/SKILL.md
- */
-async function writeSkill(name: string, content: string): Promise<void> {
-    const dir = join(globalSkillsDir(), name);
-    await mkdir(dir, { recursive: true });
-    writeFileSync(join(dir, "SKILL.md"), content, "utf-8");
-}
-
-/**
- * Delete a skill by name.
- * Handles both subdirectory (SKILL.md) and direct (.md) layouts.
- */
-function deleteSkill(name: string): boolean {
-    const dir = globalSkillsDir();
-
-    const subPath = join(dir, name);
-    if (existsSync(join(subPath, "SKILL.md"))) {
-        try {
-            rmSync(subPath, { recursive: true, force: true });
-            return true;
-        } catch {
-            return false;
-        }
-    }
-
-    const filePath = join(dir, `${name}.md`);
-    if (existsSync(filePath)) {
-        try {
-            rmSync(filePath);
-            return true;
-        } catch {
-            return false;
-        }
-    }
-
-    return false;
-}
+import {
+    type SkillMeta,
+    scanGlobalSkills,
+    readSkillContent,
+    writeSkill,
+    deleteSkill,
+} from "../skills.js";
 
 // ── Runner-wide usage cache (shared with worker processes via file) ───────────
 //

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -2,32 +2,8 @@ import { createAgentSession, DefaultResourceLoader } from "@mariozechner/pi-codi
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { defaultAgentDir, expandHome, loadConfig } from "../config.js";
-
-/**
- * Build additional skill paths for the headless worker.
- *
- * ~/.pizzapi/skills/ is already discovered via agentDir, so we only need
- * the project-local .pizzapi/skills/ plus Claude-style agents/ directories
- * (both global and project-local) which map to pi skills.
- */
-function buildSkillPaths(cwd: string, configSkills?: string[]): string[] {
-    const paths: string[] = [
-        join(cwd, ".pizzapi", "skills"),
-        join(homedir(), ".pizzapi", "agents"),
-        join(cwd, ".pizzapi", "agents"),
-        join(cwd, ".agents", "skills"),
-        join(cwd, ".agents", "agents"),
-    ];
-    if (Array.isArray(configSkills)) {
-        for (const p of configSkills) {
-            if (typeof p === "string" && p.trim()) {
-                paths.push(expandHome(p.trim()));
-            }
-        }
-    }
-    return paths;
-}
+import { defaultAgentDir, loadConfig } from "../config.js";
+import { buildWorkerSkillPaths } from "../skills.js";
 
 /**
  * Build additional prompt template paths for the headless worker.
@@ -98,7 +74,7 @@ async function main(): Promise<void> {
         cwd,
         agentDir,
         extensionFactories: [remoteExtension, mcpExtension, restartExtension, setSessionNameExtension, updateTodoExtension, spawnSessionExtension, sessionMessagingExtension, initialPromptExtension],
-        additionalSkillPaths: buildSkillPaths(cwd, config.skills),
+        additionalSkillPaths: buildWorkerSkillPaths(cwd, config.skills),
         additionalPromptTemplatePaths: buildPromptPaths(cwd),
         ...(config.systemPrompt !== undefined && {
             systemPromptOverride: () => config.systemPrompt,

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -1,0 +1,507 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import {
+    parseSkillFrontmatterFromString,
+    scanSkillsDir,
+    readSkillContent,
+    writeSkill,
+    deleteSkill,
+    buildInteractiveSkillPaths,
+    buildWorkerSkillPaths,
+} from "./skills.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Create a unique temp directory for each test. */
+function makeTmpDir(): string {
+    const dir = join(tmpdir(), `pizzapi-skill-test-${randomBytes(8).toString("hex")}`);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+}
+
+/** Write a SKILL.md inside a subdirectory of the given skills dir. */
+function writeSubdirSkill(skillsDir: string, name: string, content: string): string {
+    const dir = join(skillsDir, name);
+    mkdirSync(dir, { recursive: true });
+    const filePath = join(dir, "SKILL.md");
+    writeFileSync(filePath, content, "utf-8");
+    return filePath;
+}
+
+/** Write a direct .md skill file in the root of the skills dir. */
+function writeRootSkill(skillsDir: string, name: string, content: string): string {
+    const filePath = join(skillsDir, `${name}.md`);
+    writeFileSync(filePath, content, "utf-8");
+    return filePath;
+}
+
+const SKILL_WITH_DESCRIPTION = `---
+name: my-skill
+description: A helpful skill for testing.
+---
+
+# My Skill
+
+Do the thing.
+`;
+
+const SKILL_QUOTED_DESCRIPTION = `---
+name: quoted-skill
+description: "A quoted description"
+---
+
+# Quoted Skill
+`;
+
+const SKILL_SINGLE_QUOTED = `---
+name: single-quoted
+description: 'Single-quoted description'
+---
+
+# Single Quoted
+`;
+
+const SKILL_NO_DESCRIPTION = `---
+name: no-desc
+---
+
+# No Description
+`;
+
+const SKILL_NO_FRONTMATTER = `# Just Markdown
+
+No frontmatter here.
+`;
+
+const SKILL_EMPTY_DESCRIPTION = `---
+name: empty-desc
+description:
+---
+
+# Empty
+`;
+
+// ── parseSkillFrontmatterFromString ───────────────────────────────────────────
+
+describe("parseSkillFrontmatterFromString", () => {
+    test("parses a plain description", () => {
+        const result = parseSkillFrontmatterFromString(SKILL_WITH_DESCRIPTION);
+        expect(result.description).toBe("A helpful skill for testing.");
+    });
+
+    test("strips double quotes from description", () => {
+        const result = parseSkillFrontmatterFromString(SKILL_QUOTED_DESCRIPTION);
+        expect(result.description).toBe("A quoted description");
+    });
+
+    test("strips single quotes from description", () => {
+        const result = parseSkillFrontmatterFromString(SKILL_SINGLE_QUOTED);
+        expect(result.description).toBe("Single-quoted description");
+    });
+
+    test("returns empty string when description is missing", () => {
+        const result = parseSkillFrontmatterFromString(SKILL_NO_DESCRIPTION);
+        expect(result.description).toBe("");
+    });
+
+    test("returns empty string when there is no frontmatter", () => {
+        const result = parseSkillFrontmatterFromString(SKILL_NO_FRONTMATTER);
+        expect(result.description).toBe("");
+    });
+
+    test("returns empty string for empty description value", () => {
+        const result = parseSkillFrontmatterFromString(SKILL_EMPTY_DESCRIPTION);
+        expect(result.description).toBe("");
+    });
+
+    test("returns empty string for empty content", () => {
+        const result = parseSkillFrontmatterFromString("");
+        expect(result.description).toBe("");
+    });
+
+    test("returns empty string when closing --- is missing", () => {
+        const result = parseSkillFrontmatterFromString("---\nname: broken\ndescription: oops");
+        expect(result.description).toBe("");
+    });
+
+    test("handles multiline frontmatter with description not on first line", () => {
+        const content = `---
+name: multi
+version: 1.0
+description: Found it!
+license: MIT
+---
+
+# Multi
+`;
+        const result = parseSkillFrontmatterFromString(content);
+        expect(result.description).toBe("Found it!");
+    });
+
+    test("handles Windows-style line endings", () => {
+        const content = "---\r\nname: win\r\ndescription: Windows skill\r\n---\r\n\r\n# Win";
+        const result = parseSkillFrontmatterFromString(content);
+        expect(result.description).toBe("Windows skill");
+    });
+});
+
+// ── scanSkillsDir ─────────────────────────────────────────────────────────────
+
+describe("scanSkillsDir", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = makeTmpDir();
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("returns empty array for non-existent directory", () => {
+        const result = scanSkillsDir(join(dir, "nope"));
+        expect(result).toEqual([]);
+    });
+
+    test("returns empty array for empty directory", () => {
+        const result = scanSkillsDir(dir);
+        expect(result).toEqual([]);
+    });
+
+    test("discovers subdirectory skills (SKILL.md)", () => {
+        writeSubdirSkill(dir, "my-skill", SKILL_WITH_DESCRIPTION);
+        const result = scanSkillsDir(dir);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("my-skill");
+        expect(result[0].description).toBe("A helpful skill for testing.");
+        expect(result[0].filePath).toBe(join(dir, "my-skill", "SKILL.md"));
+    });
+
+    test("discovers direct .md files in root", () => {
+        writeRootSkill(dir, "quick-skill", SKILL_WITH_DESCRIPTION);
+        const result = scanSkillsDir(dir);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("quick-skill");
+        expect(result[0].description).toBe("A helpful skill for testing.");
+        expect(result[0].filePath).toBe(join(dir, "quick-skill.md"));
+    });
+
+    test("discovers both subdirectory and root skills", () => {
+        writeSubdirSkill(dir, "sub-skill", SKILL_WITH_DESCRIPTION);
+        writeRootSkill(dir, "root-skill", SKILL_QUOTED_DESCRIPTION);
+        const result = scanSkillsDir(dir);
+        expect(result).toHaveLength(2);
+        const names = result.map((s) => s.name).sort();
+        expect(names).toEqual(["root-skill", "sub-skill"]);
+    });
+
+    test("ignores subdirectories without SKILL.md", () => {
+        mkdirSync(join(dir, "empty-dir"));
+        writeFileSync(join(dir, "empty-dir", "README.md"), "# Not a skill", "utf-8");
+        const result = scanSkillsDir(dir);
+        expect(result).toEqual([]);
+    });
+
+    test("ignores non-.md files in root", () => {
+        writeFileSync(join(dir, "notes.txt"), "not a skill", "utf-8");
+        writeFileSync(join(dir, "config.json"), "{}", "utf-8");
+        const result = scanSkillsDir(dir);
+        expect(result).toEqual([]);
+    });
+
+    test("ignores hidden entries (dotfiles/dotdirs)", () => {
+        writeRootSkill(dir, ".hidden-skill", SKILL_WITH_DESCRIPTION);
+        mkdirSync(join(dir, ".hidden-dir"));
+        writeFileSync(join(dir, ".hidden-dir", "SKILL.md"), SKILL_WITH_DESCRIPTION, "utf-8");
+        const result = scanSkillsDir(dir);
+        expect(result).toEqual([]);
+    });
+
+    test("handles skill with no description (empty string)", () => {
+        writeSubdirSkill(dir, "no-desc", SKILL_NO_DESCRIPTION);
+        const result = scanSkillsDir(dir);
+        expect(result).toHaveLength(1);
+        expect(result[0].description).toBe("");
+    });
+
+    test("handles mixed valid and invalid skills", () => {
+        writeSubdirSkill(dir, "valid-skill", SKILL_WITH_DESCRIPTION);
+        writeRootSkill(dir, "no-frontmatter", SKILL_NO_FRONTMATTER);
+        mkdirSync(join(dir, "no-skill-md")); // dir without SKILL.md
+        writeFileSync(join(dir, "readme.txt"), "ignore me", "utf-8");
+
+        const result = scanSkillsDir(dir);
+        // valid-skill from subdir + no-frontmatter.md from root (it's still a .md file)
+        expect(result).toHaveLength(2);
+        const names = result.map((s) => s.name).sort();
+        expect(names).toEqual(["no-frontmatter", "valid-skill"]);
+    });
+
+    test("is case-insensitive for .md extension", () => {
+        writeFileSync(join(dir, "UPPER.MD"), SKILL_WITH_DESCRIPTION, "utf-8");
+        const result = scanSkillsDir(dir);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("UPPER");
+    });
+});
+
+// ── readSkillContent ──────────────────────────────────────────────────────────
+
+describe("readSkillContent", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = makeTmpDir();
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("reads subdirectory skill content", () => {
+        writeSubdirSkill(dir, "my-skill", SKILL_WITH_DESCRIPTION);
+        const content = readSkillContent("my-skill", dir);
+        expect(content).toBe(SKILL_WITH_DESCRIPTION);
+    });
+
+    test("reads direct .md skill content", () => {
+        writeRootSkill(dir, "root-skill", SKILL_QUOTED_DESCRIPTION);
+        const content = readSkillContent("root-skill", dir);
+        expect(content).toBe(SKILL_QUOTED_DESCRIPTION);
+    });
+
+    test("prefers subdirectory over direct file", () => {
+        const subContent = "---\nname: dupe\ndescription: From subdir\n---\n# Sub";
+        const rootContent = "---\nname: dupe\ndescription: From root\n---\n# Root";
+        writeSubdirSkill(dir, "dupe", subContent);
+        writeRootSkill(dir, "dupe", rootContent);
+        const content = readSkillContent("dupe", dir);
+        expect(content).toBe(subContent);
+    });
+
+    test("returns null for non-existent skill", () => {
+        const content = readSkillContent("nope", dir);
+        expect(content).toBeNull();
+    });
+});
+
+// ── writeSkill ────────────────────────────────────────────────────────────────
+
+describe("writeSkill", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = makeTmpDir();
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("creates a new skill in subdirectory layout", async () => {
+        await writeSkill("new-skill", SKILL_WITH_DESCRIPTION, dir);
+        const filePath = join(dir, "new-skill", "SKILL.md");
+        expect(existsSync(filePath)).toBe(true);
+        expect(readFileSync(filePath, "utf-8")).toBe(SKILL_WITH_DESCRIPTION);
+    });
+
+    test("overwrites existing skill content", async () => {
+        await writeSkill("update-me", "old content", dir);
+        await writeSkill("update-me", "new content", dir);
+        const filePath = join(dir, "update-me", "SKILL.md");
+        expect(readFileSync(filePath, "utf-8")).toBe("new content");
+    });
+
+    test("creates nested directory structure", async () => {
+        const nestedDir = join(dir, "nested", "path");
+        await writeSkill("deep-skill", SKILL_WITH_DESCRIPTION, nestedDir);
+        expect(existsSync(join(nestedDir, "deep-skill", "SKILL.md"))).toBe(true);
+    });
+});
+
+// ── deleteSkill ───────────────────────────────────────────────────────────────
+
+describe("deleteSkill", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = makeTmpDir();
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("deletes a subdirectory skill", async () => {
+        await writeSkill("doomed", SKILL_WITH_DESCRIPTION, dir);
+        expect(existsSync(join(dir, "doomed", "SKILL.md"))).toBe(true);
+
+        const result = deleteSkill("doomed", dir);
+        expect(result).toBe(true);
+        expect(existsSync(join(dir, "doomed"))).toBe(false);
+    });
+
+    test("deletes a direct .md skill", () => {
+        writeRootSkill(dir, "root-doomed", SKILL_WITH_DESCRIPTION);
+        expect(existsSync(join(dir, "root-doomed.md"))).toBe(true);
+
+        const result = deleteSkill("root-doomed", dir);
+        expect(result).toBe(true);
+        expect(existsSync(join(dir, "root-doomed.md"))).toBe(false);
+    });
+
+    test("prefers deleting subdirectory over direct file", async () => {
+        await writeSkill("both", "subdir content", dir);
+        writeRootSkill(dir, "both", "root content");
+
+        const result = deleteSkill("both", dir);
+        expect(result).toBe(true);
+        // Subdirectory should be gone
+        expect(existsSync(join(dir, "both"))).toBe(false);
+        // Root file should still exist
+        expect(existsSync(join(dir, "both.md"))).toBe(true);
+    });
+
+    test("returns false for non-existent skill", () => {
+        const result = deleteSkill("ghost", dir);
+        expect(result).toBe(false);
+    });
+});
+
+// ── buildInteractiveSkillPaths ────────────────────────────────────────────────
+
+describe("buildInteractiveSkillPaths", () => {
+    test("includes global and project-local .pizzapi/skills dirs", () => {
+        const paths = buildInteractiveSkillPaths("/projects/my-app");
+        const home = require("os").homedir();
+        expect(paths).toContain(join(home, ".pizzapi", "skills"));
+        expect(paths).toContain(join("/projects/my-app", ".pizzapi", "skills"));
+    });
+
+    test("appends config skill paths", () => {
+        const paths = buildInteractiveSkillPaths("/projects/my-app", [
+            "/extra/skills",
+            "~/my-skills",
+        ]);
+        expect(paths).toContain("/extra/skills");
+        // ~ should be expanded
+        const home = require("os").homedir();
+        expect(paths).toContain(join(home, "my-skills"));
+    });
+
+    test("filters out empty and whitespace-only config entries", () => {
+        const paths = buildInteractiveSkillPaths("/tmp", ["", "  ", "/valid"]);
+        // Should have 2 default paths + 1 valid config path
+        expect(paths).toHaveLength(3);
+        expect(paths[2]).toBe("/valid");
+    });
+
+    test("handles undefined configSkills", () => {
+        const paths = buildInteractiveSkillPaths("/tmp");
+        expect(paths).toHaveLength(2);
+    });
+
+    test("handles empty configSkills array", () => {
+        const paths = buildInteractiveSkillPaths("/tmp", []);
+        expect(paths).toHaveLength(2);
+    });
+});
+
+// ── buildWorkerSkillPaths ─────────────────────────────────────────────────────
+
+describe("buildWorkerSkillPaths", () => {
+    test("includes expected default paths", () => {
+        const home = require("os").homedir();
+        const paths = buildWorkerSkillPaths("/projects/my-app");
+        expect(paths).toContain(join("/projects/my-app", ".pizzapi", "skills"));
+        expect(paths).toContain(join(home, ".pizzapi", "agents"));
+        expect(paths).toContain(join("/projects/my-app", ".pizzapi", "agents"));
+        expect(paths).toContain(join("/projects/my-app", ".agents", "skills"));
+        expect(paths).toContain(join("/projects/my-app", ".agents", "agents"));
+    });
+
+    test("does NOT include global ~/.pizzapi/skills (discovered via agentDir)", () => {
+        const home = require("os").homedir();
+        const paths = buildWorkerSkillPaths("/projects/my-app");
+        expect(paths).not.toContain(join(home, ".pizzapi", "skills"));
+    });
+
+    test("appends config skill paths", () => {
+        const paths = buildWorkerSkillPaths("/tmp", ["/custom/path"]);
+        expect(paths).toContain("/custom/path");
+    });
+
+    test("expands tilde in config paths", () => {
+        const home = require("os").homedir();
+        const paths = buildWorkerSkillPaths("/tmp", ["~/custom"]);
+        expect(paths).toContain(join(home, "custom"));
+    });
+
+    test("handles undefined configSkills", () => {
+        const paths = buildWorkerSkillPaths("/tmp");
+        expect(paths).toHaveLength(5); // 5 default paths
+    });
+});
+
+// ── Integration: scan → read → write → delete lifecycle ──────────────────────
+
+describe("skill lifecycle", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = makeTmpDir();
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("full CRUD cycle", async () => {
+        // Initially empty
+        expect(scanSkillsDir(dir)).toEqual([]);
+
+        // Create
+        await writeSkill("test-skill", SKILL_WITH_DESCRIPTION, dir);
+        const scanned = scanSkillsDir(dir);
+        expect(scanned).toHaveLength(1);
+        expect(scanned[0].name).toBe("test-skill");
+        expect(scanned[0].description).toBe("A helpful skill for testing.");
+
+        // Read
+        const content = readSkillContent("test-skill", dir);
+        expect(content).toBe(SKILL_WITH_DESCRIPTION);
+
+        // Update
+        const updated = SKILL_WITH_DESCRIPTION.replace("A helpful skill for testing.", "Updated description.");
+        await writeSkill("test-skill", updated, dir);
+        const rescanned = scanSkillsDir(dir);
+        expect(rescanned).toHaveLength(1);
+        expect(rescanned[0].description).toBe("Updated description.");
+
+        // Delete
+        const deleted = deleteSkill("test-skill", dir);
+        expect(deleted).toBe(true);
+        expect(scanSkillsDir(dir)).toEqual([]);
+        expect(readSkillContent("test-skill", dir)).toBeNull();
+    });
+
+    test("multiple skills coexist", async () => {
+        await writeSkill("alpha", `---\nname: alpha\ndescription: First\n---\n# A`, dir);
+        await writeSkill("beta", `---\nname: beta\ndescription: Second\n---\n# B`, dir);
+        writeRootSkill(dir, "gamma", `---\nname: gamma\ndescription: Third\n---\n# C`);
+
+        const skills = scanSkillsDir(dir);
+        expect(skills).toHaveLength(3);
+        const names = skills.map((s) => s.name).sort();
+        expect(names).toEqual(["alpha", "beta", "gamma"]);
+
+        // Delete one, others remain
+        deleteSkill("beta", dir);
+        const remaining = scanSkillsDir(dir);
+        expect(remaining).toHaveLength(2);
+        expect(remaining.map((s) => s.name).sort()).toEqual(["alpha", "gamma"]);
+    });
+});

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -1,0 +1,232 @@
+/**
+ * Skill discovery and management utilities.
+ *
+ * Extracted from daemon.ts and the CLI/worker entry points so the logic
+ * is independently testable.
+ */
+import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface SkillMeta {
+    name: string;
+    description: string;
+    filePath: string;
+}
+
+// ── Skill directory ───────────────────────────────────────────────────────────
+
+/** Default global skills directory for PizzaPi. */
+export function globalSkillsDir(): string {
+    return join(homedir(), ".pizzapi", "skills");
+}
+
+// ── Frontmatter parsing ───────────────────────────────────────────────────────
+
+/**
+ * Parse the `description` field out of a SKILL.md frontmatter block.
+ * Returns empty string if not found or file is unreadable.
+ */
+export function parseSkillFrontmatter(filePath: string): { description: string } {
+    let content: string;
+    try {
+        content = readFileSync(filePath, "utf-8");
+    } catch {
+        return { description: "" };
+    }
+
+    return parseSkillFrontmatterFromString(content);
+}
+
+/**
+ * Parse the `description` field out of a frontmatter string.
+ * Pure function — no filesystem access.
+ */
+export function parseSkillFrontmatterFromString(content: string): { description: string } {
+    if (!content.startsWith("---")) return { description: "" };
+    const end = content.indexOf("\n---", 3);
+    if (end === -1) return { description: "" };
+
+    const block = content.slice(3, end);
+    const match = block.match(/^description:\s*(.+)$/m);
+    return { description: match ? match[1].trim().replace(/^["']|["']$/g, "") : "" };
+}
+
+// ── Skill scanning ────────────────────────────────────────────────────────────
+
+/**
+ * Scan a skills directory and return basic metadata.
+ * Mirrors the discovery rules from the Agent Skills standard:
+ *   - Direct .md files in the root → name = basename without extension
+ *   - SKILL.md files under subdirectories → name = directory name
+ */
+export function scanSkillsDir(dir: string): SkillMeta[] {
+    if (!existsSync(dir)) return [];
+
+    const skills: SkillMeta[] = [];
+
+    let entries: string[];
+    try {
+        entries = readdirSync(dir);
+    } catch {
+        return [];
+    }
+
+    for (const entry of entries) {
+        if (entry.startsWith(".")) continue;
+
+        const fullPath = join(dir, entry);
+        let st: ReturnType<typeof statSync>;
+        try {
+            st = statSync(fullPath);
+        } catch {
+            continue;
+        }
+
+        if (st.isFile() && entry.toLowerCase().endsWith(".md")) {
+            // Direct .md file in root
+            const name = entry.slice(0, -3);
+            const { description } = parseSkillFrontmatter(fullPath);
+            skills.push({ name, description, filePath: fullPath });
+        } else if (st.isDirectory()) {
+            // Look for SKILL.md inside
+            const skillMd = join(fullPath, "SKILL.md");
+            if (existsSync(skillMd)) {
+                const { description } = parseSkillFrontmatter(skillMd);
+                skills.push({ name: entry, description, filePath: skillMd });
+            }
+        }
+    }
+
+    return skills;
+}
+
+/** Scan the global PizzaPi skills directory (~/.pizzapi/skills/). */
+export function scanGlobalSkills(): SkillMeta[] {
+    return scanSkillsDir(globalSkillsDir());
+}
+
+// ── CRUD operations ───────────────────────────────────────────────────────────
+
+/**
+ * Read the full content of a skill file.
+ * Checks subdirectory layout first (<dir>/<name>/SKILL.md), then direct file (<dir>/<name>.md).
+ * Returns null if not found.
+ */
+export function readSkillContent(name: string, dir?: string): string | null {
+    const skillsDir = dir ?? globalSkillsDir();
+
+    // Try subdirectory first: <dir>/<name>/SKILL.md
+    const subPath = join(skillsDir, name, "SKILL.md");
+    if (existsSync(subPath)) {
+        try { return readFileSync(subPath, "utf-8"); } catch { return null; }
+    }
+
+    // Try direct file: <dir>/<name>.md
+    const filePath = join(skillsDir, `${name}.md`);
+    if (existsSync(filePath)) {
+        try { return readFileSync(filePath, "utf-8"); } catch { return null; }
+    }
+
+    return null;
+}
+
+/**
+ * Write (create or update) a skill.
+ * Uses the subdirectory layout: <dir>/<name>/SKILL.md
+ */
+export async function writeSkill(name: string, content: string, dir?: string): Promise<void> {
+    const skillDir = join(dir ?? globalSkillsDir(), name);
+    await mkdir(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), content, "utf-8");
+}
+
+/**
+ * Delete a skill by name.
+ * Handles both subdirectory (SKILL.md) and direct (.md) layouts.
+ * Returns true if a skill was deleted.
+ */
+export function deleteSkill(name: string, dir?: string): boolean {
+    const skillsDir = dir ?? globalSkillsDir();
+
+    const subPath = join(skillsDir, name);
+    if (existsSync(join(subPath, "SKILL.md"))) {
+        try {
+            rmSync(subPath, { recursive: true, force: true });
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    const filePath = join(skillsDir, `${name}.md`);
+    if (existsSync(filePath)) {
+        try {
+            rmSync(filePath);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+
+    return false;
+}
+
+// ── Skill path builders ───────────────────────────────────────────────────────
+
+/**
+ * Expand ~ to home directory in a path.
+ */
+function expandHome(path: string): string {
+    return path.replace(/^~/, homedir());
+}
+
+/**
+ * Build the list of additional skill paths for the interactive CLI.
+ * Always includes:
+ *   - ~/.pizzapi/skills/  (global PizzaPi skills)
+ *   - <cwd>/.pizzapi/skills/  (project-local PizzaPi skills)
+ * Plus any paths declared in config.skills.
+ */
+export function buildInteractiveSkillPaths(cwd: string, configSkills?: string[]): string[] {
+    const paths: string[] = [
+        join(homedir(), ".pizzapi", "skills"),
+        join(cwd, ".pizzapi", "skills"),
+    ];
+    if (Array.isArray(configSkills)) {
+        for (const p of configSkills) {
+            if (typeof p === "string" && p.trim()) {
+                paths.push(expandHome(p.trim()));
+            }
+        }
+    }
+    return paths;
+}
+
+/**
+ * Build additional skill paths for the headless worker.
+ *
+ * ~/.pizzapi/skills/ is already discovered via agentDir, so we only need
+ * the project-local .pizzapi/skills/ plus Claude-style agents/ directories
+ * (both global and project-local) which map to pi skills.
+ */
+export function buildWorkerSkillPaths(cwd: string, configSkills?: string[]): string[] {
+    const paths: string[] = [
+        join(cwd, ".pizzapi", "skills"),
+        join(homedir(), ".pizzapi", "agents"),
+        join(cwd, ".pizzapi", "agents"),
+        join(cwd, ".agents", "skills"),
+        join(cwd, ".agents", "agents"),
+    ];
+    if (Array.isArray(configSkills)) {
+        for (const p of configSkills) {
+            if (typeof p === "string" && p.trim()) {
+                paths.push(expandHome(p.trim()));
+            }
+        }
+    }
+    return paths;
+}

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -8,6 +8,7 @@ import type { RelayMessage } from "@/components/session-viewer/types";
 import { groupToolExecutionMessages, groupSubAgentConversations } from "@/components/session-viewer/grouping";
 import {
   hasVisibleContent,
+  resolveCommandPopoverState,
 } from "@/components/session-viewer/utils";
 import {
   renderContent,
@@ -620,6 +621,15 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
       .filter((c) => c.name.startsWith("skill:"))
       .map((c) => ({ name: c.name, description: c.description }));
   }, [availableCommands]);
+
+  // Set of all known command/skill names for quick lookup (used to auto-close popover
+  // once the user has typed a recognized command and started entering arguments).
+  const knownCommandNames = React.useMemo(() => {
+    const names = new Set<string>();
+    for (const c of supportedWebCommands) names.add(c.name.toLowerCase());
+    for (const s of skillCommands) names.add(s.name.toLowerCase());
+    return names;
+  }, [supportedWebCommands, skillCommands]);
 
   // Reset highlighted index when the query or mode changes
   React.useEffect(() => {
@@ -1390,8 +1400,9 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                   // Slash command detection
                   const trimmed = next.trimStart();
                   if (trimmed.startsWith("/")) {
-                    setCommandOpen(true);
-                    setCommandQuery(trimmed.slice(1));
+                    const { open, query } = resolveCommandPopoverState(trimmed.slice(1), knownCommandNames);
+                    setCommandOpen(open);
+                    setCommandQuery(query);
                     // Close @-mention popover when slash command opens (mutual exclusivity)
                     if (atMentionOpen) {
                       setAtMentionOpen(false);

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -631,6 +631,10 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     return names;
   }, [supportedWebCommands, skillCommands]);
 
+  // Commands that use the popover for argument-mode UI (e.g. resume shows a
+  // session picker that the user searches/filters by typing after /resume).
+  const keepPopoverOpenNames = React.useMemo(() => new Set(["resume"]), []);
+
   // Reset highlighted index when the query or mode changes
   React.useEffect(() => {
     setCommandHighlightedIndex(0);
@@ -1400,7 +1404,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                   // Slash command detection
                   const trimmed = next.trimStart();
                   if (trimmed.startsWith("/")) {
-                    const { open, query } = resolveCommandPopoverState(trimmed.slice(1), knownCommandNames);
+                    const { open, query } = resolveCommandPopoverState(trimmed.slice(1), knownCommandNames, keepPopoverOpenNames);
                     setCommandOpen(open);
                     setCommandQuery(query);
                     // Close @-mention popover when slash command opens (mutual exclusivity)

--- a/packages/ui/src/components/session-viewer/utils.test.ts
+++ b/packages/ui/src/components/session-viewer/utils.test.ts
@@ -346,6 +346,7 @@ describe("extToMime", () => {
 
 describe("resolveCommandPopoverState", () => {
     const known = new Set(["compact", "new", "resume", "skill:beads-ccpm", "skill:double-check"]);
+    const keepOpen = new Set(["resume"]);
 
     test("keeps popover open while still typing a command name", () => {
         expect(resolveCommandPopoverState("sk", known)).toEqual({ open: true, query: "sk" });
@@ -385,5 +386,18 @@ describe("resolveCommandPopoverState", () => {
     test("handles tab/newline as whitespace separator", () => {
         expect(resolveCommandPopoverState("compact\targ", known)).toEqual({ open: false, query: "" });
         expect(resolveCommandPopoverState("compact\narg", known)).toEqual({ open: false, query: "" });
+    });
+
+    test("keeps popover open for keepOpen commands with arguments (e.g. /resume)", () => {
+        expect(resolveCommandPopoverState("resume my-session", known, keepOpen)).toEqual({ open: true, query: "resume my-session" });
+        expect(resolveCommandPopoverState("resume ", known, keepOpen)).toEqual({ open: true, query: "resume " });
+    });
+
+    test("resume still closes without keepOpen set", () => {
+        expect(resolveCommandPopoverState("resume query", known)).toEqual({ open: false, query: "" });
+    });
+
+    test("keepOpen is case-insensitive", () => {
+        expect(resolveCommandPopoverState("Resume my-session", known, keepOpen)).toEqual({ open: true, query: "Resume my-session" });
     });
 });

--- a/packages/ui/src/components/session-viewer/utils.test.ts
+++ b/packages/ui/src/components/session-viewer/utils.test.ts
@@ -10,6 +10,7 @@ import {
     formatDateValue,
     parseToolInputArgs,
     extToMime,
+    resolveCommandPopoverState,
 } from "./utils";
 
 // ── hasVisibleContent ───────────────────────────────────────────────────────
@@ -338,5 +339,51 @@ describe("extToMime", () => {
         expect(extToMime("config.yml")).toBe("text/yaml");
         expect(extToMime("config.toml")).toBe("application/toml");
         expect(extToMime("query.sql")).toBe("text/x-sql");
+    });
+});
+
+// ── resolveCommandPopoverState ──────────────────────────────────────────────
+
+describe("resolveCommandPopoverState", () => {
+    const known = new Set(["compact", "new", "resume", "skill:beads-ccpm", "skill:double-check"]);
+
+    test("keeps popover open while still typing a command name", () => {
+        expect(resolveCommandPopoverState("sk", known)).toEqual({ open: true, query: "sk" });
+        expect(resolveCommandPopoverState("skill:", known)).toEqual({ open: true, query: "skill:" });
+        expect(resolveCommandPopoverState("skill:beads", known)).toEqual({ open: true, query: "skill:beads" });
+    });
+
+    test("keeps popover open for exact command name without trailing space", () => {
+        expect(resolveCommandPopoverState("compact", known)).toEqual({ open: true, query: "compact" });
+        expect(resolveCommandPopoverState("skill:beads-ccpm", known)).toEqual({ open: true, query: "skill:beads-ccpm" });
+    });
+
+    test("closes popover when recognized command has trailing space (args start)", () => {
+        expect(resolveCommandPopoverState("compact ", known)).toEqual({ open: false, query: "" });
+        expect(resolveCommandPopoverState("skill:beads-ccpm ", known)).toEqual({ open: false, query: "" });
+    });
+
+    test("closes popover when recognized skill has arguments", () => {
+        expect(resolveCommandPopoverState("skill:beads-ccpm epic-sync saymore-gm7", known)).toEqual({ open: false, query: "" });
+        expect(resolveCommandPopoverState("skill:double-check ", known)).toEqual({ open: false, query: "" });
+    });
+
+    test("keeps popover open for unrecognized command with arguments", () => {
+        const result = resolveCommandPopoverState("unknown-thing some args", known);
+        expect(result).toEqual({ open: true, query: "unknown-thing some args" });
+    });
+
+    test("is case-insensitive for command matching", () => {
+        expect(resolveCommandPopoverState("Compact ", known)).toEqual({ open: false, query: "" });
+        expect(resolveCommandPopoverState("SKILL:BEADS-CCPM args", known)).toEqual({ open: false, query: "" });
+    });
+
+    test("handles empty input", () => {
+        expect(resolveCommandPopoverState("", known)).toEqual({ open: true, query: "" });
+    });
+
+    test("handles tab/newline as whitespace separator", () => {
+        expect(resolveCommandPopoverState("compact\targ", known)).toEqual({ open: false, query: "" });
+        expect(resolveCommandPopoverState("compact\narg", known)).toEqual({ open: false, query: "" });
     });
 });

--- a/packages/ui/src/components/session-viewer/utils.ts
+++ b/packages/ui/src/components/session-viewer/utils.ts
@@ -154,3 +154,37 @@ export function extToMime(path: string): string {
   };
   return map[ext] ?? "text/plain";
 }
+
+/**
+ * Determine whether the slash-command popover should stay open for the current
+ * input value. Returns `{ open, query }`.
+ *
+ * When the first token after `/` is a recognized command/skill name AND there
+ * is at least one argument following it, the popover closes so the user can
+ * type arguments without a stale "no results" overlay.
+ *
+ * Examples (assuming "skill:beads-ccpm" and "compact" are known):
+ *   "/sk"                              → open, query="sk"
+ *   "/skill:beads-ccpm"                → open, query="skill:beads-ccpm"
+ *   "/skill:beads-ccpm "               → closed (matched + has trailing space)
+ *   "/skill:beads-ccpm epic-sync gm7"  → closed
+ *   "/compact "                        → closed
+ *   "/unknown-thing args"              → open, query="unknown-thing args"
+ */
+export function resolveCommandPopoverState(
+  afterSlash: string,
+  knownNames: Set<string>,
+): { open: boolean; query: string } {
+  const spaceIdx = afterSlash.search(/\s/);
+  if (spaceIdx === -1) {
+    // Still typing the command name — keep popover open for filtering.
+    return { open: true, query: afterSlash };
+  }
+  const cmdName = afterSlash.slice(0, spaceIdx).toLowerCase();
+  if (knownNames.has(cmdName)) {
+    // Recognised command with arguments — close the popover.
+    return { open: false, query: "" };
+  }
+  // Unrecognised — keep open so the user sees suggestions / "not found".
+  return { open: true, query: afterSlash };
+}

--- a/packages/ui/src/components/session-viewer/utils.ts
+++ b/packages/ui/src/components/session-viewer/utils.ts
@@ -163,17 +163,23 @@ export function extToMime(path: string): string {
  * is at least one argument following it, the popover closes so the user can
  * type arguments without a stale "no results" overlay.
  *
- * Examples (assuming "skill:beads-ccpm" and "compact" are known):
+ * Commands in `keepOpenNames` (e.g. "resume") keep the popover open even with
+ * arguments, because they use the popover to render argument-mode UI (session
+ * picker, search results, etc.).
+ *
+ * Examples (assuming "skill:beads-ccpm" and "compact" are known, "resume" is keepOpen):
  *   "/sk"                              → open, query="sk"
  *   "/skill:beads-ccpm"                → open, query="skill:beads-ccpm"
  *   "/skill:beads-ccpm "               → closed (matched + has trailing space)
  *   "/skill:beads-ccpm epic-sync gm7"  → closed
  *   "/compact "                        → closed
+ *   "/resume my-session"               → open, query="resume my-session"
  *   "/unknown-thing args"              → open, query="unknown-thing args"
  */
 export function resolveCommandPopoverState(
   afterSlash: string,
   knownNames: Set<string>,
+  keepOpenNames?: Set<string>,
 ): { open: boolean; query: string } {
   const spaceIdx = afterSlash.search(/\s/);
   if (spaceIdx === -1) {
@@ -181,6 +187,10 @@ export function resolveCommandPopoverState(
     return { open: true, query: afterSlash };
   }
   const cmdName = afterSlash.slice(0, spaceIdx).toLowerCase();
+  // Some commands use the popover for argument UI (e.g. resume session picker).
+  if (keepOpenNames?.has(cmdName)) {
+    return { open: true, query: afterSlash };
+  }
   if (knownNames.has(cmdName)) {
     // Recognised command with arguments — close the popover.
     return { open: false, query: "" };


### PR DESCRIPTION
## Summary

- **Extract shared skill module** (`packages/cli/src/skills.ts`) — moves skill discovery/CRUD logic out of `daemon.ts` into a testable module. Updates `daemon.ts`, `index.ts`, and `worker.ts` to import from it.

- **44 new skill tests** (`packages/cli/src/skills.test.ts`) covering:
  - Frontmatter parsing (plain, quoted, missing, empty, Windows CRLF)
  - Directory scanning (subdirectory SKILL.md, root .md, hidden files, mixed)
  - CRUD operations (read, write, delete, subdirectory vs root precedence)
  - Skill path building for both interactive and worker modes
  - Full lifecycle integration test

- **Fix command popover staying open with skill arguments** — typing `/skill:beads-ccpm epic-sync saymore-gm7` previously kept the popover open showing "No commands found". Now it closes once a recognized command/skill name is followed by arguments. Extracted `resolveCommandPopoverState()` utility with 8 tests.

- **Update pi-coding-agent repo links** to `github.com/badlogic/pi-mono`

## Test results

All 279+ tests pass across all packages (server, tools, cli, ui). Typecheck and build clean.