### PR TITLE
Fix mobile sidebar: tooltip intercepting tap & session expand click

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3182,21 +3182,17 @@ export function App() {
       <header className="md:hidden fixed top-0 left-0 right-0 z-50 flex items-center justify-between gap-2 border-b bg-background px-3 pp-safe-left pp-safe-right"
         style={{ paddingTop: "calc(0.5rem + env(safe-area-inset-top))", paddingBottom: "0.5rem" }}
       >
-        {/* Left: sidebar toggle */}
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-9 w-9 flex-shrink-0"
-              onClick={() => setSidebarOpen(prev => !prev)}
-              aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
-            >
-              <PanelLeftOpen className={`h-5 w-5 transition-transform duration-300 ${sidebarOpen ? "rotate-180" : ""}`} />
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent>{sidebarOpen ? "Close sidebar" : "Open sidebar"}</TooltipContent>
-        </Tooltip>
+        {/* Left: sidebar toggle — no Tooltip wrapper; on mobile, tooltips
+            intercept the first tap and prevent the click from firing. */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-9 w-9 flex-shrink-0"
+          onClick={() => setSidebarOpen(prev => !prev)}
+          aria-label={sidebarOpen ? "Close sidebar" : "Open sidebar"}
+        >
+          <PanelLeftOpen className={`h-5 w-5 transition-transform duration-300 ${sidebarOpen ? "rotate-180" : ""}`} />
+        </Button>
 
         {/* Center: session switcher pill or logo */}
         <div className="flex-1 min-w-0 flex justify-center">

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1079,6 +1079,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                                 <span
                                                                   role="button"
                                                                   tabIndex={0}
+                                                                  onPointerDown={(e) => {
+                                                                    // Stop the parent session button from capturing the
+                                                                    // pointer — without this, setPointerCapture steals
+                                                                    // subsequent events and the click never fires.
+                                                                    e.stopPropagation();
+                                                                  }}
                                                                   onClick={(e) => {
                                                                     e.stopPropagation();
                                                                     setExpandedNodeIds(prev => {


### PR DESCRIPTION
## Problem

Two mobile UX bugs in the sessions sidebar:

1. **Tooltip overriding click on mobile** — The `<Tooltip>` wrapping the sidebar toggle button intercepts the first tap on touch devices (Radix UI shows the tooltip instead of firing the click), making the button feel broken.

2. **Sessions not expandable on click** — The expand/collapse chevron on parent sessions never fires its `onClick` because the parent `<button>`'s `onPointerDown` calls `setPointerCapture()`, stealing all subsequent pointer events from child elements.

## Fix

1. **Remove Tooltip wrapper** from the mobile sidebar toggle button. The button retains its `aria-label` for accessibility — tooltips aren't useful on touch devices anyway.

2. **Add `onPointerDown` stopPropagation** to the chevron `<span>` so the parent button doesn't capture the pointer, allowing the chevron's click handler to fire normally.

## Changes

- `packages/ui/src/App.tsx` — Remove `<Tooltip>` around mobile sidebar toggle
- `packages/ui/src/components/SessionSidebar.tsx` — Add `onPointerDown` stopPropagation to expand/collapse chevron