### PR TITLE
feat(ui): merge Copy/Save into Export dropdown with rich markdown formatting

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/jordan/Documents/Projects/.worktrees/fix-mcp-oauth-timeout/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/feat-conversation-export/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/jordan/Documents/Projects/.worktrees/fix-mcp-oauth-timeout/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/feat-conversation-export/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -1,11 +1,9 @@
 import * as React from "react";
 
 import {
-  ConversationCopy,
-  ConversationDownload,
   ConversationEmptyState,
+  ConversationExport,
   MessageCopyButton,
-  type ConversationMessage,
 } from "@/components/ai-elements/conversation";
 import type { RelayMessage } from "@/components/session-viewer/types";
 import { SessionActionsProvider, type SessionActions } from "@/components/session-viewer/session-actions-context";
@@ -69,7 +67,7 @@ import { MultipleChoiceQuestions } from "@/components/ai-elements/multiple-choic
 import { PlanModePanel, type PlanModeAnswer } from "@/components/ai-elements/plan-mode";
 import { formatAnswersForAgent, type QuestionDisplayMode } from "@/lib/ask-user-questions";
 import { dismissNotificationsForSession } from "@/lib/push";
-import { AlertTriangleIcon, ArrowDownIcon, BookOpen, Bot, CheckCircle2, ChevronsUpDown, Circle, CircleDashed, ClipboardIcon, Copy, Loader2, MessageSquare, OctagonX, PaperclipIcon, Plus, Puzzle, ShieldAlert, Zap, Clock, X, Trash2, TerminalIcon, DownloadIcon, XCircle, FolderTree } from "lucide-react";
+import { AlertTriangleIcon, ArrowDownIcon, BookOpen, Bot, CheckCircle2, ChevronsUpDown, Circle, CircleDashed, Copy, Loader2, MessageSquare, OctagonX, PaperclipIcon, Plus, Puzzle, ShieldAlert, Zap, Clock, X, Trash2, TerminalIcon, XCircle, FolderTree } from "lucide-react";
 import { AtMentionPopover } from "@/components/AtMentionPopover";
 import type { Entry as AtMentionEntry } from "@/hooks/useAtMentionFiles";
 import { McpToggleContext, type McpToggleHandler } from "@/components/session-viewer/McpToggleContext";
@@ -1386,21 +1384,6 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     [sortedMessages],
   );
 
-  /** Serialise visible messages for download / clipboard copy, handling undefined content gracefully. */
-  const conversationMessages: ConversationMessage[] = React.useMemo(
-    () =>
-      sortedMessages.map((m) => ({
-        role: toMessageRole(m.role),
-        content:
-          typeof m.content === "string"
-            ? m.content
-            : m.content != null
-              ? JSON.stringify(m.content, null, 2)
-              : m.errorMessage ?? "",
-      })),
-    [sortedMessages],
-  );
-
   const PAGE_SIZE = 50;
 
   const scrollRef = React.useRef<HTMLDivElement | null>(null);
@@ -1618,29 +1601,13 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                 <span className="hidden sm:inline ml-1">Files</span>
               </Button>
             )}
-            <ConversationDownload
-              messages={conversationMessages}
+            <ConversationExport
+              messages={sortedMessages}
               filename={`session-${sessionId || "export"}.md`}
               className="static top-auto right-auto h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem] border-border bg-background hover:bg-accent hover:text-accent-foreground rounded-md"
               variant="outline"
               size="icon"
