### PR TITLE
feat: show provider usage/quota in list_models tool output

### DIFF
--- a/packages/cli/src/extensions/format-usage.test.ts
+++ b/packages/cli/src/extensions/format-usage.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "bun:test";
+import { formatProviderUsage, getUsageKey } from "./format-usage.js";
+import type { ProviderUsageData } from "./remote-types.js";
+
+describe("formatProviderUsage", () => {
+    test("returns empty array when data is undefined", () => {
+        expect(formatProviderUsage(undefined)).toEqual([]);
+    });
+
+    test("returns unknown message when status is unknown", () => {
+        const data: ProviderUsageData = { windows: [], status: "unknown", errorCode: 403 };
+        expect(formatProviderUsage(data)).toEqual(["  Usage: unknown (access denied)"]);
+    });
+
+    test("returns empty array when no windows", () => {
+        const data: ProviderUsageData = { windows: [], status: "ok" };
+        expect(formatProviderUsage(data)).toEqual([]);
+    });
+
+    test("formats single window", () => {
+        const data: ProviderUsageData = {
+            windows: [{ label: "7-day", utilization: 62.3, resets_at: "2026-03-14T00:00:00Z" }],
+            status: "ok",
+        };
+        expect(formatProviderUsage(data)).toEqual(["  Usage: 7-day: 62%"]);
+    });
+
+    test("formats multiple windows", () => {
+        const data: ProviderUsageData = {
+            windows: [
+                { label: "5-hour", utilization: 25, resets_at: "2026-03-10T00:00:00Z" },
+                { label: "7-day", utilization: 62, resets_at: "2026-03-14T00:00:00Z" },
+            ],
+            status: "ok",
+        };
+        expect(formatProviderUsage(data)).toEqual(["  Usage: 5-hour: 25%, 7-day: 62%"]);
+    });
+
+    test("rounds utilization to nearest integer", () => {
+        const data: ProviderUsageData = {
+            windows: [{ label: "7-day", utilization: 33.7, resets_at: "2026-03-14T00:00:00Z" }],
+            status: "ok",
+        };
+        expect(formatProviderUsage(data)).toEqual(["  Usage: 7-day: 34%"]);
+    });
+});
+
+describe("getUsageKey", () => {
+    test("maps anthropic", () => expect(getUsageKey("anthropic")).toBe("anthropic"));
+    test("maps openai-codex", () => expect(getUsageKey("openai-codex")).toBe("openai-codex"));
+    test("maps openai to openai-codex", () => expect(getUsageKey("openai")).toBe("openai-codex"));
+    test("maps google-gemini-cli", () => expect(getUsageKey("google-gemini-cli")).toBe("google-gemini-cli"));
+    test("maps google to google-gemini-cli", () => expect(getUsageKey("google")).toBe("google-gemini-cli"));
+    test("returns undefined for unknown provider", () => expect(getUsageKey("azure")).toBeUndefined());
+});

