### PR TITLE
fix: skip bad YAML in agent loading + respect Claude Code installed_plugins.json

### DIFF
--- a/packages/cli/src/extensions/subagent-agents.test.ts
+++ b/packages/cli/src/extensions/subagent-agents.test.ts
@@ -114,6 +114,23 @@ describe("discoverAgents", () => {
         expect(nonBuiltin[0].name).toBe("real");
     });
 
+    test("skips .md files with malformed YAML frontmatter", () => {
+        const agentsDir = join(tmpDir, ".pizzapi", "agents");
+        mkdirSync(agentsDir, { recursive: true });
+
+        // Malformed YAML — unbalanced braces, bad indentation, invalid syntax
+        writeFileSync(join(agentsDir, "bad-yaml.md"), `---\nname: {{broken\n  - invalid: [\n---\nBody text`, "utf-8");
+        // Another variant — YAML with tabs in wrong places
+        writeFileSync(join(agentsDir, "bad-yaml2.md"), `---\n\t\tname: bad\n: : :\n---\nBody`, "utf-8");
+        // Valid agent should still be discovered
+        createAgentFile(agentsDir, "good-agent.md", { name: "good", description: "Good agent" }, "Works fine.");
+
+        const result = discoverAgents(tmpDir, "project");
+        const nonBuiltin = result.agents.filter(a => a.filePath !== "(built-in)");
+        expect(nonBuiltin).toHaveLength(1);
+        expect(nonBuiltin[0].name).toBe("good");
+    });
+
     test("handles empty frontmatter body gracefully", () => {
         const agentsDir = join(tmpDir, ".pizzapi", "agents");
         mkdirSync(agentsDir, { recursive: true });

--- a/packages/cli/src/extensions/subagent-agents.ts
+++ b/packages/cli/src/extensions/subagent-agents.ts
@@ -110,7 +110,14 @@ function loadAgentsFromDir(dir: string, source: "user" | "project"): AgentConfig
             continue;
         }
 
-        const { frontmatter, body } = parseFrontmatter<Record<string, string | boolean | number>>(content);
+        let frontmatter: Record<string, string | boolean | number>;
+        let body: string;
+        try {
+            ({ frontmatter, body } = parseFrontmatter<Record<string, string | boolean | number>>(content));
+        } catch {
+            // Malformed YAML frontmatter — silently skip this file
+            continue;
+        }
 
         const name = String(frontmatter.name ?? "").trim();
         const description = String(frontmatter.description ?? "").trim();

--- a/packages/cli/src/plugins.test.ts
+++ b/packages/cli/src/plugins.test.ts
@@ -17,6 +17,7 @@ import {
     isPluginDir,
     scanPluginsDir,
     discoverPlugins,
+    discoverClaudeInstalledPlugins,
     pluginSearchDirs,
     globalPluginDirs,
     projectPluginDirs,
@@ -897,5 +898,201 @@ describe("pluginSearchDirs security", () => {
         } finally {
             process.env.HOME = realHome;
         }
+    });
+});
+
+// ── Claude Code installed_plugins.json discovery ──────────────────────────────
+
+describe("discoverClaudeInstalledPlugins", () => {
+    let tmpDir: string;
+    let realHome: string;
+
+    beforeAll(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "claude-installed-plugins-"));
+        realHome = process.env.HOME!;
+    });
+
+    afterAll(() => {
+        process.env.HOME = realHome;
+        try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    });
+
+    function setupHome(name: string): string {
+        const home = join(tmpDir, name);
+        mkdirSync(join(home, ".claude", "plugins"), { recursive: true });
+        process.env.HOME = home;
+        return home;
+    }
+
+    function writeInstalledPlugins(home: string, data: unknown): void {
+        writeFileSync(
+            join(home, ".claude", "plugins", "installed_plugins.json"),
+            JSON.stringify(data, null, 2),
+        );
+    }
+
+    function createCachedPlugin(home: string, marketplace: string, name: string, version: string): string {
+        const dir = join(home, ".claude", "plugins", "cache", marketplace, name, version);
+        mkdirSync(join(dir, ".claude-plugin"), { recursive: true });
+        writeFileSync(
+            join(dir, ".claude-plugin", "plugin.json"),
+            JSON.stringify({ name, description: `Test plugin ${name}`, version }),
+        );
+        mkdirSync(join(dir, "commands"), { recursive: true });
+        writeFileSync(join(dir, "commands", "hello.md"), `---\ndescription: Hello from ${name}\n---\n# Hello`);
+        return dir;
+    }
+
+    test("returns empty array when installed_plugins.json does not exist", () => {
+        const home = setupHome("no-file");
+        const result = discoverClaudeInstalledPlugins("/tmp");
+        expect(result).toEqual([]);
+    });
+
+    test("returns empty array for malformed JSON", () => {
+        const home = setupHome("bad-json");
+        writeFileSync(join(home, ".claude", "plugins", "installed_plugins.json"), "not json{{{");
+        const result = discoverClaudeInstalledPlugins("/tmp");
+        expect(result).toEqual([]);
+    });
+
+    test("returns empty array when plugins field is missing", () => {
+        const home = setupHome("no-plugins");
+        writeInstalledPlugins(home, { version: 2 });
+        const result = discoverClaudeInstalledPlugins("/tmp");
+        expect(result).toEqual([]);
+    });
+
+    test("discovers plugins from valid installed_plugins.json", () => {
+        const home = setupHome("valid");
+        const installPath = createCachedPlugin(home, "my-marketplace", "cool-plugin", "1.0.0");
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "cool-plugin@my-marketplace": [{
+                    scope: "user",
+                    installPath,
+                    version: "1.0.0",
+                    installedAt: "2026-01-15T00:00:00Z",
+                    lastUpdated: "2026-01-15T00:00:00Z",
+                }],
+            },
+        });
+
+        const result = discoverClaudeInstalledPlugins("/tmp");
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("cool-plugin");
+        expect(result[0].commands).toHaveLength(1);
+    });
+
+    test("skips plugins whose installPath does not exist", () => {
+        const home = setupHome("missing-path");
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "ghost@marketplace": [{
+                    scope: "user",
+                    installPath: join(home, ".claude", "plugins", "cache", "marketplace", "ghost", "1.0.0"),
+                    version: "1.0.0",
+                }],
+            },
+        });
+
+        const result = discoverClaudeInstalledPlugins("/tmp");
+        expect(result).toEqual([]);
+    });
+
+    test("discovers multiple plugins from different marketplaces", () => {
+        const home = setupHome("multi");
+        const path1 = createCachedPlugin(home, "mkt-a", "plugin-a", "1.0.0");
+        const path2 = createCachedPlugin(home, "mkt-b", "plugin-b", "2.0.0");
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "plugin-a@mkt-a": [{ scope: "user", installPath: path1, version: "1.0.0" }],
+                "plugin-b@mkt-b": [{ scope: "user", installPath: path2, version: "2.0.0" }],
+            },
+        });
+
+        const result = discoverClaudeInstalledPlugins("/tmp");
+        expect(result).toHaveLength(2);
+        const names = result.map(p => p.name).sort();
+        expect(names).toEqual(["plugin-a", "plugin-b"]);
+    });
+
+    test("skips project-scoped plugins that don't match cwd", () => {
+        const home = setupHome("project-scope");
+        const path1 = createCachedPlugin(home, "mkt", "project-plugin", "1.0.0");
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "project-plugin@mkt": [{
+                    scope: "project",
+                    projectPath: "/some/other/project",
+                    installPath: path1,
+                    version: "1.0.0",
+                }],
+            },
+        });
+
+        // cwd doesn't match projectPath — should be skipped
+        const result = discoverClaudeInstalledPlugins("/Users/me/my-project");
+        expect(result).toEqual([]);
+    });
+
+    test("includes project-scoped plugins that match cwd", () => {
+        const home = setupHome("project-match");
+        const path1 = createCachedPlugin(home, "mkt", "my-project-plugin", "1.0.0");
+        const projectDir = join(tmpDir, "my-real-project");
+        mkdirSync(projectDir, { recursive: true });
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "my-project-plugin@mkt": [{
+                    scope: "project",
+                    projectPath: projectDir,
+                    installPath: path1,
+                    version: "1.0.0",
+                }],
+            },
+        });
+
+        const result = discoverClaudeInstalledPlugins(projectDir);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("my-project-plugin");
+    });
+
+    test("prefers most recently updated installation", () => {
+        const home = setupHome("prefer-newest");
+        const oldPath = createCachedPlugin(home, "mkt", "evolving", "1.0.0");
+        const newPath = createCachedPlugin(home, "mkt", "evolving", "2.0.0");
+        // Overwrite the manifest to distinguish versions
+        writeFileSync(
+            join(newPath, ".claude-plugin", "plugin.json"),
+            JSON.stringify({ name: "evolving", description: "v2", version: "2.0.0" }),
+        );
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "evolving@mkt": [
+                    { scope: "user", installPath: oldPath, version: "1.0.0", lastUpdated: "2026-01-01T00:00:00Z" },
+                    { scope: "user", installPath: newPath, version: "2.0.0", lastUpdated: "2026-06-01T00:00:00Z" },
+                ],
+            },
+        });
+
+        const result = discoverClaudeInstalledPlugins("/tmp");
+        expect(result).toHaveLength(1);
+        expect(result[0].description).toBe("v2");
+    });
+
+    test("globalPluginDirs does NOT include ~/.claude/plugins", () => {
+        const home = setupHome("dirs-check");
+        const dirs = globalPluginDirs();
+        const claudePluginsDir = join(home, ".claude", "plugins");
+        expect(dirs).not.toContain(claudePluginsDir);
+        // Should include pizzapi and agents
+        expect(dirs.some(d => d.includes(".pizzapi"))).toBe(true);
+        expect(dirs.some(d => d.includes(".agents"))).toBe(true);
     });
 });

