### PR TITLE
fix: suppress MCP auth success noise + recent paths UX

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/jordan/Documents/Projects/PizzaPi-worktrees/epic-subagent/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif /Users/jordan/Documents/Projects/pizzapi-low-hanging/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/jordan/Documents/Projects/PizzaPi-worktrees/epic-subagent/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /Users/jordan/Documents/Projects/pizzapi-low-hanging/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -17,7 +17,7 @@ import { getSession } from "../ws/sio-state.js";
 import { sendSkillCommand, sendAgentCommand, sendRunnerCommand } from "../ws/namespaces/runner.js";
 import { waitForSpawnAck } from "../ws/runner-control.js";
 import { requireSession, validateApiKey } from "../middleware.js";
-import { getRecentFolders, recordRecentFolder } from "../runner-recent-folders.js";
+import { deleteRecentFolder, getRecentFolders, recordRecentFolder } from "../runner-recent-folders.js";
 import { getHiddenModels } from "../user-hidden-models.js";
 import { cwdMatchesRoots } from "../security.js";
 import { isValidSkillName } from "../validation.js";
@@ -249,6 +249,14 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         if (req.method === "GET") {
             const folders = await getRecentFolders(identity.userId, runnerId);
             return Response.json({ folders });
+        }
+
+        if (req.method === "DELETE") {
+            const body = await req.json().catch(() => null) as Record<string, unknown> | null;
+            const path = typeof body?.path === "string" ? body.path : "";
+            if (!path) return Response.json({ error: "Missing path" }, { status: 400 });
+            const deleted = await deleteRecentFolder(identity.userId, runnerId, path);
+            return Response.json({ ok: true, deleted });
         }
 
         return undefined;

--- a/packages/server/src/runner-recent-folders.ts
+++ b/packages/server/src/runner-recent-folders.ts
@@ -79,6 +79,24 @@ export async function recordRecentFolder(
     }
 }
 
