### PR TITLE
🛡️ Sentinel: [Medium] Fix command injection risk in isPidRunning

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1,4 +1,4 @@
-import { spawn, exec, execFile, execSync, type ChildProcess } from "node:child_process";
+import { spawn, exec, execFile, execFileSync, type ChildProcess } from "node:child_process";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
@@ -1506,12 +1506,13 @@ export function isPidRunning(pid: number): boolean {
         if (process.platform === "win32") {
             // On Windows, use WMIC to inspect the process command line.
             // wmic is available on Windows 7+ and returns the full command line.
-            cmd = execSync(
-                `wmic process where "ProcessId=${pid}" get CommandLine /format:list`,
+            cmd = execFileSync(
+                "wmic",
+                ["process", "where", `ProcessId=${pid}`, "get", "CommandLine", "/format:list"],
                 { encoding: "utf-8", timeout: 5000 },
             ).trim();
         } else {
-            cmd = execSync(`ps -p ${pid} -o command=`, { encoding: "utf-8", timeout: 3000 }).trim();
+            cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8", timeout: 3000 }).trim();
         }
         // Match against known runner process patterns:
         //   - "bun ... runner"          (dev: bun packages/cli/src/index.ts runner)


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `isPidRunning` function used `execSync` to run `wmic` (Windows) or `ps` (Unix) with the `pid` interpolated directly into the command string. If `pid` were ever passed as a malicious string, this could allow arbitrary command execution via the shell.
🎯 Impact: While `pid` is currently typed as a number and validated with `Number.isFinite`, dynamic typing in JS could potentially allow a string payload to slip through in future refactors, leading to Remote Code Execution (RCE) via command injection on the runner daemon.
🔧 Fix: Replaced `execSync` with `execFileSync` from `node:child_process` and passed the command arguments as an array instead of a single concatenated string. This bypasses the shell entirely, preventing any command injection.
✅ Verification: Tested locally with `bun test packages/cli`. Pre-existing tests pass and functionality is identical.

---
*PR created automatically by Jules for task [1736905417912093400](https://jules.google.com/task/1736905417912093400) started by @Pizzaface*