### PR TITLE
fix: preserve runner-session association in SQLite across runner restarts

### DIFF
--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -88,6 +88,8 @@ export interface RelaySessionTable {
     isEphemeral: number;
     expiresAt: string | null;
     isPinned: number;
+    runnerId: string | null;
+    runnerName: string | null;
 }
 
 export interface RelaySessionStateTable {

--- a/packages/server/src/sessions/runner-assoc-persist.test.ts
+++ b/packages/server/src/sessions/runner-assoc-persist.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Regression tests: runner association persists in SQLite across runner restarts.
+ *
+ * When a runner daemon restarts, TUI sockets disconnect and Redis session data
+ * is deleted. These tests verify that runnerId/runnerName survive in SQLite so
+ * historical and pinned sessions retain their runner provenance.
+ */
+import { describe, it, expect, beforeAll, afterEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { initAuth, getKysely } from "../auth.js";
+import {
+    ensureRelaySessionTables,
+    recordRelaySessionStart,
+    updateRelaySessionRunner,
+    listPersistedRelaySessionsForUser,
+    listPinnedRelaySessionsForUser,
+    pinRelaySession,
+} from "./store.js";
+
+const TEST_USER = "test-user-runner-assoc";
+const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-runner-assoc-test-"));
+const dbPath = join(tmpDir, "runner-assoc-test.db");
+
+beforeAll(async () => {
+    initAuth({ dbPath, baseURL: "http://localhost:7777", secret: "test-secret-ra" });
+    await ensureRelaySessionTables();
+});
+
+afterEach(async () => {
+    await getKysely().deleteFrom("relay_session_state").execute();
+    await getKysely().deleteFrom("relay_session").execute();
+});
+
+afterAll(() => {
+    try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+});
+
+describe("runner association persistence", () => {
+    it("recordRelaySessionStart stores runnerId and runnerName", async () => {
+        await recordRelaySessionStart({
+            sessionId: "s-ra-1",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-1",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+            runnerId: "runner-abc",
+            runnerName: "My Runner",
+        });
+
+        const row = await getKysely()
+            .selectFrom("relay_session")
+            .select(["runnerId", "runnerName"])
+            .where("id", "=", "s-ra-1")
+            .executeTakeFirst();
+
+        expect(row?.runnerId).toBe("runner-abc");
+        expect(row?.runnerName).toBe("My Runner");
+    });
+
+    it("recordRelaySessionStart stores null when no runner info provided", async () => {
+        await recordRelaySessionStart({
+            sessionId: "s-ra-2",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-2",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        const row = await getKysely()
+            .selectFrom("relay_session")
+            .select(["runnerId", "runnerName"])
+            .where("id", "=", "s-ra-2")
+            .executeTakeFirst();
+
+        expect(row?.runnerId).toBeNull();
+        expect(row?.runnerName).toBeNull();
+    });
+
+    it("updateRelaySessionRunner updates runner info after creation", async () => {
+        // Session created without runner (e.g. runner link pending)
+        await recordRelaySessionStart({
+            sessionId: "s-ra-3",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-3",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        // linkSessionToRunner fires later, updating SQLite
+        await updateRelaySessionRunner("s-ra-3", "runner-xyz", "Late Runner");
+
+        const row = await getKysely()
+            .selectFrom("relay_session")
+            .select(["runnerId", "runnerName"])
+            .where("id", "=", "s-ra-3")
+            .executeTakeFirst();
+
+        expect(row?.runnerId).toBe("runner-xyz");
+        expect(row?.runnerName).toBe("Late Runner");
+    });
+
+    it("listPersistedRelaySessionsForUser includes runner info", async () => {
+        await recordRelaySessionStart({
+            sessionId: "s-ra-4",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-4",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+            runnerId: "runner-list",
+            runnerName: "List Runner",
+        });
+
+        const sessions = await listPersistedRelaySessionsForUser(TEST_USER);
+        const found = sessions.find((s) => s.sessionId === "s-ra-4");
+
+        expect(found).toBeDefined();
+        expect(found!.runnerId).toBe("runner-list");
+        expect(found!.runnerName).toBe("List Runner");
+    });
+
+    it("listPinnedRelaySessionsForUser includes runner info", async () => {
+        await recordRelaySessionStart({
+            sessionId: "s-ra-5",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-5",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+            runnerId: "runner-pin",
+            runnerName: "Pinned Runner",
+        });
+
+        await pinRelaySession("s-ra-5", TEST_USER);
+
+        const sessions = await listPinnedRelaySessionsForUser(TEST_USER);
+        const found = sessions.find((s) => s.sessionId === "s-ra-5");
+
+        expect(found).toBeDefined();
+        expect(found!.runnerId).toBe("runner-pin");
+        expect(found!.runnerName).toBe("Pinned Runner");
+    });
+
+    it("runner info survives after session ends (regression: runner restart)", async () => {
+        // Simulate: session created with runner, then session ends (TUI disconnect).
+        // The Redis hash is deleted, but SQLite should retain runner provenance.
+        await recordRelaySessionStart({
+            sessionId: "s-ra-6",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-6",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+            runnerId: "runner-restart",
+            runnerName: "Restarting Runner",
+        });
+
+        await pinRelaySession("s-ra-6", TEST_USER);
+
+        // Simulate endSharedSession setting endedAt (Redis hash is deleted,
+        // but SQLite row persists with runner info intact)
+        await getKysely()
+            .updateTable("relay_session")
+            .set({ endedAt: new Date().toISOString() })
+            .where("id", "=", "s-ra-6")
+            .execute();
+
+        // Verify runner info is still there in pinned sessions
+        const pinned = await listPinnedRelaySessionsForUser(TEST_USER);
+        const found = pinned.find((s) => s.sessionId === "s-ra-6");
+
+        expect(found).toBeDefined();
+        expect(found!.runnerId).toBe("runner-restart");
+        expect(found!.runnerName).toBe("Restarting Runner");
+        expect(found!.endedAt).not.toBeNull();
+    });
+
+    it("updateRelaySessionRunner is a no-op for nonexistent session", async () => {
+        // Should not throw
+        await updateRelaySessionRunner("nonexistent-session", "runner-x", "Runner X");
+
+        const row = await getKysely()
+            .selectFrom("relay_session")
+            .select("id")
+            .where("id", "=", "nonexistent-session")
+            .executeTakeFirst();
+
+        expect(row).toBeUndefined();
+    });
+});

--- a/packages/server/src/sessions/runner-assoc-persist.test.ts
+++ b/packages/server/src/sessions/runner-assoc-persist.test.ts
@@ -17,6 +17,7 @@ import {
     listPersistedRelaySessionsForUser,
     listPinnedRelaySessionsForUser,
     pinRelaySession,
+    getRelaySessionUserId,
 } from "./store.js";
 
 const TEST_USER = "test-user-runner-assoc";
@@ -188,7 +189,13 @@ describe("runner association persistence", () => {
     it("updateRelaySessionRunner retries and succeeds when row appears after delay (P1 race)", async () => {
         // Simulate the race: linkSessionToRunner fires before recordRelaySessionStart
         // has finished its SQLite insert. The retry logic should catch it.
-        const delayedInsert = setTimeout(async () => {
+        //
+        // Use a short 50 ms delay (well within the first 250 ms retry window) so
+        // the test doesn't depend on wall-clock scheduling that varies on loaded CI
+        // runners. The original 300 ms could race past all three retry attempts on
+        // a slow machine where JS timers are coalesced or delayed.
+        const insertPromise = (async () => {
+            await new Promise<void>((r) => setTimeout(r, 50));
             await recordRelaySessionStart({
                 sessionId: "s-ra-race",
                 userId: TEST_USER,
@@ -199,10 +206,10 @@ describe("runner association persistence", () => {
                 // Note: no runner info — simulating a session that connected
                 // before the runner reported session_ready
             });
-        }, 300);
+        })();
 
         const result = await updateRelaySessionRunner("s-ra-race", "runner-late", "Late Linker");
-        clearTimeout(delayedInsert);
+        await insertPromise; // ensure insert completed (also cleans up any pending promises)
 
         expect(result).toBe(true);
 
@@ -253,5 +260,60 @@ describe("runner association persistence", () => {
             .executeTakeFirst();
         expect(after?.runnerId).toBe("runner-reconn");
         expect(after?.runnerName).toBe("Reconnected Runner");
+    });
+
+    it("recordRelaySessionStart does NOT null out runner info on reconnect without runner data", async () => {
+        // First insert — session created with runner info
+        await recordRelaySessionStart({
+            sessionId: "s-ra-null-guard",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-null-guard",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+            runnerId: "runner-original",
+            runnerName: "Original Runner",
+        });
+
+        // Second insert — reconnect without any runner association (Redis key expired,
+        // session predates the association feature, etc.)
+        // The existing runner info must NOT be overwritten with null.
+        await recordRelaySessionStart({
+            sessionId: "s-ra-null-guard",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-null-guard",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+            // runnerId / runnerName intentionally omitted (undefined → null)
+        });
+
+        const row = await getKysely()
+            .selectFrom("relay_session")
+            .select(["runnerId", "runnerName"])
+            .where("id", "=", "s-ra-null-guard")
+            .executeTakeFirst();
+
+        expect(row?.runnerId).toBe("runner-original");
+        expect(row?.runnerName).toBe("Original Runner");
+    });
+
+    it("getRelaySessionUserId returns userId for existing session", async () => {
+        await recordRelaySessionStart({
+            sessionId: "s-ra-uid",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-uid",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        const uid = await getRelaySessionUserId("s-ra-uid");
+        expect(uid).toBe(TEST_USER);
+    });
+
+    it("getRelaySessionUserId returns null for nonexistent session", async () => {
+        const uid = await getRelaySessionUserId("nonexistent-uid-session");
+        expect(uid).toBeNull();
     });
 });

--- a/packages/server/src/sessions/runner-assoc-persist.test.ts
+++ b/packages/server/src/sessions/runner-assoc-persist.test.ts
@@ -180,16 +180,78 @@ describe("runner association persistence", () => {
         expect(found!.endedAt).not.toBeNull();
     });
 
-    it("updateRelaySessionRunner is a no-op for nonexistent session", async () => {
-        // Should not throw
-        await updateRelaySessionRunner("nonexistent-session", "runner-x", "Runner X");
+    it("updateRelaySessionRunner returns false for nonexistent session", async () => {
+        const result = await updateRelaySessionRunner("nonexistent-session", "runner-x", "Runner X");
+        expect(result).toBe(false);
+    });
+
+    it("updateRelaySessionRunner retries and succeeds when row appears after delay (P1 race)", async () => {
+        // Simulate the race: linkSessionToRunner fires before recordRelaySessionStart
+        // has finished its SQLite insert. The retry logic should catch it.
+        const delayedInsert = setTimeout(async () => {
+            await recordRelaySessionStart({
+                sessionId: "s-ra-race",
+                userId: TEST_USER,
+                cwd: "/project",
+                shareUrl: "http://test/s-ra-race",
+                startedAt: new Date().toISOString(),
+                isEphemeral: false,
+                // Note: no runner info — simulating a session that connected
+                // before the runner reported session_ready
+            });
+        }, 300);
+
+        const result = await updateRelaySessionRunner("s-ra-race", "runner-late", "Late Linker");
+        clearTimeout(delayedInsert);
+
+        expect(result).toBe(true);
 
         const row = await getKysely()
             .selectFrom("relay_session")
-            .select("id")
-            .where("id", "=", "nonexistent-session")
+            .select(["runnerId", "runnerName"])
+            .where("id", "=", "s-ra-race")
             .executeTakeFirst();
 
-        expect(row).toBeUndefined();
+        expect(row?.runnerId).toBe("runner-late");
+        expect(row?.runnerName).toBe("Late Linker");
+    });
+
+    it("recordRelaySessionStart updates runner info on reconnect (P2 onConflict)", async () => {
+        // First insert — session created without runner info (pre-migration or no runner)
+        await recordRelaySessionStart({
+            sessionId: "s-ra-reconn",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-reconn",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        const before = await getKysely()
+            .selectFrom("relay_session")
+            .select(["runnerId", "runnerName"])
+            .where("id", "=", "s-ra-reconn")
+            .executeTakeFirst();
+        expect(before?.runnerId).toBeNull();
+
+        // Second insert — session reconnects with durable runner association
+        await recordRelaySessionStart({
+            sessionId: "s-ra-reconn",
+            userId: TEST_USER,
+            cwd: "/project",
+            shareUrl: "http://test/s-ra-reconn",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+            runnerId: "runner-reconn",
+            runnerName: "Reconnected Runner",
+        });
+
+        const after = await getKysely()
+            .selectFrom("relay_session")
+            .select(["runnerId", "runnerName"])
+            .where("id", "=", "s-ra-reconn")
+            .executeTakeFirst();
+        expect(after?.runnerId).toBe("runner-reconn");
+        expect(after?.runnerName).toBe("Reconnected Runner");
     });
 });

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -35,6 +35,8 @@ export interface RelaySessionStartInput {
     shareUrl: string;
     startedAt: string;
     isEphemeral: boolean;
+    runnerId?: string | null;
+    runnerName?: string | null;
 }
 
 export interface PersistedRelaySessionSnapshot {
@@ -60,6 +62,8 @@ export interface PersistedRelaySessionSummary {
     isEphemeral: boolean;
     expiresAt: string | null;
     isPinned: boolean;
+    runnerId: string | null;
+    runnerName: string | null;
 }
 
 export async function ensureRelaySessionTables(): Promise<void> {
@@ -77,6 +81,8 @@ export async function ensureRelaySessionTables(): Promise<void> {
         .addColumn("isEphemeral", "integer", (col) => col.notNull().defaultTo(1))
         .addColumn("expiresAt", "text")
         .addColumn("isPinned", "integer", (col) => col.notNull().defaultTo(0))
+        .addColumn("runnerId", "text")
+        .addColumn("runnerName", "text")
         .execute();
 
     // Migration: add isPinned column to existing tables
@@ -88,6 +94,32 @@ export async function ensureRelaySessionTables(): Promise<void> {
     } catch (error) {
         if (!isDuplicateColumnError(error, "isPinned")) {
             console.error("[sessions/store] Failed to migrate relay_session.isPinned:", error);
+            throw error;
+        }
+    }
+
+    // Migration: add runnerId column to existing tables
+    try {
+        await getKysely().schema
+            .alterTable("relay_session")
+            .addColumn("runnerId", "text")
+            .execute();
+    } catch (error) {
+        if (!isDuplicateColumnError(error, "runnerId")) {
+            console.error("[sessions/store] Failed to migrate relay_session.runnerId:", error);
+            throw error;
+        }
+    }
+
+    // Migration: add runnerName column to existing tables
+    try {
+        await getKysely().schema
+            .alterTable("relay_session")
+            .addColumn("runnerName", "text")
+            .execute();
+    } catch (error) {
+        if (!isDuplicateColumnError(error, "runnerName")) {
+            console.error("[sessions/store] Failed to migrate relay_session.runnerName:", error);
             throw error;
         }
     }
@@ -131,6 +163,8 @@ export async function recordRelaySessionStart(input: RelaySessionStartInput): Pr
             isEphemeral: input.isEphemeral ? 1 : 0,
             expiresAt: input.isEphemeral ? ephemeralExpiryIso(new Date(now).getTime()) : null,
             isPinned: 0,
+            runnerId: input.runnerId ?? null,
+            runnerName: input.runnerName ?? null,
         })
         .onConflict((oc) => oc.column("id").doNothing())
         .execute();
@@ -165,6 +199,18 @@ export async function recordRelaySessionState(sessionId: string, state: unknown)
         .execute();
 
     await touchRelaySession(sessionId);
+}
+
+export async function updateRelaySessionRunner(
+    sessionId: string,
+    runnerId: string | null,
+    runnerName: string | null,
+): Promise<void> {
+    await getKysely()
+        .updateTable("relay_session")
+        .set({ runnerId, runnerName })
+        .where("id", "=", sessionId)
+        .execute();
 }
 
 export async function recordRelaySessionEnd(sessionId: string): Promise<void> {
@@ -255,6 +301,8 @@ export async function listPersistedRelaySessionsForUser(
             "isEphemeral",
             "expiresAt",
             "isPinned",
+            "runnerId",
+            "runnerName",
         ])
         .where("userId", "=", userId)
         .where((eb) =>
@@ -281,6 +329,8 @@ export async function listPersistedRelaySessionsForUser(
         isEphemeral: row.isEphemeral === 1,
         expiresAt: row.expiresAt,
         isPinned: row.isPinned === 1,
+        runnerId: row.runnerId ?? null,
+        runnerName: row.runnerName ?? null,
     }));
 }
 
@@ -301,6 +351,8 @@ export async function listPinnedRelaySessionsForUser(
             "isEphemeral",
             "expiresAt",
             "isPinned",
+            "runnerId",
+            "runnerName",
         ])
         .where("userId", "=", userId)
         .where("isPinned", "=", 1)
@@ -317,6 +369,8 @@ export async function listPinnedRelaySessionsForUser(
         isEphemeral: row.isEphemeral === 1,
         expiresAt: row.expiresAt,
         isPinned: true,
+        runnerId: row.runnerId ?? null,
+        runnerName: row.runnerName ?? null,
     }));
 }
 

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -257,6 +257,22 @@ export async function getRelaySessionUserId(sessionId: string): Promise<string |
     return row?.userId ?? null;
 }
 
+/**
+ * Returns the userId for a relay session only if the session has NOT ended.
+ * Used for parent-link validation: a child should not adopt a parent that
+ * has already ended, because triggers sent to that parent will never be
+ * delivered and will block AskUserQuestion / plan_review fallback.
+ */
+export async function getActiveRelaySessionUserId(sessionId: string): Promise<string | null> {
+    const row = await getKysely()
+        .selectFrom("relay_session")
+        .select("userId")
+        .where("id", "=", sessionId)
+        .where("endedAt", "is", null)
+        .executeTakeFirst();
+    return row?.userId ?? null;
+}
+
 export async function recordRelaySessionEnd(sessionId: string): Promise<void> {
     const nowIso = new Date().toISOString();
     const newExpiry = ephemeralExpiryIso();

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -166,7 +166,15 @@ export async function recordRelaySessionStart(input: RelaySessionStartInput): Pr
             runnerId: input.runnerId ?? null,
             runnerName: input.runnerName ?? null,
         })
-        .onConflict((oc) => oc.column("id").doNothing())
+        .onConflict((oc) =>
+            oc.column("id").doUpdateSet({
+                // On reconnect, update runner info (may have been resolved from
+                // a durable association that wasn't available on the first insert).
+                runnerId: input.runnerId ?? null,
+                runnerName: input.runnerName ?? null,
+                lastActiveAt: now,
+            }),
+        )
         .execute();
 }
 
@@ -201,16 +209,36 @@ export async function recordRelaySessionState(sessionId: string, state: unknown)
     await touchRelaySession(sessionId);
 }
 
+/**
+ * Update the runner association for a persisted session.
+ *
+ * Retries briefly when the relay_session row has not been persisted yet
+ * (race between linkSessionToRunner and the fire-and-forget
+ * recordRelaySessionStart insert).
+ */
 export async function updateRelaySessionRunner(
     sessionId: string,
     runnerId: string | null,
     runnerName: string | null,
-): Promise<void> {
-    await getKysely()
-        .updateTable("relay_session")
-        .set({ runnerId, runnerName })
-        .where("id", "=", sessionId)
-        .execute();
+): Promise<boolean> {
+    const MAX_ATTEMPTS = 3;
+    const RETRY_DELAY_MS = 250;
+
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+        const result = await getKysely()
+            .updateTable("relay_session")
+            .set({ runnerId, runnerName })
+            .where("id", "=", sessionId)
+            .execute();
+
+        if ((result[0]?.numUpdatedRows ?? 0n) > 0n) return true;
+
+        if (attempt < MAX_ATTEMPTS) {
+            await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+        }
+    }
+
+    return false;
 }
 
 export async function recordRelaySessionEnd(sessionId: string): Promise<void> {

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -167,13 +167,15 @@ export async function recordRelaySessionStart(input: RelaySessionStartInput): Pr
             runnerName: input.runnerName ?? null,
         })
         .onConflict((oc) =>
-            oc.column("id").doUpdateSet({
-                // On reconnect, update runner info (may have been resolved from
-                // a durable association that wasn't available on the first insert).
-                runnerId: input.runnerId ?? null,
-                runnerName: input.runnerName ?? null,
+            oc.column("id").doUpdateSet((eb) => ({
+                // On reconnect, preserve existing runner info if the incoming data
+                // doesn't carry a runner association (e.g. session predates the
+                // association key or the Redis key has already expired).  Only
+                // overwrite when we actually have a non-null value to write.
+                runnerId: input.runnerId != null ? input.runnerId : eb.ref("relay_session.runnerId"),
+                runnerName: input.runnerName != null ? input.runnerName : eb.ref("relay_session.runnerName"),
                 lastActiveAt: now,
-            }),
+            })),
         )
         .execute();
 }
@@ -239,6 +241,20 @@ export async function updateRelaySessionRunner(
     }
 
     return false;
+}
+
+/**
+ * Returns the userId stored in SQLite for a given session, or null if the
+ * session has no row.  Used as a Redis fallback when validating parent-session
+ * links after a relay restart (Redis key gone but SQLite record still exists).
+ */
+export async function getRelaySessionUserId(sessionId: string): Promise<string | null> {
+    const row = await getKysely()
+        .selectFrom("relay_session")
+        .select("userId")
+        .where("id", "=", sessionId)
+        .executeTakeFirst();
+    return row?.userId ?? null;
 }
 
 export async function recordRelaySessionEnd(sessionId: string): Promise<void> {

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -175,6 +175,9 @@ export async function recordRelaySessionStart(input: RelaySessionStartInput): Pr
                 runnerId: input.runnerId != null ? input.runnerId : eb.ref("relay_session.runnerId"),
                 runnerName: input.runnerName != null ? input.runnerName : eb.ref("relay_session.runnerName"),
                 lastActiveAt: now,
+                // Clear endedAt on reconnect so the session is considered
+                // active again (e.g. for getActiveRelaySessionUserId).
+                endedAt: null,
             })),
         )
         .execute();

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -226,8 +226,10 @@ export async function updateRelaySessionRunner(
     runnerId: string | null,
     runnerName: string | null,
 ): Promise<boolean> {
-    const MAX_ATTEMPTS = 3;
-    const RETRY_DELAY_MS = 250;
+    // Use exponential back-off so we tolerate slow
+    // recordRelaySessionStart inserts without giving up too early.
+    const MAX_ATTEMPTS = 5;
+    const INITIAL_DELAY_MS = 200;
 
     for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
         const result = await getKysely()
@@ -239,10 +241,14 @@ export async function updateRelaySessionRunner(
         if ((result[0]?.numUpdatedRows ?? 0n) > 0n) return true;
 
         if (attempt < MAX_ATTEMPTS) {
-            await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+            const delay = INITIAL_DELAY_MS * Math.pow(2, attempt - 1);
+            await new Promise((resolve) => setTimeout(resolve, delay));
         }
     }
 
+    console.warn(
+        `[sessions/store] updateRelaySessionRunner: gave up linking runner ${runnerId} to session ${sessionId} after ${MAX_ATTEMPTS} attempts`,
+    );
     return false;
 }
 
