### PR TITLE
feat: Clean up child sessions when parent acks session_complete trigger

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/show-active-hooks/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/child-cleanup-on-ack/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/show-active-hooks/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/child-cleanup-on-ack/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/packages/cli/src/extensions/remote-session-complete.test.ts
+++ b/packages/cli/src/extensions/remote-session-complete.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "bun:test";
+
+function simulateViewerSessionCompleteFollowUp(opts: { deliveryFails: boolean }) {
+    const receivedTriggers = new Map<string, { sourceSessionId: string; type: string }>();
+    receivedTriggers.set("trigger-1", { sourceSessionId: "child-1", type: "session_complete" });
+
+    const listeners = new Map<string, Array<(data: any) => void>>();
+    const socket = {
+        on(event: string, handler: (data: any) => void) {
+            const handlers = listeners.get(event) ?? [];
+            handlers.push(handler);
+            listeners.set(event, handlers);
+        },
+        off(event: string, handler: (data: any) => void) {
+            listeners.set(event, (listeners.get(event) ?? []).filter((fn) => fn !== handler));
+        },
+        emit(event: string, data: any) {
+            if (event === "session_message" && opts.deliveryFails) {
+                for (const handler of listeners.get("session_message_error") ?? []) {
+                    handler({ targetSessionId: data.targetSessionId, error: "Target session not found or not connected" });
+                }
+            }
+        },
+    };
+
+    const pending = receivedTriggers.get("trigger-1");
+    if (!pending) throw new Error("missing pending trigger");
+
+    const childId = pending.sourceSessionId;
+    let failed = false;
+    const onError = (err: { targetSessionId: string; error: string }) => {
+        if (err.targetSessionId === childId) {
+            failed = true;
+            socket.off("session_message_error", onError);
+        }
+    };
+
+    socket.on("session_message_error", onError);
+    socket.emit("session_message", {
+        targetSessionId: childId,
+        message: "Please continue",
+        deliverAs: "input",
+    });
+
+    socket.off("session_message_error", onError);
+    if (!failed) {
+        receivedTriggers.delete("trigger-1");
+    }
+
+    return receivedTriggers;
+}
+
+describe("remote escalated session_complete follow-up delivery", () => {
+    it("keeps the trigger pending when delivery fails", () => {
+        const receivedTriggers = simulateViewerSessionCompleteFollowUp({ deliveryFails: true });
+        expect(receivedTriggers.has("trigger-1")).toBe(true);
+    });
+
+    it("clears the trigger when delivery succeeds", () => {
+        const receivedTriggers = simulateViewerSessionCompleteFollowUp({ deliveryFails: false });
+        expect(receivedTriggers.has("trigger-1")).toBe(false);
+    });
+});

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -934,13 +934,14 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 const action = data.action ?? "ack";
                 if (action === "followUp") {
                     // Deliver follow-up as agent input to resume the child.
-                    // Listen for session_message_error to detect failures.
+                    // Keep the trigger pending if delivery fails so the human
+                    // can retry instead of losing the follow-up.
                     const childId = pending.sourceSessionId;
-                    let delivered = false;
+                    let failed = false;
                     const onError = (err: { targetSessionId: string; error: string }) => {
                         if (err.targetSessionId === childId) {
+                            failed = true;
                             rctx.sioSocket!.off("session_message_error" as any, onError);
-                            // Delivery failed — keep trigger for retry
                         }
                     };
                     rctx.sioSocket.on("session_message_error" as any, onError);
@@ -950,11 +951,12 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                         message: data.response,
                         deliverAs: "input",
                     });
