### PR TITLE
fix: Windows terminals exit immediately (shell args)

### DIFF
--- a/packages/cli/src/runner/terminal-utils.test.ts
+++ b/packages/cli/src/runner/terminal-utils.test.ts
@@ -1,0 +1,132 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { getShellArgs, resolveDefaultShell } from "./terminal-utils.js";
+
+// ─── getShellArgs ──────────────────────────────────────────────────────────────
+
+describe("getShellArgs", () => {
+    // -- POSIX shells → ["-il"] -------------------------------------------
+
+    test("bash → interactive login flags", () => {
+        expect(getShellArgs("/bin/bash")).toEqual(["-il"]);
+    });
+
+    test("zsh → interactive login flags", () => {
+        expect(getShellArgs("/bin/zsh")).toEqual(["-il"]);
+    });
+
+    test("sh → interactive login flags", () => {
+        expect(getShellArgs("/bin/sh")).toEqual(["-il"]);
+    });
+
+    test("fish → interactive login flags", () => {
+        expect(getShellArgs("/usr/bin/fish")).toEqual(["-il"]);
+    });
+
+    test("/usr/local/bin/bash → interactive login flags", () => {
+        expect(getShellArgs("/usr/local/bin/bash")).toEqual(["-il"]);
+    });
+
+    // -- PowerShell → ["-NoExit", "-NoLogo"] ------------------------------
+
+    test("powershell.exe → NoExit + NoLogo", () => {
+        expect(getShellArgs("powershell.exe")).toEqual(["-NoExit", "-NoLogo"]);
+    });
+
+    test("pwsh.exe → NoExit + NoLogo", () => {
+        expect(getShellArgs("pwsh.exe")).toEqual(["-NoExit", "-NoLogo"]);
+    });
+
+    test("pwsh (no extension) → NoExit + NoLogo", () => {
+        expect(getShellArgs("pwsh")).toEqual(["-NoExit", "-NoLogo"]);
+    });
+
+    test("Windows full path to powershell → NoExit + NoLogo", () => {
+        expect(getShellArgs("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe"))
+            .toEqual(["-NoExit", "-NoLogo"]);
+    });
+
+    test("Windows full path to pwsh → NoExit + NoLogo", () => {
+        expect(getShellArgs("C:\\Program Files\\PowerShell\\7\\pwsh.exe"))
+            .toEqual(["-NoExit", "-NoLogo"]);
+    });
+
+    test("case insensitive: PowerShell.exe → NoExit + NoLogo", () => {
+        // Windows paths can have mixed case
+        expect(getShellArgs("C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\PowerShell.exe"))
+            .toEqual(["-NoExit", "-NoLogo"]);
+    });
+
+    // -- cmd.exe → [] -----------------------------------------------------
+
+    test("cmd.exe → empty args", () => {
+        expect(getShellArgs("cmd.exe")).toEqual([]);
+    });
+
+    test("cmd (no extension) → empty args", () => {
+        expect(getShellArgs("cmd")).toEqual([]);
+    });
+
+    test("Windows full path to cmd.exe → empty args", () => {
+        expect(getShellArgs("C:\\Windows\\System32\\cmd.exe")).toEqual([]);
+    });
+
+    // -- Edge cases -------------------------------------------------------
+
+    test("empty string → falls back to POSIX flags", () => {
+        expect(getShellArgs("")).toEqual(["-il"]);
+    });
+
+    test("forward-slash Windows path → still detects powershell", () => {
+        expect(getShellArgs("C:/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"))
+            .toEqual(["-NoExit", "-NoLogo"]);
+    });
+
+    test("nushell (nu) → POSIX flags (unrecognized shell)", () => {
+        expect(getShellArgs("/usr/bin/nu")).toEqual(["-il"]);
+    });
+});
+
+// ─── resolveDefaultShell ───────────────────────────────────────────────────────
+
+describe("resolveDefaultShell", () => {
+    let originalShell: string | undefined;
+
+    beforeEach(() => {
+        originalShell = process.env.SHELL;
+    });
+
+    afterEach(() => {
+        if (originalShell !== undefined) {
+            process.env.SHELL = originalShell;
+        } else {
+            delete process.env.SHELL;
+        }
+    });
+
+    test("returns explicit shell when provided", () => {
+        expect(resolveDefaultShell("/usr/local/bin/fish")).toBe("/usr/local/bin/fish");
+    });
+
+    test("explicit shell takes priority over $SHELL", () => {
+        process.env.SHELL = "/bin/zsh";
+        expect(resolveDefaultShell("/bin/bash")).toBe("/bin/bash");
+    });
+
+    test("falls back to $SHELL when no explicit shell", () => {
+        process.env.SHELL = "/bin/zsh";
+        expect(resolveDefaultShell()).toBe("/bin/zsh");
+        expect(resolveDefaultShell("")).toBe("/bin/zsh");
+    });
+
+    test("falls back to platform default when $SHELL is unset", () => {
+        delete process.env.SHELL;
+        const result = resolveDefaultShell();
+        // On this platform it should be /bin/bash (macOS/Linux) or powershell.exe (Windows)
+        expect(result === "/bin/bash" || result === "powershell.exe").toBe(true);
+    });
+
+    test("empty string explicit is treated as falsy (falls through)", () => {
+        process.env.SHELL = "/bin/zsh";
+        expect(resolveDefaultShell("")).toBe("/bin/zsh");
+    });
+});

