### PR TITLE
fix: service worker OAuth callback & viewer exec race condition

### DIFF
--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -202,50 +202,14 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             return;
         }
 
-        // Session is live — send connection info and initial snapshot BEFORE
-        // joining the broadcast room. This avoids a race where live streaming
-        // deltas arrive (via the room) before the snapshot, causing the UI to
-        // show partial content that then gets replaced by the snapshot — making
-        // messages visibly "jump".
-        //
-        // Any events emitted between snapshot read and room join are detected
-        // by the client's sequence-gap logic (seq gap > 1 → resync request).
-        const lastSeq = await getSessionSeq(sessionId);
-        socket.emit("connected", {
-            sessionId,
-            lastSeq,
-            isActive: session.isActive,
-            lastHeartbeatAt: session.lastHeartbeatAt,
-            sessionName: session.sessionName,
-        });
-
-        // Send the snapshot while the viewer is NOT yet in the room.
-        // Inline the snapshot send using already-fetched session data to avoid
-        // an extra Redis round-trip (which would widen the race window).
-        if (session.lastHeartbeat) {
-            try {
-                socket.emit("event", { event: JSON.parse(session.lastHeartbeat), seq: lastSeq });
-            } catch {}
-        }
-        if (session.lastState) {
-            try {
-                socket.emit("event", { event: { type: "session_active", state: JSON.parse(session.lastState) }, seq: lastSeq });
-            } catch {}
-        } else {
-            // No in-memory state — fall back to event cache
-            await sendLatestSnapshotFromCache(socket, sessionId);
-        }
-
-        // NOW join the room for live events — any missed events between
-        // snapshot read and this point will be caught by gap detection.
-        const ok = await addViewer(sessionId, socket);
-        if (!ok) {
-            socket.emit("disconnected", { reason: "Session ended" });
-            // Use disconnect() (not true) so the client can still auto-reconnect;
-            // the session may have just cycled and will come back shortly.
-            socket.disconnect();
-            return;
-        }
+        // ── Register ALL event handlers FIRST ────────────────────────────────
+        // Handlers must be registered synchronously before any async work
+        // (snapshot sending, addViewer, etc.) to avoid a race condition where
+        // the client receives "connected", immediately fires "exec" or
+        // "input", but the handler isn't registered yet because we're still
+        // awaiting Redis calls. This is the root cause of Check+Kill failing
+        // for non-active sessions (especially when ending 3+ sessions at
+        // once — the concurrent async work widens the race window).
 
         // ── connected — viewer greeting, notify TUI ─────────────────────────
         socket.on("connected", () => {
@@ -331,5 +295,51 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             console.log(`[sio/viewer] disconnected: ${socket.id} sessionId=${sessionId} (${reason})`);
             await removeViewer(sessionId, socket);
         });
+
+        // ── Now do async snapshot/room work ──────────────────────────────────
+        // Session is live — send connection info and initial snapshot BEFORE
+        // joining the broadcast room. This avoids a race where live streaming
+        // deltas arrive (via the room) before the snapshot, causing the UI to
+        // show partial content that then gets replaced by the snapshot — making
+        // messages visibly "jump".
+        //
+        // Any events emitted between snapshot read and room join are detected
+        // by the client's sequence-gap logic (seq gap > 1 → resync request).
+        const lastSeq = await getSessionSeq(sessionId);
+        socket.emit("connected", {
+            sessionId,
+            lastSeq,
+            isActive: session.isActive,
+            lastHeartbeatAt: session.lastHeartbeatAt,
+            sessionName: session.sessionName,
+        });
+
+        // Send the snapshot while the viewer is NOT yet in the room.
+        // Inline the snapshot send using already-fetched session data to avoid
+        // an extra Redis round-trip (which would widen the race window).
+        if (session.lastHeartbeat) {
+            try {
+                socket.emit("event", { event: JSON.parse(session.lastHeartbeat), seq: lastSeq });
+            } catch {}
+        }
+        if (session.lastState) {
+            try {
+                socket.emit("event", { event: { type: "session_active", state: JSON.parse(session.lastState) }, seq: lastSeq });
+            } catch {}
+        } else {
+            // No in-memory state — fall back to event cache
+            await sendLatestSnapshotFromCache(socket, sessionId);
+        }
+
+        // NOW join the room for live events — any missed events between
+        // snapshot read and this point will be caught by gap detection.
+        const ok = await addViewer(sessionId, socket);
+        if (!ok) {
+            socket.emit("disconnected", { reason: "Session ended" });
+            // Use disconnect() (not true) so the client can still auto-reconnect;
+            // the session may have just cycled and will come back shortly.
+            socket.disconnect();
+            return;
+        }
     });
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2446,7 +2446,10 @@ export function App() {
       return;
     }
 
-    // Non-active session: open a temporary viewer socket, fire the exec, disconnect
+    // Non-active session: open a temporary viewer socket, fire the exec, disconnect.
+    // We wait for the exec_result confirmation (or a generous timeout) instead of
+    // blindly disconnecting after 500ms, which was too aggressive and caused the
+    // exec to be dropped when the server was still processing.
     const tempSocket: Socket<ViewerServerToClientEvents, ViewerClientToServerEvents> = io("/viewer", {
       auth: { sessionId },
       withCredentials: true,
@@ -2457,12 +2460,21 @@ export function App() {
 
     tempSocket.on("connected", () => {
       clearTimeout(timeout);
+      const execId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+
+      // Listen for exec_result confirmation before disconnecting
+      const resultTimeout = setTimeout(cleanup, 5_000); // fallback if no reply
+      tempSocket.on("exec_result" as any, (data: any) => {
+        if (data && data.id === execId) {
+          clearTimeout(resultTimeout);
+          cleanup();
+        }
+      });
+
       tempSocket.emit("exec", {
-        id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        id: execId,
         command: "end_session",
       } as any);
-      // Give the exec a moment to reach the runner before disconnecting
-      setTimeout(cleanup, 500);
     });
 
     tempSocket.on("connect_error", () => {

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -77,6 +77,7 @@ export default defineConfig({
                 // Inject the push notification handler into the generated service worker.
                 importScripts: ["sw-push.js"],
                 navigateFallback: "/index.html",
+                navigateFallbackDenylist: [/^\/api\//],
                 runtimeCaching: [
                     {
                         // Cache JS chunks (including lazy shiki/mermaid language chunks)


### PR DESCRIPTION
## Summary

Two reliability fixes for MCP OAuth and session management.

### 1. Service worker intercepting OAuth callback navigation

The Workbox service worker's `navigateFallback` served `/index.html` for browser navigations to `/api/mcp-oauth-callback`, preventing the server from receiving the OAuth authorization code. The `NetworkOnly` runtime cache rule for `/api/` only applied to fetch/XHR requests, not navigation requests.

**Fix:** Add `navigateFallbackDenylist: [/^\/api\//]` so browser navigations to any `/api/` route bypass the service worker and reach the server directly. This fixes Notion (and any future MCP OAuth) callback delivery.

### 2. Race condition in Check+Kill — viewer exec handler registration

The viewer namespace connection handler registered event handlers (`exec`, `input`, `model_set`) **after** emitting the `connected` event and performing multiple async Redis operations. The client's `handleEndSession` creates a temporary socket and fires `exec` immediately upon receiving `connected`, but the handler wasn't registered yet — silently dropping the command.

This race window widened significantly when ending 3+ sessions at once.

**Server fix:** Move all `socket.on()` registrations before any async work so handlers exist by the time the client can send.

**Client fix:** Wait for `exec_result` confirmation before disconnecting the temp socket (instead of a blind 500ms timeout).