### PR TITLE
feat: add boot timing instrumentation to worker

### DIFF
--- a/packages/cli/src/runner/boot-timing.test.ts
+++ b/packages/cli/src/runner/boot-timing.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from "bun:test";
+import { createBootTimer } from "./boot-timing.js";
+
+describe("createBootTimer", () => {
+    test("logs elapsed time to stdout format", () => {
+        const logs: string[] = [];
+        const originalLog = console.log;
+        console.log = (...args: unknown[]) => {
+            logs.push(args.map(String).join(" "));
+        };
+
+        try {
+            const timer = createBootTimer();
+            timer.start("[boot] config");
+            timer.end("[boot] config");
+
+            expect(logs).toHaveLength(1);
+            expect(logs[0]).toMatch(/^\[boot\] config: \d+\.\d{3}ms$/);
+        } finally {
+            console.log = originalLog;
+        }
+    });
+
+    test("missing timer end is a no-op", () => {
+        const logs: string[] = [];
+        const originalLog = console.log;
+        console.log = (...args: unknown[]) => {
+            logs.push(args.map(String).join(" "));
+        };
+
+        try {
+            const timer = createBootTimer();
+            timer.end("[boot] never-started");
+            expect(logs).toHaveLength(0);
+        } finally {
+            console.log = originalLog;
+        }
+    });
+});

--- a/packages/cli/src/runner/boot-timing.ts
+++ b/packages/cli/src/runner/boot-timing.ts
@@ -1,0 +1,31 @@
+type TimerEntry = {
+    label: string;
+    startedAtMs: number;
+};
+
+/**
+ * Lightweight boot timer that logs to stdout via console.log.
+ *
+ * Node/Bun's console.timeEnd() writes to stderr, which causes normal
+ * boot instrumentation to appear as error logs when workers are spawned
+ * with inherited stdio. This helper keeps timing output on stdout.
+ */
+export function createBootTimer(): {
+    start: (name: string) => void;
+    end: (name: string) => void;
+} {
+    const timers = new Map<string, TimerEntry>();
+
+    return {
+        start(name: string) {
+            timers.set(name, { label: name, startedAtMs: performance.now() });
+        },
+        end(name: string) {
+            const timer = timers.get(name);
+            if (!timer) return;
+            timers.delete(name);
+            const elapsedMs = performance.now() - timer.startedAtMs;
+            console.log(`${timer.label}: ${elapsedMs.toFixed(3)}ms`);
+        },
+    };
+}

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -6,6 +6,7 @@ import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, expandHome, loadConfig, resolve
 import { buildWorkerSkillPaths } from "../skills.js";
 import { getPluginSkillPaths } from "../extensions/claude-plugins.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
+import { createBootTimer } from "./boot-timing.js";
 
 /**
  * Build additional prompt template paths for the headless worker.
@@ -39,7 +40,8 @@ import { buildPizzaPiExtensionFactories } from "../extensions/factories.js";
  *   PIZZAPI_RELAY_URL    Relay base URL (http(s)://... or ws(s)://...)
  */
 async function main(): Promise<void> {
-    console.time("[boot] total");
+    const bootTimer = createBootTimer();
+    bootTimer.start("[boot] total");
 
     const args = process.argv.slice(2);
     const cwdFlagIdx = args.indexOf("--cwd");
@@ -53,18 +55,18 @@ async function main(): Promise<void> {
         process.exit(1);
     }
 
-    console.time("[boot] config");
+    bootTimer.start("[boot] config");
     const config = loadConfig(cwd);
     const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
     const skipPlugins = process.env.PIZZAPI_NO_PLUGINS === "1";
 
     // ── Provider settings → env vars ───────────────────────────────────────
     applyProviderSettingsEnv(config);
-    console.timeEnd("[boot] config");
+    bootTimer.end("[boot] config");
 
     // ── Sandbox initialization ─────────────────────────────────────────────
     // Must happen before any tools execute (including MCP init via extensions).
-    console.time("[boot] sandbox");
+    bootTimer.start("[boot] sandbox");
     const sandboxConfig = resolveSandboxConfig(cwd, config);
 
     // PIZZAPI_SANDBOX / PIZZAPI_NO_SANDBOX env var overrides.
@@ -97,7 +99,7 @@ async function main(): Promise<void> {
     } else if (sandboxConfig.mode !== "none") {
         console.warn("pizzapi worker: sandbox was requested but is not active (platform unsupported or init failed)");
     }
-    console.timeEnd("[boot] sandbox");
+    bootTimer.end("[boot] sandbox");
 
     // ── Agent session config ───────────────────────────────────────────────
     // When spawned "as" an agent, these env vars carry the agent definition.
@@ -121,7 +123,7 @@ async function main(): Promise<void> {
         }
     }
 
-    console.time("[boot] resource-loader");
+    bootTimer.start("[boot] resource-loader");
     const loader = new DefaultResourceLoader({
         cwd,
         agentDir,
@@ -149,18 +151,18 @@ async function main(): Promise<void> {
         }),
     });
     await loader.reload();