@@ -279,6 +285,11 @@ export async function getActiveRelaySessionUserId(sessionId: string): Promise<st
 export async function recordRelaySessionEnd(sessionId: string): Promise<void> {
     const nowIso = new Date().toISOString();
     const newExpiry = ephemeralExpiryIso();
+    // Guard against stale end writes: only mark ended if the session has not
+    // been re-started since this end was triggered.  A concurrent
+    // recordRelaySessionStart upsert sets endedAt back to NULL, so if endedAt
+    // is already NULL when this runs, a newer start has landed first and we
+    // must not overwrite it.
     await getKysely()
         .updateTable("relay_session")
         .set((eb) => ({
@@ -292,6 +303,14 @@ export async function recordRelaySessionEnd(sessionId: string): Promise<void> {
                 .end(),
         }))
         .where("id", "=", sessionId)
+        // Only end the session if it hasn't already been re-started
+        // (a reconnect upsert sets endedAt = NULL and updates lastActiveAt).
+        .where((eb) =>
+            eb.or([
+                eb("endedAt", "is not", null),  // already ended — safe to update timestamp
+                eb("lastActiveAt", "<=", nowIso), // not re-started with a newer timestamp
+            ]),
+        )
         .execute();
 }
 

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -56,6 +56,7 @@ import {
     recordRelaySessionEnd,
     recordRelaySessionState,
     touchRelaySession,
+    updateRelaySessionRunner,
 } from "../sessions/store.js";
 import { appendRelayEventToCache } from "../sessions/redis.js";
 import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "./strip-images.js";
@@ -364,6 +365,8 @@ export async function registerTuiSession(
         shareUrl,
         startedAt,
         isEphemeral,
+        runnerId,
+        runnerName,
     }).catch((error) => {
         console.error("[sio-registry] Failed to persist relay session start:", error);
     });
