### PR TITLE
feat: disable MCP servers per folder (TUI + Web UI)

### DIFF
--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,0 +1,271 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { toggleMcpServer, loadConfig, _setGlobalConfigDir } from "./config.js";
+
+describe("toggleMcpServer", () => {
+  let tempDir: string;
+  let globalDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "pizzapi-config-test-"));
+    globalDir = join(tempDir, "global-pizzapi");
+    mkdirSync(globalDir, { recursive: true });
+    // Override the global config dir for tests (Bun caches os.homedir())
+    _setGlobalConfigDir(globalDir);
+    // Write a minimal global config
+    writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
+  });
+
+  afterEach(() => {
+    _setGlobalConfigDir(null);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("disabling a server adds it to project config", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ mcpServers: { playwright: { command: "npx", args: ["@playwright/mcp"] } } }),
+    );
+
+    const result = toggleMcpServer("playwright", true, projectDir);
+    expect(result.changed).toBe(true);
+    expect(result.globallyDisabled).toBe(false);
+
+    const updated = JSON.parse(readFileSync(join(projectDir, ".pizzapi", "config.json"), "utf-8"));
+    expect(updated.disabledMcpServers).toContain("playwright");
+    // Original config should be preserved
+    expect(updated.mcpServers).toBeDefined();
+  });
+
+  test("enabling a disabled server removes it from project config", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ disabledMcpServers: ["playwright", "tavily"] }),
+    );
+
+    const result = toggleMcpServer("playwright", false, projectDir);
+    expect(result.changed).toBe(true);
+    expect(result.globallyDisabled).toBe(false);
+
+    const updated = JSON.parse(readFileSync(join(projectDir, ".pizzapi", "config.json"), "utf-8"));
+    expect(updated.disabledMcpServers).toEqual(["tavily"]);
+  });
+
+  test("enabling last disabled server removes the key entirely", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ disabledMcpServers: ["playwright"] }),
+    );
+
+    const result = toggleMcpServer("playwright", false, projectDir);
+    expect(result.changed).toBe(true);
+
+    const updated = JSON.parse(readFileSync(join(projectDir, ".pizzapi", "config.json"), "utf-8"));
+    expect(updated.disabledMcpServers).toBeUndefined();
+  });
+
+  test("disabling an already disabled server returns changed: false", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ disabledMcpServers: ["playwright"] }),
+    );
+
+    const result = toggleMcpServer("playwright", true, projectDir);
+    expect(result.changed).toBe(false);
+  });
+
+  test("enabling an already enabled server returns changed: false", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({}),
+    );
+
+    const result = toggleMcpServer("playwright", false, projectDir);
+    expect(result.changed).toBe(false);
+  });
+
+  test("cannot enable a globally disabled server", () => {
+    // Set the global config to disable "playwright"
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ disabledMcpServers: ["playwright"] }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({}),
+    );
+
+    const result = toggleMcpServer("playwright", false, projectDir);
+    expect(result.changed).toBe(false);
+    expect(result.globallyDisabled).toBe(true);
+  });
+
+  test("creates .pizzapi dir if it does not exist", () => {
+    const projectDir = join(tempDir, "newproject");
+    mkdirSync(projectDir, { recursive: true });
+    // No .pizzapi directory yet
+
+    const result = toggleMcpServer("playwright", true, projectDir);
+    expect(result.changed).toBe(true);
+
+    const updated = JSON.parse(readFileSync(join(projectDir, ".pizzapi", "config.json"), "utf-8"));
+    expect(updated.disabledMcpServers).toEqual(["playwright"]);
+  });
+
+  test("preserves other config fields when toggling", () => {
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        mcpServers: { playwright: { command: "npx" } },
+        mcpTimeout: 5000,
+      }),
+    );
+
+    toggleMcpServer("playwright", true, projectDir);
+
+    const updated = JSON.parse(readFileSync(join(projectDir, ".pizzapi", "config.json"), "utf-8"));
+    expect(updated.mcpServers).toBeDefined();
+    expect(updated.mcpTimeout).toBe(5000);
+    expect(updated.disabledMcpServers).toContain("playwright");
+  });
+});
+
+describe("loadConfig disabledMcpServers merge", () => {
+  let tempDir: string;
+  let globalDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "pizzapi-config-merge-"));
+    globalDir = join(tempDir, "global-pizzapi");
+    mkdirSync(globalDir, { recursive: true });
+    _setGlobalConfigDir(globalDir);
+  });
+
+  afterEach(() => {
+    _setGlobalConfigDir(null);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("merges global and project disabledMcpServers into a union", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ disabledMcpServers: ["tavily"] }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ disabledMcpServers: ["playwright"] }),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.disabledMcpServers).toBeDefined();
+    expect(new Set(config.disabledMcpServers)).toEqual(new Set(["tavily", "playwright"]));
+  });
+
+  test("deduplicates overlapping entries", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ disabledMcpServers: ["tavily", "playwright"] }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ disabledMcpServers: ["playwright"] }),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.disabledMcpServers).toBeDefined();
+    // Should have unique entries
+    expect(config.disabledMcpServers!.length).toBe(2);
+    expect(new Set(config.disabledMcpServers)).toEqual(new Set(["tavily", "playwright"]));
+  });
+
+  test("returns no disabledMcpServers when neither config has them", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({}),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({}),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.disabledMcpServers).toBeUndefined();
+  });
+
+  test("filters out non-string values", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ disabledMcpServers: ["tavily", 123, null, true] }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({}),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.disabledMcpServers).toEqual(["tavily"]);
+  });
+
+  test("only global disabled servers present", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ disabledMcpServers: ["tavily"] }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({}),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.disabledMcpServers).toEqual(["tavily"]);
+  });
+
+  test("only project disabled servers present", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({}),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ disabledMcpServers: ["playwright"] }),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.disabledMcpServers).toEqual(["playwright"]);
+  });
+});

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -96,6 +96,29 @@ describe("toggleMcpServer", () => {
     expect(result.changed).toBe(false);
   });
 
