### PR TITLE
⚡ Bolt: [performance improvement] optimize sweepOrphanedSessions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2026-03-03 - [Optimize Orphaned Session Sweep]
+**Learning:** `sweepOrphanedSessions` runs on an interval and can cause an N+1 problem by making a cluster-wide Socket.IO `fetchSockets()` call for every single active session. Since this function is meant to clean up *orphaned* sessions, active sessions naturally have recent heartbeats. By calculating `lastActivity` and checking against the staleness threshold *first*, we can skip the expensive Socket.IO lookup entirely for the vast majority of active sessions.
+**Action:** When implementing polling or sweeping loops, filter items with cheap, local checks (like staleness from Redis data) before making expensive cluster-wide or database calls to avoid N+1 bottlenecks.

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -646,22 +646,22 @@ async function sweepOrphanedSessions(nowMs: number): Promise<void> {
         // Skip sessions that have an active local relay socket
         if (localTuiSockets.has(sessionId)) continue;
 
-        // Check if the relay socket exists on ANY server via Socket.IO rooms
-        const relaySockets = await io.of("/relay").in(relaySessionRoom(sessionId)).fetchSockets();
-        if (relaySockets.length > 0) continue;
-
-        // No relay socket anywhere — check heartbeat staleness
+        // Check heartbeat staleness FIRST to avoid expensive cluster-wide socket lookup for active sessions
         const lastHb = session.lastHeartbeatAt ? Date.parse(session.lastHeartbeatAt) : 0;
         const startedAt = session.startedAt ? Date.parse(session.startedAt) : 0;
         const lastActivity = Math.max(lastHb || 0, startedAt || 0);
 
-        if (nowMs - lastActivity > HEARTBEAT_STALE_MS) {
-            console.log(
-                `[sio-registry] Sweeping orphaned session ${sessionId} ` +
-                `(last activity: ${new Date(lastActivity).toISOString()})`,
-            );
-            await endSharedSession(sessionId, "Session orphaned (no active relay connection)");
-        }
+        if (nowMs - lastActivity <= HEARTBEAT_STALE_MS) continue;
+
+        // Session appears stale locally, check if the relay socket exists on ANY server via Socket.IO rooms
+        const relaySockets = await io.of("/relay").in(relaySessionRoom(sessionId)).fetchSockets();
+        if (relaySockets.length > 0) continue;
+
+        console.log(
+            `[sio-registry] Sweeping orphaned session ${sessionId} ` +
+            `(last activity: ${new Date(lastActivity).toISOString()})`,
+        );
+        await endSharedSession(sessionId, "Session orphaned (no active relay connection)");
     }
 }
 


### PR DESCRIPTION
💡 What: Moved the heartbeat staleness logic before the cluster-wide `fetchSockets()` socket lookup inside `sweepOrphanedSessions`.
🎯 Why: `sweepOrphanedSessions` runs on an interval to clean up sessions with no active relay connections. Previously, it executed a cluster-wide Socket.IO room query for every active session lacking a local connection. Checking staleness first guarantees we skip this expensive network lookup for the vast majority of active sessions.
📊 Impact: Completely eliminates the N+1 `fetchSockets` calls during periodic sweeping for standard, active sessions, avoiding network lag and potential bottlenecks at scale.
🔬 Measurement: Code logic remains 100% functionally equivalent (short-circuit logic). Validated by running the `packages/server` type checks and existing test suites, with all related tests passing.

---
*PR created automatically by Jules for task [3228932493079293957](https://jules.google.com/task/3228932493079293957) started by @Pizzaface*