### PR TITLE
fix: add exitReason to session_complete trigger (completed vs killed)

### DIFF
--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -117,6 +117,7 @@ export async function handleExecFromWeb(
                 replyErr("No active session");
                 return;
             }
+            rctx.wasAborted = true;
             rctx.latestCtx.abort();
             replyOk();
             rctx.forwardEvent(rctx.buildHeartbeat());

--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -395,6 +395,7 @@ export async function handleExecFromWeb(
             }
             replyOk();
             rctx.shuttingDown = true;
+            rctx.wasAborted = true;
             setTimeout(() => {
                 rctx.latestCtx?.shutdown();
             }, 100);

--- a/packages/cli/src/extensions/remote-types.ts
+++ b/packages/cli/src/extensions/remote-types.ts
@@ -193,6 +193,7 @@ export interface RelayContext {
     isAgentActive: boolean;
     isCompacting: boolean;
     shuttingDown: boolean;
+    wasAborted: boolean;
     sessionStartedAt: number | null;
     lastRetryableError: RetryState | null;
 

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -826,7 +826,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                     }
                 }
             }
-            fireSessionComplete(summary, fullOutputPath);
+            fireSessionComplete(summary, fullOutputPath, rctx.wasAborted ? "killed" : "completed");
             if (rctx.isChildSession) {
                 startFollowUpGrace(ctx);
             }

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -107,6 +107,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         isAgentActive: false,
         isCompacting: false,
         shuttingDown: false,
+        wasAborted: false,
         sessionStartedAt: null,
         lastRetryableError: null,
 
@@ -419,7 +420,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         }
     }
 
-    function fireSessionComplete(summary?: string, fullOutputPath?: string) {
+    function fireSessionComplete(summary?: string, fullOutputPath?: string, exitReason?: "completed" | "killed" | "error") {
         if (sessionCompleteFired) return;
         if (!rctx.isChildSession || !rctx.parentSessionId || !rctx.relay || !rctx.sioSocket?.connected) return;
         sessionCompleteFired = true;
@@ -432,7 +433,8 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 targetSessionId: rctx.parentSessionId,
                 payload: {
                     summary: summary ?? "Session completed",
-                    exitCode: 0,
+                    exitCode: exitReason === "killed" ? 130 : exitReason === "error" ? 1 : 0,
+                    exitReason: exitReason ?? "completed",
                     ...(fullOutputPath ? { fullOutputPath } : {}),
                 },
                 deliverAs: "followUp" as const,
@@ -763,6 +765,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
 
     pi.on("turn_start", (event) => {
         sessionCompleteFired = false;
+        rctx.wasAborted = false;
         clearFollowUpGrace();
         rctx.forwardEvent(event);
     });
@@ -773,7 +776,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         stopHeartbeat();
         stopSessionNameSync();
         _ctx = null;
-        fireSessionComplete();
+        fireSessionComplete(undefined, undefined, rctx.wasAborted ? "killed" : "completed");
         disconnect();
     });
 

