### PR TITLE
docs: move CLI reference and config docs to Starlight docs site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ packages/
   server/   Bun HTTP + WebSocket relay server (auth, session relay, attachments)
   ui/       React 19 PWA web interface (Vite, TailwindCSS v4, Radix UI / shadcn)
   tools/    Shared agent tools (bash, read-file, write-file, search, toolkit)
+  docs/     Starlight (Astro) documentation site — https://pizzaface.github.io/PizzaPi/
   npm/      npm distribution — builds & publishes `npx pizzapi` packages
 
 docker/     Docker Compose (redis + server services)
@@ -19,6 +20,33 @@ patches/    Bun patches for upstream pi packages (auto-applied on bun install)
 ```
 
 Build order: `tools` → `server` → `ui` → `cli`.
+
+---
+
+## Documentation Site
+
+User-facing documentation lives in `packages/docs/` — a [Starlight](https://starlight.astro.build/) (Astro) site deployed to GitHub Pages.
+
+- **Source**: `packages/docs/src/content/docs/` (`.mdx` files)
+- **Config**: `packages/docs/astro.config.mjs`
+- **Build**: `cd packages/docs && bun run build`
+- **Dev**: `cd packages/docs && bun run dev`
+- **Live site**: https://pizzaface.github.io/PizzaPi/
+
+**When changing CLI commands, flags, config options, or self-hosting behavior, always update the corresponding docs pages:**
+
+| Topic | Doc page |
+|-------|----------|
+| CLI commands & flags | `guides/cli-reference.mdx` |
+| `~/.pizzapi/config.json`, env vars | `guides/configuration.mdx` |
+| `pizza web`, Docker, self-hosting | `guides/self-hosting.mdx` |
+| Tailscale HTTPS setup | `guides/tailscale.mdx` |
+| Runner daemon | `guides/runner-daemon.mdx` |
+| Installation | `guides/installation.mdx` |
+| Server env vars | `reference/environment-variables.mdx` |
+| Architecture | `reference/architecture.mdx` |
+
+The README is intentionally slim — it has a quick start and links to the docs site. **Do not duplicate detailed docs in the README.**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,21 +4,6 @@ A self-hosted web interface and relay server for the [pi coding agent](https://g
 
 ---
 
-## Table of Contents
-
-- [How It Works](#how-it-works)
-- [Installation](#installation)
-  - [Option A — Use the Hosted Relay (Quickest)](#option-a--use-the-hosted-relay-quickest)
-  - [Option B — Self-Host the Relay Server](#option-b--self-host-the-relay-server)
-- [CLI Reference](#cli-reference)
-  - [`pizza web` — One-Command Self-Hosting](#pizza-web--one-command-self-hosting)
-- [Configuration](#configuration)
-- [Runner Daemon](#runner-daemon)
-- [Development](#development)
-- [License](#license)
-
----
-
 ## How It Works
 
 ```
