### PR TITLE
feat: clear pending triggers and delink children on /new

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ data/
 docs/superpowers/
 .worktrees/
 .beads/
+Library/Caches/

--- a/packages/cli/src/extensions/remote-delink-retry.test.ts
+++ b/packages/cli/src/extensions/remote-delink-retry.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "bun:test";
+import { evaluateDelinkChildrenAck, evaluateDelinkOwnParentAck } from "./remote-delink-retry.js";
+// wasDelinked flag helpers — pure logic, no dependencies
+import type { RelayServerToClientEvents } from "@pizzapi/protocol";
+
+describe("remote delink retry helpers", () => {
+    describe("evaluateDelinkChildrenAck", () => {
+        it("does not clear a newer retry timer when a stale ack arrives", () => {
+            const plan = evaluateDelinkChildrenAck({
+                ackEpoch: 100,
+                pendingEpoch: 200,
+                retryEpoch: 200,
+                ok: true,
+                connected: true,
+            });
+
+            expect(plan).toEqual({
+                ignoreAck: true,
+                clearRetryTimer: false,
+                clearPendingDelink: false,
+                scheduleRetry: false,
+            });
+        });
+
+        it("clears only the superseded retry timer when a stale ack matches that timer", () => {
+            const plan = evaluateDelinkChildrenAck({
+                ackEpoch: 100,
+                pendingEpoch: 200,
+                retryEpoch: 100,
+                ok: true,
+                connected: true,
+            });
+
+            expect(plan).toEqual({
+                ignoreAck: true,
+                clearRetryTimer: true,
+                clearPendingDelink: false,
+                scheduleRetry: false,
+            });
+        });
+
+        it("schedules a live-socket retry after a nack on the active epoch", () => {
+            const plan = evaluateDelinkChildrenAck({
+                ackEpoch: 100,
+                pendingEpoch: 100,
+                retryEpoch: null,
+                ok: false,
+                connected: true,
+            });
+
+            expect(plan).toEqual({
+                ignoreAck: false,
+                clearRetryTimer: false,
+                clearPendingDelink: false,
+                scheduleRetry: true,
+            });
+        });
+    });
+
+    describe("wasDelinked flag in registered payload", () => {
+        // These tests document the contract that remote.ts relies on:
+        // The server includes wasDelinked:true ONLY when an explicit delink
+        // marker was found for the child (parent ran /new). Transient parent
+        // offline returns parentSessionId:null without wasDelinked.
+        it("wasDelinked:true signals explicit delink — client should cancel trigger waits", () => {
+            // Build a synthetic registered payload as the server would emit it
+            type RegisteredPayload = Parameters<RelayServerToClientEvents["registered"]>[0];
+            const explicitDelink: RegisteredPayload = {
+                sessionId: "child-1",
+                token: "tok",
+                shareUrl: "https://example.com",
+                isEphemeral: true,
+                collabMode: true,
+                parentSessionId: null,
+                wasDelinked: true,
+            };
+            expect(explicitDelink.wasDelinked).toBe(true);
+            expect(explicitDelink.parentSessionId).toBeNull();
+        });
+
+        it("wasDelinked absent signals transient parent offline — client should preserve parent link", () => {
+            type RegisteredPayload = Parameters<RelayServerToClientEvents["registered"]>[0];
+            const transientOffline: RegisteredPayload = {
+                sessionId: "child-1",
+                token: "tok",
+                shareUrl: "https://example.com",
+                isEphemeral: true,
+                collabMode: true,
+                parentSessionId: null,
+                // wasDelinked intentionally omitted — server only sets it for explicit delinks
+            };
+            expect(transientOffline.wasDelinked).toBeUndefined();
+            expect(transientOffline.parentSessionId).toBeNull();
+        });
+    });
+
+    describe("evaluateDelinkOwnParentAck", () => {
+        it("retries delink_own_parent after a nack on a live socket", () => {
+            const plan = evaluateDelinkOwnParentAck({
+                ok: false,
+                pending: true,
+                connected: true,
+            });
+
+            expect(plan).toEqual({
+                confirmed: false,
+                scheduleRetry: true,
+            });
+        });
+
+        it("does not retry delink_own_parent once the pending flag is cleared", () => {
+            const plan = evaluateDelinkOwnParentAck({
+                ok: false,
+                pending: false,
+                connected: true,
+            });
+
+            expect(plan).toEqual({
+                confirmed: false,
+                scheduleRetry: false,
+            });
+        });
+    });
+});

--- a/packages/cli/src/extensions/remote-delink-retry.ts
+++ b/packages/cli/src/extensions/remote-delink-retry.ts
@@ -1,0 +1,55 @@
+export interface DelinkChildrenAckPlan {
+    ignoreAck: boolean;
+    clearRetryTimer: boolean;
+    clearPendingDelink: boolean;
+    scheduleRetry: boolean;
+}
+
+export function evaluateDelinkChildrenAck(opts: {
+    ackEpoch: number;
+    pendingEpoch: number | null;
+    retryEpoch: number | null;
+    ok: boolean | undefined;
+    connected: boolean;
+}): DelinkChildrenAckPlan {
+    if (opts.pendingEpoch !== opts.ackEpoch) {
+        return {
+            ignoreAck: true,
+            clearRetryTimer: opts.retryEpoch === opts.ackEpoch,
+            clearPendingDelink: false,
+            scheduleRetry: false,
+        };
+    }
+
+    if (opts.ok === false) {
+        return {
+            ignoreAck: false,
+            clearRetryTimer: opts.retryEpoch === opts.ackEpoch,
+            clearPendingDelink: false,
+            scheduleRetry: opts.connected,
+        };
+    }
+
+    return {
+        ignoreAck: false,
+        clearRetryTimer: opts.retryEpoch === opts.ackEpoch,
+        clearPendingDelink: true,
+        scheduleRetry: false,
+    };
+}
+
+export interface DelinkOwnParentAckPlan {
+    confirmed: boolean;
+    scheduleRetry: boolean;
+}
+
+export function evaluateDelinkOwnParentAck(opts: {
+    ok: boolean | undefined;
+    pending: boolean;
+    connected: boolean;
+}): DelinkOwnParentAckPlan {
+    return {
+        confirmed: opts.ok === true,
+        scheduleRetry: opts.ok === false && opts.pending && opts.connected,
+    };
+}

--- a/packages/cli/src/extensions/remote-registered-parent-state.test.ts
+++ b/packages/cli/src/extensions/remote-registered-parent-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "bun:test";
+import { decideRegisteredParentState } from "./remote-registered-parent-state.js";
+
+describe("decideRegisteredParentState", () => {
+    it("links the child when the server reports an active parent link", () => {
+        expect(decideRegisteredParentState({
+            serverParentSessionId: "parent-1",
+            localParentSessionId: null,
+            pendingDelinkOwnParent: false,
+        })).toEqual({ kind: "link", parentSessionId: "parent-1" });
+    });
+
+    it("ignores a stale server parent link while delink_own_parent is pending", () => {
+        expect(decideRegisteredParentState({
+            serverParentSessionId: "parent-1",
+            localParentSessionId: "parent-1",
+            pendingDelinkOwnParent: true,
+        })).toEqual({ kind: "ignore_stale_server_link" });
+    });
+
+    it("treats wasDelinked as an explicit permanent unlink", () => {
+        expect(decideRegisteredParentState({
+            serverParentSessionId: null,
+            localParentSessionId: "parent-1",
+            pendingDelinkOwnParent: false,
+            wasDelinked: true,
+        })).toEqual({ kind: "explicit_delink" });
+    });
+
+    it("preserves child mode during a transient parent outage", () => {
+        expect(decideRegisteredParentState({
+            serverParentSessionId: null,
+            localParentSessionId: "parent-1",
+            pendingDelinkOwnParent: false,
+        })).toEqual({ kind: "transient_offline" });
+    });
+
+    it("does nothing when there is no local or remote parent link", () => {
+        expect(decideRegisteredParentState({
+            serverParentSessionId: null,
+            localParentSessionId: null,
+            pendingDelinkOwnParent: false,
+        })).toEqual({ kind: "no_change" });
+    });
+});

--- a/packages/cli/src/extensions/remote-registered-parent-state.ts
+++ b/packages/cli/src/extensions/remote-registered-parent-state.ts
@@ -1,0 +1,45 @@
+export type RegisteredParentStateDecision =
+    | { kind: "link"; parentSessionId: string }
+    | { kind: "ignore_stale_server_link" }
+    | { kind: "explicit_delink" }
+    | { kind: "transient_offline" }
+    | { kind: "no_change" };
+
+/**
+ * Classify how the client should update its local parent-link state after a
+ * `registered` payload arrives from the relay.
+ *
+ * The key distinction is between:
+ * - explicit delink (`wasDelinked: true`) → clear child state permanently
+ * - transient parent outage (`parentSessionId: null`, no `wasDelinked`) → keep
+ *   child mode active so parent-routed flows recover if the parent reconnects
+ */
+export function decideRegisteredParentState(opts: {
+    serverParentSessionId: string | null | undefined;
+    localParentSessionId: string | null;
+    pendingDelinkOwnParent: boolean;
+    wasDelinked?: boolean;
+}): RegisteredParentStateDecision {
+    const {
+        serverParentSessionId,
+        localParentSessionId,
+        pendingDelinkOwnParent,
+        wasDelinked,
+    } = opts;
+
+    if (serverParentSessionId && !pendingDelinkOwnParent) {
+        return { kind: "link", parentSessionId: serverParentSessionId };
+    }
+
+    if (serverParentSessionId && pendingDelinkOwnParent) {
+        return { kind: "ignore_stale_server_link" };
+    }
+
+    if (localParentSessionId && !serverParentSessionId) {
+        return wasDelinked
+            ? { kind: "explicit_delink" }
+            : { kind: "transient_offline" };
+    }
+
+    return { kind: "no_change" };
+}

--- a/packages/cli/src/extensions/remote-trigger-response.test.ts
+++ b/packages/cli/src/extensions/remote-trigger-response.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "bun:test";
+import { isCancelTriggerAction } from "./remote-trigger-response.js";
+
+describe("isCancelTriggerAction", () => {
+    test("returns true for cancel action", () => {
+        expect(isCancelTriggerAction("cancel")).toBe(true);
+        expect(isCancelTriggerAction(" Cancel ")).toBe(true);
+        expect(isCancelTriggerAction("CANCEL")).toBe(true);
+    });
+
+    test("returns false for non-cancel values", () => {
+        expect(isCancelTriggerAction("approve")).toBe(false);
+        expect(isCancelTriggerAction(undefined)).toBe(false);
+        expect(isCancelTriggerAction(null)).toBe(false);
+        expect(isCancelTriggerAction(42)).toBe(false);
+    });
+});

--- a/packages/cli/src/extensions/remote-trigger-response.ts
+++ b/packages/cli/src/extensions/remote-trigger-response.ts
@@ -1,0 +1,3 @@
+export function isCancelTriggerAction(action: unknown): boolean {
+    return typeof action === "string" && action.trim().toLowerCase() === "cancel";
+}

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -23,6 +23,7 @@ import type { ConversationTrigger } from "../triggers/types.js";
 import type { RelayContext } from "../remote-types.js";
 import { emitSessionActive } from "./chunked-delivery.js";
 import { resetRelayRegistrationGate, signalRelayRegistered } from "./registration-gate.js";
+import { decideRegisteredParentState } from "../remote-registered-parent-state.js";
 
 // ── Module-level singletons (safe: one relay extension per process) ───────────
 
@@ -254,22 +255,34 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
             return true;
         });
 
-        if (data.parentSessionId && !handlers.isPendingDelinkOwnParent()) {
-            rctx.parentSessionId = data.parentSessionId;
-            rctx.isChildSession = true;
-            console.log(`pizzapi: linked as child of parent session ${data.parentSessionId}`);
-        } else if (data.parentSessionId && handlers.isPendingDelinkOwnParent()) {
-            // The child ran /new while disconnected — don't restore the
-            // stale parent link from Redis.
-            console.log(`pizzapi: ignoring stale parentSessionId from server (pendingDelinkOwnParent)`);
-            rctx.parentSessionId = null;
-            rctx.isChildSession = false;
-        } else if (rctx.parentSessionId && !data.parentSessionId) {
-            if (data.wasDelinked) {
+        const parentStateDecision = decideRegisteredParentState({
+            serverParentSessionId: data.parentSessionId,
+            localParentSessionId: rctx.parentSessionId,
+            pendingDelinkOwnParent: handlers.isPendingDelinkOwnParent(),
+            wasDelinked: data.wasDelinked,
+        });
+
+        switch (parentStateDecision.kind) {
+            case "link":
+                rctx.parentSessionId = parentStateDecision.parentSessionId;
+                rctx.isChildSession = true;
+                console.log(`pizzapi: linked as child of parent session ${parentStateDecision.parentSessionId}`);
+                break;
+            case "ignore_stale_server_link":
+                // The child ran /new while disconnected — don't restore the
+                // stale parent link from Redis.
+                console.log("pizzapi: ignoring stale parentSessionId from server (pendingDelinkOwnParent)");
+                rctx.parentSessionId = null;
+                rctx.isChildSession = false;
+                break;
+            case "explicit_delink":
                 handlers.onParentExplicitlyDelinked();
-            } else {
+                break;
+            case "transient_offline":
                 handlers.onParentTransientlyOffline();
-            }
+                break;
+            case "no_change":
+                break;
         }
 
         emitSessionActive(rctx);

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -45,6 +45,30 @@ export interface ConnectionHandlers {
     setModelFromWeb: (provider: string, modelId: string) => Promise<void>;
     /** Deliver a user message to the agent (called from input and session_trigger handlers). */
     sendUserMessage: (message: unknown, options?: { deliverAs?: "followUp" | "steer" }) => void;
+
+    // ── Delink handlers (PR #176) ─────────────────────────────────────────
+    /** Whether a delink_own_parent is pending (child did /new). */
+    isPendingDelinkOwnParent: () => boolean;
+    /** Set server clock offset from registered event's serverTime. */
+    setServerClockOffset: (offset: number) => void;
+    /** Check if a session_message sender is a known stale pre-/new child. */
+    isStaleChild: (sessionId: string) => boolean;
+    /** Get the stale parent ID for session_message filtering. */
+    getStalePrimaryParentId: () => string | null;
+    /** Parent explicitly delinked (wasDelinked=true in registered). */
+    onParentExplicitlyDelinked: () => void;
+    /** Parent transiently offline (Redis miss, no wasDelinked). */
+    onParentTransientlyOffline: () => void;
+    /** parent_delinked event received from server. */
+    onParentDelinked: (ack?: (result: { ok: boolean }) => void) => void;
+    /** Flush deferred delink_children + delink_own_parent + cancellations after reconnect. */
+    flushDeferredDelinks: () => void;
+    /** Called on disconnect to clean up delink timers. */
+    onDelinkDisconnect: () => void;
+    /** Called before socket teardown to stop cancellation retry loops. */
+    onSocketTeardown: () => void;
+    /** Compute parentSessionId for register (accounts for pendingDelinkOwnParent). */
+    getParentSessionIdForRegister: () => string | null | undefined;
 }
 
 // ── URL helpers ───────────────────────────────────────────────────────────────
@@ -130,6 +154,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
     }
 
     if (rctx.sioSocket) {
+        handlers.onSocketTeardown();
         rctx.sioSocket.removeAllListeners();
         rctx.sioSocket.disconnect();
         rctx.sioSocket = null;
@@ -184,13 +209,14 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
 
     sock.on("connect", () => {
         resetRelayRegistrationGate();
+        const parentSessionIdForRegister = handlers.getParentSessionIdForRegister();
         sock.emit("register", {
             sessionId: rctx.relaySessionId,
             cwd: process.cwd(),
             ephemeral: true,
             collabMode: true,
             sessionName: rctx.getCurrentSessionName() ?? undefined,
-            ...(rctx.parentSessionId ? { parentSessionId: rctx.parentSessionId } : {}),
+            ...(parentSessionIdForRegister === undefined ? {} : { parentSessionId: parentSessionIdForRegister }),
         });
     });
 
@@ -212,6 +238,11 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                 : `pizzapi: relay connected — session ${data.sessionId} (${data.shareUrl})`,
         );
 
+        // Update server clock offset for epoch calculations.
+        if (typeof data.serverTime === "number") {
+            handlers.setServerClockOffset(data.serverTime - Date.now());
+        }
+
         messageBus.setOwnSessionId(rctx.relaySessionId);
         messageBus.setSendFn((targetSessionId: string, message: string) => {
             if (!rctx.relay || !rctx.sioSocket?.connected) return false;
@@ -223,14 +254,22 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
             return true;
         });
 