-                    // Clean up error listener after 3s and assume success
+                    // After a short window without an error, consider delivery
+                    // successful and clear the trigger. On failure it stays
+                    // pending for retry.
                     setTimeout(() => {
                         rctx.sioSocket?.off("session_message_error" as any, onError);
-                        if (!delivered) {
-                            delivered = true;
+                        if (!failed) {
                             receivedTriggers.delete(data.triggerId);
                         }
                     }, 3000);

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -928,24 +928,48 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             // For session_complete triggers, handle cleanup the same way
             // as respond_to_trigger in the triggers extension — escalated
             // replies from the human viewer must also clean up the child.
+            // Keep the trigger pending until delivery is confirmed so the
+            // human can retry if it fails.
             if (pending.type === "session_complete") {
                 const action = data.action ?? "ack";
                 if (action === "followUp") {
-                    // Deliver follow-up as agent input to resume the child
+                    // Deliver follow-up as agent input to resume the child.
+                    // Listen for session_message_error to detect failures.
+                    const childId = pending.sourceSessionId;
+                    let delivered = false;
+                    const onError = (err: { targetSessionId: string; error: string }) => {
+                        if (err.targetSessionId === childId) {
+                            rctx.sioSocket!.off("session_message_error" as any, onError);
+                            // Delivery failed — keep trigger for retry
+                        }
+                    };
+                    rctx.sioSocket.on("session_message_error" as any, onError);
                     rctx.sioSocket.emit("session_message", {
                         token: rctx.relay.token,
-                        targetSessionId: pending.sourceSessionId,
+                        targetSessionId: childId,
                         message: data.response,
                         deliverAs: "input",
                     });
+                    // Clean up error listener after 3s and assume success
+                    setTimeout(() => {
+                        rctx.sioSocket?.off("session_message_error" as any, onError);
+                        if (!delivered) {
+                            delivered = true;
+                            receivedTriggers.delete(data.triggerId);
+                        }
+                    }, 3000);
                 } else {
-                    // ack — emit cleanup request to tear down the child
+                    // ack — emit cleanup request with ack callback
                     rctx.sioSocket.emit("cleanup_child_session", {
                         token: rctx.relay.token,
                         childSessionId: pending.sourceSessionId,
+                    }, (result: { ok: boolean; error?: string }) => {
+                        if (result?.ok) {
+                            receivedTriggers.delete(data.triggerId);
+                        }
+                        // On failure, trigger stays — human can retry
                     });
                 }
-                receivedTriggers.delete(data.triggerId);
                 return;
             }
 

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -924,6 +924,31 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             if (!data?.triggerId) return;
             const pending = receivedTriggers.get(data.triggerId);
             if (!pending || !rctx.relay || !rctx.sioSocket?.connected) return;
+
+            // For session_complete triggers, handle cleanup the same way
+            // as respond_to_trigger in the triggers extension — escalated
+            // replies from the human viewer must also clean up the child.
+            if (pending.type === "session_complete") {
+                const action = data.action ?? "ack";
+                if (action === "followUp") {
+                    // Deliver follow-up as agent input to resume the child
+                    rctx.sioSocket.emit("session_message", {
+                        token: rctx.relay.token,
+                        targetSessionId: pending.sourceSessionId,
+                        message: data.response,
+                        deliverAs: "input",
+                    });
+                } else {
+                    // ack — emit cleanup request to tear down the child
+                    rctx.sioSocket.emit("cleanup_child_session", {
+                        token: rctx.relay.token,
+                        childSessionId: pending.sourceSessionId,
+                    });
+                }
+                receivedTriggers.delete(data.triggerId);
+                return;
+            }
+
             rctx.sioSocket.emit("trigger_response" as any, {
                 token: rctx.relay.token,
                 triggerId: data.triggerId,

--- a/packages/cli/src/extensions/triggers/extension.test.ts
+++ b/packages/cli/src/extensions/triggers/extension.test.ts
@@ -1,0 +1,215 @@
+// ============================================================================
+// extension.test.ts — Tests for the trigger extension's respond_to_trigger tool
+//
+// Verifies that acknowledging a session_complete trigger emits a
+// cleanup_child_session event to the relay, and that followUp still works
+// without emitting cleanup.
+// ============================================================================
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { trackReceivedTrigger, receivedTriggers } from "./extension.js";
+
+// ── Mock socket for capturing emitted events ─────────────────────────────────
+
+interface EmittedEvent {
+    event: string;
+    data: unknown;
+}
+
+function createMockSocket() {
+    const emitted: EmittedEvent[] = [];
+    const listeners = new Map<string, ((...args: any[]) => void)[]>();
+
+    return {
+        emitted,
+        socket: {
+            emit(event: string, data: unknown) {
+                emitted.push({ event, data });
+            },
+            on(event: string, handler: (...args: any[]) => void) {
+                const handlers = listeners.get(event) ?? [];
+                handlers.push(handler);
+                listeners.set(event, handlers);
+            },
+            off(event: string, handler: (...args: any[]) => void) {
+                const handlers = listeners.get(event) ?? [];
+                listeners.set(event, handlers.filter(h => h !== handler));
+            },
+            connected: true,
+        },
+        token: "test-token",
+    };
+}
+
+// ── Simulated respond_to_trigger logic ───────────────────────────────────────
+//
+// We can't easily instantiate the full pi extension runtime in a unit test.
+// Instead, we extract the core logic that respond_to_trigger executes for
+// session_complete triggers and test it directly. This matches the actual
+// implementation in extension.ts.
+
+async function simulateRespondToTrigger(
+    params: { triggerId: string; response: string; action?: string },
+    conn: ReturnType<typeof createMockSocket>,
+): Promise<{ text: string } | null> {
+    const pending = receivedTriggers.get(params.triggerId);
+    if (!pending) {
+        return { text: `Error: No pending trigger with ID ${params.triggerId}` };
+    }
+
+    // TTL check
+    const TRIGGER_TTL_MS = 10 * 60 * 1000;
+    if (Date.now() - pending.trackedAt > TRIGGER_TTL_MS) {
+        receivedTriggers.delete(params.triggerId);
+        return { text: `Error: Trigger ${params.triggerId} has expired` };
+    }
+
+    if (pending.type === "session_complete") {
+        receivedTriggers.delete(params.triggerId);
+        const action = params.action ?? "ack";
+        if (action === "followUp") {
+            // Deliver as agent input (not testing the full async path here)
+            conn.socket.emit("session_message", {
+                token: conn.token,
+                targetSessionId: pending.sourceSessionId,
+                message: params.response,
+                deliverAs: "input",
+            });
+            return { text: `Follow-up sent to child ${pending.sourceSessionId}` };
+        }
+        // ack — emit cleanup request (matches extension.ts implementation)
+        conn.socket.emit("cleanup_child_session", {
+            token: conn.token,
+            childSessionId: pending.sourceSessionId,
+        });
+        return { text: `Acknowledged session completion from ${pending.sourceSessionId}` };
+    }
+
+    // Non-session_complete triggers
+    conn.socket.emit("trigger_response", {
+        token: conn.token,
+        triggerId: params.triggerId,
+        response: params.response,
+        ...(params.action ? { action: params.action } : {}),
+        targetSessionId: pending.sourceSessionId,
+    });
+    receivedTriggers.delete(params.triggerId);
+    return { text: `Response sent for trigger ${params.triggerId}` };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("respond_to_trigger — session_complete cleanup", () => {
+    beforeEach(() => {
+        receivedTriggers.clear();
+    });
+
+    it("emits cleanup_child_session when acking a session_complete trigger", async () => {
+        const conn = createMockSocket();
+        trackReceivedTrigger("trigger-1", "child-session-abc", "session_complete");
+
+        const result = await simulateRespondToTrigger(
+            { triggerId: "trigger-1", response: "ok", action: "ack" },
+            conn,
+        );
+
+        expect(result!.text).toContain("Acknowledged session completion from child-session-abc");
+
+        // Verify cleanup event was emitted
+        const cleanupEvents = conn.emitted.filter(e => e.event === "cleanup_child_session");
+        expect(cleanupEvents).toHaveLength(1);
+        expect(cleanupEvents[0].data).toEqual({
+            token: "test-token",
+            childSessionId: "child-session-abc",
+        });
+
+        // Trigger should be removed from tracking
+        expect(receivedTriggers.has("trigger-1")).toBe(false);
+    });
+
+    it("defaults to ack action for session_complete when no action specified", async () => {
+        const conn = createMockSocket();
+        trackReceivedTrigger("trigger-2", "child-session-xyz", "session_complete");
+
+        await simulateRespondToTrigger(
+            { triggerId: "trigger-2", response: "acknowledged" },
+            conn,
+        );
+
+        // Should still emit cleanup (default action is ack)
+        const cleanupEvents = conn.emitted.filter(e => e.event === "cleanup_child_session");
+        expect(cleanupEvents).toHaveLength(1);
+        expect((cleanupEvents[0].data as any).childSessionId).toBe("child-session-xyz");
+    });
+
+    it("does NOT emit cleanup_child_session on followUp action", async () => {
+        const conn = createMockSocket();
+        trackReceivedTrigger("trigger-3", "child-session-follow", "session_complete");
+
+        const result = await simulateRespondToTrigger(
+            { triggerId: "trigger-3", response: "Please fix tests", action: "followUp" },
+            conn,
+        );
+
+        expect(result!.text).toContain("Follow-up sent to child child-session-follow");
+
+        // No cleanup event should be emitted
+        const cleanupEvents = conn.emitted.filter(e => e.event === "cleanup_child_session");
+        expect(cleanupEvents).toHaveLength(0);
+
+        // Instead, a session_message should be emitted to resume the child
+        const messageEvents = conn.emitted.filter(e => e.event === "session_message");
+        expect(messageEvents).toHaveLength(1);
+        expect((messageEvents[0].data as any).targetSessionId).toBe("child-session-follow");
+        expect((messageEvents[0].data as any).message).toBe("Please fix tests");
+    });
+
+    it("does NOT emit cleanup for non-session_complete triggers", async () => {
+        const conn = createMockSocket();
+        trackReceivedTrigger("trigger-4", "child-session-plan", "plan_review");
+
+        await simulateRespondToTrigger(
+            { triggerId: "trigger-4", response: "looks good", action: "approve" },
+            conn,
+        );
+
+        // No cleanup event
+        const cleanupEvents = conn.emitted.filter(e => e.event === "cleanup_child_session");
+        expect(cleanupEvents).toHaveLength(0);
+
+        // Should emit trigger_response instead
+        const responseEvents = conn.emitted.filter(e => e.event === "trigger_response");
+        expect(responseEvents).toHaveLength(1);
+    });
+
+    it("returns error for non-existent trigger", async () => {
+        const conn = createMockSocket();
+
+        const result = await simulateRespondToTrigger(
+            { triggerId: "nonexistent", response: "ok", action: "ack" },
+            conn,
+        );
+
+        expect(result!.text).toContain("No pending trigger");
+        expect(conn.emitted).toHaveLength(0);
+    });
+
+    it("returns error for expired trigger", async () => {
+        const conn = createMockSocket();
+        // Insert a trigger that's already expired (> 10 min old)
+        receivedTriggers.set("expired-trigger", {
+            sourceSessionId: "old-child",
+            type: "session_complete",
+            trackedAt: Date.now() - 15 * 60 * 1000,
+        });
+
+        const result = await simulateRespondToTrigger(
+            { triggerId: "expired-trigger", response: "ok", action: "ack" },
+            conn,
+        );
+
+        expect(result!.text).toContain("expired");
+        expect(conn.emitted).toHaveLength(0);
+        expect(receivedTriggers.has("expired-trigger")).toBe(false);
+    });
+});

--- a/packages/cli/src/extensions/triggers/extension.test.ts
+++ b/packages/cli/src/extensions/triggers/extension.test.ts
@@ -16,15 +16,20 @@ interface EmittedEvent {
     data: unknown;
 }
 
-function createMockSocket() {
+function createMockSocket(opts?: { failSessionMessage?: boolean }) {
     const emitted: EmittedEvent[] = [];
     const listeners = new Map<string, ((...args: any[]) => void)[]>();
 
     return {
         emitted,
         socket: {
-            emit(event: string, data: unknown) {
+            emit(event: string, data: any) {
                 emitted.push({ event, data });
+                if (event === "session_message" && opts?.failSessionMessage) {
+                    for (const handler of listeners.get("session_message_error") ?? []) {
+                        handler({ targetSessionId: data.targetSessionId, error: "Target session not found or not connected" });
+                    }
+                }
             },
             on(event: string, handler: (...args: any[]) => void) {
                 const handlers = listeners.get(event) ?? [];
@@ -65,18 +70,36 @@ async function simulateRespondToTrigger(
     }
 
     if (pending.type === "session_complete") {
-        receivedTriggers.delete(params.triggerId);
         const action = params.action ?? "ack";
         if (action === "followUp") {
-            // Deliver as agent input (not testing the full async path here)
-            conn.socket.emit("session_message", {
-                token: conn.token,
-                targetSessionId: pending.sourceSessionId,
-                message: params.response,
-                deliverAs: "input",
+            const result = await new Promise<{ ok: boolean; text: string }>((resolve) => {
+                const timeout = setTimeout(() => {
+                    conn.socket.off("session_message_error", onError);
+                    resolve({ ok: true, text: `Follow-up sent to child ${pending.sourceSessionId}` });
+                }, 0);
+
+                const onError = (err: { targetSessionId: string; error: string }) => {
+                    if (err.targetSessionId === pending.sourceSessionId) {
+                        clearTimeout(timeout);
+                        conn.socket.off("session_message_error", onError);
+                        resolve({ ok: false, text: `Error sending follow-up to child ${pending.sourceSessionId}: ${err.error}` });
+                    }
+                };
+                conn.socket.on("session_message_error", onError);
+
+                conn.socket.emit("session_message", {
+                    token: conn.token,
+                    targetSessionId: pending.sourceSessionId,
+                    message: params.response,
+                    deliverAs: "input",
+                });
             });
-            return { text: `Follow-up sent to child ${pending.sourceSessionId}` };
+            if (result.ok) {
+                receivedTriggers.delete(params.triggerId);
+            }
+            return { text: result.text };
         }
+        receivedTriggers.delete(params.triggerId);
         // ack — emit cleanup request (matches extension.ts implementation)
         conn.socket.emit("cleanup_child_session", {
             token: conn.token,
@@ -162,6 +185,20 @@ describe("respond_to_trigger — session_complete cleanup", () => {
         expect(messageEvents).toHaveLength(1);
         expect((messageEvents[0].data as any).targetSessionId).toBe("child-session-follow");
         expect((messageEvents[0].data as any).message).toBe("Please fix tests");
+        expect(receivedTriggers.has("trigger-3")).toBe(false);
+    });
+
+    it("keeps a session_complete followUp trigger pending when delivery fails", async () => {
+        const conn = createMockSocket({ failSessionMessage: true });
+        trackReceivedTrigger("trigger-3b", "child-session-follow", "session_complete");
+
+        const result = await simulateRespondToTrigger(
+            { triggerId: "trigger-3b", response: "Please fix tests", action: "followUp" },
+            conn,
+        );
+
+        expect(result!.text).toContain("Error sending follow-up to child child-session-follow");
+        expect(receivedTriggers.has("trigger-3b")).toBe(true);
     });
 
     it("does NOT emit cleanup for non-session_complete triggers", async () => {

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -160,7 +160,13 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                     });
                     return { content: [{ type: "text" as const, text: result }], details: null as any };
                 }
-                // ack or any other action — just acknowledge, no message to child
+                // ack or any other action — acknowledge and clean up the child session
+                // Emit cleanup request to the relay so the server tears down the
+                // child session (removes from Redis, notifies runner, frees resources).
+                conn.socket.emit("cleanup_child_session", {
+                    token: conn.token,
+                    childSessionId: pending.sourceSessionId,
+                });
                 return { content: [{ type: "text" as const, text: `Acknowledged session completion from ${pending.sourceSessionId}` }], details: null as any };
             }
 

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -135,17 +135,17 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                     // Deliver as agent input so it starts a new turn in the child.
                     // Wait for session_message_error to detect delivery failures.
                     const childId = pending.sourceSessionId;
-                    const result = await new Promise<string>((resolve) => {
+                    const result = await new Promise<{ ok: boolean; text: string }>((resolve) => {
                         const timeout = setTimeout(() => {
                             conn.socket.off("session_message_error", onError);
-                            resolve(`Follow-up sent to child ${childId}`);
+                            resolve({ ok: true, text: `Follow-up sent to child ${childId}` });
                         }, 3000);
 
                         const onError = (err: { targetSessionId: string; error: string }) => {
                             if (err.targetSessionId === childId) {
                                 clearTimeout(timeout);
                                 conn.socket.off("session_message_error", onError);
-                                resolve(`Error sending follow-up to child ${childId}: ${err.error}`);
+                                resolve({ ok: false, text: `Error sending follow-up to child ${childId}: ${err.error}` });
                             }
                         };
                         conn.socket.on("session_message_error", onError);
@@ -157,8 +157,10 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                             deliverAs: "input",
                         });
                     });
-                    receivedTriggers.delete(params.triggerId);
-                    return { content: [{ type: "text" as const, text: result }], details: null as any };
+                    if (result.ok) {
+                        receivedTriggers.delete(params.triggerId);
+                    }
+                    return { content: [{ type: "text" as const, text: result.text }], details: null as any };
                 }
                 // ack or any other action — acknowledge and clean up the child session
                 // Emit cleanup request to the relay so the server tears down the

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -167,7 +167,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                 // relay rejects the request (auth, ownership), we keep the trigger
                 // so the agent can retry or escalate.
                 const cleanupResult = await new Promise<{ ok: boolean; error?: string }>((resolve) => {
-                    const timeout = setTimeout(() => resolve({ ok: true }), 10_000); // fire-and-forget after 10s
+                    const timeout = setTimeout(() => resolve({ ok: false, error: "Cleanup ack timed out" }), 10_000);
                     conn.socket.emit("cleanup_child_session", {
                         token: conn.token,
                         childSessionId: pending.sourceSessionId,

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -130,7 +130,6 @@ export const triggersExtension: ExtensionFactory = (pi) => {
             // - "ack": just acknowledge, no message to child
             // - "followUp": deliver as input message to resume the child (like tell_child)
             if (pending.type === "session_complete") {
-                receivedTriggers.delete(params.triggerId);
                 const action = params.action ?? "ack";
                 if (action === "followUp") {
                     // Deliver as agent input so it starts a new turn in the child.
@@ -158,15 +157,30 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                             deliverAs: "input",
                         });
                     });
+                    receivedTriggers.delete(params.triggerId);
                     return { content: [{ type: "text" as const, text: result }], details: null as any };
                 }
                 // ack or any other action — acknowledge and clean up the child session
                 // Emit cleanup request to the relay so the server tears down the
                 // child session (removes from Redis, notifies runner, frees resources).
-                conn.socket.emit("cleanup_child_session", {
-                    token: conn.token,
-                    childSessionId: pending.sourceSessionId,
+                // Wait for the server's ack before clearing the trigger — if the
+                // relay rejects the request (auth, ownership), we keep the trigger
+                // so the agent can retry or escalate.
+                const cleanupResult = await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+                    const timeout = setTimeout(() => resolve({ ok: true }), 10_000); // fire-and-forget after 10s
+                    conn.socket.emit("cleanup_child_session", {
+                        token: conn.token,
+                        childSessionId: pending.sourceSessionId,
+                    }, (result: { ok: boolean; error?: string }) => {
+                        clearTimeout(timeout);
+                        resolve(result ?? { ok: true });
+                    });
                 });
+                if (!cleanupResult.ok) {
+                    // Don't delete the trigger — agent can retry
+                    return { content: [{ type: "text" as const, text: `Failed to clean up child session ${pending.sourceSessionId}: ${cleanupResult.error ?? "unknown error"}` }], details: null as any };
+                }
+                receivedTriggers.delete(params.triggerId);
                 return { content: [{ type: "text" as const, text: `Acknowledged session completion from ${pending.sourceSessionId}` }], details: null as any };
             }
 

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -83,7 +83,7 @@ export interface RelayClientToServerEvents {
   cleanup_child_session: (data: {
     token: string;
     childSessionId: string;
-  }) => void;
+  }, ack?: (result: { ok: boolean; error?: string }) => void) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -77,6 +77,13 @@ export interface RelayClientToServerEvents {
     action?: string;
     targetSessionId: string;
   }) => void;
+
+  /** Parent requests cleanup of a completed child session.
+   *  The server validates the parent↔child relationship and tears down the child. */
+  cleanup_child_session: (data: {
+    token: string;
+    childSessionId: string;
+  }) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/ws/namespaces/relay-cleanup.test.ts
+++ b/packages/server/src/ws/namespaces/relay-cleanup.test.ts
@@ -86,6 +86,7 @@ function simulateCleanupDispatch(opts: {
     childSession: FakeSession;
     parentSessionId: string;
     childSessionId: string;
+    hasRelayRecipient: boolean;
     emitToRunner: (runnerId: string, event: string, data: unknown) => void;
     emitToRelaySession: (sessionId: string, event: string, data: unknown) => void;
     removeChildSession: (parentId: string, childId: string) => void;
@@ -115,8 +116,15 @@ function simulateCleanupDispatch(opts: {
     opts.removeChildSession(opts.parentSessionId, opts.childSessionId);
     record.removeChildSessionCalled = true;
 
-    // 4. endSharedSession is intentionally NOT called here
-    // (left to child's disconnect handler)
+    // 4. If no relay socket remains anywhere in the cluster, there is no
+    // disconnect handler left to finish teardown, so end it immediately.
+    if (!opts.hasRelayRecipient) {
+        opts.endSharedSession(opts.childSessionId, "Parent acknowledged completion");
+        record.endSharedSessionCalled = true;
+        return record;
+    }
+
+    // Otherwise leave teardown to the child's disconnect handler.
     record.endSharedSessionCalled = false;
 
     return record;
@@ -299,6 +307,7 @@ describe("cleanup_child_session — dispatch", () => {
             childSession,
             parentSessionId: PARENT_ID,
             childSessionId: CHILD_ID,
+            hasRelayRecipient: true,
             emitToRunner: (runnerId, event, data: any) => {
                 if (event === "kill_session") emittedKills.push({ runnerId, sessionId: data.sessionId });
             },
@@ -320,6 +329,7 @@ describe("cleanup_child_session — dispatch", () => {
             childSession,
             parentSessionId: PARENT_ID,
             childSessionId: CHILD_ID,
+            hasRelayRecipient: true,
             emitToRunner: () => {},
             emitToRelaySession: (sessionId, event, data: any) => {
                 broadcasts.push({ sessionId, event, command: data.command });
@@ -341,6 +351,7 @@ describe("cleanup_child_session — dispatch", () => {
             childSession,
             parentSessionId: PARENT_ID,
             childSessionId: CHILD_ID,
+            hasRelayRecipient: true,
             emitToRunner: () => {},
             emitToRelaySession: () => {},
             removeChildSession: (p, c) => removed.push([p, c]),
@@ -358,6 +369,7 @@ describe("cleanup_child_session — dispatch", () => {
             childSession,
             parentSessionId: PARENT_ID,
             childSessionId: CHILD_ID,
+            hasRelayRecipient: true,
             emitToRunner: () => {},
             emitToRelaySession: () => {},
             removeChildSession: () => {},
@@ -379,6 +391,7 @@ describe("cleanup_child_session — dispatch", () => {
             childSession: childNoRunner,
             parentSessionId: PARENT_ID,
             childSessionId: CHILD_ID,
+            hasRelayRecipient: true,
             emitToRunner: (_runnerId, event, data: any) => {
                 if (event === "kill_session") emittedKills.push(data.sessionId);
             },
@@ -389,5 +402,23 @@ describe("cleanup_child_session — dispatch", () => {
 
         expect(record.killSessionSent).toBe(false);
         expect(emittedKills).toHaveLength(0);
+    });
+
+    it("calls endSharedSession immediately when no relay socket remains", () => {
+        const endCalls: Array<{ id: string; reason: string }> = [];
+
+        const record = simulateCleanupDispatch({
+            childSession,
+            parentSessionId: PARENT_ID,
+            childSessionId: CHILD_ID,
+            hasRelayRecipient: false,
+            emitToRunner: () => {},
+            emitToRelaySession: () => {},
+            removeChildSession: () => {},
+            endSharedSession: (id, reason) => endCalls.push({ id, reason }),
+        });
+
+        expect(record.endSharedSessionCalled).toBe(true);
+        expect(endCalls).toEqual([{ id: CHILD_ID, reason: "Parent acknowledged completion" }]);
     });
 });

--- a/packages/server/src/ws/namespaces/relay-cleanup.test.ts
+++ b/packages/server/src/ws/namespaces/relay-cleanup.test.ts
@@ -70,7 +70,7 @@ function validateCleanupChildSession(opts: {
 // ── Dispatch decisions after successful validation ────────────────────────────
 //
 // After validation passes, the handler:
-//   a) emits kill_session to the runner socket (if local and connected)
+//   a) emits kill_session cluster-wide via emitToRunner
 //   b) broadcasts exec end_session to the child's relay socket room
 //   c) calls removeChildSession
 //   d) does NOT call endSharedSession (left to the child's disconnect handler)
@@ -86,7 +86,7 @@ function simulateCleanupDispatch(opts: {
     childSession: FakeSession;
     parentSessionId: string;
     childSessionId: string;
-    getRunnerSocket: (runnerId: string) => { connected: boolean; emit: (event: string, data: unknown) => void } | undefined;
+    emitToRunner: (runnerId: string, event: string, data: unknown) => void;
     emitToRelaySession: (sessionId: string, event: string, data: unknown) => void;
     removeChildSession: (parentId: string, childId: string) => void;
     endSharedSession: (sessionId: string, reason: string) => void;
@@ -98,13 +98,10 @@ function simulateCleanupDispatch(opts: {
         endSharedSessionCalled: false,
     };
 
-    // 1. kill_session → runner (local only)
+    // 1. kill_session → runner (cluster-wide via emitToRunner)
     if (opts.childSession.runnerId) {
-        const runnerSocket = opts.getRunnerSocket(opts.childSession.runnerId);
-        if (runnerSocket?.connected) {
-            runnerSocket.emit("kill_session", { sessionId: opts.childSessionId });
-            record.killSessionSent = true;
-        }
+        opts.emitToRunner(opts.childSession.runnerId, "kill_session", { sessionId: opts.childSessionId });
+        record.killSessionSent = true;
     }
 
     // 2. exec end_session → relay socket (cluster-wide broadcast)
@@ -295,55 +292,25 @@ describe("cleanup_child_session — dispatch", () => {
         runnerId: "runner-local",
     };
 
-    it("emits kill_session when local runner socket is connected", () => {
-        const emittedKills: string[] = [];
-        const localSocket = {
-            connected: true,
-            emit(event: string, data: any) {
-                if (event === "kill_session") emittedKills.push(data.sessionId);
-            },
-        };
+    it("emits kill_session cluster-wide via emitToRunner", () => {
+        const emittedKills: Array<{ runnerId: string; sessionId: string }> = [];
 
         const record = simulateCleanupDispatch({
             childSession,
             parentSessionId: PARENT_ID,
             childSessionId: CHILD_ID,
-            getRunnerSocket: () => localSocket,
+            emitToRunner: (runnerId, event, data: any) => {
+                if (event === "kill_session") emittedKills.push({ runnerId, sessionId: data.sessionId });
+            },
             emitToRelaySession: () => {},
             removeChildSession: () => {},
             endSharedSession: () => {},
         });
 
         expect(record.killSessionSent).toBe(true);
-        expect(emittedKills).toContain(CHILD_ID);
-    });
-
-    it("skips kill_session when runner socket is not local", () => {
-        const record = simulateCleanupDispatch({
-            childSession,
-            parentSessionId: PARENT_ID,
-            childSessionId: CHILD_ID,
-            getRunnerSocket: () => undefined, // runner on another node
-            emitToRelaySession: () => {},
-            removeChildSession: () => {},
-            endSharedSession: () => {},
-        });
-
-        expect(record.killSessionSent).toBe(false);
-    });
-
-    it("skips kill_session when runner socket is disconnected", () => {
-        const record = simulateCleanupDispatch({
-            childSession,
-            parentSessionId: PARENT_ID,
-            childSessionId: CHILD_ID,
-            getRunnerSocket: () => ({ connected: false, emit: () => {} }),
-            emitToRelaySession: () => {},
-            removeChildSession: () => {},
-            endSharedSession: () => {},
-        });
-
-        expect(record.killSessionSent).toBe(false);
+        expect(emittedKills).toHaveLength(1);
+        expect(emittedKills[0].runnerId).toBe("runner-local");
+        expect(emittedKills[0].sessionId).toBe(CHILD_ID);
     });
 
     it("always broadcasts exec end_session (cluster-wide)", () => {
@@ -353,7 +320,7 @@ describe("cleanup_child_session — dispatch", () => {
             childSession,
             parentSessionId: PARENT_ID,
             childSessionId: CHILD_ID,
-            getRunnerSocket: () => undefined,
+            emitToRunner: () => {},
             emitToRelaySession: (sessionId, event, data: any) => {
                 broadcasts.push({ sessionId, event, command: data.command });
             },
@@ -374,7 +341,7 @@ describe("cleanup_child_session — dispatch", () => {
             childSession,
             parentSessionId: PARENT_ID,
             childSessionId: CHILD_ID,
-            getRunnerSocket: () => undefined,
+            emitToRunner: () => {},
             emitToRelaySession: () => {},
             removeChildSession: (p, c) => removed.push([p, c]),
             endSharedSession: () => {},
@@ -391,7 +358,7 @@ describe("cleanup_child_session — dispatch", () => {
             childSession,
             parentSessionId: PARENT_ID,
             childSessionId: CHILD_ID,
-            getRunnerSocket: () => undefined,
+            emitToRunner: () => {},
             emitToRelaySession: () => {},
             removeChildSession: () => {},
             endSharedSession: (id) => endCalls.push(id),
@@ -407,18 +374,14 @@ describe("cleanup_child_session — dispatch", () => {
             runnerId: null,
         };
         const emittedKills: string[] = [];
-        const fakeSocket = {
-            connected: true,
-            emit(event: string, data: any) {
-                if (event === "kill_session") emittedKills.push(data.sessionId);
-            },
-        };
 
         const record = simulateCleanupDispatch({
             childSession: childNoRunner,
             parentSessionId: PARENT_ID,
             childSessionId: CHILD_ID,
-            getRunnerSocket: () => fakeSocket,
+            emitToRunner: (_runnerId, event, data: any) => {
+                if (event === "kill_session") emittedKills.push(data.sessionId);
+            },
             emitToRelaySession: () => {},
             removeChildSession: () => {},
             endSharedSession: () => {},

--- a/packages/server/src/ws/namespaces/relay-cleanup.test.ts
+++ b/packages/server/src/ws/namespaces/relay-cleanup.test.ts
@@ -1,0 +1,430 @@
+// ============================================================================
+// relay-cleanup.test.ts — Tests for the cleanup_child_session handler logic
+//
+// The relay handler is tightly coupled to Socket.IO and Redis at runtime,
+// so we extract and test the core validation logic and dispatch decisions
+// in isolation — the same approach used in extension.test.ts on the CLI side.
+// ============================================================================
+
+import { describe, it, expect, beforeEach } from "bun:test";
+
+// ── Types mirroring relay session shape ──────────────────────────────────────
+
+interface FakeSession {
+    sessionId: string;
+    userId: string | null;
+    parentSessionId: string | null;
+    runnerId: string | null;
+}
+
+// ── Core validation logic extracted from cleanup_child_session ───────────────
+//
+// This matches the guard sequence in relay.ts.  Tests verify the logic
+// without requiring a live Socket.IO server or Redis connection.
+
+type ValidationResult =
+    | { ok: true; childSession: FakeSession }
+    | { ok: false; error: string };
+
+function validateCleanupChildSession(opts: {
+    sessionId: string | undefined;
+    tokenFromSocket: string;
+    tokenFromData: string | undefined;
+    childSessionId: string | undefined;
+    getSession: (id: string) => FakeSession | null;
+}): ValidationResult {
+    const { sessionId, tokenFromSocket, tokenFromData, childSessionId, getSession } = opts;
+
+    // 1. Session must exist on socket + token must match
+    if (!sessionId || tokenFromData !== tokenFromSocket) {
+        return { ok: false, error: "Invalid token" };
+    }
+
+    // 2. childSessionId must be provided
+    if (!childSessionId) {
+        return { ok: false, error: "cleanup_child_session requires childSessionId" };
+    }
+
+    // 3. Child session must exist (idempotent if already gone)
+    const childSession = getSession(childSessionId);
+    if (!childSession) {
+        // Not an error — child already cleaned up.
+        // Returning a special marker so callers can distinguish from error.
+        return { ok: false, error: "CHILD_ALREADY_GONE" };
+    }
+
+    // 4. Sender must be the registered parent
+    if (childSession.parentSessionId !== sessionId) {
+        return { ok: false, error: "Sender is not the parent of the target session" };
+    }
+
+    // 5. Both sessions must belong to the same user
+    const parentSession = getSession(sessionId);
+    if (!parentSession?.userId || parentSession.userId !== childSession.userId) {
+        return { ok: false, error: "Target session belongs to a different user" };
+    }
+
+    return { ok: true, childSession };
+}
+
+// ── Dispatch decisions after successful validation ────────────────────────────
+//
+// After validation passes, the handler:
+//   a) emits kill_session to the runner socket (if local and connected)
+//   b) broadcasts exec end_session to the child's relay socket room
+//   c) calls removeChildSession
+//   d) does NOT call endSharedSession (left to the child's disconnect handler)
+
+interface DispatchRecord {
+    killSessionSent: boolean;
+    execEndSessionSent: boolean;
+    removeChildSessionCalled: boolean;
+    endSharedSessionCalled: boolean;
+}
+
+function simulateCleanupDispatch(opts: {
+    childSession: FakeSession;
+    parentSessionId: string;
+    childSessionId: string;
+    getRunnerSocket: (runnerId: string) => { connected: boolean; emit: (event: string, data: unknown) => void } | undefined;
+    emitToRelaySession: (sessionId: string, event: string, data: unknown) => void;
+    removeChildSession: (parentId: string, childId: string) => void;
+    endSharedSession: (sessionId: string, reason: string) => void;
+}): DispatchRecord {
+    const record: DispatchRecord = {
+        killSessionSent: false,
+        execEndSessionSent: false,
+        removeChildSessionCalled: false,
+        endSharedSessionCalled: false,
+    };
+
+    // 1. kill_session → runner (local only)
+    if (opts.childSession.runnerId) {
+        const runnerSocket = opts.getRunnerSocket(opts.childSession.runnerId);
+        if (runnerSocket?.connected) {
+            runnerSocket.emit("kill_session", { sessionId: opts.childSessionId });
+            record.killSessionSent = true;
+        }
+    }
+
+    // 2. exec end_session → relay socket (cluster-wide broadcast)
+    opts.emitToRelaySession(opts.childSessionId, "exec", {
+        id: `cleanup-${opts.childSessionId}-0`,
+        command: "end_session",
+    });
+    record.execEndSessionSent = true;
+
+    // 3. removeChildSession
+    opts.removeChildSession(opts.parentSessionId, opts.childSessionId);
+    record.removeChildSessionCalled = true;
+
+    // 4. endSharedSession is intentionally NOT called here
+    // (left to child's disconnect handler)
+    record.endSharedSessionCalled = false;
+
+    return record;
+}
+
+// ── Sessions fixture ──────────────────────────────────────────────────────────
+
+const USER_A = "user-a";
+const USER_B = "user-b";
+
+function makeSessionStore(sessions: FakeSession[]): (id: string) => FakeSession | null {
+    const map = new Map(sessions.map((s) => [s.sessionId, s]));
+    return (id) => map.get(id) ?? null;
+}
+
+// ── Validation tests ──────────────────────────────────────────────────────────
+
+describe("cleanup_child_session — validation", () => {
+    const parentSession: FakeSession = {
+        sessionId: "parent-1",
+        userId: USER_A,
+        parentSessionId: null,
+        runnerId: "runner-1",
+    };
+
+    const childSession: FakeSession = {
+        sessionId: "child-1",
+        userId: USER_A,
+        parentSessionId: "parent-1",
+        runnerId: "runner-1",
+    };
+
+    const getSession = makeSessionStore([parentSession, childSession]);
+
+    it("accepts a valid cleanup request", () => {
+        const result = validateCleanupChildSession({
+            sessionId: "parent-1",
+            tokenFromSocket: "tok",
+            tokenFromData: "tok",
+            childSessionId: "child-1",
+            getSession,
+        });
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+            expect(result.childSession.sessionId).toBe("child-1");
+        }
+    });
+
+    it("rejects mismatched token", () => {
+        const result = validateCleanupChildSession({
+            sessionId: "parent-1",
+            tokenFromSocket: "correct",
+            tokenFromData: "wrong",
+            childSessionId: "child-1",
+            getSession,
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toBe("Invalid token");
+    });
+
+    it("rejects when sessionId is undefined (unauthenticated socket)", () => {
+        const result = validateCleanupChildSession({
+            sessionId: undefined,
+            tokenFromSocket: "tok",
+            tokenFromData: "tok",
+            childSessionId: "child-1",
+            getSession,
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toBe("Invalid token");
+    });
+
+    it("rejects missing childSessionId", () => {
+        const result = validateCleanupChildSession({
+            sessionId: "parent-1",
+            tokenFromSocket: "tok",
+            tokenFromData: "tok",
+            childSessionId: undefined,
+            getSession,
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toContain("childSessionId");
+    });
+
+    it("returns CHILD_ALREADY_GONE when child session is not in Redis", () => {
+        const result = validateCleanupChildSession({
+            sessionId: "parent-1",
+            tokenFromSocket: "tok",
+            tokenFromData: "tok",
+            childSessionId: "nonexistent-child",
+            getSession,
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toBe("CHILD_ALREADY_GONE");
+    });
+
+    it("rejects when sender is not the parent of the child", () => {
+        const imposter: FakeSession = {
+            sessionId: "imposter",
+            userId: USER_A,
+            parentSessionId: null,
+            runnerId: "runner-2",
+        };
+        const storeWithImposter = makeSessionStore([parentSession, childSession, imposter]);
+
+        const result = validateCleanupChildSession({
+            sessionId: "imposter",
+            tokenFromSocket: "tok",
+            tokenFromData: "tok",
+            childSessionId: "child-1",
+            getSession: storeWithImposter,
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toContain("not the parent");
+    });
+
+    it("rejects cross-user cleanup attempt", () => {
+        const otherUserChild: FakeSession = {
+            sessionId: "child-other-user",
+            userId: USER_B,
+            parentSessionId: "parent-1",
+            runnerId: "runner-1",
+        };
+        const crossStore = makeSessionStore([parentSession, otherUserChild]);
+
+        const result = validateCleanupChildSession({
+            sessionId: "parent-1",
+            tokenFromSocket: "tok",
+            tokenFromData: "tok",
+            childSessionId: "child-other-user",
+            getSession: crossStore,
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toContain("different user");
+    });
+
+    it("rejects when parent has no userId", () => {
+        const parentNoUser: FakeSession = {
+            sessionId: "parent-nouser",
+            userId: null,
+            parentSessionId: null,
+            runnerId: "runner-1",
+        };
+        // Child must point to this parent so the parentId check passes
+        const childOfNoUser: FakeSession = {
+            ...childSession,
+            parentSessionId: "parent-nouser",
+        };
+        const storeNoUser = makeSessionStore([parentNoUser, childOfNoUser]);
+
+        const result = validateCleanupChildSession({
+            sessionId: "parent-nouser",
+            tokenFromSocket: "tok",
+            tokenFromData: "tok",
+            childSessionId: childOfNoUser.sessionId,
+            getSession: storeNoUser,
+        });
+        expect(result.ok).toBe(false);
+        if (!result.ok) expect(result.error).toContain("different user");
+    });
+});
+
+// ── Dispatch tests ────────────────────────────────────────────────────────────
+
+describe("cleanup_child_session — dispatch", () => {
+    const CHILD_ID = "child-dispatch";
+    const PARENT_ID = "parent-dispatch";
+
+    const childSession: FakeSession = {
+        sessionId: CHILD_ID,
+        userId: "user-x",
+        parentSessionId: PARENT_ID,
+        runnerId: "runner-local",
+    };
+
+    it("emits kill_session when local runner socket is connected", () => {
+        const emittedKills: string[] = [];
+        const localSocket = {
+            connected: true,
+            emit(event: string, data: any) {
+                if (event === "kill_session") emittedKills.push(data.sessionId);
+            },
+        };
+
+        const record = simulateCleanupDispatch({
+            childSession,
+            parentSessionId: PARENT_ID,
+            childSessionId: CHILD_ID,
+            getRunnerSocket: () => localSocket,
+            emitToRelaySession: () => {},
+            removeChildSession: () => {},
+            endSharedSession: () => {},
+        });
+
+        expect(record.killSessionSent).toBe(true);
+        expect(emittedKills).toContain(CHILD_ID);
+    });
+
+    it("skips kill_session when runner socket is not local", () => {
+        const record = simulateCleanupDispatch({
+            childSession,
+            parentSessionId: PARENT_ID,
+            childSessionId: CHILD_ID,
+            getRunnerSocket: () => undefined, // runner on another node
+            emitToRelaySession: () => {},
+            removeChildSession: () => {},
+            endSharedSession: () => {},
+        });
+
+        expect(record.killSessionSent).toBe(false);
+    });
+
+    it("skips kill_session when runner socket is disconnected", () => {
+        const record = simulateCleanupDispatch({
+            childSession,
+            parentSessionId: PARENT_ID,
+            childSessionId: CHILD_ID,
+            getRunnerSocket: () => ({ connected: false, emit: () => {} }),
+            emitToRelaySession: () => {},
+            removeChildSession: () => {},
+            endSharedSession: () => {},
+        });
+
+        expect(record.killSessionSent).toBe(false);
+    });
+
+    it("always broadcasts exec end_session (cluster-wide)", () => {
+        const broadcasts: Array<{ sessionId: string; event: string; command: string }> = [];
+
+        simulateCleanupDispatch({
+            childSession,
+            parentSessionId: PARENT_ID,
+            childSessionId: CHILD_ID,
+            getRunnerSocket: () => undefined,
+            emitToRelaySession: (sessionId, event, data: any) => {
+                broadcasts.push({ sessionId, event, command: data.command });
+            },
+            removeChildSession: () => {},
+            endSharedSession: () => {},
+        });
+
+        expect(broadcasts).toHaveLength(1);
+        expect(broadcasts[0].sessionId).toBe(CHILD_ID);
+        expect(broadcasts[0].event).toBe("exec");
+        expect(broadcasts[0].command).toBe("end_session");
+    });
+
+    it("calls removeChildSession with parent and child IDs", () => {
+        const removed: Array<[string, string]> = [];
+
+        simulateCleanupDispatch({
+            childSession,
+            parentSessionId: PARENT_ID,
+            childSessionId: CHILD_ID,
+            getRunnerSocket: () => undefined,
+            emitToRelaySession: () => {},
+            removeChildSession: (p, c) => removed.push([p, c]),
+            endSharedSession: () => {},
+        });
+
+        expect(removed).toHaveLength(1);
+        expect(removed[0]).toEqual([PARENT_ID, CHILD_ID]);
+    });
+
+    it("does NOT call endSharedSession (left to disconnect handler)", () => {
+        const endCalls: string[] = [];
+
+        const record = simulateCleanupDispatch({
+            childSession,
+            parentSessionId: PARENT_ID,
+            childSessionId: CHILD_ID,
+            getRunnerSocket: () => undefined,
+            emitToRelaySession: () => {},
+            removeChildSession: () => {},
+            endSharedSession: (id) => endCalls.push(id),
+        });
+
+        expect(record.endSharedSessionCalled).toBe(false);
+        expect(endCalls).toHaveLength(0);
+    });
+
+    it("skips kill_session when child has no runnerId", () => {
+        const childNoRunner: FakeSession = {
+            ...childSession,
+            runnerId: null,
+        };
+        const emittedKills: string[] = [];
+        const fakeSocket = {
+            connected: true,
+            emit(event: string, data: any) {
+                if (event === "kill_session") emittedKills.push(data.sessionId);
+            },
+        };
+
+        const record = simulateCleanupDispatch({
+            childSession: childNoRunner,
+            parentSessionId: PARENT_ID,
+            childSessionId: CHILD_ID,
+            getRunnerSocket: () => fakeSocket,
+            emitToRelaySession: () => {},
+            removeChildSession: () => {},
+            endSharedSession: () => {},
+        });
+
+        expect(record.killSessionSent).toBe(false);
+        expect(emittedKills).toHaveLength(0);
+    });
+});

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -19,6 +19,7 @@ import {
     getLocalTuiSocket,
     getLocalRunnerSocket,
     emitToRelaySession,
+    emitToRunner,
     updateSessionState,
     updateSessionHeartbeat,
     touchSessionActivity,
@@ -731,14 +732,11 @@ export function registerRelayNamespace(io: SocketIOServer): void {
 
             // Terminate the child process via two complementary paths:
             //
-            // 1. kill_session → runner: sends SIGTERM to the OS process.
-            //    This is the fastest path but is local-only — if the child's
-            //    runner is on a different cluster node the socket is undefined.
+            // 1. kill_session → runner (cluster-wide via emitToRunner):
+            //    sends SIGTERM to the OS process.  Reaches runners on any
+            //    cluster node through the Redis adapter.
             if (childSession.runnerId) {
-                const runnerSocket = getLocalRunnerSocket(childSession.runnerId);
-                if (runnerSocket?.connected) {
-                    runnerSocket.emit("kill_session", { sessionId: childSessionId });
-                }
+                emitToRunner(childSession.runnerId, "kill_session", { sessionId: childSessionId });
             }
 
             // 2. exec end_session → child relay socket (cluster-wide via Redis

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -754,18 +754,31 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 command: "end_session",
             });
 
+            const relaySockets = await io.of("/relay").in(`session:${childSessionId}`).fetchSockets();
+            const hasRelayRecipient = relaySockets.length > 0;
+
             // Clean up child-index entry
             void removeChildSession(sessionId, childSessionId);
 
-            // Do NOT call endSharedSession here.  The child will disconnect
-            // momentarily (from the SIGTERM or exec above), and its disconnect
-            // handler on whichever node hosts the child's relay socket will
-            // call endSharedSession there — where localRunnerSockets has the
-            // correct runner socket.  Calling it here first would delete the
-            // Redis record before that node can process the disconnect, turning
-            // its endSharedSession into a no-op and leaving adopted-session
-            // entries stranded in runningSessions on the remote runner.
-            // If the child is already gone the orphan sweeper handles cleanup.
+            if (!hasRelayRecipient) {
+                // No relay socket is currently joined for this child anywhere in
+                // the cluster, so there is no disconnect handler left to finish
+                // cleanup. Complete teardown now so acknowledged children don't
+                // linger in Redis/sidebar until the orphan sweeper runs.
+                await endSharedSession(childSessionId, "Parent acknowledged completion");
+                if (typeof ack === "function") ack({ ok: true });
+                return;
+            }
+
+            // Do NOT call endSharedSession here when a relay recipient exists.
+            // The child will disconnect momentarily (from the SIGTERM or exec
+            // above), and its disconnect handler on whichever node hosts the
+            // child's relay socket will call endSharedSession there — where the
+            // correct local runner socket is available for adopted-session
+            // cleanup. Calling it here first would delete the Redis record
+            // before that node can process the disconnect, turning its
+            // endSharedSession into a no-op and leaving adopted-session entries
+            // stranded in runningSessions on the remote runner.
 
             if (typeof ack === "function") ack({ ok: true });
         });

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -17,6 +17,7 @@ import {
     registerTuiSession,
     getSharedSession,
     getLocalTuiSocket,
+    getLocalRunnerSocket,
     emitToRelaySession,
     updateSessionState,
     updateSessionHeartbeat,
@@ -728,11 +729,27 @@ export function registerRelayNamespace(io: SocketIOServer): void {
 
             console.log(`[sio/relay] cleanup_child_session: parent=${sessionId} child=${childSessionId}`);
 
-            // Disconnect the child's relay socket (triggers session_ended on runner)
-            const childSocket = getLocalTuiSocket(childSessionId);
-            if (childSocket?.connected) {
-                childSocket.disconnect(true);
+            // Terminate the child process via two complementary paths:
+            //
+            // 1. kill_session → runner: sends SIGTERM to the OS process.
+            //    This is the fastest path but is local-only — if the child's
+            //    runner is on a different cluster node the socket is undefined.
+            if (childSession.runnerId) {
+                const runnerSocket = getLocalRunnerSocket(childSession.runnerId);
+                if (runnerSocket?.connected) {
+                    runnerSocket.emit("kill_session", { sessionId: childSessionId });
+                }
             }
+
+            // 2. exec end_session → child relay socket (cluster-wide via Redis
+            //    adapter room broadcast).  Reaches the child on any node and
+            //    causes it to clear its follow-up grace timer and shut down
+            //    cleanly.  If the runner already sent SIGTERM in step 1 the
+            //    exec arrives to an already-exiting worker (benign no-op).
+            emitToRelaySession(childSessionId, "exec", {
+                id: `cleanup-${childSessionId}-${Date.now()}`,
+                command: "end_session",
+            });
 
             // Clean up child-index entry
             void removeChildSession(sessionId, childSessionId);

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -754,8 +754,15 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             // Clean up child-index entry
             void removeChildSession(sessionId, childSessionId);
 
-            // End the shared session (Redis, viewers, runner notification)
-            await endSharedSession(childSessionId, "Parent acknowledged completion");
+            // Do NOT call endSharedSession here.  The child will disconnect
+            // momentarily (from the SIGTERM or exec above), and its disconnect
+            // handler on whichever node hosts the child's relay socket will
+            // call endSharedSession there — where localRunnerSockets has the
+            // correct runner socket.  Calling it here first would delete the
+            // Redis record before that node can process the disconnect, turning
+            // its endSharedSession into a no-op and leaving adopted-session
+            // entries stranded in runningSessions on the remote runner.
+            // If the child is already gone the orphan sweeper handles cleanup.
         });
 
         // ── disconnect ───────────────────────────────────────────────────────

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -693,6 +693,54 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             }
         });
 
+        // ── cleanup_child_session — parent requests child teardown on ack ────
+        socket.on("cleanup_child_session", async (data) => {
+            const sessionId = socket.data.sessionId;
+            if (!sessionId || data?.token !== socket.data.token) {
+                socket.emit("error", { message: "Invalid token" });
+                return;
+            }
+
+            const childSessionId = data?.childSessionId;
+            if (!childSessionId) {
+                socket.emit("error", { message: "cleanup_child_session requires childSessionId" });
+                return;
+            }
+
+            // Validate the sender is the parent of the target child session
+            const childSession = await getSharedSession(childSessionId);
+            if (!childSession) {
+                // Child already gone — nothing to clean up (idempotent)
+                return;
+            }
+
+            if (childSession.parentSessionId !== sessionId) {
+                socket.emit("error", { message: "Sender is not the parent of the target session" });
+                return;
+            }
+
+            // Validate same user ownership
+            const parentSession = await getSharedSession(sessionId);
+            if (!parentSession?.userId || parentSession.userId !== childSession.userId) {
+                socket.emit("error", { message: "Target session belongs to a different user" });
+                return;
+            }
+
+            console.log(`[sio/relay] cleanup_child_session: parent=${sessionId} child=${childSessionId}`);
+
+            // Disconnect the child's relay socket (triggers session_ended on runner)
+            const childSocket = getLocalTuiSocket(childSessionId);
+            if (childSocket?.connected) {
+                childSocket.disconnect(true);
+            }
+
+            // Clean up child-index entry
+            void removeChildSession(sessionId, childSessionId);
+
+            // End the shared session (Redis, viewers, runner notification)
+            await endSharedSession(childSessionId, "Parent acknowledged completion");
+        });
+
         // ── disconnect ───────────────────────────────────────────────────────
         socket.on("disconnect", async (reason) => {
             console.log(`[sio/relay] disconnected: ${socket.id} (${reason})`);

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -696,16 +696,18 @@ export function registerRelayNamespace(io: SocketIOServer): void {
         });
 
         // ── cleanup_child_session — parent requests child teardown on ack ────
-        socket.on("cleanup_child_session", async (data) => {
+        socket.on("cleanup_child_session", async (data, ack) => {
             const sessionId = socket.data.sessionId;
             if (!sessionId || data?.token !== socket.data.token) {
                 socket.emit("error", { message: "Invalid token" });
+                if (typeof ack === "function") ack({ ok: false, error: "Invalid token" });
                 return;
             }
 
             const childSessionId = data?.childSessionId;
             if (!childSessionId) {
                 socket.emit("error", { message: "cleanup_child_session requires childSessionId" });
+                if (typeof ack === "function") ack({ ok: false, error: "cleanup_child_session requires childSessionId" });
                 return;
             }
 
@@ -713,11 +715,13 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             const childSession = await getSharedSession(childSessionId);
             if (!childSession) {
                 // Child already gone — nothing to clean up (idempotent)
+                if (typeof ack === "function") ack({ ok: true });
                 return;
             }
 
             if (childSession.parentSessionId !== sessionId) {
                 socket.emit("error", { message: "Sender is not the parent of the target session" });
+                if (typeof ack === "function") ack({ ok: false, error: "Sender is not the parent of the target session" });
                 return;
             }
 
@@ -725,6 +729,7 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             const parentSession = await getSharedSession(sessionId);
             if (!parentSession?.userId || parentSession.userId !== childSession.userId) {
                 socket.emit("error", { message: "Target session belongs to a different user" });
+                if (typeof ack === "function") ack({ ok: false, error: "Target session belongs to a different user" });
                 return;
             }
 
@@ -761,6 +766,8 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             // its endSharedSession into a no-op and leaving adopted-session
             // entries stranded in runningSessions on the remote runner.
             // If the child is already gone the orphan sweeper handles cleanup.
+
+            if (typeof ack === "function") ack({ ok: true });
         });
 
         // ── disconnect ───────────────────────────────────────────────────────

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -110,17 +110,23 @@ function runnerRoom(runnerId: string): string {
 /** Export for use in cleanup paths that need cluster-wide runner notification. */
 export function emitToRunner(runnerId: string, eventName: string, data: unknown): void {
     if (!io) return;
+    // Primary path: cluster-wide via per-runner room (joined on registration).
+    // Reaches runners on any relay node through the Redis adapter.
     try {
         io.of("/runner")
             .to(runnerRoom(runnerId))
             .emit(eventName, data);
     } catch (err) {
-        // Fall back to local socket if the adapter publish fails.
-        const local = localRunnerSockets.get(runnerId);
-        if (local?.connected) {
-            try { local.emit(eventName, data); } catch { /* best-effort */ }
-        }
-        console.warn("[sio-registry] emitToRunner failed:", (err as Error)?.message);
+        console.warn("[sio-registry] emitToRunner room emit failed:", (err as Error)?.message);
+    }
+    // Compatibility fallback: direct local socket emit.
+    // Handles runners on this node that haven't joined the room yet
+    // (e.g. older daemon versions during a rolling deploy, or runners that
+    // connected before this server was upgraded).  The daemon's handler is
+    // idempotent via endedSessionIds, so double-delivery is safe.
+    const local = localRunnerSockets.get(runnerId);
+    if (local?.connected) {
+        try { local.emit(eventName, data); } catch { /* best-effort */ }
     }
 }
 

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -97,6 +97,33 @@ function terminalRoom(terminalId: string): string {
     return `terminal:${terminalId}`;
 }
 
+/**
+ * Room that a runner socket joins on the /runner namespace.
+ * Enables cluster-wide emission to a specific runner via the Redis adapter,
+ * so session_ended can reach the correct runner regardless of which relay node
+ * handles the cleanup request.
+ */
+function runnerRoom(runnerId: string): string {
+    return `runner:${runnerId}`;
+}
+
+/** Export for use in cleanup paths that need cluster-wide runner notification. */
+export function emitToRunner(runnerId: string, eventName: string, data: unknown): void {
+    if (!io) return;
+    try {
+        io.of("/runner")
+            .to(runnerRoom(runnerId))
+            .emit(eventName, data);
+    } catch (err) {
+        // Fall back to local socket if the adapter publish fails.
+        const local = localRunnerSockets.get(runnerId);
+        if (local?.connected) {
+            try { local.emit(eventName, data); } catch { /* best-effort */ }
+        }
+        console.warn("[sio-registry] emitToRunner failed:", (err as Error)?.message);
+    }
+}
+
 // ── Local socket references (per-server, NOT shared via Redis) ──────────────
 
 /** TUI relay sockets: sessionId → Socket on /relay namespace. */
@@ -817,11 +844,11 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
 
     // Notify the runner daemon so it can clean up its runningSessions map
     // (especially important for adopted sessions after a daemon restart).
+    // emitToRunner uses the per-runner room (joined on registration) so the
+    // event reaches the correct runner via the Redis adapter even when it is
+    // connected to a different relay node than the one calling this function.
     if (session.runnerId) {
-        const runnerSocket = localRunnerSockets.get(session.runnerId);
-        if (runnerSocket?.connected) {
-            runnerSocket.emit("session_ended", { sessionId, reason });
-        }
+        emitToRunner(session.runnerId, "session_ended", { sessionId, reason });
     }
 
     // Delete from Redis
@@ -1065,6 +1092,10 @@ export async function registerRunner(
 
     await setRunner(runnerId, runnerData);
     localRunnerSockets.set(runnerId, socket);
+
+    // Join a per-runner room so cluster-wide emits can reach this runner via
+    // the Redis adapter (see emitToRunner / endSharedSession).
+    await socket.join(runnerRoom(runnerId));
 
     return runnerId;
 }


### PR DESCRIPTION
## Summary

When a parent session acknowledges a child's `session_complete` trigger with `action: "ack"`, the child session is now automatically cleaned up — its relay socket is disconnected, it's removed from server session tracking, and the runner daemon is notified to kill the worker process and free attachments.

## Changes

### Protocol (`packages/protocol/src/relay.ts`)
- Added `cleanup_child_session` event to `RelayClientToServerEvents`

### Server (`packages/server/src/ws/namespaces/relay.ts`)
- New `cleanup_child_session` handler that validates parent↔child relationship, disconnects the child socket, removes child-index entry, and calls `endSharedSession()` to clean up Redis, viewer rooms, and notify the runner

### CLI (`packages/cli/src/extensions/triggers/extension.ts`)
- On `session_complete` with `action: "ack"`, emits `cleanup_child_session` to the relay
- `followUp` action is unaffected — still resumes the child as before

### Tests (`packages/cli/src/extensions/triggers/extension.test.ts`)
- 6 new unit tests covering:
  - Cleanup event emitted on ack
  - Default action (no explicit action) triggers cleanup
  - followUp does NOT trigger cleanup
  - Non-session_complete triggers don't trigger cleanup
  - Missing trigger error handling
  - Expired trigger error handling

## Testing
- `bun run typecheck` — clean
- `bun run test` — 277 tests pass (0 failures)