--- a/packages/cli/src/plugins.test.ts
+++ b/packages/cli/src/plugins.test.ts
@@ -1086,6 +1086,54 @@ describe("discoverClaudeInstalledPlugins", () => {
         expect(result[0].description).toBe("v2");
     });
 
+    test("falls back to older installation when newest is not a valid plugin dir", () => {
+        const home = setupHome("fallback");
+        // Create a valid v1 plugin
+        const oldPath = createCachedPlugin(home, "mkt", "flaky", "1.0.0");
+        // Create a v2 directory that exists but isn't a valid plugin dir
+        // (no commands/, hooks/, rules/, skills/, or plugin.json)
+        const newPath = join(home, ".claude", "plugins", "cache", "mkt", "flaky", "2.0.0");
+        mkdirSync(newPath, { recursive: true });
+        writeFileSync(join(newPath, "README.md"), "This is not a plugin");
+
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "flaky@mkt": [
+                    { scope: "user", installPath: newPath, version: "2.0.0", lastUpdated: "2026-06-01T00:00:00Z" },
+                    { scope: "user", installPath: oldPath, version: "1.0.0", lastUpdated: "2026-01-01T00:00:00Z" },
+                ],
+            },
+        });
+
+        const result = discoverClaudeInstalledPlugins("/tmp");
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("flaky");
+    });
+
+    test("rejects project-scoped plugin when relative path is absolute (cross-drive)", () => {
+        // Simulate cross-drive: projectPath and cwd share no common root.
+        // On POSIX, relative("/a", "/b") returns "../b" (starts with "..").
+        // On Windows cross-drive, relative("C:\\proj", "D:\\work") returns "D:\\work" (absolute).
+        // Both cases should be rejected.
+        const home = setupHome("cross-drive");
+        const path1 = createCachedPlugin(home, "mkt", "cross-drive-plugin", "1.0.0");
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "cross-drive-plugin@mkt": [{
+                    scope: "project",
+                    projectPath: "/completely/different/root",
+                    installPath: path1,
+                    version: "1.0.0",
+                }],
+            },
+        });
+
+        const result = discoverClaudeInstalledPlugins("/some/other/place");
+        expect(result).toEqual([]);
+    });
+
     test("globalPluginDirs does NOT include ~/.claude/plugins", () => {
         const home = setupHome("dirs-check");
         const dirs = globalPluginDirs();

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -22,7 +22,7 @@
  *   └── scripts/                  # Helper scripts referenced by hooks/commands
  */
 import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, join, resolve } from "node:path";
+import { basename, join, relative, resolve } from "node:path";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -185,14 +185,17 @@ export interface DiscoveredPlugin {
  *
  * These are user-controlled home directories — safe to auto-load because
  * they have the same trust level as ~/.pi/agent/extensions/ or ~/.agents/skills/.
+ *
+ * NOTE: ~/.claude/plugins/ is intentionally excluded here. Claude Code manages
+ * that directory via its marketplace system — plugins are installed into a cache
+ * subdirectory and tracked via installed_plugins.json. We discover those via
+ * discoverClaudeInstalledPlugins() instead of blindly scanning the directory.
  */
 export function globalPluginDirs(): string[] {
     const home = homedir();
     return [
         join(home, ".pizzapi", "plugins"),
         join(home, ".agents", "plugins"),
-        // Claude Code's own plugin locations (read-only discovery)
-        join(home, ".claude", "plugins"),
     ];
 }
 
@@ -235,6 +238,103 @@ export function pluginSearchDirs(cwd: string, opts?: { includeProjectLocal?: boo
         }
     }
     return [...new Set(dirs)];
+}
+
+// ── Claude Code installed plugins ─────────────────────────────────────────────
+
+/**
+ * Represents an entry from Claude Code's installed_plugins.json.
+ */
+export interface ClaudeInstalledPluginEntry {
+    scope: string;
+    installPath: string;
+    version: string;
+    lastUpdated?: string;
+    projectPath?: string;
+}
+
+/**
+ * Discover plugins installed via Claude Code's marketplace system.
+ *
+ * Reads ~/.claude/plugins/installed_plugins.json and parses each plugin
+ * from its cached installPath. Only returns plugins whose installPath
+ * actually exists on disk.
+ *
+ * This replaces the old approach of blindly scanning ~/.claude/plugins/
+ * as a flat directory, which would pick up marketplace catalogs and
+ * ignore the enable/disable state managed by Claude Code.
+ *
+ * @param cwd - Project working directory (used to filter project-scoped plugins)
+ */
+export function discoverClaudeInstalledPlugins(cwd?: string): DiscoveredPlugin[] {
+    // Use process.env.HOME directly (not homedir()) so tests can override it.
+    // homedir() caches the value at process start and ignores env changes.
+    const home = process.env.HOME || homedir();
+    const installedPath = join(home, ".claude", "plugins", "installed_plugins.json");
+
+    if (!existsSync(installedPath)) return [];
+
+    let raw: string;
+    try {
+        raw = readFileSync(installedPath, "utf-8");
+    } catch {
+        return [];
+    }
+
+    let data: { version?: number; plugins?: Record<string, ClaudeInstalledPluginEntry[]> };
+    try {
+        data = JSON.parse(raw);
+    } catch {
+        return [];
+    }
+
+    if (!data.plugins || typeof data.plugins !== "object") return [];
+
+    const plugins: DiscoveredPlugin[] = [];
+    const seen = new Set<string>();
+
+    for (const [_key, installations] of Object.entries(data.plugins)) {
+        if (!Array.isArray(installations) || installations.length === 0) continue;
+
+        // Find the best installation: prefer most recently updated
+        const sorted = [...installations]
+            .filter(inst => inst && typeof inst.installPath === "string" && inst.installPath.length > 0)
+            .sort((a, b) => {
+                const ta = typeof a.lastUpdated === "string" ? new Date(a.lastUpdated).getTime() : 0;
+                const tb = typeof b.lastUpdated === "string" ? new Date(b.lastUpdated).getTime() : 0;
+                return tb - ta;
+            });
+
+        for (const inst of sorted) {
+            // Skip project-scoped plugins that don't match current cwd.
+            // Uses path.relative to avoid platform-specific separator issues.
+            if (inst.scope === "project" && cwd && inst.projectPath) {
+                const rel = relative(resolve(inst.projectPath), resolve(cwd));
+                if (rel.startsWith("..")) {
+                    continue;
+                }
+            }
+
+            const installDir = inst.installPath;
+            if (!existsSync(installDir)) continue;
+
+            // Check it looks like a plugin directory
+            if (!isPluginDir(installDir)) continue;
+
+            try {
+                const plugin = parsePlugin(installDir);
+                if (!seen.has(plugin.name)) {
+                    seen.add(plugin.name);
+                    plugins.push(plugin);
+                }
+            } catch {
+                // Skip unparseable plugins
+            }
+            break; // Use first valid installation for this plugin key
+        }
+    }
+
+    return plugins;
 }
 
 // ── Parsing helpers ───────────────────────────────────────────────────────────
@@ -741,6 +841,12 @@ export function scanPluginsDir(dir: string): DiscoveredPlugin[] {
  * Discover all Claude Code plugins from all search directories.
  * Deduplicates by plugin name (first found wins).
  *
+ * Discovery sources (in precedence order):
+ * 1. PizzaPi plugin dirs (~/.pizzapi/plugins/, ~/.agents/plugins/)
+ * 2. Claude Code installed plugins (from ~/.claude/plugins/installed_plugins.json)
+ * 3. Project-local plugin dirs (if opts.includeProjectLocal)
+ * 4. Extra dirs (if opts.extraDirs)
+ *
  * @param cwd - Project working directory
  * @param opts.includeProjectLocal - If true, include project-local plugin dirs
  *   (default: false — project-local plugins can run arbitrary code)
@@ -751,12 +857,21 @@ export function discoverPlugins(cwd: string, opts?: { includeProjectLocal?: bool
     const seen = new Set<string>();
     const plugins: DiscoveredPlugin[] = [];
 
+    // 1. Scan PizzaPi/agents plugin dirs
     for (const dir of dirs) {
         for (const plugin of scanPluginsDir(dir)) {
             if (!seen.has(plugin.name)) {
                 seen.add(plugin.name);
                 plugins.push(plugin);
             }
+        }
+    }
+
+    // 2. Discover Claude Code marketplace-installed plugins
+    for (const plugin of discoverClaudeInstalledPlugins(cwd)) {
+        if (!seen.has(plugin.name)) {
+            seen.add(plugin.name);
+            plugins.push(plugin);
         }
     }
 

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -22,7 +22,7 @@
  *   └── scripts/                  # Helper scripts referenced by hooks/commands
  */
 import { existsSync, lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
-import { basename, join, relative, resolve } from "node:path";
+import { basename, isAbsolute, join, relative, resolve } from "node:path";
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
@@ -308,9 +308,11 @@ export function discoverClaudeInstalledPlugins(cwd?: string): DiscoveredPlugin[]
         for (const inst of sorted) {
             // Skip project-scoped plugins that don't match current cwd.
             // Uses path.relative to avoid platform-specific separator issues.
+            // On Windows, cross-drive relative() returns an absolute path, so
+            // we also reject when isAbsolute(rel) is true.
             if (inst.scope === "project" && cwd && inst.projectPath) {
                 const rel = relative(resolve(inst.projectPath), resolve(cwd));
-                if (rel.startsWith("..")) {
+                if (rel.startsWith("..") || isAbsolute(rel)) {
                     continue;
                 }
             }
@@ -327,10 +329,11 @@ export function discoverClaudeInstalledPlugins(cwd?: string): DiscoveredPlugin[]
                     seen.add(plugin.name);
                     plugins.push(plugin);
                 }
+                break; // Successfully parsed — use this installation
             } catch {
-                // Skip unparseable plugins
+                // Unparseable — fall through to try next installation
+                continue;
             }
-            break; // Use first valid installation for this plugin key
         }
     }
 


### PR DESCRIPTION
## Summary

Two related fixes for plugin/agent discovery resilience:

### 1. Skip malformed YAML in agent .md files

The upstream `parseFrontmatter()` uses `yaml.parse()` which throws on invalid YAML. A single bad `.md` file in any agents directory would crash the entire agent discovery, making even the built-in `task` agent unavailable.

**Fix:** Wrap `parseFrontmatter()` in a try/catch inside `loadAgentsFromDir()` so bad files are silently skipped.

### 2. Respect Claude Code's `installed_plugins.json`

Previously, PizzaPi scanned `~/.claude/plugins/` as a flat directory, which:
- Picked up marketplace catalog entries that aren't installed plugins
- Ignored Claude Code's enable/disable state
- Could load plugins the user explicitly disabled

**Fix:**
- Removed `~/.claude/plugins/` from `globalPluginDirs()`
- Added `discoverClaudeInstalledPlugins()` which reads `~/.claude/plugins/installed_plugins.json` and only loads plugins from their cached `installPath`
- Respects project-scoped plugins (only loaded when cwd matches)
- Prefers most recently updated installation when multiple exist
- Gracefully handles missing/malformed `installed_plugins.json`

## Tests

- 1 new test for YAML resilience in agent discovery
- 10 new tests for `discoverClaudeInstalledPlugins()`
- All 95 tests pass across both changed test files
