### PR TITLE
fix: lock PWA orientation to portrait

### DIFF
--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -39,7 +39,7 @@ export default defineConfig({
                 theme_color: "#1c1917",
                 background_color: "#1c1917",
                 display: "standalone",
-                orientation: "any",
+                orientation: "portrait",
                 scope: "/",
                 start_url: "/",
                 icons: [


### PR DESCRIPTION
Locks the PWA manifest orientation from `any` to `portrait` to prevent unwanted auto-rotation on mobile, even when the device rotation lock is enabled.

**Change:** `packages/ui/vite.config.ts` — `orientation: "any"" → `orientation: "portrait"`