### PR TITLE
feat: add repo-level hooks system for agent guardrails

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,9 +67,15 @@ jobs:
 
           case "$ACTION" in
             dev)
-              # dev.YYYYMMDDHHMMSS
-              SUFFIX="dev.$(date -u +%Y%m%d%H%M%S)"
-              FULL="${BASE}-${SUFFIX}"
+              # dev.N — find the next dev number from npm (like beta).
+              NPM_VERSIONS=$(npm view @pizzapi/pizza versions --json 2>/dev/null || echo '[]')
+              EXISTING=$(echo "$NPM_VERSIONS" | \
+                { grep -o "\"${BASE}-dev\.[0-9]*\"" || true; } | \
+                sed 's/"//g' | \
+                sed "s/${BASE}-dev\.//" | \
+                sort -n | tail -1)
+              NEXT=$(( ${EXISTING:-0} + 1 ))
+              FULL="${BASE}-dev.${NEXT}"
               TAG="dev"
               ;;
             beta)

--- a/.pizzapi/config.json
+++ b/.pizzapi/config.json
@@ -4,5 +4,46 @@
       "command": "npx",
       "args": ["@playwright/mcp@latest"]
     }
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "command": "bash \"$PIZZAPI_PROJECT_DIR/.pizzapi/hooks/block-dangerous-commands.sh\""
+          },
+          {
+            "command": "bash \"$PIZZAPI_PROJECT_DIR/.pizzapi/hooks/lights-on-bun.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "command": "bash \"$PIZZAPI_PROJECT_DIR/.pizzapi/hooks/lights-on-no-node-modules.sh\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "command": "bash \"$PIZZAPI_PROJECT_DIR/.pizzapi/hooks/lights-on-tests-post.sh\""
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "command": "bash \"$PIZZAPI_PROJECT_DIR/.pizzapi/hooks/lights-on-bash-post.sh\""
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.pizzapi/hooks/block-dangerous-commands.sh
+++ b/.pizzapi/hooks/block-dangerous-commands.sh
@@ -5,6 +5,12 @@
 # Exit 0 = allow.
 set -euo pipefail
 
+# Safety: require jq — this is a blocking hook, fail-closed without it
+if ! command -v jq &>/dev/null; then
+    echo "BLOCKED: jq is required for safety hooks but not found in PATH." >&2
+    exit 2
+fi
+
 TOOL_INPUT=$(cat 2>/dev/null) || true
 [[ -z "$TOOL_INPUT" ]] && exit 0
 
@@ -16,15 +22,15 @@ block_with_reason() {
     exit 2
 }
 
-# Force pushes to main/master
-if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force|git\s+push\s+-f'; then
-    if echo "$COMMAND" | grep -qE '\s(main|master)\b'; then
+# Force pushes to main/master (handles --force, -f, --force-with-lease)
+if echo "$COMMAND" | grep -qE 'git\s+push\s+.*(--force|--force-with-lease|-f)\b'; then
+    if echo "$COMMAND" | grep -qE '\s(main|master)\b|HEAD:main|HEAD:master'; then
         block_with_reason "Force push to main/master is forbidden. Use a feature branch."
     fi
 fi
 
 # Prevent skipping git hooks with --no-verify
-if echo "$COMMAND" | grep -qE 'git\s+commit.*--no-verify|git\s+push.*--no-verify'; then
+if echo "$COMMAND" | grep -qE 'git\s+(commit|push)\s+.*--no-verify'; then
     block_with_reason "Skipping git hooks (--no-verify) is not allowed. Fix the issue instead."
 fi
 
@@ -33,13 +39,13 @@ if echo "$COMMAND" | grep -qE 'LEFTHOOK=0|HUSKY=0'; then
     block_with_reason "Bypassing git hooks via environment variables is not allowed."
 fi
 
-# Prevent catastrophic rm -rf on root, home, or the entire project
-if echo "$COMMAND" | grep -qE 'rm\s+-rf\s+/($|\s)|rm\s+-rf\s+~|rm\s+-rf\s+\$HOME'; then
-    block_with_reason "Recursive delete of / or ~ is forbidden."
+# Prevent catastrophic recursive deletes (rm -rf, rm -fr, rm -r -f, etc.)
+if echo "$COMMAND" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+(/($|\s)|~|\$HOME|\.\.)'; then
+    block_with_reason "Recursive delete of /, ~, or .. is forbidden."
 fi
 
 # Prevent deleting the entire .git directory
-if echo "$COMMAND" | grep -qE 'rm\s+-rf?\s+\.git($|\s|/)'; then
+if echo "$COMMAND" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*)\s+.*\.git($|\s|/)'; then
     block_with_reason "Deleting .git is forbidden."
 fi
 

--- a/.pizzapi/hooks/block-dangerous-commands.sh
+++ b/.pizzapi/hooks/block-dangerous-commands.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# "Are Your Lights On?" — PreToolUse:Bash
+# Hard-blocks irreversible operations: force push, --no-verify, dangerous rm.
+# Exit 2 = hard block (stderr sent to agent as error message).
+# Exit 0 = allow.
+set -euo pipefail
+
+TOOL_INPUT=$(cat 2>/dev/null) || true
+[[ -z "$TOOL_INPUT" ]] && exit 0
+
+COMMAND=$(echo "$TOOL_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || true
+[[ -z "$COMMAND" ]] && exit 0
+
+block_with_reason() {
+    echo "BLOCKED: $1" >&2
+    exit 2
+}
+
+# Force pushes to main/master
+if echo "$COMMAND" | grep -qE 'git\s+push\s+.*--force|git\s+push\s+-f'; then
+    if echo "$COMMAND" | grep -qE '\s(main|master)\b'; then
+        block_with_reason "Force push to main/master is forbidden. Use a feature branch."
+    fi
+fi
+
+# Prevent skipping git hooks with --no-verify
+if echo "$COMMAND" | grep -qE 'git\s+commit.*--no-verify|git\s+push.*--no-verify'; then
+    block_with_reason "Skipping git hooks (--no-verify) is not allowed. Fix the issue instead."
+fi
+
+# Prevent bypassing hooks via environment variables
+if echo "$COMMAND" | grep -qE 'LEFTHOOK=0|HUSKY=0'; then
+    block_with_reason "Bypassing git hooks via environment variables is not allowed."
+fi
+
+# Prevent catastrophic rm -rf on root, home, or the entire project
+if echo "$COMMAND" | grep -qE 'rm\s+-rf\s+/($|\s)|rm\s+-rf\s+~|rm\s+-rf\s+\$HOME'; then
+    block_with_reason "Recursive delete of / or ~ is forbidden."
+fi
+
+# Prevent deleting the entire .git directory
+if echo "$COMMAND" | grep -qE 'rm\s+-rf?\s+\.git($|\s|/)'; then
+    block_with_reason "Deleting .git is forbidden."
+fi
+
+exit 0

--- a/.pizzapi/hooks/block-dangerous-commands.sh
+++ b/.pizzapi/hooks/block-dangerous-commands.sh
@@ -43,15 +43,21 @@ fi
 # Prevent catastrophic recursive deletes.
 # Detects all flag forms: combined (-rf), split (-r -f), long (--recursive
 # --force), and mixed (-r --force, --recursive -f), with optional extra flags.
+# Also catches absolute-path rm invocations (/bin/rm, /usr/bin/rm, etc.)
+# and quoted targets ("/" , '~', "$HOME").
 # ---------------------------------------------------------------------------
+
+# Regex that matches both bare `rm` and absolute-path variants like /bin/rm
+_RM_PATTERN='(^|[;&|[:space:]])(\/[^ ]*\/)?rm[[:space:]]'
+
 _rm_parse_flags() {
     # Parse rm's flags from $COMMAND, setting HAS_RECURSIVE / HAS_FORCE.
     HAS_RECURSIVE=false
     HAS_FORCE=false
-    # Extract the portion after the first `rm` token
+    # Extract the portion after the first `rm` token (bare or absolute-path)
     local args
-    args=$(echo "$COMMAND" | sed -n 's/.*[[:space:];&|]rm[[:space:]]\{1,\}\(.*\)/\1/p')
-    [[ -z "$args" ]] && args=$(echo "$COMMAND" | sed -n 's/^rm[[:space:]]\{1,\}\(.*\)/\1/p')
+    args=$(echo "$COMMAND" | sed -n 's/.*[[:space:];&|][^ ]*rm[[:space:]]\{1,\}\(.*\)/\1/p')
+    [[ -z "$args" ]] && args=$(echo "$COMMAND" | sed -n 's/^[^ ]*rm[[:space:]]\{1,\}\(.*\)/\1/p')
     [[ -z "$args" ]] && return
     for token in $args; do
         case "$token" in
@@ -68,21 +74,25 @@ _rm_parse_flags() {
     done
 }
 
-if echo "$COMMAND" | grep -qE '(^|[;&|[:space:]])rm[[:space:]]'; then
+# Strip quotes from the command for target path matching so that
+# `rm -rf "/"` and `rm -rf '~'` are caught.
+UNQUOTED_COMMAND=$(echo "$COMMAND" | sed "s/['\"]//g")
+
+if echo "$COMMAND" | grep -qE "$_RM_PATTERN"; then
     _rm_parse_flags
     if $HAS_RECURSIVE && $HAS_FORCE; then
-        # Check if any target is a dangerous path
-        if echo "$COMMAND" | grep -qE '[[:space:]]/([[:space:]]|$)|[[:space:]]~([[:space:]]|$)|[[:space:]]\$HOME([[:space:]]|$)|[[:space:]]\.\.([[:space:]]|$)'; then
+        # Check if any target is a dangerous path (using quote-stripped version)
+        if echo "$UNQUOTED_COMMAND" | grep -qE '[[:space:]]/([[:space:]]|$)|[[:space:]]~([[:space:]]|$)|[[:space:]]\$HOME([[:space:]]|$)|[[:space:]]\.\.([[:space:]]|$)'; then
             block_with_reason "Recursive delete of /, ~, or .. is forbidden."
         fi
     fi
 fi
 
 # Prevent deleting the entire .git directory
-if echo "$COMMAND" | grep -qE '(^|[;&|[:space:]])rm[[:space:]]'; then
+if echo "$COMMAND" | grep -qE "$_RM_PATTERN"; then
     _rm_parse_flags
     if $HAS_RECURSIVE; then
-        if echo "$COMMAND" | grep -qE '\.git($|[[:space:]]|/)'; then
+        if echo "$UNQUOTED_COMMAND" | grep -qE '\.git($|[[:space:]]|/)'; then
             block_with_reason "Deleting .git is forbidden."
         fi
     fi

--- a/.pizzapi/hooks/block-dangerous-commands.sh
+++ b/.pizzapi/hooks/block-dangerous-commands.sh
@@ -24,7 +24,12 @@ block_with_reason() {
 
 # Force pushes to main/master (handles --force, -f, --force-with-lease)
 if echo "$COMMAND" | grep -qE 'git\s+push\s+.*(--force|--force-with-lease|-f)\b'; then
-    if echo "$COMMAND" | grep -qE '\s(main|master)\b|HEAD:main|HEAD:master'; then
+    # Catch common protected-branch ref forms:
+    #   main / master
+    #   HEAD:main / HEAD:master
+    #   HEAD:refs/heads/main / HEAD:refs/heads/master
+    #   refs/heads/main / refs/heads/master
+    if echo "$COMMAND" | grep -qE 'HEAD:(refs/heads/)?(main|master)\b|(^|[[:space:]])refs/heads/(main|master)\b|(^|[[:space:]:])(main|master)([[:space:]]|$)'; then
         block_with_reason "Force push to main/master is forbidden. Use a feature branch."
     fi
 fi
@@ -82,8 +87,8 @@ if echo "$COMMAND" | grep -qE "$_RM_PATTERN"; then
     _rm_parse_flags
     if $HAS_RECURSIVE && $HAS_FORCE; then
         # Check if any target is a dangerous path (using quote-stripped version)
-        if echo "$UNQUOTED_COMMAND" | grep -qE '[[:space:]]/([[:space:]]|$)|[[:space:]]~([[:space:]]|$)|[[:space:]]\$HOME([[:space:]]|$)|[[:space:]]\.\.([[:space:]]|$)'; then
-            block_with_reason "Recursive delete of /, ~, or .. is forbidden."
+        if echo "$UNQUOTED_COMMAND" | grep -qE '[[:space:]]/([[:space:]]|$)|[[:space:]]~([[:space:]]|$)|[[:space:]]\$HOME([[:space:]]|$)|(^|[[:space:]])([^[:space:]]*/)?\.\.(/[^[:space:]]*)?([[:space:]]|$)'; then
+            block_with_reason "Recursive delete of /, ~, or parent-directory paths (.., ../, ../../) is forbidden."
         fi
     fi
 fi

--- a/.pizzapi/hooks/block-dangerous-commands.sh
+++ b/.pizzapi/hooks/block-dangerous-commands.sh
@@ -39,14 +39,53 @@ if echo "$COMMAND" | grep -qE 'LEFTHOOK=0|HUSKY=0'; then
     block_with_reason "Bypassing git hooks via environment variables is not allowed."
 fi
 
-# Prevent catastrophic recursive deletes (rm -rf, rm -fr, rm -r -f, etc.)
-if echo "$COMMAND" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*f|-[a-zA-Z]*f[a-zA-Z]*r)\s+(/($|\s)|~|\$HOME|\.\.)'; then
-    block_with_reason "Recursive delete of /, ~, or .. is forbidden."
+# ---------------------------------------------------------------------------
+# Prevent catastrophic recursive deletes.
+# Detects all flag forms: combined (-rf), split (-r -f), long (--recursive
+# --force), and mixed (-r --force, --recursive -f), with optional extra flags.
+# ---------------------------------------------------------------------------
+_rm_parse_flags() {
+    # Parse rm's flags from $COMMAND, setting HAS_RECURSIVE / HAS_FORCE.
+    HAS_RECURSIVE=false
+    HAS_FORCE=false
+    # Extract the portion after the first `rm` token
+    local args
+    args=$(echo "$COMMAND" | sed -n 's/.*[[:space:];&|]rm[[:space:]]\{1,\}\(.*\)/\1/p')
+    [[ -z "$args" ]] && args=$(echo "$COMMAND" | sed -n 's/^rm[[:space:]]\{1,\}\(.*\)/\1/p')
+    [[ -z "$args" ]] && return
+    for token in $args; do
+        case "$token" in
+            --recursive) HAS_RECURSIVE=true ;;
+            --force)     HAS_FORCE=true ;;
+            --*)         ;;  # other long options — skip
+            -*)
+                # Short option cluster: check for r and f individually
+                [[ "$token" == *r* ]] && HAS_RECURSIVE=true
+                [[ "$token" == *f* ]] && HAS_FORCE=true
+                ;;
+            *)  break ;;  # first non-flag token → stop scanning flags
+        esac
+    done
+}
+
+if echo "$COMMAND" | grep -qE '(^|[;&|[:space:]])rm[[:space:]]'; then
+    _rm_parse_flags
+    if $HAS_RECURSIVE && $HAS_FORCE; then
+        # Check if any target is a dangerous path
+        if echo "$COMMAND" | grep -qE '[[:space:]]/([[:space:]]|$)|[[:space:]]~([[:space:]]|$)|[[:space:]]\$HOME([[:space:]]|$)|[[:space:]]\.\.([[:space:]]|$)'; then
+            block_with_reason "Recursive delete of /, ~, or .. is forbidden."
+        fi
+    fi
 fi
 
 # Prevent deleting the entire .git directory
-if echo "$COMMAND" | grep -qE 'rm\s+(-[a-zA-Z]*r[a-zA-Z]*)\s+.*\.git($|\s|/)'; then
-    block_with_reason "Deleting .git is forbidden."
+if echo "$COMMAND" | grep -qE '(^|[;&|[:space:]])rm[[:space:]]'; then
+    _rm_parse_flags
+    if $HAS_RECURSIVE; then
+        if echo "$COMMAND" | grep -qE '\.git($|[[:space:]]|/)'; then
+            block_with_reason "Deleting .git is forbidden."
+        fi
+    fi
 fi
 
 exit 0

--- a/.pizzapi/hooks/block-dangerous-commands.sh
+++ b/.pizzapi/hooks/block-dangerous-commands.sh
@@ -22,15 +22,32 @@ block_with_reason() {
     exit 2
 }
 
-# Force pushes to main/master (handles --force, -f, --force-with-lease)
-if echo "$COMMAND" | grep -qE 'git\s+push\s+.*(--force|--force-with-lease|-f)\b'; then
-    # Catch common protected-branch ref forms:
-    #   main / master
-    #   HEAD:main / HEAD:master
-    #   HEAD:refs/heads/main / HEAD:refs/heads/master
-    #   refs/heads/main / refs/heads/master
-    if echo "$COMMAND" | grep -qE 'HEAD:(refs/heads/)?(main|master)\b|(^|[[:space:]])refs/heads/(main|master)\b|(^|[[:space:]:])(main|master)([[:space:]]|$)'; then
-        block_with_reason "Force push to main/master is forbidden. Use a feature branch."
+# Force pushes to main/master (handles --force, -f, --force-with-lease, and
+# refspec-based force updates via leading '+' e.g. `git push origin +main`).
+if echo "$COMMAND" | grep -qE 'git\s+push\b'; then
+    IS_FORCE_PUSH=false
+
+    # Explicit force flags
+    if echo "$COMMAND" | grep -qE 'git\s+push\s+.*(--force|--force-with-lease|-f)\b'; then
+        IS_FORCE_PUSH=true
+    fi
+
+    # Refspec-based force update (`+<src>` or `+<src>:<dst>`)
+    if echo "$COMMAND" | grep -qE 'git\s+push\b.*(^|[[:space:]])\+[^[:space:]]+'; then
+        IS_FORCE_PUSH=true
+    fi
+
+    if [[ "$IS_FORCE_PUSH" == true ]]; then
+        # Catch common protected-branch ref forms (with or without leading '+'):
+        #   main / master
+        #   +main / +master
+        #   HEAD:main / HEAD:master
+        #   HEAD:refs/heads/main / HEAD:refs/heads/master
+        #   refs/heads/main / refs/heads/master
+        #   +refs/heads/main / +refs/heads/master
+        if echo "$COMMAND" | grep -qE 'HEAD:(refs/heads/)?(main|master)\b|(^|[[:space:]])\+?refs/heads/(main|master)\b|(^|[[:space:]:])\+?(main|master)([[:space:]]|$)'; then
+            block_with_reason "Force push to main/master is forbidden. Use a feature branch."
+        fi
     fi
 fi
 

--- a/.pizzapi/hooks/block-dangerous-commands.sh
+++ b/.pizzapi/hooks/block-dangerous-commands.sh
@@ -75,6 +75,29 @@ if echo "$UNQUOTED_COMMAND" | grep -qE "$_GIT_PUSH_PATTERN"; then
         if echo "$UNQUOTED_COMMAND" | grep -qE 'HEAD:(refs/heads/)?(main|master)\b|(^|[[:space:]])\+?refs/heads/(main|master)\b|(^|[[:space:]:])\+?(main|master)([[:space:]]|$)'; then
             block_with_reason "Force push to main/master is forbidden. Use a feature branch."
         fi
+
+        # Handle implicit refspec: `git push --force [origin]` without an
+        # explicit branch/refspec pushes the current branch to its upstream.
+        # When the current branch IS main/master this silently bypasses the
+        # explicit-branch check above.
+        #
+        # Strategy: strip the `git ...push` prefix plus all option flags from
+        # the command, leaving only positional args (<remote> [<refspec>...]).
+        # If there are 0 or 1 positional args (i.e. no explicit refspec) and
+        # the current branch is a protected branch, block the push.
+        PUSH_TAIL=$(echo "$UNQUOTED_COMMAND" \
+            | sed -E 's/.*[[:space:]]push[[:space:]]+//' \
+            | sed -E 's/(^|[[:space:]])-[^[:space:]]*//g' \
+            | xargs)
+        # Count remaining positional tokens (at most: remote + refspecs)
+        POSITIONAL_COUNT=$(echo "$PUSH_TAIL" | wc -w | tr -d ' ')
+        if [[ "$POSITIONAL_COUNT" -le 1 ]]; then
+            # No explicit refspec — check the current branch
+            CURRENT_BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null || true)
+            if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+                block_with_reason "Force push to main/master is forbidden (current branch is $CURRENT_BRANCH). Use a feature branch."
+            fi
+        fi
     fi
 fi
 

--- a/.pizzapi/hooks/block-dangerous-commands.sh
+++ b/.pizzapi/hooks/block-dangerous-commands.sh
@@ -26,6 +26,11 @@ block_with_reason() {
     exit 2
 }
 
+# Shell separators that terminate a token/command. Used throughout to prevent
+# bypasses like `git push --force origin main; echo ok`.
+_SEP='[[:space:];&|]'
+_END="(${_SEP}|$)"
+
 # Match git invocations (bare or absolute path). We allow any leading wrapper
 # token (e.g. sudo/env/command) by matching on token boundaries.
 _GIT_CMD_PREFIX='(^|[;&|[:space:]])(\/[^[:space:]]*\/)?git'
@@ -39,7 +44,7 @@ if echo "$UNQUOTED_COMMAND" | grep -qE "$_GIT_PUSH_PATTERN"; then
     IS_DELETE_PUSH=false
 
     # Explicit force flags
-    if echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])(--force|--force-with-lease|-f)([[:space:]]|$)'; then
+    if echo "$UNQUOTED_COMMAND" | grep -qE "(^|[[:space:]])(--force|--force-with-lease|-f)${_END}"; then
         IS_FORCE_PUSH=true
     fi
 
@@ -52,11 +57,11 @@ if echo "$UNQUOTED_COMMAND" | grep -qE "$_GIT_PUSH_PATTERN"; then
     #   git push origin --delete main
     #   git push origin :main
     #   git push origin :refs/heads/main
-    if echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])--delete([[:space:]]|$)' &&
-       echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])(refs/heads/)?(main|master)([[:space:]]|$)'; then
+    if echo "$UNQUOTED_COMMAND" | grep -qE "(^|[[:space:]])--delete${_END}" &&
+       echo "$UNQUOTED_COMMAND" | grep -qE "(^|[[:space:]])(refs/heads/)?(main|master)${_END}"; then
         IS_DELETE_PUSH=true
     fi
-    if echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])\+?:(refs/heads/)?(main|master)([[:space:]]|$)'; then
+    if echo "$UNQUOTED_COMMAND" | grep -qE "(^|[[:space:]])\+?:(refs/heads/)?(main|master)${_END}"; then
         IS_DELETE_PUSH=true
     fi
 
@@ -72,7 +77,7 @@ if echo "$UNQUOTED_COMMAND" | grep -qE "$_GIT_PUSH_PATTERN"; then
         #   HEAD:refs/heads/main / HEAD:refs/heads/master
         #   refs/heads/main / refs/heads/master
         #   +refs/heads/main / +refs/heads/master
-        if echo "$UNQUOTED_COMMAND" | grep -qE 'HEAD:(refs/heads/)?(main|master)\b|(^|[[:space:]])\+?refs/heads/(main|master)\b|(^|[[:space:]:])\+?(main|master)([[:space:]]|$)'; then
+        if echo "$UNQUOTED_COMMAND" | grep -qE "HEAD:(refs/heads/)?(main|master)\b|(^|[[:space:]])\+?refs/heads/(main|master)\b|(^|[[:space:]:])\+?(main|master)${_END}"; then
             block_with_reason "Force push to main/master is forbidden. Use a feature branch."
         fi
 
@@ -85,8 +90,12 @@ if echo "$UNQUOTED_COMMAND" | grep -qE "$_GIT_PUSH_PATTERN"; then
         # the command, leaving only positional args (<remote> [<refspec>...]).
         # If there are 0 or 1 positional args (i.e. no explicit refspec) and
         # the current branch is a protected branch, block the push.