@@ -39,362 +24,37 @@ A self-hosted web interface and relay server for the [pi coding agent](https://g
 
 ---
 
-## Installation
-
-### Option A — Use the Hosted Relay (Quickest)
-
-Install the CLI, point it at an existing relay server (one you or someone else hosts), and start coding.
-
-**Requirements:** Node 18+ or Bun
+## Quick Start
 
 ```bash
-# Run without installing (npx)
-npx @pizzapi/pizza
-
-# — or — install globally
+# Install the CLI
 npm install -g @pizzapi/pizza
+
+# Start a coding session
 pizzapi
-```
 
-On first run, the setup wizard will ask for your relay URL, email, and password:
+# Self-host the relay server (requires Docker)
+pizzapi web
 
-```
-┌─────────────────────────────────────────┐
-│        PizzaPi — first-run setup        │
-└─────────────────────────────────────────┘
-
-Connect this node to a PizzaPi relay server so your sessions
-can be monitored from the web UI.
-
-Relay server URL [http://localhost:7492]: https://your-server.example.com
-Email: you@example.com
-Password: ••••••••
-
-Connecting to relay server… ✓
-✓ API key saved to ~/.pizzapi/config.json
-✓ Relay: wss://your-server.example.com
-```
-
-You can re-run setup any time:
-
-```bash
-pizzapi setup
-```
-
----
-
-### Option B — Self-Host the Relay Server
-
-Run the relay + web UI yourself with Docker Compose. You need Docker and Docker Compose installed.
-
-#### 1. Clone the repository
-
-```bash
-git clone https://github.com/Pizzaface/PizzaPi.git
-cd PizzaPi
-```
-
-#### 2. Start the server stack
-
-> **💡 Tip:** If you just want to get up and running quickly, skip the manual Docker setup and use [`pizza web`](#pizza-web--one-command-self-hosting) instead — it handles everything automatically.
-
-```bash
-docker compose -f docker/compose.yml up -d
-```
-
-This starts two services:
-
-| Service | Port | Description |
-|---------|------|-------------|
-| `redis` | 6379 | Session event buffer |
-| `server` | 7492 | Relay API + Web UI |
-
-The web UI is now available at **http://localhost:7492**.
-
-#### 3. Install the CLI
-
-```bash
-npm install -g @pizzapi/pizza
-```
-
-#### 4. Connect the CLI to your server
-
-```bash
-pizzapi setup
-# Relay server URL: http://localhost:7492
-# Email: you@example.com
-# Password: your-password
-```
-
-#### 5. Start a session
-
-```bash
-pizzapi
-```
-
-Open **http://localhost:7492** in your browser to watch the session live.
-
----
-
-#### Environment Variables (Server)
-
-| Variable | Default | Purpose |
-|----------|---------|---------|
-| `PORT` | `7492` | HTTP/WS listen port |
-| `PIZZAPI_REDIS_URL` | — | Redis connection URL (e.g. `redis://localhost:6379`) |
-
----
-
-## CLI Reference
-
-```bash
 # Show help
 pizzapi --help
-
-# Start an interactive coding session
-pizzapi
-
-# Run the headless runner daemon (spawns sessions on demand)
-pizzapi runner
-
-# Stop the runner daemon
-pizzapi runner stop
-
-# First-run setup (connect to relay server)
-pizzapi setup
-
-# Show API usage across providers
-pizzapi usage
-pizzapi usage anthropic
-pizzapi usage gemini
-pizzapi usage --json
-
-# List available models
-pizzapi models
-pizzapi models --json
-
-# Start the web hub (relay server + UI) via Docker
-pizzapi web
-pizzapi web --port 8080
-pizzapi web --origins "https://example.com"
-pizzapi web stop
-pizzapi web logs
-pizzapi web status
-pizzapi web config
-pizzapi web config set port 9000
-
-# Show version
-pizzapi --version
-```
-
-### `pizza web` — One-Command Self-Hosting
-
-`pizza web` is the easiest way to self-host the PizzaPi relay server and web UI. It manages Docker Compose for you — no need to clone the repo or write config files.
-
-**Requirements:** Docker with Docker Compose
-
-```bash
-# Show help
 pizzapi web --help
-
-# Start the hub on the default port (7492)
-pizzapi web
-
-# Start on a custom port (persisted for future runs)
-pizzapi web --port 8080
-
-# Set extra CORS origins (persisted)
-pizzapi web --origins "https://example.com,https://other.com"
-
-# Run in the foreground (useful for debugging)
-pizzapi web --foreground
-```
-
-On first run, if you're not inside the PizzaPi repo, the command will automatically clone it to `~/.pizzapi/web/repo`. On subsequent runs it pulls the latest changes.
-
-All settings and persistent data are stored in `~/.pizzapi/web/`:
-
-| File | Purpose |
-|------|---------|
-| `config.json` | All web hub settings (port, VAPID keys, origins, etc.) |
-| `compose.yml` | Auto-generated Docker Compose config (regenerated each run) |
-| `data/` | Persistent auth database |
-
-#### Configuration
-
-Settings are persisted in `~/.pizzapi/web/config.json` and applied on every `pizza web` start. CLI flags like `--port` and `--origins` update the config automatically.
-
-```bash
-# View current configuration
-pizzapi web config
-
-# Set a config value
-pizzapi web config set port 9000
-pizzapi web config set extraOrigins "https://example.com"
-pizzapi web config set vapidSubject "mailto:ops@example.com"
-```
-
-| Key | Default | Description |
-|-----|---------|-------------|
-| `port` | `7492` | Host port to expose the web UI on |
-| `vapidSubject` | `mailto:admin@pizzapi.local` | VAPID subject for push notifications |
-| `extraOrigins` | (none) | Extra allowed CORS origins, comma-separated |
-
-VAPID keys for push notifications are generated on first run and stored in `config.json`. They persist across restarts and config changes — push notification subscriptions won't break.
-
-> **Custom Docker overrides:** The `compose.yml` is regenerated on each run from the template + config. For additional Docker customizations (extra volumes, networks, etc.), create a `compose.override.yml` in the same directory — Docker Compose picks it up automatically.
-
-#### Management Commands
-
-```bash
-# View live logs
-pizzapi web logs
-
-# Check running status
-pizzapi web status
-
-# Stop the hub
-pizzapi web stop
-```
-
-#### How It Works
-
-1. Checks for Docker and Docker Compose
-2. Locates (or clones) the PizzaPi repository
-3. Loads settings from `~/.pizzapi/web/config.json` (creating with defaults on first run)
-4. Generates a `compose.yml` from the config (idempotent — only writes if changed)
-5. Runs `docker compose up` to build and start Redis + the server
-6. The web UI is available at `http://localhost:<port>`
-
----
-
-### Exposing the Web UI over HTTPS with Tailscale
-
-If you're running PizzaPi on a machine in your [Tailscale](https://tailscale.com) network, you can use **Tailscale Serve** to expose the web UI over HTTPS with a valid TLS certificate — no reverse proxy or manual cert management needed.
-
-#### 1. Generate a TLS certificate
-
-Tailscale can provision a Let's Encrypt certificate for your machine's Tailscale hostname:
-
-```bash
-tailscale cert your-hostname.tail12345.ts.net
-```
-
-This writes `your-hostname.tail12345.ts.net.crt` and `.key` to the current directory. Tailscale Serve uses these automatically — you don't need to configure them manually.
-
-#### 2. Start Tailscale Serve
-
-Proxy HTTPS traffic to the local PizzaPi port (default 7492 if using `pizza web`):
-
-```bash
-tailscale serve --bg http://localhost:7492
-```
-
-The web UI is now available at:
-
-```
-https://your-hostname.tail12345.ts.net/
-```
-
-Tailscale handles TLS termination and certificate renewal automatically.
-
-#### 3. Update allowed origins
-
-The server validates request origins for security. Add your Tailscale HTTPS URL:
-
-```bash
-pizzapi web config set extraOrigins "https://your-hostname.tail12345.ts.net"
-```
-
-> **Important:** Do not include a trailing slash — browser origins never have one.
-
-Then restart the server:
-
-```bash
-pizzapi web stop && pizzapi web
-```
-
-#### 4. Verify
-
-Open `https://your-hostname.tail12345.ts.net/` in your browser. You should see a valid certificate issued by Let's Encrypt.
-
-#### Tailscale Serve management
-
-```bash
-# Check current serve config
-tailscale serve status
-
-# Stop serving
-tailscale serve --https=443 off
-```
-
-#### Troubleshooting
-
-| Symptom | Cause | Fix |
-|---------|-------|-----|
-| SSL/certificate error in browser | Tailscale Serve not running, or accessing `:7492` directly over HTTPS | Use the default HTTPS URL (port 443) and ensure `tailscale serve` is active |
-| Blank page | Serve configured with `https+insecure://` backend | Use `http://localhost:7492` (plain HTTP) as the backend — the server doesn't speak TLS |
-| "Invalid origin" error | `extraOrigins` doesn't match the URL, or has a trailing slash | Run `pizzapi web config set extraOrigins "https://your-hostname.tail12345.ts.net"` (no trailing slash) and restart |
-| 502 Bad Gateway | Tailscale Serve config was lost (e.g. after reboot) | Re-run `tailscale serve --bg http://localhost:7492` |
-| Port already allocated | Another container or process is using the port | Run `docker ps -a --filter "publish=7492"` to find the conflict, stop it, then retry |
-
----
-
-## Configuration
-
-Config is merged from two JSON files — project-local overrides global:
-
-| File | Scope |
-|------|-------|
-| `~/.pizzapi/config.json` | Global (all projects) |
-| `.pizzapi/config.json` | Project-local |
-
-**Example:**
-
-```json
-{
-  "apiKey": "your-relay-api-key",
-  "relayUrl": "wss://your-server.example.com",
-  "systemPrompt": "You are a helpful coding assistant.",
-  "appendSystemPrompt": "Always write tests."
-}
-```
-
-You can also use environment variables:
-
-```bash
-export PIZZAPI_API_KEY="your-relay-api-key"
-export PIZZAPI_RELAY_URL="wss://your-server.example.com"
-pizzapi
 ```
 
 ---
 
-## Runner Daemon
+## Documentation
 
-The runner daemon lets you spawn **headless agent sessions on demand** from the web UI or via the `spawn_session` tool — no terminal needed.
+Full documentation is available at **[pizzaface.github.io/PizzaPi](https://pizzaface.github.io/PizzaPi/)**.
 
-```bash
-# Start the runner
-pizzapi runner
-
-# Stop the runner
-pizzapi runner stop
-```
-
-The runner registers itself with the relay server under a stable ID (stored in `~/.pizzapi/runner.json`) and spawns worker processes when requested.
-
----
-
-## Platform Support
-
-Pre-built binaries are available for:
-
-| Platform | Architectures |
-|----------|--------------|
-| Linux | x64, arm64 |
-| macOS | x64, arm64 (Apple Silicon) |
-| Windows | x64 |
+- [Getting Started](https://pizzaface.github.io/PizzaPi/getting-started/)
+- [Installation](https://pizzaface.github.io/PizzaPi/guides/installation/)
+- [CLI Reference](https://pizzaface.github.io/PizzaPi/guides/cli-reference/)
+- [Configuration](https://pizzaface.github.io/PizzaPi/guides/configuration/)
+- [Self-Hosting](https://pizzaface.github.io/PizzaPi/guides/self-hosting/)
+- [Tailscale Setup](https://pizzaface.github.io/PizzaPi/guides/tailscale/)
+- [Runner Daemon](https://pizzaface.github.io/PizzaPi/guides/runner-daemon/)
+- [Architecture](https://pizzaface.github.io/PizzaPi/reference/architecture/)
 
 ---
 
@@ -405,20 +65,11 @@ See [AGENTS.md](./AGENTS.md) for full developer documentation including build co
 **Prerequisites:** [Bun](https://bun.sh) (required — not Node/npm/yarn)
 
 ```bash
-# Install dependencies
 bun install
-
-# Build all packages
 bun run build
-
-# Start dev server + UI with hot-reload
-bun run dev
-
-# Type-check all packages
-bun run typecheck
+bun run dev        # Hot-reload dev server
+bun run typecheck  # Type-check all packages
 ```
-
-The dev server runs at **http://localhost:3001** (API) and **http://localhost:5173** (Vite UI).
 
 ---
 

--- a/packages/docs/src/content/docs/guides/cli-reference.mdx
+++ b/packages/docs/src/content/docs/guides/cli-reference.mdx
@@ -15,6 +15,28 @@ pizzapi [command] [options]
 
 When called without a command, `pizzapi` starts an **interactive coding session** and streams it to the configured relay server.
 
+Run `pizzapi --help` for a quick summary of all commands:
+
+```
+pizzapi v0.2.2 — PizzaPi coding agent
+
+Usage:
+  pizza                       Start an interactive agent session
+  pizza web [flags]           Manage the PizzaPi web hub (Docker)
+  pizza runner [args]         Manage the background runner daemon
+  pizza runner stop           Stop the runner daemon
+  pizza setup                 Run first-time setup
+  pizza usage [provider]      Show API usage stats
+  pizza models                List available models
+
+Flags:
+  --cwd <path>    Set working directory
+  -v, --version   Show version
+  -h, --help      Show this help
+
+Run `pizza <command> --help` for command-specific help.
+```
+
 ---
 
 ## Commands
@@ -85,23 +107,47 @@ pizzapi runner stop
 
 Start the **PizzaPi web hub** (relay server + web UI) using Docker Compose. This is the easiest way to self-host the relay — no need to clone the repo or configure Docker manually.
 
+Run `pizzapi web --help` for the full usage:
+
+```
+pizza web — Manage the PizzaPi web hub (server + UI via Docker Compose)
+
+Usage:
+  pizza web [flags]               Start the web hub
+  pizza web stop                  Stop the web hub
+  pizza web logs                  Tail container logs
+  pizza web status                Show container status
+  pizza web config                Show current configuration
+  pizza web config set <k> <v>    Update a config value
+
+Flags:
+  --port <port>       Set the host port (persisted to config.json)
+  --origins <list>    Set extra allowed CORS origins (comma-separated, persisted)
+  -f, --foreground    Run in the foreground (don't detach)
+  -h, --help          Show this help
+
+Configuration (~/.pizzapi/web/config.json):
+  port            Host port (default: 7492)
+  vapidSubject    VAPID subject for push notifications
+  extraOrigins    Extra CORS origins, comma-separated
+```
+
 ```bash
 # Start on the default port (7492)
 pizzapi web
 
-# Start on a custom port
+# Start on a custom port (persisted for future runs)
 pizzapi web --port 8080
+
+# Set extra CORS origins (persisted)
+pizzapi web --origins "https://example.com,https://other.com"
 
 # Run in the foreground (don't detach)
 pizzapi web --foreground
 
-# Stop the hub
+# Management
 pizzapi web stop
-
-# View logs
 pizzapi web logs
-
-# Check running status
 pizzapi web status
 ```
 
@@ -115,13 +161,57 @@ pizzapi web status
 | `stop` | Stop the running web hub |
 | `logs` | Tail the container logs |
 | `status` | Show running container status |
+| `config` | Show current configuration from `config.json` |
+| `config set <key> <value>` | Update a config value (see below) |
 
 | Flag | Description |
 |------|-------------|
-| `--port <number>` | HTTP port to expose (default: `7492`) |
+| `--port <number>` | HTTP port to expose (default: `7492`). Persisted to `config.json`. |
+| `--origins <list>` | Extra CORS origins, comma-separated. Persisted to `config.json`. |
 | `--foreground`, `-f` | Run in the foreground instead of detaching |
+| `--help`, `-h` | Show help |
 
-The generated Docker Compose file and persistent data (SQLite database) are stored in `~/.pizzapi/web/`.
+#### `pizzapi web config`
+
+View the current web hub configuration:
+
+```bash
+pizzapi web config
+```
+
+#### `pizzapi web config set`
+
+Update a configuration value. Changes are saved to `~/.pizzapi/web/config.json` and take effect on the next `pizza web` start.
+
+```bash
+pizzapi web config set port 9000
+pizzapi web config set extraOrigins "https://example.com"
+pizzapi web config set vapidSubject "mailto:ops@example.com"
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `port` | `7492` | Host port to expose the web UI on |
+| `vapidSubject` | `mailto:admin@pizzapi.local` | VAPID subject for web push notifications |
+| `extraOrigins` | *(none)* | Extra allowed CORS origins, comma-separated |
+
+<Aside type="tip">
+  CLI flags like `--port` and `--origins` automatically persist to `config.json`, so you only need to pass them once. Use `config set` to change values without starting the server.
+</Aside>
+
+All settings and persistent data are stored in `~/.pizzapi/web/`:
+
+| File | Purpose |
+|------|---------|
+| `config.json` | All web hub settings (port, VAPID keys, origins, etc.) |
+| `compose.yml` | Auto-generated Docker Compose config (regenerated each run) |
+| `data/` | Persistent auth database |
+
+VAPID keys for push notifications are generated on first run and stored in `config.json`. They persist across restarts and config changes — push notification subscriptions won't break.
+
+<Aside type="note">
+  **Custom Docker overrides:** The `compose.yml` is regenerated on each run from the template + config. For additional Docker customizations (extra volumes, networks, etc.), create a `compose.override.yml` in the same directory — Docker Compose picks it up automatically.
+</Aside>
 
 ---
 
@@ -217,6 +307,7 @@ pizzapi --version
 
 | Flag | Description |
 |------|-------------|
+| `--help`, `-h` | Show help and exit |
 | `--version`, `-v` | Print version and exit |
 | `--cwd <path>` | Override working directory (applies to the default session command) |
 

--- a/packages/docs/src/content/docs/guides/configuration.mdx
+++ b/packages/docs/src/content/docs/guides/configuration.mdx
@@ -125,3 +125,29 @@ Create `.pizzapi/config.json` in your project root to customize behavior for tha
 ```
 
 Commit this file to share it with your team — just keep `apiKey` out of project-local config (use the global file or environment variables instead).
+
+---
+
+## Web Hub Configuration
+
+The `pizza web` command has its own separate config file at `~/.pizzapi/web/config.json` for managing the self-hosted relay server. This is distinct from the CLI config above.
+
+```bash
+# View current web hub config
+pizzapi web config
+
+# Set values
+pizzapi web config set port 9000
+pizzapi web config set extraOrigins "https://example.com"
+pizzapi web config set vapidSubject "mailto:ops@example.com"
+```
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `port` | `7492` | Host port to expose the web UI on |
+| `vapidSubject` | `mailto:admin@pizzapi.local` | VAPID subject for web push notifications |
+| `extraOrigins` | *(none)* | Extra allowed CORS origins, comma-separated |
+
+CLI flags like `--port` and `--origins` also persist to this config file automatically.
+
+See the [CLI Reference](/PizzaPi/guides/cli-reference/#pizzapi-web-config-set) and [Self-Hosting guide](/PizzaPi/guides/self-hosting/) for more details.

--- a/packages/docs/src/content/docs/guides/self-hosting.mdx
+++ b/packages/docs/src/content/docs/guides/self-hosting.mdx
@@ -28,11 +28,19 @@ This automatically:
 On subsequent runs, it pulls the latest changes and rebuilds if needed.
 
 ```bash
-# Custom port
+# Custom port (persisted for future runs)
 pizzapi web --port 8080
+
+# Set extra CORS origins (persisted)
+pizzapi web --origins "https://example.com"
 
 # Run in the foreground
 pizzapi web --foreground
+
+# View / change config without starting
+pizzapi web config
+pizzapi web config set port 9000
+pizzapi web config set extraOrigins "https://example.com"
 
 # Management
 pizzapi web logs      # Tail container logs
@@ -40,10 +48,12 @@ pizzapi web status    # Show running containers
 pizzapi web stop      # Stop the hub
 ```
 
+All settings are persisted in `~/.pizzapi/web/config.json` and applied on every start. CLI flags like `--port` and `--origins` update the config automatically — you only need to pass them once.
+
 Persistent data (SQLite database) is stored in `~/.pizzapi/web/data/`.
 
 <Aside type="tip">
-  `pizza web` is ideal for personal use or quick evaluation. For production deployments with custom domains and TLS, see the manual Docker Compose setup below.
+  `pizza web` is ideal for personal use or quick evaluation. For production deployments with custom domains and TLS, see the manual Docker Compose setup below. See the [CLI Reference](/PizzaPi/guides/cli-reference/#pizzapi-web) for the full list of commands and config keys.
 </Aside>
 
 ---

--- a/packages/docs/src/content/docs/guides/tailscale.mdx
+++ b/packages/docs/src/content/docs/guides/tailscale.mdx
@@ -58,11 +58,10 @@ If you're running PizzaPi on a machine in your [Tailscale](https://tailscale.com
 
    <Tabs>
      <TabItem label="pizza web (Docker)">
-       Edit `~/.pizzapi/web/compose.yml`:
+       Use `config set` to persist the extra origin:
 
-       ```yaml
-       environment:
-         - PIZZAPI_EXTRA_ORIGINS=https://your-hostname.tail12345.ts.net
+       ```bash
+       pizzapi web config set extraOrigins "https://your-hostname.tail12345.ts.net"
        ```
 
        Then restart:


### PR DESCRIPTION
Moves detailed CLI reference, config, and self-hosting documentation from the README into the Starlight docs site at `packages/docs`.

### Changes
- **README**: Slimmed down to quick start + links to the docs site
- **cli-reference.mdx**: Added `--help` output, `web config`/`config set` docs, config key table, file layout table
- **self-hosting.mdx**: Added `config set` commands and note about config persistence
- **tailscale.mdx**: Updated `pizza web` tab to use `config set` instead of editing `compose.yml` directly
- **configuration.mdx**: Added Web Hub Configuration section for `~/.pizzapi/web/config.json`