### PR TITLE
⚡ Bolt: Use adapter.sockets() to replace expensive fetchSockets/allSockets in sio-registry

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,7 @@
 ## 2025-03-19 - Use native disconnectSockets over socketsLeave loops
 **Learning:** Using `socketsLeave` followed by a custom loop to cleanup sockets or relying on `fetchSockets` triggers expensive operations across the Redis cluster adapter. Socket.IO's native `.disconnectSockets()` achieves forceful disconnection of all clients in a room without the N+1 network overhead. When multiplexing namespaces, passing `true` to `.disconnectSockets()` tears down the entire Engine.IO connection, dropping unrelated namespace sockets (like `/hub` and `/terminal`).
 **Action:** When tearing down sessions, use `.disconnectSockets()` (without `true`) instead of `socketsLeave()` to properly tear down sockets while avoiding closing the underlying multiplexed Engine.IO connection that other namespaces rely on.
+
+## 2025-04-18 - Use adapter.sockets() for presence/count checks
+**Learning:** Using `allSockets()` or `fetchSockets()` pulls full `RemoteSocket` objects across the cluster via the Redis adapter. When only the presence of sockets or the count is needed, directly querying the adapter via `adapter.sockets(new Set([roomName]))` avoids this expensive network overhead.
+**Action:** Use `await io.of("namespace").adapter.sockets(new Set([roomName]))` to check for room presence or socket count instead of `fetchSockets()`.

--- a/packages/server/src/ws/sio-registry.ts
+++ b/packages/server/src/ws/sio-registry.ts
@@ -519,8 +519,9 @@ export async function emitToRelaySessionVerified(sessionId: string, eventName: s
     if (!io) return false;
     const room = relaySessionRoom(sessionId);
     try {
-        const sockets = await io.of("/relay").in(room).fetchSockets();
-        if (sockets.length === 0) return false;
+        // ⚡ Bolt: Fast check on adapter avoids fetching full RemoteSocket objects across cluster
+        const sockets = await io.of("/relay").adapter.sockets(new Set([room]));
+        if (sockets.size === 0) return false;
         io.of("/relay").to(room).emit(eventName, data);
         return true;
     } catch (err) {
@@ -1029,7 +1030,8 @@ export function broadcastToViewers(sessionId: string, eventName: string, data: u
  * Works across all servers via the Redis adapter.
  */
 export async function getViewerCount(sessionId: string): Promise<number> {
-    const sockets = await io.of("/viewer").in(viewerSessionRoom(sessionId)).allSockets();
+    // ⚡ Bolt: Fast size query on adapter prevents fetching full RemoteSocket objects across cluster
+    const sockets = await io.of("/viewer").adapter.sockets(new Set([viewerSessionRoom(sessionId)]));
     return sockets.size;
 }
 


### PR DESCRIPTION
💡 **What**: Replaced `fetchSockets()` and `allSockets()` with `adapter.sockets(new Set([roomName]))` in `sio-registry.ts`.
🎯 **Why**: Using `fetchSockets()` and `allSockets()` pulls full `RemoteSocket` objects across the cluster via the Redis adapter, causing excessive network overhead. The adapter query efficiently returns a `Set` of socket IDs.
📊 **Impact**: Reduces Redis adapter network overhead significantly when checking presence or counting sockets, especially for high-frequency checks like push notifications.
🔬 **Measurement**: Verify by running the test suite (`bun test`) and checking the performance of `getViewerCount` and `emitToRelaySessionVerified`.

---
*PR created automatically by Jules for task [2583128754860632142](https://jules.google.com/task/2583128754860632142) started by @Pizzaface*