+        # Strip the git...push prefix, then remove option flags AND their
+        # arguments for options that take a value (e.g. --push-option <val>,
+        # -o <val>, --repo <val>, --receive-pack <val>).
         PUSH_TAIL=$(echo "$UNQUOTED_COMMAND" \
             | sed -E 's/.*[[:space:]]push[[:space:]]+//' \
+            | sed -E 's/(^|[[:space:]])(--push-option|--receive-pack|--repo|-o)[[:space:]]+[^[:space:]-][^[:space:]]*//g' \
             | sed -E 's/(^|[[:space:]])-[^[:space:]]*//g' \
             | xargs)
         # Count remaining positional tokens (at most: remote + refspecs)
@@ -103,7 +112,7 @@ fi
 
 # Prevent skipping git hooks with --no-verify
 if echo "$UNQUOTED_COMMAND" | grep -qE "$_GIT_COMMIT_OR_PUSH_PATTERN" &&
-   echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])--no-verify([[:space:]]|$)'; then
+   echo "$UNQUOTED_COMMAND" | grep -qE "(^|[[:space:]])--no-verify${_END}"; then
     block_with_reason "Skipping git hooks (--no-verify) is not allowed. Fix the issue instead."
 fi
 
@@ -162,7 +171,7 @@ if echo "$UNQUOTED_COMMAND" | grep -qE "$_RM_PATTERN"; then
         #   ~, ~/*
         #   $HOME, $HOME/*
         #   parent-directory targets (.., ../, ../../, foo/..)
-        if echo "$UNQUOTED_COMMAND" | grep -qE '[[:space:]]/([[:space:]]|$|\*|\.\*)|[[:space:]]~([[:space:]]|$|/\*)|[[:space:]]\$HOME([[:space:]]|$|/\*)|(^|[[:space:]])([^[:space:]]*/)?\.\.(/[^[:space:]]*)?([[:space:]]|$)'; then
+        if echo "$UNQUOTED_COMMAND" | grep -qE "${_SEP}/(${_END}|\*|\.\*)|${_SEP}~(${_END}|/\*)|${_SEP}\\\$HOME(${_END}|/\*)|(^|${_SEP})([^[:space:]]*/)?\.\.(/[^[:space:]]*)?${_END}"; then
             block_with_reason "Recursive delete of /, ~, or parent-directory paths (.., ../, ../../) is forbidden."
         fi
     fi
@@ -172,7 +181,7 @@ fi
 if echo "$UNQUOTED_COMMAND" | grep -qE "$_RM_PATTERN"; then
     _rm_parse_flags
     if $HAS_RECURSIVE; then
-        if echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])([^[:space:]]*/)?\.git([[:space:]]|$|/)'; then
+        if echo "$UNQUOTED_COMMAND" | grep -qE "(^|[[:space:]])([^[:space:]]*/)?\.git(${_END}|/)"; then
             block_with_reason "Deleting .git is forbidden."
         fi
     fi

--- a/.pizzapi/hooks/block-dangerous-commands.sh
+++ b/.pizzapi/hooks/block-dangerous-commands.sh
@@ -17,24 +17,51 @@ TOOL_INPUT=$(cat 2>/dev/null) || true
 COMMAND=$(echo "$TOOL_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || true
 [[ -z "$COMMAND" ]] && exit 0
 
+# Normalize quotes so quoted executables/args still match safety checks.
+# Example: "/usr/bin/git" push --force origin "main"
+UNQUOTED_COMMAND=$(echo "$COMMAND" | sed "s/['\"]//g")
+
 block_with_reason() {
     echo "BLOCKED: $1" >&2
     exit 2
 }
 
+# Match git invocations (bare or absolute path). We allow any leading wrapper
+# token (e.g. sudo/env/command) by matching on token boundaries.
+_GIT_CMD_PREFIX='(^|[;&|[:space:]])(\/[^[:space:]]*\/)?git'
+_GIT_PUSH_PATTERN="${_GIT_CMD_PREFIX}([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+push([[:space:]]|$)"
+_GIT_COMMIT_OR_PUSH_PATTERN="${_GIT_CMD_PREFIX}([[:space:]]+[^;&|[:space:]]+)*[[:space:]]+(commit|push)([[:space:]]|$)"
+
 # Force pushes to main/master (handles --force, -f, --force-with-lease, and
 # refspec-based force updates via leading '+' e.g. `git push origin +main`).
-if echo "$COMMAND" | grep -qE 'git\s+push\b'; then
+if echo "$UNQUOTED_COMMAND" | grep -qE "$_GIT_PUSH_PATTERN"; then
     IS_FORCE_PUSH=false
+    IS_DELETE_PUSH=false
 
     # Explicit force flags
-    if echo "$COMMAND" | grep -qE 'git\s+push\s+.*(--force|--force-with-lease|-f)\b'; then
+    if echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])(--force|--force-with-lease|-f)([[:space:]]|$)'; then
         IS_FORCE_PUSH=true
     fi
 
     # Refspec-based force update (`+<src>` or `+<src>:<dst>`)
-    if echo "$COMMAND" | grep -qE 'git\s+push\b.*(^|[[:space:]])\+[^[:space:]]+'; then
+    if echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])\+[^[:space:]]+'; then
         IS_FORCE_PUSH=true
+    fi
+
+    # Protected-branch delete forms:
+    #   git push origin --delete main
+    #   git push origin :main
+    #   git push origin :refs/heads/main
+    if echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])--delete([[:space:]]|$)' &&
+       echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])(refs/heads/)?(main|master)([[:space:]]|$)'; then
+        IS_DELETE_PUSH=true
+    fi
+    if echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])\+?:(refs/heads/)?(main|master)([[:space:]]|$)'; then
+        IS_DELETE_PUSH=true
+    fi
+
+    if [[ "$IS_DELETE_PUSH" == true ]]; then
+        block_with_reason "Deleting main/master via git push is forbidden. Use a feature branch workflow."
     fi
 
     if [[ "$IS_FORCE_PUSH" == true ]]; then
@@ -45,14 +72,15 @@ if echo "$COMMAND" | grep -qE 'git\s+push\b'; then
         #   HEAD:refs/heads/main / HEAD:refs/heads/master
         #   refs/heads/main / refs/heads/master
         #   +refs/heads/main / +refs/heads/master
-        if echo "$COMMAND" | grep -qE 'HEAD:(refs/heads/)?(main|master)\b|(^|[[:space:]])\+?refs/heads/(main|master)\b|(^|[[:space:]:])\+?(main|master)([[:space:]]|$)'; then
+        if echo "$UNQUOTED_COMMAND" | grep -qE 'HEAD:(refs/heads/)?(main|master)\b|(^|[[:space:]])\+?refs/heads/(main|master)\b|(^|[[:space:]:])\+?(main|master)([[:space:]]|$)'; then
             block_with_reason "Force push to main/master is forbidden. Use a feature branch."
         fi
     fi
 fi
 
 # Prevent skipping git hooks with --no-verify
-if echo "$COMMAND" | grep -qE 'git\s+(commit|push)\s+.*--no-verify'; then
+if echo "$UNQUOTED_COMMAND" | grep -qE "$_GIT_COMMIT_OR_PUSH_PATTERN" &&
+   echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])--no-verify([[:space:]]|$)'; then
     block_with_reason "Skipping git hooks (--no-verify) is not allowed. Fix the issue instead."
 fi
 
@@ -69,22 +97,29 @@ fi
 # and quoted targets ("/" , '~', "$HOME").
 # ---------------------------------------------------------------------------
 
-# Regex that matches both bare `rm` and absolute-path variants like /bin/rm
-_RM_PATTERN='(^|[;&|[:space:]])(\/[^ ]*\/)?rm[[:space:]]'
+# Regex that matches both bare `rm` and absolute-path variants like /bin/rm.
+# We match against UNQUOTED_COMMAND so quoted executables are caught too.
+_RM_PATTERN='(^|[;&|[:space:]])(\/[^[:space:]]*\/)?rm[[:space:]]'
 
 _rm_parse_flags() {
-    # Parse rm's flags from $COMMAND, setting HAS_RECURSIVE / HAS_FORCE.
+    # Parse rm's flags from UNQUOTED_COMMAND, setting HAS_RECURSIVE / HAS_FORCE.
     HAS_RECURSIVE=false
     HAS_FORCE=false
+
     # Extract the portion after the first `rm` token (bare or absolute-path)
     local args
-    args=$(echo "$COMMAND" | sed -n 's/.*[[:space:];&|][^ ]*rm[[:space:]]\{1,\}\(.*\)/\1/p')
-    [[ -z "$args" ]] && args=$(echo "$COMMAND" | sed -n 's/^[^ ]*rm[[:space:]]\{1,\}\(.*\)/\1/p')
+    args=$(echo "$UNQUOTED_COMMAND" | sed -n 's/.*[[:space:];&|][^[:space:]]*rm[[:space:]]\{1,\}\(.*\)/\1/p')
+    [[ -z "$args" ]] && args=$(echo "$UNQUOTED_COMMAND" | sed -n 's/^[^[:space:]]*rm[[:space:]]\{1,\}\(.*\)/\1/p')
     [[ -z "$args" ]] && return
-    for token in $args; do
+
+    # rm flags are expected before the first target path.
+    local tokens
+    read -r -a tokens <<< "$args"
+    for token in "${tokens[@]}"; do
         case "$token" in
             --recursive) HAS_RECURSIVE=true ;;
             --force)     HAS_FORCE=true ;;
+            --)          break ;;
             --*)         ;;  # other long options — skip
             -*)
                 # Short option cluster: check for r and f individually
@@ -96,25 +131,25 @@ _rm_parse_flags() {
     done
 }
 
-# Strip quotes from the command for target path matching so that
-# `rm -rf "/"` and `rm -rf '~'` are caught.
-UNQUOTED_COMMAND=$(echo "$COMMAND" | sed "s/['\"]//g")
-
-if echo "$COMMAND" | grep -qE "$_RM_PATTERN"; then
+if echo "$UNQUOTED_COMMAND" | grep -qE "$_RM_PATTERN"; then
     _rm_parse_flags
     if $HAS_RECURSIVE && $HAS_FORCE; then
-        # Check if any target is a dangerous path (using quote-stripped version)
-        if echo "$UNQUOTED_COMMAND" | grep -qE '[[:space:]]/([[:space:]]|$)|[[:space:]]~([[:space:]]|$)|[[:space:]]\$HOME([[:space:]]|$)|(^|[[:space:]])([^[:space:]]*/)?\.\.(/[^[:space:]]*)?([[:space:]]|$)'; then
+        # Check for dangerous delete targets. This includes:
+        #   /, /*, /.*
+        #   ~, ~/*
+        #   $HOME, $HOME/*
+        #   parent-directory targets (.., ../, ../../, foo/..)
+        if echo "$UNQUOTED_COMMAND" | grep -qE '[[:space:]]/([[:space:]]|$|\*|\.\*)|[[:space:]]~([[:space:]]|$|/\*)|[[:space:]]\$HOME([[:space:]]|$|/\*)|(^|[[:space:]])([^[:space:]]*/)?\.\.(/[^[:space:]]*)?([[:space:]]|$)'; then
             block_with_reason "Recursive delete of /, ~, or parent-directory paths (.., ../, ../../) is forbidden."
         fi
     fi
 fi
 
 # Prevent deleting the entire .git directory
-if echo "$COMMAND" | grep -qE "$_RM_PATTERN"; then
+if echo "$UNQUOTED_COMMAND" | grep -qE "$_RM_PATTERN"; then
     _rm_parse_flags
     if $HAS_RECURSIVE; then
-        if echo "$UNQUOTED_COMMAND" | grep -qE '\.git($|[[:space:]]|/)'; then
+        if echo "$UNQUOTED_COMMAND" | grep -qE '(^|[[:space:]])([^[:space:]]*/)?\.git([[:space:]]|$|/)'; then
             block_with_reason "Deleting .git is forbidden."
         fi
     fi

--- a/.pizzapi/hooks/lights-on-bash-post.sh
+++ b/.pizzapi/hooks/lights-on-bash-post.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# "Are Your Lights On?" — PostToolUse:Bash
+# After a Bash command fails, asks three questions to break the retry loop.
+# Skips test commands (failures are expected during TDD RED phase).
+# Always exits 0 (non-blocking).
+set -euo pipefail
+
+TOOL_INPUT=$(cat 2>/dev/null) || true
+[[ -z "$TOOL_INPUT" ]] && exit 0
+
+COMMAND=$(echo "$TOOL_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || true
+TOOL_RESPONSE=$(echo "$TOOL_INPUT" | jq -r '.tool_response // empty' 2>/dev/null) || true
+
+# No response to check — skip
+[[ -z "$TOOL_RESPONSE" ]] && exit 0
+
+# Skip test commands — failures are expected during TDD RED phase
+IS_TEST_CMD=false
+if echo "$COMMAND" | grep -qE '(bun\s+test|bunx\s+jest|vitest)'; then
+    IS_TEST_CMD=true
+fi
+
+if [[ "$IS_TEST_CMD" == "false" ]]; then
+    # More specific checks first, then generic error fallback
+
+    # Build command failed — remind about build order (most specific)
+    if echo "$COMMAND" | grep -qE 'bun\s+run\s+build'; then
+        if echo "$TOOL_RESPONSE" | grep -qiE 'error:|Cannot find module|could not resolve'; then
+            jq -n '{
+                hookSpecificOutput: {
+                    hookEventName: "PostToolUse",
+                    additionalContext: "Build failed. Did you respect the build order? tools must be built before server or cli. Run `bun run build` for the correct full sequence, or build individual packages in order: build:tools → build:server → build:ui → build:cli."
+                }
+            }'
+            exit 0
+        fi
+    fi
+
+    # Generic error pattern — ask three recovery questions
+    if echo "$TOOL_RESPONSE" | grep -qiE 'error:|fatal:|command not found|no such file|permission denied|ENOENT|EACCES|panic:|traceback|ModuleNotFoundError|ImportError|Cannot find module|not found'; then
+        jq -n '{
+            hookSpecificOutput: {
+                hookEventName: "PostToolUse",
+                additionalContext: "The command appears to have failed. Before retrying the same approach: (1) Is there a dedicated tool (Read, Grep, Glob, Edit) that handles this better? (2) Did you read the error message carefully — does it tell you exactly what is wrong? (3) Is the approach itself wrong, not just the execution?"
+            }
+        }'
+        exit 0
+    fi
+fi
+
+exit 0

--- a/.pizzapi/hooks/lights-on-bun.sh
+++ b/.pizzapi/hooks/lights-on-bun.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# "Are Your Lights On?" — PreToolUse:Bash
+# PizzaPi uses Bun exclusively. Catches npm/yarn/pnpm/npx usage and asks
+# the agent to reconsider. Does NOT block — some npx usage may be legitimate
+# (e.g., npx playwright in MCP config), so we ask a question instead.
+set -euo pipefail
+
+TOOL_INPUT=$(cat 2>/dev/null) || true
+[[ -z "$TOOL_INPUT" ]] && exit 0
+
+COMMAND=$(echo "$TOOL_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || true
+[[ -z "$COMMAND" ]] && exit 0
+
+# Detect npm/yarn/pnpm as the primary command (not inside a string or comment)
+# Match: starts with the command, or appears after && / || / ; / |
+if echo "$COMMAND" | grep -qE '(^|\s|&&|\|\||;|\|)\s*(npm|yarn|pnpm|npx)\s'; then
+    # Allow npx playwright — it's used in MCP config and is correct
+    if echo "$COMMAND" | grep -qE 'npx\s+@?playwright'; then
+        exit 0
+    fi
+    jq -n '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "allow",
+            additionalContext: "This project uses Bun exclusively — not npm, yarn, or pnpm. Did you mean to use `bun`, `bunx`, or `bun run` instead? Check AGENTS.md if unsure."
+        }
+    }'
+    exit 0
+fi
+
+# Detect Node being used where Bun should be
+if echo "$COMMAND" | grep -qE '(^|\s|&&|\|\||;|\|)\s*node\s'; then
+    jq -n '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "allow",
+            additionalContext: "This project uses Bun as its runtime. Did you mean `bun` instead of `node`?"
+        }
+    }'
+    exit 0
+fi
+
+exit 0

--- a/.pizzapi/hooks/lights-on-no-node-modules.sh
+++ b/.pizzapi/hooks/lights-on-no-node-modules.sh
@@ -17,8 +17,8 @@ TOOL_INPUT=$(cat 2>/dev/null) || true
 FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null) || true
 [[ -z "$FILE_PATH" ]] && exit 0
 
-# Block any edit to files inside node_modules
-if echo "$FILE_PATH" | grep -qE '(^|/)node_modules/'; then
+# Block any edit to files inside node_modules (handle both / and \ separators)
+if echo "$FILE_PATH" | grep -qE '(^|[/\\])node_modules[/\\]'; then
     echo "BLOCKED: Do not edit files inside node_modules/ directly. Changes to upstream packages go in patches/ and are applied via \`bun install\`. See AGENTS.md." >&2
     exit 2
 fi

--- a/.pizzapi/hooks/lights-on-no-node-modules.sh
+++ b/.pizzapi/hooks/lights-on-no-node-modules.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# "Are Your Lights On?" — PreToolUse:Edit/Write
+# Hard-blocks edits to node_modules/. PizzaPi uses patches/ for upstream changes.
+# Exit 2 = hard block. Exit 0 = allow.
+set -euo pipefail
+
+TOOL_INPUT=$(cat 2>/dev/null) || true
+[[ -z "$TOOL_INPUT" ]] && exit 0
+
+FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || true
+[[ -z "$FILE_PATH" ]] && exit 0
+
+# Block any edit to files inside node_modules
+if echo "$FILE_PATH" | grep -qE '(^|/)node_modules/'; then
+    echo "BLOCKED: Do not edit files inside node_modules/ directly. Changes to upstream packages go in patches/ and are applied via \`bun install\`. See AGENTS.md." >&2
+    exit 2
+fi
+
+exit 0

--- a/.pizzapi/hooks/lights-on-no-node-modules.sh
+++ b/.pizzapi/hooks/lights-on-no-node-modules.sh
@@ -4,10 +4,17 @@
 # Exit 2 = hard block. Exit 0 = allow.
 set -euo pipefail
 
+# Safety: require jq — this is a blocking hook, fail-closed without it
+if ! command -v jq &>/dev/null; then
+    echo "BLOCKED: jq is required for safety hooks but not found in PATH." >&2
+    exit 2
+fi
+
 TOOL_INPUT=$(cat 2>/dev/null) || true
 [[ -z "$TOOL_INPUT" ]] && exit 0
 
-FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || true
+# Support both pi's "path" and Claude Code's "file_path" keys
+FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null) || true
 [[ -z "$FILE_PATH" ]] && exit 0
 
 # Block any edit to files inside node_modules

--- a/.pizzapi/hooks/lights-on-tests-post.sh
+++ b/.pizzapi/hooks/lights-on-tests-post.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+# "Are Your Lights On?" — PostToolUse:Edit/Write
+# After editing a source file, asks whether tests were added/updated.
+# Skips test files, config files, docs, and non-code files.
+# Always exits 0 (non-blocking).
+set -euo pipefail
+
+TOOL_INPUT=$(cat 2>/dev/null) || true
+[[ -z "$TOOL_INPUT" ]] && exit 0
+
+FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || true
+[[ -z "$FILE_PATH" ]] && exit 0
+
+FILENAME=$(basename "$FILE_PATH")
+EXTENSION="${FILENAME##*.}"
+
+# Only care about TypeScript/JavaScript source files (the PizzaPi stack)
+case "$EXTENSION" in
+    ts|tsx|js|jsx) ;;
+    *) exit 0 ;; # Not a code file — skip
+esac
+
+# Skip test files — writing tests is the right thing
+if echo "$FILENAME" | grep -qiE '\.test\.|\.spec\.|__test__|__spec__'; then
+    exit 0
+fi
+
+# Skip config, build, and type declaration files
+if echo "$FILENAME" | grep -qiE '\.config\.|\.d\.ts$|vite|tsconfig|tailwind|postcss'; then
+    exit 0
+fi
+
+# Skip non-source directories (docs, scripts, config)
+if echo "$FILE_PATH" | grep -qiE '/(docs|scripts|\.claude|\.pizzapi|\.github|docker|patches)/'; then
+    exit 0
+fi
+
+# Skip index/barrel files (re-exports, not logic)
+if echo "$FILENAME" | grep -qiE '^index\.(ts|js)$'; then
+    exit 0
+fi
+
+# This is production source code. Ask the testing question.
+jq -n '{
+    hookSpecificOutput: {
+        hookEventName: "PostToolUse",
+        additionalContext: "Did you add or update a .test.ts file for this change? AGENTS.md requires all new code to include tests. Co-locate tests: foo.ts → foo.test.ts."
+    }
+}'
+
+exit 0

--- a/.pizzapi/hooks/lights-on-tests-post.sh
+++ b/.pizzapi/hooks/lights-on-tests-post.sh
@@ -8,7 +8,13 @@ set -euo pipefail
 TOOL_INPUT=$(cat 2>/dev/null) || true
 [[ -z "$TOOL_INPUT" ]] && exit 0
 
-FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null) || true
+# jq is needed for output — if missing, skip silently (advisory hook)
+if ! command -v jq &>/dev/null; then
+    exit 0
+fi
+
+# Support both pi's "path" and Claude Code's "file_path" keys
+FILE_PATH=$(echo "$TOOL_INPUT" | jq -r '.tool_input.file_path // .tool_input.path // empty' 2>/dev/null) || true
 [[ -z "$FILE_PATH" ]] && exit 0
 
 FILENAME=$(basename "$FILE_PATH")

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "dev:ui": "cd packages/ui && bun run dev",
         "dev:cli": "bun packages/cli/src/index.ts",
         "dev:runner": "bun packages/cli/src/index.ts runner",
-        "test": "bun test packages/server packages/tools && cd packages/cli && bun test src/patches.test.ts && cd ../ui && bun test",
+        "test": "bun test packages/server packages/tools && cd packages/cli && bun test && cd ../ui && bun test",
         "typecheck": "tsc --build",
         "migrate": "cd packages/server && bun run migrate",
         "clean": "bun -e \"['protocol','tools','server','ui','cli','docs'].forEach(p=>require('fs').rmSync('packages/'+p+'/dist',{recursive:true,force:true}))\"",

--- a/packages/cli/build-binaries.ts
+++ b/packages/cli/build-binaries.ts
@@ -15,7 +15,7 @@
 
 import { $ } from "bun";
 import { join, dirname } from "path";
-import { existsSync, mkdirSync, cpSync, readdirSync } from "fs";
+import { existsSync, mkdirSync, cpSync, readdirSync, readFileSync, rmSync } from "fs";
 import { platform as osPlatform, arch as osArch } from "os";
 
 // ---------------------------------------------------------------------------