-        if (data.parentSessionId) {
+        if (data.parentSessionId && !handlers.isPendingDelinkOwnParent()) {
             rctx.parentSessionId = data.parentSessionId;
             rctx.isChildSession = true;
             console.log(`pizzapi: linked as child of parent session ${data.parentSessionId}`);
-        } else if (rctx.parentSessionId && !data.parentSessionId) {
-            console.log(`pizzapi: server rejected parent link (${rctx.parentSessionId}), falling back to local interaction`);
+        } else if (data.parentSessionId && handlers.isPendingDelinkOwnParent()) {
+            // The child ran /new while disconnected — don't restore the
+            // stale parent link from Redis.
+            console.log(`pizzapi: ignoring stale parentSessionId from server (pendingDelinkOwnParent)`);
             rctx.parentSessionId = null;
             rctx.isChildSession = false;
+        } else if (rctx.parentSessionId && !data.parentSessionId) {
+            if (data.wasDelinked) {
+                handlers.onParentExplicitlyDelinked();
+            } else {
+                handlers.onParentTransientlyOffline();
+            }
         }
 
         emitSessionActive(rctx);
@@ -238,6 +277,9 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         startHeartbeat(rctx);
         updateMcpRelayContext(rctx);
         signalRelayRegistered();
+
+        // Flush deferred delinks and cancellations after reconnect.
+        handlers.flushDeferredDelinks();
     });
 
     // ── Incoming events from server ───────────────────────────────────────
