### PR TITLE
feat: add checkbox and ranked-choice question types to AskUserQuestion

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/jordan/Documents/Projects/PizzaPi-worktrees/epic-subagent/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/checkbox-questions/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/jordan/Documents/Projects/PizzaPi-worktrees/epic-subagent/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/checkbox-questions/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/checkbox-questions/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif /Users/jordan/Documents/Projects/PizzaPi-worktrees/epic-subagent/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/checkbox-questions/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /Users/jordan/Documents/Projects/PizzaPi-worktrees/epic-subagent/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/packages/cli/src/extensions/remote-ask-user.ts
+++ b/packages/cli/src/extensions/remote-ask-user.ts
@@ -10,6 +10,7 @@ import type {
     RelayContext,
     AskUserQuestionParams,
     AskUserQuestionItem,
+    AskUserQuestionType,
     AskUserQuestionDisplay,
     AskUserQuestionDetails,
 } from "./remote-types.js";
@@ -32,7 +33,10 @@ export function sanitizeQuestions(params: AskUserQuestionParams): AskUserQuestio
             const opts = Array.isArray(rawOpts)
                 ? rawOpts.filter((o): o is string => typeof o === "string" && o.trim().length > 0).map((o) => o.trim())
                 : [];
-            result.push({ question: q.trim(), options: opts });
+            const rawType = raw.type;
+            const type: AskUserQuestionType | undefined =
+                rawType === "checkbox" ? "checkbox" : rawType === "ranked" ? "ranked" : rawType === "radio" ? "radio" : undefined;
+            result.push({ question: q.trim(), options: opts, ...(type ? { type } : {}) });
         }
         if (result.length > 0) return result;
     }
@@ -199,6 +203,11 @@ export function registerAskUserTool(rctx: RelayContext) {
                                 type: "array",
                                 items: { type: "string" },
                                 description: "Predefined choices for the user to select from. The UI will automatically add a \"Write your own...\" free-form option.",
+                            },
+                            type: {
+                                type: "string",
+                                enum: ["radio", "checkbox", "ranked"],
+                                description: "Selection mode. \"radio\" (default) for single-select, \"checkbox\" for multi-select, \"ranked\" for ranked-choice ordering.",
                             },
                         },
                         required: ["question", "options"],

