### PR TITLE
fix(server): harden static file serving against path traversal

### DIFF
--- a/packages/server/src/static.ts
+++ b/packages/server/src/static.ts
@@ -65,7 +65,7 @@ export async function serveStaticFile(pathname: string): Promise<Response | null
     // Prevent path traversal: resolve the real path and verify it stays within UI_DIR
     const requested = pathname === "/" ? "index.html" : pathname.slice(1);
     let filePath = resolve(UI_DIR, requested);
-    if (!filePath.startsWith(UI_DIR)) return null;
+    if (!filePath.startsWith(UI_DIR + "/")) return null;
 
     // If file doesn't exist, serve index.html for SPA routing
     if (!existsSync(filePath)) {

--- a/packages/server/src/static.ts
+++ b/packages/server/src/static.ts
@@ -62,9 +62,10 @@ export async function serveStaticFile(pathname: string): Promise<Response | null
     // Don't serve API or socket.io paths
     if (pathname.startsWith("/api/") || pathname.startsWith("/socket.io/")) return null;
 
-    // Prevent path traversal
-    const safePath = pathname.replace(/\.\./g, "").replace(/\/+/g, "/");
-    let filePath = join(UI_DIR, safePath === "/" ? "index.html" : safePath);
+    // Prevent path traversal: resolve the real path and verify it stays within UI_DIR
+    const requested = pathname === "/" ? "index.html" : pathname.slice(1);
+    let filePath = resolve(UI_DIR, requested);
+    if (!filePath.startsWith(UI_DIR)) return null;
 
     // If file doesn't exist, serve index.html for SPA routing
     if (!existsSync(filePath)) {


### PR DESCRIPTION
## Summary

Replaces the regex-based path traversal prevention in `static.ts` with the canonical `resolve()` + `startsWith()` approach.

## What changed

**Before** (regex strip):
```ts
const safePath = pathname.replace(/\.\./g, "").replace(/\/+/g, "/");
let filePath = join(UI_DIR, safePath === "/" ? "index.html" : safePath);
```

**After** (resolve + prefix check):
```ts
const requested = pathname === "/" ? "index.html" : pathname.slice(1);
let filePath = resolve(UI_DIR, requested);
if (!filePath.startsWith(UI_DIR)) return null;
```

## Why

The old regex approach was **not exploitable** in practice — `....//` doesn't bypass JavaScript's global regex — but it requires reasoning about regex edge cases to prove safety. The `resolve()` + `startsWith()` pattern is definitive: no matter how the path is crafted, if it escapes `UI_DIR`, it's rejected. This is the standard approach used by Express, Fastify, and every static file serving library.

## Testing

Verified against all common traversal vectors:
| Input | Result |
|-------|--------|
| `/` | ✅ Serves `index.html` |
| `/assets/main.js` | ✅ Serves normally |
| `/../../etc/passwd` | 🛡️ Blocked |
| `/foo/../../../etc/passwd` | 🛡️ Blocked |
| `/....//etc/passwd` | ✅ Safe (resolves inside UI_DIR) |
| `/dashboard` | ✅ SPA fallback works |

Build and typecheck pass.