### PR TITLE
fix(ui): prevent tab list from expanding past viewport on mobile

### DIFF
--- a/packages/ui/src/components/CombinedPanel.tsx
+++ b/packages/ui/src/components/CombinedPanel.tsx
@@ -207,8 +207,8 @@ export function CombinedPanel({
   return (
     <div className={cn("flex flex-col bg-background text-foreground", className)}>
       {/* Tab bar */}
-      <div className="flex items-center border-b border-border bg-muted/50 shrink-0 min-h-[32px]">
-        <div className="flex items-center flex-1 overflow-x-auto gap-0.5 px-1">
+      <div className="flex items-center border-b border-border bg-muted/50 shrink-0 min-h-[32px] overflow-hidden">
+        <div className="flex items-center flex-1 min-w-0 overflow-x-auto gap-0.5 px-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
           {tabs.map((tab) => {
             const isActive = activeTabId === tab.id;
             const hasDrag = !!tab.onDragStart;

--- a/packages/ui/src/components/TerminalManager.tsx
+++ b/packages/ui/src/components/TerminalManager.tsx
@@ -262,7 +262,7 @@ export function TerminalManager({
   return (
     <div className={cn("flex flex-col bg-background", className)}>
       {/* ── Persistent topbar ─────────────────────────────────────────────── */}
-      <div className="flex items-center border-b border-border bg-muted/50 shrink-0 min-h-[36px] md:min-h-[32px]">
+      <div className="flex items-center border-b border-border bg-muted/50 shrink-0 min-h-[36px] md:min-h-[32px] overflow-hidden">
         {/* Mobile: back button */}
         {onClose && (
           <Button


### PR DESCRIPTION
## Problem

On mobile, the tab list in the terminal bar and combined panel expands past the viewport width instead of scrolling horizontally. The parent flex container didn't constrain the inner `overflow-x-auto` child.

## Fix

- **TerminalManager.tsx** — Added `overflow-hidden` to the topbar container so the inner tab list's `overflow-x-auto` actually triggers horizontal scrolling.
- **CombinedPanel.tsx** — Same `overflow-hidden` on the tab bar container, plus `min-w-0` and hidden-scrollbar styles on the inner tab scroll area for consistency with TerminalManager.