--- a/packages/cli/src/extensions/format-usage.test.ts
+++ b/packages/cli/src/extensions/format-usage.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { formatProviderUsage, getUsageKey } from "./format-usage.js";
+import { formatProviderUsage, getUsageKey, buildUsageKeyToProviderMap, normalizeUsageKeys } from "./format-usage.js";
 import type { ProviderUsageData } from "./remote-types.js";
 
 describe("formatProviderUsage", () => {
@@ -52,4 +52,61 @@ describe("getUsageKey", () => {
     test("maps google-gemini-cli", () => expect(getUsageKey("google-gemini-cli")).toBe("google-gemini-cli"));
     test("maps google to google-gemini-cli", () => expect(getUsageKey("google")).toBe("google-gemini-cli"));
     test("returns undefined for unknown provider", () => expect(getUsageKey("azure")).toBeUndefined());
+});
+
+describe("buildUsageKeyToProviderMap", () => {
+    test("maps display providers to usage keys", () => {
+        const result = buildUsageKeyToProviderMap(["google", "openai", "anthropic"]);
+        expect(result).toEqual({
+            "google-gemini-cli": "google",
+            "openai-codex": "openai",
+            anthropic: "anthropic",
+        });
+    });
+
+    test("handles providers that are already usage keys", () => {
+        const result = buildUsageKeyToProviderMap(["openai-codex", "google-gemini-cli"]);
+        expect(result).toEqual({
+            "openai-codex": "openai-codex",
+            "google-gemini-cli": "google-gemini-cli",
+        });
+    });
+
+    test("ignores unknown providers", () => {
+        const result = buildUsageKeyToProviderMap(["azure", "anthropic"]);
+        expect(result).toEqual({ anthropic: "anthropic" });
+    });
+
+    test("first display name wins when multiple map to same usage key", () => {
+        // "openai" and "openai-codex" both map to "openai-codex" usage key
+        const result = buildUsageKeyToProviderMap(["openai", "openai-codex"]);
+        expect(result["openai-codex"]).toBe("openai");
+    });
+});
+
+describe("normalizeUsageKeys", () => {
+    const sampleData: ProviderUsageData = {
+        windows: [{ label: "7-day", utilization: 50, resets_at: "2026-03-14T00:00:00Z" }],
+        status: "ok",
+    };
+
+    test("re-keys usage data to match display provider names", () => {
+        const raw = { "google-gemini-cli": sampleData, "openai-codex": sampleData };
+        const result = normalizeUsageKeys(raw, ["google", "openai", "anthropic"]);
+        expect(Object.keys(result).sort()).toEqual(["google", "openai"]);
+        expect(result["google"]).toBe(sampleData);
+        expect(result["openai"]).toBe(sampleData);
+    });
+
+    test("keeps key unchanged if no display provider maps to it", () => {
+        const raw = { "some-custom-provider": sampleData };
+        const result = normalizeUsageKeys(raw, ["google"]);
+        expect(result["some-custom-provider"]).toBe(sampleData);
+    });
+
+    test("passes through anthropic unchanged", () => {
+        const raw = { anthropic: sampleData };
+        const result = normalizeUsageKeys(raw, ["anthropic"]);
+        expect(result["anthropic"]).toBe(sampleData);
+    });
 });

--- a/packages/cli/src/extensions/format-usage.ts
+++ b/packages/cli/src/extensions/format-usage.ts
@@ -1,0 +1,35 @@
+import type { ProviderUsageData } from "./remote-types.js";
+
+/**
+ * Format a single provider's usage data into human-readable lines.
+ * Returns empty array if no usage data available.
+ */
+export function formatProviderUsage(data: ProviderUsageData | undefined): string[] {
+    if (!data) return [];
+    if (data.status === "unknown") return ["  Usage: unknown (access denied)"];
+    if (data.windows.length === 0) return [];
+
+    const parts = data.windows.map((w) => {
+        const pct = Math.round(w.utilization);
+        return `${w.label}: ${pct}%`;
+    });
+
+    return [`  Usage: ${parts.join(", ")}`];
+}
+
+/**
+ * Map provider IDs from the model registry to provider IDs used by the usage system.
+ * The usage system uses keys like "anthropic", "openai-codex", "google-gemini-cli"
+ * while the model registry uses provider symbols/strings that may differ.
+ */
+const PROVIDER_USAGE_KEY_MAP: Record<string, string> = {
+    anthropic: "anthropic",
+    "openai-codex": "openai-codex",
+    openai: "openai-codex",
+    "google-gemini-cli": "google-gemini-cli",
+    google: "google-gemini-cli",
+};
+
+export function getUsageKey(providerKey: string): string | undefined {
+    return PROVIDER_USAGE_KEY_MAP[providerKey];
+}

--- a/packages/cli/src/extensions/format-usage.ts
+++ b/packages/cli/src/extensions/format-usage.ts
@@ -33,3 +33,39 @@ const PROVIDER_USAGE_KEY_MAP: Record<string, string> = {
 export function getUsageKey(providerKey: string): string | undefined {
     return PROVIDER_USAGE_KEY_MAP[providerKey];
 }
+
+/**
+ * Build a reverse map from usage keys back to display provider names.
+ * Given a set of provider names seen in the model registry, returns a map
+ * from internal usage key → display provider key.
+ *
+ * Example: given providers {"google", "openai", "anthropic"}, returns
+ * { "google-gemini-cli": "google", "openai-codex": "openai", "anthropic": "anthropic" }
+ */
+export function buildUsageKeyToProviderMap(providerNames: Iterable<string>): Record<string, string> {
+    const reverse: Record<string, string> = {};
+    for (const name of providerNames) {
+        const usageKey = PROVIDER_USAGE_KEY_MAP[name];
+        if (usageKey && !reverse[usageKey]) {
+            reverse[usageKey] = name;
+        }
+    }
+    return reverse;
+}
+
+/**
+ * Re-key a providerUsage record so that keys match the provider names
+ * seen in the model registry (e.g. "google" instead of "google-gemini-cli").
+ */
+export function normalizeUsageKeys(
+    raw: Record<string, import("./remote-types.js").ProviderUsageData>,
+    providerNames: Iterable<string>,
+): Record<string, import("./remote-types.js").ProviderUsageData> {
+    const keyMap = buildUsageKeyToProviderMap(providerNames);
+    const out: Record<string, import("./remote-types.js").ProviderUsageData> = {};
+    for (const [usageKey, data] of Object.entries(raw)) {
+        const displayKey = keyMap[usageKey] ?? usageKey;
+        out[displayKey] = data;
+    }
+    return out;
+}

--- a/packages/cli/src/extensions/spawn-session.ts
+++ b/packages/cli/src/extensions/spawn-session.ts
@@ -4,6 +4,8 @@ import { join } from "node:path";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import { loadConfig } from "../config.js";
 import { getRelaySessionId } from "./remote.js";
+import { buildProviderUsage } from "./remote-provider-usage.js";
+import { formatProviderUsage, getUsageKey } from "./format-usage.js";
 
 /** Minimal Component that renders nothing — keeps the tool call invisible in the TUI. */
 const silent = { render: (_width: number): string[] => [], invalidate: () => {} };
@@ -280,6 +282,9 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
                 byProvider.set(providerKey, list);
             }
 
+            // Grab cached provider usage data (non-blocking — uses whatever is cached)
+            const providerUsage = buildProviderUsage();
+
             const lines: string[] = [
                 `${models.length} model(s) — ${availableModels.length} with credentials\n`,
             ];
@@ -295,6 +300,10 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
                     ].filter(Boolean).join(", ");
                     lines.push(`  ${m.id}  (${m.name})  [${flags}]`);
                 }
