### PR TITLE
feat: rich AskUserQuestion support in child session triggers

### DIFF
--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -916,15 +916,14 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             // parent doesn't want triggers, it should spawn with linked: false.
             trackReceivedTrigger(trigger.triggerId, trigger.sourceSessionId, trigger.type);
             const rendered = renderTrigger(trigger);
-            // Strip HTML comment containing structured questions before sending to the parent agent.
-            // The HTML comment is intended for web UIs to parse rich trigger questions,
-            // but it should not appear in the parent agent's prompt (for CLI/TUI sessions
-            // where HTML comments are not hidden and would appear as plain text).
-            const renderedForParent = rendered
-              .replace(/<!-- questions64:[^>]+ -->\n?/g, "")
-              .replace(/<!-- questions:[^>]* -->\n?/g, "");
+            // Keep the <!-- questions64:... --> HTML comment in the message sent
+            // to the parent session. The web UI needs it to render rich trigger
+            // cards (checkbox, ranked, multi-question steppers). The base64
+            // encoding keeps the comment compact and avoids noisy JSON in the
+            // parent's prompt. For CLI/TUI agents, HTML comments are minimal
+            // overhead in the raw text.
             const deliverAs = trigger.deliverAs === "followUp" ? "followUp" as const : "steer" as const;
-            pi.sendUserMessage(renderedForParent, { deliverAs });
+            pi.sendUserMessage(rendered, { deliverAs });
         });
 
         sock.on("trigger_response" as any, (data: { triggerId: string; response: string; action?: string; targetSessionId?: string }) => {

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -916,12 +916,10 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             // parent doesn't want triggers, it should spawn with linked: false.
             trackReceivedTrigger(trigger.triggerId, trigger.sourceSessionId, trigger.type);
             const rendered = renderTrigger(trigger);
-            // Keep the <!-- questions64:... --> HTML comment in the message sent
-            // to the parent session. The web UI needs it to render rich trigger
-            // cards (checkbox, ranked, multi-question steppers). The base64
-            // encoding keeps the comment compact and avoids noisy JSON in the
-            // parent's prompt. For CLI/TUI agents, HTML comments are minimal
-            // overhead in the raw text.
+            // The trigger metadata line (<!-- trigger:ID source:SID questions64:... -->)
+            // carries structured question data inline so the web UI can render
+            // rich trigger cards. This keeps the agent-facing prompt clean —
+            // no separate HTML comment block is needed.
             const deliverAs = trigger.deliverAs === "followUp" ? "followUp" as const : "steer" as const;
             pi.sendUserMessage(rendered, { deliverAs });
         });

--- a/packages/cli/src/extensions/remote.ts
+++ b/packages/cli/src/extensions/remote.ts
@@ -916,8 +916,15 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             // parent doesn't want triggers, it should spawn with linked: false.
             trackReceivedTrigger(trigger.triggerId, trigger.sourceSessionId, trigger.type);
             const rendered = renderTrigger(trigger);
+            // Strip HTML comment containing structured questions before sending to the parent agent.
+            // The HTML comment is intended for web UIs to parse rich trigger questions,
+            // but it should not appear in the parent agent's prompt (for CLI/TUI sessions
+            // where HTML comments are not hidden and would appear as plain text).
+            const renderedForParent = rendered
+              .replace(/<!-- questions64:[^>]+ -->\n?/g, "")
+              .replace(/<!-- questions:[^>]* -->\n?/g, "");
             const deliverAs = trigger.deliverAs === "followUp" ? "followUp" as const : "steer" as const;
