### PR TITLE
chore: bump pi dependencies from 0.55.1 to 0.55.4

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "pizzapi",
       "dependencies": {
-        "@mariozechner/pi-agent-core": "^0.55.1",
-        "@mariozechner/pi-ai": "^0.55.1",
-        "@mariozechner/pi-tui": "^0.55.1",
+        "@mariozechner/pi-agent-core": "^0.55.4",
+        "@mariozechner/pi-ai": "^0.55.4",
+        "@mariozechner/pi-tui": "^0.55.4",
         "motion": "^12.34.2",
         "pizzapi": ".",
       },
@@ -20,13 +20,13 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.1.34",
+      "version": "0.2.2",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
       },
       "dependencies": {
-        "@mariozechner/pi-coding-agent": "^0.55.1",
+        "@mariozechner/pi-coding-agent": "^0.55.4",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@zenyr/bun-pty": "^0.4.4",
@@ -58,8 +58,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@mariozechner/pi-agent-core": "^0.55.1",
-        "@mariozechner/pi-ai": "^0.55.1",
+        "@mariozechner/pi-agent-core": "^0.55.4",
+        "@mariozechner/pi-ai": "^0.55.4",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@socket.io/redis-adapter": "^8.3.0",
@@ -82,8 +82,8 @@
       "name": "@pizzapi/tools",
       "version": "0.1.32",
       "dependencies": {
-        "@mariozechner/pi-agent-core": "^0.55.1",
-        "@mariozechner/pi-ai": "^0.55.1",
+        "@mariozechner/pi-agent-core": "^0.55.4",
+        "@mariozechner/pi-ai": "^0.55.4",
       },
       "devDependencies": {
         "typescript": "^5.7.0",
@@ -151,7 +151,7 @@
     },
   },
   "patchedDependencies": {
-    "@mariozechner/pi-coding-agent@0.55.1": "patches/@mariozechner%2Fpi-coding-agent@0.55.1.patch",
+    "@mariozechner/pi-coding-agent@0.55.4": "patches/@mariozechner%2Fpi-coding-agent@0.55.4.patch",
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
@@ -692,13 +692,13 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.55.1", "", { "dependencies": { "@mariozechner/pi-ai": "^0.55.1" } }, "sha512-t9FAb4ouy8HJSIa8gSRC7j8oeUOb2XDdhvBiHj7FhfpYafj1vRPrvGIEXUV8fPJDCI07vhK9iztP27EPk+yEWw=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.55.4", "", { "dependencies": { "@mariozechner/pi-ai": "^0.55.4" } }, "sha512-g/rZMrP8X4rjqzU4kCV5LLFqOKR0jrYW3bNG7+lpENOVn6jU2GDpq8MIT2SacT76uPKQhVJII/oI9evGpnGI3w=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.55.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.10.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.10.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-JJX1LrVWPUPMExu0f89XR4nMNP37+FNLjEE4cIHq9Hi6xQtOiiEi7OjDFMx58hWsq81xH1CwmQXqGTWBjbXKTw=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.55.4", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.10.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.10.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-q6fWN66N5wpYl/ri54v2Q3QBEz04+nBY67LmatM0xK3TKVgmeGPyQ1YXmRlyb5KhHxMDhNMxChkcHBABzfTi6g=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.55.1", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.55.1", "@mariozechner/pi-ai": "^0.55.1", "@mariozechner/pi-tui": "^0.55.1", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.1.1", "proper-lockfile": "^4.1.2", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-H2M8mbBNyDqhON6+3m4H8CjqJ9taGq/CM3B8dG73+VJJIXFm5SExhU9bdgcw2xh0wWj8yEumsj0of6Tu+F7Ffg=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.55.4", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.55.4", "@mariozechner/pi-ai": "^0.55.4", "@mariozechner/pi-tui": "^0.55.4", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-l/5NySVD1RplhzC3ssd/GtZlxkKKu34vY5VlT+m1mUBqYupBChitEwartVJR5znHoe02LtLXj4G6akOgyd36Ww=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.55.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "koffi": "^2.9.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-rnqDUp2fm/ySevC0Ltj/ZFRbEc1kZ1A4qHESejj9hA8NVrb/pX9g82XwTE762JOieEGrRWAtmHLNOm7/e4dJMw=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.55.4", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "koffi": "^2.9.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-LXoa0CV58lEfzbjXyuUMa4KwoPTzTegPZJEEzuc9p7LnlIn4/eBebhTXQmQ7Hxo+/zb3zpy2qoynKpKcEas9GQ=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
@@ -2452,7 +2452,7 @@
 
     "minimalistic-assert": ["minimalistic-assert@1.0.1", "", {}, "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="],
 
-    "minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
+    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
@@ -3412,6 +3412,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@ts-morph/common/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
+
     "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
@@ -3485,6 +3487,8 @@
     "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "get-uri/data-uri-to-buffer": ["data-uri-to-buffer@6.0.2", "", {}, "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw=="],
+
+    "glob/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "hast-util-from-html/parse5": ["parse5@7.3.0", "", { "dependencies": { "entities": "^6.0.0" } }, "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw=="],
 
@@ -3779,6 +3783,8 @@
     "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
     "widest-line/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "workbox-build/glob/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "workbox-build/stringify-object/is-obj": ["is-obj@1.0.1", "", {}, "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg=="],
 

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
         "postinstall": "true"
     },
     "dependencies": {
-        "@mariozechner/pi-agent-core": "^0.55.1",
-        "@mariozechner/pi-ai": "^0.55.1",
-        "@mariozechner/pi-tui": "^0.55.1",
+        "@mariozechner/pi-agent-core": "^0.55.4",
+        "@mariozechner/pi-ai": "^0.55.4",
+        "@mariozechner/pi-tui": "^0.55.4",
         "motion": "^12.34.2",
         "pizzapi": "."
     },
