### PR TITLE
feat: copy conversation to clipboard as Markdown

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/fix-plan-mode-fd-redirect/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/feat-clipboard-copy/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/fix-plan-mode-fd-redirect/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/feat-clipboard-copy/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -5,6 +5,7 @@ import {
   ConversationDownload,
   ConversationEmptyState,
   MessageCopyButton,
+  type ConversationMessage,
 } from "@/components/ai-elements/conversation";
 import type { RelayMessage } from "@/components/session-viewer/types";
 import { SessionActionsProvider, type SessionActions } from "@/components/session-viewer/session-actions-context";
@@ -445,7 +446,7 @@ const SessionMessageItem = React.memo(({ message, activeToolCalls, agentActive, 
             {message.timestamp && <span>• {new Date(message.timestamp).toLocaleTimeString()}</span>}
             {message.isError && <span className="text-destructive">• Error</span>}
             <MessageCopyButton
-              text={typeof message.content === "string" ? message.content : JSON.stringify(message.content, null, 2)}
+              text={typeof message.content === "string" ? message.content : message.content != null ? JSON.stringify(message.content, null, 2) : message.errorMessage ?? ""}
               className="ml-auto opacity-0 group-hover/msg:opacity-100 transition-opacity"
             />
           </div>
@@ -1385,6 +1386,21 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     [sortedMessages],
   );
 
+  /** Serialise visible messages for download / clipboard copy, handling undefined content gracefully. */
+  const conversationMessages: ConversationMessage[] = React.useMemo(
+    () =>
+      sortedMessages.map((m) => ({
+        role: toMessageRole(m.role),
+        content:
+          typeof m.content === "string"
+            ? m.content
+            : m.content != null
+              ? JSON.stringify(m.content, null, 2)
+              : m.errorMessage ?? "",
+      })),
+    [sortedMessages],
+  );
+
   const PAGE_SIZE = 50;
 
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
@@ -1603,13 +1619,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               </Button>
             )}
             <ConversationDownload
-              messages={sortedMessages.map((m) => ({
-                role: toMessageRole(m.role),
-                content:
-                  typeof m.content === "string"
-                    ? m.content
-                    : JSON.stringify(m.content, null, 2),
-              }))}
+              messages={conversationMessages}
               filename={`session-${sessionId || "export"}.md`}
               className="static top-auto right-auto h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem] border-border bg-background hover:bg-accent hover:text-accent-foreground rounded-md"
               variant="outline"
@@ -1621,13 +1631,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               <span className="hidden sm:inline ml-1">Save</span>
             </ConversationDownload>
             <ConversationCopy
-              messages={sortedMessages.map((m) => ({
-                role: toMessageRole(m.role),
-                content:
-                  typeof m.content === "string"
-                    ? m.content
-                    : JSON.stringify(m.content, null, 2),
-              }))}
+              messages={conversationMessages}
               className="static top-auto right-auto h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem] border-border bg-background hover:bg-accent hover:text-accent-foreground rounded-md"
               iconClassName="size-3.5"
               variant="outline"

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
 
 import {
+  ConversationCopy,
   ConversationDownload,
   ConversationEmptyState,
+  MessageCopyButton,
 } from "@/components/ai-elements/conversation";
 import type { RelayMessage } from "@/components/session-viewer/types";
 import { SessionActionsProvider, type SessionActions } from "@/components/session-viewer/session-actions-context";
@@ -66,7 +68,7 @@ import { MultipleChoiceQuestions } from "@/components/ai-elements/multiple-choic
 import { PlanModePanel, type PlanModeAnswer } from "@/components/ai-elements/plan-mode";
 import { formatAnswersForAgent, type QuestionDisplayMode } from "@/lib/ask-user-questions";
 import { dismissNotificationsForSession } from "@/lib/push";
-import { AlertTriangleIcon, ArrowDownIcon, BookOpen, Bot, CheckCircle2, ChevronsUpDown, Circle, CircleDashed, Copy, Loader2, MessageSquare, OctagonX, PaperclipIcon, Plus, Puzzle, ShieldAlert, Zap, Clock, X, Trash2, TerminalIcon, DownloadIcon, XCircle, FolderTree } from "lucide-react";
+import { AlertTriangleIcon, ArrowDownIcon, BookOpen, Bot, CheckCircle2, ChevronsUpDown, Circle, CircleDashed, ClipboardIcon, Copy, Loader2, MessageSquare, OctagonX, PaperclipIcon, Plus, Puzzle, ShieldAlert, Zap, Clock, X, Trash2, TerminalIcon, DownloadIcon, XCircle, FolderTree } from "lucide-react";
 import { AtMentionPopover } from "@/components/AtMentionPopover";
 import type { Entry as AtMentionEntry } from "@/hooks/useAtMentionFiles";
 import { McpToggleContext, type McpToggleHandler } from "@/components/session-viewer/McpToggleContext";