-              title="Download conversation markdown"
-              aria-label="Download conversation"
-            >
-              <DownloadIcon className="size-3.5" />
-              <span className="hidden sm:inline ml-1">Save</span>
-            </ConversationDownload>
-            <ConversationCopy
-              messages={conversationMessages}
-              className="static top-auto right-auto h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem] border-border bg-background hover:bg-accent hover:text-accent-foreground rounded-md"
-              iconClassName="size-3.5"
-              variant="outline"
-              size="icon"
-              title="Copy conversation as Markdown"
-              aria-label="Copy conversation"
-            >
-              <><ClipboardIcon className="size-3.5" /><span className="hidden sm:inline ml-1">Copy</span></>
-            </ConversationCopy>
+            />
             {onDuplicateSession && (
               <Button
                 className="h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem]"

--- a/packages/ui/src/components/ai-elements/conversation.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.tsx
@@ -13,7 +13,7 @@ import type { RelayMessage } from "@/components/session-viewer/types";
 import { exportToMarkdown } from "@/lib/export-markdown";
 import { cn } from "@/lib/utils";
 import { ArrowDownIcon, CheckIcon, ClipboardIcon, DownloadIcon, ShareIcon } from "lucide-react";
-import { useCallback, useState, useRef } from "react";
+import { useCallback, useEffect, useState, useRef } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
@@ -129,6 +129,10 @@ export const ConversationExport = ({
 }: ConversationExportProps) => {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
 
   const handleCopy = useCallback(async () => {
     const markdown = exportToMarkdown(messages);

--- a/packages/ui/src/components/ai-elements/conversation.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.tsx
@@ -3,8 +3,16 @@
 import type { ComponentProps } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import type { RelayMessage } from "@/components/session-viewer/types";
+import { exportToMarkdown } from "@/lib/export-markdown";
 import { cn } from "@/lib/utils";
-import { ArrowDownIcon, CheckIcon, ClipboardIcon, DownloadIcon } from "lucide-react";
+import { ArrowDownIcon, CheckIcon, ClipboardIcon, DownloadIcon, ShareIcon } from "lucide-react";
 import { useCallback, useState, useRef } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
@@ -100,44 +108,42 @@ export const ConversationScrollButton = ({
   );
 };
 
-export interface ConversationMessage {
-  role: "user" | "assistant" | "system" | "data" | "tool";
-  content: string;
-}
+// --- Conversation Export (dropdown: copy to clipboard / download as file) ---
 
-export type ConversationDownloadProps = Omit<
+export type ConversationExportProps = Omit<
   ComponentProps<typeof Button>,
   "onClick"
 > & {
-  messages: ConversationMessage[];
+  messages: RelayMessage[];
   filename?: string;
-  formatMessage?: (message: ConversationMessage, index: number) => string;
+  /** Duration in ms to show the success checkmark (default 2000) */
+  feedbackMs?: number;
 };
 
-const defaultFormatMessage = (message: ConversationMessage): string => {
-  const roleLabel =
-    message.role.charAt(0).toUpperCase() + message.role.slice(1);
-  return `**${roleLabel}:** ${message.content}`;
-};
-
-export const messagesToMarkdown = (
-  messages: ConversationMessage[],
-  formatMessage: (
-    message: ConversationMessage,
-    index: number
-  ) => string = defaultFormatMessage
-): string => messages.map((msg, i) => formatMessage(msg, i)).join("\n\n");
-
-export const ConversationDownload = ({
+export const ConversationExport = ({
   messages,
   filename = "conversation.md",
-  formatMessage = defaultFormatMessage,
+  feedbackMs = 2000,
   className,
-  children,
   ...props
-}: ConversationDownloadProps) => {
+}: ConversationExportProps) => {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const handleCopy = useCallback(async () => {
+    const markdown = exportToMarkdown(messages);
+    try {
+      await navigator.clipboard.writeText(markdown);
+      setCopied(true);
+      clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setCopied(false), feedbackMs);
+    } catch {
+      console.warn("Clipboard write failed");
+    }
+  }, [messages, feedbackMs]);
+
   const handleDownload = useCallback(() => {
-    const markdown = messagesToMarkdown(messages, formatMessage);
+    const markdown = exportToMarkdown(messages);
     const blob = new Blob([markdown], { type: "text/markdown" });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
@@ -147,80 +153,42 @@ export const ConversationDownload = ({
     link.click();
     link.remove();
     URL.revokeObjectURL(url);
-  }, [messages, filename, formatMessage]);
+  }, [messages, filename]);
 
   return (
-    <Button
-      className={cn(
-        "absolute top-4 right-4 rounded-full dark:bg-background dark:hover:bg-muted",
-        className
-      )}
-      onClick={handleDownload}
-      size="icon"
-      type="button"
-      variant="outline"
-      {...props}
-    >
-      {children ?? <DownloadIcon className="size-4" />}
-    </Button>
-  );
-};
-
-// --- Clipboard copy ---
-
-export type ConversationCopyProps = Omit<
-  ComponentProps<typeof Button>,
-  "onClick"
-> & {
-  messages: ConversationMessage[];
-  formatMessage?: (message: ConversationMessage, index: number) => string;
-  /** Duration in ms to show the success checkmark (default 2000) */
-  feedbackMs?: number;
-  /** Icon size class (default "size-4") */
-  iconClassName?: string;
-};
-
-export const ConversationCopy = ({
-  messages,
-  formatMessage = defaultFormatMessage,
-  feedbackMs = 2000,
-  iconClassName = "size-4",
-  className,
-  children,
-  ...props
-}: ConversationCopyProps) => {
-  const [copied, setCopied] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
-
-  const handleCopy = useCallback(async () => {
-    const markdown = messagesToMarkdown(messages, formatMessage);
-    try {
-      await navigator.clipboard.writeText(markdown);
-      setCopied(true);
-      clearTimeout(timerRef.current);
-      timerRef.current = setTimeout(() => setCopied(false), feedbackMs);
-    } catch {
-      // Fallback: some browsers block clipboard in non-secure contexts
-      console.warn("Clipboard write failed");
-    }
-  }, [messages, formatMessage, feedbackMs]);
-
-  return (
-    <Button
-      className={cn(
-        "absolute top-4 right-4 rounded-full dark:bg-background dark:hover:bg-muted",
-        className
-      )}
-      onClick={handleCopy}
-      size="icon"
-      type="button"
-      variant="outline"
-      {...props}
-    >
-      {copied
-        ? <CheckIcon className={cn(iconClassName, "text-green-500")} />
-        : (children ?? <ClipboardIcon className={iconClassName} />)}
-    </Button>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          className={cn(
+            "absolute top-4 right-4 rounded-full dark:bg-background dark:hover:bg-muted",
+            className,
+          )}
+          size="icon"
+          type="button"
+          variant="outline"
+          title="Export conversation"
+          aria-label="Export conversation"
+          {...props}
+        >
+          {copied ? (
+            <CheckIcon className="size-3.5 text-green-500" />
+          ) : (
+            <ShareIcon className="size-3.5" />
+          )}
+          <span className="hidden sm:inline ml-1">Export</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={handleCopy}>
+          <ClipboardIcon className="size-3.5 mr-2" />
+          Copy to Clipboard
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={handleDownload}>
+          <DownloadIcon className="size-3.5 mr-2" />
+          Download as File
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 };
 

--- a/packages/ui/src/lib/export-markdown.test.ts
+++ b/packages/ui/src/lib/export-markdown.test.ts
@@ -461,6 +461,61 @@ describe("exportToMarkdown", () => {
     expect(md).toContain("> **System:** Simple system message");
   });
 
+  test("tool message with hoisted thinking renders details block", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "tool",
+        toolName: "Bash",
+        toolInput: { command: "ls" },
+        content: "file1\nfile2",
+        thinking: "Let me list the files",
+        thinkingDuration: 2,
+      }),
+    ]);
+    expect(md).toContain("### 🔧 Bash");
+    expect(md).toContain("<details>");
+    expect(md).toContain("💭 Thinking (2s)");
+    expect(md).toContain("Let me list the files");
+    expect(md).toContain("file1");
+  });
+
+  test("subagent tool with details renders per-agent results", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "toolResult",
+        toolName: "subagent",
+        content: "Parallel: 2/2 done",
+        details: {
+          mode: "parallel",
+          results: [
+            {
+              agent: "researcher",
+              task: "Find the bug",
+              messages: [
+                { role: "user", content: "Find the bug" },
+                { role: "assistant", content: [{ type: "text", text: "Found it in app.tsx line 42" }] },
+              ],
+              exitCode: 0,
+            },
+            {
+              agent: "fixer",
+              task: "Fix the bug",
+              messages: [
+                { role: "assistant", content: [{ type: "text", text: "Fixed and tested" }] },
+              ],
+              exitCode: 0,
+            },
+          ],
+        },
+      }),
+    ]);
+    expect(md).toContain("#### 🤖 researcher");
+    expect(md).toContain("**Task:** Find the bug");
+    expect(md).toContain("Found it in app.tsx line 42");
+    expect(md).toContain("#### 🤖 fixer");
+    expect(md).toContain("Fixed and tested");
+  });
+
   test("failed send_message turn shows error state", () => {
     const md = exportToMarkdown([
       msg({

--- a/packages/ui/src/lib/export-markdown.test.ts
+++ b/packages/ui/src/lib/export-markdown.test.ts
@@ -333,6 +333,28 @@ describe("exportToMarkdown", () => {
     expect(md).toContain("[Bun Test](https://bun.sh/docs/test)");
   });
 
+  test("web search results escape special markdown chars in title/url", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "",
+            _webSearchResult: {
+              tool_use_id: "tu_1",
+              content: [
+                { type: "web_search_result", title: "Title with [brackets]", url: "https://example.com/path_(1)" },
+              ],
+            },
+          },
+        ],
+      }),
+    ]);
+    expect(md).toContain("\\[brackets\\]");
+    expect(md).toContain("path_\\(1\\)");
+  });
+
   test("output ends with trailing newline", () => {
     const md = exportToMarkdown([msg({ role: "user", content: "hi" })]);
     expect(md.endsWith("\n")).toBe(true);

--- a/packages/ui/src/lib/export-markdown.test.ts
+++ b/packages/ui/src/lib/export-markdown.test.ts
@@ -530,6 +530,34 @@ describe("exportToMarkdown", () => {
     expect(md).not.toContain("**→ Sent**");
   });
 
+  test("streaming wrapper {content, details} is unwrapped for tool output", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "tool",
+        toolName: "subagent",
+        toolInput: { agent: "task", task: "do stuff" },
+        content: {
+          content: [{ type: "text", text: "Partial result from agent" }],
+          details: { mode: "single", results: [] },
+        },
+      }),
+    ]);
+    expect(md).toContain("Partial result from agent");
+    expect(md).not.toContain('"content"');
+  });
+
+  test("trigger comment prefixes are stripped from exported messages", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "user",
+        content: "<!-- trigger:abc-123 -->\nThe child session completed successfully.",
+      }),
+    ]);
+    expect(md).toContain("The child session completed successfully.");
+    expect(md).not.toContain("<!-- trigger");
+    expect(md).not.toContain("abc-123");
+  });
+
   test("output ends with trailing newline", () => {
     const md = exportToMarkdown([msg({ role: "user", content: "hi" })]);
     expect(md.endsWith("\n")).toBe(true);

--- a/packages/ui/src/lib/export-markdown.test.ts
+++ b/packages/ui/src/lib/export-markdown.test.ts
@@ -399,6 +399,37 @@ describe("exportToMarkdown", () => {
     expect(md).toContain("path_\\(1\\)");
   });
 
+  test("tool output containing triple backticks uses longer fence", () => {
+    const contentWithFence = "Here is code:\n```js\nconsole.log('hi');\n```\nEnd.";
+    const md = exportToMarkdown([
+      msg({
+        role: "tool",
+        toolName: "Read",
+        toolInput: { path: "readme.md" },
+        content: contentWithFence,
+      }),
+    ]);
+    // Should contain a longer fence (at least ````)
+    expect(md).toContain("````");
+    // The original triple backtick content should be intact
+    expect(md).toContain("```js");
+    expect(md).toContain("console.log('hi');");
+  });
+
+  test("failed send_message turn shows error state", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "subAgentConversation",
+        subAgentTurns: [
+          { type: "sent", sessionId: "abc", message: "Error: sessionId is required.", isStreaming: false, isError: true },
+        ],
+      }),
+    ]);
+    expect(md).toContain("**⚠️ Send failed** to abc");
+    expect(md).toContain("Error: sessionId is required.");
+    expect(md).not.toContain("**→ Sent**");
+  });
+
   test("output ends with trailing newline", () => {
     const md = exportToMarkdown([msg({ role: "user", content: "hi" })]);
     expect(md.endsWith("\n")).toBe(true);

--- a/packages/ui/src/lib/export-markdown.test.ts
+++ b/packages/ui/src/lib/export-markdown.test.ts
@@ -26,11 +26,11 @@ describe("exportToMarkdown", () => {
         role: "assistant",
         content: "The answer is 42",
         thinking: "Let me think about this...",
-        thinkingDuration: 1500,
+        thinkingDuration: 3,
       }),
     ]);
     expect(md).toContain("<details>");