--- a/packages/cli/src/runner/terminal-utils.ts
+++ b/packages/cli/src/runner/terminal-utils.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared terminal utilities — pure functions with no side effects.
+ *
+ * Extracted so they can be unit-tested without spawning a PTY or subprocess.
+ */
+
+import { platform } from "node:os";
+
+/**
+ * Determine shell arguments based on the shell executable.
+ *
+ * `-il` (interactive login) is only valid for POSIX shells (bash, zsh, etc.).
+ * PowerShell and cmd.exe don't understand these flags and will exit immediately
+ * with code 1.
+ */
+export function getShellArgs(shellPath: string): string[] {
+    const base = shellPath.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? "";
+    // PowerShell (powershell.exe, pwsh.exe, pwsh) — use -NoExit for interactive
+    if (base.startsWith("powershell") || base.startsWith("pwsh")) {
+        return ["-NoExit", "-NoLogo"];
+    }
+    // cmd.exe — no special args needed for interactive mode
+    if (base === "cmd.exe" || base === "cmd") {
+        return [];
+    }
+    // POSIX shells (bash, zsh, fish, sh, etc.)
+    return ["-il"];
+}
+
+/**
+ * Resolve the default shell for the current platform.
+ *
+ * Prefers an explicit `shell` argument, then `$SHELL`, then a
+ * platform-appropriate default (PowerShell on Windows, /bin/bash elsewhere).
+ */
+export function resolveDefaultShell(explicit?: string): string {
+    if (explicit) return explicit;
+    if (process.env.SHELL) return process.env.SHELL;
+    return platform() === "win32" ? "powershell.exe" : "/bin/bash";
+}

