### PR TITLE
fix: exponential backoff with ±25% jitter for CLI relay WebSocket connections

### DIFF
--- a/packages/cli/src/backoff.test.ts
+++ b/packages/cli/src/backoff.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from "bun:test";
+import { computeBackoffDelay } from "./backoff.js";
+
+describe("computeBackoffDelay", () => {
+    test("first attempt returns approximately baseMs (±25% jitter by default)", () => {
+        // With jitter ±25%, result should be in [750, 1250]
+        for (let i = 0; i < 50; i++) {
+            const delay = computeBackoffDelay(0);
+            expect(delay).toBeGreaterThanOrEqual(750);
+            expect(delay).toBeLessThanOrEqual(1250);
+        }
+    });
+
+    test("second attempt returns approximately 2×baseMs (±25%)", () => {
+        // 1000 * 2^1 = 2000, with ±25%: [1500, 2500]
+        for (let i = 0; i < 50; i++) {
+            const delay = computeBackoffDelay(1);
+            expect(delay).toBeGreaterThanOrEqual(1500);
+            expect(delay).toBeLessThanOrEqual(2500);
+        }
+    });
+
+    test("third attempt returns approximately 4×baseMs (±25%)", () => {
+        // 1000 * 2^2 = 4000, with ±25%: [3000, 5000]
+        for (let i = 0; i < 50; i++) {
+            const delay = computeBackoffDelay(2);
+            expect(delay).toBeGreaterThanOrEqual(3000);
+            expect(delay).toBeLessThanOrEqual(5000);
+        }
+    });
+
+    test("caps at maxMs regardless of attempt count", () => {
+        // At attempt 10, 1000 * 2^10 = 1_024_000 >> 30_000
+        // With ±25% jitter: max is 30_000 * 1.25 = 37_500
+        for (let i = 0; i < 50; i++) {
+            const delay = computeBackoffDelay(10);
+            expect(delay).toBeLessThanOrEqual(37_500);
+        }
+    });
+
+    test("caps at maxMs for extreme attempt counts", () => {
+        for (let i = 0; i < 50; i++) {
+            const delay = computeBackoffDelay(100);
+            expect(delay).toBeLessThanOrEqual(37_500);
+        }
+    });
+
+    test("respects custom baseMs", () => {
+        for (let i = 0; i < 50; i++) {
+            const delay = computeBackoffDelay(0, { baseMs: 500 });
+            expect(delay).toBeGreaterThanOrEqual(375); // 500 * 0.75
+            expect(delay).toBeLessThanOrEqual(625);    // 500 * 1.25
+        }
+    });
+
+    test("respects custom maxMs", () => {
+        for (let i = 0; i < 50; i++) {
+            const delay = computeBackoffDelay(10, { maxMs: 5_000 });
+            expect(delay).toBeLessThanOrEqual(6_250); // 5000 * 1.25
+        }
+    });
+
+    test("zero jitterFactor produces deterministic exponential values", () => {
+        expect(computeBackoffDelay(0, { jitterFactor: 0 })).toBe(1000);
+        expect(computeBackoffDelay(1, { jitterFactor: 0 })).toBe(2000);
+        expect(computeBackoffDelay(2, { jitterFactor: 0 })).toBe(4000);
+        expect(computeBackoffDelay(3, { jitterFactor: 0 })).toBe(8000);
+        expect(computeBackoffDelay(4, { jitterFactor: 0 })).toBe(16_000);
+        expect(computeBackoffDelay(5, { jitterFactor: 0 })).toBe(30_000); // capped at maxMs
+        expect(computeBackoffDelay(6, { jitterFactor: 0 })).toBe(30_000);
+    });
+
+    test("never returns negative values even with extreme jitter", () => {
+        for (let i = 0; i < 100; i++) {
+            expect(computeBackoffDelay(0, { jitterFactor: 1.0 })).toBeGreaterThanOrEqual(0);
+        }
+    });
+
+    test("returns integer milliseconds (Math.round)", () => {
+        for (let i = 0; i < 20; i++) {
+            const delay = computeBackoffDelay(0);
+            expect(Number.isInteger(delay)).toBe(true);
+        }
+    });
+
+    test("grows monotonically in the median (no jitter)", () => {
+        const delays = [0, 1, 2, 3, 4, 5].map((a) => computeBackoffDelay(a, { jitterFactor: 0 }));
+        for (let i = 1; i < delays.length - 1; i++) {
+            // Each uncapped step should be 2× previous
+            if (delays[i] < 30_000) {
+                expect(delays[i]).toBe(delays[i - 1] * 2);
+            }
+        }
+    });
+});

