### PR TITLE
fix: shell injection in search tool — replace exec with execFile

### DIFF
--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -251,4 +251,54 @@ describe("searchTool", () => {
         });
         expect(result.content[0].text).toBe("No matches found");
     });
+
+    test("surfaces partial errors when find has results but also errors", async () => {
+        // Create a directory with an unreadable subdirectory
+        const dir = mkdtempSync(join(tmpdir(), "search-partial-"));
+        writeFileSync(join(dir, "visible.txt"), "data\n");
+        const badDir = join(dir, "noperm");
+        mkdirSync(badDir, { mode: 0o000 });
+
+        try {
+            const result = await searchTool.execute("test-partial-err", {
+                pattern: "*.txt",
+                path: dir,
+                type: "files",
+            });
+            const text = result.content[0].text;
+
+            // Should still return the visible file
+            expect(text).toContain("visible.txt");
+
+            // On systems where permission is actually denied (not running as root),
+            // should include a warning about missing results
+            if (process.getuid?.() !== 0) {
+                expect(text).toContain("[warning:");
+            }
+        } finally {
+            // Restore permissions so temp cleanup works
+            const { chmodSync } = require("fs");
+            chmodSync(badDir, 0o755);
+        }
+    });
+
+    test("handles content search on file with no trailing newline", async () => {
+        try {
+            const r = spawnSync("rg", ["--version"]);
+            if (r.status !== 0) throw new Error();
+        } catch {
+            console.log("rg not available, skipping no-trailing-newline test");
+            return;
+        }
+        const dir = mkdtempSync(join(tmpdir(), "search-nonl-"));
+        // File with no trailing newline
+        writeFileSync(join(dir, "noterminal.txt"), "last-line-no-newline");
+
+        const result = await searchTool.execute("test-nonl", {
+            pattern: "last-line",
+            path: dir,
+            type: "content",
+        });
+        expect(result.content[0].text).toContain("last-line-no-newline");
+    });
 });

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -321,19 +321,17 @@ describe("searchTool", () => {
     });
 
     test("expands ~ to home directory in path", async () => {
-        const home = process.env.HOME || process.env.USERPROFILE || "";
-        if (!home) {
-            console.log("No HOME set, skipping tilde expansion test");
-            return;
-        }
-        // Create a temp subdirectory inside home with a unique name
-        const subdir = `.pizzapi-search-test-${Date.now()}`;
-        const testDir = join(home, subdir);
-        mkdirSync(testDir);
-        writeFileSync(join(testDir, "tilde-marker.txt"), "tilde-test\n");
+        // Temporarily override HOME to a controlled temp directory so the test
+        // doesn't depend on the real home dir (which may not be writable in CI).
+        const origHome = process.env.HOME;
+        const fakeHome = mkdtempSync(join(tmpdir(), "search-tilde-home-"));
+        const subdir = "project";
+        mkdirSync(join(fakeHome, subdir));
+        writeFileSync(join(fakeHome, subdir, "tilde-marker.txt"), "tilde-test\n");
 
+        process.env.HOME = fakeHome;
         try {
-            // Search with ~/subdir path — should expand and find the file
+            // Search with ~/subdir path — should expand to fakeHome/subdir
             const result = await searchTool.execute("test-tilde", {
                 pattern: "*.txt",
                 path: `~/${subdir}`,
@@ -341,16 +339,17 @@ describe("searchTool", () => {
             });
             expect(result.content[0].text).toContain("tilde-marker.txt");
 
-            // Content search with ~/subdir should also resolve
-            const result2 = await searchTool.execute("test-tilde-content", {
-                pattern: "tilde-test",
-                path: `~/${subdir}`,
-                type: "content",
+            // Bare ~ should expand to fakeHome
+            const result2 = await searchTool.execute("test-tilde-bare", {
+                pattern: "*.txt",
+                path: "~",
+                type: "files",
             });
-            expect(result2.content[0].text).toContain("tilde-test");
+            expect(result2.content[0].text).toContain("tilde-marker.txt");
         } finally {
+            process.env.HOME = origHome;
             const { rmSync } = require("fs");
-            try { rmSync(testDir, { recursive: true }); } catch {}
+            try { rmSync(fakeHome, { recursive: true }); } catch {}
         }
     });
 

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -302,6 +302,24 @@ describe("searchTool", () => {
         expect(result.content[0].text).toContain("last-line-no-newline");
     });
 
+    test("handles null bytes in pattern and path without throwing", async () => {
+        const dir = makeTempDir();
+        // Null bytes in args would cause spawn() to throw — must be handled gracefully
+        const result1 = await searchTool.execute("test-null-pattern", {
+            pattern: "*.txt\0injected",
+            path: dir,
+            type: "files",
+        });
+        expect(typeof result1.content[0].text).toBe("string");
+
+        const result2 = await searchTool.execute("test-null-path", {
+            pattern: "hello",
+            path: `${dir}\0/etc/passwd`,
+            type: "content",
+        });
+        expect(typeof result2.content[0].text).toBe("string");
+    });
+
     test("preserves Unicode filenames in file search results", async () => {
         const dir = mkdtempSync(join(tmpdir(), "search-unicode-"));
         // Create files with multi-byte UTF-8 names: accented, CJK, emoji

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -181,15 +181,19 @@ describe("searchTool", () => {
     });
 
     test("does not allow option injection via path starting with -", async () => {
-        const dir = makeTempDir();
+        // A path like "--help" would trigger GNU find's help output if passed raw.
+        // The safePath normalization should turn it into "./--help", which is
+        // treated as a literal (non-existent) directory on both BSD and GNU find.
         const result = await searchTool.execute("test-opt-inject-2", {
-            pattern: "hello",
+            pattern: "*.txt",
             path: "--help",
             type: "files",
         });
         const text = result.content[0].text;
-        // find --help output contains "usage" — should NOT appear
-        expect(text.toLowerCase()).not.toContain("usage:");
+        // Must NOT contain help/usage output from find
+        expect(text.toLowerCase()).not.toContain("usage");
+        // Should be either "No matches found" or "Search failed: ..." (path doesn't exist)
+        expect(text === "No matches found" || text.startsWith("Search failed:")).toBe(true);
     });
 
     test("surfaces errors for missing commands or bad paths", async () => {

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -301,4 +301,49 @@ describe("searchTool", () => {
         });
         expect(result.content[0].text).toContain("last-line-no-newline");
     });
+
+    test("preserves Unicode filenames in file search results", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "search-unicode-"));
+        // Create files with multi-byte UTF-8 names: accented, CJK, emoji
+        const names = ["café.txt", "日本語.txt", "🎉party.txt"];
+        for (const name of names) {
+            writeFileSync(join(dir, name), "data\n");
+        }
+
+        const result = await searchTool.execute("test-unicode-files", {
+            pattern: "*.txt",
+            path: dir,
+            type: "files",
+        });
+        const text = result.content[0].text;
+        for (const name of names) {
+            expect(text).toContain(name);
+        }
+        // Must not contain replacement character (U+FFFD) from broken decoding
+        expect(text).not.toContain("\uFFFD");
+    });
+
+    test("preserves Unicode content in content search results", async () => {
+        try {
+            const r = spawnSync("rg", ["--version"]);
+            if (r.status !== 0) throw new Error();
+        } catch {
+            console.log("rg not available, skipping unicode content test");
+            return;
+        }
+        const dir = mkdtempSync(join(tmpdir(), "search-unicode-content-"));
+        const content = "résultat: données CJK 漢字 emoji 🚀✨\n";
+        writeFileSync(join(dir, "unicode.txt"), content);
+
+        const result = await searchTool.execute("test-unicode-content", {
+            pattern: "résultat",
+            path: dir,
+            type: "content",
+        });
+        const text = result.content[0].text;
+        expect(text).toContain("résultat");
+        expect(text).toContain("漢字");
+        expect(text).toContain("🚀");
+        expect(text).not.toContain("\uFFFD");
+    });
 });

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -5,6 +5,7 @@ import { promisify } from "util";
 import { mkdtempSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { spawnSync } from "child_process";
 
 const execFileAsync = promisify(execFile);
 
@@ -113,5 +114,59 @@ describe("searchTool", () => {
         });
         const lines = result.content[0].text.split("\n").filter(Boolean);
         expect(lines.length).toBeLessThanOrEqual(50);
+    });
+
+    test("streams results and caps at maxLines without buffering all output", async () => {
+        // Create a directory with far more files than the 50-line cap.
+        // If the implementation buffered everything first, it would need to
+        // hold all output in memory; the streaming approach kills the child
+        // after 50 lines, keeping memory bounded.
+        const dir = mkdtempSync(join(tmpdir(), "search-stream-"));
+        for (let i = 0; i < 200; i++) {
+            writeFileSync(join(dir, `item-${String(i).padStart(4, "0")}.txt`), `data ${i}\n`);
+        }
+
+        const result = await searchTool.execute("test-stream", {
+            pattern: "*.txt",
+            path: dir,
+            type: "files",
+        });
+
+        const text = result.content[0].text;
+        const lines = text.split("\n").filter(Boolean);
+
+        // Must return exactly 50 lines (the cap), not 200
+        expect(lines.length).toBe(50);
+        // Each returned line must be a real file path
+        for (const line of lines) {
+            expect(line).toContain("item-");
+        }
+    });
+
+    test("content search caps at 100 lines on large result sets", async () => {
+        // Check if rg is available
+        try {
+            const r = spawnSync("rg", ["--version"]);
+            if (r.status !== 0) throw new Error();
+        } catch {
+            console.log("rg not available, skipping content cap test");
+            return;
+        }
+        // Create a file with many matching lines
+        const dir = mkdtempSync(join(tmpdir(), "search-rg-cap-"));
+        const lines: string[] = [];
+        for (let i = 0; i < 200; i++) {
+            lines.push(`match-line-${i}`);
+        }
+        writeFileSync(join(dir, "big.txt"), lines.join("\n") + "\n");
+
+        const result = await searchTool.execute("test-rg-cap", {
+            pattern: "match-line",
+            path: dir,
+            type: "content",
+        });
+
+        const resultLines = result.content[0].text.split("\n").filter(Boolean);
+        expect(resultLines.length).toBe(100);
     });
 });

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -91,14 +91,22 @@ describe("searchTool", () => {
 
     test("does not allow shell injection via path", async () => {
         const dir = makeTempDir();
-        // A malicious path that would execute a command if passed to a shell
+        // A malicious path that would execute a command if passed to a shell.
+        // With spawn (no shell), `; echo INJECTED` is part of the literal path,
+        // so find treats it as a (nonexistent) directory — no command execution.
         const result = await searchTool.execute("test-inject-2", {
             pattern: "*.txt",
             path: `${dir}; echo INJECTED`,
             type: "files",
         });
         const text = result.content[0].text;
-        expect(text).not.toContain("INJECTED");
+        // The output should be an error (nonexistent path) or no matches —
+        // NOT actual output from `echo INJECTED` as a separate command.
+        // The error message may echo the path name, so we check it's a
+        // Search failed message (find error) rather than bare "INJECTED" output.
+        expect(text.startsWith("Search failed:") || text === "No matches found").toBe(true);
+        // Crucially, no files should be returned (injection didn't work)
+        expect(text).not.toContain("hello.txt");
     });
 
     test("truncates output to max lines", async () => {
@@ -196,16 +204,51 @@ describe("searchTool", () => {
         expect(text === "No matches found" || text.startsWith("Search failed:")).toBe(true);
     });
 
-    test("surfaces errors for missing commands or bad paths", async () => {
-        const result = await searchTool.execute("test-error", {
+    test("surfaces find errors for nonexistent paths instead of 'No matches'", async () => {
+        const result = await searchTool.execute("test-find-err", {
             pattern: "*.txt",
             path: "/nonexistent/path/that/does/not/exist",
             type: "files",
         });
         const text = result.content[0].text;
-        // Should not silently say "No matches found" — should indicate failure
-        // (find will error on nonexistent path, or return no results)
-        expect(typeof text).toBe("string");
-        expect(text.length).toBeGreaterThan(0);
+        // find exits non-zero for bad paths — must surface as error, not "No matches found"
+        expect(text).toStartWith("Search failed:");
+        expect(text).not.toBe("No matches found");
+    });
+
+    test("surfaces rg errors for invalid regex", async () => {
+        try {
+            const r = spawnSync("rg", ["--version"]);
+            if (r.status !== 0) throw new Error();
+        } catch {
+            console.log("rg not available, skipping rg error test");
+            return;
+        }
+        const dir = makeTempDir();
+        // Invalid regex — rg exits with code 2
+        const result = await searchTool.execute("test-rg-err", {
+            pattern: "[invalid",
+            path: dir,
+            type: "content",
+        });
+        const text = result.content[0].text;
+        expect(text).toStartWith("Search failed:");
+    });
+
+    test("rg exit 1 (no matches) returns 'No matches found', not an error", async () => {
+        try {
+            const r = spawnSync("rg", ["--version"]);
+            if (r.status !== 0) throw new Error();
+        } catch {
+            console.log("rg not available, skipping rg no-match test");
+            return;
+        }
+        const dir = makeTempDir();
+        const result = await searchTool.execute("test-rg-nomatch", {
+            pattern: "zzz_definitely_not_present_zzz",
+            path: dir,
+            type: "content",
+        });
+        expect(result.content[0].text).toBe("No matches found");
     });
 });

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -116,14 +116,12 @@ describe("searchTool", () => {
         expect(lines.length).toBeLessThanOrEqual(50);
     });
 
-    test("streams results and caps at maxLines without buffering all output", async () => {
-        // Create a directory with far more files than the 50-line cap.
-        // If the implementation buffered everything first, it would need to
-        // hold all output in memory; the streaming approach kills the child
-        // after 50 lines, keeping memory bounded.
+    test("files search caps at exactly 50 lines on large result sets", async () => {
+        // Create 5000 files — well beyond the 50-line cap — to stress the
+        // streaming kill logic and verify no off-by-one from post-kill data events.
         const dir = mkdtempSync(join(tmpdir(), "search-stream-"));
-        for (let i = 0; i < 200; i++) {
-            writeFileSync(join(dir, `item-${String(i).padStart(4, "0")}.txt`), `data ${i}\n`);
+        for (let i = 0; i < 5000; i++) {
+            writeFileSync(join(dir, `item-${String(i).padStart(5, "0")}.txt`), `data ${i}\n`);
         }
 
         const result = await searchTool.execute("test-stream", {
@@ -135,16 +133,14 @@ describe("searchTool", () => {
         const text = result.content[0].text;
         const lines = text.split("\n").filter(Boolean);
 
-        // Must return exactly 50 lines (the cap), not 200
+        // Must return exactly 50 lines (the cap), never 51+
         expect(lines.length).toBe(50);
-        // Each returned line must be a real file path
         for (const line of lines) {
             expect(line).toContain("item-");
         }
     });
 
-    test("content search caps at 100 lines on large result sets", async () => {
-        // Check if rg is available
+    test("content search caps at exactly 100 lines on large result sets", async () => {
         try {
             const r = spawnSync("rg", ["--version"]);
             if (r.status !== 0) throw new Error();
@@ -152,13 +148,13 @@ describe("searchTool", () => {
             console.log("rg not available, skipping content cap test");
             return;
         }
-        // Create a file with many matching lines
+        // Create a file with 5000 matching lines
         const dir = mkdtempSync(join(tmpdir(), "search-rg-cap-"));
-        const lines: string[] = [];
-        for (let i = 0; i < 200; i++) {
-            lines.push(`match-line-${i}`);
+        const fileLines: string[] = [];
+        for (let i = 0; i < 5000; i++) {
+            fileLines.push(`match-line-${i}`);
         }
-        writeFileSync(join(dir, "big.txt"), lines.join("\n") + "\n");
+        writeFileSync(join(dir, "big.txt"), fileLines.join("\n") + "\n");
 
         const result = await searchTool.execute("test-rg-cap", {
             pattern: "match-line",
@@ -168,5 +164,44 @@ describe("searchTool", () => {
 
         const resultLines = result.content[0].text.split("\n").filter(Boolean);
         expect(resultLines.length).toBe(100);
+    });
+
+    test("does not allow option injection via pattern starting with -", async () => {
+        const dir = makeTempDir();
+        // A pattern starting with -- that would be parsed as an rg flag
+        // if not protected by -e / --
+        const result = await searchTool.execute("test-opt-inject-1", {
+            pattern: "--help",
+            path: dir,
+            type: "content",
+        });
+        const text = result.content[0].text;
+        // rg --help output contains "USAGE" — that should NOT appear
+        expect(text).not.toContain("USAGE");
+    });
+
+    test("does not allow option injection via path starting with -", async () => {
+        const dir = makeTempDir();
+        const result = await searchTool.execute("test-opt-inject-2", {
+            pattern: "hello",
+            path: "--help",
+            type: "files",
+        });
+        const text = result.content[0].text;
+        // find --help output contains "usage" — should NOT appear
+        expect(text.toLowerCase()).not.toContain("usage:");
+    });
+
+    test("surfaces errors for missing commands or bad paths", async () => {
+        const result = await searchTool.execute("test-error", {
+            pattern: "*.txt",
+            path: "/nonexistent/path/that/does/not/exist",
+            type: "files",
+        });
+        const text = result.content[0].text;
+        // Should not silently say "No matches found" — should indicate failure
+        // (find will error on nonexistent path, or return no results)
+        expect(typeof text).toBe("string");
+        expect(text.length).toBeGreaterThan(0);
     });
 });

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect } from "bun:test";
+import { searchTool } from "./search";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { mkdtempSync, writeFileSync, mkdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+const execFileAsync = promisify(execFile);
+
+function makeTempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "search-test-"));
+    writeFileSync(join(dir, "hello.txt"), "hello world\nfoo bar\n");
+    writeFileSync(join(dir, "data.json"), '{"key": "value"}\n');
+    mkdirSync(join(dir, "sub"));
+    writeFileSync(join(dir, "sub", "nested.txt"), "nested content\nhello again\n");
+    return dir;
+}
+
+describe("searchTool", () => {
+    test("has correct metadata", () => {
+        expect(searchTool.name).toBe("search");
+        expect(searchTool.description).toBeTruthy();
+    });
+
+    test("files search finds matching files", async () => {
+        const dir = makeTempDir();
+        const result = await searchTool.execute("test-1", {
+            pattern: "*.txt",
+            path: dir,
+            type: "files",
+        });
+        const text = result.content[0].text;
+        expect(text).toContain("hello.txt");
+        expect(text).toContain("nested.txt");
+        expect(text).not.toContain("data.json");
+    });
+
+    test("files search returns 'No matches found' for no results", async () => {
+        const dir = makeTempDir();
+        const result = await searchTool.execute("test-2", {
+            pattern: "*.xyz",
+            path: dir,
+            type: "files",
+        });
+        expect(result.content[0].text).toBe("No matches found");
+    });
+
+    test("content search finds matching lines", async () => {
+        const dir = makeTempDir();
+        // Check if rg is available
+        try {
+            await execFileAsync("rg", ["--version"]);
+        } catch {
+            console.log("rg not available, skipping content search test");
+            return;
+        }
+        const result = await searchTool.execute("test-3", {
+            pattern: "hello",
+            path: dir,
+            type: "content",
+        });
+        const text = result.content[0].text;
+        expect(text).toContain("hello");
+    });
+
+    test("defaults to content search when type is omitted", async () => {
+        const dir = makeTempDir();
+        const result = await searchTool.execute("test-4", {
+            pattern: "nonexistent_string_xyz",
+            path: dir,
+        });
+        // Should not throw — type defaults to "content"
+        expect(result.details.type).toBe("content");
+    });
+
+    test("does not allow shell injection via pattern", async () => {
+        const dir = makeTempDir();
+        // A malicious pattern that would execute a command if passed to a shell
+        // With execFile this is safely treated as a literal find -name argument
+        const result = await searchTool.execute("test-inject-1", {
+            pattern: '"; echo INJECTED; "',
+            path: dir,
+            type: "files",
+        });
+        const text = result.content[0].text;
+        // The injection payload must NOT appear in output
+        expect(text).not.toContain("INJECTED");
+    });
+
+    test("does not allow shell injection via path", async () => {
+        const dir = makeTempDir();
+        // A malicious path that would execute a command if passed to a shell
+        const result = await searchTool.execute("test-inject-2", {
+            pattern: "*.txt",
+            path: `${dir}; echo INJECTED`,
+            type: "files",
+        });
+        const text = result.content[0].text;
+        expect(text).not.toContain("INJECTED");
+    });
+
+    test("truncates output to max lines", async () => {
+        // Create a directory with many files
+        const dir = mkdtempSync(join(tmpdir(), "search-trunc-"));
+        for (let i = 0; i < 60; i++) {
+            writeFileSync(join(dir, `file-${String(i).padStart(3, "0")}.txt`), `content ${i}\n`);
+        }
+        const result = await searchTool.execute("test-trunc", {
+            pattern: "*.txt",
+            path: dir,
+            type: "files",
+        });
+        const lines = result.content[0].text.split("\n").filter(Boolean);
+        expect(lines.length).toBeLessThanOrEqual(50);
+    });
+});

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -353,6 +353,29 @@ describe("searchTool", () => {
         }
     });
 
+    test("does not prepend ./ to Windows-style absolute paths", async () => {
+        // Windows paths like C:\Users or C:/Users should not become ./C:\Users
+        // We can't run find on fake Windows paths, but we can verify the path
+        // in the details is preserved and the tool doesn't crash.
+        const result = await searchTool.execute("test-win-path", {
+            pattern: "*.txt",
+            path: "C:\\Users\\test",
+            type: "files",
+        });
+        // Should fail gracefully (path doesn't exist), not crash
+        const text = result.content[0].text;
+        expect(text).not.toContain("./C:");
+        expect(text === "No matches found" || text.startsWith("Search failed:")).toBe(true);
+
+        // Also test forward-slash variant
+        const result2 = await searchTool.execute("test-win-path-2", {
+            pattern: "*.txt",
+            path: "D:/Projects",
+            type: "files",
+        });
+        expect(result2.content[0].text).not.toContain("./D:");
+    });
+
     test("preserves Unicode filenames in file search results", async () => {
         const dir = mkdtempSync(join(tmpdir(), "search-unicode-"));
         // Create files with multi-byte UTF-8 names: accented, CJK, emoji

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -320,6 +320,40 @@ describe("searchTool", () => {
         expect(typeof result2.content[0].text).toBe("string");
     });
 
+    test("expands ~ to home directory in path", async () => {
+        const home = process.env.HOME || process.env.USERPROFILE || "";
+        if (!home) {
+            console.log("No HOME set, skipping tilde expansion test");
+            return;
+        }
+        // Create a temp subdirectory inside home with a unique name
+        const subdir = `.pizzapi-search-test-${Date.now()}`;
+        const testDir = join(home, subdir);
+        mkdirSync(testDir);
+        writeFileSync(join(testDir, "tilde-marker.txt"), "tilde-test\n");
+
+        try {
+            // Search with ~/subdir path — should expand and find the file
+            const result = await searchTool.execute("test-tilde", {
+                pattern: "*.txt",
+                path: `~/${subdir}`,
+                type: "files",
+            });
+            expect(result.content[0].text).toContain("tilde-marker.txt");
+
+            // Content search with ~/subdir should also resolve
+            const result2 = await searchTool.execute("test-tilde-content", {
+                pattern: "tilde-test",
+                path: `~/${subdir}`,
+                type: "content",
+            });
+            expect(result2.content[0].text).toContain("tilde-test");
+        } finally {
+            const { rmSync } = require("fs");
+            try { rmSync(testDir, { recursive: true }); } catch {}
+        }
+    });
+
     test("preserves Unicode filenames in file search results", async () => {
         const dir = mkdtempSync(join(tmpdir(), "search-unicode-"));
         // Create files with multi-byte UTF-8 names: accented, CJK, emoji

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -181,7 +181,11 @@ export const searchTool: AgentTool = {
         // Normalize path so a leading "-" can't be mistaken for a flag/predicate.
         // This is the standard Unix idiom (e.g. `rm -- ./--help` vs `rm -- --help`).
         // GNU find/rg treat `./--help` as a literal path, not the --help flag.
-        const safePath = /^[.\/]/.test(rawPath) ? rawPath : `./${rawPath}`;
+        // Preserve Unix absolute (/), relative (. or ..), Windows drive (C:\ or C:/)
+        // and UNC paths (\\server) — only prepend ./ for bare relative paths.
+        const safePath = /^[.\/\\]/.test(rawPath) || /^[a-zA-Z]:/.test(rawPath)
+            ? rawPath
+            : `./${rawPath}`;
 
         // -e forces rg to treat pattern as a regex (not a flag); -- ends options before path.
         const [cmd, args, maxLines] =

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -1,15 +1,54 @@
 import { Type } from "@mariozechner/pi-ai";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { execFile } from "child_process";
-import { promisify } from "util";
+import { spawn } from "child_process";
 
-const execFileAsync = promisify(execFile);
+/**
+ * Spawn a command with an argument array (no shell) and stream stdout,
+ * collecting at most `maxLines` lines before killing the child process.
+ * This is the shell-free equivalent of `cmd args | head -N`.
+ */
+function spawnHeadLines(
+    cmd: string,
+    args: string[],
+    maxLines: number,
+    timeoutMs: number,
+): Promise<string> {
+    return new Promise((resolve) => {
+        const child = spawn(cmd, args, {
+            stdio: ["ignore", "pipe", "ignore"],
+            timeout: timeoutMs,
+        });
 
-/** Truncate output to the first `maxLines` lines. */
-function truncateLines(text: string, maxLines: number): string {
-    const lines = text.split("\n");
-    if (lines.length <= maxLines) return text;
-    return lines.slice(0, maxLines).join("\n");
+        const collected: string[] = [];
+        let partial = "";
+
+        child.stdout.on("data", (chunk: Buffer) => {
+            partial += chunk.toString();
+            const parts = partial.split("\n");
+            // Last element is an incomplete line (or "" after a trailing \n)
+            partial = parts.pop()!;
+
+            for (const line of parts) {
+                collected.push(line);
+                if (collected.length >= maxLines) {
+                    child.kill();
+                    return;
+                }
+            }
+        });
+
+        child.on("close", () => {
+            // Flush any remaining partial line if we haven't hit the cap
+            if (partial && collected.length < maxLines) {
+                collected.push(partial);
+            }
+            resolve(collected.join("\n"));
+        });
+
+        child.on("error", () => {
+            resolve(collected.join("\n"));
+        });
+    });
 }
 
 export const searchTool: AgentTool = {
@@ -28,29 +67,14 @@ export const searchTool: AgentTool = {
     async execute(_toolCallId, params: any) {
         const type = params.type ?? "content";
 
-        let stdout: string;
-        let maxLines: number;
+        const [cmd, args, maxLines] =
+            type === "files"
+                ? (["find", [params.path, "-name", params.pattern, "-type", "f"], 50] as const)
+                : (["rg", ["--no-heading", "-n", params.pattern, params.path], 100] as const);
 
-        if (type === "files") {
-            // Use execFile to safely pass arguments without a shell
-            const result = await execFileAsync(
-                "find",
-                [params.path, "-name", params.pattern, "-type", "f"],
-                { timeout: 15_000 },
-            ).catch((err) => ({ stdout: err.stdout ?? "", stderr: err.stderr ?? "" }));
-            stdout = result.stdout;
-            maxLines = 50;
-        } else {
-            const result = await execFileAsync(
-                "rg",
-                ["--no-heading", "-n", params.pattern, params.path],
-                { timeout: 15_000 },
-            ).catch((err) => ({ stdout: err.stdout ?? "", stderr: err.stderr ?? "" }));
-            stdout = result.stdout;
-            maxLines = 100;
-        }
+        const stdout = await spawnHeadLines(cmd, [...args], maxLines, 15_000);
 
-        const output = truncateLines(stdout, maxLines) || "No matches found";
+        const output = stdout || "No matches found";
         return {
             content: [{ type: "text" as const, text: output }],
             details: { pattern: params.pattern, path: params.path, type },

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -166,10 +166,11 @@ export const searchTool: AgentTool = {
         let output: string;
         if (result.lines.length > 0) {
             output = result.lines.join("\n");
-            // Surface partial errors (e.g. permission denied on some subdirs)
-            // so the caller knows results may be incomplete.
-            if (isFailure(result, normalizedType) && result.error) {
-                const reason = result.error.split("\n")[0];
+            // Surface partial errors (e.g. permission denied on some subdirs,
+            // timeout with partial output) so the caller knows results may be incomplete.
+            if (isFailure(result, normalizedType)) {
+                const reason = result.error?.split("\n")[0]
+                    || (result.exitCode === null ? "process terminated unexpectedly" : `exit code ${result.exitCode}`);
                 output += `\n\n[warning: some results may be missing — ${reason}]`;
             }
         } else if (isFailure(result, normalizedType)) {
@@ -185,7 +186,7 @@ export const searchTool: AgentTool = {
 
         return {
             content: [{ type: "text" as const, text: output }],
-            details: { pattern: params.pattern, path: params.path, type },
+            details: { pattern: params.pattern, path: params.path, type: normalizedType },
         };
     },
 };

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -2,6 +2,13 @@ import { Type } from "@mariozechner/pi-ai";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { spawn } from "child_process";
 
+interface SpawnResult {
+    lines: string[];
+    exitCode: number | null;
+    signal: string | null;
+    error?: string;
+}
+
 /**
  * Spawn a command with an argument array (no shell) and stream stdout,
  * collecting at most `maxLines` lines before killing the child process.
@@ -12,17 +19,25 @@ function spawnHeadLines(
     args: string[],
     maxLines: number,
     timeoutMs: number,
-): Promise<string> {
+): Promise<SpawnResult> {
     return new Promise((resolve) => {
         const child = spawn(cmd, args, {
-            stdio: ["ignore", "pipe", "ignore"],
+            stdio: ["ignore", "pipe", "pipe"],
             timeout: timeoutMs,
         });
 
         const collected: string[] = [];
         let partial = "";
+        let done = false;
+        let stderrChunks: string[] = [];
+
+        child.stderr!.on("data", (chunk: Buffer) => {
+            stderrChunks.push(chunk.toString());
+        });
 
         child.stdout.on("data", (chunk: Buffer) => {
+            if (done) return;
+
             partial += chunk.toString();
             const parts = partial.split("\n");
             // Last element is an incomplete line (or "" after a trailing \n)
@@ -31,22 +46,34 @@ function spawnHeadLines(
             for (const line of parts) {
                 collected.push(line);
                 if (collected.length >= maxLines) {
+                    done = true;
                     child.kill();
                     return;
                 }
             }
         });
 
-        child.on("close", () => {
+        child.on("close", (code, signal) => {
             // Flush any remaining partial line if we haven't hit the cap
-            if (partial && collected.length < maxLines) {
+            if (!done && partial && collected.length < maxLines) {
                 collected.push(partial);
             }
-            resolve(collected.join("\n"));
+            // Hard-cap as a final safety net against post-kill data events
+            resolve({
+                lines: collected.slice(0, maxLines),
+                exitCode: code,
+                signal: signal as string | null,
+                error: stderrChunks.length ? stderrChunks.join("").slice(0, 500) : undefined,
+            });
         });
 
-        child.on("error", () => {
-            resolve(collected.join("\n"));
+        child.on("error", (err) => {
+            resolve({
+                lines: collected.slice(0, maxLines),
+                exitCode: null,
+                signal: null,
+                error: err.message,
+            });
         });
     });
 }
@@ -67,14 +94,24 @@ export const searchTool: AgentTool = {
     async execute(_toolCallId, params: any) {
         const type = params.type ?? "content";
 
+        // Use -e/-- to prevent argument injection from patterns/paths starting with "-"
         const [cmd, args, maxLines] =
             type === "files"
-                ? (["find", [params.path, "-name", params.pattern, "-type", "f"], 50] as const)
-                : (["rg", ["--no-heading", "-n", params.pattern, params.path], 100] as const);
+                ? (["find", ["--", params.path, "-name", params.pattern, "-type", "f"], 50] as const)
+                : (["rg", ["--no-heading", "-n", "-e", params.pattern, "--", params.path], 100] as const);
 
-        const stdout = await spawnHeadLines(cmd, [...args], maxLines, 15_000);
+        const result = await spawnHeadLines(cmd, [...args], maxLines, 15_000);
 
-        const output = stdout || "No matches found";
+        let output: string;
+        if (result.lines.length > 0) {
+            output = result.lines.join("\n");
+        } else if (result.error && result.exitCode !== 1) {
+            // exitCode 1 is normal "no matches" for rg/find — anything else is a real error
+            output = `Search failed: ${result.error.split("\n")[0]}`;
+        } else {
+            output = "No matches found";
+        }
+
         return {
             content: [{ type: "text" as const, text: output }],
             details: { pattern: params.pattern, path: params.path, type },

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -1,9 +1,16 @@
 import { Type } from "@mariozechner/pi-ai";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+/** Truncate output to the first `maxLines` lines. */
+function truncateLines(text: string, maxLines: number): string {
+    const lines = text.split("\n");
+    if (lines.length <= maxLines) return text;
+    return lines.slice(0, maxLines).join("\n");
+}
 
 export const searchTool: AgentTool = {
     name: "search",
@@ -20,13 +27,30 @@ export const searchTool: AgentTool = {
     }),
     async execute(_toolCallId, params: any) {
         const type = params.type ?? "content";
-        const command =
-            type === "files"
-                ? `find ${params.path} -name "${params.pattern}" -type f 2>/dev/null | head -50`
-                : `rg --no-heading -n "${params.pattern}" ${params.path} 2>/dev/null | head -100`;
 
-        const { stdout } = await execAsync(command, { timeout: 15_000 });
-        const output = stdout || "No matches found";
+        let stdout: string;
+        let maxLines: number;
+
+        if (type === "files") {
+            // Use execFile to safely pass arguments without a shell
+            const result = await execFileAsync(
+                "find",
+                [params.path, "-name", params.pattern, "-type", "f"],
+                { timeout: 15_000 },
+            ).catch((err) => ({ stdout: err.stdout ?? "", stderr: err.stderr ?? "" }));
+            stdout = result.stdout;
+            maxLines = 50;
+        } else {
+            const result = await execFileAsync(
+                "rg",
+                ["--no-heading", "-n", params.pattern, params.path],
+                { timeout: 15_000 },
+            ).catch((err) => ({ stdout: err.stdout ?? "", stderr: err.stderr ?? "" }));
+            stdout = result.stdout;
+            maxLines = 100;
+        }
+
+        const output = truncateLines(stdout, maxLines) || "No matches found";
         return {
             content: [{ type: "text" as const, text: output }],
             details: { pattern: params.pattern, path: params.path, type },

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -2,10 +2,15 @@ import { Type } from "@mariozechner/pi-ai";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { spawn } from "child_process";
 
+/** Maximum bytes of stderr to retain in memory. */
+const MAX_STDERR_BYTES = 512;
+
 interface SpawnResult {
     lines: string[];
     exitCode: number | null;
     signal: string | null;
+    /** True when the child was killed because it hit the line cap. */
+    truncated: boolean;
     error?: string;
 }
 
@@ -29,10 +34,15 @@ function spawnHeadLines(
         const collected: string[] = [];
         let partial = "";
         let done = false;
-        let stderrChunks: string[] = [];
+        let stderr = "";
 
         child.stderr!.on("data", (chunk: Buffer) => {
-            stderrChunks.push(chunk.toString());
+            if (stderr.length < MAX_STDERR_BYTES) {
+                stderr += chunk.toString();
+                if (stderr.length > MAX_STDERR_BYTES) {
+                    stderr = stderr.slice(0, MAX_STDERR_BYTES);
+                }
+            }
         });
 
         child.stdout.on("data", (chunk: Buffer) => {
@@ -63,7 +73,8 @@ function spawnHeadLines(
                 lines: collected.slice(0, maxLines),
                 exitCode: code,
                 signal: signal as string | null,
-                error: stderrChunks.length ? stderrChunks.join("").slice(0, 500) : undefined,
+                truncated: done,
+                error: stderr || undefined,
             });
         });
 
@@ -72,10 +83,29 @@ function spawnHeadLines(
                 lines: collected.slice(0, maxLines),
                 exitCode: null,
                 signal: null,
+                truncated: done,
                 error: err.message,
             });
         });
     });
+}
+
+/**
+ * Determine whether a SpawnResult represents a real failure (vs. "no matches").
+ *
+ * - `rg` exit 1 = no matches (normal), exit 2+ = error.
+ * - `find` exit 0 = success (possibly no matches), exit 1+ = error.
+ * - exitCode null with no truncation = timeout or command not found.
+ */
+function isFailure(result: SpawnResult, type: string): boolean {
+    // Truncated kill is intentional, not a failure
+    if (result.truncated) return false;
+    // exitCode null means process didn't exit normally (timeout, ENOENT, etc.)
+    if (result.exitCode === null) return true;
+    // rg: exit 1 = no matches, exit 0 = matches, exit 2+ = error
+    if (type === "content") return result.exitCode >= 2;
+    // find: exit 0 = success (no matches is just empty stdout), exit 1+ = error
+    return result.exitCode !== 0;
 }
 
 export const searchTool: AgentTool = {
@@ -110,9 +140,13 @@ export const searchTool: AgentTool = {
         let output: string;
         if (result.lines.length > 0) {
             output = result.lines.join("\n");
-        } else if (result.error && result.exitCode !== 1) {
-            // exitCode 1 is normal "no matches" for rg/find — anything else is a real error
-            output = `Search failed: ${result.error.split("\n")[0]}`;
+        } else if (isFailure(result, type)) {
+            const reason = result.error?.split("\n")[0];
+            if (result.exitCode === null && !result.truncated) {
+                output = `Search failed: ${reason || "timed out or command not found"}`;
+            } else {
+                output = `Search failed: ${reason || `exit code ${result.exitCode}`}`;
+            }
         } else {
             output = "No matches found";
         }

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -1,6 +1,7 @@
 import { Type } from "@mariozechner/pi-ai";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { spawn } from "child_process";
+import { StringDecoder } from "string_decoder";
 
 /** Maximum chars of stderr to retain in memory. */
 const MAX_STDERR_CHARS = 512;
@@ -44,9 +45,15 @@ function spawnHeadLines(
         let done = false;
         let stderr = "";
 
+        // StringDecoder buffers incomplete multi-byte UTF-8 sequences across
+        // chunk boundaries, preventing corruption of non-ASCII characters
+        // (accented, CJK, emoji, etc.) that may span two data events.
+        const stdoutDecoder = new StringDecoder("utf8");
+        const stderrDecoder = new StringDecoder("utf8");
+
         child.stderr!.on("data", (chunk: Buffer) => {
             if (stderr.length < MAX_STDERR_CHARS) {
-                stderr += chunk.toString();
+                stderr += stderrDecoder.write(chunk);
                 if (stderr.length > MAX_STDERR_CHARS) {
                     stderr = stderr.slice(0, MAX_STDERR_CHARS);
                 }
@@ -56,7 +63,7 @@ function spawnHeadLines(
         child.stdout.on("data", (chunk: Buffer) => {
             if (done) return;
 
-            partial += chunk.toString();
+            partial += stdoutDecoder.write(chunk);
 
             // Guard against unbounded memory from very long lines (e.g.
             // minified JS, binary output). Flush partial as a line if it
@@ -86,6 +93,15 @@ function spawnHeadLines(
         });
 
         child.on("close", (code, signal) => {
+            // Flush any trailing bytes held by the decoder (incomplete
+            // multi-byte sequence at the very end of the stream).
+            const trailing = stdoutDecoder.end();
+            if (trailing) partial += trailing;
+            const trailingErr = stderrDecoder.end();
+            if (trailingErr && stderr.length < MAX_STDERR_CHARS) {
+                stderr += trailingErr;
+            }
+
             // Flush any remaining partial line if we haven't hit the cap
             if (!done && partial && collected.length < maxLines) {
                 collected.push(partial);

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -94,11 +94,16 @@ export const searchTool: AgentTool = {
     async execute(_toolCallId, params: any) {
         const type = params.type ?? "content";
 
-        // Use -e/-- to prevent argument injection from patterns/paths starting with "-"
+        // Normalize path so a leading "-" can't be mistaken for a flag/predicate.
+        // This is the standard Unix idiom (e.g. `rm -- ./--help` vs `rm -- --help`).
+        // GNU find/rg treat `./--help` as a literal path, not the --help flag.
+        const safePath = /^[.\/]/.test(params.path) ? params.path : `./${params.path}`;
+
+        // -e forces rg to treat pattern as a regex (not a flag); -- ends options before path.
         const [cmd, args, maxLines] =
             type === "files"
-                ? (["find", ["--", params.path, "-name", params.pattern, "-type", "f"], 50] as const)
-                : (["rg", ["--no-heading", "-n", "-e", params.pattern, "--", params.path], 100] as const);
+                ? (["find", [safePath, "-name", params.pattern, "-type", "f"], 50] as const)
+                : (["rg", ["--no-heading", "-n", "-e", params.pattern, "--", safePath], 100] as const);
 
         const result = await spawnHeadLines(cmd, [...args], maxLines, 15_000);
 

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -2,8 +2,16 @@ import { Type } from "@mariozechner/pi-ai";
 import type { AgentTool } from "@mariozechner/pi-agent-core";
 import { spawn } from "child_process";
 
-/** Maximum bytes of stderr to retain in memory. */
-const MAX_STDERR_BYTES = 512;
+/** Maximum chars of stderr to retain in memory. */
+const MAX_STDERR_CHARS = 512;
+
+/**
+ * Maximum chars to buffer in the partial (incomplete) line accumulator.
+ * Prevents OOM when a subprocess emits very long lines without newlines
+ * (e.g. minified files, binary output). When exceeded, the partial is
+ * flushed as a complete line and counting continues.
+ */
+const MAX_PARTIAL_CHARS = 256 * 1024; // 256 KB
 
 interface SpawnResult {
     lines: string[];
@@ -37,10 +45,10 @@ function spawnHeadLines(
         let stderr = "";
 
         child.stderr!.on("data", (chunk: Buffer) => {
-            if (stderr.length < MAX_STDERR_BYTES) {
+            if (stderr.length < MAX_STDERR_CHARS) {
                 stderr += chunk.toString();
-                if (stderr.length > MAX_STDERR_BYTES) {
-                    stderr = stderr.slice(0, MAX_STDERR_BYTES);
+                if (stderr.length > MAX_STDERR_CHARS) {
+                    stderr = stderr.slice(0, MAX_STDERR_CHARS);
                 }
             }
         });
@@ -49,6 +57,20 @@ function spawnHeadLines(
             if (done) return;
 
             partial += chunk.toString();
+
+            // Guard against unbounded memory from very long lines (e.g.
+            // minified JS, binary output). Flush partial as a line if it
+            // exceeds the cap, even without a newline.
+            if (!partial.includes("\n") && partial.length > MAX_PARTIAL_CHARS) {
+                collected.push(partial);
+                partial = "";
+                if (collected.length >= maxLines) {
+                    done = true;
+                    child.kill();
+                    return;
+                }
+            }
+
             const parts = partial.split("\n");
             // Last element is an incomplete line (or "" after a trailing \n)
             partial = parts.pop()!;
@@ -137,10 +159,20 @@ export const searchTool: AgentTool = {
 
         const result = await spawnHeadLines(cmd, [...args], maxLines, 15_000);
 
+        // Normalize type for isFailure — unknown values fall through to "content"
+        // (rg branch) in command selection, so must match here too.
+        const normalizedType = type === "files" ? "files" : "content";
+
         let output: string;
         if (result.lines.length > 0) {
             output = result.lines.join("\n");
-        } else if (isFailure(result, type)) {
+            // Surface partial errors (e.g. permission denied on some subdirs)
+            // so the caller knows results may be incomplete.
+            if (isFailure(result, normalizedType) && result.error) {
+                const reason = result.error.split("\n")[0];
+                output += `\n\n[warning: some results may be missing — ${reason}]`;
+            }
+        } else if (isFailure(result, normalizedType)) {
             const reason = result.error?.split("\n")[0];
             if (result.exitCode === null && !result.truncated) {
                 output = `Search failed: ${reason || "timed out or command not found"}`;

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -162,18 +162,30 @@ export const searchTool: AgentTool = {
     async execute(_toolCallId, params: any) {
         const type = params.type ?? "content";
 
+        // Strip null bytes — spawn() throws synchronously if any arg contains \0.
+        const pattern = String(params.pattern).replaceAll("\0", "");
+        const rawPath = String(params.path).replaceAll("\0", "");
+
         // Normalize path so a leading "-" can't be mistaken for a flag/predicate.
         // This is the standard Unix idiom (e.g. `rm -- ./--help` vs `rm -- --help`).
         // GNU find/rg treat `./--help` as a literal path, not the --help flag.
-        const safePath = /^[.\/]/.test(params.path) ? params.path : `./${params.path}`;
+        const safePath = /^[.\/]/.test(rawPath) ? rawPath : `./${rawPath}`;
 
         // -e forces rg to treat pattern as a regex (not a flag); -- ends options before path.
         const [cmd, args, maxLines] =
             type === "files"
-                ? (["find", [safePath, "-name", params.pattern, "-type", "f"], 50] as const)
-                : (["rg", ["--no-heading", "-n", "-e", params.pattern, "--", safePath], 100] as const);
+                ? (["find", [safePath, "-name", pattern, "-type", "f"], 50] as const)
+                : (["rg", ["--no-heading", "-n", "-e", pattern, "--", safePath], 100] as const);
 
-        const result = await spawnHeadLines(cmd, [...args], maxLines, 15_000);
+        let result: SpawnResult;
+        try {
+            result = await spawnHeadLines(cmd, [...args], maxLines, 15_000);
+        } catch (err: any) {
+            return {
+                content: [{ type: "text" as const, text: `Search failed: ${err.message}` }],
+                details: { pattern, path: rawPath, type: type === "files" ? "files" : "content" },
+            };
+        }
 
         // Normalize type for isFailure — unknown values fall through to "content"
         // (rg branch) in command selection, so must match here too.
@@ -202,7 +214,7 @@ export const searchTool: AgentTool = {
 
         return {
             content: [{ type: "text" as const, text: output }],
-            details: { pattern: params.pattern, path: params.path, type: normalizedType },
+            details: { pattern, path: rawPath, type: normalizedType },
         };
     },
 };

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -164,7 +164,19 @@ export const searchTool: AgentTool = {
 
         // Strip null bytes — spawn() throws synchronously if any arg contains \0.
         const pattern = String(params.pattern).replaceAll("\0", "");
-        const rawPath = String(params.path).replaceAll("\0", "");
+        let rawPath = String(params.path).replaceAll("\0", "");
+
+        // Expand ~ to home directory — spawn() doesn't invoke a shell so
+        // tilde expansion doesn't happen automatically. Without this,
+        // ~/project would become ./~/project and fail to resolve.
+        const home = process.env.HOME || process.env.USERPROFILE || "";
+        if (home) {
+            if (rawPath === "~") {
+                rawPath = home;
+            } else if (rawPath.startsWith("~/")) {
+                rawPath = home + rawPath.slice(1);
+            }
+        }
 
         // Normalize path so a leading "-" can't be mistaken for a flag/predicate.
         // This is the standard Unix idiom (e.g. `rm -- ./--help` vs `rm -- --help`).

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/ai-elements/conversation";
 import type { RelayMessage } from "@/components/session-viewer/types";
 import { groupToolExecutionMessages, groupSubAgentConversations } from "@/components/session-viewer/grouping";
+import { getComposerSubmitMode } from "@/components/session-viewer/composer-submit-state";
 import {
   hasVisibleContent,
   resolveCommandPopoverState,
@@ -276,10 +277,19 @@ function ComposerSubmitButton({
 }) {
   const attachments = usePromptInputAttachments();
   const hasAttachments = attachments.files.length > 0;
+  const hasDraft = input.trim().length > 0 || hasAttachments;
+  const submitMode = getComposerSubmitMode({
+    isTouchDevice: Boolean(isTouchDevice),
+    agentActive: Boolean(agentActive),
+    hasDraft,
+    canAbort: Boolean(agentActive && onExec),
+  });
 
-  // On mobile (touch), show a send/queue button instead of stop —
-  // Enter inserts newlines on mobile, so the button is the primary submit action.
-  const showStopMode = agentActive && onExec && !isTouchDevice;
+  if (submitMode === "hidden") {
+    return null;
+  }
+
+  const showStopMode = submitMode === "stop";
 
   return (
     <PromptInputSubmit
@@ -291,7 +301,7 @@ function ComposerSubmitButton({
             }
           : undefined
       }
-      disabled={!sessionId || (!showStopMode && !input.trim() && !hasAttachments)}
+      disabled={!sessionId || (!showStopMode && !hasDraft)}
     />
   );
 }

--- a/packages/ui/src/components/session-viewer/composer-submit-state.test.ts
+++ b/packages/ui/src/components/session-viewer/composer-submit-state.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { getComposerSubmitMode } from "./composer-submit-state";
+
+describe("getComposerSubmitMode", () => {
+  test("hides send on mobile when idle", () => {
+    expect(
+      getComposerSubmitMode({
+        isTouchDevice: true,
+        agentActive: false,
+        hasDraft: false,
+        canAbort: false,
+      }),
+    ).toBe("hidden");
+  });
+
+  test("shows send on mobile once draft exists", () => {
+    expect(
+      getComposerSubmitMode({
+        isTouchDevice: true,
+        agentActive: false,
+        hasDraft: true,
+        canAbort: false,
+      }),
+    ).toBe("send");
+  });
+
+  test("shows stop on mobile while streaming with no draft", () => {
+    expect(
+      getComposerSubmitMode({
+        isTouchDevice: true,
+        agentActive: true,
+        hasDraft: false,
+        canAbort: true,
+      }),
+    ).toBe("stop");
+  });
+
+  test("shows send on mobile while streaming when composing follow-up", () => {
+    expect(
+      getComposerSubmitMode({
+        isTouchDevice: true,
+        agentActive: true,
+        hasDraft: true,
+        canAbort: true,
+      }),
+    ).toBe("send");
+  });
+
+  test("desktop keeps send visible when idle", () => {
+    expect(
+      getComposerSubmitMode({
+        isTouchDevice: false,
+        agentActive: false,
+        hasDraft: false,
+        canAbort: false,
+      }),
+    ).toBe("send");
+  });
+
+  test("desktop uses stop while streaming", () => {
+    expect(
+      getComposerSubmitMode({
+        isTouchDevice: false,
+        agentActive: true,
+        hasDraft: false,
+        canAbort: true,
+      }),
+    ).toBe("stop");
+  });
+});

--- a/packages/ui/src/components/session-viewer/composer-submit-state.ts
+++ b/packages/ui/src/components/session-viewer/composer-submit-state.ts
@@ -1,0 +1,32 @@
+export type ComposerSubmitMode = "hidden" | "send" | "stop";
+
+interface ComposerSubmitStateInput {
+  isTouchDevice: boolean;
+  agentActive: boolean;
+  hasDraft: boolean;
+  canAbort: boolean;
+}
+
+/**
+ * Decide which composer submit control should be shown.
+ *
+ * - Desktop keeps a visible send button at all times and swaps to stop while streaming.
+ * - Mobile hides send until the user has a draft, but keeps stop available during streaming.
+ */
+export function getComposerSubmitMode({
+  isTouchDevice,
+  agentActive,
+  hasDraft,
+  canAbort,
+}: ComposerSubmitStateInput): ComposerSubmitMode {
+  if (agentActive && canAbort) {
+    if (!isTouchDevice) return "stop";
+    return hasDraft ? "send" : "stop";
+  }
+
+  if (isTouchDevice && !hasDraft) {
+    return "hidden";
+  }
+
+  return "send";
+}

--- a/packages/ui/src/components/session-viewer/composer-submit-state.ts
+++ b/packages/ui/src/components/session-viewer/composer-submit-state.ts
@@ -11,7 +11,9 @@ interface ComposerSubmitStateInput {
  * Decide which composer submit control should be shown.
  *
  * - Desktop keeps a visible send button at all times and swaps to stop while streaming.
- * - Mobile hides send until the user has a draft, but keeps stop available during streaming.
+ * - Mobile hides send until the user has a draft. During streaming, stop is shown
+ *   unless the user is composing a follow-up, in which case send is shown so they
+ *   can queue the next message.
  */
 export function getComposerSubmitMode({
   isTouchDevice,


### PR DESCRIPTION
## Summary

Fixes a CodeQL-flagged **shell injection vulnerability** in `packages/tools/src/search.ts`.

### Problem
`params.path` and `params.pattern` (user/library-controlled input) were directly interpolated into shell command strings via template literals and executed with `exec()`, which spawns a shell. This allows command injection via metacharacters like `; rm -rf /` or `$(malicious_command)`.

### Fix
- **`exec()` → `execFile()`**: Arguments are passed as an array directly to the process via `execvp` — no shell is spawned, so metacharacters are treated as literal strings.
- **Replaced `| head -N` shell pipe** with a `truncateLines()` JS helper (shell pipes required `exec`).
- **`.catch()` handlers** gracefully handle non-zero exits (`rg` exit 1 = no matches, `find` exit 1 = bad path).

### Tests
Added `search.test.ts` with 8 tests:
- File search, content search, default type, no results
- **Injection via pattern**: `"; echo INJECTED; "` → not interpreted
- **Injection via path**: `path; echo INJECTED` → not interpreted  
- Output truncation at max lines