### PR TITLE
fix: respect enabledPlugins when scanning ~/.claude/plugins/

### DIFF
--- a/packages/cli/src/plugins.test.ts
+++ b/packages/cli/src/plugins.test.ts
@@ -18,6 +18,7 @@ import {
     scanPluginsDir,
     discoverPlugins,
     discoverClaudeInstalledPlugins,
+    readEnabledPlugins,
     pluginSearchDirs,
     globalPluginDirs,
     projectPluginDirs,
@@ -1142,5 +1143,179 @@ describe("discoverClaudeInstalledPlugins", () => {
         // Should include pizzapi and agents
         expect(dirs.some(d => d.includes(".pizzapi"))).toBe(true);
         expect(dirs.some(d => d.includes(".agents"))).toBe(true);
+    });
+
+    test("skips plugins disabled via enabledPlugins in settings.json", () => {
+        const home = setupHome("enabled-filter");
+        const pathA = createCachedPlugin(home, "mkt", "plugin-a", "1.0.0");
+        const pathB = createCachedPlugin(home, "mkt", "plugin-b", "1.0.0");
+        const pathC = createCachedPlugin(home, "mkt", "plugin-c", "1.0.0");
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "plugin-a@mkt": [{ scope: "user", installPath: pathA, version: "1.0.0" }],
+                "plugin-b@mkt": [{ scope: "user", installPath: pathB, version: "1.0.0" }],
+                "plugin-c@mkt": [{ scope: "user", installPath: pathC, version: "1.0.0" }],
+            },
+        });
+        // Write settings with plugin-b disabled
+        writeFileSync(
+            join(home, ".claude", "settings.json"),
+            JSON.stringify({
+                enabledPlugins: {
+                    "plugin-a@mkt": true,
+                    "plugin-b@mkt": false,
+                    // plugin-c not listed → defaults to enabled
+                },
+            }),
+        );
+
+        const result = discoverClaudeInstalledPlugins("/tmp");
+        expect(result).toHaveLength(2);
+        const names = result.map(p => p.name).sort();
+        expect(names).toEqual(["plugin-a", "plugin-c"]);
+    });
+
+    test("project-level settings.json can disable a plugin", () => {
+        const home = setupHome("project-settings");
+        const pathA = createCachedPlugin(home, "mkt", "proj-plugin", "1.0.0");
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "proj-plugin@mkt": [{ scope: "user", installPath: pathA, version: "1.0.0" }],
+            },
+        });
+        // No user-level enabledPlugins, but project-level disables it
+        const projectDir = join(tmpDir, "proj-disable-test");
+        mkdirSync(join(projectDir, ".claude"), { recursive: true });
+        writeFileSync(
+            join(projectDir, ".claude", "settings.json"),
+            JSON.stringify({ enabledPlugins: { "proj-plugin@mkt": false } }),
+        );
+
+        const result = discoverClaudeInstalledPlugins(projectDir);
+        expect(result).toEqual([]);
+    });
+
+    test("project-local settings.local.json overrides project settings", () => {
+        const home = setupHome("local-override");
+        const pathA = createCachedPlugin(home, "mkt", "override-plugin", "1.0.0");
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "override-plugin@mkt": [{ scope: "user", installPath: pathA, version: "1.0.0" }],
+            },
+        });
+        const projectDir = join(tmpDir, "local-override-project");
+        mkdirSync(join(projectDir, ".claude"), { recursive: true });
+        // Project settings enable the plugin
+        writeFileSync(
+            join(projectDir, ".claude", "settings.json"),
+            JSON.stringify({ enabledPlugins: { "override-plugin@mkt": true } }),
+        );
+        // But local settings disable it
+        writeFileSync(
+            join(projectDir, ".claude", "settings.local.json"),
+            JSON.stringify({ enabledPlugins: { "override-plugin@mkt": false } }),
+        );
+
+        const result = discoverClaudeInstalledPlugins(projectDir);
+        expect(result).toEqual([]);
+    });
+
+    test("all plugins loaded when no enabledPlugins settings exist", () => {
+        const home = setupHome("no-enabled-plugins");
+        const pathA = createCachedPlugin(home, "mkt", "free-plugin", "1.0.0");
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "free-plugin@mkt": [{ scope: "user", installPath: pathA, version: "1.0.0" }],
+            },
+        });
+        // No settings.json at all — all plugins should load
+        const result = discoverClaudeInstalledPlugins("/tmp");
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("free-plugin");
+    });
+});
+
+// ── readEnabledPlugins ────────────────────────────────────────────────────────
+
+describe("readEnabledPlugins", () => {
+    let tmpDir: string;
+    let realHome: string;
+
+    beforeAll(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "enabled-plugins-"));
+        realHome = process.env.HOME!;
+    });
+
+    afterAll(() => {
+        process.env.HOME = realHome;
+        try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    });
+
+    test("returns null when no settings files exist", () => {
+        const home = join(tmpDir, "no-settings");
+        mkdirSync(join(home, ".claude"), { recursive: true });
+        process.env.HOME = home;
+        const result = readEnabledPlugins("/nonexistent/project");
+        expect(result).toBeNull();
+    });
+
+    test("reads user-level enabledPlugins", () => {
+        const home = join(tmpDir, "user-level");
+        mkdirSync(join(home, ".claude"), { recursive: true });
+        writeFileSync(
+            join(home, ".claude", "settings.json"),
+            JSON.stringify({ enabledPlugins: { "a@mkt": true, "b@mkt": false } }),
+        );
+        process.env.HOME = home;
+        const result = readEnabledPlugins("/tmp");
+        expect(result).toEqual({ "a@mkt": true, "b@mkt": false });
+    });
+
+    test("merges user and project settings (project wins)", () => {
+        const home = join(tmpDir, "merge-test");
+        mkdirSync(join(home, ".claude"), { recursive: true });
+        writeFileSync(
+            join(home, ".claude", "settings.json"),
+            JSON.stringify({ enabledPlugins: { "a@mkt": true, "b@mkt": false } }),
+        );
+        process.env.HOME = home;
+
+        const projectDir = join(tmpDir, "merge-project");
+        mkdirSync(join(projectDir, ".claude"), { recursive: true });
+        writeFileSync(
+            join(projectDir, ".claude", "settings.json"),
+            JSON.stringify({ enabledPlugins: { "b@mkt": true, "c@mkt": false } }),
+        );
+
+        const result = readEnabledPlugins(projectDir);
+        expect(result).toEqual({ "a@mkt": true, "b@mkt": true, "c@mkt": false });
+    });
+
+    test("ignores non-boolean values in enabledPlugins", () => {
+        const home = join(tmpDir, "non-bool");
+        mkdirSync(join(home, ".claude"), { recursive: true });
+        writeFileSync(
+            join(home, ".claude", "settings.json"),
+            JSON.stringify({ enabledPlugins: { "a@mkt": true, "bad@mkt": "yes", "c@mkt": 123 } }),
+        );
+        process.env.HOME = home;
+        const result = readEnabledPlugins("/tmp");
+        expect(result).toEqual({ "a@mkt": true });
+    });
+
+    test("returns null when settings exist but no enabledPlugins key", () => {
+        const home = join(tmpDir, "no-key");
+        mkdirSync(join(home, ".claude"), { recursive: true });
+        writeFileSync(
+            join(home, ".claude", "settings.json"),
+            JSON.stringify({ hooks: {} }),
+        );
+        process.env.HOME = home;
+        const result = readEnabledPlugins("/tmp");
+        expect(result).toBeNull();
     });
 });

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -254,11 +254,73 @@ export interface ClaudeInstalledPluginEntry {
 }
 
 /**
+ * Read `enabledPlugins` from Claude Code settings files and merge them.
+ *
+ * Checks (in precedence order, higher wins):
+ *   1. ~/.claude/settings.json (user-level)
+ *   2. .claude/settings.json (project-level, relative to cwd)
+ *   3. .claude/settings.local.json (project-local overrides)
+ *
+ * Returns a merged map of `"pluginName@marketplace" → boolean`.
+ * If no settings files exist or none contain `enabledPlugins`, returns null.
+ */
+export function readEnabledPlugins(cwd?: string): Record<string, boolean> | null {
+    const home = process.env.HOME || homedir();
+    const candidates: string[] = [
+        join(home, ".claude", "settings.json"),
+    ];
+    if (cwd) {
+        candidates.push(join(cwd, ".claude", "settings.json"));
+        candidates.push(join(cwd, ".claude", "settings.local.json"));
+    }
+
+    let merged: Record<string, boolean> | null = null;
+
+    for (const path of candidates) {
+        if (!existsSync(path)) continue;
+        try {
+            const raw = readFileSync(path, "utf-8");
+            const parsed = JSON.parse(raw);
+            if (parsed.enabledPlugins && typeof parsed.enabledPlugins === "object") {
+                if (!merged) merged = {};
+                // Later files (project-level) override earlier (user-level)
+                for (const [key, value] of Object.entries(parsed.enabledPlugins)) {
+                    if (typeof value === "boolean") {
+                        merged[key] = value;
+                    }
+                }
+            }
+        } catch {
+            // Skip unreadable/unparseable settings files
+        }
+    }
+
+    return merged;
+}
+
+/**
+ * Check if a plugin key (e.g. "my-plugin@marketplace") is enabled
+ * according to the `enabledPlugins` map.
+ *
+ * Rules:
+ * - If enabledPlugins is null (no settings found), all plugins are enabled.
+ * - If the key is explicitly `false`, the plugin is disabled.
+ * - If the key is not listed or is `true`, the plugin is enabled.
+ */
+function isPluginEnabled(key: string, enabledPlugins: Record<string, boolean> | null): boolean {
+    if (!enabledPlugins) return true;
+    return enabledPlugins[key] !== false;
+}
+
+/**
  * Discover plugins installed via Claude Code's marketplace system.
  *
  * Reads ~/.claude/plugins/installed_plugins.json and parses each plugin
  * from its cached installPath. Only returns plugins whose installPath
  * actually exists on disk.
+ *
+ * Also respects the `enabledPlugins` setting from Claude Code's settings
+ * files — plugins explicitly set to `false` are skipped.
  *
  * This replaces the old approach of blindly scanning ~/.claude/plugins/
  * as a flat directory, which would pick up marketplace catalogs and
@@ -290,10 +352,16 @@ export function discoverClaudeInstalledPlugins(cwd?: string): DiscoveredPlugin[]
 
     if (!data.plugins || typeof data.plugins !== "object") return [];
 
+    // Read enabledPlugins from Claude Code settings to respect disabled state
+    const enabledPlugins = readEnabledPlugins(cwd);
+
     const plugins: DiscoveredPlugin[] = [];
     const seen = new Set<string>();
 
     for (const [_key, installations] of Object.entries(data.plugins)) {
+        // Check enabledPlugins — skip plugins explicitly disabled
+        if (!isPluginEnabled(_key, enabledPlugins)) continue;
+
         if (!Array.isArray(installations) || installations.length === 0) continue;
 
         // Find the best installation: prefer most recently updated


### PR DESCRIPTION
## Problem

PizzaPi's Claude Code plugin adapter discovered installed plugins from `~/.claude/plugins/installed_plugins.json` but didn't check Claude Code's `enabledPlugins` setting. This meant plugins that a user explicitly disabled (set to `false` in settings) were still loaded — diverging from Claude Code's actual behavior.

## Solution

Before loading a plugin from `installed_plugins.json`, check the `enabledPlugins` map from Claude Code's settings files:

1. `~/.claude/settings.json` (user-level)
2. `.claude/settings.json` (project-level)
3. `.claude/settings.local.json` (project-local overrides)

Settings are merged with later files overriding earlier ones (matching Claude Code's precedence). Plugins explicitly set to `false` are skipped. If no `enabledPlugins` setting exists anywhere, all installed plugins load as before (backward compatible).

## Changes

- **`plugins.ts`**: Added `readEnabledPlugins()` and filtering in `discoverClaudeInstalledPlugins()`
- **`plugins.test.ts`**: 9 new tests covering disabled filtering, settings merging, precedence, and backward compatibility