### PR TITLE
fix: copy compose.yml.template into binary and npm builds

### DIFF
--- a/packages/cli/build-binaries.ts
+++ b/packages/cli/build-binaries.ts
@@ -78,6 +78,12 @@ function copyAssets(piPkgDir: string, outDir: string): void {
     if (existsSync(exportSrc)) {
         cpSync(exportSrc, join(outDir, "export-html"), { recursive: true });
     }
+
+    // 4. templates/ — compose.yml.template for `pizza web`
+    const templatesSrc = join(import.meta.dirname ?? __dirname, "src", "templates");
+    if (existsSync(templatesSrc)) {
+        cpSync(templatesSrc, join(outDir, "templates"), { recursive: true });
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "bun src/index.ts",
     "dev:runner": "bun src/index.ts runner",
-    "build": "tsc",
+    "build": "tsc && cp -r src/templates dist/templates",
     "start": "bun dist/index.js",
     "build:binary": "bun build-binaries.ts --target",
     "build:binary:linux-x64": "bun build-binaries.ts --target linux-x64",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "bun src/index.ts",
     "dev:runner": "bun src/index.ts runner",
-    "build": "tsc && cp -r src/templates dist/templates",
+    "build": "tsc && rm -rf dist/templates && cp -r src/templates dist/templates",
     "start": "bun dist/index.js",
     "build:binary": "bun build-binaries.ts --target",
     "build:binary:linux-x64": "bun build-binaries.ts --target linux-x64",

--- a/packages/npm/build-npm.ts
+++ b/packages/npm/build-npm.ts
@@ -142,7 +142,7 @@ for (const platform of PLATFORMS) {
 
     // Copy assets (package.json from pi, theme/, export-html/, PTY native lib)
     const assetDir = join(BINARIES_DIR, platform.binaryDir);
-    for (const asset of ["package.json", "theme", "export-html"]) {
+    for (const asset of ["package.json", "theme", "export-html", "templates"]) {
         const src = join(assetDir, asset);
         if (existsSync(src)) {
             cpSync(src, join(binDir, asset), { recursive: true });

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -34,6 +34,7 @@ import {
 import { RateLimiter, isValidEmail, isValidPassword, cwdMatchesRoots } from "../security.js";
 import { isValidSkillName } from "../validation.js";
 import { isSignupAllowed } from "../auth.js";
+import { SERVER_VERSION } from "../version.js";
 
 // 5 requests per 15 minutes
 const registerRateLimiter = new RateLimiter(5, 15 * 60 * 1000);
@@ -41,6 +42,11 @@ const registerRateLimiter = new RateLimiter(5, 15 * 60 * 1000);
 export async function handleApi(req: Request, url: URL): Promise<Response | undefined> {
     if (url.pathname === "/health") {
         return Response.json({ status: "ok" });
+    }
+
+    // ── Public endpoint: server version ─────────────────────────────────
+    if (url.pathname === "/api/version" && req.method === "GET") {
+        return Response.json({ version: SERVER_VERSION });
     }
 
     // ── Public endpoint: signup status ───────────────────────────────────

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -34,7 +34,7 @@ import {
 import { RateLimiter, isValidEmail, isValidPassword, cwdMatchesRoots } from "../security.js";
 import { isValidSkillName } from "../validation.js";
 import { isSignupAllowed } from "../auth.js";
-import { SERVER_VERSION } from "../version.js";
+import { getLatestNpmVersion } from "../version.js";
 
 // 5 requests per 15 minutes
 const registerRateLimiter = new RateLimiter(5, 15 * 60 * 1000);
@@ -44,9 +44,10 @@ export async function handleApi(req: Request, url: URL): Promise<Response | unde
         return Response.json({ status: "ok" });
     }
 
-    // ── Public endpoint: server version ─────────────────────────────────
+    // ── Public endpoint: latest published version ──────────────────────
     if (url.pathname === "/api/version" && req.method === "GET") {
-        return Response.json({ version: SERVER_VERSION });
+        const version = await getLatestNpmVersion();
+        return Response.json({ version });
     }
 
     // ── Public endpoint: signup status ───────────────────────────────────

--- a/packages/server/src/version.ts
+++ b/packages/server/src/version.ts
@@ -1,17 +1,32 @@
-import { readFileSync } from "node:fs";
-import { resolve, dirname } from "node:path";
-import { fileURLToPath } from "node:url";
+const NPM_PACKAGE = "@pizzapi/pizza";
+const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+let cachedVersion: string | null = null;
+let cachedAt = 0;
 
-function loadVersion(): string {
+/**
+ * Fetch the latest published version of @pizzapi/pizza from npm.
+ * Caches the result for 15 minutes to avoid hammering the registry.
+ */
+export async function getLatestNpmVersion(): Promise<string | null> {
+    const now = Date.now();
+    if (cachedVersion && now - cachedAt < CACHE_TTL_MS) {
+        return cachedVersion;
+    }
+
     try {
-        const pkgPath = resolve(__dirname, "..", "package.json");
-        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
-        return pkg.version ?? "unknown";
+        const res = await fetch(`https://registry.npmjs.org/${NPM_PACKAGE}/latest`, {
+            headers: { Accept: "application/json" },
+            signal: AbortSignal.timeout(5000),
+        });
+        if (!res.ok) return cachedVersion;
+        const data = (await res.json()) as { version?: string };
+        if (data.version) {
+            cachedVersion = data.version;
+            cachedAt = now;
+        }
+        return cachedVersion;
     } catch {
-        return "unknown";
+        return cachedVersion;
     }
 }
-
-export const SERVER_VERSION = loadVersion();

--- a/packages/server/src/version.ts
+++ b/packages/server/src/version.ts
@@ -16,8 +16,8 @@ export async function getLatestNpmVersion(): Promise<string | null> {
     if (cachedVersion && now - cachedAt < CACHE_TTL_MS) {
         return cachedVersion;
     }
-    if (!cachedVersion && lastFailureAt && now - lastFailureAt < FAILURE_TTL_MS) {
-        return null;
+    if (lastFailureAt && now - lastFailureAt < FAILURE_TTL_MS) {
+        return cachedVersion;
     }
 
     try {

--- a/packages/server/src/version.ts
+++ b/packages/server/src/version.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function loadVersion(): string {
+    try {
+        const pkgPath = resolve(__dirname, "..", "package.json");
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+        return pkg.version ?? "unknown";
+    } catch {
+        return "unknown";
+    }
+}
+
+export const SERVER_VERSION = loadVersion();

--- a/packages/server/src/version.ts
+++ b/packages/server/src/version.ts
@@ -1,17 +1,23 @@
 const NPM_PACKAGE = "@pizzapi/pizza";
 const CACHE_TTL_MS = 15 * 60 * 1000; // 15 minutes
+const FAILURE_TTL_MS = 60 * 1000; // 1 minute backoff on failure
 
 let cachedVersion: string | null = null;
 let cachedAt = 0;
+let lastFailureAt = 0;
 
 /**
  * Fetch the latest published version of @pizzapi/pizza from npm.
- * Caches the result for 15 minutes to avoid hammering the registry.
+ * Caches success for 15 minutes and failures for 1 minute to avoid
+ * request amplification when npm is unreachable.
  */
 export async function getLatestNpmVersion(): Promise<string | null> {
     const now = Date.now();
     if (cachedVersion && now - cachedAt < CACHE_TTL_MS) {
         return cachedVersion;
+    }
+    if (!cachedVersion && lastFailureAt && now - lastFailureAt < FAILURE_TTL_MS) {
+        return null;
     }
 
     try {
@@ -19,14 +25,19 @@ export async function getLatestNpmVersion(): Promise<string | null> {
             headers: { Accept: "application/json" },
             signal: AbortSignal.timeout(5000),
         });
-        if (!res.ok) return cachedVersion;
+        if (!res.ok) {
+            lastFailureAt = now;
+            return cachedVersion;
+        }
         const data = (await res.json()) as { version?: string };
         if (data.version) {
             cachedVersion = data.version;
             cachedAt = now;
+            lastFailureAt = 0;
         }
         return cachedVersion;
     } catch {
+        lastFailureAt = now;
         return cachedVersion;
     }
 }

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Button } from "@/components/ui/button";
-import { RefreshCw, HardDrive, Hash, Loader2, Server, ChevronDown, Plus, FolderOpen, Terminal, Clock, Power } from "lucide-react";
+import { RefreshCw, HardDrive, Hash, Loader2, Server, ChevronDown, Plus, FolderOpen, Terminal, Clock, Power, AlertTriangle } from "lucide-react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { formatPathTail } from "@/lib/path";
@@ -47,6 +47,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
     const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
     const [sessions, setSessions] = React.useState<LiveSession[]>([]);
     const [loading, setLoading] = React.useState(true);
+    const [serverVersion, setServerVersion] = React.useState<string | null>(null);
     const [restarting, setRestarting] = React.useState<Set<string>>(new Set());
     const [stopping, setStopping] = React.useState<Set<string>>(new Set());
 
@@ -92,6 +93,14 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
         const interval = setInterval(fetchData, 10000);
         return () => clearInterval(interval);
     }, [fetchData]);
+
+    // Fetch server version once
+    React.useEffect(() => {
+        fetch("/api/version")
+            .then((res) => res.ok ? res.json() : null)
+            .then((data) => { if (data?.version) setServerVersion(data.version); })
+            .catch(() => {});
+    }, []);
 
     // Fetch recent folders when a runner is selected in the spawn dialog
     React.useEffect(() => {
@@ -313,6 +322,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
                                     key={runner.runnerId}
                                     runner={runner}
                                     sessions={runnerSessions}
+                                    serverVersion={serverVersion}
                                     isRestarting={restarting.has(runner.runnerId)}
                                     isStopping={stopping.has(runner.runnerId)}
                                     onRestart={() => handleRestart(runner.runnerId)}
@@ -421,6 +431,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
 interface RunnerCardProps {
     runner: RunnerInfo;
     sessions: LiveSession[];
+    serverVersion: string | null;
     isRestarting: boolean;
     isStopping: boolean;
     onRestart: () => void;
@@ -434,13 +445,17 @@ function formatTime(iso: string): string {
     return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function RunnerCard({ runner, sessions, isRestarting, isStopping, onRestart, onStop, onNewSession, onOpenSession, onSkillsChange }: RunnerCardProps) {
+function RunnerCard({ runner, sessions, serverVersion, isRestarting, isStopping, onRestart, onStop, onNewSession, onOpenSession, onSkillsChange }: RunnerCardProps) {
     const [sessionsOpen, setSessionsOpen] = React.useState(true);
+    const isOutdated = !!(runner.version && serverVersion && runner.version !== serverVersion);
 
     return (
         <div className="group relative rounded-xl border border-border/60 bg-card hover:border-border transition-all duration-200 overflow-hidden">
             {/* Subtle top accent line */}
-            <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-green-500/40 to-transparent" />
+            <div className={cn(
+                "absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent to-transparent",
+                isOutdated ? "via-amber-500/40" : "via-green-500/40"
+            )} />
 
             <div className="p-3 sm:p-4">
                 {/* Top row: name + status + actions */}
@@ -457,8 +472,19 @@ function RunnerCard({ runner, sessions, isRestarting, isStopping, onRestart, onS
                                     {runner.name || "Unnamed Runner"}
                                 </p>
                                 {runner.version && (
-                                    <span className="inline-flex items-center text-[10px] font-mono px-1.5 py-0.5 rounded-full bg-muted/60 border border-border/40 text-muted-foreground leading-none">
+                                    <span className={cn(
+                                        "inline-flex items-center text-[10px] font-mono px-1.5 py-0.5 rounded-full border leading-none gap-1",
+                                        isOutdated
+                                            ? "bg-amber-500/10 border-amber-500/40 text-amber-600 dark:text-amber-400"
+                                            : "bg-muted/60 border-border/40 text-muted-foreground"
+                                    )}>
+                                        {isOutdated && <AlertTriangle className="h-2.5 w-2.5" />}
                                         v{runner.version}
+                                    </span>
+                                )}
+                                {isOutdated && (
+                                    <span className="text-[10px] text-amber-600 dark:text-amber-400">
+                                        Update available (server v{serverVersion})
                                     </span>
                                 )}
                             </div>

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -47,7 +47,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
     const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
     const [sessions, setSessions] = React.useState<LiveSession[]>([]);
     const [loading, setLoading] = React.useState(true);
-    const [serverVersion, setServerVersion] = React.useState<string | null>(null);
+    const [latestVersion, setServerVersion] = React.useState<string | null>(null);
     const [restarting, setRestarting] = React.useState<Set<string>>(new Set());
     const [stopping, setStopping] = React.useState<Set<string>>(new Set());
 
@@ -322,7 +322,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
                                     key={runner.runnerId}
                                     runner={runner}
                                     sessions={runnerSessions}
-                                    serverVersion={serverVersion}
+                                    latestVersion={latestVersion}
                                     isRestarting={restarting.has(runner.runnerId)}
                                     isStopping={stopping.has(runner.runnerId)}
                                     onRestart={() => handleRestart(runner.runnerId)}
@@ -431,7 +431,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
 interface RunnerCardProps {
     runner: RunnerInfo;
     sessions: LiveSession[];
-    serverVersion: string | null;
+    latestVersion: string | null;
     isRestarting: boolean;
     isStopping: boolean;
     onRestart: () => void;
@@ -445,9 +445,9 @@ function formatTime(iso: string): string {
     return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function RunnerCard({ runner, sessions, serverVersion, isRestarting, isStopping, onRestart, onStop, onNewSession, onOpenSession, onSkillsChange }: RunnerCardProps) {
+function RunnerCard({ runner, sessions, latestVersion, isRestarting, isStopping, onRestart, onStop, onNewSession, onOpenSession, onSkillsChange }: RunnerCardProps) {
     const [sessionsOpen, setSessionsOpen] = React.useState(true);
-    const isOutdated = !!(runner.version && serverVersion && runner.version !== serverVersion);
+    const isOutdated = !!(runner.version && latestVersion && runner.version !== latestVersion);
 
     return (
         <div className="group relative rounded-xl border border-border/60 bg-card hover:border-border transition-all duration-200 overflow-hidden">
@@ -484,7 +484,7 @@ function RunnerCard({ runner, sessions, serverVersion, isRestarting, isStopping,
                                 )}
                                 {isOutdated && (
                                     <span className="text-[10px] text-amber-600 dark:text-amber-400">
-                                        Update available (server v{serverVersion})
+                                        Update available (v{latestVersion})
                                     </span>
                                 )}
                             </div>

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -428,6 +428,18 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
     );
 }
 
+/** Returns true if version a < b using numeric semver comparison. */
+function semverLt(a: string, b: string): boolean {
+    const parse = (v: string) => v.replace(/^v/, "").split(".").map(Number);
+    const pa = parse(a), pb = parse(b);
+    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+        const na = pa[i] ?? 0, nb = pb[i] ?? 0;
+        if (na < nb) return true;
+        if (na > nb) return false;
+    }
+    return false;
+}
+
 interface RunnerCardProps {
     runner: RunnerInfo;
     sessions: LiveSession[];
@@ -447,7 +459,7 @@ function formatTime(iso: string): string {
 
 function RunnerCard({ runner, sessions, latestVersion, isRestarting, isStopping, onRestart, onStop, onNewSession, onOpenSession, onSkillsChange }: RunnerCardProps) {
     const [sessionsOpen, setSessionsOpen] = React.useState(true);
-    const isOutdated = !!(runner.version && latestVersion && runner.version !== latestVersion);
+    const isOutdated = !!(runner.version && latestVersion && semverLt(runner.version, latestVersion));
 
     return (
         <div className="group relative rounded-xl border border-border/60 bg-card hover:border-border transition-all duration-200 overflow-hidden">
@@ -471,17 +483,17 @@ function RunnerCard({ runner, sessions, latestVersion, isRestarting, isStopping,
                                 <p className="font-semibold text-sm leading-none truncate">
                                     {runner.name || "Unnamed Runner"}
                                 </p>
-                                {runner.version && (
-                                    <span className={cn(
-                                        "inline-flex items-center text-[10px] font-mono px-1.5 py-0.5 rounded-full border leading-none gap-1",
-                                        isOutdated
-                                            ? "bg-amber-500/10 border-amber-500/40 text-amber-600 dark:text-amber-400"
+                                <span className={cn(
+                                    "inline-flex items-center text-[10px] font-mono px-1.5 py-0.5 rounded-full border leading-none gap-1",
+                                    isOutdated
+                                        ? "bg-amber-500/10 border-amber-500/40 text-amber-600 dark:text-amber-400"
+                                        : !runner.version
+                                            ? "bg-muted/60 border-border/40 text-muted-foreground/50 italic"
                                             : "bg-muted/60 border-border/40 text-muted-foreground"
-                                    )}>
-                                        {isOutdated && <AlertTriangle className="h-2.5 w-2.5" />}
-                                        v{runner.version}
-                                    </span>
-                                )}
+                                )}>
+                                    {isOutdated && <AlertTriangle className="h-2.5 w-2.5" />}
+                                    {runner.version ? `v${runner.version}` : "unknown"}
+                                </span>
                                 {isOutdated && (
                                     <span className="text-[10px] text-amber-600 dark:text-amber-400">
                                         Update available (v{latestVersion})

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -428,15 +428,27 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
     );
 }
 
-/** Returns true if version a < b using numeric semver comparison. */
+/**
+ * Returns true if version a < b using semver ordering.
+ * Handles prerelease tags: splits on "-" first, compares core numerically,
+ * then treats any prerelease as less than the same core release
+ * (e.g. 1.2.3-rc.1 < 1.2.3, but 1.2.3-rc.1 > 1.2.2).
+ */
 function semverLt(a: string, b: string): boolean {
-    const parse = (v: string) => v.replace(/^v/, "").split(".").map(Number);
+    const parse = (v: string) => {
+        const clean = v.replace(/^v/, "");
+        const [core, pre] = clean.split("-", 2);
+        return { parts: core.split(".").map(Number), pre: pre ?? null };
+    };
     const pa = parse(a), pb = parse(b);
-    for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
-        const na = pa[i] ?? 0, nb = pb[i] ?? 0;
+    for (let i = 0; i < Math.max(pa.parts.length, pb.parts.length); i++) {
+        const na = pa.parts[i] ?? 0, nb = pb.parts[i] ?? 0;
+        if (isNaN(na) || isNaN(nb)) return false; // unparseable → don't flag
         if (na < nb) return true;
         if (na > nb) return false;
     }
+    // Same core: prerelease < release (e.g. 1.0.0-beta < 1.0.0)
+    if (pa.pre !== null && pb.pre === null) return true;
     return false;
 }
 


### PR DESCRIPTION
Fixes the `ENOENT: compose.yml.template` error Ben hit when running `pizza web` from an installed binary.

## Changes
- **cli/package.json**: copy `src/templates` → `dist/templates` after `tsc`
- **cli/build-binaries.ts**: include `templates/` in `copyAssets()`
- **npm/build-npm.ts**: include `templates/` in platform package assets

The inline `COMPOSE_TEMPLATE` fallback already prevents crashes, but shipping the actual file is more robust and avoids silent fallback behavior.

No version bump needed — takes effect on next binary build/release.