-    expect(md).toContain("💭 Thinking (1500ms)");
+    expect(md).toContain("💭 Thinking (3s)");
     expect(md).toContain("Let me think about this...");
     expect(md).toContain("</details>");
     expect(md).toContain("The answer is 42");
@@ -331,6 +331,50 @@ describe("exportToMarkdown", () => {
     expect(md).toContain("📎 **Search results:**");
     expect(md).toContain("[Bun Docs](https://bun.sh/docs)");
     expect(md).toContain("[Bun Test](https://bun.sh/docs/test)");
+  });
+
+  test("tool output with Anthropic content blocks extracts text", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "tool",
+        toolName: "spawn_session",
+        toolInput: { prompt: "do something" },
+        content: [
+          { type: "text", text: "Session spawned successfully." },
+          { type: "text", text: "Session ID: abc-123" },
+        ],
+      }),
+    ]);
+    expect(md).toContain("Session spawned successfully.");
+    expect(md).toContain("Session ID: abc-123");
+    // Should NOT contain raw JSON
+    expect(md).not.toContain('"type"');
+  });
+
+  test("image blocks render placeholder or URL", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "user",
+        content: [
+          { type: "text", text: "What's in this image?" },
+          { type: "image", source: { type: "base64", media_type: "image/png", data: "..." } },
+        ],
+      }),
+    ]);
+    expect(md).toContain("What's in this image?");
+    expect(md).toContain("🖼️ *[Image attachment]*");
+  });
+
+  test("image blocks with URL render as markdown image", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "user",
+        content: [
+          { type: "image", source: { type: "url", url: "https://example.com/img.png" } },
+        ],
+      }),
+    ]);
+    expect(md).toContain("![image](https://example.com/img.png)");
   });
 
   test("web search results escape special markdown chars in title/url", () => {

--- a/packages/ui/src/lib/export-markdown.test.ts
+++ b/packages/ui/src/lib/export-markdown.test.ts
@@ -416,6 +416,51 @@ describe("exportToMarkdown", () => {
     expect(md).toContain("console.log('hi');");
   });
 
+  test("object-shaped tool result extracts .text property", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "tool",
+        toolName: "mcp_tool",
+        toolInput: { query: "test" },
+        content: { text: "Tool result text here" },
+      }),
+    ]);
+    expect(md).toContain("Tool result text here");
+    expect(md).not.toContain('"text"');
+  });
+
+  test("object-shaped tool result extracts .content property", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "tool",
+        toolName: "mcp_tool",
+        toolInput: {},
+        content: { content: "MCP result content" },
+      }),
+    ]);
+    expect(md).toContain("MCP result content");
+    expect(md).not.toContain('"content"');
+  });
+
+  test("system messages with structured content use heading not blockquote", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "system",
+        content: { type: "command_result", data: { plugins: ["a", "b"] } },
+      }),
+    ]);
+    expect(md).toContain("### ⚙️ System");
+    // Should NOT have blockquote prefix on code fence lines
+    expect(md).not.toMatch(/^> ```/m);
+  });
+
+  test("simple system messages still use blockquote", () => {
+    const md = exportToMarkdown([
+      msg({ role: "system", content: "Simple system message" }),
+    ]);
+    expect(md).toContain("> **System:** Simple system message");
+  });
+
   test("failed send_message turn shows error state", () => {
     const md = exportToMarkdown([
       msg({

--- a/packages/ui/src/lib/export-markdown.test.ts
+++ b/packages/ui/src/lib/export-markdown.test.ts
@@ -274,6 +274,65 @@ describe("exportToMarkdown", () => {
     expect(md).toContain("**📭 No messages**");
   });
 
+  test("inline thinking blocks in content array are rendered", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "assistant",
+        content: [
+          { type: "thinking", thinking: "Let me reason about this..." },
+          { type: "text", text: "Here is my answer." },
+        ],
+      }),
+    ]);
+    expect(md).toContain("<details>");
+    expect(md).toContain("💭 Thinking");
+    expect(md).toContain("Let me reason about this...");
+    expect(md).toContain("</details>");
+    expect(md).toContain("Here is my answer.");
+  });
+
+  test("web search query metadata is preserved", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "",
+            _serverToolUse: { id: "tu_1", name: "web_search", input: { query: "bun test runner" } },
+          },
+          { type: "text", text: "Based on my search..." },
+        ],
+      }),
+    ]);
+    expect(md).toContain("🔍 **Web search:** bun test runner");
+    expect(md).toContain("Based on my search...");
+  });
+
+  test("web search results metadata is preserved", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "assistant",
+        content: [
+          {
+            type: "text",
+            text: "",
+            _webSearchResult: {
+              tool_use_id: "tu_1",
+              content: [
+                { type: "web_search_result", title: "Bun Docs", url: "https://bun.sh/docs" },
+                { type: "web_search_result", title: "Bun Test", url: "https://bun.sh/docs/test" },
+              ],
+            },
+          },
+        ],
+      }),
+    ]);
+    expect(md).toContain("📎 **Search results:**");
+    expect(md).toContain("[Bun Docs](https://bun.sh/docs)");
+    expect(md).toContain("[Bun Test](https://bun.sh/docs/test)");
+  });
+
   test("output ends with trailing newline", () => {
     const md = exportToMarkdown([msg({ role: "user", content: "hi" })]);
     expect(md.endsWith("\n")).toBe(true);

--- a/packages/ui/src/lib/export-markdown.test.ts
+++ b/packages/ui/src/lib/export-markdown.test.ts
@@ -1,0 +1,281 @@
+import { describe, test, expect } from "bun:test";
+import { exportToMarkdown } from "./export-markdown";
+import type { RelayMessage } from "@/components/session-viewer/types";
+
+/** Helper to create a minimal RelayMessage. */
+function msg(overrides: Partial<RelayMessage> & { role: string }): RelayMessage {
+  return { key: "test-" + Math.random().toString(36).slice(2, 8), ...overrides };
+}
+
+describe("exportToMarkdown", () => {
+  test("user message renders with heading and content", () => {
+    const md = exportToMarkdown([msg({ role: "user", content: "Hello world" })]);
+    expect(md).toContain("## 🧑 User");
+    expect(md).toContain("Hello world");
+  });
+
+  test("assistant message renders with heading and content", () => {
+    const md = exportToMarkdown([msg({ role: "assistant", content: "Hi there!" })]);
+    expect(md).toContain("## 🤖 Assistant");
+    expect(md).toContain("Hi there!");
+  });
+
+  test("assistant message with thinking renders details block", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "assistant",
+        content: "The answer is 42",
+        thinking: "Let me think about this...",
+        thinkingDuration: 1500,
+      }),
+    ]);
+    expect(md).toContain("<details>");
+    expect(md).toContain("💭 Thinking (1500ms)");
+    expect(md).toContain("Let me think about this...");
+    expect(md).toContain("</details>");
+    expect(md).toContain("The answer is 42");
+  });
+
+  test("assistant thinking without duration omits ms", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "assistant",
+        content: "result",
+        thinking: "hmm",
+      }),
+    ]);
+    expect(md).toContain("💭 Thinking</summary>");
+    expect(md).not.toContain("ms");
+  });
+
+  test("tool call renders with name, input, and output", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "tool",
+        toolName: "Read",
+        toolInput: { path: "src/app.tsx" },
+        content: "file contents here",
+      }),
+    ]);
+    expect(md).toContain("### 🔧 Read");
+    expect(md).toContain("**Input:**");
+    expect(md).toContain('"path": "src/app.tsx"');
+    expect(md).toContain("**Output:**");
+    expect(md).toContain("file contents here");
+  });
+
+  test("toolResult renders same as tool", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "toolResult",
+        toolName: "Bash",
+        toolInput: { command: "ls" },
+        content: "file1\nfile2",
+      }),
+    ]);
+    expect(md).toContain("### 🔧 Bash");
+    expect(md).toContain("**Input:**");
+    expect(md).toContain("**Output:**");
+  });
+
+  test("tool output over 5000 chars is truncated", () => {
+    const longOutput = "x".repeat(6000);
+    const md = exportToMarkdown([
+      msg({
+        role: "tool",
+        toolName: "Read",
+        toolInput: { path: "big.txt" },
+        content: longOutput,
+      }),
+    ]);
+    expect(md).toContain("[truncated — 6000 chars total]");
+    expect(md).not.toContain("x".repeat(6000));
+  });
+
+  test("compaction summary renders as blockquote with token count", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "compactionSummary",
+        summary: "Session context was compacted",
+        tokensBefore: 50000,
+      }),
+    ]);
+    expect(md).toContain("📦 **Context compacted** (50,000 tokens)");
+    expect(md).toContain("Session context was compacted");
+    expect(md).toContain("---");
+  });
+
+  test("branch summary renders as blockquote", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "branchSummary",
+        summary: "Branched from main session",
+      }),
+    ]);
+    expect(md).toContain("🌿 **Branch summary**");
+    expect(md).toContain("Branched from main session");
+  });
+
+  test("sub-agent conversation renders sent and received turns", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "subAgentConversation",
+        subAgentTurns: [
+          { type: "sent", sessionId: "abc123", message: "Do the thing", isStreaming: false, isError: false },
+          { type: "received", fromSessionId: "abc123", message: "Done!", isStreaming: false },
+        ],
+      }),
+    ]);
+    expect(md).toContain("#### 🤝 Sub-agent Conversation");
+    expect(md).toContain("**→ Sent** to abc123");
+    expect(md).toContain("Do the thing");
+    expect(md).toContain("**← Received** from abc123");
+    expect(md).toContain("Done!");
+  });
+
+  test("sub-agent waiting/timed-out/cancelled states", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "subAgentConversation",
+        subAgentTurns: [
+          { type: "waiting", isTimedOut: false, isCancelled: false, isStreaming: true },
+        ],
+      }),
+    ]);
+    expect(md).toContain("**⏳ Waiting** for response...");
+
+    const md2 = exportToMarkdown([
+      msg({
+        role: "subAgentConversation",
+        subAgentTurns: [
+          { type: "waiting", isTimedOut: true, isCancelled: false, isStreaming: false },
+        ],
+      }),
+    ]);
+    expect(md2).toContain("**⏳ Timed out**");
+
+    const md3 = exportToMarkdown([
+      msg({
+        role: "subAgentConversation",
+        subAgentTurns: [
+          { type: "waiting", isTimedOut: false, isCancelled: true, isStreaming: false },
+        ],
+      }),
+    ]);
+    expect(md3).toContain("**❌ Cancelled**");
+  });
+
+  test("error message renders as warning blockquote", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "assistant",
+        content: "Trying to help...",
+        stopReason: "error",
+        errorMessage: "Rate limit exceeded",
+      }),
+    ]);
+    expect(md).toContain("> ⚠️ **Error:** Rate limit exceeded");
+  });
+
+  test("mixed conversation produces correct ordering", () => {
+    const md = exportToMarkdown([
+      msg({ role: "user", content: "Fix the bug" }),
+      msg({ role: "assistant", content: "Let me look at that" }),
+      msg({ role: "tool", toolName: "Read", toolInput: { path: "bug.ts" }, content: "buggy code" }),
+      msg({ role: "assistant", content: "Found it! Here's the fix." }),
+    ]);
+    const userIdx = md.indexOf("🧑 User");
+    const assist1Idx = md.indexOf("Let me look at that");
+    const toolIdx = md.indexOf("🔧 Read");
+    const assist2Idx = md.indexOf("Found it!");
+    expect(userIdx).toBeLessThan(assist1Idx);
+    expect(assist1Idx).toBeLessThan(toolIdx);
+    expect(toolIdx).toBeLessThan(assist2Idx);
+  });
+
+  test("array content (Anthropic blocks) extracts text", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "assistant",
+        content: [
+          { type: "text", text: "First part" },
+          { type: "text", text: "Second part" },
+        ],
+      }),
+    ]);
+    expect(md).toContain("First part");
+    expect(md).toContain("Second part");
+    // Should NOT contain raw JSON
+    expect(md).not.toContain('"type"');
+  });
+
+  test("object content is JSON-stringified in code block", () => {
+    const md = exportToMarkdown([
+      msg({ role: "assistant", content: { foo: "bar", count: 42 } }),
+    ]);
+    expect(md).toContain("```json");
+    expect(md).toContain('"foo": "bar"');
+  });
+
+  test("empty/undefined content messages are skipped", () => {
+    const md = exportToMarkdown([
+      msg({ role: "user", content: undefined }),
+      msg({ role: "assistant", content: "" }),
+      msg({ role: "user", content: "Real message" }),
+    ]);
+    expect(md).not.toContain("## 🧑 User\n\n\n");
+    expect(md).toContain("Real message");
+    // Only one User heading (the empty ones were skipped)
+    expect(md.match(/## 🧑 User/g)?.length).toBe(1);
+  });
+
+  test("system messages render as blockquotes", () => {
+    const md = exportToMarkdown([
+      msg({ role: "system", content: "You are a helpful assistant" }),
+    ]);
+    expect(md).toContain("> **System:**");
+    expect(md).toContain("You are a helpful assistant");
+  });
+
+  test("tool with missing name shows Unknown tool", () => {
+    const md = exportToMarkdown([
+      msg({ role: "tool", toolInput: { x: 1 }, content: "result" }),
+    ]);
+    expect(md).toContain("### 🔧 Unknown tool");
+  });
+
+  test("check_messages sub-agent turn with messages", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "subAgentConversation",
+        subAgentTurns: [
+          {
+            type: "check",
+            messages: [{ fromSessionId: "s1", message: "hello" }],
+            isEmpty: false,
+            isStreaming: false,
+          },
+        ],
+      }),
+    ]);
+    expect(md).toContain("**← Message** from s1");
+    expect(md).toContain("hello");
+  });
+
+  test("check_messages sub-agent turn empty", () => {
+    const md = exportToMarkdown([
+      msg({
+        role: "subAgentConversation",
+        subAgentTurns: [
+          { type: "check", messages: [], isEmpty: true, isStreaming: false },
+        ],
+      }),
+    ]);
+    expect(md).toContain("**📭 No messages**");
+  });
+
+  test("output ends with trailing newline", () => {
+    const md = exportToMarkdown([msg({ role: "user", content: "hi" })]);
+    expect(md.endsWith("\n")).toBe(true);
+  });
+});

