### PR TITLE
fix: relay status text not rendering in TUI footer

### DIFF
--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -97,6 +97,13 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         ? process.env.PIZZAPI_SESSION_ID.trim()
         : randomUUID();
 
+    // ── Direct relay status text ──────────────────────────────────────────────
+    // Maintained alongside ctx.ui.setStatus() so the custom footer can read it
+    // directly from this closure variable. This avoids timing issues where the
+    // framework's extension status Map might not be populated before the first
+    // render cycle (e.g. status set during session_start before ui.start()).
+    let relayStatusText = "";
+
     // ── Provider usage cache ──────────────────────────────────────────────────
     // Generic normalized shape shared with the UI.
     interface UsageWindow { label: string; utilization: number; resets_at: string }
@@ -1184,6 +1191,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     }
 
     function setRelayStatus(text?: string) {
+        relayStatusText = text ?? "";
         if (!latestCtx) return;
         latestCtx.ui.setStatus(RELAY_STATUS_KEY, text);
     }
@@ -1435,8 +1443,12 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                         modelText += ` • ${currentAuthLabel}`;
                     }
 
-                    const extensionStatuses = footerData.getExtensionStatuses();
-                    const relayStatus = sanitizeStatusText(extensionStatuses.get(RELAY_STATUS_KEY) ?? "");
+                    // Read relay status directly from the closure variable.
+                    // The framework's extensionStatuses Map (via footerData) may not
+                    // be populated before the first render cycle when the status is
+                    // set during session_start (before ui.start()). The closure
+                    // variable is always up to date.
+                    const relayStatus = sanitizeStatusText(relayStatusText);
 
                     const statsText = statsParts.join(" ");
                     const modelBadge = `• ${modelText}`;


### PR DESCRIPTION
## Problem

Relay connection status text (e.g. "Relay not configured", "Disconnected from Relay", "Relay connection failed") never appeared in the TUI footer, despite being set correctly via the framework API.

## Root Cause

The custom footer reads relay status from the pi framework's extension status Map (`footerData.getExtensionStatuses()`), but `setRelayStatus()` populates this Map during the `session_start` event — which fires **before** `ui.start()`. The framework's `requestRender()` gets discarded because the TUI is still in its `stopped` state, creating a timing gap where the status is set but never rendered.

## Fix

Added a closure-level `relayStatusText` variable that:
1. `setRelayStatus()` writes to immediately (before the `latestCtx` guard)
2. Footer `render()` reads from directly instead of the framework's Map
3. Framework `ctx.ui.setStatus()` is still called for compatibility

This ensures the status is always current at render time, regardless of the framework's lifecycle timing.

## Scenarios Covered

| Scenario | Status text |
|---|---|
| No API key | "Relay not configured — run pizza setup" |
| URL unreachable | "Relay connection failed (url)" |
| Wrong API key | "Relay connection failed (url)" / "Relay error: ..." |
| Both wrong | "Relay not configured — run pizza setup" (key checked first) |
| Connected | "Connected to Relay" |
| Later disconnect | "Disconnected from Relay" |