### PR TITLE
⚡ Bolt: Optimize socket leaving via native broadcast

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2026-03-03 - [Optimize Orphaned Session Sweep]
 **Learning:** `sweepOrphanedSessions` runs on an interval and can cause an N+1 problem by making a cluster-wide Socket.IO `fetchSockets()` call for every single active session. Since this function is meant to clean up *orphaned* sessions, active sessions naturally have recent heartbeats. By calculating `lastActivity` and checking against the staleness threshold *first*, we can skip the expensive Socket.IO lookup entirely for the vast majority of active sessions.
 **Action:** When implementing polling or sweeping loops, filter items with cheap, local checks (like staleness from Redis data) before making expensive cluster-wide or database calls to avoid N+1 bottlenecks.
+
+## 2025-03-05 - [Optimize Socket.IO bulk leave operations]
+**Learning:** In Socket.IO, when disconnecting or removing multiple clients from a room across a Redis cluster, using `await io.in(room).fetchSockets()` followed by an iterative `.leave()` loop causes a severe N+1 problem by pulling all remote socket instances into memory unnecessarily.
+**Action:** Use native broadcast methods like `io.in(room).socketsLeave(room)` or `io.in(room).disconnectSockets(true)` to push the operation directly to the Redis adapter without pulling objects into the application layer.

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -611,10 +611,9 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
         .emit("disconnected", { reason });
 
     // Forcefully disconnect viewer sockets from the room
-    const viewerSockets = await io.of("/viewer").in(viewerSessionRoom(sessionId)).fetchSockets();
-    for (const vs of viewerSockets) {
-        vs.leave(viewerSessionRoom(sessionId));
-    }
+    // Use socketsLeave instead of fetchSockets() + loop to avoid expensive
+    // cluster-wide Socket.IO queries.
+    io.of("/viewer").in(viewerSessionRoom(sessionId)).socketsLeave(viewerSessionRoom(sessionId));
 
     // Clean up local socket reference
     localTuiSockets.delete(sessionId);


### PR DESCRIPTION
💡 What: Replaced an iterative loop that called `.leave()` on an array from `fetchSockets()` with `io.of("/viewer").in(room).socketsLeave(room)` in `endSharedSession`.
🎯 Why: `fetchSockets()` pulls all remote socket objects across the Redis cluster into memory. For large rooms or active instances, this causes massive memory overhead and a network N+1 problem just to make clients leave a room.
📊 Impact: Completely eliminates the serialization and network transfer of socket objects during session termination. `socketsLeave()` natively broadcasts the leave command down to the adapter level.
🔬 Measurement: Verify by monitoring memory usage and Redis activity during bulk `endSharedSession` calls in a distributed environment, ensuring the test suite (`cd packages/server && bun run build && bun test`) continues to pass successfully.

---
*PR created automatically by Jules for task [8149598164552033656](https://jules.google.com/task/8149598164552033656) started by @Pizzaface*