### PR TITLE
fix(ui): make runner page scrollable

### DIFF
--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -282,7 +282,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
 
     return (
         <>
-            <div className="flex flex-col gap-6 p-4 sm:p-6 max-w-4xl mx-auto w-full">
+            <div className="flex flex-col gap-6 p-4 sm:p-6 max-w-4xl mx-auto w-full flex-1 overflow-y-auto">
                 {/* Header */}
                 <div className="flex items-start justify-between">
                     <div className="space-y-0.5">


### PR DESCRIPTION
## Summary

Two fixes for the Runner Manager UI:

1. **Make runner page scrollable** — adds `flex-1 overflow-y-auto` so content scrolls when it exceeds the viewport
2. **Add Agents manager** — full CRUD support for managing agents in the web UI

## Changes

- `packages/ui/src/components/RunnerManager.tsx` — scrollable container fix + agents integration
- `packages/ui/src/components/AgentsManager.tsx` — new component (CRUD for agents)
- `packages/cli/src/agents.ts` — CLI agent support
- +12 other files supporting the agents feature