### PR TITLE
chore: bump pi packages 0.55.4 → 0.58.3, add Anthropic web search patch

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,8 +104,33 @@ bun run clean
 
 ---
 
+## Upstream Patches
+
+PizzaPi patches two upstream pi packages via `patchedDependencies` in the root `package.json`. Patches live in `patches/` and are auto-applied on `bun install`. See `patches/README.md` for full details.
+
+### @mariozechner/pi-coding-agent
+
+- **Session control:** Exposes `newSession()` / `switchSession()` on the extension API so the remote extension can trigger `/new` and `/resume` from the web UI.
+- **Version check removal:** Disables the npm registry version check and "Update Available" notification (irrelevant for PizzaPi's headless runner).
+- **Auth path display:** Shows the actual auth file path instead of hardcoded default.
+
+### @mariozechner/pi-ai
+
+- **Anthropic web search:** Adds support for Anthropic's native server-side web search tool, including streaming handling and conversation round-tripping. See `patches/README.md` for env var configuration.
+
+### Recreating patches after a version bump
+
+1. Update version specifiers in all `package.json` files
+2. `bun install` to fetch the new versions
+3. `bun patch @mariozechner/pi-coding-agent@<version>` — edit files, then `bun patch --commit 'node_modules/@mariozechner/pi-coding-agent'`
+4. `bun patch @mariozechner/pi-ai@<version>` — edit files, then `bun patch --commit 'node_modules/@mariozechner/pi-ai'`
+5. Run `cd packages/cli && bun test src/patches.test.ts` to verify
+
+---
+
 ## Configuration Conventions
 
+- **Environment variable prefix:** PizzaPi-specific env vars use the `PIZZAPI_` prefix (e.g., `PIZZAPI_SERVER_URL`, `PIZZAPI_AUTH_TOKEN`). Upstream pi env vars use the `PI_` prefix (e.g., `PI_WEB_SEARCH`, `PI_CACHE_RETENTION`). Never introduce a new env var without one of these prefixes.
 - **MCP config format:** Always use the `mcpServers{}` format (Claude Code compatible) as the preferred format. The `mcp.servers[]` array format is supported but not preferred. Claude Code compatibility is always the priority.
 
 ---

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,7 @@ PizzaPi patches two upstream pi packages via `patchedDependencies` in the root `
 
 ### @mariozechner/pi-ai
 
-- **Anthropic web search:** Adds support for Anthropic's native server-side web search tool, including streaming handling and conversation round-tripping. See `patches/README.md` for env var configuration.
+- **Anthropic web search:** Adds support for Anthropic's native server-side web search tool, including streaming handling and conversation round-tripping. Configured via `providerSettings.anthropic.webSearch` in `~/.pizzapi/config.json`. See `patches/README.md` for details.
 
 ### Recreating patches after a version bump
 

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "pizzapi",
       "dependencies": {
-        "@mariozechner/pi-agent-core": "^0.55.4",
-        "@mariozechner/pi-ai": "^0.55.4",
-        "@mariozechner/pi-tui": "^0.55.4",
+        "@mariozechner/pi-agent-core": "^0.58.3",
+        "@mariozechner/pi-ai": "^0.58.3",
+        "@mariozechner/pi-tui": "^0.58.3",
         "motion": "^12.34.2",
         "pizzapi": ".",
       },
@@ -20,13 +20,13 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.2.6-dev.1",
+      "version": "0.2.6-dev.2",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
       },
       "dependencies": {
-        "@mariozechner/pi-coding-agent": "^0.55.4",
+        "@mariozechner/pi-coding-agent": "^0.58.3",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
@@ -59,8 +59,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@mariozechner/pi-agent-core": "^0.55.4",
-        "@mariozechner/pi-ai": "^0.55.4",
+        "@mariozechner/pi-agent-core": "^0.58.3",
+        "@mariozechner/pi-ai": "^0.58.3",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@socket.io/redis-adapter": "^8.3.0",
@@ -84,8 +84,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@mariozechner/pi-agent-core": "^0.55.4",
-        "@mariozechner/pi-ai": "^0.55.4",
+        "@mariozechner/pi-agent-core": "^0.58.3",
+        "@mariozechner/pi-ai": "^0.58.3",
       },
       "devDependencies": {
         "typescript": "^5.7.0",
@@ -153,7 +153,8 @@
     },
   },
   "patchedDependencies": {
-    "@mariozechner/pi-coding-agent@0.55.4": "patches/@mariozechner%2Fpi-coding-agent@0.55.4.patch",
+    "@mariozechner/pi-coding-agent@0.58.3": "patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch",
+    "@mariozechner/pi-ai@0.58.3": "patches/@mariozechner%2Fpi-ai@0.58.3.patch",
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
@@ -696,19 +697,19 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.55.4", "", { "dependencies": { "@mariozechner/pi-ai": "^0.55.4" } }, "sha512-g/rZMrP8X4rjqzU4kCV5LLFqOKR0jrYW3bNG7+lpENOVn6jU2GDpq8MIT2SacT76uPKQhVJII/oI9evGpnGI3w=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.58.3", "", { "dependencies": { "@mariozechner/pi-ai": "^0.58.3" } }, "sha512-WGej7amRgHNxc3EcM4ATt/UEWpis8BttmzEt7zyadE2ZmuZAqI888pol3+sODnn+Lol704lNEJPlore9B9VMww=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.55.4", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.10.0", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.10.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-q6fWN66N5wpYl/ri54v2Q3QBEz04+nBY67LmatM0xK3TKVgmeGPyQ1YXmRlyb5KhHxMDhNMxChkcHBABzfTi6g=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.58.3", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-jdj6+Us94Ayrf4/rdSs7b7yCon8qMHAgU1qVQT/IIGHPgAktilD2Fkb4dv2LtgGr0Z5YKY2CAj9hyESKA6VbHw=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.55.4", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.55.4", "@mariozechner/pi-ai": "^0.55.4", "@mariozechner/pi-tui": "^0.55.4", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-l/5NySVD1RplhzC3ssd/GtZlxkKKu34vY5VlT+m1mUBqYupBChitEwartVJR5znHoe02LtLXj4G6akOgyd36Ww=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.58.3", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.58.3", "@mariozechner/pi-ai": "^0.58.3", "@mariozechner/pi-tui": "^0.58.3", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-nYZnefl8YPpbzxuIF8I6SkorodCmUtt/4Nti++DvKzQwBMOpavyzb1InCwO57hJiPSfDXkXtQSrscoWEH1W4kg=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.55.4", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "koffi": "^2.9.0", "marked": "^15.0.12", "mime-types": "^3.0.1" } }, "sha512-LXoa0CV58lEfzbjXyuUMa4KwoPTzTegPZJEEzuc9p7LnlIn4/eBebhTXQmQ7Hxo+/zb3zpy2qoynKpKcEas9GQ=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.58.3", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-eofZKuDFTrClu0fuZAInlG3w+2nAyJ25qz5bOAJylMzoTqlzsOSzqAeL0y2ZN/Nuy9ahwOzKQIXUwbrTXEVybw=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.0.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@1.10.0", "", { "dependencies": { "zod": "^3.20.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-tdIgWs4Le8vpvPiUEWne6tK0qbVc+jMenujnvTqOjogrJUsCSQhus0tHTU1avDDh5//Rq2dFgP9mWRAdIEoBqg=="],
+    "@mistralai/mistralai": ["@mistralai/mistralai@1.14.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -2550,7 +2551,7 @@
 
     "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
-    "openai": ["openai@6.10.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-ITxOGo7rO3XRMiKA5l7tQ43iNNu+iXGFAcf2t+aWVzzqRaS0i7m1K2BhxNdaveB+5eENhO0VY1FkiZzhBk4v3A=="],
+    "openai": ["openai@6.26.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.25 || ^4.0" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA=="],
 
     "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
 
@@ -3365,8 +3366,6 @@
     "@mariozechner/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@mariozechner/pi-tui/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
-
-    "@mistralai/mistralai/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 

--- a/package.json
+++ b/package.json
@@ -35,9 +35,9 @@
         "postinstall": "true"
     },
     "dependencies": {
-        "@mariozechner/pi-agent-core": "^0.55.4",
-        "@mariozechner/pi-ai": "^0.55.4",
-        "@mariozechner/pi-tui": "^0.55.4",
+        "@mariozechner/pi-agent-core": "^0.58.3",
+        "@mariozechner/pi-ai": "^0.58.3",
+        "@mariozechner/pi-tui": "^0.58.3",
         "motion": "^12.34.2",
         "pizzapi": "."
     },
@@ -48,7 +48,8 @@
         "typescript": "^5.7.0"
     },
     "patchedDependencies": {
-        "@mariozechner/pi-coding-agent@0.55.4": "patches/@mariozechner%2Fpi-coding-agent@0.55.4.patch"
+        "@mariozechner/pi-coding-agent@0.58.3": "patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch",
+        "@mariozechner/pi-ai@0.58.3": "patches/@mariozechner%2Fpi-ai@0.58.3.patch"
     },
     "version": ""
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,7 +20,7 @@
     "build:binaries": "bun build-binaries.ts"
   },
   "dependencies": {
-    "@mariozechner/pi-coding-agent": "^0.55.4",
+    "@mariozechner/pi-coding-agent": "^0.58.3",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@pizzapi/protocol": "workspace:*",
     "@pizzapi/tools": "workspace:*",

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { toggleMcpServer, loadConfig, _setGlobalConfigDir, resolveSandboxConfig, validateSandboxOverride, saveGlobalConfig } from "./config.js";
+import { toggleMcpServer, loadConfig, _setGlobalConfigDir, resolveSandboxConfig, validateSandboxOverride, saveGlobalConfig, applyProviderSettingsEnv, type PizzaPiConfig } from "./config.js";
 
 describe("toggleMcpServer", () => {
   let tempDir: string;
@@ -473,5 +473,76 @@ describe("saveGlobalConfig", () => {
     const config = loadConfig(tempDir);
     expect(config.apiKey).toBe("original");
     expect(config.sandbox?.mode).toBe("basic");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// applyProviderSettingsEnv
+// ---------------------------------------------------------------------------
+
+describe("applyProviderSettingsEnv", () => {
+  const envKeys = [
+    "PIZZAPI_WEB_SEARCH",
+    "PIZZAPI_WEB_SEARCH_MAX_USES",
+    "PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS",
+    "PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS",
+  ];
+
+  beforeEach(() => {
+    for (const k of envKeys) delete process.env[k];
+  });
+  afterEach(() => {
+    for (const k of envKeys) delete process.env[k];
+  });
+
+  test("sets PIZZAPI_WEB_SEARCH when enabled", () => {
+    applyProviderSettingsEnv({
+      providerSettings: { anthropic: { webSearch: { enabled: true } } },
+    } as PizzaPiConfig);
+    expect(process.env.PIZZAPI_WEB_SEARCH).toBe("1");
+  });
+
+  test("does not set PIZZAPI_WEB_SEARCH when disabled/missing", () => {
+    applyProviderSettingsEnv({} as PizzaPiConfig);
+    expect(process.env.PIZZAPI_WEB_SEARCH).toBeUndefined();
+
+    applyProviderSettingsEnv({
+      providerSettings: { anthropic: { webSearch: { enabled: false } } },
+    } as PizzaPiConfig);
+    expect(process.env.PIZZAPI_WEB_SEARCH).toBeUndefined();
+  });
+
+  test("sets maxUses, allowedDomains, blockedDomains", () => {
+    applyProviderSettingsEnv({
+      providerSettings: {
+        anthropic: {
+          webSearch: {
+            enabled: true,
+            maxUses: 10,
+            allowedDomains: ["a.com", "b.com"],
+            blockedDomains: ["c.com"],
+          },
+        },
+      },
+    } as PizzaPiConfig);
+    expect(process.env.PIZZAPI_WEB_SEARCH).toBe("1");
+    expect(process.env.PIZZAPI_WEB_SEARCH_MAX_USES).toBe("10");
+    expect(process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS).toBe("a.com,b.com");
+    expect(process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS).toBe("c.com");
+  });
+
+  test("env vars take precedence over config", () => {
+    process.env.PIZZAPI_WEB_SEARCH = "already-set";
+    process.env.PIZZAPI_WEB_SEARCH_MAX_USES = "99";
+    applyProviderSettingsEnv({
+      providerSettings: {
+        anthropic: {
+          webSearch: { enabled: true, maxUses: 3 },
+        },
+      },
+    } as PizzaPiConfig);
+    // Should NOT overwrite
+    expect(process.env.PIZZAPI_WEB_SEARCH).toBe("already-set");
+    expect(process.env.PIZZAPI_WEB_SEARCH_MAX_USES).toBe("99");
   });
 });

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -655,6 +655,31 @@ export function mergeSandboxConfig(rawGlobal: SandboxConfig, rawProject: Sandbox
     };
 }
 
+/**
+ * Web search configuration for a provider that supports server-side web search
+ * (e.g., Anthropic's web_search_20250305 tool).
+ */
+export interface WebSearchConfig {
+    /** Enable web search. Default: false. */
+    enabled?: boolean;
+    /** Maximum number of searches per request. Default: 5. */
+    maxUses?: number;
+    /** Only include results from these domains. */
+    allowedDomains?: string[];
+    /** Never include results from these domains. */
+    blockedDomains?: string[];
+}
+
+/**
+ * Provider-specific settings. Keys are provider names (e.g., "anthropic").
+ */
+export interface ProviderSettings {
+    [provider: string]: {
+        /** Web search configuration (Anthropic only). */
+        webSearch?: WebSearchConfig;
+    };
+}
+
 export interface PizzaPiConfig {
     /** Override the default system prompt */
     systemPrompt?: string;
@@ -737,6 +762,28 @@ export interface PizzaPiConfig {
         /** Max concurrent agent sessions running simultaneously. Default: 4. */
         maxConcurrency?: number;
     };
+
+    /**
+     * Provider-specific settings (web search, etc.).
+     * Keys are provider names (e.g., "anthropic").
+     *
+     * Example:
+     * ```json
+     * {
+     *   "providerSettings": {
+     *     "anthropic": {
+     *       "webSearch": {
+     *         "enabled": true,
+     *         "maxUses": 5,
+     *         "allowedDomains": ["docs.python.org"],
+     *         "blockedDomains": ["example.com"]
+     *       }
+     *     }
+     *   }
+     * }
+     * ```
+     */
+    providerSettings?: ProviderSettings;
 }
 
 function readJsonSafe(path: string): Partial<PizzaPiConfig> {
@@ -934,6 +981,27 @@ export function untrustPlugin(pluginRootPath: string): boolean {
 /**
  * Merge fields into ~/.pizzapi/config.json (global config).
  */
+/**
+ * Bridge providerSettings from config.json to env vars consumed by the
+ * pi-ai Anthropic patch. Env vars take precedence if already set.
+ * Call this early in both CLI and worker entry points.
+ */
+export function applyProviderSettingsEnv(config: PizzaPiConfig): void {
+    const ws = config.providerSettings?.anthropic?.webSearch;
+    if (ws?.enabled && !process.env.PIZZAPI_WEB_SEARCH) {
+        process.env.PIZZAPI_WEB_SEARCH = "1";
+    }
+    if (ws?.maxUses != null && !process.env.PIZZAPI_WEB_SEARCH_MAX_USES) {
+        process.env.PIZZAPI_WEB_SEARCH_MAX_USES = String(ws.maxUses);
+    }
+    if (ws?.allowedDomains?.length && !process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS) {
+        process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS = ws.allowedDomains.join(",");
+    }
+    if (ws?.blockedDomains?.length && !process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS) {
+        process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS = ws.blockedDomains.join(",");
+    }
+}
+
 export function saveGlobalConfig(fields: Partial<PizzaPiConfig>): void {
     const dir = globalConfigDir();
     const path = join(dir, "config.json");

--- a/packages/cli/src/extensions/remote-auth-source.ts
+++ b/packages/cli/src/extensions/remote-auth-source.ts
@@ -6,7 +6,7 @@
  */
 
 import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
-import { getEnvApiKey } from "@mariozechner/pi-ai/dist/env-api-keys.js";
+import { getEnvApiKey } from "@mariozechner/pi-ai";
 import type { AuthSource } from "./remote-types.js";
 
 /**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,7 @@ import { existsSync } from "fs";
 import { readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { homedir } from "os";
-import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, loadConfig, resolveSandboxConfig, validateSandboxOverride } from "./config.js";
+import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
 import { buildInteractiveSkillPaths } from "./skills.js";
 import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
 import { runSetup } from "./setup.js";
@@ -409,6 +409,9 @@ Run \`pizza <command> --help\` for command-specific help.
 
     const config = loadConfig(cwd);
     const agentDir = config.agentDir ? config.agentDir.replace(/^~/, homedir()) : defaultAgentDir();
+
+    // ── Provider settings → env vars ───────────────────────────────────────
+    applyProviderSettingsEnv(config);
 
     // First-run: no API key configured — prompt setup before launching TUI
     const hasApiKey = !!(process.env.PIZZAPI_API_KEY ?? config.apiKey);

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -1,11 +1,11 @@
 /**
- * Patch compatibility tests for @mariozechner/pi-coding-agent.
+ * Patch compatibility tests for @mariozechner/pi-coding-agent and @mariozechner/pi-ai.
  *
- * These tests verify that the bun patches applied to pi-coding-agent
+ * These tests verify that the bun patches applied to upstream pi packages
  * are correctly in place and the patched APIs function as expected.
  *
- * If these tests fail after a pi-coding-agent version bump, you need to
- * recreate the patch. See patches/README.md for details.
+ * If these tests fail after a version bump, you need to recreate the patches.
+ * See patches/README.md for details.
  */
 import { describe, test, expect } from "bun:test";
 import { resolve, dirname } from "path";
@@ -23,6 +23,20 @@ function piCodingAgentPath(subpath: string): string {
     const pkgRoot = resolve(dirname(pkgMain), "..");
     return resolve(pkgRoot, subpath);
 }
+
+/**
+ * Resolve a deep path inside @mariozechner/pi-ai.
+ */
+function piAiPath(subpath: string): string {
+    const pkgMainUrl = import.meta.resolve("@mariozechner/pi-ai");
+    const pkgMain = fileURLToPath(pkgMainUrl);
+    const pkgRoot = resolve(dirname(pkgMain), "..");
+    return resolve(pkgRoot, subpath);
+}
+
+// ===========================================================================
+// pi-coding-agent patches
+// ===========================================================================
 
 // ---------------------------------------------------------------------------
 // 1. Patch presence — verify patched source contains expected code
@@ -167,5 +181,72 @@ describe("pi-coding-agent API surface compatibility", () => {
     test("buildSessionContext is exported", async () => {
         const mod = await import("@mariozechner/pi-coding-agent");
         expect(typeof mod.buildSessionContext).toBe("function");
+    });
+});
+
+// ===========================================================================
+// pi-ai patches (Anthropic web search support)
+// ===========================================================================
+
+describe("pi-ai patch application — Anthropic web search", () => {
+    test("anthropic.js: convertTools passes through server-side tool objects", async () => {
+        const source = await Bun.file(
+            piAiPath("dist/providers/anthropic.js"),
+        ).text();
+
+        // The patch checks for tool.type before converting
+        expect(source).toContain("PATCH(pizzapi): pass through server-side tools");
+        expect(source).toContain('tool.type && typeof tool.type === "string"');
+    });
+
+    test("anthropic.js: buildParams injects web search tool from PI_WEB_SEARCH env", async () => {
+        const source = await Bun.file(
+            piAiPath("dist/providers/anthropic.js"),
+        ).text();
+
+        expect(source).toContain("PATCH(pizzapi): inject Anthropic web search tool");
+        expect(source).toContain("PI_WEB_SEARCH");
+        expect(source).toContain("web_search_20250305");
+        expect(source).toContain("PI_WEB_SEARCH_MAX_USES");
+        expect(source).toContain("PI_WEB_SEARCH_ALLOWED_DOMAINS");
+        expect(source).toContain("PI_WEB_SEARCH_BLOCKED_DOMAINS");
+    });
+
+    test("anthropic.js: stream handler processes server_tool_use blocks", async () => {
+        const source = await Bun.file(
+            piAiPath("dist/providers/anthropic.js"),
+        ).text();
+
+        expect(source).toContain("PATCH(pizzapi): handle server_tool_use");
+        expect(source).toContain('"server_tool_use"');
+        expect(source).toContain("_serverToolUse");
+    });
+
+    test("anthropic.js: stream handler processes web_search_tool_result blocks", async () => {
+        const source = await Bun.file(
+            piAiPath("dist/providers/anthropic.js"),
+        ).text();
+
+        expect(source).toContain("PATCH(pizzapi): handle web_search_tool_result");
+        expect(source).toContain('"web_search_tool_result"');
+        expect(source).toContain("_webSearchResult");
+    });
+
+    test("anthropic.js: convertMessages round-trips server tool blocks", async () => {
+        const source = await Bun.file(
+            piAiPath("dist/providers/anthropic.js"),
+        ).text();
+
+        expect(source).toContain("PATCH(pizzapi): round-trip server tool use");
+        // Verify both server_tool_use and web_search_tool_result are round-tripped
+        expect(source).toContain("block._serverToolUse");
+        expect(source).toContain("block._webSearchResult");
+    });
+
+    test("anthropic.js: file is syntactically valid", async () => {
+        // If the patch broke the JS syntax, this import will throw
+        const mod = await import(piAiPath("dist/providers/anthropic.js"));
+        expect(typeof mod.streamAnthropic).toBe("function");
+        expect(typeof mod.streamSimpleAnthropic).toBe("function");
     });
 });

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -199,17 +199,17 @@ describe("pi-ai patch application — Anthropic web search", () => {
         expect(source).toContain('tool.type && typeof tool.type === "string"');
     });
 
-    test("anthropic.js: buildParams injects web search tool from PI_WEB_SEARCH env", async () => {
+    test("anthropic.js: buildParams injects web search tool from PIZZAPI_WEB_SEARCH env", async () => {
         const source = await Bun.file(
             piAiPath("dist/providers/anthropic.js"),
         ).text();
 
         expect(source).toContain("PATCH(pizzapi): inject Anthropic web search tool");
-        expect(source).toContain("PI_WEB_SEARCH");
+        expect(source).toContain("PIZZAPI_WEB_SEARCH");
         expect(source).toContain("web_search_20250305");
-        expect(source).toContain("PI_WEB_SEARCH_MAX_USES");
-        expect(source).toContain("PI_WEB_SEARCH_ALLOWED_DOMAINS");
-        expect(source).toContain("PI_WEB_SEARCH_BLOCKED_DOMAINS");
+        expect(source).toContain("PIZZAPI_WEB_SEARCH_MAX_USES");
+        expect(source).toContain("PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS");
+        expect(source).toContain("PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS");
     });
 
     test("anthropic.js: stream handler processes server_tool_use blocks", async () => {

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -210,6 +210,8 @@ describe("pi-ai patch application — Anthropic web search", () => {
         expect(source).toContain("PIZZAPI_WEB_SEARCH_MAX_USES");
         expect(source).toContain("PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS");
         expect(source).toContain("PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS");
+        // P2: env var must be parsed as explicit boolean (reject "0", "false", "no", "off")
+        expect(source).toMatch(/\["0",\s*"false",\s*"no",\s*"off"\]/);
     });
 
     test("anthropic.js: stream handler processes server_tool_use blocks", async () => {

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -2,7 +2,7 @@ import { createAgentSession, DefaultResourceLoader } from "@mariozechner/pi-codi
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, loadConfig, resolveSandboxConfig, validateSandboxOverride } from "../config.js";
+import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "../config.js";
 import { buildWorkerSkillPaths } from "../skills.js";
 import { getPluginSkillPaths } from "../extensions/claude-plugins.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
@@ -54,6 +54,9 @@ async function main(): Promise<void> {
     const config = loadConfig(cwd);
     const agentDir = config.agentDir?.replace(/^~/, homedir()) ?? defaultAgentDir();
     const skipPlugins = process.env.PIZZAPI_NO_PLUGINS === "1";
+
+    // ── Provider settings → env vars ───────────────────────────────────────
+    applyProviderSettingsEnv(config);
 
     // ── Sandbox initialization ─────────────────────────────────────────────
     // Must happen before any tools execute (including MCP init via extensions).

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -116,6 +116,55 @@ You can also override any setting with **environment variables**.
 | `slowStartupWarning` | `boolean` | `true` | Show warnings when startup takes longer than expected (slow MCP servers, etc.). See [Safe Mode](/PizzaPi/security/sandbox/). |
 | `subagent.maxParallelTasks` | `number` | `8` | Max tasks in a single parallel subagent call. **Global config only.** |
 | `subagent.maxConcurrency` | `number` | `4` | Max concurrent agent sessions running simultaneously. **Global config only.** |
+| `providerSettings` | `object` | — | Provider-specific settings. See [Web Search](#web-search) below. |
+
+---
+
+## Web Search
+
+PizzaPi can inject Anthropic's server-side web search tool into requests, giving the agent the ability to search the web during conversations. This uses Anthropic's `web_search_20250305` tool type.
+
+### Configuration
+
+Add a `providerSettings` block to `~/.pizzapi/config.json`:
+
+```jsonc
+// ~/.pizzapi/config.json
+{
+  "providerSettings": {
+    "anthropic": {
+      "webSearch": {
+        "enabled": true,
+        "maxUses": 5,
+        "allowedDomains": ["docs.python.org", "developer.mozilla.org"],
+        "blockedDomains": ["example.com"]
+      }
+    }
+  }
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | `boolean` | `false` | Enable web search for Anthropic models. |
+| `maxUses` | `number` | `5` | Maximum number of searches per request. |
+| `allowedDomains` | `string[]` | — | Only return results from these domains. |
+| `blockedDomains` | `string[]` | — | Never return results from these domains. |
+
+### Environment Variables
+
+You can also enable web search via environment variables (these take precedence if the config values are not already set):
+
+| Variable | Description |
+|----------|-------------|
+| `PIZZAPI_WEB_SEARCH` | Set to `1` to enable web search. |
+| `PIZZAPI_WEB_SEARCH_MAX_USES` | Max searches per request (default: `5`). |
+| `PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS` | Comma-separated list of allowed domains. |
+| `PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS` | Comma-separated list of blocked domains. |
+
+<Aside type="note">
+  Web search works with both API key and OAuth authentication.
+</Aside>
 
 ---
 

--- a/packages/docs/src/content/docs/reference/environment-variables.mdx
+++ b/packages/docs/src/content/docs/reference/environment-variables.mdx
@@ -48,6 +48,17 @@ These variables control the [Agent Sandbox](/PizzaPi/security/sandbox/) behavior
 | `PIZZAPI_SANDBOX` | Override sandbox mode: `enforce`, `audit`, or `off`. | Config value |
 | `PIZZAPI_NO_SANDBOX` | Set to `1` to disable sandbox (shorthand for `PIZZAPI_SANDBOX=off`). | — |
 
+### Web Search Variables
+
+These variables control Anthropic's server-side web search tool. They can also be configured via `providerSettings.anthropic.webSearch` in `config.json`. See [Configuration → Web Search](/PizzaPi/customization/configuration/#web-search) for details.
+
+| Variable | Description | Default |
+|---|---|---|
+| `PIZZAPI_WEB_SEARCH` | Set to `1` to enable Anthropic web search. | — |
+| `PIZZAPI_WEB_SEARCH_MAX_USES` | Maximum number of web searches per request. | `5` |
+| `PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS` | Comma-separated list of domains to restrict search results to. | — |
+| `PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS` | Comma-separated list of domains to exclude from search results. | — |
+
 ### Worker Safe-Mode Variables
 
 These variables control which subsystems are loaded by runner-spawned worker sessions. They're equivalent to the CLI's `--no-*` flags. See [Safe Mode & Startup Performance](/PizzaPi/security/sandbox/) for details.

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -12,8 +12,8 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@mariozechner/pi-agent-core": "^0.55.4",
-        "@mariozechner/pi-ai": "^0.55.4",
+        "@mariozechner/pi-agent-core": "^0.58.3",
+        "@mariozechner/pi-ai": "^0.58.3",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "better-auth": "^1.4.18",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,8 +10,8 @@
     },
     "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@mariozechner/pi-agent-core": "^0.55.4",
-        "@mariozechner/pi-ai": "^0.55.4"
+        "@mariozechner/pi-agent-core": "^0.58.3",
+        "@mariozechner/pi-ai": "^0.58.3"
     },
     "devDependencies": {
         "typescript": "^5.7.0"

--- a/packages/ui/src/components/session-viewer/cards/WebSearchCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/WebSearchCard.tsx
@@ -1,0 +1,123 @@
+import * as React from "react";
+import { SearchIcon, ExternalLinkIcon, GlobeIcon } from "lucide-react";
+import {
+  ToolCardShell,
+  ToolCardHeader,
+  ToolCardTitle,
+  ToolCardActions,
+  StatusPill,
+} from "@/components/ui/tool-card";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+/** A single web search result with title and URL. */
+export interface WebSearchResult {
+  title: string;
+  url: string;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Extract a readable hostname from a URL (e.g. "docs.github.com"). */
+function extractDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, "");
+  } catch {
+    return url;
+  }
+}
+
+/** Google's public favicon service — returns a 16×16 icon for any domain. */
+function faviconUrl(url: string): string {
+  const domain = extractDomain(url);
+  return `https://www.google.com/s2/favicons?sz=32&domain=${encodeURIComponent(domain)}`;
+}
+
+// ── Query Card ───────────────────────────────────────────────────────────────
+
+/**
+ * Compact inline card showing the web search query that was sent.
+ */
+export function WebSearchQueryCard({ query }: { query: string }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-zinc-800 bg-zinc-950 px-4 py-2.5 text-xs text-zinc-400">
+      <SearchIcon className="size-3.5 shrink-0 text-blue-400" />
+      <span>
+        Searched for{" "}
+        <span className="font-medium text-zinc-200">&ldquo;{query}&rdquo;</span>
+      </span>
+    </div>
+  );
+}
+
+// ── Results Card ─────────────────────────────────────────────────────────────
+
+/**
+ * Card listing web search results with favicons, titles, and domain badges.
+ */
+export function WebSearchResultsCard({
+  results,
+}: {
+  results: WebSearchResult[];
+}) {
+  if (results.length === 0) return null;
+
+  return (
+    <ToolCardShell>
+      <ToolCardHeader className="py-2">
+        <ToolCardTitle
+          icon={<GlobeIcon className="size-3.5 shrink-0 text-blue-400" />}
+        >
+          <span className="text-sm font-medium text-zinc-300">
+            Search Results
+          </span>
+        </ToolCardTitle>
+        <ToolCardActions>
+          <StatusPill variant="success">
+            {results.length} {results.length === 1 ? "result" : "results"}
+          </StatusPill>
+        </ToolCardActions>
+      </ToolCardHeader>
+
+      <ul className="divide-y divide-zinc-800/60">
+        {results.map((result, idx) => (
+          <li key={`${result.url}-${idx}`}>
+            <a
+              href={result.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-3 px-4 py-2.5 hover:bg-zinc-900/60 transition-colors group"
+            >
+              {/* Favicon */}
+              <img
+                src={faviconUrl(result.url)}
+                alt=""
+                width={16}
+                height={16}
+                className="size-4 shrink-0 rounded-sm"
+                loading="lazy"
+                // Hide broken favicons gracefully
+                onError={(e) => {
+                  (e.target as HTMLImageElement).style.display = "none";
+                }}
+              />
+
+              {/* Title + domain */}
+              <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <span className="text-xs font-medium text-zinc-200 truncate group-hover:text-blue-400 transition-colors">
+                  {result.title}
+                </span>
+                <span className="text-[11px] text-zinc-500 truncate">
+                  {extractDomain(result.url)}
+                </span>
+              </div>
+
+              {/* External link icon */}
+              <ExternalLinkIcon className="size-3 shrink-0 text-zinc-600 group-hover:text-zinc-400 transition-colors" />
+            </a>
+          </li>
+        ))}
+      </ul>
+    </ToolCardShell>
+  );
+}

--- a/packages/ui/src/components/session-viewer/rendering.tsx
+++ b/packages/ui/src/components/session-viewer/rendering.tsx
@@ -60,9 +60,12 @@ import { CompactionSummaryCard } from "@/components/session-viewer/cards/Compact
 
 export { CompactionSummaryCard } from "@/components/session-viewer/cards/CompactionSummaryCard";
 export { CommandResultCard, type CommandResultData } from "@/components/session-viewer/cards/CommandResultCard";
+export { WebSearchQueryCard, WebSearchResultsCard, type WebSearchResult } from "@/components/session-viewer/cards/WebSearchCard";
+export { tryRenderServerToolBlock } from "@/components/session-viewer/server-tools";
 
 import { CommandResultCard, type CommandResultData } from "@/components/session-viewer/cards/CommandResultCard";
 import { TriggerCard } from "@/components/session-viewer/cards/TriggerCard";
+import { tryRenderServerToolBlock } from "@/components/session-viewer/server-tools";
 
 /** Type guard: is the content a structured command result? */
 export function isCommandResult(content: unknown): content is CommandResultData {
@@ -170,6 +173,10 @@ export function renderContent(
           const b = block as Record<string, unknown>;
 
           if (b.type === "text") {
+            // Check for server-side tool metadata (web search, etc.)
+            const serverToolCard = tryRenderServerToolBlock(b, i);
+            if (serverToolCard) return serverToolCard;
+
             return (
               <MessageResponse key={i}>
                 {typeof b.text === "string" ? b.text : ""}

--- a/packages/ui/src/components/session-viewer/server-tools.test.ts
+++ b/packages/ui/src/components/session-viewer/server-tools.test.ts
@@ -64,6 +64,33 @@ describe("tryRenderServerToolBlock", () => {
     expect(result).toBeNull();
   });
 
+  test("returns null for _webSearchResult with non-array content (error payload)", () => {
+    // Anthropic can return an error object instead of an array when web search
+    // hits rate limits or encounters errors
+    const block = {
+      type: "text",
+      text: "",
+      _webSearchResult: {
+        tool_use_id: "tool_123",
+        content: { type: "error", error: { message: "rate_limited" } },
+      },
+    };
+    const result = tryRenderServerToolBlock(block, 0);
+    expect(result).toBeNull();
+  });
+
+  test("returns null for _webSearchResult with undefined content", () => {
+    const block = {
+      type: "text",
+      text: "",
+      _webSearchResult: {
+        tool_use_id: "tool_123",
+      },
+    };
+    const result = tryRenderServerToolBlock(block, 0);
+    expect(result).toBeNull();
+  });
+
   test("filters out malformed search results", () => {
     const block = {
       type: "text",

--- a/packages/ui/src/components/session-viewer/server-tools.test.ts
+++ b/packages/ui/src/components/session-viewer/server-tools.test.ts
@@ -1,0 +1,84 @@
+import { describe, test, expect } from "bun:test";
+import { tryRenderServerToolBlock } from "./server-tools";
+
+describe("tryRenderServerToolBlock", () => {
+  test("returns null for plain text blocks", () => {
+    const block = { type: "text", text: "Hello world" };
+    expect(tryRenderServerToolBlock(block, 0)).toBeNull();
+  });
+
+  test("returns a component for _serverToolUse with query", () => {
+    const block = {
+      type: "text",
+      text: "\n🔍 **Web Search:** tech news\n",
+      _serverToolUse: {
+        id: "tool_123",
+        name: "web_search",
+        input: { query: "tech news" },
+      },
+    };
+    const result = tryRenderServerToolBlock(block, 0);
+    expect(result).not.toBeNull();
+  });
+
+  test("returns null for _serverToolUse without query", () => {
+    const block = {
+      type: "text",
+      text: "",
+      _serverToolUse: {
+        id: "tool_123",
+        name: "web_search",
+        input: {},
+      },
+    };
+    const result = tryRenderServerToolBlock(block, 0);
+    expect(result).toBeNull();
+  });
+
+  test("returns a component for _webSearchResult with results", () => {
+    const block = {
+      type: "text",
+      text: "\n📋 **Search Results:**\n- [Example](https://example.com)\n",
+      _webSearchResult: {
+        tool_use_id: "tool_123",
+        content: [
+          { type: "web_search_result", title: "Example", url: "https://example.com" },
+          { type: "web_search_result", title: "Test", url: "https://test.com" },
+        ],
+      },
+    };
+    const result = tryRenderServerToolBlock(block, 0);
+    expect(result).not.toBeNull();
+  });
+
+  test("returns null for _webSearchResult with empty results", () => {
+    const block = {
+      type: "text",
+      text: "",
+      _webSearchResult: {
+        tool_use_id: "tool_123",
+        content: [],
+      },
+    };
+    const result = tryRenderServerToolBlock(block, 0);
+    expect(result).toBeNull();
+  });
+
+  test("filters out malformed search results", () => {
+    const block = {
+      type: "text",
+      text: "",
+      _webSearchResult: {
+        tool_use_id: "tool_123",
+        content: [
+          { type: "web_search_result", title: "Good", url: "https://good.com" },
+          { type: "web_search_result", title: 123, url: "https://bad.com" }, // title not string
+          { type: "other_type", title: "Also Bad", url: "https://bad2.com" }, // wrong type
+        ],
+      },
+    };
+    // Should still render (one valid result)
+    const result = tryRenderServerToolBlock(block, 0);
+    expect(result).not.toBeNull();
+  });
+});

--- a/packages/ui/src/components/session-viewer/server-tools.tsx
+++ b/packages/ui/src/components/session-viewer/server-tools.tsx
@@ -66,7 +66,8 @@ export function tryRenderServerToolBlock(
   // ── Web Search Results ─────────────────────────────────────────────────
   if (block._webSearchResult) {
     const meta = block._webSearchResult as WebSearchResultMetadata;
-    const results: WebSearchResult[] = (meta.content ?? [])
+    const rawContent = Array.isArray(meta.content) ? meta.content : [];
+    const results: WebSearchResult[] = rawContent
       .filter(
         (r): r is WebSearchResultBlock =>
           r.type === "web_search_result" &&

--- a/packages/ui/src/components/session-viewer/server-tools.tsx
+++ b/packages/ui/src/components/session-viewer/server-tools.tsx
@@ -1,0 +1,89 @@
+/**
+ * Server-side tool enrichment dispatcher.
+ *
+ * Anthropic's server-side tools (web search, etc.) are stored as regular
+ * `type: "text"` blocks with hidden metadata properties (`_serverToolUse`,
+ * `_webSearchResult`). This module detects those properties and returns
+ * the appropriate card component — or `null` for plain text blocks.
+ *
+ * To add a new server tool:
+ *   1. Create a card component in `./cards/`
+ *   2. Add a detection case in `tryRenderServerToolBlock()`
+ */
+
+import * as React from "react";
+import {
+  WebSearchQueryCard,
+  WebSearchResultsCard,
+  type WebSearchResult,
+} from "@/components/session-viewer/cards/WebSearchCard";
+
+// ── Types for server tool metadata ──────────────────────────────────────────
+
+interface ServerToolUseMetadata {
+  id: string;
+  name: string;
+  input: { query?: string; [key: string]: unknown };
+}
+
+interface WebSearchResultBlock {
+  type: "web_search_result";
+  title: string;
+  url: string;
+  [key: string]: unknown;
+}
+
+interface WebSearchResultMetadata {
+  tool_use_id: string;
+  content: WebSearchResultBlock[];
+}
+
+// ── Dispatcher ──────────────────────────────────────────────────────────────
+
+/**
+ * Check a text content block for server-side tool metadata and return
+ * the appropriate card component. Returns `null` if the block is a
+ * plain text block with no server tool enrichment.
+ *
+ * @param block - A content block with `type: "text"` from the message stream.
+ * @param key   - React key for the returned element.
+ */
+export function tryRenderServerToolBlock(
+  block: Record<string, unknown>,
+  key: React.Key,
+): React.ReactNode | null {
+  // ── Web Search Query ───────────────────────────────────────────────────
+  if (block._serverToolUse) {
+    const meta = block._serverToolUse as ServerToolUseMetadata;
+    const query = meta.input?.query ?? "";
+    if (query) {
+      return <WebSearchQueryCard key={key} query={query} />;
+    }
+    // Unknown server tool — fall through to default text rendering
+    return null;
+  }
+
+  // ── Web Search Results ─────────────────────────────────────────────────
+  if (block._webSearchResult) {
+    const meta = block._webSearchResult as WebSearchResultMetadata;
+    const results: WebSearchResult[] = (meta.content ?? [])
+      .filter(
+        (r): r is WebSearchResultBlock =>
+          r.type === "web_search_result" &&
+          typeof r.title === "string" &&
+          typeof r.url === "string",
+      )
+      .map((r) => ({ title: r.title, url: r.url }));
+
+    if (results.length > 0) {
+      return <WebSearchResultsCard key={key} results={results} />;
+    }
+    return null;
+  }
+
+  // ── Future server tools go here ────────────────────────────────────────
+  // Example:
+  // if (block._codeExecution) { return <CodeExecutionCard ... />; }
+
+  return null;
+}

--- a/patches/@mariozechner%2Fpi-ai@0.58.3.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.58.3.patch
@@ -1,0 +1,97 @@
+diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
+index f574ad921537cf71e1c05c743e0c13688eb36637..63090794744ef17b13125b60b8b34e90d5f8eb9d 100644
+--- a/dist/providers/anthropic.js
++++ b/dist/providers/anthropic.js
+@@ -209,6 +209,37 @@ export const streamAnthropic = (model, context, options) => {
+                         output.content.push(block);
+                         stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+                     }
++                    // PATCH(pizzapi): handle server_tool_use (web search query) as text
++                    else if (event.content_block.type === "server_tool_use") {
++                        const searchQuery = event.content_block.input?.query || "";
++                        const block = {
++                            type: "text",
++                            text: `\n🔍 **Web Search:** ${searchQuery}\n`,
++                            _serverToolUse: { id: event.content_block.id, name: event.content_block.name, input: event.content_block.input },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
++                    // PATCH(pizzapi): handle web_search_tool_result as text with citations
++                    else if (event.content_block.type === "web_search_tool_result") {
++                        let resultText = "";
++                        if (event.content_block.content) {
++                            for (const r of event.content_block.content) {
++                                if (r.type === "web_search_result") {
++                                    resultText += `- [${r.title}](${r.url})\n`;
++                                }
++                            }
++                        }
++                        const block = {
++                            type: "text",
++                            text: resultText ? `\n📋 **Search Results:**\n${resultText}` : "",
++                            _webSearchResult: { tool_use_id: event.content_block.tool_use_id, content: event.content_block.content },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
+                 }
+                 else if (event.type === "content_block_delta") {
+                     if (event.delta.type === "text_delta") {
+@@ -496,6 +527,20 @@ function buildParams(model, context, isOAuthToken, options) {
+     if (context.tools) {
+         params.tools = convertTools(context.tools, isOAuthToken);
+     }
++    // PATCH(pizzapi): inject Anthropic web search tool when PI_WEB_SEARCH is set
++    if (typeof process !== "undefined" && process.env.PI_WEB_SEARCH) {
++        if (!params.tools) params.tools = [];
++        const webSearchTool = { type: "web_search_20250305", name: "web_search" };
++        const maxUses = parseInt(process.env.PI_WEB_SEARCH_MAX_USES || "5", 10);
++        if (maxUses > 0) webSearchTool.max_uses = maxUses;
++        if (process.env.PI_WEB_SEARCH_ALLOWED_DOMAINS) {
++            webSearchTool.allowed_domains = process.env.PI_WEB_SEARCH_ALLOWED_DOMAINS.split(",").map(d => d.trim());
++        }
++        if (process.env.PI_WEB_SEARCH_BLOCKED_DOMAINS) {
++            webSearchTool.blocked_domains = process.env.PI_WEB_SEARCH_BLOCKED_DOMAINS.split(",").map(d => d.trim());
++        }
++        params.tools.push(webSearchTool);
++    }
+     // Configure thinking mode: adaptive (Opus 4.6 and Sonnet 4.6) or budget-based (older models)
+     if (options?.thinkingEnabled && model.reasoning) {
+         if (supportsAdaptiveThinking(model.id)) {
+@@ -629,6 +674,22 @@ function convertMessages(messages, model, isOAuthToken, cacheControl) {
+                         input: block.arguments ?? {},
+                     });
+                 }
++                // PATCH(pizzapi): round-trip server tool use and web search results
++                else if (block.type === "text" && block._serverToolUse) {
++                    blocks.push({
++                        type: "server_tool_use",
++                        id: block._serverToolUse.id,
++                        name: block._serverToolUse.name,
++                        input: block._serverToolUse.input,
++                    });
++                }
++                else if (block.type === "text" && block._webSearchResult) {
++                    blocks.push({
++                        type: "web_search_tool_result",
++                        tool_use_id: block._webSearchResult.tool_use_id,
++                        content: block._webSearchResult.content,
++                    });
++                }
+             }
+             if (blocks.length === 0)
+                 continue;
+@@ -696,6 +757,10 @@ function convertTools(tools, isOAuthToken) {
+     if (!tools)
+         return [];
+     return tools.map((tool) => {
++        // PATCH(pizzapi): pass through server-side tools (e.g., web_search) as-is
++        if (tool.type && typeof tool.type === "string") {
++            return tool;
++        }
+         const jsonSchema = tool.parameters; // TypeBox already generates JSON Schema
+         return {
+             name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,

--- a/patches/@mariozechner%2Fpi-ai@0.58.3.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.58.3.patch
@@ -57,7 +57,7 @@ index f574ad921537cf71e1c05c743e0c13688eb36637..031e29f82eed13cd66ad1d9650f0b34b
          params.tools = convertTools(context.tools, isOAuthToken);
      }
 +    // PATCH(pizzapi): inject Anthropic web search tool when PIZZAPI_WEB_SEARCH is set
-+    if (typeof process !== "undefined" && process.env.PIZZAPI_WEB_SEARCH) {
++    if (typeof process !== "undefined" && process.env.PIZZAPI_WEB_SEARCH && !["0", "false", "no", "off"].includes(process.env.PIZZAPI_WEB_SEARCH.toLowerCase())) {
 +        if (!params.tools) params.tools = [];
 +        const webSearchTool = { type: "web_search_20250305", name: "web_search" };
 +        const maxUses = parseInt(process.env.PIZZAPI_WEB_SEARCH_MAX_USES || "5", 10);

--- a/patches/@mariozechner%2Fpi-ai@0.58.3.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.58.3.patch
@@ -1,3 +1,6 @@
+diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-2b215ecac77b994f b/.bun-tag-2b215ecac77b994f
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-8d8af48225a55c6a b/.bun-tag-8d8af48225a55c6a
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391

--- a/patches/@mariozechner%2Fpi-ai@0.58.3.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.58.3.patch
@@ -1,11 +1,17 @@
 diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-2b215ecac77b994f b/.bun-tag-2b215ecac77b994f
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-72b5e57c598092a8 b/.bun-tag-72b5e57c598092a8
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-738250e6e1ef017c b/.bun-tag-738250e6e1ef017c
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-8d8af48225a55c6a b/.bun-tag-8d8af48225a55c6a
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
-index f574ad921537cf71e1c05c743e0c13688eb36637..382fdd84dd099674fa9f971a79bd1b9a1798566e 100644
+index f574ad921537cf71e1c05c743e0c13688eb36637..031e29f82eed13cd66ad1d9650f0b34b9feedb8c 100644
 --- a/dist/providers/anthropic.js
 +++ b/dist/providers/anthropic.js
 @@ -209,6 +209,37 @@ export const streamAnthropic = (model, context, options) => {
@@ -67,12 +73,15 @@ index f574ad921537cf71e1c05c743e0c13688eb36637..382fdd84dd099674fa9f971a79bd1b9a
      // Configure thinking mode: adaptive (Opus 4.6 and Sonnet 4.6) or budget-based (older models)
      if (options?.thinkingEnabled && model.reasoning) {
          if (supportsAdaptiveThinking(model.id)) {
-@@ -629,6 +674,22 @@ function convertMessages(messages, model, isOAuthToken, cacheControl) {
-                         input: block.arguments ?? {},
-                     });
-                 }
+@@ -585,7 +630,25 @@ function convertMessages(messages, model, isOAuthToken, cacheControl) {
+         else if (msg.role === "assistant") {
+             const blocks = [];
+             for (const block of msg.content) {
+-                if (block.type === "text") {
 +                // PATCH(pizzapi): round-trip server tool use and web search results
-+                else if (block.type === "text" && block._serverToolUse) {
++                // These must be checked BEFORE the generic text handler since they
++                // use type:"text" with metadata that needs to be restored.
++                if (block.type === "text" && block._serverToolUse) {
 +                    blocks.push({
 +                        type: "server_tool_use",
 +                        id: block._serverToolUse.id,
@@ -87,10 +96,11 @@ index f574ad921537cf71e1c05c743e0c13688eb36637..382fdd84dd099674fa9f971a79bd1b9a
 +                        content: block._webSearchResult.content,
 +                    });
 +                }
-             }
-             if (blocks.length === 0)
-                 continue;
-@@ -696,6 +757,10 @@ function convertTools(tools, isOAuthToken) {
++                else if (block.type === "text") {
+                     if (block.text.trim().length === 0)
+                         continue;
+                     blocks.push({
+@@ -696,6 +759,10 @@ function convertTools(tools, isOAuthToken) {
      if (!tools)
          return [];
      return tools.map((tool) => {

--- a/patches/@mariozechner%2Fpi-ai@0.58.3.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.58.3.patch
@@ -1,5 +1,8 @@
+diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-8d8af48225a55c6a b/.bun-tag-8d8af48225a55c6a
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
-index f574ad921537cf71e1c05c743e0c13688eb36637..63090794744ef17b13125b60b8b34e90d5f8eb9d 100644
+index f574ad921537cf71e1c05c743e0c13688eb36637..382fdd84dd099674fa9f971a79bd1b9a1798566e 100644
 --- a/dist/providers/anthropic.js
 +++ b/dist/providers/anthropic.js
 @@ -209,6 +209,37 @@ export const streamAnthropic = (model, context, options) => {
@@ -44,17 +47,17 @@ index f574ad921537cf71e1c05c743e0c13688eb36637..63090794744ef17b13125b60b8b34e90
      if (context.tools) {
          params.tools = convertTools(context.tools, isOAuthToken);
      }
-+    // PATCH(pizzapi): inject Anthropic web search tool when PI_WEB_SEARCH is set
-+    if (typeof process !== "undefined" && process.env.PI_WEB_SEARCH) {
++    // PATCH(pizzapi): inject Anthropic web search tool when PIZZAPI_WEB_SEARCH is set
++    if (typeof process !== "undefined" && process.env.PIZZAPI_WEB_SEARCH) {
 +        if (!params.tools) params.tools = [];
 +        const webSearchTool = { type: "web_search_20250305", name: "web_search" };
-+        const maxUses = parseInt(process.env.PI_WEB_SEARCH_MAX_USES || "5", 10);
++        const maxUses = parseInt(process.env.PIZZAPI_WEB_SEARCH_MAX_USES || "5", 10);
 +        if (maxUses > 0) webSearchTool.max_uses = maxUses;
-+        if (process.env.PI_WEB_SEARCH_ALLOWED_DOMAINS) {
-+            webSearchTool.allowed_domains = process.env.PI_WEB_SEARCH_ALLOWED_DOMAINS.split(",").map(d => d.trim());
++        if (process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS) {
++            webSearchTool.allowed_domains = process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS.split(",").map(d => d.trim());
 +        }
-+        if (process.env.PI_WEB_SEARCH_BLOCKED_DOMAINS) {
-+            webSearchTool.blocked_domains = process.env.PI_WEB_SEARCH_BLOCKED_DOMAINS.split(",").map(d => d.trim());
++        if (process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS) {
++            webSearchTool.blocked_domains = process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS.split(",").map(d => d.trim());
 +        }
 +        params.tools.push(webSearchTool);
 +    }

--- a/patches/@mariozechner%2Fpi-ai@0.58.3.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.58.3.patch
@@ -10,39 +10,42 @@ index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2
 diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-8d8af48225a55c6a b/.bun-tag-8d8af48225a55c6a
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-f6a91c23f3ebaa08 b/.bun-tag-f6a91c23f3ebaa08
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
-index f574ad921537cf71e1c05c743e0c13688eb36637..031e29f82eed13cd66ad1d9650f0b34b9feedb8c 100644
+index f574ad921537cf71e1c05c743e0c13688eb36637..03a533076fbaf97e5b4c623ef74d2c53eafe370b 100644
 --- a/dist/providers/anthropic.js
 +++ b/dist/providers/anthropic.js
 @@ -209,6 +209,37 @@ export const streamAnthropic = (model, context, options) => {
                          output.content.push(block);
                          stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
                      }
-+                    // PATCH(pizzapi): handle server_tool_use (web search query) as text
++                    // PATCH(pizzapi): handle server_tool_use (web search query)
++                    // Input arrives empty ({}) at start; actual input streams via
++                    // input_json_delta events, so we accumulate partialJson just
++                    // like regular toolCall blocks. Text is left empty — the UI
++                    // renderer decides how to display web-search blocks using the
++                    // structured _serverToolUse metadata.
 +                    else if (event.content_block.type === "server_tool_use") {
-+                        const searchQuery = event.content_block.input?.query || "";
 +                        const block = {
 +                            type: "text",
-+                            text: `\n🔍 **Web Search:** ${searchQuery}\n`,
++                            text: "",
++                            partialJson: "",
 +                            _serverToolUse: { id: event.content_block.id, name: event.content_block.name, input: event.content_block.input },
 +                            index: event.index,
 +                        };
 +                        output.content.push(block);
 +                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
 +                    }
-+                    // PATCH(pizzapi): handle web_search_tool_result as text with citations
++                    // PATCH(pizzapi): handle web_search_tool_result
++                    // content is a union: Array<WebSearchResultBlock> | WebSearchToolResultError
++                    // — must check Array.isArray before iterating to avoid "{} is not iterable".
++                    // Text is left empty; the UI renderer uses _webSearchResult metadata.
 +                    else if (event.content_block.type === "web_search_tool_result") {
-+                        let resultText = "";
-+                        if (event.content_block.content) {
-+                            for (const r of event.content_block.content) {
-+                                if (r.type === "web_search_result") {
-+                                    resultText += `- [${r.title}](${r.url})\n`;
-+                                }
-+                            }
-+                        }
 +                        const block = {
 +                            type: "text",
-+                            text: resultText ? `\n📋 **Search Results:**\n${resultText}` : "",
++                            text: "",
 +                            _webSearchResult: { tool_use_id: event.content_block.tool_use_id, content: event.content_block.content },
 +                            index: event.index,
 +                        };
@@ -52,7 +55,34 @@ index f574ad921537cf71e1c05c743e0c13688eb36637..031e29f82eed13cd66ad1d9650f0b34b
                  }
                  else if (event.type === "content_block_delta") {
                      if (event.delta.type === "text_delta") {
-@@ -496,6 +527,20 @@ function buildParams(model, context, isOAuthToken, options) {
+@@ -250,6 +281,10 @@ export const streamAnthropic = (model, context, options) => {
+                                 partial: output,
+                             });
+                         }
++                        // PATCH(pizzapi): accumulate input_json_delta for server_tool_use blocks
++                        else if (block && block._serverToolUse && block.partialJson !== undefined) {
++                            block.partialJson += event.delta.partial_json;
++                        }
+                     }
+                     else if (event.delta.type === "signature_delta") {
+                         const index = blocks.findIndex((b) => b.index === event.index);
+@@ -266,6 +301,15 @@ export const streamAnthropic = (model, context, options) => {
+                     if (block) {
+                         delete block.index;
+                         if (block.type === "text") {
++                            // PATCH(pizzapi): finalize server_tool_use input from accumulated JSON
++                            if (block._serverToolUse && block.partialJson) {
++                                try {
++                                    block._serverToolUse.input = JSON.parse(block.partialJson);
++                                } catch (e) {
++                                    block._serverToolUse.input = parseStreamingJson(block.partialJson);
++                                }
++                            }
++                            delete block.partialJson;
+                             stream.push({
+                                 type: "text_end",
+                                 contentIndex: index,
+@@ -496,6 +540,20 @@ function buildParams(model, context, isOAuthToken, options) {
      if (context.tools) {
          params.tools = convertTools(context.tools, isOAuthToken);
      }
@@ -73,7 +103,7 @@ index f574ad921537cf71e1c05c743e0c13688eb36637..031e29f82eed13cd66ad1d9650f0b34b
      // Configure thinking mode: adaptive (Opus 4.6 and Sonnet 4.6) or budget-based (older models)
      if (options?.thinkingEnabled && model.reasoning) {
          if (supportsAdaptiveThinking(model.id)) {
-@@ -585,7 +630,25 @@ function convertMessages(messages, model, isOAuthToken, cacheControl) {
+@@ -585,7 +643,25 @@ function convertMessages(messages, model, isOAuthToken, cacheControl) {
          else if (msg.role === "assistant") {
              const blocks = [];
              for (const block of msg.content) {
@@ -100,7 +130,7 @@ index f574ad921537cf71e1c05c743e0c13688eb36637..031e29f82eed13cd66ad1d9650f0b34b
                      if (block.text.trim().length === 0)
                          continue;
                      blocks.push({
-@@ -696,6 +759,10 @@ function convertTools(tools, isOAuthToken) {
+@@ -696,6 +772,10 @@ function convertTools(tools, isOAuthToken) {
      if (!tools)
          return [];
      return tools.map((tool) => {

--- a/patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch
+++ b/patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch
@@ -1,8 +1,8 @@
 diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
-index a69a086d7492b99fc6e7d021e31e9561fd2b1a3a..3025ed381d2cf3e28c65459aa96d9c092c6bdf4c 100644
+index dbea1bc1410bd76d125251b5c74b431e5a2c0c60..e1c571f5369f6e75a549bbc485861683a0f2a9b5 100644
 --- a/dist/core/extensions/loader.js
 +++ b/dist/core/extensions/loader.js
-@@ -107,6 +107,9 @@ export function createExtensionRuntime() {
+@@ -118,6 +118,9 @@ export function createExtensionRuntime() {
          unregisterProvider: (name) => {
              runtime.pendingProviderRegistrations = runtime.pendingProviderRegistrations.filter((r) => r.name !== name);
          },
@@ -12,7 +12,7 @@ index a69a086d7492b99fc6e7d021e31e9561fd2b1a3a..3025ed381d2cf3e28c65459aa96d9c09
      };
      return runtime;
  }
-@@ -200,6 +203,13 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
+@@ -211,6 +214,13 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
          unregisterProvider(name) {
              runtime.unregisterProvider(name);
          },
@@ -27,7 +27,7 @@ index a69a086d7492b99fc6e7d021e31e9561fd2b1a3a..3025ed381d2cf3e28c65459aa96d9c09
      };
      return api;
 diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
-index 6c32bd9438c02e12c40b4f98171b37ab622ed18c..be32027918d34daeb819d7b7a38330cb47384a7b 100644
+index 8ef7aa25255056266cf9103bbd6f14685a09937c..79394dadbd85abef0c8847754289f2ea7abdffda 100644
 --- a/dist/core/extensions/runner.js
 +++ b/dist/core/extensions/runner.js
 @@ -153,6 +153,9 @@ export class ExtensionRunner {
@@ -40,20 +40,21 @@ index 6c32bd9438c02e12c40b4f98171b37ab622ed18c..be32027918d34daeb819d7b7a38330cb
              return;
          }
          this.waitForIdleFn = async () => { };
-@@ -161,6 +164,8 @@ export class ExtensionRunner {
+@@ -161,6 +164,9 @@ export class ExtensionRunner {
          this.navigateTreeHandler = async () => ({ cancelled: false });
          this.switchSessionHandler = async () => ({ cancelled: false });
          this.reloadHandler = async () => { };
++        // PATCH(pizzapi): expose session control on runtime for extension access
 +        this.runtime.newSession = (options) => this.newSessionHandler(options);
 +        this.runtime.switchSession = (sessionPath) => this.switchSessionHandler(sessionPath);
      }
      setUIContext(uiContext) {
          this.uiContext = uiContext ?? noOpUIContext;
 diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
-index d257afa404987930ba4de685100f5215dcf05ef0..7cf11d7d65c3450f14b48330790dcc6e0445cabe 100644
+index 038e6600ead762073fda085c806f8aa1eafef9a1..11a82c0fc46f22a71a85654f847543ee5f430cbe 100644
 --- a/dist/modes/interactive/interactive-mode.js
 +++ b/dist/modes/interactive/interactive-mode.js
-@@ -355,12 +355,6 @@ export class InteractiveMode {
+@@ -354,12 +354,6 @@ export class InteractiveMode {
       */
      async run() {
          await this.init();
@@ -63,16 +64,13 @@ index d257afa404987930ba4de685100f5215dcf05ef0..7cf11d7d65c3450f14b48330790dcc6e
 -                this.showNewVersionNotification(newVersion);
 -            }
 -        });
-         // Show startup warnings
-         const { migratedProviders, modelFallbackMessage, initialMessage, initialImages, initialMessages } = this.options;
-         if (migratedProviders && migratedProviders.length > 0) {
-@@ -406,29 +400,6 @@ export class InteractiveMode {
-             }
-         }
-     }
--    /**
--     * Check npm registry for a newer version.
--     */
+         // Check tmux keyboard setup asynchronously
+         this.checkTmuxKeyboardSetup().then((warning) => {
+             if (warning) {
+@@ -414,26 +408,6 @@ export class InteractiveMode {
+     /**
+      * Check npm registry for a newer version.
+      */
 -    async checkForNewVersion() {
 -        if (process.env.PI_SKIP_VERSION_CHECK || process.env.PI_OFFLINE)
 -            return undefined;
@@ -93,10 +91,10 @@ index d257afa404987930ba4de685100f5215dcf05ef0..7cf11d7d65c3450f14b48330790dcc6e
 -            return undefined;
 -        }
 -    }
-     /**
-      * Get changelog entries to display on startup.
-      * Only shows new entries since last seen version, skips for resumed sessions.
-@@ -2334,17 +2305,6 @@ export class InteractiveMode {
+     async checkTmuxKeyboardSetup() {
+         if (!process.env.TMUX)
+             return undefined;
+@@ -2386,17 +2360,6 @@ export class InteractiveMode {
          this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
          this.ui.requestRender();
      }
@@ -114,7 +112,7 @@ index d257afa404987930ba4de685100f5215dcf05ef0..7cf11d7d65c3450f14b48330790dcc6e
      /**
       * Get all queued messages (read-only).
       * Combines session queue and compaction queue.
-@@ -3123,7 +3083,8 @@ export class InteractiveMode {
+@@ -3163,7 +3126,8 @@ export class InteractiveMode {
              restoreEditor();
              this.session.modelRegistry.refresh();
              await this.updateAvailableProviderCount();

--- a/patches/README.md
+++ b/patches/README.md
@@ -127,8 +127,6 @@ Env vars take precedence over config.json if both are set:
   (pi's content model doesn't have a native citation type).
 - The `web_search_tool_result` content blocks may contain encrypted search
   result data; only the title/URL are extracted for display.
-- Requires Anthropic API key (not OAuth/Claude Pro subscription) with web
-  search enabled in the Claude Console.
 
 **Tests:** `packages/cli/src/patches.test.ts` verifies patch presence and
 syntactic validity. Run with `bun test packages/cli/src/patches.test.ts`.

--- a/patches/README.md
+++ b/patches/README.md
@@ -67,7 +67,7 @@ web search use a different format with a `type` field.
 | File | Change |
 |------|--------|
 | `dist/providers/anthropic.js` — `convertTools()` | Pass through objects that already have a `type` field (server-side tools) instead of converting them |
-| `dist/providers/anthropic.js` — `buildParams()` | Inject web search tool definition when `PI_WEB_SEARCH` env var is set |
+| `dist/providers/anthropic.js` — `buildParams()` | Inject web search tool definition when `PIZZAPI_WEB_SEARCH` env var is set |
 | `dist/providers/anthropic.js` — stream handler | Handle `server_tool_use` blocks (search queries) → emit as text blocks with `_serverToolUse` metadata |
 | `dist/providers/anthropic.js` — stream handler | Handle `web_search_tool_result` blocks (results with citations) → emit as text blocks with `_webSearchResult` metadata |
 | `dist/providers/anthropic.js` — `convertMessages()` | Round-trip `_serverToolUse` and `_webSearchResult` blocks back to the API format on subsequent turns |
@@ -76,24 +76,24 @@ web search use a different format with a `type` field.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `PI_WEB_SEARCH` | Set to any truthy value to enable web search | (disabled) |
-| `PI_WEB_SEARCH_MAX_USES` | Maximum number of searches per request | `5` |
-| `PI_WEB_SEARCH_ALLOWED_DOMAINS` | Comma-separated list of allowed domains | (all) |
-| `PI_WEB_SEARCH_BLOCKED_DOMAINS` | Comma-separated list of blocked domains | (none) |
+| `PIZZAPI_WEB_SEARCH` | Set to any truthy value to enable web search | (disabled) |
+| `PIZZAPI_WEB_SEARCH_MAX_USES` | Maximum number of searches per request | `5` |
+| `PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS` | Comma-separated list of allowed domains | (all) |
+| `PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS` | Comma-separated list of blocked domains | (none) |
 
 **Usage:**
 
 ```bash
 # Enable web search
-PI_WEB_SEARCH=1 pizza runner
+PIZZAPI_WEB_SEARCH=1 pizza runner
 
 # With domain restrictions
-PI_WEB_SEARCH=1 PI_WEB_SEARCH_ALLOWED_DOMAINS="docs.python.org,stackoverflow.com" pizza runner
+PIZZAPI_WEB_SEARCH=1 PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS="docs.python.org,stackoverflow.com" pizza runner
 ```
 
 **How it works:**
 
-1. When `PI_WEB_SEARCH` is set, `buildParams()` appends a `web_search_20250305`
+1. When `PIZZAPI_WEB_SEARCH` is set, `buildParams()` appends a `web_search_20250305`
    tool definition to the tools array.
 2. Claude decides when to search. The API returns `server_tool_use` (the query)
    and `web_search_tool_result` (the results) content blocks.

--- a/patches/README.md
+++ b/patches/README.md
@@ -72,24 +72,42 @@ web search use a different format with a `type` field.
 | `dist/providers/anthropic.js` — stream handler | Handle `web_search_tool_result` blocks (results with citations) → emit as text blocks with `_webSearchResult` metadata |
 | `dist/providers/anthropic.js` — `convertMessages()` | Round-trip `_serverToolUse` and `_webSearchResult` blocks back to the API format on subsequent turns |
 
-**Environment variables:**
+**Configuration (preferred):**
 
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `PIZZAPI_WEB_SEARCH` | Set to any truthy value to enable web search | (disabled) |
-| `PIZZAPI_WEB_SEARCH_MAX_USES` | Maximum number of searches per request | `5` |
-| `PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS` | Comma-separated list of allowed domains | (all) |
-| `PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS` | Comma-separated list of blocked domains | (none) |
+Add to `~/.pizzapi/config.json`:
 
-**Usage:**
-
-```bash
-# Enable web search
-PIZZAPI_WEB_SEARCH=1 pizza runner
-
-# With domain restrictions
-PIZZAPI_WEB_SEARCH=1 PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS="docs.python.org,stackoverflow.com" pizza runner
+```json
+{
+  "providerSettings": {
+    "anthropic": {
+      "webSearch": {
+        "enabled": true,
+        "maxUses": 5,
+        "allowedDomains": ["docs.python.org", "stackoverflow.com"],
+        "blockedDomains": ["example.com"]
+      }
+    }
+  }
+}
 ```
+
+| Field | Description | Default |
+|-------|-------------|---------|
+| `enabled` | Enable web search | `false` |
+| `maxUses` | Maximum searches per request | `5` |
+| `allowedDomains` | Only include results from these domains | (all) |
+| `blockedDomains` | Never include results from these domains | (none) |
+
+**Environment variable override:**
+
+Env vars take precedence over config.json if both are set:
+
+| Variable | Description |
+|----------|-------------|
+| `PIZZAPI_WEB_SEARCH` | Set to any truthy value to enable |
+| `PIZZAPI_WEB_SEARCH_MAX_USES` | Max searches per request |
+| `PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS` | Comma-separated domain whitelist |
+| `PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS` | Comma-separated domain blacklist |
 
 **How it works:**
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -68,8 +68,8 @@ web search use a different format with a `type` field.
 |------|--------|
 | `dist/providers/anthropic.js` — `convertTools()` | Pass through objects that already have a `type` field (server-side tools) instead of converting them |
 | `dist/providers/anthropic.js` — `buildParams()` | Inject web search tool definition when `PIZZAPI_WEB_SEARCH` env var is set |
-| `dist/providers/anthropic.js` — stream handler | Handle `server_tool_use` blocks (search queries) → emit as text blocks with `_serverToolUse` metadata |
-| `dist/providers/anthropic.js` — stream handler | Handle `web_search_tool_result` blocks (results with citations) → emit as text blocks with `_webSearchResult` metadata |
+| `dist/providers/anthropic.js` — stream handler | Handle `server_tool_use` blocks (search queries) → emit as text blocks with `_serverToolUse` metadata; accumulate input via `input_json_delta` events and finalize at `content_block_stop` |
+| `dist/providers/anthropic.js` — stream handler | Handle `web_search_tool_result` blocks → emit as text blocks with `_webSearchResult` metadata; safely handle both array results and `WebSearchToolResultError` objects |
 | `dist/providers/anthropic.js` — `convertMessages()` | Round-trip `_serverToolUse` and `_webSearchResult` blocks back to the API format on subsequent turns |
 
 **Configuration (preferred):**
@@ -116,17 +116,19 @@ Env vars take precedence over config.json if both are set:
 2. Claude decides when to search. The API returns `server_tool_use` (the query)
    and `web_search_tool_result` (the results) content blocks.
 3. These blocks are mapped to `text` content blocks with hidden metadata
-   (`_serverToolUse`, `_webSearchResult`) so they display in the UI and are
-   stored in session history.
-4. On subsequent turns, `convertMessages()` converts them back to the proper
+   (`_serverToolUse`, `_webSearchResult`). The text is left empty — the UI
+   renderer is responsible for presenting web-search blocks using the
+   structured metadata.
+4. For `server_tool_use`, the search query input arrives via `input_json_delta`
+   streaming events (just like regular tool calls). The patch accumulates the
+   partial JSON and finalizes it at `content_block_stop`.
+5. On subsequent turns, `convertMessages()` converts them back to the proper
    API format for context continuity.
 
 **Limitations:**
 
-- Search results appear as markdown text rather than structured citations
-  (pi's content model doesn't have a native citation type).
 - The `web_search_tool_result` content blocks may contain encrypted search
-  result data; only the title/URL are extracted for display.
+  result data; the UI renderer must decide how to present them.
 
 **Tests:** `packages/cli/src/patches.test.ts` verifies patch presence and
 syntactic validity. Run with `bun test packages/cli/src/patches.test.ts`.

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,7 +4,7 @@ Patches in this directory are applied automatically by Bun via the
 `patchedDependencies` field in the root `package.json`. They are reapplied on
 every `bun install` — no postinstall script is needed.
 
-## @mariozechner/pi-coding-agent@0.55.4
+## @mariozechner/pi-coding-agent@0.58.3
 
 **Purpose:** Two changes:
 
@@ -15,6 +15,10 @@ every `bun install` — no postinstall script is needed.
 2. **Remove version check:** Disable the npm registry version check and
    "Update Available" notification on startup (not relevant for PizzaPi's
    headless runner mode).
+
+3. **Auth path display:** Show the actual auth path from the model registry
+   instead of the hardcoded default, so the login message is accurate when
+   PizzaPi overrides the auth file location.
 
 **Why this is needed:** Upstream `ExtensionAPI` only exposes session control
 methods on `ExtensionCommandContext`, which is only available inside registered
@@ -32,6 +36,7 @@ work from anywhere in the extension.
 | `dist/core/extensions/runner.js` — `bindCommandContext()` | Copies real `newSessionHandler` / `switchSessionHandler` onto the runtime object |
 | `dist/modes/interactive/interactive-mode.js` — `run()` | Removes `checkForNewVersion()` call |
 | `dist/modes/interactive/interactive-mode.js` | Removes `checkForNewVersion()` and `showNewVersionNotification()` methods |
+| `dist/modes/interactive/interactive-mode.js` — login flow | Uses `authStorage.storage?.authPath` instead of `getAuthPath()` |
 
 **Tests:** `packages/cli/src/patches.test.ts` verifies both patch application
 (source inspection) and functional behavior (runtime method stubs, assignment,
@@ -43,7 +48,81 @@ deleted and the `patchedDependencies` entry removed from `package.json`. The
 call sites in `packages/cli/src/extensions/remote.ts` should then be updated to
 use the typed API.
 
+## @mariozechner/pi-ai@0.58.3
+
+**Purpose:** Add support for Anthropic's native web search tool
+(`web_search_20250305`), which is a server-side tool that lets Claude search
+the web during conversations without requiring an MCP server or external search
+tool.
+
+**Why this is needed:** The upstream `anthropic.js` provider only handles three
+content block types: `text`, `thinking`, and `tool_use`. The web search API
+returns `server_tool_use` and `web_search_tool_result` content blocks that are
+silently dropped. Additionally, `convertTools()` assumes all tools follow the
+standard `{name, description, input_schema}` shape, but server-side tools like
+web search use a different format with a `type` field.
+
+**What it changes:**
+
+| File | Change |
+|------|--------|
+| `dist/providers/anthropic.js` — `convertTools()` | Pass through objects that already have a `type` field (server-side tools) instead of converting them |
+| `dist/providers/anthropic.js` — `buildParams()` | Inject web search tool definition when `PI_WEB_SEARCH` env var is set |
+| `dist/providers/anthropic.js` — stream handler | Handle `server_tool_use` blocks (search queries) → emit as text blocks with `_serverToolUse` metadata |
+| `dist/providers/anthropic.js` — stream handler | Handle `web_search_tool_result` blocks (results with citations) → emit as text blocks with `_webSearchResult` metadata |
+| `dist/providers/anthropic.js` — `convertMessages()` | Round-trip `_serverToolUse` and `_webSearchResult` blocks back to the API format on subsequent turns |
+
+**Environment variables:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `PI_WEB_SEARCH` | Set to any truthy value to enable web search | (disabled) |
+| `PI_WEB_SEARCH_MAX_USES` | Maximum number of searches per request | `5` |
+| `PI_WEB_SEARCH_ALLOWED_DOMAINS` | Comma-separated list of allowed domains | (all) |
+| `PI_WEB_SEARCH_BLOCKED_DOMAINS` | Comma-separated list of blocked domains | (none) |
+
+**Usage:**
+
+```bash
+# Enable web search
+PI_WEB_SEARCH=1 pizza runner
+
+# With domain restrictions
+PI_WEB_SEARCH=1 PI_WEB_SEARCH_ALLOWED_DOMAINS="docs.python.org,stackoverflow.com" pizza runner
+```
+
+**How it works:**
+
+1. When `PI_WEB_SEARCH` is set, `buildParams()` appends a `web_search_20250305`
+   tool definition to the tools array.
+2. Claude decides when to search. The API returns `server_tool_use` (the query)
+   and `web_search_tool_result` (the results) content blocks.
+3. These blocks are mapped to `text` content blocks with hidden metadata
+   (`_serverToolUse`, `_webSearchResult`) so they display in the UI and are
+   stored in session history.
+4. On subsequent turns, `convertMessages()` converts them back to the proper
+   API format for context continuity.
+
+**Limitations:**
+
+- Search results appear as markdown text rather than structured citations
+  (pi's content model doesn't have a native citation type).
+- The `web_search_tool_result` content blocks may contain encrypted search
+  result data; only the title/URL are extracted for display.
+- Requires Anthropic API key (not OAuth/Claude Pro subscription) with web
+  search enabled in the Claude Console.
+
+**Tests:** `packages/cli/src/patches.test.ts` verifies patch presence and
+syntactic validity. Run with `bun test packages/cli/src/patches.test.ts`.
+
+**Removing this patch:** If upstream pi-ai adds native web search support,
+this patch can be deleted.
+
 ## Previously patched (no longer needed)
+
+### @mariozechner/pi-coding-agent@0.55.4 (replaced by 0.58.3 patch)
+
+Same purpose as the current patch, just targeting an older version.
 
 ### @mariozechner/pi-ai (removed in 0.55.1 upgrade)
 


### PR DESCRIPTION
## Summary

Upgrades all `@mariozechner/pi-*` packages from 0.55.4 to 0.58.3 and adds a new patch for Anthropic's native web search tool.

### Package bumps
- `@mariozechner/pi-coding-agent` ^0.55.4 → ^0.58.3
- `@mariozechner/pi-ai` ^0.55.4 → ^0.58.3
- `@mariozechner/pi-agent-core` ^0.55.4 → ^0.58.3
- `@mariozechner/pi-tui` ^0.55.4 → ^0.58.3

### Patches

**pi-coding-agent@0.58.3** (recreated for new version):
- Session control (`newSession`/`switchSession`) on extension API
- Version check + update notification removal
- Auth path display fix

**pi-ai@0.58.3** (new):
- Anthropic native web search tool (`web_search_20250305`) support
- `convertTools` passes through server-side tool definitions
- Stream handler processes `server_tool_use` and `web_search_tool_result` blocks
- `convertMessages` round-trips web search blocks for context continuity
- Controlled via `PIZZAPI_WEB_SEARCH`, `PIZZAPI_WEB_SEARCH_MAX_USES`, `PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS`, `PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS` env vars

### Other changes
- Fix deep import path for `getEnvApiKey` (pi-ai 0.58.3 added exports restrictions)
- Document upstream patches and `PIZZAPI_` env var prefix convention in AGENTS.md
- 20 patch tests, 208 total tests — all passing

### Godmother
- Captured "Dynamic model discovery from provider APIs" idea for future work