### PR TITLE
Release workflow: auto-push package versions (0.2.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -288,6 +288,7 @@ jobs:
         if: inputs.dry-run != true
         run: |
           VERSION="${{ needs.compute-version.outputs.version }}"
+          SOURCE_SHA="${{ github.sha }}"
           REF_TYPE="${{ github.ref_type }}"
           BRANCH="${{ github.ref_name }}"
 
@@ -299,24 +300,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-          # Sync to the latest remote branch tip before creating the version-bump commit.
-          git fetch origin "$BRANCH"
-          git checkout -B "$BRANCH" "origin/$BRANCH"
-
-          # Re-stamp versions on top of the latest branch state.
-          cd packages/cli
-          bun -e "
-            const pkg = JSON.parse(require('fs').readFileSync('package.json','utf8'));
-            pkg.version = '${VERSION}';
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          cd ../npm
-          bun -e "
-            const pkg = JSON.parse(require('fs').readFileSync('package.json','utf8'));
-            pkg.version = '${VERSION}';
-            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
-          "
-          cd ../..
+          # Keep release provenance tied to the original dispatch commit.
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "$CURRENT_SHA" != "$SOURCE_SHA" ]; then
+            echo "::error::Unexpected HEAD drift before version bump commit (expected ${SOURCE_SHA}, got ${CURRENT_SHA})"
+            exit 1
+          fi
 
           git add packages/cli/package.json packages/npm/package.json
 
@@ -325,36 +314,28 @@ jobs:
           else
             git commit -m "chore(release): bump package versions to ${VERSION} [skip ci]"
 
-            PUSHED=0
-            for ATTEMPT in 1 2 3; do
-              if git push origin "HEAD:${BRANCH}"; then
-                PUSHED=1
-                echo "✅ Pushed version bump commit to ${BRANCH}"
-                break
+            PUSH_OUTPUT=$(git push origin "HEAD:${BRANCH}" 2>&1) && {
+              echo "$PUSH_OUTPUT"
+              echo "✅ Pushed version bump commit to ${BRANCH}"
+            } || {
+              if echo "$PUSH_OUTPUT" | grep -qiE 'non-fast-forward|fetch first'; then
+                echo "::warning::Branch advanced during release; skipped pushing version bump commit to avoid retargeting this release. Commit $(git rev-parse HEAD) can be cherry-picked manually."
+              else
+                echo "::error::Failed to push package.json version bump"
+                echo "$PUSH_OUTPUT"
+                exit 1
               fi
-
-              if [ "$ATTEMPT" -eq 3 ]; then
-                break
-              fi
-
-              echo "⚠️ Push rejected (attempt ${ATTEMPT}); rebasing onto origin/${BRANCH} and retrying..."
-              git fetch origin "$BRANCH"
-              git rebase "origin/$BRANCH"
-            done
-
-            if [ "$PUSHED" -ne 1 ]; then
-              echo "::error::Failed to push package.json version bump after multiple retries"
-              exit 1
-            fi
+            }
           fi
 
       - name: Create git tag
         if: inputs.dry-run != true
         run: |
           VERSION="${{ needs.compute-version.outputs.version }}"
+          SOURCE_SHA="${{ github.sha }}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${VERSION}" -m "Release v${VERSION}"
+          git tag -a "v${VERSION}" "$SOURCE_SHA" -m "Release v${VERSION}"
           git push origin "v${VERSION}"
 
       - name: Summary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ on:
           - dev
           - pull
       version:
-        description: "Version (e.g. 0.2.3). For dev/beta a suffix is appended automatically. For pull, the exact version to yank."
+        description: "Version (e.g. 0.2.4). For dev/beta a suffix is appended automatically. For pull, the exact version to yank."
         required: true
         type: string
       dry-run:
@@ -283,6 +283,31 @@ jobs:
           bun packages/npm/publish-npm.ts \
             --tag ${{ needs.compute-version.outputs.tag }} \
             $ARGS
+
+      - name: Commit and push package.json version bump
+        if: inputs.dry-run != true
+        run: |
+          VERSION="${{ needs.compute-version.outputs.version }}"
+          REF_TYPE="${{ github.ref_type }}"
+          BRANCH="${{ github.ref_name }}"
+
+          if [ "$REF_TYPE" != "branch" ]; then
+            echo "::error::Release workflow must run from a branch to push package.json updates (got ref type: ${REF_TYPE})"
+            exit 1
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add packages/cli/package.json packages/npm/package.json
+
+          if git diff --cached --quiet; then
+            echo "ℹ️ No package.json changes to commit"
+          else
+            git commit -m "chore(release): bump package versions to ${VERSION} [skip ci]"
+            git push origin "HEAD:${BRANCH}"
+            echo "✅ Pushed version bump commit to ${BRANCH}"
+          fi
 
       - name: Create git tag
         if: inputs.dry-run != true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,30 @@ jobs:
           echo "::error::Only @Pizzaface can trigger releases. Actor: ${{ github.actor }}"
           exit 1
 
