### PR TITLE
fix: catch Redis EPIPE so server doesn't crash on transient disconnect

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,6 +9,20 @@ import { sweepExpiredSessions } from "./ws/sio-registry.js";
 import { sweepExpiredAttachments, rehydrateExtractedAttachments } from "./attachments/store.js";
 import { runAllMigrations } from "./migrations.js";
 
+// ── Process-level safety net ─────────────────────────────────────────────────
+// The Socket.IO Redis adapter can throw EPIPE synchronously when the Redis
+// connection drops mid-broadcast. We catch any that slip through call-site
+// try/catches so the server never exits on a transient Redis disconnect.
+process.on("uncaughtException", (err: Error) => {
+    if ((err as NodeJS.ErrnoException).code === "EPIPE") {
+        console.warn("[process] Caught EPIPE (Redis connection dropped) — ignoring:", err.message);
+        return;
+    }
+    // Re-throw anything that isn't an EPIPE so genuine bugs still surface.
+    console.error("[process] Uncaught exception:", err);
+    process.exit(1);
+});
+
 // Socket.IO imports
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Server as SocketIOServer } from "socket.io";

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -96,7 +96,14 @@ function sendCumulativeEventAck(socket: RelaySocket, seq: number): void {
 
     const sessionId = socket.data.sessionId;
     if (sessionId) {
-        socket.emit("event_ack", { sessionId, seq: next });
+        try {
+            socket.emit("event_ack", { sessionId, seq: next });
+        } catch (err) {
+            // Redis adapter can throw EPIPE when the Redis connection is temporarily
+            // closed. Log and swallow — the ack is best-effort and the TUI will
+            // resend any un-acked events on reconnect.
+            console.warn("[sio/relay] sendCumulativeEventAck emit failed (Redis EPIPE?):", (err as Error)?.message);
+        }
     }
 }
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -320,8 +320,8 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 const childSocket = getLocalTuiSocket(targetSessionId);
                 if (childSocket) {
                     childSocket.emit("trigger_response" as string, triggerPayload);
-                } else {
-                    emitToRelaySession(targetSessionId, "trigger_response", triggerPayload);
+                } else if (!emitToRelaySession(targetSessionId, "trigger_response", triggerPayload)) {
+                    socket.emit("error", { message: `Failed to deliver trigger response to child session ${targetSessionId}` });
                 }
                 return;
             }
@@ -336,8 +336,8 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             const tuiSocket = getLocalTuiSocket(sessionId);
             if (tuiSocket) {
                 tuiSocket.emit("trigger_response" as string, triggerPayloadForParent);
-            } else {
-                emitToRelaySession(sessionId, "trigger_response", triggerPayloadForParent);
+            } else if (!emitToRelaySession(sessionId, "trigger_response", triggerPayloadForParent)) {
+                socket.emit("error", { message: `Failed to deliver trigger response to session ${sessionId}` });
             }
         });
 

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -204,7 +204,20 @@ export async function broadcastToHub(
             hubNs.to(HUB_ROOM).emit(eventName, data);
         }
     } catch (err) {
-        console.warn("[sio-registry] broadcastToHub failed (Redis EPIPE?):", (err as Error)?.message);
+        // Redis adapter publishes before local fan-out, so EPIPE drops the
+        // event for local sockets too. Fall back to local-only delivery so
+        // browsers on this server still get session_added/session_removed.
+        console.warn("[sio-registry] broadcastToHub failed, falling back to local:", (err as Error)?.message);
+        try {
+            const hubNs = io.of("/hub");
+            if (targetUserId) {
+                hubNs.local.to(hubUserRoom(targetUserId)).emit(eventName, data);
+            } else {
+                hubNs.local.to(HUB_ROOM).emit(eventName, data);
+            }
+        } catch {
+            // Local delivery also failed — nothing more we can do.
+        }
     }
 }
 
@@ -418,8 +431,19 @@ export function emitToRelaySession(sessionId: string, eventName: string, data: u
             .emit(eventName, data);
         return true;
     } catch (err) {
-        console.warn("[sio-registry] emitToRelaySession failed (Redis EPIPE?):", (err as Error)?.message);
-        return false;
+        // Redis adapter publishes before local fan-out, so EPIPE drops the
+        // event for local sockets too. Fall back to local-only delivery so
+        // callers on this server (e.g. MCP OAuth callbacks) still work.
+        console.warn("[sio-registry] emitToRelaySession failed, falling back to local:", (err as Error)?.message);
+        try {
+            io.of("/relay")
+                .local
+                .to(relaySessionRoom(sessionId))
+                .emit(eventName, data);
+            return true;
+        } catch {
+            return false;
+        }
     }
 }
 
