### PR TITLE
fix: runner registration only advertises global plugins

### DIFF
--- a/packages/cli/src/plugins.test.ts
+++ b/packages/cli/src/plugins.test.ts
@@ -1041,6 +1041,33 @@ describe("discoverClaudeInstalledPlugins", () => {
         expect(result).toEqual([]);
     });
 
+    test("skips all project-scoped plugins when cwd is undefined (global-only scan)", () => {
+        const home = setupHome("no-cwd-global");
+        const path1 = createCachedPlugin(home, "mkt", "proj-plugin", "1.0.0");
+        const userPath = createCachedPlugin(home, "mkt", "user-plugin", "1.0.0");
+        writeInstalledPlugins(home, {
+            version: 2,
+            plugins: {
+                "proj-plugin@mkt": [{
+                    scope: "project",
+                    projectPath: "/some/project",
+                    installPath: path1,
+                    version: "1.0.0",
+                }],
+                "user-plugin@mkt": [{
+                    scope: "user",
+                    installPath: userPath,
+                    version: "1.0.0",
+                }],
+            },
+        });
+
+        // undefined cwd = global-only: project-scoped excluded, user-scoped included
+        const result = discoverClaudeInstalledPlugins(undefined);
+        expect(result).toHaveLength(1);
+        expect(result[0].name).toBe("user-plugin");
+    });
+
     test("includes project-scoped plugins that match cwd", () => {
         const home = setupHome("project-match");
         const path1 = createCachedPlugin(home, "mkt", "my-project-plugin", "1.0.0");

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -376,10 +376,15 @@ export function discoverClaudeInstalledPlugins(cwd?: string): DiscoveredPlugin[]
 
         for (const inst of sorted) {
             // Skip project-scoped plugins that don't match current cwd.
+            // When cwd is undefined (runner-level / global-only scan), ALL
+            // project-scoped plugins are excluded — there is no project context.
             // Uses path.relative to avoid platform-specific separator issues.
             // On Windows, cross-drive relative() returns an absolute path, so
             // we also reject when isAbsolute(rel) is true.
-            if (inst.scope === "project" && cwd && inst.projectPath) {
+            if (inst.scope === "project") {
+                if (!cwd || !inst.projectPath) {
+                    continue;
+                }
                 const rel = relative(resolve(inst.projectPath), resolve(cwd));
                 if (rel.startsWith("..") || isAbsolute(rel)) {
                     continue;

--- a/packages/cli/src/plugins.ts
+++ b/packages/cli/src/plugins.ts
@@ -224,10 +224,10 @@ export function projectPluginDirs(cwd: string): string[] {
  *   (default: false for security — project-local plugins can run arbitrary code)
  * @param opts.extraDirs - Additional directories to scan (explicitly trusted by user)
  */
-export function pluginSearchDirs(cwd: string, opts?: { includeProjectLocal?: boolean; extraDirs?: string[] }): string[] {
+export function pluginSearchDirs(cwd?: string, opts?: { includeProjectLocal?: boolean; extraDirs?: string[] }): string[] {
     const dirs = [...globalPluginDirs()];
 
-    if (opts?.includeProjectLocal) {
+    if (opts?.includeProjectLocal && cwd) {
         dirs.push(...projectPluginDirs(cwd));
     }
 
@@ -924,7 +924,7 @@ export function scanPluginsDir(dir: string): DiscoveredPlugin[] {
  *   (default: false — project-local plugins can run arbitrary code)
  * @param opts.extraDirs - Additional directories to scan
  */
-export function discoverPlugins(cwd: string, opts?: { includeProjectLocal?: boolean; extraDirs?: string[] }): DiscoveredPlugin[] {
+export function discoverPlugins(cwd?: string, opts?: { includeProjectLocal?: boolean; extraDirs?: string[] }): DiscoveredPlugin[] {
     const dirs = pluginSearchDirs(cwd, opts);
     const seen = new Set<string>();
     const plugins: DiscoveredPlugin[] = [];
@@ -1084,6 +1084,6 @@ export function toPluginInfo(plugin: DiscoveredPlugin): PluginInfo {
 /**
  * Scan and return plugin info for all discovered plugins.
  */
-export function scanAllPluginInfo(cwd: string, opts?: { includeProjectLocal?: boolean; extraDirs?: string[] }): PluginInfo[] {
+export function scanAllPluginInfo(cwd?: string, opts?: { includeProjectLocal?: boolean; extraDirs?: string[] }): PluginInfo[] {
     return discoverPlugins(cwd, opts).map(toPluginInfo);
 }

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -560,7 +560,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             // Runner registration only advertises global plugins.
             // Project-local plugins are session-scoped — they're discovered
             // per-session via list_plugins with an explicit cwd.
-            const plugins = scanAllPluginInfo(process.cwd(), { includeProjectLocal: false });
+            // Pass undefined as cwd so that discoverClaudeInstalledPlugins
+            // skips project-scoped marketplace plugins and readEnabledPlugins
+            // only reads user-level settings (not project-local overrides).
+            const plugins = scanAllPluginInfo(undefined, { includeProjectLocal: false });
             socket.emit("register_runner", {
                 runnerId: identity.runnerId,
                 runnerSecret: identity.runnerSecret,
@@ -1129,11 +1132,13 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 socket.emit("plugins_list", { plugins: [], requestId, ok: false, message: "cwd outside allowed workspace roots" });
                 return;
             }
-            const scanCwd = rawCwd ?? process.cwd();
             // Only include project-local plugins when an explicit session cwd
             // was provided AND it's within allowed workspace roots. Without an
             // explicit cwd this is a runner-level query — only global plugins.
-            const includeLocal = !!rawCwd && isCwdAllowed(scanCwd);
+            // When rawCwd is absent, pass undefined so marketplace discovery
+            // skips project-scoped plugins and respects only user-level settings.
+            const scanCwd = rawCwd ?? undefined;
+            const includeLocal = !!rawCwd && isCwdAllowed(rawCwd);
             const plugins = scanAllPluginInfo(scanCwd, { includeProjectLocal: includeLocal });
             // Echo scoped flag so the server can skip cache updates for per-session scans
             socket.emit("plugins_list", { plugins, requestId, ...(rawCwd ? { scoped: true } : {}) });

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -557,8 +557,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         const emitRegister = () => {
             const skills = scanGlobalSkills();
             const agents = scanGlobalAgents();
-            // Only include project-local plugins if daemon cwd is within allowed roots
-            const plugins = scanAllPluginInfo(process.cwd(), { includeProjectLocal: isCwdAllowed(process.cwd()) });
+            // Runner registration only advertises global plugins.
+            // Project-local plugins are session-scoped — they're discovered
+            // per-session via list_plugins with an explicit cwd.
+            const plugins = scanAllPluginInfo(process.cwd(), { includeProjectLocal: false });
             socket.emit("register_runner", {
                 runnerId: identity.runnerId,
                 runnerSecret: identity.runnerSecret,
@@ -1128,9 +1130,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 return;
             }
             const scanCwd = rawCwd ?? process.cwd();
-            // Only include project-local plugins if the scan cwd is within allowed roots.
-            // If daemon started outside workspace roots, avoid leaking local plugin metadata.
-            const includeLocal = isCwdAllowed(scanCwd);
+            // Only include project-local plugins when an explicit session cwd
+            // was provided AND it's within allowed workspace roots. Without an
+            // explicit cwd this is a runner-level query — only global plugins.
+            const includeLocal = !!rawCwd && isCwdAllowed(scanCwd);
             const plugins = scanAllPluginInfo(scanCwd, { includeProjectLocal: includeLocal });
             // Echo scoped flag so the server can skip cache updates for per-session scans
             socket.emit("plugins_list", { plugins, requestId, ...(rawCwd ? { scoped: true } : {}) });


### PR DESCRIPTION
## Problem

Project-local plugins (e.g. `.agents/plugins/beads-ccpm`) were appearing at the runner level in the UI. This happened because `emitRegister()` called `scanAllPluginInfo(process.cwd(), { includeProjectLocal: true })`, promoting whatever project the daemon was launched from to runner-wide visibility.

## Fix

- **`emitRegister()`** now always passes `includeProjectLocal: false` — runner registration only advertises global plugins (`~/.pizzapi/plugins/`, `~/.agents/plugins/`).
- **`list_plugins` handler** only includes project-local plugins when an explicit session `cwd` is provided (session-scoped query). Without one, it's a runner-level query and returns global-only.