### PR TITLE
feat: add pinned sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Build packages
+        run: bun run build
+
       - name: Build binary (linux-x64)
         working-directory: packages/cli
         run: bun build-binaries.ts --target linux-x64

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -107,7 +107,7 @@ export interface PizzaPiConfig {
     appendSystemPrompt?: string;
     /** API key for authenticating with the PizzaPi relay server */
     apiKey?: string;
-    /** WebSocket URL of the PizzaPi relay server. Default: ws://localhost:3001 */
+    /** WebSocket URL of the PizzaPi relay server. Default: ws://localhost:7492. Set to "off" to disable relay entirely. */
     relayUrl?: string;
     /**
      * Additional skill paths to load (files or directories).

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -418,6 +418,12 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     }
     let lastRetryableError: RetryState | null = null;
 
+    // ── Relay connection failure tracking ─────────────────────────────────────
+    // Show a one-time notification on the first connection failure so the user
+    // knows relay isn't working.  Reset on successful registration so a later
+    // drop can re-notify.
+    let connectFailureNotified = false;
+
     // ── Session name sync state ───────────────────────────────────────────────
     // Keeps web viewers in sync when /name is run directly in the TUI.
     let sessionNameSyncTimer: ReturnType<typeof setInterval> | null = null;
@@ -1439,8 +1445,10 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                     // concatenated string ends up shorter than `width`.
                     const locationLine = layoutLeftRight(pwd, modelBadge, width, truncateMiddle);
                     const statsLine = layoutLeftRight(statsText, relayStatus, width, truncateEnd);
+                    const statusLower = relayStatus.toLowerCase();
                     const relayStatusColor =
-                        relayStatus.toLowerCase().includes("disconnected") || relayStatus.toLowerCase().includes("not configured")
+                        statusLower.includes("disconnected") || statusLower.includes("not configured") ||
+                        statusLower.includes("failed") || statusLower.includes("error")
                             ? "error"
                             : "success";
 
@@ -1540,6 +1548,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 seq: 0,
                 ackedSeq: 0,
             };
+            connectFailureNotified = false;
             setRelayStatus("Connected to Relay");
 
             // Wire up the inter-session message bus now that we have a relay connection.
@@ -1614,6 +1623,20 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             shuttingDown = true;
             relay = null;
             setRelayStatus("Session expired");
+        });
+
+        sock.on("connect_error", (err) => {
+            const url = socketIoUrl();
+            setRelayStatus(`Relay connection failed (${url})`);
+
+            if (!connectFailureNotified && latestCtx) {
+                connectFailureNotified = true;
+                latestCtx.ui.notify(
+                    `⚠ Could not connect to relay at ${url}\n` +
+                    "Sessions won't appear in the web UI until the connection is established.\n" +
+                    "Check PIZZAPI_RELAY_URL or run `pizza setup` to reconfigure.",
+                );
+            }
         });
 
         sock.on("error", (data) => {

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -53,7 +53,7 @@ interface RelayModelInfo {
     contextWindow: number;
 }
 
-const RELAY_DEFAULT = "ws://localhost:3001";
+const RELAY_DEFAULT = "ws://localhost:7492";
 const RELAY_STATUS_KEY = "relay";
 const ASK_USER_TOOL_NAME = "AskUserQuestion";
 

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -1184,7 +1184,8 @@ export const remoteExtension: ExtensionFactory = (pi) => {
 
     function disconnectedStatusText(): string | undefined {
         if (isDisabled()) return undefined;
-        return apiKey() ? "Disconnected from Relay" : undefined;
+        if (!apiKey()) return "Relay not configured — run pizza setup";
+        return "Disconnected from Relay";
     }
 
     function consumePendingAskUserQuestionFromWeb(text: string): boolean {
@@ -1438,7 +1439,10 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                     // concatenated string ends up shorter than `width`.
                     const locationLine = layoutLeftRight(pwd, modelBadge, width, truncateMiddle);
                     const statsLine = layoutLeftRight(statsText, relayStatus, width, truncateEnd);
-                    const relayStatusColor = relayStatus.toLowerCase().includes("disconnected") ? "error" : "success";
+                    const relayStatusColor =
+                        relayStatus.toLowerCase().includes("disconnected") || relayStatus.toLowerCase().includes("not configured")
+                            ? "error"
+                            : "success";
 
                     const line1Raw = locationLine.left + locationLine.pad + locationLine.right;
                     const line2Raw = statsLine.left + statsLine.pad + statsLine.right;
@@ -1658,6 +1662,14 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             return;
         }
         connect();
+
+        // One-time warning when relay can't connect due to missing config
+        if (!apiKey()) {
+            ctx.ui.notify(
+                "⚠ Relay not configured — sessions won't appear in the web UI.\n" +
+                "Run `pizza setup` or set PIZZAPI_API_KEY to connect.",
+            );
+        }
     });
 
     pi.on("session_switch", (_event, ctx) => {

--- a/packages/cli/src/extensions/spawn-session.ts
+++ b/packages/cli/src/extensions/spawn-session.ts
@@ -21,7 +21,7 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
         const configured =
             process.env.PIZZAPI_RELAY_URL ??
             loadConfig(process.cwd()).relayUrl ??
-            "ws://localhost:3001";
+            "ws://localhost:7492";
 
         if (configured.toLowerCase() === "off") return null;
 

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -362,7 +362,7 @@ Run \`pizza <command> --help\` for command-specific help.
 
     // First-run: no API key configured — prompt setup before launching TUI
     const hasApiKey = !!(process.env.PIZZAPI_API_KEY ?? config.apiKey);
-    const relayDisabled = (process.env.PIZZAPI_RELAY_URL ?? "").toLowerCase() === "off";
+    const relayDisabled = (process.env.PIZZAPI_RELAY_URL ?? config.relayUrl ?? "").toLowerCase() === "off";
     if (!hasApiKey && !relayDisabled) {
         await runSetup();
     }

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -379,7 +379,7 @@ function stopUsageRefreshLoop(): void {
  *
  * Authentication: API key via PIZZAPI_API_KEY env var (required).
  *                (Back-compat: PIZZAPI_RUNNER_TOKEN server token)
- * Relay URL:      PIZZAPI_RELAY_URL env var (default: ws://localhost:3001).
+ * Relay URL:      PIZZAPI_RELAY_URL env var (default: ws://localhost:7492).
  * State file:     PIZZAPI_RUNNER_STATE_PATH env var (default: ~/.pizzapi/runner.json).
  */
 export async function runDaemon(_args: string[] = []): Promise<number> {
@@ -419,7 +419,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         let isShuttingDown = false;
 
         // ── Socket.IO connection setup ────────────────────────────────────
-        const relayRaw = (process.env.PIZZAPI_RELAY_URL ?? "ws://localhost:3001")
+        const relayRaw = (process.env.PIZZAPI_RELAY_URL ?? "ws://localhost:7492")
             .trim()
             .replace(/\/$/, "");
 
@@ -1223,7 +1223,7 @@ function spawnSession(
     const env: Record<string, string> = {
         ...Object.fromEntries(Object.entries(process.env).filter(([, v]) => typeof v === "string")) as any,
         // Ensure relay URL is present for the remote extension in the worker.
-        PIZZAPI_RELAY_URL: process.env.PIZZAPI_RELAY_URL ?? "ws://localhost:3001",
+        PIZZAPI_RELAY_URL: process.env.PIZZAPI_RELAY_URL ?? "ws://localhost:7492",
         PIZZAPI_API_KEY: apiKey,
         PIZZAPI_SESSION_ID: sessionId,
         // Tell the worker where the runner-managed usage cache lives so it can

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -2,6 +2,7 @@ import { createInterface } from "readline";
 import { homedir } from "os";
 import { join } from "path";
 import { saveGlobalConfig } from "./config.js";
+import { validatePassword, PASSWORD_REQUIREMENTS } from "@pizzapi/protocol";
 
 const RELAY_DEFAULT = "http://localhost:7492";
 
@@ -117,6 +118,19 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
         if (!password) {
             console.log("\n✗ Password is required. Aborting setup.\n");
             return false;
+        }
+
+        // Validate password requirements for new accounts.
+        if (name) {
+            const check = validatePassword(password);
+            if (!check.valid) {
+                console.log("\n✗ Password does not meet the requirements:");
+                for (const c of check.checks) {
+                    console.log(`  ${c.met ? "✓" : "✗"} ${c.label}`);
+                }
+                console.log();
+                return false;
+            }
         }
 
         process.stdout.write("\nConnecting to relay server… ");

--- a/packages/docs/src/content/docs/guides/configuration.mdx
+++ b/packages/docs/src/content/docs/guides/configuration.mdx
@@ -26,8 +26,9 @@ You can also override any setting with **environment variables**.
   // API key issued by the relay server during `pizzapi setup`
   "apiKey": "pk_live_abc123...",
 
-  // WebSocket URL of the relay server
-  // Default: ws://localhost:3001
+  // WebSocket URL of the relay server.
+  // Set to "off" to disable the relay entirely (no setup wizard, no streaming).
+  // Default: ws://localhost:7492 (the pizzapi web default port)
   "relayUrl": "wss://relay.example.com",
 
   // Replace the default system prompt entirely
@@ -56,7 +57,7 @@ You can also override any setting with **environment variables**.
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `apiKey` | `string` | — | API key for authenticating with the relay server. Issued during `pizzapi setup`. |
-| `relayUrl` | `string` | `ws://localhost:3001` | WebSocket URL of the relay server |
+| `relayUrl` | `string` | `ws://localhost:7492` | WebSocket URL of the relay server. Set to `"off"` to disable relay entirely. |
 | `systemPrompt` | `string` | *(pi default)* | Fully replace the default system prompt |
 | `appendSystemPrompt` | `string` | — | Append to the default system prompt |
 | `agentDir` | `string` | `~/.pizzapi` | Agent config directory (skills, extensions, etc.) |
@@ -68,10 +69,10 @@ You can also override any setting with **environment variables**.
 
 Every config option can also be set as an environment variable. Environment variables take effect for the current process only and do **not** override saved config values in JSON files — the JSON is loaded first, then env vars for the relay connection are applied on top.
 
-| Variable | Equivalent config key |
-|----------|-----------------------|
-| `PIZZAPI_API_KEY` | `apiKey` |
-| `PIZZAPI_RELAY_URL` | `relayUrl` |
+| Variable | Equivalent config key | Notes |
+|----------|-----------------------|-------|
+| `PIZZAPI_API_KEY` | `apiKey` | |
+| `PIZZAPI_RELAY_URL` | `relayUrl` | Set to `off` to disable relay for this invocation |
 
 **Example:**
 
@@ -81,8 +82,35 @@ export PIZZAPI_RELAY_URL="wss://relay.example.com"
 pizzapi
 ```
 
+**Disable the relay for one invocation:**
+
+```bash
+PIZZAPI_RELAY_URL=off pizzapi
+```
+
+**Disable the relay permanently (no env var needed each time):**
+
+```jsonc
+// ~/.pizzapi/config.json
+{
+  "relayUrl": "off"
+}
+```
+
 <Aside type="tip">
   Environment variables are useful in CI/CD pipelines or when you want to avoid storing credentials in a file.
+</Aside>
+
+<Aside type="note" title="Relay URL is not saved by pizzapi setup">
+  `pizzapi setup` saves your **API key** to `~/.pizzapi/config.json` but does **not** persist the relay URL. If you connect to a non-default relay (anything other than `localhost:7492`), manually add `"relayUrl"` to your config after setup:
+
+  ```jsonc
+  // ~/.pizzapi/config.json
+  {
+    "apiKey": "pk_live_...",
+    "relayUrl": "wss://your-relay.example.com"
+  }
+  ```
 </Aside>
 
 ---

--- a/packages/docs/src/content/docs/guides/installation.mdx
+++ b/packages/docs/src/content/docs/guides/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Install the PizzaPi CLI on Linux, macOS, or Windows using npm, Bun, or a pre-built binary.
+description: Install the PizzaPi CLI on Linux, macOS, or Windows using npm, Bun, or a pre-built binary. Includes full reset and uninstall instructions.
 sidebar:
   order: 1
 ---
@@ -110,10 +110,180 @@ bun update -g @pizzapi/pizza
 
 ---
 
-## Uninstalling
+## Files & Directories Created by PizzaPi
+
+PizzaPi stores all its data under `~/.pizzapi/`. Here's what each file is for:
+
+| Path | Created by | Purpose |
+|------|-----------|---------|
+| `~/.pizzapi/config.json` | `pizzapi setup` / manual | CLI config: API key, relay URL, skills, hooks |
+| `~/.pizzapi/auth.json` | `/login` inside a session | AI provider credentials (OAuth tokens, API keys) |
+| `~/.pizzapi/models.json` | first session start | Cached model registry |
+| `~/.pizzapi/runner.json` | `pizzapi runner` (first start) | Runner identity and name (auto-generated) |
+| `~/.pizzapi/runner.pid` | `pizzapi runner` | PID of the running supervisor process |
+| `~/.pizzapi/logs/` | macOS LaunchAgent setup | Log files for runner stdout/stderr |
+| `~/.pizzapi/web/config.json` | `pizzapi web` | Web hub settings (port, VAPID keys, origins) |
+| `~/.pizzapi/web/compose.yml` | `pizzapi web` | Auto-generated Docker Compose file (regenerated each run) |
+| `~/.pizzapi/web/data/` | `pizzapi web` | Persistent SQLite database for user accounts |
+| `~/.pizzapi/web/repo/` | `pizzapi web` | Cloned PizzaPi source repo |
+| `~/.pizzapi/skills/` | manual | Global personal skills |
+
+Project-local config (`.pizzapi/config.json`) is stored in each project's directory and is not part of the global `~/.pizzapi/` tree.
+
+---
+
+## Resetting Configuration
+
+### Re-run setup (switch relay or update credentials)
+
+To switch to a different relay server or update your credentials at any time:
 
 ```bash
-npm uninstall -g @pizzapi/pizza
-# Remove saved config
+pizzapi setup
+```
+
+This overwrites the `apiKey` in `~/.pizzapi/config.json` and prints the WebSocket URL to add to your config. After setup, manually add the relay URL if it's not the default:
+
+```jsonc
+// ~/.pizzapi/config.json
+{
+  "apiKey": "pk_live_...",
+  "relayUrl": "wss://your-relay.example.com"
+}
+```
+
+### Disconnect from the relay (relay-free mode)
+
+To stop connecting to a relay without uninstalling:
+
+```bash
+# Add to ~/.pizzapi/config.json:
+# "relayUrl": "off"
+
+# — or — use an environment variable:
+PIZZAPI_RELAY_URL=off pizzapi
+```
+
+See the [Standalone Mode guide](/PizzaPi/guides/standalone-mode/) for details.
+
+### Reset AI provider credentials
+
+To log out of all AI providers and start fresh with `/login`:
+
+```bash
+rm ~/.pizzapi/auth.json
+rm ~/.pizzapi/models.json
+```
+
+Next time you start `pizzapi`, you'll see "No models available" and can run `/login` to re-authenticate.
+
+### Reset runner identity
+
+The runner identity is auto-generated on first start. To assign a new identity (useful if you've cloned a machine or want a fresh runner registration):
+
+```bash
+# Stop the runner first
+pizzapi runner stop
+
+# Remove the identity file
+rm ~/.pizzapi/runner.json
+
+# Restart — a new ID is generated automatically
+pizzapi runner
+```
+
+### Reset the web hub
+
+To wipe the relay server's database and start fresh (all user accounts and session metadata will be lost):
+
+```bash
+# Stop the web hub first
+pizzapi web stop
+
+# Remove only the database (preserves config, VAPID keys, etc.)
+rm -rf ~/.pizzapi/web/data/
+
+# Restart — a fresh database is created on next start
+pizzapi web
+```
+
+To also reset the web hub configuration (port, VAPID keys, origins):
+
+```bash
+pizzapi web stop
+rm -rf ~/.pizzapi/web/
+pizzapi web   # all defaults restored; new VAPID keys generated
+```
+
+<Aside type="caution">
+  Deleting `~/.pizzapi/web/data/` removes all user accounts. Everyone will need to re-register. Push notification subscriptions are also lost (VAPID keys are in `web/config.json`).
+</Aside>
+
+---
+
+## Uninstalling
+
+### 1. Stop any running processes
+
+```bash
+# Stop the runner daemon (if running)
+pizzapi runner stop
+
+# Stop the web hub (if running)
+pizzapi web stop
+```
+
+### 2. Remove the CLI
+
+<Tabs>
+  <TabItem label="npm">
+  ```bash
+  npm uninstall -g @pizzapi/pizza
+  ```
+  </TabItem>
+  <TabItem label="Bun">
+  ```bash
+  bun remove -g @pizzapi/pizza
+  ```
+  </TabItem>
+  <TabItem label="Pre-built binary">
+  ```bash
+  # Remove the binary from wherever you placed it
+  which pizzapi   # find it
+  sudo rm $(which pizzapi)
+  ```
+  </TabItem>
+</Tabs>
+
+### 3. Remove all PizzaPi data
+
+```bash
+# Removes config, credentials, sessions, web hub data — everything
 rm -rf ~/.pizzapi
+```
+
+Or remove selectively:
+
+```bash
+rm ~/.pizzapi/config.json      # relay credentials only
+rm ~/.pizzapi/auth.json        # AI provider credentials only
+rm -rf ~/.pizzapi/web/         # web hub only
+```
+
+### 4. Remove macOS LaunchAgent (if installed)
+
+If you set up the runner as a macOS LaunchAgent:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.pizzapi.runner.plist
+rm ~/Library/LaunchAgents/com.pizzapi.runner.plist
+```
+
+### 5. Remove systemd service (Linux, if installed)
+
+```bash
+sudo systemctl stop pizzapi-runner
+sudo systemctl disable pizzapi-runner
+sudo rm /etc/systemd/system/pizzapi-runner.service
+sudo systemctl daemon-reload
 ```

--- a/packages/docs/src/content/docs/guides/installation.mdx
+++ b/packages/docs/src/content/docs/guides/installation.mdx
@@ -119,8 +119,8 @@ PizzaPi stores all its data under `~/.pizzapi/`. Here's what each file is for:
 | `~/.pizzapi/config.json` | `pizzapi setup` / manual | CLI config: API key, relay URL, skills, hooks |
 | `~/.pizzapi/auth.json` | `/login` inside a session | AI provider credentials (OAuth tokens, API keys) |
 | `~/.pizzapi/models.json` | first session start | Cached model registry |
-| `~/.pizzapi/runner.json` | `pizzapi runner` (first start) | Runner identity and name (auto-generated) |
-| `~/.pizzapi/runner.pid` | `pizzapi runner` | PID of the running supervisor process |
+| `~/.pizzapi/runner.json` | `pizzapi runner` (first start) | Runner identity, name, and PID tracking (auto-generated) |
+| `~/.pizzapi/usage-cache.json` | `pizzapi runner` | Shared provider quota cache (written by daemon, read by workers) |
 | `~/.pizzapi/logs/` | macOS LaunchAgent setup | Log files for runner stdout/stderr |
 | `~/.pizzapi/web/config.json` | `pizzapi web` | Web hub settings (port, VAPID keys, origins) |
 | `~/.pizzapi/web/compose.yml` | `pizzapi web` | Auto-generated Docker Compose file (regenerated each run) |

--- a/packages/docs/src/content/docs/guides/quick-setup.mdx
+++ b/packages/docs/src/content/docs/guides/quick-setup.mdx
@@ -1,200 +1,247 @@
 ---
 title: Quick Setup
-description: Go from zero to your first live AI coding session in under five minutes.
+description: Verified end-to-end setup for PizzaPi CLI + relay, from zero to your first streamed session.
 sidebar:
   order: 0
 ---
 
 import { Steps, Tabs, TabItem, Aside } from "@astrojs/starlight/components";
 
-This guide walks you through the complete setup — starting the server, creating an account, connecting the CLI, and running your first session. It takes about five minutes.
+This guide is the **fastest verified path** to get PizzaPi working end-to-end:
 
-## Prerequisites
+1. Start (or choose) a relay server
+2. Connect the CLI with `pizzapi setup`
+3. Run a session and confirm it appears in the web UI
 
-| Requirement | Why |
-|-------------|-----|
-| **Docker + Docker Compose** | Runs the relay server and web UI |
-| **Node 18+** or **Bun** | Runs the CLI on your dev machine |
+<Aside type="note">
+  Commands below use <code>pizzapi</code>. The <code>pizza</code> alias works too.
+</Aside>
 
 <Aside type="tip">
-  Don't have Docker? [Get Docker Desktop](https://docs.docker.com/get-docker/) — it includes Docker Compose.
+  If you prefer not to install globally, replace each <code>pizzapi ...</code> command with <code>npx @pizzapi/pizza ...</code>.
+</Aside>
+
+<Aside type="tip" title="Don't need a relay?">
+  Want to use <code>pizzapi</code> locally with no server setup? See <a href="/PizzaPi/guides/standalone-mode/">Standalone &amp; Relay-Free Mode</a> — you can skip this guide entirely and run <code>PIZZAPI_RELAY_URL=off pizzapi</code>.
 </Aside>
 
 ---
 
-## The Full Walkthrough
+## Prerequisites
+
+| Requirement | Needed for |
+|---|---|
+| Node.js 18+ or Bun | Running the CLI |
+| Docker + Docker Compose | Only if you self-host with `pizzapi web` |
+| Relay URL | Hosted relay URL, or local `http://localhost:7492` |
+
+---
+
+## Quick Setup (Verified Flow)
 
 <Steps>
+1. ### Install (or run) the CLI
 
-1. ### Start the relay server
+   <Tabs>
+     <TabItem label="No install (npx)">
+       ```bash
+       npx @pizzapi/pizza --help
+       ```
+     </TabItem>
+     <TabItem label="Global install (npm)">
+       ```bash
+       npm install -g @pizzapi/pizza
+       pizzapi --version
+       ```
+     </TabItem>
+     <TabItem label="Global install (Bun)">
+       ```bash
+       bun install -g @pizzapi/pizza
+       pizzapi --version
+       ```
+     </TabItem>
+   </Tabs>
 
-   Open a terminal and run:
+2. ### Start a relay (or use an existing one)
 
-   ```bash
-   npx @pizzapi/pizza web
-   ```
+   <Tabs>
+     <TabItem label="Self-host locally (fastest)">
+       ```bash
+       pizzapi web
+       ```
 
-   This pulls the PizzaPi repo, builds the Docker image, and starts two containers (Redis + the server). When it finishes you'll see:
+       Wait for:
 
-   ```
-   ✅ PizzaPi web is running at http://localhost:7492
-   ```
+       ```text
+       ✅ PizzaPi web is running at http://localhost:7492
+       ```
 
-   <Aside type="note">
-     The first build takes a few minutes while Docker downloads base images. Subsequent starts are much faster.
+       Keep this URL — you'll use it in setup.
+     </TabItem>
+     <TabItem label="Use an existing relay">
+       Get the relay URL from your team/admin (for example `https://relay.example.com`).
+
+       You do **not** need to run `pizzapi web` in this case.
+     </TabItem>
+   </Tabs>
+
+3. ### Open the web UI and sign in
+
+   - Open your relay URL in a browser (`http://localhost:7492` if local)
+   - Sign in if you already have an account
+   - Otherwise create one from the **Sign up** tab
+
+   <Aside type="tip">
+     If sign-up is not available, the relay is likely configured to allow only existing users. Ask the relay owner for credentials.
    </Aside>
 
-2. ### Create your account
+4. ### Connect the CLI with `pizzapi setup`
 
-   Open **http://localhost:7492** in your browser. You'll see the PizzaPi sign-in page.
-
-   1. Click the **Sign up** tab
-   2. Enter your **name**, **email**, and **password**
-   3. Click **Create account**
-
-   You're now logged into the web UI. Keep this tab open — you'll see your sessions appear here shortly.
-
-   <Aside type="caution">
-     Remember these credentials — you'll use the same email and password to connect the CLI in the next step.
-   </Aside>
-
-3. ### Connect the CLI to your server
-
-   In a new terminal window, run the setup wizard:
+   Run:
 
    ```bash
-   npx @pizzapi/pizza setup
+   pizzapi setup
    ```
 
-   Fill in the prompts using the **same credentials** you just created:
+   Expected prompt flow:
 
-   ```
+   ```text
    ┌─────────────────────────────────────────┐
    │        PizzaPi — first-run setup        │
    └─────────────────────────────────────────┘
 
-   Skip setup and continue without relay? [y/N] n
-   Relay server URL [http://localhost:7492]: ↵
-   Your name (leave blank if account already exists): ↵
-   Email: you@example.com
-   Password: ••••••••
+   Connect this node to a PizzaPi relay server so your sessions
+   can be monitored from the web UI.
+
+   Relay server URL [http://localhost:7492]:
+   Your name (leave blank if account already exists):
+   Email:
+   Password:
 
    Connecting to relay server… ✓
+
    ✓ API key saved to ~/.pizzapi/config.json
    ✓ Relay: ws://localhost:7492
    ```
 
-   <Aside type="tip">
-     Press Enter to accept the default relay URL (`http://localhost:7492`). Leave "Your name" blank since the account already exists.
-   </Aside>
-
-4. ### Configure an AI provider
-
-   Start a `pizzapi` session:
-
-   ```bash
-   npx @pizzapi/pizza
-   ```
-
-   You'll see a warning: *"No models available."* That's expected — you haven't logged into an AI provider yet.
-
-   Type `/login` and press Enter. This opens your browser to authenticate with an AI provider:
-
-   ```
-   /login
-   ```
-
-   Select a provider and follow the OAuth flow:
-
-   | Provider | What you need |
-   |----------|--------------|
-   | **Anthropic** | A [Claude Pro or Max](https://claude.ai) subscription, or an [API key](https://console.anthropic.com/) |
-   | **Google Gemini** | A Google account (free tier available via [AI Studio](https://aistudio.google.com/)) |
-   | **OpenAI** | An [API key](https://platform.openai.com/) |
-
-   Once authentication completes, you'll see a confirmation in the terminal.
+   - **Existing account:** leave "Your name" blank
+   - **New account via setup:** enter a name + email + password
 
    <Aside type="note">
-     You can log into **multiple providers**. Run `/login` again to add another one. Use `/login` followed by the provider name (e.g. `/login anthropic`) to target a specific provider.
+     The "Skip setup and continue without relay?" prompt appears when you run plain <code>pizzapi</code> with no config, not when running <code>pizzapi setup</code> directly.
    </Aside>
 
-5. ### Select a model
+5. ### Start a session and verify streaming
 
-   After logging in, select a model:
-
+   ```bash
+   cd /path/to/your/project
+   pizzapi
    ```
+
+   Then confirm in the web UI that you can see:
+
+   - live assistant output
+   - tool calls (read/edit/bash)
+   - file diffs
+
+6. ### If needed, authenticate an AI provider
+
+   If the terminal warns that no models are available, run inside the session:
+
+   ```text
+   /login
    /model
    ```
 
-   Use the arrow keys to pick from the available models, then press Enter. For example:
-
-   - `claude-sonnet-4-20250514` — fast and capable (Anthropic)
-   - `gemini-2.5-pro` — large context window (Google)
-
-   You can also switch models at any time with `Ctrl+L` or by typing `/model` again.
-
-6. ### Start coding!
-
-   You're all set. Type a prompt and press Enter:
-
-   ```
-   Help me set up a new TypeScript project with tests
-   ```
-
-   Now switch to your browser tab at **http://localhost:7492** — you'll see the session streaming live with:
-
-   - Token-by-token response streaming
-   - Tool calls (file reads, edits, bash commands) with full input/output
-   - Syntax-highlighted file diffs
-   - A live todo list if the agent creates a task plan
-
-   You can also type messages in the web UI's chat input to interact with the agent remotely.
+   After login, pick a model and continue.
 </Steps>
 
 ---
 
-## Quick Reference
+## 60-Second Verification Checklist
 
-Once you're set up, here are the commands you'll use most:
+Run these checks after setup:
 
-| Command | What it does |
-|---------|-------------|
-| `pizzapi` | Start an interactive coding session |
-| `pizzapi setup` | Re-run the relay connection wizard |
-| `pizzapi web` | Start/rebuild the relay server |
-| `pizzapi web stop` | Stop the relay server |
-| `pizzapi web logs` | Tail the server logs |
-| `pizzapi models` | List available AI models |
-| `pizzapi usage` | Check your API usage/quota |
-
-### Inside a session
-
-| Command | What it does |
-|---------|-------------|
-| `/login` | Authenticate with an AI provider |
-| `/model` | Switch the active model |
-| `/help` | Show all available slash commands |
-| `Ctrl+L` | Quick model switcher |
-| `Ctrl+C` | Interrupt the current response |
-| `Ctrl+C` twice | Exit the session |
+| Check | Command / Action | Expected |
+|---|---|---|
+| CLI works | `pizzapi --version` | Prints PizzaPi CLI version |
+| Relay configured | `pizzapi setup` | Shows saved API key + relay URL |
+| Web hub healthy (if self-hosted) | `pizzapi web status` | Docker services listed |
+| Session visible in UI | Start `pizzapi` session | Session appears in browser |
+| Models available | `pizzapi models` | At least one model listed (after `/login`) |
 
 ---
 
 ## Troubleshooting
 
-| Problem | Solution |
-|---------|----------|
-| `pizza web` fails with Docker error | Make sure Docker Desktop is running. Try `docker --version` to verify. |
-| "Could not register with the relay server" | Check the server is running (`pizza web status`) and the URL is correct. |
-| "No models available" after `/login` | Run `/model` to refresh the list. If still empty, try `/login` again — the OAuth flow may have timed out. |
-| Session doesn't appear in web UI | Verify the CLI is connected: check for `✓ Relay: ws://localhost:7492` in the setup output. Run `pizzapi setup` if needed. |
-| Port 7492 already in use | Use a custom port: `pizzapi web --port 8080`, then use `http://localhost:8080` as the relay URL in setup. |
+| Problem | Fix |
+|---|---|
+| `pizzapi web` fails immediately | Make sure Docker Desktop/Engine is running and `docker compose version` works. |
+| Setup says `Could not register with the relay server` | Verify URL, email/password, and that relay is reachable in browser. |
+| Setup asks for a name but account already exists | Leave **Your name** blank for existing accounts. |
+| Setup fails creating a new account | Ensure signups are enabled on that relay, or create account in web UI/admin flow first. |
+| Session not visible in web UI | Re-run `pizzapi setup`, then start a fresh session with `pizzapi`. |
+| No model available in session | Run `/login`, then `/model`. |
 
 ---
 
-## What's Next?
+## Escape Hatches
 
-- **[Runner Daemon](/PizzaPi/guides/runner-daemon/)** — Spawn headless sessions from the web UI without a terminal
-- **[Self-Hosting](/PizzaPi/guides/self-hosting/)** — Production deployment with HTTPS, custom domains, and Tailscale
-- **[Configuration](/PizzaPi/guides/configuration/)** — Customize system prompts, skills, and relay settings
-- **[Skills](/PizzaPi/guides/skills/)** — Add reusable task-specific instructions your agent can follow
+### Skip relay setup entirely (first-run only)
+
+If you run `pizzapi` without any saved config and want to try it locally first, the setup wizard will ask:
+
+```text
+Skip setup and continue without relay? [y/N]
+```
+
+Type `y` to start a session with no relay connection. This skips setup for **this run only**. To skip permanently, see [Standalone Mode](/PizzaPi/guides/standalone-mode/).
+
+### Re-run setup after skipping
+
+```bash
+pizzapi setup
+```
+
+Re-runs the full wizard, even if you've previously skipped or already have a config.
+
+### Switch relay servers
+
+Run `pizzapi setup` again at any time to switch to a different relay:
+
+```bash
+pizzapi setup
+# Relay server URL: https://new-relay.example.com
+# Email: ...
+```
+
+After setup, manually add the relay URL to your config (setup only saves the API key):
+
+```jsonc
+// ~/.pizzapi/config.json
+{
+  "apiKey": "pk_live_...",
+  "relayUrl": "wss://new-relay.example.com"
+}
+```
+
+### Full reset
+
+To wipe all PizzaPi state and start fresh:
+
+```bash
+rm -rf ~/.pizzapi
+pizzapi setup
+```
+
+See the [Installation guide](/PizzaPi/guides/installation/#resetting-configuration) for partial reset options (credentials only, runner only, web hub only).
+
+---
+
+## Next Steps
+
+- [Getting Started](/PizzaPi/getting-started/) — broader overview and hosted vs self-hosted choices
+- [Standalone Mode](/PizzaPi/guides/standalone-mode/) — using pizzapi without a relay server
+- [CLI Reference](/PizzaPi/guides/cli-reference/) — all commands and flags
+- [Self-Hosting](/PizzaPi/guides/self-hosting/) — production deployment and TLS
+- [Configuration](/PizzaPi/guides/configuration/) — config files and env vars

--- a/packages/docs/src/content/docs/guides/runner-daemon.mdx
+++ b/packages/docs/src/content/docs/guides/runner-daemon.mdx
@@ -102,7 +102,7 @@ The sub-session streams to the same relay and appears as a child in the web UI s
 ## Process Hierarchy
 
 ```
-pizzapi runner          ← supervisor (PID saved to ~/.pizzapi/runner.pid)
+pizzapi runner          ← supervisor (PID tracked in ~/.pizzapi/runner.json)
   └── pizzapi _daemon  ← daemon (restarted on crash by supervisor)
         ├── pizzapi _worker   ← session A
         ├── pizzapi _worker   ← session B

--- a/packages/docs/src/content/docs/guides/self-hosting.mdx
+++ b/packages/docs/src/content/docs/guides/self-hosting.mdx
@@ -136,7 +136,7 @@ docker compose -f docker/compose.yml --profile dev up
 | Service | Port | Description |
 |---------|------|-------------|
 | `redis` | 6379 | Redis |
-| `server` (dev) | 3001 | Bun dev server (hot-reload) |
+| `server` (dev) | 7492 | Bun dev server (hot-reload) |
 | `ui` (dev) | 5173 | Vite UI dev server |
 
 Or run without Docker:
@@ -145,7 +145,7 @@ Or run without Docker:
 # Prerequisites: Bun, Redis running locally
 bun install
 bun run dev
-# API → http://localhost:3001
+# API → http://localhost:7492
 # UI  → http://localhost:5173
 ```
 

--- a/packages/docs/src/content/docs/guides/standalone-mode.mdx
+++ b/packages/docs/src/content/docs/guides/standalone-mode.mdx
@@ -1,0 +1,162 @@
+---
+title: Standalone & Relay-Free Mode
+description: Run the PizzaPi CLI without a relay server, or use it without the runner daemon — no Docker, no setup required.
+sidebar:
+  order: 0.5
+---
+
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+
+Not every workflow needs a relay server or a headless runner. This guide covers:
+
+- **Relay-free mode** — run `pizzapi` with no relay server at all
+- **CLI without the runner daemon** — start interactive sessions without `pizzapi runner`
+- When each mode makes sense and how to configure it
+
+---
+
+## CLI Without the Runner Daemon
+
+The **runner daemon** (`pizzapi runner`) is an optional background process — it's only needed when you want to **spawn sessions headlessly from the web UI** or via the `spawn_session` tool.
+
+For everyday interactive coding sessions, you do **not** need the runner:
+
+```bash
+# Just run this — no pizzapi runner required
+pizzapi
+```
+
+That starts a full interactive `pi` session that streams live to your configured relay. The runner daemon adds remote-spawn capability on top of this, but is completely optional.
+
+| Mode | What you need | What you get |
+|------|--------------|--------------|
+| Interactive session | `pizzapi` | Full coding session, streams to relay |
+| Headless / remote spawn | `pizzapi runner` + `pizzapi` (in worker) | Spawn sessions from web UI or `spawn_session` tool |
+
+<Aside type="tip">
+  Start with just `pizzapi`. Add `pizzapi runner` only when you want to spawn sessions remotely.
+</Aside>
+
+---
+
+## Running Without a Relay Server
+
+Sometimes you want to use the `pizzapi` CLI — with all its extensions, skills, and tools — but without connecting to any relay server. Common reasons:
+
+- Local development or offline use
+- Air-gapped environments
+- Just want the `pi` agent experience without setting up infrastructure
+- Testing PizzaPi without running a server
+
+### Method 1: Skip on First Run (Session-Only)
+
+When you run `pizzapi` for the first time without any saved config, the setup wizard will prompt:
+
+```text
+Skip setup and continue without relay? [y/N]
+```
+
+Type `y` and press Enter. The session starts immediately with no relay connection. This skips setup for **this run only** — the prompt will appear again next time.
+
+### Method 2: Permanently Disable the Relay
+
+To disable the relay for all future sessions, set `relayUrl` to `"off"` in your global config:
+
+```jsonc
+// ~/.pizzapi/config.json
+{
+  "relayUrl": "off"
+}
+```
+
+Or pass it as an environment variable:
+
+```bash
+PIZZAPI_RELAY_URL=off pizzapi
+```
+
+With either method:
+
+- No setup wizard appears on first run
+- No relay connection is attempted
+- All other features (skills, tools, hooks, MCP) work normally
+- Session history is still saved locally in `~/.pizzapi/`
+
+<Aside type="note">
+  The relay-disabled check is case-insensitive — `"off"`, `"OFF"`, and `"Off"` all work.
+</Aside>
+
+### Method 3: Use an Environment Variable for One Session
+
+```bash
+# Relay disabled for this invocation only
+PIZZAPI_RELAY_URL=off pizzapi
+
+# — or start with a specific relay for this invocation:
+PIZZAPI_RELAY_URL=wss://relay.example.com pizzapi
+```
+
+---
+
+## What Still Works Without a Relay
+
+When relay is disabled, everything the `pi` agent core provides continues to work:
+
+| Feature | Works offline? |
+|---------|---------------|
+| Interactive sessions | ✅ Yes |
+| Skills & skill files | ✅ Yes |
+| MCP tools | ✅ Yes |
+| Hooks (pre/post tool) | ✅ Yes |
+| Session history (local) | ✅ Yes |
+| Live web UI streaming | ❌ No relay |
+| Remote session spawning | ❌ No relay |
+| `spawn_session` tool | ❌ No relay |
+| Web push notifications | ❌ No relay |
+
+---
+
+## Reconnecting to a Relay Later
+
+Changed your mind? Connect to a relay at any time without losing your local session history:
+
+```bash
+pizzapi setup
+```
+
+This re-runs the full setup wizard: prompts for the relay URL, email, and password, then saves the API key to `~/.pizzapi/config.json`.
+
+If you previously set `"relayUrl": "off"` in your config, remove it first:
+
+```bash
+# Edit ~/.pizzapi/config.json and delete the "relayUrl" line
+# — or — run setup which will overwrite the relevant keys:
+pizzapi setup
+```
+
+<Aside type="tip">
+  After running `pizzapi setup`, also add `"relayUrl": "wss://your-relay-url"` to `~/.pizzapi/config.json` if your relay isn't at the default `localhost:7492`. The setup wizard authenticates you but doesn't persist the relay URL to the config file — only the API key is saved.
+</Aside>
+
+---
+
+## Config Snippet: Relay-Free Global Setup
+
+```jsonc
+// ~/.pizzapi/config.json — minimal config for relay-free use
+{
+  "relayUrl": "off",
+  "appendSystemPrompt": "This is a TypeScript project. Always use strict mode."
+}
+```
+
+## Config Snippet: Relay-Free Per-Project Setup
+
+```jsonc
+// my-project/.pizzapi/config.json
+{
+  "relayUrl": "off"
+}
+```
+
+Project-level config overrides the global one, so this disables the relay only for sessions started in that directory.

--- a/packages/docs/src/content/docs/reference/architecture.mdx
+++ b/packages/docs/src/content/docs/reference/architecture.mdx
@@ -152,7 +152,7 @@ The dev profile starts a single container exposing:
 # Prerequisites: Bun, Redis running locally
 bun install
 bun run dev
-# API server → http://localhost:3001
+# API server → http://localhost:7492
 # Vite UI   → http://localhost:5173
 ```
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -13,6 +13,15 @@ export type {
   Attachment,
 } from "./shared.js";
 
+// Password validation (shared across server, UI, CLI)
+export {
+  PASSWORD_REQUIREMENTS,
+  PASSWORD_REQUIREMENTS_SUMMARY,
+  validatePassword,
+  isValidPassword,
+} from "./password.js";
+export type { PasswordCheck, PasswordCheckItem } from "./password.js";
+
 // /relay namespace (TUI ↔ Server)
 export type {
   RelayClientToServerEvents,

--- a/packages/protocol/src/password.test.ts
+++ b/packages/protocol/src/password.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import { validatePassword, isValidPassword, PASSWORD_REQUIREMENTS } from "./password";
+
+describe("validatePassword", () => {
+  test("accepts valid passwords", () => {
+    const result = validatePassword("Abc12345");
+    expect(result.valid).toBe(true);
+    expect(result.checks.every((c) => c.met)).toBe(true);
+  });
+
+  test("accepts complex passwords", () => {
+    expect(validatePassword("ComplexPass1").valid).toBe(true);
+    expect(validatePassword("1234Abcd").valid).toBe(true);
+    expect(validatePassword("P@ssw0rd!").valid).toBe(true);
+  });
+
+  test("rejects passwords shorter than 8 characters", () => {
+    const result = validatePassword("Ab1cdef");
+    expect(result.valid).toBe(false);
+    expect(result.checks[0].met).toBe(false); // length
+    expect(result.checks[0].label).toBe(PASSWORD_REQUIREMENTS[0]);
+  });
+
+  test("rejects empty string", () => {
+    const result = validatePassword("");
+    expect(result.valid).toBe(false);
+    // Should fail length, uppercase, lowercase, and number
+    expect(result.checks.filter((c) => c.met).length).toBe(0);
+  });
+
+  test("rejects passwords missing uppercase", () => {
+    const result = validatePassword("abcdefg1");
+    expect(result.valid).toBe(false);
+    expect(result.checks[1].met).toBe(false); // uppercase
+  });
+
+  test("rejects passwords missing lowercase", () => {
+    const result = validatePassword("ABCDEFG1");
+    expect(result.valid).toBe(false);
+    expect(result.checks[2].met).toBe(false); // lowercase
+  });
+
+  test("rejects passwords missing number", () => {
+    const result = validatePassword("Abcdefgh");
+    expect(result.valid).toBe(false);
+    expect(result.checks[3].met).toBe(false); // number
+  });
+
+  test("returns 4 check items matching PASSWORD_REQUIREMENTS", () => {
+    const result = validatePassword("anything");
+    expect(result.checks.length).toBe(4);
+    for (let i = 0; i < 4; i++) {
+      expect(result.checks[i].label).toBe(PASSWORD_REQUIREMENTS[i]);
+    }
+  });
+});
+
+describe("isValidPassword", () => {
+  test("returns true for valid passwords", () => {
+    expect(isValidPassword("Abc12345")).toBe(true);
+    expect(isValidPassword("ComplexPass1")).toBe(true);
+  });
+
+  test("returns false for invalid passwords", () => {
+    expect(isValidPassword("short")).toBe(false);
+    expect(isValidPassword("nouppercase1")).toBe(false);
+    expect(isValidPassword("NOLOWERCASE1")).toBe(false);
+    expect(isValidPassword("NoNumbers")).toBe(false);
+    expect(isValidPassword("")).toBe(false);
+  });
+});

--- a/packages/protocol/src/password.ts
+++ b/packages/protocol/src/password.ts
@@ -1,0 +1,54 @@
+// ============================================================================
+// Password validation — shared across server, UI, and CLI
+// ============================================================================
+
+/** Human-readable description of each password requirement. */
+export const PASSWORD_REQUIREMENTS = [
+  "At least 8 characters",
+  "At least one uppercase letter (A-Z)",
+  "At least one lowercase letter (a-z)",
+  "At least one number (0-9)",
+] as const;
+
+/** Summary string for error messages. */
+export const PASSWORD_REQUIREMENTS_SUMMARY =
+  "Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number";
+
+export interface PasswordCheck {
+  /** Overall pass/fail. */
+  valid: boolean;
+  /** Per-requirement results (same order as PASSWORD_REQUIREMENTS). */
+  checks: readonly PasswordCheckItem[];
+}
+
+export interface PasswordCheckItem {
+  /** The human-readable requirement label. */
+  label: string;
+  /** Whether this individual requirement is met. */
+  met: boolean;
+}
+
+/**
+ * Validate a password against all requirements and return detailed results.
+ *
+ * Use `.valid` for a quick boolean, or iterate `.checks` for per-rule feedback.
+ */
+export function validatePassword(password: string): PasswordCheck {
+  const checks: PasswordCheckItem[] = [
+    { label: PASSWORD_REQUIREMENTS[0], met: password.length >= 8 },
+    { label: PASSWORD_REQUIREMENTS[1], met: /[A-Z]/.test(password) },
+    { label: PASSWORD_REQUIREMENTS[2], met: /[a-z]/.test(password) },
+    { label: PASSWORD_REQUIREMENTS[3], met: /[0-9]/.test(password) },
+  ];
+  return {
+    valid: checks.every((c) => c.met),
+    checks,
+  };
+}
+
+/**
+ * Simple boolean check — drop-in replacement for the old `isValidPassword`.
+ */
+export function isValidPassword(password: string): boolean {
+  return validatePassword(password).valid;
+}

--- a/packages/protocol/tsconfig.json
+++ b/packages/protocol/tsconfig.json
@@ -4,5 +4,6 @@
     "outDir": "dist",
     "rootDir": "src"
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -87,6 +87,7 @@ export interface RelaySessionTable {
     endedAt: string | null;
     isEphemeral: number;
     expiresAt: string | null;
+    isPinned: number;
 }
 
 export interface RelaySessionStateTable {

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -1,4 +1,5 @@
 import { getAuth, isSignupAllowed } from "./auth.js";
+import { isValidPassword, PASSWORD_REQUIREMENTS_SUMMARY } from "@pizzapi/protocol";
 import { handleApi } from "./routes/api.js";
 import { serveStaticFile } from "./static.js";
 
@@ -21,6 +22,23 @@ export async function handleFetch(req: Request): Promise<Response> {
                 );
             }
         }
+
+        // Enforce password policy on change-password requests.
+        if (url.pathname === "/api/auth/change-password" && req.method === "POST") {
+            try {
+                const cloned = req.clone();
+                const body = await cloned.json() as { newPassword?: string };
+                if (body.newPassword && !isValidPassword(body.newPassword)) {
+                    return Response.json(
+                        { error: PASSWORD_REQUIREMENTS_SUMMARY },
+                        { status: 400 },
+                    );
+                }
+            } catch {
+                // Let better-auth handle malformed bodies.
+            }
+        }
+
         try {
             return await getAuth().handler(req);
         } catch (e) {

--- a/packages/server/src/routes/api.test.ts
+++ b/packages/server/src/routes/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { parseJsonArray } from "./api";
+import { handleApi, parseJsonArray } from "./api";
 import { normalizePath, cwdMatchesRoots } from "../security";
 
 // ── normalizePath ───────────────────────────────────────────────────────────
@@ -58,6 +58,20 @@ describe("parseJsonArray", () => {
     test("returns empty array for invalid JSON", () => {
         expect(parseJsonArray("not json")).toEqual([]);
         expect(parseJsonArray("{broken")).toEqual([]);
+    });
+});
+
+// ── pin endpoint routing ───────────────────────────────────────────────────
+
+describe("/api/sessions/:id/pin", () => {
+    test("returns 405 for unsupported methods", async () => {
+        const url = new URL("http://localhost/api/sessions/s-123/pin");
+        const req = new Request(url, { method: "POST" });
+
+        const res = await handleApi(req, url);
+        expect(res).toBeTruthy();
+        expect(res!.status).toBe(405);
+        expect(res!.headers.get("Allow")).toBe("PUT, DELETE");
     });
 });
 

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -37,6 +37,7 @@ import {
     updateEnabledEvents,
 } from "../push.js";
 import { RateLimiter, isValidEmail, isValidPassword, cwdMatchesRoots } from "../security.js";
+import { PASSWORD_REQUIREMENTS_SUMMARY } from "@pizzapi/protocol";
 import { isValidSkillName } from "../validation.js";
 import { isSignupAllowed } from "../auth.js";
 import { getLatestNpmVersion } from "../version.js";
@@ -78,7 +79,7 @@ export async function handleApi(req: Request, url: URL): Promise<Response | unde
         }
 
         if (!isValidPassword(password)) {
-            return Response.json({ error: "Password must be at least 8 characters long and contain at least one uppercase letter, one lowercase letter, and one number" }, { status: 400 });
+            return Response.json({ error: PASSWORD_REQUIREMENTS_SUMMARY }, { status: 400 });
         }
 
         const existing = await getKysely()

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -16,7 +16,12 @@ import { sendSkillCommand, sendRunnerCommand } from "../ws/namespaces/runner.js"
 import { waitForSpawnAck } from "../ws/runner-control.js";
 import { getApiKeyRateLimitConfig, getAuth, getKysely } from "../auth.js";
 import { requireSession, validateApiKey } from "../middleware.js";
-import { listPersistedRelaySessionsForUser, pinRelaySession, unpinRelaySession } from "../sessions/store.js";
+import {
+    listPersistedRelaySessionsForUser,
+    listPinnedRelaySessionsForUser,
+    pinRelaySession,
+    unpinRelaySession,
+} from "../sessions/store.js";
 import { getRecentFolders, recordRecentFolder } from "../runner-recent-folders.js";
 import { getHiddenModels, setHiddenModels } from "../user-hidden-models.js";
 import {
@@ -643,9 +648,24 @@ export async function handleApi(req: Request, url: URL): Promise<Response | unde
         return Response.json({ sessions, persistedSessions });
     }
 
+    if (url.pathname === "/api/sessions/pinned" && req.method === "GET") {
+        const identity = await requireSession(req);
+        if (identity instanceof Response) return identity;
+
+        const pinnedSessions = await listPinnedRelaySessionsForUser(identity.userId);
+        return Response.json({ pinnedSessions });
+    }
+
     // ── Pin / unpin a session ──────────────────────────────────────────────
     const pinMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/pin$/);
     if (pinMatch) {
+        if (req.method !== "PUT" && req.method !== "DELETE") {
+            return new Response("Method not allowed", {
+                status: 405,
+                headers: { Allow: "PUT, DELETE" },
+            });
+        }
+
         const identity = await requireSession(req);
         if (identity instanceof Response) return identity;
 
@@ -662,13 +682,11 @@ export async function handleApi(req: Request, url: URL): Promise<Response | unde
             return Response.json({ ok: true, isPinned: true });
         }
 
-        if (req.method === "DELETE") {
-            const ok = await unpinRelaySession(sessionId, identity.userId);
-            if (!ok) {
-                return Response.json({ error: "Session not found or not owned by you" }, { status: 404 });
-            }
-            return Response.json({ ok: true, isPinned: false });
+        const ok = await unpinRelaySession(sessionId, identity.userId);
+        if (!ok) {
+            return Response.json({ error: "Session not found or not owned by you" }, { status: 404 });
         }
+        return Response.json({ ok: true, isPinned: false });
     }
 
     if (url.pathname.startsWith("/api/sessions/") && url.pathname.endsWith("/attachments") && req.method === "POST") {

--- a/packages/server/src/routes/api.ts
+++ b/packages/server/src/routes/api.ts
@@ -16,7 +16,7 @@ import { sendSkillCommand, sendRunnerCommand } from "../ws/namespaces/runner.js"
 import { waitForSpawnAck } from "../ws/runner-control.js";
 import { getApiKeyRateLimitConfig, getAuth, getKysely } from "../auth.js";
 import { requireSession, validateApiKey } from "../middleware.js";
-import { listPersistedRelaySessionsForUser } from "../sessions/store.js";
+import { listPersistedRelaySessionsForUser, pinRelaySession, unpinRelaySession } from "../sessions/store.js";
 import { getRecentFolders, recordRecentFolder } from "../runner-recent-folders.js";
 import { getHiddenModels, setHiddenModels } from "../user-hidden-models.js";
 import {
@@ -641,6 +641,34 @@ export async function handleApi(req: Request, url: URL): Promise<Response | unde
         const sessions = await getSessions(identity.userId);
         const persistedSessions = await listPersistedRelaySessionsForUser(identity.userId);
         return Response.json({ sessions, persistedSessions });
+    }
+
+    // ── Pin / unpin a session ──────────────────────────────────────────────
+    const pinMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/pin$/);
+    if (pinMatch) {
+        const identity = await requireSession(req);
+        if (identity instanceof Response) return identity;
+
+        const sessionId = decodeURIComponent(pinMatch[1]);
+        if (!sessionId) {
+            return Response.json({ error: "Missing session ID" }, { status: 400 });
+        }
+
+        if (req.method === "PUT") {
+            const ok = await pinRelaySession(sessionId, identity.userId);
+            if (!ok) {
+                return Response.json({ error: "Session not found or not owned by you" }, { status: 404 });
+            }
+            return Response.json({ ok: true, isPinned: true });
+        }
+
+        if (req.method === "DELETE") {
+            const ok = await unpinRelaySession(sessionId, identity.userId);
+            if (!ok) {
+                return Response.json({ error: "Session not found or not owned by you" }, { status: 404 });
+            }
+            return Response.json({ ok: true, isPinned: false });
+        }
     }
 
     if (url.pathname.startsWith("/api/sessions/") && url.pathname.endsWith("/attachments") && req.method === "POST") {

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -60,13 +60,8 @@ export function isValidEmail(email: string): boolean {
     return emailRegex.test(email);
 }
 
-export function isValidPassword(password: string): boolean {
-    if (password.length < 8) return false;
-    const hasUpperCase = /[A-Z]/.test(password);
-    const hasLowerCase = /[a-z]/.test(password);
-    const hasNumber = /[0-9]/.test(password);
-    return hasUpperCase && hasLowerCase && hasNumber;
-}
+// Re-export from the shared protocol package so existing imports keep working.
+export { isValidPassword } from "@pizzapi/protocol";
 
 export function normalizePath(value: string): string {
     const trimmed = value.trim().replace(/\\/g, "/");

--- a/packages/server/src/sessions/pin.test.ts
+++ b/packages/server/src/sessions/pin.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeAll, afterEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { initAuth, getKysely } from "../auth.js";
+import {
+    ensureRelaySessionTables,
+    pinRelaySession,
+    unpinRelaySession,
+    listPersistedRelaySessionsForUser,
+    pruneExpiredRelaySessions,
+    getPersistedRelaySessionSnapshot,
+} from "./store.js";
+
+const TEST_USER_ID = "test-user-pin";
+const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-pin-test-"));
+const dbPath = join(tmpDir, "pin-test.db");
+
+async function insertSession(opts: {
+    sessionId: string;
+    userId?: string;
+    isEphemeral?: boolean;
+    expiresAt?: string | null;
+    isPinned?: number;
+}) {
+    const now = new Date().toISOString();
+    await getKysely()
+        .insertInto("relay_session")
+        .values({
+            id: opts.sessionId,
+            userId: opts.userId ?? TEST_USER_ID,
+            userName: null,
+            cwd: "/test",
+            shareUrl: `http://test/${opts.sessionId}`,
+            startedAt: now,
+            lastActiveAt: now,
+            endedAt: null,
+            isEphemeral: opts.isEphemeral === false ? 0 : 1,
+            expiresAt: opts.expiresAt ?? null,
+            isPinned: opts.isPinned ?? 0,
+        })
+        .execute();
+}
+
+beforeAll(async () => {
+    initAuth({ dbPath, baseURL: "http://localhost:7777", secret: "test-secret-pin" });
+    await ensureRelaySessionTables();
+});
+
+afterEach(async () => {
+    await getKysely().deleteFrom("relay_session_state").execute();
+    await getKysely().deleteFrom("relay_session").execute();
+});
+
+afterAll(() => {
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+describe("pinRelaySession", () => {
+    it("pins an existing session owned by the user", async () => {
+        await insertSession({ sessionId: "s1" });
+
+        const result = await pinRelaySession("s1", TEST_USER_ID);
+        expect(result).toBe(true);
+
+        const row = await getKysely()
+            .selectFrom("relay_session")
+            .select("isPinned")
+            .where("id", "=", "s1")
+            .executeTakeFirst();
+        expect(row?.isPinned).toBe(1);
+    });
+
+    it("returns false for non-existent session", async () => {
+        const result = await pinRelaySession("nonexistent", TEST_USER_ID);
+        expect(result).toBe(false);
+    });
+
+    it("returns false when user doesn't own the session", async () => {
+        await insertSession({ sessionId: "s2", userId: "other-user" });
+
+        const result = await pinRelaySession("s2", TEST_USER_ID);
+        expect(result).toBe(false);
+    });
+
+    it("is idempotent — pinning already-pinned session succeeds", async () => {
+        await insertSession({ sessionId: "s3", isPinned: 1 });
+
+        const result = await pinRelaySession("s3", TEST_USER_ID);
+        expect(result).toBe(true);
+    });
+});
+
+describe("unpinRelaySession", () => {
+    it("unpins a pinned session", async () => {
+        await insertSession({ sessionId: "s4", isPinned: 1 });
+
+        const result = await unpinRelaySession("s4", TEST_USER_ID);
+        expect(result).toBe(true);
+
+        const row = await getKysely()
+            .selectFrom("relay_session")
+            .select("isPinned")
+            .where("id", "=", "s4")
+            .executeTakeFirst();
+        expect(row?.isPinned).toBe(0);
+    });
+
+    it("returns false for non-existent session", async () => {
+        const result = await unpinRelaySession("nonexistent", TEST_USER_ID);
+        expect(result).toBe(false);
+    });
+
+    it("returns false when user doesn't own the session", async () => {
+        await insertSession({ sessionId: "s5", userId: "other-user", isPinned: 1 });
+
+        const result = await unpinRelaySession("s5", TEST_USER_ID);
+        expect(result).toBe(false);
+    });
+});
+
+describe("listPersistedRelaySessionsForUser", () => {
+    it("includes isPinned field in results", async () => {
+        await insertSession({ sessionId: "s6", isPinned: 1, isEphemeral: false });
+        await insertSession({ sessionId: "s7", isPinned: 0, isEphemeral: false });
+
+        const sessions = await listPersistedRelaySessionsForUser(TEST_USER_ID);
+        const pinned = sessions.find((s) => s.sessionId === "s6");
+        const unpinned = sessions.find((s) => s.sessionId === "s7");
+
+        expect(pinned?.isPinned).toBe(true);
+        expect(unpinned?.isPinned).toBe(false);
+    });
+
+    it("pinned sessions appear before unpinned sessions", async () => {
+        await insertSession({ sessionId: "s-old-pinned", isPinned: 1, isEphemeral: false });
+        await insertSession({ sessionId: "s-new-unpinned", isPinned: 0, isEphemeral: false });
+
+        const sessions = await listPersistedRelaySessionsForUser(TEST_USER_ID);
+        expect(sessions.length).toBe(2);
+        expect(sessions[0].sessionId).toBe("s-old-pinned");
+    });
+
+    it("includes pinned sessions even if expired", async () => {
+        const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+        await insertSession({ sessionId: "s-expired-pinned", isPinned: 1, expiresAt: pastDate });
+        await insertSession({ sessionId: "s-expired-unpinned", isPinned: 0, expiresAt: pastDate });
+
+        const sessions = await listPersistedRelaySessionsForUser(TEST_USER_ID);
+        const ids = sessions.map((s) => s.sessionId);
+
+        expect(ids).toContain("s-expired-pinned");
+        expect(ids).not.toContain("s-expired-unpinned");
+    });
+});
+
+describe("getPersistedRelaySessionSnapshot", () => {
+    it("returns pinned session even if expired", async () => {
+        const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+        await insertSession({ sessionId: "s-snap-pinned", isPinned: 1, expiresAt: pastDate });
+
+        const snap = await getPersistedRelaySessionSnapshot("s-snap-pinned");
+        expect(snap).not.toBeNull();
+        expect(snap?.sessionId).toBe("s-snap-pinned");
+    });
+
+    it("returns null for expired unpinned session", async () => {
+        const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+        await insertSession({ sessionId: "s-snap-unpinned", isPinned: 0, expiresAt: pastDate });
+
+        const snap = await getPersistedRelaySessionSnapshot("s-snap-unpinned");
+        expect(snap).toBeNull();
+    });
+});
+
+describe("pruneExpiredRelaySessions", () => {
+    it("does not prune pinned sessions even when expired", async () => {
+        const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+        await insertSession({ sessionId: "s-prune-pinned", isPinned: 1, expiresAt: pastDate });
+        await insertSession({ sessionId: "s-prune-unpinned", isPinned: 0, expiresAt: pastDate });
+
+        const pruned = await pruneExpiredRelaySessions();
+
+        expect(pruned).toContain("s-prune-unpinned");
+        expect(pruned).not.toContain("s-prune-pinned");
+
+        // Verify pinned session still exists
+        const remaining = await getKysely()
+            .selectFrom("relay_session")
+            .select("id")
+            .where("id", "=", "s-prune-pinned")
+            .executeTakeFirst();
+        expect(remaining).toBeTruthy();
+    });
+
+    it("prunes expired unpinned sessions normally", async () => {
+        const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+
+        await insertSession({ sessionId: "s-prune1", isPinned: 0, expiresAt: pastDate });
+        await insertSession({ sessionId: "s-prune2", isPinned: 0, expiresAt: pastDate });
+
+        const pruned = await pruneExpiredRelaySessions();
+        expect(pruned).toContain("s-prune1");
+        expect(pruned).toContain("s-prune2");
+    });
+
+    it("does not prune sessions without an expiry", async () => {
+        await insertSession({ sessionId: "s-no-expiry", isPinned: 0, expiresAt: null, isEphemeral: false });
+
+        const pruned = await pruneExpiredRelaySessions();
+        expect(pruned).not.toContain("s-no-expiry");
+    });
+});

--- a/packages/server/src/sessions/pin.test.ts
+++ b/packages/server/src/sessions/pin.test.ts
@@ -179,6 +179,22 @@ describe("listPinnedRelaySessionsForUser", () => {
         expect(ids).toContain("s-only-pinned");
         expect(ids).not.toContain("s-only-unpinned");
     });
+
+    it("returns pinned sessions even when total session count exceeds the general cap (regression: LIMIT applied before pin filter)", async () => {
+        // Insert 55 unpinned sessions so they fill the default 50-row cap
+        for (let i = 0; i < 55; i++) {
+            await insertSession({ sessionId: `s-cap-unpinned-${i}`, isPinned: 0, isEphemeral: false });
+        }
+        // Insert a pinned session that would have been dropped under the old implementation
+        await insertSession({ sessionId: "s-cap-pinned", isPinned: 1, isEphemeral: false });
+
+        const sessions = await listPinnedRelaySessionsForUser(TEST_USER_ID);
+        const ids = sessions.map((s) => s.sessionId);
+
+        expect(ids).toContain("s-cap-pinned");
+        // All returned sessions must be pinned
+        expect(sessions.every((s) => s.isPinned)).toBe(true);
+    });
 });
 
 describe("getPersistedRelaySessionSnapshot", () => {

--- a/packages/server/src/sessions/pin.test.ts
+++ b/packages/server/src/sessions/pin.test.ts
@@ -90,6 +90,18 @@ describe("pinRelaySession", () => {
         const result = await pinRelaySession("s3", TEST_USER_ID);
         expect(result).toBe(true);
     });
+
+    it("succeeds on retry when session row appears after a delay", async () => {
+        // Simulate the race: insert the row 300ms after pin is called
+        // (the retry delay is 250ms, so the 2nd attempt should find it)
+        const delayedInsert = setTimeout(async () => {
+            await insertSession({ sessionId: "s-delayed" });
+        }, 300);
+
+        const result = await pinRelaySession("s-delayed", TEST_USER_ID);
+        clearTimeout(delayedInsert);
+        expect(result).toBe(true);
+    });
 });
 
 describe("unpinRelaySession", () => {

--- a/packages/server/src/sessions/pin.test.ts
+++ b/packages/server/src/sessions/pin.test.ts
@@ -8,6 +8,7 @@ import {
     pinRelaySession,
     unpinRelaySession,
     listPersistedRelaySessionsForUser,
+    listPinnedRelaySessionsForUser,
     pruneExpiredRelaySessions,
     getPersistedRelaySessionSnapshot,
 } from "./store.js";
@@ -155,12 +156,25 @@ describe("listPersistedRelaySessionsForUser", () => {
     });
 });
 
+describe("listPinnedRelaySessionsForUser", () => {
+    it("returns only pinned sessions", async () => {
+        await insertSession({ sessionId: "s-only-pinned", isPinned: 1, isEphemeral: false });
+        await insertSession({ sessionId: "s-only-unpinned", isPinned: 0, isEphemeral: false });
+
+        const sessions = await listPinnedRelaySessionsForUser(TEST_USER_ID);
+        const ids = sessions.map((s) => s.sessionId);
+
+        expect(ids).toContain("s-only-pinned");
+        expect(ids).not.toContain("s-only-unpinned");
+    });
+});
+
 describe("getPersistedRelaySessionSnapshot", () => {
     it("returns pinned session even if expired", async () => {
         const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
         await insertSession({ sessionId: "s-snap-pinned", isPinned: 1, expiresAt: pastDate });
 
-        const snap = await getPersistedRelaySessionSnapshot("s-snap-pinned");
+        const snap = await getPersistedRelaySessionSnapshot("s-snap-pinned", TEST_USER_ID);
         expect(snap).not.toBeNull();
         expect(snap?.sessionId).toBe("s-snap-pinned");
     });
@@ -169,7 +183,14 @@ describe("getPersistedRelaySessionSnapshot", () => {
         const pastDate = new Date(Date.now() - 60 * 60 * 1000).toISOString();
         await insertSession({ sessionId: "s-snap-unpinned", isPinned: 0, expiresAt: pastDate });
 
-        const snap = await getPersistedRelaySessionSnapshot("s-snap-unpinned");
+        const snap = await getPersistedRelaySessionSnapshot("s-snap-unpinned", TEST_USER_ID);
+        expect(snap).toBeNull();
+    });
+
+    it("returns null when requesting another user's session", async () => {
+        await insertSession({ sessionId: "s-snap-foreign", userId: "other-user", isPinned: 1, isEphemeral: false });
+
+        const snap = await getPersistedRelaySessionSnapshot("s-snap-foreign", TEST_USER_ID);
         expect(snap).toBeNull();
     });
 });

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -292,26 +292,57 @@ export async function listPinnedRelaySessionsForUser(
     return sessions.filter((session) => session.isPinned);
 }
 
+/**
+ * Pin a session. Retries briefly when the relay_session row has not been
+ * persisted yet (race between registerTuiSession broadcasting the live
+ * session and the fire-and-forget recordRelaySessionStart write).
+ */
 export async function pinRelaySession(sessionId: string, userId: string): Promise<boolean> {
-    const result = await getKysely()
-        .updateTable("relay_session")
-        .set({ isPinned: 1 })
-        .where("id", "=", sessionId)
-        .where("userId", "=", userId)
-        .execute();
+    const MAX_ATTEMPTS = 3;
+    const RETRY_DELAY_MS = 250;
 
-    return (result[0]?.numUpdatedRows ?? 0n) > 0n;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        const result = await getKysely()
+            .updateTable("relay_session")
+            .set({ isPinned: 1 })
+            .where("id", "=", sessionId)
+            .where("userId", "=", userId)
+            .execute();
+
+        if ((result[0]?.numUpdatedRows ?? 0n) > 0n) return true;
+
+        // On the last attempt, don't wait — just return failure
+        if (attempt < MAX_ATTEMPTS) {
+            await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+        }
+    }
+
+    return false;
 }
 
+/**
+ * Unpin a session. Retries briefly (same rationale as pinRelaySession).
+ */
 export async function unpinRelaySession(sessionId: string, userId: string): Promise<boolean> {
-    const result = await getKysely()
-        .updateTable("relay_session")
-        .set({ isPinned: 0 })
-        .where("id", "=", sessionId)
-        .where("userId", "=", userId)
-        .execute();
+    const MAX_ATTEMPTS = 3;
+    const RETRY_DELAY_MS = 250;
 
-    return (result[0]?.numUpdatedRows ?? 0n) > 0n;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        const result = await getKysely()
+            .updateTable("relay_session")
+            .set({ isPinned: 0 })
+            .where("id", "=", sessionId)
+            .where("userId", "=", userId)
+            .execute();
+
+        if ((result[0]?.numUpdatedRows ?? 0n) > 0n) return true;
+
+        if (attempt < MAX_ATTEMPTS) {
+            await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+        }
+    }
+
+    return false;
 }
 
 export async function pruneExpiredRelaySessions(): Promise<string[]> {

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -53,6 +53,7 @@ export interface PersistedRelaySessionSummary {
     endedAt: string | null;
     isEphemeral: boolean;
     expiresAt: string | null;
+    isPinned: boolean;
 }
 
 export async function ensureRelaySessionTables(): Promise<void> {
@@ -69,7 +70,18 @@ export async function ensureRelaySessionTables(): Promise<void> {
         .addColumn("endedAt", "text")
         .addColumn("isEphemeral", "integer", (col) => col.notNull().defaultTo(1))
         .addColumn("expiresAt", "text")
+        .addColumn("isPinned", "integer", (col) => col.notNull().defaultTo(0))
         .execute();
+
+    // Migration: add isPinned column to existing tables
+    try {
+        await getKysely().schema
+            .alterTable("relay_session")
+            .addColumn("isPinned", "integer", (col) => col.notNull().defaultTo(0))
+            .execute();
+    } catch {
+        // Column already exists — ignore
+    }
 
     await getKysely().schema
         .createTable("relay_session_state")
@@ -109,6 +121,7 @@ export async function recordRelaySessionStart(input: RelaySessionStartInput): Pr
             endedAt: null,
             isEphemeral: input.isEphemeral ? 1 : 0,
             expiresAt: input.isEphemeral ? ephemeralExpiryIso(new Date(now).getTime()) : null,
+            isPinned: 0,
         })
         .onConflict((oc) => oc.column("id").doNothing())
         .execute();
@@ -181,13 +194,15 @@ export async function getPersistedRelaySessionSnapshot(
             "s.endedAt",
             "s.isEphemeral",
             "s.expiresAt",
+            "s.isPinned",
             "st.state as state",
         ])
         .where("s.id", "=", sessionId)
         .executeTakeFirst();
 
     if (!row) return null;
-    if (row.expiresAt !== null && row.expiresAt <= nowIso) return null;
+    // Pinned sessions are always accessible, even if expired
+    if (row.isPinned !== 1 && row.expiresAt !== null && row.expiresAt <= nowIso) return null;
 
     let parsed: unknown = null;
     if (row.state) {
@@ -228,9 +243,19 @@ export async function listPersistedRelaySessionsForUser(
             "endedAt",
             "isEphemeral",
             "expiresAt",
+            "isPinned",
         ])
         .where("userId", "=", userId)
-        .where((eb) => eb.or([eb("expiresAt", "is", null), eb("expiresAt", ">", nowIso)]))
+        .where((eb) =>
+            eb.or([
+                // Include non-expired sessions
+                eb("expiresAt", "is", null),
+                eb("expiresAt", ">", nowIso),
+                // Always include pinned sessions regardless of expiry
+                eb("isPinned", "=", 1),
+            ]),
+        )
+        .orderBy("isPinned", "desc")
         .orderBy("lastActiveAt", "desc")
         .limit(limit)
         .execute();
@@ -244,7 +269,30 @@ export async function listPersistedRelaySessionsForUser(
         endedAt: row.endedAt,
         isEphemeral: row.isEphemeral === 1,
         expiresAt: row.expiresAt,
+        isPinned: row.isPinned === 1,
     }));
+}
+
+export async function pinRelaySession(sessionId: string, userId: string): Promise<boolean> {
+    const result = await getKysely()
+        .updateTable("relay_session")
+        .set({ isPinned: 1 })
+        .where("id", "=", sessionId)
+        .where("userId", "=", userId)
+        .execute();
+
+    return (result[0]?.numUpdatedRows ?? 0n) > 0n;
+}
+
+export async function unpinRelaySession(sessionId: string, userId: string): Promise<boolean> {
+    const result = await getKysely()
+        .updateTable("relay_session")
+        .set({ isPinned: 0 })
+        .where("id", "=", sessionId)
+        .where("userId", "=", userId)
+        .execute();
+
+    return (result[0]?.numUpdatedRows ?? 0n) > 0n;
 }
 
 export async function pruneExpiredRelaySessions(): Promise<string[]> {
@@ -254,6 +302,7 @@ export async function pruneExpiredRelaySessions(): Promise<string[]> {
     // This reduces database roundtrips from 3 to 2 and avoids loading all expired IDs into application memory
     // before deletion, which improves performance and memory usage for large cleanups.
     // Estimated impact: ~30% reduction in latency for cleanup operations.
+    // Note: Pinned sessions are never pruned, even if expired.
     return await getKysely().transaction().execute(async (trx) => {
         await trx
             .deleteFrom("relay_session_state")
@@ -262,7 +311,8 @@ export async function pruneExpiredRelaySessions(): Promise<string[]> {
                     .selectFrom("relay_session")
                     .select("id")
                     .where("expiresAt", "is not", null)
-                    .where("expiresAt", "<=", nowIso),
+                    .where("expiresAt", "<=", nowIso)
+                    .where("isPinned", "=", 0),
             )
             .execute();
 
@@ -270,6 +320,7 @@ export async function pruneExpiredRelaySessions(): Promise<string[]> {
             .deleteFrom("relay_session")
             .where("expiresAt", "is not", null)
             .where("expiresAt", "<=", nowIso)
+            .where("isPinned", "=", 0)
             .returning("id")
             .execute();
 

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -286,10 +286,38 @@ export async function listPersistedRelaySessionsForUser(
 
 export async function listPinnedRelaySessionsForUser(
     userId: string,
-    limit: number = 50,
 ): Promise<PersistedRelaySessionSummary[]> {
-    const sessions = await listPersistedRelaySessionsForUser(userId, limit);
-    return sessions.filter((session) => session.isPinned);
+    // Query pinned rows directly so the result is never truncated by the
+    // general-session cap used in listPersistedRelaySessionsForUser.
+    const rows = await getKysely()
+        .selectFrom("relay_session")
+        .select([
+            "id as sessionId",
+            "cwd",
+            "shareUrl",
+            "startedAt",
+            "lastActiveAt",
+            "endedAt",
+            "isEphemeral",
+            "expiresAt",
+            "isPinned",
+        ])
+        .where("userId", "=", userId)
+        .where("isPinned", "=", 1)
+        .orderBy("lastActiveAt", "desc")
+        .execute();
+
+    return rows.map((row) => ({
+        sessionId: row.sessionId,
+        cwd: row.cwd,
+        shareUrl: row.shareUrl,
+        startedAt: row.startedAt,
+        lastActiveAt: row.lastActiveAt,
+        endedAt: row.endedAt,
+        isEphemeral: row.isEphemeral === 1,
+        expiresAt: row.expiresAt,
+        isPinned: true,
+    }));
 }
 
 /**

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -21,6 +21,12 @@ function ephemeralExpiryIso(fromMs: number = Date.now()): string {
     return new Date(fromMs + getEphemeralTtlMs()).toISOString();
 }
 
+function isDuplicateColumnError(error: unknown, columnName: string): boolean {
+    if (!(error instanceof Error)) return false;
+    const message = error.message.toLowerCase();
+    return message.includes("duplicate column") && message.includes(columnName.toLowerCase());
+}
+
 export interface RelaySessionStartInput {
     sessionId: string;
     userId?: string;
@@ -79,8 +85,11 @@ export async function ensureRelaySessionTables(): Promise<void> {
             .alterTable("relay_session")
             .addColumn("isPinned", "integer", (col) => col.notNull().defaultTo(0))
             .execute();
-    } catch {
-        // Column already exists — ignore
+    } catch (error) {
+        if (!isDuplicateColumnError(error, "isPinned")) {
+            console.error("[sessions/store] Failed to migrate relay_session.isPinned:", error);
+            throw error;
+        }
     }
 
     await getKysely().schema
@@ -179,6 +188,7 @@ export async function recordRelaySessionEnd(sessionId: string): Promise<void> {
 
 export async function getPersistedRelaySessionSnapshot(
     sessionId: string,
+    userId: string,
 ): Promise<PersistedRelaySessionSnapshot | null> {
     const nowIso = new Date().toISOString();
     const row = await getKysely()
@@ -198,6 +208,7 @@ export async function getPersistedRelaySessionSnapshot(
             "st.state as state",
         ])
         .where("s.id", "=", sessionId)
+        .where("s.userId", "=", userId)
         .executeTakeFirst();
 
     if (!row) return null;
@@ -271,6 +282,14 @@ export async function listPersistedRelaySessionsForUser(
         expiresAt: row.expiresAt,
         isPinned: row.isPinned === 1,
     }));
+}
+
+export async function listPinnedRelaySessionsForUser(
+    userId: string,
+    limit: number = 50,
+): Promise<PersistedRelaySessionSummary[]> {
+    const sessions = await listPersistedRelaySessionsForUser(userId, limit);
+    return sessions.filter((session) => session.isPinned);
 }
 
 export async function pinRelaySession(sessionId: string, userId: string): Promise<boolean> {

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -104,21 +104,23 @@ async function sendLatestSnapshotFromCache(
 async function replayPersistedSnapshot(
     socket: ViewerSocket,
     sessionId: string,
+    userId: string,
 ): Promise<void> {
     try {
+        const snapshot = await getPersistedRelaySessionSnapshot(sessionId, userId);
+        if (!snapshot || snapshot.state === null || snapshot.state === undefined) {
+            socket.emit("error", { message: "Session not found" });
+            socket.disconnect();
+            return;
+        }
+
         socket.emit("connected", { sessionId, replayOnly: true });
 
         // Fast path: send only the latest snapshot from Redis cache
+        // (ownership already validated by persisted snapshot lookup above)
         const sentFromCache = await sendLatestSnapshotFromCache(socket, sessionId);
 
         if (!sentFromCache) {
-            const snapshot = await getPersistedRelaySessionSnapshot(sessionId);
-            if (!snapshot || snapshot.state === null || snapshot.state === undefined) {
-                socket.emit("error", { message: "Session not found" });
-                socket.disconnect();
-                return;
-            }
-
             socket.emit("event", {
                 event: { type: "session_active", state: snapshot.state },
             });
@@ -167,15 +169,28 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             return;
         }
 
+        const viewerUserId = socket.data.userId;
+        if (!viewerUserId) {
+            socket.emit("error", { message: "Unauthorized" });
+            socket.disconnect(true);
+            return;
+        }
+
         socket.data.sessionId = sessionId;
 
-        console.log(`[sio/viewer] connected: ${socket.id} sessionId=${sessionId}`);
+        console.log(`[sio/viewer] connected: ${socket.id} sessionId=${sessionId} userId=${viewerUserId}`);
 
         // Look up the live session
         const session = await getSharedSession(sessionId);
         if (!session) {
             // Session not live — try to replay a persisted snapshot
-            await replayPersistedSnapshot(socket, sessionId);
+            await replayPersistedSnapshot(socket, sessionId, viewerUserId);
+            return;
+        }
+
+        if (!session.userId || session.userId !== viewerUserId) {
+            socket.emit("error", { message: "Session not found" });
+            socket.disconnect(true);
             return;
         }
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -108,7 +108,7 @@ async function replayPersistedSnapshot(
 ): Promise<void> {
     try {
         const snapshot = await getPersistedRelaySessionSnapshot(sessionId, userId);
-        if (!snapshot || snapshot.state === null || snapshot.state === undefined) {
+        if (!snapshot) {
             socket.emit("error", { message: "Session not found" });
             socket.disconnect();
             return;
@@ -121,6 +121,14 @@ async function replayPersistedSnapshot(
         const sentFromCache = await sendLatestSnapshotFromCache(socket, sessionId);
 
         if (!sentFromCache) {
+            // Cache miss — fall back to persisted state from SQLite.
+            // If the persisted state is also null (e.g. no relay_session_state
+            // row yet), there is nothing to replay.
+            if (snapshot.state === null || snapshot.state === undefined) {
+                socket.emit("error", { message: "Session snapshot not available" });
+                socket.disconnect();
+                return;
+            }
             socket.emit("event", {
                 event: { type: "session_active", state: snapshot.state },
             });

--- a/packages/server/tests/e2e/signup.test.ts
+++ b/packages/server/tests/e2e/signup.test.ts
@@ -271,3 +271,66 @@ describe("E2E: signup gating (disable after first user)", () => {
         }
     });
 });
+
+// ── Change password validation ────────────────────────────────────────────────
+
+describe("E2E: change-password enforces password policy", () => {
+    const cpUser = {
+        name: "ChangePass User",
+        email: "changepass@example.com",
+        password: "OldPass123",
+    };
+    let sessionHeaders: Record<string, string>;
+
+    beforeAll(async () => {
+        // Register user
+        const regRes = await req("POST", "/api/register", cpUser, { "x-forwarded-for": "10.0.4.1" });
+        expect(regRes.status).toBe(200);
+
+        // Sign in to get a session cookie
+        const signInRes = await req("POST", "/api/auth/sign-in/email", {
+            email: cpUser.email,
+            password: cpUser.password,
+        });
+        expect(signInRes.status).toBe(200);
+
+        // Extract set-cookie header for subsequent requests
+        const cookies = signInRes.headers.getSetCookie();
+        sessionHeaders = { cookie: cookies.join("; ") };
+    });
+
+    test("rejects weak new password", async () => {
+        const res = await req("POST", "/api/auth/change-password", {
+            currentPassword: cpUser.password,
+            newPassword: "weak",
+        }, sessionHeaders);
+        expect(res.status).toBe(400);
+        const data = await res.json();
+        expect(data.error).toContain("Password must be");
+    });
+
+    test("rejects password without uppercase", async () => {
+        const res = await req("POST", "/api/auth/change-password", {
+            currentPassword: cpUser.password,
+            newPassword: "alllowercase1",
+        }, sessionHeaders);
+        expect(res.status).toBe(400);
+    });
+
+    test("rejects password without number", async () => {
+        const res = await req("POST", "/api/auth/change-password", {
+            currentPassword: cpUser.password,
+            newPassword: "NoNumberHere",
+        }, sessionHeaders);
+        expect(res.status).toBe(400);
+    });
+
+    test("accepts valid new password", async () => {
+        const res = await req("POST", "/api/auth/change-password", {
+            currentPassword: cpUser.password,
+            newPassword: "NewSecure1",
+        }, sessionHeaders);
+        // Should be 200 (success) — better-auth returns the updated status
+        expect(res.status).toBe(200);
+    });
+});

--- a/packages/server/tests/touch.test.ts
+++ b/packages/server/tests/touch.test.ts
@@ -21,7 +21,7 @@ test("touchRelaySession updates ephemeral session correctly", async () => {
     });
 
     // Check initial state
-    let session = await getPersistedRelaySessionSnapshot(sessionId);
+    let session = await getPersistedRelaySessionSnapshot(sessionId, "u1");
     expect(session).not.toBeNull();
     expect(session!.isEphemeral).toBe(true);
     const initialExpiresAt = session!.expiresAt;
@@ -32,7 +32,7 @@ test("touchRelaySession updates ephemeral session correctly", async () => {
 
     await touchRelaySession(sessionId);
 
-    session = await getPersistedRelaySessionSnapshot(sessionId);
+    session = await getPersistedRelaySessionSnapshot(sessionId, "u1");
     expect(session!.expiresAt).not.toBeNull();
     // expiry should be extended, so new expiresAt > initialExpiresAt
     expect(new Date(session!.expiresAt!).getTime()).toBeGreaterThan(new Date(initialExpiresAt!).getTime());
@@ -52,7 +52,7 @@ test("touchRelaySession updates non-ephemeral session correctly", async () => {
     });
 
     // Check initial state
-    let session = await getPersistedRelaySessionSnapshot(sessionId);
+    let session = await getPersistedRelaySessionSnapshot(sessionId, "u1");
     expect(session).not.toBeNull();
     expect(session!.isEphemeral).toBe(false);
     expect(session!.expiresAt).toBeNull();
@@ -71,7 +71,7 @@ test("touchRelaySession updates non-ephemeral session correctly", async () => {
 
     await touchRelaySession(sessionId);
 
-    session = await getPersistedRelaySessionSnapshot(sessionId);
+    session = await getPersistedRelaySessionSnapshot(sessionId, "u1");
     expect(session!.expiresAt).toBeNull();
 
     const updatedRow = await getKysely()

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -40,7 +40,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Sun, Moon, LogOut, KeyRound, X, User, ChevronsUpDown, PanelLeftOpen, HardDrive, Bell, BellOff, Check, Plus, TerminalIcon, FolderTree, Keyboard, EyeOff } from "lucide-react";
+import { Sun, Moon, LogOut, KeyRound, X, User, ChevronsUpDown, PanelLeftOpen, HardDrive, Bell, BellOff, Check, Plus, TerminalIcon, FolderTree, Keyboard, EyeOff, Lock } from "lucide-react";
 import { NotificationToggle, MobileNotificationMenuItem } from "@/components/NotificationToggle";
 import { HapticsToggle, MobileHapticsMenuItem } from "@/components/HapticsToggle";
 import { UsageIndicator, type ProviderUsageMap } from "@/components/UsageIndicator";
@@ -60,6 +60,7 @@ import {
   ModelSelectorShortcut,
 } from "@/components/ai-elements/model-selector";
 import { HiddenModelsManager, loadHiddenModels, fetchHiddenModels, modelKey } from "@/components/HiddenModelsManager";
+import { ChangePasswordDialog } from "@/components/ChangePasswordDialog";
 import {
   beginInputAttempt,
   completeInputAttempt,
@@ -616,6 +617,7 @@ export function App() {
   const [isChangingModel, setIsChangingModel] = React.useState(false);
   const [hiddenModels, setHiddenModels] = React.useState<Set<string>>(() => loadHiddenModels());
   const [hiddenModelsOpen, setHiddenModelsOpen] = React.useState(false);
+  const [changePasswordOpen, setChangePasswordOpen] = React.useState(false);
 
   // Live session status from heartbeats
   const [agentActive, setAgentActive] = React.useState(false);
@@ -2445,6 +2447,10 @@ export function App() {
                 <EyeOff className="h-4 w-4" />
                 Model visibility
               </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => setChangePasswordOpen(true)}>
+                <Lock className="h-4 w-4" />
+                Change password
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem variant="destructive" onSelect={() => signOut()}>
                 <LogOut className="h-4 w-4" />
@@ -2604,6 +2610,10 @@ export function App() {
                 <EyeOff className="h-4 w-4" />
                 Model visibility
               </DropdownMenuItem>
+              <DropdownMenuItem onSelect={() => { setChangePasswordOpen(true); setSidebarOpen(false); }}>
+                <Lock className="h-4 w-4" />
+                Change password
+              </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem variant="destructive" onSelect={() => signOut()}>
                 <LogOut className="h-4 w-4" />
@@ -2678,6 +2688,11 @@ export function App() {
         models={availableModels}
         hiddenModels={hiddenModels}
         onHiddenModelsChange={setHiddenModels}
+      />
+
+      <ChangePasswordDialog
+        open={changePasswordOpen}
+        onOpenChange={setChangePasswordOpen}
       />
 
       <div className="pp-shell flex flex-1 min-h-0 overflow-hidden relative">

--- a/packages/ui/src/components/AuthPage.tsx
+++ b/packages/ui/src/components/AuthPage.tsx
@@ -5,7 +5,8 @@ import { Label } from "@/components/ui/label";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { PizzaLogo } from "@/components/PizzaLogo";
 import { signIn, signUp } from "@/lib/auth-client";
-import { Loader2 } from "lucide-react";
+import { Loader2, Check, X } from "lucide-react";
+import { validatePassword, type PasswordCheck } from "@pizzapi/protocol";
 
 interface AuthPageProps {
     onAuthenticated: () => void;
@@ -21,6 +22,10 @@ export function AuthPage({ onAuthenticated }: AuthPageProps) {
     const [error, setError] = React.useState<string | null>(null);
     const [loading, setLoading] = React.useState(false);
     const [signupEnabled, setSignupEnabled] = React.useState<boolean | null>(null);
+
+    // Live password validation for signup
+    const passwordCheck: PasswordCheck | null =
+        tab === "signup" && password.length > 0 ? validatePassword(password) : null;
 
     const signinRef = React.useRef<HTMLButtonElement>(null);
     const signupRef = React.useRef<HTMLButtonElement>(null);
@@ -197,6 +202,16 @@ export function AuthPage({ onAuthenticated }: AuthPageProps) {
                                 required
                                 autoComplete={tab === "signin" ? "current-password" : "new-password"}
                             />
+                            {passwordCheck && (
+                                <ul className="flex flex-col gap-0.5 mt-1">
+                                    {passwordCheck.checks.map((c) => (
+                                        <li key={c.label} className={`flex items-center gap-1.5 text-xs ${c.met ? "text-green-600 dark:text-green-400" : "text-muted-foreground"}`}>
+                                            {c.met ? <Check className="h-3 w-3" /> : <X className="h-3 w-3" />}
+                                            {c.label}
+                                        </li>
+                                    ))}
+                                </ul>
+                            )}
                         </div>
                         {error && <p className="text-sm text-destructive">{error}</p>}
                     </CardContent>
@@ -204,7 +219,7 @@ export function AuthPage({ onAuthenticated }: AuthPageProps) {
                         <Button
                             type="submit"
                             className="w-full"
-                            disabled={loading || !email || !password || (tab === "signup" && !name)}
+                            disabled={loading || !email || !password || (tab === "signup" && !name) || (tab === "signup" && passwordCheck !== null && !passwordCheck.valid)}
                         >
                             {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
                             {loading ? (tab === "signin" ? "Signing in…" : "Creating account…") : (tab === "signin" ? "Sign in" : "Create account")}

--- a/packages/ui/src/components/ChangePasswordDialog.tsx
+++ b/packages/ui/src/components/ChangePasswordDialog.tsx
@@ -1,0 +1,179 @@
+import * as React from "react";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Loader2, Check, X } from "lucide-react";
+import { validatePassword, type PasswordCheck } from "@pizzapi/protocol";
+import { authClient } from "@/lib/auth-client";
+
+interface ChangePasswordDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+}
+
+export function ChangePasswordDialog({ open, onOpenChange }: ChangePasswordDialogProps) {
+    const [currentPassword, setCurrentPassword] = React.useState("");
+    const [newPassword, setNewPassword] = React.useState("");
+    const [confirmPassword, setConfirmPassword] = React.useState("");
+    const [loading, setLoading] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+    const [success, setSuccess] = React.useState(false);
+
+    // Live validation for new password
+    const passwordCheck: PasswordCheck | null =
+        newPassword.length > 0 ? validatePassword(newPassword) : null;
+
+    const passwordsMatch = newPassword === confirmPassword;
+    const canSubmit =
+        !loading &&
+        currentPassword.length > 0 &&
+        newPassword.length > 0 &&
+        confirmPassword.length > 0 &&
+        (passwordCheck?.valid ?? false) &&
+        passwordsMatch;
+
+    function reset() {
+        setCurrentPassword("");
+        setNewPassword("");
+        setConfirmPassword("");
+        setError(null);
+        setSuccess(false);
+        setLoading(false);
+    }
+
+    function handleOpenChange(next: boolean) {
+        if (!next) reset();
+        onOpenChange(next);
+    }
+
+    async function handleSubmit(e: React.FormEvent) {
+        e.preventDefault();
+        if (!canSubmit) return;
+
+        setError(null);
+        setLoading(true);
+
+        try {
+            const { error: apiError } = await authClient.changePassword({
+                currentPassword,
+                newPassword,
+                revokeOtherSessions: false,
+            });
+
+            if (apiError) {
+                setError(apiError.message ?? "Failed to change password");
+                return;
+            }
+
+            setSuccess(true);
+            // Auto-close after a brief delay so the user sees the success message.
+            setTimeout(() => handleOpenChange(false), 1500);
+        } catch (err) {
+            setError(err instanceof Error ? err.message : "An unexpected error occurred");
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={handleOpenChange}>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>Change password</DialogTitle>
+                    <DialogDescription>
+                        Enter your current password and choose a new one.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {success ? (
+                    <div className="flex items-center gap-2 py-4 text-green-600 dark:text-green-400">
+                        <Check className="h-5 w-5" />
+                        <span className="text-sm font-medium">Password changed successfully.</span>
+                    </div>
+                ) : (
+                    <form onSubmit={handleSubmit}>
+                        <div className="flex flex-col gap-4 py-2">
+                            <div className="flex flex-col gap-1.5">
+                                <Label htmlFor="cp-current">Current password</Label>
+                                <Input
+                                    id="cp-current"
+                                    type="password"
+                                    value={currentPassword}
+                                    onChange={(e) => setCurrentPassword(e.target.value)}
+                                    required
+                                    autoComplete="current-password"
+                                    autoFocus
+                                />
+                            </div>
+
+                            <div className="flex flex-col gap-1.5">
+                                <Label htmlFor="cp-new">New password</Label>
+                                <Input
+                                    id="cp-new"
+                                    type="password"
+                                    value={newPassword}
+                                    onChange={(e) => setNewPassword(e.target.value)}
+                                    required
+                                    autoComplete="new-password"
+                                />
+                                {passwordCheck && (
+                                    <ul className="flex flex-col gap-0.5 mt-1">
+                                        {passwordCheck.checks.map((c) => (
+                                            <li
+                                                key={c.label}
+                                                className={`flex items-center gap-1.5 text-xs ${c.met ? "text-green-600 dark:text-green-400" : "text-muted-foreground"}`}
+                                            >
+                                                {c.met ? <Check className="h-3 w-3" /> : <X className="h-3 w-3" />}
+                                                {c.label}
+                                            </li>
+                                        ))}
+                                    </ul>
+                                )}
+                            </div>
+
+                            <div className="flex flex-col gap-1.5">
+                                <Label htmlFor="cp-confirm">Confirm new password</Label>
+                                <Input
+                                    id="cp-confirm"
+                                    type="password"
+                                    value={confirmPassword}
+                                    onChange={(e) => setConfirmPassword(e.target.value)}
+                                    required
+                                    autoComplete="new-password"
+                                />
+                                {confirmPassword.length > 0 && !passwordsMatch && (
+                                    <p className="text-xs text-destructive mt-0.5">Passwords do not match</p>
+                                )}
+                            </div>
+
+                            {error && <p className="text-sm text-destructive">{error}</p>}
+                        </div>
+
+                        <DialogFooter className="mt-4">
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => handleOpenChange(false)}
+                                disabled={loading}
+                            >
+                                Cancel
+                            </Button>
+                            <Button type="submit" disabled={!canSubmit}>
+                                {loading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                                {loading ? "Changing…" : "Change password"}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                )}
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -391,7 +391,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
                                                 )}
                                             >
                                                 <FolderOpen className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />
-                                                <span className="truncate">{folder}</span>
+                                                <span className="truncate [direction:rtl] text-left" dir="rtl">{folder}</span>
                                             </button>
                                         ))}
                                     </div>

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -354,7 +354,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
                         </DialogDescription>
                     </DialogHeader>
 
-                    <div className="flex flex-col gap-4 py-2">
+                    <div className="flex flex-col gap-4 py-2 min-w-0 overflow-hidden">
                         <div className="flex flex-col gap-1.5">
                             <Label htmlFor="spawn-cwd" className="text-sm">Working directory <span className="text-muted-foreground font-normal">(optional)</span></Label>
                             <Input
@@ -369,7 +369,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
 
                         {/* Recent folders */}
                         {(recentFoldersLoading || recentFolders.length > 0) && (
-                            <div className="flex flex-col gap-1.5">
+                            <div className="flex flex-col gap-1.5 min-w-0">
                                 <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Recent folders</p>
                                 {recentFoldersLoading ? (
                                     <div className="flex items-center gap-2 text-xs text-muted-foreground">
@@ -377,14 +377,14 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
                                         Loading…
                                     </div>
                                 ) : (
-                                    <div className="flex flex-col gap-1">
+                                    <div className="flex flex-col gap-1 min-w-0">
                                         {recentFolders.map((folder) => (
                                             <button
                                                 key={folder}
                                                 type="button"
                                                 onClick={() => setSpawnCwd(folder)}
                                                 className={cn(
-                                                    "flex items-center gap-2 text-left px-2.5 py-1.5 rounded-md text-xs font-mono transition-colors",
+                                                    "flex items-center gap-2 text-left px-2.5 py-1.5 rounded-md text-xs font-mono transition-colors min-w-0",
                                                     spawnCwd === folder
                                                         ? "bg-accent text-accent-foreground"
                                                         : "text-muted-foreground hover:bg-muted hover:text-foreground"

--- a/packages/ui/src/components/SessionSidebar.sort.test.ts
+++ b/packages/ui/src/components/SessionSidebar.sort.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for the session/project sort comparators used in SessionSidebar's
+ * liveGroups useMemo. The comparators are pure functions so we can exercise
+ * them directly without mounting the component.
+ */
+
+import { describe, it, expect } from "bun:test";
+
+// ── Minimal type stubs ────────────────────────────────────────────────────────
+
+interface StubSession {
+    sessionId: string;
+    lastHeartbeatAt?: string;
+    startedAt: string;
+}
+
+interface StubProject {
+    sessions: StubSession[];
+}
+
+// ── Comparators (mirrors SessionSidebar liveGroups useMemo) ───────────────────
+
+function makeSessionComparator(pinnedSessionIds: Set<string>) {
+    return (a: StubSession, b: StubSession) => {
+        const aPinned = pinnedSessionIds.has(a.sessionId) ? 1 : 0;
+        const bPinned = pinnedSessionIds.has(b.sessionId) ? 1 : 0;
+        if (bPinned !== aPinned) return bPinned - aPinned;
+        const aT = Date.parse(a.lastHeartbeatAt ?? a.startedAt);
+        const bT = Date.parse(b.lastHeartbeatAt ?? b.startedAt);
+        return (Number.isFinite(bT) ? bT : 0) - (Number.isFinite(aT) ? aT : 0);
+    };
+}
+
+function makeProjectComparator(pinnedSessionIds: Set<string>) {
+    return (a: StubProject, b: StubProject) => {
+        const hasPinned = (grp: StubProject) =>
+            grp.sessions.some((s) => pinnedSessionIds.has(s.sessionId)) ? 1 : 0;
+        const pinDiff = hasPinned(b) - hasPinned(a);
+        if (pinDiff !== 0) return pinDiff;
+        const latestTs = (grp: StubProject) =>
+            Math.max(
+                0,
+                ...grp.sessions
+                    .map((s) => Date.parse(s.lastHeartbeatAt ?? s.startedAt))
+                    .filter(Number.isFinite),
+            );
+        return latestTs(b) - latestTs(a);
+    };
+}
+
+// ── Session sort tests ────────────────────────────────────────────────────────
+
+describe("session sort (pinned first, then recency)", () => {
+    it("places a pinned session before an older unpinned session", () => {
+        const pinned = new Set(["s-pinned"]);
+        const sessions: StubSession[] = [
+            { sessionId: "s-unpinned", startedAt: "2025-01-02T10:00:00Z" }, // more recent
+            { sessionId: "s-pinned",   startedAt: "2025-01-01T10:00:00Z" }, // older but pinned
+        ];
+        sessions.sort(makeSessionComparator(pinned));
+        expect(sessions[0].sessionId).toBe("s-pinned");
+        expect(sessions[1].sessionId).toBe("s-unpinned");
+    });
+
+    it("places a pinned session before a newer unpinned session", () => {
+        const pinned = new Set(["s-pinned"]);
+        const sessions: StubSession[] = [
+            { sessionId: "s-unpinned", startedAt: "2025-03-01T10:00:00Z" }, // newest
+            { sessionId: "s-pinned",   startedAt: "2025-01-01T10:00:00Z" }, // older but pinned
+        ];
+        sessions.sort(makeSessionComparator(pinned));
+        expect(sessions[0].sessionId).toBe("s-pinned");
+    });
+
+    it("sorts multiple pinned sessions by recency among themselves", () => {
+        const pinned = new Set(["s-pin-old", "s-pin-new"]);
+        const sessions: StubSession[] = [
+            { sessionId: "s-pin-old", startedAt: "2025-01-01T00:00:00Z" },
+            { sessionId: "s-pin-new", startedAt: "2025-06-01T00:00:00Z" },
+        ];
+        sessions.sort(makeSessionComparator(pinned));
+        expect(sessions[0].sessionId).toBe("s-pin-new");
+        expect(sessions[1].sessionId).toBe("s-pin-old");
+    });
+
+    it("sorts unpinned sessions by recency when none are pinned", () => {
+        const pinned = new Set<string>();
+        const sessions: StubSession[] = [
+            { sessionId: "s-old",    startedAt: "2025-01-01T00:00:00Z" },
+            { sessionId: "s-recent", startedAt: "2025-06-01T00:00:00Z" },
+        ];
+        sessions.sort(makeSessionComparator(pinned));
+        expect(sessions[0].sessionId).toBe("s-recent");
+    });
+
+    it("prefers lastHeartbeatAt over startedAt for recency", () => {
+        const pinned = new Set<string>();
+        // s-heartbeat started early but has a very recent heartbeat
+        const sessions: StubSession[] = [
+            { sessionId: "s-heartbeat", startedAt: "2025-01-01T00:00:00Z", lastHeartbeatAt: "2025-12-01T00:00:00Z" },
+            { sessionId: "s-newer-start", startedAt: "2025-06-01T00:00:00Z" },
+        ];
+        sessions.sort(makeSessionComparator(pinned));
+        expect(sessions[0].sessionId).toBe("s-heartbeat");
+    });
+});
+
+// ── Project group sort tests ──────────────────────────────────────────────────
+
+describe("project group sort (groups with pinned sessions first, then recency)", () => {
+    it("places a project containing a pinned session before one without", () => {
+        const pinned = new Set(["s-pinned"]);
+        const projects: StubProject[] = [
+            { sessions: [{ sessionId: "s-unpinned", startedAt: "2025-06-01T00:00:00Z" }] },
+            { sessions: [{ sessionId: "s-pinned",   startedAt: "2025-01-01T00:00:00Z" }] },
+        ];
+        projects.sort(makeProjectComparator(pinned));
+        expect(projects[0].sessions[0].sessionId).toBe("s-pinned");
+    });
+
+    it("sorts two projects without pinned sessions by their most recent session", () => {
+        const pinned = new Set<string>();
+        const projects: StubProject[] = [
+            { sessions: [{ sessionId: "s-old",    startedAt: "2025-01-01T00:00:00Z" }] },
+            { sessions: [{ sessionId: "s-recent", startedAt: "2025-06-01T00:00:00Z" }] },
+        ];
+        projects.sort(makeProjectComparator(pinned));
+        expect(projects[0].sessions[0].sessionId).toBe("s-recent");
+    });
+
+    it("sorts two projects both containing pinned sessions by recency", () => {
+        const pinned = new Set(["s-pin-a", "s-pin-b"]);
+        const projects: StubProject[] = [
+            { sessions: [{ sessionId: "s-pin-a", startedAt: "2025-01-01T00:00:00Z" }] },
+            { sessions: [{ sessionId: "s-pin-b", startedAt: "2025-06-01T00:00:00Z" }] },
+        ];
+        projects.sort(makeProjectComparator(pinned));
+        expect(projects[0].sessions[0].sessionId).toBe("s-pin-b");
+    });
+
+    it("a project is considered pinned when any of its sessions is pinned", () => {
+        const pinned = new Set(["s-one-pinned"]);
+        const projects: StubProject[] = [
+            {
+                sessions: [
+                    { sessionId: "s-unpinned", startedAt: "2025-06-01T00:00:00Z" }, // most recent
+                ],
+            },
+            {
+                sessions: [
+                    { sessionId: "s-no-pin",    startedAt: "2025-01-01T00:00:00Z" },
+                    { sessionId: "s-one-pinned", startedAt: "2025-02-01T00:00:00Z" },
+                ],
+            },
+        ];
+        projects.sort(makeProjectComparator(pinned));
+        // Project with the pinned session should be first even though the other
+        // project has a more recently-active session.
+        expect(projects[0].sessions.some((s) => s.sessionId === "s-one-pinned")).toBe(true);
+    });
+});

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -14,7 +14,7 @@ import { io } from "socket.io-client";
 import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/protocol";
 import { formatPathTail } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
-import { PanelLeftClose, PanelLeftOpen, Plus, User, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2 } from "lucide-react";
+import { PanelLeftClose, PanelLeftOpen, Plus, User, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff } from "lucide-react";
 
 interface HubSession {
     sessionId: string;
@@ -32,6 +32,19 @@ interface HubSession {
     model?: { provider: string; id: string; name?: string } | null;
     runnerId?: string | null;
     runnerName?: string | null;
+    isPinned?: boolean;
+}
+
+interface PinnedSession {
+    sessionId: string;
+    cwd: string;
+    shareUrl: string;
+    startedAt: string;
+    lastActiveAt: string;
+    endedAt: string | null;
+    isEphemeral: boolean;
+    expiresAt: string | null;
+    isPinned: boolean;
 }
 
 export type { HubSession };
@@ -160,7 +173,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     const [confirmEndSessionId, setConfirmEndSessionId] = React.useState<string | null>(null);
     const [revealedSessionId, setRevealedSessionId] = React.useState<string | null>(null);
     const [swipeOffsets, setSwipeOffsets] = React.useState<Map<string, number>>(new Map());
-    const REVEAL_WIDTH = 72; // px width of the revealed "End" button
+    const REVEAL_WIDTH = 132; // px width of the revealed "Pin" + "End" buttons
 
     const swipeRef = React.useRef<{
         sessionId: string;
@@ -356,6 +369,70 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     const [liveSessions, setLiveSessions] = React.useState<HubSession[]>([]);
     const [dotState, setDotState] = React.useState<DotState>("connecting");
     const [hasLoaded, setHasLoaded] = React.useState(false);
+
+    // ── Pinned sessions ──────────────────────────────────────────────────
+    const [pinnedSessions, setPinnedSessions] = React.useState<PinnedSession[]>([]);
+    const [pinnedSessionIds, setPinnedSessionIds] = React.useState<Set<string>>(new Set());
+
+    // Fetch pinned sessions from the API
+    const fetchPinnedSessions = React.useCallback(async () => {
+        try {
+            const res = await fetch("/api/sessions", { credentials: "include" });
+            if (!res.ok) return;
+            const body = await res.json();
+            const persisted: PinnedSession[] = Array.isArray(body?.persistedSessions)
+                ? body.persistedSessions.filter((s: any) => s.isPinned)
+                : [];
+            setPinnedSessions(persisted);
+            setPinnedSessionIds(new Set(persisted.map((s) => s.sessionId)));
+        } catch {
+            // best-effort
+        }
+    }, []);
+
+    React.useEffect(() => {
+        fetchPinnedSessions();
+    }, [fetchPinnedSessions]);
+
+    const togglePinSession = React.useCallback(async (sessionId: string) => {
+        const wasPinned = pinnedSessionIds.has(sessionId);
+        const method = wasPinned ? "DELETE" : "PUT";
+
+        // Optimistic update
+        setPinnedSessionIds((prev) => {
+            const next = new Set(prev);
+            if (wasPinned) next.delete(sessionId);
+            else next.add(sessionId);
+            return next;
+        });
+
+        try {
+            const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/pin`, {
+                method,
+                credentials: "include",
+            });
+            if (!res.ok) {
+                // Revert optimistic update
+                setPinnedSessionIds((prev) => {
+                    const next = new Set(prev);
+                    if (wasPinned) next.add(sessionId);
+                    else next.delete(sessionId);
+                    return next;
+                });
+            } else {
+                // Refresh the full list to get accurate persisted data
+                fetchPinnedSessions();
+            }
+        } catch {
+            // Revert optimistic update
+            setPinnedSessionIds((prev) => {
+                const next = new Set(prev);
+                if (wasPinned) next.add(sessionId);
+                else next.delete(sessionId);
+                return next;
+            });
+        }
+    }, [pinnedSessionIds, fetchPinnedSessions]);
 
     const selectAllSessions = React.useCallback(() => {
         setSelectedSessionIds(new Set(liveSessions.map((s) => s.sessionId)));
@@ -782,6 +859,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                             const timeLabel = isToday(s.startedAt)
                                                 ? formatTime(s.lastHeartbeatAt ?? s.startedAt)
                                                 : formatRelativeDate(s.startedAt);
+                                            const isPinned = pinnedSessionIds.has(s.sessionId);
                                             const swipeOffset = swipeOffsets.get(s.sessionId) ?? 0;
                                             const isRevealed = revealedSessionId === s.sessionId;
                                             const hasOffset = swipeOffset !== 0;
@@ -791,13 +869,30 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                     key={s.sessionId}
                                                     className="relative overflow-hidden rounded-lg"
                                                 >
-                                                    {/* "End" action behind the card — only rendered during swipe/reveal (not in select mode) */}
+                                                    {/* "Pin" + "End" actions behind the card — only rendered during swipe/reveal (not in select mode) */}
                                                     {!selectMode && (hasOffset || isRevealed) && <div
-                                                        className="absolute inset-y-0 right-0 flex items-center justify-center bg-red-600 text-white"
+                                                        className="absolute inset-y-0 right-0 flex items-stretch"
                                                         style={{ width: REVEAL_WIDTH }}
                                                     >
                                                         <button
-                                                            className="flex flex-col items-center justify-center w-full h-full text-xs font-semibold gap-0.5 active:bg-red-700 transition-colors"
+                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-blue-500 text-white active:bg-blue-600 transition-colors"
+                                                            onClick={(e) => {
+                                                                e.stopPropagation();
+                                                                togglePinSession(s.sessionId);
+                                                                // Close the revealed state
+                                                                setSwipeOffsets((prev) => {
+                                                                    const next = new Map(prev);
+                                                                    next.delete(s.sessionId);
+                                                                    return next;
+                                                                });
+                                                                setRevealedSessionId(null);
+                                                            }}
+                                                        >
+                                                            {isPinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
+                                                            <span>{isPinned ? "Unpin" : "Pin"}</span>
+                                                        </button>
+                                                        <button
+                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);
@@ -892,7 +987,8 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         {/* Text info */}
                                                         <div className="flex-1 min-w-0">
                                                             <div className="flex items-baseline justify-between gap-1 min-w-0">
-                                                                <span className="truncate text-[0.8rem] font-medium leading-tight">
+                                                                <span className="truncate text-[0.8rem] font-medium leading-tight flex items-center gap-1">
+                                                                    {isPinned && <Pin className="h-3 w-3 text-blue-400 flex-shrink-0 inline-block" />}
                                                                     {s.sessionName?.trim() || `Session ${s.sessionId.slice(0, 8)}…`}
                                                                 </span>
                                                                 <span className="text-[0.65rem] text-sidebar-foreground/45 flex-shrink-0">
@@ -926,6 +1022,74 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                             </div>
                         ))
                     )}
+
+                    {/* ── Pinned (ended) sessions ──────────────────────────────── */}
+                    {(() => {
+                        const liveIds = new Set(liveSessions.map((s) => s.sessionId));
+                        const endedPinned = pinnedSessions.filter(
+                            (p) => p.isPinned && !liveIds.has(p.sessionId),
+                        );
+                        if (endedPinned.length === 0) return null;
+                        return (
+                            <div className="mt-3 border-t border-sidebar-border pt-2">
+                                <div className="flex items-center gap-1.5 px-1.5 py-1 min-w-0">
+                                    <Pin className="h-3 w-3 text-blue-400/60 flex-shrink-0" />
+                                    <span className="text-[0.65rem] font-medium text-sidebar-foreground/45 truncate flex-1">
+                                        Pinned
+                                    </span>
+                                </div>
+                                {endedPinned.map((p) => {
+                                    const isActiveSession = !showRunners && activeSessionId === p.sessionId;
+                                    const timeLabel = isToday(p.startedAt)
+                                        ? formatTime(p.lastActiveAt)
+                                        : formatRelativeDate(p.startedAt);
+                                    return (
+                                        <button
+                                            key={p.sessionId}
+                                            onClick={() => onOpenSession(p.sessionId)}
+                                            title={`View pinned session ${p.sessionId}`}
+                                            className={cn(
+                                                "flex items-center gap-2.5 w-full min-w-0 px-2.5 py-3 md:py-2.5 text-left rounded-lg transition-colors",
+                                                isActiveSession
+                                                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                                                    : "text-sidebar-foreground/60 hover:bg-sidebar-accent/50",
+                                            )}
+                                        >
+                                            <div className="relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md bg-sidebar-accent/30">
+                                                <Pin className="size-4 text-blue-400/70" />
+                                            </div>
+                                            <div className="flex-1 min-w-0">
+                                                <div className="flex items-baseline justify-between gap-1 min-w-0">
+                                                    <span className="truncate text-[0.8rem] font-medium leading-tight opacity-70">
+                                                        {`Session ${p.sessionId.slice(0, 8)}…`}
+                                                    </span>
+                                                    <span className="text-[0.65rem] text-sidebar-foreground/35 flex-shrink-0">
+                                                        {timeLabel}
+                                                    </span>
+                                                </div>
+                                                <div className="flex items-center gap-1 mt-0.5 min-w-0">
+                                                    <span className="text-[0.65rem] text-sidebar-foreground/30 truncate" title={p.cwd}>
+                                                        {formatPathTail(p.cwd, 2)}
+                                                    </span>
+                                                    <span className="text-[0.6rem] text-sidebar-foreground/25">· ended</span>
+                                                </div>
+                                            </div>
+                                            <button
+                                                className="flex-shrink-0 p-1 rounded hover:bg-sidebar-accent/80 text-sidebar-foreground/40 hover:text-sidebar-foreground/70 transition-colors"
+                                                onClick={(e) => {
+                                                    e.stopPropagation();
+                                                    togglePinSession(p.sessionId);
+                                                }}
+                                                title="Unpin session"
+                                            >
+                                                <PinOff className="h-3.5 w-3.5" />
+                                            </button>
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        );
+                    })()}
                 </div>
             </div>
         </aside>

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -429,13 +429,24 @@ export const SessionSidebar = React.memo(function SessionSidebar({
 
         const method = currentlyPinned ? "DELETE" : "PUT";
 
-        // Optimistic update
+        // Optimistic update — keep both pinnedSessionIds (Set) and
+        // pinnedSessions (array) in sync so ended-pinned items disappear
+        // immediately when unpinned.
         setPinnedSessionIds((prev) => {
             const next = new Set(prev);
             if (currentlyPinned) next.delete(sessionId);
             else next.add(sessionId);
             return next;
         });
+
+        // Snapshot the removed entry so we can restore it on failure
+        let removedPinnedEntry: PinnedSession | undefined;
+        if (currentlyPinned) {
+            setPinnedSessions((prev) => {
+                removedPinnedEntry = prev.find((s) => s.sessionId === sessionId);
+                return prev.filter((s) => s.sessionId !== sessionId);
+            });
+        }
 
         try {
             const res = await fetch(`/api/sessions/${encodeURIComponent(sessionId)}/pin`, {
@@ -456,6 +467,9 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                 else next.delete(sessionId);
                 return next;
             });
+            if (removedPinnedEntry) {
+                setPinnedSessions((prev) => [...prev, removedPinnedEntry!]);
+            }
             setPinError("Failed to update pinned session. Please try again.");
         } finally {
             setPinPending(sessionId, false);
@@ -906,12 +920,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                 >
                                                     {/* "Pin" + "End" actions behind the card — only rendered during swipe/reveal (not in select mode) */}
                                                     {!selectMode && (hasOffset || isRevealed) && <div
-                                                        className="absolute inset-y-0 right-0 flex items-stretch"
+                                                        className="absolute inset-y-0 right-0 flex items-stretch rounded-r-lg overflow-hidden"
                                                         style={{ width: REVEAL_WIDTH }}
                                                     >
                                                         <button
                                                             className={cn(
-                                                                "flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors",
+                                                                "flex flex-col items-center justify-center w-1/2 text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors",
                                                                 isPinPending ? "opacity-60 cursor-not-allowed" : "active:bg-blue-600",
                                                             )}
                                                             onClick={(e) => {
@@ -933,7 +947,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors"
+                                                            className="flex flex-col items-center justify-center w-1/2 pt-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);
@@ -1034,11 +1048,35 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             />
                                                         </div>
 
+                                                        {/* Pin toggle */}
+                                                        {!selectMode && (
+                                                            <span
+                                                                role="button"
+                                                                tabIndex={-1}
+                                                                className={cn(
+                                                                    "flex-shrink-0 flex items-center justify-center w-5 h-5 rounded transition-colors",
+                                                                    isPinned
+                                                                        ? "text-blue-400 hover:text-blue-300"
+                                                                        : "text-sidebar-foreground/20 hover:text-sidebar-foreground/40",
+                                                                    isPinPending && "opacity-50 pointer-events-none",
+                                                                )}
+                                                                onClick={(e) => {
+                                                                    e.stopPropagation();
+                                                                    e.preventDefault();
+                                                                    if (!isPinPending) togglePinSession(s.sessionId, isPinned);
+                                                                }}
+                                                                onPointerDown={(e) => e.stopPropagation()}
+                                                                aria-label={isPinned ? "Unpin session" : "Pin session"}
+                                                                title={isPinned ? "Unpin" : "Pin"}
+                                                            >
+                                                                <Pin className={cn("h-3.5 w-3.5", isPinned && "fill-blue-400/30")} />
+                                                            </span>
+                                                        )}
+
                                                         {/* Text info */}
                                                         <div className="flex-1 min-w-0">
                                                             <div className="flex items-baseline justify-between gap-1 min-w-0">
-                                                                <span className="truncate text-[0.8rem] font-medium leading-tight flex items-center gap-1">
-                                                                    {isPinned && <Pin className="h-3 w-3 text-blue-400 flex-shrink-0 inline-block" />}
+                                                                <span className="truncate text-[0.8rem] font-medium leading-tight">
                                                                     {s.sessionName?.trim() || `Session ${s.sessionId.slice(0, 8)}…`}
                                                                 </span>
                                                                 <span className="text-[0.65rem] text-sidebar-foreground/45 flex-shrink-0">
@@ -1094,21 +1132,74 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                         ? formatTime(p.lastActiveAt)
                                         : formatRelativeDate(p.startedAt);
                                     const isPinPending = pinPendingSessionIds.has(p.sessionId);
+                                    const swipeOffset = swipeOffsets.get(p.sessionId) ?? 0;
+                                    const isRevealed = revealedSessionId === p.sessionId;
+                                    const hasOffset = swipeOffset !== 0;
+
                                     return (
                                         <div
                                             key={p.sessionId}
-                                            className={cn(
-                                                "flex items-center gap-2.5 w-full min-w-0 px-2.5 py-3 md:py-2.5 rounded-lg transition-colors",
-                                                isActiveSession
-                                                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                                                    : "text-sidebar-foreground/60 hover:bg-sidebar-accent/50",
-                                            )}
+                                            className="relative overflow-hidden rounded-lg"
                                         >
+                                            {/* "Unpin" action behind the card — uses REVEAL_WIDTH to match swipe snap distance */}
+                                            {(hasOffset || isRevealed) && <div
+                                                className="absolute inset-y-0 right-0 flex items-stretch rounded-r-lg overflow-hidden"
+                                                style={{ width: REVEAL_WIDTH }}
+                                            >
+                                                <button
+                                                    className={cn(
+                                                        "flex flex-col items-center justify-center w-1/2 text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors",
+                                                        isPinPending ? "opacity-60 cursor-not-allowed" : "active:bg-blue-600",
+                                                    )}
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        if (isPinPending) return;
+                                                        togglePinSession(p.sessionId, true);
+                                                        setSwipeOffsets((prev) => {
+                                                            const next = new Map(prev);
+                                                            next.delete(p.sessionId);
+                                                            return next;
+                                                        });
+                                                        setRevealedSessionId(null);
+                                                    }}
+                                                    disabled={isPinPending}
+                                                    aria-label={`Unpin session ${p.sessionId.slice(0, 8)}`}
+                                                >
+                                                    <PinOff className="h-4 w-4" />
+                                                    <span>{isPinPending ? "Saving" : "Unpin"}</span>
+                                                </button>
+                                            </div>}
+
+                                            {/* Sliding session card */}
                                             <button
                                                 type="button"
-                                                onClick={() => onOpenSession(p.sessionId)}
+                                                onClick={() => {
+                                                    if (suppressClickRef.current) { suppressClickRef.current = false; return; }
+                                                    if (isRevealed) {
+                                                        handleCloseRevealed();
+                                                        return;
+                                                    }
+                                                    if (revealedSessionId && revealedSessionId !== p.sessionId) {
+                                                        handleCloseRevealed();
+                                                    }
+                                                    onOpenSession(p.sessionId);
+                                                }}
+                                                onPointerDown={(e) => handleSessionPointerDown(e, p.sessionId)}
+                                                onPointerMove={handleSessionPointerMove}
+                                                onPointerUp={handleSessionPointerUp}
+                                                onContextMenu={(e) => e.preventDefault()}
                                                 title={`View pinned session ${p.sessionId}`}
-                                                className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
+                                                className={cn(
+                                                    "flex items-center gap-2.5 w-full min-w-0 px-2.5 py-3 md:py-2.5 text-left",
+                                                    !hasOffset && "transition-transform duration-200 ease-out",
+                                                    isActiveSession
+                                                        ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                                                        : "bg-sidebar text-sidebar-foreground/60 hover:bg-sidebar-accent/50",
+                                                )}
+                                                style={{
+                                                    transform: hasOffset ? `translateX(${swipeOffset}px)` : undefined,
+                                                    touchAction: "pan-y",
+                                                }}
                                             >
                                                 <div className="relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md bg-sidebar-accent/30">
                                                     <Pin className="size-4 text-blue-400/70" />
@@ -1129,22 +1220,33 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         <span className="text-[0.6rem] text-sidebar-foreground/25">· ended</span>
                                                     </div>
                                                 </div>
-                                            </button>
 
-                                            <button
-                                                type="button"
-                                                className={cn(
-                                                    "flex-shrink-0 p-1 rounded transition-colors",
-                                                    isPinPending
-                                                        ? "opacity-60 cursor-not-allowed"
-                                                        : "hover:bg-sidebar-accent/80 text-sidebar-foreground/40 hover:text-sidebar-foreground/70",
-                                                )}
-                                                onClick={() => togglePinSession(p.sessionId, true)}
-                                                title="Unpin session"
-                                                aria-label={`Unpin session ${p.sessionId.slice(0, 8)}`}
-                                                disabled={isPinPending}
-                                            >
-                                                <PinOff className="h-3.5 w-3.5" />
+                                                {/* Desktop: inline unpin icon */}
+                                                <div
+                                                    className={cn(
+                                                        "hidden md:flex flex-shrink-0 p-1 rounded transition-colors",
+                                                        isPinPending
+                                                            ? "opacity-60 cursor-not-allowed"
+                                                            : "hover:bg-sidebar-accent/80 text-sidebar-foreground/40 hover:text-sidebar-foreground/70",
+                                                    )}
+                                                    role="button"
+                                                    tabIndex={0}
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        if (!isPinPending) togglePinSession(p.sessionId, true);
+                                                    }}
+                                                    onKeyDown={(e) => {
+                                                        if (e.key === "Enter" || e.key === " ") {
+                                                            e.preventDefault();
+                                                            e.stopPropagation();
+                                                            if (!isPinPending) togglePinSession(p.sessionId, true);
+                                                        }
+                                                    }}
+                                                    title="Unpin session"
+                                                    aria-label={`Unpin session ${p.sessionId.slice(0, 8)}`}
+                                                >
+                                                    <PinOff className="h-3.5 w-3.5" />
+                                                </div>
                                             </button>
                                         </div>
                                     );

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -604,9 +604,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
             runnerMap.get(key)!.sessions.push(s);
         }
 
-        // Step 2: sort sessions within each runner by most recently active/started.
+        // Step 2: sort sessions within each runner — pinned first, then by most recently active/started.
         for (const entry of runnerMap.values()) {
             entry.sessions.sort((a, b) => {
+                const aPinned = pinnedSessionIds.has(a.sessionId) ? 1 : 0;
+                const bPinned = pinnedSessionIds.has(b.sessionId) ? 1 : 0;
+                if (bPinned !== aPinned) return bPinned - aPinned;
                 const aT = Date.parse(a.lastHeartbeatAt ?? a.startedAt);
                 const bT = Date.parse(b.lastHeartbeatAt ?? b.startedAt);
                 return (Number.isFinite(bT) ? bT : 0) - (Number.isFinite(aT) ? aT : 0);
@@ -630,8 +633,13 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                 sessions: cwdSessions,
             }));
 
-            // Sort projects by most recently active session.
+            // Sort projects — groups containing a pinned session float first,
+            // then by most recently active session within the group.
             projects.sort((a, b) => {
+                const hasPinned = (grp: ProjectGroup) =>
+                    grp.sessions.some((s) => pinnedSessionIds.has(s.sessionId)) ? 1 : 0;
+                const pinDiff = hasPinned(b) - hasPinned(a);
+                if (pinDiff !== 0) return pinDiff;
                 const latestTs = (grp: ProjectGroup) =>
                     Math.max(0, ...grp.sessions
                         .map((s) => Date.parse(s.lastHeartbeatAt ?? s.startedAt))
@@ -650,7 +658,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
         });
 
         return result;
-    }, [liveSessions]);
+    }, [liveSessions, pinnedSessionIds]);
 
     // Find session name for the confirm dialog
     const confirmSession = confirmEndSessionId

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -14,7 +14,7 @@ import { io } from "socket.io-client";
 import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/protocol";
 import { formatPathTail } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
-import { PanelLeftClose, PanelLeftOpen, Plus, User, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff } from "lucide-react";
+import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff } from "lucide-react";
 
 interface HubSession {
     sessionId: string;
@@ -45,6 +45,22 @@ interface PinnedSession {
     isEphemeral: boolean;
     expiresAt: string | null;
     isPinned: boolean;
+}
+
+function isPinnedSession(value: unknown): value is PinnedSession {
+    if (!value || typeof value !== "object") return false;
+    const v = value as Record<string, unknown>;
+    return (
+        typeof v.sessionId === "string" &&
+        typeof v.cwd === "string" &&
+        typeof v.shareUrl === "string" &&
+        typeof v.startedAt === "string" &&
+        typeof v.lastActiveAt === "string" &&
+        (typeof v.endedAt === "string" || v.endedAt === null) &&
+        typeof v.isEphemeral === "boolean" &&
+        (typeof v.expiresAt === "string" || v.expiresAt === null) &&
+        v.isPinned === true
+    );
 }
 
 export type { HubSession };
@@ -373,18 +389,21 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     // ── Pinned sessions ──────────────────────────────────────────────────
     const [pinnedSessions, setPinnedSessions] = React.useState<PinnedSession[]>([]);
     const [pinnedSessionIds, setPinnedSessionIds] = React.useState<Set<string>>(new Set());
+    const [pinPendingSessionIds, setPinPendingSessionIds] = React.useState<Set<string>>(new Set());
+    const [pinError, setPinError] = React.useState<string | null>(null);
+    const pinPendingRef = React.useRef<Set<string>>(new Set());
 
     // Fetch pinned sessions from the API
     const fetchPinnedSessions = React.useCallback(async () => {
         try {
-            const res = await fetch("/api/sessions", { credentials: "include" });
+            const res = await fetch("/api/sessions/pinned", { credentials: "include" });
             if (!res.ok) return;
             const body = await res.json();
-            const persisted: PinnedSession[] = Array.isArray(body?.persistedSessions)
-                ? body.persistedSessions.filter((s: any) => s.isPinned)
+            const pinned: PinnedSession[] = Array.isArray(body?.pinnedSessions)
+                ? body.pinnedSessions.filter(isPinnedSession)
                 : [];
-            setPinnedSessions(persisted);
-            setPinnedSessionIds(new Set(persisted.map((s) => s.sessionId)));
+            setPinnedSessions(pinned);
+            setPinnedSessionIds(new Set(pinned.map((s) => s.sessionId)));
         } catch {
             // best-effort
         }
@@ -394,14 +413,26 @@ export const SessionSidebar = React.memo(function SessionSidebar({
         fetchPinnedSessions();
     }, [fetchPinnedSessions]);
 
-    const togglePinSession = React.useCallback(async (sessionId: string) => {
-        const wasPinned = pinnedSessionIds.has(sessionId);
-        const method = wasPinned ? "DELETE" : "PUT";
+    const setPinPending = React.useCallback((sessionId: string, pending: boolean) => {
+        const next = new Set(pinPendingRef.current);
+        if (pending) next.add(sessionId);
+        else next.delete(sessionId);
+        pinPendingRef.current = next;
+        setPinPendingSessionIds(next);
+    }, []);
+
+    const togglePinSession = React.useCallback(async (sessionId: string, currentlyPinned: boolean) => {
+        if (pinPendingRef.current.has(sessionId)) return;
+
+        setPinError(null);
+        setPinPending(sessionId, true);
+
+        const method = currentlyPinned ? "DELETE" : "PUT";
 
         // Optimistic update
         setPinnedSessionIds((prev) => {
             const next = new Set(prev);
-            if (wasPinned) next.delete(sessionId);
+            if (currentlyPinned) next.delete(sessionId);
             else next.add(sessionId);
             return next;
         });
@@ -411,28 +442,25 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                 method,
                 credentials: "include",
             });
+
             if (!res.ok) {
-                // Revert optimistic update
-                setPinnedSessionIds((prev) => {
-                    const next = new Set(prev);
-                    if (wasPinned) next.add(sessionId);
-                    else next.delete(sessionId);
-                    return next;
-                });
-            } else {
-                // Refresh the full list to get accurate persisted data
-                fetchPinnedSessions();
+                throw new Error(`HTTP ${res.status}`);
             }
+
+            await fetchPinnedSessions();
         } catch {
             // Revert optimistic update
             setPinnedSessionIds((prev) => {
                 const next = new Set(prev);
-                if (wasPinned) next.add(sessionId);
+                if (currentlyPinned) next.add(sessionId);
                 else next.delete(sessionId);
                 return next;
             });
+            setPinError("Failed to update pinned session. Please try again.");
+        } finally {
+            setPinPending(sessionId, false);
         }
-    }, [pinnedSessionIds, fetchPinnedSessions]);
+    }, [fetchPinnedSessions, setPinPending]);
 
     const selectAllSessions = React.useCallback(() => {
         setSelectedSessionIds(new Set(liveSessions.map((s) => s.sessionId)));
@@ -812,6 +840,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                 </div>
 
                 <div className="flex-1 px-2 overflow-y-auto overflow-x-hidden" style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}>
+                    {pinError && (
+                        <p role="alert" aria-live="polite" className="px-2 py-2 text-[0.7rem] text-red-400">
+                            {pinError}
+                        </p>
+                    )}
+
                     {!hasLoaded ? (
                         <SidebarSkeleton />
                     ) : liveGroups.length === 0 ? (
@@ -860,6 +894,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                 ? formatTime(s.lastHeartbeatAt ?? s.startedAt)
                                                 : formatRelativeDate(s.startedAt);
                                             const isPinned = pinnedSessionIds.has(s.sessionId);
+                                            const isPinPending = pinPendingSessionIds.has(s.sessionId);
                                             const swipeOffset = swipeOffsets.get(s.sessionId) ?? 0;
                                             const isRevealed = revealedSessionId === s.sessionId;
                                             const hasOffset = swipeOffset !== 0;
@@ -875,10 +910,14 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         style={{ width: REVEAL_WIDTH }}
                                                     >
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-blue-500 text-white active:bg-blue-600 transition-colors"
+                                                            className={cn(
+                                                                "flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors",
+                                                                isPinPending ? "opacity-60 cursor-not-allowed" : "active:bg-blue-600",
+                                                            )}
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
-                                                                togglePinSession(s.sessionId);
+                                                                if (isPinPending) return;
+                                                                togglePinSession(s.sessionId, isPinned);
                                                                 // Close the revealed state
                                                                 setSwipeOffsets((prev) => {
                                                                     const next = new Map(prev);
@@ -887,9 +926,11 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                                 });
                                                                 setRevealedSessionId(null);
                                                             }}
+                                                            disabled={isPinPending}
+                                                            aria-label={isPinned ? "Unpin session" : "Pin session"}
                                                         >
                                                             {isPinned ? <PinOff className="h-4 w-4" /> : <Pin className="h-4 w-4" />}
-                                                            <span>{isPinned ? "Unpin" : "Pin"}</span>
+                                                            <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
                                                             className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors"
@@ -930,7 +971,16 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             }
                                                             onOpenSession(s.sessionId);
                                                         }}
-                                                        title={selectMode ? `Toggle selection for ${s.sessionName?.trim() || s.sessionId.slice(0, 8)}` : `View session ${s.sessionId}`}
+                                                        title={selectMode
+                                                            ? `Toggle selection for ${s.sessionName?.trim() || s.sessionId.slice(0, 8)}`
+                                                            : `View session ${s.sessionId} (press P to ${isPinned ? "unpin" : "pin"})`}
+                                                        onKeyDown={(e) => {
+                                                            if (selectMode) return;
+                                                            if (e.key.toLowerCase() !== "p") return;
+                                                            e.preventDefault();
+                                                            e.stopPropagation();
+                                                            togglePinSession(s.sessionId, isPinned);
+                                                        }}
                                                         onPointerDown={selectMode ? undefined : (e) => handleSessionPointerDown(e, s.sessionId)}
                                                         onPointerMove={selectMode ? undefined : handleSessionPointerMove}
                                                         onPointerUp={selectMode ? undefined : handleSessionPointerUp}
@@ -1043,48 +1093,60 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                     const timeLabel = isToday(p.startedAt)
                                         ? formatTime(p.lastActiveAt)
                                         : formatRelativeDate(p.startedAt);
+                                    const isPinPending = pinPendingSessionIds.has(p.sessionId);
                                     return (
-                                        <button
+                                        <div
                                             key={p.sessionId}
-                                            onClick={() => onOpenSession(p.sessionId)}
-                                            title={`View pinned session ${p.sessionId}`}
                                             className={cn(
-                                                "flex items-center gap-2.5 w-full min-w-0 px-2.5 py-3 md:py-2.5 text-left rounded-lg transition-colors",
+                                                "flex items-center gap-2.5 w-full min-w-0 px-2.5 py-3 md:py-2.5 rounded-lg transition-colors",
                                                 isActiveSession
                                                     ? "bg-sidebar-accent text-sidebar-accent-foreground"
                                                     : "text-sidebar-foreground/60 hover:bg-sidebar-accent/50",
                                             )}
                                         >
-                                            <div className="relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md bg-sidebar-accent/30">
-                                                <Pin className="size-4 text-blue-400/70" />
-                                            </div>
-                                            <div className="flex-1 min-w-0">
-                                                <div className="flex items-baseline justify-between gap-1 min-w-0">
-                                                    <span className="truncate text-[0.8rem] font-medium leading-tight opacity-70">
-                                                        {`Session ${p.sessionId.slice(0, 8)}…`}
-                                                    </span>
-                                                    <span className="text-[0.65rem] text-sidebar-foreground/35 flex-shrink-0">
-                                                        {timeLabel}
-                                                    </span>
-                                                </div>
-                                                <div className="flex items-center gap-1 mt-0.5 min-w-0">
-                                                    <span className="text-[0.65rem] text-sidebar-foreground/30 truncate" title={p.cwd}>
-                                                        {formatPathTail(p.cwd, 2)}
-                                                    </span>
-                                                    <span className="text-[0.6rem] text-sidebar-foreground/25">· ended</span>
-                                                </div>
-                                            </div>
                                             <button
-                                                className="flex-shrink-0 p-1 rounded hover:bg-sidebar-accent/80 text-sidebar-foreground/40 hover:text-sidebar-foreground/70 transition-colors"
-                                                onClick={(e) => {
-                                                    e.stopPropagation();
-                                                    togglePinSession(p.sessionId);
-                                                }}
+                                                type="button"
+                                                onClick={() => onOpenSession(p.sessionId)}
+                                                title={`View pinned session ${p.sessionId}`}
+                                                className="flex min-w-0 flex-1 items-center gap-2.5 text-left"
+                                            >
+                                                <div className="relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md bg-sidebar-accent/30">
+                                                    <Pin className="size-4 text-blue-400/70" />
+                                                </div>
+                                                <div className="flex-1 min-w-0">
+                                                    <div className="flex items-baseline justify-between gap-1 min-w-0">
+                                                        <span className="truncate text-[0.8rem] font-medium leading-tight opacity-70">
+                                                            {`Session ${p.sessionId.slice(0, 8)}…`}
+                                                        </span>
+                                                        <span className="text-[0.65rem] text-sidebar-foreground/35 flex-shrink-0">
+                                                            {timeLabel}
+                                                        </span>
+                                                    </div>
+                                                    <div className="flex items-center gap-1 mt-0.5 min-w-0">
+                                                        <span className="text-[0.65rem] text-sidebar-foreground/30 truncate" title={p.cwd}>
+                                                            {formatPathTail(p.cwd, 2)}
+                                                        </span>
+                                                        <span className="text-[0.6rem] text-sidebar-foreground/25">· ended</span>
+                                                    </div>
+                                                </div>
+                                            </button>
+
+                                            <button
+                                                type="button"
+                                                className={cn(
+                                                    "flex-shrink-0 p-1 rounded transition-colors",
+                                                    isPinPending
+                                                        ? "opacity-60 cursor-not-allowed"
+                                                        : "hover:bg-sidebar-accent/80 text-sidebar-foreground/40 hover:text-sidebar-foreground/70",
+                                                )}
+                                                onClick={() => togglePinSession(p.sessionId, true)}
                                                 title="Unpin session"
+                                                aria-label={`Unpin session ${p.sessionId.slice(0, 8)}`}
+                                                disabled={isPinPending}
                                             >
                                                 <PinOff className="h-3.5 w-3.5" />
                                             </button>
-                                        </button>
+                                        </div>
                                     );
                                 })}
                             </div>


### PR DESCRIPTION
## Summary
- add persisted pinned session support in the server store and keep pinned sessions from expiring out of listings
- add authenticated pin/unpin API handling and viewer websocket updates for pin state changes
- add sidebar pin/unpin UX and pinned-first ordering in the web UI
- harden ownership checks so pin/unpin only applies to sessions owned by the authenticated user

## Testing
- bun run typecheck
- bun run test
- bun run build