@@ -85,24 +85,123 @@ function copyAssets(piPkgDir: string, outDir: string): void {
 // ---------------------------------------------------------------------------
 
 /**
+ * Resolve the version of @zenyr/bun-pty platform packages by reading the
+ * installed parent package metadata.
+ */
+function resolvePtyVersion(): string | null {
+    // Try import.meta.resolve on the parent @zenyr/bun-pty package
+    try {
+        const entryUrl = import.meta.resolve("@zenyr/bun-pty");
+        let dir = dirname(new URL(entryUrl).pathname);
+        while (dir !== dirname(dir)) {
+            const pkgPath = join(dir, "package.json");
+            if (existsSync(pkgPath)) {
+                const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+                if (pkg.name === "@zenyr/bun-pty") {
+                    return pkg.version;
+                }
+            }
+            dir = dirname(dir);
+        }
+    } catch {}
+
+    // Fallback: scan Bun store for @zenyr+bun-pty@<version>
+    for (const base of [join(import.meta.dirname, "node_modules"), join(import.meta.dirname, "..", "..", "node_modules")]) {
+        const bunDir = join(base, ".bun");
+        if (!existsSync(bunDir)) continue;
+        try {
+            for (const entry of readdirSync(bunDir)) {
+                const m = entry.match(/^@zenyr\+bun-pty@(\d+\.\d+\.\d+)/);
+                if (m) return m[1];
+            }
+        } catch {}
+    }
+
+    return null;
+}
+
+/**
+ * Download the PTY native library for a target platform from the npm registry.
+ * Used when the platform package isn't locally installed (cross-platform builds).
+ */
+async function downloadPtyLib(target: Target, outDir: string): Promise<boolean> {
+    const pkgName = `bun-pty-${target.ptyOs}-${target.ptyCpu}`;
+    const scopedName = `@zenyr/${pkgName}`;
+
+    const version = resolvePtyVersion();
+    if (!version) {
+        console.log(`    ✗ Could not determine @zenyr/bun-pty version`);
+        return false;
+    }
+
+    console.log(`    Downloading ${scopedName}@${version} from npm registry...`);
+
+    const tmpDir = join(outDir, ".pty-download");
+    mkdirSync(tmpDir, { recursive: true });
+
+    try {
+        // Fetch package metadata to get the tarball URL
+        const metaResp = await fetch(`https://registry.npmjs.org/${scopedName}/${version}`);
+        if (!metaResp.ok) {
+            console.log(`    ✗ Failed to fetch package metadata (HTTP ${metaResp.status})`);
+            return false;
+        }
+        const meta = (await metaResp.json()) as { dist?: { tarball?: string } };
+        const tarballUrl = meta.dist?.tarball;
+        if (!tarballUrl) {
+            console.log(`    ✗ No tarball URL in package metadata`);
+            return false;
+        }
+
+        // Download the tarball
+        const tarResp = await fetch(tarballUrl);
+        if (!tarResp.ok) {
+            console.log(`    ✗ Failed to download tarball (HTTP ${tarResp.status})`);
+            return false;
+        }
+
+        const tgzPath = join(tmpDir, `${pkgName}.tgz`);
+        await Bun.write(tgzPath, tarResp);
+
+        // Extract the tarball
+        const result = await $`tar xzf ${tgzPath} -C ${tmpDir}`.nothrow().quiet();
+        if (result.exitCode !== 0) {
+            console.log(`    ✗ Failed to extract tarball`);
+            return false;
+        }
+
+        // Copy the native library from the extracted package/ directory
+        const libSrc = join(tmpDir, "package", target.ptyLibName);
+        if (existsSync(libSrc)) {
+            cpSync(libSrc, join(outDir, target.ptyLibName));
+            return true;
+        }
+
+        console.log(`    ✗ ${target.ptyLibName} not found in downloaded package`);
+        return false;
+    } catch (err) {
+        console.log(`    ✗ Download failed: ${err}`);
+        return false;
+    } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
+    }
+}
+
+/**
  * Copy the @zenyr/bun-pty native shared library for the target platform
  * alongside the compiled binary.  At runtime the terminal worker sets
  * BUN_PTY_LIB pointing to this file so the FFI layer can find it.
  *
- * We can only copy the library for the current host platform (the .dylib/.so
- * for other platforms isn't installed via optionalDependencies).
+ * Tries three strategies in order:
+ *   1. Resolve from locally installed platform package (host-matching targets)
+ *   2. Search Bun's deduplicated node_modules store
+ *   3. Download from the npm registry (cross-platform builds)
  */
-function copyPtyLib(target: Target, outDir: string): boolean {
-    // Only copy when we're building for the current host platform
-    const hostOs = osPlatform();   // "darwin", "linux", "win32"
-    const hostCpu = osArch();      // "arm64", "x64"
-    if (target.ptyOs !== hostOs || target.ptyCpu !== hostCpu) {
-        return false;
-    }
-
+async function copyPtyLib(target: Target, outDir: string): Promise<boolean> {
     const ptyPlatformPkg = `@zenyr/bun-pty-${target.ptyOs}-${target.ptyCpu}`;
 
-    // Strategy 1: Try import.meta.resolve (works when hoisted)
+    // Strategy 1: Try import.meta.resolve (works when the platform package is
+    // installed for this host — i.e. target matches the build machine)
     try {
         const entryUrl = import.meta.resolve(ptyPlatformPkg);
         const pkgDir = dirname(new URL(entryUrl).pathname);
@@ -133,7 +232,9 @@ function copyPtyLib(target: Target, outDir: string): boolean {
         } catch {}
     }
 
-    return false;
+    // Strategy 3: Download from npm registry (for cross-platform builds where
+    // the host OS doesn't match the target and the platform package isn't installed)
+    return await downloadPtyLib(target, outDir);
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/bunfig.toml
+++ b/packages/cli/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+root = "./src"

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -53,6 +53,15 @@ export interface PizzaPiConfig {
      * exit 0 to allow (with optional additionalContext), exit 2 to block.
      */
     hooks?: HooksConfig;
+    /**
+     * Trust gate: allow project-local hooks (.pizzapi/config.json) to run.
+     * Must be set in the GLOBAL ~/.pizzapi/config.json (or via
+     * PIZZAPI_ALLOW_PROJECT_HOOKS=1 env var). Project configs cannot
+     * self-authorize.
+     *
+     * When false/unset, only hooks from ~/.pizzapi/config.json (global) run.
+     */
+    allowProjectHooks?: boolean;
 }
 
 function readJsonSafe(path: string): Partial<PizzaPiConfig> {
@@ -65,7 +74,7 @@ function readJsonSafe(path: string): Partial<PizzaPiConfig> {
 }
 
 /** Deep-merge hooks: concatenate matcher arrays from both sources. */
-function mergeHooks(a?: HooksConfig, b?: HooksConfig): HooksConfig | undefined {
+export function mergeHooks(a?: HooksConfig, b?: HooksConfig): HooksConfig | undefined {
     if (!a && !b) return undefined;
     const merged: HooksConfig = {};
     const pre = [...(a?.PreToolUse ?? []), ...(b?.PreToolUse ?? [])];
@@ -76,20 +85,45 @@ function mergeHooks(a?: HooksConfig, b?: HooksConfig): HooksConfig | undefined {
 }
 
 /**
+ * Check whether project-local hooks are trusted.
+ * Trust must come from the global config or the environment — never from
+ * the project config itself (that would be a self-authorization bypass).
+ */
+export function isProjectHooksTrusted(globalConfig: Partial<PizzaPiConfig>): boolean {
+    if (process.env.PIZZAPI_ALLOW_PROJECT_HOOKS === "1") return true;
+    return globalConfig.allowProjectHooks === true;
+}
+
+/**
  * Load PizzaPi config from:
  *   1. ~/.pizzapi/config.json  (global)
  *   2. <cwd>/.pizzapi/config.json  (project-local, wins on conflict)
  *
- * Hooks are deep-merged (concatenated) so global and project hooks both run.
+ * Hooks: global hooks always run. Project hooks only run when explicitly
+ * trusted via `allowProjectHooks: true` in the global config or the
+ * PIZZAPI_ALLOW_PROJECT_HOOKS=1 env var.
  */
 export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     const globalPath = join(homedir(), ".pizzapi", "config.json");
     const projectPath = join(cwd, ".pizzapi", "config.json");
     const global = readJsonSafe(globalPath);
     const project = readJsonSafe(projectPath);
-    const hooks = mergeHooks(global.hooks, project.hooks);
+
+    // Trust gate: project hooks require explicit authorization from global config
+    const projectHooksTrusted = isProjectHooksTrusted(global);
+    const projectHooks = projectHooksTrusted ? project.hooks : undefined;
+    if (project.hooks && !projectHooksTrusted) {
+        console.warn(
+            "[hooks] Project hooks found in .pizzapi/config.json but not trusted. " +
+                'Set "allowProjectHooks": true in ~/.pizzapi/config.json or ' +
+                "PIZZAPI_ALLOW_PROJECT_HOOKS=1 to enable.",
+        );
+    }
+
+    const hooks = mergeHooks(global.hooks, projectHooks);
     const config = { ...global, ...project };
     if (hooks) config.hooks = hooks;
+    else delete config.hooks;
     return config;
 }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,6 +2,34 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { join } from "path";
 
+/** A single hook entry — a shell command to run at a lifecycle point. */
+export interface HookEntry {
+    /** Shell command to execute. Receives JSON on stdin. */
+    command: string;
+    /** Timeout in milliseconds. Default: 10000 (10s). */
+    timeout?: number;
+}
+
+/** A matcher group — binds a tool name pattern to one or more hooks. */
+export interface HookMatcher {
+    /**
+     * Tool name pattern to match. Supports `|` for alternation.
+     * Examples: "Bash", "Edit|Write", "Read".
+     * Use ".*" to match all tools.
+     */
+    matcher: string;
+    /** Hooks to run when the matcher matches. */
+    hooks: HookEntry[];
+}
+
+/** Hook configuration — shell scripts that run at tool lifecycle points. */
+export interface HooksConfig {
+    /** Hooks that fire BEFORE a tool executes. Can block or inject context. */
+    PreToolUse?: HookMatcher[];
+    /** Hooks that fire AFTER a tool executes. Can inject context. */
+    PostToolUse?: HookMatcher[];
+}
+
 export interface PizzaPiConfig {
     /** Override the default system prompt */
     systemPrompt?: string;
@@ -19,6 +47,12 @@ export interface PizzaPiConfig {
      * Supports ~ expansion and absolute paths.
      */
     skills?: string[];
+    /**
+     * Shell-script hooks that fire at tool lifecycle points.
+     * Inspired by Claude Code hooks: scripts receive JSON on stdin,
+     * exit 0 to allow (with optional additionalContext), exit 2 to block.
+     */
+    hooks?: HooksConfig;
 }
 
 function readJsonSafe(path: string): Partial<PizzaPiConfig> {
@@ -30,17 +64,33 @@ function readJsonSafe(path: string): Partial<PizzaPiConfig> {
     }
 }
 
+/** Deep-merge hooks: concatenate matcher arrays from both sources. */
+function mergeHooks(a?: HooksConfig, b?: HooksConfig): HooksConfig | undefined {
+    if (!a && !b) return undefined;
+    const merged: HooksConfig = {};
+    const pre = [...(a?.PreToolUse ?? []), ...(b?.PreToolUse ?? [])];
+    const post = [...(a?.PostToolUse ?? []), ...(b?.PostToolUse ?? [])];
+    if (pre.length > 0) merged.PreToolUse = pre;
+    if (post.length > 0) merged.PostToolUse = post;
+    return Object.keys(merged).length > 0 ? merged : undefined;
+}
+
 /**
  * Load PizzaPi config from:
  *   1. ~/.pizzapi/config.json  (global)
  *   2. <cwd>/.pizzapi/config.json  (project-local, wins on conflict)
+ *
+ * Hooks are deep-merged (concatenated) so global and project hooks both run.
  */
 export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     const globalPath = join(homedir(), ".pizzapi", "config.json");
     const projectPath = join(cwd, ".pizzapi", "config.json");
     const global = readJsonSafe(globalPath);
     const project = readJsonSafe(projectPath);
-    return { ...global, ...project };
+    const hooks = mergeHooks(global.hooks, project.hooks);
+    const config = { ...global, ...project };
+    if (hooks) config.hooks = hooks;
+    return config;
 }
 
 export function expandHome(path: string): string {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -22,12 +22,80 @@ export interface HookMatcher {
     hooks: HookEntry[];
 }
 
-/** Hook configuration — shell scripts that run at tool lifecycle points. */
+/** Hook configuration — shell scripts that run at agent lifecycle points. */
 export interface HooksConfig {
+    // -- Tool lifecycle hooks (use matchers to target specific tools) --
+
     /** Hooks that fire BEFORE a tool executes. Can block or inject context. */
     PreToolUse?: HookMatcher[];
     /** Hooks that fire AFTER a tool executes. Can inject context. */
     PostToolUse?: HookMatcher[];
+
+    // -- Input hooks --
+
+    /**
+     * Fires when user input is received, before skill/template expansion.
+     * Can transform text, block input, or mark it as handled.
+     * Exit 0 + JSON `{ text: "..." }` → rewrite input.
+     * Exit 0 + JSON `{ action: "handled" }` → consume without processing.
+     * Exit 2 → block input (stderr shown as reason).
+     */
+    Input?: HookEntry[];
+
+    /**
+     * Fires after user prompt but before the agent loop starts.
+     * Can inject context or tweak the system prompt for this turn.
+     * Exit 0 + JSON `{ additionalContext: "...", systemPrompt: "..." }`.
+     */
+    BeforeAgentStart?: HookEntry[];
+
+    /**
+     * Fires when user executes a shell command via ! or !! prefix.
+     * Important for safety parity with PreToolUse:Bash.
+     * Exit 2 → block the command (stderr shown as reason).
+     * Exit 0 → allow.
+     */
+    UserBash?: HookEntry[];
+
+    // -- Session lifecycle hooks --
+
+    /**
+     * Fires before switching to another session. Can cancel.
+     * Exit 2 → cancel the switch (stderr shown as reason).
+     */
+    SessionBeforeSwitch?: HookEntry[];
+
+    /**
+     * Fires before forking a session. Can cancel.
+     * Exit 2 → cancel the fork (stderr shown as reason).
+     */
+    SessionBeforeFork?: HookEntry[];
+
+    /**
+     * Fires on process exit. Best-effort cleanup/checkpoint.
+     * Exit code is ignored (the process is shutting down).
+     */
+    SessionShutdown?: HookEntry[];
+
+    // -- Second wave hooks --
+
+    /**
+     * Fires before context compaction. Can cancel.
+     * Exit 2 → cancel compaction (stderr shown as reason).
+     */
+    SessionBeforeCompact?: HookEntry[];
+
+    /**
+     * Fires before navigating in the session tree. Can cancel.
+     * Exit 2 → cancel navigation (stderr shown as reason).
+     */
+    SessionBeforeTree?: HookEntry[];
+
+    /**
+     * Fires when a model is selected (observability).
+     * Exit code is ignored.
+     */
+    ModelSelect?: HookEntry[];
 }
 
 export interface PizzaPiConfig {
@@ -73,14 +141,39 @@ function readJsonSafe(path: string): Partial<PizzaPiConfig> {
     }
 }
 
-/** Deep-merge hooks: concatenate matcher arrays from both sources. */
+/** Deep-merge hooks: concatenate arrays from both sources for every hook type. */
 export function mergeHooks(a?: HooksConfig, b?: HooksConfig): HooksConfig | undefined {
     if (!a && !b) return undefined;
     const merged: HooksConfig = {};
+
+    // Matcher-based hooks (PreToolUse / PostToolUse)
     const pre = [...(a?.PreToolUse ?? []), ...(b?.PreToolUse ?? [])];
     const post = [...(a?.PostToolUse ?? []), ...(b?.PostToolUse ?? [])];
     if (pre.length > 0) merged.PreToolUse = pre;
     if (post.length > 0) merged.PostToolUse = post;
+
+    // Entry-based hooks — concatenate arrays from both sources
+    const entryKeys: (keyof HooksConfig)[] = [
+        "Input",
+        "BeforeAgentStart",
+        "UserBash",
+        "SessionBeforeSwitch",
+        "SessionBeforeFork",
+        "SessionShutdown",
+        "SessionBeforeCompact",
+        "SessionBeforeTree",
+        "ModelSelect",
+    ];
+    for (const key of entryKeys) {
+        const combined = [
+            ...((a?.[key] as HookEntry[] | undefined) ?? []),
+            ...((b?.[key] as HookEntry[] | undefined) ?? []),
+        ];
+        if (combined.length > 0) {
+            (merged as any)[key] = combined;
+        }
+    }
+
     return Object.keys(merged).length > 0 ? merged : undefined;
 }
 

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import type { HooksConfig } from "../config.js";
+import { buildPizzaPiExtensionFactories } from "./factories.js";
+import { mcpExtension } from "./mcp-extension.js";
+import { remoteExtension } from "./remote.js";
+import { restartExtension } from "./restart.js";
+import { sessionMessagingExtension } from "./session-messaging.js";
+import { setSessionNameExtension } from "./set-session-name.js";
+import { spawnSessionExtension } from "./spawn-session.js";
+import { updateTodoExtension } from "./update-todo.js";
+import { initialPromptExtension } from "./initial-prompt.js";
+
+const CORE_EXTENSIONS: ExtensionFactory[] = [
+    remoteExtension,
+    mcpExtension,
+    restartExtension,
+    setSessionNameExtension,
+    updateTodoExtension,
+    spawnSessionExtension,
+    sessionMessagingExtension,
+];
+
+describe("buildPizzaPiExtensionFactories", () => {
+    test("returns core extensions by default", () => {
+        const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test" });
+        expect(factories).toEqual(CORE_EXTENSIONS);
+    });
+
+    test("includes initial prompt extension for worker mode", () => {
+        const factories = buildPizzaPiExtensionFactories({
+            cwd: "/tmp/pizzapi-test",
+            includeInitialPrompt: true,
+        });
+
+        expect(factories).toEqual([...CORE_EXTENSIONS, initialPromptExtension]);
+    });
+
+    test("appends hooks extension when hooks are configured", () => {
+        const hooks: HooksConfig = {
+            PreToolUse: [{ matcher: "Bash", hooks: [{ command: "echo hook" }] }],
+        };
+
+        const factories = buildPizzaPiExtensionFactories({
+            cwd: "/tmp/pizzapi-test",
+            hooks,
+        });
+
+        expect(factories).toHaveLength(CORE_EXTENSIONS.length + 1);
+        expect(factories.slice(0, CORE_EXTENSIONS.length)).toEqual(CORE_EXTENSIONS);
+        expect(typeof factories[CORE_EXTENSIONS.length]).toBe("function");
+    });
+
+    test("worker mode includes initial prompt before hooks", () => {
+        const hooks: HooksConfig = {
+            PostToolUse: [{ matcher: "Edit|Write", hooks: [{ command: "echo post-hook" }] }],
+        };
+
+        const factories = buildPizzaPiExtensionFactories({
+            cwd: "/tmp/pizzapi-test",
+            hooks,
+            includeInitialPrompt: true,
+        });
+
+        expect(factories).toHaveLength(CORE_EXTENSIONS.length + 2);
+        expect(factories.slice(0, CORE_EXTENSIONS.length)).toEqual(CORE_EXTENSIONS);
+        expect(factories[CORE_EXTENSIONS.length]).toBe(initialPromptExtension);
+        expect(typeof factories[CORE_EXTENSIONS.length + 1]).toBe("function");
+    });
+});

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -1,0 +1,45 @@
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import type { HooksConfig } from "../config.js";
+import { createHooksExtension } from "./hooks.js";
+import { initialPromptExtension } from "./initial-prompt.js";
+import { mcpExtension } from "./mcp-extension.js";
+import { remoteExtension } from "./remote.js";
+import { restartExtension } from "./restart.js";
+import { sessionMessagingExtension } from "./session-messaging.js";
+import { setSessionNameExtension } from "./set-session-name.js";
+import { spawnSessionExtension } from "./spawn-session.js";
+import { updateTodoExtension } from "./update-todo.js";
+
+export interface BuildExtensionFactoriesOptions {
+    cwd: string;
+    hooks?: HooksConfig;
+    includeInitialPrompt?: boolean;
+}
+
+/**
+ * Build the standard PizzaPi extension factory list.
+ *
+ * Shared by interactive CLI and runner worker mode so capabilities stay in sync.
+ */
+export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesOptions): ExtensionFactory[] {
+    const factories: ExtensionFactory[] = [
+        remoteExtension,
+        mcpExtension,
+        restartExtension,
+        setSessionNameExtension,
+        updateTodoExtension,
+        spawnSessionExtension,
+        sessionMessagingExtension,
+    ];
+
+    if (options.includeInitialPrompt) {
+        factories.push(initialPromptExtension);
+    }
+
+    const hooksExtension = createHooksExtension(options.hooks, options.cwd);
+    if (hooksExtension) {
+        factories.push(hooksExtension);
+    }
+
+    return factories;
+}

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -1,7 +1,7 @@
 import { describe, test, expect } from "bun:test";
-import { matchesTool, runHook, parseHookOutput, normalizeToolInput } from "./hooks.js";
+import { matchesTool, runHook, parseHookOutput, normalizeToolInput, runEventHooks, runFireAndForgetHooks } from "./hooks.js";
 import { mergeHooks, isProjectHooksTrusted } from "../config.js";
-import type { HooksConfig } from "../config.js";
+import type { HooksConfig, HookEntry } from "../config.js";
 import { join } from "path";
 
 // ---------------------------------------------------------------------------
@@ -928,5 +928,543 @@ describe("real hook scripts", () => {
         expect(result.exitCode).toBe(0);
         const output = parseHookOutput(result.stdout);
         expect(output?.additionalContext).toContain("build order");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parseHookOutput — new fields (Input, BeforeAgentStart)
+// ---------------------------------------------------------------------------
+
+describe("parseHookOutput — new fields", () => {
+    test("parses Input hook text transform", () => {
+        const result = parseHookOutput(JSON.stringify({
+            text: "bun install express",
+        }));
+        expect(result?.text).toBe("bun install express");
+    });
+
+    test("parses Input hook action: handled", () => {
+        const result = parseHookOutput(JSON.stringify({
+            action: "handled",
+        }));
+        expect(result?.action).toBe("handled");
+    });
+
+    test("parses Input hook action: transform with text", () => {
+        const result = parseHookOutput(JSON.stringify({
+            action: "transform",
+            text: "rewritten text",
+        }));
+        expect(result?.action).toBe("transform");
+        expect(result?.text).toBe("rewritten text");
+    });
+
+    test("parses BeforeAgentStart systemPrompt", () => {
+        const result = parseHookOutput(JSON.stringify({
+            systemPrompt: "You are a helpful assistant focused on testing.",
+        }));
+        expect(result?.systemPrompt).toBe("You are a helpful assistant focused on testing.");
+    });
+
+    test("parses combined BeforeAgentStart context and systemPrompt", () => {
+        const result = parseHookOutput(JSON.stringify({
+            additionalContext: "Remember to use bun",
+            systemPrompt: "Custom system prompt",
+        }));
+        expect(result?.additionalContext).toBe("Remember to use bun");
+        expect(result?.systemPrompt).toBe("Custom system prompt");
+    });
+
+    test("parses nested hookSpecificOutput with new fields", () => {
+        const result = parseHookOutput(JSON.stringify({
+            hookSpecificOutput: {
+                text: "transformed text",
+                action: "transform",
+            },
+        }));
+        expect(result?.text).toBe("transformed text");
+        expect(result?.action).toBe("transform");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// runEventHooks
+// ---------------------------------------------------------------------------
+
+describe("runEventHooks", () => {
+    test("returns blocked=false when hook exits 0 with no output", async () => {
+        const hooks: HookEntry[] = [{ command: "true" }];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "Test");
+        expect(result.blocked).toBe(false);
+        expect(result.outputs).toHaveLength(0);
+    });
+
+    test("returns blocked=true when hook exits 2", async () => {
+        const hooks: HookEntry[] = [{ command: 'echo "BLOCKED: test reason" >&2; exit 2' }];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "Test");
+        expect(result.blocked).toBe(true);
+        expect(result.reason).toContain("BLOCKED: test reason");
+    });
+
+    test("returns blocked=true when hook exits non-zero (not 2)", async () => {
+        const hooks: HookEntry[] = [{ command: "exit 1" }];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "Test");
+        expect(result.blocked).toBe(true);
+        expect(result.reason).toContain("exited with code 1");
+    });
+
+    test("returns blocked=true when hook times out", async () => {
+        const hooks: HookEntry[] = [{ command: "sleep 10", timeout: 200 }];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "Test");
+        expect(result.blocked).toBe(true);
+        expect(result.reason).toContain("timed out");
+    });
+
+    test("collects JSON outputs from successful hooks", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo \'{"additionalContext":"ctx1"}\'' },
+            { command: 'echo \'{"additionalContext":"ctx2"}\'' },
+        ];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "Test");
+        expect(result.blocked).toBe(false);
+        expect(result.outputs).toHaveLength(2);
+        expect(result.outputs[0].additionalContext).toBe("ctx1");
+        expect(result.outputs[1].additionalContext).toBe("ctx2");
+    });
+
+    test("stops at first blocking hook, preserving earlier outputs", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo \'{"additionalContext":"before block"}\'' },
+            { command: "exit 2" },
+            { command: 'echo \'{"additionalContext":"should not run"}\'' },
+        ];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "Test");
+        expect(result.blocked).toBe(true);
+        expect(result.outputs).toHaveLength(1);
+        expect(result.outputs[0].additionalContext).toBe("before block");
+    });
+
+    test("passes payload to hooks on stdin", async () => {
+        const hooks: HookEntry[] = [
+            { command: "cat | jq -r '.event'" },
+        ];
+        const payload = JSON.stringify({ event: "Test", data: "hello" });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "Test");
+        expect(result.blocked).toBe(false);
+        // The hook ran jq on the input and printed "Test" to stdout
+        // which is not valid JSON, so outputs will be empty
+        expect(result.outputs).toHaveLength(0);
+    });
+
+    test("collects text transform output from Input hook", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo \'{"text":"bun install express","action":"transform"}\'' },
+        ];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "Input");
+        expect(result.blocked).toBe(false);
+        expect(result.outputs).toHaveLength(1);
+        expect(result.outputs[0].text).toBe("bun install express");
+        expect(result.outputs[0].action).toBe("transform");
+    });
+
+    test("collects systemPrompt from BeforeAgentStart hook", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo \'{"systemPrompt":"Custom prompt","additionalContext":"Remember X"}\'' },
+        ];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "BeforeAgentStart");
+        expect(result.blocked).toBe(false);
+        expect(result.outputs[0].systemPrompt).toBe("Custom prompt");
+        expect(result.outputs[0].additionalContext).toBe("Remember X");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// runFireAndForgetHooks
+// ---------------------------------------------------------------------------
+
+describe("runFireAndForgetHooks", () => {
+    test("runs hooks without blocking on errors", async () => {
+        const hooks: HookEntry[] = [
+            { command: "exit 1" },
+            { command: "true" },
+        ];
+        // Should not throw
+        await runFireAndForgetHooks(hooks, "{}", process.cwd(), "Test");
+    });
+
+    test("runs hooks without blocking on timeouts", async () => {
+        const hooks: HookEntry[] = [
+            { command: "sleep 10", timeout: 200 },
+        ];
+        const start = Date.now();
+        await runFireAndForgetHooks(hooks, "{}", process.cwd(), "Test");
+        const elapsed = Date.now() - start;
+        // Should finish relatively quickly (timeout + some overhead)
+        expect(elapsed).toBeLessThan(2000);
+    });
+
+    test("runs all hooks even if some fail", async () => {
+        // We can't easily observe that hooks ran, but we can verify no exceptions
+        const hooks: HookEntry[] = [
+            { command: "exit 1" },
+            { command: "exit 2" },
+            { command: "true" },
+        ];
+        await runFireAndForgetHooks(hooks, "{}", process.cwd(), "Test");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// mergeHooks — new event hook types
+// ---------------------------------------------------------------------------
+
+describe("mergeHooks — event hooks", () => {
+    test("merges Input hooks from both sources", () => {
+        const a: HooksConfig = {
+            Input: [{ command: "a.sh" }],
+        };
+        const b: HooksConfig = {
+            Input: [{ command: "b.sh" }],
+        };
+        const result = mergeHooks(a, b);
+        expect(result?.Input).toHaveLength(2);
+        expect(result?.Input?.[0].command).toBe("a.sh");
+        expect(result?.Input?.[1].command).toBe("b.sh");
+    });
+
+    test("merges BeforeAgentStart hooks", () => {
+        const a: HooksConfig = {
+            BeforeAgentStart: [{ command: "a.sh" }],
+        };
+        const b: HooksConfig = {};
+        const result = mergeHooks(a, b);
+        expect(result?.BeforeAgentStart).toHaveLength(1);
+    });
+
+    test("merges UserBash hooks", () => {
+        const a: HooksConfig = {};
+        const b: HooksConfig = {
+            UserBash: [{ command: "guard.sh" }],
+        };
+        const result = mergeHooks(a, b);
+        expect(result?.UserBash).toHaveLength(1);
+    });
+
+    test("merges SessionBeforeSwitch hooks", () => {
+        const a: HooksConfig = { SessionBeforeSwitch: [{ command: "a.sh" }] };
+        const b: HooksConfig = { SessionBeforeSwitch: [{ command: "b.sh" }] };
+        const result = mergeHooks(a, b);
+        expect(result?.SessionBeforeSwitch).toHaveLength(2);
+    });
+
+    test("merges SessionBeforeFork hooks", () => {
+        const a: HooksConfig = { SessionBeforeFork: [{ command: "check.sh" }] };
+        const result = mergeHooks(a, undefined);
+        expect(result?.SessionBeforeFork).toHaveLength(1);
+    });
+
+    test("merges SessionShutdown hooks", () => {
+        const a: HooksConfig = { SessionShutdown: [{ command: "cleanup.sh" }] };
+        const b: HooksConfig = { SessionShutdown: [{ command: "save.sh" }] };
+        const result = mergeHooks(a, b);
+        expect(result?.SessionShutdown).toHaveLength(2);
+    });
+
+    test("merges ModelSelect hooks", () => {
+        const result = mergeHooks(
+            { ModelSelect: [{ command: "log.sh" }] },
+            { ModelSelect: [{ command: "notify.sh" }] },
+        );
+        expect(result?.ModelSelect).toHaveLength(2);
+    });
+
+    test("merges SessionBeforeCompact hooks", () => {
+        const result = mergeHooks(
+            { SessionBeforeCompact: [{ command: "check.sh" }] },
+            undefined,
+        );
+        expect(result?.SessionBeforeCompact).toHaveLength(1);
+    });
+
+    test("merges SessionBeforeTree hooks", () => {
+        const result = mergeHooks(
+            undefined,
+            { SessionBeforeTree: [{ command: "guard.sh" }] },
+        );
+        expect(result?.SessionBeforeTree).toHaveLength(1);
+    });
+
+    test("merges mixed PreToolUse and event hooks", () => {
+        const a: HooksConfig = {
+            PreToolUse: [{ matcher: "Bash", hooks: [{ command: "pre.sh" }] }],
+            Input: [{ command: "input.sh" }],
+            SessionShutdown: [{ command: "shutdown.sh" }],
+        };
+        const b: HooksConfig = {
+            PostToolUse: [{ matcher: ".*", hooks: [{ command: "post.sh" }] }],
+            UserBash: [{ command: "bash-guard.sh" }],
+        };
+        const result = mergeHooks(a, b);
+        expect(result?.PreToolUse).toHaveLength(1);
+        expect(result?.PostToolUse).toHaveLength(1);
+        expect(result?.Input).toHaveLength(1);
+        expect(result?.SessionShutdown).toHaveLength(1);
+        expect(result?.UserBash).toHaveLength(1);
+    });
+
+    test("skips empty arrays in result", () => {
+        const a: HooksConfig = { Input: [] };
+        const b: HooksConfig = { Input: [] };
+        const result = mergeHooks(a, b);
+        // Empty arrays should not be included
+        expect(result).toBeUndefined();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: Input hook scripts
+// ---------------------------------------------------------------------------
+
+describe("event hook integration — Input", () => {
+    test("Input hook can rewrite text", async () => {
+        const hooks: HookEntry[] = [
+            // Read the input text and rewrite npm → bun
+            { command: `bash -c 'INPUT=$(cat | jq -r ".text"); echo "{\\\"text\\\": \\\"$(echo $INPUT | sed s/npm/bun/g)\\\"}"'` },
+        ];
+        const payload = JSON.stringify({ event: "Input", text: "npm install express", source: "interactive" });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "Input");
+        expect(result.blocked).toBe(false);
+        expect(result.outputs).toHaveLength(1);
+        expect(result.outputs[0].text).toBe("bun install express");
+    });
+
+    test("Input hook can block with exit 2", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo "Policy violation: forbidden input" >&2; exit 2' },
+        ];
+        const payload = JSON.stringify({ event: "Input", text: "do something bad", source: "interactive" });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "Input");
+        expect(result.blocked).toBe(true);
+        expect(result.reason).toContain("Policy violation");
+    });
+
+    test("Input hook can mark as handled", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo \'{"action":"handled"}\'' },
+        ];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "Input");
+        expect(result.blocked).toBe(false);
+        expect(result.outputs[0].action).toBe("handled");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: UserBash hook scripts
+// ---------------------------------------------------------------------------
+
+describe("event hook integration — UserBash", () => {
+    test("UserBash hook can read command from payload", async () => {
+        const hooks: HookEntry[] = [
+            // Check if command contains "rm -rf" and block
+            { command: `bash -c 'CMD=$(cat | jq -r ".command"); if echo "$CMD" | grep -q "rm -rf"; then echo "Dangerous!" >&2; exit 2; fi'` },
+        ];
+        const payload = JSON.stringify({
+            event: "UserBash",
+            command: "rm -rf /",
+            exclude_from_context: false,
+            cwd: "/tmp",
+            tool_input: { command: "rm -rf /" },
+        });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "UserBash");
+        expect(result.blocked).toBe(true);
+        expect(result.reason).toContain("Dangerous");
+    });
+
+    test("UserBash hook allows safe commands", async () => {
+        const hooks: HookEntry[] = [
+            { command: `bash -c 'CMD=$(cat | jq -r ".command"); if echo "$CMD" | grep -q "rm -rf"; then echo "Dangerous!" >&2; exit 2; fi'` },
+        ];
+        const payload = JSON.stringify({
+            event: "UserBash",
+            command: "ls -la",
+            exclude_from_context: false,
+            cwd: "/tmp",
+        });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "UserBash");
+        expect(result.blocked).toBe(false);
+    });
+
+    test("UserBash hook receives tool_input for PreToolUse script compat", async () => {
+        const hooks: HookEntry[] = [
+            // Use tool_input.command (same key as PreToolUse:Bash hooks)
+            { command: `bash -c 'cat | jq -r ".tool_input.command"'` },
+        ];
+        const payload = JSON.stringify({
+            event: "UserBash",
+            command: "echo hello",
+            tool_input: { command: "echo hello" },
+        });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "UserBash");
+        expect(result.blocked).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: SessionBeforeSwitch / SessionBeforeFork
+// ---------------------------------------------------------------------------
+
+describe("event hook integration — SessionBeforeSwitch", () => {
+    test("can block a session switch", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo "Uncommitted changes — commit first" >&2; exit 2' },
+        ];
+        const payload = JSON.stringify({
+            event: "SessionBeforeSwitch",
+            reason: "resume",
+            target_session_file: "/path/to/session.json",
+        });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "SessionBeforeSwitch");
+        expect(result.blocked).toBe(true);
+        expect(result.reason).toContain("Uncommitted changes");
+    });
+
+    test("allows session switch when hook exits 0", async () => {
+        const hooks: HookEntry[] = [{ command: "true" }];
+        const payload = JSON.stringify({
+            event: "SessionBeforeSwitch",
+            reason: "new",
+        });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "SessionBeforeSwitch");
+        expect(result.blocked).toBe(false);
+    });
+});
+
+describe("event hook integration — SessionBeforeFork", () => {
+    test("can block a session fork", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo "Dirty working tree" >&2; exit 2' },
+        ];
+        const payload = JSON.stringify({
+            event: "SessionBeforeFork",
+            entry_id: "abc-123",
+        });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "SessionBeforeFork");
+        expect(result.blocked).toBe(true);
+        expect(result.reason).toContain("Dirty working tree");
+    });
+
+    test("allows fork when hook exits 0", async () => {
+        const hooks: HookEntry[] = [{ command: "true" }];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "SessionBeforeFork");
+        expect(result.blocked).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: SessionShutdown
+// ---------------------------------------------------------------------------
+
+describe("event hook integration — SessionShutdown", () => {
+    test("runs shutdown hooks without throwing", async () => {
+        const hooks: HookEntry[] = [
+            { command: "echo cleanup" },
+            { command: "exit 1" }, // errors are swallowed
+        ];
+        const payload = JSON.stringify({ event: "SessionShutdown" });
+        // Should not throw
+        await runFireAndForgetHooks(hooks, payload, process.cwd(), "SessionShutdown");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: BeforeAgentStart
+// ---------------------------------------------------------------------------
+
+describe("event hook integration — BeforeAgentStart", () => {
+    test("can inject additionalContext", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo \'{"additionalContext":"Remember: always use bun, never npm"}\'' },
+        ];
+        const payload = JSON.stringify({
+            event: "BeforeAgentStart",
+            prompt: "install express",
+            system_prompt: "You are a helpful assistant.",
+        });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "BeforeAgentStart");
+        expect(result.blocked).toBe(false);
+        expect(result.outputs[0].additionalContext).toBe("Remember: always use bun, never npm");
+    });
+
+    test("can override systemPrompt", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo \'{"systemPrompt":"You are a strict code reviewer."}\'' },
+        ];
+        const payload = JSON.stringify({
+            event: "BeforeAgentStart",
+            prompt: "review my code",
+            system_prompt: "You are a helpful assistant.",
+        });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "BeforeAgentStart");
+        expect(result.blocked).toBe(false);
+        expect(result.outputs[0].systemPrompt).toBe("You are a strict code reviewer.");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Integration: SessionBeforeCompact / SessionBeforeTree / ModelSelect
+// ---------------------------------------------------------------------------
+
+describe("event hook integration — second wave", () => {
+    test("SessionBeforeCompact can cancel compaction", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo "Important context — do not compact" >&2; exit 2' },
+        ];
+        const payload = JSON.stringify({
+            event: "SessionBeforeCompact",
+            custom_instructions: "summarize",
+        });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "SessionBeforeCompact");
+        expect(result.blocked).toBe(true);
+        expect(result.reason).toContain("Important context");
+    });
+
+    test("SessionBeforeCompact allows when hook exits 0", async () => {
+        const hooks: HookEntry[] = [{ command: "true" }];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "SessionBeforeCompact");
+        expect(result.blocked).toBe(false);
+    });
+
+    test("SessionBeforeTree can cancel navigation", async () => {
+        const hooks: HookEntry[] = [
+            { command: 'echo "Unsaved work on current branch" >&2; exit 2' },
+        ];
+        const payload = JSON.stringify({
+            event: "SessionBeforeTree",
+            target_id: "node-123",
+            old_leaf_id: "node-456",
+        });
+        const result = await runEventHooks(hooks, payload, process.cwd(), "SessionBeforeTree");
+        expect(result.blocked).toBe(true);
+        expect(result.reason).toContain("Unsaved work");
+    });
+
+    test("SessionBeforeTree allows when hook exits 0", async () => {
+        const hooks: HookEntry[] = [{ command: "true" }];
+        const result = await runEventHooks(hooks, "{}", process.cwd(), "SessionBeforeTree");
+        expect(result.blocked).toBe(false);
+    });
+
+    test("ModelSelect runs as fire-and-forget", async () => {
+        const hooks: HookEntry[] = [
+            // Even with exit 1, should not throw
+            { command: "exit 1" },
+        ];
+        const payload = JSON.stringify({
+            event: "ModelSelect",
+            model: { provider: "anthropic", id: "claude-sonnet-4-20250514", name: "Claude 4 Sonnet" },
+            previous_model: null,
+            source: "set",
+        });
+        await runFireAndForgetHooks(hooks, payload, process.cwd(), "ModelSelect");
     });
 });

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -44,6 +44,28 @@ describe("matchesTool", () => {
         expect(matchesTool("mcp__.*", "mcp__github__search")).toBe(true);
         expect(matchesTool("mcp__.*", "bash")).toBe(false);
     });