--- a/packages/cli/src/backoff.ts
+++ b/packages/cli/src/backoff.ts
@@ -1,0 +1,57 @@
+/**
+ * Exponential backoff with jitter for relay WebSocket reconnections.
+ *
+ * Used to configure Socket.IO's built-in reconnection delays and also
+ * available as a standalone utility for tests and future use.
+ */
+
+export interface BackoffOptions {
+    /** Initial delay in milliseconds. Default: 1000 (1 s) */
+    baseMs?: number;
+    /** Maximum delay in milliseconds. Default: 30_000 (30 s) */
+    maxMs?: number;
+    /**
+     * Jitter factor as a fraction of the computed base delay.
+     * `0.25` means ±25% randomization. Default: 0.25
+     */
+    jitterFactor?: number;
+}
+
+/**
+ * Compute the delay for a reconnection attempt using exponential backoff with jitter.
+ *
+ * @param attempt - 0-indexed attempt number (0 = first retry)
+ * @param options - Backoff configuration overrides
+ * @returns Delay in milliseconds, always ≥ 0 and rounded to integer
+ *
+ * Algorithm:
+ *   base   = min(baseMs × 2^attempt, maxMs)
+ *   jitter = base × jitterFactor × random(−1, 1)
+ *   result = round(max(0, base + jitter))
+ */
+export function computeBackoffDelay(attempt: number, options?: BackoffOptions): number {
+    const baseMs = options?.baseMs ?? 1000;
+    const maxMs = options?.maxMs ?? 30_000;
+    const jitterFactor = options?.jitterFactor ?? 0.25;
+
+    const exponential = baseMs * Math.pow(2, attempt);
+    const base = Math.min(exponential, maxMs);
+    const jitter = base * jitterFactor * (Math.random() * 2 - 1);
+    return Math.round(Math.max(0, base + jitter));
+}
+
+/**
+ * Default backoff parameters used for the CLI relay Socket.IO connection.
+ * These values are passed directly to Socket.IO's reconnection config.
+ */
+export const RELAY_BACKOFF_DEFAULTS = {
+    /** Base reconnection delay (ms). Socket.IO: reconnectionDelay */
+    baseMs: 1000,
+    /** Maximum reconnection delay (ms). Socket.IO: reconnectionDelayMax */
+    maxMs: 30_000,
+    /**
+     * Jitter factor (0–1). Socket.IO: randomizationFactor
+     * 0.25 = ±25% randomization applied to each computed delay.
+     */
+    jitterFactor: 0.25,
+} as const;

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -40,6 +40,7 @@ import type { ConversationTrigger } from "./triggers/types.js";
 import { messageBus } from "./session-message-bus.js";
 import { io, type Socket } from "socket.io-client";
 import type { RelayClientToServerEvents, RelayServerToClientEvents } from "@pizzapi/protocol";
+import { RELAY_BACKOFF_DEFAULTS } from "../backoff.js";
 
 // ── Extracted modules ────────────────────────────────────────────────────────
 import type {
@@ -779,9 +780,14 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             {
                 auth: { apiKey: key },
                 transports: ["websocket"],
+                // Exponential backoff with ±25% jitter. Socket.IO doubles the
+                // delay on each reconnection attempt (up to reconnectionDelayMax)
+                // and applies randomizationFactor as a ±fraction of each delay.
                 reconnection: true,
-                reconnectionDelay: 1000,
-                reconnectionDelayMax: 30_000,
+                reconnectionAttempts: Infinity,
+                reconnectionDelay: RELAY_BACKOFF_DEFAULTS.baseMs,       // 1 s base
+                reconnectionDelayMax: RELAY_BACKOFF_DEFAULTS.maxMs,     // 30 s cap
+                randomizationFactor: RELAY_BACKOFF_DEFAULTS.jitterFactor, // ±25%
             },
         );
         rctx.sioSocket = sock;


### PR DESCRIPTION
## Summary

The CLI relay WebSocket connection uses Socket.IO's built-in exponential backoff for reconnections, but `randomizationFactor` was not explicitly set (defaulting to `0.5` = ±50% jitter). This PR corrects that and extracts the backoff parameters into a testable utility.

## Changes

### `packages/cli/src/backoff.ts` (new)
- Pure `computeBackoffDelay(attempt, options?)` function
- Exported `RELAY_BACKOFF_DEFAULTS` constants (baseMs: 1s, maxMs: 30s, jitterFactor: 0.25)

### `packages/cli/src/backoff.test.ts` (new)
- 11 unit tests covering:
  - Delay bounds at each attempt level (0, 1, 2, high)
  - Hard cap at `maxMs`
  - Custom `baseMs`, `maxMs`, `jitterFactor` overrides
  - Deterministic output with zero jitter
  - No negative values with extreme jitter
  - Integer return value (Math.round)
  - Monotonic doubling behaviour pre-cap

### `packages/cli/src/extensions/remote.ts` (modified)
- Added `randomizationFactor: 0.25` — was defaulting to 0.5 (±50%)
- Added `reconnectionAttempts: Infinity` explicitly to document intent
- Tied `reconnectionDelay` / `reconnectionDelayMax` to `RELAY_BACKOFF_DEFAULTS` constants so the testable utility and Socket.IO config stay in sync

## Backoff parameters

| Parameter | Value |
|-----------|-------|
| Base delay | 1 s |
| Max delay | 30 s |
| Jitter | ±25% |
| Growth | 2× per attempt |

With these settings the delay sequence (approximate median) is: 1 s → 2 s → 4 s → 8 s → 16 s → 30 s (capped).

## Testing

```
bun run typecheck   # ✓ no errors
bun run test        # ✓ 934 pass, 0 fail
```