### PR TITLE
fix: chunked session_active delivery for large sessions

### DIFF
--- a/docs/superpowers/specs/2026-03-18-event-driven-plugin-system-design.md
+++ b/docs/superpowers/specs/2026-03-18-event-driven-plugin-system-design.md
@@ -126,7 +126,7 @@ type EventSourceConfig = StdioEventSource | HttpEventSource;
 interface RunnerTrigger {
   name: string;
   source: string;               // event source name
-  match: Record<string, unknown>; // flat dot-path equality matching
+  match: Record<string, string | number | boolean>; // flat dot-path equality, primitives only
   action: TriggerAction;
 }
 
@@ -135,10 +135,13 @@ interface TriggerAction {
   prompt?: string;              // supports {event.*} interpolation
   cwd?: string;
   agent?: string;               // agent definition name
-  sessionId?: string;           // REQUIRED for "inject" — target session ID or name
-  // When type is "inject", sessionId must be provided.
-  // If the target session is not found (disconnected/dead), the event
-  // falls through to the next matching trigger or dead letter log.
+  sessionTag?: string;           // REQUIRED for "inject" — target session tag
+  // When type is "inject", sessionTag must be provided. Sessions opt in
+  // to receiving injected events by setting a tag (e.g., "pr-bot") via
+  // the register_trigger tool or at spawn time. The runner matches by tag,
+  // not by ephemeral session ID, so runner triggers survive session restarts.
+  // If no session with the matching tag is found, the event falls through
+  // to the next matching trigger or dead letter log.
 }
 ```
 
@@ -157,7 +160,11 @@ interface TriggerAction {
 
 Both transports use identical JSON-RPC 2.0 messages.
 
-**HTTP transport topology:** The **plugin hosts** the HTTP server. The runner is the client — it connects to the plugin's SSE endpoint (`GET {url}/events`) and sends control messages via `POST {url}/control`. This mirrors MCP's streamable-http where the server (plugin) hosts and the client (runner) connects. The `url` in config points to the plugin's base URL.
+**HTTP transport topology:** The **plugin hosts** the HTTP server. The runner is the client — it connects to the plugin's SSE endpoint and sends control messages via POST. This mirrors MCP's streamable-http where the server (plugin) hosts and the client (runner) connects. The `url` in config points to the plugin's base URL.
+
+**Fixed HTTP paths (required for all HTTP transport plugins):**
+- `GET {url}/events` — SSE event stream
+- `POST {url}/control` — JSON-RPC 2.0 control messages (initialize, subscribe, shutdown)
 
 ### Handshake
 
@@ -223,7 +230,11 @@ Both transports use identical JSON-RPC 2.0 messages.
 ### Control Messages (Runner → Plugin)
 
 ```jsonc
-// Subscribe (narrow event scope)
+// Subscribe (narrow event scope) — RESERVED FOR FUTURE USE
+// Defined in the protocol for forward-compatibility. The v1 runner does NOT
+// send these messages. Plugin authors MAY implement them but SHOULD NOT
+// depend on receiving them. Future versions will send subscribe when the
+// first trigger for a source is registered.
 {
   "jsonrpc": "2.0",
   "id": 2,
@@ -233,7 +244,7 @@ Both transports use identical JSON-RPC 2.0 messages.
   }
 }
 
-// Unsubscribe
+// Unsubscribe — RESERVED FOR FUTURE USE (same as subscribe)
 {
   "jsonrpc": "2.0",
   "id": 3,
@@ -389,7 +400,7 @@ All keys in `match` must be present and equal in the event. Missing keys in the 
 ### Routing Priority
 
 1. **Session triggers** — if multiple session triggers match, **all matching sessions receive the event** (fan-out). This is intentional: two sessions watching the same PR both get notified.
-2. **Runner triggers** — first matching rule wins (config order). Runner triggers fire **only if no session trigger matched** — session triggers take priority.
+2. **Runner triggers** — **all matching rules fire** (fan-out, same as session triggers). Multiple runner triggers can react to the same event (e.g., spawn a review session AND log to Slack). Runner triggers fire **only if no session trigger matched** — session triggers take priority. **Rationale:** A session that explicitly registers for an event has claimed ownership — it's actively working on that context (e.g., an agent watching PR #42). Runner triggers are the default automation; session triggers are the override. This prevents duplicate work (runner spawning a new session for an event an existing session already handles).
 3. **Dead letter log** — no match from either tier, event logged for debugging.
 
 ### Actions
@@ -484,6 +495,8 @@ The delivery format is generic — `context` and `payload` are serialized as JSO
 
 If a runner trigger has a `prompt` template with `{event.*}` interpolation, the rendered prompt replaces the generic format above. This allows trigger authors to produce human-readable messages for specific use cases.
 
+**Interpolation behavior:** `{event.payload.body}` resolves via dot-path into the event object. If the path doesn't resolve (field missing), it renders as an empty string. Nested objects render as JSON. This is intentionally simple — no conditionals, no loops, no expressions.
+
 ### CLI Mode (Local Sessions)
 
 Same tools work with constraints:
@@ -491,6 +504,7 @@ Same tools work with constraints:
 - CLI manages its own event source processes
 - Session must stay alive — if it exits, triggers die
 - No `spawn` action — events always inject into the current session
+- **Config validation:** If `plugins.json` contains runner triggers with `"type": "spawn"`, they are ignored in CLI mode with a warning logged at startup: `"Trigger '{name}' uses spawn action — ignored in CLI mode (no runner)"`. Runner triggers with `"type": "inject"` are also ignored in CLI mode — the CLI session uses session triggers (registered via tools) exclusively.
 
 ---
 
@@ -517,6 +531,9 @@ pizza plugin restart <name>          # Restart
 pizza plugin status <name>           # Details: config, status, event counts
 pizza plugin logs <name>             # View plugin logs
 pizza plugin logs <name> --follow    # Tail logs
+
+# Trigger management is manual (edit plugins.json) in v1.
+# CLI trigger commands (pizza trigger list/add/remove) are future scope.
 ```
 
 ### `disabled` Flag
@@ -585,7 +602,7 @@ Runner shutdown:
 | `initialize` times out (5s) | Mark errored, apply restart policy. |
 | Plugin sends `fatal: true` error | Disconnect, don't restart. Surface in runner UI. |
 | Event matches dead session trigger | Clean up stale registration, fall through to runner triggers. |
-| Event matches but session is busy | Queue event. Max 10 per session, oldest dropped. |
+| Event matches but session is busy | Queue event (FIFO). Max 10 per session, **newest dropped** when full — preserves earliest context. Warning log: `"Event {id} dropped for session {sessionId}: queue full"`. |
 
 ### Session Trigger Cleanup
 
@@ -613,6 +630,13 @@ Runner shutdown:
 - Runner dashboard UI for event source status
 - Error handling, restart policies, observability logs
 - At least one reference plugin implementation (GitHub PR comments)
+
+### Notes
+
+- **Config hot-reload:** Changes to `plugins.json` require a runner restart in v1. No file watching.
+- **Security model:** Plugins are trusted — stdio plugins run with the runner's permissions, HTTP plugins receive whatever headers are configured. No sandboxing in v1. This is the same trust model as MCP servers.
+- **Protocol version mismatch:** If the plugin responds to `initialize` with a `protocolVersion` the runner doesn't support, the runner logs a warning and disconnects. The plugin should be updated.
+- **`context` vs `payload` guidance for plugin authors:** `context` contains routing hints — fields that triggers match against (e.g., repo, PR number, channel). `payload` contains the full event body passed to the agent. Some fields may appear in both — that's fine.
 
 ### Out of scope (future)
 - Agent-side plugin management (start/stop from within sessions)

--- a/docs/superpowers/specs/2026-03-18-event-driven-plugin-system-design.md
+++ b/docs/superpowers/specs/2026-03-18-event-driven-plugin-system-design.md
@@ -1,0 +1,611 @@
+# Event-Driven Plugin System — Design Spec
+
+**Status:** Design complete, pending implementation planning
+**Priority:** P1
+**Godmother ID:** NhmvLzqj
+**Date:** 2026-03-18
+
+---
+
+## 1. Problem
+
+PizzaPi sessions are currently human-initiated — someone types a prompt or spawns a child session. There's no way for external events (GitHub PR comments, Slack messages, file changes, cron schedules) to automatically trigger agent sessions.
+
+**Primary use case:** A GitHub PR gets a comment → an agent picks it up and continues the conversation (or spawns a new one).
+
+**Generalized:** Any external event source should be able to trigger agent work, either by spawning a new session on a runner or injecting input into an existing session.
+
+---
+
+## 2. Architecture Overview
+
+```
+                                      ┌──────────────────────┐
+[github plugin]  ──events──┐          │   Trigger Router      │
+[slack plugin]   ──events──┤          │                       │
+[cron plugin]    ──events──┤──► Bus ──│  1. Session triggers   │──► inject into session
+[webhook plugin] ──events──┤          │  2. Runner triggers    │──► spawn new session
+[custom plugin]  ──events──┘          │  3. Dead letter log    │
+                                      └──────────────────────┘
+```
+
+**Event Bus Architecture** was chosen over:
+- **Hook-based** — hooks are fire-and-forget scripts, not long-lived listeners
+- **MCP-as-event-source** — MCP is request/response (pull); events are push-based
+
+The plugin process model mirrors MCP for familiarity, but the semantics are push-based event notifications.
+
+---
+
+## 3. Plugin Config (`~/.pizzapi/plugins.json`)
+
+Event sources and trigger rules live in a dedicated config file, separate from `config.json`.
+
+```jsonc
+{
+  "eventSources": {
+    // stdio transport — runner manages the process
+    "github-pr": {
+      "transport": "stdio",
+      "command": "pizzapi-plugin-github",
+      "args": ["--mode", "pr-comments"],
+      "env": {
+        "GITHUB_TOKEN": "${GITHUB_TOKEN}"
+      },
+      "disabled": false
+    },
+
+    // HTTP streamable transport — runner connects to remote service
+    "slack-mentions": {
+      "transport": "http",
+      "url": "https://my-slack-bridge.example.com/sse",
+      "headers": {
+        "Authorization": "Bearer ${SLACK_BRIDGE_TOKEN}"
+      }
+    },
+
+    "file-watcher": {
+      "transport": "stdio",
+      "command": "pizzapi-plugin-fswatcher",
+      "args": ["--watch", "./src"],
+      "disabled": true
+    }
+  },
+
+  // Runner-level trigger rules (persistent, survive restarts)
+  "triggers": [
+    {
+      "name": "pr-review-bot",
+      "source": "github-pr",
+      "match": {
+        "eventType": "comment_created",
+        "context.repo": "Pizzaface/PizzaPi"
+      },
+      "action": {
+        "type": "spawn",
+        "prompt": "Handle this PR comment:\n\nRepo: {event.context.repo}\nPR: #{event.context.pr}\nAuthor: {event.payload.author}\n\n{event.payload.body}",
+        "cwd": "/path/to/repo",
+        "agent": "pr-reviewer"
+      }
+    }
+  ]
+}
+```
+
+### Config shape
+
+```typescript
+interface PluginsConfig {
+  eventSources: Record<string, EventSourceConfig>;
+  triggers: RunnerTrigger[];
+}
+
+interface EventSourceConfigBase {
+  disabled?: boolean;           // won't start even with autoStart
+}
+
+interface StdioEventSource extends EventSourceConfigBase {
+  transport: "stdio";
+  command: string;
+  args?: string[];
+  env?: Record<string, string>; // supports ${ENV_VAR} interpolation
+  restart?: "always" | "on-failure" | "never";  // default: "on-failure"
+  maxRestarts?: number;         // within restartWindow, default: 5
+  restartWindow?: number;       // seconds, default: 300
+}
+
+interface HttpEventSource extends EventSourceConfigBase {
+  transport: "http";
+  url: string;
+  headers?: Record<string, string>;
+  reconnect?: boolean;          // default: true
+}
+
+type EventSourceConfig = StdioEventSource | HttpEventSource;
+
+interface RunnerTrigger {
+  name: string;
+  source: string;               // event source name
+  match: Record<string, unknown>; // flat dot-path equality matching
+  action: TriggerAction;
+}
+
+interface TriggerAction {
+  type: "spawn" | "inject";
+  prompt?: string;              // supports {event.*} interpolation
+  cwd?: string;
+  agent?: string;               // agent definition name
+  sessionId?: string;           // for "inject" — target session
+}
+```
+
+---
+
+## 4. Plugin Interface (MCP-aligned JSON-RPC 2.0)
+
+### Transports
+
+| Transport | Direction | Mechanism |
+|-----------|-----------|-----------|
+| **stdio** | Plugin → Runner | stdout JSON-lines |
+| | Runner → Plugin | stdin JSON-lines |
+| **HTTP** | Plugin → Runner | SSE stream (`GET /events`) |
+| | Runner → Plugin | POST requests (`POST /control`) |
+
+Both transports use identical JSON-RPC 2.0 messages.
+
+### Handshake
+
+```jsonc
+// Runner → Plugin (request)
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "initialize",
+  "params": {
+    "protocolVersion": "2025-03-01",
+    "runner": { "name": "pizzapi", "version": "0.3.1" }
+  }
+}
+
+// Plugin → Runner (response)
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "protocolVersion": "2025-03-01",
+    "name": "github-pr",
+    "version": "1.0.0",
+    "capabilities": {
+      "events": ["comment_created", "comment_edited", "review_submitted"],
+      "subscribe": true,
+      "backfill": true
+    }
+  }
+}
+
+// Runner → Plugin (notification)
+{ "jsonrpc": "2.0", "method": "notifications/initialized" }
+```
+
+### Event Notifications (Plugin → Runner)
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/event",
+  "params": {
+    "source": "github-pr",
+    "eventType": "comment_created",
+    "id": "evt_abc123",
+    "timestamp": "2026-03-18T14:30:00Z",
+    "payload": {
+      "repo": "Pizzaface/PizzaPi",
+      "pr": 42,
+      "author": "reviewer",
+      "body": "Can you fix the null check on line 87?"
+    },
+    "context": {
+      "repo": "Pizzaface/PizzaPi",
+      "pr": 42
+    }
+  }
+}
+```
+
+### Control Messages (Runner → Plugin)
+
+```jsonc
+// Subscribe (narrow event scope)
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "subscribe",
+  "params": {
+    "filter": { "repo": "Pizzaface/PizzaPi" }
+  }
+}
+
+// Unsubscribe
+{
+  "jsonrpc": "2.0",
+  "id": 3,
+  "method": "unsubscribe",
+  "params": {
+    "filter": { "repo": "Pizzaface/PizzaPi" }
+  }
+}
+
+// Shutdown
+{ "jsonrpc": "2.0", "id": 4, "method": "shutdown" }
+```
+
+### Error Messages (Plugin → Runner)
+
+```jsonc
+{
+  "jsonrpc": "2.0",
+  "method": "notifications/error",
+  "params": {
+    "message": "GitHub API rate limited",
+    "fatal": false
+  }
+}
+```
+
+### Type Definitions
+
+```typescript
+// Plugin → Runner
+type PluginMessage =
+  | { jsonrpc: "2.0"; id: number; result: PluginInitResult }
+  | { jsonrpc: "2.0"; method: "notifications/event"; params: PluginEvent }
+  | { jsonrpc: "2.0"; method: "notifications/error"; params: PluginError }
+
+interface PluginInitResult {
+  protocolVersion: string;
+  name: string;
+  version: string;
+  capabilities: {
+    events: string[];
+    subscribe?: boolean;
+    backfill?: boolean;
+  };
+}
+
+interface PluginEvent {
+  source: string;
+  eventType: string;
+  id: string;
+  timestamp: string;
+  payload: Record<string, unknown>;
+  context?: {
+    repo?: string;
+    pr?: number;
+    issue?: number;
+    channel?: string;
+    path?: string;
+  };
+}
+
+interface PluginError {
+  message: string;
+  fatal?: boolean;
+}
+
+// Runner → Plugin
+type ControlMessage =
+  | { jsonrpc: "2.0"; id: number; method: "initialize"; params: InitParams }
+  | { jsonrpc: "2.0"; method: "notifications/initialized" }
+  | { jsonrpc: "2.0"; id: number; method: "subscribe"; params: { filter: Record<string, unknown> } }
+  | { jsonrpc: "2.0"; id: number; method: "unsubscribe"; params: { filter: Record<string, unknown> } }
+  | { jsonrpc: "2.0"; id: number; method: "shutdown" }
+
+interface InitParams {
+  protocolVersion: string;
+  runner: { name: string; version: string };
+}
+```
+
+### Minimal Plugin Example
+
+```bash
+#!/bin/bash
+# Minimal cron plugin — emits a tick every 60 seconds
+
+# Read initialize request
+read -r init
+# Respond with capabilities
+echo '{"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2025-03-01","name":"cron","version":"1.0.0","capabilities":{"events":["tick"]}}}'
+# Read initialized notification
+read -r _
+
+while true; do
+  sleep 60
+  echo "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/event\",\"params\":{\"source\":\"cron\",\"eventType\":\"tick\",\"id\":\"$(uuidgen)\",\"timestamp\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"payload\":{}}}"
+done
+```
+
+---
+
+## 5. Event Bus
+
+The event bus is an in-process event emitter on the runner. No external infrastructure (no Redis, no message queue).
+
+```typescript
+interface EventBus {
+  emit(event: PluginEvent): void;
+  onEvent(handler: (event: PluginEvent) => void): void;
+  getStats(): { received: number; deduped: number; routed: number };
+}
+```
+
+**Deduplication:** Ring buffer of last 1000 event IDs. If a plugin re-sends an event (e.g., after reconnect with backfill), it's silently dropped. Best-effort — not a guarantee across runner restarts.
+
+---
+
+## 6. Trigger Router
+
+The router checks incoming events against two registries in priority order.
+
+### Session Triggers (ephemeral)
+
+Registered by live sessions via tools. Die when the session disconnects.
+
+```typescript
+interface SessionTrigger {
+  triggerId: string;
+  sessionId: string;
+  source: string;
+  filter: Record<string, unknown>;
+  label?: string;
+  registeredAt: number;
+}
+```
+
+### Runner Triggers (persistent)
+
+Configured in `plugins.json`. Survive runner restarts.
+
+### Matching Logic
+
+Flat dot-path equality against event fields:
+
+```jsonc
+{
+  "match": {
+    "eventType": "comment_created",
+    "context.repo": "Pizzaface/PizzaPi",
+    "payload.author": "reviewer"
+  }
+}
+```
+
+All keys in `match` must be present and equal in the event. Missing keys in the event = no match. No regex or glob in v1.
+
+### Routing Priority
+
+1. **Session triggers** — most recently registered wins if multiple match
+2. **Runner triggers** — first matching rule wins (config order)
+3. **Dead letter log** — no match, event logged for debugging
+
+If both a session trigger and a runner trigger match, session trigger wins (the session explicitly asked for this event).
+
+### Actions
+
+- **`spawn`** — create a new session with prompt template (supports `{event.*}` interpolation)
+- **`inject`** — send event as input to an existing session
+
+Session triggers always inject into the registering session.
+
+### Busy Session Handling
+
+If the target session is mid-turn, the event is queued. Max queue depth: 10 per session, oldest dropped when full. Delivered when the session's turn completes.
+
+---
+
+## 7. Agent-Facing Tools
+
+### `list_event_sources`
+
+```typescript
+list_event_sources()
+// Returns:
+{
+  sources: [
+    { name: "github-pr", status: "connected", events: ["comment_created", "comment_edited"] },
+    { name: "slack-mentions", status: "connected", events: ["message", "reaction_added"] },
+    { name: "cron", status: "disabled", events: ["tick"] }
+  ]
+}
+```
+
+### `register_trigger`
+
+```typescript
+register_trigger({
+  source: "github-pr",
+  filter: {
+    "eventType": "comment_created",
+    "context.repo": "Pizzaface/PizzaPi",
+    "context.pr": 42
+  },
+  label: "PR #42 comments"
+})
+// Returns:
+{ triggerId: "st_abc123", message: "Registered: will inject events matching PR #42 comments" }
+```
+
+### `unregister_trigger`
+
+```typescript
+unregister_trigger({ triggerId: "st_abc123" })
+```
+
+### `list_triggers`
+
+```typescript
+list_triggers()
+// Returns:
+{
+  triggers: [
+    {
+      triggerId: "st_abc123",
+      source: "github-pr",
+      filter: { "eventType": "comment_created", "context.pr": 42 },
+      label: "PR #42 comments",
+      registeredAt: "2026-03-18T14:30:00Z"
+    }
+  ]
+}
+```
+
+### Event Delivery Format
+
+Events are injected as conversation input using the same mechanism as `tell_child` (`deliverAs: "input"`):
+
+```markdown
+<!-- event:github-pr:comment_created -->
+📩 Event from github-pr: comment_created
+
+**Repo:** Pizzaface/PizzaPi
+**PR:** #42
+**Author:** reviewer
+**Body:**
+Can you fix the null check on line 87?
+```
+
+The agent processes it like any other user message.
+
+### CLI Mode (Local Sessions)
+
+Same tools work with constraints:
+- Event sources configured in local `~/.pizzapi/plugins.json`
+- CLI manages its own event source processes
+- Session must stay alive — if it exits, triggers die
+- No `spawn` action — events always inject into the current session
+
+---
+
+## 8. Runtime Management
+
+### CLI Commands
+
+Mirror MCP server management:
+
+```bash
+pizza plugin list                    # List event sources and status
+pizza plugin add <name> [opts]       # Add a new event source
+pizza plugin remove <name>           # Remove an event source
+pizza plugin enable <name>           # Enable (set disabled: false)
+pizza plugin disable <name>          # Disable (set disabled: true)
+pizza plugin start <name>            # Runtime start (doesn't change config)
+pizza plugin stop <name>             # Runtime stop (doesn't change config)
+pizza plugin restart <name>          # Restart
+pizza plugin status <name>           # Details: config, status, event counts
+pizza plugin logs <name>             # View plugin logs
+pizza plugin logs <name> --follow    # Tail logs
+```
+
+### `disabled` Flag
+
+`disabled: true` in config takes precedence over everything — `autoStart`, manual `pizza plugin start`, etc. Must `pizza plugin enable` first.
+
+### Runner Dashboard (Web UI)
+
+Event sources shown in runner panel:
+
+```
+Event Sources
+─────────────
+● github-pr        connected   142 events   last: 2m ago
+● slack-mentions   connected    38 events   last: 15m ago
+○ cron             disabled
+○ file-watcher     stopped
+```
+
+With controls to start/stop/restart/enable/disable from the UI.
+
+### Agent-Side Management
+
+Read-only in v1. Agents can see sources and register triggers, but cannot start/stop plugins. Infrastructure management stays with humans and CLI.
+
+---
+
+## 9. Error Handling & Lifecycle
+
+### Plugin Lifecycle
+
+```
+Runner starts
+  ↓
+For each eventSource (not disabled):
+  ├─ stdio: spawn process / http: connect
+  ├─ Send initialize → wait for ready (5s timeout)
+  ├─ On success: mark "connected", begin receiving events
+  └─ On failure: mark "errored", log, apply restart policy
+
+Runner shutdown:
+  ├─ Send shutdown to all connected plugins
+  ├─ Wait 3s for graceful exit
+  └─ SIGKILL any remaining (stdio only)
+```
+
+### Restart Policies
+
+**stdio:**
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `restart` | `"on-failure"` | `"always"`, `"on-failure"`, `"never"` |
+| `maxRestarts` | `5` | Within `restartWindow` |
+| `restartWindow` | `300` | Seconds — resets the restart counter |
+
+**HTTP:** `reconnect: true` (default) with exponential backoff: 1s, 2s, 4s, 8s, max 60s.
+
+### Failure Modes
+
+| Failure | Behavior |
+|---------|----------|
+| Plugin crashes (stdio) | Restart per policy. Events during downtime lost unless plugin supports `backfill`. |
+| HTTP connection drops | Reconnect with backoff. |
+| Malformed JSON-RPC | Log warning, skip message, keep connection alive. |
+| `initialize` times out (5s) | Mark errored, apply restart policy. |
+| Plugin sends `fatal: true` error | Disconnect, don't restart. Surface in runner UI. |
+| Event matches dead session trigger | Clean up stale registration, fall through to runner triggers. |
+| Event matches but session is busy | Queue event. Max 10 per session, oldest dropped. |
+
+### Session Trigger Cleanup
+
+- Session disconnects → all its triggers removed immediately
+- Safety sweep every 60s for stale registrations
+
+### Observability
+
+- **Runner UI dashboard:** connected sources, status, event counts, last event time
+- **Dead letter log:** `~/.pizzapi/logs/events-dead-letter.jsonl` — rotating, max 1MB
+- **Plugin stderr:** `~/.pizzapi/logs/plugin-{name}.log` — rotating, max 5MB per plugin
+
+---
+
+## 10. V1 Scope
+
+### In scope
+- Plugin config (`plugins.json`) with stdio and HTTP transports
+- JSON-RPC 2.0 plugin protocol (initialize, events, subscribe, shutdown)
+- Event bus with dedup
+- Trigger router with session triggers + runner triggers
+- Agent tools: `list_event_sources`, `register_trigger`, `unregister_trigger`, `list_triggers`
+- Event delivery as conversation input
+- CLI management: `pizza plugin list|add|remove|enable|disable|start|stop|restart|status|logs`
+- Runner dashboard UI for event source status
+- Error handling, restart policies, observability logs
+- At least one reference plugin implementation (GitHub PR comments)
+
+### Out of scope (future)
+- Agent-side plugin management (start/stop from within sessions)
+- Glob/regex matching in trigger rules
+- Event persistence across runner restarts
+- Cross-runner event routing
+- Plugin marketplace / registry
+- Web UI extension rendering for events (integrate with WqK3N8Ft later)

