### PR TITLE
feat(ui): Runners page redesign — master-detail split with sidebar integration

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3490,7 +3490,7 @@ export function App() {
             onOpenSession={handleOpenSession}
             onNewSession={handleNewSession}
             onClearSelection={handleClearSelection}
-            onShowRunners={() => { setShowRunners(true); setShowApiKeys(false); setActiveSessionId(null); setSidebarOpen(false); }}
+            onShowRunners={() => { setShowRunners(true); setShowApiKeys(false); setActiveSessionId(null); }}
             activeSessionId={activeSessionId}
             showRunners={showRunners}
             activeModel={activeModel}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -336,6 +336,13 @@ export function App() {
   const [apiKeyVersion, setApiKeyVersion] = React.useState(0);
   const [showRunners, setShowRunners] = React.useState(false);
   const [selectedRunnerId, setSelectedRunnerId] = React.useState<string | null>(null);
+  const [runnersForSidebar, setRunnersForSidebar] = React.useState<Array<{
+    runnerId: string;
+    name: string | null;
+    sessionCount: number;
+    version: string | null;
+    isOnline: boolean;
+  }>>([]);
   const [showTerminal, setShowTerminal] = React.useState(false);
   const [terminalPosition, setTerminalPosition] = React.useState<"bottom" | "right" | "left">(() => {
     try { return (localStorage.getItem("pp-terminal-position") as "bottom" | "right" | "left") ?? "bottom"; } catch { return "bottom"; }
@@ -3491,6 +3498,9 @@ export function App() {
             onSessionsChange={setLiveSessions}
             onClose={() => setSidebarOpen(false)}
             onEndSession={handleEndSession}
+            runners={runnersForSidebar}
+            selectedRunnerId={selectedRunnerId}
+            onSelectRunner={setSelectedRunnerId}
           />
         </div>
 
@@ -3662,6 +3672,7 @@ export function App() {
               {showRunners ? (
                 <RunnerManager
                     onOpenSession={(id) => { handleOpenSession(id); setShowRunners(false); }}
+                    onRunnersChange={setRunnersForSidebar}
                     selectedRunnerId={selectedRunnerId}
                     onSelectRunner={setSelectedRunnerId}
                   />

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3501,6 +3501,7 @@ export function App() {
             runners={runnersForSidebar}
             selectedRunnerId={selectedRunnerId}
             onSelectRunner={setSelectedRunnerId}
+            onShowSessions={() => setShowRunners(false)}
           />
         </div>
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -342,18 +342,32 @@ export function App() {
     sessionCount: number;
     version: string | null;
     isOnline: boolean;
-  }>>(() => {
+  }>>([]);
+  // User-scoped cache key for sidebar runners (prevents cross-account data leakage)
+  const sidebarCacheKey = React.useMemo(() => {
+    const userId = session && typeof session === "object" ? (session as any).user?.id : null;
+    return userId ? `pp-sidebar-runners:${userId}` : null;
+  }, [session]);
+  // Hydrate from cache once we know the user
+  React.useEffect(() => {
+    if (!sidebarCacheKey) return;
     try {
-      const cached = sessionStorage.getItem("pp-sidebar-runners");
-      if (cached) { const parsed = JSON.parse(cached); if (Array.isArray(parsed)) return parsed; }
+      const cached = sessionStorage.getItem(sidebarCacheKey);
+      if (cached) {
+        const parsed = JSON.parse(cached);
+        if (Array.isArray(parsed)) setRunnersForSidebar(parsed);
+      }
     } catch { /* ignore */ }
-    return [];
-  });
+    // Clean up legacy unscoped key
+    try { sessionStorage.removeItem("pp-sidebar-runners"); } catch { /* ignore */ }
+  }, [sidebarCacheKey]);
   // Write-through: persist sidebar runners to sessionStorage on every update
   const setSidebarRunners = React.useCallback((runners: typeof runnersForSidebar) => {
     setRunnersForSidebar(runners);
-    try { sessionStorage.setItem("pp-sidebar-runners", JSON.stringify(runners)); } catch { /* ignore */ }
-  }, []);
+    if (sidebarCacheKey) {
+      try { sessionStorage.setItem(sidebarCacheKey, JSON.stringify(runners)); } catch { /* ignore */ }
+    }
+  }, [sidebarCacheKey]);
   // Eager fetch: populate sidebar runners immediately on mount (before RunnerManager mounts)
   React.useEffect(() => {
     let cancelled = false;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -342,7 +342,40 @@ export function App() {
     sessionCount: number;
     version: string | null;
     isOnline: boolean;
-  }>>([]);
+  }>>(() => {
+    try {
+      const cached = sessionStorage.getItem("pp-sidebar-runners");
+      if (cached) { const parsed = JSON.parse(cached); if (Array.isArray(parsed)) return parsed; }
+    } catch { /* ignore */ }
+    return [];
+  });
+  // Write-through: persist sidebar runners to sessionStorage on every update
+  const setSidebarRunners = React.useCallback((runners: typeof runnersForSidebar) => {
+    setRunnersForSidebar(runners);
+    try { sessionStorage.setItem("pp-sidebar-runners", JSON.stringify(runners)); } catch { /* ignore */ }
+  }, []);
+  // Eager fetch: populate sidebar runners immediately on mount (before RunnerManager mounts)
+  React.useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/runners", { credentials: "include" })
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data) => {
+        if (cancelled) return;
+        const list: any[] = Array.isArray(data?.runners) ? data.runners : [];
+        const mapped = list
+          .filter((r) => typeof r?.runnerId === "string" && r.runnerId)
+          .map((r) => ({
+            runnerId: r.runnerId as string,
+            name: (typeof r.name === "string" ? r.name : null) as string | null,
+            sessionCount: (typeof r.sessionCount === "number" ? r.sessionCount : 0) as number,
+            version: (typeof r.version === "string" ? r.version : null) as string | null,
+            isOnline: true,
+          }));
+        setSidebarRunners(mapped);
+      })
+      .catch(() => { /* sidebar will stay with cached/empty data until RunnerManager loads */ });
+    return () => { cancelled = true; };
+  }, [setSidebarRunners]);
   const [showTerminal, setShowTerminal] = React.useState(false);
   const [terminalPosition, setTerminalPosition] = React.useState<"bottom" | "right" | "left">(() => {
     try { return (localStorage.getItem("pp-terminal-position") as "bottom" | "right" | "left") ?? "bottom"; } catch { return "bottom"; }
@@ -3673,7 +3706,7 @@ export function App() {
               {showRunners ? (
                 <RunnerManager
                     onOpenSession={(id) => { handleOpenSession(id); setShowRunners(false); }}
-                    onRunnersChange={setRunnersForSidebar}
+                    onRunnersChange={setSidebarRunners}
                     selectedRunnerId={selectedRunnerId}
                     onSelectRunner={setSelectedRunnerId}
                   />

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -335,6 +335,7 @@ export function App() {
   const [showApiKeys, setShowApiKeys] = React.useState(false);
   const [apiKeyVersion, setApiKeyVersion] = React.useState(0);
   const [showRunners, setShowRunners] = React.useState(false);
+  const [selectedRunnerId, setSelectedRunnerId] = React.useState<string | null>(null);
   const [showTerminal, setShowTerminal] = React.useState(false);
   const [terminalPosition, setTerminalPosition] = React.useState<"bottom" | "right" | "left">(() => {
     try { return (localStorage.getItem("pp-terminal-position") as "bottom" | "right" | "left") ?? "bottom"; } catch { return "bottom"; }
@@ -3659,7 +3660,11 @@ export function App() {
               showTerminal && terminalPosition === "left" && "order-last",
             )}>
               {showRunners ? (
-                <RunnerManager onOpenSession={(id) => { handleOpenSession(id); setShowRunners(false); }} />
+                <RunnerManager
+                    onOpenSession={(id) => { handleOpenSession(id); setShowRunners(false); }}
+                    selectedRunnerId={selectedRunnerId}
+                    onSelectRunner={setSelectedRunnerId}
+                  />
               ) : (
                 <SessionViewer
                   sessionId={activeSessionId}

--- a/packages/ui/src/components/AgentsManager.tsx
+++ b/packages/ui/src/components/AgentsManager.tsx
@@ -39,6 +39,8 @@ export interface AgentsManagerProps {
     agents: AgentInfo[];
     /** Called when agents change so the parent can update its state */
     onAgentsChange?: (agents: AgentInfo[]) => void;
+    /** When true, render without Collapsible wrapper (for tab/panel use) */
+    bare?: boolean;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -399,7 +401,7 @@ function DeleteAgentDialog({ runnerId, agent, onClose, onDeleted }: DeleteAgentD
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function AgentsManager({ runnerId, agents: initialAgents, onAgentsChange }: AgentsManagerProps) {
+export function AgentsManager({ runnerId, agents: initialAgents, onAgentsChange, bare }: AgentsManagerProps) {
     const [agents, setAgents] = React.useState<AgentInfo[]>(initialAgents);
     const [open, setOpen] = React.useState(false);
     const [refreshing, setRefreshing] = React.useState(false);
@@ -455,80 +457,97 @@ export function AgentsManager({ runnerId, agents: initialAgents, onAgentsChange 
         setEditorOpen(true);
     };
 
-    return (
-        <>
-            <Collapsible open={open} onOpenChange={setOpen}>
-                <div className="flex items-center justify-between mt-3">
-                    <CollapsibleTrigger className="flex items-center gap-1.5 text-left group/trigger">
-                        <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-                            Agents
-                        </span>
-                        <Badge
-                            variant="secondary"
-                            className="h-4 px-1.5 text-[10px] font-mono rounded-sm"
-                        >
-                            {agents.length}
-                        </Badge>
-                        <ChevronDown
-                            className={cn(
-                                "h-3 w-3 text-muted-foreground/60 transition-transform duration-200",
-                                open && "rotate-180"
-                            )}
-                        />
-                    </CollapsibleTrigger>
+    const actionButtons = (
+        <div className="flex items-center gap-1">
+            <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+                onClick={handleRefresh}
+                disabled={refreshing}
+                title="Re-scan agents from disk"
+            >
+                <RefreshCw className={cn("h-3 w-3 mr-1", refreshing && "animate-spin")} />
+                Reload
+            </Button>
+            <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+                onClick={handleNewAgent}
+            >
+                <Plus className="h-3 w-3 mr-1" />
+                New agent
+            </Button>
+        </div>
+    );
 
-                    <div className="flex items-center gap-1">
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
-                            onClick={handleRefresh}
-                            disabled={refreshing}
-                            title="Re-scan agents from disk"
-                        >
-                            <RefreshCw className={cn("h-3 w-3 mr-1", refreshing && "animate-spin")} />
-                            Reload
-                        </Button>
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
-                            onClick={handleNewAgent}
-                        >
-                            <Plus className="h-3 w-3 mr-1" />
-                            New agent
-                        </Button>
+    const agentsList = (
+        <div className={cn(bare ? "flex flex-col gap-1.5" : "mt-2 flex flex-col gap-1.5")}>
+            {agents.length === 0 ? (
+                <div className="flex flex-col items-center gap-2 py-5 text-center">
+                    <Bot className="h-5 w-5 text-muted-foreground/40" />
+                    <div className="space-y-0.5">
+                        <p className="text-xs font-medium text-muted-foreground">No agents yet</p>
+                        <p className="text-[11px] text-muted-foreground/60 max-w-[200px]">
+                            Add an agent .md file to{" "}
+                            <span className="font-mono">~/.pizzapi/agents/</span>{" "}
+                            or click &ldquo;New agent&rdquo; above.
+                        </p>
                     </div>
                 </div>
+            ) : (
+                agents.map((agent) => (
+                    <AgentRow
+                        key={agent.name}
+                        agent={agent}
+                        onEdit={handleEdit}
+                        onDelete={handleDeleteRequest}
+                        deleting={pendingDelete === agent.name}
+                    />
+                ))
+            )}
+        </div>
+    );
 
-                <CollapsibleContent>
-                    <div className="mt-2 flex flex-col gap-1.5">
-                        {agents.length === 0 ? (
-                            <div className="flex flex-col items-center gap-2 py-5 text-center">
-                                <Bot className="h-5 w-5 text-muted-foreground/40" />
-                                <div className="space-y-0.5">
-                                    <p className="text-xs font-medium text-muted-foreground">No agents yet</p>
-                                    <p className="text-[11px] text-muted-foreground/60 max-w-[200px]">
-                                        Add an agent .md file to{" "}
-                                        <span className="font-mono">~/.pizzapi/agents/</span>{" "}
-                                        or click &ldquo;New agent&rdquo; above.
-                                    </p>
-                                </div>
-                            </div>
-                        ) : (
-                            agents.map((agent) => (
-                                <AgentRow
-                                    key={agent.name}
-                                    agent={agent}
-                                    onEdit={handleEdit}
-                                    onDelete={handleDeleteRequest}
-                                    deleting={pendingDelete === agent.name}
-                                />
-                            ))
-                        )}
+    return (
+        <>
+            {bare ? (
+                <>
+                    <div className="flex items-center justify-between mb-3">
+                        <h3 className="text-sm font-medium">Agents</h3>
+                        {actionButtons}
                     </div>
-                </CollapsibleContent>
-            </Collapsible>
+                    {agentsList}
+                </>
+            ) : (
+                <Collapsible open={open} onOpenChange={setOpen}>
+                    <div className="flex items-center justify-between mt-3">
+                        <CollapsibleTrigger className="flex items-center gap-1.5 text-left group/trigger">
+                            <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+                                Agents
+                            </span>
+                            <Badge
+                                variant="secondary"
+                                className="h-4 px-1.5 text-[10px] font-mono rounded-sm"
+                            >
+                                {agents.length}
+                            </Badge>
+                            <ChevronDown
+                                className={cn(
+                                    "h-3 w-3 text-muted-foreground/60 transition-transform duration-200",
+                                    open && "rotate-180"
+                                )}
+                            />
+                        </CollapsibleTrigger>
+                        {actionButtons}
+                    </div>
+
+                    <CollapsibleContent>
+                        {agentsList}
+                    </CollapsibleContent>
+                </Collapsible>
+            )}
 
             <AgentEditorDialog
                 runnerId={runnerId}

--- a/packages/ui/src/components/PluginsManager.tsx
+++ b/packages/ui/src/components/PluginsManager.tsx
@@ -51,6 +51,7 @@ export interface PluginInfo {
 export interface PluginsManagerProps {
     runnerId: string;
     plugins: PluginInfo[];
+    onPluginsChange?: (plugins: PluginInfo[]) => void;
     /** When true, render without Collapsible wrapper (for tab/panel use) */
     bare?: boolean;
 }
@@ -341,7 +342,7 @@ const hookEventMapping: Record<string, string | null> = {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function PluginsManager({ runnerId, plugins: initialPlugins, bare }: PluginsManagerProps) {
+export function PluginsManager({ runnerId, plugins: initialPlugins, onPluginsChange, bare }: PluginsManagerProps) {
     const [plugins, setPlugins] = React.useState<PluginInfo[]>(initialPlugins);
     const [open, setOpen] = React.useState(false);
     const [refreshing, setRefreshing] = React.useState(false);
@@ -362,7 +363,9 @@ export function PluginsManager({ runnerId, plugins: initialPlugins, bare }: Plug
             if (res.ok) {
                 const data = await res.json();
                 if (Array.isArray(data.plugins)) {
-                    setPlugins(data.plugins);
+                    const updated = data.plugins as PluginInfo[];
+                    setPlugins(updated);
+                    onPluginsChange?.(updated);
                 }
             }
         } catch (err) {

--- a/packages/ui/src/components/PluginsManager.tsx
+++ b/packages/ui/src/components/PluginsManager.tsx
@@ -51,6 +51,8 @@ export interface PluginInfo {
 export interface PluginsManagerProps {
     runnerId: string;
     plugins: PluginInfo[];
+    /** When true, render without Collapsible wrapper (for tab/panel use) */
+    bare?: boolean;
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────────
@@ -339,7 +341,7 @@ const hookEventMapping: Record<string, string | null> = {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function PluginsManager({ runnerId, plugins: initialPlugins }: PluginsManagerProps) {
+export function PluginsManager({ runnerId, plugins: initialPlugins, bare }: PluginsManagerProps) {
     const [plugins, setPlugins] = React.useState<PluginInfo[]>(initialPlugins);
     const [open, setOpen] = React.useState(false);
     const [refreshing, setRefreshing] = React.useState(false);
@@ -370,70 +372,87 @@ export function PluginsManager({ runnerId, plugins: initialPlugins }: PluginsMan
         }
     };
 
+    const rescanButton = (
+        <Button
+            variant="ghost"
+            size="sm"
+            className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+            onClick={handleRefresh}
+            disabled={refreshing}
+        >
+            {refreshing ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+            ) : (
+                <RefreshCw className="h-3 w-3" />
+            )}
+            <span className="ml-1">Rescan</span>
+        </Button>
+    );
+
+    const pluginsList = (
+        <div className={cn(bare ? "flex flex-col gap-1.5" : "mt-2 flex flex-col gap-1.5")}>
+            {plugins.length === 0 ? (
+                <div className="flex flex-col items-center gap-2 py-5 text-center">
+                    <Puzzle className="h-5 w-5 text-muted-foreground/40" />
+                    <div className="space-y-0.5">
+                        <p className="text-xs font-medium text-muted-foreground">No plugins found</p>
+                        <p className="text-[11px] text-muted-foreground/60 max-w-[220px]">
+                            Add Claude Code plugins to{" "}
+                            <span className="font-mono">~/.pizzapi/plugins/</span>{" "}
+                            then click &ldquo;Rescan&rdquo;.
+                        </p>
+                    </div>
+                </div>
+            ) : (
+                plugins.map((plugin) => (
+                    <PluginRow
+                        key={plugin.name}
+                        plugin={plugin}
+                        onClick={() => setSelectedPlugin(plugin)}
+                    />
+                ))
+            )}
+        </div>
+    );
+
     return (
         <>
-            <Collapsible open={open} onOpenChange={setOpen}>
-                <div className="flex items-center justify-between mt-3">
-                    <CollapsibleTrigger className="flex items-center gap-1.5 text-left group/trigger">
-                        <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-                            Claude Plugins
-                        </span>
-                        <Badge
-                            variant="secondary"
-                            className="h-4 px-1.5 text-[10px] font-mono rounded-sm"
-                        >
-                            {plugins.length}
-                        </Badge>
-                        <ChevronDown
-                            className={cn(
-                                "h-3 w-3 text-muted-foreground/60 transition-transform duration-200",
-                                open && "rotate-180"
-                            )}
-                        />
-                    </CollapsibleTrigger>
-
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
-                        onClick={handleRefresh}
-                        disabled={refreshing}
-                    >
-                        {refreshing ? (
-                            <Loader2 className="h-3 w-3 animate-spin" />
-                        ) : (
-                            <RefreshCw className="h-3 w-3" />
-                        )}
-                        <span className="ml-1">Rescan</span>
-                    </Button>
-                </div>
-
-                <CollapsibleContent>
-                    <div className="mt-2 flex flex-col gap-1.5">
-                        {plugins.length === 0 ? (
-                            <div className="flex flex-col items-center gap-2 py-5 text-center">
-                                <Puzzle className="h-5 w-5 text-muted-foreground/40" />
-                                <div className="space-y-0.5">
-                                    <p className="text-xs font-medium text-muted-foreground">No plugins found</p>
-                                    <p className="text-[11px] text-muted-foreground/60 max-w-[220px]">
-                                        Add Claude Code plugins to{" "}
-                                        <span className="font-mono">~/.pizzapi/plugins/</span>{" "}
-                                        then click &ldquo;Rescan&rdquo;.
-                                    </p>
-                                </div>
-                            </div>
-                        ) : (
-                            plugins.map((plugin) => (
-                                <PluginRow
-                                    key={plugin.name}
-                                    plugin={plugin}
-                                    onClick={() => setSelectedPlugin(plugin)}
-                                />
-                            ))
-                        )}
+            {bare ? (
+                <>
+                    <div className="flex items-center justify-between mb-3">
+                        <h3 className="text-sm font-medium">Claude Plugins</h3>
+                        {rescanButton}
                     </div>
-                </CollapsibleContent>
-            </Collapsible>
+                    {pluginsList}
+                </>
+            ) : (
+                <Collapsible open={open} onOpenChange={setOpen}>
+                    <div className="flex items-center justify-between mt-3">
+                        <CollapsibleTrigger className="flex items-center gap-1.5 text-left group/trigger">
+                            <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+                                Claude Plugins
+                            </span>
+                            <Badge
+                                variant="secondary"
+                                className="h-4 px-1.5 text-[10px] font-mono rounded-sm"
+                            >
+                                {plugins.length}
+                            </Badge>
+                            <ChevronDown
+                                className={cn(
+                                    "h-3 w-3 text-muted-foreground/60 transition-transform duration-200",
+                                    open && "rotate-180"
+                                )}
+                            />
+                        </CollapsibleTrigger>
+                        {rescanButton}
+                    </div>
+
+                    <CollapsibleContent>
+                        {pluginsList}
+                    </CollapsibleContent>
+                </Collapsible>
+            )}
 
             <PluginDetailDialog
                 plugin={selectedPlugin}

--- a/packages/ui/src/components/RunnerDetailPanel.tsx
+++ b/packages/ui/src/components/RunnerDetailPanel.tsx
@@ -1,0 +1,409 @@
+import * as React from "react";
+import { useState, useEffect } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { formatPathTail } from "@/lib/path";
+import { SkillsManager, type SkillInfo } from "@/components/SkillsManager";
+import { AgentsManager, type AgentInfo } from "@/components/AgentsManager";
+import { PluginsManager, type PluginInfo } from "@/components/PluginsManager";
+import { SandboxManager } from "@/components/SandboxManager";
+import {
+    Plus,
+    RefreshCw,
+    Power,
+    Loader2,
+    AlertTriangle,
+    Clock,
+    Terminal,
+    ChevronRight,
+    Server,
+} from "lucide-react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RunnerTab = "sessions" | "skills" | "agents" | "plugins" | "sandbox";
+
+interface RunnerInfo {
+    runnerId: string;
+    name: string | null;
+    roots: string[];
+    sessionCount: number;
+    skills: SkillInfo[];
+    agents: AgentInfo[];
+    plugins: PluginInfo[];
+    version: string | null;
+}
+
+interface LiveSession {
+    sessionId: string;
+    shareUrl: string;
+    cwd: string;
+    startedAt: string;
+    sessionName: string | null;
+    isActive: boolean;
+    lastHeartbeatAt: string | null;
+    runnerId: string | null;
+    runnerName: string | null;
+}
+
+export interface RunnerDetailPanelProps {
+    runner: RunnerInfo | null;
+    hasRunners: boolean;
+    sessions: LiveSession[];
+    latestVersion: string | null;
+    isRestarting: boolean;
+    isStopping: boolean;
+    isOffline?: boolean;
+    onRestart: () => void;
+    onStop: () => void;
+    onNewSession: () => void;
+    onOpenSession?: (sessionId: string) => void;
+    onSkillsChange?: (runnerId: string, skills: SkillInfo[]) => void;
+    onAgentsChange?: (runnerId: string, agents: AgentInfo[]) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function semverLt(a: string, b: string): boolean {
+    const parse = (v: string) => {
+        const clean = v.replace(/^v/, "");
+        const [core, pre] = clean.split("-", 2);
+        return { parts: core.split(".").map(Number), pre: pre ?? null };
+    };
+    const pa = parse(a),
+        pb = parse(b);
+    for (let i = 0; i < Math.max(pa.parts.length, pb.parts.length); i++) {
+        const na = pa.parts[i] ?? 0,
+            nb = pb.parts[i] ?? 0;
+        if (isNaN(na) || isNaN(nb)) return false;
+        if (na < nb) return true;
+        if (na > nb) return false;
+    }
+    if (pa.pre !== null && pb.pre === null) return true;
+    return false;
+}
+
+function formatTime(iso: string): string {
+    return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+
+// ---------------------------------------------------------------------------
+// SessionsList (local)
+// ---------------------------------------------------------------------------
+
+function SessionsList({
+    sessions,
+    onOpenSession,
+}: {
+    sessions: LiveSession[];
+    onOpenSession?: (sessionId: string) => void;
+}) {
+    if (sessions.length === 0) {
+        return (
+            <p className="text-center text-xs text-muted-foreground py-8">No sessions</p>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-1.5">
+            {sessions.map((session) => {
+                const active = session.isActive;
+                return (
+                    <button
+                        key={session.sessionId}
+                        type="button"
+                        onClick={() => onOpenSession?.(session.sessionId)}
+                        className={cn(
+                            "flex items-center gap-3 rounded-lg border px-3 py-2.5 text-left transition-colors hover:bg-accent/40",
+                            active
+                                ? "bg-blue-500/[0.04] border-blue-500/[0.12]"
+                                : "bg-white/[0.02] border-white/[0.06]",
+                        )}
+                    >
+                        {/* Activity dot */}
+                        <span
+                            className={cn(
+                                "h-2 w-2 shrink-0 rounded-full",
+                                active
+                                    ? "bg-blue-400 shadow-[0_0_5px_#60a5fa80] animate-pulse"
+                                    : "bg-green-500/70",
+                            )}
+                        />
+
+                        {/* Name + cwd */}
+                        <div className="flex flex-col gap-0.5 min-w-0 flex-1">
+                            <span className="text-sm font-medium truncate">
+                                {session.sessionName ?? `Session ${session.sessionId.slice(0, 8)}…`}
+                            </span>
+                            <span className="text-[10px] font-mono text-muted-foreground truncate">
+                                {formatPathTail(session.cwd, 2)}
+                            </span>
+                        </div>
+
+                        {/* Status badge */}
+                        <span
+                            className={cn(
+                                "text-[9px] px-1.5 py-0.5 rounded-full shrink-0",
+                                active
+                                    ? "bg-blue-500/12 text-blue-300"
+                                    : "bg-green-500/8 text-green-300",
+                            )}
+                        >
+                            {active ? "active" : "idle"}
+                        </span>
+
+                        {/* Timestamp */}
+                        <span className="text-[10px] text-muted-foreground shrink-0">
+                            {formatTime(session.lastHeartbeatAt ?? session.startedAt)}
+                        </span>
+
+                        {/* Chevron */}
+                        <ChevronRight className="h-3 w-3 text-muted-foreground shrink-0" />
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TabBar
+// ---------------------------------------------------------------------------
+
+const TABS: { key: RunnerTab; label: string; countKey?: "skills" | "agents" | "plugins" }[] = [
+    { key: "sessions", label: "Sessions" },
+    { key: "skills", label: "Skills", countKey: "skills" },
+    { key: "agents", label: "Agents", countKey: "agents" },
+    { key: "plugins", label: "Plugins", countKey: "plugins" },
+    { key: "sandbox", label: "Sandbox" },
+];
+
+function TabBar({
+    activeTab,
+    onTabChange,
+    runner,
+}: {
+    activeTab: RunnerTab;
+    onTabChange: (tab: RunnerTab) => void;
+    runner: RunnerInfo;
+}) {
+    return (
+        <div className="flex gap-1 border-b border-border/40">
+            {TABS.map((tab) => {
+                const isActive = activeTab === tab.key;
+                const count = tab.countKey ? runner[tab.countKey].length : null;
+                return (
+                    <button
+                        key={tab.key}
+                        type="button"
+                        onClick={() => onTabChange(tab.key)}
+                        className={cn(
+                            "px-3 py-2 text-xs font-medium transition-all flex items-center gap-1.5",
+                            isActive
+                                ? "border-b-2 border-blue-500 text-blue-300"
+                                : "opacity-40 hover:opacity-70",
+                        )}
+                    >
+                        {tab.label}
+                        {count !== null && (
+                            <span className="text-[9px] font-mono bg-muted/60 px-1.5 py-0.5 rounded-full">
+                                {count}
+                            </span>
+                        )}
+                    </button>
+                );
+            })}
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RunnerDetailPanel
+// ---------------------------------------------------------------------------
+
+export function RunnerDetailPanel({
+    runner,
+    hasRunners,
+    sessions,
+    latestVersion,
+    isRestarting,
+    isStopping,
+    isOffline,
+    onRestart,
+    onStop,
+    onNewSession,
+    onOpenSession,
+    onSkillsChange,
+    onAgentsChange,
+}: RunnerDetailPanelProps) {
+    const [activeTab, setActiveTab] = useState<RunnerTab>("sessions");
+
+    // Reset tab when runner changes
+    useEffect(() => {
+        setActiveTab("sessions");
+    }, [runner?.runnerId]);
+
+    // ---- Empty states ----
+
+    if (!hasRunners) {
+        return (
+            <div className="flex flex-col flex-1 p-4 sm:p-6 overflow-y-auto items-center justify-center">
+                <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border/60 py-10 px-4 sm:py-16 sm:px-8 gap-4 text-center bg-muted/20">
+                    <div className="rounded-full bg-muted p-3">
+                        <Server className="h-6 w-6 text-muted-foreground" />
+                    </div>
+                    <div className="space-y-1">
+                        <p className="text-sm font-medium">No active runners</p>
+                        <p className="text-xs text-muted-foreground max-w-xs">
+                            Connect a runner by running{" "}
+                            <code className="font-mono bg-muted px-1 py-0.5 rounded text-[11px]">
+                                pizzapi runner
+                            </code>{" "}
+                            on your machine.
+                        </p>
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    if (!runner) {
+        return (
+            <div className="flex flex-col flex-1 p-4 sm:p-6 overflow-y-auto items-center justify-center">
+                <p className="text-sm text-muted-foreground">Select a runner from the sidebar.</p>
+            </div>
+        );
+    }
+
+    // ---- Version info ----
+
+    const outdated =
+        runner.version && latestVersion ? semverLt(runner.version, latestVersion) : false;
+    const actionsDisabled = !!isOffline || isRestarting || isStopping;
+
+    // ---- Tab content ----
+
+    let tabContent: React.ReactNode;
+    switch (activeTab) {
+        case "sessions":
+            tabContent = <SessionsList sessions={sessions} onOpenSession={onOpenSession} />;
+            break;
+        case "skills":
+            tabContent = (
+                <SkillsManager
+                    runnerId={runner.runnerId}
+                    skills={runner.skills}
+                    onSkillsChange={(s) => onSkillsChange?.(runner.runnerId, s)}
+                    bare
+                />
+            );
+            break;
+        case "agents":
+            tabContent = (
+                <AgentsManager
+                    runnerId={runner.runnerId}
+                    agents={runner.agents}
+                    onAgentsChange={(a) => onAgentsChange?.(runner.runnerId, a)}
+                    bare
+                />
+            );
+            break;
+        case "plugins":
+            tabContent = <PluginsManager runnerId={runner.runnerId} plugins={runner.plugins} bare />;
+            break;
+        case "sandbox":
+            tabContent = <SandboxManager runnerId={runner.runnerId} bare />;
+            break;
+    }
+
+    return (
+        <div className="flex flex-col flex-1 p-4 sm:p-6 overflow-y-auto">
+            {/* ---- Header ---- */}
+            <div className="flex flex-col gap-1 mb-4">
+                {/* Row 1 */}
+                <div className="flex items-center justify-between gap-3">
+                    {/* Left: name + version */}
+                    <div className="flex items-center gap-2 min-w-0 flex-wrap">
+                        <h2 className="text-lg font-semibold truncate">
+                            {runner.name ?? runner.runnerId}
+                        </h2>
+
+                        {runner.version && (
+                            <span
+                                className={cn(
+                                    "inline-flex items-center text-[10px] font-mono px-1.5 py-0.5 rounded-full border",
+                                    outdated
+                                        ? "bg-amber-500/10 border-amber-500/40 text-amber-600 dark:text-amber-400"
+                                        : "bg-muted/60 border-border/40 text-muted-foreground",
+                                )}
+                            >
+                                {outdated && <AlertTriangle className="h-2.5 w-2.5 mr-1" />}
+                                v{runner.version.replace(/^v/, "")}
+                            </span>
+                        )}
+
+                        {outdated && latestVersion && (
+                            <span className="text-[10px] text-amber-600 dark:text-amber-400">
+                                Update available (v{latestVersion.replace(/^v/, "")})
+                            </span>
+                        )}
+                    </div>
+
+                    {/* Right: actions */}
+                    <div className="flex items-center gap-1.5 shrink-0">
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={onNewSession}
+                            disabled={actionsDisabled}
+                        >
+                            <Plus className="h-3.5 w-3.5 mr-1" />
+                            New Session
+                        </Button>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={onRestart}
+                            disabled={actionsDisabled}
+                        >
+                            {isRestarting ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                                <RefreshCw className="h-3.5 w-3.5" />
+                            )}
+                        </Button>
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            onClick={onStop}
+                            disabled={actionsDisabled}
+                        >
+                            {isStopping ? (
+                                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                            ) : (
+                                <Power className="h-3.5 w-3.5" />
+                            )}
+                        </Button>
+                    </div>
+                </div>
+
+                {/* Row 2: runner ID */}
+                <span className="text-[10px] font-mono text-muted-foreground/35">
+                    {runner.runnerId}
+                </span>
+            </div>
+
+            {/* ---- Tabs ---- */}
+            <TabBar activeTab={activeTab} onTabChange={setActiveTab} runner={runner} />
+
+            {/* ---- Tab Content ---- */}
+            <div className="mt-4 flex-1">{tabContent}</div>
+        </div>
+    );
+}

--- a/packages/ui/src/components/RunnerDetailPanel.tsx
+++ b/packages/ui/src/components/RunnerDetailPanel.tsx
@@ -62,6 +62,7 @@ export interface RunnerDetailPanelProps {
     onOpenSession?: (sessionId: string) => void;
     onSkillsChange?: (runnerId: string, skills: SkillInfo[]) => void;
     onAgentsChange?: (runnerId: string, agents: AgentInfo[]) => void;
+    onPluginsChange?: (runnerId: string, plugins: PluginInfo[]) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -239,6 +240,7 @@ export function RunnerDetailPanel({
     onOpenSession,
     onSkillsChange,
     onAgentsChange,
+    onPluginsChange,
 }: RunnerDetailPanelProps) {
     const [activeTab, setActiveTab] = useState<RunnerTab>("sessions");
 
@@ -313,7 +315,14 @@ export function RunnerDetailPanel({
             );
             break;
         case "plugins":
-            tabContent = <PluginsManager runnerId={runner.runnerId} plugins={runner.plugins} bare />;
+            tabContent = (
+                <PluginsManager
+                    runnerId={runner.runnerId}
+                    plugins={runner.plugins}
+                    onPluginsChange={(p) => onPluginsChange?.(runner.runnerId, p)}
+                    bare
+                />
+            );
             break;
         case "sandbox":
             tabContent = <SandboxManager runnerId={runner.runnerId} bare />;

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -322,6 +322,7 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
                 onOpenSession={onOpenSession}
                 onSkillsChange={(rid, skills) => setRunners(prev => prev.map(r => r.runnerId === rid ? { ...r, skills } : r))}
                 onAgentsChange={(rid, agents) => setRunners(prev => prev.map(r => r.runnerId === rid ? { ...r, agents } : r))}
+                onPluginsChange={(rid, plugins) => setRunners(prev => prev.map(r => r.runnerId === rid ? { ...r, plugins } : r))}
             />
 
             {/* New session dialog */}

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
 import { Button } from "@/components/ui/button";
-import { RefreshCw, HardDrive, Hash, Loader2, Server, ChevronDown, Plus, FolderOpen, Terminal, Clock, Power, AlertTriangle, X } from "lucide-react";
-import { Collapsible, CollapsibleTrigger, CollapsibleContent } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
-import { formatPathTail } from "@/lib/path";
+import { Plus, FolderOpen, Loader2, RefreshCw, X } from "lucide-react";
 import {
     Dialog,
     DialogContent,
@@ -14,12 +12,12 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { SkillsManager, type SkillInfo } from "@/components/SkillsManager";
-import { AgentsManager, type AgentInfo } from "@/components/AgentsManager";
-import { PluginsManager, type PluginInfo } from "@/components/PluginsManager";
-import { SandboxManager } from "@/components/SandboxManager";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ErrorAlert } from "@/components/ui/error-alert";
+import { RunnerDetailPanel } from "@/components/RunnerDetailPanel";
+import type { SkillInfo } from "@/components/SkillsManager";
+import type { AgentInfo } from "@/components/AgentsManager";
+import type { PluginInfo } from "@/components/PluginsManager";
 
 interface RunnerInfo {
     runnerId: string;
@@ -46,9 +44,18 @@ interface LiveSession {
 
 export interface RunnerManagerProps {
     onOpenSession?: (sessionId: string) => void;
+    onRunnersChange?: (runners: Array<{
+        runnerId: string;
+        name: string | null;
+        sessionCount: number;
+        version: string | null;
+        isOnline: boolean;
+    }>) => void;
+    selectedRunnerId: string | null;
+    onSelectRunner?: (runnerId: string) => void;
 }
 
-export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
+export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId, onSelectRunner }: RunnerManagerProps) {
     const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
     const [sessions, setSessions] = React.useState<LiveSession[]>([]);
     const [loading, setLoading] = React.useState(true);
@@ -130,6 +137,24 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
             .finally(() => { if (!cancelled) setRecentFoldersLoading(false); });
         return () => { cancelled = true; };
     }, [spawnRunnerId]);
+
+    // Auto-select when there's exactly one runner
+    React.useEffect(() => {
+        if (runners.length === 1 && selectedRunnerId !== runners[0].runnerId) {
+            onSelectRunner?.(runners[0].runnerId);
+        }
+    }, [runners, selectedRunnerId, onSelectRunner]);
+
+    // Notify parent of runner list changes
+    React.useEffect(() => {
+        onRunnersChange?.(runners.map(r => ({
+            runnerId: r.runnerId,
+            name: r.name,
+            sessionCount: r.sessionCount,
+            version: r.version,
+            isOnline: true, // runners from API are always online
+        })));
+    }, [runners, onRunnersChange]);
 
     const handleRestart = async (runnerId: string) => {
         setRestarting((prev) => new Set(prev).add(runnerId));
@@ -249,112 +274,55 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
         }
     };
 
+    // Loading skeleton
     if (loading && runners.length === 0) {
         return (
-            <div className="flex flex-col gap-6 p-6 max-w-4xl mx-auto w-full animate-in fade-in duration-700">
-                <div className="flex items-start justify-between">
+            <div className="flex flex-col flex-1 p-6 gap-4 animate-in fade-in duration-700">
+                <div className="flex items-center justify-between">
                     <div className="space-y-2">
-                        <Skeleton className="h-8 w-32 rounded-md" />
-                        <Skeleton className="h-4 w-64 rounded-md" />
+                        <Skeleton className="h-6 w-48 rounded-md" />
+                        <Skeleton className="h-3 w-72 rounded-md" />
                     </div>
-                    <Skeleton className="h-8 w-24 rounded-md" />
+                    <div className="flex gap-2">
+                        <Skeleton className="h-8 w-28 rounded-md" />
+                        <Skeleton className="h-8 w-8 rounded-md" />
+                        <Skeleton className="h-8 w-8 rounded-md" />
+                    </div>
                 </div>
-                <div className="flex flex-col gap-4">
-                    {[1, 2].map((i) => (
-                        <div key={i} className="rounded-xl border border-border/40 bg-card p-4 space-y-4">
-                            <div className="flex items-start justify-between gap-3">
-                                <div className="flex items-center gap-3">
-                                    <Skeleton className="h-2 w-2 rounded-full" />
-                                    <div className="space-y-1.5">
-                                        <Skeleton className="h-4 w-32 rounded-md" />
-                                        <Skeleton className="h-3 w-48 rounded-md" />
-                                    </div>
-                                </div>
-                                <div className="flex gap-1.5">
-                                    <Skeleton className="h-7 w-24 rounded-md" />
-                                    <Skeleton className="h-7 w-20 rounded-md" />
-                                </div>
-                            </div>
-                            <div className="border-t border-border/40" />
-                            <div className="flex gap-6">
-                                <Skeleton className="h-4 w-24 rounded-md" />
-                                <Skeleton className="h-4 w-24 rounded-md" />
-                            </div>
-                        </div>
+                <div className="flex gap-4 border-b border-border/40 pb-2">
+                    {[80, 56, 64, 60, 64].map((w, i) => (
+                        <Skeleton key={i} className="h-4 rounded-md" style={{ width: w }} />
+                    ))}
+                </div>
+                <div className="flex flex-col gap-2">
+                    {[1, 2, 3].map((i) => (
+                        <Skeleton key={i} className="h-16 w-full rounded-lg" />
                     ))}
                 </div>
             </div>
         );
     }
 
+    const selectedRunner = runners.find(r => r.runnerId === selectedRunnerId) ?? null;
+    const runnerSessions = sessions.filter(s => s.runnerId === selectedRunnerId);
+
     return (
         <>
-            <div className="flex flex-col gap-6 p-4 sm:p-6 max-w-4xl mx-auto w-full flex-1 overflow-y-auto">
-                {/* Header */}
-                <div className="flex items-start justify-between">
-                    <div className="space-y-0.5">
-                        <h2 className="text-2xl font-semibold tracking-tight">Runners</h2>
-                        <p className="text-sm text-muted-foreground">Manage your remote execution environments.</p>
-                    </div>
-                    <Button
-                        variant="ghost"
-                        size="sm"
-                        onClick={fetchData}
-                        disabled={loading}
-                        className="text-muted-foreground hover:text-foreground h-8 px-2.5"
-                    >
-                        <RefreshCw className={`h-3.5 w-3.5 ${loading ? "animate-spin" : ""}`} />
-                        <span className="ml-1.5 text-xs">Refresh</span>
-                    </Button>
-                </div>
-
-                {/* Empty state */}
-                {runners.length === 0 ? (
-                    <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border/60 py-10 px-4 sm:py-16 sm:px-8 gap-4 text-center bg-muted/20">
-                        <div className="rounded-full bg-muted p-3">
-                            <Server className="h-6 w-6 text-muted-foreground" />
-                        </div>
-                        <div className="space-y-1">
-                            <p className="text-sm font-medium">No active runners</p>
-                            <p className="text-xs text-muted-foreground max-w-xs">
-                                Connect a runner by running{" "}
-                                <code className="font-mono bg-muted px-1 py-0.5 rounded text-[11px]">pizzapi runner</code>{" "}
-                                on your machine.
-                            </p>
-                        </div>
-                    </div>
-                ) : (
-                    <div className="flex flex-col gap-3">
-                        {runners.map((runner) => {
-                            const runnerSessions = sessions.filter((s) => s.runnerId === runner.runnerId);
-                            return (
-                                <RunnerCard
-                                    key={runner.runnerId}
-                                    runner={runner}
-                                    sessions={runnerSessions}
-                                    latestVersion={latestVersion}
-                                    isRestarting={restarting.has(runner.runnerId)}
-                                    isStopping={stopping.has(runner.runnerId)}
-                                    onRestart={() => handleRestart(runner.runnerId)}
-                                    onStop={() => handleStop(runner.runnerId)}
-                                    onNewSession={() => handleOpenNewSession(runner.runnerId)}
-                                    onOpenSession={onOpenSession}
-                                    onSkillsChange={(runnerId, updatedSkills) => {
-                                        setRunners((prev) => prev.map((r) =>
-                                            r.runnerId === runnerId ? { ...r, skills: updatedSkills } : r
-                                        ));
-                                    }}
-                                    onAgentsChange={(runnerId, updatedAgents) => {
-                                        setRunners((prev) => prev.map((r) =>
-                                            r.runnerId === runnerId ? { ...r, agents: updatedAgents } : r
-                                        ));
-                                    }}
-                                />
-                            );
-                        })}
-                    </div>
-                )}
-            </div>
+            <RunnerDetailPanel
+                runner={selectedRunner}
+                hasRunners={runners.length > 0}
+                sessions={runnerSessions}
+                latestVersion={latestVersion}
+                isRestarting={restarting.has(selectedRunnerId ?? "")}
+                isStopping={stopping.has(selectedRunnerId ?? "")}
+                isOffline={!selectedRunner}
+                onRestart={() => selectedRunnerId && handleRestart(selectedRunnerId)}
+                onStop={() => selectedRunnerId && handleStop(selectedRunnerId)}
+                onNewSession={() => selectedRunnerId && handleOpenNewSession(selectedRunnerId)}
+                onOpenSession={onOpenSession}
+                onSkillsChange={(rid, skills) => setRunners(prev => prev.map(r => r.runnerId === rid ? { ...r, skills } : r))}
+                onAgentsChange={(rid, agents) => setRunners(prev => prev.map(r => r.runnerId === rid ? { ...r, agents } : r))}
+            />
 
             {/* New session dialog */}
             <Dialog open={spawnRunnerId !== null} onOpenChange={(open) => { if (!open) setSpawnRunnerId(null); }}>
@@ -468,287 +436,5 @@ export function RunnerManager({ onOpenSession }: RunnerManagerProps) {
                 </DialogContent>
             </Dialog>
         </>
-    );
-}
-
-/**
- * Returns true if version a < b using semver ordering.
- * Handles prerelease tags: splits on "-" first, compares core numerically,
- * then treats any prerelease as less than the same core release
- * (e.g. 1.2.3-rc.1 < 1.2.3, but 1.2.3-rc.1 > 1.2.2).
- */
-function semverLt(a: string, b: string): boolean {
-    const parse = (v: string) => {
-        const clean = v.replace(/^v/, "");
-        const [core, pre] = clean.split("-", 2);
-        return { parts: core.split(".").map(Number), pre: pre ?? null };
-    };
-    const pa = parse(a), pb = parse(b);
-    for (let i = 0; i < Math.max(pa.parts.length, pb.parts.length); i++) {
-        const na = pa.parts[i] ?? 0, nb = pb.parts[i] ?? 0;
-        if (isNaN(na) || isNaN(nb)) return false; // unparseable → don't flag
-        if (na < nb) return true;
-        if (na > nb) return false;
-    }
-    // Same core: prerelease < release (e.g. 1.0.0-beta < 1.0.0)
-    if (pa.pre !== null && pb.pre === null) return true;
-    return false;
-}
-
-interface RunnerCardProps {
-    runner: RunnerInfo;
-    sessions: LiveSession[];
-    latestVersion: string | null;
-    isRestarting: boolean;
-    isStopping: boolean;
-    onRestart: () => void;
-    onStop: () => void;
-    onNewSession: () => void;
-    onOpenSession?: (sessionId: string) => void;
-    onSkillsChange?: (runnerId: string, skills: SkillInfo[]) => void;
-    onAgentsChange?: (runnerId: string, agents: AgentInfo[]) => void;
-}
-
-function formatTime(iso: string): string {
-    return new Date(iso).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
-}
-
-function RunnerCard({ runner, sessions, latestVersion, isRestarting, isStopping, onRestart, onStop, onNewSession, onOpenSession, onSkillsChange, onAgentsChange }: RunnerCardProps) {
-    const [sessionsOpen, setSessionsOpen] = React.useState(true);
-    const isOutdated = !!(runner.version && latestVersion && semverLt(runner.version, latestVersion));
-
-    return (
-        <div className="group relative rounded-xl border border-border/60 bg-card hover:border-border transition-all duration-200 overflow-hidden">
-            {/* Subtle top accent line */}
-            <div className={cn(
-                "absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent to-transparent",
-                isOutdated ? "via-amber-500/40" : "via-green-500/40"
-            )} />
-
-            <div className="p-3 sm:p-4">
-                {/* Top row: name + status + actions */}
-                <div className="flex items-center justify-between gap-3">
-                    <div className="flex items-center gap-3 min-w-0">
-                        {/* Online indicator dot */}
-                        <div className="relative flex-shrink-0">
-                            <div className="h-2.5 w-2.5 rounded-full bg-green-500 shadow-sm" />
-                            <div className="absolute inset-0 h-2.5 w-2.5 rounded-full bg-green-500 animate-ping opacity-40" />
-                        </div>
-                        <div className="min-w-0 flex-1">
-                            <div className="flex items-center gap-2">
-                                <p className="font-semibold text-sm leading-none truncate">
-                                    {runner.name || "Unnamed Runner"}
-                                </p>
-                                <span className={cn(
-                                    "inline-flex items-center text-[10px] font-mono px-1.5 py-0.5 rounded-full border leading-none gap-1",
-                                    isOutdated
-                                        ? "bg-amber-500/10 border-amber-500/40 text-amber-600 dark:text-amber-400"
-                                        : !runner.version
-                                            ? "bg-muted/60 border-border/40 text-muted-foreground/50 italic"
-                                            : "bg-muted/60 border-border/40 text-muted-foreground"
-                                )}>
-                                    {isOutdated && <AlertTriangle className="h-2.5 w-2.5" />}
-                                    {runner.version ? `v${runner.version}` : "unknown"}
-                                </span>
-                                {isOutdated && (
-                                    <span className="text-[10px] text-amber-600 dark:text-amber-400">
-                                        Update available (v{latestVersion})
-                                    </span>
-                                )}
-                            </div>
-                            <p className="font-mono text-[10px] text-muted-foreground/60 mt-1 truncate">
-                                {runner.runnerId}
-                            </p>
-                        </div>
-                    </div>
-
-                    <div className="flex items-center gap-1.5 flex-shrink-0">
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-8 w-8 sm:w-auto px-0 sm:px-3 text-xs border-border/60 hover:border-border hover:bg-accent/50 transition-all shadow-sm"
-                            onClick={onNewSession}
-                            title="New Session"
-                        >
-                            <Plus className="h-4 w-4 sm:h-3.5 sm:w-3.5 sm:mr-1.5" />
-                            <span className="hidden sm:inline">New Session</span>
-                        </Button>
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-8 w-8 sm:w-auto px-0 sm:px-3 text-xs border-border/60 hover:border-amber-500/40 hover:bg-amber-500/5 hover:text-amber-600 dark:hover:text-amber-400 transition-all"
-                            onClick={onRestart}
-                            disabled={isRestarting || isStopping}
-                            title="Restart Runner"
-                        >
-                            {isRestarting ? (
-                                <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-1.5" />
-                            ) : (
-                                <RefreshCw className="h-4 w-4 sm:h-3.5 sm:w-3.5 sm:mr-1.5" />
-                            )}
-                            <span className="hidden sm:inline">{isRestarting ? "Restarting…" : "Restart"}</span>
-                        </Button>
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            className="h-8 w-8 sm:w-auto px-0 sm:px-3 text-xs border-border/60 hover:border-red-500/40 hover:bg-red-500/5 hover:text-red-600 dark:hover:text-red-400 transition-all"
-                            onClick={onStop}
-                            disabled={isRestarting || isStopping}
-                            title="Stop Runner"
-                        >
-                            {isStopping ? (
-                                <Loader2 className="h-3.5 w-3.5 animate-spin sm:mr-1.5" />
-                            ) : (
-                                <Power className="h-4 w-4 sm:h-3.5 sm:w-3.5 sm:mr-1.5" />
-                            )}
-                            <span className="hidden sm:inline">{isStopping ? "Stopping…" : "Stop"}</span>
-                        </Button>
-                    </div>
-                </div>
-
-                {/* Divider */}
-                <div className="my-3 border-t border-border/40" />
-
-                {/* Stats row */}
-                <div className="flex flex-wrap items-center gap-x-5 gap-y-2">
-                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                        <Hash className="h-3.5 w-3.5 opacity-60" />
-                        <span>
-                            <span className="font-medium text-foreground">{sessions.length}</span>
-                            {" "}Active {sessions.length === 1 ? "Session" : "Sessions"}
-                        </span>
-                    </div>
-                    <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                        <HardDrive className="h-3.5 w-3.5 opacity-60" />
-                        <span>
-                            <span className="font-medium text-foreground">{runner.roots.length}</span>
-                            {" "}{runner.roots.length === 1 ? "Root" : "Roots"}
-                        </span>
-                    </div>
-                </div>
-
-                {/* Roots */}
-                {runner.roots.length > 0 && (
-                    <div className="mt-3 flex flex-wrap gap-1.5">
-                        {runner.roots.map((root, i) => (
-                            <span
-                                key={i}
-                                className="inline-flex items-center font-mono text-[10px] px-1.5 py-0.5 rounded-md bg-muted/60 border border-border/40 text-muted-foreground"
-                            >
-                                {root}
-                            </span>
-                        ))}
-                    </div>
-                )}
-
-                {/* Sessions accordion */}
-                {sessions.length > 0 && (
-                    <div className="mt-3">
-                        <Collapsible open={sessionsOpen} onOpenChange={setSessionsOpen}>
-                            <CollapsibleTrigger className="flex items-center gap-1.5 w-full text-left group/trigger">
-                                <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-                                    Sessions
-                                </span>
-                                <ChevronDown
-                                    className={cn(
-                                        "h-3 w-3 text-muted-foreground/60 transition-transform duration-200",
-                                        sessionsOpen && "rotate-180"
-                                    )}
-                                />
-                            </CollapsibleTrigger>
-                            <CollapsibleContent>
-                                <div className="mt-2 flex flex-col gap-1.5">
-                                    {sessions.map((session) => (
-                                        <SessionRow
-                                            key={session.sessionId}
-                                            session={session}
-                                            onOpen={onOpenSession}
-                                        />
-                                    ))}
-                                </div>
-                            </CollapsibleContent>
-                        </Collapsible>
-                    </div>
-                )}
-
-                {/* Skills manager */}
-                <SkillsManager
-                    runnerId={runner.runnerId}
-                    skills={runner.skills}
-                    onSkillsChange={(updated) => onSkillsChange?.(runner.runnerId, updated)}
-                />
-
-                {/* Agents manager */}
-                <AgentsManager
-                    runnerId={runner.runnerId}
-                    agents={runner.agents}
-                    onAgentsChange={(updated) => onAgentsChange?.(runner.runnerId, updated)}
-                />
-
-                {/* Plugins manager (Claude Code plugin adapter) */}
-                <PluginsManager
-                    runnerId={runner.runnerId}
-                    plugins={runner.plugins}
-                />
-
-                {/* Sandbox manager */}
-                <SandboxManager runnerId={runner.runnerId} />
-            </div>
-        </div>
-    );
-}
-
-interface SessionRowProps {
-    session: LiveSession;
-    onOpen?: (sessionId: string) => void;
-}
-
-function SessionRow({ session, onOpen }: SessionRowProps) {
-    const time = formatTime(session.lastHeartbeatAt ?? session.startedAt);
-    const label = session.sessionName?.trim() || `Session ${session.sessionId.slice(0, 8)}…`;
-    const path = session.cwd ? formatPathTail(session.cwd, 2) : null;
-
-    return (
-        <button
-            type="button"
-            onClick={() => onOpen?.(session.sessionId)}
-            disabled={!onOpen}
-            className={cn(
-                "flex items-center gap-3 w-full text-left px-3 py-2 rounded-lg border border-border/40 bg-muted/30 transition-colors",
-                onOpen ? "hover:bg-muted/60 hover:border-border/70 cursor-pointer" : "cursor-default"
-            )}
-        >
-            {/* Activity dot */}
-            <span
-                className={cn(
-                    "flex-shrink-0 h-1.5 w-1.5 rounded-full",
-                    session.isActive
-                        ? "bg-blue-400 shadow-[0_0_5px_#60a5fa80] animate-pulse"
-                        : "bg-green-500/70"
-                )}
-                title={session.isActive ? "Actively generating" : "Idle"}
-            />
-
-            {/* Label + path */}
-            <div className="flex-1 min-w-0">
-                <div className="flex items-baseline justify-between gap-2 min-w-0">
-                    <span className="text-xs font-medium truncate">{label}</span>
-                    <span className="text-[10px] text-muted-foreground/60 flex-shrink-0 flex items-center gap-1">
-                        <Clock className="h-2.5 w-2.5" />
-                        {time}
-                    </span>
-                </div>
-                {path && (
-                    <span className="flex items-center gap-1 text-[10px] text-muted-foreground/50 font-mono mt-0.5">
-                        <Terminal className="h-2.5 w-2.5 opacity-60" />
-                        {path}
-                    </span>
-                )}
-            </div>
-
-            {onOpen && (
-                <ChevronDown className="h-3 w-3 text-muted-foreground/40 flex-shrink-0 -rotate-90" />
-            )}
-        </button>
     );
 }

--- a/packages/ui/src/components/SandboxManager.tsx
+++ b/packages/ui/src/components/SandboxManager.tsx
@@ -24,6 +24,8 @@ import { cn } from "@/lib/utils";
 
 export interface SandboxManagerProps {
     runnerId: string;
+    /** When true, render without Collapsible wrapper (for tab/panel use) */
+    bare?: boolean;
 }
 
 interface SandboxStatus {
@@ -208,7 +210,7 @@ function ViolationFeed({ violations }: {
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function SandboxManager({ runnerId }: SandboxManagerProps) {
+export function SandboxManager({ runnerId, bare }: SandboxManagerProps) {
     const [open, setOpen] = React.useState(false);
     const [loading, setLoading] = React.useState(false);
     const [saving, setSaving] = React.useState(false);
@@ -283,10 +285,10 @@ export function SandboxManager({ runnerId }: SandboxManagerProps) {
     }, [runnerId]);
 
     React.useEffect(() => {
-        if (open && !status) {
+        if ((open || bare) && !status) {
             fetchStatus();
         }
-    }, [open, status, fetchStatus]);
+    }, [open, bare, status, fetchStatus]);
 
     const handleSave = async () => {
         setSaving(true);
@@ -380,26 +382,9 @@ export function SandboxManager({ runnerId }: SandboxManagerProps) {
         }));
     };
 
-    return (
-        <Collapsible open={open} onOpenChange={setOpen}>
-            <div className="flex items-center justify-between mt-3">
-                <CollapsibleTrigger className="flex items-center gap-1.5 text-left group/trigger">
-                    <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-                        Sandbox
-                    </span>
-                    {status && <ModeBadge mode={status.mode} />}
-                    <ChevronDown
-                        className={cn(
-                            "h-3 w-3 text-muted-foreground/60 transition-transform duration-200",
-                            open && "rotate-180"
-                        )}
-                    />
-                </CollapsibleTrigger>
-            </div>
-
-            <CollapsibleContent>
-                <div className="mt-2 flex flex-col gap-3">
-                    {loading && (
+    const formContent = (
+        <div className={cn(bare ? "flex flex-col gap-3" : "mt-2 flex flex-col gap-3")}>
+            {loading && (
                         <div className="flex items-center gap-2 text-xs text-muted-foreground py-3">
                             <Loader2 className="h-3.5 w-3.5 animate-spin" />
                             Loading sandbox status…
@@ -650,6 +635,39 @@ export function SandboxManager({ runnerId }: SandboxManagerProps) {
                         </>
                     )}
                 </div>
+    );
+
+    if (bare) {
+        return (
+            <>
+                <div className="flex items-center justify-between mb-3">
+                    <h3 className="text-sm font-medium">Sandbox</h3>
+                    {status && <ModeBadge mode={status.mode} />}
+                </div>
+                {formContent}
+            </>
+        );
+    }
+
+    return (
+        <Collapsible open={open} onOpenChange={setOpen}>
+            <div className="flex items-center justify-between mt-3">
+                <CollapsibleTrigger className="flex items-center gap-1.5 text-left group/trigger">
+                    <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+                        Sandbox
+                    </span>
+                    {status && <ModeBadge mode={status.mode} />}
+                    <ChevronDown
+                        className={cn(
+                            "h-3 w-3 text-muted-foreground/60 transition-transform duration-200",
+                            open && "rotate-180"
+                        )}
+                    />
+                </CollapsibleTrigger>
+            </div>
+
+            <CollapsibleContent>
+                {formContent}
             </CollapsibleContent>
         </Collapsible>
     );

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -893,35 +893,35 @@ export const SessionSidebar = React.memo(function SessionSidebar({
 
             <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
                 {/* Sessions / Runners nav tabs */}
-                <div className="px-2 pt-2 pb-1 flex-shrink-0 flex gap-1">
+                <div className="mx-3 mt-2 mb-1 flex-shrink-0 flex border-b border-sidebar-border/50">
                     <button
                         onClick={onShowSessions}
                         className={cn(
-                            "flex items-center gap-2 flex-1 px-3 py-3 md:py-2 rounded-lg text-sm font-medium transition-colors active:scale-[0.98]",
-                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+                            "flex items-center justify-center gap-1.5 px-3 pb-2 text-xs font-medium transition-colors relative",
+                            "focus-visible:outline-none",
                             !showRunners
-                                ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                                : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+                                ? "text-sidebar-foreground"
+                                : "text-sidebar-foreground/40 hover:text-sidebar-foreground/70"
                         )}
                     >
-                        <MessageSquare className={cn("h-4 w-4 flex-shrink-0", !showRunners ? "text-primary" : "text-sidebar-foreground/50")} />
+                        <MessageSquare className="h-3.5 w-3.5" />
                         <span>Sessions</span>
+                        {!showRunners && <div className="absolute bottom-0 inset-x-1 h-[2px] bg-primary rounded-full" />}
                     </button>
                     <button
                         onClick={onShowRunners}
                         className={cn(
-                            "flex items-center gap-2 flex-1 px-3 py-3 md:py-2 rounded-lg text-sm font-medium transition-colors active:scale-[0.98]",
-                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+                            "flex items-center justify-center gap-1.5 px-3 pb-2 text-xs font-medium transition-colors relative",
+                            "focus-visible:outline-none",
                             showRunners
-                                ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                                : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+                                ? "text-sidebar-foreground"
+                                : "text-sidebar-foreground/40 hover:text-sidebar-foreground/70"
                         )}
                     >
-                        <HardDrive className={cn("h-4 w-4 flex-shrink-0", showRunners ? "text-primary" : "text-sidebar-foreground/50")} />
+                        <HardDrive className="h-3.5 w-3.5" />
                         <span>Runners</span>
-                        <div className="ml-auto">
-                            <LiveDot state={dotState} />
-                        </div>
+                        <LiveDot state={dotState} />
+                        {showRunners && <div className="absolute bottom-0 inset-x-1 h-[2px] bg-primary rounded-full" />}
                     </button>
                 </div>
 

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -14,7 +14,7 @@ import { io } from "socket.io-client";
 import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/protocol";
 import { formatPathTail } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
-import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight } from "lucide-react";
+import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare } from "lucide-react";
 import { buildSessionTree, flattenSessionTree, getSessionIndent, getDescendantSessionIds } from "@/lib/session-tree";
 
 interface HubSession {
@@ -83,6 +83,8 @@ export interface SessionSidebarProps {
     onClose?: () => void;
     /** Called when the user confirms ending a session via the swipe gesture */
     onEndSession?: (sessionId: string) => void;
+    /** Called when the user wants to return from Runners view to Sessions */
+    onShowSessions?: () => void;
     /** List of runners to display when showRunners is true */
     runners?: Array<{
         runnerId: string;
@@ -178,6 +180,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     runners,
     selectedRunnerId,
     onSelectRunner,
+    onShowSessions,
 }: SessionSidebarProps) {
     const [collapsed, setCollapsed] = React.useState(false);
 
@@ -889,12 +892,25 @@ export const SessionSidebar = React.memo(function SessionSidebar({
             )}
 
             <div className="flex flex-col flex-1 min-h-0 overflow-hidden">
-                {/* Runners nav item / Live sessions header */}
-                <div className="px-2 pt-2 pb-1 flex-shrink-0">
+                {/* Sessions / Runners nav tabs */}
+                <div className="px-2 pt-2 pb-1 flex-shrink-0 flex gap-1">
+                    <button
+                        onClick={onShowSessions}
+                        className={cn(
+                            "flex items-center gap-2 flex-1 px-3 py-3 md:py-2 rounded-lg text-sm font-medium transition-colors active:scale-[0.98]",
+                            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+                            !showRunners
+                                ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                                : "text-sidebar-foreground/70 hover:bg-sidebar-accent/50 hover:text-sidebar-foreground"
+                        )}
+                    >
+                        <MessageSquare className={cn("h-4 w-4 flex-shrink-0", !showRunners ? "text-primary" : "text-sidebar-foreground/50")} />
+                        <span>Sessions</span>
+                    </button>
                     <button
                         onClick={onShowRunners}
                         className={cn(
-                            "flex items-center gap-2.5 w-full px-3 py-3 md:py-2 rounded-lg text-sm font-medium transition-colors active:scale-[0.98]",
+                            "flex items-center gap-2 flex-1 px-3 py-3 md:py-2 rounded-lg text-sm font-medium transition-colors active:scale-[0.98]",
                             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
                             showRunners
                                 ? "bg-sidebar-accent text-sidebar-accent-foreground"

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -83,6 +83,18 @@ export interface SessionSidebarProps {
     onClose?: () => void;
     /** Called when the user confirms ending a session via the swipe gesture */
     onEndSession?: (sessionId: string) => void;
+    /** List of runners to display when showRunners is true */
+    runners?: Array<{
+        runnerId: string;
+        name: string | null;
+        sessionCount: number;
+        version: string | null;
+        isOnline: boolean;
+    }>;
+    /** Currently selected runner ID */
+    selectedRunnerId?: string | null;
+    /** Called when a runner is selected */
+    onSelectRunner?: (runnerId: string) => void;
 }
 
 function formatRelativeDate(isoString: string): string {
@@ -163,6 +175,9 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     onSessionsChange,
     onClose,
     onEndSession,
+    runners,
+    selectedRunnerId,
+    onSelectRunner,
 }: SessionSidebarProps) {
     const [collapsed, setCollapsed] = React.useState(false);
 
@@ -894,7 +909,51 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                     </button>
                 </div>
 
-                <div className="flex-1 px-2 overflow-y-auto overflow-x-hidden" style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}>
+                {showRunners && runners && (
+                    <div className="px-2 mt-1 flex flex-col gap-0.5">
+                        <div className="text-[9px] font-medium text-sidebar-foreground/35 uppercase tracking-widest px-2.5 py-1">
+                            Connected Runners
+                        </div>
+                        {runners.length === 0 ? (
+                            <div className="px-2.5 py-4 text-center">
+                                <p className="text-xs font-medium text-sidebar-foreground/50">No runners connected</p>
+                                <p className="text-[10px] text-sidebar-foreground/30 mt-1">
+                                    Run <code className="font-mono bg-sidebar-accent/50 px-1 py-0.5 rounded text-[9px]">pizzapi runner</code> on your machine.
+                                </p>
+                            </div>
+                        ) : (
+                            runners.map((r) => (
+                                <button
+                                    key={r.runnerId}
+                                    onClick={() => { onSelectRunner?.(r.runnerId); if (window.innerWidth < 768) onClose?.(); }}
+                                    className={cn(
+                                        "flex items-center gap-2.5 w-full px-2.5 py-2 rounded-lg text-left transition-colors",
+                                        selectedRunnerId === r.runnerId
+                                            ? "bg-sidebar-accent border border-sidebar-border"
+                                            : r.isOnline
+                                                ? "hover:bg-sidebar-accent/50 opacity-70"
+                                                : "opacity-30"
+                                    )}
+                                >
+                                    <div className="relative flex-shrink-0">
+                                        <div className={cn(
+                                            "h-[7px] w-[7px] rounded-full",
+                                            r.isOnline ? "bg-green-500 shadow-[0_0_6px_rgba(34,197,94,0.4)]" : "bg-sidebar-foreground/30"
+                                        )} />
+                                    </div>
+                                    <div className="flex-1 min-w-0">
+                                        <div className="text-xs font-semibold truncate">{r.name || "Unnamed Runner"}</div>
+                                        <div className="text-[9px] font-mono text-sidebar-foreground/40 mt-0.5">
+                                            {r.isOnline ? `${r.sessionCount} session${r.sessionCount !== 1 ? "s" : ""}` : "offline"}
+                                        </div>
+                                    </div>
+                                </button>
+                            ))
+                        )}
+                    </div>
+                )}
+
+                {!showRunners && <div className="flex-1 px-2 overflow-y-auto overflow-x-hidden" style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}>
                     {pinError && (
                         <p role="alert" aria-live="polite" className="px-2 py-2 text-[0.7rem] text-red-400">
                             {pinError}
@@ -1371,7 +1430,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                             </div>
                         );
                     })()}
-                </div>
+                </div>}
             </div>
         </aside>
     );

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -785,7 +785,36 @@ export const SessionSidebar = React.memo(function SessionSidebar({
             </Dialog>
 
             {/* Sidebar header */}
-            {selectMode ? (
+            {showRunners ? (
+                <div className="flex items-center justify-between px-3 py-2 border-b border-sidebar-border flex-shrink-0">
+                    <div className="flex items-center gap-2">
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="hidden md:inline-flex h-7 w-7 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+                            onClick={() => setCollapsed(true)}
+                            aria-label="Collapse sidebar"
+                        >
+                            <PanelLeftClose className="h-4 w-4" />
+                        </Button>
+                        <span className="text-[0.7rem] font-semibold uppercase tracking-widest text-sidebar-foreground/60">
+                            Runners
+                        </span>
+                    </div>
+                    <div className="flex items-center gap-1">
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8 text-sidebar-foreground/60 hover:text-sidebar-foreground hover:bg-sidebar-accent"
+                            onClick={onClose}
+                            aria-label="Close sidebar"
+                            title="Close sidebar"
+                        >
+                            <X className="h-4 w-4" />
+                        </Button>
+                    </div>
+                </div>
+            ) : selectMode ? (
                 <div className="flex items-center justify-between px-3 py-2 border-b border-sidebar-border flex-shrink-0">
                     <div className="flex items-center gap-2">
                         <Button

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -955,7 +955,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                 </div>
 
                 {showRunners && runners && (
-                    <div className="px-2 mt-1 flex flex-col gap-0.5">
+                    <div className="px-2 mt-1 flex-1 flex flex-col gap-0.5 overflow-y-auto overflow-x-hidden" style={{ paddingBottom: "max(0.5rem, env(safe-area-inset-bottom))" }}>
                         <div className="text-[9px] font-medium text-sidebar-foreground/35 uppercase tracking-widest px-2.5 py-1">
                             Connected Runners
                         </div>

--- a/packages/ui/src/components/SkillsManager.tsx
+++ b/packages/ui/src/components/SkillsManager.tsx
@@ -39,6 +39,8 @@ export interface SkillsManagerProps {
     skills: SkillInfo[];
     /** Called when skills change so the parent can update its state */
     onSkillsChange?: (skills: SkillInfo[]) => void;
+    /** When true, render without Collapsible wrapper (for tab/panel use) */
+    bare?: boolean;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -391,7 +393,7 @@ function DeleteSkillDialog({ runnerId, skill, onClose, onDeleted }: DeleteSkillD
 
 // ── Main component ────────────────────────────────────────────────────────────
 
-export function SkillsManager({ runnerId, skills: initialSkills, onSkillsChange }: SkillsManagerProps) {
+export function SkillsManager({ runnerId, skills: initialSkills, onSkillsChange, bare }: SkillsManagerProps) {
     const [skills, setSkills] = React.useState<SkillInfo[]>(initialSkills);
     const [open, setOpen] = React.useState(false);
     const [refreshing, setRefreshing] = React.useState(false);
@@ -447,80 +449,97 @@ export function SkillsManager({ runnerId, skills: initialSkills, onSkillsChange 
         setEditorOpen(true);
     };
 
-    return (
-        <>
-            <Collapsible open={open} onOpenChange={setOpen}>
-                <div className="flex items-center justify-between mt-3">
-                    <CollapsibleTrigger className="flex items-center gap-1.5 text-left group/trigger">
-                        <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
-                            Agent Skills
-                        </span>
-                        <Badge
-                            variant="secondary"
-                            className="h-4 px-1.5 text-[10px] font-mono rounded-sm"
-                        >
-                            {skills.length}
-                        </Badge>
-                        <ChevronDown
-                            className={cn(
-                                "h-3 w-3 text-muted-foreground/60 transition-transform duration-200",
-                                open && "rotate-180"
-                            )}
-                        />
-                    </CollapsibleTrigger>
+    const actionButtons = (
+        <div className="flex items-center gap-1">
+            <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+                onClick={handleRefresh}
+                disabled={refreshing}
+                title="Re-scan skills from disk"
+            >
+                <RefreshCw className={cn("h-3 w-3 mr-1", refreshing && "animate-spin")} />
+                Reload
+            </Button>
+            <Button
+                variant="ghost"
+                size="sm"
+                className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
+                onClick={handleNewSkill}
+            >
+                <Plus className="h-3 w-3 mr-1" />
+                New skill
+            </Button>
+        </div>
+    );
 
-                    <div className="flex items-center gap-1">
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
-                            onClick={handleRefresh}
-                            disabled={refreshing}
-                            title="Re-scan skills from disk"
-                        >
-                            <RefreshCw className={cn("h-3 w-3 mr-1", refreshing && "animate-spin")} />
-                            Reload
-                        </Button>
-                        <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-6 px-2 text-xs text-muted-foreground hover:text-foreground"
-                            onClick={handleNewSkill}
-                        >
-                            <Plus className="h-3 w-3 mr-1" />
-                            New skill
-                        </Button>
+    const skillsList = (
+        <div className={cn(bare ? "flex flex-col gap-1.5" : "mt-2 flex flex-col gap-1.5")}>
+            {skills.length === 0 ? (
+                <div className="flex flex-col items-center gap-2 py-5 text-center">
+                    <BookOpen className="h-5 w-5 text-muted-foreground/40" />
+                    <div className="space-y-0.5">
+                        <p className="text-xs font-medium text-muted-foreground">No skills yet</p>
+                        <p className="text-[11px] text-muted-foreground/60 max-w-[200px]">
+                            Add a SKILL.md to{" "}
+                            <span className="font-mono">~/.pizzapi/skills/</span>{" "}
+                            or click &ldquo;New skill&rdquo; above.
+                        </p>
                     </div>
                 </div>
+            ) : (
+                skills.map((skill) => (
+                    <SkillRow
+                        key={skill.name}
+                        skill={skill}
+                        onEdit={handleEdit}
+                        onDelete={handleDeleteRequest}
+                        deleting={pendingDelete === skill.name}
+                    />
+                ))
+            )}
+        </div>
+    );
 
-                <CollapsibleContent>
-                    <div className="mt-2 flex flex-col gap-1.5">
-                        {skills.length === 0 ? (
-                            <div className="flex flex-col items-center gap-2 py-5 text-center">
-                                <BookOpen className="h-5 w-5 text-muted-foreground/40" />
-                                <div className="space-y-0.5">
-                                    <p className="text-xs font-medium text-muted-foreground">No skills yet</p>
-                                    <p className="text-[11px] text-muted-foreground/60 max-w-[200px]">
-                                        Add a SKILL.md to{" "}
-                                        <span className="font-mono">~/.pizzapi/skills/</span>{" "}
-                                        or click &ldquo;New skill&rdquo; above.
-                                    </p>
-                                </div>
-                            </div>
-                        ) : (
-                            skills.map((skill) => (
-                                <SkillRow
-                                    key={skill.name}
-                                    skill={skill}
-                                    onEdit={handleEdit}
-                                    onDelete={handleDeleteRequest}
-                                    deleting={pendingDelete === skill.name}
-                                />
-                            ))
-                        )}
+    return (
+        <>
+            {bare ? (
+                <>
+                    <div className="flex items-center justify-between mb-3">
+                        <h3 className="text-sm font-medium">Agent Skills</h3>
+                        {actionButtons}
                     </div>
-                </CollapsibleContent>
-            </Collapsible>
+                    {skillsList}
+                </>
+            ) : (
+                <Collapsible open={open} onOpenChange={setOpen}>
+                    <div className="flex items-center justify-between mt-3">
+                        <CollapsibleTrigger className="flex items-center gap-1.5 text-left group/trigger">
+                            <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+                                Agent Skills
+                            </span>
+                            <Badge
+                                variant="secondary"
+                                className="h-4 px-1.5 text-[10px] font-mono rounded-sm"
+                            >
+                                {skills.length}
+                            </Badge>
+                            <ChevronDown
+                                className={cn(
+                                    "h-3 w-3 text-muted-foreground/60 transition-transform duration-200",
+                                    open && "rotate-180"
+                                )}
+                            />
+                        </CollapsibleTrigger>
+                        {actionButtons}
+                    </div>
+
+                    <CollapsibleContent>
+                        {skillsList}
+                    </CollapsibleContent>
+                </Collapsible>
+            )}
 
             <SkillEditorDialog
                 runnerId={runnerId}


### PR DESCRIPTION
## Runners Page Redesign

Redesigns the Runners page from a single vertically-stacked card layout into a master-detail split with sidebar integration.

### What changed

**Layout:**
- Runner list now lives in the app's existing left sidebar (with Sessions/Runners underline tabs for navigation)
- Selected runner's detail panel renders in the main content area with header + tabbed sections
- Sub-managers (Skills, Agents, Plugins, Sandbox) render in individual tabs instead of stacked collapsibles

**New components:**
- `RunnerDetailPanel` — header with version badge, action buttons, underline tab bar, and tab content
- Sidebar runner list with online/offline status dots, session counts, and empty states

**Improvements:**
- Single runner auto-selects (no extra click needed)
- Active sessions get blue-tinted styling to distinguish from idle
- Runners-specific sidebar header (no session actions leaking through)
- RunnerManager reduced from ~750 to ~300 lines (thin orchestrator pattern)

### Files changed

| File | Change |
|------|--------|
| `RunnerDetailPanel.tsx` | **New** — header, tabs, session list |
| `SessionSidebar.tsx` | Runner list section + Sessions/Runners nav tabs |
| `RunnerManager.tsx` | Rewritten as thin orchestrator |
| `App.tsx` | Wired sidebar ↔ detail panel state |
| `SkillsManager.tsx` | Added `bare` prop |
| `AgentsManager.tsx` | Added `bare` prop |
| `PluginsManager.tsx` | Added `bare` prop |
| `SandboxManager.tsx` | Added `bare` prop |

### Quality

- ✅ TypeScript: 0 errors
- ✅ Build: clean
- ✅ Tests: 216/216 passing

### Design spec

`docs/superpowers/specs/2026-03-17-runners-page-redesign-design.md`
