### PR TITLE
feat: add Duplicate Session action (same runner & working directory)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2943,6 +2943,13 @@ export function App() {
     setNewSessionOpen(true);
   }, []);
 
+  const handleDuplicateSession = React.useCallback((runnerId: string, cwd: string) => {
+    setSpawnRunnerId(runnerId);
+    setSpawnCwd(cwd);
+    setRecentFolders([]);
+    setNewSessionOpen(true);
+  }, []);
+
   const waitForSessionToGoLive = React.useCallback(async (sessionId: string, timeoutMs: number) => {
     const deadline = Date.now() + timeoutMs;
     while (Date.now() < deadline) {
@@ -3559,6 +3566,7 @@ export function App() {
             onSessionsChange={setLiveSessions}
             onClose={() => setSidebarOpen(false)}
             onEndSession={handleEndSession}
+            onDuplicateSession={handleDuplicateSession}
             runners={runnersForSidebar}
             selectedRunnerId={selectedRunnerId}
             onSelectRunner={setSelectedRunnerId}
@@ -3779,6 +3787,7 @@ export function App() {
                   onTriggerResponse={handleTriggerResponse}
                   onQuestionDismiss={() => setPendingQuestion(null)}
                   onPlanDismiss={() => setPendingPlan(null)}
+                  onDuplicateSession={activeSessionInfo?.runnerId ? () => handleDuplicateSession(activeSessionInfo.runnerId!, activeSessionInfo.cwd || "") : undefined}
                 />
               )}
             </div>

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -14,7 +14,7 @@ import { io } from "socket.io-client";
 import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/protocol";
 import { formatPathTail } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
-import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare } from "lucide-react";
+import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare, Copy } from "lucide-react";
 import { buildSessionTree, flattenSessionTree, getSessionIndent, getDescendantSessionIds } from "@/lib/session-tree";
 
 interface HubSession {
@@ -83,6 +83,8 @@ export interface SessionSidebarProps {
     onClose?: () => void;
     /** Called when the user confirms ending a session via the swipe gesture */
     onEndSession?: (sessionId: string) => void;
+    /** Called when the user wants to duplicate a session (same runner + working directory) */
+    onDuplicateSession?: (runnerId: string, cwd: string) => void;
     /** Called when the user wants to return from Runners view to Sessions */
     onShowSessions?: () => void;
     /** List of runners to display when showRunners is true */
@@ -177,6 +179,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     onSessionsChange,
     onClose,
     onEndSession,
+    onDuplicateSession,
     runners,
     selectedRunnerId,
     onSelectRunner,
@@ -209,7 +212,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     const [confirmEndSessionId, setConfirmEndSessionId] = React.useState<string | null>(null);
     const [revealedSessionId, setRevealedSessionId] = React.useState<string | null>(null);
     const [swipeOffsets, setSwipeOffsets] = React.useState<Map<string, number>>(new Map());
-    const REVEAL_WIDTH = 132; // px width of the revealed "Pin" + "End" buttons
+    const REVEAL_WIDTH = 198; // px width of the revealed "Duplicate" + "Pin" + "End" buttons
 
     const swipeRef = React.useRef<{
         sessionId: string;
@@ -1078,14 +1081,38 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                     key={s.sessionId}
                                                     className="relative overflow-hidden rounded-lg"
                                                 >
-                                                    {/* "Pin" + "End" actions behind the card — only rendered during swipe/reveal (not in select mode) */}
+                                                    {/* "Duplicate" + "Pin" + "End" actions behind the card — only rendered during swipe/reveal (not in select mode) */}
                                                     {!selectMode && (hasOffset || isRevealed) && <div
                                                         className="absolute inset-y-0 right-0 flex items-stretch rounded-r-lg overflow-hidden"
                                                         style={{ width: REVEAL_WIDTH }}
                                                     >
                                                         <button
                                                             className={cn(
-                                                                "flex flex-col items-center justify-center w-1/2 text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors",
+                                                                "flex flex-col items-center justify-center w-1/3 text-xs font-semibold gap-0.5 bg-violet-500 text-white transition-colors",
+                                                                !s.runnerId ? "opacity-60 cursor-not-allowed" : "active:bg-violet-600",
+                                                            )}
+                                                            onClick={(e) => {
+                                                                e.stopPropagation();
+                                                                if (!s.runnerId) return;
+                                                                onDuplicateSession?.(s.runnerId, s.cwd || "");
+                                                                // Close the revealed state
+                                                                setSwipeOffsets((prev) => {
+                                                                    const next = new Map(prev);
+                                                                    next.delete(s.sessionId);
+                                                                    return next;
+                                                                });
+                                                                setRevealedSessionId(null);
+                                                            }}
+                                                            disabled={!s.runnerId}
+                                                            aria-label="Duplicate session"
+                                                            title={s.runnerId ? "New session with same runner & directory" : "No runner info available"}
+                                                        >
+                                                            <Copy className="h-4 w-4" />
+                                                            <span>Duplicate</span>
+                                                        </button>
+                                                        <button
+                                                            className={cn(
+                                                                "flex flex-col items-center justify-center w-1/3 text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors",
                                                                 isPinPending ? "opacity-60 cursor-not-allowed" : "active:bg-blue-600",
                                                             )}
                                                             onClick={(e) => {
@@ -1107,7 +1134,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
-                                                            className="flex flex-col items-center justify-center w-1/2 pt-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors"
+                                                            className="flex flex-col items-center justify-center w-1/3 pt-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -66,7 +66,7 @@ import { MultipleChoiceQuestions } from "@/components/ai-elements/multiple-choic
 import { PlanModePanel, type PlanModeAnswer } from "@/components/ai-elements/plan-mode";
 import { formatAnswersForAgent, type QuestionDisplayMode } from "@/lib/ask-user-questions";
 import { dismissNotificationsForSession } from "@/lib/push";
-import { AlertTriangleIcon, ArrowDownIcon, BookOpen, Bot, CheckCircle2, ChevronsUpDown, Circle, CircleDashed, Loader2, MessageSquare, OctagonX, PaperclipIcon, Plus, Puzzle, ShieldAlert, Zap, Clock, X, Trash2, TerminalIcon, DownloadIcon, XCircle, FolderTree } from "lucide-react";
+import { AlertTriangleIcon, ArrowDownIcon, BookOpen, Bot, CheckCircle2, ChevronsUpDown, Circle, CircleDashed, Copy, Loader2, MessageSquare, OctagonX, PaperclipIcon, Plus, Puzzle, ShieldAlert, Zap, Clock, X, Trash2, TerminalIcon, DownloadIcon, XCircle, FolderTree } from "lucide-react";
 import { AtMentionPopover } from "@/components/AtMentionPopover";
 import type { Entry as AtMentionEntry } from "@/hooks/useAtMentionFiles";
 import { McpToggleContext, type McpToggleHandler } from "@/components/session-viewer/McpToggleContext";
@@ -172,6 +172,8 @@ export interface SessionViewerProps {
   onQuestionDismiss?: () => void;
   /** Optimistically dismiss the pending plan panel after a successful response */
   onPlanDismiss?: () => void;
+  /** Open the new-session dialog pre-filled with the same runner & working directory */
+  onDuplicateSession?: () => void;
 }
 
 function formatTokenCount(n: number): string {
@@ -510,7 +512,7 @@ function SessionSkeleton() {
   );
 }
 
-export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse, onQuestionDismiss, onPlanDismiss }: SessionViewerProps) {
+export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse, onQuestionDismiss, onPlanDismiss, onDuplicateSession }: SessionViewerProps) {
   const [input, setInput] = React.useState("");
   // Per-session draft storage so switching sessions preserves unsent text
   const draftsRef = React.useRef<Map<string, string>>(new Map());
@@ -1612,6 +1614,20 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               <DownloadIcon className="size-3.5" />
               <span className="hidden sm:inline ml-1">Save</span>
             </ConversationDownload>
+            {onDuplicateSession && (
+              <Button
+                className="h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem]"
+                onClick={onDuplicateSession}
+                size="icon"
+                type="button"
+                variant="outline"
+                title="Duplicate session (same runner & directory)"
+                aria-label="Duplicate session"
+              >
+                <Copy className="size-3.5" />
+                <span className="hidden sm:inline ml-1">Duplicate</span>
+              </Button>
+            )}
             <Button
               className="h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem]"
               disabled={!onExec}


### PR DESCRIPTION
## Summary

Adds a "Duplicate" action that opens a new session pre-configured with the same runner and working directory as an existing session. No conversation history is copied — the new session starts fresh.

## Motivation

Users frequently want to start a new session on the same runner and in the same project directory as an existing one. Previously this required manually selecting the runner and typing the path each time. This feature eliminates that friction.

## Changes

### Session sidebar (swipe-to-reveal)
- Added a **Duplicate** button (violet, Copy icon) to the swipe-reveal actions alongside Pin and End
- Widened the reveal area from 132px → 198px to accommodate the third button
- Disabled when the session has no runner info

### Session viewer toolbar
- Added a **Duplicate** button in the toolbar (next to End/Clear) for quick access from the active session view
- Conditionally rendered only when the session has a known runner

### App wiring
- `handleDuplicateSession(runnerId, cwd)` pre-fills the existing "New session" dialog with the source session's runner and working directory
- The user can review/adjust values before spawning

## Testing

- `bun run typecheck` — passes
- `bun run test` — all 216 tests pass
- No new runtime logic requiring unit tests (UI wiring only — pre-fills existing dialog state)