### PR TITLE
fix: Google usage missing from runner daemon cache

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -22,7 +22,7 @@ import type { RunnerClientToServerEvents, RunnerServerToClientEvents, RunnerHook
 import { loadGlobalConfig, defaultAgentDir, expandHome, type HooksConfig } from "../config.js";
 import { AuthStorage } from "@mariozechner/pi-coding-agent";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
-import { getOAuthAccessToken, parseGeminiQuotaCredential } from "./usage-auth.js";
+import { getRefreshedOAuthToken, parseGeminiQuotaCredential } from "./usage-auth.js";
 
 /**
  * Summarise the active hooks from a HooksConfig for display in the web UI.
@@ -283,8 +283,7 @@ async function fetchAnthropicUsageData(): Promise<ProviderUsageData | null> {
     let token: string | null;
     try {
         const authStorage = createRunnerAuthStorage();
-        const credential = authStorage.get("anthropic");
-        token = getOAuthAccessToken(credential);
+        token = await getRefreshedOAuthToken(authStorage, "anthropic");
     } catch (err: any) {
         console.warn(`pizzapi runner: failed to get Anthropic credentials: ${err?.message ?? String(err)}`);
         return null;
@@ -395,8 +394,7 @@ async function fetchCodexUsageData(): Promise<ProviderUsageData | null> {
     let token: string | null;
     try {
         const authStorage = createRunnerAuthStorage();
-        const credential = authStorage.get("openai-codex");
-        token = getOAuthAccessToken(credential);
+        token = await getRefreshedOAuthToken(authStorage, "openai-codex");
     } catch (err: any) {
         console.warn(`pizzapi runner: failed to get OpenAI Codex credentials: ${err?.message ?? String(err)}`);
         return null;

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -280,15 +280,16 @@ function createRunnerAuthStorage(): AuthStorage {
 }
 
 async function fetchAnthropicUsageData(): Promise<ProviderUsageData | null> {
-    let token: string | undefined;
+    let token: string | null;
     try {
         const authStorage = createRunnerAuthStorage();
-        token = await authStorage.getApiKey("anthropic");
+        const credential = authStorage.get("anthropic");
+        token = getOAuthAccessToken(credential);
     } catch (err: any) {
         console.warn(`pizzapi runner: failed to get Anthropic credentials: ${err?.message ?? String(err)}`);
         return null;
     }
-    if (!token || typeof token !== "string") return null;
+    if (!token) return null;
     try {
         const res = await fetch("https://api.anthropic.com/api/oauth/usage", {
             headers: {
@@ -391,15 +392,16 @@ async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
 }
 
 async function fetchCodexUsageData(): Promise<ProviderUsageData | null> {
-    let token: string | undefined;
+    let token: string | null;
     try {
         const authStorage = createRunnerAuthStorage();
-        token = await authStorage.getApiKey("openai-codex");
+        const credential = authStorage.get("openai-codex");
+        token = getOAuthAccessToken(credential);
     } catch (err: any) {
         console.warn(`pizzapi runner: failed to get OpenAI Codex credentials: ${err?.message ?? String(err)}`);
         return null;
     }
-    if (!token || typeof token !== "string") return null;
+    if (!token) return null;
     try {
         const res = await fetch("https://chatgpt.com/backend-api/wham/usage", {
             headers: { Authorization: `Bearer ${token}` },

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -339,9 +339,10 @@ async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
     try {
         const parsed = (typeof rawCred === "string"
             ? JSON.parse(rawCred)
-            : rawCred) as { token?: string; projectId?: string };
-        if (!parsed.token || !parsed.projectId) return null;
-        token = parsed.token;
+            : rawCred) as { token?: string; access?: string; projectId?: string };
+        const accessToken = parsed.token ?? parsed.access;
+        if (!accessToken || !parsed.projectId) return null;
+        token = accessToken;
         projectId = parsed.projectId;
     } catch {
         return null;

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -19,7 +19,7 @@ import { join, dirname, relative, basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { io, type Socket } from "socket.io-client";
 import type { RunnerClientToServerEvents, RunnerServerToClientEvents, RunnerHook } from "@pizzapi/protocol";
-import { loadGlobalConfig, defaultAgentDir, type HooksConfig } from "../config.js";
+import { loadGlobalConfig, defaultAgentDir, expandHome, type HooksConfig } from "../config.js";
 import { AuthStorage } from "@mariozechner/pi-coding-agent";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 
@@ -268,16 +268,25 @@ function runnerUsageCacheFilePath(): string {
 /**
  * Create an AuthStorage instance for the runner daemon.
  * Uses the same auth.json as worker sessions so token refreshes are shared.
+ * Respects the `agentDir` config override so the daemon reads from the same
+ * location as the CLI/worker path (see remote-provider-usage.ts).
  * AuthStorage handles OAuth token refresh + file-locked writes automatically.
  */
 function createRunnerAuthStorage(): AuthStorage {
-    const agentDir = defaultAgentDir();
+    const config = loadGlobalConfig();
+    const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
     return AuthStorage.create(join(agentDir, "auth.json"));
 }
 
 async function fetchAnthropicUsageData(): Promise<ProviderUsageData | null> {
-    const authStorage = createRunnerAuthStorage();
-    const token = await authStorage.getApiKey("anthropic");
+    let token: string | undefined;
+    try {
+        const authStorage = createRunnerAuthStorage();
+        token = await authStorage.getApiKey("anthropic");
+    } catch (err: any) {
+        console.warn(`pizzapi runner: failed to get Anthropic credentials: ${err?.message ?? String(err)}`);
+        return null;
+    }
     if (!token || typeof token !== "string") return null;
     try {
         const res = await fetch("https://api.anthropic.com/api/oauth/usage", {
@@ -331,10 +340,16 @@ async function getRunnerAnthropicUsageData(opts: { force?: boolean } = {}): Prom
 }
 
 async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
-    const authStorage = createRunnerAuthStorage();
-    // AuthStorage.getApiKey handles OAuth token refresh and returns
-    // JSON.stringify({ token, projectId }) via the provider's getApiKey().
-    const raw = await authStorage.getApiKey("google-gemini-cli");
+    let raw: string | undefined;
+    try {
+        const authStorage = createRunnerAuthStorage();
+        // AuthStorage.getApiKey handles OAuth token refresh and returns
+        // JSON.stringify({ token, projectId }) via the provider's getApiKey().
+        raw = await authStorage.getApiKey("google-gemini-cli");
+    } catch (err: any) {
+        console.warn(`pizzapi runner: failed to get Google credentials: ${err?.message ?? String(err)}`);
+        return null;
+    }
     if (!raw) return null;
     let token: string;
     let projectId: string;
@@ -375,8 +390,14 @@ async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
 }
 
 async function fetchCodexUsageData(): Promise<ProviderUsageData | null> {
-    const authStorage = createRunnerAuthStorage();
-    const token = await authStorage.getApiKey("openai-codex");
+    let token: string | undefined;
+    try {
+        const authStorage = createRunnerAuthStorage();
+        token = await authStorage.getApiKey("openai-codex");
+    } catch (err: any) {
+        console.warn(`pizzapi runner: failed to get OpenAI Codex credentials: ${err?.message ?? String(err)}`);
+        return null;
+    }
     if (!token || typeof token !== "string") return null;
     try {
         const res = await fetch("https://chatgpt.com/backend-api/wham/usage", {

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -19,7 +19,8 @@ import { join, dirname, relative, basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { io, type Socket } from "socket.io-client";
 import type { RunnerClientToServerEvents, RunnerServerToClientEvents, RunnerHook } from "@pizzapi/protocol";
-import { loadGlobalConfig, type HooksConfig } from "../config.js";
+import { loadGlobalConfig, defaultAgentDir, type HooksConfig } from "../config.js";
+import { AuthStorage } from "@mariozechner/pi-coding-agent";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 
 /**
@@ -264,20 +265,19 @@ function runnerUsageCacheFilePath(): string {
     return join(homedir(), ".pizzapi", "usage-cache.json");
 }
 
-/** Read auth.json from the default PizzaPi home (same file used by remote.ts). */
-function readRunnerAuthJson(): Record<string, unknown> {
-    try {
-        const authPath = join(homedir(), ".pizzapi", "auth.json");
-        if (!existsSync(authPath)) return {};
-        return JSON.parse(readFileSync(authPath, "utf-8")) as Record<string, unknown>;
-    } catch {
-        return {};
-    }
+/**
+ * Create an AuthStorage instance for the runner daemon.
+ * Uses the same auth.json as worker sessions so token refreshes are shared.
+ * AuthStorage handles OAuth token refresh + file-locked writes automatically.
+ */
+function createRunnerAuthStorage(): AuthStorage {
+    const agentDir = defaultAgentDir();
+    return AuthStorage.create(join(agentDir, "auth.json"));
 }
 
 async function fetchAnthropicUsageData(): Promise<ProviderUsageData | null> {
-    const auth = readRunnerAuthJson();
-    const token = (auth as any)?.anthropic?.access;
+    const authStorage = createRunnerAuthStorage();
+    const token = await authStorage.getApiKey("anthropic");
     if (!token || typeof token !== "string") return null;
     try {
         const res = await fetch("https://api.anthropic.com/api/oauth/usage", {
@@ -331,18 +331,17 @@ async function getRunnerAnthropicUsageData(opts: { force?: boolean } = {}): Prom
 }
 
 async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
-    const auth = readRunnerAuthJson();
-    const rawCred = (auth as any)?.["google-gemini-cli"];
-    if (!rawCred) return null;
+    const authStorage = createRunnerAuthStorage();
+    // AuthStorage.getApiKey handles OAuth token refresh and returns
+    // JSON.stringify({ token, projectId }) via the provider's getApiKey().
+    const raw = await authStorage.getApiKey("google-gemini-cli");
+    if (!raw) return null;
     let token: string;
     let projectId: string;
     try {
-        const parsed = (typeof rawCred === "string"
-            ? JSON.parse(rawCred)
-            : rawCred) as { token?: string; access?: string; projectId?: string };
-        const accessToken = parsed.token ?? parsed.access;
-        if (!accessToken || !parsed.projectId) return null;
-        token = accessToken;
+        const parsed = JSON.parse(raw) as { token?: string; projectId?: string };
+        if (!parsed.token || !parsed.projectId) return null;
+        token = parsed.token;
         projectId = parsed.projectId;
     } catch {
         return null;
@@ -376,8 +375,8 @@ async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
 }
 
 async function fetchCodexUsageData(): Promise<ProviderUsageData | null> {
-    const auth = readRunnerAuthJson();
-    const token = (auth as any)?.["openai-codex"]?.access;
+    const authStorage = createRunnerAuthStorage();
+    const token = await authStorage.getApiKey("openai-codex");
     if (!token || typeof token !== "string") return null;
     try {
         const res = await fetch("https://chatgpt.com/backend-api/wham/usage", {

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -377,29 +377,29 @@ async function getRunnerAnthropicUsageData(opts: { force?: boolean } = {}): Prom
 }
 
 async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
-    let raw: string | undefined;
+    let token: string | undefined;
+    let projectId: string | undefined;
     try {
         for (const authStorage of getKnownAuthStorages()) {
             // AuthStorage.getApiKey handles OAuth token refresh and returns
             // JSON.stringify({ token, projectId }) via the provider's getApiKey().
-            raw = await authStorage.getApiKey("google-gemini-cli");
-            if (raw) break;
+            // Use parseGeminiQuotaCredential to validate the result — API-key
+            // credentials return a plain string that fails JSON.parse, so we
+            // must not short-circuit on the first truthy raw value; we need to
+            // confirm it is a valid OAuth Gemini credential before stopping.
+            const raw = await authStorage.getApiKey("google-gemini-cli");
+            const cred = parseGeminiQuotaCredential(raw);
+            if (cred) {
+                token = cred.token;
+                projectId = cred.projectId;
+                break;
+            }
         }
     } catch (err: any) {
         console.warn(`pizzapi runner: failed to get Google credentials: ${err?.message ?? String(err)}`);
         return null;
     }
-    if (!raw) return null;
-    let token: string;
-    let projectId: string;
-    try {
-        const parsed = JSON.parse(raw) as { token?: string; projectId?: string };
-        if (!parsed.token || !parsed.projectId) return null;
-        token = parsed.token;
-        projectId = parsed.projectId;
-    } catch {
-        return null;
-    }
+    if (!token || !projectId) return null;
     try {
         const endpoint = process.env["CODE_ASSIST_ENDPOINT"] ?? "https://cloudcode-pa.googleapis.com";
         const version = process.env["CODE_ASSIST_API_VERSION"] ?? "v1internal";

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -19,7 +19,7 @@ import { join, dirname, relative, basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { io, type Socket } from "socket.io-client";
 import type { RunnerClientToServerEvents, RunnerServerToClientEvents, RunnerHook } from "@pizzapi/protocol";
-import { loadGlobalConfig, defaultAgentDir, expandHome, type HooksConfig } from "../config.js";
+import { loadGlobalConfig, loadConfig, defaultAgentDir, expandHome, type HooksConfig } from "../config.js";
 import { AuthStorage } from "@mariozechner/pi-coding-agent";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 import { getRefreshedOAuthToken, parseGeminiQuotaCredential } from "./usage-auth.js";
@@ -269,12 +269,12 @@ function runnerUsageCacheFilePath(): string {
 /**
  * Create an AuthStorage instance for the runner daemon.
  * Uses the same auth.json as worker sessions so token refreshes are shared.
- * Respects the `agentDir` config override so the daemon reads from the same
- * location as the CLI/worker path (see remote-provider-usage.ts).
+ * Uses `loadConfig(process.cwd())` — the same merged config that worker
+ * sessions read — so project-level `agentDir` overrides are respected.
  * AuthStorage handles OAuth token refresh + file-locked writes automatically.
  */
 function createRunnerAuthStorage(): AuthStorage {
-    const config = loadGlobalConfig();
+    const config = loadConfig(process.cwd());
     const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
     return AuthStorage.create(join(agentDir, "auth.json"));
 }

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -262,28 +262,64 @@ const ANTHROPIC_USAGE_REFRESH_INTERVAL = 15 * 60 * 1000;
 let _usageRefreshTimer: ReturnType<typeof setInterval> | null = null;
 let _lastAnthropicUsage: { data: ProviderUsageData | null; fetchedAt: number } | null = null;
 
+/**
+ * Tracks CWDs of active worker sessions so usage fetches can probe
+ * project-local agentDir overrides when the daemon runs from a different directory.
+ * Map: cwd → set of sessionIds using that cwd.
+ */
+const _activeSessionCwds = new Map<string, Set<string>>();
+
+function trackSessionCwd(sessionId: string, cwd: string): void {
+    if (!_activeSessionCwds.has(cwd)) _activeSessionCwds.set(cwd, new Set());
+    _activeSessionCwds.get(cwd)!.add(sessionId);
+}
+
+function untrackSessionCwd(sessionId: string, cwd: string): void {
+    const sessions = _activeSessionCwds.get(cwd);
+    if (!sessions) return;
+    sessions.delete(sessionId);
+    if (sessions.size === 0) _activeSessionCwds.delete(cwd);
+}
+
 function runnerUsageCacheFilePath(): string {
     return join(homedir(), ".pizzapi", "usage-cache.json");
 }
 
 /**
- * Create an AuthStorage instance for the runner daemon.
- * Uses the same auth.json as worker sessions so token refreshes are shared.
- * Uses `loadConfig(process.cwd())` — the same merged config that worker
- * sessions read — so project-level `agentDir` overrides are respected.
- * AuthStorage handles OAuth token refresh + file-locked writes automatically.
+ * Returns all unique AuthStorage instances known to the daemon:
+ * the daemon's own startup CWD first, followed by any CWD registered by active
+ * worker sessions that maps to a different auth.json (e.g. a project-specific
+ * agentDir override).  Results are deduplicated by resolved auth.json path so
+ * the same file is never probed twice.
+ *
+ * Usage fetch functions iterate this list and use the first storage that
+ * yields valid credentials, ensuring that sessions spawned in projects with
+ * their own agentDir overrides are covered even when the daemon was started
+ * from a different directory.
  */
-function createRunnerAuthStorage(): AuthStorage {
-    const config = loadConfig(process.cwd());
-    const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
-    return AuthStorage.create(join(agentDir, "auth.json"));
+function getKnownAuthStorages(): AuthStorage[] {
+    const seen = new Set<string>();
+    const result: AuthStorage[] = [];
+    const cwds = [process.cwd(), ..._activeSessionCwds.keys()];
+    for (const cwd of cwds) {
+        const config = loadConfig(cwd);
+        const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
+        const authPath = join(agentDir, "auth.json");
+        if (!seen.has(authPath)) {
+            seen.add(authPath);
+            result.push(AuthStorage.create(authPath));
+        }
+    }
+    return result;
 }
 
 async function fetchAnthropicUsageData(): Promise<ProviderUsageData | null> {
-    let token: string | null;
+    let token: string | null = null;
     try {
-        const authStorage = createRunnerAuthStorage();
-        token = await getRefreshedOAuthToken(authStorage, "anthropic");
+        for (const authStorage of getKnownAuthStorages()) {
+            token = await getRefreshedOAuthToken(authStorage, "anthropic");
+            if (token) break;
+        }
     } catch (err: any) {
         console.warn(`pizzapi runner: failed to get Anthropic credentials: ${err?.message ?? String(err)}`);
         return null;
@@ -343,10 +379,12 @@ async function getRunnerAnthropicUsageData(opts: { force?: boolean } = {}): Prom
 async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
     let raw: string | undefined;
     try {
-        const authStorage = createRunnerAuthStorage();
-        // AuthStorage.getApiKey handles OAuth token refresh and returns
-        // JSON.stringify({ token, projectId }) via the provider's getApiKey().
-        raw = await authStorage.getApiKey("google-gemini-cli");
+        for (const authStorage of getKnownAuthStorages()) {
+            // AuthStorage.getApiKey handles OAuth token refresh and returns
+            // JSON.stringify({ token, projectId }) via the provider's getApiKey().
+            raw = await authStorage.getApiKey("google-gemini-cli");
+            if (raw) break;
+        }
     } catch (err: any) {
         console.warn(`pizzapi runner: failed to get Google credentials: ${err?.message ?? String(err)}`);
         return null;
@@ -391,10 +429,12 @@ async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
 }
 
 async function fetchCodexUsageData(): Promise<ProviderUsageData | null> {
-    let token: string | null;
+    let token: string | null = null;
     try {
-        const authStorage = createRunnerAuthStorage();
-        token = await getRefreshedOAuthToken(authStorage, "openai-codex");
+        for (const authStorage of getKnownAuthStorages()) {
+            token = await getRefreshedOAuthToken(authStorage, "openai-codex");
+            if (token) break;
+        }
     } catch (err: any) {
         console.warn(`pizzapi runner: failed to get OpenAI Codex credentials: ${err?.message ?? String(err)}`);
         return null;
@@ -1711,6 +1751,10 @@ function spawnSession(
         throw new Error(`Session already running: ${sessionId}`);
     }
 
+    // Resolve the effective cwd for this session now so we can register it for
+    // usage auth lookups and clean it up on exit without re-deriving it.
+    const effectiveCwd = requestedCwd ?? process.cwd();
+
     if (!isCwdAllowed(requestedCwd)) {
         throw new Error(`Requested cwd is outside allowed workspace root(s): ${requestedCwd}`);
     }
@@ -1779,8 +1823,13 @@ function spawnSession(
         }
     });
 
+    // Register this session's cwd so usage fetches can probe its project-local
+    // agentDir override (if any).  Cleaned up on exit below.
+    trackSessionCwd(sessionId, effectiveCwd);
+
     child.on("exit", (code, signal) => {
         runningSessions.delete(sessionId);
+        untrackSessionCwd(sessionId, effectiveCwd);
         console.log(`pizzapi runner: session ${sessionId} exited (code=${code}, signal=${signal})`);
         if (code === 43 && onRestartRequested) {
             // Restart-in-place: re-spawn immediately without touching attachments.

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -22,6 +22,7 @@ import type { RunnerClientToServerEvents, RunnerServerToClientEvents, RunnerHook
 import { loadGlobalConfig, defaultAgentDir, expandHome, type HooksConfig } from "../config.js";
 import { AuthStorage } from "@mariozechner/pi-coding-agent";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
+import { getOAuthAccessToken, parseGeminiQuotaCredential } from "./usage-auth.js";
 
 /**
  * Summarise the active hooks from a HooksConfig for display in the web UI.

--- a/packages/cli/src/runner/usage-auth.test.ts
+++ b/packages/cli/src/runner/usage-auth.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+import { getOAuthAccessToken, parseGeminiQuotaCredential } from "./usage-auth.js";
+
+describe("getOAuthAccessToken", () => {
+    test("returns OAuth access token", () => {
+        expect(getOAuthAccessToken({ type: "oauth", access: "oauth-token" })).toBe("oauth-token");
+    });
+
+    test("ignores api_key credentials", () => {
+        expect(getOAuthAccessToken({ type: "api_key", key: "sk-123" })).toBeNull();
+    });
+
+    test("returns null for invalid payload", () => {
+        expect(getOAuthAccessToken({})).toBeNull();
+        expect(getOAuthAccessToken("token")).toBeNull();
+    });
+});
+
+describe("parseGeminiQuotaCredential", () => {
+    test("parses stringified credential payload", () => {
+        expect(parseGeminiQuotaCredential('{"token":"tok","projectId":"proj"}')).toEqual({
+            token: "tok",
+            projectId: "proj",
+        });
+    });
+
+    test("parses object credential payload", () => {
+        expect(parseGeminiQuotaCredential({ token: "tok", projectId: "proj" })).toEqual({
+            token: "tok",
+            projectId: "proj",
+        });
+    });
+
+    test("ignores api_key credentials", () => {
+        expect(parseGeminiQuotaCredential({ type: "api_key", key: "AIza..." })).toBeNull();
+    });
+
+    test("returns null for invalid values", () => {
+        expect(parseGeminiQuotaCredential("AIza-api-key")).toBeNull();
+        expect(parseGeminiQuotaCredential('{"token":"tok"}')).toBeNull();
+    });
+});

--- a/packages/cli/src/runner/usage-auth.test.ts
+++ b/packages/cli/src/runner/usage-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { getOAuthAccessToken, parseGeminiQuotaCredential } from "./usage-auth.js";
+import { getOAuthAccessToken, getRefreshedOAuthToken, parseGeminiQuotaCredential } from "./usage-auth.js";
 
 describe("getOAuthAccessToken", () => {
     test("returns OAuth access token", () => {
@@ -13,6 +13,46 @@ describe("getOAuthAccessToken", () => {
     test("returns null for invalid payload", () => {
         expect(getOAuthAccessToken({})).toBeNull();
         expect(getOAuthAccessToken("token")).toBeNull();
+    });
+});
+
+describe("getRefreshedOAuthToken", () => {
+    function mockAuthStorage(credential: unknown, apiKeyResult?: string) {
+        return {
+            get: () => credential,
+            getApiKey: async () => apiKeyResult,
+        } as any;
+    }
+
+    test("returns refreshed token for OAuth credentials", async () => {
+        const storage = mockAuthStorage(
+            { type: "oauth", access: "old-token", expires: 0 },
+            "refreshed-token",
+        );
+        expect(await getRefreshedOAuthToken(storage, "anthropic")).toBe("refreshed-token");
+    });
+
+    test("returns null for API-key credentials", async () => {
+        const storage = mockAuthStorage({ type: "api_key", key: "sk-123" });
+        expect(await getRefreshedOAuthToken(storage, "anthropic")).toBeNull();
+    });
+
+    test("returns null when no credential exists", async () => {
+        const storage = mockAuthStorage(undefined);
+        expect(await getRefreshedOAuthToken(storage, "anthropic")).toBeNull();
+    });
+
+    test("returns null when getApiKey returns undefined", async () => {
+        const storage = mockAuthStorage(
+            { type: "oauth", access: "tok", expires: 0 },
+            undefined,
+        );
+        expect(await getRefreshedOAuthToken(storage, "anthropic")).toBeNull();
+    });
+
+    test("falls back to raw access for unknown credential type", async () => {
+        const storage = mockAuthStorage({ type: "custom", access: "custom-tok" });
+        expect(await getRefreshedOAuthToken(storage, "anthropic")).toBe("custom-tok");
     });
 });
 

--- a/packages/cli/src/runner/usage-auth.ts
+++ b/packages/cli/src/runner/usage-auth.ts
@@ -1,0 +1,44 @@
+export type RunnerAuthRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null;
+}
+
+/**
+ * Returns an OAuth bearer token from auth.json provider data.
+ * Ignores API-key credentials to avoid probing subscription usage endpoints.
+ */
+export function getOAuthAccessToken(raw: unknown): string | null {
+    if (!isRecord(raw)) return null;
+    const type = raw.type;
+    if (type === "api_key") return null;
+
+    const access = raw.access;
+    if (typeof access === "string" && access.trim().length > 0) return access;
+    return null;
+}
+
+/**
+ * Parse Gemini quota credential from auth.json provider data.
+ * Accepts the OAuth payload format used by Gemini CLI ({ token, projectId })
+ * but ignores API-key credentials.
+ */
+export function parseGeminiQuotaCredential(raw: unknown): { token: string; projectId: string } | null {
+    if (typeof raw === "string") {
+        try {
+            return parseGeminiQuotaCredential(JSON.parse(raw));
+        } catch {
+            return null;
+        }
+    }
+
+    if (!isRecord(raw)) return null;
+    if (raw.type === "api_key") return null;
+
+    const token = raw.token;
+    const projectId = raw.projectId;
+    if (typeof token !== "string" || typeof projectId !== "string") return null;
+    if (!token.trim() || !projectId.trim()) return null;
+
+    return { token, projectId };
+}

--- a/packages/cli/src/runner/usage-auth.ts
+++ b/packages/cli/src/runner/usage-auth.ts
@@ -1,3 +1,5 @@
+import type { AuthStorage } from "@mariozechner/pi-coding-agent";
+
 export type RunnerAuthRecord = Record<string, unknown>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -7,6 +9,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 /**
  * Returns an OAuth bearer token from auth.json provider data.
  * Ignores API-key credentials to avoid probing subscription usage endpoints.
+ *
+ * NOTE: This reads the raw credential without refreshing expired OAuth tokens.
+ * For long-lived processes (like the runner daemon), prefer {@link getRefreshedOAuthToken}
+ * which uses `AuthStorage.getApiKey()` to auto-refresh expired tokens.
  */
 export function getOAuthAccessToken(raw: unknown): string | null {
     if (!isRecord(raw)) return null;
@@ -16,6 +22,28 @@ export function getOAuthAccessToken(raw: unknown): string | null {
     const access = raw.access;
     if (typeof access === "string" && access.trim().length > 0) return access;
     return null;
+}
+
+/**
+ * Returns a refreshed OAuth bearer token for a provider, or null if the
+ * credential is an API key or missing.
+ *
+ * Unlike {@link getOAuthAccessToken}, this uses `AuthStorage.getApiKey()` which
+ * handles OAuth token refresh with file-locking for long-lived processes.
+ */
+export async function getRefreshedOAuthToken(authStorage: AuthStorage, providerId: string): Promise<string | null> {
+    // Check credential type first — skip API-key credentials entirely.
+    const raw = authStorage.get(providerId);
+    if (!isRecord(raw)) return null;
+    if (raw.type === "api_key") return null;
+    if (raw.type !== "oauth") {
+        // Unknown credential type — fall back to raw access token
+        return getOAuthAccessToken(raw);
+    }
+
+    // Use getApiKey() which handles OAuth token refresh + locking.
+    const token = await authStorage.getApiKey(providerId);
+    return typeof token === "string" && token.trim().length > 0 ? token : null;
 }
 
 /**

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -735,52 +735,57 @@ export function registerRelayNamespace(io: SocketIOServer): void {
 
             console.log(`[sio/relay] cleanup_child_session: parent=${sessionId} child=${childSessionId}`);
 
-            // Terminate the child process via two complementary paths:
-            //
-            // 1. kill_session → runner (cluster-wide via emitToRunner):
-            //    sends SIGTERM to the OS process.  Reaches runners on any
-            //    cluster node through the Redis adapter.
-            if (childSession.runnerId) {
-                emitToRunner(childSession.runnerId, "kill_session", { sessionId: childSessionId });
-            }
+            try {
+                // Terminate the child process via two complementary paths:
+                //
+                // 1. kill_session → runner (cluster-wide via emitToRunner):
+                //    sends SIGTERM to the OS process.  Reaches runners on any
+                //    cluster node through the Redis adapter.
+                if (childSession.runnerId) {
+                    emitToRunner(childSession.runnerId, "kill_session", { sessionId: childSessionId });
+                }
 
-            // 2. exec end_session → child relay socket (cluster-wide via Redis
-            //    adapter room broadcast).  Reaches the child on any node and
-            //    causes it to clear its follow-up grace timer and shut down
-            //    cleanly.  If the runner already sent SIGTERM in step 1 the
-            //    exec arrives to an already-exiting worker (benign no-op).
-            emitToRelaySession(childSessionId, "exec", {
-                id: `cleanup-${childSessionId}-${Date.now()}`,
-                command: "end_session",
-            });
+                // 2. exec end_session → child relay socket (cluster-wide via Redis
+                //    adapter room broadcast).  Reaches the child on any node and
+                //    causes it to clear its follow-up grace timer and shut down
+                //    cleanly.  If the runner already sent SIGTERM in step 1 the
+                //    exec arrives to an already-exiting worker (benign no-op).
+                emitToRelaySession(childSessionId, "exec", {
+                    id: `cleanup-${childSessionId}-${Date.now()}`,
+                    command: "end_session",
+                });
 
-            const relaySockets = await io.of("/relay").in(`session:${childSessionId}`).fetchSockets();
-            const hasRelayRecipient = relaySockets.length > 0;
+                const relaySockets = await io.of("/relay").in(`session:${childSessionId}`).fetchSockets();
+                const hasRelayRecipient = relaySockets.length > 0;
 
-            // Clean up child-index entry
-            void removeChildSession(sessionId, childSessionId);
+                // Clean up child-index entry
+                void removeChildSession(sessionId, childSessionId);
 
-            if (!hasRelayRecipient) {
-                // No relay socket is currently joined for this child anywhere in
-                // the cluster, so there is no disconnect handler left to finish
-                // cleanup. Complete teardown now so acknowledged children don't
-                // linger in Redis/sidebar until the orphan sweeper runs.
-                await endSharedSession(childSessionId, "Parent acknowledged completion");
+                if (!hasRelayRecipient) {
+                    // No relay socket is currently joined for this child anywhere in
+                    // the cluster, so there is no disconnect handler left to finish
+                    // cleanup. Complete teardown now so acknowledged children don't
+                    // linger in Redis/sidebar until the orphan sweeper runs.
+                    await endSharedSession(childSessionId, "Parent acknowledged completion");
+                    if (typeof ack === "function") ack({ ok: true });
+                    return;
+                }
+
+                // Do NOT call endSharedSession here when a relay recipient exists.
+                // The child will disconnect momentarily (from the SIGTERM or exec
+                // above), and its disconnect handler on whichever node hosts the
+                // child's relay socket will call endSharedSession there — where the
+                // correct local runner socket is available for adopted-session
+                // cleanup. Calling it here first would delete the Redis record
+                // before that node can process the disconnect, turning its
+                // endSharedSession into a no-op and leaving adopted-session entries
+                // stranded in runningSessions on the remote runner.
+
                 if (typeof ack === "function") ack({ ok: true });
-                return;
+            } catch (err: any) {
+                console.error(`[sio/relay] cleanup_child_session failed: parent=${sessionId} child=${childSessionId}`, err);
+                if (typeof ack === "function") ack({ ok: false, error: err?.message ?? "Internal error" });
             }
-
-            // Do NOT call endSharedSession here when a relay recipient exists.
-            // The child will disconnect momentarily (from the SIGTERM or exec
-            // above), and its disconnect handler on whichever node hosts the
-            // child's relay socket will call endSharedSession there — where the
-            // correct local runner socket is available for adopted-session
-            // cleanup. Calling it here first would delete the Redis record
-            // before that node can process the disconnect, turning its
-            // endSharedSession into a no-op and leaving adopted-session entries
-            // stranded in runningSessions on the remote runner.
-
-            if (typeof ack === "function") ack({ ok: true });
         });
 
         // ── disconnect ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Google's usage data never appeared in the runner daemon's usage cache (), so workers in runner mode showed no Google usage. Force-refreshing from the UI worked fine.

## Root Cause

Two bugs in the daemon's `fetchGeminiUsageData()`:

1. **Field name mismatch**: auth.json stores Google tokens as `access`, but the daemon looked for `token`. The upstream OAuth provider's `getApiKey()` transforms `{ access } → { token }`, which is why force-refresh (via AuthStorage) worked but direct file reads didn't.

2. **No token refresh**: The daemon read auth.json as raw JSON without refreshing expired OAuth tokens. Google tokens expire every ~1 hour, so even after fixing the field name, the daemon would fail silently after the first hour.

## Fix

Replace `readRunnerAuthJson()` with `AuthStorage` from pi-coding-agent for all three providers (Anthropic, Codex, Google). This handles:
- Correct field name transformation via provider's `getApiKey()`
- Automatic OAuth token refresh with file-locked writes
- Consistent `agentDir` config resolution (matches worker/CLI path)
- Logged warnings when credential retrieval fails

## Review

- GPT-5.4 reviewed and caught the `agentDir` config issue (fixed in commit 3)