--- a/docs/superpowers/specs/2026-03-18-event-driven-plugin-system-design.md
+++ b/docs/superpowers/specs/2026-03-18-event-driven-plugin-system-design.md
@@ -135,7 +135,10 @@ interface TriggerAction {
   prompt?: string;              // supports {event.*} interpolation
   cwd?: string;
   agent?: string;               // agent definition name
-  sessionId?: string;           // for "inject" — target session
+  sessionId?: string;           // REQUIRED for "inject" — target session ID or name
+  // When type is "inject", sessionId must be provided.
+  // If the target session is not found (disconnected/dead), the event
+  // falls through to the next matching trigger or dead letter log.
 }
 ```
 
@@ -153,6 +156,8 @@ interface TriggerAction {
 | | Runner → Plugin | POST requests (`POST /control`) |
 
 Both transports use identical JSON-RPC 2.0 messages.
+
+**HTTP transport topology:** The **plugin hosts** the HTTP server. The runner is the client — it connects to the plugin's SSE endpoint (`GET {url}/events`) and sends control messages via `POST {url}/control`. This mirrors MCP's streamable-http where the server (plugin) hosts and the client (runner) connects. The `url` in config points to the plugin's base URL.
 
 ### Handshake
 
@@ -212,6 +217,8 @@ Both transports use identical JSON-RPC 2.0 messages.
   }
 }
 ```
+
+> **Note on `context`:** The `context` field is `Record<string, unknown>` — plugins define whatever keys make sense for their domain. The matching system uses dot-path resolution, so `"context.repo": "Pizzaface/PizzaPi"` works regardless of what keys a plugin uses.
 
 ### Control Messages (Runner → Plugin)
 