@@ -254,6 +296,14 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
     });
 
     sock.on("input", (data) => {
+        // While waiting for delink_own_parent to be confirmed by the server,
+        // the old parent can still inject tell_child / follow-up input.
+        // Drop agent-originated input until the server-side link is severed.
+        if (handlers.isPendingDelinkOwnParent() && (data as any).client === "agent") {
+            console.log("pizzapi: dropping stale parent tell_child/follow-up input — delink_own_parent pending");
+            return;
+        }
+
         // Any new input cancels the follow-up grace period immediately
         // (don't wait for turn_start which is async).
         handlers.clearFollowUpGrace();
@@ -293,6 +343,17 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
     });
 
     sock.on("session_message", (data) => {
+        // Drop session_messages only from senders we know are pre-/new children.
+        if (handlers.isStaleChild(data.fromSessionId)) {
+            console.log(`pizzapi: dropping stale session_message from ${data.fromSessionId} — sender is a pre-/new child`);
+            return;
+        }
+        // Drop stale send_message traffic from old parent during pending delink.
+        const stalePrimary = handlers.getStalePrimaryParentId();
+        if (handlers.isPendingDelinkOwnParent() && stalePrimary && data.fromSessionId === stalePrimary) {
+            console.log(`pizzapi: dropping stale session_message from old parent ${data.fromSessionId} — delink_own_parent pending`);
+            return;
+        }
         messageBus.receive({
             fromSessionId: data.fromSessionId,
             message: data.message,
@@ -303,6 +364,11 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
     sock.on("session_trigger" as any, (data: { trigger: ConversationTrigger }) => {
         const trigger = data?.trigger;
         if (!trigger) return;
+        // Drop triggers from known pre-/new children.
+        if (handlers.isStaleChild(trigger.sourceSessionId)) {
+            console.log(`pizzapi: dropping stale session_trigger (${trigger.type}) from ${trigger.sourceSessionId} — sender is a pre-/new child`);
+            return;
+        }
 
         // NOTE: We no longer auto-suppress session_complete triggers when
         // the parent has consumed messages from the child. Linked sessions
@@ -312,10 +378,6 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         // parent doesn't want triggers, it should spawn with linked: false.
         trackReceivedTrigger(trigger.triggerId, trigger.sourceSessionId, trigger.type);
         const rendered = renderTrigger(trigger);
-        // The trigger metadata line (<!-- trigger:ID source:SID questions64:... -->)
-        // carries structured question data inline so the web UI can render
-        // rich trigger cards. This keeps the agent-facing prompt clean —
-        // no separate HTML comment block is needed.
         const deliverAs = trigger.deliverAs === "followUp" ? "followUp" as const : "steer" as const;
         handlers.sendUserMessage(rendered, { deliverAs });
     });
@@ -325,17 +387,9 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         const pending = receivedTriggers.get(data.triggerId);
         if (!pending || !rctx.relay || !rctx.sioSocket?.connected) return;
 
-        // For session_complete triggers, handle cleanup the same way
-        // as respond_to_trigger in the triggers extension — escalated
-        // replies from the human viewer must also clean up the child.
-        // Keep the trigger pending until delivery is confirmed so the
-        // human can retry if it fails.
         if (pending.type === "session_complete") {
             const action = data.action ?? "ack";
             if (action === "followUp") {
-                // Deliver follow-up as agent input to resume the child.
-                // Keep the trigger pending if delivery fails so the human
-                // can retry instead of losing the follow-up.
                 const childId = pending.sourceSessionId;
                 let failed = false;
                 const onError = (err: { targetSessionId: string; error: string }) => {
@@ -351,9 +405,6 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                     message: data.response,
                     deliverAs: "input",
                 });
-                // After a short window without an error, consider delivery
-                // successful and clear the trigger. On failure it stays
-                // pending for retry.
                 setTimeout(() => {
                     rctx.sioSocket?.off("session_message_error" as any, onError);
                     if (!failed) {
@@ -361,7 +412,6 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                     }
                 }, 3000);
             } else {
-                // ack — emit cleanup request with ack callback
                 rctx.sioSocket.emit("cleanup_child_session", {
                     token: rctx.relay.token,
                     childSessionId: pending.sourceSessionId,
@@ -369,7 +419,6 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                     if (result?.ok) {
                         receivedTriggers.delete(data.triggerId);
                     }
-                    // On failure, trigger stays — human can retry
                 });
             }
             return;
@@ -389,6 +438,11 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         rctx.shuttingDown = true;
         rctx.relay = null;
         rctx.setRelayStatus("Session expired");
+    });
+
+    // ── parent_delinked — parent started a new session ───────────────
+    sock.on("parent_delinked", (_data: any, ack?: (result: { ok: boolean }) => void) => {
+        handlers.onParentDelinked(ack);
     });
 
     sock.on("connect_error", (err) => {
@@ -412,13 +466,14 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
     });
 
     sock.on("disconnect", (_reason) => {
+        handlers.onDelinkDisconnect();
         rctx.relay = null;
         cancelPendingAskUserQuestion(rctx);
         cancelPendingPlanMode(rctx);
         rctx.setRelayStatus(rctx.disconnectedStatusText());
     });
 
-    // ── MCP OAuth relay context ───────────────────────────────────────────
+    // ── MCP OAuth relay context ───────────────────────────────────────
     sock.on("connect", () => updateMcpRelayContext(rctx));
     sock.on("disconnect", () => {
         const bridge = getMcpBridge();
@@ -445,8 +500,10 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
  * Cancels any pending ask-user-question / plan-mode prompts, clears the
  * message bus send function, and emits `session_end` before disconnecting.
  */
-export function disconnect(rctx: RelayContext): void {
+export function disconnect(rctx: RelayContext, handlers?: ConnectionHandlers): void {
     stopHeartbeat();
+    handlers?.onSocketTeardown();
+    handlers?.onDelinkDisconnect();
     cancelPendingAskUserQuestion(rctx);
     cancelPendingPlanMode(rctx);
     messageBus.setSendFn(null);

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -37,6 +37,7 @@ import { setTodoUpdateCallback, type TodoItem } from "../update-todo.js";
 import { getCurrentTodoList } from "../update-todo.js";
 import { setPlanModeChangeCallback } from "../plan-mode-toggle.js";
 import type { RemoteExecResponse } from "../remote-commands.js";
+import { clearAndCancelPendingTriggers } from "../triggers/extension.js";
 import type { ConversationTrigger } from "../triggers/types.js";
 import type { Socket } from "socket.io-client";
 import type { RelayClientToServerEvents, RelayServerToClientEvents } from "@pizzapi/protocol";
@@ -49,6 +50,10 @@ import { installFooter } from "../remote-footer.js";
 import { buildHeartbeat, stopHeartbeat } from "../remote-heartbeat.js";
 import { registerAskUserTool } from "../remote-ask-user.js";
 import { registerPlanModeTool } from "../remote-plan-mode.js";
+import { createTriggerWaitManager } from "../trigger-wait-manager.js";
+import { isCancelTriggerAction } from "../remote-trigger-response.js";
+import { evaluateDelinkChildrenAck, evaluateDelinkOwnParentAck } from "../remote-delink-retry.js";
+import { receivedTriggers } from "../triggers/extension.js";
 
 // ── Sub-modules ───────────────────────────────────────────────────────────────
 import { emitSessionActive, estimateMessagesSize, needsChunkedDelivery, capOversizedMessages, computeChunkBoundaries } from "./chunked-delivery.js";
@@ -61,6 +66,7 @@ export { estimateMessagesSize, needsChunkedDelivery, capOversizedMessages, compu
 
 const RELAY_DEFAULT = "ws://localhost:7492";
 const RELAY_STATUS_KEY = "relay";
+const TRIGGER_CANCELLATION_RETRY_INTERVAL_MS = 3_000;
 
 // ── Module-level state for external consumers ─────────────────────────────────
 let _ctx: RelayContext | null = null;
@@ -103,9 +109,205 @@ export function waitForRelayRegistration(timeoutMs: number = 10_000): Promise<vo
 export const remoteExtension: ExtensionFactory = (pi) => {
     // ── Orchestrator-local state (NOT in RelayContext) ─────────────────────
     let sessionCompleteFired = false;
+    // Set when /new fires so we can retry delink_children on reconnect if
+    // the initial emit is lost.  Cleared by the server ack callback.
+    let pendingDelink = false;
+    let pendingDelinkRetryTimer: ReturnType<typeof setTimeout> | null = null;
+    let pendingDelinkRetryEpoch: number | null = null;
+    let pendingDelinkEpoch: number | null = null;
+    const staleChildIds = new Set<string>();
+    let pendingDelinkOwnParent = false;
+    let pendingDelinkOwnParentRetryTimer: ReturnType<typeof setTimeout> | null = null;
+    let stalePrimaryParentId: string | null = null;
+    let pendingCancellations: Array<{ triggerId: string; childSessionId: string }> = [];
+    let pendingCancellationRetryTimer: ReturnType<typeof setInterval> | null = null;
+    let pendingCancellationRetryInFlight = false;
+    const triggerWaits = createTriggerWaitManager();
     let followUpGraceTimer: ReturnType<typeof setTimeout> | null = null;
+    let followUpGraceShutdown: (() => void) | null = null;
     let sessionNameSyncTimer: ReturnType<typeof setInterval> | null = null;
     let lastBroadcastSessionName: string | null = null;
+    let serverClockOffset = 0;
+
+    // ── delink_children emit helper ────────────────────────────────────────
+    const DELINK_RETRY_DELAY_MS = 3_000;
+
+    function clearPendingDelinkRetryTimer(epoch?: number | null): void {
+        if (pendingDelinkRetryTimer === null) return;
+        if (epoch !== undefined && epoch !== null && pendingDelinkRetryEpoch !== epoch) return;
+        clearTimeout(pendingDelinkRetryTimer);
+        pendingDelinkRetryTimer = null;
+        pendingDelinkRetryEpoch = null;
+    }
+
+    function emitDelinkChildren(rawEpoch: number): void {
+        if (!rctx.relay || !rctx.sioSocket?.connected) return;
+        rctx.sioSocket.emit("delink_children", {
+            token: rctx.relay.token,
+            epoch: rawEpoch + serverClockOffset,
+        }, (result: { ok: boolean; error?: string }) => {
+            const plan = evaluateDelinkChildrenAck({
+                ackEpoch: rawEpoch,
+                pendingEpoch: pendingDelinkEpoch,
+                retryEpoch: pendingDelinkRetryEpoch,
+                ok: result?.ok,
+                connected: Boolean(rctx.sioSocket?.connected),
+            });
+
+            if (plan.ignoreAck) {
+                console.log("pizzapi: ignoring stale delink_children ack (superseded by a later /new)");
+                if (plan.clearRetryTimer) clearPendingDelinkRetryTimer(rawEpoch);
+                return;
+            }
+
+            if (plan.scheduleRetry) {
+                console.log(`pizzapi: delink_children server error: ${result?.error ?? "unknown"} — scheduling retry in ${DELINK_RETRY_DELAY_MS}ms`);
+                if (plan.clearRetryTimer) clearPendingDelinkRetryTimer(rawEpoch);
+                pendingDelinkRetryEpoch = rawEpoch;
+                pendingDelinkRetryTimer = setTimeout(() => {
+                    pendingDelinkRetryTimer = null;
+                    pendingDelinkRetryEpoch = null;
+                    if (pendingDelinkEpoch === rawEpoch && rctx.sioSocket?.connected) {
+                        console.log("pizzapi: retrying delink_children after server error");
+                        emitDelinkChildren(rawEpoch);
+                    }
+                }, DELINK_RETRY_DELAY_MS);
+                return;
+            }
+
+            if (plan.clearRetryTimer) clearPendingDelinkRetryTimer(rawEpoch);
+            if (!plan.clearPendingDelink) return;
+            pendingDelink = false;
+            pendingDelinkEpoch = null;
+            staleChildIds.clear();
+            console.log("pizzapi: delink_children confirmed by server — retry guard cleared");
+        });
+    }
+
+    function clearPendingDelinkOwnParentRetryTimer(): void {
+        if (pendingDelinkOwnParentRetryTimer === null) return;
+        clearTimeout(pendingDelinkOwnParentRetryTimer);
+        pendingDelinkOwnParentRetryTimer = null;
+    }
+
+    function emitDelinkOwnParent(): void {
+        if (!pendingDelinkOwnParent || !rctx.relay || !rctx.sioSocket?.connected) return;
+        rctx.sioSocket.emit(
+            "delink_own_parent",
+            { token: rctx.relay.token, oldParentId: stalePrimaryParentId },
+            (result: { ok: boolean; error?: string }) => {
+                const plan = evaluateDelinkOwnParentAck({
+                    ok: result?.ok,
+                    pending: pendingDelinkOwnParent,
+                    connected: Boolean(rctx.sioSocket?.connected),
+                });
+
+                if (plan.confirmed) {
+                    clearPendingDelinkOwnParentRetryTimer();
+                    pendingDelinkOwnParent = false;
+                    stalePrimaryParentId = null;
+                    console.log("pizzapi: delink_own_parent confirmed by server");
+                    return;
+                }
+
+                if (!plan.scheduleRetry) return;
+                console.log(`pizzapi: delink_own_parent server error: ${result?.error ?? "unknown"} — scheduling retry in ${DELINK_RETRY_DELAY_MS}ms`);
+                clearPendingDelinkOwnParentRetryTimer();
+                pendingDelinkOwnParentRetryTimer = setTimeout(() => {
+                    pendingDelinkOwnParentRetryTimer = null;
+                    if (pendingDelinkOwnParent && rctx.sioSocket?.connected) {
+                        console.log("pizzapi: retrying delink_own_parent after server error");
+                        emitDelinkOwnParent();
+                    }
+                }, DELINK_RETRY_DELAY_MS);
+            },
+        );
+    }
+
+    // ── Cancellation retry loop ───────────────────────────────────────────
+
+    function stopPendingCancellationRetryLoop() {
+        if (pendingCancellationRetryTimer !== null) {
+            clearInterval(pendingCancellationRetryTimer);
+            pendingCancellationRetryTimer = null;
+        }
+        pendingCancellationRetryInFlight = false;
+    }
+
+    function startPendingCancellationRetryLoop() {
+        if (pendingCancellationRetryTimer !== null) return;
+        pendingCancellationRetryTimer = setInterval(() => {
+            void retryPendingTriggerCancellations("periodic");
+        }, TRIGGER_CANCELLATION_RETRY_INTERVAL_MS);
+    }
+
+    function retryPendingTriggerCancellations(reason: string) {
+        if (pendingCancellations.length === 0) {
+            stopPendingCancellationRetryLoop();
+            return;
+        }
+        if (!rctx.relay || !rctx.sioSocket?.connected) return;
+        if (pendingCancellationRetryInFlight) return;
+
+        pendingCancellationRetryInFlight = true;
+        const token = rctx.relay.token;
+        const cancellationsToRetry = [...pendingCancellations];
+        let successfulCancellations = 0;
+        let failedCancellations = 0;
+        let completedResponses = 0;
+        let finished = false;
+
+        const finishBatch = () => {
+            if (finished) return;
+            finished = true;
+            pendingCancellationRetryInFlight = false;
+            if (pendingCancellations.length === 0) {
+                stopPendingCancellationRetryLoop();
+            }
+        };
+
+        const timeout = setTimeout(() => {
+            if (finished) return;
+            const missing = cancellationsToRetry.length - completedResponses;
+            failedCancellations += missing;
+            console.log(`pizzapi: trigger cancellation retry timed out (${missing} ack callback(s) missing) — will retry`);
+            finishBatch();
+        }, 10_000);
+
+        console.log(`pizzapi: retrying ${cancellationsToRetry.length} deferred trigger cancellation(s) (${reason})`);
+
+        for (const { triggerId, childSessionId } of cancellationsToRetry) {
+            rctx.sioSocket.emit("trigger_response" as any, {
+                token,
+                triggerId,
+                response: "Parent started a new session — trigger cancelled.",
+                action: "cancel",
+                targetSessionId: childSessionId,
+            }, (result: { ok: boolean; error?: string }) => {
+                if (finished) return;
+                completedResponses++;
+
+                if (result?.ok) {
+                    successfulCancellations++;
+                    const index = pendingCancellations.findIndex(
+                        (c) => c.triggerId === triggerId && c.childSessionId === childSessionId,
+                    );
+                    if (index >= 0) {
+                        pendingCancellations.splice(index, 1);
+                    }
+                } else {
+                    failedCancellations++;
+                    console.log(`pizzapi: trigger cancellation failed for ${triggerId}: ${result?.error ?? "unknown"} — will retry`);
+                }
+
+                if (completedResponses === cancellationsToRetry.length) {
+                    clearTimeout(timeout);
+                    console.log(`pizzapi: trigger cancellation retry complete: ${successfulCancellations} succeeded, ${failedCancellations} failed`);
+                    finishBatch();
+                }
+            });
+        }
+    }
 
     // ── RelayContext creation ─────────────────────────────────────────────
     const rctx: RelayContext = {
@@ -276,34 +478,53 @@ export const remoteExtension: ExtensionFactory = (pi) => {
 
         waitForTriggerResponse(triggerId: string, timeoutMs: number, signal?: AbortSignal): Promise<TriggerResponse> {
             return new Promise<TriggerResponse>((resolve) => {
-                const timeout = setTimeout(() => {
+                const expectedParentSessionId = rctx.parentSessionId;
+                let settled = false;
+                let unregisterWait = () => {};
+
+                const finish = (result: TriggerResponse) => {
+                    if (settled) return;
+                    settled = true;
                     cleanup();
-                    resolve({ response: "Trigger timed out — no response from parent within 5 minutes.", cancelled: true });
+                    resolve(result);
+                };
+
+                const timeout = setTimeout(() => {
+                    finish({ response: "Trigger timed out — no response from parent within 5 minutes.", cancelled: true });
                 }, timeoutMs);
 
                 const handler = (data: { triggerId: string; response: string; action?: string }) => {
                     if (data.triggerId === triggerId) {
-                        cleanup();
-                        resolve({ response: data.response, action: data.action, cancelled: false });
+                        finish({
+                            response: data.response,
+                            action: data.action,
+                            cancelled: isCancelTriggerAction(data.action),
+                        });
                     }
                 };
 
                 const errorHandler = (data: { targetSessionId: string; error: string }) => {
-                    if (data.targetSessionId === rctx.parentSessionId) {
-                        cleanup();
-                        resolve({ response: `Trigger delivery failed: ${data.error}`, cancelled: true });
+                    if (expectedParentSessionId && data.targetSessionId === expectedParentSessionId) {
+                        finish({ response: `Trigger delivery failed: ${data.error}`, cancelled: true });
                     }
+                };
+
+                const abortHandler = () => {
+                    finish({ response: "Aborted", cancelled: true });
                 };
 
                 const cleanup = () => {
                     clearTimeout(timeout);
+                    unregisterWait();
                     rctx.sioSocket?.off("trigger_response" as any, handler);
                     rctx.sioSocket?.off("session_message_error" as any, errorHandler);
+                    signal?.removeEventListener("abort", abortHandler);
                 };
 
+                unregisterWait = triggerWaits.register(triggerId, finish);
                 rctx.sioSocket!.on("trigger_response" as any, handler);
                 rctx.sioSocket!.on("session_message_error" as any, errorHandler);
-                signal?.addEventListener("abort", () => { cleanup(); resolve({ response: "Aborted", cancelled: true }); });
+                signal?.addEventListener("abort", abortHandler);
             });
         },
     };
@@ -397,13 +618,26 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             clearTimeout(followUpGraceTimer);
             followUpGraceTimer = null;
         }
+        followUpGraceShutdown = null;
+    }
+
+    /** Trigger an immediate shutdown if the follow-up grace timer is running. */
+    function shutdownFollowUpGraceImmediately() {
+        if (followUpGraceShutdown) {
+            const shutdown = followUpGraceShutdown;
+            clearFollowUpGrace();
+            console.log("pizzapi: parent delinked while follow-up grace active — shutting down immediately");
+            shutdown();
+        }
     }
 
     function startFollowUpGrace(ctx: { shutdown: () => void }) {
         clearFollowUpGrace();
+        followUpGraceShutdown = ctx.shutdown;
         console.log(`pizzapi: waiting ${FOLLOWUP_GRACE_MS / 1000}s for parent follow-up before shutting down`);
         followUpGraceTimer = setTimeout(() => {
             followUpGraceTimer = null;
+            followUpGraceShutdown = null;
             console.log("pizzapi: follow-up grace period expired — shutting down");
             ctx.shutdown();
         }, FOLLOWUP_GRACE_MS);
@@ -438,13 +672,74 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     }
 
     // ── Connection wrappers ───────────────────────────────────────────────
-    // Wrap connect/disconnect with the factory-scoped handlers they need.
 
     const connectionHandlers: ConnectionHandlers = {
         clearFollowUpGrace,
         setModelFromWeb,
         sendUserMessage: (msg: unknown, opts?: { deliverAs?: "followUp" | "steer" }) =>
             pi.sendUserMessage(msg as any, opts),
+
+        // ── Delink handlers ───────────────────────────────────────────────
+        isPendingDelinkOwnParent: () => pendingDelinkOwnParent,
+        setServerClockOffset: (offset: number) => { serverClockOffset = offset; },
+        isStaleChild: (sessionId: string) => staleChildIds.has(sessionId),
+        getStalePrimaryParentId: () => stalePrimaryParentId,
+
+        onParentExplicitlyDelinked: () => {
+            const cancelledWaits = triggerWaits.cancelAll("Parent started a new session — trigger cancelled.");
+            if (cancelledWaits > 0) {
+                console.log(`pizzapi: parent explicitly delinked (wasDelinked) — cancelled ${cancelledWaits} pending trigger wait(s)`);
+            }
+            shutdownFollowUpGraceImmediately();
+            console.log(`pizzapi: parent explicitly delinked — clearing parent link permanently`);
+            rctx.parentSessionId = null;
+            rctx.isChildSession = false;
+        },
+
+        onParentTransientlyOffline: () => {
+            console.log(`pizzapi: parent temporarily offline (${rctx.parentSessionId}) — preserving parent link for reconnect`);
+            rctx.isChildSession = false;
+        },
+
+        onParentDelinked: (ack?: (result: { ok: boolean }) => void) => {
+            if (rctx.isChildSession) {
+                const cancelled = triggerWaits.cancelAll("Parent started a new session — trigger cancelled.");
+                console.log(`pizzapi: parent delinked — this session is no longer a child${cancelled > 0 ? ` — cancelled ${cancelled} pending trigger wait(s)` : ""}`);
+                rctx.parentSessionId = null;
+                rctx.isChildSession = false;
+                shutdownFollowUpGraceImmediately();
+            }
+            ack?.({ ok: true });
+        },
+
+        flushDeferredDelinks: () => {
+            if (pendingDelink && pendingDelinkEpoch !== null && rctx.sioSocket?.connected) {
+                emitDelinkChildren(pendingDelinkEpoch);
+                console.log("pizzapi: flushed deferred delink_children after reconnect");
+            }
+            if (pendingDelinkOwnParent && rctx.sioSocket?.connected) {
+                emitDelinkOwnParent();
+                console.log("pizzapi: flushed deferred delink_own_parent after reconnect");
+            }
+            if (pendingCancellations.length > 0 && rctx.sioSocket?.connected) {
+                startPendingCancellationRetryLoop();
+                retryPendingTriggerCancellations("registered");
+            }
+        },
+
+        onDelinkDisconnect: () => {
+            stopPendingCancellationRetryLoop();
+            clearPendingDelinkRetryTimer();
+            clearPendingDelinkOwnParentRetryTimer();
+        },
+
+        onSocketTeardown: () => {
+            stopPendingCancellationRetryLoop();
+        },
+
+        getParentSessionIdForRegister: () => {
+            return rctx.parentSessionId ?? (pendingDelinkOwnParent ? null : undefined);
+        },
     };
 
     function doConnect() {
@@ -452,7 +747,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     }
 
     function doDisconnect() {
-        disconnect(rctx);
+        disconnect(rctx, connectionHandlers);
     }
 
     // ── Session lifecycle events ──────────────────────────────────────────
@@ -476,10 +771,75 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         }
     });
 
-    pi.on("session_switch", (_event, ctx) => {
+    pi.on("session_switch", (event, ctx) => {
         rctx.latestCtx = ctx;
         rctx.sessionStartedAt = Date.now();
         rctx.isAgentActive = false;
+
+        // ── /new cleanup: cancel pending triggers and delink children ─────
+        if (event.reason === "new") {
+            staleChildIds.clear();
+            for (const entry of receivedTriggers.values()) {
+                staleChildIds.add(entry.sourceSessionId);
+            }
+            for (const { childSessionId } of pendingCancellations) {
+                staleChildIds.add(childSessionId);
+            }
+
+            const { cancelled, sent, failed } = clearAndCancelPendingTriggers(
+                (confirmedTriggerId, confirmedChildSessionId) => {
+                    const idx = pendingCancellations.findIndex(
+                        (c) => c.triggerId === confirmedTriggerId && c.childSessionId === confirmedChildSessionId,
+                    );
+                    if (idx >= 0) {
+                        pendingCancellations.splice(idx, 1);
+                        console.log(`pizzapi: trigger cancellation confirmed for ${confirmedTriggerId} — removed from retry queue`);
+                        if (pendingCancellations.length === 0) {
+                            stopPendingCancellationRetryLoop();
+                        }
+                    }
+                },
+            );
+            if (cancelled > 0) {
+                console.log(`pizzapi: cancelled ${cancelled} pending trigger(s) on session switch (${sent.length} sent-pending-ack, ${failed.length} deferred)`);
+            }
+
+            const allNeedingConfirmation = [...sent, ...failed];
+            if (allNeedingConfirmation.length > 0) {
+                pendingCancellations = [...pendingCancellations, ...allNeedingConfirmation];
+                for (const { childSessionId } of allNeedingConfirmation) {
+                    staleChildIds.add(childSessionId);
+                }
+                if (rctx.relay && rctx.sioSocket?.connected) {
+                    startPendingCancellationRetryLoop();
+                }
+            }
+
+            const rawDelinkEpoch = Date.now();
+            pendingDelink = true;
+            pendingDelinkEpoch = rawDelinkEpoch;
+            clearPendingDelinkRetryTimer();
+            if (rctx.relay && rctx.sioSocket?.connected) {
+                emitDelinkChildren(rawDelinkEpoch);
+            }
+
+            if (rctx.isChildSession) {
+                const cancelledChild = triggerWaits.cancelAll("Session switched — parent link cleared.");
+                console.log(`pizzapi: clearing own parent link on /new${cancelledChild > 0 ? ` — cancelled ${cancelledChild} pending trigger wait(s)` : ""}`);
+                pendingDelinkOwnParent = true;
+                clearPendingDelinkOwnParentRetryTimer();
+                stalePrimaryParentId = rctx.parentSessionId;
+                if (rctx.relay && rctx.sioSocket?.connected) {
+                    emitDelinkOwnParent();
+                }
+                rctx.parentSessionId = null;
+                rctx.isChildSession = false;
+                clearFollowUpGrace();
+            }
+        }
+
+        sessionCompleteFired = false;
+
         installFooter(rctx, ctx);
         startSessionNameSync();
         rctx.setRelayStatus(

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -697,8 +697,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         },
 
         onParentTransientlyOffline: () => {
-            console.log(`pizzapi: parent temporarily offline (${rctx.parentSessionId}) — preserving parent link for reconnect`);
-            rctx.isChildSession = false;
+            console.log(`pizzapi: parent temporarily offline (${rctx.parentSessionId}) — preserving parent link and child mode for reconnect`);
         },
 
         onParentDelinked: (ack?: (result: { ok: boolean }) => void) => {

--- a/packages/cli/src/extensions/trigger-wait-manager.test.ts
+++ b/packages/cli/src/extensions/trigger-wait-manager.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import { createTriggerWaitManager } from "./trigger-wait-manager.js";
+
+describe("createTriggerWaitManager", () => {
+    it("cancels all pending waits with the provided message", () => {
+        const manager = createTriggerWaitManager();
+        const results: Array<{ id: string; response: string; cancelled?: boolean }> = [];
+
+        manager.register("t1", (result) => results.push({ id: "t1", ...result }));
+        manager.register("t2", (result) => results.push({ id: "t2", ...result }));
+
+        expect(manager.size()).toBe(2);
+        expect(manager.cancelAll("Parent started a new session — trigger cancelled.")).toBe(2);
+        expect(manager.size()).toBe(0);
+        expect(results).toEqual([
+            { id: "t1", response: "Parent started a new session — trigger cancelled.", cancelled: true },
+            { id: "t2", response: "Parent started a new session — trigger cancelled.", cancelled: true },
+        ]);
+    });
+
+    it("unregisters individual waits", () => {
+        const manager = createTriggerWaitManager();
+        const results: Array<string> = [];
+
+        const unregister = manager.register("t1", () => results.push("t1"));
+        unregister();
+
+        expect(manager.size()).toBe(0);
+        expect(manager.cancelAll("ignored")).toBe(0);
+        expect(results).toEqual([]);
+    });
+});

--- a/packages/cli/src/extensions/trigger-wait-manager.ts
+++ b/packages/cli/src/extensions/trigger-wait-manager.ts
@@ -1,0 +1,31 @@
+import type { TriggerResponse } from "./remote-types.js";
+
+export interface TriggerWaitManager {
+    register(triggerId: string, cancel: (result: TriggerResponse) => void): () => void;
+    cancelAll(response: string): number;
+    size(): number;
+}
+
+export function createTriggerWaitManager(): TriggerWaitManager {
+    const waits = new Map<string, (result: TriggerResponse) => void>();
+
+    return {
+        register(triggerId: string, cancel: (result: TriggerResponse) => void) {
+            waits.set(triggerId, cancel);
+            return () => {
+                if (waits.get(triggerId) === cancel) waits.delete(triggerId);
+            };
+        },
+        cancelAll(response: string) {
+            const pending = [...waits.values()];
+            waits.clear();
+            for (const cancel of pending) {
+                cancel({ response, cancelled: true });
+            }
+            return pending.length;
+        },
+        size() {
+            return waits.size;
+        },
+    };
+}

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -21,6 +21,59 @@ const TRIGGER_TTL_MS = 10 * 60 * 1000; // 10 minutes
 /** Register a received trigger for response routing. Called by remote.ts on trigger receipt.
  *  If the triggerId is already tracked (e.g. after escalation re-delivers the same trigger),
  *  the original sourceSessionId is preserved so responses route back to the real child. */
+/**
+ * Clear all pending received triggers and optionally cancel them back to
+ * children via the relay. Called on /new to prevent stale triggers from
+ * the old session leaking into the new conversation.
+ *
+ * For each pending trigger that expects a response, sends a cancel
+ * trigger_response back to the child so it doesn't block waiting forever.
+ *
+ * Returns the triggers that were successfully cancelled (sent) and those that
+ * failed (relay socket was down at the time of /new).
+ */
+export function clearAndCancelPendingTriggers(
+    onConfirmed?: (triggerId: string, childSessionId: string) => void,
+): { cancelled: number; sent: Array<{ triggerId: string; childSessionId: string }>; failed: Array<{ triggerId: string; childSessionId: string }> } {
+    const conn = getRelaySocket();
+    const sent: Array<{ triggerId: string; childSessionId: string }> = [];
+    const failed: Array<{ triggerId: string; childSessionId: string }> = [];
+
+    for (const [triggerId, entry] of receivedTriggers) {
+        // Send a cancel response to children so they don't block.
+        if (conn) {
+            // Use an ack callback so we know the server received the cancel.
+            // If the socket drops before the ack arrives, the caller keeps the
+            // item in pendingCancellations and retries on the next reconnect.
+            // Only call onConfirmed once the server acknowledges the delivery —
+            // that's the signal to remove this item from the retry queue.
+            const capturedTriggerId = triggerId;
+            const capturedChildSessionId = entry.sourceSessionId;
+            conn.socket.emit("trigger_response" as any, {
+                token: conn.token,
+                triggerId: capturedTriggerId,
+                response: "Parent started a new session — trigger cancelled.",
+                action: "cancel",
+                targetSessionId: capturedChildSessionId,
+            }, (result: { ok: boolean; error?: string }) => {
+                if (result?.ok) {
+                    onConfirmed?.(capturedTriggerId, capturedChildSessionId);
+                }
+                // If !ok, the item stays in pendingCancellations for retry on reconnect.
+            });
+            // Mark as sent-pending-ack: caller should add to pendingCancellations
+            // so the retry path handles the case where the socket drops before the ack.
+            sent.push({ triggerId, childSessionId: entry.sourceSessionId });
+        } else {
+            failed.push({ triggerId, childSessionId: entry.sourceSessionId });
+        }
+    }
+
+    const count = receivedTriggers.size;
+    receivedTriggers.clear();
+    return { cancelled: count, sent, failed };
+}
+
 export function trackReceivedTrigger(triggerId: string, sourceSessionId: string, type: string): void {
     if (receivedTriggers.has(triggerId)) return; // preserve original source on re-delivery
     receivedTriggers.set(triggerId, { sourceSessionId, type, trackedAt: Date.now() });

--- a/packages/cli/src/extensions/triggers/new-session-cleanup.test.ts
+++ b/packages/cli/src/extensions/triggers/new-session-cleanup.test.ts
@@ -1,0 +1,188 @@
+// ============================================================================
+// new-session-cleanup.test.ts — Tests for trigger cleanup on /new (session switch)
+//
+// Verifies that clearAndCancelPendingTriggers():
+//   1. Clears all entries from receivedTriggers
+//   2. Sends cancel trigger_response to each child (with ack callback)
+//   3. Returns the correct count and trigger IDs
+//   4. Calls onConfirmed when the server acks the cancel (at-least-once delivery)
+// ============================================================================
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { trackReceivedTrigger, receivedTriggers, clearAndCancelPendingTriggers } from "./extension.js";
+
+// ── Mock the relay socket used by clearAndCancelPendingTriggers ──────────────
+// The function calls getRelaySocket() from ../remote.js. We mock at the module
+// level so the import inside extension.ts resolves to our mock.
+
+type AckCallback = (result: { ok: boolean; error?: string }) => void;
+
+let mockSocket: {
+    emitted: Array<{ event: string; data: unknown; ack?: AckCallback }>;
+    emit: (event: string, data: unknown, ack?: AckCallback) => void;
+} | null = null;
+
+let mockToken = "test-token-123";
+
+// Mock getRelaySocket to return our mock
+mock.module("../remote.js", () => ({
+    getRelaySocket: () =>
+        mockSocket
+            ? { socket: mockSocket, token: mockToken }
+            : null,
+    getRelaySessionId: () => "parent-session-1",
+}));
+
+describe("clearAndCancelPendingTriggers", () => {
+    beforeEach(() => {
+        receivedTriggers.clear();
+        const emitted: Array<{ event: string; data: unknown; ack?: AckCallback }> = [];
+        mockSocket = {
+            emitted,
+            emit(event: string, data: unknown, ack?: AckCallback) {
+                emitted.push({ event, data, ack });
+            },
+        };
+    });
+
+    it("clears all pending triggers", () => {
+        trackReceivedTrigger("t1", "child-1", "ask_user_question");
+        trackReceivedTrigger("t2", "child-2", "plan_review");
+        trackReceivedTrigger("t3", "child-3", "session_complete");
+
+        expect(receivedTriggers.size).toBe(3);
+
+        const result = clearAndCancelPendingTriggers();
+
+        expect(receivedTriggers.size).toBe(0);
+        expect(result.cancelled).toBe(3);
+        expect(result.sent).toHaveLength(3);
+        expect(result.sent.map((x) => x.triggerId)).toContain("t1");
+        expect(result.sent.map((x) => x.triggerId)).toContain("t2");
+        expect(result.sent.map((x) => x.triggerId)).toContain("t3");
+        expect(result.failed).toHaveLength(0);
+    });
+
+    it("sends cancel trigger_response to each child", () => {
+        trackReceivedTrigger("t1", "child-1", "ask_user_question");
+        trackReceivedTrigger("t2", "child-2", "plan_review");
+
+        clearAndCancelPendingTriggers();
+
+        expect(mockSocket!.emitted).toHaveLength(2);
+
+        // Verify cancel responses
+        for (const { event, data } of mockSocket!.emitted) {
+            expect(event).toBe("trigger_response");
+            const d = data as Record<string, unknown>;
+            expect(d.token).toBe(mockToken);
+            expect(d.action).toBe("cancel");
+            expect(d.response).toContain("new session");
+        }
+
+        // Verify correct routing to children
+        const targetIds = mockSocket!.emitted.map(
+            (e) => (e.data as Record<string, unknown>).targetSessionId,
+        );
+        expect(targetIds).toContain("child-1");
+        expect(targetIds).toContain("child-2");
+    });
+
+    it("attaches an ack callback to each emitted trigger_response", () => {
+        trackReceivedTrigger("t1", "child-1", "ask_user_question");
+        trackReceivedTrigger("t2", "child-2", "plan_review");
+
+        clearAndCancelPendingTriggers();
+
+        // Every emit should carry an ack callback so the server can confirm delivery.
+        for (const emitRecord of mockSocket!.emitted) {
+            expect(typeof emitRecord.ack).toBe("function");
+        }
+    });
+
+    it("calls onConfirmed when server acks with ok:true", () => {
+        trackReceivedTrigger("t1", "child-1", "ask_user_question");
+        trackReceivedTrigger("t2", "child-2", "plan_review");
+
+        const confirmed: Array<{ triggerId: string; childSessionId: string }> = [];
+        clearAndCancelPendingTriggers((triggerId, childSessionId) => {
+            confirmed.push({ triggerId, childSessionId });
+        });
+
+        // Simulate the server acking both cancels
+        for (const { ack } of mockSocket!.emitted) {
+            ack?.({ ok: true });
+        }
+
+        expect(confirmed).toHaveLength(2);
+        expect(confirmed.map((c) => c.triggerId)).toContain("t1");
+        expect(confirmed.map((c) => c.triggerId)).toContain("t2");
+        expect(confirmed.find((c) => c.triggerId === "t1")?.childSessionId).toBe("child-1");
+        expect(confirmed.find((c) => c.triggerId === "t2")?.childSessionId).toBe("child-2");
+    });
+
+    it("does NOT call onConfirmed when server acks with ok:false", () => {
+        trackReceivedTrigger("t1", "child-1", "ask_user_question");
+
+        const confirmed: Array<{ triggerId: string; childSessionId: string }> = [];
+        clearAndCancelPendingTriggers((triggerId, childSessionId) => {
+            confirmed.push({ triggerId, childSessionId });
+        });
+
+        // Simulate the server rejecting the cancel (delivery failure)
+        for (const { ack } of mockSocket!.emitted) {
+            ack?.({ ok: false, error: "session not found" });
+        }
+
+        // onConfirmed must NOT be called — the item stays in pendingCancellations for retry
+        expect(confirmed).toHaveLength(0);
+    });
+
+    it("does NOT call onConfirmed when no ack fires (socket dropped)", () => {
+        trackReceivedTrigger("t1", "child-1", "ask_user_question");
+
+        const confirmed: Array<{ triggerId: string; childSessionId: string }> = [];
+        clearAndCancelPendingTriggers((triggerId, childSessionId) => {
+            confirmed.push({ triggerId, childSessionId });
+        });
+
+        // Don't call any ack — simulates socket dropping before ack arrives
+        expect(confirmed).toHaveLength(0);
+    });
+
+    it("returns zero when no triggers are pending", () => {
+        const result = clearAndCancelPendingTriggers();
+        expect(result.cancelled).toBe(0);
+        expect(result.sent).toHaveLength(0);
+        expect(result.failed).toHaveLength(0);
+        expect(mockSocket!.emitted).toHaveLength(0);
+    });
+
+    it("works gracefully when relay is not connected", () => {
+        mockSocket = null; // simulate disconnected relay
+
+        trackReceivedTrigger("t1", "child-1", "ask_user_question");
+        trackReceivedTrigger("t2", "child-2", "session_complete");
+
+        // Should not throw, should still clear triggers
+        const result = clearAndCancelPendingTriggers();
+
+        expect(result.cancelled).toBe(2);
+        expect(result.sent).toHaveLength(0); // nothing sent due to disconnection
+        expect(result.failed).toHaveLength(2); // both triggers marked as failed
+        expect(receivedTriggers.size).toBe(0); // triggers cleared from map
+    });
+
+    it("includes the correct triggerId in each cancel response", () => {
+        trackReceivedTrigger("trigger-abc", "child-1", "ask_user_question");
+        trackReceivedTrigger("trigger-xyz", "child-2", "plan_review");
+
+        clearAndCancelPendingTriggers();
+
+        const triggerIds = mockSocket!.emitted.map(
+            (e) => (e.data as Record<string, unknown>).triggerId,
+        );
+        expect(triggerIds).toContain("trigger-abc");
+        expect(triggerIds).toContain("trigger-xyz");
+    });
+});

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -114,15 +114,23 @@ describe("pi-coding-agent patch application", () => {
 // ---------------------------------------------------------------------------
 
 describe("pi-coding-agent patched runtime behavior", () => {
-    test("createExtensionRuntime returns object with newSession/switchSession", async () => {
-        const { createExtensionRuntime } = await import(
-            piCodingAgentPath("dist/core/extensions/loader.js")
-        );
-        const runtime = createExtensionRuntime();
+    // The first dynamic import of loader.js is slow on cold start (the package
+    // is large and Bun's module resolver takes ~10-20s the first time in CI).
+    // Give it a generous timeout; subsequent tests in this describe block reuse
+    // the cached module and are fast.
+    test(
+        "createExtensionRuntime returns object with newSession/switchSession",
+        async () => {
+            const { createExtensionRuntime } = await import(
+                piCodingAgentPath("dist/core/extensions/loader.js")
+            );
+            const runtime = createExtensionRuntime();
 
-        expect(typeof runtime.newSession).toBe("function");
-        expect(typeof runtime.switchSession).toBe("function");
-    });
+            expect(typeof runtime.newSession).toBe("function");
+            expect(typeof runtime.switchSession).toBe("function");
+        },
+        30_000,
+    );
 
     test("runtime.newSession rejects before initialization", async () => {
         const { createExtensionRuntime } = await import(

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -84,6 +84,24 @@ export interface RelayClientToServerEvents {
     token: string;
     childSessionId: string;
   }, ack?: (result: { ok: boolean; error?: string }) => void) => void;
+
+  /** Parent requests delinking of all child sessions (e.g. on /new).
+   *  The server clears child→parent links and notifies children their parent is gone. */
+  delink_children: (data: {
+    token: string;
+    epoch?: number;
+  }, ack?: (result: { ok: boolean; error?: string }) => void) => void;
+
+  /** Child requests severing its own parent link (e.g. on /new).
+   *  The server removes the child from the parent's children set and clears
+   *  parentSessionId on the child's Redis session hash. */
+  delink_own_parent: (data: {
+    token: string;
+    /** Old parent session ID captured before clearing rctx.parentSessionId.
+     *  Used by the server to scrub stale children-set entries when
+     *  parentSessionId is already null in Redis (e.g. /new while disconnected). */
+    oldParentId?: string | null;
+  }, ack?: (result: { ok: boolean; error?: string }) => void) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -100,6 +118,14 @@ export interface RelayServerToClientEvents {
     collabMode: boolean;
     /** Confirmed parent session ID (null if not a child session). */
     parentSessionId?: string | null;
+    /** Server wall-clock time (ms since epoch) for clock-offset calculation. */
+    serverTime?: number;
+    /**
+     * True when parentSessionId is null because the parent explicitly delinked
+     * this child (ran /new). Absent or false for transient parent-offline cases.
+     * The client uses this to distinguish "permanent delink" from "retry later".
+     */
+    wasDelinked?: boolean;
   }) => void;
 
   /** Acknowledges receipt of an event with its sequence number */
@@ -165,12 +191,21 @@ export interface RelayServerToClientEvents {
   trigger_response: (data: {
     triggerId: string;
     response: string;
+    action?: string;
   }) => void;
 
   /** Notifies that a session has expired */
   session_expired: (data: {
     sessionId: string;
   }) => void;
+
+  /** Notifies a child that its parent has delinked (e.g. started a new session).
+   *  Children receiving this should cancel any pending triggers awaiting a parent response.
+   *  The optional ack lets the server confirm delivery before acknowledging the
+   *  parent's delink_children request. */
+  parent_delinked: (data: {
+    parentSessionId: string;
+  }, ack?: (result: { ok: boolean }) => void) => void;
 
   /** Generic error */
   error: (data: {

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -19,6 +19,8 @@ import {
     getLocalTuiSocket,
     getLocalRunnerSocket,
     emitToRelaySession,
+    emitToRelaySessionVerified,
+    emitToRelaySessionAwaitingAck,
     emitToRunner,
     updateSessionState,
     updateSessionHeartbeat,
@@ -36,6 +38,18 @@ import {
     clearPushPendingQuestion,
     deleteRunnerAssociation,
     removeChildSession,
+    removeChildren,
+    addPendingParentDelinkChildren,
+    getChildSessions,
+    getPendingParentDelinkChildren,
+    removePendingParentDelinkChild,
+    isPendingParentDelinkChild,
+    getSession,
+    markChildAsDelinked,
+    isChildDelinked,
+    isChildOfParent,
+    refreshChildSessionsTTL,
+    clearParentSessionId,
 } from "../sio-state.js";
 import {
     notifyAgentFinished,
@@ -309,7 +323,7 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             const isEphemeral = data.ephemeral !== false;
             const collabMode = data.collabMode !== false;
 
-            const { sessionId, token, shareUrl, parentSessionId } = await registerTuiSession(socket, cwd, {
+            const { sessionId, token, shareUrl, parentSessionId, wasDelinked } = await registerTuiSession(socket, cwd, {
                 sessionId: data.sessionId,
                 isEphemeral,
                 collabMode,
@@ -331,6 +345,12 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 isEphemeral,
                 collabMode,
                 parentSessionId,
+                // Server wall-clock time — lets the client compute
+                // clock offset for accurate epoch-based delink filtering.
+                serverTime: Date.now(),
+                // Only include wasDelinked when it is true to keep the payload
+                // minimal for non-child or non-delinked sessions.
+                ...(wasDelinked ? { wasDelinked: true } : {}),
             });
         });
 
@@ -547,6 +567,41 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 return;
             }
 
+            // Block messages from delinked children. If the sender's session
+            // still carries a parentSessionId pointing at the target (i.e. it
+            // was a linked child), but the target has already delinked it via
+            // /new, reject the message so stale children can't inject traffic
+            // into the parent's new conversation.
+            if (senderSession.parentSessionId === targetSessionId) {
+                const stillLinked = await isChildOfParent(targetSessionId, sessionId);
+                if (!stillLinked) {
+                    socket.emit("session_message_error", {
+                        targetSessionId,
+                        error: "Sender is no longer a child of the target session",
+                    });
+                    return;
+                }
+            }
+
+            // Block stale parent→child traffic. deliverAs:"input" always
+            // requires a live parent→child link (used by tell_child and
+            // session_complete follow-up). Plain session_message (used by
+            // send_message) is also blocked when the target's parentSessionId
+            // still names the sender — the parent may have run /new and
+            // delinked this child, so the old parent's plain messages must not
+            // reach the child's brand-new conversation either.
+            const isParentToChildTraffic = data.deliverAs === "input" || targetSession.parentSessionId === sessionId;
+            if (isParentToChildTraffic) {
+                const targetIsChild = await isChildOfParent(sessionId, targetSessionId);
+                if (!targetIsChild) {
+                    socket.emit("session_message_error", {
+                        targetSessionId,
+                        error: "Target session is not a child of the sender",
+                    });
+                    return;
+                }
+            }
+
             const targetSocket = getLocalTuiSocket(targetSessionId);
             if (!targetSocket) {
                 socket.emit("session_message_error", {
@@ -615,6 +670,31 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 return;
             }
 
+            if (targetSessionId !== sessionId && await isPendingParentDelinkChild(targetSessionId, sessionId)) {
+                socket.emit("session_message_error", {
+                    targetSessionId,
+                    error: "Sender is currently being delinked from the target session",
+                });
+                return;
+            }
+
+            // Reject triggers from sessions that are no longer children of the target.
+            // This closes a race window after delink_children: a connected child that
+            // emits session_trigger before it processes parent_delinked could otherwise
+            // inject a stale trigger into the parent's new conversation.
+            // Self-triggers (escalations) are explicitly excluded.
+            if (targetSessionId !== sessionId) {
+                const senderIsChild = await isChildOfParent(targetSessionId, sessionId);
+                if (!senderIsChild) {
+                    socket.emit("session_message_error", {
+                        targetSessionId,
+                        error: "Sender is no longer a child of the target session",
+                    });
+                    return;
+                }
+                await refreshChildSessionsTTL(targetSessionId);
+            }
+
             const targetSocket = getLocalTuiSocket(targetSessionId);
             if (!targetSocket) {
                 socket.emit("session_message_error", {
@@ -650,16 +730,18 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             response: string;
             action?: string;
             targetSessionId: string;
-        }) => {
+        }, ack: ((result: { ok: boolean; error?: string }) => void) | undefined) => {
             const { triggerId, response, action, targetSessionId } = data ?? {};
             if (!triggerId || !response || !targetSessionId) {
                 socket.emit("error", { message: "trigger_response requires triggerId, response, and targetSessionId" });
+                if (typeof ack === "function") ack({ ok: false, error: "Missing required fields" });
                 return;
             }
 
             // Validate sender is authenticated and token matches
             if (!socket.data.sessionId || data?.token !== socket.data.token) {
                 socket.emit("error", { message: "Invalid token" });
+                if (typeof ack === "function") ack({ ok: false, error: "Invalid token" });
                 return;
             }
 
@@ -668,6 +750,7 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             const targetSession = await getSharedSession(targetSessionId);
             if (!senderSession?.userId || !targetSession?.userId || senderSession.userId !== targetSession.userId) {
                 socket.emit("error", { message: "Target session belongs to a different user" });
+                if (typeof ack === "function") ack({ ok: false, error: "Target session belongs to a different user" });
                 return;
             }
 
@@ -680,26 +763,34 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             const isParentOfTarget = targetSession.parentSessionId === socket.data.sessionId;
             if (!isParentOfTarget) {
                 socket.emit("error", { message: "Sender is not the parent of the target session" });
+                if (typeof ack === "function") ack({ ok: false, error: "Sender is not the parent of the target session" });
                 return;
             }
 
             const triggerPayload = { triggerId, response, ...(action ? { action } : {}) };
-            // Try local socket first, fall back to relay room for cross-node delivery
+            // Try local socket first, then verified room delivery for cross-node
+            // routing. We only ack success when at least one relay recipient is
+            // actually present.
             const targetSocket = getLocalTuiSocket(targetSessionId);
-            if (targetSocket) {
+            if (targetSocket?.connected) {
                 try {
                     targetSocket.emit("trigger_response" as any, triggerPayload);
+                    if (typeof ack === "function") ack({ ok: true });
                 } catch {
                     socket.emit("session_message_error", {
                         targetSessionId,
                         error: "Failed to deliver trigger response to target session",
                     });
+                    if (typeof ack === "function") ack({ ok: false, error: "Failed to deliver trigger response to target session" });
                 }
-            } else if (!emitToRelaySession(targetSessionId, "trigger_response", triggerPayload)) {
+            } else if (!await emitToRelaySessionVerified(targetSessionId, "trigger_response", triggerPayload)) {
                 socket.emit("session_message_error", {
                     targetSessionId,
                     error: `Target session ${targetSessionId} is not connected`,
                 });
+                if (typeof ack === "function") ack({ ok: false, error: `Target session ${targetSessionId} is not connected` });
+            } else {
+                if (typeof ack === "function") ack({ ok: true });
             }
         });
 
@@ -797,6 +888,193 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             }
         });
 
+        // ── delink_children — parent severs all child links (e.g. on /new) ─
+        socket.on("delink_children", async (data, ack?: (result: { ok: boolean; error?: string }) => void) => {
+            const sessionId = socket.data.sessionId;
+            if (!sessionId || data?.token !== socket.data.token) {
+                socket.emit("error", { message: "Invalid token" });
+                if (typeof ack === "function") ack({ ok: false, error: "Invalid token" });
+                return;
+            }
+
+            // Optional epoch (ms): when provided, only delink children whose
+            // startedAt is before this timestamp.  Used by deferred delinks
+            // (sent on reconnect after /new while disconnected) to avoid
+            // inadvertently delinking children spawned during the disconnect
+            // window.
+            const epoch: number | undefined =
+                typeof data.epoch === "number" && data.epoch > 0 ? data.epoch : undefined;
+
+            console.log(`[sio/relay] delink_children: parent=${sessionId}${epoch ? ` epoch=${new Date(epoch).toISOString()}` : ""}`);
+
+            try {
+                // Snapshot current children plus any children whose
+                // parent_delinked delivery previously timed out. The pending
+                // retry set preserves recipients across delink_children retries
+                // even after we have already removed them from the membership set.
+                const [currentChildIds, pendingRetryChildIds] = await Promise.all([
+                    getChildSessions(sessionId),
+                    getPendingParentDelinkChildren(sessionId),
+                ]);
+                let childIds = Array.from(new Set([...currentChildIds, ...pendingRetryChildIds]));
+
+                // If an epoch was provided, filter out children that registered
+                // after the epoch — they belong to the new conversation and must
+                // not be delinked. However, children with existing delink markers
+                // are stale and should be included even if their startedAt > epoch
+                // (this handles the case where a stale child reconnected and got a
+                // fresh startedAt timestamp).
+                if (epoch && childIds.length > 0) {
+                    const filtered: string[] = [];
+                    for (const childId of childIds) {
+                        const childSession = await getSession(childId);
+                        if (!childSession?.startedAt) {
+                            // No session data — conservative: include it
+                            filtered.push(childId);
+                            continue;
+                        }
+                        const startedAtMs = new Date(childSession.startedAt).getTime();
+                        if (startedAtMs <= epoch) {
+                            filtered.push(childId);
+                        } else {
+                            // Child started after epoch, but check if it already has a delink marker.
+                            // If it does, it's a stale child that reconnected and should be delinked
+                            // regardless of its fresh startedAt timestamp.
+                            const hasDelinkMarker = await isChildDelinked(childId);
+                            if (hasDelinkMarker) {
+                                filtered.push(childId);
+                                console.log(`[sio/relay] delink_children: including child ${childId} (startedAt > epoch but has delink marker)`);
+                            } else {
+                                console.log(`[sio/relay] delink_children: skipping child ${childId} (startedAt=${childSession.startedAt} > epoch)`);
+                            }
+                        }
+                    }
+                    childIds = filtered;
+                }
+
+                // Write delink markers BEFORE clearing the membership set. This
+                // closes a race window: if a child reconnects between the snapshot
+                // and the clear, registerTuiSession's isChildDelinked() check will
+                // already find the marker and refuse to re-link. If we cleared
+                // first and wrote markers second, a reconnecting child could slip
+                // through before its marker exists.
+                for (const childId of childIds) {
+                    await markChildAsDelinked(childId);
+                }
+                await addPendingParentDelinkChildren(sessionId, childIds);
+
+                // Remove only the snapshotted children from the membership set.
+                // Using removeChildren() instead of clearAllChildren() avoids a
+                // race: if the parent spawns a new child between the snapshot and
+                // this removal, the new child's membership is preserved.
+                await removeChildren(sessionId, childIds);
+
+                // Notify each connected child that their parent is gone.
+                // This lets children cancel any pending triggers awaiting a response.
+                //
+                // NOTE: We intentionally do NOT clear parentSessionId in Redis here.
+                // Doing so races with any in-flight trigger_response(cancel) messages
+                // that clearAndCancelPendingTriggers() emitted just before this event.
+                // The trigger_response handler checks targetSession.parentSessionId; if
+                // we clear it concurrently, the check fails with "Sender is not the
+                // parent" and the child is left blocked until its 5-minute timeout.
+                //
+                // Instead, parentSessionId is cleaned up lazily: registerTuiSession
+                // checks isChildDelinked() on reconnect and clears the stale field
+                // then (see sio-registry.ts).  For connected children, the parent_delinked
+                // event causes rctx.parentSessionId = null so reconnects won't re-link.
+                // For offline children (who never received parent_delinked), the marker
+                // we just wrote above prevents re-link.
+                for (const childId of childIds) {
+                    const payload = { parentSessionId: sessionId };
+                    const delivery = await emitToRelaySessionAwaitingAck(childId, "parent_delinked", payload);
+                    if (delivery.hadListeners && !delivery.acked) {
+                        throw new Error(`parent_delinked delivery was not confirmed for child ${childId}`);
+                    }
+                    // Offline children are safe to clear from the retry set too:
+                    // their delink marker will prevent re-linking on reconnect.
+                    await removePendingParentDelinkChild(sessionId, childId);
+                }
+
+                // Acknowledge that the delink completed only after every
+                // connected child has confirmed parent_delinked delivery. The
+                // client uses this to clear its pendingDelink retry guard —
+                // until the ack arrives, it keeps blocking stale child
+                // session_message / session_trigger traffic from reaching the
+                // new conversation.
+                if (typeof ack === "function") ack({ ok: true });
+            } catch (err) {
+                console.error(`[sio/relay] delink_children failed for parent=${sessionId}:`, err);
+                // Always nack so the client can clear its pendingDelink guard
+                // and retry on reconnect rather than latching permanently.
+                if (typeof ack === "function") ack({ ok: false, error: String(err) });
+            }
+        });
+
+        // ── delink_own_parent — child severs its own parent link (e.g. on /new) ─
+        // When a child session starts /new, it clears its local parent link
+        // but the server still has the association. This event lets the child
+        // tell the server to remove itself from the old parent's children set
+        // and clear the parentSessionId on its own Redis session hash.
+        socket.on("delink_own_parent", async (data, ack: ((result: { ok: boolean; error?: string }) => void) | undefined) => {
+            const sessionId = socket.data.sessionId;
+            if (!sessionId || data?.token !== socket.data.token) {
+                socket.emit("error", { message: "Invalid token" });
+                if (typeof ack === "function") ack({ ok: false, error: "Invalid token" });
+                return;
+            }
+
+            const session = await getSharedSession(sessionId);
+            const parentId = session?.parentSessionId;
+            if (!parentId) {
+                // parentSessionId is already cleared in Redis (e.g. the child
+                // ran /new while the relay socket was down, so
+                // registerTuiSession wrote null before this event arrived).
+                // If the client supplied the old parent ID it captured before
+                // clearing rctx.parentSessionId, use it to scrub the stale
+                // children-set entry that the disconnect path deliberately
+                // left behind to avoid a /new race window.
+                const oldParentId = typeof data?.oldParentId === "string" ? data.oldParentId : null;
+                if (oldParentId) {
+                    console.log(
+                        `[sio/relay] delink_own_parent: child=${sessionId} parentSessionId already cleared — removing stale child entry from parent=${oldParentId}`,
+                    );
+                    try {
+                        await removeChildSession(oldParentId, sessionId);
+                    } catch (err) {
+                        console.error("[sio/relay] delink_own_parent: failed to remove stale child entry:", err);
+                        if (typeof ack === "function") ack({ ok: false, error: err instanceof Error ? err.message : String(err) });
+                        return;
+                    }
+                }
+                // Already delinked or never linked — confirm success so the
+                // client stops retrying.
+                if (typeof ack === "function") ack({ ok: true });
+                return;
+            }
+
+            console.log(`[sio/relay] delink_own_parent: child=${sessionId} parent=${parentId}`);
+
+            // Clear our own parentSessionId FIRST — this closes the race
+            // window where a stale ack/followUp/cleanup_child_session from
+            // the old parent could still see parentSessionId === oldParent
+            // and authorize operations against this now-independent session.
+            // Then remove ourselves from the parent's children set.
+            // Both writes are atomic enough for our purposes; if either
+            // throws, ack failure so the client retries on next reconnect.
+            try {
+                await clearParentSessionId(sessionId);
+                await removeChildSession(parentId, sessionId);
+            } catch (err) {
+                console.error("[sio/relay] delink_own_parent: Redis write failed:", err);
+                if (typeof ack === "function") ack({ ok: false, error: err instanceof Error ? err.message : String(err) });
+                return;
+            }
+
+            // Acknowledge success so the client can clear its retry flag.
+            if (typeof ack === "function") ack({ ok: true });
+        });
+
         // ── disconnect ───────────────────────────────────────────────────────
         socket.on("disconnect", async (reason) => {
             console.log(`[sio/relay] disconnected: ${socket.id} (${reason})`);
@@ -816,11 +1094,15 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 clearThinkingMaps(sessionId);
                 pendingChunkedStates.delete(sessionId);
                 void clearPushPendingQuestion(sessionId);
-                // Clean up child-index entry so stale memberships don't persist
-                const session = await getSharedSession(sessionId);
-                if (session?.parentSessionId) {
-                    void removeChildSession(session.parentSessionId, sessionId);
-                }
+                // NOTE: We intentionally do NOT remove the child from the
+                // parent's children set here.  Doing so races with
+                // delink_children: if the child disconnects before the parent
+                // fires /new, delink_children's getChildSessions() snapshot
+                // won't include it and no delink marker will be written.  When
+                // the child reconnects, registerTuiSession() would re-link it
+                // to the parent's new conversation.  Leaving the membership in
+                // place is harmless — delink_children will clean it up, and
+                // stale entries are pruned when the session key expires.
                 await endSharedSession(sessionId);
             }
             socketAckedSeqs.delete(socket.id);

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -760,7 +760,13 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             // respond with trigger_response to children. Allowing child→parent
             // would let a sibling session inject responses into another child's
             // pending trigger through the parent's forwarding handler.
-            const isParentOfTarget = targetSession.parentSessionId === socket.data.sessionId;
+            //
+            // Fall back to the children membership set when the child's session
+            // hash has parentSessionId=null because the parent was transiently
+            // offline during the child's last reconnect (Fix #3: the set membership
+            // is preserved by addChildSessionMembership in that path).
+            const isParentOfTarget = targetSession.parentSessionId === socket.data.sessionId
+                || await isChildOfParent(socket.data.sessionId, targetSessionId);
             if (!isParentOfTarget) {
                 socket.emit("error", { message: "Sender is not the parent of the target session" });
                 if (typeof ack === "function") ack({ ok: false, error: "Sender is not the parent of the target session" });
@@ -818,7 +824,11 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 return;
             }
 
-            if (childSession.parentSessionId !== sessionId) {
+            // Same fallback as trigger_response: when the child's parentSessionId
+            // was cleared during a transient-offline reconnect, check set membership.
+            const isParentOfChild = childSession.parentSessionId === sessionId
+                || await isChildOfParent(sessionId, childSessionId);
+            if (!isParentOfChild) {
                 socket.emit("error", { message: "Sender is not the parent of the target session" });
                 if (typeof ack === "function") ack({ ok: false, error: "Sender is not the parent of the target session" });
                 return;
@@ -959,7 +969,10 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 // first and wrote markers second, a reconnecting child could slip
                 // through before its marker exists.
                 for (const childId of childIds) {
-                    await markChildAsDelinked(childId);
+                    // Store the parent session ID in the marker so that
+                    // addChildSession can scrub the child from this parent's
+                    // pending-delink retry set when the child is re-linked elsewhere.
+                    await markChildAsDelinked(childId, sessionId);
                 }
                 await addPendingParentDelinkChildren(sessionId, childIds);
 

--- a/packages/server/src/ws/sio-registry.delink.test.ts
+++ b/packages/server/src/ws/sio-registry.delink.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "bun:test";
+import { emitToRelaySessionAwaitingAck, initSioRegistry } from "./sio-registry.js";
+import { severStaleParentLink } from "./stale-parent-link.js";
+
+describe("sio-registry delink helpers", () => {
+    it("waits for stale-child removal before reporting the child as unlinked", async () => {
+        const calls: string[] = [];
+        let sawRemoveChild = false;
+        let resolveRemoveChild: () => void = () => {
+            throw new Error("removeChildSession was not awaited");
+        };
+
+        const promise = severStaleParentLink({
+            parentSessionId: "parent-1",
+            childSessionId: "child-1",
+            clearParentField: true,
+            clearParentSessionId: async () => {
+                calls.push("clear-parent");
+            },
+            removeChildSession: async () => {
+                sawRemoveChild = true;
+                calls.push("remove-child:start");
+                await new Promise<void>((resolve) => {
+                    resolveRemoveChild = () => {
+                        calls.push("remove-child:done");
+                        resolve();
+                    };
+                });
+            },
+        });
+
+        let resolved = false;
+        promise.then(() => {
+            resolved = true;
+        });
+
+        await Promise.resolve();
+        expect(calls).toEqual(["clear-parent", "remove-child:start"]);
+        expect(resolved).toBe(false);
+
+        if (!sawRemoveChild) throw new Error("removeChildSession was not awaited");
+        resolveRemoveChild();
+        await promise;
+
+        expect(calls).toEqual(["clear-parent", "remove-child:start", "remove-child:done"]);
+        expect(resolved).toBe(true);
+    });
+
+    it("confirms parent_delinked delivery when a relay socket acks", async () => {
+        const relayNamespace = {
+            in: (_room: string) => ({
+                fetchSockets: async () => [{ id: "socket-1" }],
+            }),
+            to: (_room: string) => ({
+                timeout: (_timeoutMs: number) => ({
+                    emit: (_eventName: string, _data: unknown, ack: (err: unknown, responses?: unknown[]) => void) => {
+                        ack(null, [{ ok: true }]);
+                    },
+                }),
+            }),
+        };
+
+        initSioRegistry({
+            of: () => relayNamespace,
+        } as any);
+
+        await expect(emitToRelaySessionAwaitingAck("child-1", "parent_delinked", { parentSessionId: "parent-1" })).resolves.toEqual({
+            hadListeners: true,
+            acked: true,
+        });
+    });
+
+    it("reports failure when listeners exist but none ack parent_delinked", async () => {
+        const relayNamespace = {
+            in: (_room: string) => ({
+                fetchSockets: async () => [{ id: "socket-1" }],
+            }),
+            to: (_room: string) => ({
+                timeout: (_timeoutMs: number) => ({
+                    emit: (_eventName: string, _data: unknown, ack: (err: unknown, responses?: unknown[]) => void) => {
+                        ack(new Error("timeout"), []);
+                    },
+                }),
+            }),
+        };
+
+        initSioRegistry({
+            of: () => relayNamespace,
+        } as any);
+
+        await expect(emitToRelaySessionAwaitingAck("child-1", "parent_delinked", { parentSessionId: "parent-1" })).resolves.toEqual({
+            hadListeners: true,
+            acked: false,
+        });
+    });
+});

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -193,6 +193,46 @@ export function safeJsonParse(value: string): any {
     }
 }
 
+/**
+ * Emit an event to a relay session room and wait for the first ack callback.
+ * Returns { hadListeners: true, acked: true } if at least one socket acknowledged.
+ * Used for delivery-critical paths like parent_delinked where the caller needs
+ * to know whether the target actually processed the event.
+ */
+export async function emitToRelaySessionAwaitingAck(
+    sessionId: string,
+    eventName: string,
+    data: unknown,
+    timeoutMs: number = 1_000,
+): Promise<{ hadListeners: boolean; acked: boolean }> {
+    if (!io) return { hadListeners: false, acked: false };
+    const room = relaySessionRoom(sessionId);
+    try {
+        const sockets = await io.of("/relay").in(room).fetchSockets();
+        if (sockets.length === 0) return { hadListeners: false, acked: false };
+
+        const relayNs = io.of("/relay") as any;
+        const responses = await new Promise<unknown[]>((resolve, reject) => {
+            relayNs.to(room).timeout(timeoutMs).emit(eventName, data, (err: unknown, ackResponses: unknown[] = []) => {
+                if (Array.isArray(ackResponses) && ackResponses.length > 0) {
+                    resolve(ackResponses);
+                    return;
+                }
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve([]);
+            });
+        });
+
+        return { hadListeners: true, acked: responses.length > 0 };
+    } catch (err) {
+        console.warn("[sio-registry] emitToRelaySessionAwaitingAck failed:", (err as Error)?.message);
+        return { hadListeners: true, acked: false };
+    }
+}
+
 /** Extract a ModelInfo from a raw heartbeat payload (or return null). */
 export function modelFromHeartbeat(rawHeartbeat: unknown): ModelInfo | null {
     const rawModel = (rawHeartbeat as any)?.model;

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -5,7 +5,7 @@
 // existing callers continue importing from `../sio-registry.js` unchanged.
 // ============================================================================
 
-export { initSioRegistry, emitToRunner, emitToRelaySession, emitToRelaySessionVerified } from "./context.js";
+export { initSioRegistry, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionAwaitingAck } from "./context.js";
 export { broadcastToHub, addHubClient, removeHubClient } from "./hub.js";
 export type { RegisterTuiSessionOpts } from "./sessions.js";
 export {

--- a/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ── Minimal Redis mock (mirrors sio-state-children.test.ts) ─────────────────
+
+const store = new Map<string, string>();
+const setStore = new Map<string, Set<string>>();
+const ttlStore = new Map<string, number>();
+
+const mockMulti = () => {
+    const ops: Array<() => void> = [];
+    return {
+        hSet: mock((key: string, fields: Record<string, string>) => {
+            ops.push(() => {
+                for (const [k, v] of Object.entries(fields)) {
+                    store.set(`${key}:${k}`, v);
+                }
+                const existing = JSON.parse(store.get(`__hash__:${key}`) ?? "{}");
+                Object.assign(existing, fields);
+                store.set(`__hash__:${key}`, JSON.stringify(existing));
+            });
+            return mockMulti();
+        }),
+        sAdd: mock((key: string, ...members: string[]) => {
+            ops.push(() => {
+                const s = setStore.get(key) ?? new Set();
+                for (const m of members.flat()) s.add(m);
+                setStore.set(key, s);
+            });
+            return mockMulti();
+        }),
+        sRem: mock((key: string, ...members: string[]) => {
+            ops.push(() => {
+                const s = setStore.get(key);
+                if (s) for (const m of members.flat()) s.delete(m);
+            });
+            return mockMulti();
+        }),
+        expire: mock((key: string, ttl: number) => {
+            ops.push(() => ttlStore.set(key, ttl));
+            return mockMulti();
+        }),
+        del: mock((key: string) => {
+            ops.push(() => store.delete(key));
+            return mockMulti();
+        }),
+        exec: mock(async () => {
+            for (const op of ops) op();
+            return ops.map(() => "OK");
+        }),
+    };
+};
+
+const mockRedis = {
+    isOpen: true,
+    sAdd: mock(async (key: string, ...members: string[]) => {
+        const s = setStore.get(key) ?? new Set();
+        for (const m of members.flat()) s.add(m);
+        setStore.set(key, s);
+    }),
+    sMembers: mock(async (key: string) => {
+        return Array.from(setStore.get(key) ?? []);
+    }),
+    sRem: mock(async (key: string, ...members: string[]) => {
+        const s = setStore.get(key);
+        if (s) for (const m of members.flat()) s.delete(m);
+    }),
+    sIsMember: mock(async (key: string, member: string) => {
+        return setStore.get(key)?.has(member) ?? false;
+    }),
+    expire: mock(async (key: string, ttl: number) => {
+        ttlStore.set(key, ttl);
+    }),
+    multi: mock(() => mockMulti()),
+    on: mock(() => mockRedis),
+    connect: mock(async () => {}),
+    // String key store
+    set: mock(async (key: string, value: string, _opts?: unknown) => {
+        store.set(key, value);
+    }),
+    get: mock(async (key: string) => store.get(key) ?? null),
+    del: mock(async (key: string) => {
+        store.delete(key);
+        setStore.delete(key);
+        ttlStore.delete(key);
+    }),
+    exists: mock(async (key: string) => (store.has(key) ? 1 : 0)),
+    hGetAll: mock(async (key: string) => {
+        const raw = store.get(`__hash__:${key}`);
+        return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+    }),
+    hGet: mock(async () => null),
+    hSet: mock(async (key: string, field: string, value: string) => {
+        const existing = JSON.parse(store.get(`__hash__:${key}`) ?? "{}");
+        existing[field] = value;
+        store.set(`__hash__:${key}`, JSON.stringify(existing));
+        store.set(`${key}:${field}`, value);
+    }),
+    incr: mock(async () => 1),
+    eval: mock(async () => 0),
+};
+
+mock.module("redis", () => ({
+    createClient: () => mockRedis,
+}));
+
+// Prevent this unit test from touching the real SQLite-backed session store or
+// the global Socket.IO hub registry. Those are covered by separate integration
+// tests; here we only care about parent link resolution.
+mock.module("../../sessions/store.js", () => ({
+    getEphemeralTtlMs: () => 60_000,
+    recordRelaySessionStart: async () => {},
+    recordRelaySessionEnd: async () => {},
+    recordRelaySessionState: async () => {},
+    touchRelaySession: async () => {},
+}));
+
+mock.module("./hub.js", () => ({
+    broadcastToHub: async () => {},
+}));
+
+const { initStateRedis, markChildAsDelinked } = await import("../sio-state.js");
+const { registerTuiSession } = await import("./sessions.js");
+
+describe("registerTuiSession parent resolution", () => {
+    beforeEach(async () => {
+        store.clear();
+        setStore.clear();
+        ttlStore.clear();
+        await initStateRedis();
+    });
+
+    it("keeps membership when parent is transiently offline", async () => {
+        const socket = {
+            join: async () => {},
+            data: {},
+        } as any;
+
+        const result = await registerTuiSession(socket, "", {
+            sessionId: "child-offline-parent",
+            userId: "u1",
+            userName: "User",
+            isEphemeral: false,
+            parentSessionId: "parent-offline",
+        });
+
+        expect(result.parentSessionId).toBeNull();
+        expect(result.wasDelinked).toBe(false);
+
+        // Parent is offline → session hash parentSessionId is cleared, but the
+        // membership set should still include the child so a future /new snapshot
+        // can find it.
+        expect(setStore.get("pizzapi:sio:children:parent-offline")?.has("child-offline-parent")).toBe(true);
+    });
+
+    it("does NOT re-add membership when a delink marker exists (explicit /new)", async () => {
+        const socket = {
+            join: async () => {},
+            data: {},
+        } as any;
+
+        await markChildAsDelinked("child-delinked-offline", "parent-old");
+
+        const result = await registerTuiSession(socket, "", {
+            sessionId: "child-delinked-offline",
+            userId: "u1",
+            userName: "User",
+            isEphemeral: false,
+            parentSessionId: "parent-old",
+        });
+
+        expect(result.parentSessionId).toBeNull();
+        expect(result.wasDelinked).toBe(true);
+
+        // The delink marker means the parent ran /new — do not re-add the child
+        // to the old parent's membership set even if the parent is currently offline.
+        expect(setStore.has("pizzapi:sio:children:parent-old")).toBe(false);
+    });
+});

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -27,6 +27,10 @@ import {
     refreshRunnerAssociationTTL,
     scanExpiredSessions,
     addChildSession,
+    removeChildSession,
+    isChildDelinked,
+    clearParentSessionId,
+    refreshChildSessionsTTL,
     getRunner as getRunnerState,
 } from "../sio-state.js";
 import {
@@ -37,6 +41,7 @@ import {
 } from "../../sessions/store.js";
 import { appendRelayEventToCache } from "../../sessions/redis.js";
 import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "../strip-images.js";
+import { severStaleParentLink } from "../stale-parent-link.js";
 import type { SessionInfo } from "@pizzapi/protocol";
 import {
     getIo,
@@ -87,12 +92,15 @@ export async function registerTuiSession(
     socket: Socket,
     cwd: string = "",
     opts: RegisterTuiSessionOpts = {},
-): Promise<{ sessionId: string; token: string; shareUrl: string; parentSessionId: string | null }> {
+): Promise<{ sessionId: string; token: string; shareUrl: string; parentSessionId: string | null; wasDelinked: boolean }> {
     const requestedSessionId = typeof opts.sessionId === "string" ? opts.sessionId.trim() : "";
     const sessionId = requestedSessionId.length > 0 ? requestedSessionId : randomUUID();
     const token = randomBytes(32).toString("hex");
     const shareUrl = `${process.env.PIZZAPI_BASE_URL ?? "http://localhost:5173"}/session/${sessionId}`;
-    const startedAt = new Date().toISOString();
+    // startedAt is resolved after the existing-session check below so that
+    // reconnects preserve the original value.  This is critical for the
+    // epoch-based delink filter in delink_children.
+    let startedAt: string;
     const userId = opts.userId ?? null;
     const userName = opts.userName ?? null;
     const isEphemeral = opts.isEphemeral !== false;
@@ -114,6 +122,10 @@ export async function registerTuiSession(
         }
         await endSharedSession(sessionId, "Session reconnected");
     }
+
+    // Preserve the original startedAt on reconnect so that epoch-based
+    // delink filtering works correctly.
+    startedAt = existing?.startedAt ?? new Date().toISOString();
 
     // Check for pending runner link
     const pendingRunnerId = await getPendingRunnerLink(sessionId);
@@ -149,6 +161,9 @@ export async function registerTuiSession(
         opts.parentSessionId ??
         existing?.parentSessionId ??
         null;
+    // Set to true when resolvedParentSessionId is forced to null because the
+    // parent explicitly delinked this child (via delink_children on /new).
+    let wasExplicitlyDelinked = false;
 
     // Validate parent session exists and belongs to the same user.
     // If the parent disconnected or the ID is stale, clear it to avoid
@@ -156,6 +171,7 @@ export async function registerTuiSession(
     // Fall back to SQLite when Redis has no record (e.g. relay restarted and
     // the parent's Redis key has expired) so that parent links survive restarts.
     if (resolvedParentSessionId) {
+        const candidateParentId = resolvedParentSessionId;
         const parentSession = await getSession(resolvedParentSessionId);
         if (!parentSession) {
             // Redis miss means the parent is not connected — clear the link
@@ -163,8 +179,41 @@ export async function registerTuiSession(
             // instead of sending triggers to a dead parent ID.  The child
             // CLI will re-send parentSessionId on its next reconnect; if
             // the parent is back by then the link is restored naturally.
+            //
+            // Also evict the child from the parent's membership set so that
+            // isChildOfParent() returns false even before TTL expiry.
+            await severStaleParentLink({
+                parentSessionId: candidateParentId,
+                childSessionId: sessionId,
+                clearParentSessionId,
+                removeChildSession,
+            });
             resolvedParentSessionId = null;
         } else if (parentSession.userId !== userId) {
+            // Cross-user link attempt — evict from membership set as well.
+            await severStaleParentLink({
+                parentSessionId: candidateParentId,
+                childSessionId: sessionId,
+                clearParentSessionId,
+                removeChildSession,
+            });
+            resolvedParentSessionId = null;
+        }
+    }
+
+    // Check if parent explicitly delinked this child (via delink_children).
+    if (resolvedParentSessionId) {
+        const delinked = await isChildDelinked(sessionId);
+        if (delinked) {
+            // Parent ran /new while this child was offline — clear the link
+            // permanently and signal the client via wasDelinked.
+            await severStaleParentLink({
+                parentSessionId: resolvedParentSessionId,
+                childSessionId: sessionId,
+                clearParentSessionId,
+                removeChildSession,
+            });
+            wasExplicitlyDelinked = true;
             resolvedParentSessionId = null;
         }
     }
@@ -242,7 +291,7 @@ export async function registerTuiSession(
         userId ?? undefined,
     );
 
-    return { sessionId, token, shareUrl, parentSessionId: resolvedParentSessionId };
+    return { sessionId, token, shareUrl, parentSessionId: resolvedParentSessionId, wasDelinked: wasExplicitlyDelinked };
 }
 
 /**

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -27,6 +27,7 @@ import {
     refreshRunnerAssociationTTL,
     scanExpiredSessions,
     addChildSession,
+    addChildSessionMembership,
     removeChildSession,
     isChildDelinked,
     clearParentSessionId,
@@ -180,6 +181,11 @@ export async function registerTuiSession(
             // child in the membership set so future delink_children snapshots
             // can still find it.  The child CLI still preserves parentSessionId
             // and will re-send it when the parent reconnects.
+            // NOTE: We use addChildSessionMembership (not addChildSession) so
+            // we do NOT clear any existing delink marker — the marker may have
+            // been set by a previous /new and should still take effect when
+            // the parent comes back online.
+            await addChildSessionMembership(candidateParentId, sessionId);
             resolvedParentSessionId = null;
         } else if (parentSession.userId !== userId) {
             // Cross-user link attempt — evict from membership set as well.

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -31,6 +31,7 @@ import {
     isChildDelinked,
     clearParentSessionId,
     refreshChildSessionsTTL,
+    removePendingParentDelinkChild,
     getRunner as getRunnerState,
 } from "../sio-state.js";
 import {
@@ -115,6 +116,7 @@ export async function registerTuiSession(
     // deferred disconnect fires → endSharedSession kills the new session →
     // Socket.IO reconnects → repeat.
     const existing = await getSession(sessionId);
+    const previousParentSessionId = existing?.parentSessionId ?? null;
     if (existing) {
         const oldSocket = localTuiSockets.get(sessionId);
         if (oldSocket && oldSocket !== socket) {
@@ -174,20 +176,10 @@ export async function registerTuiSession(
         const candidateParentId = resolvedParentSessionId;
         const parentSession = await getSession(resolvedParentSessionId);
         if (!parentSession) {
-            // Redis miss means the parent is not connected — clear the link
-            // so the child falls back to normal viewer/TUI interaction
-            // instead of sending triggers to a dead parent ID.  The child
-            // CLI will re-send parentSessionId on its next reconnect; if
-            // the parent is back by then the link is restored naturally.
-            //
-            // Also evict the child from the parent's membership set so that
-            // isChildOfParent() returns false even before TTL expiry.
-            await severStaleParentLink({
-                parentSessionId: candidateParentId,
-                childSessionId: sessionId,
-                clearParentSessionId,
-                removeChildSession,
-            });
+            // Redis miss means the parent is temporarily offline — keep the
+            // child in the membership set so future delink_children snapshots
+            // can still find it.  The child CLI still preserves parentSessionId
+            // and will re-send it when the parent reconnects.
             resolvedParentSessionId = null;
         } else if (parentSession.userId !== userId) {
             // Cross-user link attempt — evict from membership set as well.
@@ -246,6 +238,12 @@ export async function registerTuiSession(
     // This is the authoritative place for linking — no more racy pre-seeding.
     if (resolvedParentSessionId) {
         await addChildSession(resolvedParentSessionId, sessionId);
+        if (previousParentSessionId) {
+            // The child is now linked to a parent again, so any old retry
+            // entries for its previous parent can be discarded to avoid
+            // later delink_children hits re-delinking this child incorrectly.
+            await removePendingParentDelinkChild(previousParentSessionId, sessionId);
+        }
     }
 
     // Store local socket reference

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -177,15 +177,32 @@ export async function registerTuiSession(
         const candidateParentId = resolvedParentSessionId;
         const parentSession = await getSession(resolvedParentSessionId);
         if (!parentSession) {
-            // Redis miss means the parent is temporarily offline — keep the
-            // child in the membership set so future delink_children snapshots
-            // can still find it.  The child CLI still preserves parentSessionId
-            // and will re-send it when the parent reconnects.
-            // NOTE: We use addChildSessionMembership (not addChildSession) so
-            // we do NOT clear any existing delink marker — the marker may have
-            // been set by a previous /new and should still take effect when
-            // the parent comes back online.
-            await addChildSessionMembership(candidateParentId, sessionId);
+            // Redis miss means the parent is temporarily offline.
+            //
+            // IMPORTANT: If the parent explicitly delinked this child via /new,
+            // a delink marker will already be present. In that case we must
+            // NOT re-add the child to the old parent's membership set, or the
+            // old parent could regain child-only privileges when it reconnects.
+            const delinked = await isChildDelinked(sessionId);
+            if (delinked) {
+                await severStaleParentLink({
+                    parentSessionId: candidateParentId,
+                    childSessionId: sessionId,
+                    clearParentSessionId,
+                    removeChildSession,
+                });
+                wasExplicitlyDelinked = true;
+            } else {
+                // Keep the child in the membership set so future delink_children
+                // snapshots can still find it. The child CLI still preserves
+                // parentSessionId and will re-send it when the parent reconnects.
+                //
+                // NOTE: We use addChildSessionMembership (not addChildSession) so
+                // we do NOT clear any existing delink marker — the marker may have
+                // been set by a previous /new and should still take effect when
+                // the parent comes back online.
+                await addChildSessionMembership(candidateParentId, sessionId);
+            }
             resolvedParentSessionId = null;
         } else if (parentSession.userId !== userId) {
             // Cross-user link attempt — evict from membership set as well.

--- a/packages/server/src/ws/sio-state-children.test.ts
+++ b/packages/server/src/ws/sio-state-children.test.ts
@@ -84,8 +84,8 @@ const mockRedis = {
     on: mock(() => mockRedis),
     connect: mock(async () => {}),
     // Simple string key store (used by markChildAsDelinked / isChildDelinked)
-    set: mock(async (key: string, _value: string, _opts?: unknown) => {
-        store.set(key, "1");
+    set: mock(async (key: string, value: string, _opts?: unknown) => {
+        store.set(key, value);
     }),
     get: mock(async (key: string) => store.get(key) ?? null),
     del: mock(async (key: string) => {
@@ -113,6 +113,7 @@ mock.module("redis", () => ({
 const {
     initStateRedis,
     addChildSession,
+    addChildSessionMembership,
     getChildSessions,
     removeChildSession,
     removeChildren,
@@ -123,6 +124,7 @@ const {
     addPendingParentDelinkChildren,
     getPendingParentDelinkChildren,
     removePendingParentDelinkChild,
+    isPendingParentDelinkChild,
     markChildAsDelinked,
     isChildDelinked,
     clearDelinkedMark,
@@ -283,25 +285,25 @@ describe("child session helpers (sio-state)", () => {
     });
 
     it("markChildAsDelinked sets the marker; isChildDelinked returns true", async () => {
-        await markChildAsDelinked("child-1");
+        await markChildAsDelinked("child-1", "parent-1");
         expect(await isChildDelinked("child-1")).toBe(true);
     });
 
     it("clearDelinkedMark removes the marker", async () => {
-        await markChildAsDelinked("child-1");
+        await markChildAsDelinked("child-1", "parent-1");
         await clearDelinkedMark("child-1");
         expect(await isChildDelinked("child-1")).toBe(false);
     });
 
     it("markers are per-child and do not affect siblings", async () => {
-        await markChildAsDelinked("child-1");
+        await markChildAsDelinked("child-1", "parent-1");
         expect(await isChildDelinked("child-1")).toBe(true);
         expect(await isChildDelinked("child-2")).toBe(false);
     });
 
     it("markChildAsDelinked is idempotent", async () => {
-        await markChildAsDelinked("child-1");
-        await markChildAsDelinked("child-1");
+        await markChildAsDelinked("child-1", "parent-1");
+        await markChildAsDelinked("child-1", "parent-1");
         expect(await isChildDelinked("child-1")).toBe(true);
         await clearDelinkedMark("child-1");
         expect(await isChildDelinked("child-1")).toBe(false);
@@ -311,10 +313,61 @@ describe("child session helpers (sio-state)", () => {
         // Simulate: parent delinked child-1, then later spawns it again.
         // The new addChildSession should clear the delink marker so future
         // reconnects don't reject the new legitimate parent link.
-        await markChildAsDelinked("child-1");
+        await markChildAsDelinked("child-1", "parent-1");
         expect(await isChildDelinked("child-1")).toBe(true);
         await addChildSession("parent-2", "child-1");
         expect(await isChildDelinked("child-1")).toBe(false);
+    });
+
+    it("addChildSession removes child from former parent's pending-delink set (Fix #2)", async () => {
+        // Scenario: P1 ran /new while C was online but delivery failed.
+        // C stays in pending-delink-children:P1.  C is later linked to P2.
+        // addChildSession(P2, C) must scrub C from pending-delink-children:P1
+        // so P1's next /new doesn't re-sever the P2→C link.
+        await markChildAsDelinked("child-1", "parent-1");
+        await addPendingParentDelinkChildren("parent-1", ["child-1"]);
+        expect(await isPendingParentDelinkChild("parent-1", "child-1")).toBe(true);
+
+        await addChildSession("parent-2", "child-1");
+
+        expect(await isChildDelinked("child-1")).toBe(false);
+        expect(await isPendingParentDelinkChild("parent-1", "child-1")).toBe(false);
+    });
+
+    it("addChildSession with old-format marker ('1') does not attempt pending-delink cleanup", async () => {
+        // Legacy markers stored "1" as the value — no parent ID available.
+        // addChildSession must still clear the marker but not try to sRem from
+        // a set keyed by "1" (that would be a garbage key operation).
+        store.set("pizzapi:sio:delinked:child-1", "1");
+        expect(await isChildDelinked("child-1")).toBe(true);
+
+        await addChildSession("parent-2", "child-1");
+
+        expect(await isChildDelinked("child-1")).toBe(false);
+        // No garbage set entry created
+        expect(setStore.has("pizzapi:sio:pending-delink-children:1")).toBe(false);
+    });
+
+    // ── addChildSessionMembership (transient-offline path) ─────────────────
+
+    it("addChildSessionMembership adds child to membership set", async () => {
+        await addChildSessionMembership("parent-1", "child-1");
+        expect(await isChildOfParent("parent-1", "child-1")).toBe(true);
+    });
+
+    it("addChildSessionMembership does NOT clear a delink marker (Fix #1)", async () => {
+        // When the parent is transiently offline during the child's reconnect,
+        // we still add the child to the membership set (so delink_children can
+        // find it), but we must NOT clear the delink marker — it may have been
+        // set by a previous /new and should still gate the child's next reconnect
+        // when the parent is actually online.
+        await markChildAsDelinked("child-1", "parent-1");
+        expect(await isChildDelinked("child-1")).toBe(true);
+
+        await addChildSessionMembership("parent-1", "child-1");
+
+        expect(await isChildOfParent("parent-1", "child-1")).toBe(true);
+        expect(await isChildDelinked("child-1")).toBe(true); // marker preserved
     });
 
     // ── removeChildren (targeted removal) ──────────────────────────────────

--- a/packages/server/src/ws/sio-state-children.test.ts
+++ b/packages/server/src/ws/sio-state-children.test.ts
@@ -319,6 +319,24 @@ describe("child session helpers (sio-state)", () => {
         expect(result).toBe(false);
     });
 
+    it("isChildOfParent does not fall back to the session hash when a delink marker exists", async () => {
+        // Simulate the post-/new window for a connected child:
+        // - The parent cleared the membership set
+        // - The child's session hash still carries parentSessionId
+        // - A delink marker exists until the child reconnects / processes parent_delinked
+        //
+        // In this state, isChildOfParent must return false and must NOT re-hydrate the set.
+        store.set(
+            "__hash__:pizzapi:sio:session:child-pending-delink",
+            JSON.stringify({ sessionId: "child-pending-delink", parentSessionId: "parent-pending" }),
+        );
+        await markChildAsDelinked("child-pending-delink", "parent-pending");
+
+        const result = await isChildOfParent("parent-pending", "child-pending-delink");
+        expect(result).toBe(false);
+        expect(setStore.has("pizzapi:sio:children:parent-pending")).toBe(false);
+    });
+
     it("isChildOfParent returns true after removeChildSession leaves sibling", async () => {
         await addChildSession("parent-1", "child-1");
         await addChildSession("parent-1", "child-2");

--- a/packages/server/src/ws/sio-state-children.test.ts
+++ b/packages/server/src/ws/sio-state-children.test.ts
@@ -94,7 +94,10 @@ const mockRedis = {
         ttlStore.delete(key);
     }),
     exists: mock(async (key: string) => (store.has(key) ? 1 : 0)),
-    hGetAll: mock(async () => ({})),
+    hGetAll: mock(async (key: string) => {
+        const raw = store.get(`__hash__:${key}`);
+        return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+    }),
     hGet: mock(async () => null),
     hSet: mock(async (key: string, field: string, value: string) => {
         const existing = JSON.parse(store.get(`__hash__:${key}`) ?? "{}");
@@ -244,6 +247,76 @@ describe("child session helpers (sio-state)", () => {
 
     it("isChildOfParent returns false for nonexistent parent set", async () => {
         expect(await isChildOfParent("ghost-parent", "child-1")).toBe(false);
+    });
+
+    // ── isChildOfParent TTL-expiry fallback ────────────────────────────────
+
+    it("isChildOfParent falls back to session hash when Redis set has expired (TTL fallback)", async () => {
+        // Simulate TTL expiry: the children set is absent, but the child's
+        // session hash still records parentSessionId pointing to this parent.
+        // isChildOfParent must return true via the session-hash fallback.
+        store.set(
+            "pizzapi:sio:session:child-fallback",
+            JSON.stringify({ sessionId: "child-fallback", parentSessionId: "parent-ttl" }),
+        );
+        store.set(
+            "__hash__:pizzapi:sio:session:child-fallback",
+            JSON.stringify({ sessionId: "child-fallback", parentSessionId: "parent-ttl" }),
+        );
+
+        // No children set entry for parent-ttl
+        expect(setStore.has("pizzapi:sio:children:parent-ttl")).toBe(false);
+
+        const result = await isChildOfParent("parent-ttl", "child-fallback");
+        expect(result).toBe(true);
+    });
+
+    it("isChildOfParent re-hydrates the children set after TTL fallback", async () => {
+        // After the fallback confirms the relationship, the child must be
+        // re-added to the Redis set so subsequent checks are fast.
+        store.set(
+            "__hash__:pizzapi:sio:session:child-rehydrate",
+            JSON.stringify({ sessionId: "child-rehydrate", parentSessionId: "parent-rehydrate" }),
+        );
+
+        await isChildOfParent("parent-rehydrate", "child-rehydrate");
+
+        // Set should now contain the child
+        expect(setStore.get("pizzapi:sio:children:parent-rehydrate")?.has("child-rehydrate")).toBe(true);
+        // TTL should have been refreshed
+        expect(ttlStore.get("pizzapi:sio:children:parent-rehydrate")).toBe(24 * 60 * 60);
+    });
+
+    it("isChildOfParent returns false via fallback when parentSessionId does not match", async () => {
+        // The child's hash has a different parentSessionId (e.g. it was re-linked
+        // to another parent). The fallback must not grant access.
+        store.set(
+            "__hash__:pizzapi:sio:session:child-other",
+            JSON.stringify({ sessionId: "child-other", parentSessionId: "different-parent" }),
+        );
+
+        const result = await isChildOfParent("parent-original", "child-other");
+        expect(result).toBe(false);
+    });
+
+    it("isChildOfParent returns false after explicit delink (clearAllChildren + clearParentSessionId)", async () => {
+        // Seed the session hash with the parent link
+        store.set(
+            "__hash__:pizzapi:sio:session:child-delinked",
+            JSON.stringify({ sessionId: "child-delinked", parentSessionId: "parent-delink" }),
+        );
+        await addChildSession("parent-delink", "child-delinked");
+
+        // Explicit delink: remove from set and clear parentSessionId in hash
+        await clearAllChildren("parent-delink");
+        store.set(
+            "__hash__:pizzapi:sio:session:child-delinked",
+            JSON.stringify({ sessionId: "child-delinked", parentSessionId: "" }),
+        );
+
+        // Both guards reject: set is cleared AND parentSessionId is ""
+        const result = await isChildOfParent("parent-delink", "child-delinked");
+        expect(result).toBe(false);
     });
 
     it("isChildOfParent returns true after removeChildSession leaves sibling", async () => {

--- a/packages/server/src/ws/sio-state-children.test.ts
+++ b/packages/server/src/ws/sio-state-children.test.ts
@@ -49,6 +49,10 @@ const mockMulti = () => {
             ops.push(() => ttlStore.set(key, ttl));
             return mockMulti();
         }),
+        del: mock((key: string) => {
+            ops.push(() => store.delete(key));
+            return mockMulti();
+        }),
         exec: mock(async () => {
             for (const op of ops) op();
             return ops.map(() => "OK");
@@ -70,19 +74,34 @@ const mockRedis = {
         const s = setStore.get(key);
         if (s) for (const m of members.flat()) s.delete(m);
     }),
+    sIsMember: mock(async (key: string, member: string) => {
+        return setStore.get(key)?.has(member) ?? false;
+    }),
     expire: mock(async (key: string, ttl: number) => {
         ttlStore.set(key, ttl);
     }),
     multi: mock(() => mockMulti()),
     on: mock(() => mockRedis),
     connect: mock(async () => {}),
-    // For other sio-state functions that might be called during import
-    set: mock(async () => {}),
-    get: mock(async () => null),
-    del: mock(async () => {}),
-    exists: mock(async () => 0),
+    // Simple string key store (used by markChildAsDelinked / isChildDelinked)
+    set: mock(async (key: string, _value: string, _opts?: unknown) => {
+        store.set(key, "1");
+    }),
+    get: mock(async (key: string) => store.get(key) ?? null),
+    del: mock(async (key: string) => {
+        store.delete(key);
+        setStore.delete(key);
+        ttlStore.delete(key);
+    }),
+    exists: mock(async (key: string) => (store.has(key) ? 1 : 0)),
     hGetAll: mock(async () => ({})),
     hGet: mock(async () => null),
+    hSet: mock(async (key: string, field: string, value: string) => {
+        const existing = JSON.parse(store.get(`__hash__:${key}`) ?? "{}");
+        existing[field] = value;
+        store.set(`__hash__:${key}`, JSON.stringify(existing));
+        store.set(`${key}:${field}`, value);
+    }),
     incr: mock(async () => 1),
     eval: mock(async () => 0),
 };
@@ -96,6 +115,17 @@ const {
     addChildSession,
     getChildSessions,
     removeChildSession,
+    removeChildren,
+    clearAllChildren,
+    clearParentSessionId,
+    isChildOfParent,
+    refreshChildSessionsTTL,
+    addPendingParentDelinkChildren,
+    getPendingParentDelinkChildren,
+    removePendingParentDelinkChild,
+    markChildAsDelinked,
+    isChildDelinked,
+    clearDelinkedMark,
 } = await import("./sio-state.js");
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -147,5 +177,189 @@ describe("child session helpers (sio-state)", () => {
         await addChildSession("parent-1", "child-1");
         const children = await getChildSessions("parent-1");
         expect(children).toEqual(["child-1"]);
+    });
+
+    it("clearAllChildren removes all children and returns their IDs", async () => {
+        await addChildSession("parent-1", "child-1");
+        await addChildSession("parent-1", "child-2");
+        await addChildSession("parent-1", "child-3");
+
+        const removed = await clearAllChildren("parent-1");
+        expect(removed.sort()).toEqual(["child-1", "child-2", "child-3"]);
+
+        // Children set should be empty now
+        const remaining = await getChildSessions("parent-1");
+        expect(remaining).toEqual([]);
+    });
+
+    it("clearAllChildren returns empty array for nonexistent parent", async () => {
+        const removed = await clearAllChildren("nonexistent");
+        expect(removed).toEqual([]);
+    });
+
+    it("clearAllChildren does not affect other parents", async () => {
+        await addChildSession("parent-1", "child-1");
+        await addChildSession("parent-2", "child-2");
+
+        await clearAllChildren("parent-1");
+
+        const p1Children = await getChildSessions("parent-1");
+        const p2Children = await getChildSessions("parent-2");
+        expect(p1Children).toEqual([]);
+        expect(p2Children).toContain("child-2");
+    });
+
+    it("clearParentSessionId clears the field in Redis", async () => {
+        // clearParentSessionId calls hSet with empty string on the session key.
+        // We verify the mock was called correctly.
+        await clearParentSessionId("child-1");
+        // The hSet mock stores the value; verify it was called
+        expect(mockRedis.hSet).toHaveBeenCalled();
+    });
+
+    // ── isChildOfParent ────────────────────────────────────────────────────
+
+    it("isChildOfParent returns true when child is in parent's set", async () => {
+        await addChildSession("parent-1", "child-1");
+        expect(await isChildOfParent("parent-1", "child-1")).toBe(true);
+    });
+
+    it("isChildOfParent returns false for non-member", async () => {
+        await addChildSession("parent-1", "child-1");
+        expect(await isChildOfParent("parent-1", "child-99")).toBe(false);
+    });
+
+    it("isChildOfParent returns false after clearAllChildren (delink_children)", async () => {
+        await addChildSession("parent-1", "child-1");
+        await addChildSession("parent-1", "child-2");
+
+        // Simulate delink_children: clear the set
+        await clearAllChildren("parent-1");
+
+        expect(await isChildOfParent("parent-1", "child-1")).toBe(false);
+        expect(await isChildOfParent("parent-1", "child-2")).toBe(false);
+    });
+
+    it("isChildOfParent returns false for nonexistent parent set", async () => {
+        expect(await isChildOfParent("ghost-parent", "child-1")).toBe(false);
+    });
+
+    it("isChildOfParent returns true after removeChildSession leaves sibling", async () => {
+        await addChildSession("parent-1", "child-1");
+        await addChildSession("parent-1", "child-2");
+        await removeChildSession("parent-1", "child-2");
+
+        expect(await isChildOfParent("parent-1", "child-1")).toBe(true);
+        expect(await isChildOfParent("parent-1", "child-2")).toBe(false);
+    });
+
+    it("refreshChildSessionsTTL refreshes the membership set TTL", async () => {
+        await addChildSession("parent-1", "child-1");
+        ttlStore.set("pizzapi:sio:children:parent-1", 1);
+
+        await refreshChildSessionsTTL("parent-1");
+
+        expect(ttlStore.get("pizzapi:sio:children:parent-1")).toBe(24 * 60 * 60);
+    });
+
+    it("tracks pending parent_delinked retries per parent", async () => {
+        await addPendingParentDelinkChildren("parent-1", ["child-1", "child-2"]);
+        expect((await getPendingParentDelinkChildren("parent-1")).sort()).toEqual(["child-1", "child-2"]);
+        expect(ttlStore.get("pizzapi:sio:pending-delink-children:parent-1")).toBe(24 * 60 * 60);
+    });
+
+    it("removePendingParentDelinkChild removes only the acked child", async () => {
+        await addPendingParentDelinkChildren("parent-1", ["child-1", "child-2"]);
+        await removePendingParentDelinkChild("parent-1", "child-1");
+        expect(await getPendingParentDelinkChildren("parent-1")).toEqual(["child-2"]);
+    });
+
+    // ── Delink markers ─────────────────────────────────────────────────────
+    // These markers are written by delink_children to prevent offline children
+    // from re-linking to the old parent on their next reconnect.
+
+    it("isChildDelinked returns false when no marker exists", async () => {
+        expect(await isChildDelinked("child-orphan")).toBe(false);
+    });
+
+    it("markChildAsDelinked sets the marker; isChildDelinked returns true", async () => {
+        await markChildAsDelinked("child-1");
+        expect(await isChildDelinked("child-1")).toBe(true);
+    });
+
+    it("clearDelinkedMark removes the marker", async () => {
+        await markChildAsDelinked("child-1");
+        await clearDelinkedMark("child-1");
+        expect(await isChildDelinked("child-1")).toBe(false);
+    });
+
+    it("markers are per-child and do not affect siblings", async () => {
+        await markChildAsDelinked("child-1");
+        expect(await isChildDelinked("child-1")).toBe(true);
+        expect(await isChildDelinked("child-2")).toBe(false);
+    });
+
+    it("markChildAsDelinked is idempotent", async () => {
+        await markChildAsDelinked("child-1");
+        await markChildAsDelinked("child-1");
+        expect(await isChildDelinked("child-1")).toBe(true);
+        await clearDelinkedMark("child-1");
+        expect(await isChildDelinked("child-1")).toBe(false);
+    });
+
+    it("addChildSession clears a stale delink marker for the child", async () => {
+        // Simulate: parent delinked child-1, then later spawns it again.
+        // The new addChildSession should clear the delink marker so future
+        // reconnects don't reject the new legitimate parent link.
+        await markChildAsDelinked("child-1");
+        expect(await isChildDelinked("child-1")).toBe(true);
+        await addChildSession("parent-2", "child-1");
+        expect(await isChildDelinked("child-1")).toBe(false);
+    });
+
+    // ── removeChildren (targeted removal) ──────────────────────────────────
+
+    it("removeChildren removes only the specified children", async () => {
+        await addChildSession("parent-1", "child-1");
+        await addChildSession("parent-1", "child-2");
+        await addChildSession("parent-1", "child-3");
+
+        await removeChildren("parent-1", ["child-1", "child-3"]);
+
+        const remaining = await getChildSessions("parent-1");
+        expect(remaining).toEqual(["child-2"]);
+    });
+
+    it("removeChildren preserves children added after the snapshot", async () => {
+        // Simulate the race: snapshot sees child-1 and child-2, but child-3
+        // is added between the snapshot and the removal.
+        await addChildSession("parent-1", "child-1");
+        await addChildSession("parent-1", "child-2");
+
+        // Snapshot: ["child-1", "child-2"]
+        const snapshot = await getChildSessions("parent-1");
+
+        // New child added after snapshot (simulates race)
+        await addChildSession("parent-1", "child-3");
+
+        // Remove only the snapshotted children
+        await removeChildren("parent-1", snapshot);
+
+        const remaining = await getChildSessions("parent-1");
+        expect(remaining).toEqual(["child-3"]);
+    });
+
+    it("removeChildren is a no-op for empty array", async () => {
+        await addChildSession("parent-1", "child-1");
+        await removeChildren("parent-1", []);
+        const remaining = await getChildSessions("parent-1");
+        expect(remaining).toEqual(["child-1"]);
+    });
+
+    it("removeChildren is safe with nonexistent children", async () => {
+        await addChildSession("parent-1", "child-1");
+        await removeChildren("parent-1", ["nonexistent"]);
+        const remaining = await getChildSessions("parent-1");
+        expect(remaining).toEqual(["child-1"]);
     });
 });

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -705,6 +705,13 @@ export async function isChildOfParent(parentSessionId: string, childSessionId: s
     const inSet = await r.sIsMember(childrenKey(parentSessionId), childSessionId);
     if (inSet) return true;
 
+    // If the parent explicitly delinked this child (via /new), we may have
+    // already cleared the children set while the child's session hash still
+    // temporarily carries parentSessionId. In that window we must NOT fall
+    // back to the hash, otherwise we'd re-hydrate the set and re-authorize
+    // stale parent/child traffic.
+    if (await isChildDelinked(childSessionId)) return false;
+
     // Fallback: the Redis children set may have expired without an explicit
     // delink.  Verify via the child's durable session hash.
     const childSession = await getSession(childSessionId);

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -652,6 +652,11 @@ export async function addChildSession(parentSessionId: string, childSessionId: s
     const multi = r.multi();
     multi.sAdd(childrenKey(parentSessionId), childSessionId);
     multi.expire(childrenKey(parentSessionId), SESSION_TTL_SECONDS);
+    // Clear any stale delink marker — a new legitimate parent link supersedes
+    // any previous delink.  The marker is kept alive in registerTuiSession
+    // (not consumed on first check) so that reconnect races are idempotent;
+    // clearing it here when a new link is explicitly created is the safe place.
+    multi.del(delinkMarkerKey(childSessionId));
     await multi.exec();
 }
 
@@ -661,10 +666,116 @@ export async function getChildSessions(parentSessionId: string): Promise<string[
     return r.sMembers(childrenKey(parentSessionId));
 }
 
+/** Check whether a session is still listed as a child of the given parent.
+ *  Returns false if delink_children was called (which clears the set). */
+export async function isChildOfParent(parentSessionId: string, childSessionId: string): Promise<boolean> {
+    const r = requireRedis();
+    return r.sIsMember(childrenKey(parentSessionId), childSessionId);
+}
+
+/** Refresh the TTL on an existing parent→children membership set. */
+export async function refreshChildSessionsTTL(parentSessionId: string): Promise<void> {
+    const r = requireRedis();
+    await r.expire(childrenKey(parentSessionId), SESSION_TTL_SECONDS);
+}
+
+/** Children that still need a parent_delinked notification retry for a parent. */
+function pendingDelinkChildrenKey(parentSessionId: string): string {
+    return `${KEY_PREFIX}:pending-delink-children:${parentSessionId}`;
+}
+
+export async function addPendingParentDelinkChildren(parentSessionId: string, childIds: string[]): Promise<void> {
+    if (childIds.length === 0) return;
+    const r = requireRedis();
+    const multi = r.multi();
+    multi.sAdd(pendingDelinkChildrenKey(parentSessionId), childIds);
+    multi.expire(pendingDelinkChildrenKey(parentSessionId), SESSION_TTL_SECONDS);
+    await multi.exec();
+}
+
+export async function getPendingParentDelinkChildren(parentSessionId: string): Promise<string[]> {
+    const r = requireRedis();
+    return r.sMembers(pendingDelinkChildrenKey(parentSessionId));
+}
+
+export async function removePendingParentDelinkChild(parentSessionId: string, childSessionId: string): Promise<void> {
+    const r = requireRedis();
+    await r.sRem(pendingDelinkChildrenKey(parentSessionId), childSessionId);
+}
+
+export async function isPendingParentDelinkChild(parentSessionId: string, childSessionId: string): Promise<boolean> {
+    const r = requireRedis();
+    const member = await r.sIsMember(pendingDelinkChildrenKey(parentSessionId), childSessionId);
+    return Boolean(member);
+}
+
+// ── Per-child delink markers ─────────────────────────────────────────────────
+// When delink_children fires (e.g. parent ran /new), we write a TTL'd marker
+// for each child.  registerTuiSession checks this on the child's next reconnect
+// and refuses to restore the link, even if the child is still carrying the old
+// parentSessionId in memory (e.g. it was offline during the delink and never
+// received parent_delinked). The marker is NOT consumed on first reconnect —
+// it persists so that reconnect races are idempotent (if the socket drops
+// after the check but before the child receives `registered`, the next
+// reconnect will still see the marker). The marker is cleared when a new
+// legitimate parent link is established via addChildSession(), or expires
+// via TTL for children that are never re-linked.
+
+const DELINK_MARKER_TTL_SECONDS = 30 * 24 * 3600; // 30 days — cleared by addChildSession or TTL expiry
+
+function delinkMarkerKey(childSessionId: string): string {
+    return `${KEY_PREFIX}:delinked:${childSessionId}`;
+}
+
+/** Mark a child as explicitly delinked (consumed on first reconnect). */
+export async function markChildAsDelinked(childSessionId: string): Promise<void> {
+    const r = requireRedis();
+    await r.set(delinkMarkerKey(childSessionId), "1", { EX: DELINK_MARKER_TTL_SECONDS });
+}
+
+/** Check if a child has a pending delink marker. */
+export async function isChildDelinked(childSessionId: string): Promise<boolean> {
+    const r = requireRedis();
+    return (await r.exists(delinkMarkerKey(childSessionId))) > 0;
+}
+
+/** Consume (delete) the delink marker for a child. */
+export async function clearDelinkedMark(childSessionId: string): Promise<void> {
+    const r = requireRedis();
+    await r.del(delinkMarkerKey(childSessionId));
+}
+
 /** Remove a child from its parent's children set. */
 export async function removeChildSession(parentSessionId: string, childSessionId: string): Promise<void> {
     const r = requireRedis();
     await r.sRem(childrenKey(parentSessionId), childSessionId);
+}
+
+/** Remove all children from a parent's children set. Returns the removed child IDs. */
+export async function clearAllChildren(parentSessionId: string): Promise<string[]> {
+    const r = requireRedis();
+    const children = await r.sMembers(childrenKey(parentSessionId));
+    if (children.length > 0) {
+        await r.del(childrenKey(parentSessionId));
+    }
+    return children;
+}
+
+/**
+ * Remove only the specified children from a parent's children set.
+ * Unlike clearAllChildren(), this is safe against races where a new child
+ * is added between snapshot and removal — the new child stays in the set.
+ */
+export async function removeChildren(parentSessionId: string, childIds: string[]): Promise<void> {
+    if (childIds.length === 0) return;
+    const r = requireRedis();
+    await r.sRem(childrenKey(parentSessionId), childIds);
+}
+
+/** Clear the parentSessionId field on a child session's Redis hash. */
+export async function clearParentSessionId(childSessionId: string): Promise<void> {
+    const r = requireRedis();
+    await r.hSet(sessionKey(childSessionId), "parentSessionId", "");
 }
 
 // ── Push pending question tracking ──────────────────────────────────────────

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -649,6 +649,12 @@ function childrenKey(parentSessionId: string): string {
 /** Record a child session under its parent. */
 export async function addChildSession(parentSessionId: string, childSessionId: string): Promise<void> {
     const r = requireRedis();
+    // Read the delink marker value BEFORE the transaction — if the marker stores
+    // the former parent's session ID, we can scrub the child from that parent's
+    // pending-delink retry set in the same atomic multi.  This prevents a child
+    // that was delinked from P1 and is now being (re)linked to P2 from being
+    // severed again when P1 next runs /new and re-processes its retry set.
+    const formerParentId = await r.get(delinkMarkerKey(childSessionId));
     const multi = r.multi();
     multi.sAdd(childrenKey(parentSessionId), childSessionId);
     multi.expire(childrenKey(parentSessionId), SESSION_TTL_SECONDS);
@@ -657,6 +663,27 @@ export async function addChildSession(parentSessionId: string, childSessionId: s
     // (not consumed on first check) so that reconnect races are idempotent;
     // clearing it here when a new link is explicitly created is the safe place.
     multi.del(delinkMarkerKey(childSessionId));
+    // If the former parent's ID was stored in the marker value (non-empty, non-"1"),
+    // remove the child from that parent's pending-delink retry set atomically.
+    if (formerParentId && formerParentId !== "1") {
+        multi.sRem(pendingDelinkChildrenKey(formerParentId), childSessionId);
+    }
+    await multi.exec();
+}
+
+/**
+ * Add a child to the parent's membership set WITHOUT clearing any delink marker.
+ *
+ * Used when the parent is transiently offline during the child's reconnect —
+ * we still want future `delink_children` snapshots to include this child, but
+ * we must not clear the delink marker (which could have been set by a previous
+ * /new and should still take effect when the parent reconnects).
+ */
+export async function addChildSessionMembership(parentSessionId: string, childSessionId: string): Promise<void> {
+    const r = requireRedis();
+    const multi = r.multi();
+    multi.sAdd(childrenKey(parentSessionId), childSessionId);
+    multi.expire(childrenKey(parentSessionId), SESSION_TTL_SECONDS);
     await multi.exec();
 }
 
@@ -727,10 +754,18 @@ function delinkMarkerKey(childSessionId: string): string {
     return `${KEY_PREFIX}:delinked:${childSessionId}`;
 }
 
-/** Mark a child as explicitly delinked (consumed on first reconnect). */
-export async function markChildAsDelinked(childSessionId: string): Promise<void> {
+/**
+ * Mark a child as explicitly delinked by the given parent.
+ *
+ * The parent session ID is stored as the marker value so that
+ * `addChildSession` can atomically remove the child from the former
+ * parent's `pending-delink-children` set when the child is re-linked to
+ * a new parent.  Consumers that only need the boolean check can continue
+ * to use `isChildDelinked()`.
+ */
+export async function markChildAsDelinked(childSessionId: string, byParentSessionId: string): Promise<void> {
     const r = requireRedis();
-    await r.set(delinkMarkerKey(childSessionId), "1", { EX: DELINK_MARKER_TTL_SECONDS });
+    await r.set(delinkMarkerKey(childSessionId), byParentSessionId, { EX: DELINK_MARKER_TTL_SECONDS });
 }
 
 /** Check if a child has a pending delink marker. */

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -694,10 +694,32 @@ export async function getChildSessions(parentSessionId: string): Promise<string[
 }
 
 /** Check whether a session is still listed as a child of the given parent.
- *  Returns false if delink_children was called (which clears the set). */
+ *  Returns false if delink_children was called (which clears the set).
+ *
+ *  Fallback: if the Redis children set has expired (24 h TTL) but the child's
+ *  session hash still records `parentSessionId` pointing at this parent, the
+ *  relationship is still live.  We re-hydrate the set in that case so that
+ *  subsequent calls are fast again (self-healing after TTL expiry). */
 export async function isChildOfParent(parentSessionId: string, childSessionId: string): Promise<boolean> {
     const r = requireRedis();
-    return r.sIsMember(childrenKey(parentSessionId), childSessionId);
+    const inSet = await r.sIsMember(childrenKey(parentSessionId), childSessionId);
+    if (inSet) return true;
+
+    // Fallback: the Redis children set may have expired without an explicit
+    // delink.  Verify via the child's durable session hash.
+    const childSession = await getSession(childSessionId);
+    if (childSession?.parentSessionId === parentSessionId) {
+        // Re-hydrate the children set and reset its TTL so future checks are
+        // fast and the delink guard (clearAllChildren / clearParentSessionId)
+        // still works correctly.
+        const multi = r.multi();
+        multi.sAdd(childrenKey(parentSessionId), childSessionId);
+        multi.expire(childrenKey(parentSessionId), SESSION_TTL_SECONDS);
+        await multi.exec();
+        return true;
+    }
+
+    return false;
 }
 
 /** Refresh the TTL on an existing parent→children membership set. */

--- a/packages/server/src/ws/stale-parent-link.ts
+++ b/packages/server/src/ws/stale-parent-link.ts
@@ -1,0 +1,12 @@
+export async function severStaleParentLink(opts: {
+    parentSessionId: string;
+    childSessionId: string;
+    clearParentField?: boolean;
+    clearParentSessionId: (childSessionId: string) => Promise<void>;
+    removeChildSession: (parentSessionId: string, childSessionId: string) => Promise<void>;
+}): Promise<void> {
+    if (opts.clearParentField) {
+        await opts.clearParentSessionId(opts.childSessionId);
+    }
+    await opts.removeChildSession(opts.parentSessionId, opts.childSessionId);
+}


### PR DESCRIPTION
## Problem

When `/new` fires, pending child triggers (`session_complete`, `plan_review`, `ask_user_question`) from the old session are left dangling. Parent↔child links persist, so a completing child could inject a trigger into a completely unrelated new conversation.

## Solution

### CLI
- Added `clearAndCancelPendingTriggers()` which clears all entries from `receivedTriggers` and sends `action: "cancel"` `trigger_response` back to each child so they don't block waiting
- On `session_switch` (fires on `/new`): calls `clearAndCancelPendingTriggers()`, emits `delink_children` to the server, resets `sessionCompleteFired`, and listens for `parent_delinked` (child-side)

### Protocol
- Added `delink_children` (client→server): parent requests severing all child links
- Added `parent_delinked` (server→client): notifies children their parent is gone

### Server
- Added `clearAllChildren()` and `clearParentSessionId()` to sio-state
- Added `delink_children` handler that gets all children, clears the set, notifies each connected child via `parent_delinked`, and clears their `parentSessionId` in Redis

### Tests
- 5 tests for trigger clearing and cancel responses
- 4 tests for `clearAllChildren` and `clearParentSessionId`

All 277 tests pass, typecheck clean.