+
+    test("preserves regex alternation inside parentheses", () => {
+        // Grouped alternation should not be split — the entire pattern is one regex
+        expect(matchesTool("mcp__(github|filesystem)__.*", "mcp__github__search")).toBe(true);
+        expect(matchesTool("mcp__(github|filesystem)__.*", "mcp__filesystem__read")).toBe(true);
+        expect(matchesTool("mcp__(github|filesystem)__.*", "mcp__slack__post")).toBe(false);
+    });
+
+    test("handles nested parentheses in regex", () => {
+        expect(matchesTool("mcp__((gh|git)hub|filesystem)__.*", "mcp__github__search")).toBe(true);
+        expect(matchesTool("mcp__((gh|git)hub|filesystem)__.*", "mcp__github__search")).toBe(true);
+        expect(matchesTool("mcp__((gh|git)hub|filesystem)__.*", "mcp__filesystem__read")).toBe(true);
+        expect(matchesTool("mcp__((gh|git)hub|filesystem)__.*", "mcp__slack__post")).toBe(false);
+    });
+
+    test("top-level | still works alongside grouped alternation", () => {
+        // "bash|mcp__(github|filesystem)__.*" has a top-level | between "bash" and the regex
+        expect(matchesTool("bash|mcp__(github|filesystem)__.*", "bash")).toBe(true);
+        expect(matchesTool("bash|mcp__(github|filesystem)__.*", "mcp__github__search")).toBe(true);
+        expect(matchesTool("bash|mcp__(github|filesystem)__.*", "mcp__filesystem__read")).toBe(true);
+        expect(matchesTool("bash|mcp__(github|filesystem)__.*", "edit")).toBe(false);
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -356,6 +378,97 @@ describe("real hook scripts", () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
             JSON.stringify({ tool_input: { command: "git push --no-verify origin main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm -r -f / (split flags)", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -r -f /" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+        expect(result.stderr).toContain("Recursive delete");
+    });
+
+    test("block-dangerous-commands.sh blocks rm -f -r / (split flags, reversed)", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -f -r /" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm --recursive --force /", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm --recursive --force /" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm --recursive -f /", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm --recursive -f /" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm -r --force ~", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -r --force ~" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm -rf ..", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -rf .." } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh allows rm -rf on safe paths", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -rf ./dist" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+    });
+
+    test("block-dangerous-commands.sh blocks rm -r .git", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -r .git" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+        expect(result.stderr).toContain(".git");
+    });
+
+    test("block-dangerous-commands.sh blocks rm --recursive .git/", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm --recursive .git/" } }),
             projectDir,
         );
         expect(result.exitCode).toBe(2);

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -1,0 +1,325 @@
+import { describe, test, expect } from "bun:test";
+import { matchesTool, runHook, parseHookOutput } from "./hooks.js";
+import { join } from "path";
+
+const FIXTURES_DIR = join(import.meta.dir, "__fixtures__", "hooks");
+
+describe("matchesTool", () => {
+    test("matches exact tool name (case-insensitive)", () => {
+        expect(matchesTool("Bash", "bash")).toBe(true);
+        expect(matchesTool("bash", "bash")).toBe(true);
+        expect(matchesTool("Bash", "Bash")).toBe(true);
+    });
+
+    test("matches display name", () => {
+        expect(matchesTool("Bash", "bash")).toBe(true);
+        expect(matchesTool("Edit", "edit")).toBe(true);
+        expect(matchesTool("Write", "write")).toBe(true);
+        expect(matchesTool("Read", "read")).toBe(true);
+    });
+
+    test("supports | alternation", () => {
+        expect(matchesTool("Edit|Write", "edit")).toBe(true);
+        expect(matchesTool("Edit|Write", "write")).toBe(true);
+        expect(matchesTool("Edit|Write", "bash")).toBe(false);
+    });
+
+    test("supports .* wildcard", () => {
+        expect(matchesTool(".*", "bash")).toBe(true);
+        expect(matchesTool(".*", "edit")).toBe(true);
+        expect(matchesTool(".*", "anything")).toBe(true);
+    });
+
+    test("does not match unrelated tools", () => {
+        expect(matchesTool("Bash", "edit")).toBe(false);
+        expect(matchesTool("Edit", "bash")).toBe(false);
+        expect(matchesTool("Read", "write")).toBe(false);
+    });
+
+    test("handles regex patterns", () => {
+        expect(matchesTool("mcp__.*", "mcp__github__search")).toBe(true);
+        expect(matchesTool("mcp__.*", "bash")).toBe(false);
+    });
+});
+
+describe("parseHookOutput", () => {
+    test("returns null for empty string", () => {
+        expect(parseHookOutput("")).toBeNull();
+    });
+
+    test("returns null for invalid JSON", () => {
+        expect(parseHookOutput("not json")).toBeNull();
+    });
+
+    test("parses flat format", () => {
+        const result = parseHookOutput(JSON.stringify({
+            additionalContext: "Did you mean bun?",
+        }));
+        expect(result).toEqual({
+            additionalContext: "Did you mean bun?",
+            permissionDecision: undefined,
+            decision: undefined,
+        });
+    });
+
+    test("parses nested hookSpecificOutput format (Claude Code compat)", () => {
+        const result = parseHookOutput(JSON.stringify({
+            hookSpecificOutput: {
+                hookEventName: "PreToolUse",
+                permissionDecision: "allow",
+                additionalContext: "Are you using bun?",
+            },
+        }));
+        expect(result).toEqual({
+            additionalContext: "Are you using bun?",
+            permissionDecision: "allow",
+            decision: undefined,
+        });
+    });
+
+    test("parses deny decision", () => {
+        const result = parseHookOutput(JSON.stringify({
+            hookSpecificOutput: {
+                hookEventName: "PreToolUse",
+                permissionDecision: "deny",
+                additionalContext: "Blocked for safety",
+            },
+        }));
+        expect(result?.permissionDecision).toBe("deny");
+        expect(result?.additionalContext).toBe("Blocked for safety");
+    });
+
+    test("parses PostToolUse with block decision", () => {
+        const result = parseHookOutput(JSON.stringify({
+            hookSpecificOutput: {
+                hookEventName: "PostToolUse",
+                additionalContext: "Check the error",
+            },
+            decision: "block",
+        }));
+        expect(result?.decision).toBe("block");
+        expect(result?.additionalContext).toBe("Check the error");
+    });
+});
+
+describe("runHook", () => {
+    test("runs a simple echo hook and captures stdout", async () => {
+        const result = await runHook(
+            { command: 'echo \'{"additionalContext":"hello"}\'' },
+            "{}",
+            process.cwd(),
+        );
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toContain("additionalContext");
+    });
+
+    test("captures exit code 2 for blocking hooks", async () => {
+        const result = await runHook(
+            { command: 'echo "BLOCKED: test" >&2; exit 2' },
+            "{}",
+            process.cwd(),
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED: test");
+    });
+
+    test("passes stdin payload to the hook", async () => {
+        const result = await runHook(
+            { command: "cat | jq -r '.tool_input.command'" },
+            JSON.stringify({ tool_input: { command: "npm install" } }),
+            process.cwd(),
+        );
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toBe("npm install");
+    });
+
+    test("sets PIZZAPI_PROJECT_DIR environment variable", async () => {
+        const result = await runHook(
+            { command: "echo $PIZZAPI_PROJECT_DIR" },
+            "{}",
+            "/tmp",
+        );
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toBe("/tmp");
+    });
+
+    test("handles hook timeout gracefully", async () => {
+        const start = Date.now();
+        const result = await runHook(
+            { command: "sleep 10", timeout: 500 },
+            "{}",
+            process.cwd(),
+        );
+        const elapsed = Date.now() - start;
+        // Should finish well before 10s — timeout killed the process
+        expect(elapsed).toBeLessThan(5000);
+        // stdout should be empty (no output from sleep)
+        expect(result.stdout).toBe("");
+    });
+
+    test("handles missing command gracefully", async () => {
+        const result = await runHook(
+            { command: "nonexistent_command_12345" },
+            "{}",
+            process.cwd(),
+        );
+        expect(result.exitCode).not.toBe(0);
+    });
+});
+
+describe("real hook scripts", () => {
+    const projectDir = join(import.meta.dir, "../../../..");
+
+    test("block-dangerous-commands.sh blocks force push to main", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push --force origin main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+        expect(result.stderr).toContain("Force push");
+    });
+
+    test("block-dangerous-commands.sh allows normal git push", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push origin feature-branch" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+    });
+
+    test("block-dangerous-commands.sh blocks --no-verify", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git commit --no-verify -m 'test'" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("lights-on-bun.sh warns about npm usage", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-bun.sh"` },
+            JSON.stringify({ tool_input: { command: "npm install express" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+        const output = parseHookOutput(result.stdout);
+        expect(output?.additionalContext).toContain("Bun exclusively");
+    });
+
+    test("lights-on-bun.sh allows bun commands", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-bun.sh"` },
+            JSON.stringify({ tool_input: { command: "bun install express" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toBe("");
+    });
+
+    test("lights-on-bun.sh allows npx playwright", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-bun.sh"` },
+            JSON.stringify({ tool_input: { command: "npx @playwright/mcp@latest" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toBe("");
+    });
+
+    test("lights-on-no-node-modules.sh blocks edits to node_modules", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-no-node-modules.sh"` },
+            JSON.stringify({ tool_input: { file_path: "node_modules/foo/index.js" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+        expect(result.stderr).toContain("patches/");
+    });
+
+    test("lights-on-no-node-modules.sh allows edits to src files", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-no-node-modules.sh"` },
+            JSON.stringify({ tool_input: { file_path: "packages/server/src/index.ts" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+    });
+
+    test("lights-on-tests-post.sh asks about tests for source files", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-tests-post.sh"` },
+            JSON.stringify({ tool_input: { file_path: "packages/server/src/auth.ts" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+        const output = parseHookOutput(result.stdout);
+        expect(output?.additionalContext).toContain("test");
+    });
+
+    test("lights-on-tests-post.sh skips test files", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-tests-post.sh"` },
+            JSON.stringify({ tool_input: { file_path: "packages/server/src/auth.test.ts" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toBe("");
+    });
+
+    test("lights-on-tests-post.sh skips non-code files", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-tests-post.sh"` },
+            JSON.stringify({ tool_input: { file_path: "README.md" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toBe("");
+    });
+
+    test("lights-on-bash-post.sh warns on command failure", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-bash-post.sh"` },
+            JSON.stringify({
+                tool_input: { command: "cat missing-file.txt" },
+                tool_response: "error: No such file or directory",
+            }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+        const output = parseHookOutput(result.stdout);
+        expect(output?.additionalContext).toContain("failed");
+    });
+
+    test("lights-on-bash-post.sh skips test command failures", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-bash-post.sh"` },
+            JSON.stringify({
+                tool_input: { command: "bun test packages/server" },
+                tool_response: "error: 2 tests failed",
+            }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+        expect(result.stdout).toBe("");
+    });
+
+    test("lights-on-bash-post.sh warns about build order on build failure", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-bash-post.sh"` },
+            JSON.stringify({
+                tool_input: { command: "bun run build:server" },
+                tool_response: "error: Cannot find module '../tools/dist/index.js'",
+            }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+        const output = parseHookOutput(result.stdout);
+        expect(output?.additionalContext).toContain("build order");
+    });
+});

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -1,8 +1,12 @@
 import { describe, test, expect } from "bun:test";
-import { matchesTool, runHook, parseHookOutput } from "./hooks.js";
+import { matchesTool, runHook, parseHookOutput, normalizeToolInput } from "./hooks.js";
+import { mergeHooks, isProjectHooksTrusted } from "../config.js";
+import type { HooksConfig } from "../config.js";
 import { join } from "path";
 
-const FIXTURES_DIR = join(import.meta.dir, "__fixtures__", "hooks");
+// ---------------------------------------------------------------------------
+// matchesTool
+// ---------------------------------------------------------------------------
 
 describe("matchesTool", () => {
     test("matches exact tool name (case-insensitive)", () => {
@@ -41,6 +45,41 @@ describe("matchesTool", () => {
         expect(matchesTool("mcp__.*", "bash")).toBe(false);
     });
 });
+
+// ---------------------------------------------------------------------------
+// normalizeToolInput
+// ---------------------------------------------------------------------------
+
+describe("normalizeToolInput", () => {
+    test("adds file_path alias when path is present", () => {
+        const result = normalizeToolInput("write", { path: "/foo/bar.ts", content: "hi" });
+        expect(result.path).toBe("/foo/bar.ts");
+        expect(result.file_path).toBe("/foo/bar.ts");
+        expect(result.content).toBe("hi");
+    });
+
+    test("adds path alias when file_path is present", () => {
+        const result = normalizeToolInput("write", { file_path: "/foo/bar.ts" });
+        expect(result.path).toBe("/foo/bar.ts");
+        expect(result.file_path).toBe("/foo/bar.ts");
+    });
+
+    test("does not overwrite if both keys exist", () => {
+        const result = normalizeToolInput("write", { path: "/a.ts", file_path: "/b.ts" });
+        expect(result.path).toBe("/a.ts");
+        expect(result.file_path).toBe("/b.ts");
+    });
+
+    test("passes through non-file tools unchanged", () => {
+        const input = { command: "ls -la" };
+        const result = normalizeToolInput("bash", input);
+        expect(result).toEqual(input);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// parseHookOutput
+// ---------------------------------------------------------------------------
 
 describe("parseHookOutput", () => {
     test("returns null for empty string", () => {
@@ -102,6 +141,10 @@ describe("parseHookOutput", () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// runHook
+// ---------------------------------------------------------------------------
+
 describe("runHook", () => {
     test("runs a simple echo hook and captures stdout", async () => {
         const result = await runHook(
@@ -111,6 +154,7 @@ describe("runHook", () => {
         );
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toContain("additionalContext");
+        expect(result.killed).toBe(false);
     });
 
     test("captures exit code 2 for blocking hooks", async () => {
@@ -121,6 +165,7 @@ describe("runHook", () => {
         );
         expect(result.exitCode).toBe(2);
         expect(result.stderr).toContain("BLOCKED: test");
+        expect(result.killed).toBe(false);
     });
 
     test("passes stdin payload to the hook", async () => {
@@ -143,7 +188,7 @@ describe("runHook", () => {
         expect(result.stdout).toBe("/tmp");
     });
 
-    test("handles hook timeout gracefully", async () => {
+    test("marks killed processes with killed=true and non-zero exit", async () => {
         const start = Date.now();
         const result = await runHook(
             { command: "sleep 10", timeout: 500 },
@@ -153,8 +198,8 @@ describe("runHook", () => {
         const elapsed = Date.now() - start;
         // Should finish well before 10s — timeout killed the process
         expect(elapsed).toBeLessThan(5000);
-        // stdout should be empty (no output from sleep)
-        expect(result.stdout).toBe("");
+        expect(result.killed).toBe(true);
+        expect(result.exitCode).not.toBe(0);
     });
 
     test("handles missing command gracefully", async () => {
@@ -167,8 +212,85 @@ describe("runHook", () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// mergeHooks
+// ---------------------------------------------------------------------------
+
+describe("mergeHooks", () => {
+    test("returns undefined when both are undefined", () => {
+        expect(mergeHooks(undefined, undefined)).toBeUndefined();
+    });
+
+    test("returns first when second is undefined", () => {
+        const a: HooksConfig = { PreToolUse: [{ matcher: "Bash", hooks: [{ command: "a.sh" }] }] };
+        expect(mergeHooks(a, undefined)).toEqual(a);
+    });
+
+    test("returns second when first is undefined", () => {
+        const b: HooksConfig = { PostToolUse: [{ matcher: "Edit", hooks: [{ command: "b.sh" }] }] };
+        expect(mergeHooks(undefined, b)).toEqual(b);
+    });
+
+    test("concatenates PreToolUse and PostToolUse arrays", () => {
+        const a: HooksConfig = {
+            PreToolUse: [{ matcher: "Bash", hooks: [{ command: "a.sh" }] }],
+            PostToolUse: [{ matcher: "Bash", hooks: [{ command: "c.sh" }] }],
+        };
+        const b: HooksConfig = {
+            PreToolUse: [{ matcher: "Edit", hooks: [{ command: "b.sh" }] }],
+            PostToolUse: [{ matcher: "Edit", hooks: [{ command: "d.sh" }] }],
+        };
+        const result = mergeHooks(a, b);
+        expect(result?.PreToolUse).toHaveLength(2);
+        expect(result?.PostToolUse).toHaveLength(2);
+        expect(result?.PreToolUse?.[0].matcher).toBe("Bash");
+        expect(result?.PreToolUse?.[1].matcher).toBe("Edit");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// isProjectHooksTrusted
+// ---------------------------------------------------------------------------
+
+describe("isProjectHooksTrusted", () => {
+    const origEnv = process.env.PIZZAPI_ALLOW_PROJECT_HOOKS;
+
+    test("returns false when global config has no allowProjectHooks", () => {
+        delete process.env.PIZZAPI_ALLOW_PROJECT_HOOKS;
+        expect(isProjectHooksTrusted({})).toBe(false);
+    });
+
+    test("returns true when global config has allowProjectHooks: true", () => {
+        delete process.env.PIZZAPI_ALLOW_PROJECT_HOOKS;
+        expect(isProjectHooksTrusted({ allowProjectHooks: true })).toBe(true);
+    });
+
+    test("returns false when global config has allowProjectHooks: false", () => {
+        delete process.env.PIZZAPI_ALLOW_PROJECT_HOOKS;
+        expect(isProjectHooksTrusted({ allowProjectHooks: false })).toBe(false);
+    });
+
+    test("returns true when PIZZAPI_ALLOW_PROJECT_HOOKS=1 env is set", () => {
+        process.env.PIZZAPI_ALLOW_PROJECT_HOOKS = "1";
+        expect(isProjectHooksTrusted({})).toBe(true);
+    });
+
+    // Restore env
+    test("cleanup", () => {
+        if (origEnv !== undefined) process.env.PIZZAPI_ALLOW_PROJECT_HOOKS = origEnv;
+        else delete process.env.PIZZAPI_ALLOW_PROJECT_HOOKS;
+        expect(true).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Real hook scripts — integration tests
+// ---------------------------------------------------------------------------
+
 describe("real hook scripts", () => {
     const projectDir = join(import.meta.dir, "../../../..");
+
+    // -- block-dangerous-commands.sh --
 
     test("block-dangerous-commands.sh blocks force push to main", async () => {
         const result = await runHook(
@@ -181,6 +303,26 @@ describe("real hook scripts", () => {
         expect(result.stderr).toContain("Force push");
     });
 
+    test("block-dangerous-commands.sh blocks -f push to main", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push -f origin main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks --force-with-lease to main", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push --force-with-lease origin main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
     test("block-dangerous-commands.sh allows normal git push", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
@@ -190,7 +332,7 @@ describe("real hook scripts", () => {
         expect(result.exitCode).toBe(0);
     });
 
-    test("block-dangerous-commands.sh blocks --no-verify", async () => {
+    test("block-dangerous-commands.sh blocks --no-verify on commit", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
             JSON.stringify({ tool_input: { command: "git commit --no-verify -m 'test'" } }),
@@ -199,6 +341,18 @@ describe("real hook scripts", () => {
         expect(result.exitCode).toBe(2);
         expect(result.stderr).toContain("BLOCKED");
     });
+
+    test("block-dangerous-commands.sh blocks --no-verify on push", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push --no-verify origin main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    // -- lights-on-bun.sh --
 
     test("lights-on-bun.sh warns about npm usage", async () => {
         const result = await runHook(
@@ -231,7 +385,9 @@ describe("real hook scripts", () => {
         expect(result.stdout).toBe("");
     });
 
-    test("lights-on-no-node-modules.sh blocks edits to node_modules", async () => {
+    // -- lights-on-no-node-modules.sh (with both path keys) --
+
+    test("lights-on-no-node-modules.sh blocks edits using file_path key", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-no-node-modules.sh"` },
             JSON.stringify({ tool_input: { file_path: "node_modules/foo/index.js" } }),
@@ -242,16 +398,39 @@ describe("real hook scripts", () => {
         expect(result.stderr).toContain("patches/");
     });
 
+    test("lights-on-no-node-modules.sh blocks edits using path key (pi format)", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-no-node-modules.sh"` },
+            JSON.stringify({ tool_input: { path: "node_modules/foo/index.js" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
     test("lights-on-no-node-modules.sh allows edits to src files", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-no-node-modules.sh"` },
-            JSON.stringify({ tool_input: { file_path: "packages/server/src/index.ts" } }),
+            JSON.stringify({ tool_input: { path: "packages/server/src/index.ts" } }),
             projectDir,
         );
         expect(result.exitCode).toBe(0);
     });
 
-    test("lights-on-tests-post.sh asks about tests for source files", async () => {
+    // -- lights-on-tests-post.sh (with both path keys) --
+
+    test("lights-on-tests-post.sh asks about tests for source files (path key)", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-tests-post.sh"` },
+            JSON.stringify({ tool_input: { path: "packages/server/src/auth.ts" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+        const output = parseHookOutput(result.stdout);
+        expect(output?.additionalContext).toContain("test");
+    });
+
+    test("lights-on-tests-post.sh asks about tests for source files (file_path key)", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-tests-post.sh"` },
             JSON.stringify({ tool_input: { file_path: "packages/server/src/auth.ts" } }),
@@ -265,7 +444,7 @@ describe("real hook scripts", () => {
     test("lights-on-tests-post.sh skips test files", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-tests-post.sh"` },
-            JSON.stringify({ tool_input: { file_path: "packages/server/src/auth.test.ts" } }),
+            JSON.stringify({ tool_input: { path: "packages/server/src/auth.test.ts" } }),
             projectDir,
         );
         expect(result.exitCode).toBe(0);
@@ -275,12 +454,14 @@ describe("real hook scripts", () => {
     test("lights-on-tests-post.sh skips non-code files", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/lights-on-tests-post.sh"` },
-            JSON.stringify({ tool_input: { file_path: "README.md" } }),
+            JSON.stringify({ tool_input: { path: "README.md" } }),
             projectDir,
         );
         expect(result.exitCode).toBe(0);
         expect(result.stdout).toBe("");
     });
+
+    // -- lights-on-bash-post.sh --
 
     test("lights-on-bash-post.sh warns on command failure", async () => {
         const result = await runHook(

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -375,6 +375,35 @@ describe("real hook scripts", () => {
         expect(result.stderr).toContain("BLOCKED");
     });
 
+    test("block-dangerous-commands.sh blocks +main refspec force push", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push origin +main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks +HEAD:main refspec force push", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push origin +HEAD:main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh allows +main:feature refspec force push", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push origin +main:feature-branch" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
+    });
+
     test("block-dangerous-commands.sh allows normal git push", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -395,6 +395,66 @@ describe("real hook scripts", () => {
         expect(result.stderr).toContain("BLOCKED");
     });
 
+    test("block-dangerous-commands.sh blocks quoted git executable force push", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: '"/usr/bin/git" push --force origin main' } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks single-quoted git executable force push", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "'/usr/bin/git' push --force origin main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks git -C force push", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git -C ./repo push --force origin main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks sudo git force push", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "sudo git push --force origin main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks command git force push", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "command git push --force origin main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks force push when branch is quoted", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: 'git push --force origin "main"' } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
     test("block-dangerous-commands.sh allows +main:feature refspec force push", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
@@ -413,6 +473,36 @@ describe("real hook scripts", () => {
         expect(result.exitCode).toBe(0);
     });
 
+    test("block-dangerous-commands.sh blocks deleting main with --delete", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push origin --delete main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks deleting main with :main refspec", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push origin :main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks deleting refs/heads/main with :refspec", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push origin :refs/heads/main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
     test("block-dangerous-commands.sh blocks --no-verify on commit", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
@@ -427,6 +517,26 @@ describe("real hook scripts", () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
             JSON.stringify({ tool_input: { command: "git push --no-verify origin main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks git -C push --no-verify", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git -C ./repo push --no-verify origin feature" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks command git commit --no-verify", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "command git commit --no-verify -m test" } }),
             projectDir,
         );
         expect(result.exitCode).toBe(2);
@@ -576,10 +686,60 @@ describe("real hook scripts", () => {
         expect(result.stderr).toContain("BLOCKED");
     });
 
+    test("block-dangerous-commands.sh blocks sudo /bin/rm -rf /", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "sudo /bin/rm -rf /" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
     test("block-dangerous-commands.sh blocks /bin/rm -r .git", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
             JSON.stringify({ tool_input: { command: "/bin/rm -r .git" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks quoted /bin/rm executable", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: '"/bin/rm" -rf /' } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks single-quoted /bin/rm executable", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "'/bin/rm' -rf /" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm -rf /*", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -rf /*" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm -rf $HOME/*", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -rf $HOME/*" } }),
             projectDir,
         );
         expect(result.exitCode).toBe(2);

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -355,6 +355,26 @@ describe("real hook scripts", () => {
         expect(result.stderr).toContain("BLOCKED");
     });
 
+    test("block-dangerous-commands.sh blocks force push to HEAD:refs/heads/main", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push --force origin HEAD:refs/heads/main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks force push to refs/heads/main", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push -f origin refs/heads/main" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
     test("block-dangerous-commands.sh allows normal git push", async () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
@@ -439,6 +459,36 @@ describe("real hook scripts", () => {
         const result = await runHook(
             { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
             JSON.stringify({ tool_input: { command: "rm -rf .." } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm -rf ../", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -rf ../" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm -rf ../../", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -rf ../../" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm -rf ./../", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -rf ./../" } }),
             projectDir,
         );
         expect(result.exitCode).toBe(2);

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { matchesTool, runHook, parseHookOutput, normalizeToolInput, runEventHooks, runFireAndForgetHooks } from "./hooks.js";
+import { matchesTool, runHook, parseHookOutput, normalizeToolInput, runEventHooks, runFireAndForgetHooks, resolveShell, _resetShellCache } from "./hooks.js";
 import { mergeHooks, isProjectHooksTrusted } from "../config.js";
 import type { HooksConfig, HookEntry } from "../config.js";
 import { join } from "path";
@@ -65,6 +65,43 @@ describe("matchesTool", () => {
         expect(matchesTool("bash|mcp__(github|filesystem)__.*", "mcp__github__search")).toBe(true);
         expect(matchesTool("bash|mcp__(github|filesystem)__.*", "mcp__filesystem__read")).toBe(true);
         expect(matchesTool("bash|mcp__(github|filesystem)__.*", "edit")).toBe(false);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// resolveShell
+// ---------------------------------------------------------------------------
+
+describe("resolveShell", () => {
+    test("returns /bin/sh -c on non-Windows", () => {
+        if (process.platform !== "win32") {
+            _resetShellCache();
+            const { shell, flag } = resolveShell();
+            expect(shell).toBe("/bin/sh");
+            expect(flag).toBe("-c");
+        }
+    });
+
+    test("shell and flag are non-empty strings", () => {
+        _resetShellCache();
+        const { shell, flag } = resolveShell();
+        expect(typeof shell).toBe("string");
+        expect(shell.length).toBeGreaterThan(0);
+        expect(typeof flag).toBe("string");
+        expect(flag.length).toBeGreaterThan(0);
+    });
+
+    test("result is cached across calls", () => {
+        _resetShellCache();
+        const first = resolveShell();
+        const second = resolveShell();
+        expect(first).toBe(second); // same object reference
+    });
+
+    test("flag is always -c (bash-compatible)", () => {
+        _resetShellCache();
+        const { flag } = resolveShell();
+        expect(flag).toBe("-c");
     });
 });
 
@@ -453,6 +490,92 @@ describe("real hook scripts", () => {
         );
         expect(result.exitCode).toBe(2);
         expect(result.stderr).toContain("BLOCKED");
+    });
+
+    // -- Implicit refspec force push (no branch on CLI → uses current branch) --
+
+    test("block-dangerous-commands.sh blocks force push with no refspec when on main", async () => {
+        // `git push --force origin` with no branch — pushes current branch.
+        // When current branch is main/master, this must be blocked.
+        // This test only works in a git repo where HEAD points to main/master
+        // or we need to simulate. We test the script directly by checking
+        // the current branch first.
+        const branchResult = await runHook(
+            { command: "git symbolic-ref --short HEAD 2>/dev/null || echo unknown" },
+            "{}",
+            projectDir,
+        );
+        const currentBranch = branchResult.stdout.trim();
+
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push --force origin" } }),
+            projectDir,
+        );
+
+        if (currentBranch === "main" || currentBranch === "master") {
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("BLOCKED");
+            expect(result.stderr).toContain("Force push");
+        } else {
+            // On a feature branch, implicit refspec is allowed
+            expect(result.exitCode).toBe(0);
+        }
+    });
+
+    test("block-dangerous-commands.sh blocks force push with no args when on main", async () => {
+        // `git push --force` — no remote, no refspec
+        const branchResult = await runHook(
+            { command: "git symbolic-ref --short HEAD 2>/dev/null || echo unknown" },
+            "{}",
+            projectDir,
+        );
+        const currentBranch = branchResult.stdout.trim();
+
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push --force" } }),
+            projectDir,
+        );
+
+        if (currentBranch === "main" || currentBranch === "master") {
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("BLOCKED");
+        } else {
+            expect(result.exitCode).toBe(0);
+        }
+    });
+
+    test("block-dangerous-commands.sh blocks -f push with no refspec when on main", async () => {
+        const branchResult = await runHook(
+            { command: "git symbolic-ref --short HEAD 2>/dev/null || echo unknown" },
+            "{}",
+            projectDir,
+        );
+        const currentBranch = branchResult.stdout.trim();
+
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push -f origin" } }),
+            projectDir,
+        );
+
+        if (currentBranch === "main" || currentBranch === "master") {
+            expect(result.exitCode).toBe(2);
+            expect(result.stderr).toContain("BLOCKED");
+        } else {
+            expect(result.exitCode).toBe(0);
+        }
+    });
+
+    test("block-dangerous-commands.sh allows force push to explicit feature branch", async () => {
+        // `git push --force origin feature-branch` — explicit non-protected refspec
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "git push --force origin feature-branch" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(0);
     });
 
     test("block-dangerous-commands.sh allows +main:feature refspec force push", async () => {

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -475,6 +475,70 @@ describe("real hook scripts", () => {
         expect(result.stderr).toContain("BLOCKED");
     });
 
+    // Absolute-path rm binaries (codex review: catch /bin/rm, /usr/bin/rm)
+
+    test("block-dangerous-commands.sh blocks /bin/rm -rf /", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "/bin/rm -rf /" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks /usr/bin/rm -rf /", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "/usr/bin/rm -rf /" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks /bin/rm -r .git", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "/bin/rm -r .git" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    // Quoted targets (codex review: rm -rf "/" should still be caught)
+
+    test('block-dangerous-commands.sh blocks rm -rf "/"', async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: 'rm -rf "/"' } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test("block-dangerous-commands.sh blocks rm -rf '~'", async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: "rm -rf '~'" } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
+    test('block-dangerous-commands.sh blocks /bin/rm -rf "/"', async () => {
+        const result = await runHook(
+            { command: `bash "${projectDir}/.pizzapi/hooks/block-dangerous-commands.sh"` },
+            JSON.stringify({ tool_input: { command: '/bin/rm -rf "/"' } }),
+            projectDir,
+        );
+        expect(result.exitCode).toBe(2);
+        expect(result.stderr).toContain("BLOCKED");
+    });
+
     // -- lights-on-bun.sh --
 
     test("lights-on-bun.sh warns about npm usage", async () => {

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -202,6 +202,16 @@ describe("runHook", () => {
         expect(result.exitCode).not.toBe(0);
     });
 
+    test("detects kill even when child traps SIGTERM and exits 0", async () => {
+        // Child traps SIGTERM and exits 0 — proc.killed should still catch it
+        const result = await runHook(
+            { command: 'trap "exit 0" TERM; sleep 10', timeout: 500 },
+            "{}",
+            process.cwd(),
+        );
+        expect(result.killed).toBe(true);
+    });
+
     test("handles missing command gracefully", async () => {
         const result = await runHook(
             { command: "nonexistent_command_12345" },

--- a/packages/cli/src/extensions/hooks.ts
+++ b/packages/cli/src/extensions/hooks.ts
@@ -56,11 +56,39 @@ function toolDisplayName(toolName: string): string {
     }
 }
 
+/**
+ * Split a matcher string on top-level `|` only — `|` inside parentheses is
+ * left intact so regex groups like `mcp__(github|filesystem)__.*` survive.
+ */
+function splitTopLevelAlternation(matcher: string): string[] {
+    const parts: string[] = [];
+    let depth = 0;
+    let current = "";
+    for (const ch of matcher) {
+        if (ch === "(") {
+            depth++;
+            current += ch;
+        } else if (ch === ")") {
+            depth = Math.max(0, depth - 1);
+            current += ch;
+        } else if (ch === "|" && depth === 0) {
+            parts.push(current);
+            current = "";
+        } else {
+            current += ch;
+        }
+    }
+    parts.push(current);
+    return parts.map((p) => p.trim());
+}
+
 /** Check if a tool name matches a hook matcher pattern (supports `|` alternation). */
 export function matchesTool(matcher: string, toolName: string): boolean {
     const displayName = toolDisplayName(toolName);
-    // Support | alternation: "Edit|Write" matches either
-    const patterns = matcher.split("|").map((p) => p.trim());
+    // Support | alternation: "Edit|Write" matches either.
+    // Uses paren-aware splitting so grouped alternation like
+    // `mcp__(github|filesystem)__.*` is preserved as a single regex.
+    const patterns = splitTopLevelAlternation(matcher);
     for (const pattern of patterns) {
         if (pattern === ".*") return true;
         // Case-insensitive match against both raw name and display name

--- a/packages/cli/src/extensions/hooks.ts
+++ b/packages/cli/src/extensions/hooks.ts
@@ -107,7 +107,8 @@ export function normalizeToolInput(toolName: string, input: Record<string, unkno
 export function runHook(entry: HookEntry, payload: string, cwd: string): Promise<HookResult> {
     const timeout = entry.timeout ?? 10_000;
     return new Promise((resolve) => {
-        let killed = false;
+        let timedOut = false;
+        let settled = false;
 
         const proc = spawn("bash", ["-c", entry.command], {
             cwd,
@@ -116,7 +117,6 @@ export function runHook(entry: HookEntry, payload: string, cwd: string): Promise
                 ...process.env,
                 PIZZAPI_PROJECT_DIR: cwd,
             },
-            timeout,
         });
 
         let stdout = "";
@@ -129,19 +129,34 @@ export function runHook(entry: HookEntry, payload: string, cwd: string): Promise
             stderr += chunk.toString();
         });
 
+        // Manual timeout with SIGKILL — can't be trapped by the child.
+        const timer = setTimeout(() => {
+            timedOut = true;
+            proc.kill("SIGKILL");
+        }, timeout);
+
         // Send the JSON payload on stdin
         proc.stdin.write(payload);
         proc.stdin.end();
 
-        proc.on("close", (code, signal) => {
-            // If the process was killed by a signal (timeout, etc.), treat as
-            // non-zero exit. This prevents fail-open on hung hooks.
-            if (signal) killed = true;
-            const exitCode = code ?? (signal ? 124 : 0);
+        const finish = (code: number | null, signal: string | null) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            const killed = timedOut || !!signal || proc.killed;
+            const exitCode = killed ? (code ?? 124) : (code ?? 0);
             resolve({ exitCode, stdout: stdout.trim(), stderr: stderr.trim(), killed });
-        });
+        };
+
+        // Listen to both `exit` and `close` — in Bun, `close` may not fire
+        // after SIGKILL, but `exit` does. First one wins via `settled` guard.
+        proc.on("exit", (code, signal) => finish(code, signal));
+        proc.on("close", (code, signal) => finish(code, signal));
 
         proc.on("error", (err) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
             resolve({ exitCode: 1, stdout: "", stderr: err.message, killed: false });
         });
     });
@@ -208,6 +223,11 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
     const hasPostHooks = (hooksConfig.PostToolUse?.length ?? 0) > 0;
     if (!hasPreHooks && !hasPostHooks) return null;
 
+    // Advisory context from PreToolUse hooks is stashed here per tool-call-id
+    // and injected into the tool_result so the agent sees it in the same turn
+    // without blocking the tool from executing.
+    const preToolContext = new Map<string, string[]>();
+
     const factory: ExtensionFactory = (pi) => {
         // PreToolUse: fire before tool executes, can block or inject context
         if (hasPreHooks) {
@@ -222,12 +242,12 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                         tool_input: normalizedInput,
                     });
 
-                    const contextParts: string[] = [];
+                    const advisoryParts: string[] = [];
 
                     for (const hook of hooks) {
                         const result = await runHook(hook, payload, cwd);
 
-                        // Signal kill (timeout) → fail-closed for safety
+                        // Killed (timeout / signal) → fail-closed for safety
                         if (result.killed) {
                             return { block: true, reason: "Hook timed out — blocking for safety. Check .pizzapi/hooks/ configuration." };
                         }
@@ -245,7 +265,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                                 return { block: true, reason: output.additionalContext || "Denied by hook" };
                             }
                             if (output?.additionalContext) {
-                                contextParts.push(output.additionalContext);
+                                advisoryParts.push(output.additionalContext);
                             }
                         }
 
@@ -255,11 +275,11 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                         }
                     }
 
-                    // Inject PreToolUse context by blocking with reason — this gives
-                    // the agent the context immediately and forces a re-plan, rather
-                    // than delaying to the next turn where it's too late.
-                    if (contextParts.length > 0) {
-                        return { block: true, reason: `[Hook advisory] ${contextParts.join(" | ")}` };
+                    // Stash advisory context — it will be appended to the
+                    // tool_result so the agent sees it in the same turn without
+                    // blocking the tool from executing.
+                    if (advisoryParts.length > 0) {
+                        preToolContext.set(event.toolCallId, advisoryParts);
                     }
                 } catch (err) {
                     // Defensive: never let hook errors crash the tool pipeline
@@ -269,44 +289,54 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
             });
         }
 
-        // PostToolUse: fire after tool executes, can inject context into result
-        if (hasPostHooks) {
+        // PostToolUse + PreToolUse advisory: fire after tool executes, inject context.
+        // This handler always runs (not gated on hasPostHooks) because it also
+        // drains advisory context stashed by PreToolUse hooks.
+        {
             pi.on("tool_result", async (event) => {
                 try {
-                    const hooks = getMatchingHooks(hooksConfig.PostToolUse, event.toolName);
-                    if (hooks.length === 0) return;
-
-                    const normalizedInput = normalizeToolInput(event.toolName, event.input as Record<string, unknown>);
-
-                    // Build the tool response text from content array
-                    const responseText = event.content
-                        ?.map((c: any) => (c.type === "text" ? c.text : ""))
-                        .filter(Boolean)
-                        .join("\n");
-
-                    const payload = JSON.stringify({
-                        tool_name: event.toolName,
-                        tool_input: normalizedInput,
-                        tool_response: responseText ?? "",
-                    });
-
                     const contextParts: string[] = [];
 
-                    for (const hook of hooks) {
-                        const result = await runHook(hook, payload, cwd);
+                    // Drain any advisory context stashed by PreToolUse hooks
+                    const preAdvice = preToolContext.get(event.toolCallId);
+                    if (preAdvice) {
+                        contextParts.push(...preAdvice);
+                        preToolContext.delete(event.toolCallId);
+                    }
 
-                        // Only process successful hooks — killed/errored PostToolUse
-                        // hooks are silently ignored (tool already ran, can't undo)
-                        if (result.exitCode === 0 && result.stdout) {
-                            const output = parseHookOutput(result.stdout);
-                            if (output?.additionalContext) {
-                                contextParts.push(output.additionalContext);
+                    // Run PostToolUse hooks
+                    const hooks = getMatchingHooks(hooksConfig.PostToolUse, event.toolName);
+                    if (hooks.length > 0) {
+                        const normalizedInput = normalizeToolInput(event.toolName, event.input as Record<string, unknown>);
+
+                        // Build the tool response text from content array
+                        const responseText = event.content
+                            ?.map((c: any) => (c.type === "text" ? c.text : ""))
+                            .filter(Boolean)
+                            .join("\n");
+
+                        const payload = JSON.stringify({
+                            tool_name: event.toolName,
+                            tool_input: normalizedInput,
+                            tool_response: responseText ?? "",
+                        });
+
+                        for (const hook of hooks) {
+                            const result = await runHook(hook, payload, cwd);
+
+                            // Only process successful hooks — killed/errored PostToolUse
+                            // hooks are silently ignored (tool already ran, can't undo)
+                            if (result.exitCode === 0 && result.stdout) {
+                                const output = parseHookOutput(result.stdout);
+                                if (output?.additionalContext) {
+                                    contextParts.push(output.additionalContext);
+                                }
                             }
                         }
                     }
 
-                    // Append all hook context to the tool result so the agent sees
-                    // it immediately in the same turn.
+                    // Append all hook context (PreToolUse advisory + PostToolUse)
+                    // to the tool result so the agent sees it in the same turn.
                     if (contextParts.length > 0) {
                         const hookNotice = contextParts.join("\n\n");
                         const existingContent = event.content ?? [];

--- a/packages/cli/src/extensions/hooks.ts
+++ b/packages/cli/src/extensions/hooks.ts
@@ -2,20 +2,26 @@ import { spawn } from "child_process";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import type { HooksConfig, HookMatcher, HookEntry } from "../config.js";
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
 /**
  * Result of running a hook script. Mirrors the Claude Code hook JSON protocol:
  * - Exit 0 + JSON with additionalContext → inject context (soft nudge)
  * - Exit 2 + stderr → hard-block the tool call
  * - Exit 0 with no output → allow silently
  */
-interface HookResult {
+export interface HookResult {
     exitCode: number;
     stdout: string;
     stderr: string;
+    /** True when the process was killed by a signal (e.g. timeout). */
+    killed: boolean;
 }
 
 /** Parsed output from a hook that returned JSON on stdout. */
-interface HookOutput {
+export interface HookOutput {
     /** Text to inject into the agent's context window. */
     additionalContext?: string;
     /** For PreToolUse: "allow" | "deny" | "ask". Default: "allow". */
@@ -24,7 +30,11 @@ interface HookOutput {
     decision?: "block";
 }
 
-/** Map tool names from pi to hook-friendly names. */
+// ---------------------------------------------------------------------------
+// Tool name helpers
+// ---------------------------------------------------------------------------
+
+/** Map tool names from pi to hook-friendly display names. */
 function toolDisplayName(toolName: string): string {
     switch (toolName) {
         case "bash":
@@ -67,10 +77,38 @@ export function matchesTool(matcher: string, toolName: string): boolean {
     return false;
 }
 
+// ---------------------------------------------------------------------------
+// Payload normalization — bridge pi tool input → hook script expectations
+// ---------------------------------------------------------------------------
+
+/**
+ * Normalize tool input for hook scripts. Pi tools use `path` for file paths,
+ * but the hook protocol (matching Claude Code) expects `file_path`. We include
+ * both so scripts work regardless of which key they check.
+ */
+export function normalizeToolInput(toolName: string, input: Record<string, unknown>): Record<string, unknown> {
+    const normalized = { ...input };
+    // If the tool has `path` but not `file_path`, add the alias
+    if ("path" in normalized && !("file_path" in normalized)) {
+        normalized.file_path = normalized.path;
+    }
+    // Reverse alias too: if script sends file_path, also set path
+    if ("file_path" in normalized && !("path" in normalized)) {
+        normalized.path = normalized.file_path;
+    }
+    return normalized;
+}
+
+// ---------------------------------------------------------------------------
+// Hook runner
+// ---------------------------------------------------------------------------
+
 /** Run a single hook script, piping JSON payload on stdin. */
 export function runHook(entry: HookEntry, payload: string, cwd: string): Promise<HookResult> {
     const timeout = entry.timeout ?? 10_000;
     return new Promise((resolve) => {
+        let killed = false;
+
         const proc = spawn("bash", ["-c", entry.command], {
             cwd,
             stdio: ["pipe", "pipe", "pipe"],
@@ -95,15 +133,23 @@ export function runHook(entry: HookEntry, payload: string, cwd: string): Promise
         proc.stdin.write(payload);
         proc.stdin.end();
 
-        proc.on("close", (code) => {
-            resolve({ exitCode: code ?? 0, stdout: stdout.trim(), stderr: stderr.trim() });
+        proc.on("close", (code, signal) => {
+            // If the process was killed by a signal (timeout, etc.), treat as
+            // non-zero exit. This prevents fail-open on hung hooks.
+            if (signal) killed = true;
+            const exitCode = code ?? (signal ? 124 : 0);
+            resolve({ exitCode, stdout: stdout.trim(), stderr: stderr.trim(), killed });
         });
 
         proc.on("error", (err) => {
-            resolve({ exitCode: 1, stdout: "", stderr: err.message });
+            resolve({ exitCode: 1, stdout: "", stderr: err.message, killed: false });
         });
     });
 }
+
+// ---------------------------------------------------------------------------
+// Output parsing
+// ---------------------------------------------------------------------------
 
 /** Parse the JSON output from a hook script, extracting additionalContext etc. */
 export function parseHookOutput(stdout: string): HookOutput | null {
@@ -122,6 +168,10 @@ export function parseHookOutput(stdout: string): HookOutput | null {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
 /** Collect all matching hook entries for a given event type and tool name. */
 function getMatchingHooks(matchers: HookMatcher[] | undefined, toolName: string): HookEntry[] {
     if (!matchers) return [];
@@ -134,6 +184,10 @@ function getMatchingHooks(matchers: HookMatcher[] | undefined, toolName: string)
     return entries;
 }
 
+// ---------------------------------------------------------------------------
+// Extension factory
+// ---------------------------------------------------------------------------
+
 /**
  * Hooks extension — runs shell scripts at tool lifecycle points.
  *
@@ -142,6 +196,11 @@ function getMatchingHooks(matchers: HookMatcher[] | undefined, toolName: string)
  *   - Exit 0 + JSON { additionalContext: "..." } → injects context into agent
  *   - Exit 2 + stderr message → hard-blocks the tool call (PreToolUse only)
  *   - Exit 0 with no output → allows silently
+ *   - Signal kill (timeout) → treated as non-zero exit (fail-closed for safety)
+ *
+ * Security: Project-local hooks (from .pizzapi/config.json) require
+ * `allowProjectHooks: true` in the global ~/.pizzapi/config.json or the
+ * PIZZAPI_ALLOW_PROJECT_HOOKS=1 env var. Global hooks always run.
  */
 export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: string): ExtensionFactory | null {
     if (!hooksConfig) return null;
@@ -149,101 +208,119 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
     const hasPostHooks = (hooksConfig.PostToolUse?.length ?? 0) > 0;
     if (!hasPreHooks && !hasPostHooks) return null;
 
-    // Store context messages to inject on the next before_agent_start
-    const pendingContext: string[] = [];
-
     const factory: ExtensionFactory = (pi) => {
-        // Inject accumulated hook context before each agent turn
-        pi.on("before_agent_start", (event) => {
-            if (pendingContext.length === 0) return;
-            const combined = pendingContext.splice(0).join("\n\n");
-            return {
-                message: {
-                    customType: "hook-context",
-                    content: combined,
-                    display: false,
-                },
-            };
-        });
-
-        // PreToolUse: fire before tool executes, can block
+        // PreToolUse: fire before tool executes, can block or inject context
         if (hasPreHooks) {
             pi.on("tool_call", async (event) => {
-                const hooks = getMatchingHooks(hooksConfig.PreToolUse, event.toolName);
-                if (hooks.length === 0) return;
+                try {
+                    const hooks = getMatchingHooks(hooksConfig.PreToolUse, event.toolName);
+                    if (hooks.length === 0) return;
 
-                const payload = JSON.stringify({
-                    tool_name: event.toolName,
-                    tool_input: event.input,
-                });
+                    const normalizedInput = normalizeToolInput(event.toolName, event.input as Record<string, unknown>);
+                    const payload = JSON.stringify({
+                        tool_name: event.toolName,
+                        tool_input: normalizedInput,
+                    });
 
-                for (const hook of hooks) {
-                    const result = await runHook(hook, payload, cwd);
+                    const contextParts: string[] = [];
 
-                    // Exit 2 = hard block
-                    if (result.exitCode === 2) {
-                        const reason = result.stderr || "Blocked by hook";
-                        return { block: true, reason };
+                    for (const hook of hooks) {
+                        const result = await runHook(hook, payload, cwd);
+
+                        // Signal kill (timeout) → fail-closed for safety
+                        if (result.killed) {
+                            return { block: true, reason: "Hook timed out — blocking for safety. Check .pizzapi/hooks/ configuration." };
+                        }
+
+                        // Exit 2 = hard block
+                        if (result.exitCode === 2) {
+                            const reason = result.stderr || "Blocked by hook";
+                            return { block: true, reason };
+                        }
+
+                        // Exit 0 with JSON output = inspect for decisions/context
+                        if (result.exitCode === 0 && result.stdout) {
+                            const output = parseHookOutput(result.stdout);
+                            if (output?.permissionDecision === "deny") {
+                                return { block: true, reason: output.additionalContext || "Denied by hook" };
+                            }
+                            if (output?.additionalContext) {
+                                contextParts.push(output.additionalContext);
+                            }
+                        }
+
+                        // Non-zero exit (other than 2) → fail-closed
+                        if (result.exitCode !== 0) {
+                            return { block: true, reason: result.stderr || `Hook exited with code ${result.exitCode}` };
+                        }
                     }
 
-                    // Exit 0 with JSON output = inject context
-                    if (result.exitCode === 0 && result.stdout) {
-                        const output = parseHookOutput(result.stdout);
-                        if (output?.permissionDecision === "deny") {
-                            return { block: true, reason: output.additionalContext || "Denied by hook" };
-                        }
-                        if (output?.additionalContext) {
-                            pendingContext.push(output.additionalContext);
-                        }
+                    // Inject PreToolUse context by blocking with reason — this gives
+                    // the agent the context immediately and forces a re-plan, rather
+                    // than delaying to the next turn where it's too late.
+                    if (contextParts.length > 0) {
+                        return { block: true, reason: `[Hook advisory] ${contextParts.join(" | ")}` };
                     }
+                } catch (err) {
+                    // Defensive: never let hook errors crash the tool pipeline
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] PreToolUse handler error: ${msg}`);
                 }
             });
         }
 
-        // PostToolUse: fire after tool executes, can inject context
+        // PostToolUse: fire after tool executes, can inject context into result
         if (hasPostHooks) {
             pi.on("tool_result", async (event) => {
-                const hooks = getMatchingHooks(hooksConfig.PostToolUse, event.toolName);
-                if (hooks.length === 0) return;
+                try {
+                    const hooks = getMatchingHooks(hooksConfig.PostToolUse, event.toolName);
+                    if (hooks.length === 0) return;
 
-                // Build the tool response text from content array
-                const responseText = event.content
-                    ?.map((c: any) => (c.type === "text" ? c.text : ""))
-                    .filter(Boolean)
-                    .join("\n");
+                    const normalizedInput = normalizeToolInput(event.toolName, event.input as Record<string, unknown>);
 
-                const payload = JSON.stringify({
-                    tool_name: event.toolName,
-                    tool_input: event.input,
-                    tool_response: responseText ?? "",
-                });
+                    // Build the tool response text from content array
+                    const responseText = event.content
+                        ?.map((c: any) => (c.type === "text" ? c.text : ""))
+                        .filter(Boolean)
+                        .join("\n");
 
-                const contextParts: string[] = [];
+                    const payload = JSON.stringify({
+                        tool_name: event.toolName,
+                        tool_input: normalizedInput,
+                        tool_response: responseText ?? "",
+                    });
 
-                for (const hook of hooks) {
-                    const result = await runHook(hook, payload, cwd);
+                    const contextParts: string[] = [];
 
-                    if (result.exitCode === 0 && result.stdout) {
-                        const output = parseHookOutput(result.stdout);
-                        if (output?.additionalContext) {
-                            contextParts.push(output.additionalContext);
+                    for (const hook of hooks) {
+                        const result = await runHook(hook, payload, cwd);
+
+                        // Only process successful hooks — killed/errored PostToolUse
+                        // hooks are silently ignored (tool already ran, can't undo)
+                        if (result.exitCode === 0 && result.stdout) {
+                            const output = parseHookOutput(result.stdout);
+                            if (output?.additionalContext) {
+                                contextParts.push(output.additionalContext);
+                            }
                         }
                     }
-                    // PostToolUse hooks can't block (tool already ran), but we
-                    // could append error info from stderr if needed.
-                }
 
-                // Append all hook context to the tool result so the agent sees it
-                // immediately, not on the next turn.
-                if (contextParts.length > 0) {
-                    const hookNotice = contextParts.join("\n\n");
-                    const existingContent = event.content ?? [];
-                    return {
-                        content: [
-                            ...existingContent,
-                            { type: "text" as const, text: `\n\n[Hook] ${hookNotice}` },
-                        ],
-                    };
+                    // Append all hook context to the tool result so the agent sees
+                    // it immediately in the same turn.
+                    if (contextParts.length > 0) {
+                        const hookNotice = contextParts.join("\n\n");
+                        const existingContent = event.content ?? [];
+                        return {
+                            content: [
+                                ...existingContent,
+                                { type: "text" as const, text: `\n\n[Hook] ${hookNotice}` },
+                            ],
+                        };
+                    }
+                } catch (err) {
+                    // Defensive: never let hook errors crash the tool pipeline
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] PostToolUse handler error: ${msg}`);
                 }
             });
         }

--- a/packages/cli/src/extensions/hooks.ts
+++ b/packages/cli/src/extensions/hooks.ts
@@ -1,0 +1,253 @@
+import { spawn } from "child_process";
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import type { HooksConfig, HookMatcher, HookEntry } from "../config.js";
+
+/**
+ * Result of running a hook script. Mirrors the Claude Code hook JSON protocol:
+ * - Exit 0 + JSON with additionalContext → inject context (soft nudge)
+ * - Exit 2 + stderr → hard-block the tool call
+ * - Exit 0 with no output → allow silently
+ */
+interface HookResult {
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+}
+
+/** Parsed output from a hook that returned JSON on stdout. */
+interface HookOutput {
+    /** Text to inject into the agent's context window. */
+    additionalContext?: string;
+    /** For PreToolUse: "allow" | "deny" | "ask". Default: "allow". */
+    permissionDecision?: "allow" | "deny" | "ask";
+    /** For PostToolUse: "block" to signal a problem. */
+    decision?: "block";
+}
+
+/** Map tool names from pi to hook-friendly names. */
+function toolDisplayName(toolName: string): string {
+    switch (toolName) {
+        case "bash":
+            return "Bash";
+        case "read":
+            return "Read";
+        case "write":
+            return "Write";
+        case "edit":
+            return "Edit";
+        case "grep":
+            return "Grep";
+        case "find":
+            return "Find";
+        case "ls":
+            return "Ls";
+        default:
+            return toolName;
+    }
+}
+
+/** Check if a tool name matches a hook matcher pattern (supports `|` alternation). */
+export function matchesTool(matcher: string, toolName: string): boolean {
+    const displayName = toolDisplayName(toolName);
+    // Support | alternation: "Edit|Write" matches either
+    const patterns = matcher.split("|").map((p) => p.trim());
+    for (const pattern of patterns) {
+        if (pattern === ".*") return true;
+        // Case-insensitive match against both raw name and display name
+        if (pattern.toLowerCase() === toolName.toLowerCase()) return true;
+        if (pattern.toLowerCase() === displayName.toLowerCase()) return true;
+        // Regex match for complex patterns (e.g., mcp__.*)
+        try {
+            const re = new RegExp(`^${pattern}$`, "i");
+            if (re.test(toolName) || re.test(displayName)) return true;
+        } catch {
+            // Invalid regex — fall through to literal comparison only
+        }
+    }
+    return false;
+}
+
+/** Run a single hook script, piping JSON payload on stdin. */
+export function runHook(entry: HookEntry, payload: string, cwd: string): Promise<HookResult> {
+    const timeout = entry.timeout ?? 10_000;
+    return new Promise((resolve) => {
+        const proc = spawn("bash", ["-c", entry.command], {
+            cwd,
+            stdio: ["pipe", "pipe", "pipe"],
+            env: {
+                ...process.env,
+                PIZZAPI_PROJECT_DIR: cwd,
+            },
+            timeout,
+        });
+
+        let stdout = "";
+        let stderr = "";
+
+        proc.stdout.on("data", (chunk: Buffer) => {
+            stdout += chunk.toString();
+        });
+        proc.stderr.on("data", (chunk: Buffer) => {
+            stderr += chunk.toString();
+        });
+
+        // Send the JSON payload on stdin
+        proc.stdin.write(payload);
+        proc.stdin.end();
+
+        proc.on("close", (code) => {
+            resolve({ exitCode: code ?? 0, stdout: stdout.trim(), stderr: stderr.trim() });
+        });
+
+        proc.on("error", (err) => {
+            resolve({ exitCode: 1, stdout: "", stderr: err.message });
+        });
+    });
+}
+
+/** Parse the JSON output from a hook script, extracting additionalContext etc. */
+export function parseHookOutput(stdout: string): HookOutput | null {
+    if (!stdout) return null;
+    try {
+        const parsed = JSON.parse(stdout);
+        // Support nested hookSpecificOutput (Claude Code format) or flat format
+        const specific = parsed.hookSpecificOutput ?? parsed;
+        return {
+            additionalContext: specific.additionalContext,
+            permissionDecision: specific.permissionDecision,
+            decision: specific.decision ?? parsed.decision,
+        };
+    } catch {
+        return null;
+    }
+}
+
+/** Collect all matching hook entries for a given event type and tool name. */
+function getMatchingHooks(matchers: HookMatcher[] | undefined, toolName: string): HookEntry[] {
+    if (!matchers) return [];
+    const entries: HookEntry[] = [];
+    for (const m of matchers) {
+        if (matchesTool(m.matcher, toolName)) {
+            entries.push(...m.hooks);
+        }
+    }
+    return entries;
+}
+
+/**
+ * Hooks extension — runs shell scripts at tool lifecycle points.
+ *
+ * Scripts receive JSON on stdin with tool_input (and tool_response for PostToolUse).
+ * Protocol:
+ *   - Exit 0 + JSON { additionalContext: "..." } → injects context into agent
+ *   - Exit 2 + stderr message → hard-blocks the tool call (PreToolUse only)
+ *   - Exit 0 with no output → allows silently
+ */
+export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: string): ExtensionFactory | null {
+    if (!hooksConfig) return null;
+    const hasPreHooks = (hooksConfig.PreToolUse?.length ?? 0) > 0;
+    const hasPostHooks = (hooksConfig.PostToolUse?.length ?? 0) > 0;
+    if (!hasPreHooks && !hasPostHooks) return null;
+
+    // Store context messages to inject on the next before_agent_start
+    const pendingContext: string[] = [];
+
+    const factory: ExtensionFactory = (pi) => {
+        // Inject accumulated hook context before each agent turn
+        pi.on("before_agent_start", (event) => {
+            if (pendingContext.length === 0) return;
+            const combined = pendingContext.splice(0).join("\n\n");
+            return {
+                message: {
+                    customType: "hook-context",
+                    content: combined,
+                    display: false,
+                },
+            };
+        });
+
+        // PreToolUse: fire before tool executes, can block
+        if (hasPreHooks) {
+            pi.on("tool_call", async (event) => {
+                const hooks = getMatchingHooks(hooksConfig.PreToolUse, event.toolName);
+                if (hooks.length === 0) return;
+
+                const payload = JSON.stringify({
+                    tool_name: event.toolName,
+                    tool_input: event.input,
+                });
+
+                for (const hook of hooks) {
+                    const result = await runHook(hook, payload, cwd);
+
+                    // Exit 2 = hard block
+                    if (result.exitCode === 2) {
+                        const reason = result.stderr || "Blocked by hook";
+                        return { block: true, reason };
+                    }
+
+                    // Exit 0 with JSON output = inject context
+                    if (result.exitCode === 0 && result.stdout) {
+                        const output = parseHookOutput(result.stdout);
+                        if (output?.permissionDecision === "deny") {
+                            return { block: true, reason: output.additionalContext || "Denied by hook" };
+                        }
+                        if (output?.additionalContext) {
+                            pendingContext.push(output.additionalContext);
+                        }
+                    }
+                }
+            });
+        }
+
+        // PostToolUse: fire after tool executes, can inject context
+        if (hasPostHooks) {
+            pi.on("tool_result", async (event) => {
+                const hooks = getMatchingHooks(hooksConfig.PostToolUse, event.toolName);
+                if (hooks.length === 0) return;
+
+                // Build the tool response text from content array
+                const responseText = event.content
+                    ?.map((c: any) => (c.type === "text" ? c.text : ""))
+                    .filter(Boolean)
+                    .join("\n");
+
+                const payload = JSON.stringify({
+                    tool_name: event.toolName,
+                    tool_input: event.input,
+                    tool_response: responseText ?? "",
+                });
+
+                const contextParts: string[] = [];
+
+                for (const hook of hooks) {
+                    const result = await runHook(hook, payload, cwd);
+
+                    if (result.exitCode === 0 && result.stdout) {
+                        const output = parseHookOutput(result.stdout);
+                        if (output?.additionalContext) {
+                            contextParts.push(output.additionalContext);
+                        }
+                    }
+                    // PostToolUse hooks can't block (tool already ran), but we
+                    // could append error info from stderr if needed.
+                }
+
+                // Append all hook context to the tool result so the agent sees it
+                // immediately, not on the next turn.
+                if (contextParts.length > 0) {
+                    const hookNotice = contextParts.join("\n\n");
+                    const existingContent = event.content ?? [];
+                    return {
+                        content: [
+                            ...existingContent,
+                            { type: "text" as const, text: `\n\n[Hook] ${hookNotice}` },
+                        ],
+                    };
+                }
+            });
+        }
+    };
+
+    return factory;
+}

--- a/packages/cli/src/extensions/hooks.ts
+++ b/packages/cli/src/extensions/hooks.ts
@@ -1,4 +1,6 @@
-import { spawn } from "child_process";
+import { spawn, execSync } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import type { HooksConfig, HookMatcher, HookEntry } from "../config.js";
 
@@ -143,6 +145,81 @@ export function normalizeToolInput(toolName: string, input: Record<string, unkno
 // Hook runner
 // ---------------------------------------------------------------------------
 
+/**
+ * Find Git for Windows' bundled bash.exe by checking well-known install
+ * paths and falling back to `git --exec-path` to derive the Git root.
+ * Returns the absolute path to bash.exe, or null if not found.
+ */
+function findGitBashOnWindows(): string | null {
+    const programFiles = process.env.ProgramFiles || "C:\\Program Files";
+    const programFilesX86 = process.env["ProgramFiles(x86)"] || "C:\\Program Files (x86)";
+    const localAppData = process.env.LOCALAPPDATA || "";
+
+    const candidates = [
+        join(programFiles, "Git", "bin", "bash.exe"),
+        join(programFilesX86, "Git", "bin", "bash.exe"),
+        ...(localAppData ? [join(localAppData, "Programs", "Git", "bin", "bash.exe")] : []),
+    ];
+
+    for (const candidate of candidates) {
+        if (existsSync(candidate)) return candidate;
+    }
+
+    // Try to derive from `git --exec-path` (e.g. C:\Program Files\Git\mingw64\libexec\git-core)
+    try {
+        const execPath = execSync("git --exec-path", {
+            encoding: "utf-8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        // Walk up to the Git root: <root>/mingw64/libexec/git-core → <root>
+        const gitRoot = join(execPath, "..", "..", "..");
+        const bashFromGit = join(gitRoot, "bin", "bash.exe");
+        if (existsSync(bashFromGit)) return bashFromGit;
+    } catch {
+        // git not in PATH or other error — fall through
+    }
+
+    return null;
+}
+
+/** Cached result so we only probe the filesystem once per process. */
+let _cachedShell: { shell: string; flag: string } | undefined;
+
+/**
+ * Resolve the platform shell and flag for running hook commands.
+ *
+ * - **Unix / macOS**: `/bin/sh -c` (POSIX-guaranteed to exist). Hook
+ *   scripts that need bash features should have a `#!/bin/bash` shebang
+ *   or be invoked explicitly via `bash my-script.sh` in the command string.
+ * - **Windows**: Git for Windows' bundled `bash.exe` (searched at common
+ *   install locations, then derived from `git --exec-path`). Falls back to
+ *   bare `bash` in PATH so the error message is clear ("bash not found")
+ *   rather than an opaque cmd.exe syntax failure.
+ *
+ * The result is cached for the lifetime of the process.
+ */
+export function resolveShell(): { shell: string; flag: string } {
+    if (_cachedShell) return _cachedShell;
+
+    if (process.platform !== "win32") {
+        _cachedShell = { shell: "/bin/sh", flag: "-c" };
+        return _cachedShell;
+    }
+
+    // Windows: prefer Git for Windows bash, fall back to bare `bash`
+    const gitBash = findGitBashOnWindows();
+    _cachedShell = { shell: gitBash ?? "bash", flag: "-c" };
+    return _cachedShell;
+}
+
+/**
+ * Reset the cached shell — only needed for testing.
+ * @internal
+ */
+export function _resetShellCache(): void {
+    _cachedShell = undefined;
+}
+
 /** Run a single hook script, piping JSON payload on stdin. */
 export function runHook(entry: HookEntry, payload: string, cwd: string): Promise<HookResult> {
     const timeout = entry.timeout ?? 10_000;
@@ -150,7 +227,8 @@ export function runHook(entry: HookEntry, payload: string, cwd: string): Promise
         let timedOut = false;
         let settled = false;
 
-        const proc = spawn("bash", ["-c", entry.command], {
+        const { shell, flag } = resolveShell();
+        const proc = spawn(shell, [flag, entry.command], {
             cwd,
             stdio: ["pipe", "pipe", "pipe"],
             env: {

--- a/packages/cli/src/extensions/hooks.ts
+++ b/packages/cli/src/extensions/hooks.ts
@@ -28,6 +28,18 @@ export interface HookOutput {
     permissionDecision?: "allow" | "deny" | "ask";
     /** For PostToolUse: "block" to signal a problem. */
     decision?: "block";
+
+    // -- Input hook fields --
+
+    /** For Input hooks: transformed text to replace the original input. */
+    text?: string;
+    /** For Input hooks: "continue" | "transform" | "handled". */
+    action?: "continue" | "transform" | "handled";
+
+    // -- BeforeAgentStart hook fields --
+
+    /** For BeforeAgentStart hooks: override the system prompt for this turn. */
+    systemPrompt?: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -205,6 +217,11 @@ export function parseHookOutput(stdout: string): HookOutput | null {
             additionalContext: specific.additionalContext,
             permissionDecision: specific.permissionDecision,
             decision: specific.decision ?? parsed.decision,
+            // Input hook fields
+            text: specific.text,
+            action: specific.action,
+            // BeforeAgentStart hook fields
+            systemPrompt: specific.systemPrompt,
         };
     } catch {
         return null;
@@ -228,28 +245,125 @@ function getMatchingHooks(matchers: HookMatcher[] | undefined, toolName: string)
 }
 
 // ---------------------------------------------------------------------------
-// Extension factory
+// Shared helpers for event hooks
 // ---------------------------------------------------------------------------
 
 /**
- * Hooks extension — runs shell scripts at tool lifecycle points.
+ * Run all hook entries for an event, returning early on block/kill.
+ * Used by cancelable events (Input, UserBash, SessionBefore*).
  *
- * Scripts receive JSON on stdin with tool_input (and tool_response for PostToolUse).
- * Protocol:
+ * Returns { blocked, reason, outputs } where outputs contains parsed
+ * JSON from successful hooks.
+ */
+export async function runEventHooks(
+    hooks: HookEntry[],
+    payload: string,
+    cwd: string,
+    eventName: string,
+): Promise<{ blocked: boolean; reason?: string; outputs: HookOutput[] }> {
+    const outputs: HookOutput[] = [];
+    for (const hook of hooks) {
+        const result = await runHook(hook, payload, cwd);
+
+        // Killed (timeout / signal) → fail-closed for safety
+        if (result.killed) {
+            return {
+                blocked: true,
+                reason: `${eventName} hook timed out — blocking for safety.`,
+                outputs,
+            };
+        }
+
+        // Exit 2 = hard block / cancel
+        if (result.exitCode === 2) {
+            return {
+                blocked: true,
+                reason: result.stderr || `Blocked by ${eventName} hook`,
+                outputs,
+            };
+        }
+
+        // Exit 0 with JSON output
+        if (result.exitCode === 0 && result.stdout) {
+            const output = parseHookOutput(result.stdout);
+            if (output) outputs.push(output);
+        }
+
+        // Non-zero exit (other than 2) → fail-closed
+        if (result.exitCode !== 0) {
+            return {
+                blocked: true,
+                reason: result.stderr || `${eventName} hook exited with code ${result.exitCode}`,
+                outputs,
+            };
+        }
+    }
+    return { blocked: false, outputs };
+}
+
+/**
+ * Run all hook entries for a fire-and-forget event (SessionShutdown, ModelSelect).
+ * Errors are logged but never block anything.
+ */
+export async function runFireAndForgetHooks(
+    hooks: HookEntry[],
+    payload: string,
+    cwd: string,
+    eventName: string,
+): Promise<void> {
+    for (const hook of hooks) {
+        try {
+            await runHook(hook, payload, cwd);
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.error(`[hooks] ${eventName} handler error: ${msg}`);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Extension factory
+// ---------------------------------------------------------------------------
+
+/** Check if a HooksConfig has any configured hooks at all. */
+function hasAnyHooks(config: HooksConfig): boolean {
+    return Object.values(config).some((v) => Array.isArray(v) && v.length > 0);
+}
+
+/**
+ * Hooks extension — runs shell scripts at agent lifecycle points.
+ *
+ * **Tool hooks** (PreToolUse / PostToolUse):
+ *   Scripts receive JSON on stdin with tool_input (and tool_response for PostToolUse).
  *   - Exit 0 + JSON { additionalContext: "..." } → injects context into agent
  *   - Exit 2 + stderr message → hard-blocks the tool call (PreToolUse only)
  *   - Exit 0 with no output → allows silently
  *   - Signal kill (timeout) → treated as non-zero exit (fail-closed for safety)
+ *
+ * **Event hooks** (Input, BeforeAgentStart, UserBash, Session*, ModelSelect):
+ *   Scripts receive JSON on stdin with event-specific fields.
+ *   - Exit 0 → allow / no-op
+ *   - Exit 2 → cancel / block (for cancelable events)
+ *   - JSON output can carry additionalContext, text transforms, systemPrompt overrides
  *
  * Security: Project-local hooks (from .pizzapi/config.json) require
  * `allowProjectHooks: true` in the global ~/.pizzapi/config.json or the
  * PIZZAPI_ALLOW_PROJECT_HOOKS=1 env var. Global hooks always run.
  */
 export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: string): ExtensionFactory | null {
-    if (!hooksConfig) return null;
+    if (!hooksConfig || !hasAnyHooks(hooksConfig)) return null;
+
     const hasPreHooks = (hooksConfig.PreToolUse?.length ?? 0) > 0;
     const hasPostHooks = (hooksConfig.PostToolUse?.length ?? 0) > 0;
-    if (!hasPreHooks && !hasPostHooks) return null;
+    const hasInputHooks = (hooksConfig.Input?.length ?? 0) > 0;
+    const hasBeforeAgentStartHooks = (hooksConfig.BeforeAgentStart?.length ?? 0) > 0;
+    const hasUserBashHooks = (hooksConfig.UserBash?.length ?? 0) > 0;
+    const hasSessionBeforeSwitchHooks = (hooksConfig.SessionBeforeSwitch?.length ?? 0) > 0;
+    const hasSessionBeforeForkHooks = (hooksConfig.SessionBeforeFork?.length ?? 0) > 0;
+    const hasSessionShutdownHooks = (hooksConfig.SessionShutdown?.length ?? 0) > 0;
+    const hasSessionBeforeCompactHooks = (hooksConfig.SessionBeforeCompact?.length ?? 0) > 0;
+    const hasSessionBeforeTreeHooks = (hooksConfig.SessionBeforeTree?.length ?? 0) > 0;
+    const hasModelSelectHooks = (hooksConfig.ModelSelect?.length ?? 0) > 0;
 
     // Advisory context from PreToolUse hooks is stashed here per tool-call-id
     // and injected into the tool_result so the agent sees it in the same turn
@@ -257,6 +371,10 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
     const preToolContext = new Map<string, string[]>();
 
     const factory: ExtensionFactory = (pi) => {
+        // ---------------------------------------------------------------
+        // Tool lifecycle hooks
+        // ---------------------------------------------------------------
+
         // PreToolUse: fire before tool executes, can block or inject context
         if (hasPreHooks) {
             pi.on("tool_call", async (event) => {
@@ -320,7 +438,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
         // PostToolUse + PreToolUse advisory: fire after tool executes, inject context.
         // This handler always runs (not gated on hasPostHooks) because it also
         // drains advisory context stashed by PreToolUse hooks.
-        {
+        if (hasPreHooks || hasPostHooks) {
             pi.on("tool_result", async (event) => {
                 try {
                     const contextParts: string[] = [];
@@ -379,6 +497,320 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                     // Defensive: never let hook errors crash the tool pipeline
                     const msg = err instanceof Error ? err.message : String(err);
                     console.error(`[hooks] PostToolUse handler error: ${msg}`);
+                }
+            });
+        }
+
+        // ---------------------------------------------------------------
+        // Input hook — catches raw user text before skill/template expansion
+        // ---------------------------------------------------------------
+
+        if (hasInputHooks) {
+            pi.on("input", async (event) => {
+                try {
+                    const payload = JSON.stringify({
+                        event: "Input",
+                        text: event.text,
+                        source: event.source,
+                    });
+
+                    const { blocked, reason, outputs } = await runEventHooks(
+                        hooksConfig.Input!,
+                        payload,
+                        cwd,
+                        "Input",
+                    );
+
+                    // Block → mark as handled so the agent doesn't see it
+                    if (blocked) {
+                        console.error(`[hooks] Input blocked: ${reason}`);
+                        return { action: "handled" as const };
+                    }
+
+                    // Check if any hook wants to transform the input or mark handled
+                    for (const output of outputs) {
+                        if (output.action === "handled") {
+                            return { action: "handled" as const };
+                        }
+                        if (output.text !== undefined) {
+                            return { action: "transform" as const, text: output.text };
+                        }
+                        if (output.action === "transform" && output.text !== undefined) {
+                            return { action: "transform" as const, text: output.text };
+                        }
+                    }
+
+                    return { action: "continue" as const };
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] Input handler error: ${msg}`);
+                    return { action: "continue" as const };
+                }
+            });
+        }
+
+        // ---------------------------------------------------------------
+        // BeforeAgentStart hook — inject context or tweak system prompt
+        // ---------------------------------------------------------------
+
+        if (hasBeforeAgentStartHooks) {
+            pi.on("before_agent_start", async (event) => {
+                try {
+                    const payload = JSON.stringify({
+                        event: "BeforeAgentStart",
+                        prompt: event.prompt,
+                        system_prompt: event.systemPrompt,
+                    });
+
+                    const { blocked, outputs } = await runEventHooks(
+                        hooksConfig.BeforeAgentStart!,
+                        payload,
+                        cwd,
+                        "BeforeAgentStart",
+                    );
+
+                    // BeforeAgentStart doesn't support blocking — just log
+                    if (blocked) {
+                        console.error("[hooks] BeforeAgentStart hook failed (non-fatal)");
+                    }
+
+                    // Collect context and system prompt overrides
+                    const contextParts: string[] = [];
+                    let systemPrompt: string | undefined;
+
+                    for (const output of outputs) {
+                        if (output.additionalContext) {
+                            contextParts.push(output.additionalContext);
+                        }
+                        if (output.systemPrompt) {
+                            systemPrompt = output.systemPrompt;
+                        }
+                    }
+
+                    const result: any = {};
+
+                    if (contextParts.length > 0) {
+                        result.message = {
+                            customType: "hook_context",
+                            content: contextParts.join("\n\n"),
+                            display: "collapsed",
+                        };
+                    }
+
+                    if (systemPrompt) {
+                        result.systemPrompt = systemPrompt;
+                    }
+
+                    if (Object.keys(result).length > 0) return result;
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] BeforeAgentStart handler error: ${msg}`);
+                }
+            });
+        }
+
+        // ---------------------------------------------------------------
+        // UserBash hook — safety parity with PreToolUse:Bash for ! / !!
+        // ---------------------------------------------------------------
+
+        if (hasUserBashHooks) {
+            pi.on("user_bash", async (event) => {
+                try {
+                    const payload = JSON.stringify({
+                        event: "UserBash",
+                        command: event.command,
+                        exclude_from_context: event.excludeFromContext,
+                        cwd: event.cwd,
+                        // Also include tool_input for compatibility with PreToolUse scripts
+                        tool_input: { command: event.command },
+                    });
+
+                    const { blocked, reason } = await runEventHooks(
+                        hooksConfig.UserBash!,
+                        payload,
+                        cwd,
+                        "UserBash",
+                    );
+
+                    if (blocked) {
+                        // Return a synthetic BashResult to prevent execution
+                        return {
+                            result: {
+                                output: `[Hook] Blocked: ${reason}`,
+                                exitCode: 1,
+                                cancelled: false,
+                                truncated: false,
+                            },
+                        };
+                    }
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] UserBash handler error: ${msg}`);
+                }
+            });
+        }
+
+        // ---------------------------------------------------------------
+        // Session lifecycle hooks
+        // ---------------------------------------------------------------
+
+        if (hasSessionBeforeSwitchHooks) {
+            pi.on("session_before_switch", async (event) => {
+                try {
+                    const payload = JSON.stringify({
+                        event: "SessionBeforeSwitch",
+                        reason: event.reason,
+                        target_session_file: event.targetSessionFile,
+                    });
+
+                    const { blocked, reason } = await runEventHooks(
+                        hooksConfig.SessionBeforeSwitch!,
+                        payload,
+                        cwd,
+                        "SessionBeforeSwitch",
+                    );
+
+                    if (blocked) {
+                        console.error(`[hooks] Session switch cancelled: ${reason}`);
+                        return { cancel: true };
+                    }
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] SessionBeforeSwitch handler error: ${msg}`);
+                }
+            });
+        }
+
+        if (hasSessionBeforeForkHooks) {
+            pi.on("session_before_fork", async (event) => {
+                try {
+                    const payload = JSON.stringify({
+                        event: "SessionBeforeFork",
+                        entry_id: event.entryId,
+                    });
+
+                    const { blocked, reason } = await runEventHooks(
+                        hooksConfig.SessionBeforeFork!,
+                        payload,
+                        cwd,
+                        "SessionBeforeFork",
+                    );
+
+                    if (blocked) {
+                        console.error(`[hooks] Session fork cancelled: ${reason}`);
+                        return { cancel: true };
+                    }
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] SessionBeforeFork handler error: ${msg}`);
+                }
+            });
+        }
+
+        if (hasSessionShutdownHooks) {
+            pi.on("session_shutdown", async () => {
+                try {
+                    const payload = JSON.stringify({ event: "SessionShutdown" });
+                    await runFireAndForgetHooks(
+                        hooksConfig.SessionShutdown!,
+                        payload,
+                        cwd,
+                        "SessionShutdown",
+                    );
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] SessionShutdown handler error: ${msg}`);
+                }
+            });
+        }
+
+        // ---------------------------------------------------------------
+        // Second wave hooks
+        // ---------------------------------------------------------------
+
+        if (hasSessionBeforeCompactHooks) {
+            pi.on("session_before_compact", async (event) => {
+                try {
+                    const payload = JSON.stringify({
+                        event: "SessionBeforeCompact",
+                        custom_instructions: event.customInstructions,
+                    });
+
+                    const { blocked, reason } = await runEventHooks(
+                        hooksConfig.SessionBeforeCompact!,
+                        payload,
+                        cwd,
+                        "SessionBeforeCompact",
+                    );
+
+                    if (blocked) {
+                        console.error(`[hooks] Session compaction cancelled: ${reason}`);
+                        return { cancel: true };
+                    }
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] SessionBeforeCompact handler error: ${msg}`);
+                }
+            });
+        }
+
+        if (hasSessionBeforeTreeHooks) {
+            pi.on("session_before_tree", async (event) => {
+                try {
+                    const payload = JSON.stringify({
+                        event: "SessionBeforeTree",
+                        target_id: event.preparation.targetId,
+                        old_leaf_id: event.preparation.oldLeafId,
+                        user_wants_summary: event.preparation.userWantsSummary,
+                    });
+
+                    const { blocked, reason } = await runEventHooks(
+                        hooksConfig.SessionBeforeTree!,
+                        payload,
+                        cwd,
+                        "SessionBeforeTree",
+                    );
+
+                    if (blocked) {
+                        console.error(`[hooks] Session tree navigation cancelled: ${reason}`);
+                        return { cancel: true };
+                    }
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] SessionBeforeTree handler error: ${msg}`);
+                }
+            });
+        }
+
+        if (hasModelSelectHooks) {
+            pi.on("model_select", async (event) => {
+                try {
+                    const payload = JSON.stringify({
+                        event: "ModelSelect",
+                        model: {
+                            provider: event.model.provider,
+                            id: event.model.id,
+                            name: event.model.name,
+                        },
+                        previous_model: event.previousModel
+                            ? {
+                                  provider: event.previousModel.provider,
+                                  id: event.previousModel.id,
+                                  name: event.previousModel.name,
+                              }
+                            : null,
+                        source: event.source,
+                    });
+
+                    await runFireAndForgetHooks(
+                        hooksConfig.ModelSelect!,
+                        payload,
+                        cwd,
+                        "ModelSelect",
+                    );
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.error(`[hooks] ModelSelect handler error: ${msg}`);
                 }
             });
         }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,14 +12,7 @@ import { join } from "path";
 import { homedir } from "os";
 import { defaultAgentDir, loadConfig } from "./config.js";
 import { buildInteractiveSkillPaths } from "./skills.js";
-import { remoteExtension } from "./extensions/remote.js";
-import { mcpExtension } from "./extensions/mcp-extension.js";
-import { restartExtension } from "./extensions/restart.js";
-import { setSessionNameExtension } from "./extensions/set-session-name.js";
-import { updateTodoExtension } from "./extensions/update-todo.js";
-import { spawnSessionExtension } from "./extensions/spawn-session.js";
-import { sessionMessagingExtension } from "./extensions/session-messaging.js";
-import { createHooksExtension } from "./extensions/hooks.js";
+import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
 import { runSetup } from "./setup.js";
 
 async function main() {
@@ -373,10 +366,11 @@ async function main() {
         agentFiles.push(...loadedAgents);
     }
 
-    // Build extension list — hooks extension is conditional on config
-    const extensionFactories = [remoteExtension, mcpExtension, restartExtension, setSessionNameExtension, updateTodoExtension, spawnSessionExtension, sessionMessagingExtension];
-    const hooksExtension = createHooksExtension(config.hooks, cwd);
-    if (hooksExtension) extensionFactories.push(hooksExtension);
+    // Build extension list — includes configured hooks when present.
+    const extensionFactories = buildPizzaPiExtensionFactories({
+        cwd,
+        hooks: config.hooks,
+    });
 
     const loader = new DefaultResourceLoader({
         cwd,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -19,6 +19,7 @@ import { setSessionNameExtension } from "./extensions/set-session-name.js";
 import { updateTodoExtension } from "./extensions/update-todo.js";
 import { spawnSessionExtension } from "./extensions/spawn-session.js";
 import { sessionMessagingExtension } from "./extensions/session-messaging.js";
+import { createHooksExtension } from "./extensions/hooks.js";
 import { runSetup } from "./setup.js";
 
 async function main() {
@@ -372,10 +373,15 @@ async function main() {
         agentFiles.push(...loadedAgents);
     }
 
+    // Build extension list — hooks extension is conditional on config
+    const extensionFactories = [remoteExtension, mcpExtension, restartExtension, setSessionNameExtension, updateTodoExtension, spawnSessionExtension, sessionMessagingExtension];
+    const hooksExtension = createHooksExtension(config.hooks, cwd);
+    if (hooksExtension) extensionFactories.push(hooksExtension);
+
     const loader = new DefaultResourceLoader({
         cwd,
         agentDir,
-        extensionFactories: [remoteExtension, mcpExtension, restartExtension, setSessionNameExtension, updateTodoExtension, spawnSessionExtension, sessionMessagingExtension],
+        extensionFactories,
         additionalSkillPaths: buildInteractiveSkillPaths(cwd, config.skills),
         ...(config.systemPrompt !== undefined && {
             systemPromptOverride: () => config.systemPrompt,

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -20,14 +20,8 @@ function buildPromptPaths(cwd: string): string[] {
         join(cwd, ".agents", "commands"),
     ];
 }
-import { remoteExtension, forwardCliError } from "../extensions/remote.js";
-import { mcpExtension } from "../extensions/mcp-extension.js";
-import { restartExtension } from "../extensions/restart.js";
-import { setSessionNameExtension } from "../extensions/set-session-name.js";
-import { updateTodoExtension } from "../extensions/update-todo.js";
-import { spawnSessionExtension } from "../extensions/spawn-session.js";
-import { sessionMessagingExtension } from "../extensions/session-messaging.js";
-import { initialPromptExtension } from "../extensions/initial-prompt.js";
+import { forwardCliError } from "../extensions/remote.js";
+import { buildPizzaPiExtensionFactories } from "../extensions/factories.js";
 
 /**
  * Headless session worker.
@@ -73,7 +67,11 @@ async function main(): Promise<void> {
     const loader = new DefaultResourceLoader({
         cwd,
         agentDir,
-        extensionFactories: [remoteExtension, mcpExtension, restartExtension, setSessionNameExtension, updateTodoExtension, spawnSessionExtension, sessionMessagingExtension, initialPromptExtension],
+        extensionFactories: buildPizzaPiExtensionFactories({
+            cwd,
+            hooks: config.hooks,
+            includeInitialPrompt: true,
+        }),
         additionalSkillPaths: buildWorkerSkillPaths(cwd, config.skills),
         additionalPromptTemplatePaths: buildPromptPaths(cwd),
         ...(config.systemPrompt !== undefined && {

--- a/packages/npm/publish-npm.ts
+++ b/packages/npm/publish-npm.ts
@@ -45,6 +45,9 @@ if (entries.length === 0) {
 
 console.log(`Publishing ${entries.length} packages${dryRun ? " (dry run)" : ""}...\n`);
 
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 5_000;
+
 let failed = false;
 
 for (const entry of entries) {
@@ -61,13 +64,26 @@ for (const entry of entries) {
     if (provenance) npmArgs.push("--provenance");
     if (access) npmArgs.push("--access", access);
 
-    const proc = Bun.spawnSync(["npm", ...npmArgs], {
-        cwd: pkgDir,
-        stdio: ["inherit", "inherit", "inherit"],
-    });
+    let published = false;
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        const proc = Bun.spawnSync(["npm", ...npmArgs], {
+            cwd: pkgDir,
+            stdio: ["inherit", "inherit", "inherit"],
+        });
 
-    if (proc.exitCode !== 0) {
-        console.error(`  ✗ Failed to publish ${pkgJson.name}`);
+        if (proc.exitCode === 0) {
+            published = true;
+            break;
+        }
+
+        if (attempt < MAX_RETRIES) {
+            console.error(`  ⚠ Attempt ${attempt}/${MAX_RETRIES} failed, retrying in ${RETRY_DELAY_MS / 1000}s...`);
+            Bun.sleepSync(RETRY_DELAY_MS);
+        }
+    }
+
+    if (!published) {
+        console.error(`  ✗ Failed to publish ${pkgJson.name} after ${MAX_RETRIES} attempts`);
         failed = true;
     } else {
         console.log(`  ✓ Published`);

--- a/packages/ui/bunfig.toml
+++ b/packages/ui/bunfig.toml
@@ -1,0 +1,4 @@
+[test]
+
+[test.module-resolution]
+paths = { "@/*" = ["./src/*"] }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -950,6 +950,35 @@ export function App() {
         updated[idx] = next;
         return updated;
       }
+
+      // When a user message arrives from the server, check for a locally-inserted
+      // steer message with the same content and replace it instead of appending a
+      // duplicate. Steer messages are added optimistically with key "user:steer:*"
+      // but the server echoes them back with a different key (e.g. "user:ts:*").
+      if (next.role === "user") {
+        const nextText = typeof next.content === "string"
+          ? next.content.trim()
+          : Array.isArray(next.content)
+            ? (next.content as Array<Record<string, unknown>>)
+                .filter((b) => b && typeof b === "object" && b.type === "text" && typeof b.text === "string")
+                .map((b) => b.text as string)
+                .join("")
+                .trim()
+            : "";
+        if (nextText) {
+          const steerIdx = base.findIndex((m) =>
+            m.key.startsWith("user:steer:") &&
+            m.role === "user" &&
+            (typeof m.content === "string" ? m.content.trim() : "") === nextText,
+          );
+          if (steerIdx >= 0) {
+            const updated = base === prev ? base.slice() : base;
+            updated[steerIdx] = next;
+            return updated;
+          }
+        }
+      }
+
       return [...base, next];
     });
   }, []);
@@ -1763,6 +1792,8 @@ export function App() {
   }, [liveSessions, openSession]);
 
 
+  // Dedup guard: prevent sending the exact same message text within a short window.
+  const lastSentRef = React.useRef<{ text: string; ts: number } | null>(null);
 
   const sendSessionInput = React.useCallback(async (message: { text: string; files?: Array<{ mediaType?: string; filename?: string; url?: string }>; deliverAs?: "steer" | "followUp" } | string) => {
     const socket = viewerWsRef.current;
@@ -1774,6 +1805,16 @@ export function App() {
 
     const payload = typeof message === "string" ? { text: message, files: [] } : message;
     const trimmed = payload.text.trim();
+
+    // Dedup guard: skip if the same text was sent in the last 500ms.
+    const now = Date.now();
+    const last = lastSentRef.current;
+    if (last && trimmed && last.text === trimmed && now - last.ts < 500) {
+      return true; // silently deduplicate
+    }
+    if (trimmed) {
+      lastSentRef.current = { text: trimmed, ts: now };
+    }
 
     const rawFiles = (payload.files ?? [])
       .filter((f) => typeof f?.url === "string" && f.url.length > 0)

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -60,6 +60,13 @@ import {
   ModelSelectorShortcut,
 } from "@/components/ai-elements/model-selector";
 import { HiddenModelsManager, loadHiddenModels, fetchHiddenModels, modelKey } from "@/components/HiddenModelsManager";
+import {
+  beginInputAttempt,
+  completeInputAttempt,
+  failInputAttempt,
+  shouldDeduplicateInput,
+  type InputDedupeState,
+} from "@/lib/input-dedupe";
 
 function toRelayMessage(raw: unknown, fallbackId: string): RelayMessage | null {
   if (!raw || typeof raw !== "object") return null;
@@ -1793,7 +1800,8 @@ export function App() {
 
 
   // Dedup guard: prevent sending the exact same message text within a short window.
-  const lastSentRef = React.useRef<{ text: string; ts: number } | null>(null);
+  const inputDedupeRef = React.useRef<InputDedupeState | null>(null);
+  const inputAttemptIdRef = React.useRef(0);
 
   const sendSessionInput = React.useCallback(async (message: { text: string; files?: Array<{ mediaType?: string; filename?: string; url?: string }>; deliverAs?: "steer" | "followUp" } | string) => {
     const socket = viewerWsRef.current;
@@ -1806,12 +1814,22 @@ export function App() {
     const payload = typeof message === "string" ? { text: message, files: [] } : message;
     const trimmed = payload.text.trim();
 
-    // Dedup guard: skip if the same text was sent in the last 500ms.
+    // Dedup guard: skip if the same text was sent/started in the last 500ms.
     const now = Date.now();
-    const last = lastSentRef.current;
-    if (last && trimmed && last.text === trimmed && now - last.ts < 500) {
+    if (shouldDeduplicateInput(inputDedupeRef.current, trimmed, now, 500)) {
       return true; // silently deduplicate
     }
+
+    let attemptId: number | null = null;
+    if (trimmed) {
+      attemptId = ++inputAttemptIdRef.current;
+      inputDedupeRef.current = beginInputAttempt(trimmed, now, attemptId);
+    }
+
+    const failCurrentAttempt = () => {
+      if (attemptId === null) return;
+      inputDedupeRef.current = failInputAttempt(inputDedupeRef.current, attemptId);
+    };
 
     const rawFiles = (payload.files ?? [])
       .filter((f) => typeof f?.url === "string" && f.url.length > 0)
@@ -1839,6 +1857,7 @@ export function App() {
           formData.append("files", uploadFile);
         } catch {
           setViewerStatus(`Failed to prepare attachment: ${displayName}`);
+          failCurrentAttempt();
           return false;
         }
 
@@ -1853,6 +1872,7 @@ export function App() {
             const body = await uploadRes.json().catch(() => null);
             const message = body && typeof body.error === "string" ? body.error : `Upload failed for ${displayName}`;
             setViewerStatus(message);
+            failCurrentAttempt();
             return false;
           }
 
@@ -1860,6 +1880,7 @@ export function App() {
           const first = Array.isArray(body?.attachments) ? body.attachments[0] : null;
           if (!first || typeof first.attachmentId !== "string") {
             setViewerStatus(`Upload failed for ${displayName}`);
+            failCurrentAttempt();
             return false;
           }
 
@@ -1872,6 +1893,7 @@ export function App() {
           });
         } catch {
           setViewerStatus(`Upload failed for ${displayName}`);
+          failCurrentAttempt();
           return false;
         }
       }
@@ -1890,9 +1912,9 @@ export function App() {
         ...(deliverAs ? { deliverAs } : {}),
       });
 
-      // Mark dedupe only after successful send
-      if (trimmed) {
-        lastSentRef.current = { text: trimmed, ts: Date.now() };
+      // Mark dedupe as sent only after successful emit.
+      if (attemptId !== null) {
+        inputDedupeRef.current = completeInputAttempt(inputDedupeRef.current, attemptId, Date.now());
       }
 
       // Track queued messages when the agent is active
@@ -1928,6 +1950,7 @@ export function App() {
       return true;
     } catch {
       setViewerStatus("Failed to send message");
+      failCurrentAttempt();
       return false;
     }
   }, []);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1812,9 +1812,6 @@ export function App() {
     if (last && trimmed && last.text === trimmed && now - last.ts < 500) {
       return true; // silently deduplicate
     }
-    if (trimmed) {
-      lastSentRef.current = { text: trimmed, ts: now };
-    }
 
     const rawFiles = (payload.files ?? [])
       .filter((f) => typeof f?.url === "string" && f.url.length > 0)
@@ -1892,6 +1889,11 @@ export function App() {
         client: "web",
         ...(deliverAs ? { deliverAs } : {}),
       });
+
+      // Mark dedupe only after successful send
+      if (trimmed) {
+        lastSentRef.current = { text: trimmed, ts: Date.now() };
+      }
 
       // Track queued messages when the agent is active
       if (deliverAs && trimmed) {

--- a/packages/ui/src/lib/input-dedupe.test.ts
+++ b/packages/ui/src/lib/input-dedupe.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import {
+  beginInputAttempt,
+  completeInputAttempt,
+  failInputAttempt,
+  shouldDeduplicateInput,
+  type InputDedupeState,
+} from "./input-dedupe";
+
+describe("input dedupe state", () => {
+  test("deduplicates same text while an attempt is pending", () => {
+    const state = beginInputAttempt("hello", 1000, 1);
+
+    expect(shouldDeduplicateInput(state, "hello", 1200, 500)).toBe(true);
+    expect(shouldDeduplicateInput(state, "hello", 1600, 500)).toBe(false);
+  });
+
+  test("clears pending marker on failure so immediate retry is allowed", () => {
+    const pending = beginInputAttempt("hello", 1000, 1);
+    const failed = failInputAttempt(pending, 1);
+
+    expect(failed).toBeNull();
+    expect(shouldDeduplicateInput(failed, "hello", 1100, 500)).toBe(false);
+  });
+
+  test("marks sent on success and deduplicates immediate retries", () => {
+    const pending = beginInputAttempt("hello", 1000, 1);
+    const sent = completeInputAttempt(pending, 1, 1200);
+
+    expect(sent).toEqual({
+      text: "hello",
+      ts: 1200,
+      phase: "sent",
+      attemptId: 1,
+    } satisfies InputDedupeState);
+    expect(shouldDeduplicateInput(sent, "hello", 1300, 500)).toBe(true);
+  });
+
+  test("keeps newer pending attempt when older attempt fails later", () => {
+    const first = beginInputAttempt("hello", 1000, 1);
+    const second = beginInputAttempt("hello", 1050, 2);
+
+    // Older attempt should not clear the newer pending marker.
+    expect(failInputAttempt(second, first.attemptId)).toEqual(second);
+  });
+
+  test("does not deduplicate different text", () => {
+    const state = beginInputAttempt("hello", 1000, 1);
+
+    expect(shouldDeduplicateInput(state, "world", 1100, 500)).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/input-dedupe.ts
+++ b/packages/ui/src/lib/input-dedupe.ts
@@ -1,0 +1,56 @@
+export type InputDedupeState = {
+  text: string;
+  ts: number;
+  phase: "pending" | "sent";
+  attemptId: number;
+};
+
+export function shouldDeduplicateInput(
+  state: InputDedupeState | null,
+  text: string,
+  now: number,
+  windowMs = 500,
+): boolean {
+  if (!state || !text) return false;
+  return state.text === text && now - state.ts < windowMs;
+}
+
+export function beginInputAttempt(
+  text: string,
+  now: number,
+  attemptId: number,
+): InputDedupeState {
+  return {
+    text,
+    ts: now,
+    phase: "pending",
+    attemptId,
+  };
+}
+
+export function failInputAttempt(
+  state: InputDedupeState | null,
+  attemptId: number,
+): InputDedupeState | null {
+  if (!state) return null;
+  if (state.phase === "pending" && state.attemptId === attemptId) {
+    return null;
+  }
+  return state;
+}
+
+export function completeInputAttempt(
+  state: InputDedupeState | null,
+  attemptId: number,
+  now: number,
+): InputDedupeState | null {
+  if (!state) return null;
+  if (state.phase === "pending" && state.attemptId === attemptId) {
+    return {
+      ...state,
+      phase: "sent",
+      ts: now,
+    };
+  }
+  return state;
+}


### PR DESCRIPTION
## Summary

Adds a shell-script hooks system to PizzaPi, inspired by [this article](https://dev.to/mikelane/replacing-800-lines-of-ai-agent-instructions-with-10-token-questions-dcd) on Claude Code hooks and the *Are Your Lights On?* pattern — delivering targeted questions at decision boundaries instead of relying on long instruction documents that drift out of context.

## What's New

### Hooks Extension (`packages/cli/src/extensions/hooks.ts`)
A new pi extension that reads hook config from `.pizzapi/config.json` and wires into pi's `tool_call` and `tool_result` events:

- **PreToolUse** hooks fire before a tool executes — can **block** (exit 2) or **inject context** (exit 0 + JSON with `additionalContext`)
- **PostToolUse** hooks fire after a tool executes — can inject context into the tool result so the agent sees it immediately
- Scripts receive JSON on stdin with `tool_input` (and `tool_response` for PostToolUse)
- `PIZZAPI_PROJECT_DIR` env var is set so scripts can reference project-relative paths

### Config Types (`packages/cli/src/config.ts`)
- `HooksConfig`, `HookMatcher`, `HookEntry` types added to `PizzaPiConfig`
- Hooks from global (`~/.pizzapi/config.json`) and project (`.pizzapi/config.json`) configs are **deep-merged** (concatenated, both run)
- Matcher supports `|` alternation and regex patterns

### Hook Scripts (`.pizzapi/hooks/`)

| Hook | Event | What It Does |
|------|-------|-------------|
| `block-dangerous-commands.sh` | PreToolUse:Bash | **Hard-blocks** force push to main, `--no-verify`, dangerous `rm -rf` |
| `lights-on-bun.sh` | PreToolUse:Bash | Asks *"Did you mean bun?"* when npm/yarn/pnpm/node detected |
| `lights-on-no-node-modules.sh` | PreToolUse:Edit\|Write | **Hard-blocks** edits to `node_modules/` — use `patches/` instead |
| `lights-on-tests-post.sh` | PostToolUse:Edit\|Write | Asks *"Did you add tests?"* after editing source files |
| `lights-on-bash-post.sh` | PostToolUse:Bash | Error recovery questions + build order reminder |

### Tests
32 tests covering:
- `matchesTool` — tool name matching with alternation and regex
- `parseHookOutput` — JSON parsing for both flat and Claude Code nested format
- `runHook` — process execution, stdin piping, env vars, timeout handling
- All 5 hook scripts with real integration tests against actual script behavior

## Design Decisions

- **Questions, not commands**: Following the article's philosophy — hooks ask questions (`"Is there a failing test?"`) rather than give commands (`"You must write tests"`). Questions force the agent to evaluate its state at the decision boundary.
- **Hard blocks for irreversible actions**: Force push and node_modules edits use exit 2 (hard block). Everything else uses soft context injection.
- **Claude Code JSON compat**: The `hookSpecificOutput` nested format from Claude Code is supported alongside a simpler flat format.
- **No overhead for non-matching tools**: Hooks exit immediately (exit 0, no output) when the tool/file doesn't match their pattern.