### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix IP Spoofing vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2025-03-16 - Prevent IP spoofing in custom Fetch Request conversion
+**Vulnerability:** The `nodeReqToFetchRequest` helper blindly passed through the `x-pizzapi-client-ip` header from incoming client requests. The `handleAuthRoute` then used an insecure method to extract client IPs (trusting `x-forwarded-for` blindly) for rate limiting. This allowed attackers to bypass rate limits by spoofing `x-pizzapi-client-ip` or `x-forwarded-for`.
+**Learning:** Custom proxy layers or request adapters (like converting Node.js `IncomingMessage` to `Request`) must proactively strip custom headers used for internal routing/security before attaching their own trusted values derived from the TCP connection.
+**Prevention:** Explicitly strip `x-pizzapi-client-ip` (and similar trusted headers) from client requests, set them securely using `req.socket.remoteAddress`, and use a shared, secure utility like `getClientIp` that respects proxy configurations (`PIZZAPI_TRUST_PROXY`).

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -20,9 +20,10 @@ services:
       # Disable new signups after the first user has registered (default: true)
       # Set to false to allow unlimited registrations.
       # - PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER=true
-      # Trust X-Forwarded-For from reverse proxies for rate limiting.
-      # Required when the proxy connects via a Docker bridge network (non-loopback).
-      # Loopback (127.0.0.1) proxies are auto-detected without this setting.
+      # Enable reverse proxy header handling. Required when the server is behind
+      # a non-loopback proxy (e.g. Docker overlay network, cloud load balancer).
+      # Loopback proxies (127.0.0.1, ::1) are auto-detected.
+      # See https://pizzaface.github.io/PizzaPi/guides/self-hosting/#reverse-proxy-configuration
       # - PIZZAPI_TRUST_PROXY=true
     volumes:
       - pizzapi-data:/app/data

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -20,6 +20,10 @@ services:
       # Disable new signups after the first user has registered (default: true)
       # Set to false to allow unlimited registrations.
       # - PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER=true
+      # Trust X-Forwarded-For from reverse proxies for rate limiting.
+      # Required when the proxy connects via a Docker bridge network (non-loopback).
+      # Loopback (127.0.0.1) proxies are auto-detected without this setting.
+      # - PIZZAPI_TRUST_PROXY=true
     volumes:
       - pizzapi-data:/app/data
     depends_on:

--- a/packages/cli/src/templates/compose.yml.template
+++ b/packages/cli/src/templates/compose.yml.template
@@ -19,7 +19,7 @@ services:
       - VAPID_PUBLIC_KEY={{VAPID_PUBLIC_KEY}}
       - VAPID_PRIVATE_KEY={{VAPID_PRIVATE_KEY}}
       - VAPID_SUBJECT={{VAPID_SUBJECT}}
-{{EXTRA_ORIGINS_LINE}}{{TRUST_PROXY_LINE}}    volumes:
+{{EXTRA_ORIGINS_LINE}}{{TRUST_PROXY_LINE}}{{PROXY_DEPTH_LINE}}    volumes:
       - {{DATA_DIR}}:/app/data:Z
     depends_on:
       - redis

--- a/packages/cli/src/templates/compose.yml.template
+++ b/packages/cli/src/templates/compose.yml.template
@@ -19,7 +19,7 @@ services:
       - VAPID_PUBLIC_KEY={{VAPID_PUBLIC_KEY}}
       - VAPID_PRIVATE_KEY={{VAPID_PRIVATE_KEY}}
       - VAPID_SUBJECT={{VAPID_SUBJECT}}
-{{EXTRA_ORIGINS_LINE}}    volumes:
+{{EXTRA_ORIGINS_LINE}}{{TRUST_PROXY_LINE}}    volumes:
       - {{DATA_DIR}}:/app/data:Z
     depends_on:
       - redis

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -31,7 +31,7 @@ services:
       - VAPID_PUBLIC_KEY={{VAPID_PUBLIC_KEY}}
       - VAPID_PRIVATE_KEY={{VAPID_PRIVATE_KEY}}
       - VAPID_SUBJECT={{VAPID_SUBJECT}}
-{{EXTRA_ORIGINS_LINE}}    volumes:
+{{EXTRA_ORIGINS_LINE}}{{TRUST_PROXY_LINE}}    volumes:
       - {{DATA_DIR}}:/app/data:Z
     depends_on:
       - redis
@@ -65,7 +65,8 @@ describe("web.ts compose template", () => {
             .replace(/\{\{VAPID_PUBLIC_KEY}}/g, "BTestPublicKey123")
             .replace(/\{\{VAPID_PRIVATE_KEY}}/g, "TestPrivateKey456")
             .replace(/\{\{VAPID_SUBJECT}}/g, "mailto:admin@pizzapi.local")
-            .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, "      - PIZZAPI_EXTRA_ORIGINS=https://example.com\n");
+            .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, "      - PIZZAPI_EXTRA_ORIGINS=https://example.com\n")
+            .replace(/\{\{TRUST_PROXY_LINE}}/g, "      # - PIZZAPI_TRUST_PROXY=\n");
 
         // No unsubstituted placeholders remain
         expect(composed).not.toContain("{{");
@@ -94,7 +95,8 @@ describe("web.ts compose template", () => {
             .replace(/\{\{VAPID_PUBLIC_KEY}}/g, "key")
             .replace(/\{\{VAPID_PRIVATE_KEY}}/g, "key")
             .replace(/\{\{VAPID_SUBJECT}}/g, "mailto:test@test.com")
-            .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, "      # - PIZZAPI_EXTRA_ORIGINS=\n");
+            .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, "      # - PIZZAPI_EXTRA_ORIGINS=\n")
+            .replace(/\{\{TRUST_PROXY_LINE}}/g, "      # - PIZZAPI_TRUST_PROXY=\n");
 
         expect(composed).toContain("# - PIZZAPI_EXTRA_ORIGINS=");
         expect(composed).not.toContain("{{");

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -1,7 +1,12 @@
 import { describe, test, expect } from "bun:test";
 import { readFileSync } from "fs";
 import { join } from "path";
