### PR TITLE
feat: surface active hooks in runner detail view

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/feat-conversation-export/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/show-active-hooks/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/feat-conversation-export/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/show-active-hooks/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/packages/cli/src/runner/daemon-hooks.test.ts
+++ b/packages/cli/src/runner/daemon-hooks.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect } from "bun:test";
+import { extractHookSummary } from "./daemon.js";
+import type { HooksConfig } from "../config.js";
+
+describe("extractHookSummary", () => {
+    test("returns empty array for undefined hooks", () => {
+        expect(extractHookSummary(undefined)).toEqual([]);
+    });
+
+    test("returns empty array for empty hooks config", () => {
+        expect(extractHookSummary({})).toEqual([]);
+    });
+
+    test("extracts PreToolUse scripts from matcher entries", () => {
+        const hooks: HooksConfig = {
+            PreToolUse: [
+                {
+                    matcher: "Bash",
+                    hooks: [{ command: "/home/user/.pizzapi/hooks/rtk-rewrite.sh" }],
+                },
+            ],
+        };
+        const result = extractHookSummary(hooks);
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe("PreToolUse");
+        expect(result[0].scripts).toContain("rtk-rewrite.sh");
+    });
+
+    test("extracts PostToolUse scripts from multiple matchers", () => {
+        const hooks: HooksConfig = {
+            PostToolUse: [
+                {
+                    matcher: "Bash",
+                    hooks: [
+                        { command: "/path/to/audit.sh" },
+                        { command: "/path/to/log.sh extra-arg" },
+                    ],
+                },
+                {
+                    matcher: "Edit|Write",
+                    hooks: [{ command: "notify-send.sh" }],
+                },
+            ],
+        };
+        const result = extractHookSummary(hooks);
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe("PostToolUse");
+        expect(result[0].scripts).toEqual(["audit.sh", "log.sh", "notify-send.sh"]);
+    });
+
+    test("extracts entry-based Input hook scripts", () => {
+        const hooks: HooksConfig = {
+            Input: [
+                { command: "/usr/local/bin/input-filter.sh" },
+            ],
+        };
+        const result = extractHookSummary(hooks);
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe("Input");
+        expect(result[0].scripts).toContain("input-filter.sh");
+    });
+
+    test("handles multiple hook types simultaneously", () => {
+        const hooks: HooksConfig = {
+            PreToolUse: [{ matcher: ".*", hooks: [{ command: "/hooks/pre.sh" }] }],
+            PostToolUse: [{ matcher: ".*", hooks: [{ command: "/hooks/post.sh" }] }],
+            Input: [{ command: "/hooks/input.sh" }],
+            SessionShutdown: [{ command: "/hooks/shutdown.sh" }],
+        };
+        const result = extractHookSummary(hooks);
+        const types = result.map((r) => r.type);
+        expect(types).toContain("PreToolUse");
+        expect(types).toContain("PostToolUse");
+        expect(types).toContain("Input");
+        expect(types).toContain("SessionShutdown");
+    });
+
+    test("skips hook types with no entries", () => {
+        const hooks: HooksConfig = {
+            PreToolUse: [], // empty matcher array
+            Input: [{ command: "/hooks/input.sh" }],
+        };
+        const result = extractHookSummary(hooks);
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe("Input");
+    });
+
+    test("uses basename of command path", () => {
+        const hooks: HooksConfig = {
+            ModelSelect: [{ command: "/very/deeply/nested/directory/track-model.sh" }],
+        };
+        const result = extractHookSummary(hooks);
+        expect(result[0].scripts[0]).toBe("track-model.sh");
+    });
+
+    test("handles command with arguments — only basenames the first token", () => {
+        const hooks: HooksConfig = {
+            BeforeAgentStart: [{ command: "/path/to/inject-context.sh --verbose --output /tmp/log" }],
+        };
+        const result = extractHookSummary(hooks);
+        expect(result[0].scripts[0]).toBe("inject-context.sh");
+    });
+
+    test("handles PreToolUse matchers with multiple hooks per matcher", () => {
+        const hooks: HooksConfig = {
+            PreToolUse: [
+                {
+                    matcher: "Bash",
+                    hooks: [
+                        { command: "/hooks/hook-a.sh" },
+                        { command: "/hooks/hook-b.sh" },
+                    ],
+                },
+            ],
+        };
+        const result = extractHookSummary(hooks);
+        expect(result[0].scripts).toEqual(["hook-a.sh", "hook-b.sh"]);
+    });
+});

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -18,9 +18,56 @@ import {
 import { join, dirname, relative, basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { io, type Socket } from "socket.io-client";
-import type { RunnerClientToServerEvents, RunnerServerToClientEvents } from "@pizzapi/protocol";
-import { loadGlobalConfig } from "../config.js";
+import type { RunnerClientToServerEvents, RunnerServerToClientEvents, RunnerHook } from "@pizzapi/protocol";
+import { loadGlobalConfig, type HooksConfig } from "../config.js";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
+
+/**
+ * Summarise the active hooks from a HooksConfig for display in the web UI.
+ * Returns one entry per hook type that has at least one configured command.
+ * Scripts are represented by the basename of the first token in the command string.
+ */
+export function extractHookSummary(hooks?: HooksConfig): RunnerHook[] {
+    if (!hooks) return [];
+    const result: RunnerHook[] = [];
+
+    // Matcher-based hooks (PreToolUse / PostToolUse)
+    for (const type of ["PreToolUse", "PostToolUse"] as const) {
+        const matchers = hooks[type] ?? [];
+        const scripts: string[] = [];
+        for (const m of matchers) {
+            for (const h of m.hooks) {
+                const cmd = h.command.trim().split(/\s+/)[0];
+                if (cmd) scripts.push(basename(cmd));
+            }
+        }
+        if (scripts.length > 0) result.push({ type, scripts });
+    }
+
+    // Entry-based hooks
+    const entryTypes = [
+        "Input",
+        "BeforeAgentStart",
+        "UserBash",
+        "SessionBeforeSwitch",
+        "SessionBeforeFork",
+        "SessionShutdown",
+        "SessionBeforeCompact",
+        "SessionBeforeTree",
+        "ModelSelect",
+    ] as const;
+    for (const type of entryTypes) {
+        const entries = (hooks[type] as { command: string }[] | undefined) ?? [];
+        const scripts: string[] = [];
+        for (const h of entries) {
+            const cmd = h.command.trim().split(/\s+/)[0];
+            if (cmd) scripts.push(basename(cmd));
+        }
+        if (scripts.length > 0) result.push({ type, scripts });
+    }
+
+    return result;
+}
 
 interface RunnerSession {
     sessionId: string;
@@ -564,6 +611,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             // skips project-scoped marketplace plugins and readEnabledPlugins
             // only reads user-level settings (not project-local overrides).
             const plugins = scanAllPluginInfo(undefined, { includeProjectLocal: false });
+            const globalConfig = loadGlobalConfig();
+            const hooks = extractHookSummary(globalConfig.hooks);
             socket.emit("register_runner", {
                 runnerId: identity.runnerId,
                 runnerSecret: identity.runnerSecret,
@@ -572,6 +621,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 skills,
                 agents,
                 plugins,
+                hooks,
                 version: cliVersion,
             });
         };

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -12,6 +12,7 @@ export type {
   RunnerSkill,
   RunnerAgent,
   RunnerPlugin,
+  RunnerHook,
   Attachment,
 } from "./shared.js";
 

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -2,7 +2,7 @@
 // /runner namespace — Runner daemon ↔ Server
 // ============================================================================
 
-import type { RunnerSkill, RunnerAgent, RunnerPlugin } from "./shared.js";
+import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Client → Server (Runner daemon sends to server)
@@ -18,6 +18,7 @@ export interface RunnerClientToServerEvents {
     skills?: RunnerSkill[];
     agents?: RunnerAgent[];
     plugins?: RunnerPlugin[];
+    hooks?: RunnerHook[];
     version?: string;
   }) => void;
 

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -30,6 +30,14 @@ export interface ModelInfo {
   name?: string;
 }
 
+/** A summary of a single hook type active on the runner */
+export interface RunnerHook {
+  /** Hook lifecycle type (e.g. "PreToolUse", "PostToolUse", "Input") */
+  type: string;
+  /** Script basenames configured for this hook type */
+  scripts: string[];
+}
+
 /** Runner daemon metadata */
 export interface RunnerInfo {
   runnerId: string;
@@ -39,6 +47,7 @@ export interface RunnerInfo {
   skills: RunnerSkill[];
   agents: RunnerAgent[];
   plugins?: RunnerPlugin[];
+  hooks?: RunnerHook[];
   version: string | null;
 }
 

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -229,6 +229,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             const skills = data.skills ?? [];
             const agents = data.agents ?? [];
             const plugins = data.plugins ?? [];
+            const hooks = data.hooks ?? [];
             const version = data.version ?? null;
 
             const result = await registerRunner(socket, {
@@ -239,6 +240,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 skills,
                 agents,
                 plugins,
+                hooks,
                 version,
                 userId: (socket.data as RunnerSocketData & { userId?: string }).userId ?? null,
                 userName: (socket.data as RunnerSocketData & { userName?: string }).userName ?? null,

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -61,7 +61,7 @@ import {
 } from "../sessions/store.js";
 import { appendRelayEventToCache } from "../sessions/redis.js";
 import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "./strip-images.js";
-import type { ModelInfo, RunnerSkill, RunnerAgent, SessionInfo, RunnerInfo } from "@pizzapi/protocol";
+import type { ModelInfo, RunnerSkill, RunnerAgent, SessionInfo, RunnerInfo, RunnerHook } from "@pizzapi/protocol";
 
 // ── Socket.IO server reference ──────────────────────────────────────────────
 
@@ -987,6 +987,7 @@ export interface RegisterRunnerOpts {
     skills?: RunnerSkill[];
     agents?: RunnerAgent[];
     plugins?: unknown[];
+    hooks?: RunnerHook[];
     userId?: string | null;
     userName?: string | null;
     version?: string | null;
@@ -1039,6 +1040,16 @@ export async function registerRunner(
             .filter((p): p is Record<string, unknown> => p !== null)
         : [];
 
+    const hooks = Array.isArray(opts.hooks)
+        ? opts.hooks.filter(
+              (h): h is RunnerHook =>
+                  h !== null &&
+                  typeof h === "object" &&
+                  typeof (h as RunnerHook).type === "string" &&
+                  Array.isArray((h as RunnerHook).scripts),
+          )
+        : [];
+
     const runnerData: RedisRunnerData = {
         runnerId,
         userId: opts.userId ?? null,
@@ -1048,6 +1059,7 @@ export async function registerRunner(
         skills: JSON.stringify(skills),
         agents: JSON.stringify(agents),
         plugins: JSON.stringify(plugins),
+        hooks: JSON.stringify(hooks),
         version: typeof opts.version === "string" ? opts.version : null,
     };
 
@@ -1218,6 +1230,7 @@ export async function getRunners(filterUserId?: string): Promise<RunnerInfo[]> {
             skills: safeJsonParse(r.skills) ?? [],
             agents: safeJsonParse(r.agents ?? "[]") ?? [],
             plugins: safeJsonParse(r.plugins ?? "[]") ?? [],
+            hooks: safeJsonParse(r.hooks ?? "[]") ?? [],
             version: r.version ?? null,
         });
     }

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -151,6 +151,8 @@ export interface RedisRunnerData {
     agents?: string;
     /** JSON-stringified PluginInfo[] — discovered Claude Code plugins */
     plugins?: string;
+    /** JSON-stringified RunnerHook[] — active hooks configured on the runner */
+    hooks?: string;
     /** Runner CLI version (e.g. "0.1.30") */
     version: string | null;
 }
@@ -220,6 +222,7 @@ function parseRunnerFromHash(hash: Record<string, string>): RedisRunnerData | nu
         skills: hash.skills || "[]",
         agents: hash.agents || "[]",
         plugins: hash.plugins || "[]",
+        hooks: hash.hooks || "[]",
         version: hash.version || null,
     };
 }

--- a/packages/ui/src/components/RunnerDetailPanel.tsx
+++ b/packages/ui/src/components/RunnerDetailPanel.tsx
@@ -17,13 +17,19 @@ import {
     Terminal,
     ChevronRight,
     Server,
+    Webhook,
 } from "lucide-react";
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type RunnerTab = "sessions" | "skills" | "agents" | "plugins" | "sandbox";
+export type RunnerTab = "sessions" | "skills" | "agents" | "plugins" | "sandbox" | "hooks";
+
+interface RunnerHook {
+    type: string;
+    scripts: string[];
+}
 
 interface RunnerInfo {
     runnerId: string;
@@ -33,6 +39,7 @@ interface RunnerInfo {
     skills: SkillInfo[];
     agents: AgentInfo[];
     plugins: PluginInfo[];
+    hooks?: RunnerHook[];
     version: string | null;
 }
 
@@ -172,14 +179,72 @@ function SessionsList({
 }
 
 // ---------------------------------------------------------------------------
+// HooksList
+// ---------------------------------------------------------------------------
+
+function HooksList({ hooks }: { hooks?: RunnerHook[] }) {
+    if (!hooks || hooks.length === 0) {
+        return (
+            <div className="flex flex-col items-center justify-center py-10 gap-3 text-center">
+                <div className="rounded-full bg-muted p-3">
+                    <Webhook className="h-5 w-5 text-muted-foreground" />
+                </div>
+                <div className="space-y-1">
+                    <p className="text-sm font-medium text-muted-foreground">No active hooks</p>
+                    <p className="text-xs text-muted-foreground/60 max-w-xs">
+                        Configure hooks in{" "}
+                        <code className="font-mono bg-muted px-1 py-0.5 rounded text-[11px]">
+                            ~/.pizzapi/config.json
+                        </code>{" "}
+                        under the <code className="font-mono bg-muted px-1 py-0.5 rounded text-[11px]">hooks</code> key.
+                    </p>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="flex flex-col gap-2">
+            {hooks.map((hook) => (
+                <div
+                    key={hook.type}
+                    className="flex flex-col gap-1.5 rounded-lg border border-border/40 bg-muted/20 px-3 py-2.5"
+                >
+                    {/* Hook type badge */}
+                    <div className="flex items-center gap-2">
+                        <span className="inline-flex items-center gap-1 text-[10px] font-mono font-semibold px-1.5 py-0.5 rounded bg-blue-500/10 border border-blue-500/20 text-blue-300">
+                            <Webhook className="h-2.5 w-2.5" />
+                            {hook.type}
+                        </span>
+                    </div>
+
+                    {/* Script names */}
+                    <div className="flex flex-wrap gap-1.5 pl-0.5">
+                        {hook.scripts.map((script, i) => (
+                            <span
+                                key={i}
+                                className="text-[11px] font-mono bg-muted/60 px-2 py-0.5 rounded border border-border/30 text-muted-foreground"
+                            >
+                                {script}
+                            </span>
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+// ---------------------------------------------------------------------------
 // TabBar
 // ---------------------------------------------------------------------------
 
-const TABS: { key: RunnerTab; label: string; countKey?: "skills" | "agents" | "plugins" }[] = [
+const TABS: { key: RunnerTab; label: string; countKey?: "skills" | "agents" | "plugins" | "hooks" }[] = [
     { key: "sessions", label: "Sessions" },
     { key: "skills", label: "Skills", countKey: "skills" },
     { key: "agents", label: "Agents", countKey: "agents" },
     { key: "plugins", label: "Plugins", countKey: "plugins" },
+    { key: "hooks", label: "Hooks", countKey: "hooks" },
     { key: "sandbox", label: "Sandbox" },
 ];
 
@@ -196,7 +261,8 @@ function TabBar({
         <div className="flex gap-1 border-b border-border/40">
             {TABS.map((tab) => {
                 const isActive = activeTab === tab.key;
-                const count = tab.countKey ? runner[tab.countKey].length : null;
+                const countSource = tab.countKey ? runner[tab.countKey] : null;
+                const count = countSource != null ? (Array.isArray(countSource) ? countSource.length : 0) : null;
                 return (
                     <button
                         key={tab.key}
@@ -323,6 +389,9 @@ export function RunnerDetailPanel({
                     bare
                 />
             );
+            break;
+        case "hooks":
+            tabContent = <HooksList hooks={runner.hooks} />;
             break;
         case "sandbox":
             tabContent = <SandboxManager runnerId={runner.runnerId} bare />;

--- a/packages/ui/src/components/RunnerDetailPanel.tsx
+++ b/packages/ui/src/components/RunnerDetailPanel.tsx
@@ -205,6 +205,9 @@ function HooksList({ hooks }: { hooks?: RunnerHook[] }) {
 
     return (
         <div className="flex flex-col gap-2">
+            <p className="text-[11px] text-muted-foreground/50 px-1">
+                Global hooks only — project-local hooks vary per session working directory.
+            </p>
             {hooks.map((hook) => (
                 <div
                     key={hook.type}

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -19,6 +19,11 @@ import type { SkillInfo } from "@/components/SkillsManager";
 import type { AgentInfo } from "@/components/AgentsManager";
 import type { PluginInfo } from "@/components/PluginsManager";
 
+interface RunnerHook {
+    type: string;
+    scripts: string[];
+}
+
 interface RunnerInfo {
     runnerId: string;
     name: string | null;
@@ -27,6 +32,7 @@ interface RunnerInfo {
     skills: SkillInfo[];
     agents: AgentInfo[];
     plugins: PluginInfo[];
+    hooks?: RunnerHook[];
     version: string | null;
 }
 
@@ -88,6 +94,7 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
                     skills: Array.isArray(r.skills) ? r.skills : [],
                     agents: Array.isArray(r.agents) ? r.agents : [],
                     plugins: Array.isArray(r.plugins) ? r.plugins : [],
+                    hooks: Array.isArray(r.hooks) ? r.hooks : [],
                     version: r.version ?? null,
                 })));
             }


### PR DESCRIPTION
## Summary

Users previously had no visibility into what hooks were configured on a runner. This PR adds a **Hooks tab** to the runner detail view showing which hook types are active and which scripts are configured for each.

## Changes

### Protocol (`@pizzapi/protocol`)
- Add `RunnerHook { type: string; scripts: string[] }` interface to `shared.ts`
- Export `RunnerHook` from the package index
- Add `hooks?: RunnerHook[]` to the `register_runner` WebSocket event

### CLI (runner daemon)
- Add `extractHookSummary(hooks?: HooksConfig): RunnerHook[]` utility that iterates all hook types (PreToolUse, PostToolUse, Input, BeforeAgentStart, UserBash, SessionBeforeSwitch/Fork/Shutdown/BeforeCompact/BeforeTree, ModelSelect) and extracts script basenames
- Include hook summary in `register_runner` payload on every connection/reconnection

### Server
- Add `hooks?: string` (JSON-stringified) to `RedisRunnerData` in `sio-state.ts`
- Update `parseRunnerFromHash` to include hooks
- Add `hooks?: RunnerHook[]` to `RegisterRunnerOpts`; validate and persist on registration
- Include `hooks` in `getRunners()` API response

### UI
- Add `RunnerHook` type and `hooks?` field to local `RunnerInfo` in both `RunnerDetailPanel.tsx` and `RunnerManager.tsx`
- Map `hooks` from API response in `RunnerManager`
- Add **Hooks** tab between Plugins and Sandbox in `RunnerDetailPanel`
- `HooksList` component: shows each active hook type as a badge with its script names listed below; shows a helpful empty state with config guidance when no hooks are configured

### Tests
- 10 unit tests for `extractHookSummary` in `daemon-hooks.test.ts`

## Screenshots

The Hooks tab shows:
- Hook type badge (e.g. `PreToolUse`, `Input`)  
- Script basenames configured for that type (e.g. `rtk-rewrite.sh`)
- Empty state with guidance to configure hooks in `~/.pizzapi/config.json`