--- a/packages/cli/src/extensions/triggers/registry.test.ts
+++ b/packages/cli/src/extensions/triggers/registry.test.ts
@@ -85,18 +85,49 @@ describe("renderTrigger", () => {
     });
 
     describe("session_complete", () => {
-        it("renders completion summary", () => {
+        it("renders completion summary with exitReason", () => {
             const trigger = makeTrigger({
                 type: "session_complete",
-                payload: { summary: "All tests pass. Feature deployed." },
+                payload: { summary: "All tests pass. Feature deployed.", exitReason: "completed" },
             });
             const result = renderTrigger(trigger);
             expect(result).toContain('Child "my-child" completed:');
+            expect(result).toContain("Exit reason: completed");
             expect(result).toContain("All tests pass. Feature deployed.");
             // session_complete supports ack/followUp responses
             expect(result).toContain("respond_to_trigger");
             expect(result).toContain("ack");
             expect(result).toContain("followUp");
+        });
+
+        it("renders killed session", () => {
+            const trigger = makeTrigger({
+                type: "session_complete",
+                payload: { summary: "Session killed by user", exitReason: "killed" },
+            });
+            const result = renderTrigger(trigger);
+            expect(result).toContain('Child "my-child" was killed:');
+            expect(result).toContain("Exit reason: killed");
+        });
+
+        it("renders errored session", () => {
+            const trigger = makeTrigger({
+                type: "session_complete",
+                payload: { summary: "Crash", exitReason: "error" },
+            });
+            const result = renderTrigger(trigger);
+            expect(result).toContain('Child "my-child" errored:');
+            expect(result).toContain("Exit reason: error");
+        });
+
+        it("defaults exitReason to completed when missing", () => {
+            const trigger = makeTrigger({
+                type: "session_complete",
+                payload: { summary: "Done" },
+            });
+            const result = renderTrigger(trigger);
+            expect(result).toContain('Child "my-child" completed:');
+            expect(result).toContain("Exit reason: completed");
         });
 
         it("includes full output path when provided", () => {

--- a/packages/cli/src/extensions/triggers/registry.ts
+++ b/packages/cli/src/extensions/triggers/registry.ts
@@ -100,9 +100,16 @@ const sessionCompleteRenderer: TriggerRenderer = {
         const fullOutputPath = typeof trigger.payload.fullOutputPath === "string"
             ? trigger.payload.fullOutputPath
             : null;
+        const exitReason = typeof trigger.payload.exitReason === "string"
+            ? trigger.payload.exitReason as "completed" | "killed" | "error"
+            : "completed";
 
+        const verb = exitReason === "killed" ? "was killed"
+            : exitReason === "error" ? "errored"
+            : "completed";
         const lines = [
-            `🔗 Child "${name}" completed:`,
+            `🔗 Child "${name}" ${verb}:`,
+            `Exit reason: ${exitReason}`,
             `---`,
             summary,
         ];

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
@@ -105,6 +105,61 @@ Respond with \`respond_to_trigger\` using trigger ID \`err123\`.`;
       expect(parsed.message).toBe("Command execution failed: file not found");
     });
 
+    test("session_error with 'errored:' in error message is NOT mis-routed to session_complete", () => {
+      // If a session_error message body contains "errored:" or "was killed:", it must
+      // still be parsed as session_error, not session_complete.
+      const body = `⚠️ Child "build-task" encountered an error:
+Build errored: exit code 1
+
+Respond with \`respond_to_trigger\` using trigger ID \`err456\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_error");
+      expect(parsed.childName).toBe("build-task");
+      expect(parsed.message).toContain("Build errored: exit code 1");
+    });
+
+    test("session_error with 'was killed:' in error message is NOT mis-routed to session_complete", () => {
+      const body = `⚠️ Child "deploy-task" encountered an error:
+Process was killed: signal SIGTERM
+
+Respond with \`respond_to_trigger\` using trigger ID \`err789\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_error");
+    });
+
+    test("session_complete with fullOutputPath is parsed and returned", () => {
+      const body = `🔗 Child "long-task" completed:
+Exit reason: completed
+---
+Analysis finished. 42 files processed.
+
+📄 Full output saved to: /tmp/session-abc123/output.txt
+(Use the Read tool to access the complete output if the above is insufficient.)
+
+Respond with \`respond_to_trigger\` using trigger ID \`comp999\`.
+Use respond_to_trigger with action: "ack" to acknowledge completion.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_complete");
+      expect(parsed.message).toBe("Analysis finished. 42 files processed.");
+      expect(parsed.fullOutputPath).toBe("/tmp/session-abc123/output.txt");
+    });
+
+    test("session_complete without fullOutputPath has undefined fullOutputPath", () => {
+      const body = `🔗 Child "short-task" completed:
+Exit reason: completed
+---
+Done.
+
+Respond with \`respond_to_trigger\` using trigger ID \`comp000\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_complete");
+      expect(parsed.fullOutputPath).toBeUndefined();
+    });
+
     test("detects escalate trigger type", () => {
       const body = `🚨 Trigger escalated from child "needs-approval":
 This requires special permission to proceed.

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
@@ -93,6 +93,44 @@ Respond with \`respond_to_trigger\` using trigger ID \`xyz789\`.`;
       expect(parsed.message).toBe("All tests passed successfully.");
     });
 
+    test("handles legacy session_complete format with 'was killed:' title — exitReason is killed", () => {
+      // Legacy format: no "Exit reason:" line, verb in title must be used to infer exitReason.
+      const body = `🔗 Child "test-task" was killed:
+Session terminated by user.
+
+Respond with \`respond_to_trigger\` using trigger ID \`xyz789\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_complete");
+      expect(parsed.childName).toBe("test-task");
+      expect(parsed.exitReason).toBe("killed");
+    });
+
+    test("handles legacy session_complete format with 'errored:' title — exitReason is error", () => {
+      const body = `🔗 Child "test-task" errored:
+Build failed with exit code 1.
+
+Respond with \`respond_to_trigger\` using trigger ID \`xyz789\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_complete");
+      expect(parsed.childName).toBe("test-task");
+      expect(parsed.exitReason).toBe("error");
+    });
+
+    test("legacy session_complete with 'completed' title is not mis-inferred as killed when summary mentions another killed child", () => {
+      // Summary text mentioning another child being killed must not affect the exitReason
+      // of the outer (completed) trigger.
+      const body = `🔗 Child "main" completed:
+Process finished. Child "worker" was killed: by system.
+
+Respond with \`respond_to_trigger\` using trigger ID \`xyz789\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_complete");
+      expect(parsed.exitReason).toBe("completed");
+    });
+
     test("detects session_error trigger type", () => {
       const body = `⚠️ Child "failed-task" encountered an error:
 Command execution failed: file not found
@@ -103,6 +141,24 @@ Respond with \`respond_to_trigger\` using trigger ID \`err123\`.`;
       expect(parsed.type).toBe("session_error");
       expect(parsed.childName).toBe("failed-task");
       expect(parsed.message).toBe("Command execution failed: file not found");
+    });
+
+    test("session_complete whose summary mentions 'encountered an error:' is NOT mis-routed to session_error", () => {
+      // A child can include a phrase like "the previous attempt encountered an error: ..."
+      // in its completion summary. parseTriggerBody must still return session_complete.
+      const body = `🔗 Child "fixer-task" completed:
+Exit reason: completed
+---
+The previous attempt encountered an error: file not found, but it is now fixed.
+
+Respond with \`respond_to_trigger\` using trigger ID \`fix123\`.
+Use respond_to_trigger with action: "ack" to acknowledge completion.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_complete");
+      expect(parsed.childName).toBe("fixer-task");
+      expect(parsed.exitReason).toBe("completed");
+      expect(parsed.message).toContain("encountered an error");
     });
 
     test("session_error with 'errored:' in error message is NOT mis-routed to session_complete", () => {

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
@@ -185,6 +185,28 @@ Respond with \`respond_to_trigger\` using trigger ID \`err789\`.`;
       expect(parsed.type).toBe("session_error");
     });
 
+    test("session_complete summary containing '📄 Generated files:' is NOT truncated at the emoji", () => {
+      // The summary regex must stop only at the specific '📄 Full output saved to:' footer,
+      // not at arbitrary 📄 lines that appear in the child's summary text.
+      const body = `🔗 Child "builder" completed:
+Exit reason: completed
+---
+Build succeeded.
+
+📄 Generated files:
+- dist/index.js
+- dist/index.css
+
+Respond with \`respond_to_trigger\` using trigger ID \`build123\`.
+Use respond_to_trigger with action: "ack" to acknowledge completion.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_complete");
+      expect(parsed.message).toContain("📄 Generated files:");
+      expect(parsed.message).toContain("dist/index.js");
+      expect(parsed.fullOutputPath).toBeUndefined();
+    });
+
     test("session_complete with fullOutputPath is parsed and returned", () => {
       const body = `🔗 Child "long-task" completed:
 Exit reason: completed

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
@@ -38,6 +38,8 @@ Respond with \`respond_to_trigger\` using trigger ID \`abc123\`.`;
 
     test("detects session_complete trigger type", () => {
       const body = `🔗 Child "test-task" completed:
+Exit reason: completed
+---
 All tests passed successfully. 5 files modified.
 
 Respond with \`respond_to_trigger\` using trigger ID \`xyz789\`.
@@ -47,6 +49,48 @@ Use respond_to_trigger with action: "ack" to acknowledge, or action: "followUp" 
       expect(parsed.type).toBe("session_complete");
       expect(parsed.childName).toBe("test-task");
       expect(parsed.message).toBe("All tests passed successfully. 5 files modified.");
+      expect(parsed.exitReason).toBe("completed");
+    });
+
+    test("detects killed session_complete trigger", () => {
+      const body = `🔗 Child "test-task" was killed:
+Exit reason: killed
+---
+Session completed
+
+Respond with \`respond_to_trigger\` using trigger ID \`xyz789\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_complete");
+      expect(parsed.childName).toBe("test-task");
+      expect(parsed.exitReason).toBe("killed");
+    });
+
+    test("detects errored session_complete trigger", () => {
+      const body = `🔗 Child "test-task" errored:
+Exit reason: error
+---
+Something went wrong
+
+Respond with \`respond_to_trigger\` using trigger ID \`xyz789\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_complete");
+      expect(parsed.childName).toBe("test-task");
+      expect(parsed.exitReason).toBe("error");
+    });
+
+    test("handles legacy session_complete format without exitReason", () => {
+      const body = `🔗 Child "test-task" completed:
+All tests passed successfully.
+
+Respond with \`respond_to_trigger\` using trigger ID \`xyz789\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("session_complete");
+      expect(parsed.childName).toBe("test-task");
+      expect(parsed.exitReason).toBe("completed");
+      expect(parsed.message).toBe("All tests passed successfully.");
     });
 
     test("detects session_error trigger type", () => {

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
@@ -222,10 +222,12 @@ function SessionCompleteCard({
   childName,
   message,
   exitReason,
+  fullOutputPath,
 }: {
   childName?: string;
   message?: string;
   exitReason?: "completed" | "killed" | "error";
+  fullOutputPath?: string;
 }) {
   const reason = exitReason ?? "completed";
   const icon = reason === "killed"
@@ -250,6 +252,15 @@ function SessionCompleteCard({
       {message && (
         <ToolCardSection>
           <p className="text-sm text-zinc-200 whitespace-pre-wrap">{message}</p>
+        </ToolCardSection>
+      )}
+
+      {fullOutputPath && (
+        <ToolCardSection>
+          <p className="text-xs text-zinc-400">
+            📄 Full output saved to:{" "}
+            <span className="font-mono text-zinc-300 break-all">{fullOutputPath}</span>
+          </p>
         </ToolCardSection>
       )}
     </ToolCardShell>
@@ -361,6 +372,7 @@ export function TriggerCard({
           childName={parsed.childName}
           message={parsed.message}
           exitReason={parsed.exitReason}
+          fullOutputPath={parsed.fullOutputPath}
         />
       );
     case "session_error":

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
@@ -4,7 +4,7 @@
  */
 
 import * as React from "react";
-import { ChevronDown, ChevronRight, Send, AlertCircle, CheckCircle2, Clock, Zap } from "lucide-react";
+import { ChevronDown, ChevronRight, Send, AlertCircle, CheckCircle2, Clock, Zap, XCircle } from "lucide-react";
 import {
   ToolCardShell,
   ToolCardHeader,
@@ -221,18 +221,28 @@ function PlanReviewCard({
 function SessionCompleteCard({
   childName,
   message,
+  exitReason,
 }: {
   childName?: string;
   message?: string;
+  exitReason?: "completed" | "killed" | "error";
 }) {
+  const reason = exitReason ?? "completed";
+  const icon = reason === "killed"
+    ? <XCircle className="size-3.5 shrink-0 text-amber-400" />
+    : reason === "error"
+    ? <AlertCircle className="size-3.5 shrink-0 text-red-400" />
+    : <CheckCircle2 className="size-3.5 shrink-0 text-emerald-400" />;
+  const verb = reason === "killed" ? "Killed"
+    : reason === "error" ? "Errored"
+    : "Completed";
+
   return (
     <ToolCardShell>
       <ToolCardHeader className="py-2.5">
-        <ToolCardTitle
-          icon={<CheckCircle2 className="size-3.5 shrink-0 text-emerald-400" />}
-        >
+        <ToolCardTitle icon={icon}>
           <span className="text-sm font-medium text-zinc-300">
-            Completed: {childName ? `"${childName}"` : "Child"}
+            {verb}: {childName ? `"${childName}"` : "Child"}
           </span>
         </ToolCardTitle>
       </ToolCardHeader>
@@ -350,6 +360,7 @@ export function TriggerCard({
         <SessionCompleteCard
           childName={parsed.childName}
           message={parsed.message}
+          exitReason={parsed.exitReason}
         />
       );
     case "session_error":

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -12,6 +12,7 @@ export interface ParsedTrigger {
   planSteps?: Array<{ title: string; description?: string }>;
   message?: string;
   reason?: string;
+  exitReason?: "completed" | "killed" | "error";
 }
 
 export function parseTriggerBody(body: string): ParsedTrigger {
@@ -23,7 +24,7 @@ export function parseTriggerBody(body: string): ParsedTrigger {
   if (body.includes("submitted a plan for review")) {
     return parsePlanReview(body);
   }
-  if (body.includes("completed:")) {
+  if (body.includes("completed:") || body.includes("was killed:") || body.includes("errored:")) {
     return parseSessionComplete(body);
   }
   if (body.includes("encountered an error:")) {
@@ -77,12 +78,20 @@ function parsePlanReview(body: string): ParsedTrigger {
 }
 
 function parseSessionComplete(body: string): ParsedTrigger {
-  const childMatch = body.match(/Child "([^"]+)" completed:/);
+  const childMatch = body.match(/Child "([^"]+)" (?:completed|was killed|errored):/);
   const childName = childMatch?.[1];
-  const summaryMatch = body.match(/completed:\n(.+?)(?=\n\n(?:Respond with|Use respond_to_trigger|Acknowledge)|$)/s);
-  const message = summaryMatch?.[1]?.trim();
 
-  return { type: "session_complete", childName, message };
+  // Parse exitReason from "Exit reason: completed|killed|error" line
+  const exitReasonMatch = body.match(/Exit reason: (completed|killed|error)/);
+  const exitReason = (exitReasonMatch?.[1] as "completed" | "killed" | "error") ?? "completed";
+
+  // Summary follows the "---" separator
+  const summaryMatch = body.match(/---\n(.+?)(?=\n\n(?:📄|Respond with|Use respond_to_trigger|Acknowledge)|$)/s);
+  // Fall back to old format (no "Exit reason:" line)
+  const fallbackMatch = !summaryMatch ? body.match(/(?:completed|was killed|errored):\n(.+?)(?=\n\n(?:Respond with|Use respond_to_trigger|Acknowledge)|$)/s) : null;
+  const message = (summaryMatch ?? fallbackMatch)?.[1]?.trim();
+
+  return { type: "session_complete", childName, message, exitReason };
 }
 
 function parseSessionError(body: string): ParsedTrigger {

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -101,8 +101,10 @@ function parseSessionComplete(body: string): ParsedTrigger {
     exitReason = "completed";
   }
 
-  // Summary follows the "---" separator
-  const summaryMatch = body.match(/---\n(.+?)(?=\n\n(?:📄|Respond with|Use respond_to_trigger|Acknowledge)|$)/s);
+  // Summary follows the "---" separator.
+  // Stop only at the *specific* footer "📄 Full output saved to:" — not at any arbitrary
+  // 📄 that might appear in the child's summary text (e.g. "📄 Generated files:").
+  const summaryMatch = body.match(/---\n(.+?)(?=\n\n(?:📄 Full output saved to:|Respond with|Use respond_to_trigger|Acknowledge)|$)/s);
   // Fall back to old format (no "Exit reason:" line)
   const fallbackMatch = !summaryMatch ? body.match(/(?:completed|was killed|errored):\n(.+?)(?=\n\n(?:Respond with|Use respond_to_trigger|Acknowledge)|$)/s) : null;
   const message = (summaryMatch ?? fallbackMatch)?.[1]?.trim();

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -25,14 +25,16 @@ export function parseTriggerBody(body: string): ParsedTrigger {
   if (body.includes("submitted a plan for review")) {
     return parsePlanReview(body);
   }
-  // Check session_error BEFORE session_complete so that error messages containing
-  // "errored:" or "was killed:" in their body text are not mis-routed.
-  if (body.includes("encountered an error:")) {
-    return parseSessionError(body);
-  }
-  // Anchor the match to the opening line to avoid false positives from summary text.
+  // Anchor session_complete to the first line BEFORE checking for "encountered an error:"
+  // because session_complete summaries can contain that phrase in their body text,
+  // which would otherwise cause a false positive match for session_error.
   if (/^🔗 Child "[^"]+" (?:completed|was killed|errored):/.test(body)) {
     return parseSessionComplete(body);
+  }
+  // Anchor session_error to the first line as well, so that summary text embedded
+  // in other trigger types (e.g. session_complete) cannot trigger a false match.
+  if (/^⚠️ Child "[^"]+" encountered an error:/.test(body)) {
+    return parseSessionError(body);
   }
   if (body.includes("Trigger escalated")) {
     return parseEscalateTrigger(body);
@@ -85,9 +87,19 @@ function parseSessionComplete(body: string): ParsedTrigger {
   const childMatch = body.match(/Child "([^"]+)" (?:completed|was killed|errored):/);
   const childName = childMatch?.[1];
 
-  // Parse exitReason from "Exit reason: completed|killed|error" line
+  // Parse exitReason from "Exit reason: completed|killed|error" line (new format).
+  // Fall back to inferring it from the title verb for legacy messages that lack that line.
   const exitReasonMatch = body.match(/Exit reason: (completed|killed|error)/);
-  const exitReason = (exitReasonMatch?.[1] as "completed" | "killed" | "error") ?? "completed";
+  let exitReason: "completed" | "killed" | "error";
+  if (exitReasonMatch?.[1]) {
+    exitReason = exitReasonMatch[1] as "completed" | "killed" | "error";
+  } else if (/^🔗 Child "[^"]+" was killed:/.test(body)) {
+    exitReason = "killed";
+  } else if (/^🔗 Child "[^"]+" errored:/.test(body)) {
+    exitReason = "error";
+  } else {
+    exitReason = "completed";
+  }
 
   // Summary follows the "---" separator
   const summaryMatch = body.match(/---\n(.+?)(?=\n\n(?:📄|Respond with|Use respond_to_trigger|Acknowledge)|$)/s);

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -13,6 +13,7 @@ export interface ParsedTrigger {
   message?: string;
   reason?: string;
   exitReason?: "completed" | "killed" | "error";
+  fullOutputPath?: string;
 }
 
 export function parseTriggerBody(body: string): ParsedTrigger {
@@ -24,11 +25,14 @@ export function parseTriggerBody(body: string): ParsedTrigger {
   if (body.includes("submitted a plan for review")) {
     return parsePlanReview(body);
   }
-  if (body.includes("completed:") || body.includes("was killed:") || body.includes("errored:")) {
-    return parseSessionComplete(body);
-  }
+  // Check session_error BEFORE session_complete so that error messages containing
+  // "errored:" or "was killed:" in their body text are not mis-routed.
   if (body.includes("encountered an error:")) {
     return parseSessionError(body);
+  }
+  // Anchor the match to the opening line to avoid false positives from summary text.
+  if (/^🔗 Child "[^"]+" (?:completed|was killed|errored):/.test(body)) {
+    return parseSessionComplete(body);
   }
   if (body.includes("Trigger escalated")) {
     return parseEscalateTrigger(body);
@@ -91,7 +95,11 @@ function parseSessionComplete(body: string): ParsedTrigger {
   const fallbackMatch = !summaryMatch ? body.match(/(?:completed|was killed|errored):\n(.+?)(?=\n\n(?:Respond with|Use respond_to_trigger|Acknowledge)|$)/s) : null;
   const message = (summaryMatch ?? fallbackMatch)?.[1]?.trim();
 
-  return { type: "session_complete", childName, message, exitReason };
+  // Capture the "📄 Full output saved to: <path>" line if present.
+  const fullOutputPathMatch = body.match(/📄 Full output saved to: (.+)/);
+  const fullOutputPath = fullOutputPathMatch?.[1]?.trim();
+
+  return { type: "session_complete", childName, message, exitReason, fullOutputPath };
 }
 
 function parseSessionError(body: string): ParsedTrigger {


### PR DESCRIPTION
## Problem

When a child session ends, the parent agent receives a `session_complete` trigger but has no way to distinguish whether the session finished naturally or was killed by the user. Parent agents need this info to decide how to respond (e.g., retry a killed task vs. acknowledge a completed one).

## Solution

Add an `exitReason` field to the `session_complete` trigger payload with three possible values:

| Value | Meaning | Exit Code |
|-------|---------|-----------|
| `"completed"` | Session ended naturally (agent finished its work) | 0 |
| `"killed"` | Session was aborted by the user or system | 130 |
| `"error"` | Crash/error exit (future use) | 1 |

### Changes

**CLI — trigger emission:**
- `remote-types.ts`: Added `wasAborted` flag to `RelayContext`
- `remote.ts`: `fireSessionComplete()` accepts and emits `exitReason` in the trigger payload. Resets `wasAborted` on each new turn. Uses `"killed"` when `session_shutdown` fires after an abort.
- `remote-exec-handler.ts`: Sets `wasAborted = true` when the abort command arrives from the UI

**CLI — trigger rendering:**
- `registry.ts`: Renders the exit reason in trigger text — verb changes per reason (`completed` / `was killed` / `errored`) and includes an `Exit reason:` metadata line

**UI — trigger display:**
- `trigger-parsers.ts`: Added `exitReason` to `ParsedTrigger`, parses from rendered text, backward-compatible with legacy format (defaults to `"completed"`)
- `TriggerCard.tsx`: `SessionCompleteCard` shows different icons (✅ green / ⚠️ amber / ❌ red) and verbs based on exit reason

**Tests:**
- Registry tests: added cases for killed, errored, and default (missing) exitReason
- UI parser tests: added cases for killed, errored, and legacy format backward compatibility

### Backward Compatibility

Fully backward compatible — triggers without `exitReason` default to `"completed"`. Existing parent agents that don't inspect the field are unaffected.