### PR TITLE
fix: prevent session kill loop from relay disconnect race condition

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -511,6 +511,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         // relay (triggered when the new worker's registerTuiSession tears down the old
         // connection) must be ignored — the new worker is already live.
         const restartingSessions = new Set<string>();
+        // Sessions we've already handled session_ended for.  Prevents log
+        // spam when the relay fires duplicate session_ended events (e.g. the
+        // orphan sweeper runs after the relay already sent session_ended on
+        // disconnect).  Entries auto-expire after 60 s to avoid unbounded growth.
+        const endedSessionIds = new Set<string>();
         const runnerName = process.env.PIZZAPI_RUNNER_NAME?.trim() || hostname();
         let runnerId: string | null = null;
         let isFirstConnect = true;
@@ -737,10 +742,17 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             const entry = runningSessions.get(sessionId);
             if (entry) {
                 runningSessions.delete(sessionId);
+                endedSessionIds.add(sessionId);
+                setTimeout(() => endedSessionIds.delete(sessionId), 60_000);
                 console.log(`pizzapi runner: session ${sessionId} ended on relay${entry.adopted ? " (adopted)" : ""}`);
-            } else {
+            } else if (!endedSessionIds.has(sessionId)) {
+                // First duplicate — log once then suppress subsequent copies
+                endedSessionIds.add(sessionId);
+                setTimeout(() => endedSessionIds.delete(sessionId), 60_000);
                 console.log(`pizzapi runner: session_ended for unknown/already-removed session ${sessionId}`);
             }
+            // else: duplicate session_ended for a session we already handled — silently ignore
+
             // Clean up persisted attachments.  For spawned sessions child.on("exit")
             // already ran cleanup, so this is a no-op (idempotent).  For adopted sessions
             // (child: null) this is the only cleanup path.

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -514,8 +514,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         // Sessions we've already handled session_ended for.  Prevents log
         // spam when the relay fires duplicate session_ended events (e.g. the
         // orphan sweeper runs after the relay already sent session_ended on
-        // disconnect).  Entries auto-expire after 60 s to avoid unbounded growth.
+        // disconnect).  Entries auto-expire after 5 min — must be comfortably
+        // longer than the relay's sweep interval (default 60 s) to avoid
+        // re-logging on the next sweep cycle.
         const endedSessionIds = new Set<string>();
+        const ENDED_SESSION_TTL_MS = 5 * 60_000;
         const runnerName = process.env.PIZZAPI_RUNNER_NAME?.trim() || hostname();
         let runnerId: string | null = null;
         let isFirstConnect = true;
