### PR TITLE
fix: handle Unicode characters in attachment filenames (macOS screenshots)

### DIFF
--- a/packages/cli/src/extensions/remote-input.ts
+++ b/packages/cli/src/extensions/remote-input.ts
@@ -110,7 +110,10 @@ export async function loadAttachmentFromRelay(
     }
 
     const mediaType = (response.headers.get("content-type") || "application/octet-stream").split(";")[0].trim();
-    const filename = response.headers.get("x-attachment-filename") ?? undefined;
+    const rawFilename = response.headers.get("x-attachment-filename") ?? undefined;
+    // The server percent-encodes this header to survive Bun's ASCII-only
+    // header validation. Decode it to recover the original Unicode filename.
+    const filename = rawFilename ? decodeURIComponent(rawFilename) : undefined;
     const dataBase64 = Buffer.from(await response.arrayBuffer()).toString("base64");
 
     return { mediaType, filename, dataBase64 };

--- a/packages/cli/src/extensions/remote-input.ts
+++ b/packages/cli/src/extensions/remote-input.ts
@@ -92,11 +92,22 @@ export async function loadAttachmentFromRelay(
     httpBaseUrl: string,
     apiKey: string,
 ): Promise<{ mediaType: string; filename?: string; dataBase64: string } | null> {
-    const response = await fetch(`${httpBaseUrl}/api/attachments/${encodeURIComponent(attachmentId)}`, {
-        headers: { "x-api-key": apiKey },
-    });
+    const url = `${httpBaseUrl}/api/attachments/${encodeURIComponent(attachmentId)}`;
+    let response: Response;
+    try {
+        response = await fetch(url, {
+            headers: { "x-api-key": apiKey },
+        });
+    } catch (err) {
+        console.error(`pizzapi: attachment fetch failed (network error): ${url} — ${err instanceof Error ? err.message : String(err)}`);
+        return null;
+    }
 
-    if (!response.ok) return null;
+    if (!response.ok) {
+        const body = await response.text().catch(() => "");
+        console.error(`pizzapi: attachment fetch failed: ${response.status} ${response.statusText} — ${url}${body ? ` — ${body}` : ""}`);
+        return null;
+    }
 
     const mediaType = (response.headers.get("content-type") || "application/octet-stream").split(";")[0].trim();
     const filename = response.headers.get("x-attachment-filename") ?? undefined;

--- a/packages/cli/src/extensions/remote-input.ts
+++ b/packages/cli/src/extensions/remote-input.ts
@@ -113,7 +113,15 @@ export async function loadAttachmentFromRelay(
     const rawFilename = response.headers.get("x-attachment-filename") ?? undefined;
     // The server percent-encodes this header to survive Bun's ASCII-only
     // header validation. Decode it to recover the original Unicode filename.
-    const filename = rawFilename ? decodeURIComponent(rawFilename) : undefined;
+    let filename: string | undefined;
+    if (rawFilename) {
+        try {
+            filename = decodeURIComponent(rawFilename);
+        } catch {
+            // Malformed percent-encoding — use the raw value as-is
+            filename = rawFilename;
+        }
+    }
     const dataBase64 = Buffer.from(await response.arrayBuffer()).toString("base64");
 
     return { mediaType, filename, dataBase64 };

--- a/packages/server/src/routes/attachments.test.ts
+++ b/packages/server/src/routes/attachments.test.ts
@@ -1,5 +1,36 @@
 import { describe, test, expect } from "bun:test";
-import { buildContentDisposition, sanitizeHeaderValue } from "./attachments";
+import { buildContentDisposition, encodeHeaderFilename, rfc5987Encode } from "./attachments";
+
+describe("rfc5987Encode", () => {
+    test("encodes basic special characters", () => {
+        expect(rfc5987Encode("hello world")).toBe("hello%20world");
+    });
+
+    test("encodes apostrophe (RFC 5987 delimiter)", () => {
+        expect(rfc5987Encode("O'Reilly")).toBe("O%27Reilly");
+    });
+
+    test("encodes parentheses and asterisk", () => {
+        expect(rfc5987Encode("file (1).txt")).toBe("file%20%281%29.txt");
+        expect(rfc5987Encode("file*.txt")).toBe("file%2A.txt");
+    });
+
+    test("encodes non-ASCII characters", () => {
+        expect(rfc5987Encode("résumé.pdf")).toContain("%C3%A9");
+    });
+
+    test("round-trips through decodeURIComponent", () => {
+        const names = [
+            "O'Reilly résumé (1).png",
+            "Screenshot 2026-03-19 at 2.02.18\u202FPM.png",
+            "截图_2026.png",
+            "file*.txt",
+        ];
+        for (const name of names) {
+            expect(decodeURIComponent(rfc5987Encode(name))).toBe(name);
+        }
+    });
+});
 
 describe("buildContentDisposition", () => {
     test("handles plain ASCII filenames", () => {
@@ -16,7 +47,6 @@ describe("buildContentDisposition", () => {
     });
 
     test("handles macOS screenshot filenames with U+202F narrow no-break space", () => {
-        // macOS uses U+202F (NARROW NO-BREAK SPACE) before AM/PM in screenshot filenames
         const filename = "Screenshot 2026-03-19 at 2.02.18\u202FPM.png";
         const result = buildContentDisposition(filename);
         // ASCII fallback should replace U+202F with underscore
@@ -58,6 +88,19 @@ describe("buildContentDisposition", () => {
         expect(r.headers.get("content-disposition")).toBeTruthy();
     });
 
+    test("handles filenames with apostrophes (RFC 5987 delimiter)", () => {
+        const filename = "O'Reilly résumé (1).png";
+        const result = buildContentDisposition(filename);
+        // Apostrophe must be percent-encoded in filename* to avoid
+        // being interpreted as the charset/language separator
+        expect(result).toContain("%27");
+        // Parentheses must also be encoded
+        expect(result).toContain("%28");
+        expect(result).toContain("%29");
+        const r = new Response("", { headers: { "content-disposition": result } });
+        expect(r.headers.get("content-disposition")).toBeTruthy();
+    });
+
     test("supports attachment mode", () => {
         const result = buildContentDisposition("file.pdf", "attachment");
         expect(result).toStartWith("attachment;");
@@ -69,27 +112,44 @@ describe("buildContentDisposition", () => {
     });
 });
 
-describe("sanitizeHeaderValue", () => {
-    test("preserves ASCII printable characters", () => {
-        expect(sanitizeHeaderValue("hello world")).toBe("hello world");
-        expect(sanitizeHeaderValue("file-name_v2.txt")).toBe("file-name_v2.txt");
+describe("encodeHeaderFilename", () => {
+    test("preserves ASCII alphanumeric and safe characters", () => {
+        const result = encodeHeaderFilename("photo.png");
+        expect(result).toBe("photo.png");
+        const r = new Response("", { headers: { "x-filename": result } });
+        expect(r.headers.get("x-filename")).toBe(result);
     });
 
-    test("replaces non-ASCII characters with ?", () => {
-        expect(sanitizeHeaderValue("file\u202Fname.txt")).toBe("file?name.txt");
-        expect(sanitizeHeaderValue("résumé.pdf")).toBe("r?sum?.pdf");
-    });
-
-    test("handles macOS screenshot names", () => {
-        const name = "Screenshot 2026-03-19 at 2.02.18\u202FPM.png";
-        const result = sanitizeHeaderValue(name);
-        expect(result).toBe("Screenshot 2026-03-19 at 2.02.18?PM.png");
+    test("percent-encodes non-ASCII characters", () => {
+        const result = encodeHeaderFilename("résumé.pdf");
+        expect(result).not.toContain("é");
+        expect(result).toContain("%C3%A9");
+        // Must round-trip
+        expect(decodeURIComponent(result)).toBe("résumé.pdf");
         // Must not throw in a header
         const r = new Response("", { headers: { "x-filename": result } });
         expect(r.headers.get("x-filename")).toBe(result);
     });
 
+    test("handles macOS screenshot names and round-trips", () => {
+        const name = "Screenshot 2026-03-19 at 2.02.18\u202FPM.png";
+        const result = encodeHeaderFilename(name);
+        // Must not throw in a header
+        const r = new Response("", { headers: { "x-filename": result } });
+        expect(r.headers.get("x-filename")).toBe(result);
+        // Must round-trip
+        expect(decodeURIComponent(result)).toBe(name);
+    });
+
+    test("handles CJK filenames and round-trips", () => {
+        const name = "截图_2026.png";
+        const result = encodeHeaderFilename(name);
+        const r = new Response("", { headers: { "x-filename": result } });
+        expect(r.headers.get("x-filename")).toBe(result);
+        expect(decodeURIComponent(result)).toBe(name);
+    });
+
     test("preserves empty string", () => {
-        expect(sanitizeHeaderValue("")).toBe("");
+        expect(encodeHeaderFilename("")).toBe("");
     });
 });

--- a/packages/server/src/routes/attachments.test.ts
+++ b/packages/server/src/routes/attachments.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from "bun:test";
+import { buildContentDisposition, sanitizeHeaderValue } from "./attachments";
+
+describe("buildContentDisposition", () => {
+    test("handles plain ASCII filenames", () => {
+        const result = buildContentDisposition("photo.png");
+        expect(result).toBe(`inline; filename="photo.png"; filename*=UTF-8''photo.png`);
+    });
+
+    test("handles filenames with regular spaces", () => {
+        const result = buildContentDisposition("my photo.png");
+        expect(result).toBe(`inline; filename="my photo.png"; filename*=UTF-8''my%20photo.png`);
+        // Must not throw when used in a Response header
+        const r = new Response("", { headers: { "content-disposition": result } });
+        expect(r.headers.get("content-disposition")).toBe(result);
+    });
+
+    test("handles macOS screenshot filenames with U+202F narrow no-break space", () => {
+        // macOS uses U+202F (NARROW NO-BREAK SPACE) before AM/PM in screenshot filenames
+        const filename = "Screenshot 2026-03-19 at 2.02.18\u202FPM.png";
+        const result = buildContentDisposition(filename);
+        // ASCII fallback should replace U+202F with underscore
+        expect(result).toContain('filename="Screenshot 2026-03-19 at 2.02.18_PM.png"');
+        // RFC 5987 encoded version should preserve the character
+        expect(result).toContain("filename*=UTF-8''");
+        expect(result).toContain("%E2%80%AF"); // U+202F in UTF-8
+        // Must not throw when used in a Response header
+        const r = new Response("", { headers: { "content-disposition": result } });
+        expect(r.headers.get("content-disposition")).toBeTruthy();
+    });
+
+    test("handles filenames with U+00A0 non-breaking space", () => {
+        const filename = "file\u00A0name.txt";
+        const result = buildContentDisposition(filename);
+        expect(result).toContain('filename="file_name.txt"');
+        const r = new Response("", { headers: { "content-disposition": result } });
+        expect(r.headers.get("content-disposition")).toBeTruthy();
+    });
+
+    test("escapes double quotes in filenames", () => {
+        const result = buildContentDisposition('file"name.txt');
+        expect(result).toContain('filename="file_name.txt"');
+    });
+
+    test("escapes backslashes in filenames", () => {
+        const result = buildContentDisposition("file\\name.txt");
+        expect(result).toContain('filename="file_name.txt"');
+    });
+
+    test("handles non-Latin characters (CJK, emoji)", () => {
+        const filename = "截图_2026.png";
+        const result = buildContentDisposition(filename);
+        // ASCII fallback replaces CJK characters
+        expect(result).toContain('filename="___2026.png"');
+        // RFC 5987 encodes them
+        expect(result).toContain("filename*=UTF-8''");
+        const r = new Response("", { headers: { "content-disposition": result } });
+        expect(r.headers.get("content-disposition")).toBeTruthy();
+    });
+
+    test("supports attachment mode", () => {
+        const result = buildContentDisposition("file.pdf", "attachment");
+        expect(result).toStartWith("attachment;");
+    });
+
+    test("defaults to inline mode", () => {
+        const result = buildContentDisposition("file.pdf");
+        expect(result).toStartWith("inline;");
+    });
+});
+
+describe("sanitizeHeaderValue", () => {
+    test("preserves ASCII printable characters", () => {
+        expect(sanitizeHeaderValue("hello world")).toBe("hello world");
+        expect(sanitizeHeaderValue("file-name_v2.txt")).toBe("file-name_v2.txt");
+    });
+
+    test("replaces non-ASCII characters with ?", () => {
+        expect(sanitizeHeaderValue("file\u202Fname.txt")).toBe("file?name.txt");
+        expect(sanitizeHeaderValue("résumé.pdf")).toBe("r?sum?.pdf");
+    });
+
+    test("handles macOS screenshot names", () => {
+        const name = "Screenshot 2026-03-19 at 2.02.18\u202FPM.png";
+        const result = sanitizeHeaderValue(name);
+        expect(result).toBe("Screenshot 2026-03-19 at 2.02.18?PM.png");
+        // Must not throw in a header
+        const r = new Response("", { headers: { "x-filename": result } });
+        expect(r.headers.get("x-filename")).toBe(result);
+    });
+
+    test("preserves empty string", () => {
+        expect(sanitizeHeaderValue("")).toBe("");
+    });
+});

--- a/packages/server/src/routes/attachments.ts
+++ b/packages/server/src/routes/attachments.ts
@@ -12,6 +12,21 @@ import {
 import type { RouteHandler } from "./types.js";
 
 /**
+ * Percent-encode a filename per RFC 5987.
+ *
+ * `encodeURIComponent` leaves `'`, `(`, `)`, `*`, and `!` unencoded, but
+ * RFC 5987 uses `'` as a delimiter (`charset'language'value`) so those
+ * characters must be encoded manually to avoid mis-parsing.
+ */
+export function rfc5987Encode(value: string): string {
+    return encodeURIComponent(value)
+        .replace(/'/g, "%27")
+        .replace(/\(/g, "%28")
+        .replace(/\)/g, "%29")
+        .replace(/\*/g, "%2A");
+}
+
+/**
  * Build a Content-Disposition header value safe for Bun's header validation.
  *
  * Bun rejects header values with non-ASCII characters (e.g. macOS screenshot
@@ -21,16 +36,19 @@ import type { RouteHandler } from "./types.js";
  */
 export function buildContentDisposition(rawFilename: string, mode: "inline" | "attachment" = "inline"): string {
     const asciiFallback = rawFilename.replace(/[^\x20-\x7E]/g, "_").replace(/["\\]/g, "_");
-    const encodedName = encodeURIComponent(rawFilename);
+    const encodedName = rfc5987Encode(rawFilename);
     return `${mode}; filename="${asciiFallback}"; filename*=UTF-8''${encodedName}`;
 }
 
 /**
- * Sanitize a filename for use in an HTTP header value.
- * Replaces non-ASCII characters with "?" to avoid Bun header validation errors.
+ * Percent-encode a filename for use in an HTTP header value.
+ *
+ * Uses full percent-encoding so the original Unicode filename can be
+ * recovered by the consumer (the runner decodes it). This preserves
+ * filenames like `résumé.txt` or `截图.png` across the wire.
  */
-export function sanitizeHeaderValue(value: string): string {
-    return value.replace(/[^\x20-\x7E]/g, "?");
+export function encodeHeaderFilename(value: string): string {
+    return rfc5987Encode(value);
 }
 
 export const handleAttachmentsRoute: RouteHandler = async (req, url) => {
@@ -128,7 +146,7 @@ export const handleAttachmentsRoute: RouteHandler = async (req, url) => {
                 "content-length": String(attachment.size),
                 "content-disposition": buildContentDisposition(attachment.filename),
                 "x-attachment-id": attachment.attachmentId,
-                "x-attachment-filename": sanitizeHeaderValue(attachment.filename),
+                "x-attachment-filename": encodeHeaderFilename(attachment.filename),
             },
         });
     }

--- a/packages/server/src/routes/attachments.ts
+++ b/packages/server/src/routes/attachments.ts
@@ -11,6 +11,28 @@ import {
 } from "../attachments/store.js";
 import type { RouteHandler } from "./types.js";
 
+/**
+ * Build a Content-Disposition header value safe for Bun's header validation.
+ *
+ * Bun rejects header values with non-ASCII characters (e.g. macOS screenshot
+ * filenames that contain U+202F NARROW NO-BREAK SPACE before "AM"/"PM").
+ * We produce both an ASCII-safe `filename` and an RFC 5987 `filename*` with
+ * the full UTF-8 name percent-encoded.
+ */
+export function buildContentDisposition(rawFilename: string, mode: "inline" | "attachment" = "inline"): string {
+    const asciiFallback = rawFilename.replace(/[^\x20-\x7E]/g, "_").replace(/["\\]/g, "_");
+    const encodedName = encodeURIComponent(rawFilename);
+    return `${mode}; filename="${asciiFallback}"; filename*=UTF-8''${encodedName}`;
+}
+
+/**
+ * Sanitize a filename for use in an HTTP header value.
+ * Replaces non-ASCII characters with "?" to avoid Bun header validation errors.
+ */
+export function sanitizeHeaderValue(value: string): string {
+    return value.replace(/[^\x20-\x7E]/g, "?");
+}
+
 export const handleAttachmentsRoute: RouteHandler = async (req, url) => {
     // ── Upload: POST /api/sessions/:id/attachments ─────────────────────
     if (
@@ -104,9 +126,9 @@ export const handleAttachmentsRoute: RouteHandler = async (req, url) => {
             headers: {
                 "content-type": attachment.mimeType,
                 "content-length": String(attachment.size),
-                "content-disposition": `inline; filename="${attachment.filename.replace(/\"/g, "")}"`,
+                "content-disposition": buildContentDisposition(attachment.filename),
                 "x-attachment-id": attachment.attachmentId,
-                "x-attachment-filename": attachment.filename,
+                "x-attachment-filename": sanitizeHeaderValue(attachment.filename),
             },
         });
     }


### PR DESCRIPTION
## Problem

macOS screenshot filenames contain U+202F (NARROW NO-BREAK SPACE) before AM/PM — e.g. `Screenshot 2026-03-19 at 2.02.18 PM.png`. Bun's `Response` constructor rejects non-ASCII characters in HTTP header values, so the attachment download endpoint threw a 500 when building the `content-disposition` header. This caused `loadAttachmentFromRelay` to silently return `null`, making image attachments fall through to the unhelpful "binary content not included" fallback.

## Fix

- **`packages/server/src/routes/attachments.ts`** — Extract `buildContentDisposition()` helper that produces an ASCII-safe `filename` parameter plus an RFC 5987 `filename*=UTF-8''...` with full percent-encoded UTF-8. Also extract `sanitizeHeaderValue()` for the `x-attachment-filename` custom header.
- **`packages/cli/src/extensions/remote-input.ts`** — Add error logging to `loadAttachmentFromRelay` so future download failures log the HTTP status + response body instead of silently returning null.
- **`packages/server/src/routes/attachments.test.ts`** — New test file covering U+202F, U+00A0, CJK characters, quotes, and backslashes in filenames.

## Testing

- All 279 tests pass
- Typecheck clean
- Verified fix works against Bun 1.3.11 in Docker