### PR TITLE
fix: group worktree child sessions under parent in sidebar

### DIFF
--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -15,7 +15,7 @@ import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/
 import { formatPathTail } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare, Copy } from "lucide-react";
-import { buildSessionTree, flattenSessionTree, getSessionIndent, getDescendantSessionIds } from "@/lib/session-tree";
+import { buildSessionTree, flattenSessionTree, getSessionIndent, getDescendantSessionIds, getGroupCwd } from "@/lib/session-tree";
 
 interface HubSession {
     sessionId: string;
@@ -660,14 +660,22 @@ export const SessionSidebar = React.memo(function SessionSidebar({
         }
 
         // Step 3: for every runner, split sessions into per-cwd project groups.
+        // Child sessions (spawned in worktrees or with a parentSessionId) are
+        // collapsed under the same project group as their root ancestor.
         const result: RunnerGroup[] = [];
         for (const [key, { label, sessions }] of runnerMap) {
             const isLocal = key === "__local__";
+
+            // Build a lookup map so getGroupCwd can follow parent chains
+            const runnerSessionMap = new Map<string, HubSession>(
+                sessions.map((s) => [s.sessionId, s]),
+            );
+
             const cwdMap = new Map<string, HubSession[]>();
             for (const s of sessions) {
-                const cwd = s.cwd || "";
-                if (!cwdMap.has(cwd)) cwdMap.set(cwd, []);
-                cwdMap.get(cwd)!.push(s);
+                const groupCwd = getGroupCwd(s, runnerSessionMap);
+                if (!cwdMap.has(groupCwd)) cwdMap.set(groupCwd, []);
+                cwdMap.get(groupCwd)!.push(s);
             }
 
             const projects: ProjectGroup[] = Array.from(cwdMap.entries()).map(([cwd, cwdSessions]) => ({
@@ -1348,6 +1356,21 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                                     {timeLabel}
                                                                 </span>
                                                             </div>
+                                                            {/* Worktree badge — shown when cwd is inside a .worktrees/ directory */}
+                                                            {(() => {
+                                                                const cwd = s.cwd || "";
+                                                                const match = cwd.match(/\/\.worktrees\/([^/]+)/);
+                                                                return match ? (
+                                                                    <div className="flex items-center gap-1 mt-0.5">
+                                                                        <span
+                                                                            className="text-[0.55rem] bg-amber-500/15 text-amber-400/80 px-1 py-0.5 rounded font-mono leading-none truncate max-w-[8rem]"
+                                                                            title={`Worktree: ${match[1]}`}
+                                                                        >
+                                                                            {match[1]}
+                                                                        </span>
+                                                                    </div>
+                                                                ) : null;
+                                                            })()}
                                                             {(s.userName || (showCwd && s.cwd)) && (
                                                                 <div className="flex items-center gap-1 mt-0.5 min-w-0">
                                                                     {s.userName && (

--- a/packages/ui/src/lib/session-tree.test.ts
+++ b/packages/ui/src/lib/session-tree.test.ts
@@ -4,6 +4,7 @@ import {
   flattenSessionTree,
   getSessionIndent,
   getDescendantSessionIds,
+  getGroupCwd,
   type HubSession,
 } from "./session-tree";
 
@@ -205,6 +206,90 @@ describe("session-tree", () => {
 
     test("handles large depth values", () => {
       expect(getSessionIndent(10)).toBe(160);
+    });
+  });
+
+  describe("getGroupCwd", () => {
+    const makeSession = (id: string, cwd: string, parentId?: string): HubSession => ({
+      sessionId: id,
+      shareUrl: `http://localhost/session/${id}`,
+      cwd,
+      startedAt: new Date().toISOString(),
+      parentSessionId: parentId ?? null,
+    });
+
+    const makeMap = (...sessions: HubSession[]) =>
+      new Map(sessions.map((s) => [s.sessionId, s]));
+
+    test("returns own cwd when no parent and no worktree", () => {
+      const s = makeSession("a", "/projects/foo");
+      expect(getGroupCwd(s, makeMap(s))).toBe("/projects/foo");
+    });
+
+    test("follows parentSessionId and returns parent cwd", () => {
+      const parent = makeSession("parent", "/projects/foo");
+      const child = makeSession("child", "/projects/bar", "parent");
+      const map = makeMap(parent, child);
+      expect(getGroupCwd(child, map)).toBe("/projects/foo");
+    });
+
+    test("follows multi-level parent chain to root cwd", () => {
+      const root = makeSession("root", "/projects/root");
+      const mid = makeSession("mid", "/projects/mid", "root");
+      const leaf = makeSession("leaf", "/projects/leaf", "mid");
+      const map = makeMap(root, mid, leaf);
+      expect(getGroupCwd(leaf, map)).toBe("/projects/root");
+    });
+
+    test("returns own cwd when parentSessionId not in map", () => {
+      const s = makeSession("orphan", "/projects/orphan", "nonexistent");
+      expect(getGroupCwd(s, makeMap(s))).toBe("/projects/orphan");
+    });
+
+    test("worktree detection: groups child under repo root when root session exists", () => {
+      const root = makeSession("root", "/projects/foo");
+      const wt = makeSession("wt", "/projects/foo/.worktrees/fix-bar");
+      const map = makeMap(root, wt);
+      expect(getGroupCwd(wt, map)).toBe("/projects/foo");
+    });
+
+    test("worktree detection: no match when root session absent", () => {
+      const wt = makeSession("wt", "/projects/foo/.worktrees/fix-bar");
+      expect(getGroupCwd(wt, makeMap(wt))).toBe("/projects/foo/.worktrees/fix-bar");
+    });
+
+    test("parentSessionId takes priority over worktree detection", () => {
+      const explicitParent = makeSession("explicit-parent", "/projects/explicit");
+      const root = makeSession("root", "/projects/foo");
+      const child = makeSession("child", "/projects/foo/.worktrees/fix-bar", "explicit-parent");
+      const map = makeMap(explicitParent, root, child);
+      // Should follow parentSessionId, not worktree detection
+      expect(getGroupCwd(child, map)).toBe("/projects/explicit");
+    });
+
+    test("worktree path with nested subdir still finds root", () => {
+      const root = makeSession("root", "/projects/foo");
+      const wt = makeSession("wt", "/projects/foo/.worktrees/my-branch/subdir");
+      const map = makeMap(root, wt);
+      expect(getGroupCwd(wt, map)).toBe("/projects/foo");
+    });
+
+    test("handles cycle in parent chain without infinite loop", () => {
+      const a = makeSession("a", "/projects/a", "b");
+      const b = makeSession("b", "/projects/b", "a");
+      const map = makeMap(a, b);
+      // Should return something without looping (either a's or b's cwd)
+      const result = getGroupCwd(a, map);
+      expect(["/projects/a", "/projects/b"]).toContain(result);
+    });
+
+    test("multiple worktree sessions all group under the same root", () => {
+      const root = makeSession("root", "/projects/foo");
+      const wt1 = makeSession("wt1", "/projects/foo/.worktrees/branch-1");
+      const wt2 = makeSession("wt2", "/projects/foo/.worktrees/branch-2");
+      const map = makeMap(root, wt1, wt2);
+      expect(getGroupCwd(wt1, map)).toBe("/projects/foo");
+      expect(getGroupCwd(wt2, map)).toBe("/projects/foo");
     });
   });
 

--- a/packages/ui/src/lib/session-tree.ts
+++ b/packages/ui/src/lib/session-tree.ts
@@ -152,6 +152,54 @@ export function getSessionIndent(depth: number): number {
 }
 
 /**
+ * Determine the canonical project-group cwd for a session so that child sessions
+ * spawned in git worktrees appear under the same project folder as their parent.
+ *
+ * Resolution order:
+ *  1. Follow parentSessionId chain → use the root ancestor's cwd.
+ *  2. Worktree subdir detection — if cwd contains `/.worktrees/` and another
+ *     session in the provided map owns the prefix, use that prefix.
+ *  3. Fall back to the session's own cwd.
+ *
+ * @param session     The session to resolve a group cwd for.
+ * @param sessionMap  Map of sessionId → HubSession covering all sessions in the
+ *                    same runner group (used to follow parent chains and detect
+ *                    worktree prefixes).
+ * @param visited     Internal cycle-guard; callers should omit this.
+ */
+export function getGroupCwd(
+  session: HubSession,
+  sessionMap: Map<string, HubSession>,
+  visited = new Set<string>(),
+): string {
+  if (visited.has(session.sessionId)) return session.cwd || "";
+  visited.add(session.sessionId);
+
+  // Priority 1: follow parentSessionId up to the root
+  if (session.parentSessionId) {
+    const parent = sessionMap.get(session.parentSessionId);
+    if (parent) {
+      return getGroupCwd(parent, sessionMap, visited);
+    }
+  }
+
+  // Priority 2: worktree subdirectory detection
+  const cwd = session.cwd || "";
+  const worktreeMarker = "/.worktrees/";
+  const idx = cwd.indexOf(worktreeMarker);
+  if (idx !== -1) {
+    const potentialRoot = cwd.substring(0, idx);
+    for (const other of sessionMap.values()) {
+      if (other.sessionId !== session.sessionId && (other.cwd || "") === potentialRoot) {
+        return potentialRoot;
+      }
+    }
+  }
+
+  return cwd;
+}
+
+/**
  * Get all descendant session IDs for a given session (children, grandchildren, etc.).
  * Searches through the flat sessions list by following parentSessionId references.
  */


### PR DESCRIPTION
## Problem

When a parent session spawns children in git worktrees (e.g. `.worktrees/fix-foo/`), each child got its own separate folder group in the sidebar because grouping was keyed on `cwd`. This scattered child sessions across many groups instead of keeping them under the parent.

## Solution

Added a `getGroupCwd()` helper in `session-tree.ts` that determines the canonical project-group key for each session using two strategies (in priority order):

### 1. `parentSessionId` chain (primary)
Follow the `parentSessionId` chain to the root ancestor and use its `cwd` as the group key. This handles explicitly-linked child sessions regardless of where they run.

### 2. Worktree subdir detection (fallback)
If a session's `cwd` contains `/.worktrees/` and another session in the same runner owns the path prefix, collapse it under that prefix. Handles cases where `parentSessionId` is not set.

Sessions with no parent link and no worktree pattern continue to group by their own `cwd` — existing behaviour is unchanged.

## Visual indicator

A small amber badge showing the branch name is shown on session cards whose `cwd` is inside a `.worktrees/` directory (e.g. `fix-foo`), making it easy to identify which branch a child session is working on.

## Files changed

- `packages/ui/src/lib/session-tree.ts` — exports new `getGroupCwd()` helper
- `packages/ui/src/lib/session-tree.test.ts` — 10 new unit tests for `getGroupCwd()`
- `packages/ui/src/components/SessionSidebar.tsx` — imports `getGroupCwd`, uses it in `liveGroups` grouping, adds worktree badge

## Testing

- All 277 tests pass (`bun run test`)
- TypeScript clean (`bun run typecheck`)
- 10 new tests covering: parentSessionId following, multi-level chains, orphan sessions, worktree detection, priority ordering, cycle protection