### PR TITLE
🛡️ Sentinel: [HIGH] Fix unhandled exceptions in bash tool

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-03-13 - [MEDIUM] Fix unhandled exceptions exposing stack traces in tools
+**Vulnerability:** The `bash` tool (and potentially others) in `packages/tools/src/bash.ts` utilized `child_process.exec` asynchronously, which throws an exception if the command exits with a non-zero code. This exception was unhandled, which could crash the host process or expose internal stack traces to the caller/logs.
+**Learning:** `child_process.exec` (promisified) natively rejects the promise on non-zero exit codes. Failing to catch this inside tool execution paths creates an application-crashing Denial of Service risk or exposes internal trace data instead of returning a proper error message payload.
+**Prevention:** Always wrap asynchronous shell executions in a `try...catch` block. Ensure the catch block safely extracts `error.stdout` and `error.stderr` and returns them as predictable tool output rather than bubbling an unhandled promise rejection.

--- a/packages/tools/src/bash.test.ts
+++ b/packages/tools/src/bash.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "bun:test";
+import { bashTool } from "./bash.ts";
+
+describe("bashTool", () => {
+    test("has correct metadata", () => {
+        expect(bashTool.name).toBe("bash");
+        expect(bashTool.description).toBeTruthy();
+    });
+
+    test("executes a successful command", async () => {
+        const result = await bashTool.execute("test-1", { command: "echo hello" });
+        expect(result.content[0].text).toContain("hello");
+    });
+
+    test("executes a failing command and catches error", async () => {
+        const result = await bashTool.execute("test-2", { command: "ls /nonexistent" });
+        expect(result.content[0].text).toContain("No such file or directory");
+    });
+});

--- a/packages/tools/src/bash.ts
+++ b/packages/tools/src/bash.ts
@@ -15,10 +15,21 @@ export const bashTool: AgentTool = {
     }),
     async execute(_toolCallId, params: any) {
         const timeout = params.timeout ?? 30_000;
-        const { stdout, stderr } = await execAsync(params.command, { timeout });
-        return {
-            content: [{ type: "text" as const, text: stdout + (stderr ? `\nstderr: ${stderr}` : "") }],
-            details: { command: params.command, stdout, stderr },
-        };
+        try {
+            const { stdout, stderr } = await execAsync(params.command, { timeout });
+            return {
+                content: [{ type: "text" as const, text: stdout + (stderr ? `\nstderr: ${stderr}` : "") }],
+                details: { command: params.command, stdout, stderr },
+            };
+        } catch (error: any) {
+            // execAsync throws on non-zero exit code.
+            // Return stdout/stderr rather than crashing the tool call.
+            const stdout = error.stdout || "";
+            const stderr = error.stderr || error.message || String(error);
+            return {
+                content: [{ type: "text" as const, text: stdout + (stderr ? `\nstderr: ${stderr}` : "") }],
+                details: { command: params.command, stdout, stderr, exitCode: error.code },
+            };
+        }
     },
 };


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `bashTool` used `execAsync` (promisified `child_process.exec`) without a `try-catch` block. When commands exited with a non-zero code (e.g., `ls /nonexistent`), an unhandled promise rejection was thrown.
🎯 Impact: Unhandled promise rejections can crash the running agent/worker process (Denial of Service) and expose internal stack traces rather than cleanly returning command errors.
🔧 Fix: Wrapped `execAsync` in a `try...catch` block. The catch block safely extracts `error.stdout` and `error.stderr` (or `error.message`) and returns them as part of the tool's standard output structure, matching how robust CLI execution should be handled.
✅ Verification: Tested locally via `bun test packages/tools/src/bash.test.ts` to confirm both passing and failing commands behave correctly without crashing.

---
*PR created automatically by Jules for task [11896802594321473836](https://jules.google.com/task/11896802594321473836) started by @Pizzaface*