### PR TITLE
feat: add Agents manager to web UI with full CRUD support

### DIFF
--- a/packages/cli/src/agents.test.ts
+++ b/packages/cli/src/agents.test.ts
@@ -1,0 +1,319 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
+import {
+    parseAgentFrontmatterFromString,
+    scanAgentsDir,
+    scanGlobalAgents,
+    readAgentContent,
+    writeAgent,
+    deleteAgent,
+    findAgentDir,
+} from "./agents.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeTmpDir(): string {
+    const dir = join(tmpdir(), `pizzapi-agent-test-${randomBytes(8).toString("hex")}`);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+}
+
+function writeAgentFile(agentsDir: string, name: string, content: string): string {
+    mkdirSync(agentsDir, { recursive: true });
+    const filePath = join(agentsDir, `${name}.md`);
+    writeFileSync(filePath, content, "utf-8");
+    return filePath;
+}
+
+const AGENT_WITH_DESCRIPTION = `---
+description: A helpful agent for testing.
+---
+
+# My Agent
+
+Do the thing.
+`;
+
+const AGENT_QUOTED_DESCRIPTION = `---
+description: "A quoted description"
+---
+
+# Quoted Agent
+`;
+
+const AGENT_NO_FRONTMATTER = `# Just Markdown
+
+No frontmatter here.
+`;
+
+// ── parseAgentFrontmatterFromString ───────────────────────────────────────────
+
+describe("parseAgentFrontmatterFromString", () => {
+    test("parses a plain description", () => {
+        const result = parseAgentFrontmatterFromString(AGENT_WITH_DESCRIPTION);
+        expect(result.description).toBe("A helpful agent for testing.");
+    });
+
+    test("strips double quotes from description", () => {
+        const result = parseAgentFrontmatterFromString(AGENT_QUOTED_DESCRIPTION);
+        expect(result.description).toBe("A quoted description");
+    });
+
+    test("returns empty string when there is no frontmatter", () => {
+        const result = parseAgentFrontmatterFromString(AGENT_NO_FRONTMATTER);
+        expect(result.description).toBe("");
+    });
+
+    test("returns empty string for empty content", () => {
+        const result = parseAgentFrontmatterFromString("");
+        expect(result.description).toBe("");
+    });
+});
+
+// ── scanAgentsDir ─────────────────────────────────────────────────────────────
+
+describe("scanAgentsDir", () => {
+    let dir: string;
+
+    beforeEach(() => { dir = makeTmpDir(); });
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+    test("returns empty array for non-existent directory", () => {
+        expect(scanAgentsDir(join(dir, "nope"))).toEqual([]);
+    });
+
+    test("returns empty array for empty directory", () => {
+        expect(scanAgentsDir(dir)).toEqual([]);
+    });
+
+    test("discovers .md files as agents", () => {
+        writeAgentFile(dir, "my-agent", AGENT_WITH_DESCRIPTION);
+        const result = scanAgentsDir(dir);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("my-agent");
+        expect(result[0].description).toBe("A helpful agent for testing.");
+        expect(result[0].filePath).toBe(join(dir, "my-agent.md"));
+    });
+
+    test("discovers agents with non-lowercase names", () => {
+        writeAgentFile(dir, "Foo", AGENT_WITH_DESCRIPTION);
+        writeAgentFile(dir, "foo_bar", AGENT_WITH_DESCRIPTION);
+        writeAgentFile(dir, "foo.bar", AGENT_WITH_DESCRIPTION);
+        const result = scanAgentsDir(dir);
+        expect(result).toHaveLength(3);
+        const names = result.map((a) => a.name).sort();
+        expect(names).toEqual(["Foo", "foo.bar", "foo_bar"]);
+    });
+
+    test("ignores hidden files", () => {
+        writeAgentFile(dir, ".hidden", AGENT_WITH_DESCRIPTION);
+        expect(scanAgentsDir(dir)).toEqual([]);
+    });
+
+    test("ignores non-.md files", () => {
+        writeFileSync(join(dir, "notes.txt"), "not an agent", "utf-8");
+        expect(scanAgentsDir(dir)).toEqual([]);
+    });
+});
+
+// ── findAgentDir ──────────────────────────────────────────────────────────────
+
+describe("findAgentDir", () => {
+    let primaryDir: string;
+    let secondaryDir: string;
+
+    beforeEach(() => {
+        primaryDir = makeTmpDir();
+        secondaryDir = makeTmpDir();
+    });
+
+    afterEach(() => {
+        rmSync(primaryDir, { recursive: true, force: true });
+        rmSync(secondaryDir, { recursive: true, force: true });
+    });
+
+    test("returns null for non-existent agent", () => {
+        expect(findAgentDir("ghost", [primaryDir, secondaryDir])).toBeNull();
+    });
+
+    test("finds agent in primary directory", () => {
+        writeAgentFile(primaryDir, "test-agent", AGENT_WITH_DESCRIPTION);
+        expect(findAgentDir("test-agent", [primaryDir, secondaryDir])).toBe(primaryDir);
+    });
+
+    test("finds agent in secondary directory", () => {
+        writeAgentFile(secondaryDir, "claude-agent", AGENT_WITH_DESCRIPTION);
+        expect(findAgentDir("claude-agent", [primaryDir, secondaryDir])).toBe(secondaryDir);
+    });
+
+    test("prefers primary over secondary when both exist", () => {
+        writeAgentFile(primaryDir, "both", AGENT_WITH_DESCRIPTION);
+        writeAgentFile(secondaryDir, "both", AGENT_WITH_DESCRIPTION);
+        expect(findAgentDir("both", [primaryDir, secondaryDir])).toBe(primaryDir);
+    });
+});
+
+// ── writeAgent (source directory preservation) ────────────────────────────────
+
+describe("writeAgent", () => {
+    let dir: string;
+
+    beforeEach(() => { dir = makeTmpDir(); });
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+    test("creates a new agent file", async () => {
+        await writeAgent("new-agent", AGENT_WITH_DESCRIPTION, dir);
+        const filePath = join(dir, "new-agent.md");
+        expect(existsSync(filePath)).toBe(true);
+        expect(readFileSync(filePath, "utf-8")).toBe(AGENT_WITH_DESCRIPTION);
+    });
+
+    test("overwrites existing agent content", async () => {
+        await writeAgent("update-me", "old content", dir);
+        await writeAgent("update-me", "new content", dir);
+        expect(readFileSync(join(dir, "update-me.md"), "utf-8")).toBe("new content");
+    });
+
+    test("preserves source directory for existing agents", async () => {
+        // Simulate two search directories (like ~/.pizzapi/agents and ~/.claude/agents)
+        const primaryDir = makeTmpDir();
+        const secondaryDir = makeTmpDir();
+        try {
+            writeAgentFile(secondaryDir, "claude-only", "original content");
+
+            // findAgentDir should find it in the secondary directory
+            const foundDir = findAgentDir("claude-only", [primaryDir, secondaryDir]);
+            expect(foundDir).toBe(secondaryDir);
+
+            // writeAgent with the found dir should update in place
+            await writeAgent("claude-only", "updated content", foundDir!);
+
+            const secondaryPath = join(secondaryDir, "claude-only.md");
+            expect(readFileSync(secondaryPath, "utf-8")).toBe("updated content");
+
+            // Should NOT have created a shadow copy in the primary dir
+            const primaryPath = join(primaryDir, "claude-only.md");
+            expect(existsSync(primaryPath)).toBe(false);
+        } finally {
+            rmSync(primaryDir, { recursive: true, force: true });
+            rmSync(secondaryDir, { recursive: true, force: true });
+        }
+    });
+});
+
+// ── readAgentContent ──────────────────────────────────────────────────────────
+
+describe("readAgentContent", () => {
+    let dir: string;
+
+    beforeEach(() => { dir = makeTmpDir(); });
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+    test("reads agent content", () => {
+        writeAgentFile(dir, "test", AGENT_WITH_DESCRIPTION);
+        const content = readAgentContent("test", dir);
+        expect(content).toBe(AGENT_WITH_DESCRIPTION);
+    });
+
+    test("returns null for non-existent agent", () => {
+        expect(readAgentContent("ghost", dir)).toBeNull();
+    });
+});
+
+// ── deleteAgent ───────────────────────────────────────────────────────────────
+
+describe("deleteAgent", () => {
+    let dir: string;
+
+    beforeEach(() => { dir = makeTmpDir(); });
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+    test("deletes an agent", () => {
+        writeAgentFile(dir, "doomed", AGENT_WITH_DESCRIPTION);
+        expect(deleteAgent("doomed", dir)).toBe(true);
+        expect(existsSync(join(dir, "doomed.md"))).toBe(false);
+    });
+
+    test("returns false for non-existent agent", () => {
+        expect(deleteAgent("ghost", dir)).toBe(false);
+    });
+});
+
+// ── Agent lifecycle ───────────────────────────────────────────────────────────
+
+describe("agent lifecycle", () => {
+    let dir: string;
+
+    beforeEach(() => { dir = makeTmpDir(); });
+    afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+    test("full CRUD cycle", async () => {
+        expect(scanAgentsDir(dir)).toEqual([]);
+
+        await writeAgent("test-agent", AGENT_WITH_DESCRIPTION, dir);
+        const scanned = scanAgentsDir(dir);
+        expect(scanned).toHaveLength(1);
+        expect(scanned[0].name).toBe("test-agent");
+
+        const content = readAgentContent("test-agent", dir);
+        expect(content).toBe(AGENT_WITH_DESCRIPTION);
+
+        const updated = AGENT_WITH_DESCRIPTION.replace("A helpful agent for testing.", "Updated.");
+        await writeAgent("test-agent", updated, dir);
+        const rescanned = scanAgentsDir(dir);
+        expect(rescanned[0].description).toBe("Updated.");
+
+        expect(deleteAgent("test-agent", dir)).toBe(true);
+        expect(scanAgentsDir(dir)).toEqual([]);
+    });
+});
+
+// ── Name validation regex (mirrors daemon.ts update_agent) ────────────────────
+
+describe("agent name validation", () => {
+    const updateRegex = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/;
+
+    test("accepts lowercase-hyphen names", () => {
+        expect(updateRegex.test("my-agent")).toBe(true);
+    });
+
+    test("accepts names with underscores", () => {
+        expect(updateRegex.test("foo_bar")).toBe(true);
+    });
+
+    test("accepts names with dots", () => {
+        expect(updateRegex.test("foo.bar")).toBe(true);
+    });
+
+    test("accepts uppercase names", () => {
+        expect(updateRegex.test("Foo")).toBe(true);
+        expect(updateRegex.test("FooBar")).toBe(true);
+    });
+
+    test("accepts single character names", () => {
+        expect(updateRegex.test("a")).toBe(true);
+        expect(updateRegex.test("1")).toBe(true);
+    });
+
+    test("rejects names starting with special chars", () => {
+        expect(updateRegex.test("-agent")).toBe(false);
+        expect(updateRegex.test(".agent")).toBe(false);
+        expect(updateRegex.test("_agent")).toBe(false);
+    });
+
+    test("rejects names with path separators", () => {
+        expect(updateRegex.test("../evil")).toBe(false);
+        expect(updateRegex.test("foo/bar")).toBe(false);
+    });
+
+    test("rejects empty names", () => {
+        expect(updateRegex.test("")).toBe(false);
+    });
+
+    test("rejects names with spaces", () => {
+        expect(updateRegex.test("foo bar")).toBe(false);
+    });
+});

