### PR TITLE
fix: add SELinux :Z label to bind-mounted volumes

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -40,7 +40,7 @@ services:
     depends_on:
       - redis
     volumes:
-      - ..:/app
+      - ..:/app:Z
       - /app/node_modules
     profiles:
       - dev

--- a/packages/cli/src/templates/compose.yml.template
+++ b/packages/cli/src/templates/compose.yml.template
@@ -20,7 +20,7 @@ services:
       - VAPID_PRIVATE_KEY={{VAPID_PRIVATE_KEY}}
       - VAPID_SUBJECT={{VAPID_SUBJECT}}
 {{EXTRA_ORIGINS_LINE}}    volumes:
-      - {{DATA_DIR}}:/app/data
+      - {{DATA_DIR}}:/app/data:Z
     depends_on:
       - redis
     restart: unless-stopped

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -32,7 +32,7 @@ services:
       - VAPID_PRIVATE_KEY={{VAPID_PRIVATE_KEY}}
       - VAPID_SUBJECT={{VAPID_SUBJECT}}
 {{EXTRA_ORIGINS_LINE}}    volumes:
-      - {{DATA_DIR}}:/app/data
+      - {{DATA_DIR}}:/app/data:Z
     depends_on:
       - redis
     restart: unless-stopped
@@ -82,7 +82,7 @@ describe("web.ts compose template", () => {
         expect(composed).toContain("VAPID_PRIVATE_KEY=TestPrivateKey456");
         expect(composed).toContain("VAPID_SUBJECT=mailto:admin@pizzapi.local");
         expect(composed).toContain("PIZZAPI_EXTRA_ORIGINS=https://example.com");
-        expect(composed).toContain("/home/user/.pizzapi/web/data:/app/data");
+        expect(composed).toContain("/home/user/.pizzapi/web/data:/app/data:Z");
     });
 
     test("template with no extra origins produces commented-out line", () => {

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -376,7 +376,7 @@ services:
       - VAPID_PRIVATE_KEY={{VAPID_PRIVATE_KEY}}
       - VAPID_SUBJECT={{VAPID_SUBJECT}}
 {{EXTRA_ORIGINS_LINE}}    volumes:
-      - {{DATA_DIR}}:/app/data
+      - {{DATA_DIR}}:/app/data:Z
     depends_on:
       - redis
     restart: unless-stopped


### PR DESCRIPTION
## Summary
- Adds the `:Z` SELinux volume label to bind-mounted directories in both `compose.yml.template` (used by `pizza web`) and `docker/compose.yml` (dev profile)
- Without this label, Podman (and Docker on SELinux-enforcing systems like Fedora) cannot access the bind mount, causing the server to crash-loop with `SQLITE_CANTOPEN`

## Context
On Fedora (and RHEL/CentOS), SELinux blocks container access to host bind mounts by default. The `:Z` flag tells the container runtime to relabel the mount with the correct SELinux context (`svirt_sandbox_file_t`), allowing the container process to read/write the directory.

Named volumes (like `pizzapi-data` in `docker/compose.yml`) are unaffected since the runtime manages their labels automatically.

## Test plan
- [ ] Run `pizza web` on a Fedora/RHEL system with SELinux enforcing — server should start without `SQLITE_CANTOPEN`
- [ ] Run `docker compose up dev` — dev service should be able to access the project directory
- [ ] Verify no regression on non-SELinux systems (`:Z` is a no-op on Docker without SELinux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)