+  test("disabling a globally disabled server is a no-op (no sticky local entry)", () => {
+    // Global config already disables "playwright"
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ disabledMcpServers: ["playwright"] }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({}),
+    );
+
+    const result = toggleMcpServer("playwright", true, projectDir);
+    expect(result.changed).toBe(false);
+    expect(result.globallyDisabled).toBe(true);
+
+    // Project config must NOT have a redundant disabledMcpServers entry
+    const updated = JSON.parse(readFileSync(join(projectDir, ".pizzapi", "config.json"), "utf-8"));
+    expect(updated.disabledMcpServers).toBeUndefined();
+  });
+
   test("cannot enable a globally disabled server", () => {
     // Set the global config to disable "playwright"
     writeFileSync(

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -162,6 +162,13 @@ export interface PizzaPiConfig {
     trustedPlugins?: string[];
 
     /**
+     * MCP server names to skip during initialization.
+     * Servers listed here won't be started or have their tools registered.
+     * Both global and project lists are merged (union).
+     */
+    disabledMcpServers?: string[];
+
+    /**
      * Timeout (in milliseconds) for each MCP server's tools/list call during
      * startup. Servers that don't respond within this window are skipped with
      * an error. Default: 30000 (30 seconds).
@@ -184,6 +191,20 @@ function readJsonSafe(path: string): Partial<PizzaPiConfig> {
     } catch {
         return {};
     }
+}
+
+/**
+ * Returns the global PizzaPi config directory path.
+ * Tests can override this via _setGlobalConfigDir() since Bun caches os.homedir().
+ */
+let _globalConfigDirOverride: string | null = null;
+export function globalConfigDir(): string {
+    return _globalConfigDirOverride ?? join(homedir(), ".pizzapi");
+}
+
+/** Test-only: override the global config directory (Bun caches os.homedir()). */
+export function _setGlobalConfigDir(dir: string | null): void {
+    _globalConfigDirOverride = dir;
 }
 
 /** Deep-merge hooks: concatenate arrays from both sources for every hook type. */
@@ -242,7 +263,7 @@ export function isProjectHooksTrusted(globalConfig: Partial<PizzaPiConfig>): boo
  * PIZZAPI_ALLOW_PROJECT_HOOKS=1 env var.
  */
 export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
-    const globalPath = join(homedir(), ".pizzapi", "config.json");
+    const globalPath = join(globalConfigDir(), "config.json");
     const projectPath = join(cwd, ".pizzapi", "config.json");
     const global = readJsonSafe(globalPath);
     const project = readJsonSafe(projectPath);
@@ -262,6 +283,18 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     const config = { ...global, ...project };
     if (hooks) config.hooks = hooks;
     else delete config.hooks;
+
+    // Merge disabledMcpServers from both scopes (union)
+    const disabledMcpServers = [
+        ...(global.disabledMcpServers ?? []),
+        ...(project.disabledMcpServers ?? []),
+    ].filter((s): s is string => typeof s === "string");
+    if (disabledMcpServers.length > 0) {
+        config.disabledMcpServers = [...new Set(disabledMcpServers)];
+    } else {
+        delete config.disabledMcpServers;
+    }
+
     return config;
 }
 
@@ -280,7 +313,7 @@ export function defaultAgentDir(): string {
  * Returns the normalized list of absolute plugin root paths.
  */
 export function getTrustedPlugins(): string[] {
-    const globalPath = join(homedir(), ".pizzapi", "config.json");
+    const globalPath = join(globalConfigDir(), "config.json");
     const global = readJsonSafe(globalPath);
     return Array.isArray(global.trustedPlugins) ? global.trustedPlugins.filter((p): p is string => typeof p === "string") : [];
 }
@@ -323,9 +356,83 @@ export function untrustPlugin(pluginRootPath: string): boolean {
  * Merge fields into ~/.pizzapi/config.json (global config).
  */
 export function saveGlobalConfig(fields: Partial<PizzaPiConfig>): void {
-    const dir = join(homedir(), ".pizzapi");
+    const dir = globalConfigDir();
     const path = join(dir, "config.json");
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
     const existing = readJsonSafe(path);
     writeFileSync(path, JSON.stringify({ ...existing, ...fields }, null, 2), "utf-8");
+}
+
+/**
+ * Merge fields into <cwd>/.pizzapi/config.json (project-local config).
+ */
+export function saveProjectConfig(fields: Partial<PizzaPiConfig>, cwd: string = process.cwd()): void {
+    const dir = join(cwd, ".pizzapi");
+    const path = join(dir, "config.json");
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const existing = readJsonSafe(path);
+    writeFileSync(path, JSON.stringify({ ...existing, ...fields }, null, 2), "utf-8");
+}
+
+// ── MCP server disable/enable helpers ─────────────────────────────────────────
+
+/**
+ * Toggle an MCP server's disabled state in the project-local config.
+ *
+ * @param name - MCP server name to toggle
+ * @param disable - true to disable, false to enable
+ * @param cwd - project root directory
+ * @returns Object describing the result:
+ *   - `changed`: whether the config was actually modified
+ *   - `globallyDisabled`: true if the server is disabled in the global config
+ *     (project enable can't override)
+ */
+export function toggleMcpServer(
+    name: string,
+    disable: boolean,
+    cwd: string = process.cwd(),
+): { changed: boolean; globallyDisabled: boolean } {
+    const globalPath = join(globalConfigDir(), "config.json");
+    const globalConfig = readJsonSafe(globalPath);
+    const globalDisabled = new Set(
+        (globalConfig.disabledMcpServers ?? []).filter((s): s is string => typeof s === "string"),
+    );
+
+    // If enabling, but server is disabled globally, project can't override
+    if (!disable && globalDisabled.has(name)) {
+        return { changed: false, globallyDisabled: true };
+    }
+
+    const projectPath = join(cwd, ".pizzapi", "config.json");
+    const projectConfig = readJsonSafe(projectPath);
+    const current = new Set(
+        (projectConfig.disabledMcpServers ?? []).filter((s): s is string => typeof s === "string"),
+    );
+
+    const hadIt = current.has(name);
+    if (disable) {
+        current.add(name);
+    } else {
+        current.delete(name);
+    }
+
+    if (disable === hadIt) {
+        return { changed: false, globallyDisabled: false };
+    }
+
+    const updated: Partial<PizzaPiConfig> = {};
+    if (current.size > 0) {
+        updated.disabledMcpServers = [...current];
+    } else {
+        // Remove the key entirely when empty
+        const full = { ...projectConfig };
+        delete full.disabledMcpServers;
+        const dir = join(cwd, ".pizzapi");
+        if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "config.json"), JSON.stringify(full, null, 2), "utf-8");
+        return { changed: true, globallyDisabled: false };
+    }
+
+    saveProjectConfig(updated, cwd);
+    return { changed: true, globallyDisabled: false };
 }

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -398,8 +398,11 @@ export function toggleMcpServer(
         (globalConfig.disabledMcpServers ?? []).filter((s): s is string => typeof s === "string"),
     );
 
-    // If enabling, but server is disabled globally, project can't override
-    if (!disable && globalDisabled.has(name)) {
+    // If the server is already disabled globally, the project toggle is a no-op:
+    //  - enable: project can't override a global disable
+    //  - disable: already effective, writing a redundant local entry would
+    //    create a sticky disable that survives removal of the global entry
+    if (globalDisabled.has(name)) {
         return { changed: false, globallyDisabled: true };
     }
 

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -284,10 +284,14 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     if (hooks) config.hooks = hooks;
     else delete config.hooks;
 
-    // Merge disabledMcpServers from both scopes (union)
+    // Merge disabledMcpServers from both scopes (union).
+    // Guard with Array.isArray — a malformed config value (e.g. a string or
+    // object) would throw or spread into characters without this check.
+    const globalDisabledRaw = Array.isArray(global.disabledMcpServers) ? global.disabledMcpServers : [];
+    const projectDisabledRaw = Array.isArray(project.disabledMcpServers) ? project.disabledMcpServers : [];
     const disabledMcpServers = [
-        ...(global.disabledMcpServers ?? []),
-        ...(project.disabledMcpServers ?? []),
+        ...globalDisabledRaw,
+        ...projectDisabledRaw,
     ].filter((s): s is string => typeof s === "string");
     if (disabledMcpServers.length > 0) {
         config.disabledMcpServers = [...new Set(disabledMcpServers)];
@@ -395,7 +399,8 @@ export function toggleMcpServer(
     const globalPath = join(globalConfigDir(), "config.json");
     const globalConfig = readJsonSafe(globalPath);
     const globalDisabled = new Set(
-        (globalConfig.disabledMcpServers ?? []).filter((s): s is string => typeof s === "string"),
+        (Array.isArray(globalConfig.disabledMcpServers) ? globalConfig.disabledMcpServers : [])
+            .filter((s): s is string => typeof s === "string"),
     );
 
     // If the server is already disabled globally, the project toggle is a no-op:
@@ -409,7 +414,8 @@ export function toggleMcpServer(
     const projectPath = join(cwd, ".pizzapi", "config.json");
     const projectConfig = readJsonSafe(projectPath);
     const current = new Set(
-        (projectConfig.disabledMcpServers ?? []).filter((s): s is string => typeof s === "string"),
+        (Array.isArray(projectConfig.disabledMcpServers) ? projectConfig.disabledMcpServers : [])
+            .filter((s): s is string => typeof s === "string"),
     );
 
     const hadIt = current.has(name);

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -1,8 +1,7 @@
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import { existsSync, readFileSync } from "fs";
-import { homedir } from "os";
 import { join } from "path";
-import { loadConfig, type PizzaPiConfig } from "../config.js";
+import { loadConfig, toggleMcpServer, globalConfigDir, type PizzaPiConfig } from "../config.js";
 import { registerMcpTools, type McpConfig, type McpServerInitResult, type McpRegistrationResult, getOAuthProviders } from "./mcp.js";
 import { setMcpBridge } from "./mcp-bridge.js";
 import type { RelayContext } from "./mcp-oauth.js";
@@ -36,6 +35,8 @@ type McpConfigInspection = {
   effectivePreferredSource: "global" | "project" | "none";
   effectiveCompatibilitySource: "global" | "project" | "none";
   effectiveServers: EffectiveMcpServer[];
+  /** Server names disabled via disabledMcpServers in global and/or project config. */
+  disabledServers: string[];
 };
 
 type McpSnapshot = {
@@ -167,7 +168,7 @@ function parseConfigFile(scope: "global" | "project", path: string): McpConfigFi
 }
 
 function inspectMcpConfig(cwd: string): McpConfigInspection {
-  const globalPath = join(homedir(), ".pizzapi", "config.json");
+  const globalPath = join(globalConfigDir(), "config.json");
   const projectPath = join(cwd, ".pizzapi", "config.json");
 
   const global = parseConfigFile("global", globalPath);
@@ -209,12 +210,17 @@ function inspectMcpConfig(cwd: string): McpConfigInspection {
     }
   }
 
+  // Collect disabled server names from merged config
+  const mergedConfig = loadConfig(cwd);
+  const disabledServers = mergedConfig.disabledMcpServers ?? [];
+
   return {
     global,
     project,
     effectivePreferredSource,
     effectiveCompatibilitySource,
     effectiveServers,
+    disabledServers,
   };
 }
 
@@ -255,12 +261,22 @@ function buildStatusLines(snapshot: McpSnapshot): string[] {
   if (snapshot.config.effectiveServers.length > 0) {
     lines.push("");
     lines.push("Effective server entries:");
+    const disabledSet = new Set(snapshot.config.disabledServers);
     for (const server of snapshot.config.effectiveServers) {
-      lines.push(`- ${server.name} [${server.transport}] from ${server.scope} (${server.sourcePath} :: ${server.keyPath})`);
+      const disabledTag = disabledSet.has(server.name) ? " [DISABLED]" : "";
+      lines.push(`- ${server.name} [${server.transport}]${disabledTag} from ${server.scope} (${server.sourcePath} :: ${server.keyPath})`);
     }
   } else {
     lines.push("");
     lines.push("No MCP server entries are currently configured.");
+  }
+
+  if (snapshot.config.disabledServers.length > 0) {
+    lines.push("");
+    lines.push("Disabled servers:");
+    for (const name of snapshot.config.disabledServers) {
+      lines.push(`- ${name} (skipped — /mcp enable ${name} to re-enable)`);
+    }
   }
 
   // Per-server timing breakdown
@@ -525,15 +541,41 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
   });
 
   pi.registerCommand?.("mcp", {
-    description: "Show MCP status, or: /mcp reload",
+    description: "MCP status/reload/disable/enable: /mcp [reload|disable <name>|enable <name>]",
     getArgumentCompletions: (prefix: string) => {
       const normalized = prefix.trim().toLowerCase();
-      return "reload".startsWith(normalized) ? [{ value: "reload", label: "reload" }] : null;
+
+      // Sub-command completion for "disable <name>" and "enable <name>"
+      if (normalized.startsWith("disable ") || normalized.startsWith("enable ")) {
+        const isDisable = normalized.startsWith("disable ");
+        const sub = isDisable ? normalized.slice(8) : normalized.slice(7);
+        const disabledSet = new Set(lastSnapshot.config.disabledServers);
+        const allServerNames = lastSnapshot.config.effectiveServers.map((s) => s.name);
+        // For "disable": show servers that are NOT already disabled
+        // For "enable": show servers that ARE disabled
+        const pool = isDisable
+          ? allServerNames.filter((n) => !disabledSet.has(n))
+          : [...disabledSet];
+        return pool
+          .filter((n) => n.toLowerCase().startsWith(sub))
+          .map((n) => ({
+            value: `${isDisable ? "disable" : "enable"} ${n}`,
+            label: n,
+          }));
+      }
+
+      // Top-level sub-command completion
+      const subcommands = ["reload", "disable", "enable"];
+      const matches = subcommands.filter((c) => c.startsWith(normalized));
+      return matches.length > 0
+        ? matches.map((c) => ({ value: c, label: c }))
+        : null;
     },
     handler: async (args: string, ctx: any) => {
-      const arg = (args ?? "").trim().toLowerCase();
+      const arg = (args ?? "").trim();
+      const argLower = arg.toLowerCase();
 
-      if (arg === "reload") {
+      if (argLower === "reload") {
         ctx?.ui?.notify?.("Reloading MCP tools…");
         try {
           // Use bridge.reload() instead of load() directly so that relay
@@ -547,6 +589,65 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
           if (report) pi.events?.emit?.("mcp:startup_report", report);
         } catch (err) {
           ctx?.ui?.notify?.(`MCP reload failed: ${err instanceof Error ? err.message : String(err)}`, "error");
+        }
+        return;
+      }
+
+      if (argLower.startsWith("disable ")) {
+        const serverName = arg.slice(8).trim();
+        if (!serverName) {
+          ctx?.ui?.notify?.("Usage: /mcp disable <server-name>", "warning");
+          return;
+        }
+        const result = toggleMcpServer(serverName, true, process.cwd());
+        if (!result.changed) {
+          ctx?.ui?.notify?.(`Server "${serverName}" is already disabled.`);
+          return;
+        }
+        ctx?.ui?.notify?.(`Disabled MCP server "${serverName}". Reloading…`);
+        try {
+          const snapshot = await bridge.reload();
+          ctx?.ui?.notify?.(
+            `✓ MCP server "${serverName}" disabled. ${snapshot.toolCount} tools loaded.\n` +
+            `Use /mcp enable ${serverName} to re-enable.`,
+          );
+          const report = buildStartupReport();
+          if (report) pi.events?.emit?.("mcp:startup_report", report);
+        } catch (err) {
+          ctx?.ui?.notify?.(`Config updated but MCP reload failed: ${err instanceof Error ? err.message : String(err)}`, "error");
+        }
+        return;
+      }
+
+      if (argLower.startsWith("enable ")) {
+        const serverName = arg.slice(7).trim();
+        if (!serverName) {
+          ctx?.ui?.notify?.("Usage: /mcp enable <server-name>", "warning");
+          return;
+        }
+        const result = toggleMcpServer(serverName, false, process.cwd());
+        if (result.globallyDisabled) {
+          ctx?.ui?.notify?.(
+            `Cannot enable "${serverName}" — it is disabled in the global config (~/.pizzapi/config.json).\n` +
+            `Remove it from disabledMcpServers in the global config to enable.`,
+            "warning",
+          );
+          return;
+        }
+        if (!result.changed) {
+          ctx?.ui?.notify?.(`Server "${serverName}" is already enabled.`);
+          return;
+        }
+        ctx?.ui?.notify?.(`Enabled MCP server "${serverName}". Reloading…`);
+        try {
+          const snapshot = await bridge.reload();
+          ctx?.ui?.notify?.(
+            `✓ MCP server "${serverName}" enabled. ${snapshot.toolCount} tools loaded.`,
+          );
+          const report = buildStartupReport();
+          if (report) pi.events?.emit?.("mcp:startup_report", report);
+        } catch (err) {
+          ctx?.ui?.notify?.(`Config updated but MCP reload failed: ${err instanceof Error ? err.message : String(err)}`, "error");
         }
         return;
       }

--- a/packages/cli/src/extensions/mcp.ts
+++ b/packages/cli/src/extensions/mcp.ts
@@ -751,11 +751,14 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
   // to prevent unbounded growth and iteration over dead providers.
   activeOAuthProviders.length = 0;
 
+  const disabled = new Set(config.disabledMcpServers ?? []);
+
   const clients: McpClient[] = [];
 
   // Preferred format
   for (const s of config.mcp?.servers ?? []) {
     if (!s || typeof s !== "object") continue;
+    if (disabled.has(s.name)) continue; // skip disabled servers
     if (s.transport === "stdio") {
       clients.push(
         createStdioMcpClient({
@@ -791,6 +794,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
   const mcpServers = config.mcpServers ?? {};
   for (const [name, def] of Object.entries(mcpServers)) {
     if (!def || typeof def !== "object") continue;
+    if (disabled.has(name)) continue; // skip disabled servers
 
     if ("command" in def && typeof (def as any).command === "string") {
       const d = def as { command: string; args?: string[]; env?: Record<string, string> };

--- a/packages/cli/src/extensions/remote-commands.ts
+++ b/packages/cli/src/extensions/remote-commands.ts
@@ -19,7 +19,8 @@ export type RemoteExecRequest =
     | { type: "exec"; id: string; command: "new_session" }
     | { type: "exec"; id: string; command: "restart" }
     | { type: "exec"; id: string; command: "end_session" }
-    | { type: "exec"; id: string; command: "plugin_trust_response"; promptId: string; trusted: boolean };
+    | { type: "exec"; id: string; command: "plugin_trust_response"; promptId: string; trusted: boolean }
+    | { type: "exec"; id: string; command: "mcp_toggle_server"; serverName: string; disabled: boolean };
 
 export type RemoteExecResponse =
     | { type: "exec_result"; id: string; ok: true; command: RemoteExecRequest["command"]; result?: unknown }

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -5,7 +5,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { AuthStorage, buildSessionContext, SessionManager, type ExtensionContext, type ExtensionFactory, type SessionInfo } from "@mariozechner/pi-coding-agent";
 import { getEnvApiKey } from "@mariozechner/pi-ai/dist/env-api-keys.js";
-import { loadConfig, defaultAgentDir } from "../config.js";
+import { loadConfig, defaultAgentDir, toggleMcpServer } from "../config.js";
 import { getMcpBridge } from "./mcp-bridge.js";
 import { getCurrentTodoList, setTodoUpdateCallback, type TodoItem } from "./update-todo.js";
 import type { RemoteExecRequest, RemoteExecResponse } from "./remote-commands.js";
@@ -910,6 +910,28 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 const action = req.action === "reload" ? "reload" : "status";
                 const result = action === "reload" ? await bridge.reload() : bridge.status();
                 replyOk({ ...result as object, action });
+                return;
+            }
+
+            if (req.command === "mcp_toggle_server") {
+                const bridge = getMcpBridge();
+                if (!bridge) {
+                    replyErr("MCP extension is not initialized yet");
+                    return;
+                }
+                const { serverName, disabled } = req;
+                if (!serverName || typeof serverName !== "string") {
+                    replyErr("Missing serverName");
+                    return;
+                }
+                const toggleResult = toggleMcpServer(serverName, disabled, process.cwd());
+                if (toggleResult.globallyDisabled) {
+                    replyErr(`Cannot enable "${serverName}" — it is disabled in the global config (~/.pizzapi/config.json)`);
+                    return;
+                }
+                // Reload MCP to apply the change
+                const snapshot = await bridge.reload();
+                replyOk({ ...snapshot as object, action: "reload", toggledServer: serverName, disabled });
                 return;
             }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1586,6 +1586,10 @@ export function App() {
           ? result.serverTools as Record<string, string[]>
           : {};
 
+        const disabledServersForMcp = Array.isArray(result?.config?.disabledServers)
+          ? result.config.disabledServers.filter((s: unknown): s is string => typeof s === "string")
+          : [];
+
         appendLocalSystemMessage({
           kind: "mcp",
           action,
@@ -1595,6 +1599,7 @@ export function App() {
           servers,
           errors,
           serverTools,
+          disabledServers: disabledServersForMcp,
           loadedAt: typeof result?.loadedAt === "string" ? result.loadedAt : undefined,
         });
 
@@ -1602,6 +1607,43 @@ export function App() {
           ? result.summary
           : `MCP tools loaded: ${toolCount}`;
         setViewerStatus(summary);
+        return;
+      }
+
+      if (command === "mcp_toggle_server") {
+        // Build the same structured card as /mcp status, showing updated state
+        const toolCount = typeof result?.toolCount === "number" ? result.toolCount : 0;
+        const toolNames = Array.isArray(result?.toolNames)
+          ? result.toolNames.filter((n: unknown): n is string => typeof n === "string")
+          : [];
+        const errors = Array.isArray(result?.errors) ? result.errors as Array<{ server: string; error: string }> : [];
+        const servers = Array.isArray(result?.config?.effectiveServers)
+          ? (result.config.effectiveServers as Array<{ name: string; transport: string; scope: string; sourcePath?: string }>)
+          : [];
+        const serverTools = result?.serverTools && typeof result.serverTools === "object" && !Array.isArray(result.serverTools)
+          ? result.serverTools as Record<string, string[]>
+          : {};
+        const disabledServers = Array.isArray(result?.config?.disabledServers)
+          ? result.config.disabledServers.filter((s: unknown): s is string => typeof s === "string")
+          : [];
+        const toggledServer = typeof result?.toggledServer === "string" ? result.toggledServer : "";
+        const disabled = result?.disabled === true;
+
+        appendLocalSystemMessage({
+          kind: "mcp",
+          action: "reload" as const,
+          toolCount,
+          toolNames,
+          serverCount: servers.length,
+          servers,
+          errors,
+          serverTools,
+          disabledServers,
+          loadedAt: typeof result?.loadedAt === "string" ? result.loadedAt : undefined,
+        });
+
+        const verb = disabled ? "Disabled" : "Enabled";
+        setViewerStatus(`${verb} MCP server "${toggledServer}". ${toolCount} tools loaded.`);
         return;
       }
 

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -672,8 +672,17 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     if (!onExec) return false;
 
     if (rawCommand === "mcp") {
-      const action = args.trim().toLowerCase() === "reload" ? "reload" : "status";
-      onExec({ type: "exec", id, command: "mcp", action });
+      const argLower = args.trim().toLowerCase();
+      if (argLower.startsWith("disable ") || argLower.startsWith("enable ")) {
+        const isDisable = argLower.startsWith("disable ");
+        const serverName = args.trim().slice(isDisable ? 8 : 7).trim();
+        if (serverName) {
+          onExec({ type: "exec", id, command: "mcp_toggle_server", serverName, disabled: isDisable });
+        }
+      } else {
+        const action = argLower === "reload" ? "reload" : "status";
+        onExec({ type: "exec", id, command: "mcp", action });
+      }
       setInput("");
       setCommandOpen(false);
       setCommandQuery("");
@@ -808,6 +817,8 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
       { name: "mcp", description: "MCP server management", subCommands: [
         { name: "status", description: "Show MCP server status" },
         { name: "reload", description: "Reload MCP servers" },
+        { name: "disable", description: "Disable an MCP server" },
+        { name: "enable", description: "Enable a disabled MCP server" },
       ]},
       { name: "plugins", description: "Show loaded plugins" },
       { name: "skills", description: "Show available skills" },

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -800,10 +800,15 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
 
   const supportedWebCommands = React.useMemo(() => {
     // Commands that we intercept/execute via exec.
+    // Commands with `subCommands` keep the popover open after typing a space
+    // so the user can pick from the available options.
     return [
       { name: "new", description: "Start a new conversation" },
       { name: "resume", description: "Resume the previous session" },
-      { name: "mcp", description: "MCP status (or /mcp reload)" },
+      { name: "mcp", description: "MCP server management", subCommands: [
+        { name: "status", description: "Show MCP server status" },
+        { name: "reload", description: "Reload MCP servers" },
+      ]},
       { name: "plugins", description: "Show loaded plugins" },
       { name: "skills", description: "Show available skills" },
       { name: "model", description: "Select model" },
@@ -815,7 +820,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
       { name: "copy", description: "Copy last assistant message" },
       { name: "stop", description: "Abort current generation" },
       { name: "restart", description: "Restart the CLI process" },
-    ];
+    ] as Array<{ name: string; description: string; subCommands?: Array<{ name: string; description: string }> }>;
   }, []);
 
   // Set of all known command/skill names for quick lookup (used to auto-close popover
@@ -829,9 +834,15 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     return names;
   }, [supportedWebCommands, extensionCommands, skillCommands, promptCommands]);
 
-  // Commands that use the popover for argument-mode UI (e.g. resume shows a
-  // session picker that the user searches/filters by typing after /resume).
-  const keepPopoverOpenNames = React.useMemo(() => new Set(["resume"]), []);
+  // Commands that keep the popover open after a space (for argument/sub-command UI).
+  // Derived from commands with subCommands, plus "resume" which has its own picker.
+  const keepPopoverOpenNames = React.useMemo(() => {
+    const names = new Set(["resume"]);
+    for (const c of supportedWebCommands) {
+      if (c.subCommands && c.subCommands.length > 0) names.add(c.name.toLowerCase());
+    }
+    return names;
+  }, [supportedWebCommands]);
 
   // Reset highlighted index when the query or mode changes
   React.useEffect(() => {
@@ -958,15 +969,40 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     });
   }, [resumeSessions, resumeQuery]);
 
+  // Sub-command mode: detect when the user has typed a command that has sub-commands
+  // e.g. "/mcp " or "/mcp rel" → show sub-command options
+  const subCommandMode = React.useMemo<{
+    active: boolean;
+    parentCommand: string;
+    subCommands: Array<{ name: string; description: string }>;
+    query: string;
+    filtered: Array<{ name: string; description: string }>;
+  }>(() => {
+    if (isResumeMode) return { active: false, parentCommand: "", subCommands: [], query: "", filtered: [] };
+    const match = trimmedInput.match(/^\/(\S+)(?:\s(.*))?$/i);
+    if (!match) return { active: false, parentCommand: "", subCommands: [], query: "", filtered: [] };
+    const cmdName = match[1]!.toLowerCase();
+    const argText = (match[2] ?? "").trim().toLowerCase();
+    const cmd = supportedWebCommands.find(c => c.name.toLowerCase() === cmdName && c.subCommands && c.subCommands.length > 0);
+    if (!cmd?.subCommands) return { active: false, parentCommand: "", subCommands: [], query: "", filtered: [] };
+    const filtered = argText
+      ? cmd.subCommands.filter(sc => sc.name.toLowerCase().includes(argText))
+      : cmd.subCommands;
+    return { active: true, parentCommand: cmd.name, subCommands: cmd.subCommands, query: argText, filtered };
+  }, [trimmedInput, isResumeMode, supportedWebCommands]);
+
   // Controlled value for cmdk Command (drives data-selected highlighting)
   const commandHighlightedValue = React.useMemo(() => {
     if (!commandOpen) return "";
     if (isResumeMode) {
       return resumeCandidates[commandHighlightedIndex]?.path ?? "";
     }
+    if (subCommandMode.active) {
+      return subCommandMode.filtered[commandHighlightedIndex]?.name ?? "";
+    }
     const combined = [...commandSuggestions, ...extensionSuggestions, ...promptSuggestions, ...skillSuggestions];
     return combined[commandHighlightedIndex]?.name ?? "";
-  }, [commandOpen, isResumeMode, resumeCandidates, commandSuggestions, extensionSuggestions, promptSuggestions, skillSuggestions, commandHighlightedIndex]);
+  }, [commandOpen, isResumeMode, subCommandMode, resumeCandidates, commandSuggestions, extensionSuggestions, promptSuggestions, skillSuggestions, commandHighlightedIndex]);
 
   const resumeRequestedRef = React.useRef<string | null>(null);
   const compactingRef = React.useRef(false);
@@ -1520,6 +1556,9 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                 if (isResumeMode) {
                   const idx = resumeCandidates.findIndex(s => s.path.toLowerCase() === v.toLowerCase());
                   if (idx !== -1) setCommandHighlightedIndex(idx);
+                } else if (subCommandMode.active) {
+                  const idx = subCommandMode.filtered.findIndex(sc => sc.name.toLowerCase() === v.toLowerCase());
+                  if (idx !== -1) setCommandHighlightedIndex(idx);
                 } else {
                   const combined = [...commandSuggestions, ...extensionSuggestions, ...promptSuggestions, ...skillSuggestions];
                   const idx = combined.findIndex(c => c.name.toLowerCase() === v.toLowerCase());
@@ -1530,7 +1569,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               {/* Close button header */}
               <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/50">
                 <span className="text-xs text-muted-foreground font-medium">
-                  {isResumeMode ? "Resume session" : "Commands"}
+                  {isResumeMode ? "Resume session" : subCommandMode.active ? `/${subCommandMode.parentCommand}` : "Commands"}
                 </span>
                 <button
                   type="button"
@@ -1580,6 +1619,26 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                       ))}
                     </CommandGroup>
                   </>
+                ) : subCommandMode.active ? (
+                  <>
+                    <CommandEmpty>No matching options</CommandEmpty>
+                    <CommandGroup heading={`/${subCommandMode.parentCommand} options`}>
+                      {subCommandMode.filtered.map((sc) => (
+                        <CommandItem
+                          key={sc.name}
+                          value={sc.name}
+                          onSelect={() => {
+                            executeSlashCommand(`/${subCommandMode.parentCommand} ${sc.name}`);
+                          }}
+                        >
+                          <div className="flex w-full items-center justify-between gap-2">
+                            <span className="font-mono text-sm">/{subCommandMode.parentCommand} {sc.name}</span>
+                            {sc.description && <span className="text-xs text-muted-foreground">{sc.description}</span>}
+                          </div>
+                        </CommandItem>
+                      ))}
+                    </CommandGroup>
+                  </>
                 ) : (
                   <>
                     <CommandEmpty>No commands or skills found</CommandEmpty>
@@ -1596,7 +1655,8 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                               }
                               setInput(`/${cmd.name} `);
                               setCommandQuery("");
-                              setCommandOpen(cmd.name === "resume");
+                              setCommandOpen(keepPopoverOpenNames.has(cmd.name.toLowerCase()));
+                              setCommandHighlightedIndex(0);
                             }}
                           >
                             <div className="flex w-full items-center justify-between gap-2">
@@ -1905,7 +1965,9 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                       event.preventDefault();
                       const totalItems = isResumeMode
                         ? resumeCandidates.length
-                        : commandSuggestions.length + extensionSuggestions.length + promptSuggestions.length + skillSuggestions.length;
+                        : subCommandMode.active
+                          ? subCommandMode.filtered.length
+                          : commandSuggestions.length + extensionSuggestions.length + promptSuggestions.length + skillSuggestions.length;
                       if (totalItems === 0) return;
                       setCommandHighlightedIndex(prev => {
                         if (event.key === "ArrowDown") {
@@ -1914,6 +1976,17 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                         return prev > 0 ? prev - 1 : totalItems - 1;
                       });
                       return;
+                    }
+
+                    // Desktop: Enter in sub-command mode executes the highlighted sub-command
+                    if (!isTouchDevice && event.key === "Enter" && !event.shiftKey && subCommandMode.active) {
+                      const highlighted = subCommandMode.filtered[commandHighlightedIndex];
+                      if (highlighted) {
+                        event.preventDefault();
+                        executeSlashCommand(`/${subCommandMode.parentCommand} ${highlighted.name}`);
+                        setCommandHighlightedIndex(0);
+                        return;
+                      }
                     }
 
                     // Desktop: Enter fills textbox with highlighted command (doesn't execute)
@@ -1936,7 +2009,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                           event.preventDefault();
                           setInput(`/${highlighted.name} `);
                           setCommandQuery("");
-                          setCommandOpen(highlighted.name === "resume");
+                          setCommandOpen(highlighted.name === "resume" || keepPopoverOpenNames.has(highlighted.name.toLowerCase()));
                           setCommandHighlightedIndex(0);
                           // Position cursor at end of filled text
                           requestAnimationFrame(() => {
@@ -1952,6 +2025,17 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                       // No highlighted match — fall through to execute the typed command
                     }
 
+                    // Tab in sub-command mode: autocomplete the highlighted sub-command and execute
+                    if (event.key === "Tab" && subCommandMode.active && subCommandMode.filtered.length > 0) {
+                      event.preventDefault();
+                      const highlighted = subCommandMode.filtered[commandHighlightedIndex] ?? subCommandMode.filtered[0];
+                      if (highlighted) {
+                        executeSlashCommand(`/${subCommandMode.parentCommand} ${highlighted.name}`);
+                        setCommandHighlightedIndex(0);
+                      }
+                      return;
+                    }
+
                     // Tab: autocomplete the highlighted command (or first match) and close the popover
                     if (event.key === "Tab" && (commandSuggestions.length > 0 || extensionSuggestions.length > 0 || promptSuggestions.length > 0 || skillSuggestions.length > 0)) {
                       event.preventDefault();
@@ -1960,7 +2044,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                       if (highlighted) {
                         setInput(`/${highlighted.name} `);
                         setCommandQuery("");
-                        setCommandOpen(highlighted.name === "resume");
+                        setCommandOpen(highlighted.name === "resume" || keepPopoverOpenNames.has(highlighted.name.toLowerCase()));
                         setCommandHighlightedIndex(0);
                       }
                       return;

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -1779,10 +1779,15 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                     return;
                   }
 
-                  // Find the last @ that is at a word boundary
+                  // Use cursor position (not end of string) to scope the search.
+                  // After a completed @mention like "@file.ts |", the cursor is past
+                  // the space, so the @ is no longer "active" from the cursor's perspective.
+                  const cursorPos = event.currentTarget.selectionStart ?? next.length;
+
+                  // Find the last @ before the cursor that is at a word boundary
                   // Word boundary: preceded by space, newline, or start of string
                   let lastAtIndex = -1;
-                  for (let i = next.length - 1; i >= 0; i--) {
+                  for (let i = cursorPos - 1; i >= 0; i--) {
                     if (next[i] === "@") {
                       // Check if at word boundary
                       if (i === 0 || next[i - 1] === " " || next[i - 1] === "\n" || next[i - 1] === "\t") {
@@ -1793,7 +1798,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                   }
 
                   if (lastAtIndex === -1) {
-                    // No valid @ trigger found
+                    // No valid @ trigger found before cursor
                     if (atMentionOpen) {
                       setAtMentionOpen(false);
                       setAtMentionQuery("");
@@ -1803,11 +1808,23 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                     return;
                   }
 
-                  // Extract query after @ (the portion user is typing)
-                  const query = next.slice(lastAtIndex + 1);
+                  // Extract the text between @ and the cursor (the active query)
+                  const query = next.slice(lastAtIndex + 1, cursorPos);
 
-                  // If there's a space after the query, user has finished typing
-                  // Don't close - let the popover decide when to close
+                  // If the query contains a space that is NOT immediately after a "/",
+                  // the mention is complete (e.g. "@file.ts " or "@src/file.ts more text").
+                  // A trailing "/" (directory drill) should keep the popover open.
+                  const spaceInQuery = query.search(/\s/);
+                  if (spaceInQuery !== -1) {
+                    // Space found — mention is finished, close the popover
+                    if (atMentionOpen) {
+                      setAtMentionOpen(false);
+                      setAtMentionQuery("");
+                      setAtMentionPath("");
+                      setAtMentionTriggerOffset(0);
+                    }
+                    return;
+                  }
                   
                   // Open popover and update state
                   setAtMentionOpen(true);

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -679,6 +679,10 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
         if (serverName) {
           onExec({ type: "exec", id, command: "mcp_toggle_server", serverName, disabled: isDisable });
         }
+      } else if (argLower === "disable" || argLower === "enable") {
+        // Bare disable/enable without a server name — show a hint instead of
+        // silently falling through to status.
+        onAppendSystemMessage?.(`Usage: \`/mcp ${argLower} <server-name>\``);
       } else {
         const action = argLower === "reload" ? "reload" : "status";
         onExec({ type: "exec", id, command: "mcp", action });
@@ -817,8 +821,8 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
       { name: "mcp", description: "MCP server management", subCommands: [
         { name: "status", description: "Show MCP server status" },
         { name: "reload", description: "Reload MCP servers" },
-        { name: "disable", description: "Disable an MCP server" },
-        { name: "enable", description: "Enable a disabled MCP server" },
+        { name: "disable", description: "Disable an MCP server", requiresArg: true },
+        { name: "enable", description: "Enable a disabled MCP server", requiresArg: true },
       ]},
       { name: "plugins", description: "Show loaded plugins" },
       { name: "skills", description: "Show available skills" },
@@ -831,7 +835,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
       { name: "copy", description: "Copy last assistant message" },
       { name: "stop", description: "Abort current generation" },
       { name: "restart", description: "Restart the CLI process" },
-    ] as Array<{ name: string; description: string; subCommands?: Array<{ name: string; description: string }> }>;
+    ] as Array<{ name: string; description: string; subCommands?: Array<{ name: string; description: string; requiresArg?: boolean }> }>;
   }, []);
 
   // Set of all known command/skill names for quick lookup (used to auto-close popover
@@ -985,9 +989,9 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
   const subCommandMode = React.useMemo<{
     active: boolean;
     parentCommand: string;
-    subCommands: Array<{ name: string; description: string }>;
+    subCommands: Array<{ name: string; description: string; requiresArg?: boolean }>;
     query: string;
-    filtered: Array<{ name: string; description: string }>;
+    filtered: Array<{ name: string; description: string; requiresArg?: boolean }>;
   }>(() => {
     if (isResumeMode) return { active: false, parentCommand: "", subCommands: [], query: "", filtered: [] };
     const match = trimmedInput.match(/^\/(\S+)(?:\s(.*))?$/i);
@@ -1639,6 +1643,23 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                           key={sc.name}
                           value={sc.name}
                           onSelect={() => {
+                            if (sc.requiresArg) {
+                              // Sub-command needs an argument (e.g. server name) — fill
+                              // the input instead of executing so the user can type it.
+                              setInput(`/${subCommandMode.parentCommand} ${sc.name} `);
+                              setCommandQuery("");
+                              setCommandOpen(false);
+                              setCommandHighlightedIndex(0);
+                              requestAnimationFrame(() => {
+                                const textarea = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+                                if (textarea) {
+                                  const len = textarea.value.length;
+                                  textarea.setSelectionRange(len, len);
+                                  textarea.focus();
+                                }
+                              });
+                              return;
+                            }
                             executeSlashCommand(`/${subCommandMode.parentCommand} ${sc.name}`);
                           }}
                         >
@@ -1989,11 +2010,27 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                       return;
                     }
 
-                    // Desktop: Enter in sub-command mode executes the highlighted sub-command
+                    // Desktop: Enter in sub-command mode executes the highlighted sub-command,
+                    // or fills the input if the sub-command requires an argument (e.g. server name).
                     if (!isTouchDevice && event.key === "Enter" && !event.shiftKey && subCommandMode.active) {
                       const highlighted = subCommandMode.filtered[commandHighlightedIndex];
                       if (highlighted) {
                         event.preventDefault();
+                        if (highlighted.requiresArg) {
+                          setInput(`/${subCommandMode.parentCommand} ${highlighted.name} `);
+                          setCommandQuery("");
+                          setCommandOpen(false);
+                          setCommandHighlightedIndex(0);
+                          requestAnimationFrame(() => {
+                            const textarea = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+                            if (textarea) {
+                              const len = textarea.value.length;
+                              textarea.setSelectionRange(len, len);
+                              textarea.focus();
+                            }
+                          });
+                          return;
+                        }
                         executeSlashCommand(`/${subCommandMode.parentCommand} ${highlighted.name}`);
                         setCommandHighlightedIndex(0);
                         return;

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -67,6 +67,7 @@ import { dismissNotificationsForSession } from "@/lib/push";
 import { AlertTriangleIcon, ArrowDownIcon, BookOpen, CheckCircle2, ChevronsUpDown, Circle, CircleDashed, Loader2, MessageSquare, OctagonX, PaperclipIcon, Plus, Puzzle, ShieldAlert, Zap, Clock, X, Trash2, TerminalIcon, DownloadIcon, XCircle, FolderTree } from "lucide-react";
 import { AtMentionPopover } from "@/components/AtMentionPopover";
 import type { Entry as AtMentionEntry } from "@/hooks/useAtMentionFiles";
+import { McpToggleContext, type McpToggleHandler } from "@/components/session-viewer/McpToggleContext";
 
 export type { RelayMessage } from "@/components/session-viewer/types";
 
@@ -525,6 +526,18 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     "effort", "cycle_effort", "compact", "name", "copy", "stop", "restart",
     "remote",
   ]), []);
+
+  // MCP toggle handler — sends mcp_toggle_server remote exec to the runner
+  const handleMcpToggle = React.useCallback<McpToggleHandler>((serverName, disabled) => {
+    if (!onExec) return;
+    onExec({
+      type: "exec",
+      id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      command: "mcp_toggle_server",
+      serverName,
+      disabled,
+    });
+  }, [onExec]);
 
   // Split availableCommands (from the CLI) into groups by source.
   // Everything not already handled by the web UI is shown in the hotbar.
@@ -1126,6 +1139,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
 
   return (
     <SessionActionsProvider value={sessionActions}>
+    <McpToggleContext.Provider value={onExec ? handleMcpToggle : null}>
     <div className="flex flex-col flex-1 min-h-0">
       {/* Session info bar */}
       {sessionId && (
@@ -2088,6 +2102,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
         </DialogContent>
       </Dialog>
     </div>
+    </McpToggleContext.Provider>
     </SessionActionsProvider>
   );
 }

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -2025,13 +2025,23 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                       // No highlighted match — fall through to execute the typed command
                     }
 
-                    // Tab in sub-command mode: autocomplete the highlighted sub-command and execute
+                    // Tab in sub-command mode: autocomplete the highlighted sub-command into the text box
                     if (event.key === "Tab" && subCommandMode.active && subCommandMode.filtered.length > 0) {
                       event.preventDefault();
                       const highlighted = subCommandMode.filtered[commandHighlightedIndex] ?? subCommandMode.filtered[0];
                       if (highlighted) {
-                        executeSlashCommand(`/${subCommandMode.parentCommand} ${highlighted.name}`);
+                        setInput(`/${subCommandMode.parentCommand} ${highlighted.name}`);
+                        setCommandQuery("");
+                        setCommandOpen(false);
                         setCommandHighlightedIndex(0);
+                        requestAnimationFrame(() => {
+                          const textarea = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+                          if (textarea) {
+                            const len = textarea.value.length;
+                            textarea.setSelectionRange(len, len);
+                            textarea.focus();
+                          }
+                        });
                       }
                       return;
                     }

--- a/packages/ui/src/components/session-viewer/McpToggleContext.tsx
+++ b/packages/ui/src/components/session-viewer/McpToggleContext.tsx
@@ -1,0 +1,16 @@
+import * as React from "react";
+
+/**
+ * Context that provides a callback to toggle an MCP server's enabled/disabled state.
+ * This avoids threading the callback through renderContent() and the full message tree.
+ *
+ * The callback sends an `mcp_toggle_server` remote exec command to the runner,
+ * which updates the project's .pizzapi/config.json and reloads MCP.
+ */
+export type McpToggleHandler = (serverName: string, disabled: boolean) => void;
+
+export const McpToggleContext = React.createContext<McpToggleHandler | null>(null);
+
+export function useMcpToggle(): McpToggleHandler | null {
+  return React.useContext(McpToggleContext);
+}

--- a/packages/ui/src/components/session-viewer/cards/CommandResultCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/CommandResultCard.tsx
@@ -18,7 +18,10 @@ import {
   FileText,
   ChevronDown,
   RefreshCw,
+  Eye,
+  EyeOff,
 } from "lucide-react";
+import { useMcpToggle } from "@/components/session-viewer/McpToggleContext";
 
 // ── Shared types ──────────────────────────────────────────────────────────────
 
@@ -53,6 +56,8 @@ export interface McpResultData {
   servers: McpServerEntry[];
   errors: McpError[];
   loadedAt?: string;
+  /** Server names currently disabled via config */
+  disabledServers?: string[];
 }
 
 // ── Plugins ───────────────────────────────────────────────────────────────────
@@ -94,36 +99,68 @@ export interface SkillsResultData {
 // ── Card Renderers ────────────────────────────────────────────────────────────
 
 /** Collapsible per-server tool group */
-function ServerToolGroup({ serverName, tools, transport, scope, defaultOpen }: {
+function ServerToolGroup({ serverName, tools, transport, scope, defaultOpen, disabled, onToggle }: {
   serverName: string;
   tools: string[];
   transport?: string;
   scope?: string;
   defaultOpen: boolean;
+  /** Whether this server is currently disabled */
+  disabled?: boolean;
+  /** Callback to toggle enabled/disabled state */
+  onToggle?: (serverName: string, disabled: boolean) => void;
 }) {
-  const [open, setOpen] = React.useState(defaultOpen);
+  const [open, setOpen] = React.useState(defaultOpen && !disabled);
 
   return (
-    <div className="border-b border-zinc-800/60 last:border-b-0">
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        className="flex items-center gap-2 w-full px-4 py-2 hover:bg-zinc-900/50 transition-colors text-left"
-      >
-        <ChevronDown className={cn("size-3 shrink-0 text-zinc-500 transition-transform", open && "rotate-180")} />
-        <Server className="size-3 shrink-0 text-zinc-500" />
-        <span className="text-xs font-mono font-medium text-zinc-300 truncate">{serverName}</span>
-        {transport && (
-          <Badge variant="outline" className="h-3.5 px-1 text-[9px] font-mono border-zinc-700 text-zinc-500">
-            {transport}
-          </Badge>
+    <div className={cn("border-b border-zinc-800/60 last:border-b-0", disabled && "opacity-50")}>
+      <div className="flex items-center gap-0 w-full">
+        <button
+          type="button"
+          onClick={() => !disabled && setOpen(!open)}
+          className={cn(
+            "flex items-center gap-2 flex-1 min-w-0 px-4 py-2 text-left transition-colors",
+            !disabled && "hover:bg-zinc-900/50",
+            disabled && "cursor-default",
+          )}
+        >
+          {!disabled && (
+            <ChevronDown className={cn("size-3 shrink-0 text-zinc-500 transition-transform", open && "rotate-180")} />
+          )}
+          <Server className="size-3 shrink-0 text-zinc-500" />
+          <span className={cn("text-xs font-mono font-medium truncate", disabled ? "text-zinc-500 line-through decoration-zinc-600" : "text-zinc-300")}>
+            {serverName}
+          </span>
+          {transport && (
+            <Badge variant="outline" className="h-3.5 px-1 text-[9px] font-mono border-zinc-700 text-zinc-500">
+              {transport}
+            </Badge>
+          )}
+          {disabled ? (
+            <span className="text-[10px] text-zinc-600 tabular-nums ml-auto shrink-0">disabled</span>
+          ) : (
+            <span className="text-[10px] text-zinc-600 tabular-nums ml-auto shrink-0">
+              {tools.length} tool{tools.length !== 1 ? "s" : ""}
+              {scope && <span className="ml-1.5 text-zinc-600/70">{scope}</span>}
+            </span>
+          )}
+        </button>
+        {onToggle && (
+          <button
+            type="button"
+            onClick={(e) => { e.stopPropagation(); onToggle(serverName, !disabled); }}
+            className="flex-shrink-0 p-2 hover:bg-zinc-900/50 transition-colors rounded-r"
+            title={disabled ? `Enable ${serverName}` : `Disable ${serverName}`}
+          >
+            {disabled ? (
+              <EyeOff className="size-3.5 text-zinc-600 hover:text-zinc-400 transition-colors" />
+            ) : (
+              <Eye className="size-3.5 text-zinc-500 hover:text-zinc-300 transition-colors" />
+            )}
+          </button>
         )}
-        <span className="text-[10px] text-zinc-600 tabular-nums ml-auto shrink-0">
-          {tools.length} tool{tools.length !== 1 ? "s" : ""}
-          {scope && <span className="ml-1.5 text-zinc-600/70">{scope}</span>}
-        </span>
-      </button>
-      {open && (
+      </div>
+      {open && !disabled && tools.length > 0 && (
         <div className="px-4 pb-2.5 pt-0.5 flex flex-wrap gap-1">
           {tools.map((name) => (
             <span key={name} className="inline-block rounded bg-zinc-800/80 px-1.5 py-0.5 text-[10px] font-mono text-zinc-400">
@@ -139,6 +176,8 @@ function ServerToolGroup({ serverName, tools, transport, scope, defaultOpen }: {
 function McpCard({ data }: { data: McpResultData }) {
   const hasErrors = data.errors.length > 0;
   const hasServerTools = Object.keys(data.serverTools ?? {}).length > 0;
+  const disabledSet = React.useMemo(() => new Set(data.disabledServers ?? []), [data.disabledServers]);
+  const mcpToggle = useMcpToggle();
 
   // Build a lookup from server name → config entry for transport/scope info
   const serverConfigMap = React.useMemo(() => {
@@ -146,6 +185,13 @@ function McpCard({ data }: { data: McpResultData }) {
     for (const s of data.servers) map.set(s.name, s);
     return map;
   }, [data.servers]);
+
+  // Disabled servers that aren't already shown in serverTools (they were skipped)
+  const disabledOnlyServers = React.useMemo(() => {
+    return [...disabledSet].filter((name) => !data.serverTools[name]);
+  }, [disabledSet, data.serverTools]);
+
+  const disabledCount = disabledSet.size;
 
   return (
     <ToolCardShell>
@@ -163,6 +209,11 @@ function McpCard({ data }: { data: McpResultData }) {
           {hasErrors && (
             <StatusPill variant="error">
               {data.errors.length} error{data.errors.length > 1 ? "s" : ""}
+            </StatusPill>
+          )}
+          {disabledCount > 0 && (
+            <StatusPill variant="neutral">
+              {disabledCount} disabled
             </StatusPill>
           )}
           <StatusPill variant={data.toolCount > 0 ? "success" : "neutral"}>
@@ -189,7 +240,7 @@ function McpCard({ data }: { data: McpResultData }) {
         </div>
       )}
 
-      {/* Tools grouped by server */}
+      {/* Tools grouped by server (active servers) */}
       {hasServerTools && (
         Object.entries(data.serverTools).map(([serverName, tools]) => {
           const config = serverConfigMap.get(serverName);
@@ -201,10 +252,29 @@ function McpCard({ data }: { data: McpResultData }) {
               transport={config?.transport}
               scope={config?.scope}
               defaultOpen={Object.keys(data.serverTools).length <= 3}
+              disabled={disabledSet.has(serverName)}
+              onToggle={mcpToggle ?? undefined}
             />
           );
         })
       )}
+
+      {/* Disabled servers that weren't in serverTools (skipped during init) */}
+      {disabledOnlyServers.map((name) => {
+        const config = serverConfigMap.get(name);
+        return (
+          <ServerToolGroup
+            key={name}
+            serverName={name}
+            tools={[]}
+            transport={config?.transport}
+            scope={config?.scope}
+            defaultOpen={false}
+            disabled={true}
+            onToggle={mcpToggle ?? undefined}
+          />
+        );
+      })}
 
       {/* Fallback: flat tool list if no serverTools grouping available (old CLI) */}
       {!hasServerTools && data.toolNames.length > 0 && (
@@ -212,7 +282,7 @@ function McpCard({ data }: { data: McpResultData }) {
       )}
 
       {/* No servers configured */}
-      {data.servers.length === 0 && data.toolCount === 0 && !hasErrors && (
+      {data.servers.length === 0 && data.toolCount === 0 && !hasErrors && disabledCount === 0 && (
         <div className="px-4 py-3 text-xs text-zinc-500 text-center">
           No MCP servers configured.
         </div>

--- a/packages/ui/src/components/session-viewer/utils.test.ts
+++ b/packages/ui/src/components/session-viewer/utils.test.ts
@@ -469,9 +469,9 @@ describe("resolveCommandPopoverState", () => {
         expect(resolveCommandPopoverState("skill:double-check ", known)).toEqual({ open: false, query: "" });
     });
 
-    test("keeps popover open for unrecognized command with arguments", () => {
+    test("closes popover for unrecognized command once a space is typed", () => {
         const result = resolveCommandPopoverState("unknown-thing some args", known);
-        expect(result).toEqual({ open: true, query: "unknown-thing some args" });
+        expect(result).toEqual({ open: false, query: "" });
     });
 
     test("is case-insensitive for command matching", () => {

--- a/packages/ui/src/components/session-viewer/utils.test.ts
+++ b/packages/ui/src/components/session-viewer/utils.test.ts
@@ -500,4 +500,12 @@ describe("resolveCommandPopoverState", () => {
     test("keepOpen is case-insensitive", () => {
         expect(resolveCommandPopoverState("Resume my-session", known, keepOpen)).toEqual({ open: true, query: "Resume my-session" });
     });
+
+    test("keeps popover open for commands with sub-commands (e.g. /mcp)", () => {
+        const keepOpenWithMcp = new Set(["resume", "mcp"]);
+        const knownWithMcp = new Set([...known, "mcp"]);
+        expect(resolveCommandPopoverState("mcp ", knownWithMcp, keepOpenWithMcp)).toEqual({ open: true, query: "mcp " });
+        expect(resolveCommandPopoverState("mcp reload", knownWithMcp, keepOpenWithMcp)).toEqual({ open: true, query: "mcp reload" });
+        expect(resolveCommandPopoverState("mcp re", knownWithMcp, keepOpenWithMcp)).toEqual({ open: true, query: "mcp re" });
+    });
 });

--- a/packages/ui/src/components/session-viewer/utils.ts
+++ b/packages/ui/src/components/session-viewer/utils.ts
@@ -229,6 +229,9 @@ export function resolveCommandPopoverState(
     // Recognised command with arguments — close the popover.
     return { open: false, query: "" };
   }
-  // Unrecognised — keep open so the user sees suggestions / "not found".
-  return { open: true, query: afterSlash };
+  // Unrecognised command with a space means the user has moved past the
+  // command name into arguments/body text — close the popover so it
+  // doesn't persist for the entire message (e.g. typing a file path
+  // like "/usr/bin/python" or a non-existent command).
+  return { open: false, query: "" };
 }

--- a/packages/ui/src/lib/remote-exec.ts
+++ b/packages/ui/src/lib/remote-exec.ts
@@ -17,7 +17,8 @@ export type RemoteExecCommand =
   | { command: "resume_session"; query?: string; sessionPath?: string }
   | { command: "new_session" }
   | { command: "restart" }
-  | { command: "end_session" };
+  | { command: "end_session" }
+  | { command: "mcp_toggle_server"; serverName: string; disabled: boolean };
 
 export type RemoteExecRequest = { type: "exec"; id: string } & RemoteExecCommand;
 


### PR DESCRIPTION
## Summary

Add `disabledMcpServers` config option to skip specific MCP servers on a per-project basis. Supports both TUI slash commands and Web UI toggle controls.

## Changes

### Config (`packages/cli/src/config.ts`)
- New `disabledMcpServers: string[]` field in `PizzaPiConfig`
- Global (`~/.pizzapi/config.json`) and project-local (`.pizzapi/config.json`) lists are merged as a union
- `toggleMcpServer()` helper with idempotency and global-disabled guard
- `globalConfigDir()` helper for testability

### TUI (`packages/cli/src/extensions/mcp-extension.ts`)
- `/mcp disable <name>` — disables a server and reloads
- `/mcp enable <name>` — re-enables a server and reloads
- Tab completion for server names in both subcommands
- Status output shows `[DISABLED]` tags and lists disabled servers

### Web UI
- **`CommandResultCard.tsx`** — Eye toggle icons on each server row in the MCP status card; disabled servers shown dimmed with strikethrough
- **`McpToggleContext.tsx`** — New React context for toggle state management
- **`SessionViewer.tsx` / `App.tsx`** — Provide toggle context, handle `mcp_toggle_server` remote exec responses, pass `disabledServers` state

### Runner ↔ UI bridge
- **`remote-commands.ts`** — New `mcp_toggle_server` command type
- **`remote.ts`** — Handle `mcp_toggle_server` exec on the runner side
- **`remote-exec.ts`** — UI-side command type addition

### Server
- **`static.ts`** — Harden static file serving against path traversal

### Tests (`packages/cli/src/config.test.ts`)
- 14 new tests covering toggle behavior, config merging, edge cases, and CI portability

## How it works

1. User disables a server via `/mcp disable <name>` (TUI) or the eye icon (Web UI)
2. The server name is added to `disabledMcpServers` in the project-local config
3. On next MCP client creation, disabled servers are filtered out
4. Global disables take precedence — project config cannot re-enable a globally disabled server