### PR TITLE
fix: relax plan mode command filtering when OS sandbox is active

### DIFF
--- a/.Jules/bolt.md
+++ b/.Jules/bolt.md
@@ -17,3 +17,7 @@
 ## 2025-03-09 - [Optimize high-frequency event stream bottlenecks]
 **Learning:** In high-frequency real-time event streams (like Socket.IO text deltas in `packages/server/src/ws/namespaces/relay.ts`), failing to early-return before executing asynchronous operations (like Redis `getSharedSession` or `getViewerCount`) causes severe systemic N+1 bottlenecks.
 **Action:** Strictly evaluate simple synchronous conditions (like `event.type`) to short-circuit the function before invoking any expensive I/O operations.
+
+## 2025-03-10 - [Batching Socket.IO Adapter and Redis Queries]
+**Learning:** Looping over candidates and making sequential network operations—even lightweight ones like `adapter.sockets` or Redis `hGet`—creates an N+1 performance bottleneck during sweeping processes (e.g., `sweepOrphanedSessions`, `scanExpiredSessions`).
+**Action:** Use concurrent fetching via `Promise.allSettled` for batched Socket.IO adapter queries, and leverage Redis pipelining via `multi()` to execute batched reads in a single network roundtrip, significantly decreasing latency for bulk processing loops.

--- a/.Jules/sentinel.md
+++ b/.Jules/sentinel.md
@@ -1,0 +1,6 @@
+
+## 2025-01-20 - Command Injection Mitigation via `execFileSync` & `spawnSync`
+**Vulnerability:** Use of `child_process.execSync` to run shell commands using string interpolation with unsanitized arguments (e.g., `git clone ${REPO_URL}` or `npm install ${versionSpec}`). This allows arbitrary command execution if an attacker manages to manipulate these arguments.
+**Learning:** Using `execSync` is inherently risky when incorporating external or dynamically computed variables. Node's `execFileSync` or `spawnSync` are safer as they run the specified executable directly without invoking a subshell. However, on Windows, Node.js cannot execute `.cmd` or `.bat` files (like the globally installed `npm.cmd` or `yarn.cmd`) using `execFileSync` without a shell.
+**Prevention:**
+To securely avoid shell injection while still maintaining cross-platform functionality for `.cmd` executables, use `spawnSync(cmd, args, { shell: process.platform === 'win32' })`. When `shell: true` is used with an arguments array, Node.js attempts to safely quote and escape the arguments for `cmd.exe`.

--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/jordan/Documents/Projects/pizzapi-low-hanging/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/plan-mode-relax/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/jordan/Documents/Projects/pizzapi-low-hanging/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/plan-mode-relax/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/packages/cli/src/extensions/plan-mode-toggle.test.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.test.ts
@@ -399,9 +399,19 @@ describe("isDestructiveCommand", () => {
         expect(isDestructiveCommand("git count-objects")).toBe(false);
     });
 