@@ -279,13 +286,7 @@ interface PluginEvent {
   id: string;
   timestamp: string;
   payload: Record<string, unknown>;
-  context?: {
-    repo?: string;
-    pr?: number;
-    issue?: number;
-    channel?: string;
-    path?: string;
-  };
+  context?: Record<string, unknown>;  // plugin-defined routing hints (e.g. { repo, pr, channel })
 }
 
 interface PluginError {
@@ -383,13 +384,13 @@ Flat dot-path equality against event fields:
 
 All keys in `match` must be present and equal in the event. Missing keys in the event = no match. No regex or glob in v1.
 
+**Match value types:** Only primitives — `string | number | boolean`. Arrays and nested objects in `match` are not supported. The dot-path resolves into the event structure (e.g., `"context.repo"` looks up `event.context.repo`), and the resolved value must strictly equal the match value.
+
 ### Routing Priority
 
-1. **Session triggers** — most recently registered wins if multiple match
-2. **Runner triggers** — first matching rule wins (config order)
-3. **Dead letter log** — no match, event logged for debugging
-
-If both a session trigger and a runner trigger match, session trigger wins (the session explicitly asked for this event).
+1. **Session triggers** — if multiple session triggers match, **all matching sessions receive the event** (fan-out). This is intentional: two sessions watching the same PR both get notified.
+2. **Runner triggers** — first matching rule wins (config order). Runner triggers fire **only if no session trigger matched** — session triggers take priority.
+3. **Dead letter log** — no match from either tier, event logged for debugging.
 
 ### Actions
 
@@ -468,14 +469,20 @@ Events are injected as conversation input using the same mechanism as `tell_chil
 <!-- event:github-pr:comment_created -->
 📩 Event from github-pr: comment_created
 
-**Repo:** Pizzaface/PizzaPi
-**PR:** #42
-**Author:** reviewer
-**Body:**
-Can you fix the null check on line 87?
+**context:**
+```json
+{"repo":"Pizzaface/PizzaPi","pr":42}
 ```
 
-The agent processes it like any other user message.
+**payload:**
+```json
+{"author":"reviewer","body":"Can you fix the null check on line 87?"}
+```
+```
+
+The delivery format is generic — `context` and `payload` are serialized as JSON blocks from the `PluginEvent`. No per-plugin rendering in v1. The agent processes it like any other user message and extracts what it needs.
+
+If a runner trigger has a `prompt` template with `{event.*}` interpolation, the rendered prompt replaces the generic format above. This allows trigger authors to produce human-readable messages for specific use cases.
 
 ### CLI Mode (Local Sessions)
 
@@ -495,7 +502,12 @@ Mirror MCP server management:
 
 ```bash
 pizza plugin list                    # List event sources and status
-pizza plugin add <name> [opts]       # Add a new event source
+
+# Add a new event source (stdio)
+pizza plugin add <name> --transport stdio --command <cmd> [--args "arg1,arg2"] [--env "KEY=val"]
+# Add a new event source (http)
+pizza plugin add <name> --transport http --url <url> [--header "Key: Value"]
+
 pizza plugin remove <name>           # Remove an event source
 pizza plugin enable <name>           # Enable (set disabled: false)
 pizza plugin disable <name>          # Disable (set disabled: true)
@@ -609,3 +621,5 @@ Runner shutdown:
 - Cross-runner event routing
 - Plugin marketplace / registry
 - Web UI extension rendering for events (integrate with WqK3N8Ft later)
+- **`backfill` capability**: declared in the handshake for forward-compatibility, but no control message or behavior is defined in v1. Plugins that support backfill should advertise it; the runner will use it in a future version to request missed events after reconnect.
+- **`subscribe`/`unsubscribe` semantics**: the control messages are defined in the protocol, but v1 does not send them automatically. They exist for plugins that want to support scope narrowing. Future versions may send `subscribe` when the first trigger for a source is registered.

--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -175,7 +175,7 @@ export async function handleExecFromWeb(
             }
             api.setThinkingLevel(level);
             replyOk({ thinkingLevel: api.getThinkingLevel() });
-            rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+            rctx.emitSessionActive();
             return;
         }
 
@@ -203,7 +203,7 @@ export async function handleExecFromWeb(
             }
 
             replyOk({ thinkingLevel: appliedLevel });
-            rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+            rctx.emitSessionActive();
             return;
         }
 
@@ -269,7 +269,7 @@ export async function handleExecFromWeb(
                 rctx.lastRetryableError = null;
                 rctx.isCompacting = false;
                 replyOk(result ?? null);
-                rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+                rctx.emitSessionActive();
                 rctx.forwardEvent(rctx.buildHeartbeat());
             } catch (err) {
                 rctx.isCompacting = false;
@@ -287,9 +287,8 @@ export async function handleExecFromWeb(
             await rctx.pi.setSessionName(req.name);
 
             callbacks.markSessionNameBroadcasted();
-            const state = rctx.buildSessionState();
-            replyOk({ sessionName: state?.sessionName ?? null });
-            rctx.forwardEvent({ type: "session_active", state });
+            replyOk({ sessionName: rctx.getCurrentSessionName() ?? null });
+            rctx.emitSessionActive();
             rctx.forwardEvent(rctx.buildHeartbeat());
             return;
         }
@@ -363,7 +362,7 @@ export async function handleExecFromWeb(
                 return;
             }
             replyOk({ session: toResumeSessionSummary(target) });
-            rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+            rctx.emitSessionActive();
             rctx.forwardEvent(rctx.buildHeartbeat());
             return;
         }
@@ -384,7 +383,7 @@ export async function handleExecFromWeb(
                 return;
             }
             replyOk();
-            rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+            rctx.emitSessionActive();
             return;
         }
 

--- a/packages/cli/src/extensions/remote-payload-cap.test.ts
+++ b/packages/cli/src/extensions/remote-payload-cap.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { estimateMessagesSize, needsChunkedDelivery } from "./remote.js";
+import { estimateMessagesSize, needsChunkedDelivery, computeChunkBoundaries } from "./remote.js";
 
 describe("estimateMessagesSize", () => {
     test("returns 2 for empty array", () => {
@@ -79,5 +79,60 @@ describe("needsChunkedDelivery", () => {
             content: `${bigContent}-${i}`,
         }));
         expect(needsChunkedDelivery(msgs)).toBe(true);
+    });
+});
+
+describe("computeChunkBoundaries", () => {
+    test("returns single chunk for small messages", () => {
+        const msgs = Array.from({ length: 5 }, (_, i) => ({ role: "user", content: `msg ${i}` }));
+        const boundaries = computeChunkBoundaries(msgs);
+        expect(boundaries).toEqual([[0, 5]]);
+    });
+
+    test("splits by message count at CHUNK_SIZE (200)", () => {
+        const msgs = Array.from({ length: 450 }, (_, i) => ({ role: "user", content: `m${i}` }));
+        const boundaries = computeChunkBoundaries(msgs);
+        // 200 + 200 + 50 = 3 chunks
+        expect(boundaries).toEqual([[0, 200], [200, 400], [400, 450]]);
+    });
+
+    test("splits by byte size when messages are large", () => {
+        // 10 messages each ~2 MB — byte limit is 8 MB, so should get ~3 chunks
+        const bigContent = "x".repeat(2_000_000);
+        const msgs = Array.from({ length: 10 }, (_, i) => ({ role: "user", content: `${bigContent}-${i}` }));
+        const boundaries = computeChunkBoundaries(msgs);
+
+        // Should have more than 1 chunk (byte limit forces splits)
+        expect(boundaries.length).toBeGreaterThan(1);
+
+        // All messages should be covered
+        const total = boundaries.reduce((sum, [s, e]) => sum + (e - s), 0);
+        expect(total).toBe(10);
+
+        // Each chunk should have ≤4 messages (each ~2 MB, limit 8 MB)
+        for (const [start, end] of boundaries) {
+            expect(end - start).toBeLessThanOrEqual(4);
+        }
+    });
+
+    test("handles single message larger than byte limit", () => {
+        // One message > 8 MB — must still produce a chunk (safety: advance by 1)
+        const hugeContent = "x".repeat(10_000_000);
+        const msgs = [{ role: "user", content: hugeContent }];
+        const boundaries = computeChunkBoundaries(msgs);
+        expect(boundaries).toEqual([[0, 1]]);
+    });
+
+    test("covers all messages without gaps", () => {
+        const msgs = Array.from({ length: 500 }, (_, i) => ({ role: "user", content: `message-${i}` }));
+        const boundaries = computeChunkBoundaries(msgs);
+
+        // No gaps: each chunk starts where the previous ended
+        for (let i = 1; i < boundaries.length; i++) {
+            expect(boundaries[i][0]).toBe(boundaries[i - 1][1]);
+        }
+        // First starts at 0, last ends at length
+        expect(boundaries[0][0]).toBe(0);
+        expect(boundaries[boundaries.length - 1][1]).toBe(500);
     });
 });

--- a/packages/cli/src/extensions/remote-payload-cap.test.ts
+++ b/packages/cli/src/extensions/remote-payload-cap.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect } from "bun:test";
+import { capMessagesPayload } from "./remote.js";
+
+describe("capMessagesPayload", () => {
+    test("returns original array when small", () => {
+        const msgs = [
+            { role: "user", content: "hello" },
+            { role: "assistant", content: "hi" },
+        ];
+        const result = capMessagesPayload(msgs);
+        expect(result).toBe(msgs); // same reference — no copy
+    });
+
+    test("returns original for empty array", () => {
+        expect(capMessagesPayload([])).toEqual([]);
+    });
+
+    test("returns original for single message", () => {
+        const msgs = [{ role: "user", content: "x" }];
+        expect(capMessagesPayload(msgs)).toBe(msgs);
+    });
+
+    test("truncates oversized messages array and prepends marker", () => {
+        // Create a large array — each message ~10 KB, 10_000 messages ≈ 100 MB estimated
+        const bigContent = "x".repeat(10_000);
+        const msgs = Array.from({ length: 10_000 }, (_, i) => ({
+            role: i % 2 === 0 ? "user" : "assistant",
+            content: `${bigContent}-${i}`,
+        }));
+
+        const result = capMessagesPayload(msgs);
+
+        // Should be truncated
+        expect(result.length).toBeLessThan(msgs.length);
+        expect(result.length).toBeGreaterThan(1);
+
+        // First element should be the truncation marker
+        const marker = result[0] as { role: string; content: string };
+        expect(marker.role).toBe("system");
+        expect(marker.content).toContain("truncated");
+        expect(marker.content).toContain(String(msgs.length));
+
+        // Remaining elements should be from the END of the original array
+        const lastOriginal = msgs[msgs.length - 1] as { content: string };
+        const lastResult = result[result.length - 1] as { content: string };
+        expect(lastResult.content).toBe(lastOriginal.content);
+    });
+});

--- a/packages/cli/src/extensions/remote-payload-cap.test.ts
+++ b/packages/cli/src/extensions/remote-payload-cap.test.ts
@@ -182,4 +182,16 @@ describe("capOversizedMessages", () => {
         expect(truncated.toolName).toBe("bash");
         expect(truncated.key).toBe("abc");
     });
+
+    test("caps oversized details field when content alone is not enough", () => {
+        // Small content but huge details (e.g. subagent results)
+        const hugeDetails = { results: [{ messages: Array.from({ length: 5000 }, (_, i) => ({ role: "assistant", content: "x".repeat(11_000) })) }] };
+        const msgs = [{ role: "assistant", content: "done", details: hugeDetails }];
+        const result = capOversizedMessages(msgs);
+        const truncated = result[0] as Record<string, unknown>;
+        expect(typeof truncated.details).toBe("string");
+        expect((truncated.details as string)).toContain("truncated");
+        // Content should also be replaced with truncation notice
+        expect((truncated.content as string)).toContain("truncated");
+    });
 });

--- a/packages/cli/src/extensions/remote-payload-cap.test.ts
+++ b/packages/cli/src/extensions/remote-payload-cap.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { estimateMessagesSize, needsChunkedDelivery, computeChunkBoundaries } from "./remote.js";
+import { estimateMessagesSize, needsChunkedDelivery, computeChunkBoundaries, capOversizedMessages } from "./remote.js";
 
 describe("estimateMessagesSize", () => {
     test("returns 2 for empty array", () => {
@@ -59,8 +59,14 @@ describe("needsChunkedDelivery", () => {
         expect(needsChunkedDelivery([])).toBe(false);
     });
 
-    test("returns false for single message", () => {
+    test("returns false for single small message", () => {
         expect(needsChunkedDelivery([{ role: "user", content: "x" }])).toBe(false);
+    });
+
+    test("returns true for single oversized message", () => {
+        // One message > 10 MB threshold
+        const huge = "x".repeat(15_000_000);
+        expect(needsChunkedDelivery([{ role: "user", content: huge }])).toBe(true);
     });
 
     test("returns false for small messages", () => {
@@ -134,5 +140,46 @@ describe("computeChunkBoundaries", () => {
         // First starts at 0, last ends at length
         expect(boundaries[0][0]).toBe(0);
         expect(boundaries[boundaries.length - 1][1]).toBe(500);
+    });
+});
+
+describe("capOversizedMessages", () => {
+    test("returns same array when all messages are small", () => {
+        const msgs = [
+            { role: "user", content: "hello" },
+            { role: "assistant", content: "hi" },
+        ];
+        const result = capOversizedMessages(msgs);
+        expect(result).toBe(msgs); // same reference — no copy
+    });
+
+    test("truncates messages exceeding 50 MB", () => {
+        const hugeContent = "x".repeat(55_000_000); // ~55 MB
+        const msgs = [
+            { role: "user", content: "hello" },
+            { role: "assistant", content: hugeContent },
+        ];
+        const result = capOversizedMessages(msgs);
+
+        // Should be a new array (copied)
+        expect(result).not.toBe(msgs);
+        // First message unchanged
+        expect(result[0]).toBe(msgs[0]);
+        // Second message truncated
+        const truncated = result[1] as Record<string, unknown>;
+        expect(typeof truncated.content).toBe("string");
+        expect((truncated.content as string).length).toBeLessThan(1000);
+        expect((truncated.content as string)).toContain("truncated");
+        expect(truncated.role).toBe("assistant");
+    });
+
+    test("preserves message metadata when truncating", () => {
+        const hugeContent = "x".repeat(55_000_000);
+        const msgs = [{ role: "assistant", content: hugeContent, toolName: "bash", key: "abc" }];
+        const result = capOversizedMessages(msgs);
+        const truncated = result[0] as Record<string, unknown>;
+        expect(truncated.role).toBe("assistant");
+        expect(truncated.toolName).toBe("bash");
+        expect(truncated.key).toBe("abc");
     });
 });

--- a/packages/cli/src/extensions/remote-payload-cap.test.ts
+++ b/packages/cli/src/extensions/remote-payload-cap.test.ts
@@ -1,48 +1,61 @@
 import { describe, test, expect } from "bun:test";
-import { capMessagesPayload } from "./remote.js";
+import { estimateMessagesSize, needsChunkedDelivery } from "./remote.js";
 
-describe("capMessagesPayload", () => {
-    test("returns original array when small", () => {
+describe("estimateMessagesSize", () => {
+    test("returns 2 for empty array", () => {
+        expect(estimateMessagesSize([])).toBe(2);
+    });
+
+    test("estimates size for small messages", () => {
         const msgs = [
             { role: "user", content: "hello" },
             { role: "assistant", content: "hi" },
         ];
-        const result = capMessagesPayload(msgs);
-        expect(result).toBe(msgs); // same reference — no copy
+        const estimated = estimateMessagesSize(msgs);
+        const actual = JSON.stringify(msgs).length;
+        // Should be within 50% of actual (sampling adds overhead estimation)
+        expect(estimated).toBeGreaterThan(actual * 0.5);
+        expect(estimated).toBeLessThan(actual * 2);
     });
 
-    test("returns original for empty array", () => {
-        expect(capMessagesPayload([])).toEqual([]);
-    });
-
-    test("returns original for single message", () => {
-        const msgs = [{ role: "user", content: "x" }];
-        expect(capMessagesPayload(msgs)).toBe(msgs);
-    });
-
-    test("truncates oversized messages array and prepends marker", () => {
-        // Create a large array — each message ~10 KB, 10_000 messages ≈ 100 MB estimated
+    test("estimates size for large messages with reasonable accuracy", () => {
         const bigContent = "x".repeat(10_000);
-        const msgs = Array.from({ length: 10_000 }, (_, i) => ({
+        const msgs = Array.from({ length: 100 }, (_, i) => ({
             role: i % 2 === 0 ? "user" : "assistant",
             content: `${bigContent}-${i}`,
         }));
+        const estimated = estimateMessagesSize(msgs);
+        const actual = JSON.stringify(msgs).length;
+        // Within 50% — sampling is approximate
+        expect(estimated).toBeGreaterThan(actual * 0.5);
+        expect(estimated).toBeLessThan(actual * 2);
+    });
+});
 
-        const result = capMessagesPayload(msgs);
+describe("needsChunkedDelivery", () => {
+    test("returns false for empty array", () => {
+        expect(needsChunkedDelivery([])).toBe(false);
+    });
 
-        // Should be truncated
-        expect(result.length).toBeLessThan(msgs.length);
-        expect(result.length).toBeGreaterThan(1);
+    test("returns false for single message", () => {
+        expect(needsChunkedDelivery([{ role: "user", content: "x" }])).toBe(false);
+    });
 
-        // First element should be the truncation marker
-        const marker = result[0] as { role: string; content: string };
-        expect(marker.role).toBe("system");
-        expect(marker.content).toContain("truncated");
-        expect(marker.content).toContain(String(msgs.length));
+    test("returns false for small messages", () => {
+        const msgs = Array.from({ length: 10 }, (_, i) => ({
+            role: "user",
+            content: `message ${i}`,
+        }));
+        expect(needsChunkedDelivery(msgs)).toBe(false);
+    });
 
-        // Remaining elements should be from the END of the original array
-        const lastOriginal = msgs[msgs.length - 1] as { content: string };
-        const lastResult = result[result.length - 1] as { content: string };
-        expect(lastResult.content).toBe(lastOriginal.content);
+    test("returns true for messages exceeding 10 MB threshold", () => {
+        // Each message ~10 KB, 2000 messages ≈ 20 MB > 10 MB threshold
+        const bigContent = "x".repeat(10_000);
+        const msgs = Array.from({ length: 2000 }, (_, i) => ({
+            role: i % 2 === 0 ? "user" : "assistant",
+            content: `${bigContent}-${i}`,
+        }));
+        expect(needsChunkedDelivery(msgs)).toBe(true);
     });
 });

--- a/packages/cli/src/extensions/remote-payload-cap.test.ts
+++ b/packages/cli/src/extensions/remote-payload-cap.test.ts
@@ -26,9 +26,31 @@ describe("estimateMessagesSize", () => {
         }));
         const estimated = estimateMessagesSize(msgs);
         const actual = JSON.stringify(msgs).length;
-        // Within 50% — sampling is approximate
+        // Within 50% — now iterates all messages, so very accurate
         expect(estimated).toBeGreaterThan(actual * 0.5);
         expect(estimated).toBeLessThan(actual * 2);
+    });
+
+    test("catches outlier-heavy distributions (few very large messages)", () => {
+        // 1000 small messages + 6 x 2MB messages clustered at the end
+        // Old sampling approach could miss these entirely
+        const smallMsgs = Array.from({ length: 1000 }, (_, i) => ({
+            role: "user",
+            content: `msg ${i}`,
+        }));
+        const bigContent = "x".repeat(2_000_000);
+        const bigMsgs = Array.from({ length: 6 }, () => ({
+            role: "assistant",
+            content: bigContent,
+        }));
+        const msgs = [...smallMsgs, ...bigMsgs];
+        const estimated = estimateMessagesSize(msgs);
+        const actual = JSON.stringify(msgs).length;
+        // Must capture the ~12 MB of big messages — estimated should be >10 MB
+        expect(estimated).toBeGreaterThan(10 * 1024 * 1024);
+        // And within reasonable accuracy of actual
+        expect(estimated).toBeGreaterThan(actual * 0.8);
+        expect(estimated).toBeLessThan(actual * 1.5);
     });
 });
 

--- a/packages/cli/src/extensions/remote-types.ts
+++ b/packages/cli/src/extensions/remote-types.ts
@@ -222,6 +222,8 @@ export interface RelayContext {
 
     // State builders
     buildSessionState(): any;
+    /** Emit session_active with automatic chunking for large sessions. */
+    emitSessionActive(): void;
     buildHeartbeat(): any;
     buildCapabilitiesState(): any;
     getConfiguredModels(): RelayModelInfo[];

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -121,13 +121,16 @@ export function needsChunkedDelivery(messages: unknown[]): boolean {
  *
  * Uses setImmediate between chunks to yield the event loop so Socket.IO
  * pings can be answered, preventing transport-close disconnects.
+ *
+ * Each chunk carries a `snapshotId` that matches the session_active event,
+ * so the UI can discard stale chunks from a previous snapshot stream.
  */
-function sendChunkedMessages(rctx: RelayContext, messages: unknown[]): void {
+function sendChunkedMessages(rctx: RelayContext, messages: unknown[], snapshotId: string): void {
     const totalChunks = Math.ceil(messages.length / CHUNK_SIZE);
 
     console.log(
         `pizzapi: session is large (${messages.length} messages, ~${(estimateMessagesSize(messages) / 1024 / 1024).toFixed(0)} MB). ` +
-        `Sending in ${totalChunks} chunks of ≤${CHUNK_SIZE} messages.`,
+        `Sending in ${totalChunks} chunks of ≤${CHUNK_SIZE} messages (snapshot=${snapshotId.slice(0, 8)}).`,
     );
 
     let chunkIndex = 0;
@@ -142,6 +145,7 @@ function sendChunkedMessages(rctx: RelayContext, messages: unknown[]): void {
 
         rctx.forwardEvent({
             type: "session_messages_chunk",
+            snapshotId,
             chunkIndex,
             totalChunks,
             totalMessages: messages.length,
@@ -187,17 +191,21 @@ function emitSessionActive(rctx: RelayContext): void {
     };
 
     if (needsChunkedDelivery(messages)) {
-        // Large session — send metadata-only session_active, then stream chunks
+        // Large session — send metadata-only session_active, then stream chunks.
+        // The snapshotId ties the metadata event to its chunk stream so the UI
+        // can discard stale chunks and the server can assemble the full state.
+        const snapshotId = randomUUID();
         rctx.forwardEvent({
             type: "session_active",
             state: {
                 ...metadata,
                 messages: [], // placeholder — real messages follow as chunks
                 chunked: true,
+                snapshotId,
                 totalMessages: messages.length,
             },
         });
-        sendChunkedMessages(rctx, messages);
+        sendChunkedMessages(rctx, messages, snapshotId);
     } else {
         // Small session — single event (original path)
         rctx.forwardEvent({

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -62,6 +62,74 @@ import { registerPlanModeTool, consumePendingPlanModeFromWeb, cancelPendingPlanM
 const RELAY_DEFAULT = "ws://localhost:7492";
 const RELAY_STATUS_KEY = "relay";
 
+// ── Payload size guard ───────────────────────────────────────────────────────
+//
+// The server's maxHttpBufferSize is 100 MB. If the serialized session_active
+// event exceeds that, Socket.IO silently kills the WebSocket connection
+// (reason: "transport close") and the client auto-reconnects — causing an
+// infinite boot loop. We cap the messages array BEFORE serialization.
+//
+// Strategy: estimate size cheaply via sampling, then truncate from the front
+// (keeping recent messages) if the estimate exceeds the budget.  The UI still
+// gets a usable recent-history snapshot and won't crash the transport.
+
+/** Maximum estimated bytes for the messages array inside session_active. */
+const SESSION_ACTIVE_MAX_BYTES = 50 * 1024 * 1024; // 50 MB — well under the 100 MB server limit
+
+/**
+ * Estimate the serialized JSON size of an array of messages by sampling.
+ * Stringifying the entire array would itself block the event loop for large
+ * sessions, so we sample a handful of elements and extrapolate.
+ */
+function estimateMessagesSize(messages: unknown[]): number {
+    if (messages.length === 0) return 2; // "[]"
+    const SAMPLE_COUNT = Math.min(10, messages.length);
+    let sampleBytes = 0;
+    const step = Math.max(1, Math.floor(messages.length / SAMPLE_COUNT));
+    let sampled = 0;
+    for (let i = 0; i < messages.length && sampled < SAMPLE_COUNT; i += step) {
+        try {
+            sampleBytes += JSON.stringify(messages[i]).length;
+        } catch {
+            sampleBytes += 1024; // fallback estimate for unserializable entries
+        }
+        sampled++;
+    }
+    const avgBytes = sampleBytes / sampled;
+    // Add ~15% overhead for array commas, brackets, and event wrapper fields
+    return Math.ceil(avgBytes * messages.length * 1.15);
+}
+
+/**
+ * Cap the messages array so the session_active payload stays under the
+ * transport limit.  Returns the original array when it's small enough,
+ * or a truncated tail slice with a synthetic "[truncated]" marker when not.
+ */
+export function capMessagesPayload(messages: unknown[]): unknown[] {
+    if (messages.length <= 1) return messages;
+
+    const estimated = estimateMessagesSize(messages);
+    if (estimated <= SESSION_ACTIVE_MAX_BYTES) return messages;
+
+    // Estimate how many messages from the end we can keep
+    const ratio = SESSION_ACTIVE_MAX_BYTES / estimated;
+    const keepCount = Math.max(1, Math.floor(messages.length * ratio * 0.9)); // 10% safety margin
+    const truncated = messages.slice(-keepCount);
+
+    console.log(
+        `pizzapi: session_active payload too large (~${(estimated / 1024 / 1024).toFixed(0)} MB, ` +
+        `${messages.length} messages). Truncating to last ${keepCount} messages ` +
+        `to stay under ${(SESSION_ACTIVE_MAX_BYTES / 1024 / 1024).toFixed(0)} MB transport limit.`,
+    );
+
+    // Prepend a synthetic system marker so the UI shows that history was truncated
+    const marker = {
+        role: "system" as const,
+        content: `[Session history truncated — showing last ${keepCount} of ${messages.length} messages. The full conversation is preserved on disk.]`,
+    };
+    return [marker, ...truncated];
+}
+
 // ── Module-level state for external consumers ────────────────────────────────
 let _ctx: RelayContext | null = null;
 
@@ -181,8 +249,18 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 rctx.latestCtx.sessionManager.getEntries(),
                 rctx.latestCtx.sessionManager.getLeafId(),
             );
+
+            // Guard: cap the messages payload to prevent oversized session_active
+            // events from exceeding the server's maxHttpBufferSize (100 MB) and
+            // silently killing the WebSocket — which triggers an infinite
+            // connect → transport close → reconnect boot loop.
+            //
+            // Estimate serialized size by sampling — full JSON.stringify on a
+            // huge array is itself expensive and would block the event loop.
+            const cappedMessages = capMessagesPayload(messages);
+
             return {
-                messages,
+                messages: cappedMessages,
                 model,
                 thinkingLevel: rctx.getCurrentThinkingLevel(),
                 sessionName: rctx.getCurrentSessionName(),

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -62,26 +62,32 @@ import { registerPlanModeTool, consumePendingPlanModeFromWeb, cancelPendingPlanM
 const RELAY_DEFAULT = "ws://localhost:7492";
 const RELAY_STATUS_KEY = "relay";
 
-// ── Payload size guard ───────────────────────────────────────────────────────
+// ── Chunked session_active delivery ──────────────────────────────────────────
 //
 // The server's maxHttpBufferSize is 100 MB. If the serialized session_active
 // event exceeds that, Socket.IO silently kills the WebSocket connection
 // (reason: "transport close") and the client auto-reconnects — causing an
-// infinite boot loop. We cap the messages array BEFORE serialization.
+// infinite boot loop.
 //
-// Strategy: estimate size cheaply via sampling, then truncate from the front
-// (keeping recent messages) if the estimate exceeds the budget.  The UI still
-// gets a usable recent-history snapshot and won't crash the transport.
+// For large sessions we split the payload: session_active carries metadata
+// only (model, name, cwd, todoList, etc.) with `chunked: true`, then the
+// full message history follows as a series of `session_messages_chunk` events
+// sent through the normal event pipeline. The UI assembles them on arrival.
+//
+// Small sessions (< CHUNK_THRESHOLD) use the original single-event path.
 
-/** Maximum estimated bytes for the messages array inside session_active. */
-const SESSION_ACTIVE_MAX_BYTES = 50 * 1024 * 1024; // 50 MB — well under the 100 MB server limit
+/** Estimated payload size (bytes) above which we chunk messages. */
+const CHUNK_THRESHOLD = 10 * 1024 * 1024; // 10 MB
+
+/** Maximum messages per chunk — keeps individual Socket.IO frames reasonable. */
+const CHUNK_SIZE = 200;
 
 /**
- * Estimate the serialized JSON size of an array of messages by sampling.
- * Stringifying the entire array would itself block the event loop for large
- * sessions, so we sample a handful of elements and extrapolate.
+ * Estimate the serialized JSON size of a messages array by sampling.
+ * Full JSON.stringify on a huge array would itself block the event loop,
+ * so we sample a handful of elements and extrapolate.
  */
-function estimateMessagesSize(messages: unknown[]): number {
+export function estimateMessagesSize(messages: unknown[]): number {
     if (messages.length === 0) return 2; // "[]"
     const SAMPLE_COUNT = Math.min(10, messages.length);
     let sampleBytes = 0;
@@ -101,33 +107,107 @@ function estimateMessagesSize(messages: unknown[]): number {
 }
 
 /**
- * Cap the messages array so the session_active payload stays under the
- * transport limit.  Returns the original array when it's small enough,
- * or a truncated tail slice with a synthetic "[truncated]" marker when not.
+ * Check whether a messages array needs chunked delivery.
  */
-export function capMessagesPayload(messages: unknown[]): unknown[] {
-    if (messages.length <= 1) return messages;
+export function needsChunkedDelivery(messages: unknown[]): boolean {
+    if (messages.length <= 1) return false;
+    return estimateMessagesSize(messages) > CHUNK_THRESHOLD;
+}
 
-    const estimated = estimateMessagesSize(messages);
-    if (estimated <= SESSION_ACTIVE_MAX_BYTES) return messages;
-
-    // Estimate how many messages from the end we can keep
-    const ratio = SESSION_ACTIVE_MAX_BYTES / estimated;
-    const keepCount = Math.max(1, Math.floor(messages.length * ratio * 0.9)); // 10% safety margin
-    const truncated = messages.slice(-keepCount);
+/**
+ * Send messages in chunks via the relay event pipeline.
+ * Each chunk is a `session_messages_chunk` event with a slice of messages,
+ * a chunk index, and total chunk count. The final chunk has `final: true`.
+ *
+ * Uses setImmediate between chunks to yield the event loop so Socket.IO
+ * pings can be answered, preventing transport-close disconnects.
+ */
+function sendChunkedMessages(rctx: RelayContext, messages: unknown[]): void {
+    const totalChunks = Math.ceil(messages.length / CHUNK_SIZE);
 
     console.log(
-        `pizzapi: session_active payload too large (~${(estimated / 1024 / 1024).toFixed(0)} MB, ` +
-        `${messages.length} messages). Truncating to last ${keepCount} messages ` +
-        `to stay under ${(SESSION_ACTIVE_MAX_BYTES / 1024 / 1024).toFixed(0)} MB transport limit.`,
+        `pizzapi: session is large (${messages.length} messages, ~${(estimateMessagesSize(messages) / 1024 / 1024).toFixed(0)} MB). ` +
+        `Sending in ${totalChunks} chunks of ≤${CHUNK_SIZE} messages.`,
     );
 
-    // Prepend a synthetic system marker so the UI shows that history was truncated
-    const marker = {
-        role: "system" as const,
-        content: `[Session history truncated — showing last ${keepCount} of ${messages.length} messages. The full conversation is preserved on disk.]`,
+    let chunkIndex = 0;
+
+    function sendNextChunk() {
+        if (!rctx.relay || !rctx.sioSocket?.connected) return; // disconnected mid-stream
+        if (chunkIndex >= totalChunks) return;
+
+        const start = chunkIndex * CHUNK_SIZE;
+        const end = Math.min(start + CHUNK_SIZE, messages.length);
+        const isFinal = chunkIndex === totalChunks - 1;
+
+        rctx.forwardEvent({
+            type: "session_messages_chunk",
+            chunkIndex,
+            totalChunks,
+            totalMessages: messages.length,
+            messages: messages.slice(start, end),
+            final: isFinal,
+        });
+
+        chunkIndex++;
+
+        if (chunkIndex < totalChunks) {
+            // Yield the event loop so Socket.IO can process pings/acks between chunks
+            setImmediate(sendNextChunk);
+        }
+    }
+
+    // Start the first chunk on the next tick so the session_active event
+    // (with chunked: true) is flushed to the socket first.
+    setImmediate(sendNextChunk);
+}
+
+/**
+ * Emit session_active — either as a single event (small sessions) or as
+ * metadata-only + chunked messages (large sessions).
+ *
+ * Returns true if chunked delivery was initiated (caller should NOT send
+ * messages in the session_active payload).
+ */
+function emitSessionActive(rctx: RelayContext): void {
+    if (!rctx.latestCtx) return;
+
+    const { messages, model } = buildSessionContext(
+        rctx.latestCtx.sessionManager.getEntries(),
+        rctx.latestCtx.sessionManager.getLeafId(),
+    );
+
+    const metadata = {
+        model,
+        thinkingLevel: rctx.getCurrentThinkingLevel(),
+        sessionName: rctx.getCurrentSessionName(),
+        cwd: rctx.latestCtx.cwd,
+        availableModels: rctx.getConfiguredModels(),
+        todoList: getCurrentTodoList(),
     };
-    return [marker, ...truncated];
+
+    if (needsChunkedDelivery(messages)) {
+        // Large session — send metadata-only session_active, then stream chunks
+        rctx.forwardEvent({
+            type: "session_active",
+            state: {
+                ...metadata,
+                messages: [], // placeholder — real messages follow as chunks
+                chunked: true,
+                totalMessages: messages.length,
+            },
+        });
+        sendChunkedMessages(rctx, messages);
+    } else {
+        // Small session — single event (original path)
+        rctx.forwardEvent({
+            type: "session_active",
+            state: {
+                ...metadata,
+                messages,
+            },
+        });
+    }
 }
 
 // ── Module-level state for external consumers ────────────────────────────────
@@ -249,18 +329,8 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 rctx.latestCtx.sessionManager.getEntries(),
                 rctx.latestCtx.sessionManager.getLeafId(),
             );
-
-            // Guard: cap the messages payload to prevent oversized session_active
-            // events from exceeding the server's maxHttpBufferSize (100 MB) and
-            // silently killing the WebSocket — which triggers an infinite
-            // connect → transport close → reconnect boot loop.
-            //
-            // Estimate serialized size by sampling — full JSON.stringify on a
-            // huge array is itself expensive and would block the event loop.
-            const cappedMessages = capMessagesPayload(messages);
-
             return {
-                messages: cappedMessages,
+                messages,
                 model,
                 thinkingLevel: rctx.getCurrentThinkingLevel(),
                 sessionName: rctx.getCurrentSessionName(),
@@ -268,6 +338,10 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 availableModels: rctx.getConfiguredModels(),
                 todoList: getCurrentTodoList(),
             };
+        },
+
+        emitSessionActive() {
+            emitSessionActive(rctx);
         },
 
         buildHeartbeat() {
@@ -429,7 +503,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             if (currentSessionName === lastBroadcastSessionName) return;
 
             lastBroadcastSessionName = currentSessionName;
-            rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+            emitSessionActive(rctx);
             rctx.forwardEvent(rctx.buildHeartbeat());
         }, 1000);
     }
@@ -461,7 +535,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 message: ok ? undefined : "Model selected, but no valid credentials were found.",
             });
             if (ok) {
-                rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+                emitSessionActive(rctx);
             }
         } catch (error) {
             rctx.forwardEvent({
@@ -635,7 +709,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 rctx.isChildSession = false;
             }
 
-            rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+            emitSessionActive(rctx);
             void refreshAllUsage();
             startHeartbeat(rctx);
             updateMcpRelayContext();
@@ -651,7 +725,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
 
         sock.on("connected", () => {
             rctx.forwardEvent(rctx.buildCapabilitiesState());
-            rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+            emitSessionActive(rctx);
         });
 
         sock.on("input", (data) => {
@@ -837,7 +911,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                   ? "Connected to Relay"
                   : rctx.disconnectedStatusText(),
         );
-        rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+        emitSessionActive(rctx);
         rctx.forwardEvent(rctx.buildHeartbeat());
     });
 
@@ -929,7 +1003,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     pi.on("tool_execution_end", (event) => rctx.forwardEvent(event));
     pi.on("model_select", (event) => {
         rctx.forwardEvent(event);
-        rctx.forwardEvent({ type: "session_active", state: rctx.buildSessionState() });
+        emitSessionActive(rctx);
     });
 
     // ── /remote command ───────────────────────────────────────────────────

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -83,6 +83,15 @@ const CHUNK_THRESHOLD = 10 * 1024 * 1024; // 10 MB
 const CHUNK_SIZE = 200;
 
 /**
+ * Maximum estimated byte size per chunk.  Even if a chunk has fewer than
+ * CHUNK_SIZE messages, it will be split if the cumulative byte size exceeds
+ * this limit.  This prevents a handful of huge messages (e.g. large tool
+ * outputs or inline images) from producing a single oversized frame that
+ * exceeds the server's maxHttpBufferSize (100 MB).
+ */
+const CHUNK_BYTE_LIMIT = 8 * 1024 * 1024; // 8 MB per chunk
+
+/**
  * Estimate the serialized JSON size of a messages array by summing per-message
  * sizes.  We stringify each message individually rather than the whole array
  * to avoid allocating a single 100 MB+ string.  This catches outlier-heavy
@@ -121,12 +130,47 @@ export function needsChunkedDelivery(messages: unknown[]): boolean {
  * Each chunk carries a `snapshotId` that matches the session_active event,
  * so the UI can discard stale chunks from a previous snapshot stream.
  */
+/**
+ * Pre-compute chunk boundaries using both message count and byte size limits.
+ * Returns an array of [start, end) index pairs.
+ */
+export function computeChunkBoundaries(messages: unknown[]): Array<[number, number]> {
+    const boundaries: Array<[number, number]> = [];
+    let start = 0;
+
+    while (start < messages.length) {
+        let end = start;
+        let chunkBytes = 0;
+
+        while (end < messages.length && (end - start) < CHUNK_SIZE) {
+            const msgSize = JSON.stringify(messages[end]).length;
+            // If adding this message would exceed the byte limit AND we already
+            // have at least one message in the chunk, break here.
+            if (chunkBytes + msgSize > CHUNK_BYTE_LIMIT && end > start) {
+                break;
+            }
+            chunkBytes += msgSize;
+            end++;
+        }
+
+        // Safety: always advance by at least 1 to avoid infinite loop on a
+        // single message larger than the byte limit.
+        if (end === start) end = start + 1;
+
+        boundaries.push([start, end]);
+        start = end;
+    }
+
+    return boundaries;
+}
+
 function sendChunkedMessages(rctx: RelayContext, messages: unknown[], snapshotId: string): void {
-    const totalChunks = Math.ceil(messages.length / CHUNK_SIZE);
+    const chunks = computeChunkBoundaries(messages);
+    const totalChunks = chunks.length;
 
     console.log(
         `pizzapi: session is large (${messages.length} messages, ~${(estimateMessagesSize(messages) / 1024 / 1024).toFixed(0)} MB). ` +
-        `Sending in ${totalChunks} chunks of ≤${CHUNK_SIZE} messages (snapshot=${snapshotId.slice(0, 8)}).`,
+        `Sending in ${totalChunks} chunks (snapshot=${snapshotId.slice(0, 8)}).`,
     );
 
     let chunkIndex = 0;
@@ -134,9 +178,10 @@ function sendChunkedMessages(rctx: RelayContext, messages: unknown[], snapshotId
     function sendNextChunk() {
         if (!rctx.relay || !rctx.sioSocket?.connected) return; // disconnected mid-stream
         if (chunkIndex >= totalChunks) return;
+        // A newer emitSessionActive() superseded this sender — stop.
+        if (activeChunkedSnapshotId !== snapshotId) return;
 
-        const start = chunkIndex * CHUNK_SIZE;
-        const end = Math.min(start + CHUNK_SIZE, messages.length);
+        const [start, end] = chunks[chunkIndex];
         const isFinal = chunkIndex === totalChunks - 1;
 
         rctx.forwardEvent({
@@ -161,6 +206,13 @@ function sendChunkedMessages(rctx: RelayContext, messages: unknown[], snapshotId
     // (with chunked: true) is flushed to the socket first.
     setImmediate(sendNextChunk);
 }
+
+/**
+ * Tracks the snapshotId of the currently active chunked sender so that
+ * `sendChunkedMessages` can bail out if a newer emitSessionActive() fires
+ * before the previous one finishes draining.
+ */
+let activeChunkedSnapshotId: string | null = null;
 
 /**
  * Emit session_active — either as a single event (small sessions) or as
@@ -191,6 +243,8 @@ function emitSessionActive(rctx: RelayContext): void {
         // The snapshotId ties the metadata event to its chunk stream so the UI
         // can discard stale chunks and the server can assemble the full state.
         const snapshotId = randomUUID();
+        // Cancel any in-flight chunked sender from a previous call.
+        activeChunkedSnapshotId = snapshotId;
         rctx.forwardEvent({
             type: "session_active",
             state: {
@@ -203,7 +257,9 @@ function emitSessionActive(rctx: RelayContext): void {
         });
         sendChunkedMessages(rctx, messages, snapshotId);
     } else {
-        // Small session — single event (original path)
+        // Small session — single event (original path).
+        // Cancel any in-flight chunked sender since we're replacing with a full snapshot.
+        activeChunkedSnapshotId = null;
         rctx.forwardEvent({
             type: "session_active",
             state: {

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -157,10 +157,31 @@ export function capOversizedMessages(messages: unknown[]): unknown[] {
                 copied = true;
             }
             const msg = messages[i] as Record<string, unknown>;
-            result[i] = {
-                ...msg,
-                content: `[Content truncated: original message was ~${(size / 1024 / 1024).toFixed(0)} MB, exceeding the ${(MAX_MESSAGE_SIZE / 1024 / 1024).toFixed(0)} MB transport safety limit]`,
-            };
+            const truncationNotice = `[Content truncated: original message was ~${(size / 1024 / 1024).toFixed(0)} MB, exceeding the ${(MAX_MESSAGE_SIZE / 1024 / 1024).toFixed(0)} MB transport safety limit]`;
+
+            // First pass: replace content
+            let capped: Record<string, unknown> = { ...msg, content: truncationNotice };
+
+            // If the message is still oversized after replacing content, the
+            // bulk is in other fields (e.g. subagent `details` carrying full
+            // child results[].messages arrays).  Strip large non-essential
+            // fields until we're under the cap.
+            const largeFieldCandidates = ["details", "toolResult", "metadata"];
+            for (const field of largeFieldCandidates) {
+                const cappedSize = Buffer.byteLength(JSON.stringify(capped), "utf8");
+                if (cappedSize <= MAX_MESSAGE_SIZE) break;
+                if (field in capped && capped[field] != null) {
+                    const fieldSize = Buffer.byteLength(JSON.stringify(capped[field]), "utf8");
+                    if (fieldSize > 1024) { // only strip fields > 1 KB
+                        capped = {
+                            ...capped,
+                            [field]: `[${field} truncated: ~${(fieldSize / 1024 / 1024).toFixed(1)} MB]`,
+                        };
+                    }
+                }
+            }
+
+            result[i] = capped;
             console.warn(
                 `pizzapi: message ${i} truncated (~${(size / 1024 / 1024).toFixed(0)} MB exceeds ${(MAX_MESSAGE_SIZE / 1024 / 1024).toFixed(0)} MB cap).`,
             );

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -100,17 +100,18 @@ const CHUNK_BYTE_LIMIT = 8 * 1024 * 1024; // 8 MB per chunk
 const MAX_MESSAGE_SIZE = 50 * 1024 * 1024; // 50 MB
 
 /**
- * Estimate the serialized JSON size of a messages array by summing per-message
- * sizes.  We stringify each message individually rather than the whole array
- * to avoid allocating a single 100 MB+ string.  This catches outlier-heavy
- * distributions (e.g. a few 20 MB tool outputs) that sampling would miss.
+ * Estimate the serialized wire size (in bytes) of a messages array.
+ * We stringify each message individually rather than the whole array
+ * to avoid allocating a single 100 MB+ string.  Uses Buffer.byteLength
+ * for accurate UTF-8 byte counts (JSON.stringify().length counts UTF-16
+ * code units, which underestimates multibyte content like emoji/CJK by 2-4x).
  */
 export function estimateMessagesSize(messages: unknown[]): number {
     if (messages.length === 0) return 2; // "[]"
     let totalBytes = 0;
     for (const msg of messages) {
         try {
-            totalBytes += JSON.stringify(msg).length;
+            totalBytes += Buffer.byteLength(JSON.stringify(msg), "utf8");
         } catch {
             totalBytes += 1024; // fallback for unserializable entries
         }
@@ -149,7 +150,7 @@ export function capOversizedMessages(messages: unknown[]): unknown[] {
     let result = messages;
 
     for (let i = 0; i < messages.length; i++) {
-        const size = JSON.stringify(messages[i]).length;
+        const size = Buffer.byteLength(JSON.stringify(messages[i]), "utf8");
         if (size > MAX_MESSAGE_SIZE) {
             if (!copied) {
                 result = [...messages];
@@ -182,7 +183,7 @@ export function computeChunkBoundaries(messages: unknown[]): Array<[number, numb
         let chunkBytes = 0;
 
         while (end < messages.length && (end - start) < CHUNK_SIZE) {
-            const msgSize = JSON.stringify(messages[end]).length;
+            const msgSize = Buffer.byteLength(JSON.stringify(messages[end]), "utf8");
             // If adding this message would exceed the byte limit AND we already
             // have at least one message in the chunk, break here.
             if (chunkBytes + msgSize > CHUNK_BYTE_LIMIT && end > start) {

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -83,27 +83,23 @@ const CHUNK_THRESHOLD = 10 * 1024 * 1024; // 10 MB
 const CHUNK_SIZE = 200;
 
 /**
- * Estimate the serialized JSON size of a messages array by sampling.
- * Full JSON.stringify on a huge array would itself block the event loop,
- * so we sample a handful of elements and extrapolate.
+ * Estimate the serialized JSON size of a messages array by summing per-message
+ * sizes.  We stringify each message individually rather than the whole array
+ * to avoid allocating a single 100 MB+ string.  This catches outlier-heavy
+ * distributions (e.g. a few 20 MB tool outputs) that sampling would miss.
  */
 export function estimateMessagesSize(messages: unknown[]): number {
     if (messages.length === 0) return 2; // "[]"
-    const SAMPLE_COUNT = Math.min(10, messages.length);
-    let sampleBytes = 0;
-    const step = Math.max(1, Math.floor(messages.length / SAMPLE_COUNT));
-    let sampled = 0;
-    for (let i = 0; i < messages.length && sampled < SAMPLE_COUNT; i += step) {
+    let totalBytes = 0;
+    for (const msg of messages) {
         try {
-            sampleBytes += JSON.stringify(messages[i]).length;
+            totalBytes += JSON.stringify(msg).length;
         } catch {
-            sampleBytes += 1024; // fallback estimate for unserializable entries
+            totalBytes += 1024; // fallback for unserializable entries
         }
-        sampled++;
     }
-    const avgBytes = sampleBytes / sampled;
-    // Add ~15% overhead for array commas, brackets, and event wrapper fields
-    return Math.ceil(avgBytes * messages.length * 1.15);
+    // Add ~10% overhead for array commas, brackets, and event wrapper fields
+    return Math.ceil(totalBytes * 1.10);
 }
 
 /**

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -92,6 +92,14 @@ const CHUNK_SIZE = 200;
 const CHUNK_BYTE_LIMIT = 8 * 1024 * 1024; // 8 MB per chunk
 
 /**
+ * Hard cap for a single message's serialized size.  Messages exceeding this
+ * are truncated before chunking so that no individual chunk frame can exceed
+ * the server's maxHttpBufferSize (100 MB).  We set this well below the
+ * transport cap to leave room for event wrapper overhead.
+ */
+const MAX_MESSAGE_SIZE = 50 * 1024 * 1024; // 50 MB
+
+/**
  * Estimate the serialized JSON size of a messages array by summing per-message
  * sizes.  We stringify each message individually rather than the whole array
  * to avoid allocating a single 100 MB+ string.  This catches outlier-heavy
@@ -115,7 +123,7 @@ export function estimateMessagesSize(messages: unknown[]): number {
  * Check whether a messages array needs chunked delivery.
  */
 export function needsChunkedDelivery(messages: unknown[]): boolean {
-    if (messages.length <= 1) return false;
+    if (messages.length === 0) return false;
     return estimateMessagesSize(messages) > CHUNK_THRESHOLD;
 }
 
@@ -130,6 +138,37 @@ export function needsChunkedDelivery(messages: unknown[]): boolean {
  * Each chunk carries a `snapshotId` that matches the session_active event,
  * so the UI can discard stale chunks from a previous snapshot stream.
  */
+/**
+ * Cap any individual message whose serialized size exceeds MAX_MESSAGE_SIZE.
+ * Returns a new array (only copies if truncation was needed).  Truncated
+ * messages have their `content` replaced with a notice so the viewer knows
+ * data was elided.
+ */
+export function capOversizedMessages(messages: unknown[]): unknown[] {
+    let copied = false;
+    let result = messages;
+
+    for (let i = 0; i < messages.length; i++) {
+        const size = JSON.stringify(messages[i]).length;
+        if (size > MAX_MESSAGE_SIZE) {
+            if (!copied) {
+                result = [...messages];
+                copied = true;
+            }
+            const msg = messages[i] as Record<string, unknown>;
+            result[i] = {
+                ...msg,
+                content: `[Content truncated: original message was ~${(size / 1024 / 1024).toFixed(0)} MB, exceeding the ${(MAX_MESSAGE_SIZE / 1024 / 1024).toFixed(0)} MB transport safety limit]`,
+            };
+            console.warn(
+                `pizzapi: message ${i} truncated (~${(size / 1024 / 1024).toFixed(0)} MB exceeds ${(MAX_MESSAGE_SIZE / 1024 / 1024).toFixed(0)} MB cap).`,
+            );
+        }
+    }
+
+    return result;
+}
+
 /**
  * Pre-compute chunk boundaries using both message count and byte size limits.
  * Returns an array of [start, end) index pairs.
@@ -164,7 +203,8 @@ export function computeChunkBoundaries(messages: unknown[]): Array<[number, numb
     return boundaries;
 }
 
-function sendChunkedMessages(rctx: RelayContext, messages: unknown[], snapshotId: string): void {
+function sendChunkedMessages(rctx: RelayContext, rawMessages: unknown[], snapshotId: string): void {
+    const messages = capOversizedMessages(rawMessages);
     const chunks = computeChunkBoundaries(messages);
     const totalChunks = chunks.length;
 
@@ -259,12 +299,13 @@ function emitSessionActive(rctx: RelayContext): void {
     } else {
         // Small session — single event (original path).
         // Cancel any in-flight chunked sender since we're replacing with a full snapshot.
+        // Still cap individual oversized messages to avoid transport failures.
         activeChunkedSnapshotId = null;
         rctx.forwardEvent({
             type: "session_active",
             state: {
                 ...metadata,
-                messages,
+                messages: capOversizedMessages(messages),
             },
         });
     }

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -96,6 +96,24 @@ interface ChunkedSessionState {
 
 const pendingChunkedStates = new Map<string, ChunkedSessionState>();
 
+/**
+ * Get the partially assembled snapshot for a session that's mid-chunked-delivery.
+ * Returns metadata + chunks received so far, or null if no chunked delivery is active.
+ */
+export function getPendingChunkedSnapshot(sessionId: string): { metadata: Record<string, unknown>; messages: unknown[]; snapshotId: string; totalMessages: number; receivedChunks: number; totalChunks: number } | null {
+    const pending = pendingChunkedStates.get(sessionId);
+    if (!pending) return null;
+    const messages = pending.chunks.flat();
+    return {
+        metadata: pending.metadata,
+        messages,
+        snapshotId: pending.snapshotId,
+        totalMessages: (pending.metadata as any).totalMessages ?? messages.length,
+        receivedChunks: pending.receivedChunks,
+        totalChunks: pending.totalChunks,
+    };
+}
+
 type RelaySocket = Socket<
     RelayClientToServerEvents,
     RelayServerToClientEvents,

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -81,6 +81,21 @@ function augmentMessageThinkingDurations(
 
 const socketAckedSeqs = new Map<string, number>();
 
+// ── Chunked session_active assembly ──────────────────────────────────────────
+// When a worker sends session_active with chunked:true, messages follow as
+// session_messages_chunk events.  We buffer them here and assemble the full
+// lastState after the final chunk so reconnecting viewers get complete data.
+
+interface ChunkedSessionState {
+    snapshotId: string;
+    metadata: Record<string, unknown>; // everything except messages
+    chunks: unknown[][]; // ordered message slices
+    totalChunks: number;
+    receivedChunks: number;
+}
+
+const pendingChunkedStates = new Map<string, ChunkedSessionState>();
+
 type RelaySocket = Socket<
     RelayClientToServerEvents,
     RelayServerToClientEvents,
@@ -293,7 +308,55 @@ export function registerRelayNamespace(io: SocketIOServer): void {
 
             // Cache session_active state so new viewers get an immediate snapshot
             if (event.type === "session_active") {
-                await updateSessionState(sessionId, event.state);
+                const state = event.state as Record<string, unknown> | undefined;
+                if (state?.chunked) {
+                    // Chunked session: store metadata and start accumulating chunks.
+                    // Don't persist incomplete state to lastState — viewers would
+                    // get an empty messages array on reconnect.
+                    const snapshotId = typeof state.snapshotId === "string" ? state.snapshotId : "";
+                    const { messages: _msgs, chunked: _c, snapshotId: _sid, totalMessages: _tm, ...metadata } = state;
+                    pendingChunkedStates.set(sessionId, {
+                        snapshotId,
+                        metadata,
+                        chunks: [],
+                        totalChunks: 0,
+                        receivedChunks: 0,
+                    });
+                    // Touch activity but DON'T update lastState yet
+                    await touchSessionActivity(sessionId);
+                } else {
+                    // Non-chunked: persist immediately (original path)
+                    pendingChunkedStates.delete(sessionId);
+                    await updateSessionState(sessionId, event.state);
+                }
+            } else if (event.type === "session_messages_chunk") {
+                // Accumulate chunk into the pending state.  When the final
+                // chunk arrives, assemble the full state and persist to lastState.
+                const pending = pendingChunkedStates.get(sessionId);
+                const chunkSnapshotId = typeof event.snapshotId === "string" ? event.snapshotId : "";
+                const chunkIndex = typeof event.chunkIndex === "number" ? event.chunkIndex : -1;
+                const chunkMessages = Array.isArray(event.messages) ? event.messages as unknown[] : [];
+                const isFinal = !!event.final;
+                const totalChunks = typeof event.totalChunks === "number" ? event.totalChunks : 0;
+
+                if (pending && pending.snapshotId === chunkSnapshotId && chunkIndex >= 0) {
+                    pending.chunks[chunkIndex] = chunkMessages;
+                    pending.receivedChunks++;
+                    pending.totalChunks = totalChunks;
+
+                    if (isFinal && pending.receivedChunks >= pending.totalChunks) {
+                        // All chunks received — assemble and persist the full state
+                        const allMessages = pending.chunks.flat();
+                        const fullState = { ...pending.metadata, messages: allMessages };
+                        pendingChunkedStates.delete(sessionId);
+                        await updateSessionState(sessionId, fullState);
+                    } else {
+                        await touchSessionActivity(sessionId);
+                    }
+                } else {
+                    // Stale or unmatched chunk — just touch activity
+                    await touchSessionActivity(sessionId);
+                }
             } else if (event.type === "heartbeat") {
                 await updateSessionHeartbeat(sessionId, event);
             } else {
@@ -559,6 +622,7 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 }
 
                 clearThinkingMaps(sessionId);
+                pendingChunkedStates.delete(sessionId);
                 void clearPushPendingQuestion(sessionId);
                 // Clean up child-index entry so stale memberships don't persist
                 const session = await getSharedSession(sessionId);

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -96,6 +96,25 @@ interface ChunkedSessionState {
 
 const pendingChunkedStates = new Map<string, ChunkedSessionState>();
 
+// ── Per-session event serialization ──────────────────────────────────────────
+// The async event handler must process events in arrival order per session.
+// Without serialization, concurrent async handlers (e.g. chunk 0 hitting a
+// Redis round-trip while chunk 1 skips it) can publish chunks out of order,
+// scrambling the viewer's message assembly.
+const sessionEventQueues = new Map<string, Promise<void>>();
+
+function enqueueSessionEvent(sessionId: string, fn: () => Promise<void>): void {
+    const prev = sessionEventQueues.get(sessionId) ?? Promise.resolve();
+    const next = prev.then(fn, fn); // always chain, even on prior rejection
+    sessionEventQueues.set(sessionId, next);
+    // Clean up the map entry when the chain settles to avoid unbounded growth
+    next.then(() => {
+        if (sessionEventQueues.get(sessionId) === next) {
+            sessionEventQueues.delete(sessionId);
+        }
+    });
+}
+
 /**
  * Get the partially assembled snapshot for a session that's mid-chunked-delivery.
  * Returns metadata + chunks received so far, or null if no chunked delivery is active.
@@ -309,7 +328,7 @@ export function registerRelayNamespace(io: SocketIOServer): void {
         });
 
         // ── event — main event pipeline ──────────────────────────────────────
-        socket.on("event", async (data) => {
+        socket.on("event", (data) => {
             const sessionId = socket.data.sessionId;
             if (!sessionId || data.token !== socket.data.token) {
                 socket.emit("error", { message: "Invalid token" });
@@ -323,6 +342,9 @@ export function registerRelayNamespace(io: SocketIOServer): void {
 
             const event = data.event as Record<string, unknown> | undefined;
             if (!event) return;
+
+            // Serialize async processing per session to guarantee chunk order.
+            enqueueSessionEvent(sessionId, async () => {
 
             // Cache session_active state so new viewers get an immediate snapshot
             if (event.type === "session_active") {
@@ -405,6 +427,8 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             }
             // Push notifications (fire-and-forget — not on hot path)
             void checkPushNotifications(sessionId, event);
+
+            }); // end enqueueSessionEvent
         });
 
         // ── session_end ──────────────────────────────────────────────────────

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -390,6 +390,14 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                         const fullState = { ...pending.metadata, messages: allMessages };
                         pendingChunkedStates.delete(sessionId);
                         await updateSessionState(sessionId, fullState);
+
+                        // Publish a full session_active to the Redis replay cache
+                        // so that findLatestSnapshotEvent() finds the assembled
+                        // state instead of the metadata-only SA from chunk start.
+                        await publishSessionEvent(sessionId, {
+                            type: "session_active",
+                            state: fullState,
+                        });
                     } else {
                         await touchSessionActivity(sessionId);
                     }

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -27,6 +27,7 @@ import {
     broadcastToViewers,
 } from "../sio-registry.js";
 import { appendRelayEventToCache } from "../../sessions/redis.js";
+import { storeAndReplaceImagesInEvent } from "../strip-images.js";
 import {
     setPushPendingQuestion,
     clearPushPendingQuestion,
@@ -400,11 +401,23 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                         // oversized frame to all viewers — the same transport
                         // issue chunking was designed to avoid.  Viewers already
                         // have the complete data from the chunk stream.
+                        // Strip inline images before caching to keep the cache
+                        // entry small and consistent with publishSessionEvent's
+                        // image-stripping pipeline.
                         const session = await getSharedSession(sessionId);
-                        await appendRelayEventToCache(sessionId, {
-                            type: "session_active",
-                            state: fullState,
-                        }, { isEphemeral: session?.isEphemeral });
+                        const userId = session?.userId ?? "unknown";
+                        const snapshotEvent = { type: "session_active" as const, state: fullState };
+                        let eventToCache: unknown = snapshotEvent;
+                        try {
+                            eventToCache = await storeAndReplaceImagesInEvent(
+                                snapshotEvent, sessionId, userId,
+                            );
+                        } catch {
+                            // Fall back to original if image stripping fails
+                        }
+                        await appendRelayEventToCache(sessionId, eventToCache, {
+                            isEphemeral: session?.isEphemeral,
+                        });
                     } else {
                         await touchSessionActivity(sessionId);
                     }

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -22,6 +22,7 @@ import {
     updateSessionHeartbeat,
     touchSessionActivity,
     publishSessionEvent,
+    broadcastSessionEventToViewers,
     endSharedSession,
     getViewerCount,
     broadcastToViewers,
@@ -446,8 +447,16 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 clearThinkingMaps(sessionId);
             }
 
-            // Publish to viewers via Redis cache + Socket.IO rooms
-            await publishSessionEvent(sessionId, eventToPublish);
+            // For session_messages_chunk, broadcast to viewers WITHOUT caching.
+            // Chunks are transient and only needed during active hydration;
+            // the final assembled snapshot is cached separately when assembly
+            // completes. Caching all chunks causes Redis bloat on large sessions.
+            if (event.type === "session_messages_chunk") {
+                await broadcastSessionEventToViewers(sessionId, eventToPublish);
+            } else {
+                // Publish to viewers via Redis cache + Socket.IO rooms
+                await publishSessionEvent(sessionId, eventToPublish);
+            }
 
             // Track push-pending state for AskUserQuestion (awaited to ensure
             // set/clear ordering; only runs for AskUserQuestion start/end events).

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -447,11 +447,18 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 clearThinkingMaps(sessionId);
             }
 
-            // For session_messages_chunk, broadcast to viewers WITHOUT caching.
-            // Chunks are transient and only needed during active hydration;
-            // the final assembled snapshot is cached separately when assembly
-            // completes. Caching all chunks causes Redis bloat on large sessions.
-            if (event.type === "session_messages_chunk") {
+            // For session_messages_chunk and chunked session_active, broadcast
+            // to viewers WITHOUT caching.  Chunks are transient and only needed
+            // during active hydration; the final assembled snapshot is cached
+            // separately when assembly completes.  The metadata-only chunked
+            // session_active must also skip the cache — if the stream is
+            // interrupted before the final chunk, the replay path would find
+            // this empty-messages snapshot and show a blank transcript instead
+            // of the last durable state.
+            const isChunkedSessionActive =
+                event.type === "session_active" &&
+                !!(event.state as Record<string, unknown> | undefined)?.chunked;
+            if (event.type === "session_messages_chunk" || isChunkedSessionActive) {
                 await broadcastSessionEventToViewers(sessionId, eventToPublish);
             } else {
                 // Publish to viewers via Redis cache + Socket.IO rooms

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -26,6 +26,7 @@ import {
     getViewerCount,
     broadcastToViewers,
 } from "../sio-registry.js";
+import { appendRelayEventToCache } from "../../sessions/redis.js";
 import {
     setPushPendingQuestion,
     clearPushPendingQuestion,
@@ -391,13 +392,19 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                         pendingChunkedStates.delete(sessionId);
                         await updateSessionState(sessionId, fullState);
 
-                        // Publish a full session_active to the Redis replay cache
+                        // Append a full session_active to the Redis replay cache
                         // so that findLatestSnapshotEvent() finds the assembled
                         // state instead of the metadata-only SA from chunk start.
-                        await publishSessionEvent(sessionId, {
+                        // We do NOT use publishSessionEvent() here because that
+                        // would broadcast the full assembled state as a single
+                        // oversized frame to all viewers — the same transport
+                        // issue chunking was designed to avoid.  Viewers already
+                        // have the complete data from the chunk stream.
+                        const session = await getSharedSession(sessionId);
+                        await appendRelayEventToCache(sessionId, {
                             type: "session_active",
                             state: fullState,
-                        });
+                        }, { isEphemeral: session?.isEphemeral });
                     } else {
                         await touchSessionActivity(sessionId);
                     }

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -109,8 +109,10 @@ function enqueueSessionEvent(sessionId: string, fn: () => Promise<void>): void {
     const prev = sessionEventQueues.get(sessionId) ?? Promise.resolve();
     const next = prev.then(fn, fn); // always chain, even on prior rejection
     sessionEventQueues.set(sessionId, next);
-    // Clean up the map entry when the chain settles to avoid unbounded growth
-    next.then(() => {
+    // Clean up the map entry when the chain settles to avoid unbounded growth.
+    // Use .finally() so cleanup runs even if fn rejects (otherwise the map
+    // entry leaks indefinitely on error, causing unbounded memory growth).
+    next.finally(() => {
         if (sessionEventQueues.get(sessionId) === next) {
             sessionEventQueues.delete(sessionId);
         }

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -213,11 +213,10 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // once — the concurrent async work widens the race window).
 
         // ── connected — viewer greeting, notify TUI ─────────────────────────
+        // Use emitToRelaySession for cluster-wide reach — the runner may
+        // be on a different server node in multi-node deployments.
         socket.on("connected", () => {
-            const tuiSocket = getLocalTuiSocket(sessionId);
-            if (tuiSocket) {
-                tuiSocket.emit("connected" as string, {});
-            }
+            emitToRelaySession(sessionId, "connected" as string, {});
         });
 
         // ── resync — send fresh snapshot ─────────────────────────────────────

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -229,12 +229,11 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             // a partial non-chunked SA (which would set lastCompletedSnapshotRef
             // and cause the UI to reject all subsequent chunks from the
             // still-active stream).
+            // Use emitToRelaySession for cluster-wide reach — the runner may
+            // be on a different server node in multi-node deployments.
             const session = await getSharedSession(sessionId);
             if (!session?.lastState) {
-                const tuiSocket = getLocalTuiSocket(sessionId);
-                if (tuiSocket) {
-                    tuiSocket.emit("connected" as string, {});
-                }
+                emitToRelaySession(sessionId, "connected" as string, {});
             }
         });
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -23,6 +23,7 @@ import {
     getLocalTuiSocket,
     emitToRelaySession,
 } from "../sio-registry.js";
+import { getPendingChunkedSnapshot } from "./relay.js";
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
 import { getCachedRelayEvents } from "../../sessions/redis.js";
 
@@ -408,11 +409,19 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         const freshSession = await getSharedSession(sessionId);
         const freshSeq = await getSessionSeq(sessionId);
 
-        if (freshSession?.lastState) {
+        // If a chunked delivery is in-flight, lastState is stale (chunked
+        // session_active intentionally skips updating it).  Emitting the old
+        // non-chunked snapshot here would overwrite the chunked header the
+        // viewer already received via the room broadcast, clear chunk-tracking
+        // in App.tsx, and cause remaining chunks to be dropped.  Skip it and
+        // let the runner's fresh chunked delivery (triggered by the "connected"
+        // notification below) hydrate the viewer instead.
+        const chunkedPending = getPendingChunkedSnapshot(sessionId);
+        if (freshSession?.lastState && !chunkedPending) {
             try {
                 socket.emit("event", { event: { type: "session_active", state: JSON.parse(freshSession.lastState) }, seq: freshSeq });
             } catch {}
-        } else {
+        } else if (!chunkedPending) {
             // No in-memory state — fall back to event cache.
             // Don't send partial chunked snapshots here — they'd arrive as
             // non-chunked SA events, set lastCompletedSnapshotRef, and cause

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -14,6 +14,7 @@ import type {
     ViewerSocketData,
 } from "@pizzapi/protocol";
 import { sessionCookieAuthMiddleware } from "./auth.js";
+import { getPendingChunkedSnapshot } from "./relay.js";
 import {
     getSharedSession,
     addViewer,
@@ -378,8 +379,23 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 socket.emit("event", { event: { type: "session_active", state: JSON.parse(session.lastState) }, seq: lastSeq });
             } catch {}
         } else {
-            // No in-memory state — fall back to event cache
-            await sendLatestSnapshotFromCache(socket, sessionId);
+            // No persisted lastState — check if a chunked delivery is in
+            // progress and send the partially assembled snapshot so the viewer
+            // has *something* to display while the runner re-sends a fresh
+            // snapshot (triggered by the viewer "connected" event below).
+            const pending = getPendingChunkedSnapshot(sessionId);
+            if (pending && pending.messages.length > 0) {
+                socket.emit("event", {
+                    event: {
+                        type: "session_active",
+                        state: { ...pending.metadata, messages: pending.messages },
+                    },
+                    seq: lastSeq,
+                });
+            } else {
+                // No in-memory state — fall back to event cache
+                await sendLatestSnapshotFromCache(socket, sessionId);
+            }
         }
 
         // NOW join the room for live events — any missed events between

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -14,7 +14,6 @@ import type {
     ViewerSocketData,
 } from "@pizzapi/protocol";
 import { sessionCookieAuthMiddleware } from "./auth.js";
-import { getPendingChunkedSnapshot } from "./relay.js";
 import {
     getSharedSession,
     addViewer,
@@ -226,17 +225,15 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             await sendSnapshotToViewer(sessionId, socket);
 
             // If no lastState was available (e.g. mid-chunked-delivery),
-            // fall back to the partially assembled snapshot from pending chunks.
+            // ask the runner to re-emit a fresh snapshot rather than sending
+            // a partial non-chunked SA (which would set lastCompletedSnapshotRef
+            // and cause the UI to reject all subsequent chunks from the
+            // still-active stream).
             const session = await getSharedSession(sessionId);
             if (!session?.lastState) {
-                const pending = getPendingChunkedSnapshot(sessionId);
-                if (pending && pending.messages.length > 0) {
-                    socket.emit("event", {
-                        event: {
-                            type: "session_active",
-                            state: { ...pending.metadata, messages: pending.messages },
-                        },
-                    });
+                const tuiSocket = getLocalTuiSocket(sessionId);
+                if (tuiSocket) {
+                    tuiSocket.emit("connected" as string, {});
                 }
             }
         });
@@ -394,23 +391,13 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 socket.emit("event", { event: { type: "session_active", state: JSON.parse(session.lastState) }, seq: lastSeq });
             } catch {}
         } else {
-            // No persisted lastState — check if a chunked delivery is in
-            // progress and send the partially assembled snapshot so the viewer
-            // has *something* to display while the runner re-sends a fresh
-            // snapshot (triggered by the viewer "connected" event below).
-            const pending = getPendingChunkedSnapshot(sessionId);
-            if (pending && pending.messages.length > 0) {
-                socket.emit("event", {
-                    event: {
-                        type: "session_active",
-                        state: { ...pending.metadata, messages: pending.messages },
-                    },
-                    seq: lastSeq,
-                });
-            } else {
-                // No in-memory state — fall back to event cache
-                await sendLatestSnapshotFromCache(socket, sessionId);
-            }
+            // No in-memory state — fall back to event cache.
+            // Don't send partial chunked snapshots here — they'd arrive as
+            // non-chunked SA events, set lastCompletedSnapshotRef, and cause
+            // the UI to reject subsequent chunks from the active stream.
+            // The runner re-emits a fresh snapshot on the "connected" event
+            // below, which will properly restart chunked delivery.
+            await sendLatestSnapshotFromCache(socket, sessionId);
         }
 
         // NOW join the room for live events — any missed events between

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -224,6 +224,21 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // ── resync — send fresh snapshot ─────────────────────────────────────
         socket.on("resync", async () => {
             await sendSnapshotToViewer(sessionId, socket);
+
+            // If no lastState was available (e.g. mid-chunked-delivery),
+            // fall back to the partially assembled snapshot from pending chunks.
+            const session = await getSharedSession(sessionId);
+            if (!session?.lastState) {
+                const pending = getPendingChunkedSnapshot(sessionId);
+                if (pending && pending.messages.length > 0) {
+                    socket.emit("event", {
+                        event: {
+                            type: "session_active",
+                            state: { ...pending.metadata, messages: pending.messages },
+                        },
+                    });
+                }
+            }
         });
 
         // ── input — collab mode: forward user input to TUI ──────────────────

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -399,9 +399,18 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             return;
         }
 
-        if (session.lastState) {
+        // Re-fetch session state and seq AFTER addViewer() to avoid emitting
+        // stale data. Between the initial fetch and here, the runner may have
+        // published a newer session_active (especially for chunked delivery).
+        // Using the old lastState + old lastSeq would overwrite the fresh
+        // snapshot and rewind lastSeqRef on the client, triggering a bogus
+        // resync on actively changing sessions.
+        const freshSession = await getSharedSession(sessionId);
+        const freshSeq = await getSessionSeq(sessionId);
+
+        if (freshSession?.lastState) {
             try {
-                socket.emit("event", { event: { type: "session_active", state: JSON.parse(session.lastState) }, seq: lastSeq });
+                socket.emit("event", { event: { type: "session_active", state: JSON.parse(freshSession.lastState) }, seq: freshSeq });
             } catch {}
         } else {
             // No in-memory state — fall back to event cache.

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -385,6 +385,21 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 socket.emit("event", { event: JSON.parse(session.lastHeartbeat), seq: lastSeq });
             } catch {}
         }
+        // Join the room BEFORE sending snapshots or notifying the runner,
+        // so the viewer is already receiving live events when the runner
+        // responds to the "connected" notification with a fresh snapshot.
+        // Without this, a fast runner response can publish session_active
+        // and early chunks before addViewer() completes, causing the
+        // viewer to miss the restart snapshot.
+        const ok = await addViewer(sessionId, socket);
+        if (!ok) {
+            socket.emit("disconnected", { reason: "Session ended" });
+            // Use disconnect() (not true) so the client can still auto-reconnect;
+            // the session may have just cycled and will come back shortly.
+            socket.disconnect();
+            return;
+        }
+
         if (session.lastState) {
             try {
                 socket.emit("event", { event: { type: "session_active", state: JSON.parse(session.lastState) }, seq: lastSeq });
@@ -397,17 +412,6 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             // The runner re-emits a fresh snapshot on the "connected" event
             // below, which will properly restart chunked delivery.
             await sendLatestSnapshotFromCache(socket, sessionId);
-        }
-
-        // NOW join the room for live events — any missed events between
-        // snapshot read and this point will be caught by gap detection.
-        const ok = await addViewer(sessionId, socket);
-        if (!ok) {
-            socket.emit("disconnected", { reason: "Session ended" });
-            // Use disconnect() (not true) so the client can still auto-reconnect;
-            // the session may have just cycled and will come back shortly.
-            socket.disconnect();
-            return;
         }
     });
 }

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -605,6 +605,30 @@ export async function touchSessionActivity(sessionId: string): Promise<void> {
 }
 
 /**
+ * Broadcast a session event to viewers WITHOUT caching to Redis.
+ * Used for transient events like session_messages_chunk that are only
+ * needed during active streaming and would bloat the Redis cache.
+ */
+export async function broadcastSessionEventToViewers(sessionId: string, event: unknown): Promise<void> {
+    const seq = await incrementSeq(sessionId);
+    try {
+        io.of("/viewer")
+            .to(viewerSessionRoom(sessionId))
+            .emit("event", { event, seq });
+    } catch (err) {
+        console.warn("[sio-registry] broadcastSessionEventToViewers failed:", (err as Error)?.message);
+        try {
+            io.of("/viewer")
+                .local
+                .to(viewerSessionRoom(sessionId))
+                .emit("event", { event, seq });
+        } catch {
+            // Local delivery also failed — event may be lost but won't break cache
+        }
+    }
+}
+
+/**
  * Publish a session event to viewers via Socket.IO rooms.
  *
  * 1. Increment seq in Redis

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -800,7 +800,11 @@ export function App() {
 
   // Chunked session delivery: when session_active arrives with chunked:true,
   // messages follow as session_messages_chunk events. This ref tracks state.
+  // The snapshotId ties chunks to their originating session_active so stale
+  // chunks from a previous stream are discarded (e.g. if a new viewer
+  // connects mid-stream and triggers a fresh emitSessionActive).
   const chunkedDeliveryRef = React.useRef<{
+    snapshotId: string;
     totalMessages: number;
     totalChunks: number;
     receivedChunks: number;
@@ -1614,7 +1618,9 @@ export function App() {
       // session_messages_chunk events when the session is large.
       if (isChunked) {
         const totalMessages = typeof (state as any)?.totalMessages === "number" ? (state as any).totalMessages : 0;
+        const snapshotId = typeof (state as any)?.snapshotId === "string" ? (state as any).snapshotId : "";
         chunkedDeliveryRef.current = {
+          snapshotId,
           totalMessages,
           totalChunks: 0, // updated as chunks arrive
           receivedChunks: 0,
@@ -1678,10 +1684,17 @@ export function App() {
     // Large sessions send messages as a series of chunks after the metadata-only
     // session_active event. Each chunk appends to the current messages array.
     if (type === "session_messages_chunk") {
+      const chunkSnapshotId = typeof (evt as any).snapshotId === "string" ? (evt as any).snapshotId : "";
       const chunkMessages = Array.isArray(evt.messages) ? evt.messages as unknown[] : [];
       const isFinal = !!(evt as any).final;
       const totalChunks = typeof (evt as any).totalChunks === "number" ? (evt as any).totalChunks : 0;
       const totalMessages = typeof (evt as any).totalMessages === "number" ? (evt as any).totalMessages : 0;
+
+      // Discard chunks from a stale snapshot stream (e.g. a new viewer
+      // connected mid-stream and triggered a fresh emitSessionActive).
+      if (chunkedDeliveryRef.current && chunkSnapshotId && chunkedDeliveryRef.current.snapshotId !== chunkSnapshotId) {
+        return; // stale chunk — ignore
+      }
 
       const normalizedChunk = normalizeMessages(chunkMessages);
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1662,6 +1662,10 @@ export function App() {
       // for toolCall blocks that have no matching toolResult.
       if (!isChunked) {
         setActiveToolCalls(detectInFlightTools(normalizedMessages));
+      } else {
+        // Clear stale tool call state from before the reconnect so old
+        // streaming badges and Kill buttons don't linger while chunks load.
+        setActiveToolCalls(new Map());
       }
       setIsChangingModel(false);
       sessionHydratedRef.current = !isChunked; // defer until final chunk
@@ -1693,6 +1697,15 @@ export function App() {
     // Large sessions send messages as a series of chunks after the metadata-only
     // session_active event. Each chunk appends to the current messages array.
     if (type === "session_messages_chunk") {
+      // Ignore chunks that arrive before the matching session_active header.
+      // This can happen when a viewer joins mid-stream: the room broadcast
+      // delivers in-flight chunks before the viewer's initial snapshot replay.
+      // Without this guard, chunks are appended to stale/empty state and then
+      // the later metadata-only session_active clears them with setMessages([]).
+      if (awaitingSnapshotRef.current && !chunkedDeliveryRef.current) {
+        return;
+      }
+
       const chunkSnapshotId = typeof (evt as any).snapshotId === "string" ? (evt as any).snapshotId : "";
       const chunkMessages = Array.isArray(evt.messages) ? evt.messages as unknown[] : [];
       const isFinal = !!(evt as any).final;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2495,8 +2495,12 @@ export function App() {
       lastViewerEventAtRef.current = Date.now();
 
       // Detect sequence gaps; request a resync if we missed events.
+      // During chunked delivery, suppress resync — chunks have their own
+      // ordering via chunkIndex/snapshotId and a resync would replace the
+      // partially-loaded messages with an empty lastState (the server
+      // hasn't assembled the full state yet).
       const seq = typeof data.seq === "number" ? data.seq : null;
-      if (seq !== null && lastSeqRef.current !== null) {
+      if (seq !== null && lastSeqRef.current !== null && !chunkedDeliveryRef.current) {
         const expected = lastSeqRef.current + 1;
         if (seq > expected) {
           // Gap detected — request a resync snapshot from the server.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -146,9 +146,9 @@ function extractAssistantText(msg: RelayMessage): string {
   return text;
 }
 
-function normalizeMessages(rawMessages: unknown[]): RelayMessage[] {
+function normalizeMessages(rawMessages: unknown[], keyOffset = 0): RelayMessage[] {
   const all = rawMessages
-    .map((m, i) => toRelayMessage(m, `snapshot-${i}`))
+    .map((m, i) => toRelayMessage(m, `snapshot-${keyOffset + i}`))
     .filter((m): m is RelayMessage => m !== null);
 
   // Drop no-timestamp assistant messages that are superseded by a later
@@ -808,6 +808,7 @@ export function App() {
     totalMessages: number;
     totalChunks: number;
     receivedChunks: number;
+    loadedMessages: number; // cumulative count for fallback key offset
   } | null>(null);
 
   // Track the last completed snapshot ID so we can reject stale chunks that
@@ -1630,6 +1631,7 @@ export function App() {
           totalMessages,
           totalChunks: 0, // updated as chunks arrive
           receivedChunks: 0,
+          loadedMessages: 0,
         };
         setViewerStatus(`Loading session (0 of ${totalMessages} messages)…`);
       } else {
@@ -1713,15 +1715,17 @@ export function App() {
         }
       }
 
-      const normalizedChunk = normalizeMessages(chunkMessages);
+      const keyOffset = chunkedDeliveryRef.current?.loadedMessages ?? 0;
+      const normalizedChunk = normalizeMessages(chunkMessages, keyOffset);
 
       setMessages((prev) => [...prev, ...normalizedChunk]);
 
       // Update chunked delivery tracking
       if (chunkedDeliveryRef.current) {
         chunkedDeliveryRef.current.receivedChunks++;
+        chunkedDeliveryRef.current.loadedMessages += chunkMessages.length;
         chunkedDeliveryRef.current.totalChunks = totalChunks;
-        const loaded = chunkedDeliveryRef.current.receivedChunks * 200; // approximate
+        const loaded = chunkedDeliveryRef.current.loadedMessages;
         setViewerStatus(`Loading session (${Math.min(loaded, totalMessages)} of ${totalMessages} messages)…`);
       }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -146,22 +146,12 @@ function extractAssistantText(msg: RelayMessage): string {
   return text;
 }
 
-function normalizeMessages(rawMessages: unknown[], keyOffset = 0): RelayMessage[] {
-  const all = rawMessages
-    .map((m, i) => toRelayMessage(m, `snapshot-${keyOffset + i}`))
-    .filter((m): m is RelayMessage => m !== null);
-
-  // Drop no-timestamp assistant messages that are superseded by a later
-  // timestamped assistant message. Two messages are considered the same turn
-  // when they share at least one toolCallId, OR when the no-timestamp message
-  // is immediately followed by a timestamped one (the original heuristic).
-  //
-  // This prevents streaming partials saved alongside the final message from
-  // producing duplicate rows (e.g. thinking blocks appearing below tool cards).
-
+/** Deduplicate assistant messages within a list. Removes no-timestamp partials
+ * that are superseded by timestamped finals, even across chunk boundaries. */
+function deduplicateMessages(messages: RelayMessage[]): RelayMessage[] {
   // Build a set of toolCallIds referenced by any timestamped assistant message.
   const timestampedToolCallIds = new Set<string>();
-  for (const msg of all) {
+  for (const msg of messages) {
     if (msg.role === "assistant" && msg.timestamp !== undefined) {
       for (const id of getAssistantToolCallIds(msg)) {
         timestampedToolCallIds.add(id);
@@ -170,12 +160,12 @@ function normalizeMessages(rawMessages: unknown[], keyOffset = 0): RelayMessage[
   }
 
   const dropIndices = new Set<number>();
-  for (let i = 0; i < all.length; i++) {
-    const cur = all[i];
+  for (let i = 0; i < messages.length; i++) {
+    const cur = messages[i];
     if (cur.role !== "assistant" || cur.timestamp !== undefined) continue;
 
     // Original heuristic: immediately followed by a timestamped assistant message.
-    const next = all[i + 1];
+    const next = messages[i + 1];
     if (next?.role === "assistant" && next.timestamp !== undefined) {
       dropIndices.add(i);
       continue;
@@ -195,8 +185,8 @@ function normalizeMessages(rawMessages: unknown[], keyOffset = 0): RelayMessage[
     if (ids.length === 0) {
       const curText = extractAssistantText(cur);
       if (curText) {
-        for (let j = i + 1; j < all.length; j++) {
-          const candidate = all[j];
+        for (let j = i + 1; j < messages.length; j++) {
+          const candidate = messages[j];
           if (candidate.role !== "assistant" || candidate.timestamp === undefined) continue;
           const candidateText = extractAssistantText(candidate);
           if (candidateText && candidateText.startsWith(curText)) {
@@ -208,8 +198,16 @@ function normalizeMessages(rawMessages: unknown[], keyOffset = 0): RelayMessage[
     }
   }
 
-  if (dropIndices.size === 0) return all;
-  return all.filter((_, i) => !dropIndices.has(i));
+  if (dropIndices.size === 0) return messages;
+  return messages.filter((_, i) => !dropIndices.has(i));
+}
+
+function normalizeMessages(rawMessages: unknown[], keyOffset = 0): RelayMessage[] {
+  const all = rawMessages
+    .map((m, i) => toRelayMessage(m, `snapshot-${keyOffset + i}`))
+    .filter((m): m is RelayMessage => m !== null);
+
+  return deduplicateMessages(all);
 }
 
 interface ConfiguredModelInfo {
@@ -1716,9 +1714,14 @@ export function App() {
       }
 
       const keyOffset = chunkedDeliveryRef.current?.loadedMessages ?? 0;
-      const normalizedChunk = normalizeMessages(chunkMessages, keyOffset);
+      // Convert messages but skip dedupe—we'll dedupe the full list when assembly completes.
+      // This prevents cross-chunk duplicates where a partial message in one chunk and
+      // its final timestamped version in another chunk would both survive per-chunk dedupe.
+      const convertedChunk = chunkMessages
+        .map((m, i) => toRelayMessage(m, `snapshot-${keyOffset + i}`))
+        .filter((m): m is RelayMessage => m !== null);
 
-      setMessages((prev) => [...prev, ...normalizedChunk]);
+      setMessages((prev) => [...prev, ...convertedChunk]);
 
       // Update chunked delivery tracking
       if (chunkedDeliveryRef.current) {
@@ -1735,11 +1738,15 @@ export function App() {
         sessionHydratedRef.current = true;
         setViewerStatus("Connected");
 
-        // Now that all messages are assembled, detect in-flight tools
+        // Now that all messages are assembled, run global dedupe to remove
+        // cross-chunk duplicates (e.g., partial messages from one chunk and
+        // their final timestamped versions from another). This prevents
+        // duplicate assistant/tool content from appearing in large-session reloads.
         setMessages((current) => {
-          setActiveToolCalls(detectInFlightTools(current));
-          patchSessionCache({ messages: current });
-          return current;
+          const deduped = deduplicateMessages(current);
+          setActiveToolCalls(detectInFlightTools(deduped));
+          patchSessionCache({ messages: deduped });
+          return deduped;
         });
       }
       return;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1634,6 +1634,9 @@ export function App() {
         setViewerStatus(`Loading session (0 of ${totalMessages} messages)…`);
       } else {
         chunkedDeliveryRef.current = null;
+        // Mark that we have a complete non-chunked snapshot so any stale
+        // chunks from a superseded chunked sender are rejected.
+        lastCompletedSnapshotRef.current = "non-chunked";
       }
 
       // Don't clobber transient statuses with a generic "Connected" when the
@@ -2511,12 +2514,13 @@ export function App() {
       lastViewerEventAtRef.current = Date.now();
 
       // Detect sequence gaps; request a resync if we missed events.
-      // During chunked delivery, suppress resync — chunks have their own
-      // ordering via chunkIndex/snapshotId and a resync would replace the
-      // partially-loaded messages with an empty lastState (the server
-      // hasn't assembled the full state yet).
+      // This is safe during chunked delivery because the server's resync
+      // handler now falls back to getPendingChunkedSnapshot() when lastState
+      // hasn't been assembled yet, and the resync response is a non-chunked
+      // session_active that sets lastCompletedSnapshotRef, rejecting any
+      // subsequently arriving stale chunks.
       const seq = typeof data.seq === "number" ? data.seq : null;
-      if (seq !== null && lastSeqRef.current !== null && !chunkedDeliveryRef.current) {
+      if (seq !== null && lastSeqRef.current !== null) {
         const expected = lastSeqRef.current + 1;
         if (seq > expected) {
           // Gap detected — request a resync snapshot from the server.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -810,6 +810,10 @@ export function App() {
     receivedChunks: number;
   } | null>(null);
 
+  // Track the last completed snapshot ID so we can reject stale chunks that
+  // arrive after the ref has been cleared (e.g. from a superseded sender).
+  const lastCompletedSnapshotRef = React.useRef<string | null>(null);
+
   // Capabilities advertised by the runner (commands, models, etc.)
   const [availableCommands, setAvailableCommands] = React.useState<Array<{ name: string; description?: string; source?: string }>>([]);
 
@@ -1323,13 +1327,15 @@ export function App() {
       awaitingSnapshotRef.current = false;
     }
 
-    // While awaiting the initial snapshot, skip streaming delta events.
-    // They'd render briefly and then be replaced when the snapshot arrives,
-    // causing visible "jumping".  This also covers tool execution events —
+    // While awaiting the initial snapshot OR during chunked hydration, skip
+    // streaming delta events.  They'd render briefly and then be replaced
+    // when the snapshot arrives, causing visible "jumping".  During chunked
+    // delivery, live events can interleave with historical chunks and produce
+    // an out-of-order transcript.  This also covers tool execution events —
     // without this guard, tool_execution_update partials can write synthetic
     // toolResult messages into state before the snapshot hydrates the real
     // conversation, producing orphan/duplicate tool output on reconnect.
-    if (awaitingSnapshotRef.current) {
+    if (awaitingSnapshotRef.current || chunkedDeliveryRef.current) {
       if (
         type === "message_update" || type === "message_start" || type === "message_end" || type === "turn_end" ||
         type === "tool_execution_start" || type === "tool_execution_update" || type === "tool_execution_end"
@@ -1690,10 +1696,18 @@ export function App() {
       const totalChunks = typeof (evt as any).totalChunks === "number" ? (evt as any).totalChunks : 0;
       const totalMessages = typeof (evt as any).totalMessages === "number" ? (evt as any).totalMessages : 0;
 
-      // Discard chunks from a stale snapshot stream (e.g. a new viewer
-      // connected mid-stream and triggered a fresh emitSessionActive).
-      if (chunkedDeliveryRef.current && chunkSnapshotId && chunkedDeliveryRef.current.snapshotId !== chunkSnapshotId) {
-        return; // stale chunk — ignore
+      // Discard chunks from a stale snapshot stream.  Two cases:
+      // 1) A newer snapshot is actively loading (ref is non-null, IDs differ).
+      // 2) A snapshot already completed (ref is null) but late chunks from
+      //    the superseded sender are still draining — reject if the ID
+      //    doesn't match the last completed snapshot.
+      if (chunkSnapshotId) {
+        if (chunkedDeliveryRef.current && chunkedDeliveryRef.current.snapshotId !== chunkSnapshotId) {
+          return; // stale chunk — a newer snapshot is loading
+        }
+        if (!chunkedDeliveryRef.current && lastCompletedSnapshotRef.current && lastCompletedSnapshotRef.current !== chunkSnapshotId) {
+          return; // stale chunk — arrived after a newer snapshot completed
+        }
       }
 
       const normalizedChunk = normalizeMessages(chunkMessages);
@@ -1709,6 +1723,7 @@ export function App() {
       }
 
       if (isFinal) {
+        lastCompletedSnapshotRef.current = chunkSnapshotId || null;
         chunkedDeliveryRef.current = null;
         sessionHydratedRef.current = true;
         setViewerStatus("Connected");
@@ -2410,6 +2425,7 @@ export function App() {
     renderedMcpReportTsRef.current = null;
     sessionHydratedRef.current = false;
     chunkedDeliveryRef.current = null;
+    lastCompletedSnapshotRef.current = null;
     setActiveSessionId(relaySessionId);
     setViewerStatus("Connecting…");
     setRetryState(null);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1322,7 +1322,12 @@ export function App() {
     // Clear the snapshot guard when we receive a state-setting event.
     // These events replace the entire message list, so any pre-snapshot
     // deltas that snuck through are harmless (they'll be overwritten).
-    if (type === "session_active" || type === "agent_end" || type === "heartbeat") {
+    // NOTE: heartbeat must NOT clear this flag — the server sends heartbeat
+    // before addViewer() completes (viewer.ts:383-395), so clearing on HB
+    // would drop the guard before the viewer is in the room, allowing
+    // in-flight chunks or deltas to be accepted and then overwritten by
+    // the later snapshot header.
+    if (type === "session_active" || type === "agent_end") {
       awaitingSnapshotRef.current = false;
     }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -798,6 +798,14 @@ export function App() {
   // messages, otherwise the report gets appended then immediately replaced.
   const sessionHydratedRef = React.useRef(false);
 
+  // Chunked session delivery: when session_active arrives with chunked:true,
+  // messages follow as session_messages_chunk events. This ref tracks state.
+  const chunkedDeliveryRef = React.useRef<{
+    totalMessages: number;
+    totalChunks: number;
+    receivedChunks: number;
+  } | null>(null);
+
   // Capabilities advertised by the runner (commands, models, etc.)
   const [availableCommands, setAvailableCommands] = React.useState<Array<{ name: string; description?: string; source?: string }>>([]);
 
@@ -1583,6 +1591,7 @@ export function App() {
     if (type === "session_active") {
       const state = evt.state as Record<string, unknown> | undefined;
       const rawMessages = Array.isArray(state?.messages) ? (state?.messages as unknown[]) : [];
+      const isChunked = !!(state as any)?.chunked;
       const stateModel = normalizeModel(state?.model);
       const stateModels = Array.isArray(state?.availableModels)
         ? normalizeModelList(state.availableModels as unknown[])
@@ -1601,12 +1610,28 @@ export function App() {
       }
       setAvailableModels(stateModels);
 
+      // Track chunked delivery state — messages arrive as subsequent
+      // session_messages_chunk events when the session is large.
+      if (isChunked) {
+        const totalMessages = typeof (state as any)?.totalMessages === "number" ? (state as any).totalMessages : 0;
+        chunkedDeliveryRef.current = {
+          totalMessages,
+          totalChunks: 0, // updated as chunks arrive
+          receivedChunks: 0,
+        };
+        setViewerStatus(`Loading session (0 of ${totalMessages} messages)…`);
+      } else {
+        chunkedDeliveryRef.current = null;
+      }
+
       // Don't clobber transient statuses with a generic "Connected" when the
       // CLI sends a session_active snapshot right after a command.
-      setViewerStatus((prev) => {
-        if (prev === "Model set" || prev === "Compacting…" || prev.startsWith("Compacted")) return prev;
-        return "Connected";
-      });
+      if (!isChunked) {
+        setViewerStatus((prev) => {
+          if (prev === "Model set" || prev === "Compacting…" || prev.startsWith("Compacted")) return prev;
+          return "Connected";
+        });
+      }
 
       // Don't unconditionally clear pendingQuestion / pendingPlan here.
       // session_active is also emitted for non-session-switch actions (model
@@ -1620,9 +1645,11 @@ export function App() {
       // keeps streaming indicators and Kill buttons visible. The snapshot payload
       // doesn't include explicit active-tool IDs, so we infer them by scanning
       // for toolCall blocks that have no matching toolResult.
-      setActiveToolCalls(detectInFlightTools(normalizedMessages));
+      if (!isChunked) {
+        setActiveToolCalls(detectInFlightTools(normalizedMessages));
+      }
       setIsChangingModel(false);
-      sessionHydratedRef.current = true;
+      sessionHydratedRef.current = !isChunked; // defer until final chunk
 
       // Clear queued messages — the snapshot contains the full conversation
       // including any follow-ups that were consumed by the agent.
@@ -1644,6 +1671,42 @@ export function App() {
         effortLevel: thinkingLevel,
         todoList: stateTodos,
       });
+      return;
+    }
+
+    // ── Chunked message delivery ───────────────────────────────────────────
+    // Large sessions send messages as a series of chunks after the metadata-only
+    // session_active event. Each chunk appends to the current messages array.
+    if (type === "session_messages_chunk") {
+      const chunkMessages = Array.isArray(evt.messages) ? evt.messages as unknown[] : [];
+      const isFinal = !!(evt as any).final;
+      const totalChunks = typeof (evt as any).totalChunks === "number" ? (evt as any).totalChunks : 0;
+      const totalMessages = typeof (evt as any).totalMessages === "number" ? (evt as any).totalMessages : 0;
+
+      const normalizedChunk = normalizeMessages(chunkMessages);
+
+      setMessages((prev) => [...prev, ...normalizedChunk]);
+
+      // Update chunked delivery tracking
+      if (chunkedDeliveryRef.current) {
+        chunkedDeliveryRef.current.receivedChunks++;
+        chunkedDeliveryRef.current.totalChunks = totalChunks;
+        const loaded = chunkedDeliveryRef.current.receivedChunks * 200; // approximate
+        setViewerStatus(`Loading session (${Math.min(loaded, totalMessages)} of ${totalMessages} messages)…`);
+      }
+
+      if (isFinal) {
+        chunkedDeliveryRef.current = null;
+        sessionHydratedRef.current = true;
+        setViewerStatus("Connected");
+
+        // Now that all messages are assembled, detect in-flight tools
+        setMessages((current) => {
+          setActiveToolCalls(detectInFlightTools(current));
+          patchSessionCache({ messages: current });
+          return current;
+        });
+      }
       return;
     }
 
@@ -2333,6 +2396,7 @@ export function App() {
     awaitingSnapshotRef.current = true;
     renderedMcpReportTsRef.current = null;
     sessionHydratedRef.current = false;
+    chunkedDeliveryRef.current = null;
     setActiveSessionId(relaySessionId);
     setViewerStatus("Connecting…");
     setRetryState(null);


### PR DESCRIPTION
## Problem

When a session JSONL exceeds ~100MB, the serialized `session_active` event payload exceeds the server's `maxHttpBufferSize` (100MB). Socket.IO silently kills the WebSocket connection (`transport close`), the client auto-reconnects, sends the same oversized payload, and loops forever — a boot loop.

Server logs showed relay sockets connecting and disconnecting within the **same second**, dozens of times:
```
[sio/relay] connected: qGfpEISMwlvHEK20AAcO
[sio/relay] disconnected: qGfpEISMwlvHEK20AAcO (transport close)
[sio/relay] connected: YK5Im48fbtP9n5yBAAcU
[sio/relay] disconnected: YK5Im48fbtP9n5yBAAcU (transport close)
```

## Solution

Chunked delivery with a 10MB threshold. Small sessions are unchanged.

### Worker (`remote.ts`)
- New `emitSessionActive(rctx)` replaces all 8 call sites that sent `session_active` with full state
- `estimateMessagesSize()` uses sampling to cheaply estimate payload size without blocking the event loop
- **Under 10MB:** Single event, zero behavior change
- **Over 10MB:** Sends metadata-only `session_active` (`chunked: true`, `totalMessages` count), then streams messages in chunks of 200 via `session_messages_chunk` events, yielding the event loop between chunks (`setImmediate`) so Socket.IO pings stay responsive

### UI (`App.tsx`)
- `session_active` with `chunked: true`: Sets metadata immediately, shows progress status
- `session_messages_chunk`: Appends messages to state, updates progress (`Loading session (N of M messages)…`)
- Final chunk: marks session hydrated, detects in-flight tools, updates cache

### Also
- `remote-exec-handler.ts`: All `session_active` sends use `rctx.emitSessionActive()`
- `remote-types.ts`: Added `emitSessionActive()` to RelayContext interface
- Tests for `estimateMessagesSize` and `needsChunkedDelivery`

## Testing
- `bun run typecheck` ✅
- `bun run build` ✅  
- `bun run test` — 228 pass, 0 fail ✅