@@ -427,7 +429,7 @@ const SessionMessageItem = React.memo(({ message, activeToolCalls, agentActive, 
   }
 
   return (
-    <div className="w-full px-4 py-1.5">
+    <div className="group/msg w-full px-4 py-1.5">
       <Message from={toMessageRole(message.role)}>
         <MessageContent
           className={cn(
@@ -442,6 +444,10 @@ const SessionMessageItem = React.memo(({ message, activeToolCalls, agentActive, 
             {message.toolName && <span>• {message.toolName}</span>}
             {message.timestamp && <span>• {new Date(message.timestamp).toLocaleTimeString()}</span>}
             {message.isError && <span className="text-destructive">• Error</span>}
+            <MessageCopyButton
+              text={typeof message.content === "string" ? message.content : JSON.stringify(message.content, null, 2)}
+              className="ml-auto opacity-0 group-hover/msg:opacity-100 transition-opacity"
+            />
           </div>
           {renderContent(
             message.content,
@@ -1614,6 +1620,23 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               <DownloadIcon className="size-3.5" />
               <span className="hidden sm:inline ml-1">Save</span>
             </ConversationDownload>
+            <ConversationCopy
+              messages={sortedMessages.map((m) => ({
+                role: toMessageRole(m.role),
+                content:
+                  typeof m.content === "string"
+                    ? m.content
+                    : JSON.stringify(m.content, null, 2),
+              }))}
+              className="static top-auto right-auto h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem] border-border bg-background hover:bg-accent hover:text-accent-foreground rounded-md"
+              iconClassName="size-3.5"
+              variant="outline"
+              size="icon"
+              title="Copy conversation as Markdown"
+              aria-label="Copy conversation"
+            >
+              <><ClipboardIcon className="size-3.5" /><span className="hidden sm:inline ml-1">Copy</span></>
+            </ConversationCopy>
             {onDuplicateSession && (
               <Button
                 className="h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem]"

--- a/packages/ui/src/components/ai-elements/conversation.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.tsx
@@ -4,8 +4,8 @@ import type { ComponentProps } from "react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { ArrowDownIcon, DownloadIcon } from "lucide-react";
-import { useCallback } from "react";
+import { ArrowDownIcon, CheckIcon, ClipboardIcon, DownloadIcon } from "lucide-react";
+import { useCallback, useState, useRef } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
@@ -162,6 +162,113 @@ export const ConversationDownload = ({
       {...props}
     >
       {children ?? <DownloadIcon className="size-4" />}
+    </Button>
+  );
+};
+
+// --- Clipboard copy ---
+
+export type ConversationCopyProps = Omit<
+  ComponentProps<typeof Button>,
+  "onClick"
+> & {
+  messages: ConversationMessage[];
+  formatMessage?: (message: ConversationMessage, index: number) => string;
+  /** Duration in ms to show the success checkmark (default 2000) */
+  feedbackMs?: number;
+  /** Icon size class (default "size-4") */
+  iconClassName?: string;
+};
+
+export const ConversationCopy = ({
+  messages,
+  formatMessage = defaultFormatMessage,
+  feedbackMs = 2000,
+  iconClassName = "size-4",
+  className,
+  children,
+  ...props
+}: ConversationCopyProps) => {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const handleCopy = useCallback(async () => {
+    const markdown = messagesToMarkdown(messages, formatMessage);
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopied(true);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), feedbackMs);
+    } catch {
+      // Fallback: some browsers block clipboard in non-secure contexts
+      console.warn("Clipboard write failed");
+    }
+  }, [messages, formatMessage, feedbackMs]);
+
+  return (
+    <Button
+      className={cn(
+        "absolute top-4 right-4 rounded-full dark:bg-background dark:hover:bg-muted",
+        className
+      )}
+      onClick={handleCopy}
+      size="icon"
+      type="button"
+      variant="outline"
+      {...props}
+    >
+      {copied
+        ? <CheckIcon className={cn(iconClassName, "text-green-500")} />
+        : (children ?? <ClipboardIcon className={iconClassName} />)}
+    </Button>
+  );
+};
+
+// --- Single-message copy (for per-message hover actions) ---
+
+export type MessageCopyButtonProps = Omit<
+  ComponentProps<typeof Button>,
+  "onClick"
+> & {
+  /** Raw markdown text to copy */
+  text: string;
+  /** Duration in ms to show the success checkmark (default 2000) */
+  feedbackMs?: number;
+};
+
+export const MessageCopyButton = ({
+  text,
+  feedbackMs = 2000,
+  className,
+  children,
+  ...props
+}: MessageCopyButtonProps) => {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), feedbackMs);
+    } catch {
+      console.warn("Clipboard write failed");
+    }
+  }, [text, feedbackMs]);
+
+  return (
+    <Button
+      className={cn("size-6 p-0 rounded-md", className)}
+      onClick={handleCopy}
+      size="icon"
+      type="button"
+      variant="ghost"
+      title="Copy message"
+      aria-label="Copy message"
+      {...props}
+    >
+      {children ?? (copied ? <CheckIcon className="size-3 text-green-500" /> : <ClipboardIcon className="size-3" />)}
     </Button>
   );
 };


### PR DESCRIPTION
## Summary

Adds a "Copy" button to the session viewer toolbar that copies the full conversation as Markdown to the clipboard, complementing the existing "Save" (download) button. Also adds a per-message copy button that appears on hover.

## Changes

### New components (`conversation.tsx`)
- **`ConversationCopy`** — Copies all messages as Markdown via `navigator.clipboard.writeText()`. Shows a green ✓ checkmark for 2s on success.
- **`MessageCopyButton`** — Small ghost button for copying a single message's content, designed for hover reveal.

### Wiring (`SessionViewer.tsx`)
- **Toolbar**: Copy button appears next to the existing Save/Download button with matching styling.
- **Per-message**: Each message header row gets a copy button that fades in on hover (`group-hover` pattern).

## Why

Previously the only way to get conversation text out was downloading a `.md` file. Clipboard copy is faster for pasting into other tools, chat threads, or docs — especially on mobile where file downloads are clunky.