-    console.timeEnd("[boot] resource-loader");
+    bootTimer.end("[boot] resource-loader");
 
-    console.time("[boot] create-session");
+    bootTimer.start("[boot] create-session");
     const { session } = await createAgentSession({
         cwd,
         agentDir,
         resourceLoader: loader,
     });
-    console.timeEnd("[boot] create-session");
+    bootTimer.end("[boot] create-session");
 
     // Bind extensions in headless mode (no UI context)
-    console.time("[boot] bind-extensions");
+    bootTimer.start("[boot] bind-extensions");
     await session.bindExtensions({
         commandContextActions: {
             waitForIdle: () => session.agent.waitForIdle(),
@@ -202,10 +204,10 @@ async function main(): Promise<void> {
             forwardCliError(err.error, err.extensionPath);
         },
     });
-    console.timeEnd("[boot] bind-extensions");
+    bootTimer.end("[boot] bind-extensions");
 
     const sessionId = process.env.PIZZAPI_SESSION_ID;
-    console.timeEnd("[boot] total");
+    bootTimer.end("[boot] total");
     console.log(`pizzapi worker: boot complete (cwd=${cwd}${sessionId ? `, sessionId=${sessionId}` : ""})`);
 
     const shutdown = async () => {

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -39,6 +39,8 @@ import { buildPizzaPiExtensionFactories } from "../extensions/factories.js";
  *   PIZZAPI_RELAY_URL    Relay base URL (http(s)://... or ws(s)://...)
  */
 async function main(): Promise<void> {
+    console.time("[boot] total");
+
     const args = process.argv.slice(2);
     const cwdFlagIdx = args.indexOf("--cwd");
     const cwdFromArgs = cwdFlagIdx !== -1 && args[cwdFlagIdx + 1] ? args[cwdFlagIdx + 1] : undefined;
@@ -51,15 +53,18 @@ async function main(): Promise<void> {
         process.exit(1);
     }
 
+    console.time("[boot] config");
     const config = loadConfig(cwd);
     const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
     const skipPlugins = process.env.PIZZAPI_NO_PLUGINS === "1";
 
     // ── Provider settings → env vars ───────────────────────────────────────
     applyProviderSettingsEnv(config);
+    console.timeEnd("[boot] config");
 
     // ── Sandbox initialization ─────────────────────────────────────────────
     // Must happen before any tools execute (including MCP init via extensions).
+    console.time("[boot] sandbox");
     const sandboxConfig = resolveSandboxConfig(cwd, config);
 
     // PIZZAPI_SANDBOX / PIZZAPI_NO_SANDBOX env var overrides.
@@ -92,6 +97,7 @@ async function main(): Promise<void> {
     } else if (sandboxConfig.mode !== "none") {
         console.warn("pizzapi worker: sandbox was requested but is not active (platform unsupported or init failed)");
     }
+    console.timeEnd("[boot] sandbox");
 
     // ── Agent session config ───────────────────────────────────────────────
     // When spawned "as" an agent, these env vars carry the agent definition.
@@ -115,6 +121,7 @@ async function main(): Promise<void> {
         }
     }
 
+    console.time("[boot] resource-loader");
     const loader = new DefaultResourceLoader({
         cwd,
         agentDir,
@@ -142,14 +149,18 @@ async function main(): Promise<void> {
         }),
     });
     await loader.reload();
+    console.timeEnd("[boot] resource-loader");
 
+    console.time("[boot] create-session");
     const { session } = await createAgentSession({
         cwd,
         agentDir,
         resourceLoader: loader,
     });
+    console.timeEnd("[boot] create-session");
 
     // Bind extensions in headless mode (no UI context)
+    console.time("[boot] bind-extensions");
     await session.bindExtensions({
         commandContextActions: {
             waitForIdle: () => session.agent.waitForIdle(),
@@ -191,9 +202,11 @@ async function main(): Promise<void> {
             forwardCliError(err.error, err.extensionPath);
         },
     });
+    console.timeEnd("[boot] bind-extensions");
 
     const sessionId = process.env.PIZZAPI_SESSION_ID;
-    console.log(`pizzapi worker: started (cwd=${cwd}${sessionId ? `, sessionId=${sessionId}` : ""}${agentName ? `, agent=${agentName}` : ""})`);
+    console.timeEnd("[boot] total");
+    console.log(`pizzapi worker: boot complete (cwd=${cwd}${sessionId ? `, sessionId=${sessionId}` : ""})`);
 
     const shutdown = async () => {
         try {


### PR DESCRIPTION
Adds `console.time`/`console.timeEnd` instrumentation around each phase of worker boot in `packages/cli/src/runner/worker.ts`:

- `[boot] config` — config load + provider settings
- `[boot] sandbox` — sandbox resolution + init
- `[boot] resource-loader` — DefaultResourceLoader + reload
- `[boot] create-session` — createAgentSession
- `[boot] bind-extensions` — bindExtensions (session_start)
- `[boot] total` — full boot sequence

No behavioral changes — just timing wraps for diagnosing slow session startup.