+  # ─── Gate: releases must run from a branch ref ────────────────
+  # Prevent partial releases when workflow_dispatch is triggered on
+  # a tag ref: publish could succeed, then branch-only git operations
+  # (version bump push) would fail afterwards.
+  validate-release-ref:
+    name: Validate release ref
+    needs: authorize
+    if: inputs.action != 'pull'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check ref type
+        run: |
+          if [ "${{ github.ref_type }}" != "branch" ]; then
+            echo "::error::Release actions (latest/beta/dev) must be dispatched from a branch ref. Got: ${{ github.ref_type }} (${{ github.ref_name }})"
+            exit 1
+          fi
+
   # ─── Compute the release version before building binaries ─────
   # The CLI reads its version from package.json at runtime (--version,
   # runner reporting).  `bun build --compile` bakes package.json into
   # the binary, so we must stamp the correct version BEFORE compiling.
   compute-version:
     name: Compute version
-    needs: authorize
+    needs: [authorize, validate-release-ref]
     if: inputs.action != 'pull'
     runs-on: ubuntu-latest
     outputs:
@@ -293,8 +310,8 @@ jobs:
           BRANCH="${{ github.ref_name }}"
 
           if [ "$REF_TYPE" != "branch" ]; then
-            echo "::error::Release workflow must run from a branch to push package.json updates (got ref type: ${REF_TYPE})"
-            exit 1
+            echo "⚠️ Skipping package.json push: non-branch ref (${REF_TYPE})"
+            exit 0
           fi
 
           git config user.name "github-actions[bot]"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,14 +299,53 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          # Sync to the latest remote branch tip before creating the version-bump commit.
+          git fetch origin "$BRANCH"
+          git checkout -B "$BRANCH" "origin/$BRANCH"
+
+          # Re-stamp versions on top of the latest branch state.
+          cd packages/cli
+          bun -e "
+            const pkg = JSON.parse(require('fs').readFileSync('package.json','utf8'));
+            pkg.version = '${VERSION}';
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          cd ../npm
+          bun -e "
+            const pkg = JSON.parse(require('fs').readFileSync('package.json','utf8'));
+            pkg.version = '${VERSION}';
+            require('fs').writeFileSync('package.json', JSON.stringify(pkg, null, 2) + '\n');
+          "
+          cd ../..
+
           git add packages/cli/package.json packages/npm/package.json
 
           if git diff --cached --quiet; then
             echo "ℹ️ No package.json changes to commit"
           else
             git commit -m "chore(release): bump package versions to ${VERSION} [skip ci]"
-            git push origin "HEAD:${BRANCH}"
-            echo "✅ Pushed version bump commit to ${BRANCH}"
+
+            PUSHED=0
+            for ATTEMPT in 1 2 3; do
+              if git push origin "HEAD:${BRANCH}"; then
+                PUSHED=1
+                echo "✅ Pushed version bump commit to ${BRANCH}"
+                break
+              fi
+
+              if [ "$ATTEMPT" -eq 3 ]; then
+                break
+              fi
+
+              echo "⚠️ Push rejected (attempt ${ATTEMPT}); rebasing onto origin/${BRANCH} and retrying..."
+              git fetch origin "$BRANCH"
+              git rebase "origin/$BRANCH"
+            done
+
+            if [ "$PUSHED" -ne 1 ]; then
+              echo "::error::Failed to push package.json version bump after multiple retries"
+              exit 1
+            fi
           fi
 
       - name: Create git tag

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pizzapi/cli",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "type": "module",
   "bin": {
     "pizza": "src/index.ts",

--- a/packages/npm/package.json
+++ b/packages/npm/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@pizzapi/npm",
-    "version": "0.1.32",
+    "version": "0.2.4",
     "private": true,
     "type": "module",
     "scripts": {


### PR DESCRIPTION
## Summary
- add a release workflow step to commit/push `packages/cli/package.json` + `packages/npm/package.json` after publish (non-dry-run)
- guard pushes to branch refs only to avoid accidental tag-ref pushes
- unify repo release versions to `0.2.4` for CLI + npm package and update workflow input example

## Validation
- bun run typecheck