### PR TITLE
feat: add structured diagnostic logging to runner subsystem

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -23,6 +23,7 @@ import { loadGlobalConfig, loadConfig, defaultAgentDir, expandHome, type HooksCo
 import { AuthStorage } from "@mariozechner/pi-coding-agent";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 import { getRefreshedOAuthToken, parseGeminiQuotaCredential } from "./usage-auth.js";
+import { setLogComponent, logInfo, logWarn, logError, logAuth } from "./logger.js";
 
 /**
  * Summarise the active hooks from a HooksConfig for display in the web UI.
@@ -142,12 +143,12 @@ function acquireStateAndIdentity(statePath: string): { runnerId: string; runnerS
             const pid = typeof existing.pid === "number" ? existing.pid : NaN;
             if (Number.isFinite(pid) && pid > 0) {
                 if (isPidRunning(pid)) {
-                    console.error(`❌ pizzapi runner already running (pid ${pid}, state: ${statePath}).`);
-                    console.error("   Stop the existing runner process first, e.g.: kill ${pid}");
+                    logError(`pizzapi runner already running (pid ${pid}, state: ${statePath}).`);
+                    logError("   Stop the existing runner process first, e.g.: kill ${pid}");
                     process.exit(1);
                 }
                 // PID is gone or belongs to an unrelated process — stale lock.
-                console.log(`pizzapi runner: clearing stale lock (pid ${pid} is no longer a runner process)`);
+                logInfo(`clearing stale lock (pid ${pid} is no longer a runner process)`);
             }
         }
 
@@ -173,7 +174,7 @@ function acquireStateAndIdentity(statePath: string): { runnerId: string; runnerS
             writeFileSync(statePath, JSON.stringify(state, null, 2), { encoding: "utf-8", mode: 0o600 });
             return { runnerId, runnerSecret };
         } catch (err: any) {
-            console.error(`❌ Failed to write runner state to ${statePath}: ${err?.message ?? String(err)}`);
+            logError(`Failed to write runner state to ${statePath}: ${err?.message ?? String(err)}`);
             process.exit(1);
         }
     }
@@ -321,7 +322,7 @@ async function fetchAnthropicUsageData(): Promise<ProviderUsageData | null> {
             if (token) break;
         }
     } catch (err: any) {
-        console.warn(`pizzapi runner: failed to get Anthropic credentials: ${err?.message ?? String(err)}`);
+        logWarn(`failed to get Anthropic credentials: ${err?.message ?? String(err)}`);
         return null;
     }
     if (!token) return null;
@@ -396,7 +397,7 @@ async function fetchGeminiUsageData(): Promise<ProviderUsageData | null> {
             }
         }
     } catch (err: any) {
-        console.warn(`pizzapi runner: failed to get Google credentials: ${err?.message ?? String(err)}`);
+        logWarn(`failed to get Google credentials: ${err?.message ?? String(err)}`);
         return null;
     }
     if (!token || !projectId) return null;
@@ -436,7 +437,7 @@ async function fetchCodexUsageData(): Promise<ProviderUsageData | null> {
             if (token) break;
         }
     } catch (err: any) {
-        console.warn(`pizzapi runner: failed to get OpenAI Codex credentials: ${err?.message ?? String(err)}`);
+        logWarn(`failed to get OpenAI Codex credentials: ${err?.message ?? String(err)}`);
         return null;
     }
     if (!token) return null;
@@ -516,9 +517,9 @@ async function refreshAndWriteRunnerUsageCache(opts: { forceAnthropic?: boolean 
     const cache: RunnerUsageCacheFile = { fetchedAt: Date.now(), providers };
     try {
         writeFileSync(runnerUsageCacheFilePath(), JSON.stringify(cache, null, 2), { encoding: "utf-8", mode: 0o600 });
-        console.log(`pizzapi runner: usage cache refreshed (${Object.keys(providers).join(", ")})`);
+        logInfo(`usage cache refreshed (${Object.keys(providers).join(", ")})`);
     } catch (err: any) {
-        console.warn(`pizzapi runner: failed to write usage cache: ${err?.message ?? String(err)}`);
+        logWarn(`failed to write usage cache: ${err?.message ?? String(err)}`);
     }
 }
 
@@ -554,6 +555,7 @@ function stopUsageRefreshLoop(): void {
  * State file:     PIZZAPI_RUNNER_STATE_PATH env var (default: ~/.pizzapi/runner.json).
  */
 export async function runDaemon(_args: string[] = []): Promise<number> {
+    setLogComponent("daemon");
     const statePath = defaultStatePath();
     const identity = acquireStateAndIdentity(statePath);
 
@@ -588,7 +590,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
     const token = process.env.PIZZAPI_RUNNER_TOKEN;
 
     if (!apiKey && !token) {
-        console.error("❌ Set PIZZAPI_API_KEY (or PIZZAPI_API_TOKEN), or set apiKey in ~/.pizzapi/config.json.");
+        logError("Set PIZZAPI_API_KEY (or PIZZAPI_API_TOKEN), or set apiKey in ~/.pizzapi/config.json.");
         releaseStateLock(statePath);
         process.exit(1);
     }
@@ -647,7 +649,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             },
         );
 
