### PR TITLE
⚡ Bolt: [performance improvement] Avoid N+1 fetchSockets calls in Socket.IO sweeper

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-04 - [Optimize Socket.IO sweeper N+1 queries]
+**Learning:** In sweeping or polling loops across distributed sessions, calling `fetchSockets()` (e.g., in `packages/server/src/ws/sio-registry.ts`) triggers an expensive, cluster-wide network operation (N+1 bottleneck) for each session check.
+**Action:** Perform cheap local state or staleness checks (like checking last heartbeat or start time locally) before executing expensive cluster-wide network operations. If the local condition fails, the remote query is bypassed, significantly reducing unnecessary network/Redis roundtrips for healthy sessions.

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -646,22 +646,25 @@ async function sweepOrphanedSessions(nowMs: number): Promise<void> {
         // Skip sessions that have an active local relay socket
         if (localTuiSockets.has(sessionId)) continue;
 
-        // Check if the relay socket exists on ANY server via Socket.IO rooms
-        const relaySockets = await io.of("/relay").in(relaySessionRoom(sessionId)).fetchSockets();
-        if (relaySockets.length > 0) continue;
-
-        // No relay socket anywhere — check heartbeat staleness
+        // Check heartbeat staleness locally FIRST (fast memory check)
+        // to avoid expensive cluster-wide N+1 fetchSockets() calls for healthy sessions
         const lastHb = session.lastHeartbeatAt ? Date.parse(session.lastHeartbeatAt) : 0;
         const startedAt = session.startedAt ? Date.parse(session.startedAt) : 0;
         const lastActivity = Math.max(lastHb || 0, startedAt || 0);
 
-        if (nowMs - lastActivity > HEARTBEAT_STALE_MS) {
-            console.log(
-                `[sio-registry] Sweeping orphaned session ${sessionId} ` +
-                `(last activity: ${new Date(lastActivity).toISOString()})`,
-            );
-            await endSharedSession(sessionId, "Session orphaned (no active relay connection)");
+        if (nowMs - lastActivity <= HEARTBEAT_STALE_MS) {
+            continue; // Session is active/recent enough, skip remote socket check
         }
+
+        // Session appears stale locally, verify if a relay socket exists on ANY server
+        const relaySockets = await io.of("/relay").in(relaySessionRoom(sessionId)).fetchSockets();
+        if (relaySockets.length > 0) continue;
+
+        console.log(
+            `[sio-registry] Sweeping orphaned session ${sessionId} ` +
+            `(last activity: ${new Date(lastActivity).toISOString()})`,
+        );
+        await endSharedSession(sessionId, "Session orphaned (no active relay connection)");
     }
 }
 


### PR DESCRIPTION
💡 **What:** Modified `sweepOrphanedSessions` in `packages/server/src/ws/sio-registry.ts` to check the session heartbeat staleness locally (in memory) *before* asking Socket.IO to query for relay sockets across the cluster via `fetchSockets()`.
🎯 **Why:** Previously, the code performed an expensive, cluster-wide `fetchSockets()` network operation for *every single session* that wasn't locally connected to that specific server instance. This created an N+1 query/network bottleneck during the periodic sweeping process. By reversing the checks, healthy active sessions are short-circuited immediately.
📊 **Impact:** Drastically reduces unnecessary network and Redis roundtrips. For a deployment with N healthy, remote sessions, it saves N `fetchSockets()` calls per sweep execution.
🔬 **Measurement:** Verify tests run cleanly with `cd packages/server && bun test`. The `.jules/bolt.md` journal has been updated to document this specific learning.

---
*PR created automatically by Jules for task [16669698519529954115](https://jules.google.com/task/16669698519529954115) started by @Pizzaface*