-    test("allows newly-added read-only git subcommands", () => {
+    test("flags git archive -o/--output (file write)", () => {
+        expect(isDestructiveCommand("git archive -o out.tar HEAD")).toBe(true);
+        expect(isDestructiveCommand("git archive -oout.tar HEAD")).toBe(true);
+        expect(isDestructiveCommand("git archive --output=out.tar HEAD")).toBe(true);
+        expect(isDestructiveCommand("git archive --output out.tar HEAD")).toBe(true);
+    });
+
+    test("allows git archive to stdout (read-only)", () => {
         expect(isDestructiveCommand("git archive HEAD")).toBe(false);
         expect(isDestructiveCommand("git archive --format=tar HEAD")).toBe(false);
+    });
+
+    test("allows newly-added read-only git subcommands", () => {
         expect(isDestructiveCommand("git cherry main")).toBe(false);
         expect(isDestructiveCommand("git cherry -v main feature")).toBe(false);
         expect(isDestructiveCommand("git range-diff main~3..main~1 main~2..main")).toBe(false);

--- a/packages/cli/src/extensions/plan-mode-toggle.test.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.test.ts
@@ -399,6 +399,17 @@ describe("isDestructiveCommand", () => {
         expect(isDestructiveCommand("git count-objects")).toBe(false);
     });
 
+    test("allows newly-added read-only git subcommands", () => {
+        expect(isDestructiveCommand("git archive HEAD")).toBe(false);
+        expect(isDestructiveCommand("git archive --format=tar HEAD")).toBe(false);
+        expect(isDestructiveCommand("git cherry main")).toBe(false);
+        expect(isDestructiveCommand("git cherry -v main feature")).toBe(false);
+        expect(isDestructiveCommand("git range-diff main~3..main~1 main~2..main")).toBe(false);
+        expect(isDestructiveCommand("git diff-tree HEAD")).toBe(false);
+        expect(isDestructiveCommand("git diff-files")).toBe(false);
+        expect(isDestructiveCommand("git diff-index HEAD")).toBe(false);
+    });
+
     // sort -o file-write bypass
     test("flags sort with -o/--output (file write)", () => {
         expect(isDestructiveCommand("sort -o out.txt input.txt")).toBe(true);
@@ -461,6 +472,136 @@ describe("isDestructiveCommand", () => {
         expect(isDestructiveCommand("make --dry-run")).toBe(false);
         expect(isDestructiveCommand("make -n")).toBe(false);
         expect(isDestructiveCommand("make --just-print")).toBe(false);
+    });
+});
+
+// ── isDestructiveCommand with sandboxActive=true ─────────────────────────────
+//
+// When the OS sandbox is active, only non-filesystem side effects are checked.
+// The sandbox's read-only overlay handles filesystem write protection, so
+// command substitution, output redirection, script interpreters, find -exec,
+// and most filesystem-mutating commands are allowed through.
+
+describe("isDestructiveCommand (sandboxActive=true)", () => {
+    // ── Commands that SHOULD be allowed with sandbox ─────────────────────
+
+    test("allows command substitution when sandbox active", () => {
+        expect(isDestructiveCommand('echo "$(wc -l < file)"', true)).toBe(false);
+        expect(isDestructiveCommand("ls $(cat filelist.txt)", true)).toBe(false);
+    });
+
+    test("allows backtick expansion when sandbox active", () => {
+        expect(isDestructiveCommand("echo `wc -l file`", true)).toBe(false);
+    });
+
+    test("allows process substitution when sandbox active", () => {
+        expect(isDestructiveCommand("diff <(cat a.txt) <(cat b.txt)", true)).toBe(false);
+    });
+
+    test("allows output redirection when sandbox active", () => {
+        expect(isDestructiveCommand("echo foo > /tmp/scratch.txt", true)).toBe(false);
+        expect(isDestructiveCommand("echo foo >> /tmp/log.txt", true)).toBe(false);
+    });
+
+    test("allows find -exec when sandbox active", () => {
+        expect(isDestructiveCommand("find . -name '*.ts' -exec grep foo {} \\;", true)).toBe(false);
+        expect(isDestructiveCommand("find . -type f -exec wc -l {} +", true)).toBe(false);
+    });
+
+    test("allows script interpreters when sandbox active", () => {
+        expect(isDestructiveCommand("python3 analyze.py", true)).toBe(false);
+        expect(isDestructiveCommand("python -c 'print(1+1)'", true)).toBe(false);
+        expect(isDestructiveCommand("node script.js", true)).toBe(false);
+        expect(isDestructiveCommand("ruby script.rb", true)).toBe(false);
+    });
+
+    test("allows make when sandbox active", () => {
+        expect(isDestructiveCommand("make", true)).toBe(false);
+        expect(isDestructiveCommand("make test", true)).toBe(false);
+    });
+
+    test("allows filesystem-mutating commands when sandbox active (OS blocks writes)", () => {
+        expect(isDestructiveCommand("rm file.txt", true)).toBe(false);
+        expect(isDestructiveCommand("mv foo bar", true)).toBe(false);
+        expect(isDestructiveCommand("cp foo bar", true)).toBe(false);
+        expect(isDestructiveCommand("mkdir test", true)).toBe(false);
+        expect(isDestructiveCommand("touch file", true)).toBe(false);
+    });
+
+    test("allows sed -i when sandbox active (OS blocks writes)", () => {
+        expect(isDestructiveCommand("sed -i 's/foo/bar/' file.txt", true)).toBe(false);
+    });
+
+    test("allows curl with -o when sandbox active (OS blocks writes)", () => {
+        expect(isDestructiveCommand("curl -o out.bin https://example.com", true)).toBe(false);
+    });
+
+    test("allows package managers when sandbox active (OS blocks writes)", () => {
+        expect(isDestructiveCommand("npm install", true)).toBe(false);
+        expect(isDestructiveCommand("bun add foo", true)).toBe(false);
+        expect(isDestructiveCommand("pip install requests", true)).toBe(false);
+    });
+
+    test("allows git push/commit when sandbox active", () => {
+        expect(isDestructiveCommand("git push", true)).toBe(false);
+        expect(isDestructiveCommand("git commit -m 'test'", true)).toBe(false);
+    });
+
+    test("allows editors when sandbox active (OS blocks writes)", () => {
+        expect(isDestructiveCommand("vim file.txt", true)).toBe(false);
+        expect(isDestructiveCommand("nano file.txt", true)).toBe(false);
+    });
+
+    // ── Commands that SHOULD still be blocked with sandbox ───────────────
+
+    test("still blocks sudo when sandbox active", () => {
+        expect(isDestructiveCommand("sudo ls", true)).toBe(true);
+        expect(isDestructiveCommand("sudo rm -rf /", true)).toBe(true);
+    });
+
+    test("still blocks su when sandbox active", () => {
+        expect(isDestructiveCommand("su root", true)).toBe(true);
+    });
+
+    test("still blocks kill/pkill/killall when sandbox active", () => {
+        expect(isDestructiveCommand("kill -9 1234", true)).toBe(true);
+        expect(isDestructiveCommand("pkill node", true)).toBe(true);
+        expect(isDestructiveCommand("killall python", true)).toBe(true);
+    });
+
+    test("still blocks reboot/shutdown when sandbox active", () => {
+        expect(isDestructiveCommand("reboot", true)).toBe(true);
+        expect(isDestructiveCommand("shutdown -h now", true)).toBe(true);
+    });
+
+    test("still blocks systemctl start/stop/restart when sandbox active", () => {
+        expect(isDestructiveCommand("systemctl stop nginx", true)).toBe(true);
+        expect(isDestructiveCommand("systemctl restart docker", true)).toBe(true);
+    });
+
+    test("still blocks service start/stop/restart when sandbox active", () => {
+        expect(isDestructiveCommand("service nginx stop", true)).toBe(true);
+        expect(isDestructiveCommand("service docker restart", true)).toBe(true);
+    });
+
+    test("still blocks multi-line payloads when sandbox active", () => {
+        expect(isDestructiveCommand("ls\nkill 1234", true)).toBe(true);
+        expect(isDestructiveCommand("cat foo\nsudo rm bar", true)).toBe(true);
+    });
+
+    test("still blocks chains containing dangerous commands when sandbox active", () => {
+        expect(isDestructiveCommand("ls && kill 1234", true)).toBe(true);
+        expect(isDestructiveCommand("echo hello; sudo rm -rf /", true)).toBe(true);
+    });
+
+    // ── Read-only commands still allowed (sanity check) ──────────────────
+
+    test("allows read-only commands when sandbox active (unchanged)", () => {
+        expect(isDestructiveCommand("ls -la", true)).toBe(false);
+        expect(isDestructiveCommand("cat foo.txt", true)).toBe(false);
+        expect(isDestructiveCommand("grep -r pattern src/", true)).toBe(false);
+        expect(isDestructiveCommand("git status", true)).toBe(false);
+        expect(isDestructiveCommand("find . -name '*.ts'", true)).toBe(false);
     });
 });
 

--- a/packages/cli/src/extensions/plan-mode-toggle.test.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.test.ts
@@ -566,8 +566,21 @@ describe("isDestructiveCommand (sandboxActive=true)", () => {
         expect(isDestructiveCommand("git remote set-url origin https://x", true)).toBe(true);
     });
 
-    test("allows git commit when sandbox active (local-only, OS blocks writes)", () => {
-        expect(isDestructiveCommand("git commit -m 'test'", true)).toBe(false);
+    test("blocks git plumbing commands that mutate remotes when sandbox active", () => {
+        expect(isDestructiveCommand("git send-pack origin refs/heads/main", true)).toBe(true);
+        expect(isDestructiveCommand("git receive-pack /path/to/repo", true)).toBe(true);
+        expect(isDestructiveCommand("git http-push https://example.com/repo", true)).toBe(true);
+    });
+
+    test("allows safe git subcommands when sandbox active", () => {
+        expect(isDestructiveCommand("git status", true)).toBe(false);
+        expect(isDestructiveCommand("git log --oneline", true)).toBe(false);
+        expect(isDestructiveCommand("git diff HEAD", true)).toBe(false);
+        expect(isDestructiveCommand("git archive HEAD", true)).toBe(false);
+    });
+
+    test("blocks git commit when sandbox active (not on safe subcommand list)", () => {
+        expect(isDestructiveCommand("git commit -m 'test'", true)).toBe(true);
     });
 
     test("blocks npm publish when sandbox active (remote side effect)", () => {

--- a/packages/cli/src/extensions/plan-mode-toggle.test.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.test.ts
@@ -485,17 +485,19 @@ describe("isDestructiveCommand", () => {
 describe("isDestructiveCommand (sandboxActive=true)", () => {
     // ── Commands that SHOULD be allowed with sandbox ─────────────────────
 
-    test("allows command substitution when sandbox active", () => {
-        expect(isDestructiveCommand('echo "$(wc -l < file)"', true)).toBe(false);
-        expect(isDestructiveCommand("ls $(cat filelist.txt)", true)).toBe(false);
+    test("blocks command substitution when sandbox active (prevents smuggling)", () => {
+        expect(isDestructiveCommand('echo "$(wc -l < file)"', true)).toBe(true);
+        expect(isDestructiveCommand("ls $(cat filelist.txt)", true)).toBe(true);
+        expect(isDestructiveCommand("echo $(kill -9 1234)", true)).toBe(true);
     });
 
-    test("allows backtick expansion when sandbox active", () => {
-        expect(isDestructiveCommand("echo `wc -l file`", true)).toBe(false);
+    test("blocks backtick expansion when sandbox active (prevents smuggling)", () => {
+        expect(isDestructiveCommand("echo `wc -l file`", true)).toBe(true);
+        expect(isDestructiveCommand("echo `kill -9 1234`", true)).toBe(true);
     });
 
-    test("allows process substitution when sandbox active", () => {
-        expect(isDestructiveCommand("diff <(cat a.txt) <(cat b.txt)", true)).toBe(false);
+    test("blocks process substitution when sandbox active (prevents smuggling)", () => {
+        expect(isDestructiveCommand("diff <(cat a.txt) <(cat b.txt)", true)).toBe(true);
     });
 
     test("allows output redirection when sandbox active", () => {
@@ -542,9 +544,45 @@ describe("isDestructiveCommand (sandboxActive=true)", () => {
         expect(isDestructiveCommand("pip install requests", true)).toBe(false);
     });
 
-    test("allows git push/commit when sandbox active", () => {
-        expect(isDestructiveCommand("git push", true)).toBe(false);
+    test("blocks git push when sandbox active (remote side effect)", () => {
+        expect(isDestructiveCommand("git push", true)).toBe(true);
+        expect(isDestructiveCommand("git push origin main", true)).toBe(true);
+        expect(isDestructiveCommand("git push --force", true)).toBe(true);
+    });
+
+    test("blocks git remote mutations when sandbox active", () => {
+        expect(isDestructiveCommand("git remote add origin https://x", true)).toBe(true);
+        expect(isDestructiveCommand("git remote remove origin", true)).toBe(true);
+        expect(isDestructiveCommand("git remote set-url origin https://x", true)).toBe(true);
+    });
+
+    test("allows git commit when sandbox active (local-only, OS blocks writes)", () => {
         expect(isDestructiveCommand("git commit -m 'test'", true)).toBe(false);
+    });
+
+    test("blocks npm publish when sandbox active (remote side effect)", () => {
+        expect(isDestructiveCommand("npm publish", true)).toBe(true);
+        expect(isDestructiveCommand("npm publish --tag beta", true)).toBe(true);
+    });
+
+    test("blocks npx when sandbox active (arbitrary code execution)", () => {
+        expect(isDestructiveCommand("npx some-package", true)).toBe(true);
+    });
+
+    test("blocks docker push when sandbox active (remote side effect)", () => {
+        expect(isDestructiveCommand("docker push myimage:latest", true)).toBe(true);
+    });
+
+    test("blocks gh CLI mutations when sandbox active (remote side effect)", () => {
+        expect(isDestructiveCommand("gh issue create --title test", true)).toBe(true);
+        expect(isDestructiveCommand("gh pr merge 123", true)).toBe(true);
+        expect(isDestructiveCommand("gh release create v1.0", true)).toBe(true);
+    });
+
+    test("allows gh CLI read operations when sandbox active", () => {
+        expect(isDestructiveCommand("gh issue list", true)).toBe(false);
+        expect(isDestructiveCommand("gh pr view 123", true)).toBe(false);
+        expect(isDestructiveCommand("gh api /repos", true)).toBe(false);
     });
 
     test("allows editors when sandbox active (OS blocks writes)", () => {

--- a/packages/cli/src/extensions/plan-mode-toggle.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.ts
@@ -80,6 +80,8 @@ const GIT_SAFE_SUBCOMMAND_DESTRUCTIVE_OVERRIDES: RegExp[] = [
     /^\s*git\s+reflog\s+(delete|expire)\b/i,
     // worktree: add/remove/move/repair are mutating; list is safe
     /^\s*git\s+worktree\s+(add|remove|move|repair|lock|unlock)\b/i,
+    // archive: -o / --output writes to a file instead of stdout
+    /^\s*git\s+archive\b.*\s(-o\s|-o\S|--output\b|--output=)/i,
 ];
 
 /**

--- a/packages/cli/src/extensions/plan-mode-toggle.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.ts
@@ -47,6 +47,10 @@ const GIT_SAFE_SUBCOMMANDS = new Set([
     "ls-files", "ls-tree", "ls-remote", "cat-file", "rev-parse",
     "rev-list", "for-each-ref", "name-rev", "describe", "merge-base",
     "count-objects", "fsck", "verify-commit", "verify-tag", "verify-pack",
+    // Diff plumbing (read-only)
+    "diff-tree", "diff-files", "diff-index",
+    // History / patch inspection (read-only, stdout-only)
+    "archive", "cherry", "range-diff",
     // Misc read-only
     "help", "version", "config", "reflog", "worktree",
 ]);
@@ -76,6 +80,22 @@ const GIT_SAFE_SUBCOMMAND_DESTRUCTIVE_OVERRIDES: RegExp[] = [
     /^\s*git\s+reflog\s+(delete|expire)\b/i,
     // worktree: add/remove/move/repair are mutating; list is safe
     /^\s*git\s+worktree\s+(add|remove|move|repair|lock|unlock)\b/i,
+];
+
+/**
+ * Patterns that are dangerous regardless of filesystem sandbox.
+ * These cause non-filesystem side effects (process control, privilege
+ * escalation, system management) that the OS sandbox does NOT prevent.
+ *
+ * When the sandbox IS active, only these patterns are checked — the sandbox's
+ * read-only overlay handles filesystem write protection at the OS level.
+ */
+const SANDBOX_ONLY_CMD_PATTERNS = [
+    /^\s*sudo\b/i, /^\s*su\b/i,
+    /^\s*kill\b/i, /^\s*pkill\b/i, /^\s*killall\b/i,
+    /^\s*reboot\b/i, /^\s*shutdown\b/i,
+    /^\s*systemctl\s+(start|stop|restart|enable|disable)/i,
+    /^\s*service\s+\S+\s+(start|stop|restart)/i,
 ];
 
 /**
@@ -189,14 +209,36 @@ function isDestructiveGitCommand(segment: string): boolean {
  * is too large to enumerate reliably (git clean, git apply, git restore,
  * git am, git bisect, etc.).
  *
- * This is used as a best-effort advisory check when the OS-level sandbox is
- * not active. When the sandbox IS active, plan mode uses the sandbox's
- * read-only overlay instead (which enforces at the OS level regardless of
- * what command is run).
+ * When `sandboxActive` is true, only non-filesystem side effects are checked
+ * (process control, privilege escalation, system management). The OS-level
+ * sandbox enforces filesystem write restrictions, so command substitution,
+ * output redirection, script interpreters, and `find -exec` are all safe.
+ *
+ * When `sandboxActive` is false (default), the full regex battery is applied
+ * as the only line of defense against destructive commands.
  *
  * @internal Exported for testing only.
  */
-export function isDestructiveCommand(command: string): boolean {
+export function isDestructiveCommand(command: string, sandboxActive = false): boolean {
+    // ── Sandbox-active path: lightweight check ───────────────────────────
+    // The OS sandbox enforces a read-only filesystem overlay. We only need
+    // to block non-filesystem side effects that the sandbox doesn't cover.
+    if (sandboxActive) {
+        // Multi-line payloads are still rejected — they can smuggle commands
+        // past the per-segment check regardless of sandbox state.
+        if (/\n/.test(command)) return true;
+
+        const parts = splitShellSegments(command);
+        for (const part of parts) {
+            const trimmed = part.trim();
+            if (!trimmed) continue;
+
+            if (SANDBOX_ONLY_CMD_PATTERNS.some((p) => p.test(trimmed))) return true;
+        }
+        return false;
+    }
+
+    // ── No-sandbox path: full regex battery ──────────────────────────────
     // Reject command substitution, backtick expansion, process substitution,
     // and multi-line payloads that could smuggle destructive commands past
     // the per-segment check.
@@ -522,13 +564,13 @@ export const planModeToggleExtension: ExtensionFactory = (pi) => {
         }
 
         // Block destructive bash commands in plan mode.
-        // The sandbox read-only overlay enforces filesystem write restrictions,
-        // but non-filesystem side effects (kill, network calls, etc.) are not
-        // blocked by the overlay — so we always check the destructive pattern
-        // regardless of sandbox state.
+        // When the OS sandbox is active, its read-only overlay enforces
+        // filesystem write restrictions — so we only check for non-filesystem
+        // side effects (kill, sudo, systemctl, etc.). When the sandbox is NOT
+        // active, we apply the full regex battery as the only line of defense.
         if (event.toolName === "bash") {
             const command = (event.input as any).command as string;
-            if (isDestructiveCommand(command)) {
+            if (isDestructiveCommand(command, isSandboxActive())) {
                 return {
                     block: true,
                     reason: `Plan mode: command blocked (matches destructive pattern). Use toggle_plan_mode to exit plan mode first.\nCommand: ${command}`,

--- a/packages/cli/src/extensions/plan-mode-toggle.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.ts
@@ -91,11 +91,19 @@ const GIT_SAFE_SUBCOMMAND_DESTRUCTIVE_OVERRIDES: RegExp[] = [
  * read-only overlay handles filesystem write protection at the OS level.
  */
 const SANDBOX_ONLY_CMD_PATTERNS = [
+    // Process control & privilege escalation
     /^\s*sudo\b/i, /^\s*su\b/i,
     /^\s*kill\b/i, /^\s*pkill\b/i, /^\s*killall\b/i,
     /^\s*reboot\b/i, /^\s*shutdown\b/i,
     /^\s*systemctl\s+(start|stop|restart|enable|disable)/i,
     /^\s*service\s+\S+\s+(start|stop|restart)/i,
+    // Remote / network side effects — sandbox only protects local filesystem
+    /^\s*git\s+push\b/i,
+    /^\s*git\s+remote\s+(add|remove|rename|set-url)\b/i,
+    /^\s*npm\s+publish\b/i,
+    /^\s*npx\b/i,
+    /^\s*docker\s+push\b/i,
+    /^\s*gh\s+(issue|pr|release)\s+(create|edit|close|merge|delete|comment)\b/i,
 ];
 
 /**
@@ -210,9 +218,10 @@ function isDestructiveGitCommand(segment: string): boolean {
  * git am, git bisect, etc.).
  *
  * When `sandboxActive` is true, only non-filesystem side effects are checked
- * (process control, privilege escalation, system management). The OS-level
- * sandbox enforces filesystem write restrictions, so command substitution,
- * output redirection, script interpreters, and `find -exec` are all safe.
+ * (process control, privilege escalation, system management, remote mutations).
+ * The OS-level sandbox enforces filesystem write restrictions, so output
+ * redirection, script interpreters, and `find -exec` are all safe.
+ * Command substitution is still rejected to prevent smuggling blocked commands.
  *
  * When `sandboxActive` is false (default), the full regex battery is applied
  * as the only line of defense against destructive commands.
@@ -224,9 +233,10 @@ export function isDestructiveCommand(command: string, sandboxActive = false): bo
     // The OS sandbox enforces a read-only filesystem overlay. We only need
     // to block non-filesystem side effects that the sandbox doesn't cover.
     if (sandboxActive) {
-        // Multi-line payloads are still rejected — they can smuggle commands
-        // past the per-segment check regardless of sandbox state.
-        if (/\n/.test(command)) return true;
+        // Multi-line payloads and command/backtick/process substitution are
+        // still rejected — they can smuggle commands past the per-segment
+        // check regardless of sandbox state.
+        if (/\$\(|`|\n|<\(|>\(/.test(command)) return true;
 
         const parts = splitShellSegments(command);
         for (const part of parts) {
@@ -566,8 +576,9 @@ export const planModeToggleExtension: ExtensionFactory = (pi) => {
         // Block destructive bash commands in plan mode.
         // When the OS sandbox is active, its read-only overlay enforces
         // filesystem write restrictions — so we only check for non-filesystem
-        // side effects (kill, sudo, systemctl, etc.). When the sandbox is NOT
-        // active, we apply the full regex battery as the only line of defense.
+        // side effects (kill, sudo, systemctl, remote mutations, etc.).
+        // When the sandbox is NOT active, we apply the full regex battery
+        // as the only line of defense.
         if (event.toolName === "bash") {
             const command = (event.input as any).command as string;
             if (isDestructiveCommand(command, isSandboxActive())) {

--- a/packages/cli/src/extensions/plan-mode-toggle.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.ts
@@ -100,8 +100,7 @@ const SANDBOX_ONLY_CMD_PATTERNS = [
     /^\s*systemctl\s+(start|stop|restart|enable|disable)/i,
     /^\s*service\s+\S+\s+(start|stop|restart)/i,
     // Remote / network side effects — sandbox only protects local filesystem
-    /^\s*git\s+push\b/i,
-    /^\s*git\s+remote\s+(add|remove|rename|set-url)\b/i,
+    // (Git commands are handled separately via the GIT_SAFE_SUBCOMMANDS allowlist)
     /^\s*npm\s+publish\b/i,
     /^\s*npx\b/i,
     /^\s*docker\s+push\b/i,
@@ -246,6 +245,16 @@ export function isDestructiveCommand(command: string, sandboxActive = false): bo
             if (!trimmed) continue;
 
             if (SANDBOX_ONLY_CMD_PATTERNS.some((p) => p.test(trimmed))) return true;
+
+            // Git: reuse the same allowlist as the no-sandbox path. Any git
+            // subcommand not on the safe list (send-pack, http-push, etc.)
+            // is treated as destructive — this covers all plumbing commands
+            // that can mutate remotes without enumerating them individually.
+            // Note: we skip DESTRUCTIVE_FLAG_PATTERNS here because the
+            // sandbox handles filesystem writes (redirection, -o, etc.).
+            if (/^\s*git\b/i.test(trimmed)) {
+                if (isDestructiveGitCommand(trimmed)) return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
## Summary

Relaxes plan mode's command filtering when the OS-level sandbox is already active, since the sandbox itself enforces the security boundary.

## Changes

When `sandboxMode` is enabled at the OS level, plan mode no longer blocks commands that the sandbox already restricts. This prevents false-positive rejections of safe read-only commands that happen to match plan mode's conservative blocklist.

## Testing

Manual testing with sandbox enabled and plan mode active.