@@ -741,23 +744,25 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
             const entry = runningSessions.get(sessionId);
             if (entry) {
-                // If the child process is still alive, don't remove the entry —
-                // the worker will reconnect to the relay and re-register.
-                // Removing it here would orphan the child process (can't be
-                // killed, can't be resumed).
+                // If the child process is still alive AND this is a transient
+                // relay disconnect (not an expiry/orphan sweep), keep the entry
+                // so the worker can reconnect.  For server-initiated cleanup
+                // (expired/orphaned), always honor the removal — the session
+                // is legitimately dead and the worker should exit on its own.
                 const childAlive = entry.child && !entry.child.killed && entry.child.exitCode === null;
-                if (childAlive) {
+                const isTransientDisconnect = !reason || reason === "Session ended";
+                if (childAlive && isTransientDisconnect) {
                     console.log(`pizzapi runner: session_ended for ${sessionId} but worker still alive — keeping entry for reconnect`);
                     return;
                 }
                 runningSessions.delete(sessionId);
                 endedSessionIds.add(sessionId);
-                setTimeout(() => endedSessionIds.delete(sessionId), 60_000);
-                console.log(`pizzapi runner: session ${sessionId} ended on relay${entry.adopted ? " (adopted)" : ""}`);
+                setTimeout(() => endedSessionIds.delete(sessionId), ENDED_SESSION_TTL_MS);
+                console.log(`pizzapi runner: session ${sessionId} ended on relay${entry.adopted ? " (adopted)" : ""}${reason ? ` (${reason})` : ""}`);
             } else if (!endedSessionIds.has(sessionId)) {
                 // First duplicate — log once then suppress subsequent copies
                 endedSessionIds.add(sessionId);
-                setTimeout(() => endedSessionIds.delete(sessionId), 60_000);
+                setTimeout(() => endedSessionIds.delete(sessionId), ENDED_SESSION_TTL_MS);
                 console.log(`pizzapi runner: session_ended for unknown/already-removed session ${sessionId}`);
             }
             // else: duplicate session_ended for a session we already handled — silently ignore

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -741,6 +741,15 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
             const entry = runningSessions.get(sessionId);
             if (entry) {
+                // If the child process is still alive, don't remove the entry —
+                // the worker will reconnect to the relay and re-register.
+                // Removing it here would orphan the child process (can't be
+                // killed, can't be resumed).
+                const childAlive = entry.child && !entry.child.killed && entry.child.exitCode === null;
+                if (childAlive) {
+                    console.log(`pizzapi runner: session_ended for ${sessionId} but worker still alive — keeping entry for reconnect`);
+                    return;
+                }
                 runningSessions.delete(sessionId);
                 endedSessionIds.add(sessionId);
                 setTimeout(() => endedSessionIds.delete(sessionId), 60_000);

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -547,6 +547,17 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             console.log(`[sio/relay] disconnected: ${socket.id} (${reason})`);
             const sessionId = socket.data.sessionId;
             if (sessionId) {
+                // If a newer socket already re-registered this session (reconnect),
+                // don't tear down the new session.  registerTuiSession clears our
+                // sessionId as a primary guard, but this check is defense-in-depth
+                // for any remaining race windows.
+                const currentSocket = getLocalTuiSocket(sessionId);
+                if (currentSocket && currentSocket !== socket) {
+                    console.log(`[sio/relay] disconnect for ${socket.id} — session ${sessionId} already owned by ${currentSocket.id}, skipping teardown`);
+                    socketAckedSeqs.delete(socket.id);
+                    return;
+                }
+
                 clearThinkingMaps(sessionId);
                 void clearPushPendingQuestion(sessionId);
                 // Clean up child-index entry so stale memberships don't persist

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -287,9 +287,19 @@ export async function registerTuiSession(
     const collabMode = opts.collabMode !== false;
     const sessionName = normalizeSessionName(opts.sessionName);
 
-    // If session already exists, end it first (reconnect)
+    // If session already exists, end it first (reconnect).
+    // IMPORTANT: Clear the old socket's sessionId BEFORE ending the session
+    // to prevent a race where the old socket's disconnect handler fires after
+    // the new session is created and kills it.  Without this, Socket.IO
+    // reconnects create a kill loop: new socket registers → old socket's
+    // deferred disconnect fires → endSharedSession kills the new session →
+    // Socket.IO reconnects → repeat.
     const existing = await getSession(sessionId);
     if (existing) {
+        const oldSocket = localTuiSockets.get(sessionId);
+        if (oldSocket && oldSocket !== socket) {
+            oldSocket.data.sessionId = undefined;
+        }
         await endSharedSession(sessionId, "Session reconnected");
     }
 


### PR DESCRIPTION
## Problem

When a Socket.IO transport blip causes a reconnect, sessions get stuck in a kill loop — unable to be resumed from the CLI or web UI.

### Root Cause

A race condition between the old socket's disconnect handler and the new socket's registration in registerTuiSession:

1. Old socket A connects, registers → session in Redis
2. Socket A disconnects (network blip)
3. Socket.IO auto-reconnects → new socket B registers
4. registerTuiSession finds existing → endSharedSession('Session reconnected') → deletes from Redis (runner ignores ✓)
5. registerTuiSession creates NEW session in Redis
6. Old socket A's disconnect handler fires (async) → finds the NEW session → kills it → runner deletes from runningSessions
7. Repeat until Socket.IO gives up

Session becomes un-resumable: deleted from Redis each cycle, runningSessions entry removed but child alive (orphaned).

## Fix

**Server (sio-registry.ts):** Clear old socket's sessionId in registerTuiSession before reconnect teardown — makes the old disconnect handler a no-op.

**Runner (daemon.ts):** When session_ended arrives for a session with a live child process, keep the runningSessions entry. Also deduplicate repeated log messages.