-import { extractVapidFromCompose, extractSettingsFromCompose, resolveBetterAuthSecret } from "./web";
+import {
+    extractVapidFromCompose,
+    extractSettingsFromCompose,
+    resolveBetterAuthSecret,
+    resolveMissingProxySettings,
+} from "./web";
 
 /**
  * Validates that the inlined COMPOSE_TEMPLATE in web.ts matches
@@ -222,5 +227,46 @@ describe("resolveBetterAuthSecret", () => {
             generate: () => "Generated",
         });
         expect(resolved).toEqual({ secret: "Generated", source: "generated" });
+    });
+});
+
+describe("resolveMissingProxySettings", () => {
+    test("keeps existing proxy settings", () => {
+        const resolved = resolveMissingProxySettings({
+            currentTrustProxy: false,
+            currentProxyDepth: 0,
+            composeContents: ["- PIZZAPI_TRUST_PROXY=true\n- PIZZAPI_PROXY_DEPTH=3"],
+        });
+        expect(resolved).toEqual({
+            trustProxy: false,
+            proxyDepth: 0,
+            source: "existing",
+        });
+    });
+
+    test("backfills missing trustProxy and proxyDepth from compose", () => {
+        const resolved = resolveMissingProxySettings({
+            currentTrustProxy: undefined,
+            currentProxyDepth: undefined,
+            composeContents: ["- PIZZAPI_TRUST_PROXY=true\n- PIZZAPI_PROXY_DEPTH=1"],
+        });
+        expect(resolved).toEqual({
+            trustProxy: true,
+            proxyDepth: 1,
+            source: "compose",
+        });
+    });
+
+    test("uses override compose first and fills only missing fields", () => {
+        const resolved = resolveMissingProxySettings({
+            currentTrustProxy: undefined,
+            currentProxyDepth: 2,
+            composeContents: ["- PIZZAPI_TRUST_PROXY=false", "- PIZZAPI_TRUST_PROXY=true\n- PIZZAPI_PROXY_DEPTH=1"],
+        });
+        expect(resolved).toEqual({
+            trustProxy: false,
+            proxyDepth: 2,
+            source: "compose",
+        });
     });
 });

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -212,6 +212,17 @@ describe("extractSettingsFromCompose", () => {
         expect(result.proxyDepth).toBe(1);
     });
 
+    test("strips inline YAML comments from proxy settings", () => {
+        const content = `services:
+  server:
+    environment:
+      PIZZAPI_TRUST_PROXY: "true" # Caddy
+      PIZZAPI_PROXY_DEPTH: "1" # trusted hop count`;
+        const result = extractSettingsFromCompose(content);
+        expect(result.trustProxy).toBe(true);
+        expect(result.proxyDepth).toBe(1);
+    });
+
     test("parses YAML mapping syntax for all env vars", () => {
         const content = `services:
   server:

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -176,6 +176,73 @@ describe("extractSettingsFromCompose", () => {
         const result = extractSettingsFromCompose(content);
         expect(result.port).toBe(9000);
     });
+
+    test("parses YAML mapping syntax for proxy settings (double-quoted)", () => {
+        // This is the format shown in self-hosting docs and produced by standard
+        // YAML tools — the compose.override.yml uses mapping form, not list form.
+        const content = `services:
+  server:
+    environment:
+      PIZZAPI_TRUST_PROXY: "true"
+      PIZZAPI_PROXY_DEPTH: "1"`;
+        const result = extractSettingsFromCompose(content);
+        expect(result.trustProxy).toBe(true);
+        expect(result.proxyDepth).toBe(1);
+    });
+
+    test("parses YAML mapping syntax for proxy settings (single-quoted)", () => {
+        const content = `services:
+  server:
+    environment:
+      PIZZAPI_TRUST_PROXY: 'false'
+      PIZZAPI_PROXY_DEPTH: '2'`;
+        const result = extractSettingsFromCompose(content);
+        expect(result.trustProxy).toBe(false);
+        expect(result.proxyDepth).toBe(2);
+    });
+
+    test("parses YAML mapping syntax for proxy settings (unquoted)", () => {
+        const content = `services:
+  server:
+    environment:
+      PIZZAPI_TRUST_PROXY: true
+      PIZZAPI_PROXY_DEPTH: 1`;
+        const result = extractSettingsFromCompose(content);
+        expect(result.trustProxy).toBe(true);
+        expect(result.proxyDepth).toBe(1);
+    });
+
+    test("parses YAML mapping syntax for all env vars", () => {
+        const content = `services:
+  server:
+    ports:
+      - "8080:7492"
+    environment:
+      VAPID_PUBLIC_KEY: "MapPubKey123"
+      VAPID_PRIVATE_KEY: "MapPrivKey456"
+      VAPID_SUBJECT: "mailto:map@example.com"
+      BETTER_AUTH_SECRET: "MapSecret789"
+      PIZZAPI_EXTRA_ORIGINS: "https://map.example.com"
+      PIZZAPI_TRUST_PROXY: "true"
+      PIZZAPI_PROXY_DEPTH: "2"`;
+        const result = extractSettingsFromCompose(content);
+        expect(result.vapid).toEqual({ publicKey: "MapPubKey123", privateKey: "MapPrivKey456" });
+        expect(result.vapidSubject).toBe("mailto:map@example.com");
+        expect(result.betterAuthSecret).toBe("MapSecret789");
+        expect(result.extraOrigins).toBe("https://map.example.com");
+        expect(result.port).toBe(8080);
+        expect(result.trustProxy).toBe(true);
+        expect(result.proxyDepth).toBe(2);
+    });
+
+    test("list form still takes priority over mapping form", () => {
+        // When both forms exist, list form regex matches first (realistic edge case)
+        const content = `    environment:
+      - PIZZAPI_TRUST_PROXY=true
+      PIZZAPI_TRUST_PROXY: "false"`;
+        const result = extractSettingsFromCompose(content);
+        expect(result.trustProxy).toBe(true);
+    });
 });
 
 describe("extractVapidFromCompose (backward compat)", () => {

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -31,7 +31,7 @@ services:
       - VAPID_PUBLIC_KEY={{VAPID_PUBLIC_KEY}}
       - VAPID_PRIVATE_KEY={{VAPID_PRIVATE_KEY}}
       - VAPID_SUBJECT={{VAPID_SUBJECT}}
-{{EXTRA_ORIGINS_LINE}}{{TRUST_PROXY_LINE}}    volumes:
+{{EXTRA_ORIGINS_LINE}}{{TRUST_PROXY_LINE}}{{PROXY_DEPTH_LINE}}    volumes:
       - {{DATA_DIR}}:/app/data:Z
     depends_on:
       - redis
@@ -66,7 +66,8 @@ describe("web.ts compose template", () => {
             .replace(/\{\{VAPID_PRIVATE_KEY}}/g, "TestPrivateKey456")
             .replace(/\{\{VAPID_SUBJECT}}/g, "mailto:admin@pizzapi.local")
             .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, "      - PIZZAPI_EXTRA_ORIGINS=https://example.com\n")
-            .replace(/\{\{TRUST_PROXY_LINE}}/g, "      # - PIZZAPI_TRUST_PROXY=\n");
+            .replace(/\{\{TRUST_PROXY_LINE}}/g, "      # - PIZZAPI_TRUST_PROXY=\n")
+            .replace(/\{\{PROXY_DEPTH_LINE}}/g, "      # - PIZZAPI_PROXY_DEPTH=\n");
 
         // No unsubstituted placeholders remain
         expect(composed).not.toContain("{{");
@@ -96,7 +97,8 @@ describe("web.ts compose template", () => {
             .replace(/\{\{VAPID_PRIVATE_KEY}}/g, "key")
             .replace(/\{\{VAPID_SUBJECT}}/g, "mailto:test@test.com")
             .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, "      # - PIZZAPI_EXTRA_ORIGINS=\n")
-            .replace(/\{\{TRUST_PROXY_LINE}}/g, "      # - PIZZAPI_TRUST_PROXY=\n");
+            .replace(/\{\{TRUST_PROXY_LINE}}/g, "      # - PIZZAPI_TRUST_PROXY=\n")
+            .replace(/\{\{PROXY_DEPTH_LINE}}/g, "      # - PIZZAPI_PROXY_DEPTH=\n");
 
         expect(composed).toContain("# - PIZZAPI_EXTRA_ORIGINS=");
         expect(composed).not.toContain("{{");

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -177,6 +177,43 @@ export function resolveBetterAuthSecret(opts: {
     return { secret: gen(), source: "generated" };
 }
 
+export function resolveMissingProxySettings(opts: {
+    currentTrustProxy: boolean | undefined;
+    currentProxyDepth: number | undefined;
+    composeContents: Array<string | null | undefined>;
+}): { trustProxy: boolean | undefined; proxyDepth: number | undefined; source: "existing" | "compose" } {
+    let trustProxy = opts.currentTrustProxy;
+    let proxyDepth = opts.currentProxyDepth;
+
+    if (trustProxy !== undefined && proxyDepth !== undefined) {
+        return { trustProxy, proxyDepth, source: "existing" };
+    }
+
+    for (const content of opts.composeContents) {
+        if (!content) continue;
+        const extracted = extractSettingsFromCompose(content);
+
+        if (trustProxy === undefined && extracted.trustProxy !== undefined) {
+            trustProxy = extracted.trustProxy;
+        }
+
+        if (proxyDepth === undefined && extracted.proxyDepth !== undefined) {
+            proxyDepth = extracted.proxyDepth;
+        }
+
+        if (trustProxy !== undefined && proxyDepth !== undefined) {
+            break;
+        }
+    }
+
+    const source: "existing" | "compose" =
+        trustProxy !== opts.currentTrustProxy || proxyDepth !== opts.currentProxyDepth
+            ? "compose"
+            : "existing";
+
+    return { trustProxy, proxyDepth, source };
+}
+
 /** @deprecated Use extractSettingsFromCompose instead */
 export function extractVapidFromCompose(content: string): { publicKey: string; privateKey: string } | null {
     return extractSettingsFromCompose(content).vapid ?? null;
@@ -256,15 +293,15 @@ export function loadWebConfig(): WebConfig {
             // Merge with defaults so new fields get default values
             const config: WebConfig = { ...DEFAULT_CONFIG, ...stored };
 
+            const composePath = join(WEB_DIR, "compose.yml");
+            const overridePath = join(WEB_DIR, "compose.override.yml");
+
+            const overrideContent = existsSync(overridePath) ? readFileSync(overridePath, "utf-8") : null;
+            const composeContent = existsSync(composePath) ? readFileSync(composePath, "utf-8") : null;
+
             // Ensure required secrets exist (migrate older configs)
             let changed = false;
             if (!config.betterAuthSecret) {
-                const composePath = join(WEB_DIR, "compose.yml");
-                const overridePath = join(WEB_DIR, "compose.override.yml");
-
-                const overrideContent = existsSync(overridePath) ? readFileSync(overridePath, "utf-8") : null;
-                const composeContent = existsSync(composePath) ? readFileSync(composePath, "utf-8") : null;
-
                 const resolved = resolveBetterAuthSecret({
                     currentSecret: config.betterAuthSecret,
                     composeContents: [overrideContent, composeContent],
@@ -273,6 +310,25 @@ export function loadWebConfig(): WebConfig {
                 config.betterAuthSecret = resolved.secret;
                 changed = true;
             }
+
+            // Backfill newly introduced proxy settings from existing compose files
+            // when upgrading from older config.json versions.
+            const resolvedProxySettings = resolveMissingProxySettings({
+                currentTrustProxy: config.trustProxy,
+                currentProxyDepth: config.proxyDepth,
+                composeContents: [overrideContent, composeContent],
+            });
+
+            if (resolvedProxySettings.trustProxy !== config.trustProxy) {
+                config.trustProxy = resolvedProxySettings.trustProxy;
+                changed = true;
+            }
+
+            if (resolvedProxySettings.proxyDepth !== config.proxyDepth) {
+                config.proxyDepth = resolvedProxySettings.proxyDepth;
+                changed = true;
+            }
+
             if (changed) {
                 saveWebConfig(config);
             }

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -375,7 +375,7 @@ services:
       - VAPID_PUBLIC_KEY={{VAPID_PUBLIC_KEY}}
       - VAPID_PRIVATE_KEY={{VAPID_PRIVATE_KEY}}
       - VAPID_SUBJECT={{VAPID_SUBJECT}}
-{{EXTRA_ORIGINS_LINE}}    volumes:
+{{EXTRA_ORIGINS_LINE}}{{TRUST_PROXY_LINE}}    volumes:
       - {{DATA_DIR}}:/app/data:Z
     depends_on:
       - redis
@@ -401,6 +401,12 @@ function generateComposeFile(repoPath: string, config: WebConfig): string {
         ? `      - PIZZAPI_EXTRA_ORIGINS=${config.extraOrigins}\n`
         : `      # - PIZZAPI_EXTRA_ORIGINS=\n`;
 
+    // Pass PIZZAPI_TRUST_PROXY through to the container if set in the environment
+    const trustProxy = process.env.PIZZAPI_TRUST_PROXY;
+    const trustProxyLine = trustProxy
+        ? `      - PIZZAPI_TRUST_PROXY=${trustProxy}\n`
+        : `      # - PIZZAPI_TRUST_PROXY=\n`;
+
     const compose = template
         .replace(/\{\{REPO_PATH}}/g, repoPath)
         .replace(/\{\{PORT}}/g, String(config.port))
@@ -409,7 +415,8 @@ function generateComposeFile(repoPath: string, config: WebConfig): string {
         .replace(/\{\{VAPID_PRIVATE_KEY}}/g, config.vapid.privateKey)
         .replace(/\{\{VAPID_SUBJECT}}/g, config.vapidSubject)
         .replace(/\{\{BETTER_AUTH_SECRET}}/g, config.betterAuthSecret)
-        .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, extraOriginsLine);
+        .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, extraOriginsLine)
+        .replace(/\{\{TRUST_PROXY_LINE}}/g, trustProxyLine);
 
     // Only write if changed
     const existing = existsSync(composePath) ? readFileSync(composePath, "utf-8") : null;

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -86,16 +86,55 @@ export interface ExtractedComposeSettings {
     proxyDepth?: number;
 }
 
+/**
+ * Match an environment variable from compose YAML content.
+ * Supports three formats:
+ *   1. List form: `- KEY=value`
+ *   2. YAML mapping form: `KEY: "value"` or `KEY: value` (indented, inside environment block)
+ *   3. Bare form: `KEY=value` (no prefix, used in simpler/partial compose snippets)
+ * For mapping form, strips surrounding quotes from the value.
+ * Returns null if the key is not found or is commented out.
+ */
+function matchEnvVar(content: string, key: string): string | null {
+    // List form: `- KEY=value` (non-commented)
+    const listRegex = new RegExp(`^\\s*-\\s+${key}=(.+)`, "m");
+    const listMatch = content.match(listRegex);
+    if (listMatch?.[1]) {
+        return listMatch[1].trim();
+    }
+
+    // YAML mapping form: `KEY: "value"` or `KEY: value` (non-commented)
+    // The key must be indented (part of an environment block)
+    const mapRegex = new RegExp(`^\\s+${key}:\\s+(.+)`, "m");
+    const mapMatch = content.match(mapRegex);
+    if (mapMatch?.[1]) {
+        let val = mapMatch[1].trim();
+        // Strip surrounding quotes (both single and double)
+        if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+            val = val.slice(1, -1);
+        }
+        return val;
+    }
+
+    // Bare form fallback: `KEY=value` on a non-commented line (no list/mapping prefix).
+    // Match lines where KEY= appears and the line doesn't start with optional whitespace + #.
+    const bareRegex = new RegExp(`^(?!\\s*#).*${key}=(.+)`, "m");
+    const bareMatch = content.match(bareRegex);
+    if (bareMatch?.[1]) {
+        return bareMatch[1].trim();
+    }
+
+    return null;
+}
+
 /** Extract all user settings from compose.yml content (pure function, exported for testing) */
 export function extractSettingsFromCompose(content: string): ExtractedComposeSettings {
     const result: ExtractedComposeSettings = {};
 
     // VAPID keys
-    const pubMatch = content.match(/VAPID_PUBLIC_KEY=(.+)/);
-    const privMatch = content.match(/VAPID_PRIVATE_KEY=(.+)/);
-    if (pubMatch?.[1] && privMatch?.[1]) {
-        const pub = pubMatch[1].trim();
-        const priv = privMatch[1].trim();
+    const pub = matchEnvVar(content, "VAPID_PUBLIC_KEY");
+    const priv = matchEnvVar(content, "VAPID_PRIVATE_KEY");
+    if (pub && priv) {
         // Skip template placeholders
         if (!pub.startsWith("{{")) {
             result.vapid = { publicKey: pub, privateKey: priv };
@@ -103,30 +142,21 @@ export function extractSettingsFromCompose(content: string): ExtractedComposeSet
     }
 
     // VAPID subject
-    const subjectMatch = content.match(/VAPID_SUBJECT=(.+)/);
-    if (subjectMatch?.[1]) {
-        const val = subjectMatch[1].trim();
-        if (!val.startsWith("{{")) {
-            result.vapidSubject = val;
-        }
+    const subject = matchEnvVar(content, "VAPID_SUBJECT");
+    if (subject && !subject.startsWith("{{")) {
+        result.vapidSubject = subject;
     }
 
     // better-auth secret
-    const secretMatch = content.match(/^\s*(?:-\s+)?BETTER_AUTH_SECRET=(.+)$/m);
-    if (secretMatch?.[1]) {
-        const val = secretMatch[1].trim();
-        if (!val.startsWith("{{")) {
-            result.betterAuthSecret = val;
-        }
+    const secret = matchEnvVar(content, "BETTER_AUTH_SECRET");
+    if (secret && !secret.startsWith("{{")) {
+        result.betterAuthSecret = secret;
     }
 
     // Extra origins (skip commented-out lines)
-    const originsMatch = content.match(/^\s*-\s+PIZZAPI_EXTRA_ORIGINS=(.+)/m);
-    if (originsMatch?.[1]) {
-        const val = originsMatch[1].trim();
-        if (!val.startsWith("{{") && val.length > 0) {
-            result.extraOrigins = val;
-        }
+    const origins = matchEnvVar(content, "PIZZAPI_EXTRA_ORIGINS");
+    if (origins && !origins.startsWith("{{") && origins.length > 0) {
+        result.extraOrigins = origins;
     }
 
     // Port from the host:container mapping (e.g. "8080:7492")
@@ -138,18 +168,18 @@ export function extractSettingsFromCompose(content: string): ExtractedComposeSet
         }
     }
 
-    // Trust proxy setting (active, non-commented line only)
-    const trustProxyMatch = content.match(/^\s*-\s+PIZZAPI_TRUST_PROXY=(.+)/m);
-    if (trustProxyMatch?.[1]) {
-        const val = trustProxyMatch[1].trim().toLowerCase();
-        if (val === "true") result.trustProxy = true;
-        else if (val === "false") result.trustProxy = false;
+    // Trust proxy setting
+    const trustProxyVal = matchEnvVar(content, "PIZZAPI_TRUST_PROXY");
+    if (trustProxyVal) {
+        const lower = trustProxyVal.toLowerCase();
+        if (lower === "true") result.trustProxy = true;
+        else if (lower === "false") result.trustProxy = false;
     }
 
-    // Proxy depth setting (active, non-commented line only)
-    const proxyDepthMatch = content.match(/^\s*-\s+PIZZAPI_PROXY_DEPTH=(.+)/m);
-    if (proxyDepthMatch?.[1]) {
-        const val = parseInt(proxyDepthMatch[1].trim(), 10);
+    // Proxy depth setting
+    const proxyDepthVal = matchEnvVar(content, "PIZZAPI_PROXY_DEPTH");
+    if (proxyDepthVal) {
+        const val = parseInt(proxyDepthVal, 10);
         if (!isNaN(val) && val >= 1) result.proxyDepth = val;
     }
 

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -96,11 +96,20 @@ export interface ExtractedComposeSettings {
  * Returns null if the key is not found or is commented out.
  */
 function matchEnvVar(content: string, key: string): string | null {
+    const normalizeValue = (raw: string): string => {
+        let val = raw.replace(/\s+#.*$/, "").trim();
+        // Strip surrounding quotes (both single and double)
+        if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+            val = val.slice(1, -1);
+        }
+        return val;
+    };
+
     // List form: `- KEY=value` (non-commented)
     const listRegex = new RegExp(`^\\s*-\\s+${key}=(.+)`, "m");
     const listMatch = content.match(listRegex);
     if (listMatch?.[1]) {
-        return listMatch[1].trim();
+        return normalizeValue(listMatch[1]);
     }
 
     // YAML mapping form: `KEY: "value"` or `KEY: value` (non-commented)
@@ -108,12 +117,7 @@ function matchEnvVar(content: string, key: string): string | null {
     const mapRegex = new RegExp(`^\\s+${key}:\\s+(.+)`, "m");
     const mapMatch = content.match(mapRegex);
     if (mapMatch?.[1]) {
-        let val = mapMatch[1].trim();
-        // Strip surrounding quotes (both single and double)
-        if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
-            val = val.slice(1, -1);
-        }
-        return val;
+        return normalizeValue(mapMatch[1]);
     }
 
     // Bare form fallback: `KEY=value` on a non-commented line (no list/mapping prefix).
@@ -121,7 +125,7 @@ function matchEnvVar(content: string, key: string): string | null {
     const bareRegex = new RegExp(`^(?!\\s*#).*${key}=(.+)`, "m");
     const bareMatch = content.match(bareRegex);
     if (bareMatch?.[1]) {
-        return bareMatch[1].trim();
+        return normalizeValue(bareMatch[1]);
     }
 
     return null;

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -143,6 +143,7 @@ export function extractSettingsFromCompose(content: string): ExtractedComposeSet
     if (trustProxyMatch?.[1]) {
         const val = trustProxyMatch[1].trim().toLowerCase();
         if (val === "true") result.trustProxy = true;
+        else if (val === "false") result.trustProxy = false;
     }
 
     // Proxy depth setting (active, non-commented line only)
@@ -452,9 +453,11 @@ function generateComposeFile(repoPath: string, config: WebConfig): string {
     // Persist any env-driven changes back to config.json
     saveWebConfig(config);
 
-    const trustProxyLine = config.trustProxy
+    const trustProxyLine = config.trustProxy === true
         ? `      - PIZZAPI_TRUST_PROXY=true\n`
-        : `      # - PIZZAPI_TRUST_PROXY=\n`;
+        : config.trustProxy === false
+            ? `      - PIZZAPI_TRUST_PROXY=false\n`
+            : `      # - PIZZAPI_TRUST_PROXY=\n`;
 
     const proxyDepthLine = config.proxyDepth && config.proxyDepth > 1
         ? `      - PIZZAPI_PROXY_DEPTH=${config.proxyDepth}\n`

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -31,6 +31,10 @@ export interface WebConfig {
     extraOrigins: string;
     /** Secret key used by better-auth for session signing (persisted). */
     betterAuthSecret: string;
+    /** Whether to trust X-Forwarded-For headers from a reverse proxy (persisted). */
+    trustProxy?: boolean;
+    /** Number of trusted proxy hops for X-Forwarded-For (persisted). */
+    proxyDepth?: number;
 }
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -78,6 +82,8 @@ export interface ExtractedComposeSettings {
     extraOrigins?: string;
     port?: number;
     betterAuthSecret?: string;
+    trustProxy?: boolean;
+    proxyDepth?: number;
 }
 
 /** Extract all user settings from compose.yml content (pure function, exported for testing) */
@@ -130,6 +136,20 @@ export function extractSettingsFromCompose(content: string): ExtractedComposeSet
         if (!isNaN(p) && p > 0 && p <= 65535) {
             result.port = p;
         }
+    }
+
+    // Trust proxy setting (active, non-commented line only)
+    const trustProxyMatch = content.match(/^\s*-\s+PIZZAPI_TRUST_PROXY=(.+)/m);
+    if (trustProxyMatch?.[1]) {
+        const val = trustProxyMatch[1].trim().toLowerCase();
+        if (val === "true") result.trustProxy = true;
+    }
+
+    // Proxy depth setting (active, non-commented line only)
+    const proxyDepthMatch = content.match(/^\s*-\s+PIZZAPI_PROXY_DEPTH=(.+)/m);
+    if (proxyDepthMatch?.[1]) {
+        const val = parseInt(proxyDepthMatch[1].trim(), 10);
+        if (!isNaN(val) && val >= 1) result.proxyDepth = val;
     }
 
     return result;
@@ -207,6 +227,14 @@ function migrateLegacySettings(): Partial<WebConfig> {
                 migrated.betterAuthSecret = extracted.betterAuthSecret;
                 sources.push("compose.yml (betterAuthSecret)");
             }
+            if (extracted.trustProxy != null) {
+                migrated.trustProxy = extracted.trustProxy;
+                sources.push("compose.yml (trustProxy)");
+            }
+            if (extracted.proxyDepth != null) {
+                migrated.proxyDepth = extracted.proxyDepth;
+                sources.push("compose.yml (proxyDepth)");
+            }
         } catch { /* can't read */ }
     }
 
@@ -267,6 +295,8 @@ export function loadWebConfig(): WebConfig {
     if (legacy.vapidSubject) config.vapidSubject = legacy.vapidSubject;
     if (legacy.extraOrigins) config.extraOrigins = legacy.extraOrigins;
     if (legacy.port) config.port = legacy.port;
+    if (legacy.trustProxy != null) config.trustProxy = legacy.trustProxy;
+    if (legacy.proxyDepth != null) config.proxyDepth = legacy.proxyDepth;
 
     if (legacy.betterAuthSecret) {
         config.betterAuthSecret = legacy.betterAuthSecret;
@@ -375,7 +405,7 @@ services:
       - VAPID_PUBLIC_KEY={{VAPID_PUBLIC_KEY}}
       - VAPID_PRIVATE_KEY={{VAPID_PRIVATE_KEY}}
       - VAPID_SUBJECT={{VAPID_SUBJECT}}
-{{EXTRA_ORIGINS_LINE}}{{TRUST_PROXY_LINE}}    volumes:
+{{EXTRA_ORIGINS_LINE}}{{TRUST_PROXY_LINE}}{{PROXY_DEPTH_LINE}}    volumes:
       - {{DATA_DIR}}:/app/data:Z
     depends_on:
       - redis
@@ -401,11 +431,34 @@ function generateComposeFile(repoPath: string, config: WebConfig): string {
         ? `      - PIZZAPI_EXTRA_ORIGINS=${config.extraOrigins}\n`
         : `      # - PIZZAPI_EXTRA_ORIGINS=\n`;
 
-    // Pass PIZZAPI_TRUST_PROXY through to the container if set in the environment
-    const trustProxy = process.env.PIZZAPI_TRUST_PROXY;
-    const trustProxyLine = trustProxy
-        ? `      - PIZZAPI_TRUST_PROXY=${trustProxy}\n`
+    // PIZZAPI_TRUST_PROXY: env var overrides config, and gets persisted back.
+    // This ensures `PIZZAPI_TRUST_PROXY=true pizza web` is remembered on subsequent runs.
+    const envTrustProxy = process.env.PIZZAPI_TRUST_PROXY?.toLowerCase();
+    if (envTrustProxy === "true") {
+        config.trustProxy = true;
+    } else if (envTrustProxy === "false") {
+        config.trustProxy = false;
+    }
+
+    // PIZZAPI_PROXY_DEPTH: env var overrides config, and gets persisted back.
+    const envProxyDepth = process.env.PIZZAPI_PROXY_DEPTH;
+    if (envProxyDepth) {
+        const parsed = parseInt(envProxyDepth, 10);
+        if (!isNaN(parsed) && parsed >= 1) {
+            config.proxyDepth = parsed;
+        }
+    }
+
+    // Persist any env-driven changes back to config.json
+    saveWebConfig(config);
+
+    const trustProxyLine = config.trustProxy
+        ? `      - PIZZAPI_TRUST_PROXY=true\n`
         : `      # - PIZZAPI_TRUST_PROXY=\n`;
+
+    const proxyDepthLine = config.proxyDepth && config.proxyDepth > 1
+        ? `      - PIZZAPI_PROXY_DEPTH=${config.proxyDepth}\n`
+        : `      # - PIZZAPI_PROXY_DEPTH=\n`;
 
     const compose = template
         .replace(/\{\{REPO_PATH}}/g, repoPath)
@@ -416,7 +469,8 @@ function generateComposeFile(repoPath: string, config: WebConfig): string {
         .replace(/\{\{VAPID_SUBJECT}}/g, config.vapidSubject)
         .replace(/\{\{BETTER_AUTH_SECRET}}/g, config.betterAuthSecret)
         .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, extraOriginsLine)
-        .replace(/\{\{TRUST_PROXY_LINE}}/g, trustProxyLine);
+        .replace(/\{\{TRUST_PROXY_LINE}}/g, trustProxyLine)
+        .replace(/\{\{PROXY_DEPTH_LINE}}/g, proxyDepthLine);
 
     // Only write if changed
     const existing = existsSync(composePath) ? readFileSync(composePath, "utf-8") : null;

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -445,7 +445,7 @@ function generateComposeFile(repoPath: string, config: WebConfig): string {
     const envProxyDepth = process.env.PIZZAPI_PROXY_DEPTH;
     if (envProxyDepth) {
         const parsed = parseInt(envProxyDepth, 10);
-        if (!isNaN(parsed) && parsed >= 1) {
+        if (!isNaN(parsed) && parsed >= 0) {
             config.proxyDepth = parsed;
         }
     }
@@ -459,7 +459,7 @@ function generateComposeFile(repoPath: string, config: WebConfig): string {
             ? `      - PIZZAPI_TRUST_PROXY=false\n`
             : `      # - PIZZAPI_TRUST_PROXY=\n`;
 
-    const proxyDepthLine = config.proxyDepth !== undefined && config.proxyDepth >= 1
+    const proxyDepthLine = config.proxyDepth !== undefined && config.proxyDepth >= 0
         ? `      - PIZZAPI_PROXY_DEPTH=${config.proxyDepth}\n`
         : `      # - PIZZAPI_PROXY_DEPTH=\n`;
 

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -459,7 +459,7 @@ function generateComposeFile(repoPath: string, config: WebConfig): string {
             ? `      - PIZZAPI_TRUST_PROXY=false\n`
             : `      # - PIZZAPI_TRUST_PROXY=\n`;
 
-    const proxyDepthLine = config.proxyDepth && config.proxyDepth > 1
+    const proxyDepthLine = config.proxyDepth !== undefined && config.proxyDepth >= 1
         ? `      - PIZZAPI_PROXY_DEPTH=${config.proxyDepth}\n`
         : `      # - PIZZAPI_PROXY_DEPTH=\n`;
 

--- a/packages/docs/src/content/docs/deployment/self-hosting.mdx
+++ b/packages/docs/src/content/docs/deployment/self-hosting.mdx
@@ -214,18 +214,15 @@ When PizzaPi runs behind a reverse proxy (like Caddy, nginx, or Traefik in Docke
 
 ### Loopback Proxies (Auto-Detected)
 
-If your reverse proxy is on the **same host** (loopback / 127.0.0.1) — which is typical for Docker Compose on a single machine — no configuration is needed. The server auto-detects this and safely trusts `X-Forwarded-For` headers.
+If your reverse proxy is on the **same host** and connects to PizzaPi via loopback (`127.0.0.1`) — for example, a system-installed nginx or Caddy forwarding to `localhost:7492` — no configuration is needed. The server auto-detects this and safely trusts `X-Forwarded-For` headers.
 
-Example: Docker Compose with Caddy locally → PizzaPi on localhost:7492
-
-```bash
-# No env var needed — auto-detected as loopback
-docker compose -f docker/compose.yml up -d
-```
+:::caution[Docker Compose is not loopback]
+In Docker Compose, **all inter-container traffic goes over a bridge network** (e.g. `172.x.x.x`), even when all containers run on the same machine. PizzaPi sees the proxy's bridge IP — not `127.0.0.1` — so the auto-detection does **not** apply. Docker Compose deployments with a reverse proxy always need `PIZZAPI_TRUST_PROXY=true` (see below).
+:::
 
 ### Non-Loopback Proxies
 
-If your reverse proxy is on a **different host or Docker bridge network** (e.g. Traefik on a Docker overlay network, or a cloud load balancer), set `PIZZAPI_TRUST_PROXY=true`.
+If your reverse proxy reaches PizzaPi via a **non-loopback address** — including any Docker Compose setup, a Docker overlay network, or a cloud load balancer — set `PIZZAPI_TRUST_PROXY=true`.
 
 The simplest approach is to pass the variable inline — it will be forwarded to the Docker container:
 

--- a/packages/docs/src/content/docs/deployment/self-hosting.mdx
+++ b/packages/docs/src/content/docs/deployment/self-hosting.mdx
@@ -235,7 +235,7 @@ services:
       PIZZAPI_TRUST_PROXY: "true"
 ```
 
-Or as a direct variable:
+Or pass the variable when launching with `pizzapi web` (it will be forwarded to the Docker container):
 
 ```bash
 PIZZAPI_TRUST_PROXY=true pizzapi web
@@ -244,6 +244,27 @@ PIZZAPI_TRUST_PROXY=true pizzapi web
 <Aside type="caution">
   Only set `PIZZAPI_TRUST_PROXY=true` if you have a reverse proxy in front of PizzaPi. Enabling this without a proxy allows clients to spoof their IP address and bypass rate limiting.
 </Aside>
+
+### Multi-Proxy Chains
+
+By default, PizzaPi uses the **rightmost** `X-Forwarded-For` entry — the IP appended by the directly-connected proxy. This is safe against client spoofing for single-proxy setups.
+
+If you have **multiple trusted proxy hops** (e.g. CDN → nginx → PizzaPi), set `PIZZAPI_PROXY_DEPTH` to the number of trusted proxies:
+
+```yaml
+# docker/compose.override.yml — CDN + local proxy = 2 hops
+services:
+  server:
+    environment:
+      PIZZAPI_TRUST_PROXY: "true"
+      PIZZAPI_PROXY_DEPTH: "2"
+```
+
+| Depth | Use case | XFF entry used |
+|-------|----------|----------------|
+| `1` (default) | Single proxy (Caddy, nginx, Traefik) | Rightmost |
+| `2` | CDN + local proxy | Second from right |
+| `N` | N trusted hops | Nth from right |
 
 ---
 

--- a/packages/docs/src/content/docs/deployment/self-hosting.mdx
+++ b/packages/docs/src/content/docs/deployment/self-hosting.mdx
@@ -208,6 +208,45 @@ cp packages/server/auth.db packages/server/auth.db.backup
 
 ---
 
+## Reverse Proxy Configuration
+
+When PizzaPi runs behind a reverse proxy (like Caddy, nginx, or Traefik in Docker), the server needs to trust proxy headers to correctly identify the real client IP for rate limiting and other security features.
+
+### Loopback Proxies (Auto-Detected)
+
+If your reverse proxy is on the **same host** (loopback / 127.0.0.1) — which is typical for Docker Compose on a single machine — no configuration is needed. The server auto-detects this and safely trusts `X-Forwarded-For` headers.
+
+Example: Docker Compose with Caddy locally → PizzaPi on localhost:7492
+
+```bash
+# No env var needed — auto-detected as loopback
+docker compose -f docker/compose.yml up -d
+```
+
+### Non-Loopback Proxies
+
+If your reverse proxy is on a **different host or Docker bridge network** (e.g. Traefik on a Docker overlay network, or a cloud load balancer), set `PIZZAPI_TRUST_PROXY=true`:
+
+```yaml
+# docker/compose.override.yml
+services:
+  server:
+    environment:
+      PIZZAPI_TRUST_PROXY: "true"
+```
+
+Or as a direct variable:
+
+```bash
+PIZZAPI_TRUST_PROXY=true pizzapi web
+```
+
+<Aside type="caution">
+  Only set `PIZZAPI_TRUST_PROXY=true` if you have a reverse proxy in front of PizzaPi. Enabling this without a proxy allows clients to spoof their IP address and bypass rate limiting.
+</Aside>
+
+---
+
 ## HTTPS with Caddy
 
 Caddy automatically provisions TLS certificates via Let's Encrypt:

--- a/packages/docs/src/content/docs/deployment/self-hosting.mdx
+++ b/packages/docs/src/content/docs/deployment/self-hosting.mdx
@@ -225,7 +225,15 @@ docker compose -f docker/compose.yml up -d
 
 ### Non-Loopback Proxies
 
-If your reverse proxy is on a **different host or Docker bridge network** (e.g. Traefik on a Docker overlay network, or a cloud load balancer), set `PIZZAPI_TRUST_PROXY=true`:
+If your reverse proxy is on a **different host or Docker bridge network** (e.g. Traefik on a Docker overlay network, or a cloud load balancer), set `PIZZAPI_TRUST_PROXY=true`.
+
+The simplest approach is to pass the variable inline — it will be forwarded to the Docker container:
+
+```bash
+PIZZAPI_TRUST_PROXY=true pizzapi web
+```
+
+Alternatively, add it to `docker/compose.override.yml` and pass **both** compose files explicitly (Docker only auto-merges `compose.override.yml` when you omit `-f`):
 
 ```yaml
 # docker/compose.override.yml
@@ -235,10 +243,8 @@ services:
       PIZZAPI_TRUST_PROXY: "true"
 ```
 
-Or pass the variable when launching with `pizzapi web` (it will be forwarded to the Docker container):
-
 ```bash
-PIZZAPI_TRUST_PROXY=true pizzapi web
+docker compose -f docker/compose.yml -f docker/compose.override.yml up -d
 ```
 
 <Aside type="caution">
@@ -249,22 +255,37 @@ PIZZAPI_TRUST_PROXY=true pizzapi web
 
 By default, PizzaPi uses the **rightmost** `X-Forwarded-For` entry — the IP appended by the directly-connected proxy. This is safe against client spoofing for single-proxy setups.
 
-If you have **multiple trusted proxy hops** (e.g. CDN → nginx → PizzaPi), set `PIZZAPI_PROXY_DEPTH` to the number of trusted proxies:
+If you have **multiple trusted proxy hops** (e.g. CDN → nginx → PizzaPi), set `PIZZAPI_PROXY_DEPTH` to the number of **intermediate** hops between the outermost trusted proxy and the real client:
+
+```bash
+# CDN + local reverse proxy = 1 intermediate hop
+PIZZAPI_TRUST_PROXY=true PIZZAPI_PROXY_DEPTH=1 pizzapi web
+```
+
+Or with both compose files explicitly (required when using `-f`):
 
 ```yaml
-# docker/compose.override.yml — CDN + local proxy = 2 hops
+# docker/compose.override.yml — CDN + local proxy = 1 intermediate hop
 services:
   server:
     environment:
       PIZZAPI_TRUST_PROXY: "true"
-      PIZZAPI_PROXY_DEPTH: "2"
+      PIZZAPI_PROXY_DEPTH: "1"
 ```
 
-| Depth | Use case | XFF entry used |
+```bash
+docker compose -f docker/compose.yml -f docker/compose.override.yml up -d
+```
+
+| Depth | Topology | XFF entry used |
 |-------|----------|----------------|
-| `1` (default) | Single proxy (Caddy, nginx, Traefik) | Rightmost |
-| `2` | CDN + local proxy | Second from right |
-| `N` | N trusted hops | Nth from right |
+| `0` (default) | Single proxy (Caddy, nginx, Traefik) | Rightmost |
+| `1` | CDN + local proxy (2 total hops) | Second from right |
+| `N` | N+1 total trusted hops | N positions from the right |
+
+:::note
+`PIZZAPI_PROXY_DEPTH` counts **intermediate** hops, not total proxies. A single reverse proxy uses `depth=0` (the default). If in doubt, leave it unset.
+:::
 
 ---
 

--- a/packages/docs/src/content/docs/reference/environment-variables.mdx
+++ b/packages/docs/src/content/docs/reference/environment-variables.mdx
@@ -92,13 +92,14 @@ These variables control which subsystems are loaded by runner-spawned worker ses
 | `BETTER_AUTH_SECRET` | Secret key used by better-auth for session signing. **Must be set in production.** | — |
 | `BETTER_AUTH_BASE_URL` | Base URL that better-auth uses for its own endpoints. | `http://localhost:<PORT>` |
 
-### Rate Limiting
+### Rate Limiting & Security
 
 | Variable | Description | Default |
 |---|---|---|
 | `PIZZAPI_API_KEY_RATE_LIMIT_ENABLED` | Enable rate limiting on API-key-authenticated requests (`true` / `false`). | `false` |
 | `PIZZAPI_API_KEY_RATE_LIMIT_MAX_REQUESTS` | Maximum number of requests allowed per time window. | `10` |
 | `PIZZAPI_API_KEY_RATE_LIMIT_TIME_WINDOW_MS` | Length of the rate-limit sliding window in milliseconds. | `86400000` (24 h) |
+| `PIZZAPI_TRUST_PROXY` | Enable reverse proxy header handling for rate limiting and client IP detection. Set to `true` when the server is behind a non-loopback reverse proxy (e.g. Docker bridge network, Caddy, nginx). Loopback proxies (127.0.0.1, ::1) are auto-detected without this setting. Set to `false` to disable proxy detection entirely. See [Self-Hosting](/PizzaPi/guides/self-hosting/#reverse-proxy-configuration) for details. | `unset` (auto-detect loopback only) |
 
 ### Attachments
 

--- a/packages/docs/src/content/docs/reference/environment-variables.mdx
+++ b/packages/docs/src/content/docs/reference/environment-variables.mdx
@@ -100,7 +100,7 @@ These variables control which subsystems are loaded by runner-spawned worker ses
 | `PIZZAPI_API_KEY_RATE_LIMIT_MAX_REQUESTS` | Maximum number of requests allowed per time window. | `10` |
 | `PIZZAPI_API_KEY_RATE_LIMIT_TIME_WINDOW_MS` | Length of the rate-limit sliding window in milliseconds. | `86400000` (24 h) |
 | `PIZZAPI_TRUST_PROXY` | Enable reverse proxy header handling for rate limiting and client IP detection. Set to `true` when the server is behind a non-loopback reverse proxy (e.g. Docker bridge network, Caddy, nginx). Loopback proxies (127.0.0.1, ::1) are auto-detected without this setting. Set to `false` to disable proxy detection entirely. See [Self-Hosting](/PizzaPi/guides/self-hosting/#reverse-proxy-configuration) for details. | `unset` (auto-detect loopback only) |
-| `PIZZAPI_PROXY_DEPTH` | Number of trusted proxy hops for `X-Forwarded-For` parsing. The server uses the Nth-from-right XFF entry (where N = depth). Set to `2` for CDN + local proxy setups, `3` for three proxy hops, etc. Only meaningful when proxy trust is enabled. See [Self-Hosting](/PizzaPi/guides/self-hosting/#multi-proxy-chains). | `1` |
+| `PIZZAPI_PROXY_DEPTH` | Number of intermediate proxy hops between the server and the original client, for `X-Forwarded-For` parsing. `0` (default) = single proxy — use the right-most XFF entry. `1` = two proxies (e.g. CDN + local reverse proxy) — use the second-from-right entry. `N` = N+1 total proxies — use the entry N positions from the right. Only meaningful when proxy trust is enabled. See [Self-Hosting](/PizzaPi/guides/self-hosting/#multi-proxy-chains). | `0` |
 
 ### Attachments
 

--- a/packages/docs/src/content/docs/reference/environment-variables.mdx
+++ b/packages/docs/src/content/docs/reference/environment-variables.mdx
@@ -100,6 +100,7 @@ These variables control which subsystems are loaded by runner-spawned worker ses
 | `PIZZAPI_API_KEY_RATE_LIMIT_MAX_REQUESTS` | Maximum number of requests allowed per time window. | `10` |
 | `PIZZAPI_API_KEY_RATE_LIMIT_TIME_WINDOW_MS` | Length of the rate-limit sliding window in milliseconds. | `86400000` (24 h) |
 | `PIZZAPI_TRUST_PROXY` | Enable reverse proxy header handling for rate limiting and client IP detection. Set to `true` when the server is behind a non-loopback reverse proxy (e.g. Docker bridge network, Caddy, nginx). Loopback proxies (127.0.0.1, ::1) are auto-detected without this setting. Set to `false` to disable proxy detection entirely. See [Self-Hosting](/PizzaPi/guides/self-hosting/#reverse-proxy-configuration) for details. | `unset` (auto-detect loopback only) |
+| `PIZZAPI_PROXY_DEPTH` | Number of trusted proxy hops for `X-Forwarded-For` parsing. The server uses the Nth-from-right XFF entry (where N = depth). Set to `2` for CDN + local proxy setups, `3` for three proxy hops, etc. Only meaningful when proxy trust is enabled. See [Self-Hosting](/PizzaPi/guides/self-hosting/#multi-proxy-chains). | `1` |
 
 ### Attachments
 

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -200,6 +200,19 @@ function _createAuth(opts: {
         database: { dialect: opts.dialect, type: "sqlite" as const, transaction: true },
         trustedOrigins: opts.trustedOrigins,
         emailAndPassword: { enabled: true },
+        advanced: {
+            ipAddress: {
+                // Use our securely-injected header instead of the default x-forwarded-for.
+                // x-pizzapi-client-ip is set in nodeReqToFetchRequest() from the TCP socket's
+                // remoteAddress and stripped from any client-supplied value, making it
+                // spoofing-proof. This prevents attackers from rotating X-Forwarded-For to
+                // bypass Better Auth's built-in rate limits on /sign-in, /sign-up, etc.
+                // handler.ts further rewrites x-pizzapi-client-ip to the fully-resolved
+                // client IP (accounting for trusted reverse proxy hops) before auth routes
+                // are dispatched.
+                ipAddressHeaders: ["x-pizzapi-client-ip"],
+            },
+        },
         plugins: [
             apiKey({
                 enableSessionForAPIKeys: true,

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -2,6 +2,7 @@ import { getAuth, isSignupAllowed } from "./auth.js";
 import { isValidPassword, PASSWORD_REQUIREMENTS_SUMMARY } from "@pizzapi/protocol";
 import { handleApi } from "./routes/index.js";
 import { serveStaticFile } from "./static.js";
+import { getClientIp } from "./security.js";
 
 /**
  * Fetch-style request handler (REST + auth + static).
@@ -40,7 +41,17 @@ export async function handleFetch(req: Request): Promise<Response> {
         }
 
         try {
-            return await getAuth().handler(req);
+            // Rewrite x-pizzapi-client-ip with the fully-resolved client IP (accounting
+            // for trusted reverse-proxy hops via getClientIp) before handing off to
+            // Better Auth. Better Auth is configured to key its built-in rate limiter on
+            // x-pizzapi-client-ip (see auth.ts advanced.ipAddress.ipAddressHeaders), so
+            // this ensures per-client rate limiting works correctly in proxy deployments
+            // while remaining immune to X-Forwarded-For spoofing.
+            const resolvedIp = getClientIp(req);
+            const authHeaders = new Headers(req.headers);
+            authHeaders.set("x-pizzapi-client-ip", resolvedIp);
+            const authReq = new Request(req, { headers: authHeaders });
+            return await getAuth().handler(authReq);
         } catch (e) {
             console.error("[auth] handler threw:", e);
             return Response.json({ error: "Auth error" }, { status: 500 });

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -56,11 +56,17 @@ function nodeReqToFetchRequest(req: IncomingMessage): Request {
     const headers = new Headers();
     for (const [key, value] of Object.entries(req.headers)) {
         if (value === undefined) continue;
+        if (key.toLowerCase() === "x-pizzapi-client-ip") continue; // Prevent spoofing
         if (Array.isArray(value)) {
             for (const v of value) headers.append(key, v);
         } else {
             headers.set(key, value);
         }
+    }
+
+    // Securely attach the real client IP so downstream routes can use it for rate limiting, etc.
+    if (req.socket.remoteAddress) {
+        headers.set("x-pizzapi-client-ip", req.socket.remoteAddress);
     }
 
     const method = (req.method ?? "GET").toUpperCase();

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -24,12 +24,14 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
     // ── Public endpoint: register (create user + generate CLI API key) ──
     if (url.pathname === "/api/register" && req.method === "POST") {
         const clientIp = getClientIp(req);
-        // Only rate-limit when we have a real client IP. When the IP is
-        // "unknown" (e.g. handleFetch called directly without the Node
-        // adapter injecting x-pizzapi-client-ip), skipping the check avoids
-        // collapsing every request into a single shared bucket and
-        // incorrectly returning 429 to unrelated clients.
-        if (clientIp !== "unknown" && !registerRateLimiter.check(clientIp)) {
+        // Always apply rate limiting — never skip based on IP value.
+        // When getClientIp() cannot resolve a real client IP (e.g. XFF chain
+        // mismatch in multi-proxy setups), it falls back to the raw socket IP.
+        // Even in the edge case where the IP is "unknown" (handleFetch called
+        // directly without the Node adapter), we still rate-limit: better to
+        // share a single bucket for headerless callers than to leave the
+        // endpoint completely unthrottled for brute-force.
+        if (!registerRateLimiter.check(clientIp)) {
             return Response.json(
                 { error: "Too many registration attempts. Please try again later." },
                 { status: 429 },

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -24,7 +24,12 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
     // ── Public endpoint: register (create user + generate CLI API key) ──
     if (url.pathname === "/api/register" && req.method === "POST") {
         const clientIp = getClientIp(req);
-        if (!registerRateLimiter.check(clientIp)) {
+        // Only rate-limit when we have a real client IP. When the IP is
+        // "unknown" (e.g. handleFetch called directly without the Node
+        // adapter injecting x-pizzapi-client-ip), skipping the check avoids
+        // collapsing every request into a single shared bucket and
+        // incorrectly returning 429 to unrelated clients.
+        if (clientIp !== "unknown" && !registerRateLimiter.check(clientIp)) {
             return Response.json(
                 { error: "Too many registration attempts. Please try again later." },
                 { status: 429 },

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -7,7 +7,7 @@
  */
 
 import { getApiKeyRateLimitConfig, getAuth, getKysely, isSignupAllowed } from "../auth.js";
-import { RateLimiter, isValidEmail, isValidPassword } from "../security.js";
+import { RateLimiter, isValidEmail, isValidPassword, getClientIp } from "../security.js";
 import { PASSWORD_REQUIREMENTS_SUMMARY } from "@pizzapi/protocol";
 import type { RouteHandler } from "./types.js";
 
@@ -23,7 +23,7 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
 
     // ── Public endpoint: register (create user + generate CLI API key) ──
     if (url.pathname === "/api/register" && req.method === "POST") {
-        const clientIp = req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || "unknown";
+        const clientIp = getClientIp(req);
         if (!registerRateLimiter.check(clientIp)) {
             return Response.json(
                 { error: "Too many registration attempts. Please try again later." },

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -294,30 +294,35 @@ describe("getClientIp", () => {
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
-    test("fails closed to socket IP when depth>0 and XFF chain has extra left-side padding", () => {
+    test("accepts padded XFF chain when depth>0 and reads the correct right-anchored slot", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
         process.env.PIZZAPI_PROXY_DEPTH = "2";
-        // depth=2 expects exactly 3 entries. With a padded chain of 4 entries,
-        // reject the chain instead of selecting a potentially attacker-controlled slot.
+        // depth=2 expects 3 entries minimum. With 4 entries the client has prepended
+        // a bogus left-side hop. The formula parts[parts.length - 1 - depth] still
+        // reads from the right, so the correct client slot is unaffected.
+        //   parts = ["1.1.1.1", "2.2.2.2", "3.3.3.3", "203.0.113.50"]
+        //   index = 4 - 1 - 2 = 1 → "2.2.2.2" (the outermost trusted proxy's view of client)
         const req = makeReq({
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3, 203.0.113.50",
         });
-        expect(getClientIp(req)).toBe("172.17.0.1");
+        expect(getClientIp(req)).toBe("2.2.2.2");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
-    test("fails closed to socket IP when depth=1 and client prepends extra XFF hop", () => {
-        // The core attack from the review: CDN -> nginx -> PizzaPi with depth=1.
-        // A malicious client prepends its own XFF hop, creating 3 entries instead of
-        // the expected 2. Falls back to the socket IP so rate limiting still applies.
+    test("accepts padded XFF chain when depth=1 and returns the CDN-appended real client IP", () => {
+        // With depth=1 (CDN → local proxy → server), each trusted proxy appends its peer:
+        //   Client sends request → CDN appends real client IP → local proxy appends CDN IP
+        // XFF = "evil-spoofed, 203.0.113.50, 198.51.100.5"
+        //   parts[3 - 1 - 1] = parts[1] = "203.0.113.50" (what the CDN saw as client)
+        // Left-side padding cannot shift the right-anchored trusted slots.
         process.env.PIZZAPI_TRUST_PROXY = "true";
         process.env.PIZZAPI_PROXY_DEPTH = "1";
         const req = makeReq({
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "evil-spoofed, 203.0.113.50, 198.51.100.5",
         });
-        expect(getClientIp(req)).toBe("172.17.0.1");
+        expect(getClientIp(req)).toBe("203.0.113.50");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -297,6 +297,22 @@ describe("getClientIp", () => {
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
+    test("fails closed when PIZZAPI_PROXY_DEPTH=1 with only 2 XFF entries (selects client-controlled index 0)", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+        process.env.PIZZAPI_PROXY_DEPTH = "1";
+        // Single-proxy setup misconfigured with depth=1.  The client sends one
+        // spoofed XFF entry; the proxy appends the real client IP, giving 2 entries.
+        // depth=1 with parts.length=2 would select index 0 (client-controlled).
+        // The updated guard requires parts.length >= depth+2 = 3, so it fails closed.
+        const req = makeReq({
+            "x-pizzapi-client-ip": "172.17.0.1",
+            "x-forwarded-for": "1.2.3.4, 203.0.113.50",
+        });
+        // depth=1 but only 2 entries — would land on spoofed slot → fail closed
+        expect(getClientIp(req)).toBe("172.17.0.1");
+        delete process.env.PIZZAPI_PROXY_DEPTH;
+    });
+
     test("single-entry XFF returns that entry (depth=0 default)", () => {
         delete process.env.PIZZAPI_TRUST_PROXY;
         delete process.env.PIZZAPI_PROXY_DEPTH;

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -276,8 +276,9 @@ describe("getClientIp", () => {
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "203.0.113.50, 198.51.100.5",
         });
-        // Should fall back to direct client IP (fail closed)
-        expect(getClientIp(req)).toBe("172.17.0.1");
+        // Returns "unknown" — NOT clientIp (the proxy's shared address).
+        // Rate-limiting on the proxy IP would let one attacker 429 everyone behind it.
+        expect(getClientIp(req)).toBe("unknown");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
@@ -289,7 +290,7 @@ describe("getClientIp", () => {
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "1.2.3.4, 5.6.7.8",
         });
-        expect(getClientIp(req)).toBe("172.17.0.1");
+        expect(getClientIp(req)).toBe("unknown");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
@@ -302,7 +303,21 @@ describe("getClientIp", () => {
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3, 203.0.113.50",
         });
-        expect(getClientIp(req)).toBe("172.17.0.1");
+        expect(getClientIp(req)).toBe("unknown");
+        delete process.env.PIZZAPI_PROXY_DEPTH;
+    });
+
+    test("fails closed with 'unknown' when depth=1 and client prepends extra XFF hop", () => {
+        // The core attack from the review: CDN -> nginx -> PizzaPi with depth=1.
+        // A malicious client prepends its own XFF hop, creating 3 entries instead of
+        // the expected 2. Returning "unknown" prevents rate-limiting on the proxy IP.
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+        process.env.PIZZAPI_PROXY_DEPTH = "1";
+        const req = makeReq({
+            "x-pizzapi-client-ip": "172.17.0.1",
+            "x-forwarded-for": "evil-spoofed, 203.0.113.50, 198.51.100.5",
+        });
+        expect(getClientIp(req)).toBe("unknown");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -254,15 +254,14 @@ describe("getClientIp", () => {
         expect(getClientIp(req)).toBe("10.0.0.1");
     });
 
-    test("PIZZAPI_PROXY_DEPTH=1 uses second-from-right for multi-proxy chains", () => {
+    test("PIZZAPI_PROXY_DEPTH=1 accepts the normal two-hop chain with 2 entries", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
         process.env.PIZZAPI_PROXY_DEPTH = "1";
-        // CDN → nginx → PizzaPi:
-        //   XFF: <spoofed>, <real-client>, <CDN-IP>
-        // depth=1 (1 intermediate hop) → parts[length - 1 - 1] = parts[length - 2] = real-client
+        // Typical CDN → local proxy → PizzaPi request with no client-supplied XFF:
+        //   XFF: <real-client>, <cdn-proxy>
         const req = makeReq({
             "x-pizzapi-client-ip": "172.17.0.1",
-            "x-forwarded-for": "1.2.3.4, 203.0.113.50, 198.51.100.5",
+            "x-forwarded-for": "203.0.113.50, 198.51.100.5",
         });
         expect(getClientIp(req)).toBe("203.0.113.50");
         delete process.env.PIZZAPI_PROXY_DEPTH;
@@ -285,30 +284,24 @@ describe("getClientIp", () => {
     test("fails closed when PIZZAPI_PROXY_DEPTH equals XFF chain length (padding attack)", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
         process.env.PIZZAPI_PROXY_DEPTH = "2";
-        // Attack: single-proxy setup mis-configured with depth=2.
-        // Attacker pads XFF to exactly 2 entries so parts.length - 2 - 1 would land
-        // on a spoofed left-side value. The strict >= fail-closed catches this.
+        // Chain too short for depth=2.
         const req = makeReq({
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "1.2.3.4, 5.6.7.8",
         });
-        // depth=2 >= parts.length=2 → fail closed to the peer IP
         expect(getClientIp(req)).toBe("172.17.0.1");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
-    test("fails closed when PIZZAPI_PROXY_DEPTH=1 with only 2 XFF entries (selects client-controlled index 0)", () => {
+    test("fails closed when depth>0 and XFF chain has extra left-side padding", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
-        process.env.PIZZAPI_PROXY_DEPTH = "1";
-        // Single-proxy setup misconfigured with depth=1.  The client sends one
-        // spoofed XFF entry; the proxy appends the real client IP, giving 2 entries.
-        // depth=1 with parts.length=2 would select index 0 (client-controlled).
-        // The updated guard requires parts.length >= depth+2 = 3, so it fails closed.
+        process.env.PIZZAPI_PROXY_DEPTH = "2";
+        // depth=2 expects exactly 3 entries. With a padded chain of 4 entries,
+        // reject the chain instead of selecting a potentially attacker-controlled slot.
         const req = makeReq({
             "x-pizzapi-client-ip": "172.17.0.1",
-            "x-forwarded-for": "1.2.3.4, 203.0.113.50",
+            "x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3, 203.0.113.50",
         });
-        // depth=1 but only 2 entries — would land on spoofed slot → fail closed
         expect(getClientIp(req)).toBe("172.17.0.1");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -338,10 +338,30 @@ describe("getClientIp", () => {
         expect(getClientIp(req)).toBe("198.51.100.1");
     });
 
-    test("PIZZAPI_TRUST_PROXY=true forces XFF trust even for public IPs", () => {
+    test("PIZZAPI_TRUST_PROXY=true does NOT trust XFF from public-IP peers (prevents spoofing)", () => {
+        // Security: if the backend port is directly reachable alongside the proxy,
+        // a public-IP client must NOT be able to spoof its IP via XFF.
         process.env.PIZZAPI_TRUST_PROXY = "true";
         const req = makeReq({
             "x-pizzapi-client-ip": "203.0.113.50",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("203.0.113.50");
+    });
+
+    test("PIZZAPI_TRUST_PROXY=true trusts XFF from 10.x.x.x peers (private Docker/LAN proxy)", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+        const req = makeReq({
+            "x-pizzapi-client-ip": "10.0.0.1",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.1");
+    });
+
+    test("PIZZAPI_TRUST_PROXY=true trusts XFF from 192.168.x.x peers (private proxy)", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+        const req = makeReq({
+            "x-pizzapi-client-ip": "192.168.1.1",
             "x-forwarded-for": "198.51.100.1",
         });
         expect(getClientIp(req)).toBe("198.51.100.1");

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -267,7 +267,7 @@ describe("getClientIp", () => {
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
-    test("fails closed when PIZZAPI_PROXY_DEPTH exceeds XFF chain length", () => {
+    test("fails closed to socket IP when PIZZAPI_PROXY_DEPTH exceeds XFF chain length", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
         process.env.PIZZAPI_PROXY_DEPTH = "3";
         // Only 2 hops in the chain but depth expects 3 — depth >= parts.length,
@@ -276,13 +276,13 @@ describe("getClientIp", () => {
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "203.0.113.50, 198.51.100.5",
         });
-        // Returns "unknown" — NOT clientIp (the proxy's shared address).
-        // Rate-limiting on the proxy IP would let one attacker 429 everyone behind it.
-        expect(getClientIp(req)).toBe("unknown");
+        // Falls back to the raw socket/proxy IP so callers can still apply
+        // per-IP rate limiting instead of skipping it entirely.
+        expect(getClientIp(req)).toBe("172.17.0.1");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
-    test("fails closed when PIZZAPI_PROXY_DEPTH equals XFF chain length (padding attack)", () => {
+    test("fails closed to socket IP when PIZZAPI_PROXY_DEPTH equals XFF chain length (padding attack)", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
         process.env.PIZZAPI_PROXY_DEPTH = "2";
         // Chain too short for depth=2.
@@ -290,11 +290,11 @@ describe("getClientIp", () => {
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "1.2.3.4, 5.6.7.8",
         });
-        expect(getClientIp(req)).toBe("unknown");
+        expect(getClientIp(req)).toBe("172.17.0.1");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
-    test("fails closed when depth>0 and XFF chain has extra left-side padding", () => {
+    test("fails closed to socket IP when depth>0 and XFF chain has extra left-side padding", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
         process.env.PIZZAPI_PROXY_DEPTH = "2";
         // depth=2 expects exactly 3 entries. With a padded chain of 4 entries,
@@ -303,21 +303,21 @@ describe("getClientIp", () => {
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "1.1.1.1, 2.2.2.2, 3.3.3.3, 203.0.113.50",
         });
-        expect(getClientIp(req)).toBe("unknown");
+        expect(getClientIp(req)).toBe("172.17.0.1");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
-    test("fails closed with 'unknown' when depth=1 and client prepends extra XFF hop", () => {
+    test("fails closed to socket IP when depth=1 and client prepends extra XFF hop", () => {
         // The core attack from the review: CDN -> nginx -> PizzaPi with depth=1.
         // A malicious client prepends its own XFF hop, creating 3 entries instead of
-        // the expected 2. Returning "unknown" prevents rate-limiting on the proxy IP.
+        // the expected 2. Falls back to the socket IP so rate limiting still applies.
         process.env.PIZZAPI_TRUST_PROXY = "true";
         process.env.PIZZAPI_PROXY_DEPTH = "1";
         const req = makeReq({
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "evil-spoofed, 203.0.113.50, 198.51.100.5",
         });
-        expect(getClientIp(req)).toBe("unknown");
+        expect(getClientIp(req)).toBe("172.17.0.1");
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -226,10 +226,47 @@ describe("getClientIp", () => {
         expect(getClientIp(req)).toBe("198.51.100.1");
     });
 
-    test("auto-detects reverse proxy for IPv4-mapped private IPs (::ffff:192.168.x.x)", () => {
+    test("does NOT auto-trust XFF for private (non-loopback) IPs like 192.168.x.x", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        const req = makeReq({
+            "x-pizzapi-client-ip": "192.168.1.1",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        // Private IPs are NOT auto-trusted — they could be direct LAN clients
+        expect(getClientIp(req)).toBe("192.168.1.1");
+    });
+
+    test("does NOT auto-trust XFF for IPv4-mapped private IPs (::ffff:192.168.x.x)", () => {
         delete process.env.PIZZAPI_TRUST_PROXY;
         const req = makeReq({
             "x-pizzapi-client-ip": "::ffff:192.168.1.1",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("::ffff:192.168.1.1");
+    });
+
+    test("does NOT auto-trust XFF for 10.x.x.x private IPs", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        const req = makeReq({
+            "x-pizzapi-client-ip": "10.0.0.1",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("10.0.0.1");
+    });
+
+    test("does NOT auto-trust XFF for Docker bridge IPs (172.17.x.x)", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        const req = makeReq({
+            "x-pizzapi-client-ip": "172.17.0.1",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("172.17.0.1");
+    });
+
+    test("PIZZAPI_TRUST_PROXY=true allows XFF trust for Docker bridge IPs", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+        const req = makeReq({
+            "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "198.51.100.1",
         });
         expect(getClientIp(req)).toBe("198.51.100.1");
@@ -244,7 +281,7 @@ describe("getClientIp", () => {
         expect(getClientIp(req)).toBe("198.51.100.1");
     });
 
-    test("PIZZAPI_TRUST_PROXY=false disables auto-detection for private IPs", () => {
+    test("PIZZAPI_TRUST_PROXY=false disables auto-detection for loopback IPs", () => {
         process.env.PIZZAPI_TRUST_PROXY = "false";
         const req = makeReq({
             "x-pizzapi-client-ip": "127.0.0.1",

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { RateLimiter, isValidEmail, isValidPassword, cwdMatchesRoots } from "./security";
+import { RateLimiter, isValidEmail, isValidPassword, cwdMatchesRoots, getClientIp } from "./security";
 
 describe("RateLimiter", () => {
     test("allows requests within limit", () => {
@@ -180,5 +180,91 @@ describe("isValidPassword", () => {
         expect(cwdMatchesRoots([root], "/home/user/project/")).toBe(true);
         expect(cwdMatchesRoots(["/home/user/project/"], "/home/user/project")).toBe(true);
         expect(cwdMatchesRoots(["/home/user/project/"], "/home/user/project/src")).toBe(true);
+    });
+});
+
+describe("getClientIp", () => {
+    const makeReq = (headers: Record<string, string>) =>
+        new Request("http://localhost/test", { headers });
+
+    const originalEnv = process.env.PIZZAPI_TRUST_PROXY;
+    afterAll(() => {
+        if (originalEnv === undefined) delete process.env.PIZZAPI_TRUST_PROXY;
+        else process.env.PIZZAPI_TRUST_PROXY = originalEnv;
+    });
+
+    test("returns x-pizzapi-client-ip for direct connections", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        const req = makeReq({ "x-pizzapi-client-ip": "203.0.113.50" });
+        expect(getClientIp(req)).toBe("203.0.113.50");
+    });
+
+    test("does not trust x-forwarded-for for public IPs", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        const req = makeReq({
+            "x-pizzapi-client-ip": "203.0.113.50",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("203.0.113.50");
+    });
+
+    test("auto-detects reverse proxy when remoteAddress is 127.0.0.1", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        const req = makeReq({
+            "x-pizzapi-client-ip": "127.0.0.1",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.1");
+    });
+
+    test("auto-detects reverse proxy when remoteAddress is IPv4-mapped ::ffff:127.0.0.1", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        const req = makeReq({
+            "x-pizzapi-client-ip": "::ffff:127.0.0.1",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.1");
+    });
+
+    test("auto-detects reverse proxy for IPv4-mapped private IPs (::ffff:192.168.x.x)", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        const req = makeReq({
+            "x-pizzapi-client-ip": "::ffff:192.168.1.1",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.1");
+    });
+
+    test("PIZZAPI_TRUST_PROXY=true forces XFF trust even for public IPs", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+        const req = makeReq({
+            "x-pizzapi-client-ip": "203.0.113.50",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("198.51.100.1");
+    });
+
+    test("PIZZAPI_TRUST_PROXY=false disables auto-detection for private IPs", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "false";
+        const req = makeReq({
+            "x-pizzapi-client-ip": "127.0.0.1",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("127.0.0.1");
+    });
+
+    test("PIZZAPI_TRUST_PROXY=false disables auto-detection for loopback", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "false";
+        const req = makeReq({
+            "x-pizzapi-client-ip": "::ffff:127.0.0.1",
+            "x-forwarded-for": "198.51.100.1",
+        });
+        expect(getClientIp(req)).toBe("::ffff:127.0.0.1");
+    });
+
+    test("returns 'unknown' when no headers present", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        const req = makeReq({});
+        expect(getClientIp(req)).toBe("unknown");
     });
 });

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -250,16 +250,16 @@ describe("getClientIp", () => {
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "203.0.113.99, 10.0.0.1",
         });
-        // Right-most entry (10.0.0.1) is the proxy-appended real client
+        // Right-most entry (10.0.0.1) is the proxy-appended real client (depth=0 default)
         expect(getClientIp(req)).toBe("10.0.0.1");
     });
 
-    test("PIZZAPI_PROXY_DEPTH=2 uses second-from-right for multi-proxy chains", () => {
+    test("PIZZAPI_PROXY_DEPTH=1 uses second-from-right for multi-proxy chains", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
-        process.env.PIZZAPI_PROXY_DEPTH = "2";
+        process.env.PIZZAPI_PROXY_DEPTH = "1";
         // CDN → nginx → PizzaPi:
         //   XFF: <spoofed>, <real-client>, <CDN-IP>
-        // depth=2 → parts[length - 2] = real-client
+        // depth=1 (1 intermediate hop) → parts[length - 1 - 1] = parts[length - 2] = real-client
         const req = makeReq({
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "1.2.3.4, 203.0.113.50, 198.51.100.5",
@@ -271,8 +271,8 @@ describe("getClientIp", () => {
     test("fails closed when PIZZAPI_PROXY_DEPTH exceeds XFF chain length", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
         process.env.PIZZAPI_PROXY_DEPTH = "3";
-        // Only 2 hops in the chain but depth expects 3 — the chain is shorter
-        // than expected, so we can't safely identify the real client.
+        // Only 2 hops in the chain but depth expects 3 — depth >= parts.length,
+        // so we can't safely identify the real client.
         const req = makeReq({
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "203.0.113.50, 198.51.100.5",
@@ -282,13 +282,29 @@ describe("getClientIp", () => {
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
-    test("single-entry XFF returns that entry regardless of depth", () => {
+    test("fails closed when PIZZAPI_PROXY_DEPTH equals XFF chain length (padding attack)", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+        process.env.PIZZAPI_PROXY_DEPTH = "2";
+        // Attack: single-proxy setup mis-configured with depth=2.
+        // Attacker pads XFF to exactly 2 entries so parts.length - 2 - 1 would land
+        // on a spoofed left-side value. The strict >= fail-closed catches this.
+        const req = makeReq({
+            "x-pizzapi-client-ip": "172.17.0.1",
+            "x-forwarded-for": "1.2.3.4, 5.6.7.8",
+        });
+        // depth=2 >= parts.length=2 → fail closed to the peer IP
+        expect(getClientIp(req)).toBe("172.17.0.1");
+        delete process.env.PIZZAPI_PROXY_DEPTH;
+    });
+
+    test("single-entry XFF returns that entry (depth=0 default)", () => {
         delete process.env.PIZZAPI_TRUST_PROXY;
         delete process.env.PIZZAPI_PROXY_DEPTH;
         const req = makeReq({
             "x-pizzapi-client-ip": "127.0.0.1",
             "x-forwarded-for": "203.0.113.50",
         });
+        // depth=0 (default): parts.length=1 > depth=0 → proceed, index=0 → client_ip
         expect(getClientIp(req)).toBe("203.0.113.50");
     });
 
@@ -338,15 +354,17 @@ describe("getClientIp", () => {
         expect(getClientIp(req)).toBe("198.51.100.1");
     });
 
-    test("PIZZAPI_TRUST_PROXY=true does NOT trust XFF from public-IP peers (prevents spoofing)", () => {
-        // Security: if the backend port is directly reachable alongside the proxy,
-        // a public-IP client must NOT be able to spoof its IP via XFF.
+    test("PIZZAPI_TRUST_PROXY=true trusts XFF from public-IP peers (explicit cloud LB opt-in)", () => {
+        // When the operator explicitly sets PIZZAPI_TRUST_PROXY=true they are asserting
+        // that all traffic arrives via a trusted proxy — including public cloud load
+        // balancers whose peer address is a public IP.  The explicit opt-in is the
+        // authorization; no additional peer-IP check is applied.
         process.env.PIZZAPI_TRUST_PROXY = "true";
         const req = makeReq({
             "x-pizzapi-client-ip": "203.0.113.50",
             "x-forwarded-for": "198.51.100.1",
         });
-        expect(getClientIp(req)).toBe("203.0.113.50");
+        expect(getClientIp(req)).toBe("198.51.100.1");
     });
 
     test("PIZZAPI_TRUST_PROXY=true trusts XFF from 10.x.x.x peers (private Docker/LAN proxy)", () => {

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -268,6 +268,20 @@ describe("getClientIp", () => {
         delete process.env.PIZZAPI_PROXY_DEPTH;
     });
 
+    test("fails closed when PIZZAPI_PROXY_DEPTH exceeds XFF chain length", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+        process.env.PIZZAPI_PROXY_DEPTH = "3";
+        // Only 2 hops in the chain but depth expects 3 — the chain is shorter
+        // than expected, so we can't safely identify the real client.
+        const req = makeReq({
+            "x-pizzapi-client-ip": "172.17.0.1",
+            "x-forwarded-for": "203.0.113.50, 198.51.100.5",
+        });
+        // Should fall back to direct client IP (fail closed)
+        expect(getClientIp(req)).toBe("172.17.0.1");
+        delete process.env.PIZZAPI_PROXY_DEPTH;
+    });
+
     test("single-entry XFF returns that entry regardless of depth", () => {
         delete process.env.PIZZAPI_TRUST_PROXY;
         delete process.env.PIZZAPI_PROXY_DEPTH;

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -187,10 +187,13 @@ describe("getClientIp", () => {
     const makeReq = (headers: Record<string, string>) =>
         new Request("http://localhost/test", { headers });
 
-    const originalEnv = process.env.PIZZAPI_TRUST_PROXY;
+    const originalTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
+    const originalProxyDepth = process.env.PIZZAPI_PROXY_DEPTH;
     afterAll(() => {
-        if (originalEnv === undefined) delete process.env.PIZZAPI_TRUST_PROXY;
-        else process.env.PIZZAPI_TRUST_PROXY = originalEnv;
+        if (originalTrustProxy === undefined) delete process.env.PIZZAPI_TRUST_PROXY;
+        else process.env.PIZZAPI_TRUST_PROXY = originalTrustProxy;
+        if (originalProxyDepth === undefined) delete process.env.PIZZAPI_PROXY_DEPTH;
+        else process.env.PIZZAPI_PROXY_DEPTH = originalProxyDepth;
     });
 
     test("returns x-pizzapi-client-ip for direct connections", () => {
@@ -226,26 +229,53 @@ describe("getClientIp", () => {
         expect(getClientIp(req)).toBe("198.51.100.1");
     });
 
-    test("uses left-most XFF entry as the original client IP in multi-hop chains", () => {
+    test("uses right-most XFF entry to prevent client spoofing (single proxy)", () => {
         delete process.env.PIZZAPI_TRUST_PROXY;
-        // Standard reverse proxy behavior: creates fresh X-Forwarded-For header(s)
-        // In multi-proxy chains: X-Forwarded-For: <client-ip>, <proxy-1>, <proxy-2>, ...
-        // The left-most is the original client IP.
+        delete process.env.PIZZAPI_PROXY_DEPTH;
+        // nginx $proxy_add_x_forwarded_for appends $remote_addr to any existing header:
+        //   Client sends: X-Forwarded-For: 1.2.3.4 (spoofed)
+        //   Proxy appends: X-Forwarded-For: 1.2.3.4, 203.0.113.50 (real client IP)
+        // Right-most is the proxy-appended real client IP.
         const req = makeReq({
             "x-pizzapi-client-ip": "127.0.0.1",
-            "x-forwarded-for": "203.0.113.50, 198.51.100.5",
+            "x-forwarded-for": "1.2.3.4, 203.0.113.50",
         });
-        // Return left-most (original client)
         expect(getClientIp(req)).toBe("203.0.113.50");
     });
 
-    test("uses left-most XFF entry with TRUST_PROXY=true", () => {
+    test("uses right-most XFF entry with TRUST_PROXY=true", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
+        delete process.env.PIZZAPI_PROXY_DEPTH;
         const req = makeReq({
             "x-pizzapi-client-ip": "172.17.0.1",
             "x-forwarded-for": "203.0.113.99, 10.0.0.1",
         });
-        expect(getClientIp(req)).toBe("203.0.113.99");
+        // Right-most entry (10.0.0.1) is the proxy-appended real client
+        expect(getClientIp(req)).toBe("10.0.0.1");
+    });
+
+    test("PIZZAPI_PROXY_DEPTH=2 uses second-from-right for multi-proxy chains", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+        process.env.PIZZAPI_PROXY_DEPTH = "2";
+        // CDN → nginx → PizzaPi:
+        //   XFF: <spoofed>, <real-client>, <CDN-IP>
+        // depth=2 → parts[length - 2] = real-client
+        const req = makeReq({
+            "x-pizzapi-client-ip": "172.17.0.1",
+            "x-forwarded-for": "1.2.3.4, 203.0.113.50, 198.51.100.5",
+        });
+        expect(getClientIp(req)).toBe("203.0.113.50");
+        delete process.env.PIZZAPI_PROXY_DEPTH;
+    });
+
+    test("single-entry XFF returns that entry regardless of depth", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        delete process.env.PIZZAPI_PROXY_DEPTH;
+        const req = makeReq({
+            "x-pizzapi-client-ip": "127.0.0.1",
+            "x-forwarded-for": "203.0.113.50",
+        });
+        expect(getClientIp(req)).toBe("203.0.113.50");
     });
 
     test("does NOT auto-trust XFF for private (non-loopback) IPs like 192.168.x.x", () => {

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -226,23 +226,24 @@ describe("getClientIp", () => {
         expect(getClientIp(req)).toBe("198.51.100.1");
     });
 
-    test("uses right-most XFF entry to prevent client spoofing via prepended hops", () => {
+    test("uses left-most XFF entry as the original client IP in multi-hop chains", () => {
         delete process.env.PIZZAPI_TRUST_PROXY;
-        // Simulates nginx $proxy_add_x_forwarded_for: client sends "X-Forwarded-For: 1.2.3.4",
-        // nginx appends real client IP → "1.2.3.4, 203.0.113.50"
+        // Standard reverse proxy behavior: creates fresh X-Forwarded-For header(s)
+        // In multi-proxy chains: X-Forwarded-For: <client-ip>, <proxy-1>, <proxy-2>, ...
+        // The left-most is the original client IP.
         const req = makeReq({
             "x-pizzapi-client-ip": "127.0.0.1",
-            "x-forwarded-for": "1.2.3.4, 203.0.113.50",
+            "x-forwarded-for": "203.0.113.50, 198.51.100.5",
         });
-        // Must return right-most (proxy-appended) IP, NOT the spoofed left-most
+        // Return left-most (original client)
         expect(getClientIp(req)).toBe("203.0.113.50");
     });
 
-    test("uses right-most XFF entry with TRUST_PROXY=true", () => {
+    test("uses left-most XFF entry with TRUST_PROXY=true", () => {
         process.env.PIZZAPI_TRUST_PROXY = "true";
         const req = makeReq({
             "x-pizzapi-client-ip": "172.17.0.1",
-            "x-forwarded-for": "10.0.0.1, 203.0.113.99",
+            "x-forwarded-for": "203.0.113.99, 10.0.0.1",
         });
         expect(getClientIp(req)).toBe("203.0.113.99");
     });

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -226,6 +226,27 @@ describe("getClientIp", () => {
         expect(getClientIp(req)).toBe("198.51.100.1");
     });
 
+    test("uses right-most XFF entry to prevent client spoofing via prepended hops", () => {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+        // Simulates nginx $proxy_add_x_forwarded_for: client sends "X-Forwarded-For: 1.2.3.4",
+        // nginx appends real client IP → "1.2.3.4, 203.0.113.50"
+        const req = makeReq({
+            "x-pizzapi-client-ip": "127.0.0.1",
+            "x-forwarded-for": "1.2.3.4, 203.0.113.50",
+        });
+        // Must return right-most (proxy-appended) IP, NOT the spoofed left-most
+        expect(getClientIp(req)).toBe("203.0.113.50");
+    });
+
+    test("uses right-most XFF entry with TRUST_PROXY=true", () => {
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+        const req = makeReq({
+            "x-pizzapi-client-ip": "172.17.0.1",
+            "x-forwarded-for": "10.0.0.1, 203.0.113.99",
+        });
+        expect(getClientIp(req)).toBe("203.0.113.99");
+    });
+
     test("does NOT auto-trust XFF for private (non-loopback) IPs like 192.168.x.x", () => {
         delete process.env.PIZZAPI_TRUST_PROXY;
         const req = makeReq({

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -118,24 +118,19 @@ function normalizeIp(ip: string): string {
 }
 
 /**
- * Check if an IP address is private/loopback (indicating likely reverse proxy setup).
+ * Check if an IP address is loopback (indicating a reverse proxy on the same host).
  * Handles IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1) via normalizeIp().
+ *
+ * SECURITY NOTE: Only loopback is safe for auto-detection. Broader private ranges
+ * (10.x, 172.16-31.x, 192.168.x) are NOT auto-trusted because the server may be
+ * directly accessible on the LAN (e.g. Docker published on 0.0.0.0), where direct
+ * clients also arrive with private IPs. Trusting XFF from those would let any LAN
+ * client spoof their rate-limit key. Operators behind a non-loopback proxy (e.g.
+ * Docker bridge network) should set PIZZAPI_TRUST_PROXY=true explicitly.
  */
-function isPrivateOrLoopbackIp(rawIp: string): boolean {
+function isLoopbackIp(rawIp: string): boolean {
     const ip = normalizeIp(rawIp);
-    // Loopback
-    if (ip === "127.0.0.1" || ip === "::1" || ip === "localhost") return true;
-    // IPv4 private ranges
-    if (ip.startsWith("10.")) return true;
-    if (ip.startsWith("172.") && /^172\.([1-2][0-9]|3[0-1])\./.test(ip)) return true;
-    if (ip.startsWith("192.168.")) return true;
-    // IPv4 link-local
-    if (ip.startsWith("169.254.")) return true;
-    // IPv6 unique local
-    if (ip.startsWith("fc") || ip.startsWith("fd")) return true;
-    // IPv6 link-local
-    if (ip.startsWith("fe80")) return true;
-    return false;
+    return ip === "127.0.0.1" || ip === "::1" || ip === "localhost";
 }
 
 /**
@@ -145,10 +140,13 @@ function isPrivateOrLoopbackIp(rawIp: string): boolean {
  * from the TCP connection's remoteAddress, preventing client spoofing.
  *
  * In reverse proxy setups (common deployment): Detects when remoteAddress is
- * a private/loopback IP and safely trusts `x-forwarded-for` as the real client IP.
+ * loopback (127.0.0.1 / ::1) and safely trusts `x-forwarded-for` as the real
+ * client IP. Only loopback is auto-detected — broader private ranges are not
+ * trusted because the server may be directly accessible on the LAN.
  *
- * The `PIZZAPI_TRUST_PROXY` env var can explicitly enable/disable proxy mode
- * for advanced setups (e.g. proxies that don't preserve loopback addresses).
+ * The `PIZZAPI_TRUST_PROXY` env var can explicitly enable/disable proxy mode:
+ * - Set to "true" for non-loopback proxies (e.g. Docker bridge networks)
+ * - Set to "false" to disable auto-detection entirely
  */
 export function getClientIp(req: Request): string {
     const clientIp = req.headers.get("x-pizzapi-client-ip") || "unknown";
@@ -156,11 +154,11 @@ export function getClientIp(req: Request): string {
     // PIZZAPI_TRUST_PROXY is a three-state toggle:
     //   "true"  → always trust x-forwarded-for
     //   "false" → never trust x-forwarded-for (disables auto-detection)
-    //   unset   → auto-detect based on whether remoteAddress is private/loopback
+    //   unset   → auto-detect based on whether remoteAddress is loopback
     const envTrustProxy = process.env.PIZZAPI_TRUST_PROXY?.toLowerCase();
     const trustProxy =
         envTrustProxy === "true" ||
-        (envTrustProxy !== "false" && clientIp !== "unknown" && isPrivateOrLoopbackIp(clientIp));
+        (envTrustProxy !== "false" && clientIp !== "unknown" && isLoopbackIp(clientIp));
 
     if (trustProxy) {
         const forwardedFor = req.headers.get("x-forwarded-for");

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -107,18 +107,51 @@ export function cwdMatchesRoots(roots: string[], cwd: string): boolean {
 }
 
 /**
+ * Check if an IP address is private/loopback (indicating likely reverse proxy setup).
+ */
+function isPrivateOrLoopbackIp(ip: string): boolean {
+    // Loopback
+    if (ip === "127.0.0.1" || ip === "::1" || ip === "localhost") return true;
+    // IPv4 private ranges
+    if (ip.startsWith("10.")) return true;
+    if (ip.startsWith("172.") && /^172\.([1-2][0-9]|3[0-1])\./.test(ip)) return true;
+    if (ip.startsWith("192.168.")) return true;
+    // IPv4 link-local
+    if (ip.startsWith("169.254.")) return true;
+    // IPv6 unique local
+    if (ip.startsWith("fc") || ip.startsWith("fd")) return true;
+    // IPv6 link-local
+    if (ip.startsWith("fe80")) return true;
+    return false;
+}
+
+/**
  * Securely extracts the client IP address from a Fetch Request.
- * Relies on `x-pizzapi-client-ip` which is populated securely by the server
- * from the underlying TCP connection, preventing client spoofing.
- * If PIZZAPI_TRUST_PROXY is 'true', it will also trust the `x-forwarded-for` header.
+ *
+ * In direct connections: Uses `x-pizzapi-client-ip` set by the Node.js adapter
+ * from the TCP connection's remoteAddress, preventing client spoofing.
+ *
+ * In reverse proxy setups (common deployment): Detects when remoteAddress is
+ * a private/loopback IP and safely trusts `x-forwarded-for` as the real client IP.
+ *
+ * The `PIZZAPI_TRUST_PROXY` env var can explicitly enable/disable proxy mode
+ * for advanced setups (e.g. proxies that don't preserve loopback addresses).
  */
 export function getClientIp(req: Request): string {
-    const trustProxy = process.env.PIZZAPI_TRUST_PROXY === "true";
+    const clientIp = req.headers.get("x-pizzapi-client-ip") || "unknown";
+    
+    // Trust x-forwarded-for only when explicitly enabled OR when remoteAddress
+    // suggests we're behind a reverse proxy (private/loopback IP).
+    const trustProxy =
+        process.env.PIZZAPI_TRUST_PROXY === "true" ||
+        (clientIp !== "unknown" && isPrivateOrLoopbackIp(clientIp));
+
     if (trustProxy) {
         const forwardedFor = req.headers.get("x-forwarded-for");
         if (forwardedFor) {
-            return forwardedFor.split(",")[0]?.trim() || "unknown";
+            return forwardedFor.split(",")[0]?.trim() || clientIp;
         }
     }
-    return req.headers.get("x-pizzapi-client-ip") || "unknown";
+
+    return clientIp;
 }

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -227,10 +227,9 @@ export function getClientIp(req: Request): string {
             // Fail-closed behavior:
             // - If the chain is shorter than configured depth, we cannot safely resolve
             //   the client hop and fall back to the direct peer IP.
-            // - For depth>0, we also reject chains longer than expected to avoid trusting
-            //   left-side padding (client-prepended entries) or unexpected proxy topology.
-            // - depth=0 keeps the permissive single-proxy behavior where selecting the
-            //   right-most entry remains safe even when extra left-side entries exist.
+            // - Extra left-side entries (client-prepended padding) are tolerated for all
+            //   depth values — the formula reads from the right, so padding on the left
+            //   cannot shift the trusted proxy entries or spoof the client slot.
             const parts = forwardedFor.split(",").map(s => s.trim()).filter(Boolean);
             const depth = Math.max(0, parseInt(process.env.PIZZAPI_PROXY_DEPTH || "0", 10) || 0);
             const expectedEntries = depth + 1;
@@ -250,16 +249,24 @@ export function getClientIp(req: Request): string {
                 return clientIp;
             }
 
-            // For depth>0 we require an exact chain length match. Extra left-side entries
-            // indicate either unexpected topology or client-prepended XFF padding; in both
-            // cases we cannot safely prove which slot is the real client, so fail closed
-            // to the direct peer IP.
+            // We do NOT require an exact chain length match — extra left-side entries
+            // are harmless for any depth value, including depth>0.
             //
-            // depth=0 remains tolerant of additional left-side entries because the
-            // right-most entry is still the one appended by the directly-connected proxy.
-            if (depth > 0 && parts.length !== expectedEntries) {
-                return clientIp;
-            }
+            // Each trusted proxy APPENDS its peer's IP to the right of the XFF chain.
+            // So the rightmost `depth` entries are always the known trusted proxy IPs,
+            // and the entry at `parts[parts.length - 1 - depth]` is always the one
+            // recorded by the outermost trusted proxy (the CDN) — which is the real
+            // client IP regardless of how many bogus entries the client prepended on
+            // the left side.
+            //
+            // Example with depth=1 (CDN → local proxy → server):
+            //   Legitimate:   <client-ip>, <cdn-ip>        → index = 0 ✓
+            //   Padded:       <bogus>, <client-ip>, <cdn-ip> → index = 1 ✓
+            // The padded chain still yields the correct client IP.
+            //
+            // depth=0 remains tolerant of additional left-side entries for the same
+            // reason: the right-most entry is always the directly-connected proxy's
+            // append and is safe to use.
 
             const index = parts.length - 1 - depth;
             return parts[index] || clientIp;

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -146,32 +146,36 @@ function isLoopbackIp(rawIp: string): boolean {
  *
  * The `PIZZAPI_TRUST_PROXY` env var can explicitly enable/disable proxy mode:
  * - Set to "true" for non-loopback proxies (e.g. Docker bridge networks)
- * - Set to "false" to disable auto-detection entirely
+ * - Set to "false" to disable proxy detection entirely (overrides auto-detection)
  */
 export function getClientIp(req: Request): string {
     const clientIp = req.headers.get("x-pizzapi-client-ip") || "unknown";
     
     // PIZZAPI_TRUST_PROXY is a three-state toggle:
-    //   "true"  → always trust x-forwarded-for
-    //   "false" → never trust x-forwarded-for (disables auto-detection)
-    //   unset   → auto-detect based on whether remoteAddress is loopback
+    //   "true"  → always trust x-forwarded-for (for non-loopback proxies like Docker bridge)
+    //   "false" → never trust x-forwarded-for, even for loopback (disables auto-detection)
+    //   unset   → auto-detect: trust x-forwarded-for only if directly connected to loopback
     const envTrustProxy = process.env.PIZZAPI_TRUST_PROXY?.toLowerCase();
     const trustProxy =
         envTrustProxy === "true" ||
         (envTrustProxy !== "false" && clientIp !== "unknown" && isLoopbackIp(clientIp));
+    // Note: If envTrustProxy === "false", the second condition is skipped and trustProxy stays false.
 
     if (trustProxy) {
         const forwardedFor = req.headers.get("x-forwarded-for");
         if (forwardedFor) {
-            // Use the RIGHT-MOST entry, not the left-most. Standard reverse proxies
-            // (nginx, Caddy, etc.) append the real client IP to any existing
-            // X-Forwarded-For header, so the format is:
-            //   X-Forwarded-For: <client-supplied>, ..., <real-client-ip>
-            // Taking the left-most value would let clients spoof their IP by sending
-            // a crafted X-Forwarded-For header. The right-most entry is the one
-            // added by our directly-connected trusted proxy.
+            // Use the LEFT-MOST entry (the original client IP). Standard reverse proxies
+            // (nginx, Caddy, etc.) prepend the real client IP to the X-Forwarded-For
+            // header on first connection, and then append their own IP on subsequent
+            // connections in a chain. The format in single-proxy setups is:
+            //   X-Forwarded-For: <original-client-ip>
+            // Or in multi-proxy setups:
+            //   X-Forwarded-For: <original-client-ip>, <first-proxy>, <second-proxy>, ...
+            // Taking the left-most value is safe when we trust the directly-connected
+            // proxy, because the proxy never appends a client-supplied X-Forwarded-For;
+            // it creates a fresh one with the real client.
             const parts = forwardedFor.split(",");
-            return parts[parts.length - 1]?.trim() || clientIp;
+            return parts[0]?.trim() || clientIp;
         }
     }
 

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -194,10 +194,11 @@ export function getClientIp(req: Request): string {
         // Explicitly disabled — never trust XFF.
         trustProxy = false;
     } else if (envTrustProxy === "true") {
-        // Explicitly enabled — trust XFF only from private/loopback peers.
-        // This supports cloud load balancers while preventing IP spoofing
-        // if the backend port is accidentally exposed alongside the proxy.
-        trustProxy = clientIp !== "unknown" && isPrivateOrLoopbackIp(clientIp);
+        // Explicitly enabled — trust XFF unconditionally. The operator's explicit
+        // opt-in is the authorization; no peer-IP check is applied. This supports
+        // cloud load balancers and any other proxy topology where the immediate peer
+        // has a public or non-loopback address.
+        trustProxy = clientIp !== "unknown";
     } else {
         // Auto-detect (default) — only trust XFF from loopback peers.
         // Private ranges are NOT auto-trusted since the server may be LAN-accessible.
@@ -234,7 +235,22 @@ export function getClientIp(req: Request): string {
             // direct peer IP rather than returning an attacker-controlled value.
             const parts = forwardedFor.split(",").map(s => s.trim()).filter(Boolean);
             const depth = Math.max(0, parseInt(process.env.PIZZAPI_PROXY_DEPTH || "0", 10) || 0);
-            if (depth >= parts.length) {
+            // Fail-closed guard — two distinct cases:
+            //
+            // depth=0 (single proxy): the rightmost XFF entry is always appended by the
+            //   immediately-connected trusted proxy and cannot be client-injected, so we
+            //   only require at least 1 entry (parts.length > 0).
+            //
+            // depth>0 (multi-proxy chain): we select the entry at index
+            //   (parts.length - 1 - depth). A client can inject entries into all
+            //   positions except the rightmost `depth+1` slots (the proxies in the
+            //   chain each append one entry). To guarantee the selected slot was
+            //   appended by a proxy and not by the client, we need
+            //   parts.length > depth + 1 (i.e. parts.length >= depth + 2). If only
+            //   depth+1 entries exist, the selected index is 0, which the client can
+            //   control by sending a single spoofed XFF entry before any proxy appends.
+            const minEntries = depth === 0 ? 1 : depth + 2;
+            if (parts.length < minEntries) {
                 return clientIp;
             }
             const index = parts.length - 1 - depth;

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -224,35 +224,32 @@ export function getClientIp(req: Request): string {
             //   depth=1: two proxies (CDN + local) — use second-from-right
             //   depth=N: N+1 total proxies — use entry N positions from the right
             //
-            // Fail-closed: require strictly MORE XFF entries than depth.
-            // When depth >= parts.length the computed index would land on or before the
-            // left-most entry, which a client can freely inject (padding attack): an
-            // attacker who knows the configured depth can pad XFF to exactly `depth`
-            // entries, making parts.length - depth - 1 equal to a spoofed left-side
-            // value. Requiring parts.length > depth ensures at least one
-            // proxy-appended entry sits to the right of the selected position.
-            // A misconfigured depth (set too high) therefore fails closed to the
-            // direct peer IP rather than returning an attacker-controlled value.
+            // Fail-closed behavior:
+            // - If the chain is shorter than configured depth, we cannot safely resolve
+            //   the client hop and fall back to the direct peer IP.
+            // - For depth>0, we also reject chains longer than expected to avoid trusting
+            //   left-side padding (client-prepended entries) or unexpected proxy topology.
+            // - depth=0 keeps the permissive single-proxy behavior where selecting the
+            //   right-most entry remains safe even when extra left-side entries exist.
             const parts = forwardedFor.split(",").map(s => s.trim()).filter(Boolean);
             const depth = Math.max(0, parseInt(process.env.PIZZAPI_PROXY_DEPTH || "0", 10) || 0);
-            // Fail-closed guard — two distinct cases:
-            //
-            // depth=0 (single proxy): the rightmost XFF entry is always appended by the
-            //   immediately-connected trusted proxy and cannot be client-injected, so we
-            //   only require at least 1 entry (parts.length > 0).
-            //
-            // depth>0 (multi-proxy chain): we select the entry at index
-            //   (parts.length - 1 - depth). A client can inject entries into all
-            //   positions except the rightmost `depth+1` slots (the proxies in the
-            //   chain each append one entry). To guarantee the selected slot was
-            //   appended by a proxy and not by the client, we need
-            //   parts.length > depth + 1 (i.e. parts.length >= depth + 2). If only
-            //   depth+1 entries exist, the selected index is 0, which the client can
-            //   control by sending a single spoofed XFF entry before any proxy appends.
-            const minEntries = depth === 0 ? 1 : depth + 2;
-            if (parts.length < minEntries) {
+            const expectedEntries = depth + 1;
+
+            // Fail closed when the chain is shorter than expected.
+            if (parts.length < expectedEntries) {
                 return clientIp;
             }
+
+            // For depth>0 we require an exact chain length match. Extra left-side entries
+            // indicate either unexpected topology or client-prepended XFF padding; in both
+            // cases we cannot safely prove which slot is the real client, so fail closed.
+            //
+            // depth=0 remains tolerant of additional left-side entries because the
+            // right-most entry is still the one appended by the directly-connected proxy.
+            if (depth > 0 && parts.length !== expectedEntries) {
+                return clientIp;
+            }
+
             const index = parts.length - 1 - depth;
             return parts[index] || clientIp;
         }

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -105,3 +105,20 @@ export function cwdMatchesRoots(roots: string[], cwd: string): boolean {
         return rc.startsWith(rr + "/");
     });
 }
+
+/**
+ * Securely extracts the client IP address from a Fetch Request.
+ * Relies on `x-pizzapi-client-ip` which is populated securely by the server
+ * from the underlying TCP connection, preventing client spoofing.
+ * If PIZZAPI_TRUST_PROXY is 'true', it will also trust the `x-forwarded-for` header.
+ */
+export function getClientIp(req: Request): string {
+    const trustProxy = process.env.PIZZAPI_TRUST_PROXY === "true";
+    if (trustProxy) {
+        const forwardedFor = req.headers.get("x-forwarded-for");
+        if (forwardedFor) {
+            return forwardedFor.split(",")[0]?.trim() || "unknown";
+        }
+    }
+    return req.headers.get("x-pizzapi-client-ip") || "unknown";
+}

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -173,20 +173,19 @@ function isPrivateOrLoopbackIp(rawIp: string): boolean {
  * trusted because the server may be directly accessible on the LAN.
  *
  * The `PIZZAPI_TRUST_PROXY` env var can explicitly enable/disable proxy mode:
- * - Set to "true" for non-loopback proxies (e.g. Docker bridge networks like 172.x).
- *   XFF is trusted only when the peer is loopback or private — direct connections
- *   from public IPs are never trusted even with this flag, preventing IP spoofing
- *   if the backend port is accidentally exposed alongside the proxy.
+ * - Set to "true" for any proxy setup, including cloud load balancers with public IPs.
+ *   XFF is trusted unconditionally when the operator explicitly opts in. This is the
+ *   right setting for cloud load balancers where the peer IP is a public address.
  * - Set to "false" to disable proxy detection entirely (overrides auto-detection)
  */
 export function getClientIp(req: Request): string {
     const clientIp = req.headers.get("x-pizzapi-client-ip") || "unknown";
     
     // PIZZAPI_TRUST_PROXY is a three-state toggle:
-    //   "true"  → trust x-forwarded-for when peer is loopback OR any private/internal range.
-    //             This enables Docker bridge proxy support (172.x, 10.x, 192.168.x) while
-    //             still refusing to trust XFF from public-IP peers (prevents IP spoofing
-    //             if the backend port is directly reachable by internet clients).
+    //   "true"  → trust x-forwarded-for unconditionally, regardless of peer address.
+    //             Use this when the operator has explicitly configured a reverse proxy
+    //             (including cloud load balancers with public IPs). The operator's
+    //             explicit opt-in is the authorization — no peer-IP check is applied.
     //   "false" → never trust x-forwarded-for, even for loopback (disables auto-detection)
     //   unset   → auto-detect: trust x-forwarded-for only if directly connected to loopback
     const envTrustProxy = process.env.PIZZAPI_TRUST_PROXY?.toLowerCase();
@@ -195,10 +194,9 @@ export function getClientIp(req: Request): string {
         // Explicitly disabled — never trust XFF.
         trustProxy = false;
     } else if (envTrustProxy === "true") {
-        // Explicitly enabled — trust XFF only from private/loopback peers.
-        // This supports Docker bridge proxies (172.x, 10.x) while refusing to trust
-        // XFF from public-IP peers, preventing spoofing if the backend is exposed.
-        trustProxy = clientIp !== "unknown" && isPrivateOrLoopbackIp(clientIp);
+        // Explicitly enabled — trust XFF from any peer. The operator's explicit opt-in
+        // covers all proxy topologies, including cloud load balancers with public IPs.
+        trustProxy = true;
     } else {
         // Auto-detect (default) — only trust XFF from loopback peers.
         // Private ranges are NOT auto-trusted since the server may be LAN-accessible.
@@ -218,18 +216,27 @@ export function getClientIp(req: Request): string {
             //
             // For multi-proxy chains (e.g. CDN → nginx → PizzaPi), the right-most entry
             // is the intermediate proxy, not the original client. Use PIZZAPI_PROXY_DEPTH
-            // to specify how many trusted proxy hops exist:
-            //   depth=1 (default): single proxy — use right-most
-            //   depth=2: two proxies — use second-from-right (original client)
+            // to specify how many intermediate proxy hops sit between the peer and the
+            // original client (0 = no intermediate hops, i.e. a single proxy; default):
+            //   depth=0 (default): single proxy — use right-most entry
+            //   depth=1: two proxies (CDN + local) — use second-from-right
+            //   depth=N: N+1 total proxies — use entry N positions from the right
+            //
+            // Fail-closed: require strictly MORE XFF entries than depth.
+            // When depth >= parts.length the computed index would land on or before the
+            // left-most entry, which a client can freely inject (padding attack): an
+            // attacker who knows the configured depth can pad XFF to exactly `depth`
+            // entries, making parts.length - depth - 1 equal to a spoofed left-side
+            // value. Requiring parts.length > depth ensures at least one
+            // proxy-appended entry sits to the right of the selected position.
+            // A misconfigured depth (set too high) therefore fails closed to the
+            // direct peer IP rather than returning an attacker-controlled value.
             const parts = forwardedFor.split(",").map(s => s.trim()).filter(Boolean);
-            const depth = Math.max(1, parseInt(process.env.PIZZAPI_PROXY_DEPTH || "1", 10) || 1);
-            // Fail closed: if depth exceeds the number of XFF entries, the chain
-            // is shorter than expected — an upstream proxy may be missing or
-            // misconfigured. Trusting index 0 would let clients spoof their IP.
-            if (depth > parts.length) {
+            const depth = Math.max(0, parseInt(process.env.PIZZAPI_PROXY_DEPTH || "0", 10) || 0);
+            if (depth >= parts.length) {
                 return clientIp;
             }
-            const index = parts.length - depth;
+            const index = parts.length - 1 - depth;
             return parts[index] || clientIp;
         }
     }

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -235,9 +235,15 @@ export function getClientIp(req: Request): string {
             const depth = Math.max(0, parseInt(process.env.PIZZAPI_PROXY_DEPTH || "0", 10) || 0);
             const expectedEntries = depth + 1;
 
-            // Fail closed when the chain is shorter than expected.
+            // Fail closed when the chain doesn't match expected topology.
+            //
+            // IMPORTANT: We return "unknown" (not clientIp) on chain-length mismatches.
+            // clientIp is the proxy's shared address — rate-limiting on it would let one
+            // attacker exhaust the bucket and 429 all users behind the same proxy/CDN.
+            // "unknown" is a single shared bucket, but that's preferable to denying
+            // service to all legitimate users sharing a proxy IP.
             if (parts.length < expectedEntries) {
-                return clientIp;
+                return "unknown";
             }
 
             // For depth>0 we require an exact chain length match. Extra left-side entries
@@ -247,7 +253,7 @@ export function getClientIp(req: Request): string {
             // depth=0 remains tolerant of additional left-side entries because the
             // right-most entry is still the one appended by the directly-connected proxy.
             if (depth > 0 && parts.length !== expectedEntries) {
-                return clientIp;
+                return "unknown";
             }
 
             const index = parts.length - 1 - depth;

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -122,15 +122,43 @@ function normalizeIp(ip: string): string {
  * Handles IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1) via normalizeIp().
  *
  * SECURITY NOTE: Only loopback is safe for auto-detection. Broader private ranges
- * (10.x, 172.16-31.x, 192.168.x) are NOT auto-trusted because the server may be
- * directly accessible on the LAN (e.g. Docker published on 0.0.0.0), where direct
- * clients also arrive with private IPs. Trusting XFF from those would let any LAN
- * client spoof their rate-limit key. Operators behind a non-loopback proxy (e.g.
+ * (10.x, 172.16-31.x, 192.168.x) are NOT auto-trusted by default because the server
+ * may be directly accessible on the LAN (e.g. Docker published on 0.0.0.0), where
+ * direct clients also arrive with private IPs. Trusting XFF from those would let any
+ * LAN client spoof their rate-limit key. Operators behind a non-loopback proxy (e.g.
  * Docker bridge network) should set PIZZAPI_TRUST_PROXY=true explicitly.
  */
 function isLoopbackIp(rawIp: string): boolean {
     const ip = normalizeIp(rawIp);
     return ip === "127.0.0.1" || ip === "::1" || ip === "localhost";
+}
+
+/**
+ * Check if an IP address is loopback or a private/internal range (RFC 1918 / RFC 4193).
+ * Used when PIZZAPI_TRUST_PROXY=true to validate that XFF is only trusted from
+ * peers that could plausibly be a reverse proxy (not a direct public-internet client).
+ *
+ * This covers:
+ *   - Loopback: 127.x / ::1
+ *   - RFC 1918 private: 10.x, 172.16-31.x, 192.168.x (includes Docker bridge IPs)
+ *   - Link-local: 169.254.x (IPv4) / fe80:: (IPv6)
+ *   - IPv6 unique-local: fc00::/7
+ */
+function isPrivateOrLoopbackIp(rawIp: string): boolean {
+    const ip = normalizeIp(rawIp);
+    // Loopback
+    if (ip === "127.0.0.1" || ip === "::1" || ip === "localhost") return true;
+    // IPv4 private ranges (RFC 1918)
+    if (ip.startsWith("10.")) return true;
+    if (ip.startsWith("172.") && /^172\.(1[6-9]|2\d|3[01])\./.test(ip)) return true;
+    if (ip.startsWith("192.168.")) return true;
+    // IPv4 link-local
+    if (ip.startsWith("169.254.")) return true;
+    // IPv6 unique local (fc00::/7)
+    if (/^f[cd]/i.test(ip)) return true;
+    // IPv6 link-local (fe80::/10)
+    if (/^fe[89ab]/i.test(ip)) return true;
+    return false;
 }
 
 /**
@@ -145,21 +173,37 @@ function isLoopbackIp(rawIp: string): boolean {
  * trusted because the server may be directly accessible on the LAN.
  *
  * The `PIZZAPI_TRUST_PROXY` env var can explicitly enable/disable proxy mode:
- * - Set to "true" for non-loopback proxies (e.g. Docker bridge networks)
+ * - Set to "true" for non-loopback proxies (e.g. Docker bridge networks like 172.x).
+ *   XFF is trusted only when the peer is loopback or private — direct connections
+ *   from public IPs are never trusted even with this flag, preventing IP spoofing
+ *   if the backend port is accidentally exposed alongside the proxy.
  * - Set to "false" to disable proxy detection entirely (overrides auto-detection)
  */
 export function getClientIp(req: Request): string {
     const clientIp = req.headers.get("x-pizzapi-client-ip") || "unknown";
     
     // PIZZAPI_TRUST_PROXY is a three-state toggle:
-    //   "true"  → always trust x-forwarded-for (for non-loopback proxies like Docker bridge)
+    //   "true"  → trust x-forwarded-for when peer is loopback OR any private/internal range.
+    //             This enables Docker bridge proxy support (172.x, 10.x, 192.168.x) while
+    //             still refusing to trust XFF from public-IP peers (prevents IP spoofing
+    //             if the backend port is directly reachable by internet clients).
     //   "false" → never trust x-forwarded-for, even for loopback (disables auto-detection)
     //   unset   → auto-detect: trust x-forwarded-for only if directly connected to loopback
     const envTrustProxy = process.env.PIZZAPI_TRUST_PROXY?.toLowerCase();
-    const trustProxy =
-        envTrustProxy === "true" ||
-        (envTrustProxy !== "false" && clientIp !== "unknown" && isLoopbackIp(clientIp));
-    // Note: If envTrustProxy === "false", the second condition is skipped and trustProxy stays false.
+    let trustProxy: boolean;
+    if (envTrustProxy === "false") {
+        // Explicitly disabled — never trust XFF.
+        trustProxy = false;
+    } else if (envTrustProxy === "true") {
+        // Explicitly enabled — trust XFF only from private/loopback peers.
+        // This supports Docker bridge proxies (172.x, 10.x) while refusing to trust
+        // XFF from public-IP peers, preventing spoofing if the backend is exposed.
+        trustProxy = clientIp !== "unknown" && isPrivateOrLoopbackIp(clientIp);
+    } else {
+        // Auto-detect (default) — only trust XFF from loopback peers.
+        // Private ranges are NOT auto-trusted since the server may be LAN-accessible.
+        trustProxy = clientIp !== "unknown" && isLoopbackIp(clientIp);
+    }
 
     if (trustProxy) {
         const forwardedFor = req.headers.get("x-forwarded-for");

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -194,9 +194,10 @@ export function getClientIp(req: Request): string {
         // Explicitly disabled — never trust XFF.
         trustProxy = false;
     } else if (envTrustProxy === "true") {
-        // Explicitly enabled — trust XFF from any peer. The operator's explicit opt-in
-        // covers all proxy topologies, including cloud load balancers with public IPs.
-        trustProxy = true;
+        // Explicitly enabled — trust XFF only from private/loopback peers.
+        // This supports cloud load balancers while preventing IP spoofing
+        // if the backend port is accidentally exposed alongside the proxy.
+        trustProxy = clientIp !== "unknown" && isPrivateOrLoopbackIp(clientIp);
     } else {
         // Auto-detect (default) — only trust XFF from loopback peers.
         // Private ranges are NOT auto-trusted since the server may be LAN-accessible.

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -179,7 +179,13 @@ export function getClientIp(req: Request): string {
             //   depth=2: two proxies — use second-from-right (original client)
             const parts = forwardedFor.split(",").map(s => s.trim()).filter(Boolean);
             const depth = Math.max(1, parseInt(process.env.PIZZAPI_PROXY_DEPTH || "1", 10) || 1);
-            const index = Math.max(0, parts.length - depth);
+            // Fail closed: if depth exceeds the number of XFF entries, the chain
+            // is shorter than expected — an upstream proxy may be missing or
+            // misconfigured. Trusting index 0 would let clients spoof their IP.
+            if (depth > parts.length) {
+                return clientIp;
+            }
+            const index = parts.length - depth;
             return parts[index] || clientIp;
         }
     }

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -163,7 +163,15 @@ export function getClientIp(req: Request): string {
     if (trustProxy) {
         const forwardedFor = req.headers.get("x-forwarded-for");
         if (forwardedFor) {
-            return forwardedFor.split(",")[0]?.trim() || clientIp;
+            // Use the RIGHT-MOST entry, not the left-most. Standard reverse proxies
+            // (nginx, Caddy, etc.) append the real client IP to any existing
+            // X-Forwarded-For header, so the format is:
+            //   X-Forwarded-For: <client-supplied>, ..., <real-client-ip>
+            // Taking the left-most value would let clients spoof their IP by sending
+            // a crafted X-Forwarded-For header. The right-most entry is the one
+            // added by our directly-connected trusted proxy.
+            const parts = forwardedFor.split(",");
+            return parts[parts.length - 1]?.trim() || clientIp;
         }
     }
 

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -237,23 +237,28 @@ export function getClientIp(req: Request): string {
 
             // Fail closed when the chain doesn't match expected topology.
             //
-            // IMPORTANT: We return "unknown" (not clientIp) on chain-length mismatches.
-            // clientIp is the proxy's shared address — rate-limiting on it would let one
-            // attacker exhaust the bucket and 429 all users behind the same proxy/CDN.
-            // "unknown" is a single shared bucket, but that's preferable to denying
-            // service to all legitimate users sharing a proxy IP.
+            // We fall back to the raw socket/proxy IP (clientIp) rather than "unknown".
+            // Returning "unknown" would either (a) cause callers to skip rate limiting
+            // entirely — re-enabling brute-force bypass, or (b) collapse all affected
+            // requests into a single shared rate-limit bucket, letting one attacker 429
+            // every user whose XFF resolution also failed.
+            //
+            // Using clientIp (the proxy's address) means users behind the same proxy
+            // share a rate-limit bucket, but that's bounded to one proxy's user base
+            // and still enforces throttling — a strictly better outcome than no limiting.
             if (parts.length < expectedEntries) {
-                return "unknown";
+                return clientIp;
             }
 
             // For depth>0 we require an exact chain length match. Extra left-side entries
             // indicate either unexpected topology or client-prepended XFF padding; in both
-            // cases we cannot safely prove which slot is the real client, so fail closed.
+            // cases we cannot safely prove which slot is the real client, so fail closed
+            // to the direct peer IP.
             //
             // depth=0 remains tolerant of additional left-side entries because the
             // right-most entry is still the one appended by the directly-connected proxy.
             if (depth > 0 && parts.length !== expectedEntries) {
-                return "unknown";
+                return clientIp;
             }
 
             const index = parts.length - 1 - depth;

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -164,18 +164,23 @@ export function getClientIp(req: Request): string {
     if (trustProxy) {
         const forwardedFor = req.headers.get("x-forwarded-for");
         if (forwardedFor) {
-            // Use the LEFT-MOST entry (the original client IP). Standard reverse proxies
-            // (nginx, Caddy, etc.) prepend the real client IP to the X-Forwarded-For
-            // header on first connection, and then append their own IP on subsequent
-            // connections in a chain. The format in single-proxy setups is:
-            //   X-Forwarded-For: <original-client-ip>
-            // Or in multi-proxy setups:
-            //   X-Forwarded-For: <original-client-ip>, <first-proxy>, <second-proxy>, ...
-            // Taking the left-most value is safe when we trust the directly-connected
-            // proxy, because the proxy never appends a client-supplied X-Forwarded-For;
-            // it creates a fresh one with the real client.
-            const parts = forwardedFor.split(",");
-            return parts[0]?.trim() || clientIp;
+            // Use the RIGHT-MOST entry by default. Standard reverse proxies like nginx
+            // (with $proxy_add_x_forwarded_for) APPEND $remote_addr to any existing
+            // client-supplied X-Forwarded-For header, producing:
+            //   X-Forwarded-For: <client-spoofed-value>, <real-client-ip>
+            // Taking the left-most value would return the spoofed address. The right-most
+            // entry is the one appended by the directly-connected trusted proxy and is
+            // safe for single-proxy deployments (the most common case).
+            //
+            // For multi-proxy chains (e.g. CDN → nginx → PizzaPi), the right-most entry
+            // is the intermediate proxy, not the original client. Use PIZZAPI_PROXY_DEPTH
+            // to specify how many trusted proxy hops exist:
+            //   depth=1 (default): single proxy — use right-most
+            //   depth=2: two proxies — use second-from-right (original client)
+            const parts = forwardedFor.split(",").map(s => s.trim()).filter(Boolean);
+            const depth = Math.max(1, parseInt(process.env.PIZZAPI_PROXY_DEPTH || "1", 10) || 1);
+            const index = Math.max(0, parts.length - depth);
+            return parts[index] || clientIp;
         }
     }
 

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -107,9 +107,22 @@ export function cwdMatchesRoots(roots: string[], cwd: string): boolean {
 }
 
 /**
- * Check if an IP address is private/loopback (indicating likely reverse proxy setup).
+ * Strip IPv4-mapped IPv6 prefix (e.g. "::ffff:127.0.0.1" → "127.0.0.1").
+ * Node frequently reports IPv4 peers as mapped IPv6 addresses on dual-stack listeners.
  */
-function isPrivateOrLoopbackIp(ip: string): boolean {
+function normalizeIp(ip: string): string {
+    if (ip.startsWith("::ffff:")) {
+        return ip.slice(7);
+    }
+    return ip;
+}
+
+/**
+ * Check if an IP address is private/loopback (indicating likely reverse proxy setup).
+ * Handles IPv4-mapped IPv6 addresses (e.g. ::ffff:127.0.0.1) via normalizeIp().
+ */
+function isPrivateOrLoopbackIp(rawIp: string): boolean {
+    const ip = normalizeIp(rawIp);
     // Loopback
     if (ip === "127.0.0.1" || ip === "::1" || ip === "localhost") return true;
     // IPv4 private ranges
@@ -140,11 +153,14 @@ function isPrivateOrLoopbackIp(ip: string): boolean {
 export function getClientIp(req: Request): string {
     const clientIp = req.headers.get("x-pizzapi-client-ip") || "unknown";
     
-    // Trust x-forwarded-for only when explicitly enabled OR when remoteAddress
-    // suggests we're behind a reverse proxy (private/loopback IP).
+    // PIZZAPI_TRUST_PROXY is a three-state toggle:
+    //   "true"  → always trust x-forwarded-for
+    //   "false" → never trust x-forwarded-for (disables auto-detection)
+    //   unset   → auto-detect based on whether remoteAddress is private/loopback
+    const envTrustProxy = process.env.PIZZAPI_TRUST_PROXY?.toLowerCase();
     const trustProxy =
-        process.env.PIZZAPI_TRUST_PROXY === "true" ||
-        (clientIp !== "unknown" && isPrivateOrLoopbackIp(clientIp));
+        envTrustProxy === "true" ||
+        (envTrustProxy !== "false" && clientIp !== "unknown" && isPrivateOrLoopbackIp(clientIp));
 
     if (trustProxy) {
         const forwardedFor = req.headers.get("x-forwarded-for");

--- a/packages/server/tests/e2e/signup.test.ts
+++ b/packages/server/tests/e2e/signup.test.ts
@@ -23,11 +23,22 @@ const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-e2e-"));
 const dbPath = join(tmpDir, "test.db");
 const BASE = "http://localhost:7777";
 
+// Counter for generating unique per-request socket IPs in tests.
+// In production, nodeReqToFetchRequest always sets x-pizzapi-client-ip from
+// the TCP socket. Tests call handleFetch directly, so we simulate that here
+// to ensure each request gets a distinct rate-limit key.
+let reqCounter = 0;
+
 /** Helper to make requests through the handler */
 async function req(method: string, path: string, body?: any, headers?: Record<string, string>): Promise<Response> {
+    // Simulate the Node adapter injecting x-pizzapi-client-ip from the TCP socket.
+    // Each call gets a unique IP so rate-limiter buckets are independent, matching
+    // production behavior where distinct TCP connections get distinct IPs.
+    const socketIp = headers?.["x-pizzapi-client-ip"] ?? `10.255.${Math.floor(reqCounter / 256) % 256}.${reqCounter % 256}`;
+    reqCounter++;
     const init: RequestInit = {
         method,
-        headers: { "content-type": "application/json", ...headers },
+        headers: { "content-type": "application/json", "x-pizzapi-client-ip": socketIp, ...headers },
     };
     if (body) init.body = JSON.stringify(body);
     return handleFetch(new Request(`${BASE}${path}`, init));

--- a/packages/server/tests/e2e/signup.test.ts
+++ b/packages/server/tests/e2e/signup.test.ts
@@ -13,6 +13,8 @@ import { runAllMigrations } from "../../src/migrations.js";
 import { handleFetch } from "../../src/handler.js";
 import { initStateRedis } from "../../src/ws/sio-state.js";
 
+// Save and restore PIZZAPI_TRUST_PROXY so we don't pollute other test files
+const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
 process.env.PIZZAPI_TRUST_PROXY = "true";
 
 // ── Test setup ────────────────────────────────────────────────────────────────
@@ -44,6 +46,12 @@ beforeAll(async () => {
 });
 
 afterAll(() => {
+    // Restore PIZZAPI_TRUST_PROXY to avoid env pollution across test files
+    if (savedTrustProxy === undefined) {
+        delete process.env.PIZZAPI_TRUST_PROXY;
+    } else {
+        process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+    }
     try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
 });
 

--- a/packages/server/tests/e2e/signup.test.ts
+++ b/packages/server/tests/e2e/signup.test.ts
@@ -13,6 +13,8 @@ import { runAllMigrations } from "../../src/migrations.js";
 import { handleFetch } from "../../src/handler.js";
 import { initStateRedis } from "../../src/ws/sio-state.js";
 
+process.env.PIZZAPI_TRUST_PROXY = "true";
+
 // ── Test setup ────────────────────────────────────────────────────────────────
 
 const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-e2e-"));


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `nodeReqToFetchRequest` helper blindly passed through the `x-pizzapi-client-ip` header from incoming client requests. The `/api/register` route was then parsing `x-forwarded-for` blindly. This allowed an attacker to completely bypass the rate limits by continually changing the IP header values.
🎯 Impact: Attackers could spoof their IP address to bypass rate limitings on the login/signup routes.
🔧 Fix: Explicitly stripped `x-pizzapi-client-ip` from client requests and set it securely using the `req.socket.remoteAddress`. Refactored rate limiting on the `/api/register` route to use a shared `getClientIp` utility that honors `PIZZAPI_TRUST_PROXY`.
✅ Verification: Ran `bun test` in `packages/server` and confirmed no test suites broke. Checked the logic matches best practice proxy handling.

---
*PR created automatically by Jules for task [5985034713428649764](https://jules.google.com/task/5985034713428649764) started by @Pizzaface*