### PR TITLE
Add Claude Code worker session support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,3 @@ Library/Caches/
 .playwright-cli/
 .python-version
 01-landing.png
-.playwright-cli/

--- a/.pizzapi/hooks/worktree-base-main.sh
+++ b/.pizzapi/hooks/worktree-base-main.sh
@@ -1,7 +1,33 @@
-#!/usr/bin/env bash
-# Placeholder hook used by PizzaPi's project-local config.
-#
-# In some workflows, this can be replaced with a hook that enforces worktree
-# policies (e.g. ensuring feature work happens off main). For now it's a no-op.
+#!/bin/bash
+# "Are Your Lights On?" — PreToolUse:Bash
+# Warns when the agent is about to run a git commit on the main/master branch
+# without a feature branch. Does NOT block git operations on main — the
+# block-dangerous-commands.sh hook handles hard blocks (force push, etc.).
+# Exit 0 = allow (always).
+set -euo pipefail
+
+TOOL_INPUT=$(cat 2>/dev/null) || true
+[[ -z "$TOOL_INPUT" ]] && exit 0
+
+COMMAND=$(echo "$TOOL_INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null) || true
+[[ -z "$COMMAND" ]] && exit 0
+
+# Only check git commit commands
+if ! echo "$COMMAND" | grep -qE '(^|\s|&&|\|\||;|\|)\s*git\s+commit\s'; then
+    exit 0
+fi
+
+# Get the current branch name
+CURRENT_BRANCH=$(git -C "${PIZZAPI_PROJECT_DIR:-.}" symbolic-ref --short HEAD 2>/dev/null || true)
+
+if [[ "$CURRENT_BRANCH" == "main" || "$CURRENT_BRANCH" == "master" ]]; then
+    jq -n '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "allow",
+            additionalContext: "⚠️  You are about to commit directly to the main/master branch. Per AGENTS.md, you should always create a feature branch first (git checkout -b feat/<name>). Are you sure this is intentional?"
+        }
+    }'
+fi
 
 exit 0

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,18 @@ bun run clean
 
 ---
 
+## Responsive Design (Mobile-First)
+
+PizzaPi is a PWA used heavily on mobile. **Every UI change must work on small screens.**
+
+- **Single-column on mobile.** Lists of cards (runners, sessions, folders) must stack vertically on narrow viewports. Never use `grid-cols-2` or multi-column grids without verifying the mobile experience — prefer single-column (`flex flex-col`) as the base and only expand columns at `sm:` or wider.
+- **Touch targets.** Interactive elements must be at least 44×44 CSS pixels per Apple HIG. Don't shrink buttons or cards to fit a grid — make them full-width rows instead.
+- **Test at 375px width.** Before shipping any layout change, verify it renders correctly at iPhone SE width (375px). Use browser DevTools responsive mode.
+- **Dialogs and modals.** Content inside `DialogContent` must be scrollable on small screens. Don't assume the viewport is tall enough to show all steps at once.
+- **Truncation over wrapping.** Runner names, session names, and paths should `truncate` rather than wrap and blow out card heights.
+
+---
+
 ## Upstream Patches
 
 PizzaPi patches two upstream pi packages via `patchedDependencies` in the root `package.json`. Patches live in `patches/` and are auto-applied on `bun install`. See `patches/README.md` for full details.

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.3.1-dev.3",
+      "version": "0.4.5-dev.2",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
@@ -30,6 +30,7 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
+        "@pizzapi/tunnel": "workspace:*",
         "@zenyr/bun-pty": "^0.4.4",
         "socket.io-client": "^4.8.1",
       },
@@ -64,6 +65,7 @@
         "@mariozechner/pi-ai": "^0.63.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
+        "@pizzapi/tunnel": "workspace:*",
         "@socket.io/redis-adapter": "^8.3.0",
         "better-auth": "^1.4.18",
         "kysely": "^0.28.11",
@@ -72,11 +74,14 @@
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1",
         "web-push": "^3.6.7",
+        "ws": "^8.18.0",
       },
       "devDependencies": {
         "@better-auth/cli": "^1.4.18",
         "@types/bun": "^1.3.9",
         "@types/web-push": "^3.6.4",
+        "@types/ws": "^8.5.0",
+        "redis-memory-server": "^0.16.0",
         "typescript": "^5.7.0",
       },
     },
@@ -89,6 +94,14 @@
         "@mariozechner/pi-ai": "^0.63.1",
       },
       "devDependencies": {
+        "typescript": "^5.7.0",
+      },
+    },
+    "packages/tunnel": {
+      "name": "@pizzapi/tunnel",
+      "version": "0.1.32",
+      "devDependencies": {
+        "@types/bun": "^1.3.9",
         "typescript": "^5.7.0",
       },
     },
@@ -130,6 +143,7 @@
         "react-dom": "^19.2.4",
         "react-icons": "^5.5.0",
         "react-resizable": "^3.0.5",
+        "recharts": "^3.8.0",
         "shiki": "^3.22.0",
         "socket.io-client": "^4.8.1",
         "streamdown": "^2.3.0",
@@ -138,12 +152,14 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.0",
+        "@testing-library/react": "^16.3.2",
         "@types/react-resizable": "^3.0.8",
         "@vite-pwa/assets-generator": "^1.0.2",
         "@vitejs/plugin-react-swc": "^4.3.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
+        "happy-dom": "^20.8.4",
         "shadcn": "^3.8.5",
         "tailwindcss": "^4.2.0",
         "tw-animate-css": "^1.4.0",
@@ -656,7 +672,9 @@
 
     "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
 
-    "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -759,6 +777,8 @@
     "@pizzapi/server": ["@pizzapi/server@workspace:packages/server"],
 
     "@pizzapi/tools": ["@pizzapi/tools@workspace:packages/tools"],
+
+    "@pizzapi/tunnel": ["@pizzapi/tunnel@workspace:packages/tunnel"],
 
     "@pizzapi/ui": ["@pizzapi/ui@workspace:packages/ui"],
 
@@ -923,6 +943,8 @@
     "@redis/search": ["@redis/search@1.2.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw=="],
 
     "@redis/time-series": ["@redis/time-series@1.1.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g=="],
+
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
@@ -1116,6 +1138,8 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
+
     "@streamdown/cjk": ["@streamdown/cjk@1.0.2", "", { "dependencies": { "remark-cjk-friendly": "^1.2.3", "remark-cjk-friendly-gfm-strikethrough": "^1.2.3", "unist-util-visit": "^5.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-5OOuZjj2Lnae92Zmg2gA5hloSbcKj25gv+QY4iKbYI+iRsiGWbgmYxmgxNUSO9SR6BKOCy783UHN1HM/QEUpdw=="],
 
     "@streamdown/code": ["@streamdown/code@1.0.3", "", { "dependencies": { "shiki": "^3.19.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-3Ym5TCLcGhrHY2qBaUVWpqNRtxnZvqh4Y5Qm/pTIKA4AmEWwAAoYjZnxG7mOsvOpWVWiDwETjUtchNL1XzQEAw=="],
@@ -1186,6 +1210,10 @@
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.18", "", {}, "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -1193,6 +1221,8 @@
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
+
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -1318,9 +1348,15 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
+
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
     "@types/web-push": ["@types/web-push@3.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ=="],
+
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
+    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -1492,7 +1528,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
+    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001770", "", {}, "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw=="],
 
@@ -1514,7 +1550,7 @@
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
-    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
+    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
@@ -1561,6 +1597,8 @@
     "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
+
+    "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
     "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
 
@@ -1692,6 +1730,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
+
     "decode-bmp": ["decode-bmp@0.2.1", "", { "dependencies": { "@canvas/image-data": "^1.0.0", "to-data-view": "^1.1.0" } }, "sha512-NiOaGe+GN0KJqi2STf24hfMkFitDUaIoUU3eKvP/wAbLe8o6FuW5n/x7MHPR0HKvBokp6MQY/j7w8lewEeVCIA=="],
 
     "decode-ico": ["decode-ico@0.4.1", "", { "dependencies": { "@canvas/image-data": "^1.0.0", "decode-bmp": "^0.2.0", "to-data-view": "^1.1.0" } }, "sha512-69NZfbKIzux1vBOd31al3XnMnH+2mqDhEgLdpygErm4d60N+UwA5Sq5WFjmEDQzumgB9fElojGwWG0vybVfFmA=="],
@@ -1744,6 +1784,8 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
+    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
+
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
@@ -1788,7 +1830,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
-    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -1807,6 +1849,8 @@
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -1898,6 +1942,12 @@
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
+    "find-cache-dir": ["find-cache-dir@3.3.2", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^3.0.2", "pkg-dir": "^4.1.0" } }, "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig=="],
+
+    "find-package-json": ["find-package-json@1.2.0", "", {}, "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw=="],
+
+    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
+
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
 
     "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
@@ -1954,6 +2004,8 @@
 
     "get-own-enumerable-property-symbols": ["get-own-enumerable-property-symbols@3.0.2", "", {}, "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="],
 
+    "get-port": ["get-port@5.1.1", "", {}, "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="],
+
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -1989,6 +2041,8 @@
     "h3": ["h3@1.15.5", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
+
+    "happy-dom": ["happy-dom@20.8.9", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-Tz23LR9T9jOGVZm2x1EPdXqwA37G/owYMxRwU0E4miurAtFsPMQ1d2Jc2okUaSjZqAFz2oEn3FLXC5a0a+siyA=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -2089,6 +2143,8 @@
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -2202,7 +2258,7 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
@@ -2310,6 +2366,10 @@
 
     "linkify-it": ["linkify-it@3.0.3", "", { "dependencies": { "uc.micro": "^1.0.1" } }, "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ=="],
 
+    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "lockfile": ["lockfile@1.0.4", "", { "dependencies": { "signal-exit": "^3.0.2" } }, "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA=="],
+
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
     "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
@@ -2330,9 +2390,13 @@
 
     "lucide-react": ["lucide-react@0.575.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg=="],
 
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
+
+    "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
 
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
@@ -2492,6 +2556,8 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
+    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
+
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
@@ -2584,11 +2650,15 @@
 
     "p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
 
+    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
     "p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
     "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 
@@ -2621,6 +2691,8 @@
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -2662,6 +2734,8 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
+
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
@@ -2695,6 +2769,8 @@
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
+
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
@@ -2750,6 +2826,8 @@
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -2764,6 +2842,8 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
+    "recharts": ["recharts@3.8.1", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg=="],
+
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 
     "recma-jsx": ["recma-jsx@1.0.1", "", { "dependencies": { "acorn-jsx": "^5.0.0", "estree-util-to-js": "^2.0.0", "recma-parse": "^1.0.0", "recma-stringify": "^1.0.0", "unified": "^11.0.0" }, "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w=="],
@@ -2773,6 +2853,12 @@
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
 
     "redis": ["redis@4.7.1", "", { "dependencies": { "@redis/bloom": "1.2.0", "@redis/client": "1.6.1", "@redis/graph": "1.1.1", "@redis/json": "1.0.7", "@redis/search": "1.2.0", "@redis/time-series": "1.1.0" } }, "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ=="],
+
+    "redis-memory-server": ["redis-memory-server@0.16.0", "", { "dependencies": { "camelcase": "^6.3.0", "cross-spawn": "^7.0.3", "debug": "^4.3.4", "extract-zip": "^2.0.1", "find-cache-dir": "^3.3.2", "find-package-json": "^1.2.0", "get-port": "^5.1.1", "https-proxy-agent": "^7.0.0", "lockfile": "^1.0.4", "rimraf": "^5.0.1", "semver": "^7.5.3", "tar": "^7.5.4", "tmp": "^0.2.1", "uuid": "^8.3.2" }, "bin": { "redis-memory-server": "bin/index.js" } }, "sha512-NumE5HHR5ku8k3hD54xUjBhv2XoKQd/UC8gtlAh3jFKqhH3kSn3C8pB3MBS5K3hj7rhgiJbXu+2Xhm+Mqi+SWQ=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -2841,6 +2927,8 @@
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -3046,6 +3134,8 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
+    "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
+
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
@@ -3071,6 +3161,8 @@
     "tldts": ["tldts@7.0.23", "", { "dependencies": { "tldts-core": "^7.0.23" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw=="],
 
     "tldts-core": ["tldts-core@7.0.23", "", {}, "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ=="],
+
+    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
 
     "to-data-view": ["to-data-view@1.1.0", "", {}, "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ=="],
 
@@ -3200,7 +3292,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
@@ -3211,6 +3303,8 @@
     "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
+
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
@@ -3237,6 +3331,8 @@
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
 
@@ -3304,7 +3400,7 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -3382,6 +3478,10 @@
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
     "@mariozechner/pi-ai/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@mariozechner/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
@@ -3420,6 +3520,10 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "@redis/client/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
+
     "@rollup/plugin-babel/@rollup/pluginutils": ["@rollup/pluginutils@3.1.0", "", { "dependencies": { "@types/estree": "0.0.39", "estree-walker": "^1.0.1", "picomatch": "^2.2.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0" } }, "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg=="],
 
     "@rollup/plugin-babel/rollup": ["rollup@2.79.2", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ=="],
@@ -3448,6 +3552,8 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
     "@ts-morph/common/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -3461,6 +3567,8 @@
     "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "better-call/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "boxen/camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
     "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -3538,7 +3646,11 @@
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
+    "make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "mermaid/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -3554,6 +3666,8 @@
 
     "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
+    "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -3567,6 +3681,12 @@
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
+
+    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
@@ -3609,6 +3729,8 @@
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
+
+    "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "tempy/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
@@ -3661,6 +3783,10 @@
     "@dotenvx/dotenvx/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
     "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@pizzapi/ui/motion/framer-motion": ["framer-motion@12.34.3", "", { "dependencies": { "motion-dom": "^12.34.3", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q=="],
 
@@ -3742,6 +3868,10 @@
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
+    "hast-util-from-html/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "hast-util-raw/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
     "langium/chevrotain/@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.1.1", "", { "dependencies": { "@chevrotain/gast": "11.1.1", "@chevrotain/types": "11.1.1", "lodash-es": "4.17.23" } }, "sha512-fRHyv6/f542qQqiRGalrfJl/evD39mAvbJLCekPazhiextEatq1Jx1K/i9gSd5NNO0ds03ek0Cbo/4uVKmOBcw=="],
 
     "langium/chevrotain/@chevrotain/gast": ["@chevrotain/gast@11.1.1", "", { "dependencies": { "@chevrotain/types": "11.1.1", "lodash-es": "4.17.23" } }, "sha512-Ko/5vPEYy1vn5CbCjjvnSO4U7GgxyGm+dfUZZJIWTlQFkXkyym0jFYrWEU10hyCjrA7rQtiHtBr0EaZqvHFZvg=="],
@@ -3753,8 +3883,6 @@
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
-    "rimraf/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "rimraf/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
@@ -3822,6 +3950,8 @@
 
     "widest-line/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
+    "workbox-build/glob/jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
+
     "workbox-build/glob/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "workbox-build/stringify-object/is-obj": ["is-obj@1.0.1", "", {}, "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg=="],
@@ -3848,22 +3978,14 @@
 
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
-    "rimraf/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
-
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
+    "workbox-build/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
+
     "cli-highlight/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
-    "rimraf/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "rimraf/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
     "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
-
-    "rimraf/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "rimraf/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
   }
 }

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.4.5-dev.2",
+      "version": "0.3.1-dev.3",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
@@ -30,13 +30,13 @@
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
-        "@pizzapi/tunnel": "workspace:*",
         "@zenyr/bun-pty": "^0.4.4",
         "socket.io-client": "^4.8.1",
       },
       "devDependencies": {
         "@types/bun": "^1.3.9",
         "typescript": "^5.7.0",
+        "zod": "^3.25",
       },
     },
     "packages/docs": {
@@ -64,7 +64,6 @@
         "@mariozechner/pi-ai": "^0.63.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
-        "@pizzapi/tunnel": "workspace:*",
         "@socket.io/redis-adapter": "^8.3.0",
         "better-auth": "^1.4.18",
         "kysely": "^0.28.11",
@@ -73,14 +72,11 @@
         "socket.io": "^4.8.1",
         "socket.io-client": "^4.8.1",
         "web-push": "^3.6.7",
-        "ws": "^8.18.0",
       },
       "devDependencies": {
         "@better-auth/cli": "^1.4.18",
         "@types/bun": "^1.3.9",
         "@types/web-push": "^3.6.4",
-        "@types/ws": "^8.5.0",
-        "redis-memory-server": "^0.16.0",
         "typescript": "^5.7.0",
       },
     },
@@ -93,14 +89,6 @@
         "@mariozechner/pi-ai": "^0.63.1",
       },
       "devDependencies": {
-        "typescript": "^5.7.0",
-      },
-    },
-    "packages/tunnel": {
-      "name": "@pizzapi/tunnel",
-      "version": "0.1.32",
-      "devDependencies": {
-        "@types/bun": "^1.3.9",
         "typescript": "^5.7.0",
       },
     },
@@ -142,7 +130,6 @@
         "react-dom": "^19.2.4",
         "react-icons": "^5.5.0",
         "react-resizable": "^3.0.5",
-        "recharts": "^3.8.0",
         "shiki": "^3.22.0",
         "socket.io-client": "^4.8.1",
         "streamdown": "^2.3.0",
@@ -151,14 +138,12 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.0",
-        "@testing-library/react": "^16.3.2",
         "@types/react-resizable": "^3.0.8",
         "@vite-pwa/assets-generator": "^1.0.2",
         "@vitejs/plugin-react-swc": "^4.3.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
-        "happy-dom": "^20.8.4",
         "shadcn": "^3.8.5",
         "tailwindcss": "^4.2.0",
         "tw-animate-css": "^1.4.0",
@@ -671,9 +656,7 @@
 
     "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
 
-    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
-
-    "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
+    "@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -776,8 +759,6 @@
     "@pizzapi/server": ["@pizzapi/server@workspace:packages/server"],
 
     "@pizzapi/tools": ["@pizzapi/tools@workspace:packages/tools"],
-
-    "@pizzapi/tunnel": ["@pizzapi/tunnel@workspace:packages/tunnel"],
 
     "@pizzapi/ui": ["@pizzapi/ui@workspace:packages/ui"],
 
@@ -942,8 +923,6 @@
     "@redis/search": ["@redis/search@1.2.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-tYoDBbtqOVigEDMAcTGsRlMycIIjwMCgD8eR2t0NANeQmgK/lvxNAvYyb6bZDD4frHRhIHkJu2TBRvB0ERkOmw=="],
 
     "@redis/time-series": ["@redis/time-series@1.1.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g=="],
-
-    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
@@ -1137,8 +1116,6 @@
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
-    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
-
     "@streamdown/cjk": ["@streamdown/cjk@1.0.2", "", { "dependencies": { "remark-cjk-friendly": "^1.2.3", "remark-cjk-friendly-gfm-strikethrough": "^1.2.3", "unist-util-visit": "^5.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-5OOuZjj2Lnae92Zmg2gA5hloSbcKj25gv+QY4iKbYI+iRsiGWbgmYxmgxNUSO9SR6BKOCy783UHN1HM/QEUpdw=="],
 
     "@streamdown/code": ["@streamdown/code@1.0.3", "", { "dependencies": { "shiki": "^3.19.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-3Ym5TCLcGhrHY2qBaUVWpqNRtxnZvqh4Y5Qm/pTIKA4AmEWwAAoYjZnxG7mOsvOpWVWiDwETjUtchNL1XzQEAw=="],
@@ -1209,10 +1186,6 @@
 
     "@tanstack/virtual-core": ["@tanstack/virtual-core@3.13.18", "", {}, "sha512-Mx86Hqu1k39icq2Zusq+Ey2J6dDWTjDvEv43PJtRCoEYTLyfaPnxIQ6iy7YAOK0NV/qOEmZQ/uCufrppZxTgcg=="],
 
-    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
-
-    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
-
     "@tokenizer/inflate": ["@tokenizer/inflate@0.4.1", "", { "dependencies": { "debug": "^4.4.3", "token-types": "^6.1.1" } }, "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA=="],
 
     "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
@@ -1220,8 +1193,6 @@
     "@tootallnate/quickjs-emscripten": ["@tootallnate/quickjs-emscripten@0.23.0", "", {}, "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA=="],
 
     "@ts-morph/common": ["@ts-morph/common@0.27.0", "", { "dependencies": { "fast-glob": "^3.3.3", "minimatch": "^10.0.1", "path-browserify": "^1.0.1" } }, "sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ=="],
-
-    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
@@ -1347,15 +1318,9 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
-    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
-
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
     "@types/web-push": ["@types/web-push@3.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ=="],
-
-    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
-
-    "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -1527,7 +1492,7 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
-    "camelcase": ["camelcase@6.3.0", "", {}, "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="],
+    "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001770", "", {}, "sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw=="],
 
@@ -1549,7 +1514,7 @@
 
     "chokidar": ["chokidar@5.0.0", "", { "dependencies": { "readdirp": "^5.0.0" } }, "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw=="],
 
-    "chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
+    "chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "ci-info": ["ci-info@4.4.0", "", {}, "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg=="],
 
@@ -1596,8 +1561,6 @@
     "common-ancestor-path": ["common-ancestor-path@1.0.1", "", {}, "sha512-L3sHRo1pXXEqX8VU28kfgUY+YGsk09hPqZiZmLacNib6XNTCM8ubYeT7ryXQw8asB1sKgcU5lkB7ONug08aB8w=="],
 
     "common-tags": ["common-tags@1.8.2", "", {}, "sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA=="],
-
-    "commondir": ["commondir@1.0.1", "", {}, "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg=="],
 
     "concurrently": ["concurrently@9.2.1", "", { "dependencies": { "chalk": "4.1.2", "rxjs": "7.8.2", "shell-quote": "1.8.3", "supports-color": "8.1.1", "tree-kill": "1.2.2", "yargs": "17.7.2" }, "bin": { "conc": "dist/bin/concurrently.js", "concurrently": "dist/bin/concurrently.js" } }, "sha512-fsfrO0MxV64Znoy8/l1vVIjjHa29SZyyqPgQBwhiDcaW8wJc2W3XWVOGx4M3oJBnv/zdUZIIp1gDeS98GzP8Ng=="],
 
@@ -1729,8 +1692,6 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
-    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
-
     "decode-bmp": ["decode-bmp@0.2.1", "", { "dependencies": { "@canvas/image-data": "^1.0.0", "to-data-view": "^1.1.0" } }, "sha512-NiOaGe+GN0KJqi2STf24hfMkFitDUaIoUU3eKvP/wAbLe8o6FuW5n/x7MHPR0HKvBokp6MQY/j7w8lewEeVCIA=="],
 
     "decode-ico": ["decode-ico@0.4.1", "", { "dependencies": { "@canvas/image-data": "^1.0.0", "decode-bmp": "^0.2.0", "to-data-view": "^1.1.0" } }, "sha512-69NZfbKIzux1vBOd31al3XnMnH+2mqDhEgLdpygErm4d60N+UwA5Sq5WFjmEDQzumgB9fElojGwWG0vybVfFmA=="],
@@ -1783,8 +1744,6 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
-    "dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
-
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
     "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
@@ -1829,7 +1788,7 @@
 
     "enhanced-resolve": ["enhanced-resolve@5.19.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.0" } }, "sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg=="],
 
-    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+    "entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
 
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
@@ -1848,8 +1807,6 @@
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
-
-    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -1941,12 +1898,6 @@
 
     "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
-    "find-cache-dir": ["find-cache-dir@3.3.2", "", { "dependencies": { "commondir": "^1.0.1", "make-dir": "^3.0.2", "pkg-dir": "^4.1.0" } }, "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig=="],
-
-    "find-package-json": ["find-package-json@1.2.0", "", {}, "sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw=="],
-
-    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
-
     "flattie": ["flattie@1.1.1", "", {}, "sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ=="],
 
     "fontace": ["fontace@0.4.1", "", { "dependencies": { "fontkitten": "^1.0.2" } }, "sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw=="],
@@ -2003,8 +1954,6 @@
 
     "get-own-enumerable-property-symbols": ["get-own-enumerable-property-symbols@3.0.2", "", {}, "sha512-I0UBV/XOz1XkIJHEUDMZAbzCThU/H8DxmSfmdGcKPnVhu2VfFqr34jr9777IyaTYvxjedWhqVIilEDsCdP5G6g=="],
 
-    "get-port": ["get-port@5.1.1", "", {}, "sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ=="],
-
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-stream": ["get-stream@5.2.0", "", { "dependencies": { "pump": "^3.0.0" } }, "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA=="],
@@ -2040,8 +1989,6 @@
     "h3": ["h3@1.15.5", "", { "dependencies": { "cookie-es": "^1.2.2", "crossws": "^0.3.5", "defu": "^6.1.4", "destr": "^2.0.5", "iron-webcrypto": "^1.2.1", "node-mock-http": "^1.0.4", "radix3": "^1.1.2", "ufo": "^1.6.3", "uncrypto": "^0.1.3" } }, "sha512-xEyq3rSl+dhGX2Lm0+eFQIAzlDN6Fs0EcC4f7BNUmzaRX/PTzeuM+Tr2lHB8FoXggsQIeXLj8EDVgs5ywxyxmg=="],
 
     "hachure-fill": ["hachure-fill@0.5.2", "", {}, "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg=="],
-
-    "happy-dom": ["happy-dom@20.8.4", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.18.3" } }, "sha512-GKhjq4OQCYB4VLFBzv8mmccUadwlAusOZOI7hC1D9xDIT5HhzkJK17c4el2f6R6C715P9xB4uiMxeKUa2nHMwQ=="],
 
     "has-bigints": ["has-bigints@1.1.0", "", {}, "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg=="],
 
@@ -2142,8 +2089,6 @@
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
-
-    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -2257,7 +2202,7 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+    "jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
 
     "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
 
@@ -2365,10 +2310,6 @@
 
     "linkify-it": ["linkify-it@3.0.3", "", { "dependencies": { "uc.micro": "^1.0.1" } }, "sha512-ynTsyrFSdE5oZ/O9GEf00kPngmOfVwazR5GKDq6EYfhlpFug3J2zybX56a2PRRpc9P+FuSoGNAwjlbDs9jJBPQ=="],
 
-    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
-
-    "lockfile": ["lockfile@1.0.4", "", { "dependencies": { "signal-exit": "^3.0.2" } }, "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA=="],
-
     "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
 
     "lodash-es": ["lodash-es@4.17.23", "", {}, "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg=="],
@@ -2389,13 +2330,9 @@
 
     "lucide-react": ["lucide-react@0.575.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg=="],
 
-    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
-
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
-
-    "make-dir": ["make-dir@3.1.0", "", { "dependencies": { "semver": "^6.0.0" } }, "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw=="],
 
     "markdown-extensions": ["markdown-extensions@2.0.0", "", {}, "sha512-o5vL7aDWatOTX8LzaS1WMoaoxIiLRQJuIKKe2wAw6IeULDHaqbiqiggmx+pKvZDb1Sj+pE46Sn1T7lCqfFtg1Q=="],
 
@@ -2555,8 +2492,6 @@
 
     "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
 
-    "minizlib": ["minizlib@3.1.0", "", { "dependencies": { "minipass": "^7.1.2" } }, "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw=="],
-
     "mkdirp-classic": ["mkdirp-classic@0.5.3", "", {}, "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="],
 
     "mlly": ["mlly@1.8.0", "", { "dependencies": { "acorn": "^8.15.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.1" } }, "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g=="],
@@ -2649,15 +2584,11 @@
 
     "p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
 
-    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
-
     "p-queue": ["p-queue@8.1.1", "", { "dependencies": { "eventemitter3": "^5.0.1", "p-timeout": "^6.1.2" } }, "sha512-aNZ+VfjobsWryoiPnEApGGmf5WmNsCo9xu8dfaYamG5qaLP7ClhLN6NgsFe6SwJ2UbLEBK5dv9x8Mn5+RVhMWQ=="],
 
     "p-retry": ["p-retry@4.6.2", "", { "dependencies": { "@types/retry": "0.12.0", "retry": "^0.13.1" } }, "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ=="],
 
     "p-timeout": ["p-timeout@6.1.4", "", {}, "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg=="],
-
-    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
 
     "pac-proxy-agent": ["pac-proxy-agent@7.2.0", "", { "dependencies": { "@tootallnate/quickjs-emscripten": "^0.23.0", "agent-base": "^7.1.2", "debug": "^4.3.4", "get-uri": "^6.0.1", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.6", "pac-resolver": "^7.0.1", "socks-proxy-agent": "^8.0.5" } }, "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA=="],
 
@@ -2690,8 +2621,6 @@
     "path-browserify": ["path-browserify@1.0.1", "", {}, "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g=="],
 
     "path-data-parser": ["path-data-parser@0.1.0", "", {}, "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w=="],
-
-    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -2733,8 +2662,6 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
-    "pkg-dir": ["pkg-dir@4.2.0", "", { "dependencies": { "find-up": "^4.0.0" } }, "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ=="],
-
     "pkg-types": ["pkg-types@2.3.0", "", { "dependencies": { "confbox": "^0.2.2", "exsolve": "^1.0.7", "pathe": "^2.0.3" } }, "sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig=="],
 
     "playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
@@ -2768,8 +2695,6 @@
     "prettier": ["prettier@3.8.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg=="],
 
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
-
-    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
 
     "pretty-ms": ["pretty-ms@9.3.0", "", { "dependencies": { "parse-ms": "^4.0.0" } }, "sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ=="],
 
@@ -2825,8 +2750,6 @@
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
-    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
-
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -2841,8 +2764,6 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
-    "recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
-
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 
     "recma-jsx": ["recma-jsx@1.0.1", "", { "dependencies": { "acorn-jsx": "^5.0.0", "estree-util-to-js": "^2.0.0", "recma-parse": "^1.0.0", "recma-stringify": "^1.0.0", "unified": "^11.0.0" }, "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w=="],
@@ -2852,12 +2773,6 @@
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
 
     "redis": ["redis@4.7.1", "", { "dependencies": { "@redis/bloom": "1.2.0", "@redis/client": "1.6.1", "@redis/graph": "1.1.1", "@redis/json": "1.0.7", "@redis/search": "1.2.0", "@redis/time-series": "1.1.0" } }, "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ=="],
-
-    "redis-memory-server": ["redis-memory-server@0.16.0", "", { "dependencies": { "camelcase": "^6.3.0", "cross-spawn": "^7.0.3", "debug": "^4.3.4", "extract-zip": "^2.0.1", "find-cache-dir": "^3.3.2", "find-package-json": "^1.2.0", "get-port": "^5.1.1", "https-proxy-agent": "^7.0.0", "lockfile": "^1.0.4", "rimraf": "^5.0.1", "semver": "^7.5.3", "tar": "^7.5.4", "tmp": "^0.2.1", "uuid": "^8.3.2" }, "bin": { "redis-memory-server": "bin/index.js" } }, "sha512-NumE5HHR5ku8k3hD54xUjBhv2XoKQd/UC8gtlAh3jFKqhH3kSn3C8pB3MBS5K3hj7rhgiJbXu+2Xhm+Mqi+SWQ=="],
-
-    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
-
-    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -2926,8 +2841,6 @@
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
-    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -3133,8 +3046,6 @@
 
     "tapable": ["tapable@2.3.0", "", {}, "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg=="],
 
-    "tar": ["tar@7.5.13", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng=="],
-
     "tar-fs": ["tar-fs@2.1.4", "", { "dependencies": { "chownr": "^1.1.1", "mkdirp-classic": "^0.5.2", "pump": "^3.0.0", "tar-stream": "^2.1.4" } }, "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ=="],
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
@@ -3160,8 +3071,6 @@
     "tldts": ["tldts@7.0.23", "", { "dependencies": { "tldts-core": "^7.0.23" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw=="],
 
     "tldts-core": ["tldts-core@7.0.23", "", {}, "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ=="],
-
-    "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
 
     "to-data-view": ["to-data-view@1.1.0", "", {}, "sha512-1eAdufMg6mwgmlojAx3QeMnzB/BTVp7Tbndi3U7ftcT2zCZadjxkkmLmd97zmaxWi+sgGcgWrokmpEoy0Dn0vQ=="],
 
@@ -3291,7 +3200,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@8.3.2", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="],
+    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
@@ -3302,8 +3211,6 @@
     "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
-
-    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
 
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
@@ -3330,8 +3237,6 @@
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
 
     "webidl-conversions": ["webidl-conversions@4.0.2", "", {}, "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="],
-
-    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "whatwg-url": ["whatwg-url@7.1.0", "", { "dependencies": { "lodash.sortby": "^4.7.0", "tr46": "^1.0.1", "webidl-conversions": "^4.0.2" } }, "sha512-WUu7Rg1DroM7oQvGWfOiAK21n74Gg+T4elXEQYkOhtyLeWiJFoOGLXPKI/9gzIie9CtwVLm8wtw6YJdKyxSjeg=="],
 
@@ -3399,7 +3304,7 @@
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
-    "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -3417,17 +3322,13 @@
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
-    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
     "zod-to-ts": ["zod-to-ts@1.2.0", "", { "peerDependencies": { "typescript": "^4.9.4 || ^5.0.2", "zod": "^3" } }, "sha512-x30XE43V+InwGpvTySRNz9kB7qFU8DlyEy7BsSTCHPH1R0QasMmHWZDCzYm6bVXtj/9NNJAZF3jW8rzFvH5OFA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@anthropic-ai/sandbox-runtime/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@astrojs/sitemap/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
@@ -3463,6 +3364,10 @@
 
     "@better-auth/cli/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "@better-auth/cli/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@better-auth/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -3477,15 +3382,15 @@
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
-
-    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
-
     "@mariozechner/pi-ai/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@mariozechner/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
     "@mariozechner/pi-tui/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@mistralai/mistralai/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
@@ -3515,10 +3420,6 @@
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
-    "@redis/client/yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
-
-    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
-
     "@rollup/plugin-babel/@rollup/pluginutils": ["@rollup/pluginutils@3.1.0", "", { "dependencies": { "@types/estree": "0.0.39", "estree-walker": "^1.0.1", "picomatch": "^2.2.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0" } }, "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg=="],
 
     "@rollup/plugin-babel/rollup": ["rollup@2.79.2", "", { "optionalDependencies": { "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ=="],
@@ -3547,8 +3448,6 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
-
     "@ts-morph/common/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "accepts/mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
@@ -3557,11 +3456,11 @@
 
     "astro/sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
 
-    "astro/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "boxen/camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
+    "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+
+    "better-call/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "boxen/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
@@ -3639,11 +3538,7 @@
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
 
-    "make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
-
-    "mermaid/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
@@ -3659,8 +3554,6 @@
 
     "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
-    "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
-
     "p-retry/retry": ["retry@0.13.1", "", {}, "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
@@ -3674,12 +3567,6 @@
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "postcss-nested/postcss-selector-parser": ["postcss-selector-parser@6.1.2", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg=="],
-
-    "pretty-format/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "pretty-format/ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
-
-    "pretty-format/react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
 
@@ -3705,8 +3592,6 @@
 
     "shadcn/open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
-    "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "sitemap/@types/node": ["@types/node@17.0.45", "", {}, "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw=="],
 
     "socket.io-adapter/ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
@@ -3724,8 +3609,6 @@
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "svgo/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
-
-    "tar-fs/chownr": ["chownr@1.1.4", "", {}, "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="],
 
     "tempy/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
 
@@ -3757,8 +3640,6 @@
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
-    "zod-to-ts/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
     "@aws-crypto/sha1-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
@@ -3780,10 +3661,6 @@
     "@dotenvx/dotenvx/which/isexe": ["isexe@3.1.5", "", {}, "sha512-6B3tLtFqtQS4ekarvLVMZ+X+VlvQekbe4taUkf/rhVO3d/h0M2rfARm/pXLcPEsjjMsFgrFgSrhQIxcSVrBz8w=="],
 
     "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
-
-    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "@pizzapi/ui/motion/framer-motion": ["framer-motion@12.34.3", "", { "dependencies": { "motion-dom": "^12.34.3", "motion-utils": "^12.29.2", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-v81ecyZKYO/DfpTwHivqkxSUBzvceOpoI+wLfgCgoUIKxlFKEXdg0oR9imxwXumT4SFy8vRk9xzJ5l3/Du/55Q=="],
 
@@ -3865,10 +3742,6 @@
 
     "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
-    "hast-util-from-html/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
-    "hast-util-raw/parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
-
     "langium/chevrotain/@chevrotain/cst-dts-gen": ["@chevrotain/cst-dts-gen@11.1.1", "", { "dependencies": { "@chevrotain/gast": "11.1.1", "@chevrotain/types": "11.1.1", "lodash-es": "4.17.23" } }, "sha512-fRHyv6/f542qQqiRGalrfJl/evD39mAvbJLCekPazhiextEatq1Jx1K/i9gSd5NNO0ds03ek0Cbo/4uVKmOBcw=="],
 
     "langium/chevrotain/@chevrotain/gast": ["@chevrotain/gast@11.1.1", "", { "dependencies": { "@chevrotain/types": "11.1.1", "lodash-es": "4.17.23" } }, "sha512-Ko/5vPEYy1vn5CbCjjvnSO4U7GgxyGm+dfUZZJIWTlQFkXkyym0jFYrWEU10hyCjrA7rQtiHtBr0EaZqvHFZvg=="],
@@ -3880,6 +3753,8 @@
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
 
     "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "rimraf/glob/jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "rimraf/glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
@@ -3947,8 +3822,6 @@
 
     "widest-line/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
-    "workbox-build/glob/jackspeak": ["jackspeak@4.2.3", "", { "dependencies": { "@isaacs/cliui": "^9.0.0" } }, "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg=="],
-
     "workbox-build/glob/minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 
     "workbox-build/stringify-object/is-obj": ["is-obj@1.0.1", "", {}, "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg=="],
@@ -3975,14 +3848,22 @@
 
     "filelist/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "rimraf/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
     "rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
-    "workbox-build/glob/jackspeak/@isaacs/cliui": ["@isaacs/cliui@9.0.0", "", {}, "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg=="],
-
     "cli-highlight/yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "rimraf/glob/jackspeak/@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "rimraf/glob/jackspeak/@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
     "rimraf/glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "rimraf/glob/jackspeak/@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "rimraf/glob/jackspeak/@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
   }
 }

--- a/docs/specs/2026-03-22-subagent-tool-cards-design.md
+++ b/docs/specs/2026-03-22-subagent-tool-cards-design.md
@@ -1,0 +1,261 @@
+# Subagent Tool Card Rendering — Design Spec
+
+**Date**: 2026-03-22  
+**Status**: Draft  
+**Branch**: `feat/subagent-tool-cards`
+
+## Problem
+
+When a Claude Code worker's subagent (Task/Agent tool) runs tool calls (bash, read, edit, write), the `SubagentResultCard` in the web UI displays the raw `<tool_call>...<tool_result>...` XML text instead of proper tool cards. Pi subagents have structured tool call data in their `messages` array but it's only rendered as a count line ("→ N tool calls"). Neither session type shows what the subagent actually did.
+
+## Goal
+
+Render subagent tool calls as inline tool cards (bash terminals, file type cards, diff views, etc.) inside the `SubagentResultCard` — identically for both pi and Claude Code sessions. The data format unification happens in the bridge; the UI renders from one shape.
+
+## Architecture
+
+Two layers of change:
+
+1. **Bridge** (`packages/cli/src/runner/`): Parse Claude Code's XML into structured messages matching pi's format
+2. **UI** (`packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx`): Render tool calls from the unified `messages` array using existing tool card renderers
+
+### Data Flow
+
+```
+Claude Code subagent result (raw XML text)
+    ↓
+synthesizeSubagentDetails() in claude-code-bridge.ts
+    ↓  calls parseSubagentToolCalls() from claude-code-ndjson.ts
+    ↓
+SingleResult.messages[] — synthetic partial Message[] (same shape as pi)
+    ↓
+SubagentResultCard → AgentExchange component
+    ↓  extractToolExecutions() pairs tool calls with results
+    ↓
+SubagentToolCallsSection component (must be a React component for hook safety)
+    ↓  calls renderGroupedToolExecution() per pair
+    ↓
+Bash terminals, file cards, diffs, write cards, etc.
+```
+
+**Note on synthetic messages**: Messages produced by the parser are shape-compatible with pi-ai's `Message` types but lack some required fields (`api`, `provider`, `model`, `usage`, `stopReason` on `AssistantMessage`). The UI accesses messages through loose typing (`{ role: string; content: unknown[] }`) and never passes them to pi-ai functions that expect the full type, so this is safe.
+
+## Bridge: XML Parser
+
+### Input Format
+
+Claude Code serializes subagent conversations as text with XML-like tags:
+
+```
+<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "head -20 README.md"}</tool_input> </tool_call> <tool_result>
+# PizzaPi 🍕
+A self-hosted web interface...
+</tool_result>
+
+PizzaPi is a self-hosted web interface and relay server.
+```
+
+Multiple tool calls may appear in sequence, with interleaved assistant text. Consecutive `<tool_call>` blocks before any `<tool_result>` (parallel tool use) are accumulated as content parts in a single `AssistantMessage`, matching pi-ai's convention.
+
+### Parser: `parseSubagentToolCalls(text: string): Message[]`
+
+**Location**: `packages/cli/src/runner/claude-code-ndjson.ts` (pure function, testable)
+
+**Algorithm** (state machine):
+
+The parser uses a simple state machine (`outside` → `in_call` → `in_result` → `outside`) to avoid misinterpreting `<tool_call>` text that appears inside a `<tool_result>` block (e.g., bash output that contains those literal tags).
+
+1. Scan the text for `<tool_call>` markers
+2. If none found, return fallback (single text message — current behavior)
+3. Walk text with state machine:
+   - **State: `outside`** — accumulate text into assistant message content. On `<tool_call>`, flush accumulated text, transition to `in_call`
+   - **State: `in_call`** — extract `<tool_name>` and `<tool_input>` (JSON parse into `Record<string, any>`), create `ToolCall` content part with generated ID (`cc-tc-N`). Consecutive tool calls before any result are grouped as multiple content parts in the same assistant message. On `<tool_result>`, transition to `in_result`
+   - **State: `in_result`** — scan **only** for `</tool_result>` (not `<tool_call>`!). All text within is result content. On `</tool_result>`, create `ToolResultMessage` with matching `toolCallId` and `toolName` from preceding `<tool_call>`, transition to `outside`
+4. Flush any trailing text as a final assistant message
+
+**Output shape**:
+
+```typescript
+[
+  { role: "assistant", content: [
+    { type: "toolCall", id: "cc-tc-0", name: "bash", arguments: { command: "head -20 README.md" } }
+  ], usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { ... } }, stopReason: "toolUse", ... },
+  { role: "toolResult", toolCallId: "cc-tc-0", toolName: "bash", content: [
+    { type: "text", text: "# PizzaPi 🍕\nA self-hosted web..." }
+  ], isError: false, timestamp: 0 },
+  { role: "assistant", content: [
+    { type: "text", text: "PizzaPi is a self-hosted web interface and relay server." }
+  ], usage: { ... }, stopReason: "stop", ... }
+]
+```
+
+**Key type decisions**:
+
+| Field | Value | Rationale |
+|-------|-------|-----------|
+| `id` on ToolCall | `"cc-tc-N"` | Matches pi-ai's `ToolCall` interface which uses `id` (not `toolCallId`). Note: the NDJSON normalizer uses `toolCallId` for top-level messages — `extractToolExecutions()` must check both `id` and `toolCallId` for compatibility (see below). |
+| `arguments` on ToolCall | `Record<string, any>` (parsed object) | UI's `extractToolExecutions()` passes it directly as `toolInput` to `renderGroupedToolExecution()`, which calls `parseToolInputArgs()` expecting an object. Note: the NDJSON normalizer produces `arguments` as a string (`JSON.stringify`), so `extractToolExecutions()` must defensively handle both object and string formats, matching the pattern in `grouping.ts:17–35`. |
+| `toolName` on ToolResultMessage | from `<tool_name>` | XML format doesn't carry tool name in `<tool_result>` — parser threads it from the preceding `<tool_call>` block |
+| `content` on ToolResultMessage | `[{ type: "text", text }]` array | Matches pi-ai's `(TextContent | ImageContent)[]` format, passed directly to `renderGroupedToolExecution` |
+| `isError` on ToolResultMessage | `false` (default) | Claude Code's XML doesn't include an explicit error flag. Parser checks for `<is_error>true</is_error>` if present, otherwise defaults to false. Limitation: bash failures won't be flagged unless Claude Code includes the tag. |
+| Required AssistantMessage fields | Stub values | Populate `usage: { input: 0, output: 0, ... }`, `stopReason: "stop"`, etc. so objects are genuinely shape-compatible with pi-ai's `Message` type, avoiding runtime crashes if accessed. |
+
+**Error handling**:
+- Malformed `<tool_input>` JSON → wrap raw text as `{ raw: text }` in the tool call arguments
+- Missing `</tool_result>` → treat remaining text as the result
+- Nested/recursive tool calls → not expected, handle gracefully (flatten)
+
+### Integration: `synthesizeSubagentDetails()`
+
+**Location**: `packages/cli/src/runner/claude-code-bridge.ts`
+
+Replace the current minimal messages construction:
+
+```typescript
+// Before (current):
+messages: resultText ? [{ role: "assistant", content: [{ type: "text", text: resultText }] }] : []
+
+// After:
+messages: resultText ? parseSubagentToolCalls(resultText) : []
+```
+
+If `parseSubagentToolCalls` finds no tool call tags, it returns the same single-message array as before — backward compatible.
+
+## UI: Inline Tool Cards in SubagentResultCard
+
+### Tool Execution Extraction
+
+New helper function in `SubagentResultCard.tsx`:
+
+```typescript
+interface ToolExecution {
+  toolKey: string;    // unique key for React rendering, e.g. "cc-tc-0"
+  toolName: string;   // from the toolCall content part's `name` field
+  toolInput: unknown; // from the toolCall content part's `arguments` field (parsed object)
+  content: unknown;   // the ToolResultMessage.content array, passed as-is to renderGroupedToolExecution
+  isError: boolean;   // from ToolResultMessage.isError
+}
+
+function extractToolExecutions(messages: Array<{ role: string; content: unknown[] }>): ToolExecution[]
+```
+
+Walks the messages array, pairs `toolCall` blocks (from assistant messages) with `ToolResultMessage` entries matched by ID. Must check **both** `id` and `toolCallId` on ToolCall content parts for cross-format compatibility (pi-ai uses `id`, NDJSON normalizer uses `toolCallId`), matching the defensive pattern in `grouping.ts:691–695`. Must also handle `arguments` as either object or string (pi-native = object, NDJSON normalizer = string). Unmatched tool calls (no result) are included with `content: null`.
+
+**This function works identically for pi and Claude Code subagents** — both produce the same messages shape.
+
+### Rendering Changes in `AgentExchange`
+
+Replace the `ToolCallActivity` count line with inline tool cards:
+
+```tsx
+// Before:
+<ToolCallActivity count={toolCallCount} />
+
+// After:
+{toolExecutions.length > 0 && (
+  <SubagentToolCallsSection executions={toolExecutions} />
+)}
+```
+
+**`SubagentToolCallsSection` must be a React component** (not a helper function) because `renderGroupedToolExecution` creates child components (e.g. `BashToolCard`) that use hooks (`useSessionActions()`). Hooks require a React component render context.
+
+Each call to `renderGroupedToolExecution` passes:
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| `toolKey` | `ToolExecution.toolKey` | |
+| `toolName` | `ToolExecution.toolName` | |
+| `toolInput` | `ToolExecution.toolInput` | Parsed object from `arguments` |
+| `content` | `ToolExecution.content` | `ToolResultMessage.content` array as-is |
+| `isError` | `ToolExecution.isError` | |
+| `isStreaming` | `false` | Subagent is always complete |
+| `thinking` | `undefined` | Not available for subagent tool calls |
+| `thinkingDuration` | `undefined` | |
+| `details` | `undefined` | Leaf tool executions, not nested subagents |
+
+### Collapsible Behavior
+
+`SubagentToolCallsSection` wraps tool cards in a `<details>` element:
+
+- **1 tool call**: auto-open
+- **≥2 tool calls**: collapsed with summary line "N tool calls" (mobile-first — even 2 bash terminals can overflow viewport at 375px width)
+
+### Visual Treatment
+
+Tool cards inside the subagent bubble have subtle visual nesting:
+
+- Slightly reduced spacing (tighter padding via wrapper class)
+- Thin left border or indented container to show these are "nested" operations
+- No kill button (subagent is always complete — `isStreaming: false`)
+
+### Layout
+
+```
+┌──────────────────────────────────────────────┐
+│ 🤖 Subagent: summarizer  [user]     ✅ Done │
+├──────────────────────────────────────────────┤
+│                         ┌────────────────────┤
+│                         │ Read the first 20… ││  ← task bubble
+│                         └────────────────────┤
+│                                              │
+│  ▶ 1 tool call                               │  ← collapsible header
+│  ┌───────────────────────────────────────┐   │
+│  │ $ head -20 .../README.md              │   │  ← bash terminal card
+│  │ ┌─ Output ─────────────────────────┐  │   │
+│  │ │ # PizzaPi 🍕                     │  │   │
+│  │ └──────────────────────────────────┘  │   │
+│  └───────────────────────────────────────┘   │
+│                                              │
+│ ┌────────────────────┐                       │
+│ │ PizzaPi is a self… │                       │  ← response bubble
+│ └────────────────────┘                       │
+├──────────────────────────────────────────────┤
+│ 1 turn · ↑12k · ↓3.2k · $0.02               │
+└──────────────────────────────────────────────┘
+```
+
+### Hook Safety
+
+`renderGroupedToolExecution` calls `useSessionActions()` internally (for the bash kill button). Since subagent results are always complete:
+
+- All tool cards render with `isStreaming: false`
+- The kill button never appears
+- `useSessionActions()` returns safely (it's already in a `SessionActionsContext` from the parent viewer)
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `packages/cli/src/runner/claude-code-ndjson.ts` | Add `parseSubagentToolCalls()` pure function + export |
+| `packages/cli/src/runner/claude-code-ndjson.test.ts` | Tests for XML parsing |
+| `packages/cli/src/runner/claude-code-bridge.ts` | Call `parseSubagentToolCalls()` in `synthesizeSubagentDetails()` |
+| `packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx` | Add `extractToolExecutions()`, add `SubagentToolCallsSection` component, replace `ToolCallActivity` |
+
+## Testing
+
+### Bridge Parser Tests
+
+- Single tool call with result
+- Multiple sequential tool calls
+- Consecutive tool calls before results (parallel tool use — grouped in one assistant message)
+- Interleaved text between tool calls
+- Tool call with no matching result (incomplete/truncated)
+- Malformed JSON in `<tool_input>`
+- No `<tool_call>` tags (fallback to plain text)
+- Empty input
+- Nested tags (graceful handling)
+- Tool result containing JSON text (e.g. read tool output like `{"path": "...", "content": "..."}`)
+
+### UI Rendering
+
+- Manual verification: create a mock `SingleResult` with structured messages, verify tool cards render
+- Extract tool executions from pi-native `SingleResult.messages` (uses `id` field, object `arguments`) — verify pairing works
+- Extract tool executions from Claude Code synthetic messages (uses `id` field from parser) — verify pairing works
+- Existing `SubagentResultCard` rendering paths still work (no regression)
+- Verify bash, read, edit, write tool types all render correctly inside the subagent card
+
+## Out of Scope
+
+- Streaming subagent tool calls (real-time display as subagent runs) — would require event buffering in bridge
+- Capturing subagent usage/token data from Claude Code (not available in current protocol)
+- Rendering tool calls for `spawn_session` child sessions (different mechanism)

--- a/docs/specs/2026-03-22-subagent-tool-cards-plan.md
+++ b/docs/specs/2026-03-22-subagent-tool-cards-plan.md
@@ -1,0 +1,745 @@
+# Subagent Tool Card Rendering — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render subagent tool calls (bash, read, edit, write) as proper inline tool cards inside the SubagentResultCard, for both pi and Claude Code sessions.
+
+**Architecture:** Bridge-side XML parser converts Claude Code's `<tool_call>` XML into structured messages matching pi's format. UI extracts tool call+result pairs from the unified messages array and renders them via the existing `renderGroupedToolExecution` renderer. Two independent work streams: bridge (CLI package) and UI.
+
+**Tech Stack:** TypeScript, Bun test runner, React 19
+
+**Spec:** `docs/specs/2026-03-22-subagent-tool-cards-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility |
+|------|---------------|
+| `packages/cli/src/runner/claude-code-ndjson.ts` | Add `parseSubagentToolCalls()` — pure state-machine XML parser |
+| `packages/cli/src/runner/claude-code-ndjson.test.ts` | Tests for the parser |
+| `packages/cli/src/runner/claude-code-bridge.ts` | Call parser in `synthesizeSubagentDetails()` |
+| `packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx` | Add `extractToolExecutions()` + `SubagentToolCallsSection` component, replace `ToolCallActivity` |
+
+---
+
+## Chunk 1: Bridge — XML Parser
+
+### Task 1: Write `parseSubagentToolCalls` tests
+
+**Files:**
+- Modify: `packages/cli/src/runner/claude-code-ndjson.test.ts` (append new describe block)
+
+- [ ] **Step 1: Extend import and add describe block**
+
+In `claude-code-ndjson.test.ts`, find the existing import at the top (line ~2):
+
+```typescript
+import { translateNdjsonLine, SUBAGENT_TOOL_NAMES } from "./claude-code-ndjson.js";
+```
+
+Extend it to include `parseSubagentToolCalls`:
+
+```typescript
+import { translateNdjsonLine, SUBAGENT_TOOL_NAMES, parseSubagentToolCalls } from "./claude-code-ndjson.js";
+```
+
+Then at the **bottom** of the file, add a new top-level describe block:
+
+```typescript
+describe("parseSubagentToolCalls", () => {
+  // tests go here
+});
+```
+
+- [ ] **Step 2: Write test — no tool_call tags returns fallback**
+
+```typescript
+test("returns single text message when no <tool_call> tags found", () => {
+  const result = parseSubagentToolCalls("Just a plain text response.");
+  expect(result).toHaveLength(1);
+  expect(result[0].role).toBe("assistant");
+  expect(result[0].content).toEqual([{ type: "text", text: "Just a plain text response." }]);
+});
+
+test("returns single text message for empty input", () => {
+  const result = parseSubagentToolCalls("");
+  expect(result).toHaveLength(1);
+  expect(result[0].role).toBe("assistant");
+  expect(result[0].content).toEqual([{ type: "text", text: "" }]);
+});
+```
+
+- [ ] **Step 3: Write test — single tool call with result**
+
+```typescript
+test("parses single tool call with result", () => {
+  const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "ls"}</tool_input> </tool_call> <tool_result>
+file1.ts
+file2.ts
+</tool_result>`;
+
+  const result = parseSubagentToolCalls(input);
+
+  // Should produce: assistant (with toolCall) + toolResult
+  expect(result.length).toBeGreaterThanOrEqual(2);
+
+  const assistant = result.find(m => m.role === "assistant" && Array.isArray(m.content) && m.content.some((c: any) => c.type === "toolCall"));
+  expect(assistant).toBeDefined();
+
+  const toolCall = (assistant!.content as any[]).find((c: any) => c.type === "toolCall");
+  expect(toolCall.name).toBe("bash");
+  expect(toolCall.arguments).toEqual({ command: "ls" });
+  expect(toolCall.id).toMatch(/^cc-tc-/);
+
+  const toolResult = result.find(m => m.role === "toolResult") as any;
+  expect(toolResult).toBeDefined();
+  expect(toolResult.toolCallId).toBe(toolCall.id);
+  expect(toolResult.toolName).toBe("bash");
+  expect(toolResult.isError).toBe(false);
+});
+```
+
+- [ ] **Step 4: Write test — multiple sequential tool calls**
+
+```typescript
+test("parses multiple sequential tool calls", () => {
+  const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "pwd"}</tool_input> </tool_call> <tool_result>/home/user</tool_result>
+
+<tool_call> <tool_name>read</tool_name> <tool_input>{"path": "README.md"}</tool_input> </tool_call> <tool_result>
+# Hello
+</tool_result>`;
+
+  const result = parseSubagentToolCalls(input);
+  const toolResults = result.filter(m => m.role === "toolResult");
+  expect(toolResults).toHaveLength(2);
+
+  expect((toolResults[0] as any).toolName).toBe("bash");
+  expect((toolResults[1] as any).toolName).toBe("read");
+});
+```
+
+- [ ] **Step 5: Write test — interleaved text between tool calls**
+
+```typescript
+test("captures interleaved text between tool calls", () => {
+  const input = `Let me check the files.
+
+<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "ls"}</tool_input> </tool_call> <tool_result>file1.ts</tool_result>
+
+Found the file. Now reading it.
+
+<tool_call> <tool_name>read</tool_name> <tool_input>{"path": "file1.ts"}</tool_input> </tool_call> <tool_result>content</tool_result>
+
+Done reviewing.`;
+
+  const result = parseSubagentToolCalls(input);
+
+  // Should have text messages for the interleaved prose
+  const textMessages = result.filter(m =>
+    m.role === "assistant" && Array.isArray(m.content) &&
+    m.content.some((c: any) => c.type === "text")
+  );
+  expect(textMessages.length).toBeGreaterThanOrEqual(1);
+
+  // Final text should contain "Done reviewing"
+  const lastAssistant = [...result].reverse().find(m => m.role === "assistant");
+  const lastText = (lastAssistant!.content as any[]).find((c: any) => c.type === "text");
+  expect(lastText?.text).toContain("Done reviewing");
+});
+```
+
+- [ ] **Step 6: Write test — tool_call text inside tool_result is not parsed**
+
+```typescript
+test("does not parse <tool_call> inside <tool_result>", () => {
+  const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "cat example.xml"}</tool_input> </tool_call> <tool_result>
+Here is the file:
+<tool_call> <tool_name>fake</tool_name> <tool_input>{"not": "real"}</tool_input> </tool_call>
+</tool_result>`;
+
+  const result = parseSubagentToolCalls(input);
+  const toolResults = result.filter(m => m.role === "toolResult");
+  // Only one real tool call — the fake one inside the result is just text
+  expect(toolResults).toHaveLength(1);
+  expect((toolResults[0] as any).toolName).toBe("bash");
+
+  // The result content should contain the literal <tool_call> text
+  const resultText = (toolResults[0] as any).content[0].text;
+  expect(resultText).toContain("<tool_call>");
+});
+```
+
+- [ ] **Step 7: Write test — malformed JSON in tool_input**
+
+```typescript
+test("handles malformed JSON in tool_input", () => {
+  const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>not valid json</tool_input> </tool_call> <tool_result>output</tool_result>`;
+
+  const result = parseSubagentToolCalls(input);
+  const assistant = result.find(m => m.role === "assistant" && Array.isArray(m.content) && m.content.some((c: any) => c.type === "toolCall"));
+  const toolCall = (assistant!.content as any[]).find((c: any) => c.type === "toolCall");
+  // Should have a fallback — raw text wrapped in an object
+  expect(toolCall.arguments).toEqual({ raw: "not valid json" });
+});
+```
+
+- [ ] **Step 8: Write test — missing closing tool_result tag**
+
+```typescript
+test("handles missing </tool_result> tag", () => {
+  const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "ls"}</tool_input> </tool_call> <tool_result>
+output without closing tag`;
+
+  const result = parseSubagentToolCalls(input);
+  const toolResult = result.find(m => m.role === "toolResult") as any;
+  expect(toolResult).toBeDefined();
+  expect(toolResult.content[0].text).toContain("output without closing tag");
+});
+```
+
+- [ ] **Step 9: Write test — tool result containing JSON text**
+
+```typescript
+test("preserves JSON text in tool result (read tool output)", () => {
+  const input = `<tool_call> <tool_name>read</tool_name> <tool_input>{"path": "data.json"}</tool_input> </tool_call> <tool_result>{"key": "value", "nested": {"a": 1}}</tool_result>`;
+
+  const result = parseSubagentToolCalls(input);
+  const toolResult = result.find(m => m.role === "toolResult") as any;
+  expect(toolResult.content[0].text).toBe('{"key": "value", "nested": {"a": 1}}');
+});
+```
+
+- [ ] **Step 10: Write test — consecutive (parallel) tool calls grouped in one assistant message**
+
+```typescript
+test("groups consecutive tool calls into a single assistant message", () => {
+  const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "pwd"}</tool_input> </tool_call> <tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "whoami"}</tool_input> </tool_call> <tool_result>/home/user</tool_result> <tool_result>jordan</tool_result>`;
+
+  const result = parseSubagentToolCalls(input);
+  // First message should be assistant with TWO toolCall content parts
+  const firstAssistant = result[0] as any;
+  expect(firstAssistant.role).toBe("assistant");
+  const toolCalls = firstAssistant.content.filter((c: any) => c.type === "toolCall");
+  expect(toolCalls).toHaveLength(2);
+  expect(toolCalls[0].name).toBe("bash");
+  expect(toolCalls[1].name).toBe("bash");
+  expect(toolCalls[0].id).not.toBe(toolCalls[1].id);
+});
+```
+
+- [ ] **Step 11: Run tests to verify they all fail (function doesn't exist yet)**
+
+Run: `cd packages/cli && bun test src/runner/claude-code-ndjson.test.ts -t "parseSubagentToolCalls"`
+Expected: All tests FAIL with import/reference error
+
+- [ ] **Step 12: Commit test file**
+
+```bash
+git add packages/cli/src/runner/claude-code-ndjson.test.ts
+git commit -m "test: add parseSubagentToolCalls tests (red phase)"
+```
+
+---
+
+### Task 2: Implement `parseSubagentToolCalls`
+
+**Files:**
+- Modify: `packages/cli/src/runner/claude-code-ndjson.ts` (add function + export)
+
+- [ ] **Step 1: Add the function signature and export**
+
+At the bottom of `packages/cli/src/runner/claude-code-ndjson.ts`, add:
+
+```typescript
+/**
+ * Parse Claude Code's XML-serialized subagent tool calls into structured
+ * Message-compatible objects. Uses a state machine to avoid misinterpreting
+ * <tool_call> text that appears inside <tool_result> blocks.
+ *
+ * Returns an array of synthetic messages matching pi-ai's Message shape:
+ * - AssistantMessage with ToolCall content parts
+ * - ToolResultMessage with content and toolName
+ *
+ * If no <tool_call> tags are found, returns a single assistant text message
+ * (backward-compatible fallback).
+ */
+export function parseSubagentToolCalls(text: string): Record<string, unknown>[] {
+```
+
+- [ ] **Step 2: Implement the fallback check**
+
+```typescript
+  // Quick check: if no tool_call tags, return plain text fallback
+  if (!text.includes("<tool_call>")) {
+    return [makeAssistantMessage([{ type: "text", text }])];
+  }
+```
+
+Add helper at top of function (or as module-level helpers):
+
+```typescript
+const STUB_USAGE = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0, cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 } };
+
+function makeAssistantMessage(content: Record<string, unknown>[], stopReason = "stop"): Record<string, unknown> {
+  return { role: "assistant", content, usage: { ...STUB_USAGE }, stopReason, timestamp: 0 };
+}
+
+function makeToolResultMessage(toolCallId: string, toolName: string, rawContent: string): Record<string, unknown> {
+  const isError = rawContent.includes("<is_error>true</is_error>");
+  const text = rawContent.replace(/<is_error>.*?<\/is_error>/gs, "").trim();
+  return { role: "toolResult", toolCallId, toolName, content: [{ type: "text", text }], isError, timestamp: 0 };
+}
+```
+
+- [ ] **Step 3: Implement the state machine parser**
+
+```typescript
+  const messages: Record<string, unknown>[] = [];
+  let assistantContent: Record<string, unknown>[] = [];
+  let toolCallCounter = 0;
+  let lastToolName = "";
+  let lastToolCallId = "";
+
+  type State = "outside" | "in_call" | "in_result";
+  let state: State = "outside";
+  let pos = 0;
+
+  while (pos < text.length) {
+    if (state === "outside") {
+      const nextCall = text.indexOf("<tool_call>", pos);
+      if (nextCall === -1) {
+        // Rest is plain text
+        const remaining = text.slice(pos).trim();
+        if (remaining) assistantContent.push({ type: "text", text: remaining });
+        break;
+      }
+      // Text before the tool call
+      const before = text.slice(pos, nextCall).trim();
+      if (before) assistantContent.push({ type: "text", text: before });
+      pos = nextCall + "<tool_call>".length;
+      state = "in_call";
+      continue;
+    }
+
+    if (state === "in_call") {
+      const endCall = text.indexOf("</tool_call>", pos);
+      if (endCall === -1) break; // malformed — bail
+
+      const callBody = text.slice(pos, endCall);
+
+      // Extract tool_name
+      const nameMatch = callBody.match(/<tool_name>(.*?)<\/tool_name>/s);
+      const toolName = nameMatch ? nameMatch[1].trim() : "unknown";
+
+      // Extract tool_input
+      const inputMatch = callBody.match(/<tool_input>(.*?)<\/tool_input>/s);
+      const rawInput = inputMatch ? inputMatch[1].trim() : "";
+      let toolInput: Record<string, unknown>;
+      try {
+        toolInput = JSON.parse(rawInput);
+      } catch {
+        toolInput = { raw: rawInput };
+      }
+
+      const toolCallId = `cc-tc-${toolCallCounter++}`;
+      lastToolName = toolName;
+      lastToolCallId = toolCallId;
+
+      assistantContent.push({ type: "toolCall", id: toolCallId, name: toolName, arguments: toolInput });
+
+      pos = endCall + "</tool_call>".length;
+
+      // Look ahead for <tool_result> — skip whitespace
+      const afterClose = text.slice(pos);
+      const resultStart = afterClose.match(/^\s*<tool_result>/);
+      if (resultStart) {
+        // Flush assistant message before entering result
+        if (assistantContent.length > 0) {
+          messages.push(makeAssistantMessage(assistantContent, "toolUse"));
+          assistantContent = [];
+        }
+        pos += resultStart[0].length;
+        state = "in_result";
+      } else {
+        // Another tool_call might follow (parallel), or text
+        const nextCallAhead = afterClose.match(/^\s*<tool_call>/);
+        if (nextCallAhead) {
+          // Stay and accumulate more tool calls in same assistant message
+          pos += nextCallAhead[0].length;
+          state = "in_call";
+        } else {
+          // Flush and go back to outside
+          if (assistantContent.length > 0) {
+            messages.push(makeAssistantMessage(assistantContent, "toolUse"));
+            assistantContent = [];
+          }
+          state = "outside";
+        }
+      }
+      continue;
+    }
+
+    if (state === "in_result") {
+      // Only scan for </tool_result> — NOT <tool_call>
+      const endResult = text.indexOf("</tool_result>", pos);
+      let resultText: string;
+      if (endResult === -1) {
+        // No closing tag — rest of text is the result
+        resultText = text.slice(pos).trim();
+        messages.push(makeToolResultMessage(lastToolCallId, lastToolName, resultText));
+        break;
+      }
+      resultText = text.slice(pos, endResult).trim();
+      messages.push(makeToolResultMessage(lastToolCallId, lastToolName, resultText));
+      pos = endResult + "</tool_result>".length;
+      state = "outside";
+      continue;
+    }
+  }
+
+  // Flush any remaining assistant content
+  if (assistantContent.length > 0) {
+    messages.push(makeAssistantMessage(assistantContent));
+  }
+
+  return messages.length > 0 ? messages : [makeAssistantMessage([{ type: "text", text }])];
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd packages/cli && bun test src/runner/claude-code-ndjson.test.ts -t "parseSubagentToolCalls"`
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit implementation**
+
+```bash
+git add packages/cli/src/runner/claude-code-ndjson.ts
+git commit -m "feat: add parseSubagentToolCalls XML parser"
+```
+
+---
+
+### Task 3: Integrate parser into `synthesizeSubagentDetails`
+
+**Files:**
+- Modify: `packages/cli/src/runner/claude-code-bridge.ts:988–1020` (the `synthesizeSubagentDetails` function)
+
+- [ ] **Step 1: Add import**
+
+At the top of `claude-code-bridge.ts`, find the existing import from `claude-code-ndjson.ts` and add `parseSubagentToolCalls`:
+
+```typescript
+import { translateNdjsonLine, SUBAGENT_TOOL_NAMES, parseSubagentToolCalls } from "./claude-code-ndjson.js";
+```
+
+- [ ] **Step 2: Replace messages construction**
+
+In `synthesizeSubagentDetails()`, find line ~1019:
+
+```typescript
+messages: resultText ? [{ role: "assistant", content: [{ type: "text", text: resultText }] }] : [],
+```
+
+Replace with:
+
+```typescript
+messages: resultText ? parseSubagentToolCalls(resultText) : [],
+```
+
+- [ ] **Step 3: Run existing tests to verify no regression**
+
+Run: `cd packages/cli && bun test src/runner/claude-code-ndjson.test.ts`
+Expected: All existing tests still PASS
+
+- [ ] **Step 4: Run typecheck**
+
+Run: `cd packages/cli && bunx tsc --noEmit`
+Expected: Clean (or only pre-existing errors)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/cli/src/runner/claude-code-bridge.ts
+git commit -m "feat: use parseSubagentToolCalls in synthesizeSubagentDetails"
+```
+
+---
+
+## Chunk 2: UI — Inline Tool Card Rendering
+
+### Task 4: Add `extractToolExecutions` helper
+
+**Files:**
+- Modify: `packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx`
+
+- [ ] **Step 1: Add the ToolExecution interface and extraction function**
+
+Add after the existing `getToolCallCount` function (around line 143):
+
+```typescript
+// ── Tool execution extraction ──────────────────────────────────────────
+
+interface ToolExecution {
+  toolKey: string;
+  toolName: string;
+  toolInput: unknown;
+  content: unknown;
+  isError: boolean;
+}
+
+/**
+ * Extract tool call + result pairs from the subagent's messages array.
+ * Works identically for pi-native messages (id field, object arguments)
+ * and Claude Code synthetic messages (id field from parser).
+ */
+function extractToolExecutions(messages: Array<{ role: string; content: unknown[] }>): ToolExecution[] {
+  const executions: ToolExecution[] = [];
+
+  // First pass: collect all tool calls from assistant messages
+  interface PendingCall { id: string; name: string; input: unknown }
+  const pendingCalls: PendingCall[] = [];
+
+  for (const msg of messages) {
+    if (msg.role === "assistant" && Array.isArray(msg.content)) {
+      for (const part of msg.content) {
+        if (!part || typeof part !== "object") continue;
+        const p = part as Record<string, unknown>;
+        if (p.type !== "toolCall") continue;
+
+        // Defensive: check both id and toolCallId (pi-ai vs NDJSON normalizer)
+        const id = typeof p.toolCallId === "string" ? p.toolCallId
+          : typeof p.id === "string" ? p.id
+          : "";
+        const name = typeof p.name === "string" ? p.name : "unknown";
+
+        // Defensive: handle arguments as object or string
+        let input: unknown = p.arguments;
+        if (typeof input === "string") {
+          try { input = JSON.parse(input); } catch { input = {}; }
+        }
+
+        pendingCalls.push({ id, name, input });
+      }
+    }
+  }
+
+  // Second pass: match tool results to pending calls
+  const matchedIds = new Set<string>();
+
+  for (const msg of messages) {
+    if (msg.role !== "toolResult") continue;
+    const m = msg as Record<string, unknown>;
+    const toolCallId = typeof m.toolCallId === "string" ? m.toolCallId : "";
+
+    // Find matching pending call
+    const matchIdx = pendingCalls.findIndex(c => c.id && c.id === toolCallId && !matchedIds.has(c.id));
+    if (matchIdx < 0) continue;
+
+    const call = pendingCalls[matchIdx];
+    matchedIds.add(call.id);
+
+    executions.push({
+      toolKey: call.id || `tool-${executions.length}`,
+      toolName: typeof m.toolName === "string" ? m.toolName : call.name,
+      toolInput: call.input,
+      content: m.content,
+      isError: m.isError === true,
+    });
+  }
+
+  // Include unmatched calls (no result) — e.g. truncated or still running
+  for (const call of pendingCalls) {
+    if (call.id && matchedIds.has(call.id)) continue;
+    executions.push({
+      toolKey: call.id || `tool-${executions.length}`,
+      toolName: call.name,
+      toolInput: call.input,
+      content: null,
+      isError: false,
+    });
+  }
+
+  return executions;
+}
+```
+
+- [ ] **Step 2: Verify typecheck passes**
+
+Run: `cd packages/ui && bunx tsc --noEmit`
+Expected: Clean
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
+git commit -m "feat: add extractToolExecutions helper to SubagentResultCard"
+```
+
+---
+
+### Task 5: Add `SubagentToolCallsSection` component
+
+**Files:**
+- Modify: `packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx`
+
+- [ ] **Step 1: Add import for renderGroupedToolExecution**
+
+At the top of SubagentResultCard.tsx, add:
+
+```typescript
+import { renderGroupedToolExecution } from "@/components/session-viewer/tool-rendering";
+```
+
+Also add `ChevronDownIcon` to the lucide-react import if not already there.
+
+- [ ] **Step 2: Add the SubagentToolCallsSection component**
+
+Add after `extractToolExecutions`, before `AgentExchange`:
+
+```typescript
+/** Renders inline tool cards for subagent tool calls. Must be a React
+ *  component (not a helper function) because renderGroupedToolExecution
+ *  creates child components that use hooks (useSessionActions). */
+function SubagentToolCallsSection({ executions }: { executions: ToolExecution[] }) {
+  if (executions.length === 0) return null;
+
+  const autoOpen = executions.length === 1;
+
+  return (
+    <details open={autoOpen || undefined} className="group/tools">
+      <summary className="cursor-pointer list-none">
+        <div className="flex items-center gap-1.5 text-[11px] text-zinc-500 px-1 py-0.5 hover:text-zinc-400 transition-colors">
+          <WrenchIcon className="size-3 shrink-0" />
+          <span>{executions.length} tool call{executions.length !== 1 ? "s" : ""}</span>
+          <ChevronDownIcon className="size-3 transition-transform group-open/tools:rotate-180" />
+        </div>
+      </summary>
+      <div className="flex flex-col gap-2 pl-1 border-l-2 border-zinc-800 ml-1.5 mt-1 mb-1">
+        {executions.map((exec) => (
+          <div key={exec.toolKey} className="[&>*]:text-xs">
+            {renderGroupedToolExecution(
+              exec.toolKey,
+              exec.toolName,
+              exec.toolInput,
+              exec.content,
+              exec.isError,
+              false,       // isStreaming — always false for completed subagents
+              undefined,   // thinking
+              undefined,   // thinkingDuration
+              undefined,   // details
+            )}
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+```
+
+- [ ] **Step 3: Verify typecheck passes**
+
+Run: `cd packages/ui && bunx tsc --noEmit`
+Expected: Clean
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
+git commit -m "feat: add SubagentToolCallsSection component"
+```
+
+---
+
+### Task 6: Wire up `SubagentToolCallsSection` in `AgentExchange`
+
+**Files:**
+- Modify: `packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx` (the `AgentExchange` component, ~line 280)
+
+- [ ] **Step 1: Replace ToolCallActivity with SubagentToolCallsSection**
+
+In the `AgentExchange` component, find:
+
+```tsx
+  const finalOutput = getFinalOutput(result.messages);
+  const toolCallCount = getToolCallCount(result.messages);
+```
+
+Replace with:
+
+```tsx
+  const finalOutput = getFinalOutput(result.messages);
+  const toolExecutions = extractToolExecutions(result.messages);
+```
+
+Then find:
+
+```tsx
+      {/* Tool call activity */}
+      <ToolCallActivity count={toolCallCount} />
+```
+
+Replace with:
+
+```tsx
+      {/* Inline tool cards */}
+      <SubagentToolCallsSection executions={toolExecutions} />
+```
+
+- [ ] **Step 2: Remove dead code**
+
+Delete the now-unused `getToolCallCount` function (~line 131) and the `ToolCallActivity` component (~line 253). Both are unreferenced after this change.
+
+- [ ] **Step 3: Verify typecheck passes**
+
+Run: `cd packages/ui && bunx tsc --noEmit`
+Expected: Clean
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
+git commit -m "feat: replace ToolCallActivity count with inline tool cards"
+```
+
+---
+
+### Task 7: Build and verify
+
+**Files:** All modified files
+
+- [ ] **Step 1: Run full typecheck**
+
+Run: `bun run typecheck`
+Expected: Clean
+
+- [ ] **Step 2: Run all tests**
+
+Run: `bun run test`
+Expected: All pass
+
+- [ ] **Step 3: Build everything**
+
+Run: `bun run build`
+Expected: Clean build
+
+- [ ] **Step 4: Final commit and push**
+
+```bash
+git add -A
+git status  # verify only expected files changed
+git push -u origin feat/subagent-tool-cards
+```
+
+---
+
+## Task Dependency Graph
+
+```
+Task 1 (parser tests) → Task 2 (parser implementation) → Task 3 (bridge integration)
+                                                                ↓
+Task 4 (extractToolExecutions) → Task 5 (SubagentToolCallsSection) → Task 6 (wire up) → Task 7 (build & verify)
+```
+
+Tasks 1–3 (bridge) and Tasks 4–5 (UI) can be parallelized if using subagent-driven development. Task 6 depends on both tracks. Task 7 is the final integration check.

--- a/packages/cli/build-binaries.ts
+++ b/packages/cli/build-binaries.ts
@@ -84,6 +84,26 @@ function copyAssets(piPkgDir: string, outDir: string): void {
     if (existsSync(templatesSrc)) {
         cpSync(templatesSrc, join(outDir, "templates"), { recursive: true });
     }
+
+    const cliDist = join(import.meta.dirname, "dist");
+    const runnerDist = join(cliDist, "runner");
+    const runnerSrc = join(import.meta.dirname, "src", "runner");
+    const runnerSource = existsSync(runnerDist) ? runnerDist : runnerSrc;
+    if (existsSync(runnerSource)) {
+        cpSync(runnerSource, join(outDir, "runner"), { recursive: true });
+    }
+
+    // Always copy static assets from src first, then overlay compiled scripts
+    // from dist if present. Using dist-only would miss static files (plugin.json,
+    // skill markdown, etc.) that are never compiled into dist.
+    const pluginDist = join(cliDist, "claude-code-plugin");
+    const pluginSrc = join(import.meta.dirname, "src", "claude-code-plugin");
+    if (existsSync(pluginSrc)) {
+        cpSync(pluginSrc, join(outDir, "claude-code-plugin"), { recursive: true });
+    }
+    if (existsSync(pluginDist)) {
+        cpSync(pluginDist, join(outDir, "claude-code-plugin"), { recursive: true });
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -295,7 +315,7 @@ for (const target of targets) {
     copyAssets(piPkgDir, outDir);
     console.log(`  ✓ Assets copied`);
 
-    if (copyPtyLib(target, outDir)) {
+    if (await copyPtyLib(target, outDir)) {
         console.log(`  ✓ PTY native library copied (${target.ptyLibName})`);
     } else {
         console.log(`  ⚠ PTY native library not available for ${target.ptyOs}-${target.ptyCpu} (cross-compile — must be added separately)`);

--- a/packages/cli/build-binaries.ts
+++ b/packages/cli/build-binaries.ts
@@ -17,6 +17,7 @@ import { $ } from "bun";
 import { join, dirname } from "path";
 import { existsSync, mkdirSync, cpSync, readdirSync, readFileSync, rmSync } from "fs";
 import { platform as osPlatform, arch as osArch } from "os";
+import { fileURLToPath } from "url";
 
 // ---------------------------------------------------------------------------
 // Platform targets
@@ -49,7 +50,7 @@ const ALL_TARGETS: Target[] = [
 function resolvePiPackageDir(): string {
     // import.meta.resolve gives us the main entry point URL; walk up to find package.json
     const entryUrl = import.meta.resolve("@mariozechner/pi-coding-agent");
-    let dir = dirname(new URL(entryUrl).pathname);
+    let dir = dirname(fileURLToPath(new URL(entryUrl).href));
     while (dir !== dirname(dir)) {
         if (existsSync(join(dir, "package.json"))) {
             return dir;
@@ -118,7 +119,7 @@ function resolvePtyVersion(): string | null {
     // Try import.meta.resolve on the parent @zenyr/bun-pty package
     try {
         const entryUrl = import.meta.resolve("@zenyr/bun-pty");
-        let dir = dirname(new URL(entryUrl).pathname);
+        let dir = dirname(fileURLToPath(new URL(entryUrl).href));
         while (dir !== dirname(dir)) {
             const pkgPath = join(dir, "package.json");
             if (existsSync(pkgPath)) {
@@ -189,7 +190,17 @@ async function downloadPtyLib(target: Target, outDir: string): Promise<boolean> 
         const tgzPath = join(tmpDir, `${pkgName}.tgz`);
         await Bun.write(tgzPath, tarResp);
 
-        // Extract the tarball
+        // Extract the tarball — require tar to be present (not available on all Windows
+        // or minimal CI environments; fail early with a clear message rather than silently
+        // returning false and leaving the PTY library missing)
+        const tarCheck = await $`tar --version`.nothrow().quiet();
+        if (tarCheck.exitCode !== 0) {
+            throw new Error(
+                "'tar' is not available on this system. " +
+                "On Windows, install Git for Windows or Windows Subsystem for Linux (which includes tar). " +
+                "On minimal Linux/CI environments, install the 'tar' package (e.g. apt-get install tar)."
+            );
+        }
         const result = await $`tar xzf ${tgzPath} -C ${tmpDir}`.nothrow().quiet();
         if (result.exitCode !== 0) {
             console.log(`    ✗ Failed to extract tarball`);
@@ -230,7 +241,7 @@ async function copyPtyLib(target: Target, outDir: string): Promise<boolean> {
     // installed for this host — i.e. target matches the build machine)
     try {
         const entryUrl = import.meta.resolve(ptyPlatformPkg);
-        const pkgDir = dirname(new URL(entryUrl).pathname);
+        const pkgDir = dirname(fileURLToPath(new URL(entryUrl).href));
         const libSrc = join(pkgDir, target.ptyLibName);
         if (existsSync(libSrc)) {
             cpSync(libSrc, join(outDir, target.ptyLibName));

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.9",
-    "typescript": "^5.7.0"
+    "typescript": "^5.7.0",
+    "zod": "^3.25"
   }
 }

--- a/packages/cli/src/claude-code-plugin/.claude-plugin/plugin.json
+++ b/packages/cli/src/claude-code-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,5 @@
+{
+  "name": "pizzapi",
+  "version": "1.0.0",
+  "description": "PizzaPi integration — inter-session tools, session management"
+}

--- a/packages/cli/src/claude-code-plugin/scripts/hook-handler.ts
+++ b/packages/cli/src/claude-code-plugin/scripts/hook-handler.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env bun
+/**
+ * PizzaPi Claude Code hook handler.
+ * Invoked by Claude Code for each lifecycle event.
+ * Forwards events to the bridge via Unix IPC socket.
+ * IPC socket path is passed as --ipc <path> in argv.
+ *
+ * Usage: bun hook-handler.ts --ipc /path/to/bridge.sock
+ *
+ * For PermissionRequest events this script does NOT handle them —
+ * --permission-prompt-tool stdio handles those on stdin/stdout.
+ * This script handles: SessionStart, SessionEnd, PostToolUse,
+ * PostToolUseFailure, Stop, SubagentStart, SubagentStop,
+ * Notification, UserPromptSubmit, PreCompact.
+ */
+
+import { createConnection } from "node:net";
+import { serializeFrame, type PluginMessage } from "../../runner/claude-code-ipc.js";
+
+const args = process.argv.slice(2);
+const ipcIdx = args.indexOf("--ipc");
+const ipcPath = ipcIdx !== -1 ? args[ipcIdx + 1] : process.env.PIZZAPI_CC_BRIDGE_IPC;
+
+if (!ipcPath) {
+  process.exit(0); // no IPC path — fail gracefully
+}
+
+// Read hook input from stdin
+let stdinData = "";
+process.stdin.setEncoding("utf8");
+for await (const chunk of process.stdin) {
+  stdinData += chunk;
+}
+
+let hookInput: Record<string, unknown>;
+try {
+  hookInput = JSON.parse(stdinData);
+} catch {
+  process.exit(0);
+}
+
+const eventType = hookInput.hook_event_name as string | undefined;
+if (!eventType) process.exit(0);
+
+// Events we care about — everything else exits silently
+const FORWARDED_EVENTS = new Set([
+  "SessionStart", "SessionEnd", "PostToolUse", "PostToolUseFailure",
+  "Stop", "SubagentStart", "SubagentStop", "Notification",
+  "UserPromptSubmit", "PreCompact",
+]);
+
+if (!FORWARDED_EVENTS.has(eventType)) process.exit(0);
+
+const sessionId = hookInput.session_id as string | undefined ?? "unknown";
+const msg: PluginMessage = {
+  type: "hook_event",
+  event: eventType,
+  sessionId,
+  data: hookInput,
+};
+
+// Connect to bridge IPC, send message, and exit
+const socket = createConnection(ipcPath);
+
+await new Promise<void>((resolve) => {
+  socket.on("connect", () => {
+    socket.write(serializeFrame(msg), () => {
+      socket.end();
+      resolve();
+    });
+  });
+  socket.on("error", () => resolve()); // bridge not up yet — fail gracefully
+});
+
+process.exit(0);

--- a/packages/cli/src/claude-code-plugin/scripts/mcp-server.ts
+++ b/packages/cli/src/claude-code-plugin/scripts/mcp-server.ts
@@ -1,0 +1,283 @@
+#!/usr/bin/env bun
+/**
+ * PizzaPi MCP server — provides inter-session tools to Claude Code sessions.
+ * Runs as a stdio MCP server; Claude Code spawns it from the generated mcp.json.
+ * Forwards all tool calls to the bridge via Unix IPC socket.
+ *
+ * NOTE: We register tools via the low-level Server API to avoid TS2589
+ * "excessively deep type instantiation" from the McpServer + Zod generics.
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { createConnection } from "node:net";
+import { randomUUID } from "node:crypto";
+import {
+  serializeFrame,
+  framesFromBuffer,
+  type PluginMessage,
+  type BridgeMessage,
+} from "../../runner/claude-code-ipc.js";
+
+const ipcPath = process.env.PIZZAPI_CC_BRIDGE_IPC;
+const sessionId = process.env.PIZZAPI_SESSION_ID ?? "unknown";
+
+if (!ipcPath) {
+  console.error("[pizzapi-mcp] PIZZAPI_CC_BRIDGE_IPC not set — exiting");
+  process.exit(1);
+}
+
+// ── IPC helpers ─────────────────────────────────────────────────────────
+
+const IPC_TIMEOUT_GRACE_MS = 250;
+
+async function callBridge(
+  tool: string,
+  args: unknown,
+  timeoutMs = 25_000,
+): Promise<unknown> {
+  const requestId = randomUUID();
+  return new Promise((resolve, reject) => {
+    const socket = createConnection(ipcPath!);
+    let buf: Buffer = Buffer.alloc(0);
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      socket.destroy();
+      reject(new Error(`Bridge IPC timeout for tool ${tool}`));
+    }, timeoutMs + IPC_TIMEOUT_GRACE_MS);
+
+    socket.on("connect", () => {
+      const msg: PluginMessage = {
+        type: "mcp_call",
+        tool,
+        args,
+        requestId,
+      };
+      socket.write(serializeFrame(msg));
+    });
+
+    socket.on("data", (chunk: Buffer) => {
+      buf = Buffer.concat([buf, chunk]);
+      const parsed = framesFromBuffer(buf);
+      buf = parsed.remaining;
+      for (const frame of parsed.frames) {
+        const f = frame as BridgeMessage;
+        if (f.type === "mcp_response" && f.requestId === requestId) {
+          settled = true;
+          clearTimeout(timer);
+          socket.destroy();
+          if (f.error) reject(new Error(f.error));
+          else resolve(f.result);
+        }
+      }
+    });
+
+    socket.on("error", (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+
+    socket.on("close", () => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(new Error(`Bridge IPC closed before responding to tool ${tool}`));
+    });
+  });
+}
+
+// ── Tool definitions ────────────────────────────────────────────────────
+
+interface ToolDef {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+const TOOLS: ToolDef[] = [
+  {
+    name: "set_session_name",
+    description:
+      "Set a short display name for this session. Call this exactly once at the start of your first response with a 3–6 word summary of the user's request.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        name: { type: "string", description: "A 3–6 word summary of the session topic" },
+      },
+      required: ["name"],
+    },
+  },
+  {
+    name: "pizzapi_get_session_id",
+    description: "Get this session's PizzaPi session ID.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "pizzapi_list_models",
+    description: "List models available on the runner.",
+    inputSchema: { type: "object", properties: {} },
+  },
+  {
+    name: "pizzapi_spawn_session",
+    description:
+      "Spawn a new agent session on the PizzaPi runner. Returns { sessionId, shareUrl }.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        prompt: { type: "string", description: "The initial prompt for the new session" },
+        model: {
+          type: "object",
+          description: "Model to use for the spawned session",
+          properties: {
+            provider: { type: "string", description: "Model provider (e.g. 'anthropic')" },
+            id: { type: "string", description: "Model ID (e.g. 'claude-sonnet-4-20250514')" },
+          },
+          required: ["provider", "id"],
+        },
+        cwd: { type: "string", description: "Working directory for the session" },
+        linked: { type: "boolean", description: "Whether to link as a child session (default true)" },
+        runnerId: { type: "string", description: "Target runner ID (defaults to current runner)" },
+      },
+      required: ["prompt"],
+    },
+  },
+  {
+    name: "pizzapi_send_message",
+    description: "Send a message to another agent session.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: { type: "string", description: "Target session ID" },
+        message: { type: "string", description: "Message content" },
+      },
+      required: ["sessionId", "message"],
+    },
+  },
+  {
+    name: "pizzapi_wait_for_message",
+    description: "Wait for a message from another session (max 25s).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        fromSessionId: { type: "string", description: "Session ID to wait for a message from" },
+        timeout: { type: "number", description: "Timeout in ms (default 20000, max 25000)" },
+      },
+    },
+  },
+  {
+    name: "pizzapi_check_messages",
+    description: "Non-blocking check for pending messages from another session.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        fromSessionId: { type: "string", description: "Optional session ID filter" },
+      },
+    },
+  },
+  {
+    name: "pizzapi_respond_to_trigger",
+    description: "Respond to a trigger from a child session.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        triggerId: { type: "string", description: "The trigger ID to respond to" },
+        response: { type: "string", description: "Response text" },
+        action: { type: "string", description: 'Action: "ack" or "followUp" (default "ack")' },
+      },
+      required: ["triggerId", "response"],
+    },
+  },
+  {
+    name: "pizzapi_tell_child",
+    description: "Send a message to a linked child session.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        sessionId: { type: "string", description: "Child session ID" },
+        message: { type: "string", description: "Message to send" },
+      },
+      required: ["sessionId", "message"],
+    },
+  },
+  {
+    name: "pizzapi_escalate_trigger",
+    description: "Escalate a trigger to the human viewer.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        triggerId: { type: "string", description: "The trigger ID to escalate" },
+        context: { type: "string", description: "Additional context for the viewer" },
+      },
+      required: ["triggerId"],
+    },
+  },
+];
+
+// ── Server setup ────────────────────────────────────────────────────────
+
+const server = new Server(
+  { name: "pizzapi", version: "1.0.0" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: TOOLS.map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+  })),
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args = {} } = request.params;
+
+  // Local-only tool — no bridge call needed
+  if (name === "pizzapi_get_session_id") {
+    return {
+      content: [{ type: "text" as const, text: sessionId }],
+    };
+  }
+
+  // Validate tool name
+  if (!TOOLS.find((t) => t.name === name)) {
+    return {
+      content: [{ type: "text" as const, text: `Error: unknown tool ${name}` }],
+      isError: true,
+    };
+  }
+
+  // Forward to bridge
+  try {
+    const result = await callBridge(name, args);
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: typeof result === "string" ? result : JSON.stringify(result),
+        },
+      ],
+    };
+  } catch (err) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Error: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      ],
+      isError: true,
+    };
+  }
+});
+
+// ── Start ─────────────────────────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/cli/src/claude-code-plugin/scripts/mcp-server.ts
+++ b/packages/cli/src/claude-code-plugin/scripts/mcp-server.ts
@@ -144,6 +144,7 @@ const TOOLS: ToolDef[] = [
         cwd: { type: "string", description: "Working directory for the session" },
         linked: { type: "boolean", description: "Whether to link as a child session (default true)" },
         runnerId: { type: "string", description: "Target runner ID (defaults to current runner)" },
+        workerType: { type: "string", enum: ["pi", "claude-code"], description: "Worker type for the spawned session (default 'claude-code')" },
       },
       required: ["prompt"],
     },

--- a/packages/cli/src/claude-code-plugin/skills/pizzapi-tools/SKILL.md
+++ b/packages/cli/src/claude-code-plugin/skills/pizzapi-tools/SKILL.md
@@ -1,0 +1,20 @@
+# PizzaPi Tools
+
+These tools are available in this session via the `pizzapi` MCP server.
+
+## Inter-Session Communication
+
+- **`pizzapi_spawn_session`** — Spawn a child session on the PizzaPi runner. Returns `{ sessionId, shareUrl }`. Spawned sessions are automatically linked as children (triggers flow back to this session).
+- **`pizzapi_send_message`** / **`pizzapi_wait_for_message`** / **`pizzapi_check_messages`** — Async messaging between sessions. `wait_for_message` blocks up to 20s; call in a loop for longer waits.
+- **`pizzapi_get_session_id`** — Returns this session's stable ID (for use in `send_message` calls from other sessions).
+
+## Trigger System
+
+When a child session completes, a `session_complete` trigger arrives as a user message. Use:
+- **`pizzapi_respond_to_trigger`** — Reply to a pending trigger with `action: "ack"` or `action: "followUp"`.
+- **`pizzapi_tell_child`** — Proactively send instructions to a running child.
+- **`pizzapi_escalate_trigger`** — Forward a trigger to the human viewer.
+
+## Session Info
+
+- **`pizzapi_list_models`** — List models configured on this runner.

--- a/packages/cli/src/config/system-prompt.ts
+++ b/packages/cli/src/config/system-prompt.ts
@@ -1,6 +1,16 @@
 import { ASK_USER_QUESTION_PROMPT_FRAGMENT } from "../prompts/ask-user-question.js";
 
 /**
+ * Instruction fragment for session naming.
+ *
+ * Tells the agent to call `set_session_name` once at the start of its first
+ * response. Used by Pi sessions (injected via Pi TUI) and explicitly passed
+ * to Claude Code sessions via `--append-system-prompt`.
+ */
+export const SET_SESSION_NAME_PROMPT =
+    "At the start of your FIRST response only, call the `set_session_name` tool with a 3–6 word summary of the user's request. Do NOT output the session name as text in your response.";
+
+/**
  * Built-in system prompt additions — always appended by the CLI.
  * User config `appendSystemPrompt` is concatenated after this.
  */

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -55,6 +55,25 @@ async function main() {
         return;
     }
 
+    // `_claude_code_bridge` / `_claude_code_hook_handler` /
+    // `_claude_code_mcp_server` → internal entrypoints used by compiled
+    // binaries so Claude Code sidecars can run without requiring a separate
+    // system Bun/Node runtime on PATH.
+    if (args[0] === "_claude_code_bridge") {
+        await import("./runner/claude-code-bridge.js");
+        return;
+    }
+
+    if (args[0] === "_claude_code_hook_handler") {
+        await import("./claude-code-plugin/scripts/hook-handler.js");
+        return;
+    }
+
+    if (args[0] === "_claude_code_mcp_server") {
+        await import("./claude-code-plugin/scripts/mcp-server.js");
+        return;
+    }
+
     // `_terminal-worker` → internal entrypoint for terminal PTY workers
     //   inside compiled binaries. Not intended to be called directly.
     if (args[0] === "_terminal-worker") {

--- a/packages/cli/src/plugins-cli.test.ts
+++ b/packages/cli/src/plugins-cli.test.ts
@@ -1,4 +1,7 @@
-import { describe, test, expect, afterAll } from "bun:test";
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import {
     getTrustedPlugins,
     isPluginTrusted,
@@ -10,13 +13,33 @@ import {
  * Tests for the plugin trust config helpers.
  *
  * These use unique path names to avoid collisions with any real trusted
- * plugins. All test paths are cleaned up in afterAll.
- *
- * NOTE: Bun caches homedir() from process start, so overriding
- * process.env.HOME doesn't change where config is written. These
- * tests write to the real ~/.pizzapi/config.json but only touch the
- * trustedPlugins array with unique test paths that are removed after.
+ * plugins. The real ~/.pizzapi/config.json is snapshotted before tests
+ * and unconditionally restored after, so even a crash mid-test cannot
+ * corrupt the user's config.
  */
+
+const CONFIG_PATH = join(homedir(), ".pizzapi", "config.json");
+let configSnapshot: string | null = null;
+
+beforeAll(() => {
+    // Snapshot the real config so we can restore it no matter what
+    try {
+        configSnapshot = existsSync(CONFIG_PATH) ? readFileSync(CONFIG_PATH, "utf-8") : null;
+    } catch {
+        configSnapshot = null;
+    }
+});
+
+afterAll(() => {
+    // Unconditionally restore the original config — this runs even if tests crash
+    try {
+        if (configSnapshot !== null) {
+            writeFileSync(CONFIG_PATH, configSnapshot, "utf-8");
+        }
+    } catch {
+        // Best-effort restore
+    }
+});
 
 const TEST_PREFIX = "/tmp/__plugins-cli-test__";
 const testPaths: string[] = [];
@@ -26,13 +49,6 @@ function testPath(suffix: string): string {
     testPaths.push(p);
     return p;
 }
-
-afterAll(() => {
-    // Clean up any test paths that were trusted
-    for (const p of testPaths) {
-        untrustPlugin(p);
-    }
-});
 
 describe("plugin trust config helpers", () => {
     test("isPluginTrusted returns false for unknown plugin", () => {

--- a/packages/cli/src/runner/CLAUDE_CODE_PROTOCOL.md
+++ b/packages/cli/src/runner/CLAUDE_CODE_PROTOCOL.md
@@ -1,0 +1,1356 @@
+# Claude Code WebSocket SDK Protocol — Reverse Engineered
+
+> **Reverse-engineered from Claude Code CLI v2.1.37 (`cli.js`) and Agent SDK v0.2.37 (`sdk.mjs`, `sdk.d.ts`)**
+>
+> This document describes the undocumented WebSocket protocol that Claude Code CLI uses for programmatic control via the `--sdk-url` flag. This is the same NDJSON protocol used over stdin/stdout, but transported over WebSocket — enabling full bidirectional control without tmux or PTY hacks.
+
+---
+
+## Table of Contents
+
+1. [Overview](#1-overview)
+2. [Launching Claude Code in WebSocket Mode](#2-launching-claude-code-in-websocket-mode)
+3. [Transport Architecture](#3-transport-architecture)
+4. [Connection Lifecycle](#4-connection-lifecycle)
+5. [Wire Protocol (NDJSON)](#5-wire-protocol-ndjson)
+6. [Message Types — Complete Reference](#6-message-types--complete-reference)
+7. [Control Protocol (13 Subtypes)](#7-control-protocol-13-subtypes)
+8. [Permission / Tool Approval Flow](#8-permission--tool-approval-flow)
+9. [Session Management](#9-session-management)
+10. [Reconnection & Resilience](#10-reconnection--resilience)
+11. [Environment Variables](#11-environment-variables)
+12. [Transport Class Hierarchy](#12-transport-class-hierarchy)
+13. [Implementation Guide](#13-implementation-guide)
+
+---
+
+## 1. Overview
+
+Claude Code CLI has a **hidden** `--sdk-url <ws-url>` flag (`.hideHelp()` in Commander) that makes the CLI act as a **WebSocket client**, connecting to a server you control. The protocol is **NDJSON** (newline-delimited JSON) — the same format used over stdin/stdout by the official `@anthropic-ai/claude-agent-sdk`.
+
+### Why This Matters
+
+- **No SDK dependency**: The `--sdk-url` flag is baked into the CLI binary itself
+- **Uses your Claude Code subscription**: No API billing, uses your existing plan
+- **Full programmatic control**: Send prompts, approve/deny permissions, interrupt execution
+- **Replaces tmux hacks**: Clean WebSocket channel instead of PTY automation
+- **Same protocol as Claude Code Web**: The web UI uses the same NDJSON-over-WebSocket approach
+
+### Key Characteristics
+
+| Property | Value |
+|----------|-------|
+| Transport | WebSocket (`ws://` or `wss://`) |
+| Protocol | NDJSON (one JSON object per `\n`-terminated line) |
+| Direction | CLI connects TO your server (CLI = client) |
+| Auth | `Authorization: Bearer <token>` header on upgrade |
+| First message | Server sends `user` message, CLI responds with `system/init` |
+| Keepalive | `keep_alive` messages + WebSocket ping/pong every 10s |
+
+---
+
+## 2. Launching Claude Code in WebSocket Mode
+
+### Basic Command
+
+```bash
+claude --sdk-url ws://localhost:8765 \
+       --print \
+       --output-format stream-json \
+       --input-format stream-json \
+       --verbose \
+       -p "placeholder"
+```
+
+### Required Flags
+
+| Flag | Required | Purpose |
+|------|----------|---------|
+| `--sdk-url <url>` | Yes | WebSocket URL to connect to |
+| `--print` (`-p`) | Yes | Enables headless/non-interactive mode |
+| `--output-format stream-json` | Yes | NDJSON output (validated by CLI) |
+| `--input-format stream-json` | Yes | NDJSON input (validated by CLI) |
+
+### Useful Optional Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--verbose` | Include `stream_event` messages (token-by-token streaming) |
+| `--model <model>` | Override model (e.g., `claude-opus-4-6`) |
+| `--permission-mode <mode>` | Set initial permission mode |
+| `--allowedTools <tools>` | Auto-approve specific tools |
+| `--resume <session-id>` | Resume a previous session |
+| `--continue` | Continue the most recent session |
+| `--max-turns <n>` | Limit conversation turns |
+
+### Notes
+
+- The `-p "placeholder"` prompt argument is **ignored** when `--sdk-url` is used — the CLI waits for a `user` message over WebSocket instead
+- Both `--input-format` and `--output-format` must be `stream-json` (CLI exits with error otherwise)
+- The CLI will wait indefinitely for the first `user` message after connecting
+
+---
+
+## 3. Transport Architecture
+
+Six transport classes were deobfuscated from the minified CLI:
+
+```
+                           ┌─────────────────────┐
+                           │  ad1 (ProcessInput)  │  Base: NDJSON parser + control request/response
+                           │  - read() generator  │
+                           │  - sendRequest()     │
+                           │  - createCanUseTool() │
+                           └──────────┬──────────┘
+                                      │ extends
+                           ┌──────────▼──────────┐
+                           │  LQA (SdkUrl)        │  --sdk-url mode  ← OUR TARGET
+                           │  - PassThrough bridge │
+                           │  - transport delegate │
+                           └──────────┬──────────┘
+                                      │ uses
+                    ┌─────────────────┼─────────────────┐
+                    │                                     │
+          ┌─────────▼─────────┐              ┌───────────▼───────────┐
+          │  sd1 (WebSocket)   │              │  kQA (Hybrid)          │
+          │  - WS send+receive │              │  extends sd1           │
+          │  - reconnect logic │              │  - WS receive only     │
+          │  - message buffer  │              │  - HTTP POST for send  │
+          │  - ping/pong       │              │  - retry with backoff  │
+          └────────────────────┘              └────────────────────────┘
+
+  Web UI / Remote Sessions:
+          ┌────────────────────┐         ┌─────────────────────────┐
+          │  MFA (SessionsWS)  │◄────────│  WFA (RemoteSessionMgr) │
+          │  - Subscribe WS    │         │  - Permission routing   │
+          │  - API auth        │         │  - HTTP POST for send   │
+          └────────────────────┘         └─────────────────────────┘
+
+  Direct Connect (Browser):
+          ┌────────────────────┐
+          │  fFA (DirectConnect)│  Simplified WS for browser use
+          │  - sendMessage()   │
+          │  - respondToPermit │
+          │  - sendInterrupt() │
+          └────────────────────┘
+```
+
+### Transport Selection Logic
+
+```typescript
+function createTransport(url: URL, headers?: Record<string, string>, sessionId?: string) {
+  if (url.protocol === "ws:" || url.protocol === "wss:") {
+    if (process.env.CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2) {
+      return new HybridTransport(url, headers, sessionId);  // WS receive + HTTP POST send
+    }
+    return new WebSocketTransport(url, headers, sessionId);  // Pure WebSocket
+  }
+  throw Error(`Unsupported protocol: ${url.protocol}`);
+}
+```
+
+---
+
+## 4. Connection Lifecycle
+
+### Sequence Diagram
+
+```
+  Your Server (WS)                          Claude Code CLI
+       │                                         │
+       │◄──────── WebSocket CONNECT ──────────────│  (with Auth header)
+       │                                         │
+       │                                         │──► system/init message
+       │◄──────── {"type":"system","subtype":"init",...} ──│
+       │                                         │
+       │──── {"type":"user","message":{...}} ────►│  (you send first prompt)
+       │                                         │
+       │                                         │──► LLM processing...
+       │                                         │
+       │◄──── {"type":"stream_event",...} ────────│  (if --verbose)
+       │◄──── {"type":"stream_event",...} ────────│
+       │◄──── {"type":"assistant",...} ───────────│  (full response)
+       │                                         │
+       │  (if tool needs permission)              │
+       │◄──── {"type":"control_request",          │
+       │       "request":{"subtype":"can_use_tool"│
+       │       ,"tool_name":"Bash",...}} ─────────│
+       │                                         │
+       │──── {"type":"control_response",          │  (you approve/deny)
+       │      "response":{"subtype":"success",    │
+       │      "request_id":"...","response":      │
+       │      {"behavior":"allow",...}}} ─────────►│
+       │                                         │
+       │◄──── {"type":"assistant",...} ───────────│  (continues after approval)
+       │◄──── {"type":"result",...} ──────────────│  (query complete)
+       │                                         │
+       │──── {"type":"user","message":{...}} ────►│  (next turn, optional)
+       │         ...                              │
+```
+
+### Authentication
+
+The CLI sends authentication via HTTP headers on the WebSocket upgrade request:
+
+```
+Authorization: Bearer <session_access_token>
+X-Environment-Runner-Version: <version>  (optional)
+X-Last-Request-Id: <uuid>  (on reconnect, for message replay)
+```
+
+**Token sources** (priority order):
+1. `CLAUDE_CODE_SESSION_ACCESS_TOKEN` environment variable
+2. Internal session ingress token
+3. Token read from file descriptor specified by `CLAUDE_CODE_WEBSOCKET_AUTH_FILE_DESCRIPTOR`
+
+---
+
+## 5. Wire Protocol (NDJSON)
+
+Each message is a single JSON object followed by `\n` (newline). Multiple messages can be sent in sequence.
+
+```
+{"type":"user","message":{"role":"user","content":"Hello"},"parent_tool_use_id":null,"session_id":""}\n
+{"type":"assistant","message":{...},"session_id":"abc123","uuid":"..."}\n
+```
+
+### Message Categories
+
+| Direction | Types |
+|-----------|-------|
+| **Server → CLI** | `user`, `control_response`, `control_cancel_request`, `keep_alive`, `update_environment_variables` |
+| **CLI → Server** | `system`, `assistant`, `result`, `stream_event`, `tool_progress`, `tool_use_summary`, `auth_status`, `control_request` (can_use_tool, hook_callback), `keep_alive`, `streamlined_text`, `streamlined_tool_use_summary` |
+| **Bidirectional** | `control_request`, `control_response`, `keep_alive` |
+
+### Filtered by SDK (present on wire but not exposed to consumers)
+
+These types are present in the NDJSON stream but the official SDK filters them out:
+- `control_request` / `control_response` / `control_cancel_request` — handled internally
+- `keep_alive` — silently consumed
+- `streamlined_text` / `streamlined_tool_use_summary` — internal streamlined mode
+
+---
+
+## 6. Message Types — Complete Reference
+
+### 6.1. `user` — User Message (Server → CLI)
+
+Send a prompt or follow-up message to the Claude Code agent.
+
+```typescript
+interface SDKUserMessage {
+  type: "user";
+  message: {
+    role: "user";
+    content: string | ContentBlock[];  // string for simple text, array for structured
+  };
+  parent_tool_use_id: string | null;   // null for top-level, string for sub-agent
+  session_id: string;                  // "" for first message, then use session_id from init
+  uuid?: string;                       // optional
+  isSynthetic?: boolean;               // true for internally-generated messages
+}
+```
+
+**Example — Simple text prompt:**
+```json
+{
+  "type": "user",
+  "message": { "role": "user", "content": "What files are in this project?" },
+  "parent_tool_use_id": null,
+  "session_id": ""
+}
+```
+
+### 6.2. `system/init` — Initialization (CLI → Server)
+
+First message sent by the CLI after WebSocket connection. Contains full capability info.
+
+```typescript
+interface SDKSystemMessage {
+  type: "system";
+  subtype: "init";
+  cwd: string;
+  session_id: string;
+  tools: string[];                     // ["Task", "Bash", "Glob", "Grep", "Read", "Edit", "Write", ...]
+  mcp_servers: { name: string; status: string }[];
+  model: string;                       // "claude-sonnet-4-5-20250929"
+  permissionMode: PermissionMode;
+  apiKeySource: string;
+  claude_code_version: string;         // "2.1.37"
+  slash_commands: string[];
+  agents?: string[];
+  skills?: string[];
+  plugins?: { name: string; path: string }[];
+  output_style: string;
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.3. `assistant` — LLM Response (CLI → Server)
+
+Full assistant message after LLM completes a response.
+
+```typescript
+interface SDKAssistantMessage {
+  type: "assistant";
+  message: {
+    id: string;                        // "msg_01..."
+    type: "message";
+    role: "assistant";
+    model: string;
+    content: ContentBlock[];           // text blocks, tool_use blocks, thinking blocks
+    stop_reason: string | null;        // "end_turn", "tool_use", etc.
+    usage: {
+      input_tokens: number;
+      output_tokens: number;
+      cache_creation_input_tokens: number;
+      cache_read_input_tokens: number;
+    };
+  };
+  parent_tool_use_id: string | null;
+  error?: "authentication_failed" | "billing_error" | "rate_limit" | "invalid_request" | "server_error" | "unknown";
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.4. `stream_event` — Streaming Chunks (CLI → Server)
+
+Token-by-token streaming events. Only sent when `--verbose` flag is used.
+
+```typescript
+interface SDKPartialAssistantMessage {
+  type: "stream_event";
+  event: BetaRawMessageStreamEvent;    // Anthropic streaming event
+  parent_tool_use_id: string | null;
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.5. `result` — Query Complete (CLI → Server)
+
+Sent when the query finishes (success or error).
+
+```typescript
+// Success
+interface SDKResultSuccess {
+  type: "result";
+  subtype: "success";
+  is_error: false;
+  result: string;                      // final text result
+  duration_ms: number;
+  duration_api_ms: number;
+  num_turns: number;
+  total_cost_usd: number;
+  stop_reason: string | null;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+    cache_creation_input_tokens: number;
+    cache_read_input_tokens: number;
+  };
+  modelUsage: Record<string, {
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadInputTokens: number;
+    cacheCreationInputTokens: number;
+    webSearchRequests: number;
+    costUSD: number;
+    contextWindow: number;
+    maxOutputTokens: number;
+  }>;
+  permission_denials: { tool_name: string; tool_use_id: string; tool_input: Record<string, unknown> }[];
+  structured_output?: unknown;
+  uuid: string;
+  session_id: string;
+}
+
+// Error
+interface SDKResultError {
+  type: "result";
+  subtype: "error_during_execution" | "error_max_turns" | "error_max_budget_usd" | "error_max_structured_output_retries";
+  is_error: true;
+  errors: string[];
+  duration_ms: number;
+  duration_api_ms: number;
+  num_turns: number;
+  total_cost_usd: number;
+  stop_reason: string | null;
+  usage: NonNullableUsage;
+  modelUsage: Record<string, ModelUsage>;
+  permission_denials: SDKPermissionDenial[];
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.6. `system/status` — Status Change (CLI → Server)
+
+```typescript
+interface SDKStatusMessage {
+  type: "system";
+  subtype: "status";
+  status: "compacting" | null;         // null = compacting ended
+  permissionMode?: PermissionMode;     // included when mode changes
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.7. `system/compact_boundary` — Post-Compaction (CLI → Server)
+
+```typescript
+interface SDKCompactBoundaryMessage {
+  type: "system";
+  subtype: "compact_boundary";
+  compact_metadata: {
+    trigger: "manual" | "auto";
+    pre_tokens: number;
+  };
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.8. `tool_progress` — Tool Execution Heartbeat (CLI → Server)
+
+```typescript
+interface SDKToolProgressMessage {
+  type: "tool_progress";
+  tool_use_id: string;
+  tool_name: string;
+  parent_tool_use_id: string | null;
+  elapsed_time_seconds: number;
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.9. `tool_use_summary` — Tool Execution Summary (CLI → Server)
+
+```typescript
+interface SDKToolUseSummaryMessage {
+  type: "tool_use_summary";
+  summary: string;
+  preceding_tool_use_ids: string[];
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.10. `auth_status` — Authentication Flow (CLI → Server)
+
+```typescript
+interface SDKAuthStatusMessage {
+  type: "auth_status";
+  isAuthenticating: boolean;
+  output: string[];
+  error?: string;
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.11. `system/task_notification` — Sub-Agent Task Done (CLI → Server)
+
+```typescript
+interface SDKTaskNotificationMessage {
+  type: "system";
+  subtype: "task_notification";
+  task_id: string;
+  status: "completed" | "failed" | "stopped";
+  output_file: string;
+  summary: string;
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.12. `system/files_persisted` — Files Uploaded (CLI → Server)
+
+```typescript
+interface SDKFilesPersistedEvent {
+  type: "system";
+  subtype: "files_persisted";
+  files: { filename: string; file_id: string }[];
+  failed: { filename: string; error: string }[];
+  processed_at: string;
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.13. Hook Lifecycle Messages (CLI → Server)
+
+```typescript
+interface SDKHookStartedMessage {
+  type: "system";
+  subtype: "hook_started";
+  hook_id: string;
+  hook_name: string;
+  hook_event: string;
+  uuid: string;
+  session_id: string;
+}
+
+interface SDKHookProgressMessage {
+  type: "system";
+  subtype: "hook_progress";
+  hook_id: string;
+  hook_name: string;
+  hook_event: string;
+  stdout: string;
+  stderr: string;
+  output: string;
+  uuid: string;
+  session_id: string;
+}
+
+interface SDKHookResponseMessage {
+  type: "system";
+  subtype: "hook_response";
+  hook_id: string;
+  hook_name: string;
+  hook_event: string;
+  output: string;
+  stdout: string;
+  stderr: string;
+  exit_code?: number;
+  outcome: "success" | "error" | "cancelled";
+  uuid: string;
+  session_id: string;
+}
+```
+
+### 6.14. Transport-Internal Messages
+
+```typescript
+// Keep-alive (bidirectional)
+interface SDKKeepAliveMessage {
+  type: "keep_alive";
+}
+
+// Streamlined text (CLI → Server, filtered by SDK)
+interface SDKStreamlinedTextMessage {
+  type: "streamlined_text";
+  text: string;
+  session_id: string;
+  uuid: string;
+}
+
+// Streamlined tool use summary (CLI → Server, filtered by SDK)
+interface SDKStreamlinedToolUseSummaryMessage {
+  type: "streamlined_tool_use_summary";
+  tool_summary: string;
+  session_id: string;
+  uuid: string;
+}
+
+// Update environment variables (Server → CLI, stdin only)
+interface UpdateEnvironmentVariables {
+  type: "update_environment_variables";
+  variables: Record<string, string>;
+}
+```
+
+---
+
+## 7. Control Protocol (13 Subtypes)
+
+Control messages use a request/response pattern with correlated `request_id` fields.
+
+### Envelope Format
+
+```typescript
+// Request
+interface SDKControlRequest {
+  type: "control_request";
+  request_id: string;              // UUID for correlation
+  request: ControlRequestPayload;  // discriminated by "subtype"
+}
+
+// Success Response
+interface SDKControlResponse {
+  type: "control_response";
+  response: {
+    subtype: "success";
+    request_id: string;            // matches the request
+    response?: Record<string, unknown>;
+  };
+}
+
+// Error Response
+interface SDKControlErrorResponse {
+  type: "control_response";
+  response: {
+    subtype: "error";
+    request_id: string;
+    error: string;
+    pending_permission_requests?: SDKControlRequest[];  // queued permissions
+  };
+}
+
+// Cancel Request
+interface SDKControlCancelRequest {
+  type: "control_cancel_request";
+  request_id: string;              // request to cancel
+}
+```
+
+### 7.1. `initialize` (Server → CLI)
+
+Register hooks, MCP servers, agents, system prompt. **Must be sent before the first `user` message**.
+
+```typescript
+// Request
+{
+  subtype: "initialize",
+  hooks?: Record<HookEvent, { matcher?: string; hookCallbackIds: string[]; timeout?: number }[]>,
+  sdkMcpServers?: string[],
+  jsonSchema?: Record<string, unknown>,
+  systemPrompt?: string,
+  appendSystemPrompt?: string,
+  agents?: Record<string, AgentDefinition>
+}
+
+// Response
+{
+  commands: { name: string; description: string; argumentHint?: string }[],
+  output_style: string,
+  available_output_styles: string[],
+  models: { value: string; displayName: string; description: string }[],
+  account: { email?: string; organization?: string; subscriptionType?: string; apiKeySource?: string },
+  fast_mode?: boolean
+}
+```
+
+**Error**: `"Already initialized"` if called twice.
+
+### 7.2. `can_use_tool` (CLI → Server)
+
+**The most important control message.** The CLI asks the server for permission to use a tool.
+
+```typescript
+// Request (from CLI)
+{
+  subtype: "can_use_tool",
+  tool_name: string,                    // "Bash", "Edit", "Write", "Read", etc.
+  input: Record<string, unknown>,       // tool arguments
+  permission_suggestions?: PermissionUpdate[],
+  blocked_path?: string,
+  decision_reason?: string,             // "hook"|"asyncAgent"|"sandboxOverride"|"classifier"|"workingDir"|"other"
+  tool_use_id: string,
+  agent_id?: string,
+  description?: string
+}
+
+// Response: Allow
+{
+  behavior: "allow",
+  updatedInput: Record<string, unknown>,  // REQUIRED — can modify tool args
+  updatedPermissions?: PermissionUpdate[], // save rules for future
+  toolUseID?: string
+}
+
+// Response: Deny
+{
+  behavior: "deny",
+  message: string,
+  interrupt?: boolean,                    // true = abort entire session
+  toolUseID?: string
+}
+```
+
+### 7.3. `interrupt` (Server → CLI)
+
+Abort the current agent turn.
+
+```typescript
+// Request
+{ subtype: "interrupt" }
+
+// Response: empty success
+```
+
+### 7.4. `set_permission_mode` (Server → CLI)
+
+```typescript
+// Request
+{ subtype: "set_permission_mode", mode: PermissionMode }
+
+// Response
+{ mode: PermissionMode }
+```
+
+**Error**: `"Cannot set permission mode to bypassPermissions because it is disabled by settings or configuration"`
+
+### 7.5. `set_model` (Server → CLI)
+
+```typescript
+// Request
+{ subtype: "set_model", model?: string }  // "default" to reset
+
+// Response: empty success
+```
+
+### 7.6. `set_max_thinking_tokens` (Server → CLI)
+
+```typescript
+// Request
+{ subtype: "set_max_thinking_tokens", max_thinking_tokens: number | null }
+
+// Response: empty success
+```
+
+### 7.7. `mcp_status` (Server → CLI)
+
+```typescript
+// Request
+{ subtype: "mcp_status" }
+
+// Response
+{
+  mcpServers: {
+    name: string,
+    status: "connected" | "failed" | "disabled" | "connecting",
+    serverInfo?: any,
+    error?: string,
+    config: { type: string; url?: string; command?: string; args?: string[] },
+    scope: string,
+    tools?: { name: string; annotations?: { readOnly?: boolean; destructive?: boolean; openWorld?: boolean } }[]
+  }[]
+}
+```
+
+### 7.8. `mcp_message` (Bidirectional)
+
+Route JSON-RPC messages to/from MCP servers.
+
+```typescript
+// Request
+{ subtype: "mcp_message", server_name: string, message: JSONRPCMessage }
+
+// Response: empty success (or { mcp_response: ... } from SDK side)
+```
+
+### 7.9. `mcp_reconnect` (Server → CLI)
+
+```typescript
+{ subtype: "mcp_reconnect", serverName: string }
+```
+
+### 7.10. `mcp_toggle` (Server → CLI)
+
+```typescript
+{ subtype: "mcp_toggle", serverName: string, enabled: boolean }
+```
+
+### 7.11. `mcp_set_servers` (Server → CLI)
+
+```typescript
+{
+  subtype: "mcp_set_servers",
+  servers: Record<string, {
+    type: "stdio" | "sse" | "http" | "sdk",
+    command?: string,
+    args?: string[],
+    env?: Record<string, string>,
+    url?: string
+  }>
+}
+```
+
+### 7.12. `rewind_files` (Server → CLI)
+
+```typescript
+// Request
+{ subtype: "rewind_files", user_message_id: string, dry_run?: boolean }
+
+// Response (success)
+{ canRewind: true, filesChanged?: number, insertions?: number, deletions?: number }
+```
+
+### 7.13. `hook_callback` (CLI → Server)
+
+The CLI invokes a registered hook callback.
+
+```typescript
+// Request (from CLI)
+{
+  subtype: "hook_callback",
+  callback_id: string,
+  input: HookInput,
+  tool_use_id?: string
+}
+
+// Sync response
+{
+  continue?: boolean,
+  suppressOutput?: boolean,
+  stopReason?: string,
+  decision?: "approve" | "block",
+  reason?: string,
+  systemMessage?: string,
+  hookSpecificOutput?: {
+    hookEventName: "PreToolUse" | "PostToolUse" | "PermissionRequest",
+    permissionDecision?: "allow" | "deny" | "ask",
+    permissionDecisionReason?: string,
+    updatedInput?: Record<string, unknown>,
+    additionalContext?: string,
+    decision?: { behavior: "allow" | "deny", ... }
+  }
+}
+
+// Async response
+{ async: true, asyncTimeout?: number }
+```
+
+### Direction Summary
+
+| Subtype | Direction | Purpose |
+|---------|-----------|---------|
+| `initialize` | Server → CLI | Setup hooks, MCP, agents |
+| `can_use_tool` | CLI → Server | Permission request |
+| `interrupt` | Server → CLI | Abort current turn |
+| `set_permission_mode` | Server → CLI | Change mode at runtime |
+| `set_model` | Server → CLI | Change model at runtime |
+| `set_max_thinking_tokens` | Server → CLI | Change thinking budget |
+| `mcp_status` | Server → CLI | Get MCP server statuses |
+| `mcp_message` | Bidirectional | Route JSON-RPC messages |
+| `mcp_reconnect` | Server → CLI | Reconnect MCP server |
+| `mcp_toggle` | Server → CLI | Enable/disable MCP server |
+| `mcp_set_servers` | Server → CLI | Configure MCP servers |
+| `rewind_files` | Server → CLI | Rewind files to checkpoint |
+| `hook_callback` | CLI → Server | Invoke registered hook |
+
+---
+
+## 8. Permission / Tool Approval Flow
+
+### Three-Layer Decision Pipeline
+
+The CLI evaluates permissions through three layers before sending a `can_use_tool` over the wire:
+
+```
+Tool Use Request
+  │
+  ├─► Layer 1: PreToolUse Hooks (local shell scripts)
+  │     ├─ allow → tool executes
+  │     ├─ deny → tool blocked
+  │     └─ ask → fall through
+  │
+  ├─► Layer 2: Local Rule Evaluation (R5z)
+  │     ├─ Check deny rules → if match → DENIED
+  │     ├─ Check ask rules → if match → behavior="ask"
+  │     ├─ Check mode:
+  │     │   bypassPermissions → ALLOWED (never reaches wire)
+  │     │   dontAsk → DENIED (never reaches wire)
+  │     ├─ Check allow rules (incl. --allowedTools) → ALLOWED
+  │     └─ Default → behavior="ask"
+  │
+  └─► Layer 3: Remote Prompt (WebSocket)
+        └─ Sends control_request { subtype: "can_use_tool", ... }
+           ├─ Response: { behavior: "allow", updatedInput: {...} } → EXECUTE
+           └─ Response: { behavior: "deny", message: "..." } → BLOCKED
+```
+
+### `updatedInput` — Modifying Tool Arguments
+
+When responding with `{ behavior: "allow" }`, you **must** include `updatedInput`. This replaces the tool's input entirely. You can:
+- Pass through unchanged: `updatedInput: original_input`
+- Sanitize commands: Change `rm -rf /` to `echo "blocked"`
+- Modify paths: Restrict file access
+
+### `updatedPermissions` — Learning Rules
+
+Return `updatedPermissions` to save rules for the session or settings:
+
+```typescript
+type PermissionUpdate =
+  | { type: "addRules", rules: { toolName: string, ruleContent?: string }[], behavior: "allow"|"deny"|"ask", destination: PermissionDestination }
+  | { type: "replaceRules", rules: [...], behavior: "...", destination: "..." }
+  | { type: "removeRules", rules: [...], behavior: "...", destination: "..." }
+  | { type: "setMode", mode: PermissionMode, destination: PermissionDestination }
+  | { type: "addDirectories", directories: string[], destination: PermissionDestination }
+  | { type: "removeDirectories", directories: string[], destination: PermissionDestination }
+
+type PermissionDestination = "userSettings" | "projectSettings" | "localSettings" | "session" | "cliArg";
+```
+
+**Example — Auto-approve future git commands:**
+```json
+{
+  "behavior": "allow",
+  "updatedInput": { "command": "git status" },
+  "updatedPermissions": [
+    {
+      "type": "addRules",
+      "rules": [{ "toolName": "Bash", "ruleContent": "git:*" }],
+      "behavior": "allow",
+      "destination": "session"
+    }
+  ]
+}
+```
+
+### Timeout Behavior
+
+- If the server never responds to `can_use_tool`, the CLI blocks indefinitely
+- The CLI can send `control_cancel_request` to cancel its own pending request
+- On transport close, all pending requests are rejected with `"Tool permission stream closed before response received"`
+
+---
+
+## 9. Session Management
+
+### Session ID
+
+- Generated by CLI via `crypto.randomUUID()` on startup
+- Included in every outgoing message (`session_id` field)
+- Stored in global state, accessible via `U6()` internally
+- Use for session resume: `--resume <session-id>`
+
+### Initialization Sequence (Detailed)
+
+The `initialize` control_request should be sent **before** the first `user` message. The exact sequence is:
+
+```
+Server                                  CLI
+  |                                      |
+  |<-- WS connect ----------------------|
+  |                                      |
+  |-- control_request {initialize} ---->|  (optional: register hooks, MCP, agents)
+  |<-- control_response {success} ------|  (returns commands, models, account info)
+  |                                      |
+  |-- user message --------------------->|  (first prompt)
+  |<-- system/init ----------------------|  (tools, model, session_id, etc.)
+  |<-- assistant ... --------------------|
+  |<-- result ----------------------------|
+```
+
+The `initialize` request lets you:
+- Set a custom `systemPrompt` or `appendSystemPrompt`
+- Register hook callbacks (with `hookCallbackIds` that map to `hook_callback` control requests)
+- Register SDK-side MCP server names
+- Set a JSON schema for structured output
+- Register custom agent definitions
+
+### Multi-Turn Conversations
+
+After receiving a `result` message, you can send another `user` message to continue the conversation. Internally, user messages are queued in `queuedCommands` and processed in a loop by the CLI's `c()` function.
+
+```
+Server: {"type":"user","message":{"role":"user","content":"First question"},...}
+CLI:    {"type":"system","subtype":"init",...}
+CLI:    {"type":"assistant",...}
+CLI:    {"type":"result","subtype":"success",...}
+
+Server: {"type":"user","message":{"role":"user","content":"Follow-up"},...}
+CLI:    {"type":"assistant",...}
+CLI:    {"type":"result","subtype":"success",...}
+```
+
+**Duplicate detection**: Messages with a `uuid` field are checked against a dedup function. Duplicates are skipped but acknowledged with `isReplay: true` if `replayUserMessages` is enabled.
+
+**Session end behavior**:
+- For single-turn queries: stdin/transport is closed after first result
+- For multi-turn (streaming input): CLI keeps running, waiting for more user messages
+- The CLI remains alive as long as the WebSocket connection is open
+
+### Session Resume
+
+```bash
+claude --sdk-url ws://localhost:8765 --print --output-format stream-json --input-format stream-json --resume <session-id> -p ""
+```
+
+When resuming:
+1. CLI reads the transcript JSONL file from `~/.claude/projects/<project>/<sessionId>.jsonl`
+2. Loads and replays previous messages with `isReplay: true`
+3. Sets `sessionId` to the resumed session's ID
+4. Then waits for new `user` message
+
+**Resume at specific message**: `--resume-session-at <uuid>` truncates history to that message.
+
+### Fork Session
+
+```bash
+claude --sdk-url ws://localhost:8765 --print --output-format stream-json --input-format stream-json --resume <session-id> --fork-session -p ""
+```
+
+When forking:
+- A NEW session ID is generated
+- The old session's messages are loaded as context
+- The new session gets a fresh UUID — this allows branching without modifying the original session
+
+### Context Compaction
+
+When the context window fills up:
+1. CLI sends `{"type":"system","subtype":"status","status":"compacting"}`
+2. After compaction: `{"type":"system","subtype":"compact_boundary","compact_metadata":{"trigger":"auto","pre_tokens":N}}`
+3. Then: `{"type":"system","subtype":"status","status":null}` (compacting ended)
+
+### Result Triggers
+
+| Result Subtype | Trigger |
+|----------------|---------|
+| `success` | Normal completion — assistant finished responding |
+| `error_during_execution` | Unhandled error during tool execution |
+| `error_max_turns` | Reached `--max-turns` limit |
+| `error_max_budget_usd` | Exceeded USD budget |
+| `error_max_structured_output_retries` | Failed structured output after N retries |
+
+---
+
+## 10. Reconnection & Resilience
+
+### WebSocket Reconnection (sd1 class)
+
+| Constant | Value |
+|----------|-------|
+| Max reconnect attempts | 3 |
+| Base reconnect delay | 1000ms |
+| Max reconnect delay | 30000ms |
+| Backoff formula | `min(1000 * 2^(attempt-1), 30000)` |
+| Ping interval | 10000ms |
+| Circular buffer capacity | 1000 messages |
+
+### Reconnection Flow
+
+1. WebSocket connection drops
+2. CLI attempts reconnect with exponential backoff
+3. Sends `X-Last-Request-Id` header with last sent message UUID
+4. Server should replay messages sent after that UUID
+5. CLI replays buffered outgoing messages from circular buffer
+6. After 3 failed attempts → state = "closed", fires close callback
+
+### Keepalive
+
+- CLI sends `{"type":"keep_alive"}` periodically
+- WebSocket ping/pong every 10 seconds (Node.js only, skipped on Bun)
+- If no pong received before next ping → connection considered dead → triggers reconnect
+
+### Hybrid Transport (kQA) — HTTP POST Resilience
+
+When `CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2` is set:
+
+| Constant | Value |
+|----------|-------|
+| Max POST retries | 10 |
+| Base POST delay | 500ms |
+| Max POST delay | 8000ms |
+| Backoff formula | `min(500 * 2^(attempt-1), 8000)` |
+
+URL conversion: `wss://host/ws/path` → `https://host/session/path/events`
+
+POST body format:
+```json
+{ "events": [<message>] }
+```
+
+---
+
+## 11. Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `CLAUDE_CODE_SESSION_ACCESS_TOKEN` | Bearer token for WebSocket auth (highest priority) |
+| `CLAUDE_CODE_WEBSOCKET_AUTH_FILE_DESCRIPTOR` | File descriptor to read auth token from |
+| `CLAUDE_CODE_POST_FOR_SESSION_INGRESS_V2` | Enable hybrid transport (WS receive + HTTP POST send) |
+| `CLAUDE_CODE_ENVIRONMENT_RUNNER_VERSION` | Sent as `x-environment-runner-version` header |
+| `CLAUDE_CODE_REMOTE` | Indicates running in remote mode |
+| `CLAUDE_CODE_REMOTE_SESSION_ID` | Remote session identifier |
+| `CLAUDE_CODE_CONTAINER_ID` | Container ID for remote environments |
+
+---
+
+## 12. Transport Class Hierarchy
+
+### `ad1` — ProcessInputTransport (Base)
+
+```typescript
+class ProcessInputTransport {
+  input: ReadableStream;
+  replayUserMessages: boolean;
+  pendingRequests: Map<string, PendingRequest>;
+  inputClosed: boolean;
+  unexpectedResponseCallback?: (msg: any) => Promise<void>;
+
+  async *read(): AsyncGenerator<ParsedMessage>;
+  async processLine(line: string): Promise<ParsedMessage | undefined>;
+  async write(message: any): Promise<void>;
+  async sendRequest(request: ControlRequestPayload, schema?: ZodSchema, signal?: AbortSignal): Promise<any>;
+  createCanUseTool(onPrompt?: () => void): CanUseToolFn;
+  createHookCallback(callbackId: string, timeout: number): HookCallback;
+  async sendMcpMessage(serverName: string, message: any): Promise<any>;
+  getPendingPermissionRequests(): ControlRequest[];
+}
+```
+
+### `sd1` — WebSocketTransport
+
+```typescript
+class WebSocketTransport {
+  ws: WebSocket | null;
+  url: URL;
+  state: "idle" | "connecting" | "reconnecting" | "connected" | "closing" | "closed";
+  headers: Record<string, string>;
+  sessionId: string | undefined;
+  reconnectAttempts: number;
+  messageBuffer: CircularBuffer;  // capacity: 1000
+
+  async connect(): Promise<void>;
+  sendLine(data: string): boolean;
+  async write(message: any): Promise<void>;
+  handleConnectionError(): void;      // exponential backoff reconnect
+  replayBufferedMessages(lastReceivedId: string): void;
+  startPingInterval(): void;          // 10s ping/pong
+  close(): void;
+  setOnData(cb: (data: string) => void): void;
+  setOnClose(cb: () => void): void;
+}
+```
+
+### `kQA` — HybridTransport (extends sd1)
+
+```typescript
+class HybridTransport extends WebSocketTransport {
+  postUrl: string;  // wss://host/ws/path → https://host/session/path/events
+
+  async write(message: any): Promise<void>;  // HTTP POST with retry
+}
+```
+
+### `LQA` — SdkUrlTransport (extends ad1)
+
+```typescript
+class SdkUrlTransport extends ProcessInputTransport {
+  url: URL;
+  transport: WebSocketTransport | HybridTransport;
+  inputStream: PassThrough;
+
+  constructor(sdkUrl: string, replayStream?: AsyncIterable<string>, replayUserMessages?: boolean);
+  async write(message: any): Promise<void>;  // delegates to transport
+  close(): void;
+}
+```
+
+### `fFA` — DirectConnectWebSocket (Browser Client)
+
+This is the simplest client implementation — useful as a reference for building your own:
+
+```typescript
+class DirectConnectWebSocket {
+  ws: WebSocket | null;
+  config: { wsUrl: string; authToken?: string };
+  callbacks: {
+    onMessage: (msg: any) => void;
+    onConnected?: () => void;
+    onDisconnected?: () => void;
+    onError?: (err: Error) => void;
+    onPermissionRequest: (request: CanUseToolRequest, requestId: string) => void;
+  };
+
+  connect(): void;
+  sendMessage(content: string): boolean;
+  respondToPermissionRequest(requestId: string, response: PermissionResponse): void;
+  sendInterrupt(): void;
+  disconnect(): void;
+  isConnected(): boolean;
+}
+```
+
+**Key implementation details from `fFA`:**
+```javascript
+// Sending a user message
+sendMessage(content) {
+  const msg = JSON.stringify({
+    type: "user",
+    message: { role: "user", content },
+    parent_tool_use_id: null,
+    session_id: ""
+  });
+  this.ws.send(msg);
+}
+
+// Responding to a permission request
+respondToPermissionRequest(requestId, response) {
+  const msg = JSON.stringify({
+    type: "control_response",
+    response: {
+      subtype: "success",
+      request_id: requestId,
+      response: { behavior: response.behavior, ...response }
+    }
+  });
+  this.ws.send(msg);
+}
+
+// Sending an interrupt
+sendInterrupt() {
+  const msg = JSON.stringify({
+    type: "control_request",
+    request_id: crypto.randomUUID(),
+    request: { subtype: "interrupt" }
+  });
+  this.ws.send(msg);
+}
+```
+
+---
+
+## 13. Implementation Guide
+
+### Minimal WebSocket Server (Bun)
+
+```typescript
+const messages: any[] = [];
+
+Bun.serve({
+  port: 8765,
+  fetch(req, server) {
+    if (server.upgrade(req)) return;
+    return new Response("WebSocket server for Claude Code", { status: 200 });
+  },
+  websocket: {
+    open(ws) {
+      console.log("[CONNECTED] Claude Code connected");
+    },
+    message(ws, data) {
+      const lines = data.toString().split("\n").filter(Boolean);
+      for (const line of lines) {
+        const msg = JSON.parse(line);
+        messages.push({ direction: "IN", ...msg });
+
+        // Handle system/init
+        if (msg.type === "system" && msg.subtype === "init") {
+          console.log(`[INIT] session=${msg.session_id} model=${msg.model}`);
+
+          // Send first user message
+          const userMsg = JSON.stringify({
+            type: "user",
+            message: { role: "user", content: "Hello! What can you do?" },
+            parent_tool_use_id: null,
+            session_id: msg.session_id
+          }) + "\n";
+          ws.send(userMsg);
+        }
+
+        // Handle permission requests
+        if (msg.type === "control_request" && msg.request?.subtype === "can_use_tool") {
+          console.log(`[PERMISSION] ${msg.request.tool_name}: ${JSON.stringify(msg.request.input)}`);
+
+          // Auto-approve everything (or add your logic here)
+          const response = JSON.stringify({
+            type: "control_response",
+            response: {
+              subtype: "success",
+              request_id: msg.request_id,
+              response: {
+                behavior: "allow",
+                updatedInput: msg.request.input
+              }
+            }
+          }) + "\n";
+          ws.send(response);
+        }
+
+        // Handle assistant messages
+        if (msg.type === "assistant") {
+          const text = msg.message?.content
+            ?.filter((b: any) => b.type === "text")
+            .map((b: any) => b.text)
+            .join("");
+          console.log(`[ASSISTANT] ${text?.substring(0, 200)}`);
+        }
+
+        // Handle result
+        if (msg.type === "result") {
+          console.log(`[RESULT] ${msg.subtype} | cost=$${msg.total_cost_usd} | turns=${msg.num_turns}`);
+        }
+
+        // Ignore keep_alive
+        if (msg.type === "keep_alive") return;
+      }
+    },
+    close(ws) {
+      console.log("[DISCONNECTED]");
+    }
+  }
+});
+
+console.log("WebSocket server running on ws://localhost:8765");
+```
+
+### Launch Claude Code
+
+```bash
+claude --sdk-url ws://localhost:8765 \
+       --print \
+       --output-format stream-json \
+       --input-format stream-json \
+       --verbose \
+       -p ""
+```
+
+### Building a Full Controller
+
+To build a production controller on top of this protocol:
+
+1. **WebSocket Server**: Accept connections, handle NDJSON messages
+2. **Message Router**: Dispatch by `type` field (system, assistant, result, control_request, etc.)
+3. **Permission Handler**: Implement policy for `can_use_tool` requests (auto-approve, deny, or prompt user)
+4. **Session Manager**: Track session_id, support resume via `--resume`
+5. **Multi-Turn**: Send additional `user` messages after each `result`
+6. **Streaming**: Process `stream_event` messages for real-time output
+7. **Error Handling**: Handle `result` with `is_error: true`, connection drops, reconnection
+8. **Lifecycle**: Use `initialize` control_request for hooks/MCP, `interrupt` to abort
+
+### Key Differences from the Filesystem Inbox Protocol
+
+| Aspect | Filesystem Inbox | WebSocket Protocol |
+|--------|-----------------|-------------------|
+| Transport | JSON files in `~/.claude/teams/` | NDJSON over WebSocket |
+| Permissions | Not natively routed through inbox | Full `can_use_tool` flow |
+| Latency | Polling (500ms) | Real-time |
+| Multi-turn | Send message → poll for response | Send message → stream response |
+| Streaming | Not supported | `stream_event` messages |
+| Session control | Limited (mode, shutdown) | Full (model, thinking, MCP, rewind) |
+| Dependency | Teammate mode required | Standalone (`--print` mode) |
+
+---
+
+## Appendix: Permission Mode Reference
+
+| Mode | `can_use_tool` sent? | Behavior |
+|------|---------------------|----------|
+| `default` | Yes (when rules don't resolve) | Normal flow |
+| `acceptEdits` | Yes (for non-edit tools) | Auto-approves file edits |
+| `bypassPermissions` | **Never** | Everything auto-approved locally |
+| `plan` | Yes (limited) | Read-only exploration mode |
+| `delegate` | N/A | Restricted to coordination tools only |
+| `dontAsk` | **Never** | Auto-denies unresolved permissions |
+
+---
+
+## Appendix: Shared Types
+
+```typescript
+type PermissionMode = "default" | "acceptEdits" | "bypassPermissions" | "plan" | "delegate" | "dontAsk";
+
+type HookEvent =
+  | "PreToolUse" | "PostToolUse" | "PostToolUseFailure"
+  | "Notification" | "UserPromptSubmit"
+  | "SessionStart" | "SessionEnd"
+  | "Stop" | "SubagentStart" | "SubagentStop"
+  | "PreCompact" | "PermissionRequest"
+  | "Setup" | "TeammateIdle" | "TaskCompleted";
+
+type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "tool_use"; id: string; name: string; input: Record<string, unknown> }
+  | { type: "tool_result"; tool_use_id: string; content: string | ContentBlock[]; is_error?: boolean }
+  | { type: "thinking"; thinking: string; budget_tokens?: number };
+```
+

--- a/packages/cli/src/runner/claude-code-bridge-spawn.test.ts
+++ b/packages/cli/src/runner/claude-code-bridge-spawn.test.ts
@@ -1,0 +1,46 @@
+import { test, expect, mock } from "bun:test";
+
+test("spawnClaudeCodeSession forwards prompt/model env to bridge", async () => {
+  const origSpawn = Bun.spawn;
+  let capturedCmd: string[] | undefined;
+  let capturedOpts: Record<string, unknown> | undefined;
+  (Bun as any).spawn = mock((cmd: string[], opts: Record<string, unknown>) => {
+    capturedCmd = cmd;
+    capturedOpts = opts;
+    return { pid: 12345, exited: Promise.resolve(0) };
+  });
+
+  try {
+    const { spawnClaudeCodeSession } = await import("./claude-code-bridge-spawn.js");
+
+    const proc = spawnClaudeCodeSession({
+      sessionId: "test-session",
+      apiKey: "test-key",
+      relayUrl: "ws://localhost:7492",
+      cwd: "/tmp",
+      prompt: "hello",
+      parentSessionId: "parent-1",
+      model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+    });
+
+    expect(proc.pid).toBe(12345);
+    // First element should be a bun executable path (either "bun" or a full path)
+    expect(capturedCmd?.[0]).toBeTruthy();
+    expect(capturedCmd?.[0]).toMatch(/bun|\.bin/);
+    // Second element should be the bridge script (either .ts or .js)
+    expect(capturedCmd?.[1]).toMatch(/claude-code-bridge\.(ts|js)/);
+    expect(capturedOpts?.cwd).toBe("/tmp");
+    expect(capturedOpts?.env).toMatchObject({
+      PIZZAPI_SESSION_ID: "test-session",
+      PIZZAPI_WORKER_CWD: "/tmp",
+      PIZZAPI_API_KEY: "test-key",
+      PIZZAPI_RELAY_URL: "ws://localhost:7492",
+      PIZZAPI_WORKER_INITIAL_PROMPT: "hello",
+      PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER: "anthropic",
+      PIZZAPI_WORKER_INITIAL_MODEL_ID: "claude-sonnet-4-6",
+      PIZZAPI_WORKER_PARENT_SESSION_ID: "parent-1",
+    });
+  } finally {
+    (Bun as any).spawn = origSpawn;
+  }
+});

--- a/packages/cli/src/runner/claude-code-bridge-spawn.ts
+++ b/packages/cli/src/runner/claude-code-bridge-spawn.ts
@@ -1,0 +1,106 @@
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { existsSync } from "node:fs";
+
+export interface ClaudeCodeSpawnOptions {
+  sessionId: string;
+  apiKey: string;
+  relayUrl: string;
+  /** Working directory. If undefined, the bridge should fall back to process.cwd(). */
+  cwd: string | undefined;
+  prompt?: string;
+  parentSessionId?: string;
+  model?: { provider: string; id: string };
+  /** Models to hide from the model picker (same format as pi worker: "provider/id"). */
+  hiddenModels?: string[];
+}
+
+/** Is this process running inside a compiled Bun single-file binary? */
+export const isCompiledBinary =
+  import.meta.url.includes("$bunfs") || import.meta.url.includes("~BUN") || import.meta.url.includes("%7EBUN");
+
+/**
+ * Resolve the bridge script path.
+ *
+ * Search order:
+ *  1. Compiled JS next to this module file (dev build: dist/runner/claude-code-bridge.js)
+ *  2. TS source next to this module file (dev source checkout)
+ *  3. runner/claude-code-bridge.js next to the pizza binary (packaged/npm install)
+ *
+ * In a Bun single-file compiled binary, import.meta.url resolves to a virtual
+ * path inside the bundle that doesn't exist on disk, so checks 1 and 2 will
+ * return false and we fall through to check 3 (the sidecar runner/ directory).
+ */
+function resolveBridgeScript(): string {
+  const currentDir = fileURLToPath(new URL(".", import.meta.url));
+  const jsPath = join(currentDir, "claude-code-bridge.js");
+  const tsPath = join(currentDir, "claude-code-bridge.ts");
+
+  if (existsSync(jsPath)) return jsPath;
+  if (existsSync(tsPath)) return tsPath;
+
+  // Compiled/binary install: build-binaries.ts copies runner/ next to the executable.
+  const binDir = dirname(process.execPath);
+  const runnerJsPath = join(binDir, "runner", "claude-code-bridge.js");
+  if (existsSync(runnerJsPath)) return runnerJsPath;
+
+  throw new Error(
+    `Claude Code bridge script not found.\n` +
+    `  Checked: ${jsPath}\n` +
+    `  Checked: ${tsPath}\n` +
+    `  Checked: ${runnerJsPath}\n` +
+    `Run 'bun run build' in packages/cli to generate the compiled bridge.`,
+  );
+}
+
+/**
+ * Get the current bun executable path.
+ * Falls back to "bun" if process.execPath doesn't point to a bun executable.
+ */
+function getBunExecutable(): string {
+  const execPath = process.execPath ?? "";
+  if (execPath && (execPath.includes("bun") || existsSync(execPath))) {
+    return execPath;
+  }
+  return "bun";
+}
+
+export function resolveClaudeCodeBridgeCommand(): string[] {
+  if (isCompiledBinary) {
+    return [process.execPath, "_claude_code_bridge"];
+  }
+
+  const bridgeScript = resolveBridgeScript();
+  const bunExe = getBunExecutable();
+  return [bunExe, bridgeScript];
+}
+
+export function spawnClaudeCodeSession(opts: ClaudeCodeSpawnOptions): ReturnType<typeof Bun.spawn> {
+  const cmd = resolveClaudeCodeBridgeCommand();
+
+  const proc = Bun.spawn(cmd, {
+    cwd: opts.cwd ?? process.cwd(),
+    stdin: "ignore",
+    stdout: "inherit",
+    stderr: "inherit",
+    env: {
+      ...process.env,
+      PIZZAPI_SESSION_ID: opts.sessionId,
+      PIZZAPI_WORKER_CWD: opts.cwd ?? process.cwd(),
+      PIZZAPI_API_KEY: opts.apiKey,
+      PIZZAPI_RELAY_URL: opts.relayUrl,
+      ...(opts.prompt ? { PIZZAPI_WORKER_INITIAL_PROMPT: opts.prompt } : {}),
+      ...(opts.model ? {
+        PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER: opts.model.provider,
+        PIZZAPI_WORKER_INITIAL_MODEL_ID: opts.model.id,
+      } : {}),
+      ...(opts.parentSessionId ? { PIZZAPI_WORKER_PARENT_SESSION_ID: opts.parentSessionId } : {}),
+      ...(opts.hiddenModels && opts.hiddenModels.length > 0
+        ? { PIZZAPI_HIDDEN_MODELS: JSON.stringify(opts.hiddenModels) }
+        : {}),
+    },
+  });
+
+  console.log(`[daemon] spawned Claude Code bridge pid=${proc.pid} session=${opts.sessionId}`);
+  return proc;
+}

--- a/packages/cli/src/runner/claude-code-bridge.ts
+++ b/packages/cli/src/runner/claude-code-bridge.ts
@@ -1,0 +1,1711 @@
+/**
+ * Claude Code bridge process.
+ *
+ * Spawned by the daemon instead of worker.ts for Claude Code sessions.
+ * - Creates a private temp dir with Unix IPC socket
+ * - Generates per-session hooks.json and mcp.json
+ * - Connects to PizzaPi relay via Socket.IO
+ * - Spawns `claude` CLI subprocess with stream-json flags
+ * - Translates NDJSON stdout → relay events
+ * - Injects relay input → claude stdin
+ *
+ * Environment vars (from daemon):
+ *   PIZZAPI_SESSION_ID, PIZZAPI_WORKER_CWD, PIZZAPI_API_KEY,
+ *   PIZZAPI_RELAY_URL, PIZZAPI_WORKER_PARENT_SESSION_ID
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { mkdtemp, writeFile, rm, chmod } from "node:fs/promises";
+import { dirname, join, resolve as resolvePath } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir, tmpdir } from "node:os";
+import { createServer as createNetServer } from "node:net";
+import type { Server as NetServer, Socket as NetSocket } from "node:net";
+import { io, type Socket } from "socket.io-client";
+import type { RelayClientToServerEvents, RelayServerToClientEvents } from "@pizzapi/protocol";
+import { randomUUID } from "node:crypto";
+import { translateNdjsonLine, SUBAGENT_TOOL_NAMES, parseSubagentToolCalls } from "./claude-code-ndjson.js";
+import { serializeFrame, framesFromBuffer, type PluginMessage, type BridgeMessage } from "./claude-code-ipc.js";
+import { SET_SESSION_NAME_PROMPT } from "../config/system-prompt.js";
+import { buildSpawnSessionBody } from "./claude-code-spawn-request.js";
+import { renderTrigger } from "../extensions/triggers/registry.js";
+import type { ConversationTrigger } from "../extensions/triggers/types.js";
+import { normalizeRemoteInputAttachments, buildUserMessageFromRemoteInput } from "../extensions/remote-input.js";
+import {
+  needsChunkedDelivery, capOversizedMessages, computeChunkBoundaries,
+} from "../extensions/remote.js";
+import { setLogComponent, setLogSessionId, logInfo, logWarn, logError } from "./logger.js";
+
+const RELAY_DEFAULT = "ws://localhost:7492";
+
+// ── Config from env ───────────────────────────────────────────────────────
+const sessionId = process.env.PIZZAPI_SESSION_ID ?? randomUUID();
+const cwd = process.env.PIZZAPI_WORKER_CWD ?? process.cwd();
+const apiKey = process.env.PIZZAPI_API_KEY;
+const relayUrl = (process.env.PIZZAPI_RELAY_URL ?? RELAY_DEFAULT).replace(/\/$/, "");
+const parentSessionId = process.env.PIZZAPI_WORKER_PARENT_SESSION_ID ?? null;
+let initialPrompt = process.env.PIZZAPI_WORKER_INITIAL_PROMPT ?? "";
+const initialModelProvider = process.env.PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER?.trim() ?? "";
+const initialModelId = process.env.PIZZAPI_WORKER_INITIAL_MODEL_ID?.trim() ?? "";
+
+// ── Structured logging ────────────────────────────────────────────────────
+// Use the shared logger so cc-bridge output interleaves cleanly with pi
+// worker and daemon logs in runner.log / runner-error.log.
+setLogComponent("cc-bridge");
+setLogSessionId(sessionId);
+
+/** When true, log every NDJSON event and relay forward at info level.
+ *  Enable with PIZZAPI_CC_EVENT_LOG=1. Off by default to avoid log flood. */
+const VERBOSE_EVENT_LOG = process.env.PIZZAPI_CC_EVENT_LOG === "1";
+
+// Plugin dir: absolute path to the static plugin directory shipped with the CLI.
+// The runner may execute from either src/runner/*.ts or dist/runner/*.js, but the
+// plugin assets live under packages/cli/src/claude-code-plugin in this repo.
+// Use fileURLToPath (not .pathname) to correctly handle Windows drive letters and
+// URL-encoded characters (e.g. spaces) in the install path.
+const PACKAGE_ROOT = resolvePath(fileURLToPath(new URL("../..", import.meta.url)));
+const PLUGIN_DIR_CANDIDATES = [
+  join(PACKAGE_ROOT, "src", "claude-code-plugin"),
+  join(PACKAGE_ROOT, "claude-code-plugin"),
+  // Packaged/npm installs: plugin dir lives next to the shipped binary or runner sidecar
+  join(dirname(process.execPath), "claude-code-plugin"),
+];
+const PLUGIN_DIR: string = (() => {
+  const found = PLUGIN_DIR_CANDIDATES.find((candidate) => existsSync(candidate));
+  if (!found) {
+    throw new Error(`Claude Code plugin directory not found. Looked in: ${PLUGIN_DIR_CANDIDATES.join(", ")}`);
+  }
+  return found;
+})();
+
+const IS_COMPILED_BINARY = import.meta.url.includes("$bunfs") || import.meta.url.includes("~BUN") || import.meta.url.includes("%7EBUN");
+const BUN_RUNTIME = process.execPath && existsSync(process.execPath) ? process.execPath : "bun";
+
+// Detect whether compiled (.js) plugin scripts exist alongside source (.ts).
+const HOOK_HANDLER_JS = join(PLUGIN_DIR, "scripts", "hook-handler.js");
+const MCP_SERVER_JS = join(PLUGIN_DIR, "scripts", "mcp-server.js");
+const PLUGIN_SCRIPTS_COMPILED = existsSync(HOOK_HANDLER_JS) && existsSync(MCP_SERVER_JS);
+const HOOK_HANDLER_SCRIPT = PLUGIN_SCRIPTS_COMPILED
+  ? HOOK_HANDLER_JS
+  : join(PLUGIN_DIR, "scripts", "hook-handler.ts");
+const MCP_SERVER_SCRIPT = PLUGIN_SCRIPTS_COMPILED
+  ? MCP_SERVER_JS
+  : join(PLUGIN_DIR, "scripts", "mcp-server.ts");
+
+function shellQuote(arg: string): string {
+  // Escape backslashes first, then double-quotes, so a trailing backslash
+  // or a `\"` sequence in the input cannot break out of the quoted string.
+  return `"${arg.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function getHookHandlerCommand(ipcSocketPath: string): string {
+  const args = IS_COMPILED_BINARY
+    ? [process.execPath, "_claude_code_hook_handler", "--ipc", ipcSocketPath]
+    : [BUN_RUNTIME, HOOK_HANDLER_SCRIPT, "--ipc", ipcSocketPath];
+  return args.map(shellQuote).join(" ");
+}
+
+function getMcpServerCommand(): { command: string; args: string[] } {
+  if (IS_COMPILED_BINARY) {
+    return { command: process.execPath, args: ["_claude_code_mcp_server"] };
+  }
+  return { command: BUN_RUNTIME, args: [MCP_SERVER_SCRIPT] };
+}
+
+// ── State ─────────────────────────────────────────────────────────────────
+let tmpDir: string | null = null;
+let ipcServer: NetServer | null = null;
+let sioSocket: Socket<RelayServerToClientEvents, RelayClientToServerEvents> | null = null;
+let claudeProcess: ReturnType<typeof Bun.spawn> | null = null;
+let claudeSessionId: string = sessionId;
+let relayToken: string | null = null;
+let seq = 0;
+let currentModel: string | null = null;
+let messages: unknown[] = [];
+
+// Track whether Claude is currently processing a turn (vs idle/waiting for input)
+let claudeIsWorking = false;
+
+// ── Parity state (matches pi worker heartbeat/session_active contract) ────
+const startTime = Date.now();
+let currentSessionName: string | null = null;
+let currentModelObject: { provider: string; id: string; name: string; reasoning?: boolean } | null = null;
+let currentThinkingLevel: string | null = null;
+let currentTokenUsage: { inputTokens: number; outputTokens: number; cacheCreationInputTokens?: number; cacheReadInputTokens?: number; contextWindow?: number } | null = null;
+let currentTodoList: unknown[] = [];
+let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+
+// Pending AskUserQuestion: tool_use_id → { resolve, timer }
+const pendingQuestions = new Map<string, { resolve: (answer: string) => void; timer: ReturnType<typeof setTimeout> }>();
+// Pending tool executions: tool_use_id → { toolName, toolInput }
+// Populated when tool_use blocks appear in assistant messages; consumed when
+// tool_result blocks arrive in user messages. Used to emit synthetic
+// tool_execution_start/end events and annotate toolResult messages.
+const pendingToolCallMap = new Map<string, { toolName: string; toolInput: unknown }>();
+
+// Subagent hook data: agent_id → metadata from SubagentStart/SubagentStop hooks.
+// Claude Code fires these when the Task/Agent tool spawns or completes a subagent.
+// We cache this data so we can enrich toolResult messages with subagent details.
+interface SubagentHookInfo {
+  agentId: string;
+  subagentType?: string;
+  description?: string;
+  parentAgentId?: string;
+  transcriptPath?: string;
+  startedAt: number;
+  stoppedAt?: number;
+}
+const subagentHookData = new Map<string, SubagentHookInfo>();
+// Pending permission requests: requestId → pending handler metadata
+interface PendingPermissionEntry {
+  resolve: (decision: "allow" | "deny") => void;
+  timer: ReturnType<typeof setTimeout>;
+  toolName: string;
+  toolInput: unknown;
+  ts: number;
+}
+const pendingPermissions = new Map<string, PendingPermissionEntry>();
+// Pending triggers this session has received from linked children.
+const receivedTriggers = new Map<string, { sourceSessionId: string; type: string; trackedAt: number }>();
+const TRIGGER_TTL_MS = 10 * 60 * 1000;
+const IS_WINDOWS = process.platform === "win32";
+
+// Buffered session messages from other sessions (for pizzapi_check_messages).
+// Each entry: { fromSessionId, message }
+const messageQueue: Array<{ fromSessionId: string; message: string }> = [];
+
+// Pending message waiters: filters → resolver
+// Allows pizzapi_wait_for_message to efficiently wait for matching messages
+type MessageWaiter = {
+  fromSessionIdFilter?: string;
+  resolve: (msg: { fromSessionId: string; message: string }) => void;
+  cancel: () => void;  // resolves outer Promise with null on teardown
+  timer: ReturnType<typeof setTimeout>;
+};
+const messageWaiters: MessageWaiter[] = [];
+
+// Generation counter — prevents stale watchClaudeExit from triggering shutdown
+let processGeneration = 0;
+let pendingRespawnTimer: ReturnType<typeof setTimeout> | null = null;
+
+function clearPendingState(): void {
+  claudeIsWorking = false;
+  for (const { timer } of pendingQuestions.values()) clearTimeout(timer);
+  pendingQuestions.clear();
+  pendingQuestionState.clear();
+  for (const { timer } of pendingPermissions.values()) clearTimeout(timer);
+  pendingPermissions.clear();
+  pendingAskUserPermissionId = null;
+  for (const waiter of messageWaiters) {
+    clearTimeout(waiter.timer);
+    waiter.cancel();
+  }
+  messageWaiters.length = 0;
+  pendingToolCallMap.clear();
+  subagentHookData.clear();
+}
+
+function trackReceivedTrigger(trigger: ConversationTrigger): void {
+  if (receivedTriggers.has(trigger.triggerId)) return;
+  receivedTriggers.set(trigger.triggerId, {
+    sourceSessionId: trigger.sourceSessionId,
+    type: trigger.type,
+    trackedAt: Date.now(),
+  });
+  const now = Date.now();
+  for (const [id, entry] of receivedTriggers) {
+    if (now - entry.trackedAt > TRIGGER_TTL_MS) receivedTriggers.delete(id);
+  }
+}
+
+function getReceivedTrigger(triggerId: string) {
+  const pending = receivedTriggers.get(triggerId);
+  if (!pending) return null;
+  if (Date.now() - pending.trackedAt > TRIGGER_TTL_MS) {
+    receivedTriggers.delete(triggerId);
+    return null;
+  }
+  return pending;
+}
+
+/**
+ * Handle an incoming session message.
+ * Delivers to waiting listeners or buffers for later retrieval.
+ */
+function handleIncomingSessionMessage(data: { fromSessionId: string; message: string }): void {
+  // Try to deliver to a waiting listener
+  let waiterIdx = -1;
+  for (let i = 0; i < messageWaiters.length; i++) {
+    const waiter = messageWaiters[i];
+    if (!waiter.fromSessionIdFilter || waiter.fromSessionIdFilter === data.fromSessionId) {
+      clearTimeout(waiter.timer);
+      messageWaiters.splice(i, 1);
+      waiter.resolve(data);
+      return;
+    }
+  }
+
+  // No matching waiter — buffer the message
+  messageQueue.push(data);
+}
+
+// ── IPC connected clients ─────────────────────────────────────────────────
+const ipcClients = new Set<NetSocket>();
+
+function broadcastToIpc(msg: BridgeMessage): void {
+  const frame = serializeFrame(msg);
+  for (const client of ipcClients) {
+    if (!client.destroyed) client.write(frame);
+  }
+}
+
+function sendToIpcClient(client: NetSocket, msg: BridgeMessage): void {
+  if (!client.destroyed) client.write(serializeFrame(msg));
+}
+
+// ── Relay helpers ─────────────────────────────────────────────────────────
+function relayHttpBase(): string {
+  const base = relayUrl.replace(/\/ws\/sessions$/, "");
+  if (base.startsWith("ws://")) return `http://${base.slice(5)}`;
+  if (base.startsWith("wss://")) return `https://${base.slice(6)}`;
+  return base;
+}
+
+function sioHttpUrl(): string {
+  return relayUrl.replace(/^ws:/, "http:").replace(/^wss:/, "https:").replace(/\/$/, "");
+}
+
+function forwardEvent(event: unknown): void {
+  if (!sioSocket?.connected || !relayToken) return;
+  if (VERBOSE_EVENT_LOG) {
+    const e = event as Record<string, unknown>;
+    const parts = [`→relay seq=${seq + 1} type=${e.type ?? "?"}`];
+    if (e.role) parts.push(`role=${e.role}`);
+    if (e.toolName) parts.push(`tool=${e.toolName}`);
+    if (e.toolCallId) parts.push(`callId=${(e.toolCallId as string).slice(0, 12)}`);
+    // For message_update, peek inside the message for role/toolName
+    if (e.type === "message_update" && e.message && typeof e.message === "object") {
+      const m = e.message as Record<string, unknown>;
+      if (m.role) parts.push(`msg.role=${m.role}`);
+      if (m.toolName) parts.push(`msg.tool=${m.toolName}`);
+      if (m.toolCallId) parts.push(`msg.callId=${(m.toolCallId as string).slice(0, 12)}`);
+    }
+    logInfo(parts.join(" "));
+  }
+  sioSocket.emit("event", { sessionId, token: relayToken, event, seq: ++seq });
+}
+
+function emitHeartbeat(status?: string): void {
+  const hb: Record<string, unknown> = {
+    type: "heartbeat",
+    workerType: "claude-code",
+    active: claudeIsWorking,
+    isAgentActive: claudeIsWorking,
+    model: currentModelObject ?? (currentModel ? parseModelString(currentModel) : null),
+    sessionName: currentSessionName,
+    ts: Date.now(),
+    ...(status ? { status } : {}),
+  };
+
+  // Always include pendingQuestion so the UI's hasOwnProperty guard fires
+  // and clears any stale prompt after resolution/timeout.
+  if (pendingQuestionState.size > 0) {
+    const [toolCallId, pendingQ] = [...pendingQuestionState.entries()][0];
+    hb.pendingQuestion = {
+      toolCallId,
+      questions: pendingQ.questions,
+      display: "modal", // default to modal for Claude Code sessions
+    };
+  } else if (pendingQuestions.size > 0) {
+    // Fallback: if we have an entry in pendingQuestions but not in pendingQuestionState
+    // (shouldn't happen, but be defensive)
+    const [toolCallId] = [...pendingQuestions.entries()][0];
+    hb.pendingQuestion = {
+      toolCallId,
+      questions: [],
+      display: "modal",
+    };
+  } else {
+    hb.pendingQuestion = null;
+  }
+
+  // Always include pendingPermission so the UI's hasOwnProperty guard fires
+  // and clears any stale card after a timeout/resolution.
+  if (pendingPermissions.size > 0) {
+    const [requestId, entry] = [...pendingPermissions.entries()][0];
+    hb.pendingPermission = {
+      requestId,
+      toolName: entry.toolName,
+      toolInput: entry.toolInput,
+      ts: entry.ts,
+    };
+  } else {
+    hb.pendingPermission = null;
+  }
+
+  forwardEvent(hb);
+}
+
+// ── Capabilities ──────────────────────────────────────────────────────────
+function emitCapabilities(): void {
+  const { models } = listAvailableModels();
+  forwardEvent({
+    type: "capabilities",
+    models,
+    commands: [],
+  });
+}
+
+// ── Heartbeat timer ───────────────────────────────────────────────────────
+function startHeartbeatTimer(): void {
+  if (heartbeatTimer) clearInterval(heartbeatTimer);
+  heartbeatTimer = setInterval(() => {
+    emitHeartbeat();
+  }, 10_000);
+}
+
+function stopHeartbeatTimer(): void {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+}
+
+// ── Model string parser ──────────────────────────────────────────────────
+/** Strip Claude CLI model suffixes like `[1m]` (thinking budget indicators). */
+function stripModelSuffix(modelStr: string): string {
+  return modelStr.replace(/\[.*?\]$/, "").trim();
+}
+
+/** Parse a Claude model ID string into a structured model object.
+ *  Looks up the well-known models list to find a clean display name.
+ *  Falls back to a prettified version of the raw ID if not found.
+ */
+function parseModelString(modelStr: string): { provider: string; id: string; name: string; reasoning?: boolean } {
+  const baseId = stripModelSuffix(modelStr);
+
+  // Try to find a matching well-known model by exact ID or stripped ID
+  const match = WELL_KNOWN_MODELS.find(
+    (m) => m.id === baseId || m.id === modelStr,
+  );
+
+  if (match) {
+    return {
+      provider: match.provider,
+      id: baseId,
+      name: match.name,
+      ...(match.reasoning ? { reasoning: true } : {}),
+    };
+  }
+
+  // Fallback: prettify the raw model string (e.g. "claude-opus-4-6" → "Claude Opus 4 6")
+  const prettyName = baseId
+    .replace(/^claude-/, "Claude ")
+    .replace(/-/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+  const reasoning = /opus|sonnet|claude-4|claude-3/.test(modelStr);
+
+  return {
+    provider: "anthropic",
+    id: baseId,
+    name: prettyName,
+    ...(reasoning ? { reasoning: true } : {}),
+  };
+}
+
+// ── Model list ────────────────────────────────────────────────────────────
+/** Well-known models per provider — used to populate pizzapi_list_models. */
+const WELL_KNOWN_MODELS: Array<{ provider: string; id: string; name: string; reasoning?: boolean }> = [
+  // Anthropic
+  { provider: "anthropic", id: "claude-opus-4-6",    name: "Claude Opus 4.6",   reasoning: true },
+  { provider: "anthropic", id: "claude-sonnet-4-6",  name: "Claude Sonnet 4.6", reasoning: true },
+  { provider: "anthropic", id: "claude-haiku-4-6",   name: "Claude Haiku 4.6" },
+  { provider: "anthropic", id: "claude-opus-4-5",    name: "Claude Opus 4.5",   reasoning: true },
+  { provider: "anthropic", id: "claude-sonnet-4-5",  name: "Claude Sonnet 4.5", reasoning: true },
+  { provider: "anthropic", id: "claude-haiku-4-5",   name: "Claude Haiku 4.5" },
+  { provider: "anthropic", id: "claude-opus-4",      name: "Claude Opus 4",     reasoning: true },
+  { provider: "anthropic", id: "claude-sonnet-4",    name: "Claude Sonnet 4",   reasoning: true },
+  { provider: "anthropic", id: "claude-haiku-4",     name: "Claude Haiku 4" },
+  { provider: "anthropic", id: "claude-3-7-sonnet-20250219", name: "Claude 3.7 Sonnet", reasoning: true },
+  { provider: "anthropic", id: "claude-3-5-sonnet-20241022", name: "Claude 3.5 Sonnet" },
+  { provider: "anthropic", id: "claude-3-5-haiku-20241022",  name: "Claude 3.5 Haiku" },
+  // Google
+  { provider: "google",    id: "gemini-2.5-pro",     name: "Gemini 2.5 Pro",   reasoning: true },
+  { provider: "google",    id: "gemini-2.5-flash",   name: "Gemini 2.5 Flash", reasoning: true },
+  { provider: "google",    id: "gemini-2.0-flash",   name: "Gemini 2.0 Flash" },
+  // OpenAI
+  { provider: "openai",    id: "o3",                 name: "o3",               reasoning: true },
+  { provider: "openai",    id: "o4-mini",            name: "o4-mini",          reasoning: true },
+  { provider: "openai",    id: "gpt-4.1",            name: "GPT-4.1" },
+  { provider: "openai",    id: "gpt-4o",             name: "GPT-4o" },
+];
+
+/**
+ * Return models available on this runner.
+ * Reads ~/.pizzapi/auth.json (or $PIZZAPI_AGENT_DIR/auth.json) to discover
+ * which providers have credentials, then filters the well-known model list to
+ * those providers.  Always includes the current session model as a fallback.
+ */
+// Auth.json key → canonical provider name used in WELL_KNOWN_MODELS.
+// The CLI stores credentials under provider-specific keys that don't match
+// the shorter names used in the model list (e.g. "google-gemini-cli" → "google").
+const AUTH_PROVIDER_MAP: Record<string, string> = {
+  "google-gemini-cli": "google",
+  "openai-codex": "openai",
+};
+
+function listAvailableModels(): { models: Array<{ provider: string; id: string; name: string; reasoning?: boolean }> } {
+  // Detect which providers have credentials
+  const agentDir = process.env.PIZZAPI_AGENT_DIR ?? join(homedir(), ".pizzapi");
+  let configuredProviders = new Set<string>();
+  try {
+    const raw = readFileSync(join(agentDir, "auth.json"), "utf-8");
+    const auth = JSON.parse(raw) as Record<string, unknown>;
+    // Normalize auth.json keys to canonical provider names used in WELL_KNOWN_MODELS.
+    configuredProviders = new Set(
+      Object.keys(auth).map((k) => AUTH_PROVIDER_MAP[k] ?? k),
+    );
+  } catch {
+    // auth.json missing or unreadable — fall back to current model only
+  }
+
+  // If we can read credentials, filter to configured providers; otherwise return all models
+  // (so the tool is still useful even if auth.json is temporarily unavailable).
+  let models = configuredProviders.size > 0
+    ? WELL_KNOWN_MODELS.filter((m) => configuredProviders.has(m.provider))
+    : [...WELL_KNOWN_MODELS];
+
+  // Always include the current session model so the list is never empty.
+  if (
+    currentModelObject &&
+    !models.some((m) => m.provider === currentModelObject!.provider && m.id === currentModelObject!.id)
+  ) {
+    models.unshift(currentModelObject);
+  }
+
+  // Apply hidden-model filter from the environment (set by daemon via PIZZAPI_HIDDEN_MODELS).
+  const hiddenRaw = process.env.PIZZAPI_HIDDEN_MODELS;
+  if (hiddenRaw) {
+    try {
+      const hidden = JSON.parse(hiddenRaw) as unknown;
+      if (Array.isArray(hidden) && hidden.length > 0) {
+        const hiddenKeys = new Set(hidden.filter((h): h is string => typeof h === "string"));
+        models = models.filter((m) => !hiddenKeys.has(`${m.provider}/${m.id}`));
+      }
+    } catch {
+      // Malformed PIZZAPI_HIDDEN_MODELS — ignore
+    }
+  }
+
+  return { models };
+}
+
+// ── Temp dir and config file generation ──────────────────────────────────
+async function setupTempDir(): Promise<{ ipcSocketPath: string; hooksPath: string; mcpPath: string }> {
+  tmpDir = await mkdtemp(join(tmpdir(), "pizzapi-cc-"));
+  await chmod(tmpDir, 0o700);
+
+  const ipcSocketPath = IS_WINDOWS
+    ? `\\\\.\\pipe\\pizzapi-cc-${randomUUID()}`
+    : join(tmpDir, "bridge.sock");
+
+  const hooksJson = {
+    hooks: Object.fromEntries(
+      ["SessionStart","SessionEnd","PostToolUse","PostToolUseFailure",
+       "Stop","SubagentStart","SubagentStop","Notification","UserPromptSubmit","PreCompact"].map(
+        (evt) => [evt, [{ hooks: [{ type: "command", command: getHookHandlerCommand(ipcSocketPath) }] }]]
+      )
+    ),
+  };
+  const hooksPath = join(tmpDir, "hooks.json");
+  await writeFile(hooksPath, JSON.stringify(hooksJson, null, 2), { mode: 0o600 });
+
+  const mcpServerCommand = getMcpServerCommand();
+  const mcpJson = {
+    mcpServers: {
+      pizzapi: {
+        command: mcpServerCommand.command,
+        args: mcpServerCommand.args,
+        env: {
+          PIZZAPI_CC_BRIDGE_IPC: ipcSocketPath,
+          PIZZAPI_SESSION_ID: sessionId,
+        },
+      },
+    },
+  };
+  const mcpPath = join(tmpDir, "mcp.json");
+  await writeFile(mcpPath, JSON.stringify(mcpJson, null, 2), { mode: 0o600 });
+
+  return { ipcSocketPath, hooksPath, mcpPath };
+}
+
+async function cleanupTempDir(): Promise<void> {
+  if (tmpDir) {
+    try { await rm(tmpDir, { recursive: true, force: true }); } catch {}
+    tmpDir = null;
+  }
+}
+
+// ── IPC server ────────────────────────────────────────────────────────────
+function startIpcServer(socketPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ipcServer = createNetServer((client) => {
+      ipcClients.add(client);
+      let buf: Buffer<ArrayBufferLike> = Buffer.alloc(0);
+
+      client.on("data", (chunk: Buffer) => {
+        buf = Buffer.concat([buf, chunk]);
+        const { frames, remaining } = framesFromBuffer(buf as Buffer<ArrayBuffer>);
+        buf = remaining;
+        for (const frame of frames) {
+          handleIpcMessage(client, frame as PluginMessage);
+        }
+      });
+
+      client.on("close", () => ipcClients.delete(client));
+      client.on("error", () => ipcClients.delete(client));
+    });
+
+    ipcServer.listen(socketPath, () => resolve());
+    ipcServer.on("error", reject);
+  });
+}
+
+function handleIpcMessage(client: NetSocket, msg: PluginMessage): void {
+  if (msg.type === "hook_event") {
+    // Extract enriched data from SubagentStart/SubagentStop hook events.
+    // Claude Code fires these when the Task/Agent tool spawns or completes
+    // a subagent. The hook input (msg.data) carries agent details that we
+    // can use to provide richer UI rendering.
+    if (msg.event === "SubagentStart" || msg.event === "SubagentStop") {
+      const hookData = msg.data as Record<string, unknown> | undefined;
+      if (hookData) {
+        // Store subagent metadata keyed by agent_id so we can attach it
+        // to the tool_result when SubagentStop fires later.
+        const agentId = typeof hookData.agent_id === "string" ? hookData.agent_id : undefined;
+        const subagentType = typeof hookData.subagent_type === "string" ? hookData.subagent_type : undefined;
+        const parentAgentId = typeof hookData.parent_agent_id === "string" ? hookData.parent_agent_id : undefined;
+        logInfo(`hook: ${msg.event} agent=${agentId ?? "?"} type=${subagentType ?? "?"} parent=${parentAgentId ?? "?"}`);
+        if (msg.event === "SubagentStart" && agentId) {
+          subagentHookData.set(agentId, {
+            agentId,
+            subagentType,
+            description: typeof hookData.description === "string" ? hookData.description : undefined,
+            parentAgentId,
+            startedAt: Date.now(),
+          });
+        }
+        if (msg.event === "SubagentStop" && agentId) {
+          const startData = subagentHookData.get(agentId);
+          if (startData) {
+            startData.stoppedAt = Date.now();
+            startData.transcriptPath = typeof hookData.transcript_path === "string" ? hookData.transcript_path : undefined;
+          }
+        }
+      }
+    }
+    forwardEvent({ type: "hook_event", event: msg.event, ts: Date.now() });
+  }
+
+  if (msg.type === "mcp_call") {
+    void handleMcpCall(client, msg.tool, msg.args as Record<string, unknown>, msg.requestId);
+  }
+}
+
+async function handleMcpCall(
+  client: NetSocket,
+  tool: string,
+  args: Record<string, unknown>,
+  requestId: string,
+): Promise<void> {
+  try {
+    const result = await dispatchMcpTool(tool, args);
+    sendToIpcClient(client, { type: "mcp_response", requestId, result });
+  } catch (err) {
+    sendToIpcClient(client, { type: "mcp_response", requestId, result: null, error: err instanceof Error ? err.message : String(err) });
+  }
+}
+
+async function dispatchMcpTool(tool: string, args: Record<string, unknown>): Promise<unknown> {
+  switch (tool) {
+    case "set_session_name": {
+      const name = typeof args.name === "string" ? args.name.trim() : "";
+      if (name) {
+        currentSessionName = name;
+        // Broadcast immediately so the server updates the session name without
+        // waiting for the next scheduled heartbeat.
+        emitHeartbeat();
+      }
+      return "ok";
+    }
+
+    case "pizzapi_get_session_id":
+      return sessionId;
+
+    case "pizzapi_spawn_session": {
+      const base = relayHttpBase();
+      const resp = await fetch(`${base}/api/runners/spawn`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "x-api-key": apiKey ?? "" },
+        body: JSON.stringify(buildSpawnSessionBody(args, sessionId)),
+      });
+      const body = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        throw new Error(typeof (body as { error?: unknown }).error === "string"
+          ? (body as { error: string }).error
+          : `Spawn failed: HTTP ${resp.status}`);
+      }
+      return body;
+    }
+
+    case "pizzapi_send_message": {
+      if (!sioSocket?.connected || !relayToken) throw new Error("Not connected to relay");
+      sioSocket.emit("session_message", {
+        token: relayToken,
+        targetSessionId: String(args.sessionId ?? ""),
+        message: String(args.message ?? ""),
+      });
+      return "sent";
+    }
+
+    case "pizzapi_wait_for_message": {
+      const requestedTimeout = Number(args.timeout ?? 20_000);
+      const normalizedTimeout = Number.isFinite(requestedTimeout) ? requestedTimeout : 20_000;
+      const timeoutMs = Math.min(Math.max(normalizedTimeout, 0), 25_000);
+      return new Promise<unknown>((resolve) => {
+        // First check if there's an already-buffered message that matches
+        const fromSessionIdFilter = typeof args.fromSessionId === "string" ? args.fromSessionId : undefined;
+        let foundIdx = -1;
+
+        if (!fromSessionIdFilter) {
+          // Only consume index 0 if the queue actually has an entry; an empty
+          // queue leaves foundIdx at -1 so we fall through to the waiter path.
+          foundIdx = messageQueue.length > 0 ? 0 : -1;
+        } else {
+          foundIdx = messageQueue.findIndex((m) => m.fromSessionId === fromSessionIdFilter);
+        }
+
+        if (foundIdx >= 0) {
+          const msg = messageQueue.splice(foundIdx, 1)[0];
+          resolve({ fromSessionId: msg.fromSessionId, message: msg.message });
+          return;
+        }
+
+        if (timeoutMs === 0) {
+          resolve(null);
+          return;
+        }
+
+        const deadlineAt = Date.now() + timeoutMs;
+        const waiter: MessageWaiter = {
+          fromSessionIdFilter,
+          resolve: (msg) => resolve({ fromSessionId: msg.fromSessionId, message: msg.message }),
+          cancel: () => resolve(null),
+          timer: null as unknown as ReturnType<typeof setTimeout>,
+        };
+
+        const pollForTimeout = () => {
+          if (!messageWaiters.includes(waiter)) return;
+          if (Date.now() >= deadlineAt) {
+            const idx = messageWaiters.indexOf(waiter);
+            if (idx >= 0) messageWaiters.splice(idx, 1);
+            resolve(null);
+            return;
+          }
+          waiter.timer = setTimeout(pollForTimeout, 100);
+        };
+
+        waiter.timer = setTimeout(pollForTimeout, 100);
+        messageWaiters.push(waiter);
+      });
+    }
+
+    case "pizzapi_check_messages": {
+      const fromSessionIdFilter = typeof args.fromSessionId === "string" ? args.fromSessionId : undefined;
+      const result = fromSessionIdFilter
+        ? messageQueue.filter((m) => m.fromSessionId === fromSessionIdFilter)
+        : messageQueue.slice();
+
+      if (fromSessionIdFilter) {
+        // Remove the returned messages from the queue
+        messageQueue.splice(
+          0,
+          messageQueue.length,
+          ...messageQueue.filter((m) => m.fromSessionId !== fromSessionIdFilter),
+        );
+      } else {
+        // Clear the entire queue
+        messageQueue.length = 0;
+      }
+
+      return result.length > 0 ? result : null;
+    }
+
+    case "pizzapi_respond_to_trigger": {
+      await respondToReceivedTrigger({
+        triggerId: String(args.triggerId ?? ""),
+        response: String(args.response ?? ""),
+        ...(args.action ? { action: String(args.action) } : {}),
+      });
+      return "sent";
+    }
+
+    case "pizzapi_tell_child":
+      await deliverInputMessageToSession(String(args.sessionId ?? ""), String(args.message ?? ""));
+      return "sent";
+
+    case "pizzapi_escalate_trigger":
+      await escalateReceivedTrigger(String(args.triggerId ?? ""), typeof args.context === "string" ? args.context : undefined);
+      return "sent";
+
+    case "pizzapi_list_models":
+      return listAvailableModels();
+
+    default:
+      throw new Error(`Unknown PizzaPi tool: ${tool}`);
+  }
+}
+
+async function deliverInputMessageToSession(targetSessionId: string, message: string): Promise<void> {
+  if (!targetSessionId) throw new Error("Missing target session ID");
+  if (!sioSocket?.connected || !relayToken) throw new Error("Not connected to relay");
+  const socket = sioSocket;
+  const token = relayToken;
+
+  await new Promise<void>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      socket.off("session_message_error" as any, onError);
+      resolve();
+    }, 3000);
+
+    const onError = (err: { targetSessionId: string; error: string }) => {
+      if (err.targetSessionId !== targetSessionId) return;
+      clearTimeout(timeout);
+      socket.off("session_message_error" as any, onError);
+      reject(new Error(err.error));
+    };
+
+    socket.on("session_message_error" as any, onError);
+    socket.emit("session_message", {
+      token,
+      targetSessionId,
+      message,
+      deliverAs: "input",
+    });
+  });
+}
+
+async function cleanupChildSession(childSessionId: string): Promise<void> {
+  if (!childSessionId) throw new Error("Missing child session ID");
+  if (!sioSocket?.connected || !relayToken) throw new Error("Not connected to relay");
+  const socket = sioSocket;
+  const token = relayToken;
+
+  const result = await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+    const timeout = setTimeout(() => resolve({ ok: false, error: "Cleanup ack timed out" }), 10_000);
+    socket.emit("cleanup_child_session", {
+      token,
+      childSessionId,
+    }, (ack: { ok: boolean; error?: string }) => {
+      clearTimeout(timeout);
+      resolve(ack ?? { ok: true });
+    });
+  });
+
+  if (!result.ok) {
+    throw new Error(result.error ?? `Failed to clean up child session ${childSessionId}`);
+  }
+}
+
+async function respondToReceivedTrigger(data: { triggerId: string; response: string; action?: string }): Promise<void> {
+  if (!data.triggerId) throw new Error("Missing trigger ID");
+  const pending = getReceivedTrigger(data.triggerId);
+  if (!pending) throw new Error(`No pending trigger with ID ${data.triggerId}`);
+  if (!sioSocket?.connected || !relayToken) throw new Error("Not connected to relay");
+
+  if (pending.type === "session_complete") {
+    const action = data.action ?? "ack";
+    if (action === "followUp") {
+      await deliverInputMessageToSession(pending.sourceSessionId, data.response);
+      receivedTriggers.delete(data.triggerId);
+      return;
+    }
+    await cleanupChildSession(pending.sourceSessionId);
+    receivedTriggers.delete(data.triggerId);
+    return;
+  }
+
+  sioSocket.emit("trigger_response", {
+    token: relayToken,
+    triggerId: data.triggerId,
+    response: data.response,
+    ...(data.action ? { action: data.action } : {}),
+    targetSessionId: pending.sourceSessionId,
+  });
+  receivedTriggers.delete(data.triggerId);
+}
+
+async function escalateReceivedTrigger(triggerId: string, context?: string): Promise<void> {
+  const pending = getReceivedTrigger(triggerId);
+  if (!pending) throw new Error(`No pending trigger with ID ${triggerId}`);
+  if (!sioSocket?.connected || !relayToken) throw new Error("Not connected to relay");
+
+  sioSocket.emit("session_trigger" as any, {
+    token: relayToken,
+    trigger: {
+      type: "escalate",
+      sourceSessionId: pending.sourceSessionId,
+      targetSessionId: sessionId,
+      payload: { reason: context ?? "Parent escalated", originalTriggerId: triggerId },
+      deliverAs: "steer" as const,
+      expectsResponse: true,
+      triggerId,
+      ts: new Date().toISOString(),
+    },
+  });
+  receivedTriggers.delete(triggerId);
+}
+
+// ── Claude subprocess ─────────────────────────────────────────────────────
+function spawnClaude(tmpDirPath: string, resume = false): void {
+  logInfo(`spawning claude (resume=${resume}, generation=${processGeneration + 1}, cwd=${cwd})`);
+  _stdoutBuf = "";  // reset on every spawn
+  _stdoutDecoder = new TextDecoder();  // clear stale multi-byte state
+  processGeneration++;
+  const myGeneration = processGeneration;
+
+  const mcpPath = join(tmpDirPath, "mcp.json");
+  const hooksPath = join(tmpDirPath, "hooks.json");
+
+  // `--settings` is a verified Claude Code flag (accepts path to settings JSON).
+  // The settings file contains the `hooks` key for per-session hook delivery.
+  const cliArgs = [
+    "--input-format", "stream-json",
+    "--output-format", "stream-json",
+    "--include-partial-messages",
+    "--verbose",
+    "--replay-user-messages",
+    "--permission-prompt-tool", "stdio",
+    "--session-id", claudeSessionId,
+    "--plugin-dir", PLUGIN_DIR,
+    "--mcp-config", mcpPath,
+    "--settings", hooksPath,
+    "--add-dir", cwd,
+    // Instruct Claude to call set_session_name at the start of each new
+    // conversation so PizzaPi can display a meaningful session title.
+    // Skipped on --resume because the session already has a name from its
+    // first turn (the conversation history already contains the first
+    // set_session_name call), so re-injecting the instruction is unnecessary
+    // noise and could cause a spurious rename.
+    ...(!resume ? ["--append-system-prompt", SET_SESSION_NAME_PROMPT] : []),
+    ...(initialModelId
+      ? initialModelProvider && initialModelProvider !== "anthropic"
+        ? []
+        : ["--model", initialModelId]
+      : []),
+    ...(resume ? ["--resume", claudeSessionId] : []),
+  ];
+
+  if (initialModelId && initialModelProvider && initialModelProvider !== "anthropic") {
+    logWarn(`ignoring unsupported initial model provider for Claude Code worker: ${initialModelProvider}`);
+  }
+
+  const command = resume
+    ? ["claude", "-p", ...cliArgs]
+    : ["claude", "-p", initialPrompt, ...cliArgs];
+
+  claudeProcess = Bun.spawn(command, {
+    cwd,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      PIZZAPI_CC_BRIDGE_IPC: join(tmpDirPath, "bridge.sock"),
+      PIZZAPI_SESSION_ID: sessionId,
+    },
+  });
+
+  void readClaudeStdout(myGeneration);
+  void readClaudeStderr();
+  void watchClaudeExit(tmpDirPath, myGeneration);
+}
+
+function writeToClaudeStdin(msg: unknown): void {
+  if (!claudeProcess?.stdin) return;
+  const data = JSON.stringify(msg) + "\n";
+  (claudeProcess.stdin as any).write(data);
+}
+
+let _stdoutDecoder = new TextDecoder();
+const _stderrDecoder = new TextDecoder();
+let _stdoutBuf = "";
+
+async function readClaudeStdout(generation: number): Promise<void> {
+  if (!claudeProcess?.stdout) return;
+  // Bun subprocess stdout is a ReadableStream — use async iteration
+  for await (const chunk of claudeProcess.stdout as AsyncIterable<Uint8Array>) {
+    if (generation !== processGeneration) return; // stale process — drop
+    processStdoutChunk(chunk);
+  }
+}
+
+function processStdoutChunk(chunk: Uint8Array): void {
+  const text = _stdoutDecoder.decode(chunk, { stream: true });
+  _stdoutBuf += text;
+  const lines = _stdoutBuf.split("\n");
+  _stdoutBuf = lines.pop() ?? "";
+  for (const line of lines) {
+    if (line.trim()) handleNdjsonLine(line);
+  }
+}
+
+async function readClaudeStderr(): Promise<void> {
+  if (!claudeProcess?.stderr) return;
+  for await (const chunk of claudeProcess.stderr as AsyncIterable<Uint8Array>) {
+    const text = _stderrDecoder.decode(chunk, { stream: true });
+    if (text.trim()) logWarn(`[claude stderr] ${text.trimEnd()}`);
+  }
+}
+
+async function watchClaudeExit(tmpDirPath: string, generation: number): Promise<void> {
+  if (!claudeProcess) return;
+  const exitCode = await claudeProcess.exited;
+  claudeProcess = null;
+
+  // If a newer process has been spawned since, this watcher is stale
+  if (generation !== processGeneration) {
+    logInfo(`stale exit watcher (generation=${generation}, current=${processGeneration}) — ignoring exit code ${exitCode}`);
+    return;
+  }
+
+  if (exitCode === 43) {
+    logInfo("claude exited with code 43 — restarting with --resume");
+    spawnClaude(tmpDirPath, true);
+    return;
+  }
+
+  logInfo(`claude exited with code ${exitCode} — shutting down (${exitCode === 0 ? "completed" : "error"})`);
+  shutdown(exitCode === 0 ? "completed" : "error");
+}
+
+// ── Subagent details synthesis ─────────────────────────────────────────────
+/**
+ * Synthesize a pi-style SubagentDetails object from Claude Code's Task/Agent
+ * tool input and result content. This allows the SubagentResultCard to render
+ * structured results (agent name, task, usage) instead of just plain text.
+ *
+ * The resulting object matches the shape expected by SubagentResultCard:
+ *   { mode, agentScope, projectAgentsDir, results: [{ agent, task, exitCode, messages, usage, ... }] }
+ */
+function synthesizeSubagentDetails(toolName: string, toolInput: unknown, resultContent: unknown): Record<string, unknown> {
+  const input = toolInput && typeof toolInput === "object" ? toolInput as Record<string, unknown> : {};
+
+  // Extract agent info from tool input (Claude Code Task/Agent schema)
+  const agentName = typeof input.subagent_type === "string" ? input.subagent_type
+    : typeof input.agent === "string" ? input.agent
+    : "agent";
+  const task = typeof input.prompt === "string" ? input.prompt
+    : typeof input.task === "string" ? input.task
+    : typeof input.description === "string" ? input.description
+    : "";
+
+  // Extract the text result from content
+  let resultText = "";
+  if (typeof resultContent === "string") {
+    resultText = resultContent;
+  } else if (Array.isArray(resultContent)) {
+    for (const block of resultContent) {
+      if (block && typeof block === "object" && (block as Record<string, unknown>).type === "text") {
+        resultText += (resultText ? "\n" : "") + String((block as Record<string, unknown>).text ?? "");
+      }
+    }
+  }
+
+  // Build a SingleResult-compatible object
+  const singleResult: Record<string, unknown> = {
+    agent: agentName,
+    agentSource: "user",
+    task,
+    exitCode: 0,
+    // Provide a minimal messages array with the final assistant response
+    messages: resultText ? parseSubagentToolCalls(resultText) : [],
+    stderr: "",
+    usage: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: 0, turns: 0 },
+  };
+
+  // Try to find matching hook data for richer metadata
+  // (SubagentStart/SubagentStop hooks carry agent_id, duration, etc.)
+  for (const [, hookInfo] of subagentHookData) {
+    if (hookInfo.subagentType === agentName || hookInfo.description === (input.description as string)) {
+      if (hookInfo.stoppedAt && hookInfo.startedAt) {
+        // Can't directly set usage.durationMs but it's useful context
+        singleResult.model = hookInfo.subagentType;
+      }
+      // Clean up consumed hook data
+      subagentHookData.delete(hookInfo.agentId);
+      break;
+    }
+  }
+
+  return {
+    mode: "single",
+    agentScope: "user",
+    projectAgentsDir: null,
+    results: [singleResult],
+  };
+}
+
+// ── NDJSON event handling ─────────────────────────────────────────────────
+function handleNdjsonLine(line: string): void {
+  const result = translateNdjsonLine(line);
+
+  if (VERBOSE_EVENT_LOG) {
+    const parts = [`←ndjson kind=${result.kind}`];
+    if (result.toolName) parts.push(`tool=${result.toolName}`);
+    if (result.toolCallId) parts.push(`callId=${result.toolCallId.slice(0, 12)}`);
+    if (result.sessionId) parts.push(`ccSessionId=${result.sessionId}`);
+    if (result.model) parts.push(`model=${result.model}`);
+    if (result.sessionName) parts.push(`name="${result.sessionName}"`);
+    if (result.toolCalls?.length) {
+      const tcSummary = result.toolCalls.map(tc => tc.toolName).join(",");
+      parts.push(`toolCalls=[${tcSummary}]`);
+    }
+    if (result.relayEvent) {
+      const e = result.relayEvent as Record<string, unknown>;
+      parts.push(`event.type=${e.type ?? "?"}`);
+      if (e.role) parts.push(`event.role=${e.role}`);
+      const m = e.message as Record<string, unknown> | undefined;
+      if (m?.role) parts.push(`msg.role=${m.role}`);
+      if (m?.toolName) parts.push(`msg.tool=${m.toolName}`);
+    }
+    if (result.relayEvents?.length) {
+      const roles = result.relayEvents.map(e => {
+        const m = (e as Record<string, unknown>).message as Record<string, unknown> | undefined;
+        return m?.role ?? (e as Record<string, unknown>).type ?? "?";
+      });
+      parts.push(`events=[${roles.join(",")}]`);
+    }
+    logInfo(parts.join(" "));
+  }
+
+  if (result.kind === "control_request") {
+    if (result.controlRequestId && result.toolName) {
+      handleControlRequest(result.controlRequestId, result.toolName, result.toolInput);
+    }
+    return;
+  }
+
+  if (result.kind === "session_init") {
+    logInfo(`session_init: ccSessionId=${result.sessionId ?? "?"} model=${result.model ?? "?"}`);
+    if (result.sessionId) claudeSessionId = result.sessionId;
+    if (result.model) {
+      currentModel = result.model;
+      currentModelObject = parseModelString(result.model);
+    }
+    claudeIsWorking = false;
+    emitCapabilities();
+    emitSessionActive();
+    return;
+  }
+
+  if (result.kind === "ask_user_question") {
+    // Forward the assistant message to history first so reconnecting viewers
+    // see the full conversation including the AskUserQuestion turn.
+    if (result.relayEvent?.message) {
+      messages.push(result.relayEvent.message);
+      claudeIsWorking = true;
+      forwardEvent(result.relayEvent);
+    }
+    if (result.toolCallId) {
+      handleAskUserQuestion(result.toolCallId, result.questions ?? []);
+    }
+    return;
+  }
+
+  if (result.kind === "relay_event" && (result.relayEvent || result.relayEvents)) {
+    // ── Suppress subagent-internal events early ──────────────────────
+    // Claude Code sets `parent_tool_use_id` on every NDJSON message.
+    // When non-null, the event belongs to a subagent (Agent/Task tool)
+    // and should not appear in the parent conversation.  The subagent's
+    // final result is delivered as a toolResult matching the parent's
+    // toolCallId, which has `parent_tool_use_id: null` — so it passes
+    // through normally.
+    // IMPORTANT: this guard must come BEFORE any side-effect application
+    // (todoList, sessionName, tokenUsage) to prevent subagent state from
+    // corrupting the parent session.
+    if (result.parentToolUseId) {
+      if (VERBOSE_EVENT_LOG) {
+        logInfo(`suppressed subagent-internal (parent=${result.parentToolUseId.slice(0, 12)})`);
+      }
+      return;
+    }
+
+    // Update parity state from side-effects carried on the translation result
+    if (result.todoList) {
+      currentTodoList = result.todoList;
+      forwardEvent({ type: "todo_update", todos: result.todoList, ts: Date.now() });
+    }
+    if (result.sessionName !== undefined) {
+      currentSessionName = result.sessionName;
+      // Emit an immediate heartbeat so the relay picks up the new name without
+      // waiting for the next scheduled 10-second heartbeat.
+      emitHeartbeat();
+    }
+    if (result.tokenUsage) {
+      currentTokenUsage = result.tokenUsage;
+    }
+
+    // ── Emit synthetic tool_execution_start events ────────────────────
+    // When an assistant message contains tool_use blocks, emit start events
+    // so the UI can track active tool calls (spinning indicators).
+    if (result.toolCalls) {
+      for (const tc of result.toolCalls) {
+        pendingToolCallMap.set(tc.toolCallId, { toolName: tc.toolName, toolInput: tc.toolInput });
+        forwardEvent({
+          type: "tool_execution_start",
+          toolCallId: tc.toolCallId,
+          toolName: tc.toolName,
+          args: tc.toolInput,
+        });
+      }
+    }
+
+    // Support both single (relayEvent) and multiple (relayEvents) events.
+    // relayEvents is used when one NDJSON line produces multiple relay events
+    // (e.g. a user message containing several tool_result blocks).
+    const events = result.relayEvents ?? (result.relayEvent ? [result.relayEvent] : []);
+
+    // First pass: annotate toolResult messages with toolName from the
+    // pending tool call, and collect tool_execution_end events to emit.
+    const toolEndEvents: Array<{ toolCallId: string; toolName: string; isError: boolean }> = [];
+
+    for (const relayEvent of events) {
+      if (relayEvent.type !== "message_update") continue;
+      const msg = relayEvent.message as Record<string, unknown> | undefined;
+      if (!msg || msg.role !== "toolResult") continue;
+
+      const toolCallId = typeof msg.toolCallId === "string" ? msg.toolCallId : undefined;
+      if (!toolCallId) continue;
+
+      const pending = pendingToolCallMap.get(toolCallId);
+      if (!pending) continue;
+
+      // Annotate with toolName so the UI's rendering pipeline can select the
+      // correct card component (e.g. SubagentResultCard for "subagent").
+      if (!msg.toolName) {
+        msg.toolName = pending.toolName;
+      }
+
+      // For subagent tools (Task/Agent/subagent), synthesize a pi-style
+      // `details` object so the SubagentResultCard can render structured
+      // results instead of falling back to plain text.
+      if (SUBAGENT_TOOL_NAMES.has(pending.toolName) && !msg.details) {
+        msg.details = synthesizeSubagentDetails(pending.toolName, pending.toolInput, msg.content);
+      }
+
+      // Queue a synthetic tool_execution_end event
+      toolEndEvents.push({
+        toolCallId,
+        toolName: pending.toolName,
+        isError: msg.isError === true,
+      });
+      pendingToolCallMap.delete(toolCallId);
+    }
+
+    // Emit tool_execution_end events BEFORE forwarding the relay messages,
+    // matching the pi-native event order (end event clears activeToolCalls
+    // in the UI, then the message_update adds the final tool result).
+    for (const endEvt of toolEndEvents) {
+      forwardEvent({
+        type: "tool_execution_end",
+        toolCallId: endEvt.toolCallId,
+        toolName: endEvt.toolName,
+        result: null,
+        isError: endEvt.isError,
+      });
+    }
+
+    // Second pass: forward relay events and update bridge state.
+    for (const relayEvent of events) {
+      const eventType = relayEvent.type;
+      if (eventType === "message_update") {
+        if (relayEvent.message) {
+          messages.push(relayEvent.message);
+        }
+        claudeIsWorking = true;  // Claude is actively working/outputting
+      } else if (eventType === "agent_end" || eventType === "turn_end") {
+        claudeIsWorking = false;  // Turn complete, Claude is now idle
+      }
+      forwardEvent(relayEvent);
+    }
+  }
+}
+
+// ── Permission request via control protocol ───────────────────────────────
+/** Tools that should be auto-allowed without showing a permission request card.
+ *  - ToolSearch: harmless internal tool for discovering available tools
+ *  - EnterPlanMode: just enters read-only exploration mode (no side effects) */
+const AUTO_ALLOW_TOOLS = new Set(["ToolSearch", "EnterPlanMode"]);
+
+/** Check whether a tool should be auto-allowed.
+ *  Matches exact names in AUTO_ALLOW_TOOLS and all PizzaPi MCP tools. */
+function shouldAutoAllow(toolName: string): boolean {
+  if (AUTO_ALLOW_TOOLS.has(toolName)) return true;
+  // Auto-allow all PizzaPi MCP tools — they're our own trusted tools
+  if (toolName.startsWith("mcp__pizzapi__")) return true;
+  return false;
+}
+
+// Pending AskUserQuestion permission: held open until user answers the question.
+// The control_response is sent in deliverAskUserAnswer() to unblock Claude Code.
+let pendingAskUserPermissionId: string | null = null;
+
+function handleControlRequest(requestId: string, toolName: string, toolInput: unknown): void {
+  // Auto-allow safe internal tools — no permission card needed
+  if (shouldAutoAllow(toolName)) {
+    sendPermissionResponse(requestId, "allow", toolInput);
+    return;
+  }
+
+  // AskUserQuestion: hold the permission open (don't respond yet).
+  // The NDJSON-based question system handles user interaction.  When the
+  // user answers, deliverAskUserAnswer() sends both the tool_result AND
+  // the permission response to unblock Claude Code.
+  if (toolName === "AskUserQuestion") {
+    pendingAskUserPermissionId = requestId;
+    return;
+  }
+
+  const requestTs = Date.now();
+  forwardEvent({
+    type: "permission_request",
+    requestId,
+    toolName,
+    toolInput,
+    ts: requestTs,
+  });
+
+  const timer = setTimeout(() => {
+    pendingPermissions.delete(requestId);
+    sendPermissionResponse(requestId, "deny");
+    emitHeartbeat();
+  }, 5 * 60 * 1000);
+
+  const pendingPermissionEntry: PendingPermissionEntry = {
+    resolve: (decision) => {
+      clearTimeout(timer);
+      pendingPermissions.delete(requestId);
+      sendPermissionResponse(requestId, decision, toolInput);
+      emitHeartbeat();
+    },
+    timer,
+    toolName,
+    toolInput,
+    ts: requestTs,
+  };
+  pendingPermissions.set(requestId, pendingPermissionEntry);
+  emitHeartbeat("Waiting for permission…");
+  emitSessionActive();
+}
+
+function sendPermissionResponse(requestId: string, behavior: "allow" | "deny", toolInput?: unknown): void {
+  writeToClaudeStdin({
+    type: "control_response",
+    response: {
+      subtype: "success",
+      request_id: requestId,
+      response: behavior === "allow"
+        ? { behavior: "allow", updatedInput: (toolInput && typeof toolInput === "object" ? toolInput : {}) as Record<string, unknown> }
+        : { behavior: "deny", message: "Denied via PizzaPi web UI" },
+    },
+  });
+}
+
+// ── AskUserQuestion ───────────────────────────────────────────────────────
+interface PendingQuestion {
+  questions: Array<{ question: string; options: string[]; type?: string }>;
+  resolve: (answer: string) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+// Pending AskUserQuestion: tool_use_id → { questions, resolve, timer }
+const pendingQuestionState = new Map<string, PendingQuestion>();
+
+function handleAskUserQuestion(toolCallId: string, questions: Array<{ question: string; options: string[]; type?: string }>): void {
+  forwardEvent({ type: "tool_execution_start", toolName: "AskUserQuestion", toolCallId, args: { questions } });
+
+  const timer = setTimeout(() => {
+    pendingQuestionState.delete(toolCallId);
+    pendingQuestions.delete(toolCallId);
+    deliverAskUserAnswer(toolCallId, "");
+  }, 5 * 60 * 1000);
+
+  const pendingQ: PendingQuestion = {
+    questions,
+    resolve: (answer) => {
+      clearTimeout(timer);
+      pendingQuestionState.delete(toolCallId);
+      pendingQuestions.delete(toolCallId);
+      deliverAskUserAnswer(toolCallId, answer);
+    },
+    timer,
+  };
+
+  pendingQuestionState.set(toolCallId, pendingQ);
+  pendingQuestions.set(toolCallId, { resolve: pendingQ.resolve, timer });
+
+  emitHeartbeat("Waiting for answer…");
+}
+
+function deliverAskUserAnswer(toolCallId: string, answer: string): void {
+  forwardEvent({ type: "tool_execution_end", toolName: "AskUserQuestion", toolCallId });
+
+  // Unblock Claude Code by responding to the held permission request.
+  // Must happen BEFORE the tool_result so Claude Code is ready to receive it.
+  if (pendingAskUserPermissionId) {
+    sendPermissionResponse(pendingAskUserPermissionId, "allow");
+    pendingAskUserPermissionId = null;
+  }
+
+  writeToClaudeStdin({
+    type: "user",
+    message: {
+      role: "user",
+      content: [{ type: "tool_result", tool_use_id: toolCallId, content: answer }],
+    },
+  });
+  emitHeartbeat("Connected");
+}
+
+// ── session_active snapshot ───────────────────────────────────────────────
+function emitSessionActive(): void {
+  const sessionState: Record<string, unknown> = {
+    model: currentModelObject ?? (currentModel ? parseModelString(currentModel) : null),
+    messages: capOversizedMessages(messages),
+    cwd,
+    sessionName: currentSessionName,
+    availableModels: listAvailableModels().models,
+    todoList: currentTodoList,
+    thinkingLevel: currentThinkingLevel,
+    workerType: "claude-code",
+  };
+
+  // Include pending prompts so they persist across reconnects
+  if (pendingQuestionState.size > 0) {
+    const [toolCallId, pendingQ] = [...pendingQuestionState.entries()][0];
+    sessionState.pendingQuestion = {
+      toolCallId,
+      questions: pendingQ.questions,
+      display: "modal",
+    };
+  }
+
+  if (pendingPermissions.size > 0) {
+    const [requestId, entry] = [...pendingPermissions.entries()][0];
+    sessionState.pendingPermission = {
+      requestId,
+      toolName: entry.toolName,
+      toolInput: entry.toolInput,
+      ts: entry.ts,
+    };
+  }
+
+  if (needsChunkedDelivery(messages)) {
+    const snapshotId = randomUUID();
+    forwardEvent({ type: "session_active", state: { ...sessionState, messages: [], chunked: true, snapshotId, totalMessages: messages.length } });
+    sendChunkedMessages(snapshotId);
+  } else {
+    forwardEvent({ type: "session_active", state: sessionState });
+  }
+}
+
+function sendChunkedMessages(snapshotId: string): void {
+  const capped = capOversizedMessages(messages);
+  const chunks = computeChunkBoundaries(capped);
+  let i = 0;
+  function next() {
+    if (i >= chunks.length) return;
+    const [start, end] = chunks[i];
+    const isFinal = i === chunks.length - 1;
+    forwardEvent({ type: "session_messages_chunk", snapshotId, chunkIndex: i, totalChunks: chunks.length, totalMessages: capped.length, messages: capped.slice(start, end), final: isFinal });
+    i++;
+    if (i < chunks.length) setImmediate(next);
+  }
+  setImmediate(next);
+}
+
+// ── Relay connection ──────────────────────────────────────────────────────
+function connectRelay(): void {
+  if (!apiKey) {
+    logWarn("PIZZAPI_API_KEY not set — relay disabled");
+    return;
+  }
+
+  const sockUrl = sioHttpUrl();
+  const sock = io(sockUrl + "/relay", {
+    auth: { apiKey },
+    transports: ["websocket"],
+    reconnection: true,
+    reconnectionAttempts: Infinity,
+    reconnectionDelay: 1000,
+    reconnectionDelayMax: 30_000,
+    randomizationFactor: 0.25,
+  }) as Socket<RelayServerToClientEvents, RelayClientToServerEvents>;
+
+  sioSocket = sock;
+
+  sock.on("connect", () => {
+    logInfo(`relay connected (url=${sockUrl})`);
+    sock.emit("register", {
+      sessionId,
+      cwd,
+      ephemeral: true,
+      collabMode: true,
+      ...(parentSessionId ? { parentSessionId } : {}),
+    });
+  });
+
+  sock.on("registered", (data) => {
+    logInfo("relay registered");
+    relayToken = data.token;
+    emitCapabilities();
+    emitHeartbeat("Starting Claude Code…");
+    emitSessionActive();
+    startHeartbeatTimer();
+  });
+
+  sock.on("session_trigger" as any, (data: { trigger: ConversationTrigger }) => {
+    const trigger = data?.trigger;
+    if (!trigger) return;
+    trackReceivedTrigger(trigger);
+    writeToClaudeStdin({
+      type: "user",
+      message: { role: "user", content: renderTrigger(trigger) },
+    });
+  });
+
+  sock.on("trigger_response" as any, (data: { triggerId: string; response: string; action?: string }) => {
+    void respondToReceivedTrigger(data).catch((err) => {
+      logError(`failed to handle trigger response: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  });
+
+  sock.on("input", (data) => {
+    const text = typeof data.text === "string" ? data.text : "";
+
+    // If a question is pending, deliver the input as the answer
+    if (pendingQuestions.size > 0) {
+      const [_toolCallId, entry] = [...pendingQuestions.entries()][0];
+      entry.resolve(text);
+      return;
+    }
+
+    const attachments = normalizeRemoteInputAttachments(data.attachments);
+    void (async () => {
+      try {
+        const content = await buildUserMessageFromRemoteInput(
+          text,
+          attachments,
+          relayHttpBase(),
+          apiKey ?? "",
+          claudeSessionId,
+        );
+        writeToClaudeStdin({
+          type: "user",
+          message: { role: "user", content },
+        });
+      } catch (err) {
+        logError(`failed to deliver input: ${err instanceof Error ? err.message : String(err)}`);
+      }
+    })();
+  });
+
+  // Handle incoming messages from other sessions
+  // Delivers to waiting listeners or buffers for later retrieval (for pizzapi_check_messages)
+  sock.on("session_message" as any, (data: { fromSessionId: string; message: string }) => {
+    handleIncomingSessionMessage(data);
+  });
+
+  sock.on("exec", (data) => {
+    const execData = data as { id: string; command: string; [key: string]: unknown };
+    switch (execData.command) {
+      case "abort":
+        writeToClaudeStdin({ type: "control_request", request_id: randomUUID(), request: { subtype: "interrupt" } });
+        sock.emit("exec_result", { id: execData.id, ok: true, command: execData.command });
+        break;
+      case "end_session":
+        logInfo("exec: end_session");
+        sock.emit("exec_result", { id: execData.id, ok: true, command: execData.command });
+        shutdown("completed");
+        break;
+      case "new_session":
+        logInfo("exec: new_session — killing claude, clearing state, respawning");
+        claudeSessionId = randomUUID();
+        initialPrompt = "";
+        messages = [];
+        currentModel = null;
+        currentModelObject = null;
+        currentSessionName = null;
+        currentTokenUsage = null;
+        currentTodoList = [];
+        clearPendingState();
+        processGeneration++;
+        if (claudeProcess) { try { claudeProcess.kill("SIGTERM"); } catch {} claudeProcess = null; }
+        if (pendingRespawnTimer) { clearTimeout(pendingRespawnTimer); pendingRespawnTimer = null; }
+        pendingRespawnTimer = setTimeout(() => { pendingRespawnTimer = null; if (tmpDir) spawnClaude(tmpDir); }, 100);
+        sock.emit("exec_result", { id: execData.id, ok: true, command: execData.command });
+        break;
+      case "reload":
+        logInfo("exec: reload — killing claude, respawning with --resume");
+        clearPendingState();
+        processGeneration++;
+        if (claudeProcess) { try { claudeProcess.kill("SIGTERM"); } catch {} claudeProcess = null; }
+        if (pendingRespawnTimer) { clearTimeout(pendingRespawnTimer); pendingRespawnTimer = null; }
+        pendingRespawnTimer = setTimeout(() => { pendingRespawnTimer = null; if (tmpDir) spawnClaude(tmpDir, true); }, 100);
+        sock.emit("exec_result", { id: execData.id, ok: true, command: execData.command });
+        break;
+      case "permission_response":
+        if (execData.requestId && execData.decision) {
+          pendingPermissions.get(String(execData.requestId))?.resolve(execData.decision as "allow" | "deny");
+        }
+        sock.emit("exec_result", { id: execData.id, ok: true, command: execData.command });
+        break;
+      case "set_model": {
+        // Use Claude Code's control protocol to change model mid-session.
+        const modelId = typeof execData.modelId === "string" ? execData.modelId : undefined;
+        if (!modelId) {
+          sock.emit("exec_result", { id: execData.id, ok: false, command: execData.command, error: "Missing modelId." });
+          break;
+        }
+        logInfo(`exec: set_model model=${modelId}`);
+        writeToClaudeStdin({
+          type: "control_request",
+          request_id: randomUUID(),
+          request: { subtype: "set_model", model: modelId },
+        });
+        // Update our tracking — the actual confirmation comes from Claude's
+        // next system/init or assistant message with the new model.
+        currentModel = modelId;
+        currentModelObject = parseModelString(modelId);
+        emitHeartbeat();
+        sock.emit("exec_result", { id: execData.id, ok: true, command: execData.command });
+        forwardEvent({ type: "model_set_result", ok: true, provider: currentModelObject?.provider, modelId });
+        break;
+      }
+      case "set_thinking_level": {
+        // Use Claude Code's control protocol to change thinking budget.
+        const level = typeof execData.level === "string" ? execData.level : undefined;
+        // Map PizzaPi thinking levels to token counts.
+        // null = default (let Claude decide), 0 = off, positive = budget.
+        const tokenMap: Record<string, number | null> = {
+          off: 0, low: 1024, medium: 8192, high: 32768, max: 128000,
+        };
+        const tokens = level && level in tokenMap ? tokenMap[level] : undefined;
+        if (tokens === undefined) {
+          sock.emit("exec_result", { id: execData.id, ok: false, command: execData.command, error: `Unknown thinking level: ${level}` });
+          break;
+        }
+        logInfo(`exec: set_thinking_level level=${level} tokens=${tokens}`);
+        writeToClaudeStdin({
+          type: "control_request",
+          request_id: randomUUID(),
+          request: { subtype: "set_max_thinking_tokens", max_thinking_tokens: tokens === 0 ? null : tokens },
+        });
+        currentThinkingLevel = level ?? null;
+        emitHeartbeat();
+        sock.emit("exec_result", { id: execData.id, ok: true, command: execData.command });
+        break;
+      }
+      case "fork":
+      case "navigate_tree":
+      default:
+        sock.emit("exec_result", { id: execData.id, ok: false, command: execData.command, error: "Not supported for Claude Code sessions." });
+    }
+  });
+
+  sock.on("model_set", (data) => {
+    // Legacy model_set event from older UI — route through set_model control protocol
+    const modelId = typeof data?.modelId === "string" ? data.modelId : undefined;
+    if (!modelId) {
+      forwardEvent({ type: "model_set_result", ok: false, message: "Missing modelId." });
+      return;
+    }
+    logInfo(`model_set (legacy): model=${modelId}`);
+    writeToClaudeStdin({
+      type: "control_request",
+      request_id: randomUUID(),
+      request: { subtype: "set_model", model: modelId },
+    });
+    currentModel = modelId;
+    currentModelObject = parseModelString(modelId);
+    emitHeartbeat();
+    forwardEvent({ type: "model_set_result", ok: true, provider: currentModelObject?.provider, modelId });
+  });
+
+  sock.on("connected", () => {
+    emitSessionActive();
+  });
+
+  sock.on("disconnect", (reason) => {
+    logInfo(`relay disconnected: ${reason}`);
+    relayToken = null;
+    stopHeartbeatTimer();
+  });
+}
+
+// ── Shutdown ──────────────────────────────────────────────────────────────
+let shutdownCalled = false;
+async function shutdown(reason: "completed" | "error" | "killed" = "completed"): Promise<void> {
+  if (shutdownCalled) return;
+  shutdownCalled = true;
+  logInfo(`shutdown: reason=${reason}`);
+
+  clearPendingState();
+
+  if (claudeProcess) {
+    try { claudeProcess.kill("SIGTERM"); } catch {}
+    claudeProcess = null;
+  }
+
+  if (sioSocket?.connected && relayToken) {
+    sioSocket.emit("session_end", { sessionId, token: relayToken });
+  }
+  sioSocket?.disconnect();
+
+  if (ipcServer) {
+    ipcServer.close();
+    ipcServer = null;
+  }
+
+  await cleanupTempDir();
+  process.exit(reason === "error" ? 1 : 0);
+}
+
+process.on("SIGTERM", () => { void shutdown("killed"); });
+process.on("SIGINT", () => { void shutdown("killed"); });
+
+// ── Main ──────────────────────────────────────────────────────────────────
+async function main(): Promise<void> {
+  logInfo(`started (cwd=${cwd}, parent=${parentSessionId ?? "none"}, verbose=${VERBOSE_EVENT_LOG})`);
+
+  const { ipcSocketPath, hooksPath: _hooksPath, mcpPath: _mcpPath } = await setupTempDir();
+  await startIpcServer(ipcSocketPath);
+  connectRelay();
+
+  // PIZZAPI_CC_PLUGIN_DIR: the spec lists this as a daemon-provided env var, but
+  // the bridge resolves it from import.meta.url instead — making it self-contained.
+  // If overriding the plugin dir is needed (e.g. npm packaging), read
+  // process.env.PIZZAPI_CC_PLUGIN_DIR first.
+  setTimeout(() => { if (tmpDir) spawnClaude(tmpDir); }, 200);
+
+  await new Promise<void>(() => {}); // keep process alive
+}
+
+main().catch((err) => {
+  logError(`fatal: ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
+  process.exit(1);
+});
+
+// Suppress unused variable warnings — broadcastToIpc will be used in future features
+void broadcastToIpc;

--- a/packages/cli/src/runner/claude-code-bridge.ts
+++ b/packages/cli/src/runner/claude-code-bridge.ts
@@ -114,6 +114,7 @@ function getMcpServerCommand(): { command: string; args: string[] } {
 
 // ── State ─────────────────────────────────────────────────────────────────
 let tmpDir: string | null = null;
+let ipcSocketPath: string | null = null;
 let ipcServer: NetServer | null = null;
 let sioSocket: Socket<RelayServerToClientEvents, RelayClientToServerEvents> | null = null;
 let claudeProcess: ReturnType<typeof Bun.spawn> | null = null;
@@ -195,7 +196,8 @@ function clearPendingState(): void {
   pendingQuestionState.clear();
   for (const { timer } of pendingPermissions.values()) clearTimeout(timer);
   pendingPermissions.clear();
-  pendingAskUserPermissionId = null;
+  pendingAskUserPermissionQueue.length = 0;
+  askUserPermissionByToolCallId.clear();
   for (const waiter of messageWaiters) {
     clearTimeout(waiter.timer);
     waiter.cancel();
@@ -505,15 +507,20 @@ async function setupTempDir(): Promise<{ ipcSocketPath: string; hooksPath: strin
   tmpDir = await mkdtemp(join(tmpdir(), "pizzapi-cc-"));
   await chmod(tmpDir, 0o700);
 
-  const ipcSocketPath = IS_WINDOWS
+  // Compute the IPC path once and store it in the module-level variable so
+  // spawnClaude() can reuse the exact same path.  Always re-deriving it with
+  // join(tmpDir, "bridge.sock") would silently produce the wrong path on
+  // Windows, where a named pipe is required instead of a filesystem socket.
+  const resolvedIpcPath = IS_WINDOWS
     ? `\\\\.\\pipe\\pizzapi-cc-${randomUUID()}`
     : join(tmpDir, "bridge.sock");
+  ipcSocketPath = resolvedIpcPath;
 
   const hooksJson = {
     hooks: Object.fromEntries(
       ["SessionStart","SessionEnd","PostToolUse","PostToolUseFailure",
        "Stop","SubagentStart","SubagentStop","Notification","UserPromptSubmit","PreCompact"].map(
-        (evt) => [evt, [{ hooks: [{ type: "command", command: getHookHandlerCommand(ipcSocketPath) }] }]]
+        (evt) => [evt, [{ hooks: [{ type: "command", command: getHookHandlerCommand(resolvedIpcPath) }] }]]
       )
     ),
   };
@@ -527,7 +534,7 @@ async function setupTempDir(): Promise<{ ipcSocketPath: string; hooksPath: strin
         command: mcpServerCommand.command,
         args: mcpServerCommand.args,
         env: {
-          PIZZAPI_CC_BRIDGE_IPC: ipcSocketPath,
+          PIZZAPI_CC_BRIDGE_IPC: resolvedIpcPath,
           PIZZAPI_SESSION_ID: sessionId,
         },
       },
@@ -536,7 +543,7 @@ async function setupTempDir(): Promise<{ ipcSocketPath: string; hooksPath: strin
   const mcpPath = join(tmpDir, "mcp.json");
   await writeFile(mcpPath, JSON.stringify(mcpJson, null, 2), { mode: 0o600 });
 
-  return { ipcSocketPath, hooksPath, mcpPath };
+  return { ipcSocketPath: resolvedIpcPath, hooksPath, mcpPath };
 }
 
 async function cleanupTempDir(): Promise<void> {
@@ -921,7 +928,10 @@ function spawnClaude(tmpDirPath: string, resume = false): void {
     stderr: "pipe",
     env: {
       ...process.env,
-      PIZZAPI_CC_BRIDGE_IPC: join(tmpDirPath, "bridge.sock"),
+      // Use the pre-computed ipcSocketPath (set by setupTempDir) so Windows
+      // named pipe paths are preserved.  Falling back to a Unix socket path
+      // constructed from tmpDirPath would break on Windows.
+      PIZZAPI_CC_BRIDGE_IPC: ipcSocketPath ?? join(tmpDirPath, "bridge.sock"),
       PIZZAPI_SESSION_ID: sessionId,
     },
   });
@@ -1257,9 +1267,13 @@ function shouldAutoAllow(toolName: string): boolean {
   return false;
 }
 
-// Pending AskUserQuestion permission: held open until user answers the question.
-// The control_response is sent in deliverAskUserAnswer() to unblock Claude Code.
-let pendingAskUserPermissionId: string | null = null;
+// Pending AskUserQuestion permissions: queue of unmatched controlRequestIds waiting
+// to be paired with a toolCallId once the ask_user_question event arrives.
+// Using a queue (FIFO) + per-toolCallId map handles multiple concurrent requests
+// correctly without overwriting earlier IDs.
+const pendingAskUserPermissionQueue: string[] = [];
+// toolCallId → controlRequestId, populated when ask_user_question is processed
+const askUserPermissionByToolCallId = new Map<string, string>();
 
 function handleControlRequest(requestId: string, toolName: string, toolInput: unknown): void {
   // Auto-allow safe internal tools — no permission card needed
@@ -1268,12 +1282,11 @@ function handleControlRequest(requestId: string, toolName: string, toolInput: un
     return;
   }
 
-  // AskUserQuestion: hold the permission open (don't respond yet).
-  // The NDJSON-based question system handles user interaction.  When the
-  // user answers, deliverAskUserAnswer() sends both the tool_result AND
-  // the permission response to unblock Claude Code.
+  // AskUserQuestion: enqueue the permission request ID.  It will be matched to
+  // a toolCallId when the corresponding ask_user_question event is processed.
+  // Using a queue preserves ordering and supports multiple concurrent requests.
   if (toolName === "AskUserQuestion") {
-    pendingAskUserPermissionId = requestId;
+    pendingAskUserPermissionQueue.push(requestId);
     return;
   }
 
@@ -1335,6 +1348,13 @@ const pendingQuestionState = new Map<string, PendingQuestion>();
 function handleAskUserQuestion(toolCallId: string, questions: Array<{ question: string; options: string[]; type?: string }>): void {
   forwardEvent({ type: "tool_execution_start", toolName: "AskUserQuestion", toolCallId, args: { questions } });
 
+  // Pair this toolCallId with the next queued permission request ID (FIFO order
+  // matches the order in which control_request events arrive).
+  const permId = pendingAskUserPermissionQueue.shift();
+  if (permId) {
+    askUserPermissionByToolCallId.set(toolCallId, permId);
+  }
+
   const timer = setTimeout(() => {
     pendingQuestionState.delete(toolCallId);
     pendingQuestions.delete(toolCallId);
@@ -1363,9 +1383,10 @@ function deliverAskUserAnswer(toolCallId: string, answer: string): void {
 
   // Unblock Claude Code by responding to the held permission request.
   // Must happen BEFORE the tool_result so Claude Code is ready to receive it.
-  if (pendingAskUserPermissionId) {
-    sendPermissionResponse(pendingAskUserPermissionId, "allow");
-    pendingAskUserPermissionId = null;
+  const permId = askUserPermissionByToolCallId.get(toolCallId);
+  if (permId) {
+    sendPermissionResponse(permId, "allow");
+    askUserPermissionByToolCallId.delete(toolCallId);
   }
 
   writeToClaudeStdin({

--- a/packages/cli/src/runner/claude-code-bridge.ts
+++ b/packages/cli/src/runner/claude-code-bridge.ts
@@ -1100,11 +1100,18 @@ function handleNdjsonLine(line: string): void {
   }
 
   if (result.kind === "control_request") {
-    // Suppress permission/control requests that originate inside a subagent.
-    // These should never surface as top-level permission prompts in the parent session.
+    // Auto-approve permission/control requests that originate inside a subagent.
+    // Silently dropping them would deadlock subagent tool execution — Claude Code
+    // requires a control_response for every control_request it emits, regardless
+    // of whether the request came from a top-level session or a nested subagent.
+    // We never surface these as permission cards in the parent UI, but we must
+    // still send the protocol handshake so the subagent can continue.
     if (result.parentToolUseId) {
       if (VERBOSE_EVENT_LOG) {
-        logInfo(`suppressed subagent control_request (parent=${result.parentToolUseId.slice(0, 12)})`);
+        logInfo(`auto-approving subagent control_request tool=${result.toolName ?? "?"} (parent=${result.parentToolUseId.slice(0, 12)})`);
+      }
+      if (result.controlRequestId) {
+        sendPermissionResponse(result.controlRequestId, "allow", result.toolInput);
       }
       return;
     }
@@ -1128,11 +1135,22 @@ function handleNdjsonLine(line: string): void {
   }
 
   if (result.kind === "ask_user_question") {
-    // Suppress AskUserQuestion calls that originate inside a subagent.
-    // Subagent questions must not create pending question state in the parent session.
+    // Subagent AskUserQuestion: do not surface the question in the parent UI, but we
+    // MUST send a tool_result back so the subagent isn't left waiting indefinitely.
+    // (The corresponding control_request was already auto-approved in the block above,
+    // so no second sendPermissionResponse is needed here — just deliver an empty answer.)
     if (result.parentToolUseId) {
       if (VERBOSE_EVENT_LOG) {
-        logInfo(`suppressed subagent ask_user_question (parent=${result.parentToolUseId.slice(0, 12)})`);
+        logInfo(`auto-responding to subagent ask_user_question (parent=${result.parentToolUseId.slice(0, 12)})`);
+      }
+      if (result.toolCallId) {
+        writeToClaudeStdin({
+          type: "user",
+          message: {
+            role: "user",
+            content: [{ type: "tool_result", tool_use_id: result.toolCallId, content: "" }],
+          },
+        });
       }
       return;
     }

--- a/packages/cli/src/runner/claude-code-bridge.ts
+++ b/packages/cli/src/runner/claude-code-bridge.ts
@@ -662,7 +662,19 @@ async function dispatchMcpTool(tool: string, args: Record<string, unknown>): Pro
           ? (body as { error: string }).error
           : `Spawn failed: HTTP ${resp.status}`);
       }
-      return body;
+      // The /api/runners/spawn route returns { ok, runnerId, sessionId, pending }.
+      // Callers of pizzapi_spawn_session expect { sessionId, shareUrl } — construct
+      // the shareUrl here from the sessionId and the relay HTTP base.
+      const spawnedSessionId = (body as { sessionId?: unknown }).sessionId;
+      if (typeof spawnedSessionId !== "string") {
+        throw new Error("Spawn response missing sessionId");
+      }
+      const shareUrl = `${base}/session/${spawnedSessionId}`;
+      return {
+        sessionId: spawnedSessionId,
+        shareUrl,
+        pending: (body as { pending?: unknown }).pending === true,
+      };
     }
 
     case "pizzapi_send_message": {
@@ -1517,6 +1529,7 @@ function connectRelay(): void {
       cwd,
       ephemeral: true,
       collabMode: true,
+      workerType: "claude-code" as const,
       ...(parentSessionId ? { parentSessionId } : {}),
     });
   });

--- a/packages/cli/src/runner/claude-code-bridge.ts
+++ b/packages/cli/src/runner/claude-code-bridge.ts
@@ -1100,6 +1100,14 @@ function handleNdjsonLine(line: string): void {
   }
 
   if (result.kind === "control_request") {
+    // Suppress permission/control requests that originate inside a subagent.
+    // These should never surface as top-level permission prompts in the parent session.
+    if (result.parentToolUseId) {
+      if (VERBOSE_EVENT_LOG) {
+        logInfo(`suppressed subagent control_request (parent=${result.parentToolUseId.slice(0, 12)})`);
+      }
+      return;
+    }
     if (result.controlRequestId && result.toolName) {
       handleControlRequest(result.controlRequestId, result.toolName, result.toolInput);
     }
@@ -1120,6 +1128,14 @@ function handleNdjsonLine(line: string): void {
   }
 
   if (result.kind === "ask_user_question") {
+    // Suppress AskUserQuestion calls that originate inside a subagent.
+    // Subagent questions must not create pending question state in the parent session.
+    if (result.parentToolUseId) {
+      if (VERBOSE_EVENT_LOG) {
+        logInfo(`suppressed subagent ask_user_question (parent=${result.parentToolUseId.slice(0, 12)})`);
+      }
+      return;
+    }
     // Forward the assistant message to history first so reconnecting viewers
     // see the full conversation including the AskUserQuestion turn.
     if (result.relayEvent?.message) {

--- a/packages/cli/src/runner/claude-code-ipc.test.ts
+++ b/packages/cli/src/runner/claude-code-ipc.test.ts
@@ -1,0 +1,32 @@
+import { test, expect, describe } from "bun:test";
+import { framesFromBuffer, serializeFrame } from "./claude-code-ipc.js";
+
+describe("framesFromBuffer", () => {
+  test("parses a single newline-delimited JSON frame", () => {
+    const msg = { type: "hook_event", event: "Stop", sessionId: "s1", data: {} };
+    const buf = serializeFrame(msg);
+    const { frames, remaining } = framesFromBuffer(buf);
+    expect(frames).toHaveLength(1);
+    expect(frames[0]).toEqual(msg);
+    expect(remaining).toHaveLength(0);
+  });
+
+  test("parses multiple frames from one buffer", () => {
+    const a = serializeFrame({ type: "ready", component: "hooks" });
+    const b = serializeFrame({ type: "ready", component: "mcp" });
+    const { frames } = framesFromBuffer(Buffer.concat([a, b]));
+    expect(frames).toHaveLength(2);
+  });
+
+  test("returns partial frame as remaining when buffer is incomplete", () => {
+    const partial = Buffer.from('{"type":"hook_event"');
+    const { frames, remaining } = framesFromBuffer(partial);
+    expect(frames).toHaveLength(0);
+    expect(remaining.toString()).toBe('{"type":"hook_event"');
+  });
+
+  test("serializeFrame appends a newline", () => {
+    const buf = serializeFrame({ type: "shutdown" });
+    expect(buf[buf.length - 1]).toBe(0x0a); // \n
+  });
+});

--- a/packages/cli/src/runner/claude-code-ipc.ts
+++ b/packages/cli/src/runner/claude-code-ipc.ts
@@ -1,0 +1,46 @@
+// ── IPC Protocol Types ───────────────────────────────────────────────────
+// All messages over the Unix socket are newline-delimited JSON.
+
+// Plugin → Bridge
+export type PluginMessage =
+  | { type: "hook_event"; event: string; sessionId: string; data: unknown; requestId?: string }
+  | { type: "mcp_call"; tool: string; args: unknown; requestId: string }
+  | { type: "ready"; component: "hooks" | "mcp" };
+
+// Bridge → Plugin
+export type BridgeMessage =
+  | { type: "hook_response"; requestId: string; decision: string; reason?: string }
+  | { type: "mcp_response"; requestId: string; result: unknown; error?: string }
+  | { type: "relay_input"; text: string; attachments?: unknown[] }
+  | { type: "session_message"; fromSessionId: string; message: string }
+  | { type: "trigger"; trigger: unknown }
+  | { type: "shutdown" };
+
+// ── Frame helpers ────────────────────────────────────────────────────────
+
+/** Serialize a message to a newline-terminated JSON buffer. */
+export function serializeFrame(msg: unknown): Buffer {
+  return Buffer.from(JSON.stringify(msg) + "\n", "utf8");
+}
+
+/** Parse all complete newline-delimited JSON frames from a buffer.
+ *  Returns parsed frames and any trailing incomplete bytes. */
+export function framesFromBuffer(buf: Buffer): { frames: unknown[]; remaining: Buffer } {
+  const frames: unknown[] = [];
+  let start = 0;
+
+  for (let i = 0; i < buf.length; i++) {
+    if (buf[i] === 0x0a) { // \n
+      const line = buf.slice(start, i).toString("utf8").trim();
+      start = i + 1;
+      if (!line) continue;
+      try {
+        frames.push(JSON.parse(line));
+      } catch {
+        // Malformed frame — skip
+      }
+    }
+  }
+
+  return { frames, remaining: buf.slice(start) };
+}

--- a/packages/cli/src/runner/claude-code-ndjson.test.ts
+++ b/packages/cli/src/runner/claude-code-ndjson.test.ts
@@ -1,0 +1,852 @@
+import { test, expect, describe } from "bun:test";
+import { translateNdjsonLine, SUBAGENT_TOOL_NAMES, parseSubagentToolCalls } from "./claude-code-ndjson.js";
+
+describe("translateNdjsonLine", () => {
+  test("ignores control_request frames (not relay events)", () => {
+    const line = JSON.stringify({ type: "control_request", request_id: "r1", request: { subtype: "can_use_tool", tool_name: "Bash", input: {} } });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("control_request");
+    expect(result.relayEvent).toBeUndefined();
+  });
+
+  test("ignores control_response frames", () => {
+    const line = JSON.stringify({ type: "control_response", response: { request_id: "r1", subtype: "success" } });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("control_response");
+  });
+
+  test("translates system/init to session_active metadata", () => {
+    const line = JSON.stringify({ type: "system", subtype: "init", session_id: "sess1", model: "claude-sonnet-4-6", cwd: "/tmp", tools: ["Bash", "Read"], slash_commands: [] });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("session_init");
+    expect(result.sessionId).toBe("sess1");
+    expect(result.model).toBe("claude-sonnet-4-6");
+  });
+
+  test("translates assistant message to message_update", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "Hello" }] },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect(result.relayEvent?.type).toBe("message_update");
+  });
+
+  test("normalizes tool_use blocks to toolCall format", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Let me run that." },
+          { type: "tool_use", id: "tu_123", name: "Bash", input: { command: "ls" } },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    const msg = (result.relayEvent as any)?.message;
+    expect(msg.content[0]).toMatchObject({ type: "text", text: "Let me run that." });
+    expect(msg.content[1]).toMatchObject({
+      type: "toolCall",
+      toolCallId: "tu_123",
+      name: "Bash",
+      arguments: JSON.stringify({ command: "ls" }),
+    });
+  });
+
+  test("detects TodoWrite tool_use in assistant message", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tu1", name: "TodoWrite", input: { todos: [{ id: "1", content: "Do thing", status: "pending", priority: "high" }] } }],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect(result.todoList).toBeDefined();
+    expect(result.todoList).toHaveLength(1);
+    expect(result.todoList?.[0]).toMatchObject({
+      text: "Do thing",
+      content: "Do thing",
+      status: "pending",
+      priority: "high",
+    });
+  });
+
+  test("normalizes TodoWrite statuses to the UI enum", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tu1", name: "TodoWrite", input: { todos: [{ id: "1", text: "Ship it", status: "completed" }] } }],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.todoList?.[0]).toMatchObject({
+      text: "Ship it",
+      status: "pending",
+    });
+  });
+
+  test("detects AskUserQuestion tool_use — emits tool_execution_start", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", id: "tu2", name: "AskUserQuestion", input: { questions: [{ question: "Pick one", options: ["A", "B"] }] } }],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("ask_user_question");
+    expect(result.toolCallId).toBe("tu2");
+    expect(result.questions).toHaveLength(1);
+    // relayEvent must be present so the bridge can save the assistant message to history
+    expect(result.relayEvent).toBeDefined();
+    expect(result.relayEvent?.type).toBe("message_update");
+  });
+
+  test("translates result to agent_end", () => {
+    const line = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      num_turns: 2,
+      total_cost_usd: 0.01,
+      duration_ms: 1234,
+      duration_api_ms: 1000,
+      is_error: false,
+      session_id: "sess1",
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect(result.relayEvent?.type).toBe("turn_end");
+  });
+
+  test("extracts tokenUsage from result event", () => {
+    const line = JSON.stringify({
+      type: "result",
+      subtype: "success",
+      num_turns: 1,
+      usage: { input_tokens: 500, output_tokens: 200, cache_creation_input_tokens: 100, cache_read_input_tokens: 50 },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.tokenUsage).toEqual({
+      inputTokens: 500,
+      outputTokens: 200,
+      cacheCreationInputTokens: 100,
+      cacheReadInputTokens: 50,
+    });
+  });
+
+  test("detects set_session_name in assistant message", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", name: "set_session_name", id: "call_1", input: { name: "My Session" } },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.sessionName).toBe("My Session");
+  });
+
+  test("translates stream_event to message_update with assistantMessageEvent", () => {
+    const line = JSON.stringify({
+      type: "stream_event",
+      event: "text_delta",
+      delta: { text: "Hello" },
+      index: 0,
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect(result.relayEvent?.type).toBe("message_update");
+    const ae = (result.relayEvent as any)?.assistantMessageEvent;
+    expect(ae?.partial).toBeDefined();
+    expect(ae?.type).toBe("text_delta");
+    expect(ae?.delta).toBe("Hello");
+    expect(ae?.contentIndex).toBe(0);
+  });
+
+  test("stream_event with string delta", () => {
+    const line = JSON.stringify({
+      type: "stream_event",
+      event: "thinking_delta",
+      delta: "some thought",
+      index: 1,
+    });
+    const result = translateNdjsonLine(line);
+    const ae = (result.relayEvent as any)?.assistantMessageEvent;
+    expect(ae?.type).toBe("thinking_delta");
+    expect(ae?.delta).toBe("some thought");
+    expect(ae?.contentIndex).toBe(1);
+  });
+
+  test("returns unknown for unrecognised line", () => {
+    const result = translateNdjsonLine("not-json!!!");
+    expect(result.kind).toBe("unknown");
+  });
+
+  // ── tool_result extraction from user messages ─────────────────────────
+
+  test("user message with string tool_result content → toolResult relay event", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "toolu_abc123", content: "file1\nfile2" },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    // Single event → uses relayEvent (not relayEvents)
+    expect(result.relayEvent).toBeDefined();
+    const msg = (result.relayEvent as any).message;
+    expect(msg.role).toBe("toolResult");
+    expect(msg.toolCallId).toBe("toolu_abc123");
+    expect(msg.content).toBe("file1\nfile2");
+    expect(msg.isError).toBe(false);
+  });
+
+  test("user message with array tool_result content → toolResult relay event", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_xyz",
+            content: [{ type: "text", text: "some output" }],
+          },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    const msg = (result.relayEvent as any).message;
+    expect(msg.role).toBe("toolResult");
+    expect(msg.toolCallId).toBe("toolu_xyz");
+    expect(Array.isArray(msg.content)).toBe(true);
+    expect((msg.content as any[])[0]).toMatchObject({ type: "text", text: "some output" });
+    expect(msg.isError).toBe(false);
+  });
+
+  test("tool_result with is_error: true → isError: true on relay event", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          {
+            type: "tool_result",
+            tool_use_id: "toolu_err",
+            content: "Command failed",
+            is_error: true,
+          },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    const msg = (result.relayEvent as any).message;
+    expect(msg.role).toBe("toolResult");
+    expect(msg.isError).toBe(true);
+    expect(msg.content).toBe("Command failed");
+  });
+
+  test("multiple tool_result blocks in one user message → relayEvents array", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "toolu_1", content: "result1" },
+          { type: "tool_result", tool_use_id: "toolu_2", content: "result2" },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    // Multiple events → uses relayEvents
+    expect(result.relayEvents).toBeDefined();
+    expect(result.relayEvent).toBeUndefined();
+    expect(result.relayEvents).toHaveLength(2);
+    const [ev1, ev2] = result.relayEvents!;
+    expect((ev1.message as any).role).toBe("toolResult");
+    expect((ev1.message as any).toolCallId).toBe("toolu_1");
+    expect((ev1.message as any).content).toBe("result1");
+    expect((ev2.message as any).role).toBe("toolResult");
+    expect((ev2.message as any).toolCallId).toBe("toolu_2");
+    expect((ev2.message as any).content).toBe("result2");
+  });
+
+  test("user message with tool_result AND text blocks → toolResult + user events", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "toolu_3", content: "tool output" },
+          { type: "text", text: "follow-up user text" },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    // Two events: toolResult first, then user
+    expect(result.relayEvents).toBeDefined();
+    expect(result.relayEvent).toBeUndefined();
+    expect(result.relayEvents).toHaveLength(2);
+    const [toolEv, userEv] = result.relayEvents!;
+    expect((toolEv.message as any).role).toBe("toolResult");
+    expect((toolEv.message as any).toolCallId).toBe("toolu_3");
+    expect((toolEv.message as any).content).toBe("tool output");
+    expect((userEv.message as any).role).toBe("user");
+    expect((userEv.message as any).content).toEqual([{ type: "text", text: "follow-up user text" }]);
+  });
+
+  test("user message with no tool_results passes through as-is", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: { role: "user", content: [{ type: "text", text: "Hello!" }] },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect(result.relayEvents).toBeUndefined();
+    const msg = (result.relayEvent as any).message;
+    expect(msg.role).toBe("user");
+  });
+
+  test("user message with no content array passes through as-is", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: { role: "user", content: "plain string content" },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect(result.relayEvents).toBeUndefined();
+    const msg = (result.relayEvent as any).message;
+    expect(msg.role).toBe("user");
+  });
+
+  test("tool_result with empty/absent content → content defaults to empty string", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "toolu_empty" },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    const msg = (result.relayEvent as any).message;
+    expect(msg.role).toBe("toolResult");
+    expect(msg.toolCallId).toBe("toolu_empty");
+    // Absent content defaults to empty string
+    expect(msg.content).toBe("");
+    expect(msg.isError).toBe(false);
+  });
+
+  // ── toolCalls extraction from assistant messages ──────────────────────
+
+  test("extracts toolCalls from assistant message with tool_use blocks", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "text", text: "Running commands." },
+          { type: "tool_use", id: "tc_1", name: "Bash", input: { command: "ls" } },
+          { type: "tool_use", id: "tc_2", name: "Read", input: { path: "file.txt" } },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect(result.toolCalls).toBeDefined();
+    expect(result.toolCalls).toHaveLength(2);
+    expect(result.toolCalls![0]).toMatchObject({
+      toolCallId: "tc_1",
+      toolName: "Bash",
+      toolInput: { command: "ls" },
+    });
+    expect(result.toolCalls![1]).toMatchObject({
+      toolCallId: "tc_2",
+      toolName: "Read",
+      toolInput: { path: "file.txt" },
+    });
+  });
+
+  test("extracts toolCalls for subagent tool_use", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tc_sub", name: "subagent", input: { agent: "task", task: "Do something" } },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0]).toMatchObject({
+      toolCallId: "tc_sub",
+      toolName: "subagent",
+      toolInput: { agent: "task", task: "Do something" },
+    });
+  });
+
+  test("excludes side-effect-only tools from toolCalls", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tc_todo", name: "TodoWrite", input: { todos: [] } },
+          { type: "tool_use", id: "tc_name", name: "set_session_name", input: { name: "Test" } },
+          { type: "tool_use", id: "tc_utodo", name: "update_todo", input: { todos: [] } },
+          { type: "tool_use", id: "tc_bash", name: "Bash", input: { command: "echo hi" } },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    // Only Bash should be in toolCalls — side-effect tools are excluded
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].toolName).toBe("Bash");
+  });
+
+  test("excludes AskUserQuestion from toolCalls (has its own path)", () => {
+    // AskUserQuestion returns ask_user_question kind, not relay_event, so
+    // toolCalls should not be populated. Verify by using a message with both
+    // AskUserQuestion and another tool — AskUserQuestion takes over the result.
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tc_ask", name: "AskUserQuestion", input: { questions: [] } },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("ask_user_question");
+    // AskUserQuestion returns early — no toolCalls extracted
+    expect(result.toolCalls).toBeUndefined();
+  });
+
+  test("no toolCalls for assistant messages without tool_use blocks", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "Just text, no tools." }],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.toolCalls).toBeUndefined();
+  });
+
+  // ── toolResultIds extraction from user messages ───────────────────────
+
+  test("extracts toolResultIds from tool_result blocks", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tc_1", content: "result 1" },
+          { type: "tool_result", tool_use_id: "tc_2", content: "result 2" },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.toolResultIds).toEqual(["tc_1", "tc_2"]);
+  });
+
+  test("single tool_result extracts toolResultIds", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: {
+        role: "user",
+        content: [
+          { type: "tool_result", tool_use_id: "tc_single", content: "done" },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.toolResultIds).toEqual(["tc_single"]);
+  });
+
+  test("no toolResultIds for user messages without tool_results", () => {
+    const line = JSON.stringify({
+      type: "user",
+      message: { role: "user", content: [{ type: "text", text: "Hello" }] },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.toolResultIds).toBeUndefined();
+  });
+
+  // ── Claude Code subagent tool recognition ─────────────────────────────
+
+  test("SUBAGENT_TOOL_NAMES includes Task, Agent, and subagent", () => {
+    expect(SUBAGENT_TOOL_NAMES.has("Task")).toBe(true);
+    expect(SUBAGENT_TOOL_NAMES.has("Agent")).toBe(true);
+    expect(SUBAGENT_TOOL_NAMES.has("subagent")).toBe(true);
+    // Common non-subagent tools should NOT be in the set
+    expect(SUBAGENT_TOOL_NAMES.has("Bash")).toBe(false);
+    expect(SUBAGENT_TOOL_NAMES.has("Read")).toBe(false);
+  });
+
+  test("extracts toolCalls for Claude Code Task tool", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tc_task", name: "Task", input: {
+            subagent_type: "Explore",
+            description: "Find auth code",
+            prompt: "Search for authentication patterns",
+          } },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0]).toMatchObject({
+      toolCallId: "tc_task",
+      toolName: "Task",
+      toolInput: {
+        subagent_type: "Explore",
+        description: "Find auth code",
+        prompt: "Search for authentication patterns",
+      },
+    });
+  });
+
+  test("extracts toolCalls for Claude Code Agent tool (newer SDK)", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tc_agent", name: "Agent", input: {
+            subagent_type: "general-purpose",
+            prompt: "Implement the feature",
+          } },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls![0].toolName).toBe("Agent");
+  });
+
+  test("normalizes Task tool_use to toolCall format like any other tool", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", id: "tc_task", name: "Task", input: {
+            subagent_type: "Explore",
+            prompt: "Find files",
+          } },
+        ],
+      },
+    });
+    const result = translateNdjsonLine(line);
+    const msg = (result.relayEvent as any)?.message;
+    expect(msg.content[0]).toMatchObject({
+      type: "toolCall",
+      toolCallId: "tc_task",
+      name: "Task",
+      arguments: JSON.stringify({ subagent_type: "Explore", prompt: "Find files" }),
+    });
+  });
+
+  // ── parentToolUseId extraction ──────────────────────────────────────
+
+  test("extracts parentToolUseId from assistant message", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      parent_tool_use_id: "toolu_abc123",
+      message: { role: "assistant", content: [{ type: "text", text: "subagent response" }] },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.parentToolUseId).toBe("toolu_abc123");
+  });
+
+  test("parentToolUseId is undefined when parent_tool_use_id is null", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      parent_tool_use_id: null,
+      message: { role: "assistant", content: [{ type: "text", text: "top-level response" }] },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.parentToolUseId).toBeUndefined();
+  });
+
+  test("parentToolUseId is undefined when field is absent", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "no parent" }] },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.parentToolUseId).toBeUndefined();
+  });
+
+  test("extracts parentToolUseId from user message", () => {
+    const line = JSON.stringify({
+      type: "user",
+      parent_tool_use_id: "toolu_xyz789",
+      message: { role: "user", content: "subagent prompt" },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.parentToolUseId).toBe("toolu_xyz789");
+  });
+
+  test("extracts parentToolUseId from stream_event", () => {
+    const line = JSON.stringify({
+      type: "stream_event",
+      parent_tool_use_id: "toolu_stream1",
+      event: "text_delta",
+      delta: "partial text",
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.parentToolUseId).toBe("toolu_stream1");
+  });
+
+  // ── tool_progress events ────────────────────────────────────────────
+
+  test("translates tool_progress to relay event", () => {
+    const line = JSON.stringify({
+      type: "tool_progress",
+      tool_use_id: "tc_bash1",
+      tool_name: "Bash",
+      parent_tool_use_id: null,
+      elapsed_time_seconds: 12.5,
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect(result.relayEvent).toMatchObject({
+      type: "tool_progress",
+      toolCallId: "tc_bash1",
+      toolName: "Bash",
+      elapsedSeconds: 12.5,
+    });
+    expect(result.parentToolUseId).toBeUndefined();
+  });
+
+  test("tool_progress from subagent has parentToolUseId", () => {
+    const line = JSON.stringify({
+      type: "tool_progress",
+      tool_use_id: "tc_read1",
+      tool_name: "Read",
+      parent_tool_use_id: "toolu_agent1",
+      elapsed_time_seconds: 3,
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.parentToolUseId).toBe("toolu_agent1");
+  });
+
+  // ── system/status events ────────────────────────────────────────────
+
+  test("translates system/status compacting to relay event", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "status",
+      status: "compacting",
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect(result.relayEvent).toMatchObject({
+      type: "system_status",
+      status: "compacting",
+    });
+  });
+
+  test("translates system/status null (compaction ended) to relay event", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "status",
+      status: null,
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect((result.relayEvent as any).status).toBeNull();
+  });
+
+  // ── compact_boundary events ─────────────────────────────────────────
+
+  test("translates system/compact_boundary to relay event", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "compact_boundary",
+      compact_metadata: { trigger: "auto", pre_tokens: 180000 },
+    });
+    const result = translateNdjsonLine(line);
+    expect(result.kind).toBe("relay_event");
+    expect(result.relayEvent).toMatchObject({
+      type: "compact_boundary",
+      trigger: "auto",
+      preTokens: 180000,
+    });
+  });
+});
+
+describe("parseSubagentToolCalls", () => {
+  test("returns single text message when no <tool_call> tags found", () => {
+    const result = parseSubagentToolCalls("Just a plain text response.");
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("assistant");
+    expect(result[0].content).toEqual([{ type: "text", text: "Just a plain text response." }]);
+  });
+
+  test("returns single text message for empty input", () => {
+    const result = parseSubagentToolCalls("");
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("assistant");
+    expect(result[0].content).toEqual([{ type: "text", text: "" }]);
+  });
+
+  test("parses single tool call with result", () => {
+    const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "ls"}</tool_input> </tool_call> <tool_result>
+file1.ts
+file2.ts
+</tool_result>`;
+
+    const result = parseSubagentToolCalls(input);
+
+    expect(result.length).toBeGreaterThanOrEqual(2);
+
+    const assistant = result.find(m => m.role === "assistant" && Array.isArray(m.content) && (m.content as any[]).some((c: any) => c.type === "toolCall"));
+    expect(assistant).toBeDefined();
+
+    const toolCall = (assistant!.content as any[]).find((c: any) => c.type === "toolCall");
+    expect(toolCall.name).toBe("bash");
+    expect(toolCall.arguments).toEqual({ command: "ls" });
+    expect(toolCall.id).toMatch(/^cc-tc-/);
+
+    const toolResult = result.find(m => m.role === "toolResult") as any;
+    expect(toolResult).toBeDefined();
+    expect(toolResult.toolCallId).toBe(toolCall.id);
+    expect(toolResult.toolName).toBe("bash");
+    expect(toolResult.isError).toBe(false);
+  });
+
+  test("parses multiple sequential tool calls", () => {
+    const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "pwd"}</tool_input> </tool_call> <tool_result>/home/user</tool_result>
+
+<tool_call> <tool_name>read</tool_name> <tool_input>{"path": "README.md"}</tool_input> </tool_call> <tool_result>
+# Hello
+</tool_result>`;
+
+    const result = parseSubagentToolCalls(input);
+    const toolResults = result.filter(m => m.role === "toolResult");
+    expect(toolResults).toHaveLength(2);
+    expect((toolResults[0] as any).toolName).toBe("bash");
+    expect((toolResults[1] as any).toolName).toBe("read");
+  });
+
+  test("captures interleaved text between tool calls", () => {
+    const input = `Let me check the files.
+
+<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "ls"}</tool_input> </tool_call> <tool_result>file1.ts</tool_result>
+
+Found the file. Now reading it.
+
+<tool_call> <tool_name>read</tool_name> <tool_input>{"path": "file1.ts"}</tool_input> </tool_call> <tool_result>content</tool_result>
+
+Done reviewing.`;
+
+    const result = parseSubagentToolCalls(input);
+
+    const textMessages = result.filter(m =>
+      m.role === "assistant" && Array.isArray(m.content) &&
+      (m.content as any[]).some((c: any) => c.type === "text")
+    );
+    expect(textMessages.length).toBeGreaterThanOrEqual(1);
+
+    const lastAssistant = [...result].reverse().find(m => m.role === "assistant");
+    const lastText = (lastAssistant!.content as any[]).find((c: any) => c.type === "text");
+    expect(lastText?.text).toContain("Done reviewing");
+  });
+
+  test("does not parse <tool_call> inside <tool_result>", () => {
+    const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "cat example.xml"}</tool_input> </tool_call> <tool_result>
+Here is the file:
+<tool_call> <tool_name>fake</tool_name> <tool_input>{"not": "real"}</tool_input> </tool_call>
+</tool_result>`;
+
+    const result = parseSubagentToolCalls(input);
+    const toolResults = result.filter(m => m.role === "toolResult");
+    expect(toolResults).toHaveLength(1);
+    expect((toolResults[0] as any).toolName).toBe("bash");
+
+    const resultText = (toolResults[0] as any).content[0].text;
+    expect(resultText).toContain("<tool_call>");
+  });
+
+  test("handles malformed JSON in tool_input", () => {
+    const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>not valid json</tool_input> </tool_call> <tool_result>output</tool_result>`;
+
+    const result = parseSubagentToolCalls(input);
+    const assistant = result.find(m => m.role === "assistant" && Array.isArray(m.content) && (m.content as any[]).some((c: any) => c.type === "toolCall"));
+    const toolCall = (assistant!.content as any[]).find((c: any) => c.type === "toolCall");
+    expect(toolCall.arguments).toEqual({ raw: "not valid json" });
+  });
+
+  test("handles missing </tool_result> tag", () => {
+    const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "ls"}</tool_input> </tool_call> <tool_result>
+output without closing tag`;
+
+    const result = parseSubagentToolCalls(input);
+    const toolResult = result.find(m => m.role === "toolResult") as any;
+    expect(toolResult).toBeDefined();
+    expect(toolResult.content[0].text).toContain("output without closing tag");
+  });
+
+  test("preserves JSON text in tool result (read tool output)", () => {
+    const input = `<tool_call> <tool_name>read</tool_name> <tool_input>{"path": "data.json"}</tool_input> </tool_call> <tool_result>{"key": "value", "nested": {"a": 1}}</tool_result>`;
+
+    const result = parseSubagentToolCalls(input);
+    const toolResult = result.find(m => m.role === "toolResult") as any;
+    expect(toolResult.content[0].text).toBe('{"key": "value", "nested": {"a": 1}}');
+  });
+
+  test("groups consecutive tool calls into a single assistant message", () => {
+    const input = `<tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "pwd"}</tool_input> </tool_call> <tool_call> <tool_name>bash</tool_name> <tool_input>{"command": "whoami"}</tool_input> </tool_call> <tool_result>/home/user</tool_result> <tool_result>jordan</tool_result>`;
+
+    const result = parseSubagentToolCalls(input);
+    const firstAssistant = result[0] as any;
+    expect(firstAssistant.role).toBe("assistant");
+    const toolCalls = firstAssistant.content.filter((c: any) => c.type === "toolCall");
+    expect(toolCalls).toHaveLength(2);
+    expect(toolCalls[0].name).toBe("bash");
+    expect(toolCalls[1].name).toBe("bash");
+    expect(toolCalls[0].id).not.toBe(toolCalls[1].id);
+
+    // Both tool results must be present and correctly attributed (parallel result matching)
+    const toolResults = result.filter(m => m.role === "toolResult") as any[];
+    expect(toolResults).toHaveLength(2);
+    expect(toolResults[0].toolCallId).toBe(toolCalls[0].id);
+    expect(toolResults[1].toolCallId).toBe(toolCalls[1].id);
+
+    // No stray assistant text message should contain raw <tool_result> markup
+    const leakedMarkup = result.filter(m =>
+      m.role === "assistant" &&
+      Array.isArray(m.content) &&
+      (m.content as any[]).some(
+        (c: any) => c.type === "text" && typeof c.text === "string" && c.text.includes("<tool_result>"),
+      ),
+    );
+    expect(leakedMarkup).toHaveLength(0);
+  });
+});

--- a/packages/cli/src/runner/claude-code-ndjson.ts
+++ b/packages/cli/src/runner/claude-code-ndjson.ts
@@ -85,6 +85,7 @@ export function translateNdjsonLine(line: string): TranslationResult {
       controlRequestId: typeof msg.request_id === "string" ? msg.request_id : undefined,
       toolName: typeof req?.tool_name === "string" ? req.tool_name : undefined,
       toolInput: req?.input,
+      parentToolUseId,
     };
   }
 
@@ -167,6 +168,7 @@ export function translateNdjsonLine(line: string): TranslationResult {
           toolCallId: typeof b.id === "string" ? b.id : undefined,
           questions,
           relayEvent: { type: "message_update", role: "assistant", message: normalizedMessage },
+          parentToolUseId,
         };
       }
 

--- a/packages/cli/src/runner/claude-code-ndjson.ts
+++ b/packages/cli/src/runner/claude-code-ndjson.ts
@@ -1,0 +1,608 @@
+/**
+ * Translates Claude Code CLI NDJSON output lines into PizzaPi relay events.
+ */
+
+/** Tool names that Claude Code uses for subagent invocations.
+ *  "Task" is the older name, "Agent" is the current SDK name.
+ *  Pi uses "subagent". All are recognized for lifecycle tracking. */
+export const SUBAGENT_TOOL_NAMES = new Set(["Task", "Agent", "subagent"]);
+
+/** Info about a tool_use block extracted from an assistant message. */
+export interface ToolCallInfo {
+  toolCallId: string;
+  toolName: string;
+  toolInput: unknown;
+}
+
+export interface TranslationResult {
+  kind:
+    | "control_request"   // needs a response on stdin
+    | "control_response"  // bridge sent this, echoed back (ignore)
+    | "session_init"      // system/init — carry session metadata
+    | "ask_user_question" // AskUserQuestion tool — needs UI interaction
+    | "relay_event"       // normal relay event to forward
+    | "unknown";          // unrecognised / malformed
+  relayEvent?: Record<string, unknown>;
+  /** When one NDJSON line produces multiple relay events (e.g. a user message
+   *  containing several tool_result blocks), use this array instead of
+   *  `relayEvent`. The bridge iterates over all entries and forwards each one. */
+  relayEvents?: Array<Record<string, unknown>>;
+  // control_request fields
+  controlRequestId?: string;
+  toolName?: string;
+  toolInput?: unknown;
+  // session_init fields
+  sessionId?: string;
+  model?: string;
+  cwd?: string;
+  // ask_user_question fields
+  toolCallId?: string;
+  questions?: Array<{ question: string; options: string[]; type?: string }>;
+  // todoWrite side-effect
+  todoList?: Array<{ id: string; text: string; content: string; status: string; priority: string }>;
+  // set_session_name side-effect
+  sessionName?: string;
+  // token usage from result events
+  tokenUsage?: { inputTokens: number; outputTokens: number; cacheCreationInputTokens?: number; cacheReadInputTokens?: number };
+  /** Tool calls extracted from assistant messages — used by the bridge to
+   *  track pending tool executions and emit synthetic tool_execution_start/end
+   *  events. Excludes side-effect-only tools (TodoWrite, set_session_name)
+   *  and AskUserQuestion (which has its own handling path). */
+  toolCalls?: ToolCallInfo[];
+  /** Tool call IDs extracted from tool_result blocks in user messages — used
+   *  by the bridge to emit synthetic tool_execution_end events. */
+  toolResultIds?: string[];
+  /** When non-null, this event belongs to a subagent invocation (Agent/Task
+   *  tool) and should not appear in the parent conversation.  The value is
+   *  the tool_use_id of the Agent/Task tool call that spawned the subagent.
+   *  Claude Code sets `parent_tool_use_id` on every NDJSON message; top-level
+   *  messages have it as `null`. */
+  parentToolUseId?: string;
+}
+
+export function translateNdjsonLine(line: string): TranslationResult {
+  let msg: Record<string, unknown>;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return { kind: "unknown" };
+  }
+
+  const type = msg.type;
+
+  // ── Subagent nesting indicator ────────────────────────────────────────
+  // Claude Code sets `parent_tool_use_id` on every NDJSON message.
+  // - `null` → top-level (parent conversation)
+  // - string → subagent-internal (belongs to Agent/Task tool with that id)
+  const rawParent = msg.parent_tool_use_id;
+  const parentToolUseId = typeof rawParent === "string" ? rawParent : undefined;
+
+  // ── Control protocol frames ───────────────────────────────────────────
+  if (type === "control_request") {
+    const req = msg.request as Record<string, unknown> | undefined;
+    return {
+      kind: "control_request",
+      controlRequestId: typeof msg.request_id === "string" ? msg.request_id : undefined,
+      toolName: typeof req?.tool_name === "string" ? req.tool_name : undefined,
+      toolInput: req?.input,
+    };
+  }
+
+  if (type === "control_response") {
+    return { kind: "control_response" };
+  }
+
+  // ── System init ───────────────────────────────────────────────────────
+  if (type === "system" && msg.subtype === "init") {
+    return {
+      kind: "session_init",
+      sessionId: typeof msg.session_id === "string" ? msg.session_id : undefined,
+      model: typeof msg.model === "string" ? msg.model : undefined,
+      cwd: typeof msg.cwd === "string" ? msg.cwd : undefined,
+    };
+  }
+
+  // ── Assistant messages ────────────────────────────────────────────────
+  if (type === "assistant") {
+    const message = msg.message as Record<string, unknown> | undefined;
+    const content = Array.isArray(message?.content) ? message.content as unknown[] : [];
+
+    // Side-effect extraction
+    let todoList: TranslationResult["todoList"] | undefined;
+    let sessionName: string | undefined;
+
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const b = block as Record<string, unknown>;
+      if (b.type !== "tool_use") continue;
+
+      // AskUserQuestion — needs special handling (returns immediately)
+      if (b.name === "AskUserQuestion") {
+        const input = b.input as Record<string, unknown> | undefined;
+        const rawQs = Array.isArray(input?.questions) ? input!.questions as unknown[] : [];
+        const questions = rawQs
+          .filter((q): q is Record<string, unknown> => !!q && typeof q === "object")
+          .map((q) => ({
+            question: typeof q.question === "string" ? q.question : "",
+            // Handle both string options and object options { label, description }
+            options: Array.isArray(q.options)
+              ? (q.options as unknown[])
+                  .map((o) => {
+                    if (typeof o === "string") return o;
+                    if (o && typeof o === "object") {
+                      const obj = o as Record<string, unknown>;
+                      return typeof obj.label === "string" ? obj.label : null;
+                    }
+                    return null;
+                  })
+                  .filter((o): o is string => o !== null && o.trim().length > 0)
+              : [],
+            // Handle both `type` (pi) and `multiSelect` (Claude Code) formats
+            type: typeof q.type === "string"
+              ? q.type
+              : q.multiSelect === true
+                ? "checkbox"
+                : "radio",
+          }));
+        // Normalize message content (convert tool_use → toolCall) before
+        // forwarding, so the UI renders a proper toolCall block instead of
+        // dumping raw tool_use JSON.
+        const normalizedContent = content.map((blk) => {
+          if (!blk || typeof blk !== "object") return blk;
+          const bl = blk as Record<string, unknown>;
+          if (bl.type !== "tool_use") return blk;
+          return {
+            type: "toolCall",
+            toolCallId: typeof bl.id === "string" ? bl.id : undefined,
+            name: typeof bl.name === "string" ? bl.name : undefined,
+            arguments: bl.input != null ? JSON.stringify(bl.input) : undefined,
+          };
+        });
+        const normalizedMessage = { ...message, content: normalizedContent };
+        // Include relayEvent so the bridge can save the assistant message to
+        // history before presenting the question.  Without this the AskUserQuestion
+        // turn is silently dropped, which breaks reconnect snapshots.
+        return {
+          kind: "ask_user_question",
+          toolCallId: typeof b.id === "string" ? b.id : undefined,
+          questions,
+          relayEvent: { type: "message_update", role: "assistant", message: normalizedMessage },
+        };
+      }
+
+      // TodoWrite — extract todo list as a side-effect
+      if (b.name === "TodoWrite" || b.name === "update_todo") {
+        const input = b.input as Record<string, unknown> | undefined;
+        const rawTodos = Array.isArray(input?.todos) ? input!.todos as unknown[] : [];
+        todoList = rawTodos
+          .filter((t): t is Record<string, unknown> => !!t && typeof t === "object")
+          .map((t) => {
+            const text = String(t.text ?? t.content ?? "");
+            const rawStatus = String(t.status ?? "pending").trim();
+            const status = rawStatus === "in_progress" || rawStatus === "done" || rawStatus === "cancelled"
+              ? rawStatus
+              : "pending";
+            return {
+              id: String(t.id ?? ""),
+              text,
+              content: text,
+              status,
+              priority: String(t.priority ?? "medium"),
+            };
+          });
+      }
+
+      // set_session_name — extract session name as a side-effect
+      if (b.name === "set_session_name") {
+        const input = b.input as Record<string, unknown> | undefined;
+        const name = typeof input?.name === "string" ? input.name.trim() : "";
+        if (name) sessionName = name;
+      }
+    }
+
+    // Normalize Claude tool_use blocks into PizzaPi toolCall blocks so the
+    // viewer's grouping/rendering path (which expects type:"toolCall" with
+    // toolCallId/arguments) works correctly.
+    //
+    // Also collect ToolCallInfo for each tool_use that represents a real tool
+    // execution (not side-effect-only tools or AskUserQuestion).
+    const toolCalls: ToolCallInfo[] = [];
+    const SIDE_EFFECT_TOOLS = new Set(["TodoWrite", "update_todo", "set_session_name"]);
+
+    const normalizedContent = content.map((block) => {
+      if (!block || typeof block !== "object") return block;
+      const b = block as Record<string, unknown>;
+      if (b.type !== "tool_use") return block;
+
+      const toolCallId = typeof b.id === "string" ? b.id : undefined;
+      const name = typeof b.name === "string" ? b.name : undefined;
+
+      // Collect tool call info for tools that will actually execute
+      // (exclude side-effect-only tools and AskUserQuestion which has its own path)
+      if (toolCallId && name && !SIDE_EFFECT_TOOLS.has(name) && name !== "AskUserQuestion") {
+        toolCalls.push({ toolCallId, toolName: name, toolInput: b.input });
+      }
+
+      return {
+        type: "toolCall",
+        toolCallId,
+        name,
+        arguments: b.input != null ? JSON.stringify(b.input) : undefined,
+      };
+    });
+    const normalizedMessage = { ...message, content: normalizedContent };
+
+    const result: TranslationResult = {
+      kind: "relay_event",
+      relayEvent: { type: "message_update", role: "assistant", message: normalizedMessage },
+      parentToolUseId,
+    };
+    if (todoList) result.todoList = todoList;
+    if (sessionName) result.sessionName = sessionName;
+    if (toolCalls.length > 0) result.toolCalls = toolCalls;
+    return result;
+  }
+
+  // ── User messages (replayed with --replay-user-messages) ──────────────
+  //
+  // Claude Code sends tool results inside user messages:
+  //   { type: "user", message: { role: "user", content: [{ type: "tool_result", ... }] } }
+  //
+  // The UI expects tool results as separate relay events with role "toolResult"
+  // and a top-level toolCallId field — not wrapped in a generic user message.
+  // Detect tool_result blocks in the content and split them into individual events.
+  if (type === "user") {
+    const message = msg.message as Record<string, unknown> | undefined;
+    const rawContent = Array.isArray(message?.content)
+      ? (message!.content as unknown[])
+      : null;
+
+    // No content array — pass through as a plain user message
+    if (!rawContent) {
+      return {
+        kind: "relay_event",
+        relayEvent: { type: "message_update", role: "user", message },
+        parentToolUseId,
+      };
+    }
+
+    // Partition content into tool_result blocks and everything else
+    const toolResultBlocks: Record<string, unknown>[] = [];
+    const otherBlocks: unknown[] = [];
+    for (const block of rawContent) {
+      if (block && typeof block === "object" &&
+          (block as Record<string, unknown>).type === "tool_result") {
+        toolResultBlocks.push(block as Record<string, unknown>);
+      } else {
+        otherBlocks.push(block);
+      }
+    }
+
+    // No tool_result blocks — pass through as a plain user message
+    if (toolResultBlocks.length === 0) {
+      return {
+        kind: "relay_event",
+        relayEvent: { type: "message_update", role: "user", message },
+        parentToolUseId,
+      };
+    }
+
+    // Build one relay event per tool_result block, plus one user event for any
+    // remaining non-tool_result blocks.
+    const events: Array<Record<string, unknown>> = [];
+    const toolResultIds: string[] = [];
+
+    for (const block of toolResultBlocks) {
+      const toolCallId = typeof block.tool_use_id === "string" ? block.tool_use_id : undefined;
+      // content can be a string, an array of content blocks, or absent
+      const blockContent = block.content ?? "";
+      const isError = block.is_error === true;
+
+      if (toolCallId) toolResultIds.push(toolCallId);
+
+      events.push({
+        type: "message_update",
+        message: {
+          role: "toolResult",
+          ...(toolCallId !== undefined ? { toolCallId } : {}),
+          content: blockContent,
+          isError,
+        },
+      });
+    }
+
+    // Remaining non-tool_result content (e.g. text blocks) → plain user message
+    if (otherBlocks.length > 0) {
+      events.push({
+        type: "message_update",
+        message: {
+          role: "user",
+          content: otherBlocks,
+        },
+      });
+    }
+
+    const translationResult: TranslationResult = events.length === 1
+      ? { kind: "relay_event", relayEvent: events[0], parentToolUseId }
+      : { kind: "relay_event", relayEvents: events, parentToolUseId };
+
+    if (toolResultIds.length > 0) translationResult.toolResultIds = toolResultIds;
+    return translationResult;
+  }
+
+  // ── Result (turn complete) ────────────────────────────────────────────
+  if (type === "result") {
+    // Extract token usage
+    let tokenUsage: TranslationResult["tokenUsage"] | undefined;
+    const usage = msg.usage as Record<string, unknown> | undefined;
+    if (usage && typeof usage === "object") {
+      const inputTokens = typeof usage.input_tokens === "number" ? usage.input_tokens : 0;
+      const outputTokens = typeof usage.output_tokens === "number" ? usage.output_tokens : 0;
+      tokenUsage = { inputTokens, outputTokens };
+      if (typeof usage.cache_creation_input_tokens === "number") tokenUsage.cacheCreationInputTokens = usage.cache_creation_input_tokens;
+      if (typeof usage.cache_read_input_tokens === "number") tokenUsage.cacheReadInputTokens = usage.cache_read_input_tokens;
+    }
+
+    return {
+      kind: "relay_event",
+      relayEvent: {
+        type: "turn_end",
+        subtype: msg.subtype,
+        numTurns: msg.num_turns,
+        costUsd: msg.total_cost_usd,
+        durationMs: msg.duration_ms,
+        isError: msg.is_error,
+        usage: msg.usage,
+      },
+      ...(tokenUsage ? { tokenUsage } : {}),
+    };
+  }
+
+  // ── Partial streaming events ──────────────────────────────────────────
+  // Translate stream_event into message_update with assistantMessageEvent
+  // so the UI can handle partial streaming content
+  if (type === "stream_event") {
+    // Extract the event subtype — Claude Code uses "event" for the delta type name
+    // (e.g. "text_delta", "thinking_delta", "thinking_start", "thinking_end", "toolcall_delta").
+    const eventType = typeof msg.event === "string" ? msg.event : undefined;
+    // Delta may be a string directly, or an object with a .text field.
+    const rawDelta = msg.delta;
+    const delta = typeof rawDelta === "string"
+      ? rawDelta
+      : (rawDelta && typeof rawDelta === "object" && typeof (rawDelta as Record<string, unknown>).text === "string")
+        ? (rawDelta as Record<string, unknown>).text as string
+        : undefined;
+    const contentIndex = typeof msg.index === "number" ? msg.index : undefined;
+
+    return {
+      kind: "relay_event",
+      relayEvent: {
+        type: "message_update",
+        assistantMessageEvent: {
+          type: eventType,
+          delta,
+          contentIndex,
+          partial: msg,
+        },
+      },
+      parentToolUseId,
+    };
+  }
+
+  // ── Tool progress heartbeats ──────────────────────────────────────────
+  // Claude Code emits these periodically for long-running tool executions.
+  if (type === "tool_progress") {
+    return {
+      kind: "relay_event",
+      relayEvent: {
+        type: "tool_progress",
+        toolCallId: typeof msg.tool_use_id === "string" ? msg.tool_use_id : undefined,
+        toolName: typeof msg.tool_name === "string" ? msg.tool_name : undefined,
+        elapsedSeconds: typeof msg.elapsed_time_seconds === "number" ? msg.elapsed_time_seconds : undefined,
+      },
+      parentToolUseId,
+    };
+  }
+
+  // ── System status changes (compaction, etc.) ──────────────────────────
+  if (type === "system" && msg.subtype === "status") {
+    return {
+      kind: "relay_event",
+      relayEvent: {
+        type: "system_status",
+        status: typeof msg.status === "string" ? msg.status : null,
+        permissionMode: typeof msg.permissionMode === "string" ? msg.permissionMode : undefined,
+      },
+    };
+  }
+
+  // ── Compact boundary ──────────────────────────────────────────────────
+  if (type === "system" && msg.subtype === "compact_boundary") {
+    const meta = msg.compact_metadata as Record<string, unknown> | undefined;
+    return {
+      kind: "relay_event",
+      relayEvent: {
+        type: "compact_boundary",
+        trigger: typeof meta?.trigger === "string" ? meta.trigger : "auto",
+        preTokens: typeof meta?.pre_tokens === "number" ? meta.pre_tokens : undefined,
+      },
+    };
+  }
+
+  return { kind: "unknown" };
+}
+
+// ── Subagent tool call XML parser ──────────────────────────────────────
+
+const STUB_USAGE = {
+  input: 0, output: 0, cacheRead: 0, cacheWrite: 0, totalTokens: 0,
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+};
+
+function makeAssistantMessage(
+  content: Record<string, unknown>[],
+  stopReason = "stop",
+): Record<string, unknown> {
+  return { role: "assistant", content, usage: { ...STUB_USAGE, cost: { ...STUB_USAGE.cost } }, stopReason, timestamp: 0 };
+}
+
+function makeToolResultMessage(
+  toolCallId: string,
+  toolName: string,
+  rawContent: string,
+): Record<string, unknown> {
+  const isError = /<is_error>\s*true\s*<\/is_error>/i.test(rawContent);
+  const text = rawContent.replace(/<is_error>.*?<\/is_error>/gsi, "").trim();
+  return {
+    role: "toolResult",
+    toolCallId,
+    toolName,
+    content: [{ type: "text", text }],
+    isError,
+    timestamp: 0,
+  };
+}
+
+/**
+ * Parse Claude Code's XML-serialized subagent tool calls into structured
+ * Message-compatible objects. Uses a state machine to avoid misinterpreting
+ * <tool_call> text that appears inside <tool_result> blocks.
+ *
+ * Returns an array of synthetic messages matching pi-ai's Message shape:
+ * - AssistantMessage with ToolCall content parts (role: "assistant")
+ * - ToolResultMessage (role: "toolResult")
+ *
+ * If no <tool_call> tags are found, returns a single assistant text message
+ * (backward-compatible fallback).
+ */
+export function parseSubagentToolCalls(text: string): Record<string, unknown>[] {
+  // Quick check: if no tool_call tags, return plain text fallback
+  if (!text.includes("<tool_call>")) {
+    return [makeAssistantMessage([{ type: "text", text }])];
+  }
+
+  const messages: Record<string, unknown>[] = [];
+  let assistantContent: Record<string, unknown>[] = [];
+  let toolCallCounter = 0;
+  // FIFO queue of pending tool calls awaiting results; supports parallel tool calls.
+  const pendingResults: Array<{ id: string; name: string }> = [];
+
+  type State = "outside" | "in_call" | "in_result";
+  let state: State = "outside";
+  let pos = 0;
+
+  while (pos < text.length) {
+    if (state === "outside") {
+      const nextCall = text.indexOf("<tool_call>", pos);
+      // If there are pending results, also watch for the next <tool_result>
+      const nextResult = pendingResults.length > 0 ? text.indexOf("<tool_result>", pos) : -1;
+
+      if (nextResult !== -1 && (nextCall === -1 || nextResult < nextCall)) {
+        // A <tool_result> comes before the next <tool_call> — consume it
+        const before = text.slice(pos, nextResult).trim();
+        if (before) assistantContent.push({ type: "text", text: before });
+        pos = nextResult + "<tool_result>".length;
+        state = "in_result";
+        continue;
+      }
+
+      if (nextCall === -1) {
+        // Rest is plain text
+        const remaining = text.slice(pos).trim();
+        if (remaining) assistantContent.push({ type: "text", text: remaining });
+        break;
+      }
+      // Text before the tool call
+      const before = text.slice(pos, nextCall).trim();
+      if (before) assistantContent.push({ type: "text", text: before });
+      pos = nextCall + "<tool_call>".length;
+      state = "in_call";
+      continue;
+    }
+
+    if (state === "in_call") {
+      const endCall = text.indexOf("</tool_call>", pos);
+      if (endCall === -1) break; // malformed — bail
+
+      const callBody = text.slice(pos, endCall);
+
+      // Extract tool_name
+      const nameMatch = callBody.match(/<tool_name>(.*?)<\/tool_name>/s);
+      const toolName = nameMatch ? nameMatch[1].trim() : "unknown";
+
+      // Extract tool_input
+      const inputMatch = callBody.match(/<tool_input>(.*?)<\/tool_input>/s);
+      const rawInput = inputMatch ? inputMatch[1].trim() : "";
+      let toolInput: Record<string, unknown>;
+      try {
+        toolInput = JSON.parse(rawInput) as Record<string, unknown>;
+      } catch {
+        toolInput = { raw: rawInput };
+      }
+
+      const toolCallId = `cc-tc-${toolCallCounter++}`;
+      // Push to FIFO queue so results are matched in order
+      pendingResults.push({ id: toolCallId, name: toolName });
+
+      assistantContent.push({ type: "toolCall", id: toolCallId, name: toolName, arguments: toolInput });
+
+      pos = endCall + "</tool_call>".length;
+
+      // Look ahead: another <tool_call> immediately (parallel), or <tool_result>, or return outside
+      const afterClose = text.slice(pos);
+      const resultStart = afterClose.match(/^\s*<tool_result>/);
+      if (resultStart) {
+        // Flush assistant message before entering result
+        if (assistantContent.length > 0) {
+          messages.push(makeAssistantMessage(assistantContent, "toolUse"));
+          assistantContent = [];
+        }
+        pos += resultStart[0].length;
+        state = "in_result";
+      } else {
+        const nextCallAhead = afterClose.match(/^\s*<tool_call>/);
+        if (nextCallAhead) {
+          // Another tool call — stay in in_call, accumulate in same assistant message
+          pos += nextCallAhead[0].length;
+          state = "in_call";
+        } else {
+          // Back to outside
+          if (assistantContent.length > 0) {
+            messages.push(makeAssistantMessage(assistantContent, "toolUse"));
+            assistantContent = [];
+          }
+          state = "outside";
+        }
+      }
+      continue;
+    }
+
+    if (state === "in_result") {
+      // Only scan for </tool_result> — NOT <tool_call> (state machine safety)
+      const endResult = text.indexOf("</tool_result>", pos);
+      // Dequeue the oldest pending tool call to match this result
+      const pending = pendingResults.shift();
+      const currentId = pending?.id ?? "";
+      const currentName = pending?.name ?? "";
+      let resultText: string;
+      if (endResult === -1) {
+        // No closing tag — rest of text is the result
+        resultText = text.slice(pos).trim();
+        messages.push(makeToolResultMessage(currentId, currentName, resultText));
+        break;
+      }
+      resultText = text.slice(pos, endResult).trim();
+      messages.push(makeToolResultMessage(currentId, currentName, resultText));
+      pos = endResult + "</tool_result>".length;
+      state = "outside";
+      continue;
+    }
+  }
+
+  // Flush any remaining assistant content
+  if (assistantContent.length > 0) {
+    messages.push(makeAssistantMessage(assistantContent));
+  }
+
+  return messages.length > 0 ? messages : [makeAssistantMessage([{ type: "text", text }])];
+}

--- a/packages/cli/src/runner/claude-code-spawn-request.test.ts
+++ b/packages/cli/src/runner/claude-code-spawn-request.test.ts
@@ -12,7 +12,6 @@ describe("buildSpawnSessionBody", () => {
       cwd: "/tmp/project",
       runnerId: "runner-1",
       model: { provider: "anthropic", id: "claude-sonnet-4-6" },
-      workerType: "pi",
       linked: true,
       agent: { name: "danger" },
     }, "parent-1")).toEqual({
@@ -21,7 +20,28 @@ describe("buildSpawnSessionBody", () => {
       runnerId: "runner-1",
       model: { provider: "anthropic", id: "claude-sonnet-4-6" },
       parentSessionId: "parent-1",
+      workerType: "claude-code",
     });
+  });
+
+  test("passes explicit workerType: 'pi' through to body", () => {
+    expect(buildSpawnSessionBody({
+      prompt: "Fix it",
+      cwd: "/tmp/project",
+      runnerId: "runner-1",
+      workerType: "pi",
+    }, "parent-1")).toEqual({
+      prompt: "Fix it",
+      cwd: "/tmp/project",
+      runnerId: "runner-1",
+      parentSessionId: "parent-1",
+      workerType: "pi",
+    });
+  });
+
+  test("defaults workerType to claude-code when not provided", () => {
+    const result = buildSpawnSessionBody({ prompt: "Hi" }, "parent-1");
+    expect(result.workerType).toBe("claude-code");
   });
 
   test("omits parent session when linked is false", () => {

--- a/packages/cli/src/runner/claude-code-spawn-request.test.ts
+++ b/packages/cli/src/runner/claude-code-spawn-request.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test, mock } from "bun:test";
+import { buildSpawnSessionBody } from "./claude-code-spawn-request.js";
+
+// Mock process.cwd() for consistent testing
+const originalCwd = process.cwd;
+const mockCwd = mock(() => "/default/project");
+
+describe("buildSpawnSessionBody", () => {
+  test("whitelists supported fields and links by default", () => {
+    expect(buildSpawnSessionBody({
+      prompt: "Fix it",
+      cwd: "/tmp/project",
+      runnerId: "runner-1",
+      model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+      workerType: "pi",
+      linked: true,
+      agent: { name: "danger" },
+    }, "parent-1")).toEqual({
+      prompt: "Fix it",
+      cwd: "/tmp/project",
+      runnerId: "runner-1",
+      model: { provider: "anthropic", id: "claude-sonnet-4-6" },
+      parentSessionId: "parent-1",
+    });
+  });
+
+  test("omits parent session when linked is false", () => {
+    // Should still include cwd and runnerId defaults even when linked is false
+    const result = buildSpawnSessionBody({ prompt: "Fix it", linked: false }, "parent-1");
+    expect(result.prompt).toBe("Fix it");
+    expect(result.parentSessionId).toBeUndefined();
+    expect(result.cwd).toBeDefined();
+    expect(typeof result.cwd).toBe("string");
+  });
+
+  test("drops malformed model payloads", () => {
+    const result = buildSpawnSessionBody({
+      prompt: "Fix it",
+      model: { provider: "anthropic" },
+    }, "parent-1");
+    expect(result.prompt).toBe("Fix it");
+    expect(result.parentSessionId).toBe("parent-1");
+    expect(result.model).toBeUndefined();
+    expect(result.cwd).toBeDefined();
+    expect(typeof result.cwd).toBe("string");
+  });
+
+  test("defaults cwd to process.cwd() if not provided", () => {
+    const result = buildSpawnSessionBody({
+      prompt: "Fix it",
+      runnerId: "runner-1",
+    }, "parent-1");
+    expect(result.cwd).toBe(process.cwd());
+  });
+
+  test("preserves explicitly provided cwd", () => {
+    const result = buildSpawnSessionBody({
+      prompt: "Fix it",
+      cwd: "/explicit/path",
+      runnerId: "runner-1",
+    }, "parent-1");
+    expect(result.cwd).toBe("/explicit/path");
+  });
+});

--- a/packages/cli/src/runner/claude-code-spawn-request.ts
+++ b/packages/cli/src/runner/claude-code-spawn-request.ts
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export interface ClaudeCodeSpawnSessionBody {
+  prompt?: string;
+  cwd?: string;
+  runnerId?: string;
+  model?: { provider: string; id: string };
+  parentSessionId?: string;
+}
+
+/**
+ * Get the current runner ID from the state file.
+ * Mirrors the logic in spawn-session.ts.
+ */
+function getRunnerIdFromState(): string | null {
+  const statePath = process.env.PIZZAPI_RUNNER_STATE_PATH ?? join(homedir(), ".pizzapi", "runner.json");
+  try {
+    if (!existsSync(statePath)) return null;
+    const state = JSON.parse(readFileSync(statePath, "utf-8"));
+    return typeof state.runnerId === "string" ? state.runnerId : null;
+  } catch {
+    return null;
+  }
+}
+
+export function buildSpawnSessionBody(args: Record<string, unknown>, parentSessionId: string): ClaudeCodeSpawnSessionBody {
+  const body: ClaudeCodeSpawnSessionBody = {};
+
+  if (typeof args.prompt === "string") body.prompt = args.prompt;
+
+  // Default cwd to process.cwd() if not provided, matching spawn_session.ts behavior
+  body.cwd = typeof args.cwd === "string" ? args.cwd : process.cwd();
+
+  // Default runnerId to state file value if not provided, matching spawn_session.ts behavior
+  if (typeof args.runnerId === "string") {
+    body.runnerId = args.runnerId;
+  } else {
+    const runnerId = getRunnerIdFromState();
+    if (runnerId) {
+      body.runnerId = runnerId;
+    }
+  }
+
+  const model = args.model;
+  if (
+    model &&
+    typeof model === "object" &&
+    typeof (model as Record<string, unknown>).provider === "string" &&
+    typeof (model as Record<string, unknown>).id === "string"
+  ) {
+    body.model = {
+      provider: (model as Record<string, string>).provider,
+      id: (model as Record<string, string>).id,
+    };
+  }
+
+  if (args.linked !== false) {
+    body.parentSessionId = parentSessionId;
+  }
+
+  return body;
+}

--- a/packages/cli/src/runner/claude-code-spawn-request.ts
+++ b/packages/cli/src/runner/claude-code-spawn-request.ts
@@ -8,6 +8,7 @@ export interface ClaudeCodeSpawnSessionBody {
   runnerId?: string;
   model?: { provider: string; id: string };
   parentSessionId?: string;
+  workerType?: "pi" | "claude-code";
 }
 
 /**
@@ -58,6 +59,18 @@ export function buildSpawnSessionBody(args: Record<string, unknown>, parentSessi
 
   if (args.linked !== false) {
     body.parentSessionId = parentSessionId;
+  }
+
+  // When spawning from a Claude Code session the child should also be a
+  // Claude Code worker by default.  The caller can opt-out by explicitly
+  // passing workerType: "pi".
+  if (args.workerType === "pi") {
+    body.workerType = "pi";
+  } else if (args.workerType === "claude-code" || args.workerType === undefined) {
+    body.workerType = "claude-code";
+  } else {
+    // Unknown value — fall back to claude-code (safe default in CC context)
+    body.workerType = "claude-code";
   }
 
   return body;

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1,9 +1,14 @@
-import { exec } from "node:child_process";
+import { exec, execFile, execFileSync, spawn, type ChildProcess } from "node:child_process";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+import { readdir, stat } from "node:fs/promises";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, realpathSync, renameSync, cpSync, rmSync } from "node:fs";
 import { hostname, homedir } from "node:os";
-import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { randomUUID, randomBytes } from "node:crypto";
+import { join, basename, resolve } from "node:path";
 import { ServiceRegistry } from "./service-handler.js";
 import { TerminalService } from "./services/terminal-service.js";
 import { FileExplorerService } from "./services/file-explorer-service.js";
@@ -11,6 +16,14 @@ import { GitService } from "./services/git-service.js";
 import { TunnelService } from "./services/tunnel-service.js";
 import { discoverServices } from "./service-loader.js";
 import { globalPluginDirs } from "../plugins/discover.js";
+import {
+    spawnTerminal,
+    writeTerminalInput,
+    resizeTerminal,
+    killTerminal,
+    listTerminals,
+    killAllTerminals,
+} from "./terminal.js";
 import { io, type Socket } from "socket.io-client";
 import {
     SOCKET_PROTOCOL_VERSION,
@@ -21,10 +34,12 @@ import { TunnelClient } from "@pizzapi/tunnel";
 import { loadGlobalConfig } from "../config.js";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 import type { ServiceTriggerDef } from "@pizzapi/protocol";
-import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
+import { spawnClaudeCodeSession } from "./claude-code-bridge-spawn.js";
+import { getRefreshedOAuthToken, parseGeminiQuotaCredential } from "./usage-auth.js";
+import { setLogComponent, logInfo, logWarn, logError, logAuth } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
 import { defaultStatePath, acquireStateAndIdentity, releaseStateLock } from "./runner-state.js";
-import { startUsageRefreshLoop, stopUsageRefreshLoop } from "./runner-usage-cache.js";
+import { startUsageRefreshLoop, stopUsageRefreshLoop, runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd } from "./runner-usage-cache.js";
 import { getWorkspaceRoots, isCwdAllowed } from "./workspace.js";
 import { type RunnerSession, spawnSession } from "./session-spawner.js";
 
@@ -466,11 +481,13 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     let adopted = 0;
                     for (const { sessionId, cwd } of existingSessions) {
                         if (runningSessions.has(sessionId)) continue; // already tracked
+                        if (typeof cwd === "string" && cwd.length > 0) trackSessionCwd(sessionId, cwd);
                         runningSessions.set(sessionId, {
                             sessionId,
                             child: null,
                             startedAt: Date.now(),
                             adopted: true,
+                            cwd: typeof cwd === "string" && cwd.length > 0 ? cwd : undefined,
                         });
                         adopted++;
                     }
@@ -492,6 +509,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         socket.on("new_session", (data: any) => {
             if (isShuttingDown) return;
             const { sessionId, cwd: requestedCwd, prompt: requestedPrompt, model: requestedModel, hiddenModels: requestedHiddenModels, agent: requestedAgent, parentSessionId: requestedParentSessionId } = data;
+            const workerType: "pi" | "claude-code" = data.workerType === "claude-code" ? "claude-code" : "pi";
 
             if (!sessionId) {
                 socket.emit("session_error", { sessionId: sessionId ?? "", message: "Missing sessionId" });
@@ -559,7 +577,62 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     });
                 }
             };
-            doSpawn();
+            // Validate cwd against allowed workspace roots (same guard as the pi path in spawnSession)
+            if (requestedCwd && !isCwdAllowed(requestedCwd)) {
+                socket.emit("session_error", {
+                    sessionId,
+                    message: `cwd not allowed: ${requestedCwd}`,
+                });
+                return;
+            }
+
+            if (workerType === "claude-code") {
+                // Claude Code bridge path — session_ready fires synchronously after spawn
+                // (same pattern as the pi path inside doSpawn). The bridge owns the
+                // relay connection, so the daemon tracks it as an adopted session.
+                try {
+                    const effectiveCwd = requestedCwd ?? process.cwd();
+                    const bridge = spawnClaudeCodeSession({
+                        sessionId,
+                        apiKey: apiKey!,
+                        relayUrl: relayRaw,
+                        cwd: requestedCwd,
+                        prompt: requestedPrompt,
+                        parentSessionId: requestedParentSessionId,
+                        model: requestedModel,
+                        hiddenModels: requestedHiddenModels,
+                    });
+                    trackSessionCwd(sessionId, effectiveCwd);
+                    runningSessions.set(sessionId, {
+                        sessionId,
+                        child: null,
+                        startedAt: Date.now(),
+                        adopted: true,
+                        bridgeManaged: true,
+                        bridgeAlive: true,
+                        parentSessionId: requestedParentSessionId,
+                        cwd: effectiveCwd,
+                    });
+                    void bridge.exited.then((code) => {
+                        const entry = runningSessions.get(sessionId);
+                        if (entry) entry.bridgeAlive = false;
+                        if (entry?.adopted) {
+                            runningSessions.delete(sessionId);
+                            if (entry.cwd) untrackSessionCwd(sessionId, entry.cwd);
+                            void cleanupSessionAttachments(sessionId).catch(() => {});
+                            logInfo(`Claude Code bridge for session ${sessionId} exited (code=${code})`);
+                        }
+                    }).catch(() => {});
+                    socket.emit("session_ready", { sessionId });
+                } catch (err) {
+                    socket.emit("session_error", {
+                        sessionId,
+                        message: err instanceof Error ? err.message : String(err),
+                    });
+                }
+            } else {
+                doSpawn(); // existing pi worker path — unchanged
+            }
         });
 
         socket.on("kill_session", (data: any) => {
@@ -580,6 +653,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     // socket, which sends end_session then force-disconnects.
                     socket.emit("disconnect_session", { sessionId });
                 }
+                if (entry.cwd) untrackSessionCwd(sessionId, entry.cwd);
                 runningSessions.delete(sessionId);
                 logInfo(`killed session ${sessionId}${entry.adopted ? " (adopted)" : ""}`);
                 socket.emit("session_killed", { sessionId });
@@ -619,11 +693,13 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 // (expired/orphaned), always honor the removal — the session
                 // is legitimately dead and the worker should exit on its own.
                 const childAlive = entry.child && !entry.child.killed && entry.child.exitCode === null;
+                const bridgeAlive = entry.bridgeManaged && entry.bridgeAlive;
                 const isTransientDisconnect = !reason || reason === "Session ended";
-                if (childAlive && isTransientDisconnect) {
+                if ((childAlive || bridgeAlive) && isTransientDisconnect) {
                     logInfo(`session_ended for ${sessionId} but worker still alive — keeping entry for reconnect`);
                     return;
                 }
+                if (entry.cwd) untrackSessionCwd(sessionId, entry.cwd);
                 runningSessions.delete(sessionId);
                 killedSessions.delete(sessionId);
                 endedSessionIds.set(sessionId, Date.now());
@@ -1044,4 +1120,53 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             logError(`server error: ${data.message}`);
         });
     });
+}
+export function isPidRunning(pid: number): boolean {
+    if (!Number.isFinite(pid) || pid <= 0) return false;
+    try {
+        process.kill(pid, 0);
+    } catch (err: any) {
+        // ESRCH = process does not exist. EPERM = exists but no permission.
+        if (err?.code === "ESRCH") return false;
+        // On Windows, process.kill(pid, 0) throws EPERM when the process exists
+        // but we lack permission, and throws with code ESRCH (or sometimes just
+        // a generic error) when it doesn't.  If we get here without ESRCH, assume alive.
+    }
+
+    // The PID is alive, but it may have been reused by an unrelated process.
+    // Verify the command line contains a pizzapi / runner signature.
+    try {
+        let cmd: string;
+        if (process.platform === "win32") {
+            // On Windows, use WMIC to inspect the process command line.
+            // wmic is available on Windows 7+ and returns the full command line.
+            cmd = execFileSync(
+                "wmic",
+                ["process", "where", `ProcessId=${pid}`, "get", "CommandLine", "/format:list"],
+                { encoding: "utf-8", timeout: 5000 },
+            ).trim();
+        } else {
+            cmd = execFileSync("ps", ["-p", String(pid), "-o", "command="], { encoding: "utf-8", timeout: 3000 }).trim();
+        }
+        // Match against known runner process patterns:
+        //   - "bun ... runner"          (dev: bun packages/cli/src/index.ts runner)
+        //   - "bun ... daemon.ts"       (dev: direct daemon run)
+        //   - "bun ... _daemon"         (supervisor-spawned child)
+        //   - "pizzapi ... runner"      (production CLI)
+        //   - "node ... runner"         (unlikely but possible)
+        const isRunner =
+            /\brunner\b/i.test(cmd) ||
+            /\bdaemon\b/i.test(cmd) ||
+            /\bpizzapi\b/i.test(cmd) ||
+            /\b_daemon\b/i.test(cmd);
+        if (!isRunner) {
+            // PID exists but belongs to an unrelated process — stale lock.
+            return false;
+        }
+    } catch {
+        // If we can't check the command (e.g. ps/wmic not available), fall back to
+        // assuming the process is the runner (safe default — avoids double-start).
+    }
+
+    return true;
 }

--- a/packages/cli/src/runner/logger.ts
+++ b/packages/cli/src/runner/logger.ts
@@ -26,7 +26,7 @@ let _component: string = "unknown";
 let _sessionId: string | null = null;
 
 /** Set the component name (call once at process start). */
-export function setLogComponent(component: "supervisor" | "daemon" | "worker"): void {
+export function setLogComponent(component: "supervisor" | "daemon" | "worker" | "cc-bridge"): void {
     _component = component;
 }
 

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -16,8 +16,14 @@ export interface RunnerSession {
      * running independently with its own relay connection.
      */
     adopted?: boolean;
+    /** True when this daemon owns the adopted Claude Code bridge process. */
+    bridgeManaged?: boolean;
+    /** Whether the adopted Claude Code bridge process is still believed alive. */
+    bridgeAlive?: boolean;
     /** ID of the parent session that spawned this one. */
     parentSessionId?: string;
+    /** Effective cwd for usage-auth tracking and cleanup. */
+    cwd?: string;
 }
 
 /** Is this process running inside a compiled Bun single-file binary? */

--- a/packages/npm/build-npm.ts
+++ b/packages/npm/build-npm.ts
@@ -140,12 +140,19 @@ for (const platform of PLATFORMS) {
         chmodSync(destBinary, 0o755);
     }
 
-    // Copy assets (package.json from pi, theme/, export-html/, PTY native lib)
+    // Copy assets (package.json from pi, theme/, export-html/, templates/)
     const assetDir = join(BINARIES_DIR, platform.binaryDir);
     for (const asset of ["package.json", "theme", "export-html", "templates"]) {
         const src = join(assetDir, asset);
         if (existsSync(src)) {
             cpSync(src, join(binDir, asset), { recursive: true });
+        }
+    }
+
+    for (const dirName of ["runner", "claude-code-plugin"]) {
+        const src = join(assetDir, dirName);
+        if (existsSync(src)) {
+            cpSync(src, join(binDir, dirName), { recursive: true });
         }
     }
 

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -18,6 +18,10 @@ export interface RelayClientToServerEvents {
     sessionName?: string | null;
     /** Parent session ID for child→parent linking (trigger system). */
     parentSessionId?: string | null;
+    /** Worker type — "pi" for the standard pi agent, "claude-code" for the
+     *  Claude Code CLI worker.  When present, stored in Redis at registration
+     *  time so the UI knows the worker type before the first heartbeat. */
+    workerType?: "pi" | "claude-code";
   }) => void;
 
   /** TUI forwards an agent event (heartbeat, message_update, etc.)

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -187,6 +187,8 @@ export interface RunnerServerToClientEvents {
     };
     /** ID of the parent session that spawned this one. */
     parentSessionId?: string;
+    /** Worker type to spawn. Defaults to "pi" if absent (backward-compatible). */
+    workerType?: "pi" | "claude-code";
   }) => void;
 
   /** Instructs runner to kill a session */

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -31,6 +31,10 @@ export interface SessionInfo {
   runnerName: string | null;
   /** ID of the parent session that spawned this one, or null for top-level. */
   parentSessionId?: string | null;
+  /** Worker type — "pi" for the standard pi agent, "claude-code" for the
+   *  Claude Code CLI worker.  Derived from the session's last heartbeat.
+   *  Undefined for sessions that have never sent a heartbeat. */
+  workerType?: "pi" | "claude-code";
 }
 
 /** Model provider and identifier */

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -248,11 +248,17 @@ async function _handleFetch(req: Request): Promise<Response> {
             // x-pizzapi-client-ip (see auth.ts advanced.ipAddress.ipAddressHeaders), so
             // this ensures per-client rate limiting works correctly in proxy deployments
             // while remaining immune to X-Forwarded-For spoofing.
+            //
+            // IMPORTANT: We mutate the headers on the original Request rather than
+            // constructing `new Request(req, { headers })`. In Bun's node:http compat
+            // layer, Requests created from a Node.js IncomingMessage carry a streaming
+            // body; `new Request(original, { headers })` fails to transfer that body
+            // (reads hang forever). Mutating in-place avoids the Bun bug entirely and
+            // is safe here because we own the Headers object (created in
+            // nodeReqToFetchRequest).
             const resolvedIp = getClientIp(req);
-            const authHeaders = new Headers(req.headers);
-            authHeaders.set("x-pizzapi-client-ip", resolvedIp);
-            const authReq = new Request(req, { headers: authHeaders });
-            return await getAuth().handler(authReq);
+            req.headers.set("x-pizzapi-client-ip", resolvedIp);
+            return await getAuth().handler(req);
         } catch (e) {
             authLog.error("handler threw:", e);
             return Response.json({ error: "Auth error" }, { status: 500 });

--- a/packages/server/src/routes/runners-worker-type.test.ts
+++ b/packages/server/src/routes/runners-worker-type.test.ts
@@ -1,0 +1,18 @@
+import { test, expect } from "bun:test";
+import { normaliseWorkerType } from "./runners.js";
+
+test("defaults to pi when absent", () => {
+  expect(normaliseWorkerType(undefined)).toBe("pi");
+});
+
+test("accepts claude-code", () => {
+  expect(normaliseWorkerType("claude-code")).toBe("claude-code");
+});
+
+test("defaults to pi for unknown string", () => {
+  expect(normaliseWorkerType("banana")).toBe("pi");
+});
+
+test("defaults to pi for pi (redundant but explicit)", () => {
+  expect(normaliseWorkerType("pi")).toBe("pi");
+});

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -32,6 +32,11 @@ const skillsLog = createLogger("skills");
 const agentsLog = createLogger("agents");
 const pluginsLog = createLogger("plugins");
 
+/** Normalise a raw workerType value from the request body. Unknown values default to "pi". */
+export function normaliseWorkerType(raw: unknown): "pi" | "claude-code" {
+    return raw === "claude-code" ? "claude-code" : "pi";
+}
+
 export const handleRunnersRoute: RouteHandler = async (req, url) => {
     // ── List runners ───────────────────────────────────────────────────
     if (url.pathname === "/api/runners" && req.method === "GET") {
@@ -91,6 +96,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 : undefined;
 
         const requestedParentSessionId = typeof body.parentSessionId === "string" ? body.parentSessionId : undefined;
+        const workerType = normaliseWorkerType(body.workerType);
 
         if (!requestedRunnerId) {
             return Response.json({ error: "Missing runnerId" }, { status: 400 });
@@ -160,6 +166,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 ...(hiddenModels.length > 0 ? { hiddenModels } : {}),
                 ...(requestedAgent ? { agent: requestedAgent } : {}),
                 ...(validatedParentSessionId ? { parentSessionId: validatedParentSessionId } : {}),
+                ...(workerType !== "pi" ? { workerType } : {}),
             });
         } catch {
             return Response.json({ error: "Failed to send spawn request to runner" }, { status: 502 });

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -28,6 +28,9 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
         const isEphemeral = data.ephemeral !== false;
         const collabMode = data.collabMode !== false;
 
+        const workerType = data.workerType === "claude-code" ? "claude-code" as const :
+            data.workerType === "pi" ? "pi" as const : undefined;
+
         const { sessionId, token, shareUrl, parentSessionId, wasDelinked } = await registerTuiSession(socket, cwd, {
             sessionId: data.sessionId,
             isEphemeral,
@@ -36,6 +39,7 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             userId: socket.data.userId,
             userName: (socket.data as RelaySocketData & { userName?: string }).userName,
             parentSessionId: data.parentSessionId ?? undefined,
+            workerType,
         });
 
         socket.data.sessionId = sessionId;

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -391,6 +391,11 @@ export async function getSessions(filterUserId?: string): Promise<SessionInfo[]>
     return sessions.map((s) => {
         const heartbeat = s.lastHeartbeat ? safeJsonParse(s.lastHeartbeat) : null;
         const model = modelFromHeartbeat(heartbeat);
+        const rawWorkerType = (heartbeat as any)?.workerType;
+        const workerType: "pi" | "claude-code" | undefined =
+            rawWorkerType === "claude-code" ? "claude-code" :
+            rawWorkerType === "pi" ? "pi" :
+            undefined;
 
         return {
             sessionId: s.sessionId,
@@ -410,6 +415,7 @@ export async function getSessions(filterUserId?: string): Promise<SessionInfo[]>
             runnerId: s.runnerId,
             runnerName: s.runnerName,
             parentSessionId: s.parentSessionId,
+            workerType,
         };
     });
 }

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -88,6 +88,9 @@ export interface RegisterTuiSessionOpts {
     userName?: string;
     /** Parent session ID — set when registering a child session. */
     parentSessionId?: string | null;
+    /** Worker type — stored at registration time so the UI knows it before
+     *  the first heartbeat arrives.  Absent for standard pi sessions. */
+    workerType?: "pi" | "claude-code";
 }
 
 /**
@@ -270,6 +273,11 @@ export async function registerTuiSession(
         }
     }
 
+    const registrationWorkerType: "pi" | "claude-code" | null =
+        opts.workerType === "claude-code" ? "claude-code" :
+        opts.workerType === "pi" ? "pi" :
+        null;
+
     const sessionData: RedisSessionData = {
         sessionId,
         token,
@@ -291,6 +299,7 @@ export async function registerTuiSession(
         seq: 0,
         parentSessionId: resolvedParentSessionId,
         linkedParentId,
+        ...(registrationWorkerType ? { workerType: registrationWorkerType } : {}),
     };
 
     await setSession(sessionId, sessionData);
@@ -363,6 +372,7 @@ export async function registerTuiSession(
             runnerId,
             runnerName,
             parentSessionId: resolvedParentSessionId,
+            ...(registrationWorkerType ? { workerType: registrationWorkerType } : {}),
         } satisfies SessionInfo,
         userId ?? undefined,
     );
@@ -391,10 +401,16 @@ export async function getSessions(filterUserId?: string): Promise<SessionInfo[]>
     return sessions.map((s) => {
         const heartbeat = s.lastHeartbeat ? safeJsonParse(s.lastHeartbeat) : null;
         const model = modelFromHeartbeat(heartbeat);
-        const rawWorkerType = (heartbeat as any)?.workerType;
+        // Prefer the workerType stored at registration time (available before the
+        // first heartbeat) and fall back to the heartbeat-derived value for
+        // sessions created before this field was added.
+        const storedWorkerType = s.workerType;
+        const rawHeartbeatWorkerType = (heartbeat as any)?.workerType;
         const workerType: "pi" | "claude-code" | undefined =
-            rawWorkerType === "claude-code" ? "claude-code" :
-            rawWorkerType === "pi" ? "pi" :
+            storedWorkerType === "claude-code" ? "claude-code" :
+            storedWorkerType === "pi" ? "pi" :
+            rawHeartbeatWorkerType === "claude-code" ? "claude-code" :
+            rawHeartbeatWorkerType === "pi" ? "pi" :
             undefined;
 
         return {

--- a/packages/server/src/ws/sio-state/serialization.ts
+++ b/packages/server/src/ws/sio-state/serialization.ts
@@ -42,6 +42,7 @@ export const SESSION_SUMMARY_FIELDS = [
     "runnerId",
     "runnerName",
     "parentSessionId",
+    "workerType",
 ] as const;
 
 export function parseSessionSummaryFromHash(hash: Record<string, string>): RedisSessionSummaryData | null {
@@ -62,6 +63,7 @@ export function parseSessionSummaryFromHash(hash: Record<string, string>): Redis
         runnerId: hash.runnerId || null,
         runnerName: hash.runnerName || null,
         parentSessionId: hash.parentSessionId || null,
+        workerType: (hash.workerType === "claude-code" ? "claude-code" : hash.workerType === "pi" ? "pi" : null) as "pi" | "claude-code" | null | undefined,
     };
 }
 
@@ -130,6 +132,7 @@ export function parseRunnerFromHash(hash: Record<string, string>): RedisRunnerDa
         serviceIds: hash.serviceIds || undefined,
         panels: hash.panels || undefined,
         triggerDefs: hash.triggerDefs || undefined,
+        warnings: hash.warnings || undefined,
     };
 }
 

--- a/packages/server/src/ws/sio-state/serialization.ts
+++ b/packages/server/src/ws/sio-state/serialization.ts
@@ -109,6 +109,7 @@ export function parseSessionFromHash(hash: Record<string, string>): RedisSession
         parentSessionId: hash.parentSessionId || null,
         linkedParentId: hash.linkedParentId || null,
         metaState: hash.metaState || null,
+        workerType: (hash.workerType === "claude-code" ? "claude-code" : hash.workerType === "pi" ? "pi" : null) as "pi" | "claude-code" | null | undefined,
     };
 }
 

--- a/packages/server/src/ws/sio-state/types.ts
+++ b/packages/server/src/ws/sio-state/types.ts
@@ -65,6 +65,10 @@ export interface RedisSessionData {
      *  Absent for sessions created before this feature; callers must use
      *  defaultMetaState() as fallback. */
     metaState?: string | null;
+    /** Worker type stored at registration time — "pi" or "claude-code".
+     *  Available immediately (before the first heartbeat).
+     *  Absent for sessions created before this field was added. */
+    workerType?: "pi" | "claude-code" | null;
 }
 
 /**

--- a/packages/server/src/ws/sio-state/types.ts
+++ b/packages/server/src/ws/sio-state/types.ts
@@ -93,6 +93,8 @@ export interface RedisSessionSummaryData {
     runnerId: string | null;
     runnerName: string | null;
     parentSessionId: string | null;
+    /** Worker type — "pi" or "claude-code". Absent for older sessions. */
+    workerType?: "pi" | "claude-code" | null;
 }
 
 export interface RedisRunnerData {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@pizzapi/protocol": "workspace:*",
     "@pizzapi/tools": "workspace:*",
     "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dialog": "^1.1.15",
@@ -43,11 +44,10 @@
     "react-resizable": "^3.0.5",
     "recharts": "^3.8.0",
     "shiki": "^3.22.0",
+    "socket.io-client": "^4.8.1",
     "streamdown": "^2.3.0",
     "tailwind-merge": "^3.5.0",
-    "use-stick-to-bottom": "^1.1.3",
-    "socket.io-client": "^4.8.1",
-    "@pizzapi/protocol": "workspace:*"
+    "use-stick-to-bottom": "^1.1.3"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.2.0",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4808,6 +4808,7 @@ export function App() {
           runnersLoading={runnersStatus === "connecting"}
           preselectedRunnerId={spawnPreselectedRunnerId}
           initialCwd={spawnCwd}
+          initialWorkerType={spawnWorkerType}
           onSpawn={handleWizardSpawn}
         />
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -47,6 +47,7 @@ import {
 import { Spinner } from "@/components/ui/spinner";
 import { Skeleton } from "@/components/ui/skeleton";
 import { ErrorBoundary } from "@/components/ui/error-boundary";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -174,6 +175,8 @@ interface SessionState {
   availableCommands: Array<{ name: string; description?: string; source?: string }>;
   resumeSessions: ResumeSessionOption[];
   resumeSessionsLoading: boolean;
+  pendingPermission: { requestId: string; toolName: string; toolInput: unknown; ts: number } | null;
+  workerType: string;
 }
 
 function createInitialSessionState(): SessionState {
@@ -204,6 +207,8 @@ function createInitialSessionState(): SessionState {
     availableCommands: [],
     resumeSessions: [],
     resumeSessionsLoading: false,
+    pendingPermission: null,
+    workerType: "pi",
   };
 }
 // ─────────────────────────────────────────────────────────────────────────────
@@ -229,6 +234,7 @@ export function App() {
     modelSelectorOpen, isChangingModel, agentActive, effortLevel, authSource,
     tokenUsage, providerUsage, usageRefreshing, lastHeartbeatAt,
     availableCommands, resumeSessions, resumeSessionsLoading,
+    pendingPermission, workerType,
   } = sessionState;
 
   // Thin setter wrappers — identical signatures to the original useState setters
@@ -364,6 +370,16 @@ export function App() {
       setSessionState((p: SessionState) => ({ ...p, resumeSessionsLoading: typeof v === "function" ? v(p.resumeSessionsLoading) : v })),
     []
   );
+  const setPendingPermission = React.useCallback(
+    (v: React.SetStateAction<SessionState["pendingPermission"]>) =>
+      setSessionState((p: SessionState) => ({ ...p, pendingPermission: typeof v === "function" ? v(p.pendingPermission) : v })),
+    []
+  );
+  const setWorkerType = React.useCallback(
+    (v: React.SetStateAction<string>) =>
+      setSessionState((p: SessionState) => ({ ...p, workerType: typeof v === "function" ? v(p.workerType) : v })),
+    []
+  );
   // ────────────────────────────────────────────────────────────────────────────
   // Ref kept in sync with `messages` via useLayoutEffect so we can read the
   // latest committed value in event handlers without needing functional updaters.
@@ -440,6 +456,7 @@ export function App() {
 
   const [newSessionOpen, setNewSessionOpen] = React.useState(false);
   const [spawnRunnerId, setSpawnRunnerId] = React.useState<string | undefined>(undefined);
+  const [spawnWorkerType, setSpawnWorkerType] = React.useState<"pi" | "claude-code">("pi");
   const [spawnCwd, setSpawnCwd] = React.useState<string>("");
   const [spawnPreselectedRunnerId, setSpawnPreselectedRunnerId] = React.useState<string | null>(null);
   const [spawningSession, setSpawningSession] = React.useState(false);
@@ -451,6 +468,7 @@ export function App() {
 
   /** Set of session IDs that are actively compacting their context window. */
   const [sessionsCompacting, setSessionsCompacting] = React.useState<Set<string>>(new Set());
+
 
   // Cached fallback promptKey for when toolCallId is absent (legacy/compat).
   // Only changes when the question content changes, preventing heartbeat
@@ -478,6 +496,7 @@ export function App() {
   const [isCompacting, setIsCompacting] = React.useState(false);
   const [planModeEnabled, setPlanModeEnabled] = React.useState(false);
   const [todoList, setTodoList] = React.useState<TodoItem[]>([]);
+
 
   // Keyboard shortcuts
   const isMac = React.useMemo(() => {
@@ -682,6 +701,7 @@ export function App() {
       todoList: prev?.todoList ?? [],
       pendingQuestion: prev?.pendingQuestion ?? null,
       pendingPlan: prev?.pendingPlan ?? null,
+      workerType: prev?.workerType ?? "pi",
       ...patch,
       lastAccessed: Date.now(),
     };
@@ -1428,11 +1448,138 @@ export function App() {
         cachePatch.lastHeartbeatAt = hb.ts;
       }
 
+
+      if ((hb as any).providerUsage !== undefined) {
+        const nextProviderUsage = (hb as any).providerUsage ?? null;
+        setProviderUsage(nextProviderUsage);
+        cachePatch.providerUsage = nextProviderUsage;
+      }
+
+      if ((hb as any).authSource !== undefined) {
+        const nextAuthSource = typeof (hb as any).authSource === "string" ? (hb as any).authSource : null;
+        setAuthSource(nextAuthSource);
+        cachePatch.authSource = nextAuthSource;
+      }
+
+      if ((hb as any).workerType !== undefined) {
+        const nextWorkerType = typeof (hb as any).workerType === "string" ? (hb as any).workerType : "pi";
+        setWorkerType(nextWorkerType);
+        cachePatch.workerType = nextWorkerType;
+      }
+
+
       if (Object.prototype.hasOwnProperty.call(hb, "sessionName")) {
         const nextName = normalizeSessionName(hb.sessionName);
         setSessionName(nextName);
         cachePatch.sessionName = nextName;
       }
+
+
+      if (Array.isArray((hb as any).todoList)) {
+        const todos = (hb as any).todoList as TodoItem[];
+        setTodoList(todos);
+        cachePatch.todoList = todos;
+      }
+
+      // Restore pending AskUserQuestion state when reconnecting to a session.
+      if (Object.prototype.hasOwnProperty.call(hb, "pendingQuestion")) {
+        const pq = (hb as any).pendingQuestion as { toolCallId: string; questions?: Array<{ question: string; options: string[] }>; display?: string; question?: string; options?: string[] } | null;
+        if (pq) {
+          const questions = parsePendingQuestions(pq);
+          if (questions.length > 0) {
+            const resolved = {
+              toolCallId: typeof pq.toolCallId === "string" ? pq.toolCallId : getFallbackPromptKey(questions),
+              questions,
+              display: parsePendingQuestionDisplayMode(pq, questions.length),
+            };
+            setPendingQuestion(resolved);
+            cachePatch.pendingQuestion = resolved;
+            setViewerStatus("Waiting for answer…");
+          } else {
+            setPendingQuestion(null);
+            cachePatch.pendingQuestion = null;
+          }
+        } else {
+          // Heartbeat explicitly says no pending question; clear any stale state.
+          setPendingQuestion(null);
+          cachePatch.pendingQuestion = null;
+        }
+      }
+
+      // Restore pending plan mode state when reconnecting to a session.
+      if (Object.prototype.hasOwnProperty.call(hb, "pendingPlan")) {
+        const pp = (hb as any).pendingPlan as {
+          toolCallId: string;
+          title: string;
+          description?: string | null;
+          steps?: Array<{ title: string; description?: string }>;
+        } | null;
+        if (pp && typeof pp.toolCallId === "string" && typeof pp.title === "string" && pp.title.trim()) {
+          const steps = Array.isArray(pp.steps)
+            ? pp.steps.filter((s): s is { title: string; description?: string } =>
+                s !== null && typeof s === "object" && typeof s.title === "string" && s.title.trim().length > 0,
+              )
+            : [];
+          const resolved = {
+            toolCallId: pp.toolCallId,
+            title: pp.title.trim(),
+            description: typeof pp.description === "string" && pp.description.trim() ? pp.description.trim() : null,
+            steps,
+          };
+          setPendingPlan(resolved);
+          cachePatch.pendingPlan = resolved;
+          setViewerStatus("Waiting for plan review…");
+        } else {
+          setPendingPlan(null);
+          cachePatch.pendingPlan = null;
+        }
+      }
+
+      // Restore pending permission prompts when reconnecting.
+      if (Object.prototype.hasOwnProperty.call(hb, "pendingPermission")) {
+        const pp = (hb as any).pendingPermission as {
+          requestId: string;
+          toolName?: string;
+          toolInput?: unknown;
+          ts?: number;
+        } | null;
+        if (pp && typeof pp.requestId === "string") {
+          setPendingPermission({
+            requestId: pp.requestId,
+            toolName: typeof pp.toolName === "string" ? pp.toolName : "Unknown",
+            toolInput: pp.toolInput ?? null,
+            ts: typeof pp.ts === "number" ? pp.ts : Date.now(),
+          });
+        } else {
+          setPendingPermission(null);
+        }
+      }
+
+      // Track auto-retry state from CLI so we can show a retry indicator.
+      if (Object.prototype.hasOwnProperty.call(hb, "retryState")) {
+        const rs = (hb as any).retryState as { errorMessage: string; detectedAt: number } | null;
+        setRetryState(rs);
+      }
+
+      // Restore pending plugin trust prompt when reconnecting.
+      if (Object.prototype.hasOwnProperty.call(hb, "pendingPluginTrust")) {
+        const pt = (hb as any).pendingPluginTrust as {
+          promptId: string;
+          pluginNames: string[];
+          pluginSummaries: string[];
+        } | null;
+        if (pt && typeof pt.promptId === "string" && Array.isArray(pt.pluginNames) && pt.pluginNames.length > 0) {
+          setPluginTrustPrompt({
+            promptId: pt.promptId,
+            pluginNames: pt.pluginNames,
+            pluginSummaries: Array.isArray(pt.pluginSummaries) ? pt.pluginSummaries : pt.pluginNames,
+          });
+        } else {
+          setPluginTrustPrompt(null);
+        }
+      }
+
+      // Heartbeats also carry the current model; keep activeModel in sync.
 
       if (hb.model) {
         const m = normalizeModel(hb.model);
@@ -1613,6 +1760,28 @@ export function App() {
       const stateTodos = Array.isArray(state?.todoList) ? (state.todoList as TodoItem[]) : [];
       setTodoList(stateTodos);
 
+      // Extract workerType from session snapshot (defaults to "pi")
+      const stateWorkerType = typeof state?.workerType === "string" ? state.workerType : "pi";
+      setWorkerType(stateWorkerType);
+
+      // Rehydrate pending permission request from the snapshot so that the
+      // permission card is shown immediately on reconnect, without waiting
+      // for the next heartbeat.  The heartbeat also carries pendingPermission
+      // and acts as the authoritative state, but the snapshot restores it
+      // synchronously so there is no visible gap while the HB travels.
+      const snapshotPP = state?.pendingPermission as Record<string, unknown> | null | undefined;
+      if (snapshotPP && typeof snapshotPP.requestId === "string") {
+        setPendingPermission({
+          requestId: snapshotPP.requestId,
+          toolName: typeof snapshotPP.toolName === "string" ? snapshotPP.toolName : "Unknown",
+          toolInput: snapshotPP.toolInput ?? null,
+          ts: typeof snapshotPP.ts === "number" ? snapshotPP.ts : Date.now(),
+        });
+      } else if (Object.prototype.hasOwnProperty.call(state ?? {}, "pendingPermission")) {
+        // Snapshot explicitly carries null — clear any stale card.
+        setPendingPermission(null);
+      }
+
       patchSessionCache({
         messages: normalizedMessages,
         activeModel: stateModel,
@@ -1620,6 +1789,7 @@ export function App() {
         availableModels: stateModels,
         effortLevel: thinkingLevel,
         todoList: stateTodos,
+        workerType: stateWorkerType,
       });
       return;
     }
@@ -1749,6 +1919,7 @@ export function App() {
       patchSessionCache({ messages: withInjected });
       setPendingQuestion(null);
       setPendingPlan(null);
+      setPendingPermission(null);
       setRetryState(null);
       setActiveToolCalls(new Map());
       // Clear message queue — the agent processed any queued steer/followUp messages
@@ -2182,6 +2353,20 @@ export function App() {
       return;
     }
 
+    // ── Permission request from Claude Code worker ─────────────────────────
+    if (type === "permission_request") {
+      const e = evt as Record<string, unknown>;
+      if (typeof e.requestId === "string") {
+        setPendingPermission({
+          requestId: e.requestId,
+          toolName: typeof e.toolName === "string" ? e.toolName : "Unknown",
+          toolInput: e.toolInput ?? null,
+          ts: typeof e.ts === "number" ? e.ts : Date.now(),
+        });
+      }
+      return;
+    }
+
     if (type === "tool_execution_start") {
       const toolCallId = typeof evt.toolCallId === "string" ? evt.toolCallId : "";
       const toolName = typeof evt.toolName === "string" ? evt.toolName : "unknown";
@@ -2373,6 +2558,7 @@ export function App() {
     if (type === "agent_end") {
       cancelHaptic();
       setActiveToolCalls(new Map());
+      setPendingPermission(null);
     }
 
     if (type === "message_update") {
@@ -2688,6 +2874,8 @@ export function App() {
     setIsCompacting(cached?.isCompacting ?? false);
     setEffortLevel(cached?.effortLevel ?? null);
     setPlanModeEnabled(cached?.planModeEnabled ?? false);
+    setAuthSource(cached?.authSource ?? null);
+    setWorkerType(cached?.workerType ?? "pi");
     setTokenUsage(cached?.tokenUsage ?? null);
     setLastHeartbeatAt(cached?.lastHeartbeatAt ?? null);
     setTodoList(cached?.todoList ?? []);
@@ -2706,6 +2894,7 @@ export function App() {
     // authoritative values from the runner.
     setPendingQuestion(null);
     setPendingPlan(null);
+    setPendingPermission(null);
 
     let socket = viewerWsRef.current;
     if (!socket) {
@@ -3175,6 +3364,18 @@ export function App() {
     }
   }, [sendRemoteExec, pluginTrustPrompt]);
 
+  /** Respond to a permission request from the Claude Code worker. */
+  const handlePermissionDecision = React.useCallback((requestId: string, decision: "allow" | "deny") => {
+    setPendingPermission(null);
+    sendRemoteExec({
+      type: "exec",
+      id: `permission-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      command: "permission_response",
+      requestId,
+      decision,
+    });
+  }, [sendRemoteExec]);
+
   /**
    * End a session by session ID. If it's the currently active session the
    * existing viewer socket is used; otherwise a temporary socket is opened
@@ -3380,6 +3581,7 @@ export function App() {
   const handleNewSession = React.useCallback(() => {
     setSpawnRunnerId(undefined);
     setSpawnPreselectedRunnerId(null);
+    setSpawnWorkerType("pi");
     setSpawnCwd("");
     setRecentFolders([]);
     setNewSessionOpen(true);
@@ -3388,6 +3590,7 @@ export function App() {
   const handleDuplicateSession = React.useCallback((runnerId: string, cwd: string) => {
     setSpawnRunnerId(runnerId);
     setSpawnPreselectedRunnerId(runnerId);
+    setSpawnWorkerType("pi");
     setSpawnCwd(cwd);
     setRecentFolders([]);
     setNewSessionOpen(true);
@@ -3442,6 +3645,7 @@ export function App() {
     const payload: any = {
       runnerId: spawnRunnerId,
       ...(spawnCwd.trim() ? { cwd: spawnCwd.trim() } : {}),
+      ...(spawnWorkerType !== "pi" ? { workerType: spawnWorkerType } : {}),
     };
 
     let sessionId: string | null = null;
@@ -3498,13 +3702,13 @@ export function App() {
     } finally {
       setSpawningSession(false);
     }
-  }, [spawningSession, spawnRunnerId, spawnCwd, handleOpenSession, waitForSessionToGoLive]);
+  }, [spawningSession, spawnRunnerId, spawnWorkerType, spawnCwd, handleOpenSession, waitForSessionToGoLive]);
 
   /** Spawn handler for the new wizard dialog. */
-  const handleWizardSpawn = React.useCallback(async (runnerId: string, cwd: string | undefined) => {
+  const handleWizardSpawn = React.useCallback(async (runnerId: string, cwd: string | undefined, workerType: "pi" | "claude-code" = "pi") => {
     setViewerStatus("Spawning session…");
 
-    const payload: any = { runnerId, ...(cwd ? { cwd } : {}) };
+    const payload: any = { runnerId, ...(cwd ? { cwd } : {}), ...(workerType !== "pi" ? { workerType } : {}) };
     const res = await fetch("/api/runners/spawn", {
       method: "POST",
       credentials: "include",
@@ -4394,6 +4598,9 @@ export function App() {
                         onPlanDismiss={() => setPendingPlan(null)}
                         onDuplicateSession={activeSessionInfo?.runnerId ? () => handleDuplicateSession(activeSessionInfo.runnerId!, activeSessionInfo.cwd || "") : undefined}
                         runnerInfo={activeRunnerInfo}
+                        pendingPermission={pendingPermission}
+                        onPermissionDecision={handlePermissionDecision}
+                        workerType={workerType}
                         mcpOAuthPastes={mcpOAuthPastes}
                         onMcpOAuthPaste={(nonce, code, state) => {
                           const socket = viewerWsRef.current;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1760,8 +1760,13 @@ export function App() {
       const stateTodos = Array.isArray(state?.todoList) ? (state.todoList as TodoItem[]) : [];
       setTodoList(stateTodos);
 
-      // Extract workerType from session snapshot (defaults to "pi")
-      const stateWorkerType = typeof state?.workerType === "string" ? state.workerType : "pi";
+      // Extract workerType from session snapshot.  If absent (snapshot sent
+      // before the worker type was added), fall back to the hub session's stored
+      // workerType (available since registration) so Claude Code sessions are
+      // correctly identified before the first heartbeat arrives.
+      const snapshotWorkerType = typeof state?.workerType === "string" ? state.workerType : undefined;
+      const hubWorkerTypeForSnapshot = liveSessionsRef.current.find((s) => s.sessionId === activeSessionRef.current)?.workerType;
+      const stateWorkerType = snapshotWorkerType ?? hubWorkerTypeForSnapshot ?? "pi";
       setWorkerType(stateWorkerType);
 
       // Rehydrate pending permission request from the snapshot so that the
@@ -2875,7 +2880,11 @@ export function App() {
     setEffortLevel(cached?.effortLevel ?? null);
     setPlanModeEnabled(cached?.planModeEnabled ?? false);
     setAuthSource(cached?.authSource ?? null);
-    setWorkerType(cached?.workerType ?? "pi");
+    // Prefer cached workerType (set by heartbeat/snapshot).  Fall back to the
+    // hub session's stored workerType (populated at registration time) so the
+    // UI knows it's a Claude Code session before the first heartbeat arrives.
+    const hubWorkerType = liveSessionsRef.current.find((s) => s.sessionId === relaySessionId)?.workerType;
+    setWorkerType(cached?.workerType ?? hubWorkerType ?? "pi");
     setTokenUsage(cached?.tokenUsage ?? null);
     setLastHeartbeatAt(cached?.lastHeartbeatAt ?? null);
     setTodoList(cached?.todoList ?? []);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3587,10 +3587,10 @@ export function App() {
     setNewSessionOpen(true);
   }, []);
 
-  const handleDuplicateSession = React.useCallback((runnerId: string, cwd: string) => {
+  const handleDuplicateSession = React.useCallback((runnerId: string, cwd: string, sourceWorkerType?: "pi" | "claude-code") => {
     setSpawnRunnerId(runnerId);
     setSpawnPreselectedRunnerId(runnerId);
-    setSpawnWorkerType("pi");
+    setSpawnWorkerType(sourceWorkerType ?? "pi");
     setSpawnCwd(cwd);
     setRecentFolders([]);
     setNewSessionOpen(true);
@@ -4596,7 +4596,7 @@ export function App() {
                         onTriggerResponse={handleTriggerResponse}
                         onQuestionDismiss={() => setPendingQuestion(null)}
                         onPlanDismiss={() => setPendingPlan(null)}
-                        onDuplicateSession={activeSessionInfo?.runnerId ? () => handleDuplicateSession(activeSessionInfo.runnerId!, activeSessionInfo.cwd || "") : undefined}
+                        onDuplicateSession={activeSessionInfo?.runnerId ? () => handleDuplicateSession(activeSessionInfo.runnerId!, activeSessionInfo.cwd || "", workerType as "pi" | "claude-code") : undefined}
                         runnerInfo={activeRunnerInfo}
                         pendingPermission={pendingPermission}
                         onPermissionDecision={handlePermissionDecision}

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -57,6 +57,12 @@ export interface NewSessionWizardDialogProps {
     initialCwd?: string;
 
     /**
+     * Optional initial worker type (e.g. when duplicating a session).
+     * Defaults to "pi" if not provided.
+     */
+    initialWorkerType?: "pi" | "claude-code";
+
+    /**
      * Called when the user clicks "Start Session".
      * `cwd` is `undefined` when the field is blank.
      */
@@ -104,6 +110,7 @@ export function NewSessionWizardDialog({
     runnersLoading,
     preselectedRunnerId,
     initialCwd,
+    initialWorkerType,
     onSpawn,
 }: NewSessionWizardDialogProps) {
     const isPreselected = preselectedRunnerId != null;
@@ -118,7 +125,7 @@ export function NewSessionWizardDialog({
     const selectedRunnerIdRef = React.useRef(selectedRunnerId);
     selectedRunnerIdRef.current = selectedRunnerId;
     const [cwd, setCwd] = React.useState(initialCwd ?? "");
-    const [workerType, setWorkerType] = React.useState<"pi" | "claude-code">("pi");
+    const [workerType, setWorkerType] = React.useState<"pi" | "claude-code">(initialWorkerType ?? "pi");
     const [spawning, setSpawning] = React.useState(false);
     const [spawnError, setSpawnError] = React.useState<string | null>(null);
     const [disconnectedMsg, setDisconnectedMsg] = React.useState<string | null>(null);
@@ -151,7 +158,7 @@ export function NewSessionWizardDialog({
         setStep(isPreselected ? "folder" : "runner");
         setSelectedRunnerId(preselectedRunnerId ?? null);
         setCwd(initialCwd ?? "");
-        setWorkerType("pi");
+        setWorkerType(initialWorkerType ?? "pi");
         setSpawnError(null);
         setDisconnectedMsg(null);
         setRecentFolders([]);

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -15,6 +15,7 @@ import { filterFolders } from "@/lib/filterFolders";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import {
     Dialog,
     DialogContent,
@@ -59,7 +60,7 @@ export interface NewSessionWizardDialogProps {
      * Called when the user clicks "Start Session".
      * `cwd` is `undefined` when the field is blank.
      */
-    onSpawn: (runnerId: string, cwd: string | undefined) => Promise<void>;
+    onSpawn: (runnerId: string, cwd: string | undefined, workerType: "pi" | "claude-code") => Promise<void>;
 }
 
 // ── Constants ──────────────────────────────────────────────────────────────
@@ -117,6 +118,7 @@ export function NewSessionWizardDialog({
     const selectedRunnerIdRef = React.useRef(selectedRunnerId);
     selectedRunnerIdRef.current = selectedRunnerId;
     const [cwd, setCwd] = React.useState(initialCwd ?? "");
+    const [workerType, setWorkerType] = React.useState<"pi" | "claude-code">("pi");
     const [spawning, setSpawning] = React.useState(false);
     const [spawnError, setSpawnError] = React.useState<string | null>(null);
     const [disconnectedMsg, setDisconnectedMsg] = React.useState<string | null>(null);
@@ -149,6 +151,7 @@ export function NewSessionWizardDialog({
         setStep(isPreselected ? "folder" : "runner");
         setSelectedRunnerId(preselectedRunnerId ?? null);
         setCwd(initialCwd ?? "");
+        setWorkerType("pi");
         setSpawnError(null);
         setDisconnectedMsg(null);
         setRecentFolders([]);
@@ -259,7 +262,7 @@ export function NewSessionWizardDialog({
         setSpawning(true);
         setSpawnError(null);
         try {
-            await onSpawn(selectedRunnerId, cwd.trim() || undefined);
+            await onSpawn(selectedRunnerId, cwd.trim() || undefined, workerType);
         } catch (err) {
             setSpawnError(err instanceof Error ? err.message : String(err));
         } finally {
@@ -377,6 +380,30 @@ export function NewSessionWizardDialog({
                             <p className="text-xs text-muted-foreground">
                                 This is the path on the runner machine.
                             </p>
+                        </div>
+
+                        {/* Worker type */}
+                        <div className="flex flex-col gap-1.5">
+                            <Label>Session type</Label>
+                            <RadioGroup
+                                value={workerType}
+                                onValueChange={(v) => setWorkerType(v as "pi" | "claude-code")}
+                                className="flex gap-4"
+                                disabled={spawning}
+                            >
+                                <div className="flex items-center gap-2">
+                                    <RadioGroupItem value="pi" id="wt-pi" />
+                                    <Label htmlFor="wt-pi" className="font-normal cursor-pointer">
+                                        pi <span className="text-muted-foreground text-xs">(default)</span>
+                                    </Label>
+                                </div>
+                                <div className="flex items-center gap-2">
+                                    <RadioGroupItem value="claude-code" id="wt-cc" />
+                                    <Label htmlFor="wt-cc" className="font-normal cursor-pointer">
+                                        Claude Code
+                                    </Label>
+                                </div>
+                            </RadioGroup>
                         </div>
 
                         {/* Recent projects */}

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -181,12 +181,12 @@ export function RunnerManager({
         setSpawnRunnerId(runnerId);
     };
 
-    const handleWizardSpawn = async (runnerId: string, cwd: string | undefined) => {
+    const handleWizardSpawn = async (runnerId: string, cwd: string | undefined, workerType: "pi" | "claude-code" = "pi") => {
         const res = await fetch("/api/runners/spawn", {
             method: "POST",
             credentials: "include",
             headers: { "content-type": "application/json" },
-            body: JSON.stringify({ runnerId, ...(cwd ? { cwd } : {}) }),
+            body: JSON.stringify({ runnerId, ...(cwd ? { cwd } : {}), ...(workerType !== "pi" ? { workerType } : {}) }),
         });
         const body = await res.json().catch(() => null) as { error?: string; sessionId?: string } | null;
         if (!res.ok) {

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -37,6 +37,7 @@ interface HubSession {
     runnerName?: string | null;
     isPinned?: boolean;
     parentSessionId?: string | null;
+    workerType?: "pi" | "claude-code";
 }
 
 interface PinnedSession {
@@ -88,7 +89,7 @@ export interface SessionSidebarProps {
     /** Called when the user confirms ending a session via the swipe gesture */
     onEndSession?: (sessionId: string) => void;
     /** Called when the user wants to duplicate a session (same runner + working directory) */
-    onDuplicateSession?: (runnerId: string, cwd: string) => void;
+    onDuplicateSession?: (runnerId: string, cwd: string, workerType?: "pi" | "claude-code") => void;
     /** Called when the user wants to return from Runners view to Sessions */
     onShowSessions?: () => void;
     /** List of runners to display when showRunners is true */
@@ -1284,7 +1285,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             className="flex flex-col items-center justify-center flex-1 pb-[3px] text-xs font-semibold gap-0.5 bg-violet-500 text-white active:bg-violet-600 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
-                                                                onDuplicateSession?.(s.runnerId!, s.cwd || "");
+                                                                onDuplicateSession?.(s.runnerId!, s.cwd || "", s.workerType);
                                                                 // Close the revealed state
                                                                 setSwipeOffsets((prev) => {
                                                                     const next = new Map(prev);

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -698,6 +698,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                         runnerId: s.runnerId ?? null,
                         runnerName: s.runnerName ?? null,
                         parentSessionId: s.parentSessionId ?? null,
+                        workerType: s.workerType,
                     },
                 ];
             });

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -50,6 +50,7 @@ import {
   AttachmentRemove,
   Attachments,
 } from "@/components/ai-elements/attachments";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -91,6 +92,7 @@ import { McpToggleContext, type McpToggleHandler } from "@/components/session-vi
 import { isTriggerMessage, renderTriggerCard } from "@/components/session-viewer/cards/InterAgentCards";
 import { type IncompleteTriggerItem, type TriggerHistoryEntry, getIncompleteTriggers } from "@/components/TriggersPanel";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { PermissionRequestCard } from "@/components/session-viewer/cards/PermissionRequestCard";
 
 
 export type { RelayMessage } from "@/components/session-viewer/types";
@@ -199,6 +201,17 @@ export interface SessionViewerProps {
   onMcpOAuthPasteDismiss?: (serverName: string) => void;
   /** Disable an MCP server (from OAuth paste prompt). */
   onMcpServerDisable?: (serverName: string) => void;
+  /** Pending permission request from a Claude Code worker */
+  pendingPermission?: {
+    requestId: string;
+    toolName: string;
+    toolInput: unknown;
+    ts: number;
+  } | null;
+  /** Respond to a permission request (allow or deny) */
+  onPermissionDecision?: (requestId: string, decision: "allow" | "deny") => void;
+  /** Worker type for the current session (e.g. "pi" or "claude-code") */
+  workerType?: string;
 }
 
 function formatTokenCount(n: number): string {
@@ -686,7 +699,7 @@ function HeaderOverflowMenu({ showTerminalButton, onToggleTerminal, isTerminalOp
   );
 }
 
-export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onEditQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, onToggleGit, showGitButton, isTerminalOpen, isFileExplorerOpen, isGitOpen, onToggleTriggers, showTriggersButton, isTriggersOpen, triggerCount, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse, onQuestionDismiss, onPlanDismiss, onDuplicateSession, runnerInfo, extraHeaderButtons, mcpOAuthPastes, onMcpOAuthPaste, onMcpOAuthPasteDismiss, onMcpServerDisable }: SessionViewerProps) {
+export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onEditQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, onToggleGit, showGitButton, isTerminalOpen, isFileExplorerOpen, isGitOpen, onToggleTriggers, showTriggersButton, isTriggersOpen, triggerCount, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse, onQuestionDismiss, onPlanDismiss, onDuplicateSession, runnerInfo, extraHeaderButtons, mcpOAuthPastes, onMcpOAuthPaste, onMcpOAuthPasteDismiss, onMcpServerDisable, pendingPermission, onPermissionDecision, workerType }: SessionViewerProps) {
   const [input, setInput] = React.useState("");
   // Per-session draft storage so switching sessions preserves unsent text
   const draftsRef = React.useRef<Map<string, string>>(new Map());
@@ -1709,7 +1722,10 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
           {/* Right: badges + end session */}
           <div className="flex items-center gap-1.5 flex-shrink-0">
             <HeartbeatStaleBadge lastHeartbeatAt={lastHeartbeatAt} />
-            {(activeModel?.reasoning || effortLevel != null) && (
+            {workerType === "claude-code" && (
+              <Badge variant="outline" className="text-[0.65rem] shrink-0 font-mono py-0.5">Claude Code</Badge>
+            )}
+            {workerType !== "claude-code" && (activeModel?.reasoning || effortLevel != null) && (
               <button
                 className="rounded-full border border-border bg-muted px-2 py-0.5 text-[0.65rem] font-medium text-muted-foreground uppercase tracking-wide hover:bg-muted/80 transition-colors cursor-pointer"
                 onClick={() => {
@@ -2156,6 +2172,14 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               </div>
             </div>
           </div>
+        )}
+
+        {/* Permission request card (Claude Code worker) */}
+        {pendingPermission && onPermissionDecision && (
+          <PermissionRequestCard
+            request={pendingPermission}
+            onDecision={onPermissionDecision}
+          />
         )}
 
         {/* Multiple-choice questions (shown above the input area) */}

--- a/packages/ui/src/components/session-viewer/cards/PermissionRequestCard.test.ts
+++ b/packages/ui/src/components/session-viewer/cards/PermissionRequestCard.test.ts
@@ -1,0 +1,29 @@
+import { test, expect, describe } from "bun:test";
+import { parsePermissionRequest } from "./permission-request.js";
+
+describe("parsePermissionRequest", () => {
+  test("parses a valid permission_request event", () => {
+    const event = {
+      type: "permission_request",
+      requestId: "req-1",
+      toolName: "Bash",
+      toolInput: { command: "rm -rf /tmp/build" },
+      ts: 1234567890,
+    };
+    const result = parsePermissionRequest(event);
+    expect(result).not.toBeNull();
+    expect(result!.requestId).toBe("req-1");
+    expect(result!.toolName).toBe("Bash");
+    expect(result!.toolInput).toEqual({ command: "rm -rf /tmp/build" });
+  });
+
+  test("returns null for non-permission_request events", () => {
+    expect(parsePermissionRequest({ type: "heartbeat" })).toBeNull();
+    expect(parsePermissionRequest(null)).toBeNull();
+    expect(parsePermissionRequest(undefined)).toBeNull();
+  });
+
+  test("returns null when requestId is missing", () => {
+    expect(parsePermissionRequest({ type: "permission_request", toolName: "Bash", toolInput: {} })).toBeNull();
+  });
+});

--- a/packages/ui/src/components/session-viewer/cards/PermissionRequestCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/PermissionRequestCard.tsx
@@ -1,0 +1,116 @@
+import * as React from "react";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { ShieldAlert, FileTextIcon, ChevronDownIcon } from "lucide-react";
+import type { ParsedPermissionRequest } from "./permission-request";
+
+interface Props {
+  request: ParsedPermissionRequest;
+  onDecision: (requestId: string, decision: "allow" | "deny") => void;
+}
+
+export function PermissionRequestCard({ request, onDecision }: Props) {
+  const isExitPlanMode = request.toolName === "ExitPlanMode";
+  const planContent = React.useMemo(() => {
+    if (!isExitPlanMode || !request.toolInput) return null;
+    const input = request.toolInput as Record<string, unknown>;
+    return typeof input.plan === "string" ? input.plan : null;
+  }, [isExitPlanMode, request.toolInput]);
+
+  const planFilePath = React.useMemo(() => {
+    if (!isExitPlanMode || !request.toolInput) return null;
+    const input = request.toolInput as Record<string, unknown>;
+    return typeof input.planFilePath === "string" ? input.planFilePath : null;
+  }, [isExitPlanMode, request.toolInput]);
+
+  const inputStr = React.useMemo(() => {
+    if (!request.toolInput) return null;
+    // For ExitPlanMode, don't show raw JSON — the plan content is rendered separately
+    if (isExitPlanMode && planContent) return null;
+    try { return JSON.stringify(request.toolInput, null, 2); }
+    catch { return String(request.toolInput); }
+  }, [request.toolInput, isExitPlanMode, planContent]);
+
+  // ExitPlanMode → plan review card
+  if (isExitPlanMode && planContent) {
+    const planTitle = planContent.match(/^#\s+(?:Plan:\s*)?(.+)/m)?.[1] ?? "Plan";
+    const planFileName = planFilePath?.split(/[\\/]/).pop() ?? "plan.md";
+
+    return (
+      <div className="rounded-lg border border-blue-500/40 bg-blue-500/5 p-4 flex flex-col gap-3">
+        <div className="flex items-center gap-2">
+          <FileTextIcon className="size-4 text-blue-400 shrink-0" />
+          <span className="font-medium text-sm">Plan Review</span>
+          <Badge variant="outline" className="ml-auto text-xs font-mono">{planFileName}</Badge>
+        </div>
+
+        <div className="text-sm font-medium text-zinc-200">{planTitle}</div>
+
+        <details className="group">
+          <summary className="cursor-pointer list-none">
+            <div className="flex items-center gap-2 text-xs text-zinc-500 hover:text-zinc-400 transition-colors">
+              <span>View plan details</span>
+              <ChevronDownIcon className="size-3 transition-transform group-open:rotate-180" />
+            </div>
+          </summary>
+          <pre className="mt-2 text-xs font-mono bg-muted rounded p-3 overflow-auto max-h-64 whitespace-pre-wrap break-words">
+            {planContent}
+          </pre>
+        </details>
+
+        <div className="flex gap-2 justify-end">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => onDecision(request.requestId, "deny")}
+            className="text-destructive border-destructive/40 hover:bg-destructive/10"
+          >
+            Reject
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => onDecision(request.requestId, "allow")}
+            className="bg-blue-500 hover:bg-blue-600 text-white"
+          >
+            Approve Plan
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  // Default permission request card
+  return (
+    <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-4 flex flex-col gap-3">
+      <div className="flex items-center gap-2">
+        <ShieldAlert className="size-4 text-amber-500 shrink-0" />
+        <span className="font-medium text-sm">Permission Request</span>
+        <Badge variant="outline" className="ml-auto text-xs font-mono">{request.toolName}</Badge>
+      </div>
+
+      {inputStr && (
+        <pre className="text-xs font-mono bg-muted rounded p-2 overflow-x-auto max-h-32 whitespace-pre-wrap break-all">
+          {inputStr}
+        </pre>
+      )}
+
+      <div className="flex gap-2 justify-end">
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => onDecision(request.requestId, "deny")}
+          className="text-destructive border-destructive/40 hover:bg-destructive/10"
+        >
+          Deny
+        </Button>
+        <Button
+          size="sm"
+          onClick={() => onDecision(request.requestId, "allow")}
+          className="bg-amber-500 hover:bg-amber-600 text-white"
+        >
+          Allow
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
@@ -30,6 +30,7 @@
 import * as React from "react";
 import {
   BotIcon,
+  ChevronDownIcon,
   Loader2Icon,
   CheckCircle2Icon,
   XCircleIcon,
@@ -40,6 +41,7 @@ import {
 import { ToolCardShell } from "@/components/ui/tool-card";
 import { MessageResponse } from "@/components/ai-elements/message";
 import { extractTextFromToolContent, parseToolInputArgs } from "@/components/session-viewer/utils";
+import { renderGroupedToolExecution } from "@/components/session-viewer/tool-rendering";
 
 // ── Types (mirroring CLI extension types) ──────────────────────────────
 
@@ -128,18 +130,131 @@ function getFinalOutput(messages: Array<{ role: string; content: unknown[] }>): 
   return "";
 }
 
-function getToolCallCount(messages: Array<{ role: string; content: unknown[] }>): number {
-  let count = 0;
+// ── Tool execution extraction ──────────────────────────────────────────
+
+interface ToolExecution {
+  toolKey: string;
+  toolName: string;
+  toolInput: unknown;
+  content: unknown;
+  isError: boolean;
+}
+
+/**
+ * Extract tool call + result pairs from the subagent's messages array.
+ * Works for both pi-native messages (uses `id` field, object arguments) and
+ * Claude Code synthetic messages (uses `id` field from the XML parser).
+ * Also handles the NDJSON normalizer convention of `toolCallId` field and
+ * stringified arguments defensively.
+ */
+function extractToolExecutions(messages: Array<{ role: string; content: unknown[] }>): ToolExecution[] {
+  const executions: ToolExecution[] = [];
+
+  // First pass: collect all tool calls from assistant messages
+  interface PendingCall { id: string; name: string; input: unknown }
+  const pendingCalls: PendingCall[] = [];
+
   for (const msg of messages) {
-    if (msg.role === "assistant") {
+    if (msg.role === "assistant" && Array.isArray(msg.content)) {
       for (const part of msg.content) {
-        if (part && typeof part === "object" && "type" in part && (part as any).type === "toolCall") {
-          count++;
+        if (!part || typeof part !== "object") continue;
+        const p = part as Record<string, unknown>;
+        if (p.type !== "toolCall") continue;
+
+        // Defensive: check both id and toolCallId (pi-ai uses id, NDJSON normalizer uses toolCallId)
+        const id = typeof p.toolCallId === "string" ? p.toolCallId
+          : typeof p.id === "string" ? p.id
+          : "";
+        const name = typeof p.name === "string" ? p.name : "unknown";
+
+        // Defensive: handle arguments as object or string (NDJSON normalizer produces string)
+        let input: unknown = p.arguments;
+        if (typeof input === "string") {
+          try { input = JSON.parse(input); } catch { input = {}; }
         }
+
+        pendingCalls.push({ id, name, input });
       }
     }
   }
-  return count;
+
+  // Second pass: match tool results to pending calls in order
+  const matchedIds = new Set<string>();
+
+  for (const msg of messages) {
+    if (msg.role !== "toolResult") continue;
+    const m = msg as Record<string, unknown>;
+    const toolCallId = typeof m.toolCallId === "string" ? m.toolCallId : "";
+
+    // Find matching pending call
+    const matchIdx = pendingCalls.findIndex(c => c.id && c.id === toolCallId && !matchedIds.has(c.id));
+    if (matchIdx < 0) continue;
+
+    const call = pendingCalls[matchIdx];
+    matchedIds.add(call.id);
+
+    executions.push({
+      toolKey: call.id || `tool-${executions.length}`,
+      toolName: typeof m.toolName === "string" ? m.toolName : call.name,
+      toolInput: call.input,
+      content: m.content,
+      isError: m.isError === true,
+    });
+  }
+
+  // Include unmatched calls (no result yet — e.g. truncated or still running)
+  for (const call of pendingCalls) {
+    if (call.id && matchedIds.has(call.id)) continue;
+    executions.push({
+      toolKey: call.id || `tool-${executions.length}`,
+      toolName: call.name,
+      toolInput: call.input,
+      content: null,
+      isError: false,
+    });
+  }
+
+  return executions;
+}
+
+// ── Inline tool cards for subagent tool calls ──────────────────────────
+
+/** Renders inline tool cards for subagent tool calls. Must be a React
+ *  component (not a helper function) because renderGroupedToolExecution
+ *  creates child components that use hooks (useSessionActions). */
+function SubagentToolCallsSection({ executions }: { executions: ToolExecution[] }) {
+  if (executions.length === 0) return null;
+
+  const autoOpen = executions.length === 1;
+
+  return (
+    <details open={autoOpen || undefined} className="group/tools">
+      <summary className="cursor-pointer list-none">
+        <div className="flex items-center gap-1.5 text-[11px] text-zinc-500 px-1 py-0.5 hover:text-zinc-400 transition-colors">
+          <WrenchIcon className="size-3 shrink-0" />
+          <span>{executions.length} tool call{executions.length !== 1 ? "s" : ""}</span>
+          <ChevronDownIcon className="size-3 transition-transform group-open/tools:rotate-180" />
+        </div>
+      </summary>
+      <div className="flex flex-col gap-2 pl-1 border-l-2 border-zinc-800 ml-1.5 mt-1 mb-1">
+        {executions.map((exec) => (
+          <div key={exec.toolKey} className="[&>*]:text-xs">
+            {renderGroupedToolExecution(
+              exec.toolKey,
+              exec.toolName,
+              exec.toolInput,
+              exec.content,
+              exec.isError,
+              false,       // isStreaming — always false for completed subagents
+              undefined,   // thinking
+              undefined,   // thinkingDuration
+              undefined,   // details
+            )}
+          </div>
+        ))}
+      </div>
+    </details>
+  );
 }
 
 // ── Parse details from top-level details prop ──────────────────────────
@@ -249,17 +364,6 @@ function ErrorBubble({ message, agentName }: { message: string; agentName: strin
   );
 }
 
-/** Small inline activity line between bubbles */
-function ToolCallActivity({ count }: { count: number }) {
-  if (count === 0) return null;
-  return (
-    <div className="flex items-center gap-1.5 text-[11px] text-zinc-600 px-1">
-      <WrenchIcon className="size-3 shrink-0" />
-      <span>{count} tool call{count !== 1 ? "s" : ""}</span>
-    </div>
-  );
-}
-
 /** Animated typing/thinking indicator */
 function ThinkingBubble() {
   return (
@@ -288,7 +392,7 @@ function AgentExchange({
 }) {
   const isError = result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
   const finalOutput = getFinalOutput(result.messages);
-  const toolCallCount = getToolCallCount(result.messages);
+  const toolExecutions = extractToolExecutions(result.messages);
 
   return (
     <>
@@ -306,8 +410,8 @@ function AgentExchange({
       {/* Task bubble (sent) */}
       <TaskBubble task={result.task} />
 
-      {/* Tool call activity */}
-      <ToolCallActivity count={toolCallCount} />
+      {/* Inline tool cards */}
+      <SubagentToolCallsSection executions={toolExecutions} />
 
       {/* Agent response or running state */}
       {isRunning ? (

--- a/packages/ui/src/components/session-viewer/cards/permission-request.ts
+++ b/packages/ui/src/components/session-viewer/cards/permission-request.ts
@@ -1,0 +1,20 @@
+export interface ParsedPermissionRequest {
+  requestId: string;
+  toolName: string;
+  toolInput: unknown;
+  ts: number;
+}
+
+/** Parse a raw relay event into a permission request, or null if not applicable. */
+export function parsePermissionRequest(event: unknown): ParsedPermissionRequest | null {
+  if (!event || typeof event !== "object") return null;
+  const e = event as Record<string, unknown>;
+  if (e.type !== "permission_request") return null;
+  if (typeof e.requestId !== "string" || !e.requestId) return null;
+  return {
+    requestId: e.requestId,
+    toolName: typeof e.toolName === "string" ? e.toolName : "Unknown Tool",
+    toolInput: e.toolInput ?? null,
+    ts: typeof e.ts === "number" ? e.ts : Date.now(),
+  };
+}

--- a/packages/ui/src/components/session-viewer/rendering.tsx
+++ b/packages/ui/src/components/session-viewer/rendering.tsx
@@ -232,6 +232,18 @@ export function renderContent(
                   : ({} as Record<string, unknown>);
 
             const normalizedToolName = normalizeToolName(toolName);
+
+            // Hide Claude Code internal tools from assistant message content —
+            // they're rendered as grouped tool executions via tool-rendering.tsx
+            // or are pure side-effects (session name, todos).
+            const HIDDEN_TOOL_CALLS = new Set([
+              "toolsearch", "enterplanmode", "exitplanmode",
+              "askuserquestion", "todowrite", "set_session_name",
+            ]);
+            if (HIDDEN_TOOL_CALLS.has(normalizedToolName)) {
+              return null;
+            }
+
             const isEdit =
               (normalizedToolName === "edit" || normalizedToolName.endsWith(".edit")) &&
               typeof args.path === "string" &&

--- a/packages/ui/src/components/session-viewer/tool-rendering.tsx
+++ b/packages/ui/src/components/session-viewer/tool-rendering.tsx
@@ -799,7 +799,7 @@ export function renderGroupedToolExecution(
         isStreaming={isStreaming}
       />
     );
-  } else if (norm === "subagent" || norm.endsWith(".subagent") || norm === "task" || norm.endsWith(".task")) {
+  } else if (norm === "subagent" || norm.endsWith(".subagent") || norm === "task" || norm.endsWith(".task") || norm === "agent" || norm.endsWith(".agent")) {
     card = (
       <SubagentResultCard
         toolInput={toolInput}
@@ -831,6 +831,26 @@ export function renderGroupedToolExecution(
     const inputArgs = parseToolInputArgs(toolInput);
     const enabled = inputArgs.enabled === true;
     card = <TogglePlanModeCard enabled={enabled} />;
+  } else if (norm === "toolsearch") {
+    // Claude Code internal tool — hide from UI (implementation detail)
+    card = null;
+  } else if (norm === "enterplanmode") {
+    card = <TogglePlanModeCard enabled={true} />;
+  } else if (norm === "exitplanmode") {
+    // ExitPlanMode may carry a plan submission — show plan file if available
+    const inputArgs = parseToolInputArgs(toolInput);
+    const plan = typeof inputArgs.plan === "string" ? inputArgs.plan : null;
+    const planFilePath = typeof inputArgs.planFilePath === "string" ? inputArgs.planFilePath : null;
+    if (plan && planFilePath) {
+      const fileName = planFilePath.split(/[\\/]/).pop() ?? "plan.md";
+      card = (
+        <FileTypeCard path={planFilePath} fileName={fileName} mimeType="text/markdown">
+          <CopyableCodeBlock code={plan} language="markdown" className="border-0 rounded-none" />
+        </FileTypeCard>
+      );
+    } else {
+      card = <TogglePlanModeCard enabled={false} />;
+    }
   } else {
     // Default / Generic tool card
     const outputText = hasOutput ? extractTextFromToolContent(content) : null;

--- a/packages/ui/src/components/session-viewer/utils.ts
+++ b/packages/ui/src/components/session-viewer/utils.ts
@@ -60,7 +60,18 @@ export function tryParseJsonObject(text: string): Record<string, unknown> | null
 }
 
 export function normalizeToolName(toolName?: string): string {
-  return (toolName ?? "").trim().toLowerCase();
+  let name = (toolName ?? "").trim().toLowerCase();
+  // Strip Claude Code MCP prefix: mcp__servername__toolname → toolname
+  if (name.startsWith("mcp__")) {
+    const sep = name.indexOf("__", 5); // 5 = "mcp__".length
+    if (sep !== -1) name = name.slice(sep + 2);
+  }
+  // Strip pizzapi_ prefix used by PizzaPi MCP tools
+  // (e.g. pizzapi_spawn_session → spawn_session)
+  if (name.startsWith("pizzapi_")) {
+    name = name.slice(8);
+  }
+  return name;
 }
 
 export function extractTextFromToolContent(content: unknown): string | null {

--- a/packages/ui/src/components/ui/radio-group.tsx
+++ b/packages/ui/src/components/ui/radio-group.tsx
@@ -1,0 +1,43 @@
+import * as React from "react"
+import { CircleIcon } from "lucide-react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "aspect-square size-4 shrink-0 rounded-full border border-input text-primary shadow-xs transition-[color,box-shadow] outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="relative flex items-center justify-center"
+      >
+        <CircleIcon className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 fill-primary" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/packages/ui/src/lib/ask-user-questions.ts
+++ b/packages/ui/src/lib/ask-user-questions.ts
@@ -26,11 +26,28 @@ export function parsePendingQuestions(data: Record<string, unknown> | undefined 
     const result: ParsedQuestion[] = [];
     for (const q of data.questions) {
       if (q && typeof q === "object" && typeof (q as any).question === "string" && (q as any).question.trim()) {
+        // Handle both string options and object options { label, description }
+        // (Claude Code sends objects; pi sends strings)
         const opts = Array.isArray((q as any).options)
-          ? ((q as any).options as unknown[]).filter((o): o is string => typeof o === "string" && o.trim().length > 0).map((o) => o.trim())
+          ? ((q as any).options as unknown[])
+              .map((o) => {
+                if (typeof o === "string") return o.trim();
+                if (o && typeof o === "object") {
+                  const obj = o as Record<string, unknown>;
+                  return typeof obj.label === "string" ? obj.label.trim() : null;
+                }
+                return null;
+              })
+              .filter((o): o is string => o !== null && o.length > 0)
           : [];
+        // Handle both `type` (pi) and `multiSelect` (Claude Code) formats
         const rawType = (q as any).type;
-        const type: QuestionType = rawType === "checkbox" ? "checkbox" : rawType === "ranked" ? "ranked" : "radio";
+        const multiSelect = (q as any).multiSelect;
+        const type: QuestionType = rawType === "checkbox" || multiSelect === true
+          ? "checkbox"
+          : rawType === "ranked"
+            ? "ranked"
+            : "radio";
         result.push({ question: (q as any).question.trim(), options: opts, type });
       }
     }
@@ -40,7 +57,16 @@ export function parsePendingQuestions(data: Record<string, unknown> | undefined 
   // Legacy format: { question, options }
   if (typeof data.question === "string" && data.question.trim()) {
     const opts = Array.isArray(data.options)
-      ? (data.options as unknown[]).filter((o): o is string => typeof o === "string" && o.trim().length > 0).map((o) => o.trim())
+      ? (data.options as unknown[])
+          .map((o) => {
+            if (typeof o === "string") return o.trim();
+            if (o && typeof o === "object") {
+              const obj = o as Record<string, unknown>;
+              return typeof obj.label === "string" ? obj.label.trim() : null;
+            }
+            return null;
+          })
+          .filter((o): o is string => o !== null && o.length > 0)
       : [];
     return [{ question: (data.question as string).trim(), options: opts, type: "radio" as QuestionType }];
   }

--- a/packages/ui/src/lib/session-tree.ts
+++ b/packages/ui/src/lib/session-tree.ts
@@ -20,6 +20,7 @@ export interface HubSession {
   runnerName?: string | null;
   isPinned?: boolean;
   parentSessionId?: string | null;
+  workerType?: "pi" | "claude-code";
 }
 
 export interface SessionTreeNode {

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -67,6 +67,7 @@ export interface SessionUiCacheEntry {
     description: string | null;
     steps: Array<{ title: string; description?: string }>;
   } | null;
+  workerType: string;
 
   // ── Runner-scoped (preserved on same-runner session switch) ───────────
   // These values are identical across sessions on the same runner.


### PR DESCRIPTION
## Summary
- add runner/server/UI support for spawning Claude Code worker sessions, including a worker type selector and Claude Code session badge/permission card UI
- add the Claude Code bridge, plugin hook handler, MCP server, NDJSON translation, and IPC plumbing needed to relay Claude Code sessions through PizzaPi
- harden the Claude Code worker lifecycle by forwarding initial prompt/model state, sanitizing spawned-session requests, and tracking bridge-managed sessions for reconnect/cleanup handling

## Test Plan
- [x] `bun run typecheck`
- [x] `bun run test`
- [x] `bun run build`