--- a/packages/cli/src/runner/terminal-worker.ts
+++ b/packages/cli/src/runner/terminal-worker.ts
@@ -49,9 +49,28 @@ function send(msg: Record<string, unknown>): void {
 
 // ── Spawn PTY ──────────────────────────────────────────────────────────────────
 
+/**
+ * Determine shell arguments based on the shell executable.
+ * `-il` (interactive login) is only valid for POSIX shells (bash, zsh, etc.).
+ * PowerShell and cmd.exe don't understand these flags and will exit immediately.
+ */
+function getShellArgs(shellPath: string): string[] {
+    const base = shellPath.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? "";
+    // PowerShell (powershell.exe, pwsh.exe, pwsh) — use -NoExit for interactive
+    if (base.startsWith("powershell") || base.startsWith("pwsh")) {
+        return ["-NoExit", "-NoLogo"];
+    }
+    // cmd.exe — no special args needed for interactive mode
+    if (base === "cmd.exe" || base === "cmd") {
+        return [];
+    }
+    // POSIX shells (bash, zsh, fish, sh, etc.)
+    return ["-il"];
+}
+
 let ptyProcess: ReturnType<typeof spawnPty>;
 try {
-    ptyProcess = spawnPty(shell, ["-il"], {
+    ptyProcess = spawnPty(shell, getShellArgs(shell), {
         name: "xterm-256color",
         cols,
         rows,

--- a/packages/cli/src/runner/terminal-worker.ts
+++ b/packages/cli/src/runner/terminal-worker.ts
@@ -30,14 +30,12 @@
  */
 
 import { spawn as spawnPty } from "@zenyr/bun-pty";
-import { platform, homedir } from "node:os";
+import { homedir } from "node:os";
+import { getShellArgs, resolveDefaultShell } from "./terminal-utils.js";
 
 const terminalId = process.env.TERMINAL_WORKER_ID ?? "unknown";
 const cwd = process.env.TERMINAL_WORKER_CWD || homedir();
-const shell =
-    process.env.TERMINAL_WORKER_SHELL ||
-    process.env.SHELL ||
-    (platform() === "win32" ? "powershell.exe" : "/bin/bash");
+const shell = resolveDefaultShell(process.env.TERMINAL_WORKER_SHELL);
 const cols = Math.max(1, parseInt(process.env.TERMINAL_WORKER_COLS ?? "80", 10) || 80);
 const rows = Math.max(1, parseInt(process.env.TERMINAL_WORKER_ROWS ?? "24", 10) || 24);
 
@@ -48,25 +46,6 @@ function send(msg: Record<string, unknown>): void {
 }
 
 // ── Spawn PTY ──────────────────────────────────────────────────────────────────
-
-/**
- * Determine shell arguments based on the shell executable.
- * `-il` (interactive login) is only valid for POSIX shells (bash, zsh, etc.).
- * PowerShell and cmd.exe don't understand these flags and will exit immediately.
- */
-function getShellArgs(shellPath: string): string[] {
-    const base = shellPath.replace(/\\/g, "/").split("/").pop()?.toLowerCase() ?? "";
-    // PowerShell (powershell.exe, pwsh.exe, pwsh) — use -NoExit for interactive
-    if (base.startsWith("powershell") || base.startsWith("pwsh")) {
-        return ["-NoExit", "-NoLogo"];
-    }
-    // cmd.exe — no special args needed for interactive mode
-    if (base === "cmd.exe" || base === "cmd") {
-        return [];
-    }
-    // POSIX shells (bash, zsh, fish, sh, etc.)
-    return ["-il"];
-}
 
 let ptyProcess: ReturnType<typeof spawnPty>;
 try {

--- a/packages/cli/src/runner/terminal.ts
+++ b/packages/cli/src/runner/terminal.ts
@@ -25,6 +25,7 @@ import { existsSync } from "node:fs";
 import { platform, arch, homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
+import { resolveDefaultShell } from "./terminal-utils.js";
 
 export interface TerminalEntry {
     terminalId: string;
@@ -125,10 +126,7 @@ export function spawnTerminal(
         return;
     }
 
-    const shell =
-        opts.shell ||
-        process.env.SHELL ||
-        (platform() === "win32" ? "powershell.exe" : "/bin/bash");
+    const shell = resolveDefaultShell(opts.shell);
 
     const cols = opts.cols && opts.cols > 0 ? opts.cols : 80;
     const rows = opts.rows && opts.rows > 0 ? opts.rows : 24;


### PR DESCRIPTION
## Problem

Terminals on Windows immediately close with `Process exited with Exit Code 1`.

## Root Cause

`terminal-worker.ts` unconditionally passed `-il` (bash interactive login flags) to all shells. PowerShell and cmd.exe don't understand these flags and exit immediately.

## Fix

Extracted shell resolution into a shared `terminal-utils.ts` module with:
- `getShellArgs()` — returns platform-appropriate args:
  - PowerShell/pwsh → `[-NoExit, -NoLogo]`
  - cmd.exe → `[]`
  - POSIX shells → `[-il]` (unchanged)
- `resolveDefaultShell()` — explicit > \$SHELL > platform default

Both `terminal-worker.ts` and `terminal.ts` now import from the shared module.

## Tests

22 new unit tests in `terminal-utils.test.ts` covering all shell variants, Windows paths, case insensitivity, and edge cases.

## Verification

- `bun run typecheck` ✅
- `bun run build` ✅  
- `bun test packages/cli` ✅ (22 new tests pass)