### PR TITLE
🎨 Palette: Add aria-label to mobile user menu button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2024-03-04 - [Add focus visible states]
 **Learning:** Common accessible interactive elements without native `<button>` or `<input>` tags, or custom styled buttons (like the `FileTypeCard`, `EditFileCard`, and `CompactionSummaryCard` which look like generic UI cards but use the `<button>` element) often lack default focus indicators because `hover:bg-muted` masks the visual cues of focus for keyboard-only users.
 **Action:** Always ensure that custom styled `button` cards contain `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background` to provide a clear focus ring that maintains keyboard accessibility.
+
+## 2025-03-05 - [aria-label on buttons with text]
+**Learning:** Adding an `aria-label` to a button that already has visible text (like the user menu button which shows the user's name) completely overrides the visible text in the accessibility tree. This causes a WCAG 2.5.3 (Label in Name) violation, making it harder for assistive technology users (like Voice Control) to interact with the button using its visible label.
+**Action:** Never add `aria-label` attributes to buttons that already contain visible text. Only apply `aria-label` to icon-only buttons or those lacking any visible descriptive text.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2589,7 +2589,7 @@ export function App() {
           )}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-9 w-9">
+              <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="User menu">
                 <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-muted text-[11px] font-semibold">
                   {initials(userLabel)}
                 </span>


### PR DESCRIPTION
💡 **What**: Added `aria-label="User menu"` to the mobile user menu trigger button.
🎯 **Why**: The mobile user menu button is icon-only (displaying only the user's initials) and lacked a descriptive label for screen readers.
♿ **Accessibility**: Improves keyboard and screen reader accessibility by providing a clear name for the icon-only button without violating WCAG 2.5.3 (Label in Name) by ensuring `aria-label` is not added to buttons that already have visible text.

---
*PR created automatically by Jules for task [10854110687448270957](https://jules.google.com/task/10854110687448270957) started by @Pizzaface*