@@ -1011,6 +1014,12 @@ export async function linkSessionToRunner(runnerId: string, sessionId: string): 
     // The session hash is deleted on relay disconnect, but this TTL key
     // persists so reconnecting TUI agents can restore their runner link.
     await setRunnerAssociation(sessionId, runnerId, runner.name);
+
+    // Also persist the runner link in SQLite so historical/pinned sessions
+    // retain their runner provenance after the Redis session hash is deleted.
+    void updateRelaySessionRunner(sessionId, runnerId, runner.name).catch((error) => {
+        console.error("[sio-registry] Failed to persist runner link to SQLite:", error);
+    });
 
     const heartbeat = session.lastHeartbeat ? safeJsonParse(session.lastHeartbeat) : null;
 

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -57,7 +57,6 @@ import {
     recordRelaySessionState,
     touchRelaySession,
     updateRelaySessionRunner,
-    getActiveRelaySessionUserId,
     getRelaySessionUserId,
 } from "../sessions/store.js";
 import { appendRelayEventToCache } from "../sessions/redis.js";
@@ -320,14 +319,12 @@ export async function registerTuiSession(
     if (resolvedParentSessionId) {
         const parentSession = await getSession(resolvedParentSessionId);
         if (!parentSession) {
-            // Redis miss — check SQLite as a fallback, but only if the
-            // parent session has not ended.  An ended parent will never
-            // deliver triggers, so keeping the link would block
-            // AskUserQuestion / plan_review fallback in the child.
-            const sqliteUserId = await getActiveRelaySessionUserId(resolvedParentSessionId);
-            if (!sqliteUserId || sqliteUserId !== userId) {
-                resolvedParentSessionId = null;
-            }
+            // Redis miss means the parent is not connected — clear the link
+            // so the child falls back to normal viewer/TUI interaction
+            // instead of sending triggers to a dead parent ID.  The child
+            // CLI will re-send parentSessionId on its next reconnect; if
+            // the parent is back by then the link is restored naturally.
+            resolvedParentSessionId = null;
         } else if (parentSession.userId !== userId) {
             resolvedParentSessionId = null;
         }

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -57,6 +57,7 @@ import {
     recordRelaySessionState,
     touchRelaySession,
     updateRelaySessionRunner,
+    getRelaySessionUserId,
 } from "../sessions/store.js";
 import { appendRelayEventToCache } from "../sessions/redis.js";
 import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "./strip-images.js";
@@ -313,9 +314,17 @@ export async function registerTuiSession(
     // Validate parent session exists and belongs to the same user.
     // If the parent disconnected or the ID is stale, clear it to avoid
     // dangling trigger flows that would time out.
+    // Fall back to SQLite when Redis has no record (e.g. relay restarted and
+    // the parent's Redis key has expired) so that parent links survive restarts.
     if (resolvedParentSessionId) {
         const parentSession = await getSession(resolvedParentSessionId);
-        if (!parentSession || parentSession.userId !== userId) {
+        if (!parentSession) {
+            // Redis miss — check SQLite as a fallback
+            const sqliteUserId = await getRelaySessionUserId(resolvedParentSessionId);
+            if (!sqliteUserId || sqliteUserId !== userId) {
+                resolvedParentSessionId = null;
+            }
+        } else if (parentSession.userId !== userId) {
             resolvedParentSessionId = null;
         }
     }

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -57,6 +57,7 @@ import {
     recordRelaySessionState,
     touchRelaySession,
     updateRelaySessionRunner,
+    getActiveRelaySessionUserId,
     getRelaySessionUserId,
 } from "../sessions/store.js";
 import { appendRelayEventToCache } from "../sessions/redis.js";
@@ -319,8 +320,11 @@ export async function registerTuiSession(
     if (resolvedParentSessionId) {
         const parentSession = await getSession(resolvedParentSessionId);
         if (!parentSession) {
-            // Redis miss — check SQLite as a fallback
-            const sqliteUserId = await getRelaySessionUserId(resolvedParentSessionId);
+            // Redis miss — check SQLite as a fallback, but only if the
+            // parent session has not ended.  An ended parent will never
+            // deliver triggers, so keeping the link would block
+            // AskUserQuestion / plan_review fallback in the child.
+            const sqliteUserId = await getActiveRelaySessionUserId(resolvedParentSessionId);
             if (!sqliteUserId || sqliteUserId !== userId) {
                 resolvedParentSessionId = null;
             }

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -600,6 +600,22 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                         : s,
                 ),
             );
+
+            // Also refresh pinned entries so late runner-link updates are not
+            // lost when the session ends and drops out of liveSessions.
+            if (runnerId !== undefined || runnerName !== undefined) {
+                setPinnedSessions((prev) =>
+                    prev.map((p) =>
+                        p.sessionId === sessionId
+                            ? {
+                                  ...p,
+                                  runnerId: runnerId !== undefined ? runnerId : p.runnerId,
+                                  runnerName: runnerName !== undefined ? runnerName : p.runnerName,
+                              }
+                            : p,
+                    ),
+                );
+            }
         });
 
         return () => {

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -47,6 +47,8 @@ interface PinnedSession {
     isEphemeral: boolean;
     expiresAt: string | null;
     isPinned: boolean;
+    runnerId: string | null;
+    runnerName: string | null;
 }
 
 function isPinnedSession(value: unknown): value is PinnedSession {
@@ -1465,6 +1467,11 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         <span className="text-[0.65rem] text-sidebar-foreground/30 truncate" title={p.cwd}>
                                                             {formatPathTail(p.cwd, 2)}
                                                         </span>
+                                                        {p.runnerName && (
+                                                            <span className="text-[0.6rem] text-sidebar-foreground/25 truncate max-w-[6rem]" title={p.runnerName}>
+                                                                · {p.runnerName}
+                                                            </span>
+                                                        )}
                                                         <span className="text-[0.6rem] text-sidebar-foreground/25">· ended</span>
                                                     </div>
                                                 </div>

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1467,9 +1467,9 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         <span className="text-[0.65rem] text-sidebar-foreground/30 truncate" title={p.cwd}>
                                                             {formatPathTail(p.cwd, 2)}
                                                         </span>
-                                                        {p.runnerName && (
-                                                            <span className="text-[0.6rem] text-sidebar-foreground/25 truncate max-w-[6rem]" title={p.runnerName}>
-                                                                · {p.runnerName}
+                                                        {(p.runnerName || p.runnerId) && (
+                                                            <span className="text-[0.6rem] text-sidebar-foreground/25 truncate max-w-[6rem]" title={p.runnerName ?? `Runner ${p.runnerId}`}>
+                                                                · {p.runnerName || `Runner ${p.runnerId?.slice(0, 8)}…`}
                                                             </span>
                                                         )}
                                                         <span className="text-[0.6rem] text-sidebar-foreground/25">· ended</span>


### PR DESCRIPTION
## Problem

When a runner daemon restarts, its worker processes die, their TUI sockets disconnect, and `endSharedSession` deletes session data from Redis. The `runnerId`/`runnerName` fields only lived in the ephemeral Redis session hash — so when it was deleted, the runner association was lost entirely. Sessions appeared detached from their runner in the UI.

## Root Cause

The disconnect chain:
1. Runner restarts → child worker processes killed → TUI sockets disconnect
2. Relay `disconnect` handler calls `endSharedSession` → `deleteSession` (removes Redis hash)
3. Runner reconnects with same stable ID, but sessions are already gone from Redis
4. The `relay_session` SQLite table (which persists historical sessions) had no runner columns

## Fix

Persist `runnerId` and `runnerName` in the SQLite `relay_session` table so historical and pinned sessions retain their runner provenance after the Redis session hash is deleted.

### Changes

**`packages/server/src/auth.ts`** — Added `runnerId`/`runnerName` to `RelaySessionTable` Kysely type

**`packages/server/src/sessions/store.ts`** —
- Added `runnerId`/`runnerName` columns to `relay_session` table (with migration for existing DBs)
- Extended `RelaySessionStartInput` and `PersistedRelaySessionSummary` interfaces
- Added `updateRelaySessionRunner()` for updating runner info post-creation
- Updated query functions to return runner info

**`packages/server/src/ws/sio-registry.ts`** —
- Pass `runnerId`/`runnerName` to `recordRelaySessionStart`
- Call `updateRelaySessionRunner` in `linkSessionToRunner` (covers late-linking)

**`packages/ui/src/components/SessionSidebar.tsx`** —
- Extended `PinnedSession` interface with `runnerId`/`runnerName`
- Display runner name in ended-pinned sessions in the sidebar

### Regression Tests

7 tests in `packages/server/src/sessions/runner-assoc-persist.test.ts`:
- Runner info stored on session creation
- Null handling when no runner associated
- Late-linking via `updateRelaySessionRunner`
- Runner info in persisted/pinned session list APIs
- **Core regression: runner info survives after session ends**
- No-op for nonexistent sessions
