### PR TITLE
fix: follow-up delivery mode — route trigger responses directly to child sessions

### DIFF
--- a/packages/cli/src/extensions/triggers/integration.test.ts
+++ b/packages/cli/src/extensions/triggers/integration.test.ts
@@ -12,11 +12,11 @@ import type { ConversationTrigger } from "./types.js";
 
 // Duplicate trigger message parsing from UI package (can't cross-import packages)
 // Matches: <!-- trigger:ID --> or <!-- trigger:ID source:sessionID -->
-const TRIGGER_PREFIX_RE = /^<!--\s*trigger:([\w-]+)(?:\s+source:[\w-]+)?\s*-->\n?/;
-function parseTriggerMessage(text: string): { triggerId: string; body: string } | null {
+const TRIGGER_PREFIX_RE = /^<!--\s*trigger:([\w-]+)(?:\s+source:([\w-]+))?\s*-->\n?/;
+function parseTriggerMessage(text: string): { triggerId: string; sourceSessionId?: string; body: string } | null {
     const match = text.match(TRIGGER_PREFIX_RE);
     if (!match) return null;
-    return { triggerId: match[1], body: text.slice(match[0].length) };
+    return { triggerId: match[1], sourceSessionId: match[2], body: text.slice(match[0].length) };
 }
 function isTriggerMessage(text: string): boolean {
     return TRIGGER_PREFIX_RE.test(text);
@@ -54,6 +54,7 @@ describe("trigger routing flow", () => {
             const parsed = parseTriggerMessage(rendered);
             expect(parsed).not.toBeNull();
             expect(parsed!.triggerId).toBe("trigger-abc-123");
+            expect(parsed!.sourceSessionId).toBe("child-session-1");
             expect(parsed!.body).toContain("Which database?");
         });
 

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -86,7 +86,7 @@ export interface ViewerClientToServerEvents {
     response: string;
     action?: string;
     targetSessionId: string;
-  }, ack?: () => void) => void;
+  }, ack: () => void) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -356,9 +356,14 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             // Validate ownership: the target session must belong to the same user.
             if (targetSessionId) {
                 const targetSession = await getSharedSession(targetSessionId);
-                if (!targetSession || targetSession.userId !== viewerUserId) {
-                    // Target session doesn't exist or belongs to a different user — nack.
-                    // Use trigger_error (not error) so the client can correlate by triggerId.
+                if (!targetSession) {
+                    // Target session no longer exists (child exited) — don't ack so the
+                    // UI keeps retry controls visible, and emit trigger_error for feedback.
+                    (socket as any).emit("trigger_error", { message: `Child session ${targetSessionId} is no longer available`, triggerId });
+                    return;
+                }
+                if (targetSession.userId !== viewerUserId) {
+                    // Security: belongs to a different user — nack with trigger_error.
                     (socket as any).emit("trigger_error", { message: `Target session ${targetSessionId} not found or unauthorized`, triggerId });
                     return;
                 }

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -634,6 +634,8 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     setCommandQuery("");
     setCommandHighlightedIndex(0);
     setAtMentionOpen(false);
+    // Reset delivery mode to followUp so it doesn't persist across sessions
+    setDeliveryMode("followUp");
     // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally reading `input` at transition time only
   }, [sessionId]);
 

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -571,6 +571,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
   const [input, setInput] = React.useState("");
   // Per-session draft storage so switching sessions preserves unsent text
   const draftsRef = React.useRef<Map<string, string>>(new Map());
+  const deliveryModeRef = React.useRef<Map<string, "steer" | "followUp">>(new Map());
   // Inline editing state for queued messages
   const [editingQueuedId, setEditingQueuedId] = React.useState<string | null>(null);
   const [editingQueuedText, setEditingQueuedText] = React.useState("");
@@ -619,12 +620,15 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     const prevId = prevSessionIdRef.current;
     if (prevId) {
       draftsRef.current.set(prevId, input);
+      deliveryModeRef.current.set(prevId, deliveryMode);
     }
-    // Restore the draft for the new session (or clear if null)
+    // Restore the draft and delivery mode for the new session (or clear if null)
     if (sessionId) {
       setInput(draftsRef.current.get(sessionId) ?? "");
+      setDeliveryMode(deliveryModeRef.current.get(sessionId) ?? "followUp");
     } else {
       setInput("");
+      setDeliveryMode("followUp");
     }
     prevSessionIdRef.current = sessionId ?? null;
     setComposerError(null);
@@ -634,9 +638,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     setCommandQuery("");
     setCommandHighlightedIndex(0);
     setAtMentionOpen(false);
-    // Reset delivery mode to followUp so it doesn't persist across sessions
-    setDeliveryMode("followUp");
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally reading `input` at transition time only
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally reading `input` and `deliveryMode` at transition time only
   }, [sessionId]);
 
   // Reset the compacting guard when the heartbeat confirms compact is done
@@ -1032,6 +1034,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               setCommandOpen(false);
               setCommandQuery("");
               draftsRef.current.delete(originSessionId);
+              deliveryModeRef.current.delete(originSessionId);
             } else if (originSessionId) {
               // User switched away. Only clear the saved draft if it still
               // matches what was sent — if the user typed new text after
@@ -1040,6 +1043,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               const saved = draftsRef.current.get(originSessionId)?.trim();
               if (saved === sentText || saved === undefined || saved === "") {
                 draftsRef.current.delete(originSessionId);
+                deliveryModeRef.current.delete(originSessionId);
               }
             }
           } else {


### PR DESCRIPTION
## Summary

Fixes how trigger responses (follow-up instructions, question answers) are delivered to child sessions. Instead of relying on indirect relay routing, responses are now sent directly to the correct child session.

## Changes

### CLI (`packages/cli`)
- **`remote.ts`**: Updated trigger response handling
- **`triggers/registry.ts`**: Improved trigger registry with delivery mode awareness
- **`runner/daemon.ts`**: Simplified daemon — removed unused usage-auth module (~150 lines deleted)

### Server (`packages/server`)
- **`relay.ts`**: Reworked relay namespace to route trigger responses directly
- **`viewer.ts`**: Updated viewer namespace for delivery acknowledgment

### UI (`packages/ui`)
- **`TriggerCard.tsx`**: Improved trigger card rendering with better follow-up support
- **`trigger-parsers.ts`**: Enhanced trigger parsing with UTF-8 safe base64 encoding
- **`InterAgentCards.tsx`**: Updated inter-agent card rendering
- **`App.tsx` / `SessionViewer.tsx`**: Reset delivery mode on session changes
- Added **TriggerCard tests** (176 lines)

## Key fixes
- Route trigger responses directly to child session (no indirect relay hop)
- UTF-8 safe base64 encoding for trigger questions
- Guard `atob` decoding for malformed payloads
- Escape `-->` sequences in HTML comments to prevent parsing issues
- Reset deliveryMode when sessionId changes
- Propagate send failures to UI for immediate retry

## Testing
- New `TriggerCard.test.ts` with comprehensive parser/render tests
- Updated `registry.test.ts` for delivery mode changes
- Removed obsolete `usage-auth.test.ts` (module deleted)