### PR TITLE
fix(ui): widen worktree branch badge to prevent truncation

### DIFF
--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1360,7 +1360,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                                 return match ? (
                                                                     <div className="flex items-center gap-1 mt-0.5">
                                                                         <span
-                                                                            className="text-[0.55rem] bg-amber-500/15 text-amber-400/80 px-1 py-0.5 rounded font-mono leading-none truncate max-w-[8rem]"
+                                                                            className="text-[0.55rem] bg-amber-500/15 text-amber-400/80 px-1 py-0.5 rounded font-mono leading-none truncate max-w-full"
                                                                             title={`Worktree: ${match[1]}`}
                                                                         >
                                                                             {match[1]}


### PR DESCRIPTION
## Bug
The git worktree branch name badge in the session sidebar was truncated too aggressively with a fixed `max-w-[8rem]` constraint. This prevented longer branch names from displaying properly even though space was available.

## Fix
Changed `max-w-[8rem]` to `max-w-full` in the badge className (line 1363 of SessionSidebar.tsx). This allows the badge to use the full width of its parent container. The existing `truncate` class will still handle overflow with ellipsis if needed, but the constraint is now based on the sidebar's actual width rather than an arbitrary 8rem cap.

## Verification
- `bun run typecheck` passes
- `bun run build` passes
- Single line CSS change, no functional logic modified