### PR TITLE
🎨 Palette: Consistent tooltips for header icon buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,7 @@
 ## 2025-03-05 - [aria-label on buttons with text]
 **Learning:** Adding an `aria-label` to a button that already has visible text (like the user menu button which shows the user's name) completely overrides the visible text in the accessibility tree. This causes a WCAG 2.5.3 (Label in Name) violation, making it harder for assistive technology users (like Voice Control) to interact with the button using its visible label.
 **Action:** Never add `aria-label` attributes to buttons that already contain visible text. Only apply `aria-label` to icon-only buttons or those lacking any visible descriptive text.
+
+## 2026-03-06 - Tooltip Consistency for Icon Buttons
+**Learning:** Mixing native `title` attributes with custom `Tooltip` components in the same icon button group creates a jarring, inconsistent hover experience for users. Native tooltips have unpredictable delays and styling.
+**Action:** Always use the design system's `Tooltip` component for top-level icon-only actions to ensure a snappy, visually cohesive interface.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -33,6 +33,12 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -2398,41 +2404,65 @@ export function App() {
         </div>
 
         <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9"
-            onClick={() => setIsDark((d) => !d)}
-            aria-label="Toggle dark mode"
-            title="Toggle dark mode"
-          >
-            {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9"
+                  onClick={() => setIsDark((d) => !d)}
+                  aria-label="Toggle dark mode"
+                >
+                  {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Toggle dark mode</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
 
           <NotificationToggle />
           <HapticsToggle />
 
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9"
-            onClick={() => { setShowApiKeys(true); setShowRunners(false); }}
-            aria-label="Manage API keys"
-            title="Manage API keys"
-          >
-            <KeyRound className="h-4 w-4" />
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9"
+                  onClick={() => { setShowApiKeys(true); setShowRunners(false); }}
+                  aria-label="Manage API keys"
+                >
+                  <KeyRound className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Manage API keys</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
 
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9"
-            onClick={() => setShowShortcutsHelp(true)}
-            aria-label="Keyboard shortcuts"
-            title="Keyboard shortcuts (?)"
-          >
-            <Keyboard className="h-4 w-4" />
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-9 w-9"
+                  onClick={() => setShowShortcutsHelp(true)}
+                  aria-label="Keyboard shortcuts"
+                >
+                  <Keyboard className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Keyboard shortcuts (?)</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>


### PR DESCRIPTION
* 💡 What: Replaced native `title` attributes on the Dark Mode, API Keys, and Shortcuts icon buttons in the App header with the design system's `Tooltip` component.
* 🎯 Why: To ensure a snappy, visually cohesive hover experience. Native tooltips have unpredictable delays and styling, creating an inconsistent UI.
* ♿ Accessibility: Preserved the `aria-label` attributes on the buttons to ensure they remain properly labeled for screen readers while improving the visual hover text for sighted mouse users.

---
*PR created automatically by Jules for task [15114551669241408565](https://jules.google.com/task/15114551669241408565) started by @Pizzaface*