### PR TITLE
🎨 Palette: Add Tooltip to icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -9,3 +9,17 @@
 ## 2025-03-05 - [aria-label on buttons with text]
 **Learning:** Adding an `aria-label` to a button that already has visible text (like the user menu button which shows the user's name) completely overrides the visible text in the accessibility tree. This causes a WCAG 2.5.3 (Label in Name) violation, making it harder for assistive technology users (like Voice Control) to interact with the button using its visible label.
 **Action:** Never add `aria-label` attributes to buttons that already contain visible text. Only apply `aria-label` to icon-only buttons or those lacking any visible descriptive text.
+
+## $(date +%Y-%m-%d) - Component Composition with Radix UI Tooltips and DropdownMenus
+**Learning:** When adding `Tooltip` components (from shadcn/ui / Radix UI) to buttons that act as triggers for other Radix UI components (like `DropdownMenuTrigger`), placing the `<Tooltip>` wrapper directly inside the `<DropdownMenuTrigger asChild>` breaks event delegation. Because `<Tooltip>` is a context provider and doesn't forward refs or DOM events, the child trigger loses its click/touch listeners. This causes critical functional regressions, especially noticeable on mobile interfaces where the dropdown becomes unopenable.
+**Action:** When composing multiple Radix UI triggers (e.g., a Tooltip on a DropdownMenu trigger), always wrap the inner trigger with the outer one using nested `asChild` props. The correct compositional pattern is:
+```tsx
+<Tooltip>
+  <TooltipTrigger asChild>
+    <DropdownMenuTrigger asChild>
+      <Button>...</Button>
+    </DropdownMenuTrigger>
+  </TooltipTrigger>
+  <TooltipContent>...</TooltipContent>
+</Tooltip>
+```

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -23,6 +23,7 @@
   <TooltipContent>...</TooltipContent>
 </Tooltip>
 ```
+
 ## 2026-03-06 - Tooltip Consistency for Icon Buttons
 **Learning:** Mixing native `title` attributes with custom `Tooltip` components in the same icon button group creates a jarring, inconsistent hover experience for users. Native tooltips have unpredictable delays and styling.
 **Action:** Always use the design system's `Tooltip` component for top-level icon-only actions to ensure a snappy, visually cohesive interface.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -13,6 +13,7 @@ import type { ViewerServerToClientEvents, ViewerClientToServerEvents } from "@pi
 import { cn } from "@/lib/utils";
 import { pulseStreamingHaptic, cancelHaptic, startToolHaptic, stopToolHaptic } from "@/lib/haptics";
 import { Button } from "@/components/ui/button";
+import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Separator } from "@/components/ui/separator";
 import {
   Dialog,
@@ -2378,6 +2379,7 @@ export function App() {
   }
 
   return (
+    <TooltipProvider delayDuration={0}>
     <div className="flex h-[100dvh] w-full flex-col overflow-hidden bg-background pp-safe-left pp-safe-right">
       {/* ── Desktop header ────────────────────────────────────────────── */}
       <header className="hidden md:flex items-center justify-between gap-3 border-b bg-background px-4 pb-2 pt-[calc(0.5rem_+_env(safe-area-inset-top))] flex-shrink-0">
@@ -2398,41 +2400,53 @@ export function App() {
         </div>
 
         <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9"
-            onClick={() => setIsDark((d) => !d)}
-            aria-label="Toggle dark mode"
-            title="Toggle dark mode"
-          >
-            {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9"
+                onClick={() => setIsDark((d) => !d)}
+                aria-label="Toggle dark mode"
+              >
+                {isDark ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Toggle dark mode</TooltipContent>
+          </Tooltip>
 
           <NotificationToggle />
           <HapticsToggle />
 
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9"
-            onClick={() => { setShowApiKeys(true); setShowRunners(false); }}
-            aria-label="Manage API keys"
-            title="Manage API keys"
-          >
-            <KeyRound className="h-4 w-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9"
+                onClick={() => { setShowApiKeys(true); setShowRunners(false); }}
+                aria-label="Manage API keys"
+              >
+                <KeyRound className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Manage API keys</TooltipContent>
+          </Tooltip>
 
-          <Button
-            variant="ghost"
-            size="icon"
-            className="h-9 w-9"
-            onClick={() => setShowShortcutsHelp(true)}
-            aria-label="Keyboard shortcuts"
-            title="Keyboard shortcuts (?)"
-          >
-            <Keyboard className="h-4 w-4" />
-          </Button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-9 w-9"
+                onClick={() => setShowShortcutsHelp(true)}
+                aria-label="Keyboard shortcuts"
+              >
+                <Keyboard className="h-4 w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Keyboard shortcuts (?)</TooltipContent>
+          </Tooltip>
 
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -2484,15 +2498,20 @@ export function App() {
         style={{ paddingTop: "calc(0.5rem + env(safe-area-inset-top))", paddingBottom: "0.5rem" }}
       >
         {/* Left: sidebar toggle */}
-        <Button
-          variant="ghost"
-          size="icon"
-          className="h-9 w-9 flex-shrink-0"
-          onClick={() => setSidebarOpen(prev => !prev)}
-          aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
-        >
-          <PanelLeftOpen className={`h-5 w-5 transition-transform duration-300 ${sidebarOpen ? "rotate-180" : ""}`} />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-9 w-9 flex-shrink-0"
+              onClick={() => setSidebarOpen(prev => !prev)}
+              aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
+            >
+              <PanelLeftOpen className={`h-5 w-5 transition-transform duration-300 ${sidebarOpen ? "rotate-180" : ""}`} />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>{sidebarOpen ? "Close sidebar" : "Open sidebar"}</TooltipContent>
+        </Tooltip>
 
         {/* Center: session switcher pill or logo */}
         <div className="flex-1 min-w-0 flex justify-center">
@@ -2588,13 +2607,18 @@ export function App() {
             </div>
           )}
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="User menu">
-                <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-muted text-[11px] font-semibold">
-                  {initials(userLabel)}
-                </span>
-              </Button>
-            </DropdownMenuTrigger>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" size="icon" className="h-9 w-9" aria-label="User menu">
+                    <span className="inline-flex h-7 w-7 items-center justify-center rounded-full bg-muted text-[11px] font-semibold">
+                      {initials(userLabel)}
+                    </span>
+                  </Button>
+                </DropdownMenuTrigger>
+              </TooltipTrigger>
+              <TooltipContent>User menu</TooltipContent>
+            </Tooltip>
             <DropdownMenuContent align="end" className="w-64">
               <DropdownMenuLabel className="flex items-center gap-2">
                 <User className="h-4 w-4 text-muted-foreground" />
@@ -3233,15 +3257,20 @@ export function App() {
           <div className="absolute inset-y-0 right-0 z-40 flex w-full max-w-md flex-col shadow-xl border-l bg-background">
             <div className="flex items-center justify-between px-4 py-3 border-b">
               <span className="font-semibold text-sm">API Keys</span>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-7 w-7"
-                onClick={() => setShowApiKeys(false)}
-                aria-label="Close"
-              >
-                <X className="h-4 w-4" />
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7"
+                    onClick={() => setShowApiKeys(false)}
+                    aria-label="Close"
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Close</TooltipContent>
+              </Tooltip>
             </div>
             <div className="flex-1 overflow-y-auto p-4">
               <div className="flex flex-col gap-4">
@@ -3286,5 +3315,6 @@ export function App() {
         </Dialog>
       </div>
     </div>
+    </TooltipProvider>
   );
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -34,12 +34,6 @@ import {
 } from "@/components/ui/select";
 import { Spinner } from "@/components/ui/spinner";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,


### PR DESCRIPTION
💡 **What:** Replaced native HTML `title` attributes with shadcn/ui `Tooltip` components for icon-only buttons in `packages/ui/src/App.tsx`. Wrapped the application with `<TooltipProvider>`.
🎯 **Why:** To improve micro-UX by providing a consistent, branded, and predictable hover experience instead of relying on the browser's default `title` behavior.
♿ **Accessibility:** Replaced inconsistent browser tooltips with accessible ARIA tooltips powered by Radix UI, enhancing usability for all users.

---
*PR created automatically by Jules for task [11757839674047845757](https://jules.google.com/task/11757839674047845757) started by @Pizzaface*