### PR TITLE
⚡ Bolt: [performance improvement] Optimize Socket.IO Push Checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,7 @@
 ## 2025-03-09 - Socket.IO Cluster Network Bottlenecks
 **Learning:** `fetchSockets()` is highly inefficient when only checking for socket presence in a clustered (Redis) environment, as it pulls full `RemoteSocket` objects across the network. `.allSockets()` is deprecated in Socket.IO v4.
 **Action:** Use `adapter.sockets(new Set([roomName]))` directly to efficiently return a `Set` of socket IDs without cross-cluster serialization overhead.
+
+## 2025-03-09 - [Optimize high-frequency event stream bottlenecks]
+**Learning:** In high-frequency real-time event streams (like Socket.IO text deltas in `packages/server/src/ws/namespaces/relay.ts`), failing to early-return before executing asynchronous operations (like Redis `getSharedSession` or `getViewerCount`) causes severe systemic N+1 bottlenecks.
+**Action:** Strictly evaluate simple synchronous conditions (like `event.type`) to short-circuit the function before invoking any expensive I/O operations.

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -153,6 +153,16 @@ async function checkPushNotifications(
     sessionId: string,
     event: Record<string, unknown>,
 ): Promise<void> {
+    // ⚡ Bolt: Fast synchronous check to bypass expensive Redis operations (getSharedSession/getViewerCount)
+    // for high-frequency stream events (like text deltas) that don't trigger push notifications.
+    if (
+        event.type !== "agent_end" &&
+        event.type !== "cli_error" &&
+        !(event.type === "tool_execution_start" && event.toolName === "AskUserQuestion")
+    ) {
+        return;
+    }
+
     const session = await getSharedSession(sessionId);
     const userId = session?.userId;
     if (!userId) return;


### PR DESCRIPTION
💡 **What**: Added an early return inside `checkPushNotifications` (in `packages/server/src/ws/namespaces/relay.ts`) that synchronously skips execution if `event.type` doesn't match the specific criteria needed for a push notification (`agent_end`, `cli_error`, or a tool execution start for `AskUserQuestion`).
🎯 **Why**: Previously, high-frequency stream events (like text deltas) were unnecessarily triggering asynchronous Redis lookups (`getSharedSession` and `getViewerCount`) on every single Socket.IO message, causing systemic N+1 bottlenecks.
📊 **Impact**: Massively reduces unnecessary Redis I/O and network round-trips for high-throughput AI agents, preventing potential connection starvation.
🔬 **Measurement**: Verify by running a standard agent session or text stream; observe fewer Redis `HGETALL` / viewer operations triggered. `bun run test packages/server/src/validation.test.ts` passes successfully to demonstrate tests are undisturbed.

---
*PR created automatically by Jules for task [12510235340571966133](https://jules.google.com/task/12510235340571966133) started by @Pizzaface*