### PR TITLE
fix(ui): draft lifecycle and subagent concurrency follow-ups

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -729,6 +729,14 @@ export interface PizzaPiConfig {
      * Default: true. Set to false to suppress these warnings.
      */
     slowStartupWarning?: boolean;
+
+    /** Subagent execution settings */
+    subagent?: {
+        /** Max number of parallel tasks in a single subagent call. Default: 8. */
+        maxParallelTasks?: number;
+        /** Max concurrent agent sessions running simultaneously. Default: 4. */
+        maxConcurrency?: number;
+    };
 }
 
 function readJsonSafe(path: string): Partial<PizzaPiConfig> {

--- a/packages/cli/src/extensions/subagent.test.ts
+++ b/packages/cli/src/extensions/subagent.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { formatTokens, formatUsageStats } from "./subagent.js";
+import { formatTokens, formatUsageStats, toFinitePositiveInt } from "./subagent.js";
 import { _setGlobalConfigDir, loadConfig } from "../config.js";
 
 /**
@@ -147,6 +147,44 @@ describe("SubagentDetails type exports", () => {
     });
 });
 
+describe("toFinitePositiveInt", () => {
+    test("returns the value for valid positive integers", () => {
+        expect(toFinitePositiveInt(4, 99)).toBe(4);
+        expect(toFinitePositiveInt(1, 99)).toBe(1);
+        expect(toFinitePositiveInt(100, 99)).toBe(100);
+    });
+
+    test("floors floating point values", () => {
+        expect(toFinitePositiveInt(4.7, 99)).toBe(4);
+        expect(toFinitePositiveInt(1.1, 99)).toBe(1);
+    });
+
+    test("coerces numeric strings", () => {
+        expect(toFinitePositiveInt("8", 99)).toBe(8);
+        expect(toFinitePositiveInt("3.9", 99)).toBe(3);
+    });
+
+    test("returns fallback for non-numeric strings", () => {
+        expect(toFinitePositiveInt("fast", 99)).toBe(99);
+        expect(toFinitePositiveInt("", 99)).toBe(99);
+    });
+
+    test("returns fallback for zero, negative, Infinity, NaN", () => {
+        expect(toFinitePositiveInt(0, 99)).toBe(99);
+        expect(toFinitePositiveInt(-1, 99)).toBe(99);
+        expect(toFinitePositiveInt(Infinity, 99)).toBe(99);
+        expect(toFinitePositiveInt(-Infinity, 99)).toBe(99);
+        expect(toFinitePositiveInt(NaN, 99)).toBe(99);
+    });
+
+    test("returns fallback for objects, arrays, null, undefined", () => {
+        expect(toFinitePositiveInt({}, 99)).toBe(99);
+        expect(toFinitePositiveInt([], 99)).toBe(99);
+        expect(toFinitePositiveInt(null, 99)).toBe(99);
+        expect(toFinitePositiveInt(undefined, 99)).toBe(99);
+    });
+});
+
 describe("subagent config", () => {
     test("loadConfig reads subagent settings", () => {
         const tmp = mkdtempSync(join(tmpdir(), "subagent-config-"));
@@ -160,6 +198,22 @@ describe("subagent config", () => {
         const config = loadConfig(tmp);
         expect(config.subagent?.maxParallelTasks).toBe(16);
         expect(config.subagent?.maxConcurrency).toBe(8);
+        _setGlobalConfigDir(null);
+    });
+
+    test("loadConfig falls back to defaults for non-numeric subagent values", () => {
+        const tmp = mkdtempSync(join(tmpdir(), "subagent-config-"));
+        _setGlobalConfigDir(tmp);
+        writeFileSync(
+            join(tmp, "config.json"),
+            JSON.stringify({
+                subagent: { maxParallelTasks: "fast", maxConcurrency: {} },
+            }),
+        );
+        const config = loadConfig(tmp);
+        // toFinitePositiveInt should reject these at consumption time
+        expect(toFinitePositiveInt(config.subagent?.maxParallelTasks, 8)).toBe(8);
+        expect(toFinitePositiveInt(config.subagent?.maxConcurrency, 4)).toBe(4);
         _setGlobalConfigDir(null);
     });
 

--- a/packages/cli/src/extensions/subagent.test.ts
+++ b/packages/cli/src/extensions/subagent.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import { formatTokens, formatUsageStats } from "./subagent.js";
+import { _setGlobalConfigDir, loadConfig } from "../config.js";
 
 /**
  * Tests for the subagent tool utility functions.
@@ -140,5 +144,31 @@ describe("SubagentDetails type exports", () => {
         };
         expect(usage.input).toBe(100);
         expect(usage.turns).toBe(1);
+    });
+});
+
+describe("subagent config", () => {
+    test("loadConfig reads subagent settings", () => {
+        const tmp = mkdtempSync(join(tmpdir(), "subagent-config-"));
+        _setGlobalConfigDir(tmp);
+        writeFileSync(
+            join(tmp, "config.json"),
+            JSON.stringify({
+                subagent: { maxParallelTasks: 16, maxConcurrency: 8 },
+            }),
+        );
+        const config = loadConfig(tmp);
+        expect(config.subagent?.maxParallelTasks).toBe(16);
+        expect(config.subagent?.maxConcurrency).toBe(8);
+        _setGlobalConfigDir(null);
+    });
+
+    test("loadConfig returns defaults when subagent is not set", () => {
+        const tmp = mkdtempSync(join(tmpdir(), "subagent-config-"));
+        _setGlobalConfigDir(tmp);
+        writeFileSync(join(tmp, "config.json"), JSON.stringify({}));
+        const config = loadConfig(tmp);
+        expect(config.subagent).toBeUndefined();
+        _setGlobalConfigDir(null);
     });
 });

--- a/packages/cli/src/extensions/subagent.test.ts
+++ b/packages/cli/src/extensions/subagent.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { formatTokens, formatUsageStats, toFinitePositiveInt } from "./subagent.js";
-import { _setGlobalConfigDir, loadConfig } from "../config.js";
+import { _setGlobalConfigDir, loadConfig, loadGlobalConfig } from "../config.js";
 
 /**
  * Tests for the subagent tool utility functions.
@@ -223,6 +223,32 @@ describe("subagent config", () => {
         writeFileSync(join(tmp, "config.json"), JSON.stringify({}));
         const config = loadConfig(tmp);
         expect(config.subagent).toBeUndefined();
+        _setGlobalConfigDir(null);
+    });
+
+    test("project config cannot override global subagent limits via loadGlobalConfig", () => {
+        const tmp = mkdtempSync(join(tmpdir(), "subagent-config-"));
+        _setGlobalConfigDir(tmp);
+        // Global config sets conservative limits
+        writeFileSync(
+            join(tmp, "config.json"),
+            JSON.stringify({ subagent: { maxParallelTasks: 4, maxConcurrency: 2 } }),
+        );
+        // Create a project dir with aggressive limits
+        const projectDir = mkdtempSync(join(tmpdir(), "subagent-project-"));
+        const { mkdirSync } = require("fs");
+        mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+        writeFileSync(
+            join(projectDir, ".pizzapi", "config.json"),
+            JSON.stringify({ subagent: { maxParallelTasks: 100, maxConcurrency: 50 } }),
+        );
+        // loadGlobalConfig ignores project config entirely
+        const globalConfig = loadGlobalConfig();
+        expect(toFinitePositiveInt(globalConfig.subagent?.maxParallelTasks, 8)).toBe(4);
+        expect(toFinitePositiveInt(globalConfig.subagent?.maxConcurrency, 4)).toBe(2);
+        // loadConfig would merge project over global — verify the difference
+        const mergedConfig = loadConfig(projectDir);
+        expect(mergedConfig.subagent?.maxParallelTasks).toBe(100); // project wins in merged
         _setGlobalConfigDir(null);
     });
 });

--- a/packages/cli/src/extensions/subagent.ts
+++ b/packages/cli/src/extensions/subagent.ts
@@ -39,7 +39,7 @@ import {
 import { Container, Markdown, Spacer, Text } from "@mariozechner/pi-tui";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./subagent-agents.js";
 import { getPluginAgentPaths } from "./claude-plugins.js";
-import { defaultAgentDir, loadConfig } from "../config.js";
+import { defaultAgentDir, loadGlobalConfig } from "../config.js";
 
 // ── Constants ──────────────────────────────────────────────────────────
 
@@ -540,9 +540,11 @@ export const subagentExtension = (pi: ExtensionAPI) => {
         parameters: SubagentParams as any,
 
         async execute(_toolCallId, rawParams, signal, onUpdate, ctx) {
-            const config = loadConfig(ctx.cwd);
-            const maxParallelTasks = toFinitePositiveInt(config.subagent?.maxParallelTasks, DEFAULT_MAX_PARALLEL_TASKS);
-            const maxConcurrency = toFinitePositiveInt(config.subagent?.maxConcurrency, DEFAULT_MAX_CONCURRENCY);
+            // Read concurrency limits from global config only — project-local
+            // config must not be able to raise fan-out limits for untrusted repos.
+            const globalConfig = loadGlobalConfig();
+            const maxParallelTasks = toFinitePositiveInt(globalConfig.subagent?.maxParallelTasks, DEFAULT_MAX_PARALLEL_TASKS);
+            const maxConcurrency = toFinitePositiveInt(globalConfig.subagent?.maxConcurrency, DEFAULT_MAX_CONCURRENCY);
 
             const params = (rawParams ?? {}) as {
                 agent?: string;

--- a/packages/cli/src/extensions/subagent.ts
+++ b/packages/cli/src/extensions/subagent.ts
@@ -39,12 +39,12 @@ import {
 import { Container, Markdown, Spacer, Text } from "@mariozechner/pi-tui";
 import { type AgentConfig, type AgentScope, discoverAgents } from "./subagent-agents.js";
 import { getPluginAgentPaths } from "./claude-plugins.js";
-import { defaultAgentDir } from "../config.js";
+import { defaultAgentDir, loadConfig } from "../config.js";
 
 // ── Constants ──────────────────────────────────────────────────────────
 
-const MAX_PARALLEL_TASKS = 8;
-const MAX_CONCURRENCY = 4;
+const DEFAULT_MAX_PARALLEL_TASKS = 8;
+const DEFAULT_MAX_CONCURRENCY = 4;
 const COLLAPSED_ITEM_COUNT = 10;
 
 // ── Usage formatting helpers ───────────────────────────────────────────
@@ -533,6 +533,10 @@ export const subagentExtension = (pi: ExtensionAPI) => {
         parameters: SubagentParams as any,
 
         async execute(_toolCallId, rawParams, signal, onUpdate, ctx) {
+            const config = loadConfig(ctx.cwd);
+            const maxParallelTasks = config.subagent?.maxParallelTasks ?? DEFAULT_MAX_PARALLEL_TASKS;
+            const maxConcurrency = config.subagent?.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
+
             const params = (rawParams ?? {}) as {
                 agent?: string;
                 task?: string;
@@ -660,10 +664,10 @@ export const subagentExtension = (pi: ExtensionAPI) => {
 
             // ── Parallel mode ──────────────────────────────────────────
             if (params.tasks && params.tasks.length > 0) {
-                if (params.tasks.length > MAX_PARALLEL_TASKS)
+                if (params.tasks.length > maxParallelTasks)
                     return {
                         content: [
-                            { type: "text", text: `Too many parallel tasks (${params.tasks.length}). Max is ${MAX_PARALLEL_TASKS}.` },
+                            { type: "text", text: `Too many parallel tasks (${params.tasks.length}). Max is ${maxParallelTasks}.` },
                         ],
                         details: makeDetails("parallel")([]),
                     };
@@ -692,7 +696,7 @@ export const subagentExtension = (pi: ExtensionAPI) => {
                     }
                 };
 
-                const results = await mapWithConcurrencyLimit(params.tasks, MAX_CONCURRENCY, async (t, index) => {
+                const results = await mapWithConcurrencyLimit(params.tasks, maxConcurrency, async (t, index) => {
                     const result = await runSingleAgent(
                         ctx.cwd, agents, t.agent, t.task, t.cwd, undefined, signal,
                         (partial) => {

--- a/packages/cli/src/extensions/subagent.ts
+++ b/packages/cli/src/extensions/subagent.ts
@@ -47,6 +47,13 @@ const DEFAULT_MAX_PARALLEL_TASKS = 8;
 const DEFAULT_MAX_CONCURRENCY = 4;
 const COLLAPSED_ITEM_COUNT = 10;
 
+/** Coerce an unknown config value to a finite positive integer, or return the fallback. */
+export function toFinitePositiveInt(value: unknown, fallback: number): number {
+    const n = Number(value);
+    if (!Number.isFinite(n) || n < 1) return fallback;
+    return Math.floor(n);
+}
+
 // ── Usage formatting helpers ───────────────────────────────────────────
 
 export function formatTokens(count: number): string {
@@ -534,8 +541,8 @@ export const subagentExtension = (pi: ExtensionAPI) => {
 
         async execute(_toolCallId, rawParams, signal, onUpdate, ctx) {
             const config = loadConfig(ctx.cwd);
-            const maxParallelTasks = config.subagent?.maxParallelTasks ?? DEFAULT_MAX_PARALLEL_TASKS;
-            const maxConcurrency = config.subagent?.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
+            const maxParallelTasks = toFinitePositiveInt(config.subagent?.maxParallelTasks, DEFAULT_MAX_PARALLEL_TASKS);
+            const maxConcurrency = toFinitePositiveInt(config.subagent?.maxConcurrency, DEFAULT_MAX_CONCURRENCY);
 
             const params = (rawParams ?? {}) as {
                 agent?: string;

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -114,6 +114,8 @@ You can also override any setting with **environment variables**.
 | `sandbox.filesystem.allowWrite` | `string[]` | `[".", "/tmp"]` | Paths allowed for writing (replaces preset when set). |
 | `sandbox.filesystem.denyWrite` | `string[]` | *merged with preset* | Additional paths blocked from writing. |
 | `slowStartupWarning` | `boolean` | `true` | Show warnings when startup takes longer than expected (slow MCP servers, etc.). See [Safe Mode](/PizzaPi/security/sandbox/). |
+| `subagent.maxParallelTasks` | `number` | `8` | Max tasks in a single parallel subagent call. **Global config only.** |
+| `subagent.maxConcurrency` | `number` | `4` | Max concurrent agent sessions running simultaneously. **Global config only.** |
 
 ---
 

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -958,12 +958,13 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               setInput("");
               setCommandOpen(false);
               setCommandQuery("");
-            }
-            // Always clear the saved draft for the originating session so
-            // stale text isn't rehydrated on switch-back.
-            if (originSessionId) {
+              // Also clear the saved draft entry — safe because the user is
+              // still on this session so no newer draft could have been saved.
               draftsRef.current.delete(originSessionId);
             }
+            // If the user already switched away, DON'T delete the draft —
+            // the switch effect may have saved newer unsent text for this
+            // session that we must not clobber.
           } else {
             setComposerError("Failed to send message.");
           }

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -2181,6 +2181,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
         )}
 
         <PromptInput
+          key={sessionId ?? "__none"}
           onSubmit={handleSubmit}
           maxFiles={8}
           maxFileSize={20 * 1024 * 1024}

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -945,12 +945,21 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
         ? { ...message, deliverAs: deliveryMode }
         : message;
 
+      // Capture the originating sessionId so we can clear its draft even if
+      // the user switches sessions before the async send resolves.
+      const originSessionId = sessionId;
+
       Promise.resolve(onSendInput(payload))
         .then((result) => {
           if (result !== false) {
             setInput("");
             setCommandOpen(false);
             setCommandQuery("");
+            // Clear the saved draft for the originating session so stale text
+            // isn't rehydrated when switching back after an off-session resolve.
+            if (originSessionId) {
+              draftsRef.current.delete(originSessionId);
+            }
           } else {
             setComposerError("Failed to send message.");
           }

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -952,11 +952,15 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
       Promise.resolve(onSendInput(payload))
         .then((result) => {
           if (result !== false) {
-            setInput("");
-            setCommandOpen(false);
-            setCommandQuery("");
-            // Clear the saved draft for the originating session so stale text
-            // isn't rehydrated when switching back after an off-session resolve.
+            // Only clear the live composer if the user is still on the
+            // originating session — otherwise we'd erase the new session's draft.
+            if (sessionIdRef.current === originSessionId) {
+              setInput("");
+              setCommandOpen(false);
+              setCommandQuery("");
+            }
+            // Always clear the saved draft for the originating session so
+            // stale text isn't rehydrated on switch-back.
             if (originSessionId) {
               draftsRef.current.delete(originSessionId);
             }

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -508,6 +508,9 @@ function SessionSkeleton() {
 
 export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse }: SessionViewerProps) {
   const [input, setInput] = React.useState("");
+  // Per-session draft storage so switching sessions preserves unsent text
+  const draftsRef = React.useRef<Map<string, string>>(new Map());
+  const prevSessionIdRef = React.useRef<string | null>(null);
   const [composerError, setComposerError] = React.useState<string | null>(null);
   const [showClearDialog, setShowClearDialog] = React.useState(false);
   const [showEndSessionDialog, setShowEndSessionDialog] = React.useState(false);
@@ -548,10 +551,20 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
   const [atMentionHighlightedAgent, setAtMentionHighlightedAgent] = React.useState<string | null>(null);
 
   React.useEffect(() => {
-    if (!sessionId) {
+    // Save the current draft for the previous session
+    const prevId = prevSessionIdRef.current;
+    if (prevId) {
+      draftsRef.current.set(prevId, input);
+    }
+    // Restore the draft for the new session (or clear if null)
+    if (sessionId) {
+      setInput(draftsRef.current.get(sessionId) ?? "");
+    } else {
       setInput("");
     }
+    prevSessionIdRef.current = sessionId ?? null;
     setComposerError(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally reading `input` at transition time only
   }, [sessionId]);
 
   // Reset the compacting guard when the heartbeat confirms compact is done

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -564,6 +564,12 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     }
     prevSessionIdRef.current = sessionId ?? null;
     setComposerError(null);
+    // Reset command picker / @-mention popover so stale state from the
+    // previous session's slash-command input doesn't bleed through.
+    setCommandOpen(false);
+    setCommandQuery("");
+    setCommandHighlightedIndex(0);
+    setAtMentionOpen(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally reading `input` at transition time only
   }, [sessionId]);
 
@@ -945,26 +951,31 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
         ? { ...message, deliverAs: deliveryMode }
         : message;
 
-      // Capture the originating sessionId so we can clear its draft even if
-      // the user switches sessions before the async send resolves.
+      // Capture the originating sessionId and the text being sent so we can
+      // correctly clear state even if the user switches sessions before the
+      // async send resolves.
       const originSessionId = sessionId;
+      const sentText = text;
 
       Promise.resolve(onSendInput(payload))
         .then((result) => {
           if (result !== false) {
-            // Only clear the live composer if the user is still on the
-            // originating session — otherwise we'd erase the new session's draft.
             if (sessionIdRef.current === originSessionId) {
+              // Still on the originating session — clear live composer state.
               setInput("");
               setCommandOpen(false);
               setCommandQuery("");
-              // Also clear the saved draft entry — safe because the user is
-              // still on this session so no newer draft could have been saved.
               draftsRef.current.delete(originSessionId);
+            } else if (originSessionId) {
+              // User switched away. Only clear the saved draft if it still
+              // matches what was sent — if the user typed new text after
+              // submitting (before switching), the switch effect saved the
+              // newer draft and we must not clobber it.
+              const saved = draftsRef.current.get(originSessionId);
+              if (saved === sentText || saved === "") {
+                draftsRef.current.delete(originSessionId);
+              }
             }
-            // If the user already switched away, DON'T delete the draft —
-            // the switch effect may have saved newer unsent text for this
-            // session that we must not clobber.
           } else {
             setComposerError("Failed to send message.");
           }

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -971,8 +971,8 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               // matches what was sent — if the user typed new text after
               // submitting (before switching), the switch effect saved the
               // newer draft and we must not clobber it.
-              const saved = draftsRef.current.get(originSessionId);
-              if (saved === sentText || saved === "") {
+              const saved = draftsRef.current.get(originSessionId)?.trim();
+              if (saved === sentText || saved === undefined || saved === "") {
                 draftsRef.current.delete(originSessionId);
               }
             }


### PR DESCRIPTION
## Summary

Follow-up fixes to #125 — additional UI draft lifecycle improvements and subagent concurrency docs.

## Changes

### UI Fixes
- Clear stale draft on off-session send & reset command picker on switch
- Normalize draft text before off-session send comparison
- Reset attachments on session switch via `PromptInput` key
- Only delete draft on send when still on originating session
- Guard composer clear against off-session send resolution

### CLI / Docs
- Read subagent concurrency from global config only (not project config)
- Added subagent concurrency config keys to configuration reference docs

## Files Changed

- `packages/ui/src/components/SessionViewer.tsx`
- `packages/cli/src/config.ts`
- `packages/cli/src/extensions/subagent.ts` + test
- `packages/docs/src/content/docs/customization/configuration.mdx`
