### PR TITLE
fix: expand ~ using os.homedir() for LaunchAgent compatibility

### DIFF
--- a/packages/cli/src/extensions/mcp.ts
+++ b/packages/cli/src/extensions/mcp.ts
@@ -1,5 +1,5 @@
 import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
-import type { PizzaPiConfig } from "../config.js";
+import { expandHome, type PizzaPiConfig } from "../config.js";
 import { PizzaPiOAuthProvider, type RelayContext } from "./mcp-oauth.js";
 import { getSandboxEnv, isSandboxActive, getResolvedConfig } from "@pizzapi/tools";
 
@@ -155,10 +155,17 @@ async function createStdioMcpClient(opts: { name: string; command: string; args?
   // Network sandboxing still applies via the proxy env vars injected above —
   // outbound traffic is routed through srt's proxy for domain filtering when
   // sandbox is active in "full" mode.
-  const child: ChildProcessWithoutNullStreams = spawn(opts.command, opts.args ?? [], {
+  // Expand ~ in command, args, and cwd so paths resolve correctly even when
+  // launched by macOS launchd (LaunchAgent/LaunchDaemon) where shell tilde
+  // expansion doesn't occur.
+  const command = expandHome(opts.command);
+  const args = (opts.args ?? []).map(expandHome);
+  const cwd = opts.cwd ? expandHome(opts.cwd) : undefined;
+
+  const child: ChildProcessWithoutNullStreams = spawn(command, args, {
     stdio: "pipe",
     env: mergedEnv,
-    ...(opts.cwd ? { cwd: opts.cwd } : {}),
+    ...(cwd ? { cwd } : {}),
   });
 
   let nextId = 1;

--- a/packages/cli/src/extensions/remote-provider-usage.ts
+++ b/packages/cli/src/extensions/remote-provider-usage.ts
@@ -6,10 +6,9 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { AuthStorage } from "@mariozechner/pi-coding-agent";
-import { loadConfig, defaultAgentDir } from "../config.js";
+import { loadConfig, defaultAgentDir, expandHome } from "../config.js";
 import type { UsageWindow, ProviderUsageData } from "./remote-types.js";
 
 const DEFAULT_USAGE_CACHE_TTL = 5 * 60 * 1000; // 5 min
@@ -25,7 +24,7 @@ export function getOAuthToken(providerId: string): string | null {
     try {
         const config = loadConfig(process.cwd());
         const agentDir = config.agentDir
-            ? config.agentDir.replace(/^~/, homedir())
+            ? expandHome(config.agentDir)
             : defaultAgentDir();
         const authPath = join(agentDir, "auth.json");
         if (!existsSync(authPath)) return null;
@@ -230,7 +229,7 @@ async function refreshGeminiUsage(opts: { force?: boolean } = {}): Promise<void>
     let projectId: string;
     try {
         const config = loadConfig(process.cwd());
-        const agentDir = config.agentDir ? config.agentDir.replace(/^~/, homedir()) : defaultAgentDir();
+        const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
         const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
         const raw = await authStorage.getApiKey("google-gemini-cli");
         if (!raw) return;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -9,8 +9,7 @@ import {
 import { existsSync } from "fs";
 import { readFile, readdir } from "fs/promises";
 import { join } from "path";
-import { homedir } from "os";
-import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
+import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
 import { buildInteractiveSkillPaths } from "./skills.js";
 import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
 import { runSetup } from "./setup.js";
@@ -78,7 +77,7 @@ async function main() {
 
     if (args[0] === "usage") {
         const config = loadConfig(cwd);
-        const agentDir = config.agentDir ? config.agentDir.replace(/^~/, homedir()) : defaultAgentDir();
+        const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
         const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
         const showJson = args.includes("--json");
 
@@ -289,7 +288,7 @@ async function main() {
 
     if (args[0] === "models") {
         const config = loadConfig(cwd);
-        const agentDir = config.agentDir ? config.agentDir.replace(/^~/, homedir()) : defaultAgentDir();
+        const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
 
         const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
         const modelRegistry = new ModelRegistry(authStorage, join(agentDir, "models.json"));
@@ -408,7 +407,7 @@ Run \`pizza <command> --help\` for command-specific help.
     }
 
     const config = loadConfig(cwd);
-    const agentDir = config.agentDir ? config.agentDir.replace(/^~/, homedir()) : defaultAgentDir();
+    const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
 
     // ── Provider settings → env vars ───────────────────────────────────────
     applyProviderSettingsEnv(config);

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -45,6 +45,7 @@ function readFileCapped(path: string, maxBytes: number = MAX_PLUGIN_FILE_SIZE): 
     }
 }
 import { homedir } from "node:os";
+import { expandHome } from "./config.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -233,7 +234,7 @@ export function pluginSearchDirs(cwd: string, opts?: { includeProjectLocal?: boo
     if (Array.isArray(opts?.extraDirs)) {
         for (const d of opts!.extraDirs) {
             if (typeof d === "string" && d.trim()) {
-                dirs.push(d.replace(/^~/, homedir()));
+                dirs.push(expandHome(d));
             }
         }
     }

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -2,7 +2,7 @@ import { createAgentSession, DefaultResourceLoader } from "@mariozechner/pi-codi
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "../config.js";
+import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "../config.js";
 import { buildWorkerSkillPaths } from "../skills.js";
 import { getPluginSkillPaths } from "../extensions/claude-plugins.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
@@ -52,7 +52,7 @@ async function main(): Promise<void> {
     }
 
     const config = loadConfig(cwd);
-    const agentDir = config.agentDir?.replace(/^~/, homedir()) ?? defaultAgentDir();
+    const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
     const skipPlugins = process.env.PIZZAPI_NO_PLUGINS === "1";
 
     // ── Provider settings → env vars ───────────────────────────────────────

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -8,6 +8,7 @@ import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, wri
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { expandHome } from "./config.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -177,12 +178,7 @@ export function deleteSkill(name: string, dir?: string): boolean {
 
 // ── Skill path builders ───────────────────────────────────────────────────────
 
-/**
- * Expand ~ to home directory in a path.
- */
-function expandHome(path: string): string {
-    return path.replace(/^~/, homedir());
-}
+// expandHome is imported from config.ts
 
 /**
  * Build the list of additional skill paths for the interactive CLI.


### PR DESCRIPTION
## Problem

When the PizzaPi runner is started by macOS launchd (LaunchAgent or LaunchDaemon), shell tilde `~` expansion does **not** occur. Paths like `~/.pizzapi/config.json` resolve incorrectly or fail entirely unless `HOME` is explicitly set in the plist's `EnvironmentVariables`.

**Reported by:** Zach Kanzler (workaround was manually setting `HOME` in his LaunchAgent plist).

## Fix

Consolidates all `~` path expansion to use the shared `expandHome()` utility from `config.ts`, which replaces a leading `~` with `os.homedir()`. This works regardless of whether the process was launched from a shell or from launchd.

### Changes

| File | What changed |
|------|-------------|
| `skills.ts` | Removed duplicate local `expandHome()`; now imports from `config.ts` |
| `index.ts` | 3 inline `.replace(/^~/, homedir())` → `expandHome()` |
| `runner/worker.ts` | 1 inline replace → `expandHome()` |
| `extensions/remote-provider-usage.ts` | 2 inline replaces → `expandHome()` |
| `plugins.ts` | 1 inline replace → `expandHome()` |
| `extensions/mcp.ts` | **New:** Expands `~` in MCP stdio server `command`, `args[]`, and `cwd` — `spawn()` doesn't use a shell, so `~` was silently broken |

### Cleanup
- Removed unused `import { homedir }` from `index.ts` and `remote-provider-usage.ts`

## Testing

- All existing tests pass (skills, config, plugins, sandbox-config)
- No new type errors introduced