### PR TITLE
fix: deep-merge mcpServers between global and project configs

### DIFF
--- a/.beads/hooks/pre-commit
+++ b/.beads/hooks/pre-commit
@@ -16,9 +16,9 @@ call_lefthook()
   elif lefthook -h >/dev/null 2>&1
   then
     lefthook "$@"
-  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/child-cleanup-on-ack/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
+  elif /Users/jordan/Documents/Projects/PizzaPi/.worktrees/fix-mcp-merge/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook -h >/dev/null 2>&1
   then
-    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/child-cleanup-on-ack/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
+    /Users/jordan/Documents/Projects/PizzaPi/.worktrees/fix-mcp-merge/node_modules/.bun/lefthook-darwin-arm64@2.1.1/node_modules/lefthook-darwin-arm64/bin/lefthook "$@"
   else
     dir="$(git rev-parse --show-toplevel)"
     osArch=$(uname | tr '[:upper:]' '[:lower:]')

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -412,6 +412,174 @@ describe("validateSandboxOverride", () => {
   });
 });
 
+// ── loadConfig mcpServers deep-merge ──────────────────────────────────────────
+
+describe("loadConfig mcpServers deep-merge", () => {
+  let tempDir: string;
+  let globalDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "pizzapi-mcp-merge-"));
+    globalDir = join(tempDir, "global-pizzapi");
+    mkdirSync(globalDir, { recursive: true });
+    _setGlobalConfigDir(globalDir);
+  });
+
+  afterEach(() => {
+    _setGlobalConfigDir(null);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("global-only mcpServers passes through", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          godmother: { command: "godmother", args: ["serve"] },
+          tavily: { command: "tavily-mcp" },
+        },
+      }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(join(projectDir, ".pizzapi", "config.json"), JSON.stringify({}));
+
+    const config = loadConfig(projectDir) as any;
+    expect(Object.keys(config.mcpServers)).toEqual(["godmother", "tavily"]);
+    expect(config.mcpServers.godmother.command).toBe("godmother");
+  });
+
+  test("project-only mcpServers passes through", () => {
+    writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          playwright: { command: "npx", args: ["@playwright/mcp"] },
+        },
+      }),
+    );
+
+    const config = loadConfig(projectDir) as any;
+    expect(Object.keys(config.mcpServers)).toEqual(["playwright"]);
+  });
+
+  test("both defined: servers merge, project wins on name conflicts", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          godmother: { command: "godmother", args: ["serve"] },
+          shared: { command: "global-version" },
+        },
+      }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          playwright: { command: "npx", args: ["@playwright/mcp"] },
+          shared: { command: "project-version" },
+        },
+      }),
+    );
+
+    const config = loadConfig(projectDir) as any;
+    // All three servers should be present
+    expect(new Set(Object.keys(config.mcpServers))).toEqual(
+      new Set(["godmother", "shared", "playwright"]),
+    );
+    // Global-only server preserved
+    expect(config.mcpServers.godmother.command).toBe("godmother");
+    // Project-only server present
+    expect(config.mcpServers.playwright.command).toBe("npx");
+    // Conflict: project wins
+    expect(config.mcpServers.shared.command).toBe("project-version");
+  });
+
+  test("mcp.servers (preferred format) merges by server name", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({
+        mcp: {
+          servers: [
+            { name: "godmother", transport: "stdio", command: "godmother" },
+            { name: "shared", transport: "stdio", command: "global-ver" },
+          ],
+        },
+      }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        mcp: {
+          servers: [
+            { name: "playwright", transport: "stdio", command: "npx" },
+            { name: "shared", transport: "stdio", command: "project-ver" },
+          ],
+        },
+      }),
+    );
+
+    const config = loadConfig(projectDir) as any;
+    const names = config.mcp.servers.map((s: any) => s.name);
+    expect(new Set(names)).toEqual(new Set(["godmother", "shared", "playwright"]));
+    const shared = config.mcp.servers.find((s: any) => s.name === "shared");
+    expect(shared.command).toBe("project-ver");
+  });
+
+  test("one has mcpServers, other has mcp.servers — both formats load", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          godmother: { command: "godmother", args: ["serve"] },
+        },
+      }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        mcp: {
+          servers: [
+            { name: "playwright", transport: "stdio", command: "npx" },
+          ],
+        },
+      }),
+    );
+
+    const config = loadConfig(projectDir) as any;
+    // mcpServers from global
+    expect(config.mcpServers.godmother.command).toBe("godmother");
+    // mcp.servers from project
+    expect(config.mcp.servers[0].name).toBe("playwright");
+  });
+
+  test("neither config has mcpServers — no key added", () => {
+    writeFileSync(join(globalDir, "config.json"), JSON.stringify({ apiKey: "test" }));
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(join(projectDir, ".pizzapi", "config.json"), JSON.stringify({}));
+
+    const config = loadConfig(projectDir) as any;
+    expect(config.mcpServers).toBeUndefined();
+  });
+});
+
 // ── saveGlobalConfig ──────────────────────────────────────────────────────────
 
 describe("saveGlobalConfig", () => {

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -2,6 +2,11 @@ import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { join, resolve } from "path";
 
+/** Check if a value is a plain object (not null, not an array). */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
 /** A single hook entry — a shell command to run at a lifecycle point. */
 export interface HookEntry {
     /** Shell command to execute. Receives JSON on stdin. */
@@ -904,6 +909,37 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
             global.sandbox ?? {},
             project.sandbox ?? {},
         );
+    }
+
+    // Deep-merge mcpServers (Claude Code compatibility format) from both scopes.
+    // Project entries win on name conflicts, but global servers are preserved.
+    // mcpServers is not in the PizzaPiConfig type — it flows through as untyped JSON.
+    const globalMcpServers = isPlainObject((global as any).mcpServers) ? (global as any).mcpServers : undefined;
+    const projectMcpServers = isPlainObject((project as any).mcpServers) ? (project as any).mcpServers : undefined;
+    if (globalMcpServers || projectMcpServers) {
+        (config as any).mcpServers = { ...globalMcpServers, ...projectMcpServers };
+    }
+
+    // Deep-merge mcp.servers (preferred array format) from both scopes.
+    // Project entries win on name conflicts (matched by server name).
+    const globalMcp = isPlainObject((global as any).mcp) ? (global as any).mcp : undefined;
+    const projectMcp = isPlainObject((project as any).mcp) ? (project as any).mcp : undefined;
+    if (globalMcp || projectMcp) {
+        const globalServers: any[] = Array.isArray(globalMcp?.servers) ? globalMcp.servers : [];
+        const projectServers: any[] = Array.isArray(projectMcp?.servers) ? projectMcp.servers : [];
+        // Build a map keyed by server name — project entries overwrite global ones
+        const serverMap = new Map<string, any>();
+        for (const s of globalServers) {
+            if (isPlainObject(s) && typeof s.name === "string") serverMap.set(s.name, s);
+        }
+        for (const s of projectServers) {
+            if (isPlainObject(s) && typeof s.name === "string") serverMap.set(s.name, s);
+        }
+        (config as any).mcp = {
+            ...globalMcp,
+            ...projectMcp,
+            servers: [...serverMap.values()],
+        };
     }
 
     // Merge disabledMcpServers from both scopes (union).

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -32,8 +32,8 @@ type EffectiveMcpServer = McpServerConfigEntry & {
 type McpConfigInspection = {
   global: McpConfigFileState;
   project: McpConfigFileState;
-  effectivePreferredSource: "global" | "project" | "none";
-  effectiveCompatibilitySource: "global" | "project" | "none";
+  effectivePreferredSource: "global" | "project" | "both" | "none";
+  effectiveCompatibilitySource: "global" | "project" | "both" | "none";
   effectiveServers: EffectiveMcpServer[];
   /** Server names disabled via disabledMcpServers in global and/or project config. */
   disabledServers: string[];
@@ -174,39 +174,63 @@ function inspectMcpConfig(cwd: string): McpConfigInspection {
   const global = parseConfigFile("global", globalPath);
   const project = parseConfigFile("project", projectPath);
 
-  const effectivePreferredSource: "global" | "project" | "none" = project.hasMcpKey
-    ? "project"
-    : global.hasMcpKey
-      ? "global"
-      : "none";
+  // Determine effective sources — "both" when both scopes define the key
+  const effectivePreferredSource: "global" | "project" | "both" | "none" =
+    global.hasMcpKey && project.hasMcpKey
+      ? "both"
+      : project.hasMcpKey
+        ? "project"
+        : global.hasMcpKey
+          ? "global"
+          : "none";
 
-  const effectiveCompatibilitySource: "global" | "project" | "none" = project.hasMcpServersKey
-    ? "project"
-    : global.hasMcpServersKey
-      ? "global"
-      : "none";
+  const effectiveCompatibilitySource: "global" | "project" | "both" | "none" =
+    global.hasMcpServersKey && project.hasMcpServersKey
+      ? "both"
+      : project.hasMcpServersKey
+        ? "project"
+        : global.hasMcpServersKey
+          ? "global"
+          : "none";
 
   const effectiveServers: EffectiveMcpServer[] = [];
 
+  // mcp.servers (preferred format): merge by server name, project wins on conflicts
   if (effectivePreferredSource !== "none") {
-    const source = effectivePreferredSource === "project" ? project : global;
-    for (const entry of source.preferredServers) {
-      effectiveServers.push({
-        ...entry,
-        scope: source.scope,
-        sourcePath: source.path,
-      });
+    if (effectivePreferredSource === "both") {
+      // Merge: start with global, project overwrites by name
+      const serverMap = new Map<string, EffectiveMcpServer>();
+      for (const entry of global.preferredServers) {
+        serverMap.set(entry.name, { ...entry, scope: "global", sourcePath: global.path });
+      }
+      for (const entry of project.preferredServers) {
+        serverMap.set(entry.name, { ...entry, scope: "project", sourcePath: project.path });
+      }
+      effectiveServers.push(...serverMap.values());
+    } else {
+      const source = effectivePreferredSource === "project" ? project : global;
+      for (const entry of source.preferredServers) {
+        effectiveServers.push({ ...entry, scope: source.scope, sourcePath: source.path });
+      }
     }
   }
 
+  // mcpServers (compatibility format): merge by server name, project wins on conflicts
   if (effectiveCompatibilitySource !== "none") {
-    const source = effectiveCompatibilitySource === "project" ? project : global;
-    for (const entry of source.compatibilityServers) {
-      effectiveServers.push({
-        ...entry,
-        scope: source.scope,
-        sourcePath: source.path,
-      });
+    if (effectiveCompatibilitySource === "both") {
+      const serverMap = new Map<string, EffectiveMcpServer>();
+      for (const entry of global.compatibilityServers) {
+        serverMap.set(entry.name, { ...entry, scope: "global", sourcePath: global.path });
+      }
+      for (const entry of project.compatibilityServers) {
+        serverMap.set(entry.name, { ...entry, scope: "project", sourcePath: project.path });
+      }
+      effectiveServers.push(...serverMap.values());
+    } else {
+      const source = effectiveCompatibilitySource === "project" ? project : global;
+      for (const entry of source.compatibilityServers) {
+        effectiveServers.push({ ...entry, scope: source.scope, sourcePath: source.path });
+      }
     }
   }
 

--- a/packages/docs/src/content/docs/customization/mcp-servers.mdx
+++ b/packages/docs/src/content/docs/customization/mcp-servers.mdx
@@ -67,7 +67,7 @@ Two config formats are supported:
   </TabItem>
 </Tabs>
 
-Project-local config overrides global config **by top-level key**. If your project `.pizzapi/config.json` defines `mcpServers`, it replaces the entire global `mcpServers` object — the two are not merged. To use a global server alongside project-specific ones, redeclare it in the project config.
+Project-local and global MCP servers are **deep-merged** — servers from both scopes are combined. If a server with the same name appears in both configs, the project-local definition wins. Global-only servers are preserved alongside project-specific ones, so you don't need to redeclare them.
 
 See the [Configuration guide](/PizzaPi/customization/configuration/) for full details on config file loading and precedence.
 


### PR DESCRIPTION
## Problem

When both `~/.pizzapi/config.json` (global) and `.pizzapi/config.json` (project) define `mcpServers`, the project config **completely replaces** the global config instead of merging them. This causes global MCP servers (like Godmother) to silently disappear when a project defines its own MCP servers.

## Root Cause

Two locations had the same issue:

1. **`loadConfig()` in `config.ts`**: The shallow spread `{ ...global, ...project }` clobbers `mcpServers` from global when project also defines it.
2. **`inspectMcpConfig()` in `mcp-extension.ts`**: Picks **either** project or global as the source for `mcpServers`, never both.

## Fix

### `loadConfig()` — `config.ts`
After the shallow spread, explicitly deep-merge:
- `mcpServers` (Claude Code compatibility format): `{ ...globalMcpServers, ...projectMcpServers }` — project entries win on name conflicts, global-only servers preserved.
- `mcp.servers` (preferred array format): Merge by server name into a Map, project overwrites global on conflict.

Follows the same pattern as existing `hooks`, `sandbox`, and `disabledMcpServers` merging.

### `inspectMcpConfig()` — `mcp-extension.ts`
When both global and project define `mcpServers` (or `mcp.servers`), set `effectiveSource` to `"both"` and combine servers from both scopes using a Map keyed by server name (project wins on conflicts).

## Tests Added

6 new tests in `config.test.ts`:
- Global-only mcpServers passes through
- Project-only mcpServers passes through  
- Both defined: servers merge, project wins on name conflicts
- `mcp.servers` (preferred format) merges by server name
- One has mcpServers, other has mcp.servers — both formats load
- Neither config has mcpServers — no key added

All tests pass. Typecheck clean.