-            pi.sendUserMessage(rendered, { deliverAs });
+            pi.sendUserMessage(renderedForParent, { deliverAs });
         });
 
         sock.on("trigger_response" as any, (data: { triggerId: string; response: string; action?: string; targetSessionId?: string }) => {

--- a/packages/cli/src/extensions/triggers/integration.test.ts
+++ b/packages/cli/src/extensions/triggers/integration.test.ts
@@ -11,7 +11,8 @@ import { trackReceivedTrigger, receivedTriggers } from "./extension.js";
 import type { ConversationTrigger } from "./types.js";
 
 // Duplicate trigger message parsing from UI package (can't cross-import packages)
-const TRIGGER_PREFIX_RE = /^<!--\s*trigger:([\w-]+)\s*-->\n?/;
+// Matches: <!-- trigger:ID --> or <!-- trigger:ID source:sessionID -->
+const TRIGGER_PREFIX_RE = /^<!--\s*trigger:([\w-]+)(?:\s+source:[\w-]+)?\s*-->\n?/;
 function parseTriggerMessage(text: string): { triggerId: string; body: string } | null {
     const match = text.match(TRIGGER_PREFIX_RE);
     if (!match) return null;

--- a/packages/cli/src/extensions/triggers/registry.test.ts
+++ b/packages/cli/src/extensions/triggers/registry.test.ts
@@ -48,6 +48,28 @@ describe("renderTrigger", () => {
             expect(result).toContain("> What now?");
             expect(result).not.toContain("Options:");
         });
+
+        it("encodes UTF-8 questions (emoji, CJK) as valid base64 without throwing", () => {
+            const trigger = makeTrigger({
+                type: "ask_user_question",
+                payload: {
+                    question: "Choose 🎉",
+                    options: ["日本語"],
+                    questions: [
+                        { question: "Choose 🎉", options: ["日本語", "中文", "\u201csmart\u201d"], type: "radio" },
+                    ],
+                },
+            });
+            const result = renderTrigger(trigger);
+            // Must contain a valid base64 block
+            const match = result.match(/<!-- questions64:([\w+/=]+) -->/);
+            expect(match).toBeTruthy();
+            // Round-trip: decode and verify
+            const decoded = Buffer.from(match![1], "base64").toString("utf-8");
+            const parsed = JSON.parse(decoded);
+            expect(parsed[0].question).toBe("Choose 🎉");
+            expect(parsed[0].options).toContain("日本語");
+        });
     });
 
     describe("plan_review", () => {

--- a/packages/cli/src/extensions/triggers/registry.test.ts
+++ b/packages/cli/src/extensions/triggers/registry.test.ts
@@ -21,7 +21,7 @@ describe("renderTrigger", () => {
     it("prefixes output with trigger ID metadata comment", () => {
         const trigger = makeTrigger({ payload: { question: "Pick one", options: ["A", "B"] } });
         const result = renderTrigger(trigger);
-        expect(result).toStartWith("<!-- trigger:trigger-001 -->");
+        expect(result).toStartWith("<!-- trigger:trigger-001 source:child-abc-123 -->");
     });
 
     describe("ask_user_question", () => {

--- a/packages/cli/src/extensions/triggers/registry.test.ts
+++ b/packages/cli/src/extensions/triggers/registry.test.ts
@@ -61,8 +61,8 @@ describe("renderTrigger", () => {
                 },
             });
             const result = renderTrigger(trigger);
-            // Must contain a valid base64 block
-            const match = result.match(/<!-- questions64:([\w+/=]+) -->/);
+            // Must contain a valid base64 block in the trigger metadata comment
+            const match = result.match(/questions64:([\w+/=]+)/);
             expect(match).toBeTruthy();
             // Round-trip: decode and verify
             const decoded = Buffer.from(match![1], "base64").toString("utf-8");

--- a/packages/cli/src/extensions/triggers/registry.ts
+++ b/packages/cli/src/extensions/triggers/registry.ts
@@ -31,19 +31,7 @@ const askUserQuestionRenderer: TriggerRenderer = {
             ? (trigger.payload.options as string[])
             : [];
 
-        // Embed structured questions as a base64-encoded HTML comment so the
-        // web UI can render rich multi-question / checkbox / ranked triggers.
-        // Base64 avoids "-->" breaking the comment and keeps the raw JSON out
-        // of the parent agent's prompt (CLI agents see only the human-readable
-        // text below the comment).
-        const questions = Array.isArray(trigger.payload.questions)
-            ? trigger.payload.questions
-            : undefined;
-        const questionsBlock = questions
-            ? `<!-- questions64:${Buffer.from(JSON.stringify(questions), "utf-8").toString("base64")} -->\n`
-            : "";
-
-        const lines = [`🔗 Child "${name}" asks:`, questionsBlock + `> ${question}`];
+        const lines = [`🔗 Child "${name}" asks:`, `> ${question}`];
         if (options.length > 0) {
             lines.push(`Options: ${options.map((o, i) => `${i + 1}. ${o}`).join("  ")}`);
         }
@@ -203,7 +191,17 @@ export function renderTrigger(trigger: ConversationTrigger): string {
     const body = renderer
         ? renderer.render(trigger)
         : `🔗 Child "${displayName(trigger)}" sent unknown trigger "${trigger.type}". Payload: ${JSON.stringify(trigger.payload)}`;
-    return `<!-- trigger:${trigger.triggerId} source:${trigger.sourceSessionId} -->\n${body}`;
+
+    // Embed structured questions as base64 inside the trigger metadata comment
+    // so the web UI can render rich multi-question / checkbox / ranked triggers
+    // without polluting the agent-facing prompt text with a separate comment.
+    const questions = trigger.type === "ask_user_question" && Array.isArray(trigger.payload.questions)
+        ? trigger.payload.questions
+        : undefined;
+    const q64 = questions
+        ? ` questions64:${Buffer.from(JSON.stringify(questions), "utf-8").toString("base64")}`
+        : "";
+    return `<!-- trigger:${trigger.triggerId} source:${trigger.sourceSessionId}${q64} -->\n${body}`;
 }
 
 /** Parse a response using the trigger type's parser, if available. */

--- a/packages/cli/src/extensions/triggers/registry.ts
+++ b/packages/cli/src/extensions/triggers/registry.ts
@@ -31,17 +31,16 @@ const askUserQuestionRenderer: TriggerRenderer = {
             ? (trigger.payload.options as string[])
             : [];
 
-        // Embed structured questions data as an HTML comment so the web UI
-        // can render rich multi-question / checkbox / ranked triggers.
-        // CLI agents see only the human-readable text below the comment.
+        // Embed structured questions as a base64-encoded HTML comment so the
+        // web UI can render rich multi-question / checkbox / ranked triggers.
+        // Base64 avoids "-->" breaking the comment and keeps the raw JSON out
+        // of the parent agent's prompt (CLI agents see only the human-readable
+        // text below the comment).
         const questions = Array.isArray(trigger.payload.questions)
             ? trigger.payload.questions
             : undefined;
-        // Escape all "--" sequences in the serialized JSON so they can't
-        // prematurely close the HTML comment or trigger quirks-mode parsing.
-        // The UI parser reverses this before JSON.parse().
         const questionsBlock = questions
-            ? `<!-- questions:${JSON.stringify(questions).replace(/--/g, "__DASH__")} -->\n`
+            ? `<!-- questions64:${btoa(JSON.stringify(questions))} -->\n`
             : "";
 
         const lines = [`🔗 Child "${name}" asks:`, questionsBlock + `> ${question}`];

--- a/packages/cli/src/extensions/triggers/registry.ts
+++ b/packages/cli/src/extensions/triggers/registry.ts
@@ -37,10 +37,11 @@ const askUserQuestionRenderer: TriggerRenderer = {
         const questions = Array.isArray(trigger.payload.questions)
             ? trigger.payload.questions
             : undefined;
-        // Escape "-->" in the serialized JSON so it can't prematurely close
-        // the HTML comment.  The UI parser reverses this before JSON.parse().
+        // Escape all "--" sequences in the serialized JSON so they can't
+        // prematurely close the HTML comment or trigger quirks-mode parsing.
+        // The UI parser reverses this before JSON.parse().
         const questionsBlock = questions
-            ? `<!-- questions:${JSON.stringify(questions).replace(/-->/g, "--\\>")} -->\n`
+            ? `<!-- questions:${JSON.stringify(questions).replace(/--/g, "__DASH__")} -->\n`
             : "";
 
         const lines = [`🔗 Child "${name}" asks:`, questionsBlock + `> ${question}`];

--- a/packages/cli/src/extensions/triggers/registry.ts
+++ b/packages/cli/src/extensions/triggers/registry.ts
@@ -37,8 +37,10 @@ const askUserQuestionRenderer: TriggerRenderer = {
         const questions = Array.isArray(trigger.payload.questions)
             ? trigger.payload.questions
             : undefined;
+        // Escape "-->" in the serialized JSON so it can't prematurely close
+        // the HTML comment.  The UI parser reverses this before JSON.parse().
         const questionsBlock = questions
-            ? `<!-- questions:${JSON.stringify(questions)} -->\n`
+            ? `<!-- questions:${JSON.stringify(questions).replace(/-->/g, "--\\>")} -->\n`
             : "";
 
         const lines = [`🔗 Child "${name}" asks:`, questionsBlock + `> ${question}`];

--- a/packages/cli/src/extensions/triggers/registry.ts
+++ b/packages/cli/src/extensions/triggers/registry.ts
@@ -31,7 +31,17 @@ const askUserQuestionRenderer: TriggerRenderer = {
             ? (trigger.payload.options as string[])
             : [];
 
-        const lines = [`🔗 Child "${name}" asks:`, `> ${question}`];
+        // Embed structured questions data as an HTML comment so the web UI
+        // can render rich multi-question / checkbox / ranked triggers.
+        // CLI agents see only the human-readable text below the comment.
+        const questions = Array.isArray(trigger.payload.questions)
+            ? trigger.payload.questions
+            : undefined;
+        const questionsBlock = questions
+            ? `<!-- questions:${JSON.stringify(questions)} -->\n`
+            : "";
+
+        const lines = [`🔗 Child "${name}" asks:`, questionsBlock + `> ${question}`];
         if (options.length > 0) {
             lines.push(`Options: ${options.map((o, i) => `${i + 1}. ${o}`).join("  ")}`);
         }

--- a/packages/cli/src/extensions/triggers/registry.ts
+++ b/packages/cli/src/extensions/triggers/registry.ts
@@ -203,7 +203,7 @@ export function renderTrigger(trigger: ConversationTrigger): string {
     const body = renderer
         ? renderer.render(trigger)
         : `🔗 Child "${displayName(trigger)}" sent unknown trigger "${trigger.type}". Payload: ${JSON.stringify(trigger.payload)}`;
-    return `<!-- trigger:${trigger.triggerId} -->\n${body}`;
+    return `<!-- trigger:${trigger.triggerId} source:${trigger.sourceSessionId} -->\n${body}`;
 }
 
 /** Parse a response using the trigger type's parser, if available. */

--- a/packages/cli/src/extensions/triggers/registry.ts
+++ b/packages/cli/src/extensions/triggers/registry.ts
@@ -40,7 +40,7 @@ const askUserQuestionRenderer: TriggerRenderer = {
             ? trigger.payload.questions
             : undefined;
         const questionsBlock = questions
-            ? `<!-- questions64:${btoa(JSON.stringify(questions))} -->\n`
+            ? `<!-- questions64:${Buffer.from(JSON.stringify(questions), "utf-8").toString("base64")} -->\n`
             : "";
 
         const lines = [`🔗 Child "${name}" asks:`, questionsBlock + `> ${question}`];

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -78,13 +78,15 @@ export interface ViewerClientToServerEvents {
     [key: string]: unknown;
   }) => void;
 
-  /** Human viewer responds to a pending trigger from a child session */
+  /** Human viewer responds to a pending trigger from a child session.
+   *  Supports Socket.IO ack — server calls the ack callback only on
+   *  successful delivery, so the client can detect failed sends. */
   trigger_response: (data: {
     triggerId: string;
     response: string;
     action?: string;
     targetSessionId: string;
-  }) => void;
+  }, ack?: () => void) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -375,10 +375,13 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 const childSocket = getLocalTuiSocket(targetSessionId);
                 if (childSocket) {
                     childSocket.emit("trigger_response" as string, triggerPayload);
+                    if (typeof ack === "function") ack();
                 } else if (!emitToRelaySession(targetSessionId, "trigger_response", triggerPayload)) {
                     socket.emit("error", { message: `Failed to deliver trigger response to child session ${targetSessionId}` });
+                } else {
+                    // emitToRelaySession succeeded
+                    if (typeof ack === "function") ack();
                 }
-                if (typeof ack === "function") ack();
                 return;
             }
 
@@ -392,10 +395,13 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             const tuiSocket = getLocalTuiSocket(sessionId);
             if (tuiSocket) {
                 tuiSocket.emit("trigger_response" as string, triggerPayloadForParent);
+                if (typeof ack === "function") ack();
             } else if (!emitToRelaySession(sessionId, "trigger_response", triggerPayloadForParent)) {
                 socket.emit("error", { message: `Failed to deliver trigger response to session ${sessionId}` });
+            } else {
+                // emitToRelaySession succeeded
+                if (typeof ack === "function") ack();
             }
-            if (typeof ack === "function") ack();
         });
 
         // ── disconnect ───────────────────────────────────────────────────────

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -343,7 +343,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // Route directly to the child session via its relay socket,
         // bypassing the parent CLI. This avoids depending on an in-memory
         // handler in the parent to forward the response.
-        socket.on("trigger_response", async (data) => {
+        socket.on("trigger_response", async (data: any, ack?: (...args: any[]) => void) => {
             const { triggerId, response, action, targetSessionId } = data ?? {};
             if (!triggerId || !response) return;
 
@@ -356,7 +356,8 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             if (targetSessionId) {
                 const targetSession = await getSharedSession(targetSessionId);
                 if (!targetSession || targetSession.userId !== viewerUserId) {
-                    // Target session doesn't exist or belongs to a different user — ignore.
+                    // Target session doesn't exist or belongs to a different user — nack.
+                    socket.emit("error", { message: `Target session ${targetSessionId} not found or unauthorized` });
                     return;
                 }
                 const triggerPayload = {
@@ -364,11 +365,16 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                     response,
                     ...(action ? { action } : {}),
                 };
-                // Try local socket first, fall back to relay room for cross-node delivery
+                // Try local socket first, fall back to relay room for cross-node delivery.
+                // Only ack on successful delivery so the client can distinguish
+                // delivered responses from dropped ones.
                 const childSocket = getLocalTuiSocket(targetSessionId);
                 if (childSocket) {
                     childSocket.emit("trigger_response" as string, triggerPayload);
-                } else if (!emitToRelaySession(targetSessionId, "trigger_response", triggerPayload)) {
+                    if (typeof ack === "function") ack();
+                } else if (emitToRelaySession(targetSessionId, "trigger_response", triggerPayload)) {
+                    if (typeof ack === "function") ack();
+                } else {
                     socket.emit("error", { message: `Failed to deliver trigger response to child session ${targetSessionId}` });
                 }
                 return;
@@ -384,7 +390,10 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             const tuiSocket = getLocalTuiSocket(sessionId);
             if (tuiSocket) {
                 tuiSocket.emit("trigger_response" as string, triggerPayloadForParent);
-            } else if (!emitToRelaySession(sessionId, "trigger_response", triggerPayloadForParent)) {
+                if (typeof ack === "function") ack();
+            } else if (emitToRelaySession(sessionId, "trigger_response", triggerPayloadForParent)) {
+                if (typeof ack === "function") ack();
+            } else {
                 socket.emit("error", { message: `Failed to deliver trigger response to session ${sessionId}` });
             }
         });

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -343,13 +343,19 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // Route directly to the child session via its relay socket,
         // bypassing the parent CLI. This avoids depending on an in-memory
         // handler in the parent to forward the response.
-        socket.on("trigger_response", async (data) => {
+        socket.on("trigger_response", async (data, ack) => {
             const { triggerId, response, action, targetSessionId } = data ?? {};
-            if (!triggerId || !response) return;
+            if (!triggerId || !response) {
+                if (typeof ack === "function") ack();
+                return;
+            }
 
             // Require collab mode — same gate as input/exec/model_set
             const currentSession = await getSharedSession(sessionId);
-            if (!currentSession?.collabMode) return;
+            if (!currentSession?.collabMode) {
+                if (typeof ack === "function") ack();
+                return;
+            }
 
             // If targetSessionId is explicitly provided, route to that child.
             // Validate ownership: the target session must belong to the same user.
@@ -357,6 +363,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 const targetSession = await getSharedSession(targetSessionId);
                 if (!targetSession || targetSession.userId !== viewerUserId) {
                     // Target session doesn't exist or belongs to a different user — ignore.
+                    if (typeof ack === "function") ack();
                     return;
                 }
                 const triggerPayload = {
@@ -371,6 +378,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 } else if (!emitToRelaySession(targetSessionId, "trigger_response", triggerPayload)) {
                     socket.emit("error", { message: `Failed to deliver trigger response to child session ${targetSessionId}` });
                 }
+                if (typeof ack === "function") ack();
                 return;
             }
 
@@ -387,6 +395,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             } else if (!emitToRelaySession(sessionId, "trigger_response", triggerPayloadForParent)) {
                 socket.emit("error", { message: `Failed to deliver trigger response to session ${sessionId}` });
             }
+            if (typeof ack === "function") ack();
         });
 
         // ── disconnect ───────────────────────────────────────────────────────

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -22,6 +22,7 @@ import {
     sendSnapshotToViewer,
     getLocalTuiSocket,
     emitToRelaySession,
+    emitToRelaySessionVerified,
 } from "../sio-registry.js";
 import { getPendingChunkedSnapshot } from "./relay.js";
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
@@ -372,7 +373,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 if (childSocket) {
                     childSocket.emit("trigger_response" as string, triggerPayload);
                     if (typeof ack === "function") ack();
-                } else if (emitToRelaySession(targetSessionId, "trigger_response", triggerPayload)) {
+                } else if (await emitToRelaySessionVerified(targetSessionId, "trigger_response", triggerPayload)) {
                     if (typeof ack === "function") ack();
                 } else {
                     socket.emit("error", { message: `Failed to deliver trigger response to child session ${targetSessionId}` });
@@ -391,7 +392,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             if (tuiSocket) {
                 tuiSocket.emit("trigger_response" as string, triggerPayloadForParent);
                 if (typeof ack === "function") ack();
-            } else if (emitToRelaySession(sessionId, "trigger_response", triggerPayloadForParent)) {
+            } else if (await emitToRelaySessionVerified(sessionId, "trigger_response", triggerPayloadForParent)) {
                 if (typeof ack === "function") ack();
             } else {
                 socket.emit("error", { message: `Failed to deliver trigger response to session ${sessionId}` });

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -358,7 +358,8 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 const targetSession = await getSharedSession(targetSessionId);
                 if (!targetSession || targetSession.userId !== viewerUserId) {
                     // Target session doesn't exist or belongs to a different user — nack.
-                    socket.emit("error", { message: `Target session ${targetSessionId} not found or unauthorized` });
+                    // Use trigger_error (not error) so the client can correlate by triggerId.
+                    (socket as any).emit("trigger_error", { message: `Target session ${targetSessionId} not found or unauthorized`, triggerId });
                     return;
                 }
                 const triggerPayload = {
@@ -376,7 +377,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 } else if (await emitToRelaySessionVerified(targetSessionId, "trigger_response", triggerPayload)) {
                     if (typeof ack === "function") ack();
                 } else {
-                    socket.emit("error", { message: `Failed to deliver trigger response to child session ${targetSessionId}` });
+                    (socket as any).emit("trigger_error", { message: `Failed to deliver trigger response to child session ${targetSessionId}`, triggerId });
                 }
                 return;
             }
@@ -395,7 +396,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             } else if (await emitToRelaySessionVerified(sessionId, "trigger_response", triggerPayloadForParent)) {
                 if (typeof ack === "function") ack();
             } else {
-                socket.emit("error", { message: `Failed to deliver trigger response to session ${sessionId}` });
+                (socket as any).emit("trigger_error", { message: `Failed to deliver trigger response to session ${sessionId}`, triggerId });
             }
         });
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -343,19 +343,13 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // Route directly to the child session via its relay socket,
         // bypassing the parent CLI. This avoids depending on an in-memory
         // handler in the parent to forward the response.
-        socket.on("trigger_response", async (data, ack) => {
+        socket.on("trigger_response", async (data) => {
             const { triggerId, response, action, targetSessionId } = data ?? {};
-            if (!triggerId || !response) {
-                if (typeof ack === "function") ack();
-                return;
-            }
+            if (!triggerId || !response) return;
 
             // Require collab mode — same gate as input/exec/model_set
             const currentSession = await getSharedSession(sessionId);
-            if (!currentSession?.collabMode) {
-                if (typeof ack === "function") ack();
-                return;
-            }
+            if (!currentSession?.collabMode) return;
 
             // If targetSessionId is explicitly provided, route to that child.
             // Validate ownership: the target session must belong to the same user.
@@ -363,7 +357,6 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 const targetSession = await getSharedSession(targetSessionId);
                 if (!targetSession || targetSession.userId !== viewerUserId) {
                     // Target session doesn't exist or belongs to a different user — ignore.
-                    if (typeof ack === "function") ack();
                     return;
                 }
                 const triggerPayload = {
@@ -375,12 +368,8 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 const childSocket = getLocalTuiSocket(targetSessionId);
                 if (childSocket) {
                     childSocket.emit("trigger_response" as string, triggerPayload);
-                    if (typeof ack === "function") ack();
                 } else if (!emitToRelaySession(targetSessionId, "trigger_response", triggerPayload)) {
                     socket.emit("error", { message: `Failed to deliver trigger response to child session ${targetSessionId}` });
-                } else {
-                    // emitToRelaySession succeeded
-                    if (typeof ack === "function") ack();
                 }
                 return;
             }
@@ -395,12 +384,8 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             const tuiSocket = getLocalTuiSocket(sessionId);
             if (tuiSocket) {
                 tuiSocket.emit("trigger_response" as string, triggerPayloadForParent);
-                if (typeof ack === "function") ack();
             } else if (!emitToRelaySession(sessionId, "trigger_response", triggerPayloadForParent)) {
                 socket.emit("error", { message: `Failed to deliver trigger response to session ${sessionId}` });
-            } else {
-                // emitToRelaySession succeeded
-                if (typeof ack === "function") ack();
             }
         });
 

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -507,6 +507,29 @@ export function emitToRelaySession(sessionId: string, eventName: string, data: u
 }
 
 /**
+ * Emit an event to the relay session room, but only if at least one socket
+ * is actually in the room. Unlike `emitToRelaySession()`, this is async
+ * because it uses `fetchSockets()` to verify room membership before emitting.
+ * Returns true only if the emit reached at least one socket.
+ *
+ * Use this for delivery-critical paths (e.g. trigger responses) where
+ * falsely reporting success would leave the client stuck.
+ */
+export async function emitToRelaySessionVerified(sessionId: string, eventName: string, data: unknown): Promise<boolean> {
+    if (!io) return false;
+    const room = relaySessionRoom(sessionId);
+    try {
+        const sockets = await io.of("/relay").in(room).fetchSockets();
+        if (sockets.length === 0) return false;
+        io.of("/relay").to(room).emit(eventName, data);
+        return true;
+    } catch (err) {
+        console.warn("[sio-registry] emitToRelaySessionVerified failed:", (err as Error)?.message);
+        return false;
+    }
+}
+
+/**
  * Remove the local TUI socket reference for a session.
  */
 export function removeLocalTuiSocket(sessionId: string): void {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3186,7 +3186,7 @@ export function App() {
   }, [spawningSession, spawnRunnerId, spawnCwd, handleOpenSession, waitForSessionToGoLive]);
 
   // ── Respond to a trigger from a child session ─────────────────────────────
-  const handleTriggerResponse = React.useCallback((triggerId: string, response: string, action?: string): boolean => {
+  const handleTriggerResponse = React.useCallback((triggerId: string, response: string, action?: string, sourceSessionId?: string): boolean => {
     const socket = viewerWsRef.current;
     const sessionId = activeSessionRef.current;
     if (!socket || !socket.connected || !sessionId) {
@@ -3194,11 +3194,16 @@ export function App() {
       return false;
     }
 
+    // Use the child's sourceSessionId (extracted from the trigger comment) as
+    // targetSessionId so the server can route directly to the child session,
+    // bypassing the parent's in-memory receivedTriggers map. This makes
+    // delivery resilient to parent reconnects/resumes where the map is gone.
+    // Falls back to the parent session ID for legacy triggers without source.
     socket.timeout(5000).emit("trigger_response", {
       triggerId,
       response,
       ...(action ? { action } : {}),
-      targetSessionId: sessionId,
+      targetSessionId: sourceSessionId ?? sessionId,
     }, (err: Error | null) => {
       if (err) {
         // Server didn't acknowledge within timeout — surface to user

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3194,11 +3194,16 @@ export function App() {
       return false;
     }
 
-    socket.emit("trigger_response", {
+    socket.timeout(5000).emit("trigger_response", {
       triggerId,
       response,
       ...(action ? { action } : {}),
       targetSessionId: sessionId,
+    }, (err: Error | null) => {
+      if (err) {
+        // Server didn't acknowledge within timeout — surface to user
+        setViewerStatus("Trigger response may not have been delivered");
+      }
     });
     return true;
   }, []);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3186,12 +3186,12 @@ export function App() {
   }, [spawningSession, spawnRunnerId, spawnCwd, handleOpenSession, waitForSessionToGoLive]);
 
   // ── Respond to a trigger from a child session ─────────────────────────────
-  const handleTriggerResponse = React.useCallback((triggerId: string, response: string, action?: string) => {
+  const handleTriggerResponse = React.useCallback((triggerId: string, response: string, action?: string): boolean => {
     const socket = viewerWsRef.current;
     const sessionId = activeSessionRef.current;
     if (!socket || !socket.connected || !sessionId) {
       setViewerStatus("Not connected to a live session");
-      return;
+      return false;
     }
 
     socket.emit("trigger_response", {
@@ -3200,6 +3200,7 @@ export function App() {
       ...(action ? { action } : {}),
       targetSessionId: sessionId,
     });
+    return true;
   }, []);
 
   // ── Spawn a new session as a specific agent ─────────────────────────────

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3209,15 +3209,17 @@ export function App() {
         resolve(success);
       };
 
-      // Listen for server error events — the server emits these immediately
+      // Listen for trigger_error events — the server emits these immediately
       // when the target child is missing, unauthorized, or relay delivery fails.
-      // This lets us resolve the promise right away instead of waiting for the
-      // 5-second ack timeout.
-      const onError = () => {
-        settle(false, "Trigger delivery failed — try again");
+      // Each error carries its triggerId so concurrent trigger submissions
+      // don't interfere with each other (unlike the shared "error" event).
+      const onTriggerError = (data: any) => {
+        if (data?.triggerId === triggerId) {
+          settle(false, "Trigger delivery failed — try again");
+        }
       };
-      socket.on("error", onError);
-      const errorCleanup = () => { socket.off("error", onError); };
+      socket.on("trigger_error" as any, onTriggerError);
+      const errorCleanup = () => { socket.off("trigger_error" as any, onTriggerError); };
 
       // Send with Socket.IO ack — server only acks on successful delivery.
       socket.emit("trigger_response", {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3201,6 +3201,24 @@ export function App() {
     // Falls back to the parent session ID for legacy triggers without source.
     return new Promise<boolean>((resolve) => {
       let resolved = false;
+      const settle = (success: boolean, message?: string) => {
+        if (resolved) return;
+        resolved = true;
+        if (message) setViewerStatus(message);
+        errorCleanup();
+        resolve(success);
+      };
+
+      // Listen for server error events — the server emits these immediately
+      // when the target child is missing, unauthorized, or relay delivery fails.
+      // This lets us resolve the promise right away instead of waiting for the
+      // 5-second ack timeout.
+      const onError = () => {
+        settle(false, "Trigger delivery failed — try again");
+      };
+      socket.on("error", onError);
+      const errorCleanup = () => { socket.off("error", onError); };
+
       // Send with Socket.IO ack — server only acks on successful delivery.
       socket.emit("trigger_response", {
         triggerId,
@@ -3209,15 +3227,11 @@ export function App() {
         targetSessionId: sourceSessionId ?? sessionId,
       }, () => {
         // Server acknowledged successful delivery
-        if (!resolved) { resolved = true; resolve(true); }
+        settle(true);
       });
       // If no ack arrives within 5s, treat as a failed delivery
       setTimeout(() => {
-        if (!resolved) {
-          resolved = true;
-          setViewerStatus("Trigger response may not have been delivered — try again");
-          resolve(false);
-        }
+        settle(false, "Trigger response may not have been delivered — try again");
       }, 5000);
     });
   }, []);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3186,12 +3186,12 @@ export function App() {
   }, [spawningSession, spawnRunnerId, spawnCwd, handleOpenSession, waitForSessionToGoLive]);
 
   // ── Respond to a trigger from a child session ─────────────────────────────
-  const handleTriggerResponse = React.useCallback((triggerId: string, response: string, action?: string, sourceSessionId?: string): boolean => {
+  const handleTriggerResponse = React.useCallback((triggerId: string, response: string, action?: string, sourceSessionId?: string): Promise<boolean> => {
     const socket = viewerWsRef.current;
     const sessionId = activeSessionRef.current;
     if (!socket || !socket.connected || !sessionId) {
       setViewerStatus("Not connected to a live session");
-      return false;
+      return Promise.resolve(false);
     }
 
     // Use the child's sourceSessionId (extracted from the trigger comment) as
@@ -3199,13 +3199,27 @@ export function App() {
     // bypassing the parent's in-memory receivedTriggers map. This makes
     // delivery resilient to parent reconnects/resumes where the map is gone.
     // Falls back to the parent session ID for legacy triggers without source.
-    socket.emit("trigger_response", {
-      triggerId,
-      response,
-      ...(action ? { action } : {}),
-      targetSessionId: sourceSessionId ?? sessionId,
+    return new Promise<boolean>((resolve) => {
+      let resolved = false;
+      // Send with Socket.IO ack — server only acks on successful delivery.
+      socket.emit("trigger_response", {
+        triggerId,
+        response,
+        ...(action ? { action } : {}),
+        targetSessionId: sourceSessionId ?? sessionId,
+      }, () => {
+        // Server acknowledged successful delivery
+        if (!resolved) { resolved = true; resolve(true); }
+      });
+      // If no ack arrives within 5s, treat as a failed delivery
+      setTimeout(() => {
+        if (!resolved) {
+          resolved = true;
+          setViewerStatus("Trigger response may not have been delivered — try again");
+          resolve(false);
+        }
+      }, 5000);
     });
-    return true;
   }, []);
 
   // ── Spawn a new session as a specific agent ─────────────────────────────

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3199,16 +3199,11 @@ export function App() {
     // bypassing the parent's in-memory receivedTriggers map. This makes
     // delivery resilient to parent reconnects/resumes where the map is gone.
     // Falls back to the parent session ID for legacy triggers without source.
-    socket.timeout(5000).emit("trigger_response", {
+    socket.emit("trigger_response", {
       triggerId,
       response,
       ...(action ? { action } : {}),
       targetSessionId: sourceSessionId ?? sessionId,
-    }, (err: Error | null) => {
-      if (err) {
-        // Server didn't acknowledge within timeout — surface to user
-        setViewerStatus("Trigger response may not have been delivered");
-      }
     });
     return true;
   }, []);

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -170,7 +170,7 @@ export interface SessionViewerProps {
   /** Spawn a new session configured as a specific agent */
   onSpawnAgentSession?: (agent: { name: string; description?: string; systemPrompt?: string; tools?: string; disallowedTools?: string }) => void;
   /** Respond to a trigger from a child session */
-  onTriggerResponse?: (triggerId: string, response: string, action?: string) => void;
+  onTriggerResponse?: (triggerId: string, response: string, action?: string) => boolean | void;
   /** Optimistically dismiss the pending question panel after a successful response */
   onQuestionDismiss?: () => void;
   /** Optimistically dismiss the pending plan panel after a successful response */
@@ -346,7 +346,7 @@ const SessionMessageItem = React.memo(({ message, activeToolCalls, agentActive, 
   activeToolCalls?: Map<string, string>;
   agentActive?: boolean;
   isLast: boolean;
-  onTriggerResponse?: (triggerId: string, response: string, action?: string) => void;
+  onTriggerResponse?: (triggerId: string, response: string, action?: string) => boolean | void;
 }) => {
   // System messages with structured command result data render as standalone cards
   if (message.role === "system" && isCommandResult(message.content)) {

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -170,7 +170,7 @@ export interface SessionViewerProps {
   /** Spawn a new session configured as a specific agent */
   onSpawnAgentSession?: (agent: { name: string; description?: string; systemPrompt?: string; tools?: string; disallowedTools?: string }) => void;
   /** Respond to a trigger from a child session */
-  onTriggerResponse?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => boolean | void;
+  onTriggerResponse?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => boolean | void | Promise<boolean>;
   /** Optimistically dismiss the pending question panel after a successful response */
   onQuestionDismiss?: () => void;
   /** Optimistically dismiss the pending plan panel after a successful response */
@@ -346,7 +346,7 @@ const SessionMessageItem = React.memo(({ message, activeToolCalls, agentActive, 
   activeToolCalls?: Map<string, string>;
   agentActive?: boolean;
   isLast: boolean;
-  onTriggerResponse?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => boolean | void;
+  onTriggerResponse?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => boolean | void | Promise<boolean>;
 }) => {
   // System messages with structured command result data render as standalone cards
   if (message.role === "system" && isCommandResult(message.content)) {

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -170,7 +170,7 @@ export interface SessionViewerProps {
   /** Spawn a new session configured as a specific agent */
   onSpawnAgentSession?: (agent: { name: string; description?: string; systemPrompt?: string; tools?: string; disallowedTools?: string }) => void;
   /** Respond to a trigger from a child session */
-  onTriggerResponse?: (triggerId: string, response: string, action?: string) => boolean | void;
+  onTriggerResponse?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => boolean | void;
   /** Optimistically dismiss the pending question panel after a successful response */
   onQuestionDismiss?: () => void;
   /** Optimistically dismiss the pending plan panel after a successful response */
@@ -346,7 +346,7 @@ const SessionMessageItem = React.memo(({ message, activeToolCalls, agentActive, 
   activeToolCalls?: Map<string, string>;
   agentActive?: boolean;
   isLast: boolean;
-  onTriggerResponse?: (triggerId: string, response: string, action?: string) => boolean | void;
+  onTriggerResponse?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => boolean | void;
 }) => {
   // System messages with structured command result data render as standalone cards
   if (message.role === "system" && isCommandResult(message.content)) {

--- a/packages/ui/src/components/session-viewer/cards/InterAgentCards.tsx
+++ b/packages/ui/src/components/session-viewer/cards/InterAgentCards.tsx
@@ -26,13 +26,13 @@ export function truncateSessionId(id: string): string {
 
 // ── Trigger message utilities ────────────────────────────────────────────────
 
-const TRIGGER_PREFIX_RE = /^<!--\s*trigger:([\w-]+)\s*-->\n?/;
+const TRIGGER_PREFIX_RE = /^<!--\s*trigger:([\w-]+)(?:\s+source:([\w-]+))?\s*-->\n?/;
 
-/** Check if a message is a trigger-injected message and extract the trigger ID. */
-export function parseTriggerMessage(text: string): { triggerId: string; body: string } | null {
+/** Check if a message is a trigger-injected message and extract the trigger ID and optional source session ID. */
+export function parseTriggerMessage(text: string): { triggerId: string; sourceSessionId?: string; body: string } | null {
   const match = text.match(TRIGGER_PREFIX_RE);
   if (!match) return null;
-  return { triggerId: match[1], body: text.slice(match[0].length) };
+  return { triggerId: match[1], sourceSessionId: match[2], body: text.slice(match[0].length) };
 }
 
 /** Returns true if the text is a trigger-injected message. */
@@ -46,18 +46,25 @@ export function isTriggerMessage(text: string): boolean {
  */
 export function renderTriggerCard(
   text: string,
-  onRespond?: (triggerId: string, response: string, action?: string) => void,
+  onRespond?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => void,
   isResponding?: boolean
 ): React.ReactElement | null {
   const parsed = parseTriggerMessage(text);
   if (!parsed) return null;
-  
+
+  // Wrap the callback to include the child's sourceSessionId so the relay
+  // can route the response directly to the child session.
+  const wrappedOnRespond = onRespond && parsed.sourceSessionId
+    ? (triggerId: string, response: string, action?: string) =>
+        onRespond(triggerId, response, action, parsed.sourceSessionId)
+    : onRespond;
+
   return (
     <TriggerCard
       key={parsed.triggerId}
       triggerId={parsed.triggerId}
       body={parsed.body}
-      onRespond={onRespond}
+      onRespond={wrappedOnRespond}
       isResponding={isResponding}
     />
   );

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
@@ -395,6 +395,21 @@ Respond with \`respond_to_trigger\` using trigger ID \`brk123\`.`;
       expect(parsed.options).toEqual(["Yes", "No"]);
     });
 
+    test("falls back gracefully when base64 is invalid (truncated/corrupted)", () => {
+      // Invalid base64 that matches the regex but throws on atob()
+      const body = `🔗 Child "corrupt-child" asks:
+<!-- questions64:notvalidbase64padding -->
+> What?
+Options: 1. Yes  2. No
+
+Respond with \`respond_to_trigger\` using trigger ID \`corrupt123\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("ask_user_question");
+      expect(parsed.questions).toBeUndefined();
+      expect(parsed.options).toEqual(["Yes", "No"]);
+    });
+
     test("legacy format: unescapes __DASH__ sequences in embedded JSON questions", () => {
       // Legacy format used __DASH__ escaping for "--" sequences.
       const raw = `[{"question":"Use --> in code?","options":["Yes","No"]}]`;

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
@@ -446,5 +446,24 @@ Respond with \`respond_to_trigger\` using trigger ID \`flt123\`.`;
       expect(parsed.questions).toHaveLength(1);
       expect(parsed.questions![0].question).toBe("Valid?");
     });
+
+    test("parses UTF-8 content (emoji, CJK, smart quotes) from base64-encoded questions", () => {
+      const questions = [
+        { question: "Choisissez l'option 🎉", options: ["日本語", "中文", "\u201csmart quotes\u201d"], type: "radio" },
+      ];
+      // Encode as UTF-8 base64 (same as server-side Buffer.from(..., 'utf-8').toString('base64'))
+      const encoded = btoa(String.fromCharCode(...new TextEncoder().encode(JSON.stringify(questions))));
+      const body = `🔗 Child "utf8-child" asks:
+<!-- questions64:${encoded} -->
+> Choisissez l'option 🎉
+
+Respond with \`respond_to_trigger\` using trigger ID \`utf8-123\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("ask_user_question");
+      expect(parsed.questions).toHaveLength(1);
+      expect(parsed.questions![0].question).toBe("Choisissez l'option 🎉");
+      expect(parsed.questions![0].options).toEqual(["日本語", "中文", "\u201csmart quotes\u201d"]);
+    });
   });
 });

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
@@ -376,6 +376,25 @@ Respond with \`respond_to_trigger\` using trigger ID \`brk123\`.`;
       expect(parsed.options).toEqual(["Yes", "No"]);
     });
 
+    test("unescapes --> in embedded JSON questions (registry escapes it as --\\>)", () => {
+      // The trigger renderer escapes "-->" as "--\>" to avoid breaking the HTML comment.
+      // The parser must reverse this before JSON.parse.
+      const raw = `[{"question":"Use --> in code?","options":["Yes","No"]}]`;
+      const escaped = raw.replace(/-->/g, "--\\>");
+      const body = `🔗 Child "escape-child" asks:
+<!-- questions:${escaped} -->
+> Use --> in code?
+Options: 1. Yes  2. No
+
+Respond with \`respond_to_trigger\` using trigger ID \`esc123\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("ask_user_question");
+      expect(parsed.questions).toHaveLength(1);
+      expect(parsed.questions![0].question).toBe("Use --> in code?");
+      expect(parsed.questions![0].options).toEqual(["Yes", "No"]);
+    });
+
     test("ignores questions with missing question field in embedded JSON", () => {
       const questions = [
         { question: "Valid?", options: ["Yes"] },

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
@@ -307,13 +307,14 @@ Use respond_to_trigger with action: "approve" to accept, "cancel" to reject, or 
 
     // ── Structured questions (rich trigger format) ────────────────────────
 
-    test("parses embedded structured questions JSON from trigger body", () => {
+    test("parses base64-encoded structured questions from trigger body", () => {
       const questions = [
         { question: "Pick a color", options: ["Red", "Blue"], type: "radio" },
         { question: "Select features", options: ["Auth", "API", "UI"], type: "checkbox" },
       ];
+      const encoded = btoa(JSON.stringify(questions));
       const body = `🔗 Child "rich-child" asks:
-<!-- questions:${JSON.stringify(questions)} -->
+<!-- questions64:${encoded} -->
 > Pick a color; Select features
 Options: 1. Red  2. Blue  3. Auth  4. API  5. UI
 
@@ -332,12 +333,13 @@ Respond with \`respond_to_trigger\` using trigger ID \`rich123\`.`;
       expect(parsed.options).toContain("Red");
     });
 
-    test("parses ranked question type from embedded JSON", () => {
+    test("parses ranked question type from base64-encoded JSON", () => {
       const questions = [
         { question: "Prioritize tasks", options: ["Fix bug", "Add feature", "Write docs"], type: "ranked" },
       ];
+      const encoded = btoa(JSON.stringify(questions));
       const body = `🔗 Child "ranker" asks:
-<!-- questions:${JSON.stringify(questions)} -->
+<!-- questions64:${encoded} -->
 > Prioritize tasks
 Options: 1. Fix bug  2. Add feature  3. Write docs
 
@@ -347,6 +349,23 @@ Respond with \`respond_to_trigger\` using trigger ID \`rank123\`.`;
       expect(parsed.type).toBe("ask_user_question");
       expect(parsed.questions).toHaveLength(1);
       expect(parsed.questions![0].type).toBe("ranked");
+    });
+
+    test("parses legacy raw JSON questions format (backward compat)", () => {
+      const questions = [
+        { question: "Pick a color", options: ["Red", "Blue"], type: "radio" },
+      ];
+      const body = `🔗 Child "legacy-rich" asks:
+<!-- questions:${JSON.stringify(questions)} -->
+> Pick a color
+Options: 1. Red  2. Blue
+
+Respond with \`respond_to_trigger\` using trigger ID \`legrich123\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("ask_user_question");
+      expect(parsed.questions).toHaveLength(1);
+      expect(parsed.questions![0].question).toBe("Pick a color");
     });
 
     test("falls back to legacy parsing when embedded JSON is absent", () => {
@@ -376,9 +395,8 @@ Respond with \`respond_to_trigger\` using trigger ID \`brk123\`.`;
       expect(parsed.options).toEqual(["Yes", "No"]);
     });
 
-    test("unescapes -- sequences in embedded JSON questions (registry escapes them as __DASH__)", () => {
-      // The trigger renderer escapes all "--" sequences as "__DASH__" to avoid breaking the HTML comment.
-      // The parser must reverse this before JSON.parse.
+    test("legacy format: unescapes __DASH__ sequences in embedded JSON questions", () => {
+      // Legacy format used __DASH__ escaping for "--" sequences.
       const raw = `[{"question":"Use --> in code?","options":["Yes","No"]}]`;
       const escaped = raw.replace(/--/g, "__DASH__");
       const body = `🔗 Child "escape-child" asks:
@@ -395,13 +413,30 @@ Respond with \`respond_to_trigger\` using trigger ID \`esc123\`.`;
       expect(parsed.questions![0].options).toEqual(["Yes", "No"]);
     });
 
+    test("base64 format handles special characters like --> without issues", () => {
+      const questions = [{ question: "Use --> in code?", options: ["Yes", "No"] }];
+      const encoded = btoa(JSON.stringify(questions));
+      const body = `🔗 Child "b64-child" asks:
+<!-- questions64:${encoded} -->
+> Use --> in code?
+Options: 1. Yes  2. No
+
+Respond with \`respond_to_trigger\` using trigger ID \`b64123\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("ask_user_question");
+      expect(parsed.questions).toHaveLength(1);
+      expect(parsed.questions![0].question).toBe("Use --> in code?");
+    });
+
     test("ignores questions with missing question field in embedded JSON", () => {
       const questions = [
         { question: "Valid?", options: ["Yes"] },
         { options: ["orphan"] },  // missing question field
       ];
+      const encoded = btoa(JSON.stringify(questions));
       const body = `🔗 Child "filter-child" asks:
-<!-- questions:${JSON.stringify(questions)} -->
+<!-- questions64:${encoded} -->
 > Valid?
 Options: 1. Yes
 

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
@@ -376,11 +376,11 @@ Respond with \`respond_to_trigger\` using trigger ID \`brk123\`.`;
       expect(parsed.options).toEqual(["Yes", "No"]);
     });
 
-    test("unescapes --> in embedded JSON questions (registry escapes it as --\\>)", () => {
-      // The trigger renderer escapes "-->" as "--\>" to avoid breaking the HTML comment.
+    test("unescapes -- sequences in embedded JSON questions (registry escapes them as __DASH__)", () => {
+      // The trigger renderer escapes all "--" sequences as "__DASH__" to avoid breaking the HTML comment.
       // The parser must reverse this before JSON.parse.
       const raw = `[{"question":"Use --> in code?","options":["Yes","No"]}]`;
-      const escaped = raw.replace(/-->/g, "--\\>");
+      const escaped = raw.replace(/--/g, "__DASH__");
       const body = `🔗 Child "escape-child" asks:
 <!-- questions:${escaped} -->
 > Use --> in code?

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.test.ts
@@ -304,5 +304,93 @@ Use respond_to_trigger with action: "approve" to accept, "cancel" to reject, or 
       // Ensure instructions are NOT absorbed into last step
       expect(parsed.planSteps?.[1].description).toBeUndefined();
     });
+
+    // ── Structured questions (rich trigger format) ────────────────────────
+
+    test("parses embedded structured questions JSON from trigger body", () => {
+      const questions = [
+        { question: "Pick a color", options: ["Red", "Blue"], type: "radio" },
+        { question: "Select features", options: ["Auth", "API", "UI"], type: "checkbox" },
+      ];
+      const body = `🔗 Child "rich-child" asks:
+<!-- questions:${JSON.stringify(questions)} -->
+> Pick a color; Select features
+Options: 1. Red  2. Blue  3. Auth  4. API  5. UI
+
+Respond with \`respond_to_trigger\` using trigger ID \`rich123\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("ask_user_question");
+      expect(parsed.childName).toBe("rich-child");
+      expect(parsed.questions).toHaveLength(2);
+      expect(parsed.questions![0].question).toBe("Pick a color");
+      expect(parsed.questions![0].options).toEqual(["Red", "Blue"]);
+      expect(parsed.questions![1].question).toBe("Select features");
+      expect(parsed.questions![1].type).toBe("checkbox");
+      expect(parsed.questions![1].options).toEqual(["Auth", "API", "UI"]);
+      // Legacy fields still populated for backward compat
+      expect(parsed.options).toContain("Red");
+    });
+
+    test("parses ranked question type from embedded JSON", () => {
+      const questions = [
+        { question: "Prioritize tasks", options: ["Fix bug", "Add feature", "Write docs"], type: "ranked" },
+      ];
+      const body = `🔗 Child "ranker" asks:
+<!-- questions:${JSON.stringify(questions)} -->
+> Prioritize tasks
+Options: 1. Fix bug  2. Add feature  3. Write docs
+
+Respond with \`respond_to_trigger\` using trigger ID \`rank123\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("ask_user_question");
+      expect(parsed.questions).toHaveLength(1);
+      expect(parsed.questions![0].type).toBe("ranked");
+    });
+
+    test("falls back to legacy parsing when embedded JSON is absent", () => {
+      const body = `🔗 Child "legacy-child" asks:
+> What do you prefer?
+Options: 1. Option A  2. Option B
+
+Respond with \`respond_to_trigger\` using trigger ID \`leg123\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("ask_user_question");
+      expect(parsed.questions).toBeUndefined();
+      expect(parsed.options).toEqual(["Option A", "Option B"]);
+    });
+
+    test("falls back gracefully when embedded JSON is malformed", () => {
+      const body = `🔗 Child "broken-child" asks:
+<!-- questions:{invalid json} -->
+> What?
+Options: 1. Yes  2. No
+
+Respond with \`respond_to_trigger\` using trigger ID \`brk123\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.type).toBe("ask_user_question");
+      expect(parsed.questions).toBeUndefined();
+      expect(parsed.options).toEqual(["Yes", "No"]);
+    });
+
+    test("ignores questions with missing question field in embedded JSON", () => {
+      const questions = [
+        { question: "Valid?", options: ["Yes"] },
+        { options: ["orphan"] },  // missing question field
+      ];
+      const body = `🔗 Child "filter-child" asks:
+<!-- questions:${JSON.stringify(questions)} -->
+> Valid?
+Options: 1. Yes
+
+Respond with \`respond_to_trigger\` using trigger ID \`flt123\`.`;
+
+      const parsed = parseTriggerBody(body);
+      expect(parsed.questions).toHaveLength(1);
+      expect(parsed.questions![0].question).toBe("Valid?");
+    });
   });
 });

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
@@ -56,15 +56,18 @@ function AskUserQuestionCard({
   const hasStructuredQuestions = questions && questions.length > 0;
 
   const handleMultiChoiceSubmit = React.useCallback(
-    (answers: MultipleChoiceAnswers) => {
-      if (submitted) return;
+    (answers: MultipleChoiceAnswers): Promise<boolean | void> => {
+      if (submitted) return Promise.resolve();
       const text = formatAnswersForAgent(answers);
       const result = onRespond?.(triggerId, text);
       // Only mark as submitted if the response was actually sent.
       // onRespond returns false when the socket is disconnected.
-      if (result !== false) {
-        setSubmitted(true);
+      if (result === false) {
+        // Return false so MultipleChoiceQuestions re-enables the submit button immediately
+        return Promise.resolve(false);
       }
+      setSubmitted(true);
+      return Promise.resolve();
     },
     [triggerId, onRespond, submitted],
   );

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
@@ -65,6 +65,9 @@ function AskUserQuestionCard({
       if (result !== false) {
         setSubmitted(true);
       }
+      // Return the result so MultipleChoiceQuestions can detect send failures
+      // and re-enable the submit button immediately instead of waiting for the 10-second timeout.
+      return result;
     },
     [triggerId, onRespond, submitted],
   );

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
@@ -15,6 +15,9 @@ import {
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { parseTriggerBody } from "./trigger-parsers";
+import type { ParsedTriggerQuestion } from "./trigger-parsers";
+import { MultipleChoiceQuestions, type MultipleChoiceAnswers } from "@/components/ai-elements/multiple-choice";
+import { formatAnswersForAgent } from "@/lib/ask-user-questions";
 export { parseTriggerBody } from "./trigger-parsers";
 export type { ParsedTrigger } from "./trigger-parsers";
 
@@ -32,6 +35,7 @@ function AskUserQuestionCard({
   childName,
   question,
   options,
+  questions,
   onRespond,
   isResponding,
 }: {
@@ -39,12 +43,27 @@ function AskUserQuestionCard({
   childName?: string;
   question?: string;
   options?: string[];
+  questions?: ParsedTriggerQuestion[];
   onRespond?: (triggerId: string, response: string) => void;
   isResponding?: boolean;
 }) {
   const [selectedOption, setSelectedOption] = React.useState<string>("");
   const [freeText, setFreeText] = React.useState<string>("");
+  const [submitted, setSubmitted] = React.useState(false);
   const hasOptions = options && options.length > 0;
+
+  // Use rich multi-question UI when structured questions are available
+  const hasStructuredQuestions = questions && questions.length > 0;
+
+  const handleMultiChoiceSubmit = React.useCallback(
+    (answers: MultipleChoiceAnswers) => {
+      if (submitted) return;
+      setSubmitted(true);
+      const text = formatAnswersForAgent(answers);
+      onRespond?.(triggerId, text);
+    },
+    [triggerId, onRespond, submitted],
+  );
 
   return (
     <ToolCardShell>
@@ -58,72 +77,92 @@ function AskUserQuestionCard({
         </ToolCardTitle>
       </ToolCardHeader>
 
-      {question && (
+      {/* Rich multi-question UI (radio / checkbox / ranked stepper) */}
+      {hasStructuredQuestions && (
         <ToolCardSection>
-          <p className="text-sm text-zinc-200">{question}</p>
-        </ToolCardSection>
-      )}
-
-      {hasOptions && (
-        <ToolCardSection>
-          <div className="space-y-2">
-            {options.map((option, i) => (
-              <button
-                key={i}
-                onClick={() => {
-                  setSelectedOption(option);
-                  onRespond?.(triggerId, option);
-                }}
-                disabled={isResponding}
-                className={cn(
-                  "w-full text-left px-3 py-2 rounded-md border text-sm transition-colors",
-                  selectedOption === option
-                    ? "border-blue-500 bg-blue-500/20 text-blue-300"
-                    : "border-zinc-700 bg-zinc-800/40 text-zinc-300 hover:bg-zinc-800/60 hover:border-zinc-600",
-                  isResponding && "opacity-50 cursor-not-allowed"
-                )}
-              >
-                {option}
-              </button>
-            ))}
-          </div>
-        </ToolCardSection>
-      )}
-
-      {/* Free-text input for open-ended questions (no options) */}
-      {!hasOptions && (
-        <ToolCardSection>
-          <div className="flex gap-2">
-            <input
-              type="text"
-              value={freeText}
-              onChange={(e) => setFreeText(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === "Enter" && freeText.trim()) {
-                  onRespond?.(triggerId, freeText.trim());
-                }
-              }}
-              disabled={isResponding}
-              placeholder="Type your response…"
-              className={cn(
-                "flex-1 px-3 py-2 rounded-md border text-sm bg-zinc-800/40 text-zinc-200",
-                "border-zinc-700 placeholder:text-zinc-500 focus:outline-none focus:border-blue-500",
-                isResponding && "opacity-50 cursor-not-allowed"
-              )}
+          {submitted ? (
+            <p className="text-sm text-zinc-400 italic">Response submitted.</p>
+          ) : (
+            <MultipleChoiceQuestions
+              questions={questions}
+              promptKey={triggerId}
+              onSubmit={handleMultiChoiceSubmit}
             />
-            <Button
-              size="sm"
-              variant="default"
-              onClick={() => {
-                if (freeText.trim()) onRespond?.(triggerId, freeText.trim());
-              }}
-              disabled={isResponding || !freeText.trim()}
-              className="bg-blue-600 hover:bg-blue-700"
-            >
-              <Send className="size-3.5" />
-            </Button>
-          </div>
+          )}
         </ToolCardSection>
+      )}
+
+      {/* Legacy single-question UI: shown only when no structured questions */}
+      {!hasStructuredQuestions && (
+        <>
+          {question && (
+            <ToolCardSection>
+              <p className="text-sm text-zinc-200">{question}</p>
+            </ToolCardSection>
+          )}
+
+          {hasOptions && (
+            <ToolCardSection>
+              <div className="space-y-2">
+                {options.map((option, i) => (
+                  <button
+                    key={i}
+                    onClick={() => {
+                      setSelectedOption(option);
+                      onRespond?.(triggerId, option);
+                    }}
+                    disabled={isResponding}
+                    className={cn(
+                      "w-full text-left px-3 py-2 rounded-md border text-sm transition-colors",
+                      selectedOption === option
+                        ? "border-blue-500 bg-blue-500/20 text-blue-300"
+                        : "border-zinc-700 bg-zinc-800/40 text-zinc-300 hover:bg-zinc-800/60 hover:border-zinc-600",
+                      isResponding && "opacity-50 cursor-not-allowed"
+                    )}
+                  >
+                    {option}
+                  </button>
+                ))}
+              </div>
+            </ToolCardSection>
+          )}
+
+          {/* Free-text input for open-ended questions (no options) */}
+          {!hasOptions && (
+            <ToolCardSection>
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={freeText}
+                  onChange={(e) => setFreeText(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" && freeText.trim()) {
+                      onRespond?.(triggerId, freeText.trim());
+                    }
+                  }}
+                  disabled={isResponding}
+                  placeholder="Type your response…"
+                  className={cn(
+                    "flex-1 px-3 py-2 rounded-md border text-sm bg-zinc-800/40 text-zinc-200",
+                    "border-zinc-700 placeholder:text-zinc-500 focus:outline-none focus:border-blue-500",
+                    isResponding && "opacity-50 cursor-not-allowed"
+                  )}
+                />
+                <Button
+                  size="sm"
+                  variant="default"
+                  onClick={() => {
+                    if (freeText.trim()) onRespond?.(triggerId, freeText.trim());
+                  }}
+                  disabled={isResponding || !freeText.trim()}
+                  className="bg-blue-600 hover:bg-blue-700"
+                >
+                  <Send className="size-3.5" />
+                </Button>
+              </div>
+            </ToolCardSection>
+          )}
+        </>
       )}
     </ToolCardShell>
   );
@@ -351,6 +390,7 @@ export function TriggerCard({
           childName={parsed.childName}
           question={parsed.question}
           options={parsed.options}
+          questions={parsed.questions}
           onRespond={onRespond}
           isResponding={isResponding}
         />

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
@@ -24,7 +24,7 @@ export type { ParsedTrigger } from "./trigger-parsers";
 export interface TriggerCardProps {
   triggerId: string;
   body: string;
-  onRespond?: (triggerId: string, response: string, action?: string) => boolean | void;
+  onRespond?: (triggerId: string, response: string, action?: string) => boolean | void | Promise<boolean>;
   isResponding?: boolean;
 }
 
@@ -44,7 +44,7 @@ function AskUserQuestionCard({
   question?: string;
   options?: string[];
   questions?: ParsedTriggerQuestion[];
-  onRespond?: (triggerId: string, response: string) => boolean | void;
+  onRespond?: (triggerId: string, response: string) => boolean | void | Promise<boolean>;
   isResponding?: boolean;
 }) {
   const [selectedOption, setSelectedOption] = React.useState<string>("");
@@ -56,18 +56,20 @@ function AskUserQuestionCard({
   const hasStructuredQuestions = questions && questions.length > 0;
 
   const handleMultiChoiceSubmit = React.useCallback(
-    (answers: MultipleChoiceAnswers): Promise<boolean | void> => {
-      if (submitted) return Promise.resolve();
+    async (answers: MultipleChoiceAnswers): Promise<boolean | void> => {
+      if (submitted) return;
       const text = formatAnswersForAgent(answers);
       const result = onRespond?.(triggerId, text);
+      // Await the result — onRespond may return a Promise<boolean> when
+      // using ack-based delivery (e.g. socket.timeout().emit with ack).
+      const resolved = await Promise.resolve(result);
       // Only mark as submitted if the response was actually sent.
-      // onRespond returns false when the socket is disconnected.
-      if (result === false) {
+      // onRespond returns false when the socket is disconnected or ack times out.
+      if (resolved === false) {
         // Return false so MultipleChoiceQuestions re-enables the submit button immediately
-        return Promise.resolve(false);
+        return false;
       }
       setSubmitted(true);
-      return Promise.resolve();
     },
     [triggerId, onRespond, submitted],
   );
@@ -189,7 +191,7 @@ function PlanReviewCard({
   childName?: string;
   planTitle?: string;
   planSteps?: Array<{ title: string; description?: string }>;
-  onRespond?: (triggerId: string, response: string, action: string) => boolean | void;
+  onRespond?: (triggerId: string, response: string, action: string) => boolean | void | Promise<boolean>;
   isResponding?: boolean;
 }) {
   return (

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
@@ -65,9 +65,6 @@ function AskUserQuestionCard({
       if (result !== false) {
         setSubmitted(true);
       }
-      // Return the result so MultipleChoiceQuestions can detect send failures
-      // and re-enable the submit button immediately instead of waiting for the 10-second timeout.
-      return result;
     },
     [triggerId, onRespond, submitted],
   );

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
@@ -24,7 +24,7 @@ export type { ParsedTrigger } from "./trigger-parsers";
 export interface TriggerCardProps {
   triggerId: string;
   body: string;
-  onRespond?: (triggerId: string, response: string, action?: string) => void;
+  onRespond?: (triggerId: string, response: string, action?: string) => boolean | void;
   isResponding?: boolean;
 }
 
@@ -44,7 +44,7 @@ function AskUserQuestionCard({
   question?: string;
   options?: string[];
   questions?: ParsedTriggerQuestion[];
-  onRespond?: (triggerId: string, response: string) => void;
+  onRespond?: (triggerId: string, response: string) => boolean | void;
   isResponding?: boolean;
 }) {
   const [selectedOption, setSelectedOption] = React.useState<string>("");
@@ -58,9 +58,13 @@ function AskUserQuestionCard({
   const handleMultiChoiceSubmit = React.useCallback(
     (answers: MultipleChoiceAnswers) => {
       if (submitted) return;
-      setSubmitted(true);
       const text = formatAnswersForAgent(answers);
-      onRespond?.(triggerId, text);
+      const result = onRespond?.(triggerId, text);
+      // Only mark as submitted if the response was actually sent.
+      // onRespond returns false when the socket is disconnected.
+      if (result !== false) {
+        setSubmitted(true);
+      }
     },
     [triggerId, onRespond, submitted],
   );
@@ -182,7 +186,7 @@ function PlanReviewCard({
   childName?: string;
   planTitle?: string;
   planSteps?: Array<{ title: string; description?: string }>;
-  onRespond?: (triggerId: string, response: string, action: string) => void;
+  onRespond?: (triggerId: string, response: string, action: string) => boolean | void;
   isResponding?: boolean;
 }) {
   return (

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -72,8 +72,9 @@ function parsAskUserQuestion(body: string): ParsedTrigger {
   const jsonMatch = body.match(/<!-- questions:(.*?) -->/);
   if (jsonMatch?.[1]) {
     try {
-      // Reverse the "--\>" escape applied by the trigger renderer
-      const parsed = JSON.parse(jsonMatch[1].replace(/--\\>/g, "-->"));
+      // Reverse the "__DASH__" escape applied by the trigger renderer
+      // (which escapes all "--" to avoid breaking HTML comment parsing)
+      const parsed = JSON.parse(jsonMatch[1].replace(/__DASH__/g, "--"));
       if (Array.isArray(parsed) && parsed.length > 0) {
         questions = parsed
           .filter((q: any) => q && typeof q === "object" && typeof q.question === "string")

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -72,7 +72,8 @@ function parsAskUserQuestion(body: string): ParsedTrigger {
   const jsonMatch = body.match(/<!-- questions:(.*?) -->/);
   if (jsonMatch?.[1]) {
     try {
-      const parsed = JSON.parse(jsonMatch[1]);
+      // Reverse the "--\>" escape applied by the trigger renderer
+      const parsed = JSON.parse(jsonMatch[1].replace(/--\\>/g, "-->"));
       if (Array.isArray(parsed) && parsed.length > 0) {
         questions = parsed
           .filter((q: any) => q && typeof q === "object" && typeof q.question === "string")

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -66,15 +66,18 @@ function parsAskUserQuestion(body: string): ParsedTrigger {
         .filter(Boolean)
     : [];
 
-  // Extract structured questions from embedded JSON comment if present.
-  // Format: <!-- questions:[...] -->
+  // Extract structured questions from embedded HTML comment if present.
+  // Current format: <!-- questions64:<base64> --> (base64-encoded JSON)
+  // Legacy format:  <!-- questions:<json> -->     (raw or __DASH__-escaped JSON)
   let questions: ParsedTriggerQuestion[] | undefined;
-  const jsonMatch = body.match(/<!-- questions:(.*?) -->/);
-  if (jsonMatch?.[1]) {
+  const b64Match = body.match(/<!-- questions64:([\w+/=]+) -->/);
+  const jsonMatch = !b64Match ? body.match(/<!-- questions:(.*?) -->/) : null;
+  const rawJson = b64Match?.[1]
+    ? atob(b64Match[1])
+    : jsonMatch?.[1]?.replace(/__DASH__/g, "--") ?? null;
+  if (rawJson) {
     try {
-      // Reverse the "__DASH__" escape applied by the trigger renderer
-      // (which escapes all "--" to avoid breaking HTML comment parsing)
-      const parsed = JSON.parse(jsonMatch[1].replace(/__DASH__/g, "--"));
+      const parsed = JSON.parse(rawJson);
       if (Array.isArray(parsed) && parsed.length > 0) {
         questions = parsed
           .filter((q: any) => q && typeof q === "object" && typeof q.question === "string")

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -66,11 +66,13 @@ function parsAskUserQuestion(body: string): ParsedTrigger {
         .filter(Boolean)
     : [];
 
-  // Extract structured questions from embedded HTML comment if present.
-  // Current format: <!-- questions64:<base64> --> (base64-encoded JSON)
-  // Legacy format:  <!-- questions:<json> -->     (raw or __DASH__-escaped JSON)
+  // Extract structured questions from embedded metadata.
+  // Current format: questions64:<base64> inside the trigger metadata comment
+  //                 <!-- trigger:ID source:SID questions64:<base64> -->
+  // Legacy format:  <!-- questions64:<base64> --> (separate comment, pre-consolidation)
+  //                 <!-- questions:<json> -->     (raw or __DASH__-escaped JSON)
   let questions: ParsedTriggerQuestion[] | undefined;
-  const b64Match = body.match(/<!-- questions64:([\w+/=]+) -->/);
+  const b64Match = body.match(/questions64:([\w+/=]+)/);
   const jsonMatch = !b64Match ? body.match(/<!-- questions:(.*?) -->/) : null;
   let rawJson: string | null = null;
   try {

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -72,9 +72,14 @@ function parsAskUserQuestion(body: string): ParsedTrigger {
   let questions: ParsedTriggerQuestion[] | undefined;
   const b64Match = body.match(/<!-- questions64:([\w+/=]+) -->/);
   const jsonMatch = !b64Match ? body.match(/<!-- questions:(.*?) -->/) : null;
-  const rawJson = b64Match?.[1]
-    ? new TextDecoder().decode(Uint8Array.from(atob(b64Match[1]), (c) => c.charCodeAt(0)))
-    : jsonMatch?.[1]?.replace(/__DASH__/g, "--") ?? null;
+  let rawJson: string | null = null;
+  try {
+    rawJson = b64Match?.[1]
+      ? new TextDecoder().decode(Uint8Array.from(atob(b64Match[1]), (c) => c.charCodeAt(0)))
+      : jsonMatch?.[1]?.replace(/__DASH__/g, "--") ?? null;
+  } catch {
+    // Invalid base64 — fall back to legacy parsing
+  }
   if (rawJson) {
     try {
       const parsed = JSON.parse(rawJson);

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -73,7 +73,7 @@ function parsAskUserQuestion(body: string): ParsedTrigger {
   const b64Match = body.match(/<!-- questions64:([\w+/=]+) -->/);
   const jsonMatch = !b64Match ? body.match(/<!-- questions:(.*?) -->/) : null;
   const rawJson = b64Match?.[1]
-    ? atob(b64Match[1])
+    ? new TextDecoder().decode(Uint8Array.from(atob(b64Match[1]), (c) => c.charCodeAt(0)))
     : jsonMatch?.[1]?.replace(/__DASH__/g, "--") ?? null;
   if (rawJson) {
     try {

--- a/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
+++ b/packages/ui/src/components/session-viewer/cards/trigger-parsers.ts
@@ -3,11 +3,20 @@
  * Extracted from TriggerCard.tsx so tests can import without JSX dependencies.
  */
 
+/** Structured question from a child AskUserQuestion trigger. */
+export interface ParsedTriggerQuestion {
+  question: string;
+  options: string[];
+  type?: "radio" | "checkbox" | "ranked";
+}
+
 export interface ParsedTrigger {
   type: "ask_user_question" | "plan_review" | "session_complete" | "session_error" | "escalate" | "unknown";
   childName?: string;
   question?: string;
   options?: string[];
+  /** Structured questions array (multi-question, checkbox, ranked support). */
+  questions?: ParsedTriggerQuestion[];
   planTitle?: string;
   planSteps?: Array<{ title: string; description?: string }>;
   message?: string;
@@ -57,7 +66,29 @@ function parsAskUserQuestion(body: string): ParsedTrigger {
         .filter(Boolean)
     : [];
 
-  return { type: "ask_user_question", childName, question, options };
+  // Extract structured questions from embedded JSON comment if present.
+  // Format: <!-- questions:[...] -->
+  let questions: ParsedTriggerQuestion[] | undefined;
+  const jsonMatch = body.match(/<!-- questions:(.*?) -->/);
+  if (jsonMatch?.[1]) {
+    try {
+      const parsed = JSON.parse(jsonMatch[1]);
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        questions = parsed
+          .filter((q: any) => q && typeof q === "object" && typeof q.question === "string")
+          .map((q: any) => ({
+            question: q.question,
+            options: Array.isArray(q.options) ? q.options.filter((o: any) => typeof o === "string") : [],
+            ...(q.type === "checkbox" || q.type === "ranked" ? { type: q.type } : {}),
+          }));
+        if (questions.length === 0) questions = undefined;
+      }
+    } catch {
+      // Malformed JSON — fall back to legacy parsing
+    }
+  }
+
+  return { type: "ask_user_question", childName, question, options, questions };
 }
 
 function parsePlanReview(body: string): ParsedTrigger {

--- a/packages/ui/src/components/session-viewer/rendering.tsx
+++ b/packages/ui/src/components/session-viewer/rendering.tsx
@@ -101,7 +101,7 @@ export function renderContent(
   thinkingDuration?: number,
   subAgentTurns?: SubAgentTurn[],
   details?: unknown,
-  onTriggerResponse?: (triggerId: string, response: string, action?: string) => void,
+  onTriggerResponse?: (triggerId: string, response: string, action?: string) => boolean | void,
 ) {
   // Structured command result cards (MCP, plugins, skills)
   if (role === "system" && isCommandResult(content)) {

--- a/packages/ui/src/components/session-viewer/rendering.tsx
+++ b/packages/ui/src/components/session-viewer/rendering.tsx
@@ -101,7 +101,7 @@ export function renderContent(
   thinkingDuration?: number,
   subAgentTurns?: SubAgentTurn[],
   details?: unknown,
-  onTriggerResponse?: (triggerId: string, response: string, action?: string) => boolean | void,
+  onTriggerResponse?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => boolean | void,
 ) {
   // Structured command result cards (MCP, plugins, skills)
   if (role === "system" && isCommandResult(content)) {
@@ -140,15 +140,21 @@ export function renderContent(
     // Only parse triggers from user/system messages — assistant messages could
     // contain forged trigger blocks that trick viewers into sending responses.
     const isTrustedRole = role === "user" || role === "system";
-    const triggerMatch = isTrustedRole ? content.match(/^<!--\s*trigger:([\w-]+)\s*-->\n?/) : null;
+    const triggerMatch = isTrustedRole ? content.match(/^<!--\s*trigger:([\w-]+)(?:\s+source:([\w-]+))?\s*-->\n?/) : null;
     if (triggerMatch) {
       const triggerId = triggerMatch[1];
+      const sourceSessionId = triggerMatch[2];
       const body = content.slice(triggerMatch[0].length);
+      // Wrap callback to include child sourceSessionId for direct routing
+      const wrappedOnRespond = onTriggerResponse && sourceSessionId
+        ? (tid: string, response: string, action?: string) =>
+            onTriggerResponse(tid, response, action, sourceSessionId)
+        : onTriggerResponse;
       return (
         <TriggerCard
           triggerId={triggerId}
           body={body}
-          onRespond={onTriggerResponse}
+          onRespond={wrappedOnRespond}
         />
       );
     }

--- a/packages/ui/src/components/session-viewer/rendering.tsx
+++ b/packages/ui/src/components/session-viewer/rendering.tsx
@@ -101,7 +101,7 @@ export function renderContent(
   thinkingDuration?: number,
   subAgentTurns?: SubAgentTurn[],
   details?: unknown,
-  onTriggerResponse?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => boolean | void,
+  onTriggerResponse?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => boolean | void | Promise<boolean>,
 ) {
   // Structured command result cards (MCP, plugins, skills)
   if (role === "system" && isCommandResult(content)) {

--- a/packages/ui/src/lib/export-markdown.test.ts
+++ b/packages/ui/src/lib/export-markdown.test.ts
@@ -558,6 +558,20 @@ describe("exportToMarkdown", () => {
     expect(md).not.toContain("abc-123");
   });
 
+  test("questions64 metadata comments are stripped from exported messages", () => {
+    const base64Payload = Buffer.from(JSON.stringify([{ question: "Pick one", options: ["A", "B"] }])).toString("base64");
+    const md = exportToMarkdown([
+      msg({
+        role: "user",
+        content: `<!-- trigger:t-1 source:s-1 -->\n> Pick one\n<!-- questions64:${base64Payload} -->\nOptions: A | B`,
+      }),
+    ]);
+    expect(md).toContain("Pick one");
+    expect(md).toContain("Options: A | B");
+    expect(md).not.toContain("questions64");
+    expect(md).not.toContain(base64Payload);
+  });
+
   test("contentToString fallback uses safeFence when content contains backticks", () => {
     // If an unrecognized object contains triple backticks, the fence must be longer
     const md = exportToMarkdown([

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -43,8 +43,8 @@ function extractWebSearch(block: Record<string, unknown>): string | null {
   return null;
 }
 
-/** Strip `<!-- trigger:ID -->` prefixes injected by linked-session triggers. */
-const TRIGGER_PREFIX_RE = /^<!--\s*trigger:[\w-]+\s*-->\n?/;
+/** Strip `<!-- trigger:ID [source:ID] -->` prefixes injected by linked-session triggers. */
+const TRIGGER_PREFIX_RE = /^<!--\s*trigger:[\w-]+(?:\s+source:[\w-]+)?\s*-->\n?/;
 
 /** Stringify unknown content into a readable string. */
 function contentToString(content: unknown): string {

--- a/packages/ui/src/lib/export-markdown.ts
+++ b/packages/ui/src/lib/export-markdown.ts
@@ -46,10 +46,13 @@ function extractWebSearch(block: Record<string, unknown>): string | null {
 /** Strip `<!-- trigger:ID [source:ID] -->` prefixes injected by linked-session triggers. */
 const TRIGGER_PREFIX_RE = /^<!--\s*trigger:[\w-]+(?:\s+source:[\w-]+)?\s*-->\n?/;
 
+/** Strip `<!-- questions64:... -->` metadata injected for rich AskUserQuestion triggers. */
+const QUESTIONS64_RE = /<!--\s*questions64:[A-Za-z0-9+/=]+\s*-->\n?/g;
+
 /** Stringify unknown content into a readable string. */
 function contentToString(content: unknown): string {
   if (content == null) return "";
-  if (typeof content === "string") return content.replace(TRIGGER_PREFIX_RE, "");
+  if (typeof content === "string") return content.replace(TRIGGER_PREFIX_RE, "").replace(QUESTIONS64_RE, "");
   // Anthropic-style content blocks: [{type:"text", text:"..."}, {type:"thinking", thinking:"..."}, ...]
   if (Array.isArray(content)) {
     const parts: string[] = [];


### PR DESCRIPTION
## Summary

Adds full multi-question / checkbox / ranked support to the child session trigger pipeline, so the web UI renders the same rich interactive stepper for child-session questions as it does for direct questions.

### Changes

- **Fix checkbox docs**: `zero or more` → `one or more` (matches actual UI behavior where at least one selection is required)
- **Embed structured questions in trigger text**: The CLI trigger renderer now includes a `<!-- questions:JSON -->` HTML comment in the rendered text, carrying the full `questions` array (with types) through the text-based relay pipeline
- **Parse structured questions in UI**: `trigger-parsers.ts` extracts the embedded JSON when present, falling back gracefully to legacy regex parsing for old triggers
- **Rich TriggerCard UI**: When structured questions are available, `AskUserQuestionCard` renders the existing `MultipleChoiceQuestions` component (radio/checkbox/ranked stepper). Responses are formatted as JSON via `formatAnswersForAgent`. Legacy single-select button UI preserved as fallback.
- **5 new tests**: Structured JSON parsing, ranked type, legacy fallback, malformed JSON recovery, missing-field filtering

### Addresses PR #182 review comments
- P2: Checkbox `zero or more` → `one or more`
- P2: AskUserQuestion now works end-to-end in child sessions (not just scoped away)

Supersedes #182 (cherry-picks the original prompt docs commit).