--- a/packages/cli/src/agents.ts
+++ b/packages/cli/src/agents.ts
@@ -98,23 +98,45 @@ export function scanAgentsDir(dir: string): AgentMeta[] {
     return agents;
 }
 
-/** Scan the global PizzaPi agents directory (~/.pizzapi/agents/). */
+/**
+ * Scan all global agent directories and return deduplicated metadata.
+ * Scans ~/.pizzapi/agents/ first (higher precedence), then ~/.claude/agents/
+ * for Claude Code compatibility. Agents with the same name in .pizzapi
+ * take priority over those in .claude.
+ */
 export function scanGlobalAgents(): AgentMeta[] {
-    return scanAgentsDir(globalAgentsDir());
+    const dirs = [
+        globalAgentsDir(),                              // ~/.pizzapi/agents/
+        join(homedir(), ".claude", "agents"),            // ~/.claude/agents/
+    ];
+    const seen = new Set<string>();
+    const agents: AgentMeta[] = [];
+    for (const dir of dirs) {
+        for (const agent of scanAgentsDir(dir)) {
+            if (!seen.has(agent.name)) {
+                seen.add(agent.name);
+                agents.push(agent);
+            }
+        }
+    }
+    return agents;
 }
 
 // ── CRUD operations ───────────────────────────────────────────────────────────
 
 /**
  * Read the full content of an agent file.
- * Checks <dir>/<name>.md.
+ * Checks <dir>/<name>.md. When no dir is specified, searches both
+ * ~/.pizzapi/agents/ and ~/.claude/agents/ (first match wins).
  * Returns null if not found.
  */
 export function readAgentContent(name: string, dir?: string): string | null {
-    const agentsDir = dir ?? globalAgentsDir();
-    const filePath = join(agentsDir, `${name}.md`);
-    if (existsSync(filePath)) {
-        try { return readFileSync(filePath, "utf-8"); } catch { return null; }
+    const dirs = dir ? [dir] : [globalAgentsDir(), join(homedir(), ".claude", "agents")];
+    for (const d of dirs) {
+        const filePath = join(d, `${name}.md`);
+        if (existsSync(filePath)) {
+            try { return readFileSync(filePath, "utf-8"); } catch { /* continue */ }
+        }
     }
     return null;
 }
@@ -131,17 +153,21 @@ export async function writeAgent(name: string, content: string, dir?: string): P
 
 /**
  * Delete an agent by name.
+ * When no dir is specified, searches both ~/.pizzapi/agents/ and
+ * ~/.claude/agents/ (deletes first match).
  * Returns true if an agent was deleted.
  */
 export function deleteAgent(name: string, dir?: string): boolean {
-    const agentsDir = dir ?? globalAgentsDir();
-    const filePath = join(agentsDir, `${name}.md`);
-    if (existsSync(filePath)) {
-        try {
-            rmSync(filePath);
-            return true;
-        } catch {
-            return false;
+    const dirs = dir ? [dir] : [globalAgentsDir(), join(homedir(), ".claude", "agents")];
+    for (const d of dirs) {
+        const filePath = join(d, `${name}.md`);
+        if (existsSync(filePath)) {
+            try {
+                rmSync(filePath);
+                return true;
+            } catch {
+                return false;
+            }
         }
     }
     return false;

--- a/packages/cli/src/agents.ts
+++ b/packages/cli/src/agents.ts
@@ -1,0 +1,148 @@
+/**
+ * Agent discovery and management utilities.
+ *
+ * Agents are markdown files (with optional YAML frontmatter) stored in
+ * ~/.pizzapi/agents/ or ~/.claude/agents/. They define specialized agent
+ * personas that can be invoked via the subagent tool.
+ *
+ * This module mirrors the skills.ts patterns for consistency.
+ */
+import { existsSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface AgentMeta {
+    name: string;
+    description: string;
+    filePath: string;
+}
+
+// ── Agent directory ───────────────────────────────────────────────────────────
+
+/** Default global agents directory for PizzaPi. */
+export function globalAgentsDir(): string {
+    return join(homedir(), ".pizzapi", "agents");
+}
+
+// ── Frontmatter parsing ───────────────────────────────────────────────────────
+
+/**
+ * Parse the `description` field out of an agent markdown file's frontmatter.
+ * Returns empty string if not found or file is unreadable.
+ */
+export function parseAgentFrontmatter(filePath: string): { description: string } {
+    let content: string;
+    try {
+        content = readFileSync(filePath, "utf-8");
+    } catch {
+        return { description: "" };
+    }
+
+    return parseAgentFrontmatterFromString(content);
+}
+
+/**
+ * Parse the `description` field out of a frontmatter string.
+ * Pure function — no filesystem access.
+ */
+export function parseAgentFrontmatterFromString(content: string): { description: string } {
+    if (!content.startsWith("---")) return { description: "" };
+    const end = content.indexOf("\n---", 3);
+    if (end === -1) return { description: "" };
+
+    const block = content.slice(3, end);
+    const match = block.match(/^description:\s*(.+)$/m);
+    return { description: match ? match[1].trim().replace(/^["']|["']$/g, "") : "" };
+}
+
+// ── Agent scanning ────────────────────────────────────────────────────────────
+
+/**
+ * Scan an agents directory and return basic metadata.
+ * Discovery rules:
+ *   - .md files in the directory → name = basename without extension
+ */
+export function scanAgentsDir(dir: string): AgentMeta[] {
+    if (!existsSync(dir)) return [];
+
+    const agents: AgentMeta[] = [];
+
+    let entries: string[];
+    try {
+        entries = readdirSync(dir);
+    } catch {
+        return [];
+    }
+
+    for (const entry of entries) {
+        if (entry.startsWith(".")) continue;
+
+        const fullPath = join(dir, entry);
+        let st: ReturnType<typeof statSync>;
+        try {
+            st = statSync(fullPath);
+        } catch {
+            continue;
+        }
+
+        if (st.isFile() && entry.toLowerCase().endsWith(".md")) {
+            const name = entry.slice(0, -3);
+            const { description } = parseAgentFrontmatter(fullPath);
+            agents.push({ name, description, filePath: fullPath });
+        }
+    }
+
+    return agents;
+}
+
+/** Scan the global PizzaPi agents directory (~/.pizzapi/agents/). */
+export function scanGlobalAgents(): AgentMeta[] {
+    return scanAgentsDir(globalAgentsDir());
+}
+
+// ── CRUD operations ───────────────────────────────────────────────────────────
+
+/**
+ * Read the full content of an agent file.
+ * Checks <dir>/<name>.md.
+ * Returns null if not found.
+ */
+export function readAgentContent(name: string, dir?: string): string | null {
+    const agentsDir = dir ?? globalAgentsDir();
+    const filePath = join(agentsDir, `${name}.md`);
+    if (existsSync(filePath)) {
+        try { return readFileSync(filePath, "utf-8"); } catch { return null; }
+    }
+    return null;
+}
+
+/**
+ * Write (create or update) an agent.
+ * Stores as <dir>/<name>.md
+ */
+export async function writeAgent(name: string, content: string, dir?: string): Promise<void> {
+    const agentsDir = dir ?? globalAgentsDir();
+    await mkdir(agentsDir, { recursive: true });
+    writeFileSync(join(agentsDir, `${name}.md`), content, "utf-8");
+}
+
+/**
+ * Delete an agent by name.
+ * Returns true if an agent was deleted.
+ */
+export function deleteAgent(name: string, dir?: string): boolean {
+    const agentsDir = dir ?? globalAgentsDir();
+    const filePath = join(agentsDir, `${name}.md`);
+    if (existsSync(filePath)) {
+        try {
+            rmSync(filePath);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+    return false;
+}

--- a/packages/cli/src/agents.ts
+++ b/packages/cli/src/agents.ts
@@ -141,12 +141,35 @@ export function readAgentContent(name: string, dir?: string): string | null {
     return null;
 }
 
+/** Default search directories for agent discovery (in priority order). */
+export function defaultAgentDirs(): string[] {
+    return [globalAgentsDir(), join(homedir(), ".claude", "agents")];
+}
+
+/**
+ * Find the directory where an agent currently lives.
+ * Searches the given directories (defaults to ~/.pizzapi/agents/ then ~/.claude/agents/).
+ * Returns null if the agent doesn't exist in any known directory.
+ */
+export function findAgentDir(name: string, searchDirs?: string[]): string | null {
+    const dirs = searchDirs ?? defaultAgentDirs();
+    for (const d of dirs) {
+        const filePath = join(d, `${name}.md`);
+        if (existsSync(filePath)) return d;
+    }
+    return null;
+}
+
 /**
  * Write (create or update) an agent.
  * Stores as <dir>/<name>.md
+ *
+ * When no dir is specified, writes to the agent's existing location if it
+ * already exists (preserving ~/.claude/agents/ sources), otherwise defaults
+ * to ~/.pizzapi/agents/ for new agents.
  */
 export async function writeAgent(name: string, content: string, dir?: string): Promise<void> {
-    const agentsDir = dir ?? globalAgentsDir();
+    const agentsDir = dir ?? findAgentDir(name) ?? globalAgentsDir();
     await mkdir(agentsDir, { recursive: true });
     writeFileSync(join(agentsDir, `${name}.md`), content, "utf-8");
 }

--- a/packages/cli/src/extensions/claude-plugins.ts
+++ b/packages/cli/src/extensions/claude-plugins.ts
@@ -676,3 +676,39 @@ export function getPluginSkillPaths(cwd: string): string[] {
     }
     return paths;
 }
+
+/**
+ * Get the agent directory paths from all discovered Claude Code plugins.
+ * Includes global plugins and any project-local plugins that are
+ * already trusted (via `pizza plugins trust`).
+ * Used by the subagent extension to discover plugin-provided agents.
+ */
+export function getPluginAgentPaths(cwd: string): string[] {
+    // Start with global (auto-trusted) plugins
+    const globalPlugins = discoverPlugins(cwd);
+    const globalNames = new Set(globalPlugins.map(p => p.name));
+
+    // Same dedup logic as getPluginSkillPaths — prefer trusted candidates.
+    const localDirs = projectPluginDirs(cwd);
+    const localByName = new Map<string, DiscoveredPlugin>();
+    for (const dir of localDirs) {
+        for (const plugin of scanPluginsDir(dir)) {
+            if (globalNames.has(plugin.name)) continue;
+            const existing = localByName.get(plugin.name);
+            if (!existing) {
+                localByName.set(plugin.name, plugin);
+            } else if (!isPluginTrusted(existing.rootPath) && isPluginTrusted(plugin.rootPath)) {
+                localByName.set(plugin.name, plugin);
+            }
+        }
+    }
+    const trustedLocal = Array.from(localByName.values()).filter(p => isPluginTrusted(p.rootPath));
+
+    const paths: string[] = [];
+    for (const plugin of [...globalPlugins, ...trustedLocal]) {
+        if (plugin.agents.length > 0) {
+            paths.push(join(plugin.rootPath, "agents"));
+        }
+    }
+    return paths;
+}

--- a/packages/cli/src/extensions/subagent-agents.ts
+++ b/packages/cli/src/extensions/subagent-agents.ts
@@ -219,8 +219,12 @@ export function getUserAgentsDir(): string {
  *
  * When scope is "both" and a project agent has the same name as a user agent,
  * the project agent takes precedence (override pattern).
+ *
+ * @param opts.extraUserDirs - Additional directories to treat as user-scope
+ *   (e.g. plugin agents/ dirs). Loaded after ~/.pizzapi and ~/.claude, so
+ *   user-owned agents always take precedence.
  */
-export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryResult {
+export function discoverAgents(cwd: string, scope: AgentScope, opts?: { extraUserDirs?: string[] }): AgentDiscoveryResult {
     const userDirs = getUserAgentsDirs();
     const projectAgentsDirs = findNearestProjectAgentsDirs(cwd);
 
@@ -228,7 +232,8 @@ export function discoverAgents(cwd: string, scope: AgentScope): AgentDiscoveryRe
     let userAgents: AgentConfig[] = [];
     if (scope !== "project") {
         const seen = new Set<string>();
-        for (const dir of userDirs) {
+        const allUserDirs = [...userDirs, ...(opts?.extraUserDirs ?? [])];
+        for (const dir of allUserDirs) {
             for (const agent of loadAgentsFromDir(dir, "user")) {
                 if (!seen.has(agent.name)) {
                     seen.add(agent.name);

--- a/packages/cli/src/extensions/subagent.ts
+++ b/packages/cli/src/extensions/subagent.ts
@@ -38,6 +38,7 @@ import {
 } from "@mariozechner/pi-coding-agent";
 import { Container, Markdown, Spacer, Text } from "@mariozechner/pi-tui";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./subagent-agents.js";
+import { getPluginAgentPaths } from "./claude-plugins.js";
 import { defaultAgentDir } from "../config.js";
 
 // ── Constants ──────────────────────────────────────────────────────────
@@ -542,7 +543,8 @@ export const subagentExtension = (pi: ExtensionAPI) => {
                 cwd?: string;
             };
             const agentScope: AgentScope = params.agentScope ?? "user";
-            const discovery = discoverAgents(ctx.cwd, agentScope);
+            const pluginAgentDirs = getPluginAgentPaths(ctx.cwd);
+            const discovery = discoverAgents(ctx.cwd, agentScope, { extraUserDirs: pluginAgentDirs });
             const agents = discovery.agents;
             const confirmProjectAgents = params.confirmProjectAgents ?? true;
 

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -135,6 +135,13 @@ export interface PluginSkillRef {
     skillMdPath: string;
 }
 
+export interface PluginAgentRef {
+    /** Agent name (filename without .md extension) */
+    name: string;
+    /** Absolute path to the agent .md file */
+    filePath: string;
+}
+
 export interface PluginRule {
     /** Rule name (filename without .md extension) */
     name: string;
@@ -159,11 +166,13 @@ export interface DiscoveredPlugin {
     hooks: HooksConfig | null;
     /** Skills directories (passed through to pi — already compatible format) */
     skills: PluginSkillRef[];
+    /** Agent definitions (markdown files in agents/ directory) */
+    agents: PluginAgentRef[];
     /** Rules — markdown guidelines injected into the system prompt */
     rules: PluginRule[];
     /** Whether the plugin has MCP configuration (informational — not adapted) */
     hasMcp: boolean;
-    /** Whether the plugin has agent definitions (informational — not adapted) */
+    /** Whether the plugin has agent definitions */
     hasAgents: boolean;
     /** Whether the plugin has LSP configuration (informational — not adapted) */
     hasLsp: boolean;
@@ -542,6 +551,50 @@ export function parsePluginSkills(pluginDir: string): PluginSkillRef[] {
 }
 
 /**
+ * Discover agent definitions within a plugin's agents/ directory.
+ * Agents are markdown files (*.md) with frontmatter — same format
+ * as user agents in ~/.pizzapi/agents/ or ~/.claude/agents/.
+ */
+export function parsePluginAgents(pluginDir: string): PluginAgentRef[] {
+    const agentsDir = join(pluginDir, "agents");
+    if (!existsSync(agentsDir)) return [];
+
+    // Reject if agents/ itself is a symlink
+    try {
+        if (lstatSync(agentsDir).isSymbolicLink()) return [];
+    } catch { return []; }
+
+    const agents: PluginAgentRef[] = [];
+
+    let entries: string[];
+    try {
+        entries = readdirSync(agentsDir).slice(0, MAX_ENTRIES_PER_DIR);
+    } catch {
+        return [];
+    }
+
+    for (const entry of entries) {
+        if (!entry.endsWith(".md")) continue;
+
+        const filePath = join(agentsDir, entry);
+        try {
+            // Use lstatSync: skip symlinks and non-regular files
+            const s = lstatSync(filePath);
+            if (s.isSymbolicLink() || !s.isFile()) continue;
+        } catch {
+            continue;
+        }
+
+        agents.push({
+            name: entry.slice(0, -3), // Strip .md
+            filePath,
+        });
+    }
+
+    return agents;
+}
+
+/**
  * Discover rules within a plugin's rules/ directory.
  * Rules are markdown files containing guidelines injected into the system prompt.
  */
@@ -609,6 +662,9 @@ export function isPluginDir(dir: string): boolean {
     // Skills-only dirs are valid plugins — their SKILL.md entries are
     // added to pi via getPluginSkillPaths() and need to be discovered here.
     if (existsSync(join(dir, "skills"))) return true;
+    // Agents-only dirs are valid plugins — their agent .md files are
+    // discovered via getPluginAgentPaths() for the subagent extension.
+    if (existsSync(join(dir, "agents"))) return true;
     return false;
 }
 
@@ -621,6 +677,7 @@ export function parsePlugin(pluginDir: string): DiscoveredPlugin {
     const commands = parseCommands(rootPath);
     const hooks = parseHooks(rootPath);
     const skills = parsePluginSkills(rootPath);
+    const agents = parsePluginAgents(rootPath);
     const rules = parseRules(rootPath);
 
     return {
@@ -631,9 +688,10 @@ export function parsePlugin(pluginDir: string): DiscoveredPlugin {
         commands,
         hooks,
         skills,
+        agents,
         rules,
         hasMcp: existsSync(join(rootPath, ".mcp.json")),
-        hasAgents: existsSync(join(rootPath, "agents")),
+        hasAgents: agents.length > 0,
         hasLsp: existsSync(join(rootPath, ".lsp.json")),
     };
 }
@@ -797,6 +855,7 @@ export interface PluginInfo {
     commands: { name: string; description?: string; argumentHint?: string }[];
     hookEvents: string[];
     skills: { name: string; dirPath: string }[];
+    agents: { name: string }[];
     rules: { name: string }[];
     hasMcp: boolean;
     hasAgents: boolean;
@@ -825,6 +884,7 @@ export function toPluginInfo(plugin: DiscoveredPlugin): PluginInfo {
         })),
         hookEvents: plugin.hooks ? Object.keys(plugin.hooks.hooks) : [],
         skills: plugin.skills.map(s => ({ name: s.name, dirPath: s.dirPath })),
+        agents: plugin.agents.map(a => ({ name: a.name })),
         rules: plugin.rules.map(r => ({ name: r.name })),
         hasMcp: plugin.hasMcp,
         hasAgents: plugin.hasAgents,

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -161,6 +161,14 @@ import {
 } from "../skills.js";
 
 import {
+    type AgentMeta,
+    scanGlobalAgents,
+    readAgentContent,
+    writeAgent,
+    deleteAgent,
+} from "../agents.js";
+
+import {
     scanAllPluginInfo,
     type PluginInfo,
 } from "../plugins.js";
@@ -512,6 +520,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         // ── Helper: emit registration ─────────────────────────────────────
         const emitRegister = () => {
             const skills = scanGlobalSkills();
+            const agents = scanGlobalAgents();
             // Only include project-local plugins if daemon cwd is within allowed roots
             const plugins = scanAllPluginInfo(process.cwd(), { includeProjectLocal: isCwdAllowed(process.cwd()) });
             socket.emit("register_runner", {
@@ -520,6 +529,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 name: runnerName,
                 roots: getWorkspaceRoots(),
                 skills,
+                agents,
                 plugins,
                 version: cliVersion,
             });
@@ -873,6 +883,113 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 socket.emit("skill_result", { requestId, ok: false, message: "Skill not found" });
             } else {
                 socket.emit("skill_result", { requestId, ok: true, name: skillName, content });
+            }
+        });
+
+        // ── Agents management ──────────────────────────────────────────────
+
+        socket.on("list_agents", (data) => {
+            if (isShuttingDown) return;
+            const requestId = data.requestId;
+            const agents = scanGlobalAgents();
+            socket.emit("agents_list", { agents, requestId });
+        });
+
+        socket.on("create_agent", async (data) => {
+            if (isShuttingDown) return;
+            const requestId = data.requestId;
+            const agentName = (data.name ?? "").trim();
+            const agentContent = data.content ?? "";
+
+            if (!agentName) {
+                socket.emit("agent_result", { requestId, ok: false, message: "Missing agent name" });
+                return;
+            }
+
+            if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(agentName) && !/^[a-z0-9]$/.test(agentName)) {
+                socket.emit("agent_result", {
+                    requestId,
+                    ok: false,
+                    message: "Invalid agent name: must be lowercase letters, numbers, and hyphens only",
+                });
+                return;
+            }
+
+            try {
+                await writeAgent(agentName, agentContent);
+                const agents = scanGlobalAgents();
+                socket.emit("agent_result", { requestId, ok: true, agents });
+            } catch (err) {
+                socket.emit("agent_result", {
+                    requestId,
+                    ok: false,
+                    message: err instanceof Error ? err.message : String(err),
+                });
+            }
+        });
+
+        socket.on("update_agent", async (data) => {
+            if (isShuttingDown) return;
+            const requestId = data.requestId;
+            const agentName = (data.name ?? "").trim();
+            const agentContent = data.content ?? "";
+
+            if (!agentName) {
+                socket.emit("agent_result", { requestId, ok: false, message: "Missing agent name" });
+                return;
+            }
+
+            if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(agentName) && !/^[a-z0-9]$/.test(agentName)) {
+                socket.emit("agent_result", {
+                    requestId,
+                    ok: false,
+                    message: "Invalid agent name: must be lowercase letters, numbers, and hyphens only",
+                });
+                return;
+            }
+
+            try {
+                await writeAgent(agentName, agentContent);
+                const agents = scanGlobalAgents();
+                socket.emit("agent_result", { requestId, ok: true, agents });
+            } catch (err) {
+                socket.emit("agent_result", {
+                    requestId,
+                    ok: false,
+                    message: err instanceof Error ? err.message : String(err),
+                });
+            }
+        });
+
+        socket.on("delete_agent", (data) => {
+            if (isShuttingDown) return;
+            const requestId = data.requestId;
+            const agentName = (data.name ?? "").trim();
+
+            if (!agentName) {
+                socket.emit("agent_result", { requestId, ok: false, message: "Missing agent name" });
+                return;
+            }
+
+            const deleted = deleteAgent(agentName);
+            const agents = scanGlobalAgents();
+            socket.emit("agent_result", {
+                requestId,
+                ok: deleted,
+                message: deleted ? undefined : "Agent not found",
+                agents,
+            });
+        });
+
+        socket.on("get_agent", (data) => {
+            if (isShuttingDown) return;
+            const requestId = data.requestId;
+            const agentName = (data.name ?? "").trim();
+            const content = agentName ? readAgentContent(agentName) : null;
+            if (content === null) {
+                socket.emit("agent_result", { requestId, ok: false, message: "Agent not found" });
+            } else {
+                socket.emit("agent_result", { requestId, ok: true, name: agentName, content });
             }
         });
 

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -939,11 +939,14 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 return;
             }
 
-            if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(agentName) && !/^[a-z0-9]$/.test(agentName)) {
+            // Relaxed validation for updates: accept any name the scanner
+            // can discover (letters, digits, hyphens, underscores, dots)
+            // but reject path separators to prevent directory traversal.
+            if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(agentName)) {
                 socket.emit("agent_result", {
                     requestId,
                     ok: false,
-                    message: "Invalid agent name: must be lowercase letters, numbers, and hyphens only",
+                    message: "Invalid agent name: must start with a letter or digit and contain only letters, digits, hyphens, underscores, or dots",
                 });
                 return;
             }

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -10,6 +10,7 @@ export type {
   ModelInfo,
   RunnerInfo,
   RunnerSkill,
+  RunnerAgent,
   RunnerPlugin,
   Attachment,
 } from "./shared.js";

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -2,7 +2,7 @@
 // /runner namespace — Runner daemon ↔ Server
 // ============================================================================
 
-import type { RunnerSkill, RunnerPlugin } from "./shared.js";
+import type { RunnerSkill, RunnerAgent, RunnerPlugin } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Client → Server (Runner daemon sends to server)
@@ -16,6 +16,7 @@ export interface RunnerClientToServerEvents {
     runnerId?: string;
     runnerSecret?: string;
     skills?: RunnerSkill[];
+    agents?: RunnerAgent[];
     plugins?: RunnerPlugin[];
     version?: string;
   }) => void;
@@ -35,6 +36,22 @@ export interface RunnerClientToServerEvents {
     message?: string;
     /** true when this was a per-cwd scoped scan (should not overwrite global cache) */
     scoped?: boolean;
+  }) => void;
+
+  /** Runner responds with its list of agents */
+  agents_list: (data: {
+    agents: RunnerAgent[];
+    requestId?: string;
+  }) => void;
+
+  /** Runner responds to an agent CRUD operation */
+  agent_result: (data: {
+    requestId?: string;
+    ok: boolean;
+    message?: string;
+    agents?: RunnerAgent[];
+    content?: string;
+    name?: string;
   }) => void;
 
   /** Runner responds to a skill CRUD operation */
@@ -185,6 +202,37 @@ export interface RunnerServerToClientEvents {
 
   /** Requests a list of active terminals */
   list_terminals: (data: Record<string, never>) => void;
+
+  /** Requests a list of agents */
+  list_agents: (data: {
+    requestId?: string;
+  }) => void;
+
+  /** Creates a new agent */
+  create_agent: (data: {
+    requestId?: string;
+    name: string;
+    content: string;
+  }) => void;
+
+  /** Updates an existing agent */
+  update_agent: (data: {
+    requestId?: string;
+    name: string;
+    content: string;
+  }) => void;
+
+  /** Deletes an agent */
+  delete_agent: (data: {
+    requestId?: string;
+    name: string;
+  }) => void;
+
+  /** Reads an agent's content */
+  get_agent: (data: {
+    requestId?: string;
+    name: string;
+  }) => void;
 
   /** Requests a list of skills */
   list_skills: (data: {

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -35,6 +35,7 @@ export interface RunnerInfo {
   roots: string[];
   sessionCount: number;
   skills: RunnerSkill[];
+  agents: RunnerAgent[];
   plugins?: RunnerPlugin[];
   version: string | null;
 }
@@ -57,6 +58,13 @@ export interface RunnerPlugin {
 
 /** A skill available on a runner */
 export interface RunnerSkill {
+  name: string;
+  description: string;
+  filePath: string;
+}
+
+/** An agent definition available on a runner */
+export interface RunnerAgent {
   name: string;
   description: string;
   filePath: string;

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -48,6 +48,7 @@ export interface RunnerPlugin {
   commands: { name: string; description?: string; argumentHint?: string }[];
   hookEvents: string[];
   skills: { name: string; dirPath: string }[];
+  agents?: { name: string }[];
   rules?: { name: string }[];
   hasMcp: boolean;
   hasAgents: boolean;

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -13,7 +13,7 @@ import {
     recordRunnerSession,
     registerTerminal,
 } from "../ws/sio-registry.js";
-import { sendSkillCommand, sendRunnerCommand } from "../ws/namespaces/runner.js";
+import { sendSkillCommand, sendAgentCommand, sendRunnerCommand } from "../ws/namespaces/runner.js";
 import { waitForSpawnAck } from "../ws/runner-control.js";
 import { requireSession, validateApiKey } from "../middleware.js";
 import { getRecentFolders, recordRecentFolder } from "../runner-recent-folders.js";
@@ -291,6 +291,89 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
             } catch (err) {
                 console.error(`[skills] DELETE ${skillName} failed:`, err);
                 return Response.json({ error: "Failed to delete skill" }, { status: 502 });
+            }
+        }
+
+        return undefined;
+    }
+
+    // ── Agents (agent definitions) ───────────────────────────────────
+    const agentsMatch = url.pathname.match(/^\/api\/runners\/([^/]+)\/agents(?:\/([^/]+))?$/);
+    if (agentsMatch) {
+        const identity = await requireSession(req);
+        if (identity instanceof Response) return identity;
+
+        const runnerId = decodeURIComponent(agentsMatch[1]);
+        const agentName = agentsMatch[2] ? decodeURIComponent(agentsMatch[2]) : undefined;
+
+        const runner = await getRunnerData(runnerId);
+        if (!runner) return Response.json({ error: "Runner not found" }, { status: 404 });
+        if (runner.userId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
+
+        // GET /api/runners/:id/agents — list agents (from Redis cache)
+        if (req.method === "GET" && !agentName) {
+            return Response.json({ agents: parseJsonArray(runner.agents) });
+        }
+
+        // GET /api/runners/:id/agents/:name — get full agent content
+        if (req.method === "GET" && agentName) {
+            if (!isValidSkillName(agentName)) return Response.json({ error: "Invalid agent name" }, { status: 400 });
+            try {
+                const result = await sendAgentCommand(runnerId, { type: "get_agent", name: agentName });
+                if (!result.ok) return Response.json({ error: result.message ?? "Agent not found" }, { status: 404 });
+                return Response.json({ name: result.name, content: result.content });
+            } catch (err) {
+                console.error(`[agents] GET ${agentName} failed:`, err);
+                return Response.json({ error: "Failed to retrieve agent" }, { status: 502 });
+            }
+        }
+
+        // POST /api/runners/:id/agents — create a new agent
+        if (req.method === "POST" && !agentName) {
+            let body: any = {};
+            try { body = await req.json(); } catch {}
+            const name = typeof body.name === "string" ? body.name.trim() : "";
+            const content = typeof body.content === "string" ? body.content : "";
+
+            if (!name) return Response.json({ error: "Missing agent name" }, { status: 400 });
+            if (!isValidSkillName(name)) return Response.json({ error: "Invalid agent name" }, { status: 400 });
+
+            try {
+                const result = await sendAgentCommand(runnerId, { type: "create_agent", name, content });
+                if (!result.ok) return Response.json({ error: result.message ?? "Failed to create agent" }, { status: 400 });
+                return Response.json({ ok: true, agents: result.agents ?? [] });
+            } catch (err) {
+                console.error(`[agents] POST ${name} failed:`, err);
+                return Response.json({ error: "Failed to create agent" }, { status: 502 });
+            }
+        }
+
+        // PUT /api/runners/:id/agents/:name — update an agent
+        if (req.method === "PUT" && agentName) {
+            if (!isValidSkillName(agentName)) return Response.json({ error: "Invalid agent name" }, { status: 400 });
+            let body: any = {};
+            try { body = await req.json(); } catch {}
+            const content = typeof body.content === "string" ? body.content : "";
+            try {
+                const result = await sendAgentCommand(runnerId, { type: "update_agent", name: agentName, content });
+                if (!result.ok) return Response.json({ error: result.message ?? "Failed to update agent" }, { status: 400 });
+                return Response.json({ ok: true, agents: result.agents ?? [] });
+            } catch (err) {
+                console.error(`[agents] PUT ${agentName} failed:`, err);
+                return Response.json({ error: "Failed to update agent" }, { status: 502 });
+            }
+        }
+
+        // DELETE /api/runners/:id/agents/:name — delete an agent
+        if (req.method === "DELETE" && agentName) {
+            if (!isValidSkillName(agentName)) return Response.json({ error: "Invalid agent name" }, { status: 400 });
+            try {
+                const result = await sendAgentCommand(runnerId, { type: "delete_agent", name: agentName });
+                if (!result.ok) return Response.json({ error: result.message ?? "Agent not found" }, { status: 404 });
+                return Response.json({ ok: true, agents: result.agents ?? [] });
+            } catch (err) {
+                console.error(`[agents] DELETE ${agentName} failed:`, err);
+                return Response.json({ error: "Failed to delete agent" }, { status: 502 });
             }
         }
 

--- a/packages/server/src/ws/namespaces/index.ts
+++ b/packages/server/src/ws/namespaces/index.ts
@@ -14,4 +14,4 @@ export function registerNamespaces(io: SocketIOServer): void {
 }
 
 // Re-export runner command functions for use by REST API routes
-export { sendSkillCommand, sendRunnerCommand } from "./runner.js";
+export { sendSkillCommand, sendAgentCommand, sendRunnerCommand } from "./runner.js";

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -17,11 +17,13 @@ import type {
     RunnerInterServerEvents,
     RunnerSocketData,
     RunnerSkill,
+    RunnerAgent,
 } from "@pizzapi/protocol";
 import { apiKeyAuthMiddleware } from "./auth.js";
 import {
     registerRunner,
     updateRunnerSkills,
+    updateRunnerAgents,
     updateRunnerPlugins,
     publishSessionEvent,
     recordRunnerSession,
@@ -90,6 +92,58 @@ export async function sendSkillCommand(
         } catch (err) {
             clearTimeout(timer);
             pendingSkillRequests.delete(requestId);
+            reject(err);
+        }
+    });
+}
+
+// ── Agent request/response registry ──────────────────────────────────────────
+// Maps requestId → { resolve, timer }. Used to correlate agent command
+// responses (agent_result) from the runner back to the HTTP request handler.
+
+interface PendingAgentRequest {
+    resolve: (result: {
+        ok: boolean;
+        message?: string;
+        agents?: RunnerAgent[];
+        content?: string;
+        name?: string;
+    }) => void;
+    timer: ReturnType<typeof setTimeout>;
+}
+
+const pendingAgentRequests = new Map<string, PendingAgentRequest>();
+
+/**
+ * Send an agent command to a runner via Socket.IO and wait for the response.
+ * Returns the runner's agent_result payload or throws on timeout.
+ */
+export async function sendAgentCommand(
+    runnerId: string,
+    command: Record<string, unknown>,
+    timeoutMs = 10_000,
+): Promise<{ ok: boolean; message?: string; agents?: RunnerAgent[]; content?: string; name?: string }> {
+    const socket = getLocalRunnerSocket(runnerId);
+    if (!socket) throw new Error("Runner not found");
+
+    const requestId = Math.random().toString(36).slice(2) + Date.now().toString(36);
+    const eventName = typeof command.type === "string" ? command.type : "";
+    if (!eventName) throw new Error("Missing command type");
+
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            pendingAgentRequests.delete(requestId);
+            reject(new Error("Agent command timed out"));
+        }, timeoutMs);
+
+        pendingAgentRequests.set(requestId, { resolve, timer });
+
+        try {
+            const { type: _type, ...rest } = command;
+            (socket as Socket).emit(eventName, { ...rest, requestId });
+        } catch (err) {
+            clearTimeout(timer);
+            pendingAgentRequests.delete(requestId);
             reject(err);
         }
     });
@@ -253,6 +307,51 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             // If the runner also sent an updated skills list, persist it
             if (socket.data.runnerId && data.skills) {
                 await updateRunnerSkills(socket.data.runnerId, data.skills);
+            }
+        });
+
+        // ── agents_list — runner reports updated agents ──────────────────────
+        socket.on("agents_list", async (data) => {
+            const runnerId = socket.data.runnerId;
+            const agents = data.agents ?? [];
+
+            if (runnerId) {
+                await updateRunnerAgents(runnerId, agents);
+            }
+
+            // Resolve pending agent request if any
+            const requestId = data.requestId;
+            if (requestId) {
+                const pending = pendingAgentRequests.get(requestId);
+                if (pending) {
+                    clearTimeout(pending.timer);
+                    pendingAgentRequests.delete(requestId);
+                    pending.resolve({ ok: true, agents });
+                }
+            }
+        });
+
+        // ── agent_result — runner responds to agent CRUD ─────────────────────
+        socket.on("agent_result", async (data) => {
+            const requestId = data.requestId;
+            if (requestId) {
+                const pending = pendingAgentRequests.get(requestId);
+                if (pending) {
+                    clearTimeout(pending.timer);
+                    pendingAgentRequests.delete(requestId);
+                    pending.resolve({
+                        ok: data.ok,
+                        message: data.message,
+                        agents: data.agents,
+                        content: data.content,
+                        name: data.name,
+                    });
+                }
+            }
+
+            // If the runner also sent an updated agents list, persist it
+            if (socket.data.runnerId && data.agents) {
+                await updateRunnerAgents(socket.data.runnerId, data.agents);
             }
         });
 

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -227,6 +227,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             const requestedRunnerId = data.runnerId;
             const runnerSecret = data.runnerSecret;
             const skills = data.skills ?? [];
+            const agents = data.agents ?? [];
             const plugins = data.plugins ?? [];
             const version = data.version ?? null;
 
@@ -236,6 +237,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 requestedRunnerId,
                 runnerSecret,
                 skills,
+                agents,
                 plugins,
                 version,
                 userId: (socket.data as RunnerSocketData & { userId?: string }).userId ?? null,

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -871,6 +871,7 @@ function normalizePlugin(raw: Record<string, unknown>): Record<string, unknown> 
         commands: Array.isArray(raw.commands) ? raw.commands.filter((c: unknown) => c && typeof c === "object") : [],
         hookEvents: Array.isArray(raw.hookEvents) ? raw.hookEvents.filter((e: unknown) => typeof e === "string") : [],
         skills: Array.isArray(raw.skills) ? raw.skills.filter((s: unknown) => s && typeof s === "object") : [],
+        agents: Array.isArray(raw.agents) ? raw.agents.filter((a: unknown) => a && typeof a === "object") : undefined,
         rules: Array.isArray(raw.rules)
             ? raw.rules.filter((r: unknown): r is { name: string } => r !== null && typeof r === "object" && typeof (r as any).name === "string")
             : undefined,

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -57,7 +57,7 @@ import {
     touchRelaySession,
 } from "../sessions/store.js";
 import { appendRelayEventToCache } from "../sessions/redis.js";
-import type { ModelInfo, RunnerSkill, SessionInfo, RunnerInfo } from "@pizzapi/protocol";
+import type { ModelInfo, RunnerSkill, RunnerAgent, SessionInfo, RunnerInfo } from "@pizzapi/protocol";
 
 // ── Socket.IO server reference ──────────────────────────────────────────────
 
@@ -169,6 +169,18 @@ function normalizeSkills(raw: unknown): RunnerSkill[] {
             filePath: typeof s.filePath === "string" ? s.filePath : "",
         }))
         .filter((s) => s.name.length > 0);
+}
+
+function normalizeAgents(raw: unknown): RunnerAgent[] {
+    if (!Array.isArray(raw)) return [];
+    return raw
+        .filter((a): a is Record<string, unknown> => a !== null && typeof a === "object")
+        .map((a) => ({
+            name: typeof a.name === "string" ? a.name : "",
+            description: typeof a.description === "string" ? a.description : "",
+            filePath: typeof a.filePath === "string" ? a.filePath : "",
+        }))
+        .filter((a) => a.name.length > 0);
 }
 
 // ── Hub broadcasting ────────────────────────────────────────────────────────
@@ -760,6 +772,7 @@ export interface RegisterRunnerOpts {
     requestedRunnerId?: string;
     runnerSecret?: string;
     skills?: RunnerSkill[];
+    agents?: RunnerAgent[];
     plugins?: unknown[];
     userId?: string | null;
     userName?: string | null;
@@ -805,6 +818,7 @@ export async function registerRunner(
         .filter(Boolean);
 
     const skills = normalizeSkills(opts.skills);
+    const agents = normalizeAgents(opts.agents);
     const plugins = Array.isArray(opts.plugins)
         ? opts.plugins
             .filter((p): p is Record<string, unknown> => p !== null && typeof p === "object")
@@ -819,6 +833,7 @@ export async function registerRunner(
         name: opts.name?.trim() || null,
         roots: JSON.stringify(roots),
         skills: JSON.stringify(skills),
+        agents: JSON.stringify(agents),
         plugins: JSON.stringify(plugins),
         version: typeof opts.version === "string" ? opts.version : null,
     };
@@ -833,6 +848,12 @@ export async function registerRunner(
 export async function updateRunnerSkills(runnerId: string, skills: RunnerSkill[]): Promise<void> {
     const normalized = normalizeSkills(skills);
     await updateRunnerFields(runnerId, { skills: JSON.stringify(normalized) });
+}
+
+/** Update agents for an already-registered runner. */
+export async function updateRunnerAgents(runnerId: string, agents: RunnerAgent[]): Promise<void> {
+    const normalized = normalizeAgents(agents);
+    await updateRunnerFields(runnerId, { agents: JSON.stringify(normalized) });
 }
 
 /**
@@ -975,6 +996,7 @@ export async function getRunners(filterUserId?: string): Promise<RunnerInfo[]> {
             roots: safeJsonParse(r.roots) ?? [],
             sessionCount: sessionCounts.get(r.runnerId) ?? 0,
             skills: safeJsonParse(r.skills) ?? [],
+            agents: safeJsonParse(r.agents ?? "[]") ?? [],
             plugins: safeJsonParse(r.plugins ?? "[]") ?? [],
             version: r.version ?? null,
         });

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -145,6 +145,8 @@ export interface RedisRunnerData {
     roots: string;
     /** JSON-stringified RunnerSkill[] */
     skills: string;
+    /** JSON-stringified RunnerAgent[] */
+    agents?: string;
     /** JSON-stringified PluginInfo[] — discovered Claude Code plugins */
     plugins?: string;
     /** Runner CLI version (e.g. "0.1.30") */
@@ -213,6 +215,7 @@ function parseRunnerFromHash(hash: Record<string, string>): RedisRunnerData | nu
         name: hash.name || null,
         roots: hash.roots || "[]",
         skills: hash.skills || "[]",
+        agents: hash.agents || "[]",
         plugins: hash.plugins || "[]",
         version: hash.version || null,
     };

--- a/packages/ui/src/components/AgentsManager.tsx
+++ b/packages/ui/src/components/AgentsManager.tsx
@@ -175,8 +175,14 @@ function AgentEditorDialog({ runnerId, open, agent, onClose, onSaved }: AgentEdi
             return;
         }
 
-        // Validate name
-        if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(trimmedName)) {
+        // Validate name — strict for new agents, relaxed for edits (discovered
+        // agents may have uppercase, underscores, or dots in their names)
+        if (isEditing) {
+            if (!/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(trimmedName)) {
+                setError("Invalid agent name");
+                return;
+            }
+        } else if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(trimmedName)) {
             setError("Name must contain only lowercase letters, numbers, and hyphens");
             return;
         }

--- a/packages/ui/src/components/AgentsManager.tsx
+++ b/packages/ui/src/components/AgentsManager.tsx
@@ -1,0 +1,510 @@
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog";
+import {
+    Bot,
+    Loader2,
+    Plus,
+    Pencil,
+    Trash2,
+    ChevronDown,
+    Wand2,
+} from "lucide-react";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface AgentInfo {
+    name: string;
+    description: string;
+    filePath: string;
+}
+
+export interface AgentsManagerProps {
+    runnerId: string;
+    /** Initial agent list (already fetched by parent) */
+    agents: AgentInfo[];
+    /** Called when agents change so the parent can update its state */
+    onAgentsChange?: (agents: AgentInfo[]) => void;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function buildDefaultAgentContent(name: string, description: string): string {
+    return `---
+name: ${name}
+description: ${description || `A custom agent named ${name}.`}
+tools: read,bash,edit,write
+---
+
+# ${name}
+
+You are a specialized agent. Describe your role and behavior here.
+
+## Guidelines
+
+- What this agent is responsible for
+- How it should approach tasks
+- What tools it should use
+- What output format to follow
+`;
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+interface AgentRowProps {
+    agent: AgentInfo;
+    onEdit: (agent: AgentInfo) => void;
+    onDelete: (agent: AgentInfo) => void;
+    deleting: boolean;
+}
+
+function AgentRow({ agent, onEdit, onDelete, deleting }: AgentRowProps) {
+    return (
+        <div className="flex items-start justify-between gap-3 px-3 py-2.5 rounded-lg border border-border/40 bg-muted/20 hover:bg-muted/40 transition-colors group">
+            <div className="flex items-start gap-2.5 min-w-0">
+                <Bot className="h-3.5 w-3.5 mt-0.5 flex-shrink-0 text-primary/60" />
+                <div className="min-w-0">
+                    <p className="text-xs font-semibold font-mono truncate text-foreground">{agent.name}</p>
+                    {agent.description && (
+                        <p className="text-[11px] text-muted-foreground mt-0.5 line-clamp-2">{agent.description}</p>
+                    )}
+                </div>
+            </div>
+            <div className="flex items-center gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="h-6 w-6 text-muted-foreground hover:text-foreground"
+                    onClick={() => onEdit(agent)}
+                    title="Edit agent"
+                >
+                    <Pencil className="h-3 w-3" />
+                </Button>
+                <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                    onClick={() => onDelete(agent)}
+                    disabled={deleting}
+                    title="Delete agent"
+                >
+                    {deleting ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                    ) : (
+                        <Trash2 className="h-3 w-3" />
+                    )}
+                </Button>
+            </div>
+        </div>
+    );
+}
+
+// ── Agent editor dialog ───────────────────────────────────────────────────────
+
+interface AgentEditorDialogProps {
+    runnerId: string;
+    open: boolean;
+    /** null = creating new, AgentInfo = editing existing */
+    agent: AgentInfo | null;
+    onClose: () => void;
+    onSaved: (updatedAgents: AgentInfo[]) => void;
+}
+
+function AgentEditorDialog({ runnerId, open, agent, onClose, onSaved }: AgentEditorDialogProps) {
+    const isEditing = agent !== null;
+
+    const [name, setName] = React.useState("");
+    const [content, setContent] = React.useState("");
+    const [saving, setSaving] = React.useState(false);
+    const [loadingContent, setLoadingContent] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+
+    // When dialog opens, populate fields
+    React.useEffect(() => {
+        if (!open) return;
+
+        if (!isEditing) {
+            setName("");
+            setContent("");
+            setError(null);
+            return;
+        }
+
+        // Load existing content from the runner
+        setLoadingContent(true);
+        setError(null);
+        setName(agent.name);
+        setContent("");
+
+        fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents/${encodeURIComponent(agent.name)}`, {
+            credentials: "include",
+        })
+            .then((res) => (res.ok ? res.json() : res.json().then((b: any) => Promise.reject(new Error(b?.error ?? `HTTP ${res.status}`)))))
+            .then((data: any) => {
+                setContent(typeof data.content === "string" ? data.content : "");
+            })
+            .catch((err: Error) => {
+                setError(err.message);
+            })
+            .finally(() => setLoadingContent(false));
+    }, [open, isEditing, agent, runnerId]);
+
+    const handleGenerateTemplate = () => {
+        const descMatch = content.match(/^description:\s*(.+)$/m);
+        const desc = descMatch ? descMatch[1].trim().replace(/^["']|["']$/g, "") : "";
+        setContent(buildDefaultAgentContent(name || "my-agent", desc));
+    };
+
+    const handleSave = async () => {
+        const trimmedName = name.trim();
+        if (!trimmedName) {
+            setError("Agent name is required");
+            return;
+        }
+
+        // Validate name
+        if (!/^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/.test(trimmedName)) {
+            setError("Name must contain only lowercase letters, numbers, and hyphens");
+            return;
+        }
+
+        setSaving(true);
+        setError(null);
+
+        try {
+            const url = isEditing
+                ? `/api/runners/${encodeURIComponent(runnerId)}/agents/${encodeURIComponent(trimmedName)}`
+                : `/api/runners/${encodeURIComponent(runnerId)}/agents`;
+
+            const method = isEditing ? "PUT" : "POST";
+            const body = isEditing
+                ? JSON.stringify({ content })
+                : JSON.stringify({ name: trimmedName, content });
+
+            const res = await fetch(url, {
+                method,
+                headers: { "Content-Type": "application/json" },
+                body,
+                credentials: "include",
+            });
+
+            const data = await res.json().catch(() => null) as any;
+            if (!res.ok) {
+                setError(data?.error ?? `Failed to save agent (HTTP ${res.status})`);
+                return;
+            }
+
+            onSaved(Array.isArray(data?.agents) ? data.agents : []);
+            onClose();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => { if (!o) onClose(); }}>
+            <DialogContent className="sm:max-w-2xl max-h-[90vh] flex flex-col">
+                <DialogHeader>
+                    <DialogTitle>{isEditing ? `Edit agent: ${agent?.name}` : "New Agent"}</DialogTitle>
+                    <DialogDescription>
+                        {isEditing
+                            ? "Edit the agent definition markdown file."
+                            : "Create a new agent definition in ~/.pizzapi/agents/."}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="flex flex-col gap-4 flex-1 min-h-0 overflow-y-auto py-1">
+                    {/* Name (only editable when creating) */}
+                    {!isEditing && (
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="agent-name" className="text-sm">
+                                Agent name
+                                <span className="ml-1 text-muted-foreground font-normal">(lowercase, hyphens)</span>
+                            </Label>
+                            <Input
+                                id="agent-name"
+                                placeholder="my-agent"
+                                value={name}
+                                onChange={(e) => setName(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ""))}
+                                className="font-mono text-sm"
+                                disabled={saving}
+                            />
+                        </div>
+                    )}
+
+                    {/* Agent markdown content */}
+                    <div className="flex flex-col gap-1.5 flex-1 min-h-0">
+                        <div className="flex items-center justify-between">
+                            <Label htmlFor="agent-content" className="text-sm">
+                                Agent definition
+                            </Label>
+                            {!isEditing && (
+                                <Button
+                                    type="button"
+                                    variant="ghost"
+                                    size="sm"
+                                    className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+                                    onClick={handleGenerateTemplate}
+                                    disabled={saving}
+                                >
+                                    <Wand2 className="h-3 w-3 mr-1" />
+                                    Generate template
+                                </Button>
+                            )}
+                        </div>
+
+                        {loadingContent ? (
+                            <div className="flex items-center gap-2 text-xs text-muted-foreground py-4">
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                Loading agent content…
+                            </div>
+                        ) : (
+                            <textarea
+                                id="agent-content"
+                                className={cn(
+                                    "flex-1 min-h-[280px] w-full rounded-md border border-input bg-background px-3 py-2",
+                                    "font-mono text-xs resize-y focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+                                    "placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
+                                )}
+                                placeholder={`---\nname: my-agent\ndescription: What this agent does.\ntools: read,bash,edit,write\n---\n\n# My Agent\n\nDescribe the agent's role and behavior here.\n`}
+                                value={content}
+                                onChange={(e) => setContent(e.target.value)}
+                                disabled={saving}
+                                spellCheck={false}
+                            />
+                        )}
+                    </div>
+
+                    {error && <ErrorAlert>{error}</ErrorAlert>}
+                </div>
+
+                <DialogFooter>
+                    <Button variant="ghost" onClick={onClose} disabled={saving}>
+                        Cancel
+                    </Button>
+                    <Button onClick={handleSave} disabled={saving || loadingContent}>
+                        {saving ? (
+                            <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                Saving…
+                            </>
+                        ) : (
+                            <>
+                                <Bot className="mr-2 h-4 w-4" />
+                                {isEditing ? "Save Changes" : "Create Agent"}
+                            </>
+                        )}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+// ── Delete confirmation dialog ────────────────────────────────────────────────
+
+interface DeleteAgentDialogProps {
+    runnerId: string;
+    agent: AgentInfo | null;
+    onClose: () => void;
+    onDeleted: (updatedAgents: AgentInfo[]) => void;
+}
+
+function DeleteAgentDialog({ runnerId, agent, onClose, onDeleted }: DeleteAgentDialogProps) {
+    const [deleting, setDeleting] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+
+    const handleDelete = async () => {
+        if (!agent) return;
+        setDeleting(true);
+        setError(null);
+
+        try {
+            const res = await fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents/${encodeURIComponent(agent.name)}`, {
+                method: "DELETE",
+                credentials: "include",
+            });
+            const data = await res.json().catch(() => null) as any;
+            if (!res.ok) {
+                setError(data?.error ?? `Failed to delete agent (HTTP ${res.status})`);
+                return;
+            }
+            onDeleted(Array.isArray(data?.agents) ? data.agents : []);
+            onClose();
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setDeleting(false);
+        }
+    };
+
+    return (
+        <Dialog open={agent !== null} onOpenChange={(o) => { if (!o) onClose(); }}>
+            <DialogContent className="sm:max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>Delete agent</DialogTitle>
+                    <DialogDescription>
+                        Are you sure you want to delete{" "}
+                        <span className="font-mono font-semibold text-foreground">{agent?.name}</span>?
+                        This will remove the agent definition from the runner.
+                    </DialogDescription>
+                </DialogHeader>
+
+                {error && <ErrorAlert>{error}</ErrorAlert>}
+
+                <DialogFooter>
+                    <Button variant="ghost" onClick={onClose} disabled={deleting}>
+                        Cancel
+                    </Button>
+                    <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+                        {deleting ? (
+                            <>
+                                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                Deleting…
+                            </>
+                        ) : (
+                            <>
+                                <Trash2 className="mr-2 h-4 w-4" />
+                                Delete
+                            </>
+                        )}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export function AgentsManager({ runnerId, agents: initialAgents, onAgentsChange }: AgentsManagerProps) {
+    const [agents, setAgents] = React.useState<AgentInfo[]>(initialAgents);
+    const [open, setOpen] = React.useState(false);
+
+    // Editor dialog state
+    const [editorOpen, setEditorOpen] = React.useState(false);
+    const [editingAgent, setEditingAgent] = React.useState<AgentInfo | null>(null);
+
+    // Delete dialog state
+    const [deletingAgent, setDeletingAgent] = React.useState<AgentInfo | null>(null);
+    const [pendingDelete, setPendingDelete] = React.useState<string | null>(null);
+
+    // Keep in sync with parent
+    React.useEffect(() => {
+        setAgents(initialAgents);
+    }, [initialAgents]);
+
+    const handleAgentsChange = (updated: AgentInfo[]) => {
+        setAgents(updated);
+        onAgentsChange?.(updated);
+    };
+
+    const handleEdit = (agent: AgentInfo) => {
+        setEditingAgent(agent);
+        setEditorOpen(true);
+    };
+
+    const handleDeleteRequest = (agent: AgentInfo) => {
+        setPendingDelete(agent.name);
+        setDeletingAgent(agent);
+    };
+
+    const handleNewAgent = () => {
+        setEditingAgent(null);
+        setEditorOpen(true);
+    };
+
+    return (
+        <>
+            <Collapsible open={open} onOpenChange={setOpen}>
+                <div className="flex items-center justify-between mt-3">
+                    <CollapsibleTrigger className="flex items-center gap-1.5 text-left group/trigger">
+                        <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+                            Agents
+                        </span>
+                        <Badge
+                            variant="secondary"
+                            className="h-4 px-1.5 text-[10px] font-mono rounded-sm"
+                        >
+                            {agents.length}
+                        </Badge>
+                        <ChevronDown
+                            className={cn(
+                                "h-3 w-3 text-muted-foreground/60 transition-transform duration-200",
+                                open && "rotate-180"
+                            )}
+                        />
+                    </CollapsibleTrigger>
+
+                    <Button
+                        variant="ghost"
+                        size="sm"
+                        className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+                        onClick={handleNewAgent}
+                    >
+                        <Plus className="h-3 w-3 mr-1" />
+                        New agent
+                    </Button>
+                </div>
+
+                <CollapsibleContent>
+                    <div className="mt-2 flex flex-col gap-1.5">
+                        {agents.length === 0 ? (
+                            <div className="flex flex-col items-center gap-2 py-5 text-center">
+                                <Bot className="h-5 w-5 text-muted-foreground/40" />
+                                <div className="space-y-0.5">
+                                    <p className="text-xs font-medium text-muted-foreground">No agents yet</p>
+                                    <p className="text-[11px] text-muted-foreground/60 max-w-[200px]">
+                                        Add an agent .md file to{" "}
+                                        <span className="font-mono">~/.pizzapi/agents/</span>{" "}
+                                        or click &ldquo;New agent&rdquo; above.
+                                    </p>
+                                </div>
+                            </div>
+                        ) : (
+                            agents.map((agent) => (
+                                <AgentRow
+                                    key={agent.name}
+                                    agent={agent}
+                                    onEdit={handleEdit}
+                                    onDelete={handleDeleteRequest}
+                                    deleting={pendingDelete === agent.name}
+                                />
+                            ))
+                        )}
+                    </div>
+                </CollapsibleContent>
+            </Collapsible>
+
+            <AgentEditorDialog
+                runnerId={runnerId}
+                open={editorOpen}
+                agent={editingAgent}
+                onClose={() => { setEditorOpen(false); setEditingAgent(null); }}
+                onSaved={(updated) => { handleAgentsChange(updated); }}
+            />
+
+            <DeleteAgentDialog
+                runnerId={runnerId}
+                agent={deletingAgent}
+                onClose={() => { setDeletingAgent(null); setPendingDelete(null); }}
+                onDeleted={(updated) => { handleAgentsChange(updated); setPendingDelete(null); }}
+            />
+        </>
+    );
+}

--- a/packages/ui/src/components/PluginsManager.tsx
+++ b/packages/ui/src/components/PluginsManager.tsx
@@ -39,6 +39,7 @@ export interface PluginInfo {
     commands: PluginCommand[];
     hookEvents: string[];
     skills: { name: string; dirPath: string }[];
+    agents?: { name: string }[];
     rules: { name: string }[];
     hasMcp: boolean;
     hasAgents: boolean;
@@ -104,12 +105,7 @@ function PluginRow({ plugin, onClick }: PluginRowProps) {
                         <PluginCapBadge icon={Zap} label={plugin.hookEvents.length === 1 ? "hook" : "hooks"} count={plugin.hookEvents.length} />
                         <PluginCapBadge icon={BookOpen} label={plugin.skills.length === 1 ? "skill" : "skills"} count={plugin.skills.length} />
                         <PluginCapBadge icon={FileText} label={(plugin.rules?.length ?? 0) === 1 ? "rule" : "rules"} count={plugin.rules?.length ?? 0} />
-                        {plugin.hasAgents && (
-                            <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
-                                <Bot className="h-2.5 w-2.5" />
-                                Agents
-                            </span>
-                        )}
+                        <PluginCapBadge icon={Bot} label={(plugin.agents?.length ?? 0) === 1 ? "agent" : "agents"} count={plugin.agents?.length ?? 0} />
                         {plugin.hasMcp && <UnsupportedBadge label="MCP" />}
                     </div>
                 </div>
@@ -238,6 +234,29 @@ function PluginDetailDialog({ plugin, onClose }: PluginDetailDialogProps) {
                                         className="px-2.5 py-1.5 rounded-md bg-muted/30 border border-border/30"
                                     >
                                         <span className="text-[11px] font-mono text-foreground">{skill.name}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    {/* Agents */}
+                    {(plugin.agents?.length ?? 0) > 0 && (
+                        <div>
+                            <h4 className="text-xs font-medium text-foreground mb-1.5 flex items-center gap-1.5">
+                                <Bot className="h-3 w-3 text-muted-foreground" />
+                                Bundled Agents
+                                <Badge variant="secondary" className="h-4 px-1.5 text-[10px] font-mono rounded-sm">
+                                    {plugin.agents!.length}
+                                </Badge>
+                            </h4>
+                            <div className="space-y-1">
+                                {plugin.agents!.map((agent) => (
+                                    <div
+                                        key={agent.name}
+                                        className="px-2.5 py-1.5 rounded-md bg-muted/30 border border-border/30"
+                                    >
+                                        <span className="text-[11px] font-mono text-foreground">{agent.name}</span>
                                     </div>
                                 ))}
                             </div>

--- a/packages/ui/src/components/PluginsManager.tsx
+++ b/packages/ui/src/components/PluginsManager.tsx
@@ -104,8 +104,13 @@ function PluginRow({ plugin, onClick }: PluginRowProps) {
                         <PluginCapBadge icon={Zap} label={plugin.hookEvents.length === 1 ? "hook" : "hooks"} count={plugin.hookEvents.length} />
                         <PluginCapBadge icon={BookOpen} label={plugin.skills.length === 1 ? "skill" : "skills"} count={plugin.skills.length} />
                         <PluginCapBadge icon={FileText} label={(plugin.rules?.length ?? 0) === 1 ? "rule" : "rules"} count={plugin.rules?.length ?? 0} />
+                        {plugin.hasAgents && (
+                            <span className="inline-flex items-center gap-0.5 text-[10px] text-muted-foreground">
+                                <Bot className="h-2.5 w-2.5" />
+                                Agents
+                            </span>
+                        )}
                         {plugin.hasMcp && <UnsupportedBadge label="MCP" />}
-                        {plugin.hasAgents && <UnsupportedBadge label="Agents" />}
                     </div>
                 </div>
             </div>
@@ -263,7 +268,7 @@ function PluginDetailDialog({ plugin, onClose }: PluginDetailDialogProps) {
                     )}
 
                     {/* Unsupported features */}
-                    {(plugin.hasMcp || plugin.hasAgents || plugin.hasLsp) && (
+                    {(plugin.hasMcp || plugin.hasLsp) && (
                         <div className="rounded-md bg-amber-500/5 border border-amber-500/20 p-2.5">
                             <h4 className="text-[11px] font-medium text-amber-600 dark:text-amber-400 mb-1 flex items-center gap-1">
                                 <AlertTriangle className="h-3 w-3" />
@@ -274,12 +279,6 @@ function PluginDetailDialog({ plugin, onClose }: PluginDetailDialogProps) {
                                     <Badge variant="outline" className="text-[10px] border-amber-500/30 text-amber-600 dark:text-amber-400">
                                         <Server className="h-2.5 w-2.5 mr-1" />
                                         MCP Servers
-                                    </Badge>
-                                )}
-                                {plugin.hasAgents && (
-                                    <Badge variant="outline" className="text-[10px] border-amber-500/30 text-amber-600 dark:text-amber-400">
-                                        <Bot className="h-2.5 w-2.5 mr-1" />
-                                        Subagents
                                     </Badge>
                                 )}
                                 {plugin.hasLsp && (

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -15,6 +15,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { SkillsManager, type SkillInfo } from "@/components/SkillsManager";
+import { AgentsManager, type AgentInfo } from "@/components/AgentsManager";
 import { PluginsManager, type PluginInfo } from "@/components/PluginsManager";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ErrorAlert } from "@/components/ui/error-alert";
@@ -25,6 +26,7 @@ interface RunnerInfo {
     roots: string[];
     sessionCount: number;
     skills: SkillInfo[];
+    agents: AgentInfo[];
     plugins: PluginInfo[];
     version: string | null;
 }
@@ -76,6 +78,7 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
                     roots: r.roots ?? [],
                     sessionCount: r.sessionCount ?? 0,
                     skills: Array.isArray(r.skills) ? r.skills : [],
+                    agents: Array.isArray(r.agents) ? r.agents : [],
                     plugins: Array.isArray(r.plugins) ? r.plugins : [],
                     version: r.version ?? null,
                 })));
@@ -337,6 +340,11 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
                                             r.runnerId === runnerId ? { ...r, skills: updatedSkills } : r
                                         ));
                                     }}
+                                    onAgentsChange={(runnerId, updatedAgents) => {
+                                        setRunners((prev) => prev.map((r) =>
+                                            r.runnerId === runnerId ? { ...r, agents: updatedAgents } : r
+                                        ));
+                                    }}
                                 />
                             );
                         })}
@@ -466,13 +474,14 @@ interface RunnerCardProps {
     onNewSession: () => void;
     onOpenSession?: (sessionId: string) => void;
     onSkillsChange?: (runnerId: string, skills: SkillInfo[]) => void;
+    onAgentsChange?: (runnerId: string, agents: AgentInfo[]) => void;
 }
 
 function formatTime(iso: string): string {
     return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
 }
 
-function RunnerCard({ runner, sessions, latestVersion, isRestarting, isStopping, onRestart, onStop, onNewSession, onOpenSession, onSkillsChange }: RunnerCardProps) {
+function RunnerCard({ runner, sessions, latestVersion, isRestarting, isStopping, onRestart, onStop, onNewSession, onOpenSession, onSkillsChange, onAgentsChange }: RunnerCardProps) {
     const [sessionsOpen, setSessionsOpen] = React.useState(true);
     const isOutdated = !!(runner.version && latestVersion && semverLt(runner.version, latestVersion));
 
@@ -635,6 +644,13 @@ function RunnerCard({ runner, sessions, latestVersion, isRestarting, isStopping,
                     runnerId={runner.runnerId}
                     skills={runner.skills}
                     onSkillsChange={(updated) => onSkillsChange?.(runner.runnerId, updated)}
+                />
+
+                {/* Agents manager */}
+                <AgentsManager
+                    runnerId={runner.runnerId}
+                    agents={runner.agents}
+                    onAgentsChange={(updated) => onAgentsChange?.(runner.runnerId, updated)}
                 />
 
                 {/* Plugins manager (Claude Code plugin adapter) */}

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -605,7 +605,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
         .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
         .then((data: any) => {
           if (dispatchSessionId !== sessionIdRef.current) return; // session changed, discard
-          const raw: Array<{ name: string; description?: string; commands?: Array<{ name: string; description?: string }>; hookEvents?: string[]; skills?: Array<{ name: string }>; rules?: Array<{ name: string }>; version?: string; hasMcp?: boolean; hasAgents?: boolean }> = Array.isArray(data?.plugins) ? data.plugins : [];
+          const raw: Array<{ name: string; description?: string; commands?: Array<{ name: string; description?: string }>; hookEvents?: string[]; skills?: Array<{ name: string }>; agents?: Array<{ name: string }>; rules?: Array<{ name: string }>; version?: string; hasMcp?: boolean; hasAgents?: boolean }> = Array.isArray(data?.plugins) ? data.plugins : [];
           onAppendSystemMessage?.({
             kind: "plugins",
             plugins: raw.map((p) => ({
@@ -615,6 +615,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               commands: (p.commands ?? []).map((c) => ({ name: c.name, description: c.description })),
               hookCount: p.hookEvents?.length ?? 0,
               skillCount: p.skills?.length ?? 0,
+              agentCount: p.agents?.length ?? 0,
               ruleCount: p.rules?.length ?? 0,
               hasMcp: !!p.hasMcp,
               hasAgents: !!p.hasAgents,

--- a/packages/ui/src/components/session-viewer/cards/CommandResultCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/CommandResultCard.tsx
@@ -74,6 +74,7 @@ export interface PluginEntry {
   commands: PluginCommandEntry[];
   hookCount: number;
   skillCount: number;
+  agentCount?: number;
   ruleCount: number;
   hasMcp?: boolean;
   hasAgents?: boolean;
@@ -380,10 +381,10 @@ function PluginEntryRow({ plugin }: { plugin: PluginEntry }) {
                 MCP
               </span>
             )}
-            {plugin.hasAgents && (
+            {(plugin.agentCount ?? 0) > 0 && (
               <span className="inline-flex items-center gap-0.5 text-[10px] text-zinc-400">
                 <Bot className="size-2.5" />
-                Agents
+                {plugin.agentCount} agent{plugin.agentCount! > 1 ? "s" : ""}
               </span>
             )}
           </div>

--- a/packages/ui/src/components/session-viewer/cards/CommandResultCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/CommandResultCard.tsx
@@ -381,7 +381,7 @@ function PluginEntryRow({ plugin }: { plugin: PluginEntry }) {
               </span>
             )}
             {plugin.hasAgents && (
-              <span className="inline-flex items-center gap-0.5 text-[10px] text-amber-500/80">
+              <span className="inline-flex items-center gap-0.5 text-[10px] text-zinc-400">
                 <Bot className="size-2.5" />
                 Agents
               </span>


### PR DESCRIPTION
## Summary

Adds a full Agents manager to the web UI with create, read, update, and delete support.

## Changes

- `packages/ui/src/components/AgentsManager.tsx` — new CRUD component for managing agents
- `packages/ui/src/components/RunnerManager.tsx` — integrates AgentsManager into runner cards
- `packages/cli/src/agents.ts` — CLI agent support
- +11 other supporting files