### PR TITLE
⚡ Bolt: [performance improvement] Optimize Socket.IO orphaned session sweeps

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-03-05 - [Optimize Socket.IO bulk leave operations]
 **Learning:** In Socket.IO, when disconnecting or removing multiple clients from a room across a Redis cluster, using `await io.in(room).fetchSockets()` followed by an iterative `.leave()` loop causes a severe N+1 problem by pulling all remote socket instances into memory unnecessarily.
 **Action:** Use native broadcast methods like `io.in(room).socketsLeave(room)` or `io.in(room).disconnectSockets(true)` to push the operation directly to the Redis adapter without pulling objects into the application layer.
+
+## 2025-03-09 - Socket.IO Cluster Network Bottlenecks
+**Learning:** `fetchSockets()` is highly inefficient when only checking for socket presence in a clustered (Redis) environment, as it pulls full `RemoteSocket` objects across the network. `.allSockets()` is deprecated in Socket.IO v4.
+**Action:** Use `adapter.sockets(new Set([roomName]))` directly to efficiently return a `Set` of socket IDs without cross-cluster serialization overhead.

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -676,7 +676,7 @@ async function sweepOrphanedSessions(nowMs: number): Promise<void> {
         if (localTuiSockets.has(sessionId)) continue;
 
         // Check heartbeat staleness locally FIRST (fast memory check)
-        // to avoid expensive cluster-wide N+1 fetchSockets() calls for healthy sessions
+        // to avoid expensive cluster-wide N+1 socket queries for healthy sessions
         const lastHb = session.lastHeartbeatAt ? Date.parse(session.lastHeartbeatAt) : 0;
         const startedAt = session.startedAt ? Date.parse(session.startedAt) : 0;
         const lastActivity = Math.max(lastHb || 0, startedAt || 0);
@@ -686,8 +686,12 @@ async function sweepOrphanedSessions(nowMs: number): Promise<void> {
         }
 
         // Session appears stale locally, verify if a relay socket exists on ANY server
-        const relaySockets = await io.of("/relay").in(relaySessionRoom(sessionId)).fetchSockets();
-        if (relaySockets.length > 0) continue;
+        // ⚡ Bolt: Using the adapter directly prevents an expensive cluster-wide N+1
+        // fetchSockets() call that pulls all socket instances into memory, and avoids
+        // the deprecated allSockets() method.
+        const roomName = relaySessionRoom(sessionId);
+        const relaySockets = await io.of("/relay").adapter.sockets(new Set([roomName]));
+        if (relaySockets.size > 0) continue;
 
         console.log(
             `[sio-registry] Sweeping orphaned session ${sessionId} ` +


### PR DESCRIPTION
💡 What: Replaced an expensive `.fetchSockets()` call with a direct query to the Socket.IO adapter (`adapter.sockets(new Set([roomName]))`) in `sweepOrphanedSessions`.
🎯 Why: `fetchSockets()` pulls full `RemoteSocket` objects (including handshake, data, and room lists) across the Redis cluster for every socket. In a clustered environment, checking for socket presence this way is extremely expensive and causes N+1 network pressure during sweeping. 
📊 Impact: Considerably reduces memory overhead and cluster network traffic during orphaned session sweeps.
🔬 Measurement: Verify changes locally or in test coverage; monitor memory and network usage reductions during clustered sweeping cycles. The build and core tests still pass successfully.

---
*PR created automatically by Jules for task [8061987863011953911](https://jules.google.com/task/8061987863011953911) started by @Pizzaface*