+export async function deleteRecentFolder(
+    userId: string,
+    runnerId: string,
+    path: string,
+): Promise<boolean> {
+    const normalizedPath = path.trim();
+    if (!normalizedPath) return false;
+
+    const result = await getKysely()
+        .deleteFrom("runner_recent_folder")
+        .where("userId", "=", userId)
+        .where("runnerId", "=", runnerId)
+        .where("path", "=", normalizedPath)
+        .executeTakeFirst();
+
+    return (result.numDeletedRows ?? 0n) > 0n;
+}
+
 export async function getRecentFolders(
     userId: string,
     runnerId: string,

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1888,21 +1888,8 @@ export function App() {
     }
 
     if (type === "mcp_auth_complete") {
-      const serverName = typeof evt.serverName === "string" ? evt.serverName : "MCP server";
-      const ts = typeof evt.ts === "number" ? evt.ts : Date.now();
-
-      const message: RelayMessage = {
-        key: `mcp_auth_ok:${ts}:${Math.random().toString(16).slice(2)}`,
-        role: "system",
-        timestamp: ts,
-        content: `✅ Authenticated with **${serverName}**`,
-        isError: false,
-      };
-      setMessages((prev) => {
-        const next = [...prev, message];
-        patchSessionCache({ messages: next });
-        return next;
-      });
+      // Silently ignore — auth success is noise on the happy path.
+      // The CLI still logs to stderr for debugging.
       return;
     }
 
@@ -3912,20 +3899,44 @@ export function App() {
                     <span className="text-xs font-medium text-muted-foreground">Recent</span>
                     <div className="flex flex-wrap gap-1.5">
                       {recentFolders.map((folder) => (
-                        <button
+                        <div
                           key={folder}
-                          type="button"
-                          disabled={spawningSession}
-                          onClick={() => setSpawnCwd(folder)}
-                          className={`inline-flex items-center rounded border px-2 py-0.5 font-mono text-[11px] transition-colors
+                          className={`inline-flex items-center rounded border font-mono text-[11px] transition-colors
                             ${spawnCwd === folder
                               ? "border-primary bg-primary/10 text-primary"
                               : "border-border bg-muted/50 text-muted-foreground hover:border-foreground/30 hover:text-foreground"
                             }`}
-                          title={folder}
                         >
-                          <span className="max-w-[220px] truncate">{folder}</span>
-                        </button>
+                          <button
+                            type="button"
+                            disabled={spawningSession}
+                            onClick={() => setSpawnCwd(folder)}
+                            className="px-2 py-0.5"
+                            title={folder}
+                          >
+                            <span className="max-w-[220px] truncate">{folder.split("/").filter(Boolean).pop() || folder}</span>
+                          </button>
+                          <button
+                            type="button"
+                            disabled={spawningSession}
+                            onClick={async (e) => {
+                              e.stopPropagation();
+                              if (spawnRunnerId) {
+                                await fetch(`/api/runners/${encodeURIComponent(spawnRunnerId)}/recent-folders`, {
+                                  method: "DELETE",
+                                  credentials: "include",
+                                  headers: { "Content-Type": "application/json" },
+                                  body: JSON.stringify({ path: folder }),
+                                });
+                              }
+                              setRecentFolders((prev) => prev.filter((f) => f !== folder));
+                            }}
+                            className="px-1 py-0.5 border-l border-inherit text-muted-foreground hover:text-destructive"
+                            title="Remove from recent"
+                          >
+                            ×
+                          </button>
+                        </div>
                       ))}
                     </div>
                   </div>

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Button } from "@/components/ui/button";
-import { RefreshCw, HardDrive, Hash, Loader2, Server, ChevronDown, Plus, FolderOpen, Terminal, Clock, Power, AlertTriangle } from "lucide-react";
+import { RefreshCw, HardDrive, Hash, Loader2, Server, ChevronDown, Plus, FolderOpen, Terminal, Clock, Power, AlertTriangle, X } from "lucide-react";
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
 import { formatPathTail } from "@/lib/path";
@@ -391,20 +391,44 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
                                 ) : (
                                     <div className="flex flex-col gap-1 min-w-0">
                                         {recentFolders.map((folder) => (
-                                            <button
+                                            <div
                                                 key={folder}
-                                                type="button"
-                                                onClick={() => setSpawnCwd(folder)}
                                                 className={cn(
-                                                    "flex items-center gap-2 text-left px-2.5 py-1.5 rounded-md text-xs font-mono transition-colors min-w-0",
+                                                    "flex items-center gap-2 text-left px-2.5 py-1.5 rounded-md text-xs font-mono transition-colors min-w-0 group",
                                                     spawnCwd === folder
                                                         ? "bg-accent text-accent-foreground"
                                                         : "text-muted-foreground hover:bg-muted hover:text-foreground"
                                                 )}
                                             >
-                                                <FolderOpen className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />
-                                                <span className="truncate [direction:rtl] text-left" dir="rtl">{folder}</span>
-                                            </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={() => setSpawnCwd(folder)}
+                                                    className="flex items-center gap-2 min-w-0 flex-1"
+                                                    title={folder}
+                                                >
+                                                    <FolderOpen className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />
+                                                    <span className="truncate">{folder.split("/").filter(Boolean).pop() || folder}</span>
+                                                </button>
+                                                <button
+                                                    type="button"
+                                                    onClick={async (e) => {
+                                                        e.stopPropagation();
+                                                        if (spawnRunnerId) {
+                                                            await fetch(`/api/runners/${encodeURIComponent(spawnRunnerId)}/recent-folders`, {
+                                                                method: "DELETE",
+                                                                credentials: "include",
+                                                                headers: { "Content-Type": "application/json" },
+                                                                body: JSON.stringify({ path: folder }),
+                                                            });
+                                                        }
+                                                        setRecentFolders((prev) => prev.filter((f) => f !== folder));
+                                                    }}
+                                                    className="flex-shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity"
+                                                    title="Remove from recent"
+                                                >
+                                                    <X className="h-3 w-3" />
+                                                </button>
+                                            </div>
                                         ))}
                                     </div>
                                 )}

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -416,15 +416,19 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
                                                     type="button"
                                                     onClick={async (e) => {
                                                         e.stopPropagation();
-                                                        if (spawnRunnerId) {
-                                                            await fetch(`/api/runners/${encodeURIComponent(spawnRunnerId)}/recent-folders`, {
+                                                        const targetRunner = spawnRunnerId;
+                                                        if (targetRunner) {
+                                                            await fetch(`/api/runners/${encodeURIComponent(targetRunner)}/recent-folders`, {
                                                                 method: "DELETE",
                                                                 credentials: "include",
                                                                 headers: { "Content-Type": "application/json" },
                                                                 body: JSON.stringify({ path: folder }),
                                                             });
                                                         }
-                                                        setRecentFolders((prev) => prev.filter((f) => f !== folder));
+                                                        // Only update local state if the runner hasn't changed during the request
+                                                        if (spawnRunnerId === targetRunner) {
+                                                            setRecentFolders((prev) => prev.filter((f) => f !== folder));
+                                                        }
                                                     }}
                                                     className="flex-shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity"
                                                     title="Remove from recent"

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -115,6 +115,9 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
             setRecentFolders([]);
             return;
         }
+        // Clear stale folders immediately so chips from the previous runner
+        // can't be deleted against the newly selected runner.
+        setRecentFolders([]);
         let cancelled = false;
         setRecentFoldersLoading(true);
         fetch(`/api/runners/${encodeURIComponent(spawnRunnerId)}/recent-folders`, { credentials: "include" })

--- a/packages/ui/src/components/TerminalManager.tsx
+++ b/packages/ui/src/components/TerminalManager.tsx
@@ -135,6 +135,9 @@ export function TerminalManager({
       setRecentFolders([]);
       return;
     }
+    // Clear stale folders immediately so chips from the previous runner
+    // can't be deleted against the newly selected runner.
+    setRecentFolders([]);
     let cancelled = false;
     void fetch(`/api/runners/${encodeURIComponent(selectedRunnerId)}/recent-folders`, { credentials: "include" })
       .then((res) => res.ok ? res.json() : Promise.reject())

--- a/packages/ui/src/components/TerminalManager.tsx
+++ b/packages/ui/src/components/TerminalManager.tsx
@@ -465,6 +465,7 @@ export function TerminalManager({
         cwd={cwd}
         onCwdChange={setCwd}
         recentFolders={recentFolders}
+        onRemoveFolder={(folder) => setRecentFolders((prev) => prev.filter((f) => f !== folder))}
         spawning={spawning}
         onSpawn={spawnFromDialog}
       />
@@ -644,6 +645,7 @@ interface NewTerminalDialogProps {
   cwd: string;
   onCwdChange: (cwd: string) => void;
   recentFolders: string[];
+  onRemoveFolder: (folder: string) => void;
   spawning: boolean;
   onSpawn: () => void;
 }
@@ -658,6 +660,7 @@ function NewTerminalDialog({
   cwd,
   onCwdChange,
   recentFolders,
+  onRemoveFolder,
   spawning,
   onSpawn,
 }: NewTerminalDialogProps) {
@@ -713,13 +716,34 @@ function NewTerminalDialog({
             {recentFolders.length > 0 && (
               <div className="flex flex-wrap gap-1 mt-1">
                 {recentFolders.slice(0, 5).map((folder) => (
-                  <button
+                  <div
                     key={folder}
-                    onClick={() => onCwdChange(folder)}
-                    className="rounded bg-secondary px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground transition-colors truncate max-w-[200px]"
+                    className="inline-flex items-center rounded bg-secondary text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground transition-colors group"
                   >
-                    {folder.split("/").pop() || folder}
-                  </button>
+                    <button
+                      onClick={() => onCwdChange(folder)}
+                      className="px-2 py-0.5 truncate max-w-[200px]"
+                      title={folder}
+                    >
+                      {folder.split("/").filter(Boolean).pop() || folder}
+                    </button>
+                    <button
+                      onClick={async (e) => {
+                        e.stopPropagation();
+                        await fetch(`/api/runners/${encodeURIComponent(selectedRunnerId)}/recent-folders`, {
+                          method: "DELETE",
+                          credentials: "include",
+                          headers: { "Content-Type": "application/json" },
+                          body: JSON.stringify({ path: folder }),
+                        });
+                        onRemoveFolder(folder);
+                      }}
+                      className="px-1 py-0.5 opacity-0 group-hover:opacity-100 hover:text-destructive transition-opacity"
+                      title="Remove from recent"
+                    >
+                      ×
+                    </button>
+                  </div>
                 ))}
               </div>
             )}


### PR DESCRIPTION
## Changes

1. **Suppress MCP auth success message** — stop showing "✅ Authenticated with X" as a system message in the UI on the happy path. The stderr debug log in the CLI remains for troubleshooting.

2. **Recent Paths: remove entries** — new `DELETE /api/runners/:id/recent-folders` endpoint + `×` button on each chip so users can remove stale entries.

3. **Recent Paths: better display** — show last path segment as chip label (e.g. `PizzaPi` instead of `/Users/jordan/Documents/Projects/PizzaPi`), full path in tooltip.

All 3 UI locations updated: New Session dialog, Runner Manager spawn dialog, Terminal Manager dialog.

Closes Godmother ideas `nUAmPtvZ` and `nDBjsSaM`.