+                // Append usage/quota info for this provider if available
+                const usageKey = getUsageKey(provider);
+                const usageData = usageKey ? providerUsage[usageKey] : undefined;
+                for (const line of formatProviderUsage(usageData)) lines.push(line);
                 lines.push("");
             }
 
@@ -310,7 +319,7 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
 
             return {
                 content: [{ type: "text" as const, text: lines.join("\n").trimEnd() }],
-                details: { models: details } as any,
+                details: { models: details, providerUsage } as any,
             };
         },
 

--- a/packages/cli/src/extensions/spawn-session.ts
+++ b/packages/cli/src/extensions/spawn-session.ts
@@ -4,8 +4,8 @@ import { join } from "node:path";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import { loadConfig } from "../config.js";
 import { getRelaySessionId } from "./remote.js";
-import { buildProviderUsage } from "./remote-provider-usage.js";
-import { formatProviderUsage, getUsageKey } from "./format-usage.js";
+import { buildProviderUsage, refreshAllUsage } from "./remote-provider-usage.js";
+import { formatProviderUsage, getUsageKey, normalizeUsageKeys } from "./format-usage.js";
 
 /** Minimal Component that renders nothing — keeps the tool call invisible in the TUI. */
 const silent = { render: (_width: number): string[] => [], invalidate: () => {} };
@@ -282,7 +282,8 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
                 byProvider.set(providerKey, list);
             }
 
-            // Grab cached provider usage data (non-blocking — uses whatever is cached)
+            // Ensure usage cache is populated (reads runner cache file or fetches live)
+            await refreshAllUsage();
             const providerUsage = buildProviderUsage();
 
             const lines: string[] = [
@@ -317,9 +318,12 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
                 maxTokens: m.maxTokens,
             }));
 
+            // Re-key providerUsage so keys match models[*].provider names
+            const normalizedUsage = normalizeUsageKeys(providerUsage, byProvider.keys());
+
             return {
                 content: [{ type: "text" as const, text: lines.join("\n").trimEnd() }],
-                details: { models: details, providerUsage } as any,
+                details: { models: details, providerUsage: normalizedUsage } as any,
             };
         },
 


### PR DESCRIPTION
## Summary

Wires the existing provider usage cache (Anthropic, Codex, Google) into the `list_models` tool so agents can see at a glance which providers are practically available vs. quota-exhausted.

## Changes

- **`format-usage.ts`** — New helper with `formatProviderUsage()` and `getUsageKey()`
- **`format-usage.test.ts`** — 12 unit tests
- **`spawn-session.ts`** — Calls `buildProviderUsage()` in `list_models`, appends per-provider usage lines to text output and `providerUsage` to structured details

## Example output

```
Provider: anthropic
  claude-sonnet-4-20250514  (Claude Sonnet 4)  [✓ credentials, reasoning, ctx:200k]
  Usage: 5-hour: 25%, 7-day: 62%
```

Closes Godmother idea `oDVN7KsY`.