@@ -712,7 +736,15 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
             .to(viewerSessionRoom(sessionId))
             .emit("disconnected", { reason });
     } catch (err) {
-        console.warn("[sio-registry] endSharedSession viewer notify failed (Redis EPIPE?):", (err as Error)?.message);
+        console.warn("[sio-registry] endSharedSession viewer notify failed, falling back to local:", (err as Error)?.message);
+        try {
+            io.of("/viewer")
+                .local
+                .to(viewerSessionRoom(sessionId))
+                .emit("disconnected", { reason });
+        } catch {
+            // Local delivery also failed.
+        }
     }
 
     // Forcefully disconnect viewer sockets from the room

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -196,11 +196,15 @@ export async function broadcastToHub(
     data: unknown,
     targetUserId?: string,
 ): Promise<void> {
-    const hubNs = io.of("/hub");
-    if (targetUserId) {
-        hubNs.to(hubUserRoom(targetUserId)).emit(eventName, data);
-    } else {
-        hubNs.to(HUB_ROOM).emit(eventName, data);
+    try {
+        const hubNs = io.of("/hub");
+        if (targetUserId) {
+            hubNs.to(hubUserRoom(targetUserId)).emit(eventName, data);
+        } else {
+            hubNs.to(HUB_ROOM).emit(eventName, data);
+        }
+    } catch (err) {
+        console.warn("[sio-registry] broadcastToHub failed (Redis EPIPE?):", (err as Error)?.message);
     }
 }
 
@@ -408,10 +412,15 @@ export function getLocalTuiSocket(sessionId: string): Socket | undefined {
  */
 export function emitToRelaySession(sessionId: string, eventName: string, data: unknown): boolean {
     if (!io) return false;
-    io.of("/relay")
-        .to(relaySessionRoom(sessionId))
-        .emit(eventName, data);
-    return true;
+    try {
+        io.of("/relay")
+            .to(relaySessionRoom(sessionId))
+            .emit(eventName, data);
+        return true;
+    } catch (err) {
+        console.warn("[sio-registry] emitToRelaySession failed (Redis EPIPE?):", (err as Error)?.message);
+        return false;
+    }
 }
 
 /**
@@ -574,7 +583,10 @@ export async function publishSessionEvent(sessionId: string, event: unknown): Pr
 
     const seq = await incrementSeq(sessionId);
 
-    void appendRelayEventToCache(sessionId, strippedEvent, { isEphemeral: session?.isEphemeral });
+    // Await the cache write so the event is durably stored before we broadcast.
+    // If this also fails (same Redis blip), the event is lost — but at least
+    // we don't falsely claim it was cached when swallowing the broadcast error.
+    await appendRelayEventToCache(sessionId, strippedEvent, { isEphemeral: session?.isEphemeral });
 
     // Broadcast to all viewer sockets in the session room
     try {
@@ -583,8 +595,9 @@ export async function publishSessionEvent(sessionId: string, event: unknown): Pr
             .emit("event", { event: strippedEvent, seq });
     } catch (err) {
         // Redis adapter throws EPIPE when the Redis connection drops mid-broadcast.
-        // The event was already appended to the Redis cache; viewers will catch up
-        // via replay on reconnect, so this is safe to swallow.
+        // The event was awaited into the Redis cache above; viewers will catch up
+        // via replay on reconnect. If the cache write also failed (same blip),
+        // this event is lost — but that's better than crashing the server.
         console.warn("[sio-registry] publishSessionEvent broadcast failed (Redis EPIPE?):", (err as Error)?.message);
     }
 
@@ -694,9 +707,13 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
     if (!session) return;
 
     // Notify all viewers in the room and disconnect them
-    io.of("/viewer")
-        .to(viewerSessionRoom(sessionId))
-        .emit("disconnected", { reason });
+    try {
+        io.of("/viewer")
+            .to(viewerSessionRoom(sessionId))
+            .emit("disconnected", { reason });
+    } catch (err) {
+        console.warn("[sio-registry] endSharedSession viewer notify failed (Redis EPIPE?):", (err as Error)?.message);
+    }
 
     // Forcefully disconnect viewer sockets from the room
     // Use socketsLeave instead of fetchSockets() + loop to avoid expensive
@@ -843,7 +860,20 @@ export function broadcastToViewers(sessionId: string, eventName: string, data: u
             .to(viewerSessionRoom(sessionId))
             .emit(eventName, data);
     } catch (err) {
-        console.warn("[sio-registry] broadcastToViewers failed (Redis EPIPE?):", (err as Error)?.message);
+        // Redis adapter throws EPIPE when the connection drops mid-broadcast.
+        // Unlike sequenced session events, payloads like exec_result are not
+        // cached in Redis, so viewers can't recover them via replay. Fall back
+        // to local-only delivery so at least viewers connected to this server
+        // instance still receive the event.
+        console.warn("[sio-registry] broadcastToViewers Redis broadcast failed, falling back to local:", (err as Error)?.message);
+        try {
+            io.of("/viewer")
+                .local
+                .to(viewerSessionRoom(sessionId))
+                .emit(eventName, data);
+        } catch {
+            // Local delivery also failed — nothing more we can do.
+        }
     }
 }
 

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -577,9 +577,16 @@ export async function publishSessionEvent(sessionId: string, event: unknown): Pr
     void appendRelayEventToCache(sessionId, strippedEvent, { isEphemeral: session?.isEphemeral });
 
     // Broadcast to all viewer sockets in the session room
-    io.of("/viewer")
-        .to(viewerSessionRoom(sessionId))
-        .emit("event", { event: strippedEvent, seq });
+    try {
+        io.of("/viewer")
+            .to(viewerSessionRoom(sessionId))
+            .emit("event", { event: strippedEvent, seq });
+    } catch (err) {
+        // Redis adapter throws EPIPE when the Redis connection drops mid-broadcast.
+        // The event was already appended to the Redis cache; viewers will catch up
+        // via replay on reconnect, so this is safe to swallow.
+        console.warn("[sio-registry] publishSessionEvent broadcast failed (Redis EPIPE?):", (err as Error)?.message);
+    }
 
     return seq;
 }
@@ -831,9 +838,13 @@ export async function removeViewer(sessionId: string, socket: Socket): Promise<v
  * Broadcast data to all viewers of a session via Socket.IO rooms.
  */
 export function broadcastToViewers(sessionId: string, eventName: string, data: unknown): void {
-    io.of("/viewer")
-        .to(viewerSessionRoom(sessionId))
-        .emit(eventName, data);
+    try {
+        io.of("/viewer")
+            .to(viewerSessionRoom(sessionId))
+            .emit(eventName, data);
+    } catch (err) {
+        console.warn("[sio-registry] broadcastToViewers failed (Redis EPIPE?):", (err as Error)?.message);
+    }
 }
 
 /**

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -432,9 +432,12 @@ export function emitToRelaySession(sessionId: string, eventName: string, data: u
         return true;
     } catch (err) {
         // Redis adapter publishes before local fan-out, so EPIPE drops the
-        // event for local sockets too. Fall back to local-only delivery so
-        // callers on this server (e.g. MCP OAuth callbacks) still work.
+        // event for local sockets too. Fall back to local-only delivery, but
+        // only if the session's TUI socket is actually on this server —
+        // otherwise the local room is empty and returning true would mislead
+        // callers (e.g. MCP OAuth would consume the nonce for a dropped callback).
         console.warn("[sio-registry] emitToRelaySession failed, falling back to local:", (err as Error)?.message);
+        if (!localTuiSockets.has(sessionId)) return false;
         try {
             io.of("/relay")
                 .local
@@ -619,10 +622,19 @@ export async function publishSessionEvent(sessionId: string, event: unknown): Pr
             .emit("event", { event: strippedEvent, seq });
     } catch (err) {
         // Redis adapter throws EPIPE when the Redis connection drops mid-broadcast.
-        // The event was awaited into the Redis cache above; viewers will catch up
-        // via replay on reconnect. If the cache write also failed (same blip),
-        // this event is lost — but that's better than crashing the server.
-        console.warn("[sio-registry] publishSessionEvent broadcast failed (Redis EPIPE?):", (err as Error)?.message);
+        // Fall back to local-only delivery so viewers on this server still receive
+        // the event and its seq — without seeing the new seq they'd never trigger
+        // a resync and would permanently miss this event even though it was cached.
+        console.warn("[sio-registry] publishSessionEvent broadcast failed, falling back to local:", (err as Error)?.message);
+        try {
+            io.of("/viewer")
+                .local
+                .to(viewerSessionRoom(sessionId))
+                .emit("event", { event: strippedEvent, seq });
+        } catch {
+            // Local delivery also failed — event may be lost for connected viewers,
+            // but it's in the cache (if Redis accepted it) for future replay.
+        }
     }
 
     return seq;


### PR DESCRIPTION
## Problem

The Socket.IO Redis adapter throws `EPIPE` synchronously when the Redis connection drops mid-broadcast (e.g. Redis restarts, network blip). Since nothing caught it, Bun exited and the server crashed — repeatedly, in a tight loop.

## Fix

Three layers of defence:

1. **`relay.ts` — `sendCumulativeEventAck`**: wraps `socket.emit` in try/catch. This is the exact call site in the stack trace. Acks are best-effort — the TUI resends un-acked events on reconnect.
2. **`sio-registry.ts` — `publishSessionEvent` and `broadcastToViewers`**: wraps `io.emit` calls. Events are already appended to the Redis cache before broadcast, so viewers catch up via replay on reconnect.
3. **`index.ts` — `process.on('uncaughtException')`**: last-resort safety net. Swallows `EPIPE`, re-throws everything else so genuine bugs still surface.