-        console.log(`pizzapi runner: connecting to relay at ${sioUrl}/runner…`);
+        logInfo(`connecting to relay at ${sioUrl}/runner…`);
 
         const shutdown = (code: number) => {
             if (isShuttingDown) return;
@@ -697,13 +699,13 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             }
             const verb = isFirstConnect ? "connected" : "reconnected";
             isFirstConnect = false;
-            console.log(`pizzapi runner: ${verb}. Registering as ${identity.runnerId}…`);
+            logInfo(`${verb}. Registering as ${identity.runnerId}…`);
             emitRegister();
         });
 
         socket.on("disconnect", (reason) => {
             if (isShuttingDown) return;
-            console.log(`pizzapi runner: disconnected (${reason}). Socket.IO will reconnect automatically.`);
+            logInfo(`disconnected (${reason}). Socket.IO will reconnect automatically.`);
         });
 
         // ── Registration confirmation ─────────────────────────────────────
@@ -711,11 +713,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         socket.on("runner_registered", (data: any) => {
             runnerId = data.runnerId;
             if (runnerId !== identity.runnerId) {
-                console.warn(
-                    `pizzapi runner: server assigned unexpected ID ${runnerId} (expected ${identity.runnerId})`,
-                );
+                logWarn(`server assigned unexpected ID ${runnerId} (expected ${identity.runnerId})`);
             }
-            console.log(`pizzapi runner: registered as ${runnerId}`);
+            logInfo(`registered as ${runnerId}`);
 
             // Re-adopt orphaned sessions that survived a daemon restart.
             // Their worker processes are still running and connected to the relay.
@@ -733,7 +733,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     adopted++;
                 }
                 if (adopted > 0) {
-                    console.log(`pizzapi runner: re-adopted ${adopted} orphaned session(s): ${existingSessions.map((s: any) => s.sessionId.slice(0, 8)).join(", ")}`);
+                    logInfo(`re-adopted ${adopted} orphaned session(s): ${existingSessions.map((s: any) => s.sessionId.slice(0, 8)).join(", ")}`);
                 }
             }
 
@@ -786,7 +786,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     }
                     resolvedAgent = { ...resolvedAgent, systemPrompt: body, tools, disallowedTools };
                 } else {
-                    console.warn(`pizzapi runner: agent "${resolvedAgent.name}" not found on disk`);
+                    logWarn(`agent "${resolvedAgent.name}" not found on disk`);
                     socket.emit("session_error", { sessionId, message: `Agent "${resolvedAgent.name}" not found on this runner` });
                     return;
                 }
@@ -829,7 +829,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     socket.emit("disconnect_session", { sessionId });
                 }
                 runningSessions.delete(sessionId);
-                console.log(`pizzapi runner: killed session ${sessionId}${entry.adopted ? " (adopted)" : ""}`);
+                logInfo(`killed session ${sessionId}${entry.adopted ? " (adopted)" : ""}`);
                 socket.emit("session_killed", { sessionId });
                 // Clean up persisted attachments for this session
                 void cleanupSessionAttachments(sessionId).catch(() => {});
@@ -847,7 +847,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             // delete its entry and don't touch its attachments.
             if (restartingSessions.has(sessionId)) {
                 restartingSessions.delete(sessionId);
-                console.log(`pizzapi runner: session_ended for ${sessionId} — restarting in place, skipping teardown`);
+                logInfo(`session_ended for ${sessionId} — restarting in place, skipping teardown`);
                 return;
             }
 
@@ -855,7 +855,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             // before re-registering the same worker.  The worker is still alive —
             // don't delete its runningSessions entry or its attachments.
             if (reason === "Session reconnected") {
-                console.log(`pizzapi runner: session_ended for ${sessionId} — relay reconnect, skipping teardown`);
+                logInfo(`session_ended for ${sessionId} — relay reconnect, skipping teardown`);
                 return;
             }
 
@@ -869,18 +869,18 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 const childAlive = entry.child && !entry.child.killed && entry.child.exitCode === null;
                 const isTransientDisconnect = !reason || reason === "Session ended";
                 if (childAlive && isTransientDisconnect) {
-                    console.log(`pizzapi runner: session_ended for ${sessionId} but worker still alive — keeping entry for reconnect`);
+                    logInfo(`session_ended for ${sessionId} but worker still alive — keeping entry for reconnect`);
                     return;
                 }
                 runningSessions.delete(sessionId);
                 endedSessionIds.add(sessionId);
                 setTimeout(() => endedSessionIds.delete(sessionId), ENDED_SESSION_TTL_MS);
-                console.log(`pizzapi runner: session ${sessionId} ended on relay${entry.adopted ? " (adopted)" : ""}${reason ? ` (${reason})` : ""}`);
+                logInfo(`session ${sessionId} ended on relay${entry.adopted ? " (adopted)" : ""}${reason ? ` (${reason})` : ""}`);
             } else if (!endedSessionIds.has(sessionId)) {
                 // First duplicate — log once then suppress subsequent copies
                 endedSessionIds.add(sessionId);
                 setTimeout(() => endedSessionIds.delete(sessionId), ENDED_SESSION_TTL_MS);
-                console.log(`pizzapi runner: session_ended for unknown/already-removed session ${sessionId}`);
+                logInfo(`session_ended for unknown/already-removed session ${sessionId}`);
             }
             // else: duplicate session_ended for a session we already handled — silently ignore
 
