### PR TITLE
🎨 Palette: Add keyboard focus states to interactive cards

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-04 - [Add focus visible states]
+**Learning:** Common accessible interactive elements without native `<button>` or `<input>` tags, or custom styled buttons (like the `FileTypeCard`, `EditFileCard`, and `CompactionSummaryCard` which look like generic UI cards but use the `<button>` element) often lack default focus indicators because `hover:bg-muted` masks the visual cues of focus for keyboard-only users.
+**Action:** Always ensure that custom styled `button` cards contain `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background` to provide a clear focus ring that maintains keyboard accessibility.

--- a/packages/ui/src/components/ai-elements/edit-file-card.tsx
+++ b/packages/ui/src/components/ai-elements/edit-file-card.tsx
@@ -47,7 +47,7 @@ export function EditFileCard({
         type="button"
         onClick={() => setOpen(true)}
         className={cn(
-          "group flex w-full items-center gap-2.5 rounded-lg border border-border/80 bg-muted/30 px-3 py-2.5 text-left transition-colors hover:bg-muted/60 hover:border-border cursor-pointer",
+          "group flex w-full items-center gap-2.5 rounded-lg border border-border/80 bg-muted/30 px-3 py-2.5 text-left transition-colors hover:bg-muted/60 hover:border-border cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
           className,
         )}
       >

--- a/packages/ui/src/components/ai-elements/file-type-card.tsx
+++ b/packages/ui/src/components/ai-elements/file-type-card.tsx
@@ -45,7 +45,7 @@ export function FileTypeCard({
         type="button"
         onClick={() => setOpen(true)}
         className={cn(
-          "group flex w-full items-center gap-2.5 rounded-lg border border-border/80 bg-muted/30 px-3 py-2.5 text-left transition-colors hover:bg-muted/60 hover:border-border cursor-pointer",
+          "group flex w-full items-center gap-2.5 rounded-lg border border-border/80 bg-muted/30 px-3 py-2.5 text-left transition-colors hover:bg-muted/60 hover:border-border cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background",
           className,
         )}
       >

--- a/packages/ui/src/components/session-viewer/cards/CompactionSummaryCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/CompactionSummaryCard.tsx
@@ -21,7 +21,7 @@ export function CompactionSummaryCard({ summary, tokensBefore }: CompactionSumma
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
-        className="w-full flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:bg-muted/50 transition-colors cursor-pointer"
+        className="w-full flex items-center gap-2 px-3 py-2 text-xs text-muted-foreground hover:bg-muted/50 transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background"
       >
         <span className="shrink-0">📋</span>
         <span className="font-medium">Context compacted</span>


### PR DESCRIPTION
💡 **What:** Added `focus-visible` styles (`focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background`) to `FileTypeCard`, `EditFileCard`, and `CompactionSummaryCard`.
🎯 **Why:** These interactive elements are styled as cards rather than traditional buttons and were missing visual focus indicators. This made them difficult to identify and use for users navigating the UI with a keyboard.
♿ **Accessibility:** Improved keyboard navigation significantly by ensuring focus states are clearly visible and conform to standard shadcn UI ring patterns.

Additionally, recorded learnings regarding accessible focus state patterns on custom styled components in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [7205747829806781110](https://jules.google.com/task/7205747829806781110) started by @Pizzaface*