### PR TITLE
fix: add background to prompt input footer and fix conversation scroll

### DIFF
--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -1639,7 +1639,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
         </div>
       )}
 
-      <div className="relative flex-1 min-h-0">
+      <div className="relative flex flex-col flex-1 min-h-0">
         {!sessionId ? (
           <ConversationEmptyState
             icon={<MessageSquare className="size-8 opacity-40" />}
@@ -1681,7 +1681,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
         )}
       </div>
 
-      <div className="border-t border-border px-3 py-2 pp-safe-bottom">
+      <div className="border-t border-border bg-background px-3 py-2 pp-safe-bottom">
         {/* Message queue display */}
         {sessionId && messageQueue && messageQueue.length > 0 && (
           <div className="mb-2 rounded-md border border-border bg-muted/30 px-2.5 py-2">


### PR DESCRIPTION
## Problem

1. The composer footer area had no background color, so conversation content was visible through it when scrolling.
2. The conversation wrapper div wasn't a flex container, so `flex-1` on the `<Conversation>` (StickToBottom) component had no effect — the scroll container's height was content-based and never overflowed.

## Fixes

- Add `bg-background` to the composer footer container
- Add `flex flex-col` to the conversation wrapper div so the StickToBottom component gets a constrained height and scrolls properly