--- a/packages/cli/src/extensions/remote-types.ts
+++ b/packages/cli/src/extensions/remote-types.ts
@@ -28,9 +28,13 @@ export interface RelayState {
 
 export type AskUserQuestionDisplay = "stepper";
 
+export type AskUserQuestionType = "radio" | "checkbox" | "ranked";
+
 export interface AskUserQuestionItem {
     question: string;
     options: string[];
+    /** Selection mode: "radio" (single select, default), "checkbox" (multiselect), or "ranked" (ranked choice). */
+    type?: AskUserQuestionType;
 }
 
 export interface AskUserQuestionParams {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -614,7 +614,7 @@ export function App() {
   const [recentFolders, setRecentFolders] = React.useState<string[]>([]);
   const [recentFoldersLoading, setRecentFoldersLoading] = React.useState(false);
 
-  const [pendingQuestion, setPendingQuestion] = React.useState<{ toolCallId: string; questions: Array<{ question: string; options: string[] }>; display: QuestionDisplayMode } | null>(null);
+  const [pendingQuestion, setPendingQuestion] = React.useState<{ toolCallId: string; questions: Array<{ question: string; options: string[]; type?: import("@/lib/ask-user-questions").QuestionType }>; display: QuestionDisplayMode } | null>(null);
 
   /** Pending plan mode prompt from the worker — shown as a plan review panel in the viewer. */
   const [pendingPlan, setPendingPlan] = React.useState<{

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -111,7 +111,7 @@ export interface SessionViewerProps {
   /** Active model info for the current session (used to show provider indicator) */
   activeModel?: { provider: string; id: string; name?: string; reasoning?: boolean } | null;
   activeToolCalls?: Map<string, string>;
-  pendingQuestion?: { toolCallId: string; questions: Array<{ question: string; options: string[] }>; display: QuestionDisplayMode } | null;
+  pendingQuestion?: { toolCallId: string; questions: Array<{ question: string; options: string[]; type?: import("@/lib/ask-user-questions").QuestionType }>; display: QuestionDisplayMode } | null;
   /** Pending plan mode prompt — shown as a plan review panel */
   pendingPlan?: { toolCallId: string; title: string; description: string | null; steps: Array<{ title: string; description?: string }> } | null;
   /** Plugin trust prompt from the worker — shown as a confirmation dialog */

--- a/packages/ui/src/components/ai-elements/multiple-choice.tsx
+++ b/packages/ui/src/components/ai-elements/multiple-choice.tsx
@@ -1,11 +1,13 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { MessageCircleQuestion, PenLine, Send, Check, ArrowLeft, ArrowRight } from "lucide-react";
+import { MessageCircleQuestion, PenLine, Send, Check, ArrowLeft, ArrowRight, GripVertical, ArrowUp, ArrowDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import type { QuestionType } from "@/lib/ask-user-questions";
 
 export interface MultipleChoiceQuestion {
   question: string;
   options: string[];
+  type?: QuestionType;
 }
 
 /** Answer payload: array of { question, answer } tuples (preserves order, handles duplicate questions). */
@@ -19,9 +21,20 @@ export interface MultipleChoiceQuestionsProps {
   className?: string;
 }
 
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function getQuestionType(q: MultipleChoiceQuestion): QuestionType {
+  return q.type ?? "radio";
+}
+
 /**
  * Stepper-style multiple-choice question panel that replaces the text input
  * when the agent asks one or more questions.
+ *
+ * Supports three question types:
+ * - "radio"    — single-select (default, backward-compatible)
+ * - "checkbox" — multi-select (at least one required)
+ * - "ranked"   — drag-to-reorder ranked choice
  */
 export function MultipleChoiceQuestions({
   questions,
@@ -29,23 +42,33 @@ export function MultipleChoiceQuestions({
   onSubmit,
   className,
 }: MultipleChoiceQuestionsProps) {
-  // Track selected option index per question (null = none selected)
+  // ── Radio state: selected option index per question ────────────────────────
   const [selections, setSelections] = React.useState<Map<number, number>>(new Map());
-  // Track custom text per question (used when "Write your own…" is selected)
+
+  // ── Checkbox state: set of selected option indices per question ─────────────
+  const [checkboxSelections, setCheckboxSelections] = React.useState<Map<number, Set<number>>>(new Map());
+
+  // ── Ranked state: ordered array of option indices per question ──────────────
+  const [rankedOrders, setRankedOrders] = React.useState<Map<number, number[]>>(new Map());
+
+  // ── Shared state ───────────────────────────────────────────────────────────
   const [customTexts, setCustomTexts] = React.useState<Map<number, string>>(new Map());
-  // Track active step
   const [currentStep, setCurrentStep] = React.useState(0);
-  // Guard against double-submit
   const [isSubmitting, setIsSubmitting] = React.useState(false);
-  // Track the safety-net timeout so it can be cleared on prompt change
   const submitTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Reset state when the prompt identity changes (new AskUserQuestion)
+  // Drag state for ranked questions
+  const [dragIdx, setDragIdx] = React.useState<number | null>(null);
+
+  // Reset state when the prompt identity changes
   React.useEffect(() => {
     setSelections(new Map());
+    setCheckboxSelections(new Map());
+    setRankedOrders(new Map());
     setCustomTexts(new Map());
     setCurrentStep(0);
     setIsSubmitting(false);
+    setDragIdx(null);
     if (submitTimeoutRef.current !== null) {
       clearTimeout(submitTimeoutRef.current);
       submitTimeoutRef.current = null;
@@ -58,9 +81,28 @@ export function MultipleChoiceQuestions({
     }
   }, [currentStep, questions.length]);
 
+  // ── "Is answered?" logic per type ──────────────────────────────────────────
+
   const isQuestionAnswered = (idx: number) => {
     const q = questions[idx];
     if (!q) return false;
+    const type = getQuestionType(q);
+
+    if (type === "ranked") {
+      // Ranked is answered once the user has an ordering (auto-initialized)
+      const order = rankedOrders.get(idx);
+      return !!order && order.length > 0;
+    }
+
+    if (type === "checkbox") {
+      const checked = checkboxSelections.get(idx);
+      if (!checked || checked.size === 0) return false;
+      // If "write your own" is checked, require text
+      if (checked.has(q.options.length)) return (customTexts.get(idx) ?? "").trim().length > 0;
+      return true;
+    }
+
+    // Radio
     const sel = selections.get(idx);
     if (sel === undefined || sel === null) return false;
     if (sel === q.options.length) return (customTexts.get(idx) ?? "").trim().length > 0;
@@ -71,10 +113,26 @@ export function MultipleChoiceQuestions({
   const currentQuestionAnswered = isQuestionAnswered(currentStep);
   const isLastStep = currentStep >= questions.length - 1;
 
-  const handleSelect = (qIdx: number, optIdx: number) => {
+  // ── Handlers ───────────────────────────────────────────────────────────────
+
+  const handleRadioSelect = (qIdx: number, optIdx: number) => {
     setSelections((prev) => {
       const next = new Map(prev);
       next.set(qIdx, optIdx);
+      return next;
+    });
+  };
+
+  const handleCheckboxToggle = (qIdx: number, optIdx: number) => {
+    setCheckboxSelections((prev) => {
+      const next = new Map(prev);
+      const current = new Set(prev.get(qIdx) ?? []);
+      if (current.has(optIdx)) {
+        current.delete(optIdx);
+      } else {
+        current.add(optIdx);
+      }
+      next.set(qIdx, current);
       return next;
     });
   };
@@ -83,6 +141,28 @@ export function MultipleChoiceQuestions({
     setCustomTexts((prev) => {
       const next = new Map(prev);
       next.set(qIdx, text);
+      return next;
+    });
+  };
+
+  // Initialize ranked order when the question first renders
+  const ensureRankedOrder = React.useCallback((qIdx: number, optionCount: number) => {
+    setRankedOrders((prev) => {
+      if (prev.has(qIdx)) return prev;
+      const next = new Map(prev);
+      next.set(qIdx, Array.from({ length: optionCount }, (_, i) => i));
+      return next;
+    });
+  }, []);
+
+  const handleRankedMove = (qIdx: number, fromPos: number, toPos: number) => {
+    setRankedOrders((prev) => {
+      const order = [...(prev.get(qIdx) ?? [])];
+      if (fromPos < 0 || fromPos >= order.length || toPos < 0 || toPos >= order.length) return prev;
+      const [item] = order.splice(fromPos, 1);
+      order.splice(toPos, 0, item);
+      const next = new Map(prev);
+      next.set(qIdx, order);
       return next;
     });
   };
@@ -96,16 +176,43 @@ export function MultipleChoiceQuestions({
     setCurrentStep((prev) => Math.max(prev - 1, 0));
   };
 
+  // ── Build answer string per question type ──────────────────────────────────
+
+  const buildAnswer = (q: MultipleChoiceQuestion, qIdx: number): string => {
+    const type = getQuestionType(q);
+
+    if (type === "ranked") {
+      const order = rankedOrders.get(qIdx) ?? [];
+      return order.map((optIdx, rank) => `${rank + 1}. ${q.options[optIdx]}`).join(", ");
+    }
+
+    if (type === "checkbox") {
+      const checked = checkboxSelections.get(qIdx) ?? new Set<number>();
+      const parts: string[] = [];
+      for (const optIdx of checked) {
+        if (optIdx === q.options.length) {
+          parts.push((customTexts.get(qIdx) ?? "").trim());
+        } else {
+          parts.push(q.options[optIdx]);
+        }
+      }
+      return parts.join(", ");
+    }
+
+    // Radio
+    const sel = selections.get(qIdx)!;
+    return sel === q.options.length
+      ? (customTexts.get(qIdx) ?? "").trim()
+      : q.options[sel];
+  };
+
   const handleSubmit = () => {
     if (!allAnswered || isSubmitting) return;
     setIsSubmitting(true);
-    const answers: MultipleChoiceAnswers = questions.map((q, i) => {
-      const sel = selections.get(i)!;
-      const answer = sel === q.options.length
-        ? (customTexts.get(i) ?? "").trim()
-        : q.options[sel];
-      return { question: q.question, answer };
-    });
+    const answers: MultipleChoiceAnswers = questions.map((q, i) => ({
+      question: q.question,
+      answer: buildAnswer(q, i),
+    }));
 
     if (submitTimeoutRef.current !== null) clearTimeout(submitTimeoutRef.current);
     submitTimeoutRef.current = setTimeout(() => {
@@ -126,11 +233,257 @@ export function MultipleChoiceQuestions({
       });
   };
 
-  const renderQuestion = (q: MultipleChoiceQuestion, qIdx: number) => {
+  // ── Render helpers ─────────────────────────────────────────────────────────
+
+  const renderRadioQuestion = (q: MultipleChoiceQuestion, qIdx: number) => {
     const selected = selections.get(qIdx);
     const writeYourOwnIdx = q.options.length;
     const isCustom = selected === writeYourOwnIdx;
     const groupName = `mc-q-${promptKey ?? "default"}-${qIdx}`;
+
+    const visibleOptions = q.options
+      .map((option, origIdx) => ({ option, origIdx }))
+      .filter(({ option }) => option.toLowerCase().replace(/[^a-z]/g, "") !== "typeyourown");
+
+    return (
+      <div className="space-y-1.5" role="radiogroup" aria-label={q.question}>
+        {visibleOptions.map(({ option, origIdx }, displayIdx) => {
+          const isSelected = selected === origIdx;
+          const inputId = `${groupName}-opt-${origIdx}`;
+          return (
+            <label key={origIdx} htmlFor={inputId} className={cn(
+              "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm cursor-pointer transition-all",
+              isSelected
+                ? "border border-violet-500/40 bg-violet-500/15 text-violet-100"
+                : "border border-transparent hover:border-violet-500/20 hover:bg-violet-500/[0.07] text-foreground/70 hover:text-foreground/90",
+            )}>
+              <input type="radio" id={inputId} name={groupName} value={option} checked={isSelected}
+                onChange={() => handleRadioSelect(qIdx, origIdx)} className="sr-only" />
+              <span className={cn(
+                "flex size-4 shrink-0 items-center justify-center rounded-full border transition-all",
+                isSelected ? "border-violet-400 bg-violet-500" : "border-violet-500/30 bg-transparent",
+              )} aria-hidden="true">
+                {isSelected && <Check className="size-2.5 text-white" strokeWidth={3} />}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className={cn(
+                  "flex size-4 items-center justify-center rounded text-[10px] font-medium shrink-0",
+                  isSelected ? "bg-violet-500/30 text-violet-200" : "bg-violet-500/15 text-violet-300/70",
+                )} aria-hidden="true">{String.fromCharCode(65 + displayIdx)}</span>
+                <span className="text-left leading-snug">{option}</span>
+              </span>
+            </label>
+          );
+        })}
+
+        {renderWriteYourOwn(qIdx, groupName, isCustom, "radio")}
+
+        {isCustom && renderCustomInput(qIdx, q.question)}
+      </div>
+    );
+  };
+
+  const renderCheckboxQuestion = (q: MultipleChoiceQuestion, qIdx: number) => {
+    const checked = checkboxSelections.get(qIdx) ?? new Set<number>();
+    const writeYourOwnIdx = q.options.length;
+    const isCustomChecked = checked.has(writeYourOwnIdx);
+    const groupName = `mc-q-${promptKey ?? "default"}-${qIdx}`;
+
+    const visibleOptions = q.options
+      .map((option, origIdx) => ({ option, origIdx }))
+      .filter(({ option }) => option.toLowerCase().replace(/[^a-z]/g, "") !== "typeyourown");
+
+    return (
+      <div className="space-y-1.5" role="group" aria-label={q.question}>
+        <div className="text-[11px] text-violet-300/60 px-2.5 mb-1">Select all that apply</div>
+        {visibleOptions.map(({ option, origIdx }, displayIdx) => {
+          const isSelected = checked.has(origIdx);
+          const inputId = `${groupName}-opt-${origIdx}`;
+          return (
+            <label key={origIdx} htmlFor={inputId} className={cn(
+              "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm cursor-pointer transition-all",
+              isSelected
+                ? "border border-violet-500/40 bg-violet-500/15 text-violet-100"
+                : "border border-transparent hover:border-violet-500/20 hover:bg-violet-500/[0.07] text-foreground/70 hover:text-foreground/90",
+            )}>
+              <input type="checkbox" id={inputId} checked={isSelected}
+                onChange={() => handleCheckboxToggle(qIdx, origIdx)} className="sr-only" />
+              <span className={cn(
+                "flex size-4 shrink-0 items-center justify-center rounded border transition-all",
+                isSelected ? "border-violet-400 bg-violet-500" : "border-violet-500/30 bg-transparent",
+              )} aria-hidden="true">
+                {isSelected && <Check className="size-2.5 text-white" strokeWidth={3} />}
+              </span>
+              <span className="flex items-center gap-1.5">
+                <span className={cn(
+                  "flex size-4 items-center justify-center rounded text-[10px] font-medium shrink-0",
+                  isSelected ? "bg-violet-500/30 text-violet-200" : "bg-violet-500/15 text-violet-300/70",
+                )} aria-hidden="true">{String.fromCharCode(65 + displayIdx)}</span>
+                <span className="text-left leading-snug">{option}</span>
+              </span>
+            </label>
+          );
+        })}
+
+        {renderWriteYourOwn(qIdx, groupName, isCustomChecked, "checkbox")}
+
+        {isCustomChecked && renderCustomInput(qIdx, q.question)}
+      </div>
+    );
+  };
+
+  const renderRankedQuestion = (q: MultipleChoiceQuestion, qIdx: number) => {
+    const visibleOptions = q.options
+      .map((option, origIdx) => ({ option, origIdx }))
+      .filter(({ option }) => option.toLowerCase().replace(/[^a-z]/g, "") !== "typeyourown");
+
+    // Ensure order is initialized
+    ensureRankedOrder(qIdx, visibleOptions.length);
+    const order = rankedOrders.get(qIdx) ?? visibleOptions.map((_, i) => i);
+
+    return (
+      <div className="space-y-1" aria-label={q.question}>
+        <div className="text-[11px] text-violet-300/60 px-2.5 mb-1">Drag or use arrows to rank by preference (top = most preferred)</div>
+        {order.map((optIdx, rank) => {
+          const item = visibleOptions[optIdx];
+          if (!item) return null;
+          const isDragging = dragIdx === rank;
+
+          return (
+            <div
+              key={optIdx}
+              draggable
+              onDragStart={(e) => {
+                setDragIdx(rank);
+                e.dataTransfer.effectAllowed = "move";
+              }}
+              onDragOver={(e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = "move";
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                if (dragIdx !== null && dragIdx !== rank) {
+                  handleRankedMove(qIdx, dragIdx, rank);
+                }
+                setDragIdx(null);
+              }}
+              onDragEnd={() => setDragIdx(null)}
+              className={cn(
+                "flex items-center gap-2 rounded-md px-2.5 py-2 text-sm transition-all border",
+                isDragging
+                  ? "border-violet-400/60 bg-violet-500/20 opacity-50"
+                  : "border-violet-500/20 bg-violet-500/[0.05] hover:bg-violet-500/[0.1]",
+              )}
+            >
+              <GripVertical className="size-3.5 text-violet-400/50 cursor-grab shrink-0" />
+              <span className={cn(
+                "flex size-5 items-center justify-center rounded-full text-[11px] font-semibold shrink-0",
+                rank === 0 ? "bg-violet-500/30 text-violet-200" : "bg-violet-500/15 text-violet-300/70",
+              )}>
+                {rank + 1}
+              </span>
+              <span className="text-left leading-snug flex-1 text-foreground/80">{item.option}</span>
+              <div className="flex flex-col gap-0.5 shrink-0">
+                <button
+                  type="button"
+                  disabled={rank === 0}
+                  onClick={() => handleRankedMove(qIdx, rank, rank - 1)}
+                  className={cn(
+                    "p-0.5 rounded transition-colors",
+                    rank === 0 ? "text-violet-500/20 cursor-not-allowed" : "text-violet-400/60 hover:text-violet-300 hover:bg-violet-500/20",
+                  )}
+                  aria-label={`Move ${item.option} up`}
+                >
+                  <ArrowUp className="size-3" />
+                </button>
+                <button
+                  type="button"
+                  disabled={rank === order.length - 1}
+                  onClick={() => handleRankedMove(qIdx, rank, rank + 1)}
+                  className={cn(
+                    "p-0.5 rounded transition-colors",
+                    rank === order.length - 1 ? "text-violet-500/20 cursor-not-allowed" : "text-violet-400/60 hover:text-violet-300 hover:bg-violet-500/20",
+                  )}
+                  aria-label={`Move ${item.option} down`}
+                >
+                  <ArrowDown className="size-3" />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  const renderWriteYourOwn = (qIdx: number, groupName: string, isActive: boolean, inputType: "radio" | "checkbox") => (
+    <label
+      htmlFor={`${groupName}-write`}
+      className={cn(
+        "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm cursor-pointer transition-all",
+        isActive
+          ? "border border-violet-500/40 bg-violet-500/15 text-violet-100"
+          : "border border-dashed border-violet-500/20 hover:border-violet-400/30 hover:bg-violet-500/[0.07] text-violet-300/80 hover:text-violet-200",
+      )}
+    >
+      <input
+        type={inputType}
+        id={`${groupName}-write`}
+        name={inputType === "radio" ? groupName : undefined}
+        value="__write_your_own__"
+        checked={isActive}
+        onChange={() => {
+          const q = questions[qIdx];
+          if (!q) return;
+          if (inputType === "checkbox") {
+            handleCheckboxToggle(qIdx, q.options.length);
+          } else {
+            handleRadioSelect(qIdx, q.options.length);
+          }
+        }}
+        className="sr-only"
+      />
+      <span className={cn(
+        "flex size-4 shrink-0 items-center justify-center border transition-all",
+        inputType === "checkbox" ? "rounded" : "rounded-full",
+        isActive ? "border-violet-400 bg-violet-500" : "border-violet-500/30 bg-transparent",
+      )} aria-hidden="true">
+        {isActive && <Check className="size-2.5 text-white" strokeWidth={3} />}
+      </span>
+      <PenLine className="size-3 shrink-0 opacity-70" aria-hidden="true" />
+      <span className="leading-snug">Write your own…</span>
+    </label>
+  );
+
+  const renderCustomInput = (qIdx: number, questionText: string) => (
+    <div className="ml-9 mt-1">
+      <input
+        type="text"
+        autoFocus
+        value={customTexts.get(qIdx) ?? ""}
+        onChange={(e) => handleCustomText(qIdx, e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key !== "Enter") return;
+          e.preventDefault();
+          if (!isLastStep && currentQuestionAnswered) {
+            handleNext();
+          } else if (isLastStep && allAnswered) {
+            handleSubmit();
+          }
+        }}
+        placeholder="Type your answer…"
+        aria-label={`Custom answer for: ${questionText}`}
+        className={cn(
+          "w-full rounded-md border border-violet-500/25 bg-violet-500/[0.05] px-2.5 py-1.5 text-sm text-foreground/90",
+          "placeholder:text-violet-300/40 focus:border-violet-400/50 focus:outline-none focus:ring-1 focus:ring-violet-400/30",
+        )}
+      />
+    </div>
+  );
+
+  const renderQuestion = (q: MultipleChoiceQuestion, qIdx: number) => {
+    const type = getQuestionType(q);
 
     return (
       <fieldset key={qIdx} className="px-3 py-3 border-0">
@@ -143,122 +496,10 @@ export function MultipleChoiceQuestions({
           {q.question}
         </legend>
 
-        <div className="space-y-1.5 clear-both" role="radiogroup" aria-label={q.question}>
-          {(() => {
-            const visibleOptions = q.options
-              .map((option, origIdx) => ({ option, origIdx }))
-              .filter(({ option }) => option.toLowerCase().replace(/[^a-z]/g, "") !== "typeyourown");
-
-            return visibleOptions.map(({ option, origIdx }, displayIdx) => {
-              const isSelected = selected === origIdx;
-              const inputId = `${groupName}-opt-${origIdx}`;
-
-              return (
-                <label
-                  key={origIdx}
-                  htmlFor={inputId}
-                  className={cn(
-                    "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm cursor-pointer transition-all",
-                    isSelected
-                      ? "border border-violet-500/40 bg-violet-500/15 text-violet-100"
-                      : "border border-transparent hover:border-violet-500/20 hover:bg-violet-500/[0.07] text-foreground/70 hover:text-foreground/90",
-                  )}
-                >
-                  <input
-                    type="radio"
-                    id={inputId}
-                    name={groupName}
-                    value={option}
-                    checked={isSelected}
-                    onChange={() => handleSelect(qIdx, origIdx)}
-                    className="sr-only"
-                  />
-                  <span
-                    className={cn(
-                      "flex size-4 shrink-0 items-center justify-center rounded-full border transition-all",
-                      isSelected
-                        ? "border-violet-400 bg-violet-500"
-                        : "border-violet-500/30 bg-transparent",
-                    )}
-                    aria-hidden="true"
-                  >
-                    {isSelected && <Check className="size-2.5 text-white" strokeWidth={3} />}
-                  </span>
-                  <span className="flex items-center gap-1.5">
-                    <span
-                      className={cn(
-                        "flex size-4 items-center justify-center rounded text-[10px] font-medium shrink-0",
-                        isSelected ? "bg-violet-500/30 text-violet-200" : "bg-violet-500/15 text-violet-300/70",
-                      )}
-                      aria-hidden="true"
-                    >
-                      {String.fromCharCode(65 + displayIdx)}
-                    </span>
-                    <span className="text-left leading-snug">{option}</span>
-                  </span>
-                </label>
-              );
-            });
-          })()}
-
-          <label
-            htmlFor={`${groupName}-write`}
-            className={cn(
-              "flex items-center gap-2.5 rounded-md px-2.5 py-2 text-sm cursor-pointer transition-all",
-              isCustom
-                ? "border border-violet-500/40 bg-violet-500/15 text-violet-100"
-                : "border border-dashed border-violet-500/20 hover:border-violet-400/30 hover:bg-violet-500/[0.07] text-violet-300/80 hover:text-violet-200",
-            )}
-          >
-            <input
-              type="radio"
-              id={`${groupName}-write`}
-              name={groupName}
-              value="__write_your_own__"
-              checked={isCustom}
-              onChange={() => handleSelect(qIdx, writeYourOwnIdx)}
-              className="sr-only"
-            />
-            <span
-              className={cn(
-                "flex size-4 shrink-0 items-center justify-center rounded-full border transition-all",
-                isCustom
-                  ? "border-violet-400 bg-violet-500"
-                  : "border-violet-500/30 bg-transparent",
-              )}
-              aria-hidden="true"
-            >
-              {isCustom && <Check className="size-2.5 text-white" strokeWidth={3} />}
-            </span>
-            <PenLine className="size-3 shrink-0 opacity-70" aria-hidden="true" />
-            <span className="leading-snug">Write your own…</span>
-          </label>
-
-          {isCustom && (
-            <div className="ml-9 mt-1">
-              <input
-                type="text"
-                autoFocus
-                value={customTexts.get(qIdx) ?? ""}
-                onChange={(e) => handleCustomText(qIdx, e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key !== "Enter") return;
-                  e.preventDefault();
-                  if (!isLastStep && currentQuestionAnswered) {
-                    handleNext();
-                  } else if (isLastStep && allAnswered) {
-                    handleSubmit();
-                  }
-                }}
-                placeholder="Type your answer…"
-                aria-label={`Custom answer for: ${q.question}`}
-                className={cn(
-                  "w-full rounded-md border border-violet-500/25 bg-violet-500/[0.05] px-2.5 py-1.5 text-sm text-foreground/90",
-                  "placeholder:text-violet-300/40 focus:border-violet-400/50 focus:outline-none focus:ring-1 focus:ring-violet-400/30",
-                )}
-              />
-            </div>
-          )}
+        <div className="clear-both">
+          {type === "checkbox" && renderCheckboxQuestion(q, qIdx)}
+          {type === "ranked" && renderRankedQuestion(q, qIdx)}
+          {type === "radio" && renderRadioQuestion(q, qIdx)}
         </div>
       </fieldset>
     );

--- a/packages/ui/src/components/ai-elements/multiple-choice.tsx
+++ b/packages/ui/src/components/ai-elements/multiple-choice.tsx
@@ -145,12 +145,13 @@ export function MultipleChoiceQuestions({
     });
   };
 
-  // Initialize ranked order when the question first renders
-  const ensureRankedOrder = React.useCallback((qIdx: number, optionCount: number) => {
+  // Initialize ranked order when the question first renders.
+  // Stores origIdx values (indices into q.options) so buildAnswer can look up correctly.
+  const ensureRankedOrder = React.useCallback((qIdx: number, origIndices: number[]) => {
     setRankedOrders((prev) => {
       if (prev.has(qIdx)) return prev;
       const next = new Map(prev);
-      next.set(qIdx, Array.from({ length: optionCount }, (_, i) => i));
+      next.set(qIdx, [...origIndices]);
       return next;
     });
   }, []);
@@ -337,21 +338,24 @@ export function MultipleChoiceQuestions({
       .map((option, origIdx) => ({ option, origIdx }))
       .filter(({ option }) => option.toLowerCase().replace(/[^a-z]/g, "") !== "typeyourown");
 
-    // Ensure order is initialized
-    ensureRankedOrder(qIdx, visibleOptions.length);
-    const order = rankedOrders.get(qIdx) ?? visibleOptions.map((_, i) => i);
+    // Build a lookup from origIdx → visible option for rendering
+    const origIdxToVisible = new Map(visibleOptions.map((v) => [v.origIdx, v]));
+
+    // Ensure order is initialized with origIdx values
+    ensureRankedOrder(qIdx, visibleOptions.map((v) => v.origIdx));
+    const order = rankedOrders.get(qIdx) ?? visibleOptions.map((v) => v.origIdx);
 
     return (
       <div className="space-y-1" aria-label={q.question}>
         <div className="text-[11px] text-violet-300/60 px-2.5 mb-1">Drag or use arrows to rank by preference (top = most preferred)</div>
-        {order.map((optIdx, rank) => {
-          const item = visibleOptions[optIdx];
+        {order.map((origIdx, rank) => {
+          const item = origIdxToVisible.get(origIdx);
           if (!item) return null;
           const isDragging = dragIdx === rank;
 
           return (
             <div
-              key={optIdx}
+              key={origIdx}
               draggable
               onDragStart={(e) => {
                 setDragIdx(rank);

--- a/packages/ui/src/components/ai-elements/multiple-choice.tsx
+++ b/packages/ui/src/components/ai-elements/multiple-choice.tsx
@@ -145,16 +145,25 @@ export function MultipleChoiceQuestions({
     });
   };
 
-  // Initialize ranked order when the question first renders.
+  // Initialize ranked order for all ranked questions via effect (not during render).
   // Stores origIdx values (indices into q.options) so buildAnswer can look up correctly.
-  const ensureRankedOrder = React.useCallback((qIdx: number, origIndices: number[]) => {
+  React.useEffect(() => {
     setRankedOrders((prev) => {
-      if (prev.has(qIdx)) return prev;
+      let changed = false;
       const next = new Map(prev);
-      next.set(qIdx, [...origIndices]);
-      return next;
+      for (let qIdx = 0; qIdx < questions.length; qIdx++) {
+        const q = questions[qIdx];
+        if (getQuestionType(q) !== "ranked" || next.has(qIdx)) continue;
+        const visibleOrigIndices = q.options
+          .map((option, origIdx) => ({ option, origIdx }))
+          .filter(({ option }) => option.toLowerCase().replace(/[^a-z]/g, "") !== "typeyourown")
+          .map(({ origIdx }) => origIdx);
+        next.set(qIdx, visibleOrigIndices);
+        changed = true;
+      }
+      return changed ? next : prev;
     });
-  }, []);
+  }, [questions, promptKey]);
 
   const handleRankedMove = (qIdx: number, fromPos: number, toPos: number) => {
     setRankedOrders((prev) => {
@@ -343,8 +352,7 @@ export function MultipleChoiceQuestions({
     // Build a lookup from origIdx → visible option for rendering
     const origIdxToVisible = new Map(visibleOptions.map((v) => [v.origIdx, v]));
 
-    // Ensure order is initialized with origIdx values
-    ensureRankedOrder(qIdx, visibleOptions.map((v) => v.origIdx));
+    // Order is initialized by the useEffect above; fallback for first render before effect runs
     const order = rankedOrders.get(qIdx) ?? visibleOptions.map((v) => v.origIdx);
 
     return (

--- a/packages/ui/src/components/ai-elements/multiple-choice.tsx
+++ b/packages/ui/src/components/ai-elements/multiple-choice.tsx
@@ -190,7 +190,9 @@ export function MultipleChoiceQuestions({
     if (type === "checkbox") {
       const checked = checkboxSelections.get(qIdx) ?? new Set<number>();
       const parts: string[] = [];
-      for (const optIdx of checked) {
+      // Sort by option index to maintain display order regardless of click order
+      const sortedIndices = Array.from(checked).sort((a, b) => a - b);
+      for (const optIdx of sortedIndices) {
         if (optIdx === q.options.length) {
           parts.push((customTexts.get(qIdx) ?? "").trim());
         } else {

--- a/packages/ui/src/lib/ask-user-questions.test.ts
+++ b/packages/ui/src/lib/ask-user-questions.test.ts
@@ -25,8 +25,8 @@ describe("parsePendingQuestions", () => {
       ],
     });
     expect(result).toEqual([
-      { question: "Color?", options: ["Red", "Blue"] },
-      { question: "Size?", options: ["S", "M", "L"] },
+      { question: "Color?", options: ["Red", "Blue"], type: "radio" },
+      { question: "Size?", options: ["S", "M", "L"], type: "radio" },
     ]);
   });
 
@@ -34,28 +34,28 @@ describe("parsePendingQuestions", () => {
     const result = parsePendingQuestions({
       questions: [{ question: "Ready?", options: ["Yes", "No"] }],
     });
-    expect(result).toEqual([{ question: "Ready?", options: ["Yes", "No"] }]);
+    expect(result).toEqual([{ question: "Ready?", options: ["Yes", "No"], type: "radio" }]);
   });
 
   test("trims whitespace from questions", () => {
     const result = parsePendingQuestions({
       questions: [{ question: "  Padded?  ", options: ["Yes"] }],
     });
-    expect(result).toEqual([{ question: "Padded?", options: ["Yes"] }]);
+    expect(result).toEqual([{ question: "Padded?", options: ["Yes"], type: "radio" }]);
   });
 
   test("filters out non-string options", () => {
     const result = parsePendingQuestions({
       questions: [{ question: "Pick", options: ["A", 42, null, "B"] }],
     });
-    expect(result).toEqual([{ question: "Pick", options: ["A", "B"] }]);
+    expect(result).toEqual([{ question: "Pick", options: ["A", "B"], type: "radio" }]);
   });
 
   test("trims options and filters empty/whitespace options", () => {
     const result = parsePendingQuestions({
       questions: [{ question: "Pick", options: ["  A  ", "", "  ", "B"] }],
     });
-    expect(result).toEqual([{ question: "Pick", options: ["A", "B"] }]);
+    expect(result).toEqual([{ question: "Pick", options: ["A", "B"], type: "radio" }]);
   });
 
   test("skips questions with empty text", () => {
@@ -65,14 +65,14 @@ describe("parsePendingQuestions", () => {
         { question: "Valid?", options: ["Yes"] },
       ],
     });
-    expect(result).toEqual([{ question: "Valid?", options: ["Yes"] }]);
+    expect(result).toEqual([{ question: "Valid?", options: ["Yes"], type: "radio" }]);
   });
 
   test("handles missing options in questions array items", () => {
     const result = parsePendingQuestions({
       questions: [{ question: "No opts?" }],
     });
-    expect(result).toEqual([{ question: "No opts?", options: [] }]);
+    expect(result).toEqual([{ question: "No opts?", options: [], type: "radio" }]);
   });
 
   test("returns empty for empty questions array", () => {
@@ -83,7 +83,45 @@ describe("parsePendingQuestions", () => {
     const result = parsePendingQuestions({
       questions: [null, "string", 42, { question: "Valid?", options: ["Yes"] }],
     });
-    expect(result).toEqual([{ question: "Valid?", options: ["Yes"] }]);
+    expect(result).toEqual([{ question: "Valid?", options: ["Yes"], type: "radio" }]);
+  });
+
+  // ── Question types ───────────────────────────────────────────────────
+
+  test("parses checkbox question type", () => {
+    const result = parsePendingQuestions({
+      questions: [{ question: "Select all", options: ["A", "B", "C"], type: "checkbox" }],
+    });
+    expect(result).toEqual([{ question: "Select all", options: ["A", "B", "C"], type: "checkbox" }]);
+  });
+
+  test("parses ranked question type", () => {
+    const result = parsePendingQuestions({
+      questions: [{ question: "Rank these", options: ["X", "Y", "Z"], type: "ranked" }],
+    });
+    expect(result).toEqual([{ question: "Rank these", options: ["X", "Y", "Z"], type: "ranked" }]);
+  });
+
+  test("defaults unknown type to radio", () => {
+    const result = parsePendingQuestions({
+      questions: [{ question: "Pick", options: ["A"], type: "unknown_type" }],
+    });
+    expect(result).toEqual([{ question: "Pick", options: ["A"], type: "radio" }]);
+  });
+
+  test("mixed question types", () => {
+    const result = parsePendingQuestions({
+      questions: [
+        { question: "Pick one", options: ["A", "B"], type: "radio" },
+        { question: "Pick many", options: ["X", "Y"], type: "checkbox" },
+        { question: "Rank them", options: ["1", "2", "3"], type: "ranked" },
+      ],
+    });
+    expect(result).toEqual([
+      { question: "Pick one", options: ["A", "B"], type: "radio" },
+      { question: "Pick many", options: ["X", "Y"], type: "checkbox" },
+      { question: "Rank them", options: ["1", "2", "3"], type: "ranked" },
+    ]);
   });
 
   // ── Legacy format (backward compat) ──────────────────────────────────
@@ -94,7 +132,7 @@ describe("parsePendingQuestions", () => {
       options: ["Red", "Blue", "Green"],
     });
     expect(result).toEqual([
-      { question: "What color?", options: ["Red", "Blue", "Green"] },
+      { question: "What color?", options: ["Red", "Blue", "Green"], type: "radio" },
     ]);
   });
 
@@ -103,7 +141,7 @@ describe("parsePendingQuestions", () => {
       question: "What do you think?",
     });
     expect(result).toEqual([
-      { question: "What do you think?", options: [] },
+      { question: "What do you think?", options: [], type: "radio" },
     ]);
   });
 
@@ -113,7 +151,7 @@ describe("parsePendingQuestions", () => {
       question: "Old format",
       options: ["B"],
     });
-    expect(result).toEqual([{ question: "New format", options: ["A"] }]);
+    expect(result).toEqual([{ question: "New format", options: ["A"], type: "radio" }]);
   });
 
   test("falls back to legacy when questions array is empty", () => {
@@ -122,7 +160,7 @@ describe("parsePendingQuestions", () => {
       question: "Fallback?",
       options: ["Yes"],
     });
-    expect(result).toEqual([{ question: "Fallback?", options: ["Yes"] }]);
+    expect(result).toEqual([{ question: "Fallback?", options: ["Yes"], type: "radio" }]);
   });
 
   test("ignores legacy format with blank question", () => {

--- a/packages/ui/src/lib/ask-user-questions.ts
+++ b/packages/ui/src/lib/ask-user-questions.ts
@@ -4,9 +4,13 @@
 
 export type QuestionDisplayMode = "stepper";
 
+export type QuestionType = "radio" | "checkbox" | "ranked";
+
 export interface ParsedQuestion {
   question: string;
   options: string[];
+  /** Selection mode: "radio" (single select, default), "checkbox" (multiselect), or "ranked" (ranked choice). */
+  type: QuestionType;
 }
 
 /**
@@ -25,7 +29,9 @@ export function parsePendingQuestions(data: Record<string, unknown> | undefined 
         const opts = Array.isArray((q as any).options)
           ? ((q as any).options as unknown[]).filter((o): o is string => typeof o === "string" && o.trim().length > 0).map((o) => o.trim())
           : [];
-        result.push({ question: (q as any).question.trim(), options: opts });
+        const rawType = (q as any).type;
+        const type: QuestionType = rawType === "checkbox" ? "checkbox" : rawType === "ranked" ? "ranked" : "radio";
+        result.push({ question: (q as any).question.trim(), options: opts, type });
       }
     }
     if (result.length > 0) return result;
@@ -36,7 +42,7 @@ export function parsePendingQuestions(data: Record<string, unknown> | undefined 
     const opts = Array.isArray(data.options)
       ? (data.options as unknown[]).filter((o): o is string => typeof o === "string" && o.trim().length > 0).map((o) => o.trim())
       : [];
-    return [{ question: (data.question as string).trim(), options: opts }];
+    return [{ question: (data.question as string).trim(), options: opts, type: "radio" as QuestionType }];
   }
 
   return [];


### PR DESCRIPTION
## Summary

Adds **checkbox** (multi-select) and **ranked-choice** (drag-to-reorder) question types to the `AskUserQuestion` tool, alongside the existing radio (single-select) type.

## Changes

- New `type` field on questions: `radio` (default), `checkbox`, `ranked`
- Checkbox renders multi-select with toggle UI
- Ranked renders a drag-to-reorder list for priority ordering
- Answers are returned in display order (checkbox) or user-ranked order (ranked)
- Fixed index mismatch when filtering options with "Write your own..." entries
- Moved ranked order initialization out of render into `useEffect` to avoid React warnings

## Testing

Manual testing of all three question types in the web UI.