@@ -48,7 +48,7 @@
         "typescript": "^5.7.0"
     },
     "patchedDependencies": {
-        "@mariozechner/pi-coding-agent@0.55.1": "patches/@mariozechner%2Fpi-coding-agent@0.55.1.patch"
+        "@mariozechner/pi-coding-agent@0.55.4": "patches/@mariozechner%2Fpi-coding-agent@0.55.4.patch"
     },
     "version": ""
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "build:binaries": "bun build-binaries.ts"
   },
   "dependencies": {
-    "@mariozechner/pi-coding-agent": "^0.55.1",
+    "@mariozechner/pi-coding-agent": "^0.55.4",
     "@pizzapi/tools": "workspace:*",
     "@zenyr/bun-pty": "^0.4.4",
     "socket.io-client": "^4.8.1",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,8 +12,8 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@mariozechner/pi-agent-core": "^0.55.1",
-        "@mariozechner/pi-ai": "^0.55.1",
+        "@mariozechner/pi-agent-core": "^0.55.4",
+        "@mariozechner/pi-ai": "^0.55.4",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "better-auth": "^1.4.18",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -9,8 +9,8 @@
         "dev": "tsc --watch"
     },
     "dependencies": {
-        "@mariozechner/pi-ai": "^0.55.1",
-        "@mariozechner/pi-agent-core": "^0.55.1"
+        "@mariozechner/pi-ai": "^0.55.4",
+        "@mariozechner/pi-agent-core": "^0.55.4"
     },
     "devDependencies": {
         "typescript": "^5.7.0"

--- a/patches/@mariozechner%2Fpi-coding-agent@0.55.4.patch
+++ b/patches/@mariozechner%2Fpi-coding-agent@0.55.4.patch
@@ -1,23 +1,20 @@
-diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-36c1615415ab9e2b b/.bun-tag-36c1615415ab9e2b
-new file mode 100644
-index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
-index 5125e76b6490f859fa63cea32b0f1df9fb7aed50..cc2a11988ec12fad5afacc81c43aad46dea3b628 100644
+index a69a086d7492b99fc6e7d021e31e9561fd2b1a3a..3025ed381d2cf3e28c65459aa96d9c092c6bdf4c 100644
 --- a/dist/core/extensions/loader.js
 +++ b/dist/core/extensions/loader.js
-@@ -97,6 +97,9 @@ export function createExtensionRuntime() {
-         setThinkingLevel: notInitialized,
-         flagValues: new Map(),
-         pendingProviderRegistrations: [],
+@@ -107,6 +107,9 @@ export function createExtensionRuntime() {
+         unregisterProvider: (name) => {
+             runtime.pendingProviderRegistrations = runtime.pendingProviderRegistrations.filter((r) => r.name !== name);
+         },
 +        // PATCH(pizzapi): session control for extensions
 +        newSession: () => Promise.reject(new Error("Extension runtime not initialized")),
 +        switchSession: () => Promise.reject(new Error("Extension runtime not initialized")),
      };
+     return runtime;
  }
- /**
-@@ -185,6 +188,13 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
-         registerProvider(name, config) {
-             runtime.pendingProviderRegistrations.push({ name, config });
+@@ -200,6 +203,13 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
+         unregisterProvider(name) {
+             runtime.unregisterProvider(name);
          },
 +        // PATCH(pizzapi): session control for extensions
 +        newSession(options) {
@@ -30,10 +27,10 @@ index 5125e76b6490f859fa63cea32b0f1df9fb7aed50..cc2a11988ec12fad5afacc81c43aad46
      };
      return api;
 diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
-index da287dd66dc0b4a356d4a615addd1e5cf40073ec..4f50eb5748741e68669a960f1a01c1042a99bc4a 100644
+index 6c32bd9438c02e12c40b4f98171b37ab622ed18c..be32027918d34daeb819d7b7a38330cb47384a7b 100644
 --- a/dist/core/extensions/runner.js
 +++ b/dist/core/extensions/runner.js
-@@ -148,6 +148,9 @@ export class ExtensionRunner {
+@@ -153,6 +153,9 @@ export class ExtensionRunner {
              this.navigateTreeHandler = actions.navigateTree;
              this.switchSessionHandler = actions.switchSession;
              this.reloadHandler = actions.reload;
@@ -43,7 +40,7 @@ index da287dd66dc0b4a356d4a615addd1e5cf40073ec..4f50eb5748741e68669a960f1a01c104
              return;
          }
          this.waitForIdleFn = async () => { };
-@@ -156,6 +159,8 @@ export class ExtensionRunner {
+@@ -161,6 +164,8 @@ export class ExtensionRunner {
          this.navigateTreeHandler = async () => ({ cancelled: false });
          this.switchSessionHandler = async () => ({ cancelled: false });
          this.reloadHandler = async () => { };
@@ -53,7 +50,7 @@ index da287dd66dc0b4a356d4a615addd1e5cf40073ec..4f50eb5748741e68669a960f1a01c104
      setUIContext(uiContext) {
          this.uiContext = uiContext ?? noOpUIContext;
 diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
-index 920f62d9c4370c034ab0a052cd02050e2e6be37e..fb97b46838e4f61f516b7cf6b01eb274bb45ef0c 100644
+index d257afa404987930ba4de685100f5215dcf05ef0..7cf11d7d65c3450f14b48330790dcc6e0445cabe 100644
 --- a/dist/modes/interactive/interactive-mode.js
 +++ b/dist/modes/interactive/interactive-mode.js
 @@ -355,12 +355,6 @@ export class InteractiveMode {
@@ -99,7 +96,7 @@ index 920f62d9c4370c034ab0a052cd02050e2e6be37e..fb97b46838e4f61f516b7cf6b01eb274
      /**
       * Get changelog entries to display on startup.
       * Only shows new entries since last seen version, skips for resumed sessions.
-@@ -2330,17 +2301,6 @@ export class InteractiveMode {
+@@ -2334,17 +2305,6 @@ export class InteractiveMode {
          this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
          this.ui.requestRender();
      }
@@ -117,7 +114,7 @@ index 920f62d9c4370c034ab0a052cd02050e2e6be37e..fb97b46838e4f61f516b7cf6b01eb274
      /**
       * Get all queued messages (read-only).
       * Combines session queue and compaction queue.
-@@ -3119,7 +3079,8 @@ export class InteractiveMode {
+@@ -3123,7 +3083,8 @@ export class InteractiveMode {
              restoreEditor();
              this.session.modelRegistry.refresh();
              await this.updateAvailableProviderCount();
@@ -127,9 +124,3 @@ index 920f62d9c4370c034ab0a052cd02050e2e6be37e..fb97b46838e4f61f516b7cf6b01eb274
          }
          catch (error) {
              restoreEditor();
-diff --git a/examples/server-web-client/node_modules/.vite/deps/_metadata.json b/Users/jordan/.bun/install/cache/@mariozechner/pi-coding-agent@0.55.1@@@1/examples/server-web-client/node_modules/.vite/deps/_metadata.json
-deleted file mode 100644
-index 8c3d274affafed48bf93b210b1f55815c06c028a..0000000000000000000000000000000000000000
-diff --git a/examples/server-web-client/node_modules/.vite/deps/package.json b/Users/jordan/.bun/install/cache/@mariozechner/pi-coding-agent@0.55.1@@@1/examples/server-web-client/node_modules/.vite/deps/package.json
-deleted file mode 100644
-index 3dbc1ca591c0557e35b6004aeba250e6a70b56e3..0000000000000000000000000000000000000000

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,7 +4,7 @@ Patches in this directory are applied automatically by Bun via the
 `patchedDependencies` field in the root `package.json`. They are reapplied on
 every `bun install` — no postinstall script is needed.
 
-## @mariozechner/pi-coding-agent@0.55.1
+## @mariozechner/pi-coding-agent@0.55.4
 
 **Purpose:** Two changes:
 


### PR DESCRIPTION
Upgrade all @mariozechner/pi-* packages to 0.55.4:
- pi-coding-agent: ^0.55.1 → ^0.55.4
- pi-agent-core: ^0.55.1 → ^0.55.4
- pi-ai: ^0.55.1 → ^0.55.4
- pi-tui: ^0.55.1 → ^0.55.4

Upstream changes (0.55.2–0.55.4):
- Dynamic provider register/unregister without /reload
- Dynamic tool registration with promptSnippet/promptGuidelines
- Session message persistence ordering fix (#1717)
- Custom tool renderer spacing fix (#1719)
- Windows image paste keybinding fix (#1682)

Regenerated patch for 0.55.4 (same changes: session control on extension API + version check removal + authPath fix).