@@ -901,14 +901,14 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         // ── Daemon control ────────────────────────────────────────────────
 
         socket.on("restart", () => {
-            console.log("pizzapi runner: restart request received. Exiting with code 42...");
+            logInfo("restart request received. Exiting with code 42...");
             setTimeout(() => {
                 shutdown(42);
             }, 500);
         });
 
         socket.on("shutdown", () => {
-            console.log("pizzapi runner: shutdown request received. Exiting cleanly...");
+            logInfo("shutdown request received. Exiting cleanly...");
             setTimeout(() => {
                 shutdown(0);
             }, 500);
@@ -925,16 +925,16 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         socket.on("new_terminal", (data: any) => {
             if (isShuttingDown) return;
             const { terminalId, cwd: requestedCwd, cols, rows, shell } = data;
-            console.log(
+            logInfo(
                 `[terminal] new_terminal received: terminalId=${terminalId} cwd=${requestedCwd ?? "(default)"} cols=${cols ?? 80} rows=${rows ?? 24} shell=${shell ?? "(default)"}`,
             );
             if (!terminalId) {
-                console.warn("[terminal] new_terminal: missing terminalId — rejecting");
+                logWarn("[terminal] new_terminal: missing terminalId — rejecting");
                 socket.emit("terminal_error", { terminalId: "", message: "Missing terminalId" });
                 return;
             }
             if (requestedCwd && !isCwdAllowed(requestedCwd)) {
-                console.warn(
+                logWarn(
                     `[terminal] new_terminal: cwd="${requestedCwd}" outside allowed roots — rejecting terminalId=${terminalId}`,
                 );
                 socket.emit("terminal_error", {
@@ -952,9 +952,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         (socket as any).emit(type, rest);
                     }
                 } catch (err) {
-                    console.error(
-                        `[terminal] termSend: failed to send ${payload.type} for terminalId=${terminalId}:`,
-                        err,
+                    logError(
+                        `[terminal] termSend: failed to send ${payload.type} for terminalId=${terminalId}: ${err}`,
                     );
                 }
             };
@@ -970,7 +969,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             if (isShuttingDown) return;
             const { terminalId, data: inputData } = data;
             if (!terminalId || !inputData) {
-                console.warn(
+                logWarn(
                     `[terminal] terminal_input: missing terminalId or data (terminalId=${terminalId} dataLen=${inputData?.length ?? 0})`,
                 );
                 return;
@@ -982,10 +981,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             if (isShuttingDown) return;
             const { terminalId, cols, rows } = data;
             if (!terminalId) {
-                console.warn("[terminal] terminal_resize: missing terminalId");
+                logWarn("[terminal] terminal_resize: missing terminalId");
                 return;
             }
-            console.log(`[terminal] terminal_resize: terminalId=${terminalId} ${cols}x${rows}`);
+            logInfo(`[terminal] terminal_resize: terminalId=${terminalId} ${cols}x${rows}`);
             resizeTerminal(terminalId, cols, rows);
         });
 
@@ -993,12 +992,12 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             if (isShuttingDown) return;
             const { terminalId } = data;
             if (!terminalId) {
-                console.warn("[terminal] kill_terminal: missing terminalId");
+                logWarn("[terminal] kill_terminal: missing terminalId");
                 return;
             }
-            console.log(`[terminal] kill_terminal: terminalId=${terminalId}`);
+            logInfo(`[terminal] kill_terminal: terminalId=${terminalId}`);
             const killed = killTerminal(terminalId);
-            console.log(`[terminal] kill_terminal: result=${killed} terminalId=${terminalId}`);
+            logInfo(`[terminal] kill_terminal: result=${killed} terminalId=${terminalId}`);
             if (killed) {
                 socket.emit("terminal_exit", { terminalId, exitCode: -1 });
             } else {
@@ -1009,7 +1008,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         socket.on("list_terminals", () => {
             if (isShuttingDown) return;
             const list = listTerminals();
-            console.log(`[terminal] list_terminals: ${list.length} active (${list.join(", ") || "none"})`);
+            logInfo(`[terminal] list_terminals: ${list.length} active (${list.join(", ") || "none"})`);
             // terminals_list is not in the typed protocol yet — emit untyped
             (socket as any).emit("terminals_list", { terminals: list });
         });
@@ -1628,7 +1627,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         // ── Error handling ────────────────────────────────────────────────
 
         socket.on("error", (data: any) => {
-            console.error(`pizzapi runner: server error: ${data.message}`);
+            logError(`server error: ${data.message}`);
         });
     });
 }
@@ -1745,7 +1744,7 @@ function spawnSession(
         parentSessionId?: string;
     },
 ): void {
-    console.log(`pizzapi runner: spawning headless worker for session ${sessionId}…`);
+    logInfo(`spawning headless worker for session ${sessionId}…`);
 
     if (runningSessions.has(sessionId)) {
         throw new Error(`Session already running: ${sessionId}`);
@@ -1819,7 +1818,7 @@ function spawnSession(
     child.on("message", (msg: unknown) => {
         if (typeof msg === "object" && msg !== null && (msg as Record<string, unknown>).type === "pre_restart") {
             restartingSessions.add(sessionId);
-            console.log(`pizzapi runner: session ${sessionId} signaled pre-restart via IPC`);
+            logInfo(`session ${sessionId} signaled pre-restart via IPC`);
         }
     });
 
@@ -1830,7 +1829,7 @@ function spawnSession(
     child.on("exit", (code, signal) => {
         runningSessions.delete(sessionId);
         untrackSessionCwd(sessionId, effectiveCwd);
-        console.log(`pizzapi runner: session ${sessionId} exited (code=${code}, signal=${signal})`);
+        logInfo(`session ${sessionId} exited (code=${code}, signal=${signal})`);
         if (code === 43 && onRestartRequested) {
             // Restart-in-place: re-spawn immediately without touching attachments.
             // The session continues under the same ID — files saved to
@@ -1839,7 +1838,7 @@ function spawnSession(
             // message above; this add is a belt-and-suspenders fallback for the
             // (unlikely) case where the IPC message was not sent or was lost.
             restartingSessions.add(sessionId);
-            console.log(`pizzapi runner: re-spawning session ${sessionId} (worker restart requested)`);
+            logInfo(`re-spawning session ${sessionId} (worker restart requested)`);
             onRestartRequested();
         } else {
             // True termination — clean up persisted attachments now.
@@ -1850,7 +1849,7 @@ function spawnSession(
     });
 
     runningSessions.set(sessionId, { sessionId, child, startedAt: Date.now(), parentSessionId: options?.parentSessionId });
-    console.log(`pizzapi runner: session ${sessionId} worker spawned (pid=${child.pid})`);
+    logInfo(`session ${sessionId} worker spawned (pid=${child.pid})`);
 }
 
 /** Is this process running inside a compiled Bun single-file binary? */

--- a/packages/cli/src/runner/logger.ts
+++ b/packages/cli/src/runner/logger.ts
@@ -1,0 +1,76 @@
+/**
+ * Structured logger for the PizzaPi runner subsystem.
+ *
+ * Every line is prefixed with an ISO timestamp so log files (which are plain
+ * file redirects from launchd) become correlatable.  An optional session ID
+ * tag lets us trace interleaved output from the daemon, supervisor, and
+ * multiple concurrent worker processes back to individual sessions.
+ *
+ * Format:
+ *   2026-03-19T22:31:20.123Z [component] message
+ *   2026-03-19T22:31:20.123Z [component:a1b2c3d4] message   (with session)
+ *
+ * The short session ID (first 8 chars) keeps lines readable while still
+ * being unique enough to grep for.
+ */
+
+type LogLevel = "info" | "warn" | "error";
+
+const WRITERS: Record<LogLevel, (msg: string) => void> = {
+    info:  (msg) => process.stdout.write(msg + "\n"),
+    warn:  (msg) => process.stderr.write(msg + "\n"),
+    error: (msg) => process.stderr.write(msg + "\n"),
+};
+
+let _component: string = "unknown";
+let _sessionId: string | null = null;
+
+/** Set the component name (call once at process start). */
+export function setLogComponent(component: "supervisor" | "daemon" | "worker"): void {
+    _component = component;
+}
+
+/** Set the session ID for this process (workers only). */
+export function setLogSessionId(sessionId: string | null): void {
+    _sessionId = sessionId;
+}
+
+function formatTag(sessionOverride?: string | null): string {
+    const sid = sessionOverride !== undefined ? sessionOverride : _sessionId;
+    if (sid) {
+        return `[${_component}:${sid.slice(0, 8)}]`;
+    }
+    return `[${_component}]`;
+}
+
+function formatLine(level: LogLevel, msg: string, sessionOverride?: string | null): string {
+    const ts = new Date().toISOString();
+    const tag = formatTag(sessionOverride);
+    return `${ts} ${tag} ${msg}`;
+}
+
+/** Log at info level (→ stdout → runner.log). */
+export function logInfo(msg: string, sessionId?: string | null): void {
+    WRITERS.info(formatLine("info", msg, sessionId));
+}
+
+/** Log at warn level (→ stderr → runner-error.log). */
+export function logWarn(msg: string, sessionId?: string | null): void {
+    WRITERS.warn(formatLine("warn", msg, sessionId));
+}
+
+/** Log at error level (→ stderr → runner-error.log). */
+export function logError(msg: string, sessionId?: string | null): void {
+    WRITERS.error(formatLine("error", msg, sessionId));
+}
+
+/**
+ * Log an auth diagnostic event.  These go to stdout (runner.log) so they're
+ * available alongside normal operational logs for correlation.
+ */
+export function logAuth(event: string, details: Record<string, unknown>, sessionId?: string | null): void {
+    const detailStr = Object.entries(details)
+        .map(([k, v]) => `${k}=${typeof v === "string" ? v : JSON.stringify(v)}`)
+        .join(" ");
+    WRITERS.info(formatLine("info", `[auth] ${event}: ${detailStr}`, sessionId));
+}

--- a/packages/cli/src/runner/logger.ts
+++ b/packages/cli/src/runner/logger.ts
@@ -46,7 +46,13 @@ function formatTag(sessionOverride?: string | null): string {
 function formatLine(level: LogLevel, msg: string, sessionOverride?: string | null): string {
     const ts = new Date().toISOString();
     const tag = formatTag(sessionOverride);
-    return `${ts} ${tag} ${msg}`;
+    const prefix = `${ts} ${tag} `;
+    // Prefix every line so multiline messages (e.g. stack traces) stay
+    // correlatable when interleaved with output from other workers.
+    return msg
+        .split("\n")
+        .map((line) => `${prefix}${line}`)
+        .join("\n");
 }
 
 /** Log at info level (→ stdout → runner.log). */

--- a/packages/cli/src/runner/supervisor.ts
+++ b/packages/cli/src/runner/supervisor.ts
@@ -27,6 +27,7 @@ import { spawn, type ChildProcess } from "node:child_process";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { defaultStatePath } from "./daemon.js";
+import { setLogComponent, logInfo, logError } from "./logger.js";
 
 const RESTART_DELAY_BASE = 2_000;  // 2 s
 const RESTART_DELAY_MAX  = 60_000; // 60 s
@@ -91,7 +92,8 @@ export async function runSupervisor(_args: string[] = []): Promise<number> {
         // Best-effort — the daemon will create the file if it doesn't exist.
     }
 
-    console.log("pizzapi supervisor: starting runner daemon as subprocess…");
+    setLogComponent("supervisor");
+    logInfo("starting runner daemon as subprocess…");
 
     while (true) {
         const exitCode = await new Promise<number>((resolve) => {
@@ -106,7 +108,7 @@ export async function runSupervisor(_args: string[] = []): Promise<number> {
             });
 
             child.on("error", (err) => {
-                console.error("pizzapi supervisor: failed to spawn daemon child:", err);
+                logError(`failed to spawn daemon child: ${err}`);
                 resolve(1);
             });
         });
@@ -114,31 +116,31 @@ export async function runSupervisor(_args: string[] = []): Promise<number> {
         child = null;
 
         if (isShuttingDown) {
-            console.log("pizzapi supervisor: shutdown requested — exiting.");
+            logInfo("shutdown requested — exiting.");
             return 0;
         }
 
         if (exitCode === 0) {
-            console.log("pizzapi supervisor: daemon exited cleanly.");
+            logInfo("daemon exited cleanly.");
             return 0;
         }
 
         if (exitCode === 42) {
             // Daemon requested a self-restart (e.g. via /restart command).
-            console.log("pizzapi supervisor: daemon requested restart — re-spawning immediately…");
+            logInfo("daemon requested restart — re-spawning immediately…");
             restartDelay = RESTART_DELAY_BASE; // reset back-off
             continue;
         }
 
         // Crash or unexpected exit — apply back-off then restart.
-        console.error(
-            `pizzapi supervisor: daemon exited with code ${exitCode}. ` +
+        logError(
+            `daemon exited with code ${exitCode}. ` +
             `Restarting in ${(restartDelay / 1000).toFixed(0)}s…`
         );
         await new Promise((r) => setTimeout(r, restartDelay));
         restartDelay = Math.min(restartDelay * 2, RESTART_DELAY_MAX);
 
         if (isShuttingDown) return 0;
-        console.log("pizzapi supervisor: re-spawning daemon…");
+        logInfo("re-spawning daemon…");
     }
 }

--- a/packages/cli/src/runner/supervisor.ts
+++ b/packages/cli/src/runner/supervisor.ts
@@ -108,7 +108,12 @@ export async function runSupervisor(_args: string[] = []): Promise<number> {
             });
 
             child.on("error", (err) => {
-                logError(`failed to spawn daemon child: ${err}`);
+                logError(`failed to spawn daemon child: ${err.message}`);
+                if (err.stack) logError(err.stack);
+                // Log extra SpawnError fields (path, spawnargs, etc.)
+                for (const key of ["code", "path", "spawnargs", "syscall"] as const) {
+                    if (key in err) logError(`  ${key}: ${JSON.stringify((err as unknown as Record<string, unknown>)[key])}`);
+                }
                 resolve(1);
             });
         });

--- a/packages/cli/src/runner/terminal.ts
+++ b/packages/cli/src/runner/terminal.ts
@@ -225,7 +225,8 @@ export function spawnTerminal(
 
     worker.on("error", (err) => {
         runningTerminals.delete(terminalId);
-        logError(`[terminal ${terminalId}] worker process error: ${err}`);
+        logError(`[terminal ${terminalId}] worker process error: ${err.message}`);
+        if (err.stack) logError(err.stack);
         send({ type: "terminal_error", terminalId, message: err.message });
     });
 

--- a/packages/cli/src/runner/terminal.ts
+++ b/packages/cli/src/runner/terminal.ts
@@ -26,6 +26,7 @@ import { platform, arch, homedir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 import { resolveDefaultShell } from "./terminal-utils.js";
+import { logInfo, logWarn, logError } from "./logger.js";
 
 export interface TerminalEntry {
     terminalId: string;
@@ -168,7 +169,7 @@ export function spawnTerminal(
 
     // Surface any stderr from the worker to the daemon log.
     worker.stderr?.on("data", (chunk: Buffer) => {
-        console.error(`[terminal ${terminalId}] worker stderr:`, chunk.toString("utf-8").trim());
+        logError(`[terminal ${terminalId}] worker stderr: ${chunk.toString("utf-8").trim()}`);
     });
 
     let isReady = false;
@@ -181,7 +182,7 @@ export function spawnTerminal(
             case "ready": {
                 isReady = true;
                 send({ type: "terminal_ready", terminalId });
-                console.log(
+                logInfo(
                     `pizzapi runner: terminal ${terminalId} spawned (shell=${shell}, cwd=${cwd}, ${cols}x${rows}, pid=${worker.pid})`,
                 );
                 break;
@@ -191,7 +192,7 @@ export function spawnTerminal(
                 break;
             }
             case "exit": {
-                console.log(
+                logInfo(
                     `[terminal ${terminalId}] PTY exited (exitCode=${m.exitCode})`,
                 );
                 runningTerminals.delete(terminalId);
@@ -213,7 +214,7 @@ export function spawnTerminal(
         const entry = runningTerminals.get(terminalId);
         if (!entry) return; // already removed by "exit" IPC message
         runningTerminals.delete(terminalId);
-        console.log(
+        logInfo(
             `[terminal ${terminalId}] worker exited (code=${code}, signal=${signal})`,
         );
         // If the worker was killed without sending a clean "exit" IPC message
@@ -224,7 +225,7 @@ export function spawnTerminal(
 
     worker.on("error", (err) => {
         runningTerminals.delete(terminalId);
-        console.error(`[terminal ${terminalId}] worker process error:`, err);
+        logError(`[terminal ${terminalId}] worker process error: ${err}`);
         send({ type: "terminal_error", terminalId, message: err.message });
     });
 
@@ -240,13 +241,13 @@ export function spawnTerminal(
 export function writeTerminalInput(terminalId: string, dataBase64: string): void {
     const entry = runningTerminals.get(terminalId);
     if (!entry) {
-        console.warn(`[terminal] writeTerminalInput: no running terminal for terminalId=${terminalId} — input dropped`);
+        logWarn(`[terminal] writeTerminalInput: no running terminal for terminalId=${terminalId} — input dropped`);
         return;
     }
     try {
         entry.worker.send({ type: "input", data: dataBase64 });
     } catch (err) {
-        console.warn(`[terminal] writeTerminalInput: failed for terminalId=${terminalId}:`, err);
+        logWarn(`[terminal] writeTerminalInput: failed for terminalId=${terminalId}: ${err}`);
     }
 }
 
@@ -258,17 +259,17 @@ export function resizeTerminal(
 ): void {
     const entry = runningTerminals.get(terminalId);
     if (!entry) {
-        console.warn(`[terminal] resizeTerminal: no running terminal for terminalId=${terminalId} — resize dropped`);
+        logWarn(`[terminal] resizeTerminal: no running terminal for terminalId=${terminalId} — resize dropped`);
         return;
     }
     if (cols > 0 && rows > 0) {
         try {
             entry.worker.send({ type: "resize", cols, rows });
         } catch (err) {
-            console.warn(`[terminal] resizeTerminal: failed for terminalId=${terminalId}:`, err);
+            logWarn(`[terminal] resizeTerminal: failed for terminalId=${terminalId}: ${err}`);
         }
     } else {
-        console.warn(`[terminal] resizeTerminal: invalid dimensions ${cols}x${rows} for terminalId=${terminalId} — resize skipped`);
+        logWarn(`[terminal] resizeTerminal: invalid dimensions ${cols}x${rows} for terminalId=${terminalId} — resize skipped`);
     }
 }
 
@@ -276,7 +277,7 @@ export function resizeTerminal(
 export function killTerminal(terminalId: string): boolean {
     const entry = runningTerminals.get(terminalId);
     if (!entry) {
-        console.warn(`[terminal] killTerminal: no running terminal for terminalId=${terminalId}`);
+        logWarn(`[terminal] killTerminal: no running terminal for terminalId=${terminalId}`);
         return false;
     }
     runningTerminals.delete(terminalId);
@@ -286,7 +287,7 @@ export function killTerminal(terminalId: string): boolean {
     try {
         entry.worker.kill("SIGTERM");
     } catch (err) {
-        console.warn(`[terminal] killTerminal: worker.kill() failed for terminalId=${terminalId}:`, err);
+        logWarn(`[terminal] killTerminal: worker.kill() failed for terminalId=${terminalId}: ${err}`);
     }
     return true;
 }

--- a/packages/cli/src/runner/usage-auth.ts
+++ b/packages/cli/src/runner/usage-auth.ts
@@ -1,4 +1,5 @@
 import type { AuthStorage } from "@mariozechner/pi-coding-agent";
+import { logAuth } from "./logger.js";
 
 export type RunnerAuthRecord = Record<string, unknown>;
 
@@ -41,8 +42,31 @@ export async function getRefreshedOAuthToken(authStorage: AuthStorage, providerI
         return getOAuthAccessToken(raw);
     }
 
+    // Snapshot pre-refresh state for diagnostic logging
+    const preExpires = typeof raw.expires === "number" ? raw.expires : 0;
+    const preAccessPrefix = typeof raw.access === "string" ? raw.access.slice(0, 8) : "?";
+    const wasExpired = Date.now() >= preExpires;
+
     // Use getApiKey() which handles OAuth token refresh + locking.
     const token = await authStorage.getApiKey(providerId);
+
+    // Log if a refresh actually occurred (access token changed)
+    const postRaw = authStorage.get(providerId);
+    if (isRecord(postRaw) && postRaw.type === "oauth") {
+        const postAccessPrefix = typeof postRaw.access === "string" ? postRaw.access.slice(0, 8) : "?";
+        const postExpires = typeof postRaw.expires === "number" ? postRaw.expires : 0;
+        if (preAccessPrefix !== postAccessPrefix) {
+            logAuth("token-refreshed", {
+                provider: providerId,
+                wasExpired: wasExpired ? "yes" : "no",
+                oldExpiresIn: `${Math.round((preExpires - Date.now()) / 1000)}s`,
+                newExpiresIn: `${Math.round((postExpires - Date.now()) / 1000)}s`,
+                oldTokenPrefix: preAccessPrefix,
+                newTokenPrefix: postAccessPrefix,
+            });
+        }
+    }
+
     return typeof token === "string" && token.trim().length > 0 ? token : null;
 }
 

--- a/packages/cli/src/runner/usage-auth.ts
+++ b/packages/cli/src/runner/usage-auth.ts
@@ -44,7 +44,9 @@ export async function getRefreshedOAuthToken(authStorage: AuthStorage, providerI
 
     // Snapshot pre-refresh state for diagnostic logging
     const preExpires = typeof raw.expires === "number" ? raw.expires : 0;
-    const preAccessPrefix = typeof raw.access === "string" ? raw.access.slice(0, 8) : "?";
+    const preAccessHash = typeof raw.access === "string"
+        ? new Bun.CryptoHasher("sha256").update(raw.access).digest("hex").slice(0, 8)
+        : "?";
     const wasExpired = Date.now() >= preExpires;
 
     // Use getApiKey() which handles OAuth token refresh + locking.
@@ -53,16 +55,18 @@ export async function getRefreshedOAuthToken(authStorage: AuthStorage, providerI
     // Log if a refresh actually occurred (access token changed)
     const postRaw = authStorage.get(providerId);
     if (isRecord(postRaw) && postRaw.type === "oauth") {
-        const postAccessPrefix = typeof postRaw.access === "string" ? postRaw.access.slice(0, 8) : "?";
+        const postAccessHash = typeof postRaw.access === "string"
+            ? new Bun.CryptoHasher("sha256").update(postRaw.access).digest("hex").slice(0, 8)
+            : "?";
         const postExpires = typeof postRaw.expires === "number" ? postRaw.expires : 0;
-        if (preAccessPrefix !== postAccessPrefix) {
+        if (preAccessHash !== postAccessHash) {
             logAuth("token-refreshed", {
                 provider: providerId,
                 wasExpired: wasExpired ? "yes" : "no",
                 oldExpiresIn: `${Math.round((preExpires - Date.now()) / 1000)}s`,
                 newExpiresIn: `${Math.round((postExpires - Date.now()) / 1000)}s`,
-                oldTokenPrefix: preAccessPrefix,
-                newTokenPrefix: postAccessPrefix,
+                oldTokenHash: preAccessHash,
+                newTokenHash: postAccessHash,
             });
         }
     }

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -7,6 +7,7 @@ import { buildWorkerSkillPaths } from "../skills.js";
 import { getPluginSkillPaths } from "../extensions/claude-plugins.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 import { createBootTimer } from "./boot-timing.js";
+import { setLogComponent, setLogSessionId, logInfo, logWarn, logError, logAuth } from "./logger.js";
 
 /**
  * Build additional prompt template paths for the headless worker.
@@ -43,6 +44,10 @@ async function main(): Promise<void> {
     const bootTimer = createBootTimer();
     bootTimer.start("[boot] total");
 
+    setLogComponent("worker");
+    const sessionId = process.env.PIZZAPI_SESSION_ID ?? null;
+    setLogSessionId(sessionId);
+
     const args = process.argv.slice(2);
     const cwdFlagIdx = args.indexOf("--cwd");
     const cwdFromArgs = cwdFlagIdx !== -1 && args[cwdFlagIdx + 1] ? args[cwdFlagIdx + 1] : undefined;
@@ -51,7 +56,7 @@ async function main(): Promise<void> {
     try {
         process.chdir(cwd);
     } catch (err) {
-        console.error(`pizzapi worker: failed to chdir to ${cwd}: ${err instanceof Error ? err.message : String(err)}`);
+        logError(`failed to chdir to ${cwd}: ${err instanceof Error ? err.message : String(err)}`);
         process.exit(1);
     }
 
@@ -89,15 +94,13 @@ async function main(): Promise<void> {
     try {
         await initSandbox(sandboxConfig);
     } catch (err) {
-        console.warn(
-            `pizzapi worker: sandbox init failed, continuing unsandboxed: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        logWarn(`sandbox init failed, continuing unsandboxed: ${err instanceof Error ? err.message : String(err)}`);
     }
     if (isSandboxActive()) {
         process.env.PIZZAPI_SANDBOX_ACTIVE = "1";
         process.env.PIZZAPI_SANDBOX_MODE = sandboxConfig.mode;
     } else if (sandboxConfig.mode !== "none") {
-        console.warn("pizzapi worker: sandbox was requested but is not active (platform unsupported or init failed)");
+        logWarn("sandbox was requested but is not active (platform unsupported or init failed)");
     }
     bootTimer.end("[boot] sandbox");
 
@@ -117,7 +120,7 @@ async function main(): Promise<void> {
                 try {
                     agentFiles.push({ path: filePath, content: readFileSync(filePath, "utf-8") });
                 } catch (err) {
-                    console.warn(`pizzapi worker: skipping unreadable agent file ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+                    logWarn(`skipping unreadable agent file ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
                 }
             }
         }
@@ -152,6 +155,36 @@ async function main(): Promise<void> {
     });
     await loader.reload();
     bootTimer.end("[boot] resource-loader");
+
+    // ── Auth diagnostics — log credential state before first API call ────
+    // This helps diagnose intermittent "No API key found" failures in
+    // concurrent worker sessions (see Godmother idea fIUvBDLZ).
+    try {
+        const { AuthStorage } = await import("@mariozechner/pi-coding-agent");
+        const diagAuthStorage = AuthStorage.create(join(agentDir, "auth.json"));
+        for (const provider of ["anthropic", "google-gemini-cli", "openai-codex"]) {
+            const raw = diagAuthStorage.get(provider);
+            if (raw && typeof raw === "object" && "type" in raw) {
+                const cred = raw as { type: string; expires?: number };
+                if (cred.type === "oauth" && cred.expires) {
+                    const remainingMs = cred.expires - Date.now();
+                    logAuth("credential-state", {
+                        provider,
+                        type: cred.type,
+                        expiresIn: `${Math.round(remainingMs / 1000)}s`,
+                        expired: remainingMs <= 0 ? "YES" : "no",
+                    });
+                } else {
+                    logAuth("credential-state", { provider, type: cred.type });
+                }
+            } else if (raw) {
+                logAuth("credential-state", { provider, type: "unknown-format" });
+            }
+            // Silently skip missing providers — not all may be configured
+        }
+    } catch {
+        // Non-fatal — diagnostic only
+    }
 
     bootTimer.start("[boot] create-session");
     const { session } = await createAgentSession({
@@ -199,16 +232,15 @@ async function main(): Promise<void> {
             }
         },
         onError: (err) => {
-            console.error(`[extension] ${err.extensionPath}: ${err.error}`);
-            if (err.stack) console.error(err.stack);
+            logError(`[extension] ${err.extensionPath}: ${err.error}`);
+            if (err.stack) logError(err.stack);
             forwardCliError(err.error, err.extensionPath);
         },
     });
     bootTimer.end("[boot] bind-extensions");
 
-    const sessionId = process.env.PIZZAPI_SESSION_ID;
     bootTimer.end("[boot] total");
-    console.log(`pizzapi worker: boot complete (cwd=${cwd}${sessionId ? `, sessionId=${sessionId}` : ""})`);
+    logInfo(`started (cwd=${cwd}${agentName ? `, agent=${agentName}` : ""})`);
 
     const shutdown = async () => {
         try {
@@ -228,6 +260,6 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
-    console.error(err instanceof Error ? err.stack ?? err.message : String(err));
+    logError(err instanceof Error ? err.stack ?? err.message : String(err));
     process.exit(1);
 });


### PR DESCRIPTION
## Summary

Add a shared logger (`runner/logger.ts`) to the runner subsystem that prefixes every log line with ISO timestamps, component tags, and session IDs. This makes it possible to correlate interleaved output from the daemon and concurrent worker processes back to individual sessions.

Previously, all runner logs (supervisor, daemon, workers) shared the same stdout/stderr file descriptors with **no timestamps or session IDs**, making it impossible to diagnose intermittent failures.

## Changes

### New: `packages/cli/src/runner/logger.ts`
- `logInfo()`, `logWarn()`, `logError()` — structured logging with ISO timestamp + component + optional session ID
- `logAuth()` — auth-specific event logging with key-value details
- Format: `2026-03-19T22:31:20.123Z [worker:a1b2c3d4] message`

### Auth diagnostics (`worker.ts`, `usage-auth.ts`)
- Workers log credential state (type, expiry, expired?) for each provider at startup — before the first API call
- `getRefreshedOAuthToken()` now logs when a token is actually refreshed (old/new expiry, token prefix delta)
- This will reveal if the daemon's usage refresh is invalidating tokens that workers hold in-memory

### Retrofitted logging
- **daemon.ts**: all ~42 `console.log/warn/error` calls → `logInfo/logWarn/logError`
- **supervisor.ts**: all 7 console calls retrofitted
- **terminal.ts**: all console calls retrofitted, multi-arg calls fixed
- **worker.ts**: all console calls retrofitted, session ID included via `setLogSessionId()`

## Motivation

Intermittent "No API key found for anthropic" failures in spawned child sessions (Godmother `fIUvBDLZ`). Without timestamps or session IDs in the logs, it was impossible to correlate errors with specific sessions or determine whether daemon token refreshes were racing with worker API calls.

## Testing
- `bun run typecheck` — clean
- `bun test packages/cli/` — no regressions (same pre-existing failures on main)