### PR TITLE
perf: start MCP server init eagerly to overlap with session setup

### DIFF
--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -13,6 +13,7 @@ import {
 } from "./mcp.js";
 import { setMcpBridge } from "./mcp-bridge.js";
 import type { RelayContext } from "./mcp-oauth.js";
+import { waitForRelayRegistration } from "./remote.js";
 
 type McpServerConfigEntry = {
   name: string;
@@ -588,10 +589,17 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
 
   // ── session_start: await eager load + report timing to TUI/web UI ────────
   pi.on?.("session_start", async (_event: any, ctx: any) => {
-    // Anchor relay wait timeout to session_start; any OAuth waiters created
-    // during eager init begin their fallback window now.
+    // Anchor relay wait timeout to relay registration, not session_start.
+    // The relay context is only published after the Socket.IO `registered`
+    // round-trip (remote.ts), which can happen well after session_start.
+    // Starting the 15s fallback timer here would still consume the budget
+    // before the relay is actually usable in slow-tunnel / cold-relay scenarios.
     setDeferOAuthRelayWaitTimeoutUntilAnchor(false);
-    markOAuthRelayWaitAnchorReady();
+    // Wait for the relay to finish registration (or timeout after 10s if
+    // relay is unreachable), then open the fallback window for OAuth waiters.
+    void waitForRelayRegistration().then(() => {
+      markOAuthRelayWaitAnchorReady();
+    });
 
     try {
       if (eagerLoadPromise) {

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -531,20 +531,40 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
   // (relay context's waitForCallback delegates here).
   (bridge as any)._pendingOAuthCallbacks = pendingOAuthCallbacks;
 
-  // NOTE: MCP initialization is deferred to session_start (below) rather than
-  // running here in the factory.  Extension factories are awaited sequentially
-  // by pi, and session_start only fires AFTER all factories complete.  If an
-  // MCP server needs OAuth during init, the OAuth provider must wait for the
-  // relay connection (which happens asynchronously during session_start).
-  // Running load() here would deadlock: the relay can't connect because
-  // session_start hasn't fired, and session_start can't fire because load()
-  // is blocking the factory.  By deferring to session_start, the relay
-  // connection can establish in parallel while MCP servers initialize.
+  // Start MCP initialization eagerly — kick off server spawning and
+  // handshakes immediately so they overlap with other extension factory
+  // loading and relay connection setup.
+  //
+  // We do NOT await load() here, so the factory completes immediately and
+  // other extension factories continue loading.  Non-OAuth servers (stdio
+  // like godmother) will complete their handshake while other factories load.
+  // OAuth servers that need the relay will block inside waitForRelayContext()
+  // until session_start fires and the relay connects — no deadlock because
+  // we're not blocking the factory.
+  let eagerLoadPromise: Promise<McpSnapshot | null> | null = null;
+  try {
+    eagerLoadPromise = load().catch((err) => {
+      // Don't crash the factory — session_start will handle diagnostics
+      console.warn(`pizzapi: MCP eager init failed, will retry in session_start: ${err instanceof Error ? err.message : String(err)}`);
+      return null;
+    });
+  } catch {
+    // Swallow synchronous errors from load() setup
+  }
 
-  // ── session_start: load MCP tools + report timing to TUI/web UI ──────────
+  // ── session_start: await eager load + report timing to TUI/web UI ────────
   pi.on?.("session_start", async (_event: any, ctx: any) => {
     try {
-      await load();
+      if (eagerLoadPromise) {
+        const result = await eagerLoadPromise;
+        eagerLoadPromise = null;
+        if (!result) {
+          // Eager load failed — retry now that relay is connected
+          await load();
+        }
+      } else {
+        await load();
+      }
     } catch {
       // Swallow — user can diagnose via /mcp.
     }

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -527,6 +527,18 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
   const bridge: McpBridge = {
     status: () => lastSnapshot,
     async reload() {
+      // Cancel any in-flight eager/background load so it can't finish after
+      // this reload, tear down our freshly loaded clients, and restore stale
+      // MCP tool state.  Rotate the lifecycle controller so the cancelled
+      // load's completion is discarded by the staleness check in load().
+      if (eagerLoadPromise) {
+        loadLifecycleController.abort();
+        loadLifecycleController = new AbortController();
+        // Wait for the eager load to settle (it will see the abort and bail)
+        await eagerLoadPromise.catch(() => {});
+        eagerLoadPromise = null;
+      }
+
       const snapshot = await load();
       // Reapply relay context to newly created providers after reload
       if (currentRelayContext) {

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -398,6 +398,10 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
   // Stash the last registration result so session_start can build reports.
   let lastRegistrationResult: McpRegistrationResult | null = null;
 
+  // Abort/cancel token for in-flight MCP loads. Replaced on session_shutdown
+  // so stale eager init work cannot repopulate clients for a new session.
+  let loadLifecycleController = new AbortController();
+
   async function load(): Promise<McpSnapshot> {
     const mergedConfig = loadConfig(process.cwd()) as PizzaPiConfig & McpConfig;
     const inspection = inspectMcpConfig(process.cwd());
@@ -410,7 +414,22 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
     // already connected — without this, providers fall back to local OAuth.
     // During initial session_start, currentRelayContext is null (relay hasn't
     // connected yet) and providers use waitForRelayContext() as before.
-    const res = await registerMcpTools(pi, mergedConfig, currentRelayContext);
+    const lifecycleAtLoadStart = loadLifecycleController;
+    const res = await registerMcpTools(pi, mergedConfig, currentRelayContext, lifecycleAtLoadStart.signal);
+
+    // If this load belongs to an old session lifecycle (or the lifecycle was
+    // aborted), discard it so a late eager init cannot repopulate clients
+    // after session_shutdown.
+    if (lifecycleAtLoadStart !== loadLifecycleController || lifecycleAtLoadStart.signal.aborted) {
+      for (const client of res.clients) {
+        try {
+          client.close();
+        } catch {
+          // ignore best-effort shutdown errors
+        }
+      }
+      throw new Error("MCP load aborted due session lifecycle change");
+    }
 
     for (const client of activeClients) {
       try {
@@ -555,8 +574,12 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
   let eagerLoadPromise: Promise<McpSnapshot | null> | null = null;
   try {
     eagerLoadPromise = load().catch((err) => {
-      // Don't crash the factory — session_start will handle diagnostics
-      console.warn(`pizzapi: MCP eager init failed, will retry in session_start: ${err instanceof Error ? err.message : String(err)}`);
+      // Don't crash the factory — session_start will handle diagnostics.
+      // Ignore expected aborts when session lifecycle changes.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (!/aborted/i.test(msg)) {
+        console.warn(`pizzapi: MCP eager init failed, will retry in session_start: ${msg}`);
+      }
       return null;
     });
   } catch {
@@ -751,6 +774,11 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
   });
 
   pi.on?.("session_shutdown", () => {
+    // Cancel any in-flight eager/background MCP load so stale completion can't
+    // repopulate active clients after shutdown.
+    loadLifecycleController.abort();
+    loadLifecycleController = new AbortController();
+
     for (const client of activeClients) {
       try {
         client.close();
@@ -759,6 +787,7 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
       }
     }
     activeClients = [];
+    lastRegistrationResult = null;
     setMcpBridge(null);
   });
 };

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -2,7 +2,15 @@ import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { loadConfig, toggleMcpServer, globalConfigDir, type PizzaPiConfig } from "../config.js";
-import { registerMcpTools, type McpConfig, type McpServerInitResult, type McpRegistrationResult, getOAuthProviders } from "./mcp.js";
+import {
+  registerMcpTools,
+  type McpConfig,
+  type McpServerInitResult,
+  type McpRegistrationResult,
+  getOAuthProviders,
+  setDeferOAuthRelayWaitTimeoutUntilAnchor,
+  markOAuthRelayWaitAnchorReady,
+} from "./mcp.js";
 import { setMcpBridge } from "./mcp-bridge.js";
 import type { RelayContext } from "./mcp-oauth.js";
 
@@ -536,11 +544,14 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
   // loading and relay connection setup.
   //
   // We do NOT await load() here, so the factory completes immediately and
-  // other extension factories continue loading.  Non-OAuth servers (stdio
-  // like godmother) will complete their handshake while other factories load.
-  // OAuth servers that need the relay will block inside waitForRelayContext()
-  // until session_start fires and the relay connects — no deadlock because
-  // we're not blocking the factory.
+  // other extension factories continue loading. Non-OAuth servers (stdio like
+  // godmother) complete their handshake while other factories load.
+  //
+  // For OAuth streamable servers, defer the relay wait timeout window until
+  // session_start so a long startup/registration path doesn't consume the
+  // 15s fallback budget before the relay can publish context.
+  setDeferOAuthRelayWaitTimeoutUntilAnchor(true);
+
   let eagerLoadPromise: Promise<McpSnapshot | null> | null = null;
   try {
     eagerLoadPromise = load().catch((err) => {
@@ -554,6 +565,11 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
 
   // ── session_start: await eager load + report timing to TUI/web UI ────────
   pi.on?.("session_start", async (_event: any, ctx: any) => {
+    // Anchor relay wait timeout to session_start; any OAuth waiters created
+    // during eager init begin their fallback window now.
+    setDeferOAuthRelayWaitTimeoutUntilAnchor(false);
+    markOAuthRelayWaitAnchorReady();
+
     try {
       if (eagerLoadPromise) {
         const result = await eagerLoadPromise;

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -601,15 +601,24 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
 
   // ── session_start: await eager load + report timing to TUI/web UI ────────
   pi.on?.("session_start", async (_event: any, ctx: any) => {
-    // Anchor relay wait timeout to relay registration, not session_start.
-    // The relay context is only published after the Socket.IO `registered`
-    // round-trip (remote.ts), which can happen well after session_start.
-    // Starting the 15s fallback timer here would still consume the budget
-    // before the relay is actually usable in slow-tunnel / cold-relay scenarios.
-    setDeferOAuthRelayWaitTimeoutUntilAnchor(false);
-    // Wait for the relay to finish registration (or timeout after 10s if
-    // relay is unreachable), then open the fallback window for OAuth waiters.
+    // Re-arm deferred relay waits for this session's OAuth providers.
+    // Every session_start needs deferral enabled — not just the first.
+    // Subsequent sessions create fresh providers via load() that also
+    // need to defer their 15s localhost fallback until the relay is
+    // registered.  Without this, sessions after the first start the
+    // fallback timer immediately, reintroducing the remote/headless
+    // auth regression.
+    setDeferOAuthRelayWaitTimeoutUntilAnchor(true);
+
+    // Tie the relay-anchor wait to the current session lifecycle so that
+    // session_shutdown cancels stale callbacks from a previous session.
+    // Without this guard, a slow relay registration from session N can
+    // fire markOAuthRelayWaitAnchorReady() into session N+1's providers,
+    // opening the fallback window prematurely.
+    const lifecycleAtStart = loadLifecycleController;
     void waitForRelayRegistration().then(() => {
+      if (lifecycleAtStart.signal.aborted) return; // stale — session was shut down
+      setDeferOAuthRelayWaitTimeoutUntilAnchor(false);
       markOAuthRelayWaitAnchorReady();
     });
 

--- a/packages/cli/src/extensions/mcp-oauth.test.ts
+++ b/packages/cli/src/extensions/mcp-oauth.test.ts
@@ -184,6 +184,47 @@ describe("PizzaPiOAuthProvider", () => {
             expect(results).toContain(3);
         });
 
+        test("resolves immediately when signal is already aborted", async () => {
+            const provider = createProvider();
+            const ac = new AbortController();
+            ac.abort();
+
+            const start = Date.now();
+            await provider.waitForRelayContext(5000, ac.signal);
+            expect(Date.now() - start).toBeLessThan(100);
+        });
+
+        test("resolves when signal is aborted while waiting", async () => {
+            const provider = createProvider();
+            const ac = new AbortController();
+            let resolved = false;
+
+            const waitPromise = provider.waitForRelayContext(5000, ac.signal).then(() => {
+                resolved = true;
+            });
+
+            // Not resolved yet — no context, no abort, no timeout
+            await new Promise((r) => setTimeout(r, 50));
+            expect(resolved).toBe(false);
+
+            // Abort should resolve immediately
+            ac.abort();
+            await waitPromise;
+            expect(resolved).toBe(true);
+        });
+
+        test("abort cleans up relay ready resolvers", async () => {
+            const provider = createProvider();
+            const ac = new AbortController();
+
+            const waitPromise = provider.waitForRelayContext(5000, ac.signal);
+            ac.abort();
+            await waitPromise;
+
+            // Setting context after abort should not cause issues
+            provider.relayContext = createMockRelayContext();
+        });
+
         test("setting context to null does not resolve waiters", async () => {
             const provider = createProvider();
             let resolved = false;

--- a/packages/cli/src/extensions/mcp-oauth.test.ts
+++ b/packages/cli/src/extensions/mcp-oauth.test.ts
@@ -103,6 +103,65 @@ describe("PizzaPiOAuthProvider", () => {
             expect(provider.relayContext).toBeNull(); // still null
         });
 
+        test("deferred timeout starts only after relay wait anchor is ready", async () => {
+            const provider = new PizzaPiOAuthProvider({
+                serverUrl: `https://defer-timeout-${Date.now()}.example.com/mcp`,
+                serverName: "defer-timeout",
+                deferRelayWaitTimeoutUntilAnchor: true,
+            });
+
+            const start = Date.now();
+            const waitPromise = provider.waitForRelayContext(100);
+
+            // Before anchor is ready, timeout should not fire.
+            await new Promise((r) => setTimeout(r, 150));
+            let settled = false;
+            waitPromise.then(() => {
+                settled = true;
+            });
+            await new Promise((r) => setTimeout(r, 20));
+            expect(settled).toBe(false);
+
+            provider.markRelayWaitAnchorReady();
+            await waitPromise;
+            const elapsed = Date.now() - start;
+
+            // ~150ms pre-anchor + ~100ms timeout after anchor.
+            expect(elapsed).toBeGreaterThanOrEqual(220);
+            expect(elapsed).toBeLessThan(700);
+        });
+
+        test("deferred wait resolves immediately if relay arrives before anchor", async () => {
+            const provider = new PizzaPiOAuthProvider({
+                serverUrl: `https://defer-relay-${Date.now()}.example.com/mcp`,
+                serverName: "defer-relay",
+                deferRelayWaitTimeoutUntilAnchor: true,
+            });
+
+            const waitPromise = provider.waitForRelayContext(200);
+            setTimeout(() => {
+                provider.relayContext = createMockRelayContext();
+            }, 40);
+
+            await waitPromise;
+            expect(provider.relayContext).not.toBeNull();
+        });
+
+        test("deferred wait with timeout 0 falls back immediately", async () => {
+            const provider = new PizzaPiOAuthProvider({
+                serverUrl: `https://defer-zero-${Date.now()}.example.com/mcp`,
+                serverName: "defer-zero",
+                deferRelayWaitTimeoutUntilAnchor: true,
+            });
+
+            const start = Date.now();
+            await provider.waitForRelayContext(0);
+            const elapsed = Date.now() - start;
+
+            expect(elapsed).toBeLessThan(50);
+            expect(provider.relayContext).toBeNull();
+        });
+
         test("multiple waiters are all resolved when context is set", async () => {
             const provider = createProvider();
 

--- a/packages/cli/src/extensions/mcp-oauth.ts
+++ b/packages/cli/src/extensions/mcp-oauth.ts
@@ -355,8 +355,9 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
    * If deferRelayWaitTimeoutUntilAnchor is enabled, timeout counting begins
    * only after markRelayWaitAnchorReady() is called.
    */
-  waitForRelayContext(timeoutMs: number = 15_000): Promise<void> {
+  waitForRelayContext(timeoutMs: number = 15_000, signal?: AbortSignal): Promise<void> {
     if (this._relayContext) return Promise.resolve();
+    if (signal?.aborted) return Promise.resolve();
     return new Promise<void>((resolve) => {
       let finished = false;
       let timer: ReturnType<typeof setTimeout> | null = null;
@@ -370,6 +371,7 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
           clearTimeout(timer);
           timer = null;
         }
+        signal?.removeEventListener("abort", onAbort);
       };
 
       const finish = () => {
@@ -377,6 +379,10 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
         finished = true;
         cleanup();
         resolve();
+      };
+
+      const onAbort = () => {
+        finish();
       };
 
       const wrappedResolve = () => {
@@ -391,6 +397,7 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
       };
 
       this._relayReadyResolvers.push(wrappedResolve);
+      signal?.addEventListener("abort", onAbort, { once: true });
 
       if (timeoutMs <= 0) {
         finish();

--- a/packages/cli/src/extensions/mcp-oauth.ts
+++ b/packages/cli/src/extensions/mcp-oauth.ts
@@ -216,6 +216,11 @@ export type McpOAuthOptions = {
   onAuthStart?: (authUrl: string) => void;
   /** Callback when auth completes. */
   onAuthComplete?: () => void;
+  /**
+   * When true, waitForRelayContext() defers its fallback timeout until
+   * markRelayWaitAnchorReady() is called.
+   */
+  deferRelayWaitTimeoutUntilAnchor?: boolean;
 };
 
 /**
@@ -263,6 +268,15 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
   /** Callbacks waiting for relay context to become available. */
   private _relayReadyResolvers: Array<() => void> = [];
 
+  /** Whether waitForRelayContext timeout is deferred until anchor is marked ready. */
+  private _deferRelayWaitTimeoutUntilAnchor: boolean;
+
+  /** Whether the timeout anchor has been opened (session_start reached). */
+  private _relayWaitAnchorReady: boolean;
+
+  /** Waiters to notify when the timeout anchor is opened. */
+  private _relayWaitAnchorResolvers: Array<() => void> = [];
+
   /** Nonce for the current auth flow (relay mode). */
   private _currentNonce: string | null = null;
 
@@ -275,6 +289,8 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
     this._callbackPort = opts.callbackPort ?? 0;
     this._onAuthStart = opts.onAuthStart;
     this._onAuthComplete = opts.onAuthComplete;
+    this._deferRelayWaitTimeoutUntilAnchor = opts.deferRelayWaitTimeoutUntilAnchor === true;
+    this._relayWaitAnchorReady = !this._deferRelayWaitTimeoutUntilAnchor;
     this._persisted = loadPersistedAuth(this._serverUrl);
   }
 
@@ -317,27 +333,75 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
   }
 
   /**
+   * Open the timeout anchor for waitForRelayContext().
+   *
+   * When deferRelayWaitTimeoutUntilAnchor is enabled, this starts the
+   * fallback timeout window for all currently waiting callers.
+   */
+  markRelayWaitAnchorReady(): void {
+    if (this._relayWaitAnchorReady) return;
+    this._relayWaitAnchorReady = true;
+    const resolvers = this._relayWaitAnchorResolvers.splice(0);
+    for (const resolve of resolvers) resolve();
+  }
+
+  /**
    * Wait for relay context to become available (e.g. during startup when
    * MCP init races ahead of the relay connection).
    *
    * Returns immediately if relay context is already set, otherwise waits
    * up to `timeoutMs` before resolving (caller falls back to local mode).
+   *
+   * If deferRelayWaitTimeoutUntilAnchor is enabled, timeout counting begins
+   * only after markRelayWaitAnchorReady() is called.
    */
   waitForRelayContext(timeoutMs: number = 15_000): Promise<void> {
     if (this._relayContext) return Promise.resolve();
     return new Promise<void>((resolve) => {
-      const timer = setTimeout(() => {
-        // Timeout — remove from waiters and resolve so caller falls back to local mode
+      let finished = false;
+      let timer: ReturnType<typeof setTimeout> | null = null;
+
+      const cleanup = () => {
         const idx = this._relayReadyResolvers.indexOf(wrappedResolve);
         if (idx >= 0) this._relayReadyResolvers.splice(idx, 1);
-        resolve();
-      }, timeoutMs);
+        const anchorIdx = this._relayWaitAnchorResolvers.indexOf(startTimeout);
+        if (anchorIdx >= 0) this._relayWaitAnchorResolvers.splice(anchorIdx, 1);
+        if (timer) {
+          clearTimeout(timer);
+          timer = null;
+        }
+      };
 
-      const wrappedResolve = () => {
-        clearTimeout(timer);
+      const finish = () => {
+        if (finished) return;
+        finished = true;
+        cleanup();
         resolve();
       };
+
+      const wrappedResolve = () => {
+        finish();
+      };
+
+      const startTimeout = () => {
+        if (finished || timer || timeoutMs <= 0) return;
+        timer = setTimeout(() => {
+          finish();
+        }, timeoutMs);
+      };
+
       this._relayReadyResolvers.push(wrappedResolve);
+
+      if (timeoutMs <= 0) {
+        finish();
+        return;
+      }
+
+      if (!this._deferRelayWaitTimeoutUntilAnchor || this._relayWaitAnchorReady) {
+        startTimeout();
+      } else {
+        this._relayWaitAnchorResolvers.push(startTimeout);
+      }
     });
   }
 

--- a/packages/cli/src/extensions/mcp.test.ts
+++ b/packages/cli/src/extensions/mcp.test.ts
@@ -740,7 +740,73 @@ describe("MCP init timeout cancellation", () => {
             // and since the abort signal cancels the fetch, the response
             // shouldn't arrive at all. But if it does (race condition),
             // the closed flag ensures DELETE is sent.
-            // Either way: no orphaned session.
+            if (deleteReceived) {
+                expect(deleteSessionId).toBe(SESSION_ID);
+            }
+        } finally {
+            server.stop(true);
+        }
+    });
+
+    test("registerMcpTools abort signal prevents late tool registration", async () => {
+        const server = Bun.serve({
+            port: 0,
+            async fetch(req) {
+                const body = await req.json() as any;
+                if (!("id" in body)) return new Response(null, { status: 202 });
+
+                if (body.method === "initialize") {
+                    await new Promise((r) => setTimeout(r, 200));
+                    return Response.json({
+                        jsonrpc: "2.0",
+                        id: body.id,
+                        result: {
+                            protocolVersion: MCP_PROTOCOL_VERSION,
+                            capabilities: {},
+                            serverInfo: { name: "abortable", version: "1.0" },
+                        },
+                    });
+                }
+
+                if (body.method === "tools/list") {
+                    await new Promise((r) => setTimeout(r, 200));
+                    return Response.json({
+                        jsonrpc: "2.0",
+                        id: body.id,
+                        result: { tools: [{ name: "should_not_register" }] },
+                    });
+                }
+
+                return Response.json({ jsonrpc: "2.0", id: body.id, result: {} });
+            },
+        });
+
+        try {
+            const mockPi = {
+                registeredTools: [] as any[],
+                registerTool(t: any) { this.registeredTools.push(t); },
+                on() {},
+            };
+
+            const ac = new AbortController();
+            setTimeout(() => ac.abort(), 50);
+
+            const result = await registerMcpTools(
+                mockPi,
+                {
+                    mcpServers: {
+                        abortable: { url: `http://localhost:${server.port}` },
+                    },
+                    mcpInitTimeout: 5_000,
+                    mcpTimeout: 5_000,
+                } as any,
+                null,
+                ac.signal,
+            );
+
+            expect(result.toolCount).toBe(0);
+            expect(result.clients).toHaveLength(0);
+            expect(mockPi.registeredTools).toHaveLength(0);
         } finally {
             server.stop(true);
         }

--- a/packages/cli/src/extensions/mcp.ts
+++ b/packages/cli/src/extensions/mcp.ts
@@ -1173,7 +1173,22 @@ export async function registerMcpTools(
           }
         } else {
           if (signal?.aborted) throw new Error("MCP registration aborted");
-          await client.initialize();
+          // Even without a timeout, forward the lifecycle abort signal so
+          // session shutdown can interrupt a hung initialize/OAuth flow.
+          // Without this, disabling the init timeout (mcpInitTimeout: 0)
+          // would leave stale eager loads uninterruptible on shutdown.
+          const ac = new AbortController();
+          const onOuterAbort = () => ac.abort();
+          signal?.addEventListener("abort", onOuterAbort, { once: true });
+          try {
+            await client.initialize(ac.signal);
+          } catch (err) {
+            ac.abort();
+            try { client.close(); } catch {}
+            throw err;
+          } finally {
+            signal?.removeEventListener("abort", onOuterAbort);
+          }
         }
 
         // Now list tools with the configurable timeout.  Since initialize()

--- a/packages/cli/src/extensions/mcp.ts
+++ b/packages/cli/src/extensions/mcp.ts
@@ -1006,30 +1006,62 @@ export type McpRegistrationResult = {
  * to prevent unhandled rejection crashes (the child process will be killed by
  * the caller, which causes the pending request to reject).
  */
-async function listToolsWithTimeout(client: McpClient, timeoutMs: number): Promise<{ tools: McpTool[]; error?: string; timedOut: boolean }> {
+async function listToolsWithTimeout(
+  client: McpClient,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<{ tools: McpTool[]; error?: string; timedOut: boolean }> {
+  if (signal?.aborted) {
+    try { client.close(); } catch {}
+    return { tools: [], error: "MCP registration aborted", timedOut: false };
+  }
+
   if (timeoutMs <= 0) {
     // Timeout disabled — call directly
-    const tools = await client.listTools();
-    return { tools, timedOut: false };
+    try {
+      const tools = await client.listTools();
+      return { tools, timedOut: false };
+    } catch (err) {
+      return {
+        tools: [],
+        error: err instanceof Error ? err.message : String(err),
+        timedOut: false,
+      };
+    }
   }
 
   // Keep a reference to the listTools promise so we can suppress its rejection
-  // if the timeout fires first (the child process will be killed, causing the
-  // pending JSON-RPC request to reject with "server exited").
+  // if the timeout/abort fires first (the child process will be killed,
+  // causing the pending JSON-RPC request to reject with "server exited").
   const listToolsPromise = client.listTools().then(
-    (tools) => ({ tools, timedOut: false as const }),
+    (tools) => ({ tools, error: undefined as string | undefined, timedOut: false as const }),
   );
 
-  const timeoutPromise = new Promise<{ tools: McpTool[]; error: string; timedOut: true }>((resolve) =>
-    setTimeout(
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<{ tools: McpTool[]; error: string; timedOut: true }>((resolve) => {
+    timeoutHandle = setTimeout(
       () => resolve({ tools: [], error: `Timed out after ${Math.round(timeoutMs / 1000)}s waiting for tools/list`, timedOut: true }),
       timeoutMs,
-    ),
-  );
+    );
+  });
 
-  const result = await Promise.race([listToolsPromise, timeoutPromise]);
+  let onAbort: (() => void) | null = null;
+  const abortPromise = signal
+    ? new Promise<{ tools: McpTool[]; error: string; timedOut: false }>((resolve) => {
+      onAbort = () => resolve({ tools: [], error: "MCP registration aborted", timedOut: false as const });
+      if (signal.aborted) onAbort();
+      else signal.addEventListener("abort", onAbort, { once: true });
+    })
+    : null;
 
-  if (result.timedOut) {
+  const result = await (abortPromise
+    ? Promise.race([listToolsPromise, timeoutPromise, abortPromise])
+    : Promise.race([listToolsPromise, timeoutPromise]));
+
+  if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
+  if (signal && onAbort) signal.removeEventListener("abort", onAbort);
+
+  if (result.timedOut || result.error === "MCP registration aborted") {
     // Close the client immediately to abort the in-flight request and prevent
     // it from establishing a remote MCP session that would never be cleaned up.
     try { client.close(); } catch {}
@@ -1040,11 +1072,30 @@ async function listToolsWithTimeout(client: McpClient, timeoutMs: number): Promi
   return result;
 }
 
-export async function registerMcpTools(pi: any, config: PizzaPiConfig & McpConfig, relayContext?: RelayContext | null): Promise<McpRegistrationResult> {
+export async function registerMcpTools(
+  pi: any,
+  config: PizzaPiConfig & McpConfig,
+  relayContext?: RelayContext | null,
+  signal?: AbortSignal,
+): Promise<McpRegistrationResult> {
   const totalStart = Date.now();
   const clients = await createMcpClientsFromConfig(config);
   const empty: McpRegistrationResult = { clients: [], toolCount: 0, toolNames: [], errors: [], serverTools: {}, serverTimings: [], totalDurationMs: 0 };
   if (clients.length === 0) return { ...empty, totalDurationMs: Date.now() - totalStart };
+
+  if (signal?.aborted) {
+    for (const c of clients) {
+      try { c.close(); } catch {}
+    }
+    return { ...empty, totalDurationMs: Date.now() - totalStart };
+  }
+
+  const closeAllClients = () => {
+    for (const c of clients) {
+      try { c.close(); } catch {}
+    }
+  };
+  signal?.addEventListener("abort", closeAllClients);
 
   // Apply relay context to newly created OAuth providers before initialization.
   // During /mcp reload the relay is already connected, so providers need the
@@ -1070,6 +1121,10 @@ export async function registerMcpTools(pi: any, config: PizzaPiConfig & McpConfi
     clients.map(async (client): Promise<McpServerInitResult> => {
       const start = Date.now();
       try {
+        if (signal?.aborted) {
+          try { client.close(); } catch {}
+          return { name: client.name, tools: [], error: "MCP registration aborted", durationMs: Date.now() - start, timedOut: false };
+        }
         // Initialize the MCP handshake (+ any OAuth) with a generous timeout.
         // OAuth flows have their own 2-min callback timeout; the init timeout
         // (default 3 min) is a safety net against hung processes / stalled
@@ -1085,6 +1140,8 @@ export async function registerMcpTools(pi: any, config: PizzaPiConfig & McpConfi
         //     unhandled-rejection crashes.
         if (initTimeoutMs > 0) {
           const ac = new AbortController();
+          const onOuterAbort = () => ac.abort();
+          signal?.addEventListener("abort", onOuterAbort, { once: true });
           let timer: ReturnType<typeof setTimeout> | undefined;
           const initPromise = client.initialize(ac.signal);
           try {
@@ -1103,16 +1160,18 @@ export async function registerMcpTools(pi: any, config: PizzaPiConfig & McpConfi
             initPromise.catch(() => {});
             throw err;
           } finally {
+            signal?.removeEventListener("abort", onOuterAbort);
             if (timer !== undefined) clearTimeout(timer);
           }
         } else {
+          if (signal?.aborted) throw new Error("MCP registration aborted");
           await client.initialize();
         }
 
         // Now list tools with the configurable timeout.  Since initialize()
         // already resolved, ensureInitialized() inside listTools() returns
         // immediately — the timeout only covers the tools/list request.
-        const { tools, error, timedOut } = await listToolsWithTimeout(client, timeoutMs);
+        const { tools, error, timedOut } = await listToolsWithTimeout(client, timeoutMs, signal);
         const durationMs = Date.now() - start;
         if (error) {
           return { name: client.name, tools: [], error, durationMs, timedOut };
@@ -1130,6 +1189,12 @@ export async function registerMcpTools(pi: any, config: PizzaPiConfig & McpConfi
       }
     }),
   );
+
+  if (signal?.aborted) {
+    closeAllClients();
+    signal.removeEventListener("abort", closeAllClients);
+    return { ...empty, totalDurationMs: Date.now() - totalStart, serverTimings: initResults };
+  }
 
   // ── Phase 2: Register tools sequentially (name allocation needs Set) ─────
   let toolCount = 0;
@@ -1193,5 +1258,6 @@ export async function registerMcpTools(pi: any, config: PizzaPiConfig & McpConfi
   });
 
   const totalDurationMs = Date.now() - totalStart;
+  signal?.removeEventListener("abort", closeAllClients);
   return { clients: liveClients, toolCount, toolNames, errors, serverTools, serverTimings: initResults, totalDurationMs };
 }

--- a/packages/cli/src/extensions/mcp.ts
+++ b/packages/cli/src/extensions/mcp.ts
@@ -600,7 +600,7 @@ function createStreamableMcpClient(opts: {
         // which is unreachable when running remotely. Waiting here gives the
         // relay connection time to establish so OAuth uses the server callback
         // URL instead. Falls back to local mode after the timeout.
-        await oauthProvider.waitForRelayContext();
+        await oauthProvider.waitForRelayContext(15_000, signal);
 
         const { auth, extractWWWAuthenticateParams } = await import(
           "@modelcontextprotocol/sdk/client/auth.js"

--- a/packages/cli/src/extensions/mcp.ts
+++ b/packages/cli/src/extensions/mcp.ts
@@ -602,6 +602,14 @@ function createStreamableMcpClient(opts: {
         // URL instead. Falls back to local mode after the timeout.
         await oauthProvider.waitForRelayContext(15_000, signal);
 
+        // If the signal was aborted while waiting (e.g., session shutdown),
+        // bail out instead of falling through to the OAuth flow. Without this
+        // check, a stale eager init would open a local OAuth flow and keep
+        // eagerLoadPromise alive until the callback timeout.
+        if (signal?.aborted) {
+          throw new Error("MCP OAuth aborted: session shut down during relay wait");
+        }
+
         const { auth, extractWWWAuthenticateParams } = await import(
           "@modelcontextprotocol/sdk/client/auth.js"
         );

--- a/packages/cli/src/extensions/mcp.ts
+++ b/packages/cli/src/extensions/mcp.ts
@@ -765,6 +765,28 @@ export type McpConfig = {
 /** Track active OAuth providers so the relay context can be injected later. */
 const activeOAuthProviders: PizzaPiOAuthProvider[] = [];
 
+/**
+ * Controls whether newly created OAuth providers defer relay wait timeout
+ * counting until markOAuthRelayWaitAnchorReady() is called.
+ */
+let deferOAuthRelayWaitTimeoutUntilAnchor = false;
+
+/** Configure timeout anchoring behavior for subsequently created providers. */
+export function setDeferOAuthRelayWaitTimeoutUntilAnchor(enabled: boolean): void {
+  deferOAuthRelayWaitTimeoutUntilAnchor = enabled;
+}
+
+/**
+ * Mark the relay wait timeout anchor as ready on all active OAuth providers.
+ * Used by the MCP extension at session_start so timeout counting begins when
+ * the relay has had a chance to register.
+ */
+export function markOAuthRelayWaitAnchorReady(): void {
+  for (const provider of activeOAuthProviders) {
+    provider.markRelayWaitAnchorReady();
+  }
+}
+
 /** Get all active OAuth providers (used by the MCP extension to inject relay context). */
 export function getOAuthProviders(): PizzaPiOAuthProvider[] {
   return activeOAuthProviders;
@@ -863,7 +885,11 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
       );
     } else if (s.transport === "streamable") {
       if (!isMcpDomainAllowed(s.url, s.name)) continue;
-      const provider = new PizzaPiOAuthProvider({ serverUrl: s.url, serverName: s.name });
+      const provider = new PizzaPiOAuthProvider({
+        serverUrl: s.url,
+        serverName: s.name,
+        deferRelayWaitTimeoutUntilAnchor: deferOAuthRelayWaitTimeoutUntilAnchor,
+      });
       activeOAuthProviders.push(provider);
       clients.push(
         createStreamableMcpClient({
@@ -914,7 +940,11 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
         (d.type === "http" && d.transport === undefined);
 
       if (useStreamable) {
-        const provider = new PizzaPiOAuthProvider({ serverUrl: d.url, serverName: name });
+        const provider = new PizzaPiOAuthProvider({
+          serverUrl: d.url,
+          serverName: name,
+          deferRelayWaitTimeoutUntilAnchor: deferOAuthRelayWaitTimeoutUntilAnchor,
+        });
         activeOAuthProviders.push(provider);
         clients.push(createStreamableMcpClient({
           name,


### PR DESCRIPTION
**The problem:** MCP server initialization was fully deferred to the `session_start` event handler, which runs sequentially across all extensions. This meant MCP handshakes (spawning subprocesses, initialize protocol, tools/list) blocked relay connection, plugin loading, and initial prompt delivery.

**The fix:** Start MCP initialization eagerly as a fire-and-forget promise at the end of the extension factory, then await the result in `session_start`. This way:

- **Non-OAuth stdio servers** (like godmother) complete their handshake while other extension factories load and the relay connects
- **OAuth servers** that need the relay still work — they use `waitForRelayContext()` which resolves once the relay connects during `session_start`
- If the eager load fails, `session_start` retries with full relay context available

**No deadlock risk:** The factory doesn't `await load()` — it just kicks it off. Other factories continue, `session_start` fires, and the relay connects in parallel.

**Impact:** MCP boot time now overlaps with resource loader setup, session creation, and relay connection instead of running after all of them.