--- a/packages/ui/src/lib/export-markdown.test.ts
+++ b/packages/ui/src/lib/export-markdown.test.ts
@@ -558,6 +558,21 @@ describe("exportToMarkdown", () => {
     expect(md).not.toContain("abc-123");
   });
 
+  test("contentToString fallback uses safeFence when content contains backticks", () => {
+    // If an unrecognized object contains triple backticks, the fence must be longer
+    const md = exportToMarkdown([
+      msg({
+        role: "tool",
+        toolName: "some_tool",
+        toolInput: "x",
+        content: { weird: "has ```json inside" },
+      }),
+    ]);
+    // The output section should use a longer fence (````) not the default (```)
+    expect(md).toMatch(/^````$/m);
+    expect(md).toContain("has ```json inside");
+  });
+
   test("output ends with trailing newline", () => {
     const md = exportToMarkdown([msg({ role: "user", content: "hi" })]);
     expect(md.endsWith("\n")).toBe(true);

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -32,7 +32,11 @@ function extractWebSearch(block: Record<string, unknown>): string | null {
         )
       : [];
     if (results.length > 0) {
-      const lines = results.map((r) => `- [${r.title}](${r.url})`);
+      const lines = results.map((r) => {
+        const title = (r.title ?? "").replace(/[\[\]]/g, "\\$&");
+        const url = (r.url ?? "").replace(/[()]/g, "\\$&");
+        return `- [${title}](${url})`;
+      });
       return `📎 **Search results:**\n${lines.join("\n")}`;
     }
   }

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -10,23 +10,70 @@ import type { RelayMessage, SubAgentTurn } from "@/components/session-viewer/typ
 /** Maximum characters for tool output before truncation. */
 const TOOL_OUTPUT_MAX = 5000;
 
+/** Extract web-search metadata from an Anthropic content block, if present. */
+function extractWebSearch(block: Record<string, unknown>): string | null {
+  // Server tool use (query)
+  if (block._serverToolUse) {
+    const meta = block._serverToolUse as { input?: { query?: string } };
+    const query = meta.input?.query;
+    if (query) return `🔍 **Web search:** ${query}`;
+  }
+  // Web search results
+  if (block._webSearchResult) {
+    const meta = block._webSearchResult as {
+      content?: Array<{ type: string; title?: string; url?: string }>;
+    };
+    const results = Array.isArray(meta.content)
+      ? meta.content.filter(
+          (r) =>
+            r.type === "web_search_result" &&
+            typeof r.title === "string" &&
+            typeof r.url === "string",
+        )
+      : [];
+    if (results.length > 0) {
+      const lines = results.map((r) => `- [${r.title}](${r.url})`);
+      return `📎 **Search results:**\n${lines.join("\n")}`;
+    }
+  }
+  return null;
+}
+
 /** Stringify unknown content into a readable string. */
 function contentToString(content: unknown): string {
   if (content == null) return "";
   if (typeof content === "string") return content;
-  // Anthropic-style content blocks: [{type:"text", text:"..."}, ...]
+  // Anthropic-style content blocks: [{type:"text", text:"..."}, {type:"thinking", thinking:"..."}, ...]
   if (Array.isArray(content)) {
-    const texts = content
-      .filter(
-        (block): block is { type: string; text: string } =>
-          typeof block === "object" &&
-          block !== null &&
-          "text" in block &&
-          typeof (block as Record<string, unknown>).text === "string",
-      )
-      .map((block) => block.text);
-    if (texts.length > 0) return texts.join("\n\n");
-    // Fallback: stringify the array
+    const parts: string[] = [];
+    for (const block of content) {
+      if (typeof block !== "object" || block === null) continue;
+      const b = block as Record<string, unknown>;
+
+      // Inline thinking blocks (not yet hoisted to message.thinking)
+      if (b.type === "thinking" && typeof b.thinking === "string" && b.thinking) {
+        parts.push(
+          `<details>\n<summary>💭 Thinking</summary>\n\n${b.thinking}\n\n</details>`,
+        );
+        continue;
+      }
+
+      // Web search metadata on text blocks
+      const webSearch = extractWebSearch(b);
+      if (webSearch) {
+        parts.push(webSearch);
+        // Also include any text content on the same block
+        if (typeof b.text === "string" && b.text) parts.push(b.text);
+        continue;
+      }
+
+      // Regular text blocks
+      if (typeof b.text === "string" && b.text) {
+        parts.push(b.text);
+      }
+    }
+    if (parts.length > 0) return parts.join("\n\n");
+    // Fallback: stringify the array if no recognized blocks
     return "```json\n" + JSON.stringify(content, null, 2) + "\n```";
   }
   if (typeof content === "object") {

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -99,12 +99,22 @@ function contentToString(content: unknown): string {
   return String(content);
 }
 
+/**
+ * Pick a fence delimiter that doesn't collide with content.
+ * If the text contains ```, use a longer fence (````` or more).
+ */
+function safeFence(text: string, lang = ""): string {
+  let fence = "```";
+  while (text.includes(fence)) fence += "`";
+  return `${fence}${lang}\n${text}\n${fence}`;
+}
+
 /** Pretty-print tool input as a JSON code block. */
 function formatToolInput(input: unknown): string {
   if (input == null) return "";
   const json =
     typeof input === "string" ? input : JSON.stringify(input, null, 2);
-  return "**Input:**\n```json\n" + json + "\n```";
+  return "**Input:**\n" + safeFence(json, "json");
 }
 
 /** Extract text from tool content (Anthropic-style arrays or plain strings). */
@@ -136,13 +146,16 @@ function formatToolOutput(content: unknown): string {
       ? text.slice(0, TOOL_OUTPUT_MAX) +
         `\n\n[truncated — ${text.length} chars total]`
       : text;
-  return "**Output:**\n```\n" + truncated + "\n```";
+  return "**Output:**\n" + safeFence(truncated);
 }
 
 /** Render a single sub-agent turn. */
 function formatSubAgentTurn(turn: SubAgentTurn): string {
   switch (turn.type) {
     case "sent":
+      if (turn.isError) {
+        return `> **⚠️ Send failed** to ${turn.sessionId}:\n> ${turn.message.split("\n").join("\n> ")}`;
+      }
       return `> **→ Sent** to ${turn.sessionId}:\n> ${turn.message.split("\n").join("\n> ")}`;
     case "received":
       return `> **← Received** from ${turn.fromSessionId}:\n> ${turn.message.split("\n").join("\n> ")}`;

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -223,6 +223,16 @@ function formatMessage(message: RelayMessage): string | null {
     const name = message.toolName || "Unknown tool";
     const parts: string[] = [`### 🔧 ${name}`];
 
+    // Thinking hoisted onto tool messages by grouping
+    if (message.thinking) {
+      const duration = message.thinkingDuration
+        ? ` (${message.thinkingDuration}s)`
+        : "";
+      parts.push(
+        `<details>\n<summary>💭 Thinking${duration}</summary>\n\n${message.thinking}\n\n</details>`,
+      );
+    }
+
     if (message.toolInput != null) {
       const input = formatToolInput(message.toolInput);
       if (input) parts.push(input);
@@ -233,6 +243,37 @@ function formatMessage(message: RelayMessage): string | null {
 
     if (message.isError && message.content) {
       parts.push(`> ⚠️ Tool returned an error`);
+    }
+
+    // Subagent details — extract per-agent task/response pairs
+    if (message.details && typeof message.details === "object") {
+      const det = message.details as {
+        mode?: string;
+        results?: Array<{
+          agent?: string;
+          task?: string;
+          messages?: Array<{ role: string; content: unknown }>;
+          exitCode?: number;
+          errorMessage?: string;
+        }>;
+      };
+      if (Array.isArray(det.results) && det.results.length > 0) {
+        for (const r of det.results) {
+          const agentName = r.agent || "subagent";
+          const lines: string[] = [`#### 🤖 ${agentName}`];
+          if (r.task) lines.push(`**Task:** ${r.task}`);
+          // Extract last assistant message as the response
+          const lastAssistant = r.messages
+            ?.filter((m) => m.role === "assistant")
+            .pop();
+          if (lastAssistant) {
+            const responseText = contentToString(lastAssistant.content);
+            if (responseText) lines.push(`**Response:**\n${responseText}`);
+          }
+          if (r.errorMessage) lines.push(`> ⚠️ ${r.errorMessage}`);
+          parts.push(lines.join("\n\n"));
+        }
+      }
     }
 
     return parts.length > 1 ? parts.join("\n\n") : null;

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -43,10 +43,13 @@ function extractWebSearch(block: Record<string, unknown>): string | null {
   return null;
 }
 
+/** Strip `<!-- trigger:ID -->` prefixes injected by linked-session triggers. */
+const TRIGGER_PREFIX_RE = /^<!--\s*trigger:[\w-]+\s*-->\n?/;
+
 /** Stringify unknown content into a readable string. */
 function contentToString(content: unknown): string {
   if (content == null) return "";
-  if (typeof content === "string") return content;
+  if (typeof content === "string") return content.replace(TRIGGER_PREFIX_RE, "");
   // Anthropic-style content blocks: [{type:"text", text:"..."}, {type:"thinking", thinking:"..."}, ...]
   if (Array.isArray(content)) {
     const parts: string[] = [];
@@ -132,11 +135,12 @@ function toolContentToString(content: unknown): string {
     }
     if (parts.length > 0) return parts.join("\n\n");
   }
-  // Object with .text or .content property (common for MCP tool results)
+  // Object with .text or .content property (common for MCP tool results and streaming wrappers)
   if (content && typeof content === "object" && !Array.isArray(content)) {
     const obj = content as Record<string, unknown>;
     if (typeof obj.text === "string") return obj.text;
-    if (typeof obj.content === "string") return obj.content;
+    // .content can be a string or a nested array (streaming wrapper shape: { content, details })
+    if (obj.content != null) return toolContentToString(obj.content);
   }
   // Fallback: JSON stringify
   return JSON.stringify(content, null, 2);

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -1,0 +1,180 @@
+/**
+ * Rich markdown formatter for exporting conversation sessions.
+ *
+ * Takes raw RelayMessage[] and produces well-structured markdown with proper
+ * rendering of tool calls, thinking blocks, sub-agent conversations, etc.
+ */
+
+import type { RelayMessage, SubAgentTurn } from "@/components/session-viewer/types";
+
+/** Maximum characters for tool output before truncation. */
+const TOOL_OUTPUT_MAX = 5000;
+
+/** Stringify unknown content into a readable string. */
+function contentToString(content: unknown): string {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  // Anthropic-style content blocks: [{type:"text", text:"..."}, ...]
+  if (Array.isArray(content)) {
+    const texts = content
+      .filter(
+        (block): block is { type: string; text: string } =>
+          typeof block === "object" &&
+          block !== null &&
+          "text" in block &&
+          typeof (block as Record<string, unknown>).text === "string",
+      )
+      .map((block) => block.text);
+    if (texts.length > 0) return texts.join("\n\n");
+    // Fallback: stringify the array
+    return "```json\n" + JSON.stringify(content, null, 2) + "\n```";
+  }
+  if (typeof content === "object") {
+    return "```json\n" + JSON.stringify(content, null, 2) + "\n```";
+  }
+  return String(content);
+}
+
+/** Pretty-print tool input as a JSON code block. */
+function formatToolInput(input: unknown): string {
+  if (input == null) return "";
+  const json =
+    typeof input === "string" ? input : JSON.stringify(input, null, 2);
+  return "**Input:**\n```json\n" + json + "\n```";
+}
+
+/** Format tool output, truncating if too long. */
+function formatToolOutput(content: unknown): string {
+  if (content == null) return "";
+  const text = typeof content === "string" ? content : JSON.stringify(content, null, 2);
+  if (!text) return "";
+  const truncated =
+    text.length > TOOL_OUTPUT_MAX
+      ? text.slice(0, TOOL_OUTPUT_MAX) +
+        `\n\n[truncated — ${text.length} chars total]`
+      : text;
+  return "**Output:**\n```\n" + truncated + "\n```";
+}
+
+/** Render a single sub-agent turn. */
+function formatSubAgentTurn(turn: SubAgentTurn): string {
+  switch (turn.type) {
+    case "sent":
+      return `> **→ Sent** to ${turn.sessionId}:\n> ${turn.message.split("\n").join("\n> ")}`;
+    case "received":
+      return `> **← Received** from ${turn.fromSessionId}:\n> ${turn.message.split("\n").join("\n> ")}`;
+    case "waiting":
+      if (turn.isTimedOut) return "> **⏳ Timed out** waiting for response";
+      if (turn.isCancelled) return "> **❌ Cancelled** waiting for response";
+      return "> **⏳ Waiting** for response...";
+    case "check": {
+      if (turn.isEmpty) return "> **📭 No messages** in queue";
+      return turn.messages
+        .map(
+          (m) =>
+            `> **← Message** from ${m.fromSessionId}:\n> ${m.message.split("\n").join("\n> ")}`,
+        )
+        .join("\n\n");
+    }
+  }
+}
+
+/** Format a single RelayMessage into markdown. */
+function formatMessage(message: RelayMessage): string | null {
+  const { role } = message;
+
+  // ── User ──
+  if (role === "user") {
+    const text = contentToString(message.content);
+    if (!text) return null;
+    return `## 🧑 User\n\n${text}`;
+  }
+
+  // ── Assistant ──
+  if (role === "assistant") {
+    const parts: string[] = [];
+    parts.push("## 🤖 Assistant");
+
+    // Thinking block
+    if (message.thinking) {
+      const duration = message.thinkingDuration
+        ? ` (${message.thinkingDuration}ms)`
+        : "";
+      parts.push(
+        `<details>\n<summary>💭 Thinking${duration}</summary>\n\n${message.thinking}\n\n</details>`,
+      );
+    }
+
+    const text = contentToString(message.content);
+    if (text) parts.push(text);
+
+    // Error
+    if (message.stopReason === "error" && message.errorMessage) {
+      parts.push(`> ⚠️ **Error:** ${message.errorMessage}`);
+    }
+
+    return parts.length > 1 ? parts.join("\n\n") : null;
+  }
+
+  // ── Tool call / Tool result ──
+  if (role === "tool" || role === "toolResult") {
+    const name = message.toolName || "Unknown tool";
+    const parts: string[] = [`### 🔧 ${name}`];
+
+    if (message.toolInput != null) {
+      const input = formatToolInput(message.toolInput);
+      if (input) parts.push(input);
+    }
+
+    const output = formatToolOutput(message.content);
+    if (output) parts.push(output);
+
+    if (message.isError && message.content) {
+      parts.push(`> ⚠️ Tool returned an error`);
+    }
+
+    return parts.length > 1 ? parts.join("\n\n") : null;
+  }
+
+  // ── Compaction summary ──
+  if (role === "compactionSummary" && message.summary) {
+    const tokens = message.tokensBefore
+      ? ` (${message.tokensBefore.toLocaleString()} tokens)`
+      : "";
+    return `---\n\n> 📦 **Context compacted**${tokens}\n>\n> ${message.summary.split("\n").join("\n> ")}\n\n---`;
+  }
+
+  // ── Branch summary ──
+  if (role === "branchSummary" && message.summary) {
+    return `---\n\n> 🌿 **Branch summary**\n>\n> ${message.summary.split("\n").join("\n> ")}\n\n---`;
+  }
+
+  // ── Sub-agent conversation ──
+  if (role === "subAgentConversation" && message.subAgentTurns?.length) {
+    const turns = message.subAgentTurns.map(formatSubAgentTurn).join("\n\n");
+    return `#### 🤝 Sub-agent Conversation\n\n${turns}`;
+  }
+
+  // ── System messages ──
+  if (role === "system") {
+    const text = contentToString(message.content);
+    if (!text) return null;
+    return `> **System:** ${text.split("\n").join("\n> ")}`;
+  }
+
+  // ── Fallback: unknown roles with content ──
+  const fallback = contentToString(message.content);
+  if (fallback) return `### ${role}\n\n${fallback}`;
+
+  return null;
+}
+
+/**
+ * Convert an array of RelayMessages into a well-formatted markdown document.
+ */
+export function exportToMarkdown(messages: RelayMessage[]): string {
+  const sections = messages
+    .map(formatMessage)
+    .filter((s): s is string => s !== null);
+  return sections.join("\n\n") + "\n";
+}

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -94,10 +94,10 @@ function contentToString(content: unknown): string {
     }
     if (parts.length > 0) return parts.join("\n\n");
     // Fallback: stringify the array if no recognized blocks
-    return "```json\n" + JSON.stringify(content, null, 2) + "\n```";
+    return safeFence(JSON.stringify(content, null, 2), "json");
   }
   if (typeof content === "object") {
-    return "```json\n" + JSON.stringify(content, null, 2) + "\n```";
+    return safeFence(JSON.stringify(content, null, 2), "json");
   }
   return String(content);
 }

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -132,6 +132,12 @@ function toolContentToString(content: unknown): string {
     }
     if (parts.length > 0) return parts.join("\n\n");
   }
+  // Object with .text or .content property (common for MCP tool results)
+  if (content && typeof content === "object" && !Array.isArray(content)) {
+    const obj = content as Record<string, unknown>;
+    if (typeof obj.text === "string") return obj.text;
+    if (typeof obj.content === "string") return obj.content;
+  }
   // Fallback: JSON stringify
   return JSON.stringify(content, null, 2);
 }
@@ -255,6 +261,11 @@ function formatMessage(message: RelayMessage): string | null {
   if (role === "system") {
     const text = contentToString(message.content);
     if (!text) return null;
+    // If content is structured (contains code fences), use a heading instead
+    // of blockquote to avoid broken markdown
+    if (text.includes("```")) {
+      return `### ⚙️ System\n\n${text}`;
+    }
     return `> **System:** ${text.split("\n").join("\n> ")}`;
   }
 

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -33,8 +33,8 @@ function extractWebSearch(block: Record<string, unknown>): string | null {
       : [];
     if (results.length > 0) {
       const lines = results.map((r) => {
-        const title = (r.title ?? "").replace(/[\[\]]/g, "\\$&");
-        const url = (r.url ?? "").replace(/[()]/g, "\\$&");
+        const title = (r.title ?? "").replace(/\\/g, "\\\\").replace(/[\[\]]/g, "\\$&");
+        const url = (r.url ?? "").replace(/\\/g, "\\\\").replace(/[()]/g, "\\$&");
         return `- [${title}](${url})`;
       });
       return `📎 **Search results:**\n${lines.join("\n")}`;
@@ -71,6 +71,19 @@ function contentToString(content: unknown): string {
         continue;
       }
 
+      // Image blocks — preserve a reference since we can't inline binary data
+      if (b.type === "image") {
+        const src = typeof b.source === "object" && b.source !== null
+          ? (b.source as Record<string, unknown>)
+          : null;
+        if (src?.type === "url" && typeof src.url === "string") {
+          parts.push(`![image](${src.url})`);
+        } else {
+          parts.push("🖼️ *[Image attachment]*");
+        }
+        continue;
+      }
+
       // Regular text blocks
       if (typeof b.text === "string" && b.text) {
         parts.push(b.text);
@@ -94,10 +107,29 @@ function formatToolInput(input: unknown): string {
   return "**Input:**\n```json\n" + json + "\n```";
 }
 
+/** Extract text from tool content (Anthropic-style arrays or plain strings). */
+function toolContentToString(content: unknown): string {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  // Anthropic-style content blocks: [{type:"text", text:"..."}, ...]
+  if (Array.isArray(content)) {
+    const parts: string[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const b = block as Record<string, unknown>;
+      if (typeof b.text === "string") parts.push(b.text);
+      else if (typeof b.content === "string") parts.push(b.content);
+    }
+    if (parts.length > 0) return parts.join("\n\n");
+  }
+  // Fallback: JSON stringify
+  return JSON.stringify(content, null, 2);
+}
+
 /** Format tool output, truncating if too long. */
 function formatToolOutput(content: unknown): string {
   if (content == null) return "";
-  const text = typeof content === "string" ? content : JSON.stringify(content, null, 2);
+  const text = toolContentToString(content);
   if (!text) return "";
   const truncated =
     text.length > TOOL_OUTPUT_MAX
@@ -149,7 +181,7 @@ function formatMessage(message: RelayMessage): string | null {
     // Thinking block
     if (message.thinking) {
       const duration = message.thinkingDuration
-        ? ` (${message.thinkingDuration}ms)`
+        ? ` (${message.thinkingDuration}s)`
         : "";
       parts.push(
         `<details>\n<summary>💭 Thinking${duration}</summary>\n\n${message.thinking}\n\n</details>`,


### PR DESCRIPTION
## Summary

Merges the two separate "Copy" and "Save" conversation buttons into a single **Export** dropdown that properly processes `RelayMessage` data into readable markdown.

## Problem

The old buttons used a lossy intermediate (`ConversationMessage`) that discarded tool names, thinking blocks, sub-agent turns, summaries, and error details. Non-string content was just `JSON.stringify`'d — producing unreadable raw JSON in exports.

## Changes

- **New `export-markdown.ts`** — pure formatter that handles all message roles:
  - User/Assistant messages with clean headings
  - Thinking blocks in `<details>` with duration
  - Tool calls with name, JSON input, formatted output (truncated at 5000 chars)
  - Compaction/branch summaries as blockquotes
  - Sub-agent conversations with sent/received/waiting turns
  - Error messages as warning blockquotes
  - Anthropic content block arrays properly extracted
- **New `ConversationExport` dropdown** replaces both `ConversationCopy` and `ConversationDownload`
  - "Copy to Clipboard" and "Download as File" in a single dropdown
- **Removed** lossy `ConversationMessage` intermediate and old components
- **21 new tests** covering all message roles and edge cases

## Quality

- ✅ 249 tests pass (21 new)
- ✅ Typecheck clean
- ✅ Build succeeds
- ✅ Code review passed (GPT-5.1 Codex Mini — LGTM)