### PR TITLE
🎨 Palette: Consistent tooltips and ARIA labels for secret banner

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -27,3 +27,7 @@
 ## 2026-03-06 - Tooltip Consistency for Icon Buttons
 **Learning:** Mixing native `title` attributes with custom `Tooltip` components in the same icon button group creates a jarring, inconsistent hover experience for users. Native tooltips have unpredictable delays and styling.
 **Action:** Always use the design system's `Tooltip` component for top-level icon-only actions to ensure a snappy, visually cohesive interface.
+
+## 2026-03-10 - Consistent Icon Button Accessibility and Tooltips
+**Learning:** Relying on native `title` attributes for icon-only buttons creates inconsistent hover delays across different components and lacks screen-reader robustness when not paired with explicit `aria-label` attributes. Within specific utility components like banner actions, this discrepancy becomes especially noticeable when other parts of the application utilize unified design system tooltips.
+**Action:** Consistently replace native `title` attributes on icon-only buttons with the design system's `Tooltip` components (`TooltipProvider`, `Tooltip`, `TooltipTrigger`, `TooltipContent`). Furthermore, always explicitly declare `aria-label` on these buttons so that screen readers correctly identify their action, rather than relying solely on tooltip text or raw DOM content.

--- a/packages/ui/src/components/ui/revealed-secret.tsx
+++ b/packages/ui/src/components/ui/revealed-secret.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Button } from "@/components/ui/button";
 import { Copy, Check } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 
 /**
  * Banner shown once when a secret (API key / token) is first created.
@@ -28,28 +29,46 @@ export function RevealedSecretBanner({
       <code className="flex-1 truncate font-mono text-xs text-green-700 dark:text-green-400">
         {value}
       </code>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-7 w-7 flex-shrink-0"
-        onClick={handleCopy}
-        title="Copy"
-      >
-        {copied ? (
-          <Check className="h-3.5 w-3.5 text-green-600" />
-        ) : (
-          <Copy className="h-3.5 w-3.5" />
-        )}
-      </Button>
-      <Button
-        variant="ghost"
-        size="icon"
-        className="h-7 w-7 flex-shrink-0 text-muted-foreground"
-        onClick={onDismiss}
-        title="Dismiss"
-      >
-        ×
-      </Button>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 flex-shrink-0"
+              onClick={handleCopy}
+              aria-label="Copy"
+            >
+              {copied ? (
+                <Check className="h-3.5 w-3.5 text-green-600" />
+              ) : (
+                <Copy className="h-3.5 w-3.5" />
+              )}
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Copy</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 flex-shrink-0 text-muted-foreground"
+              onClick={onDismiss}
+              aria-label="Dismiss"
+            >
+              ×
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p>Dismiss</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     </div>
   );
 }


### PR DESCRIPTION
💡 **What:** 
Replaced native `title` attributes with the design system's `Tooltip` components for the "Copy" and "Dismiss" icon-only buttons in the `RevealedSecretBanner` component (`packages/ui/src/components/ui/revealed-secret.tsx`). Added explicit `aria-label` attributes to both buttons.

🎯 **Why:** 
Native `title` attributes have unpredictable delays and inconsistent styling compared to the custom `Tooltip` components used elsewhere in the application, creating a jarring UX. Additionally, icon-only buttons require explicit `aria-label`s to ensure screen reader accessibility, as the tooltip content alone may not be reliably announced.

📸 **Before/After:**
*Before:* The banner actions relied on standard OS tooltips with native delay and styling, potentially missing context for assistive tech without proper ARIA properties.
*After:* The banner actions now display immediate, consistently-styled tooltips from the Radix/Shadcn design system, and are fully accessible via keyboard focus and screen readers.

♿ **Accessibility:**
Explicit `aria-label`s ("Copy" and "Dismiss") were added to both buttons. The new tooltips properly implement ARIA attributes (`aria-describedby` handling via Radix UI) for robust accessibility support.

---
*PR created automatically by Jules for task [1088894881944867654](https://jules.google.com/task/1088894881944867654) started by @Pizzaface*