### PR TITLE
refactor(ui): extract shared types, hooks, and helpers from App.tsx

### DIFF
--- a/packages/cli/src/runner/runner-usage-cache.test.ts
+++ b/packages/cli/src/runner/runner-usage-cache.test.ts
@@ -8,7 +8,16 @@ describe("runner-usage-cache", () => {
     test("refreshes usage data with tracked cwd auth paths and drops them after untracking", () => {
         const repoRoot = join(import.meta.dir, "../../../..");
         const tmpHome = mkdtempSync(join(tmpdir(), "runner-usage-cache-test-"));
-        const childTestPath = join(import.meta.dir, `.runner-usage-cache-child-${Date.now()}-${Math.random().toString(16).slice(2)}.test.ts`);
+
+        // Always write the child test file into the **source** tree (src/runner/)
+        // so that its relative `import("./runner-usage-cache.ts")` and
+        // `mock.module("../config.js")` etc. resolve to the correct source modules.
+        // This also makes the test correct when bun discovers and runs the compiled
+        // dist/runner/runner-usage-cache.test.js from the project root.
+        const runnerSrcDir = import.meta.dir.includes("/dist/runner")
+            ? import.meta.dir.replace("/dist/runner", "/src/runner")
+            : import.meta.dir;
+        const childTestPath = join(runnerSrcDir, `.runner-usage-cache-child-${Date.now()}-${Math.random().toString(16).slice(2)}.test.ts`);
 
         try {
             writeFileSync(

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -45,7 +45,10 @@ services:
 
 describe("web.ts compose template", () => {
     test("inlined template matches external template file", () => {
-        const externalPath = join(import.meta.dirname, "templates", "compose.yml.template");
+        // Always look in src/templates/ so this test passes when bun discovers
+        // the compiled dist/web.test.js from the project root as well as when
+        // running directly from packages/cli/src/web.test.ts.
+        const externalPath = join(import.meta.dirname, "..", "src", "templates", "compose.yml.template");
         const external = readFileSync(externalPath, "utf-8");
         expect(COMPOSE_TEMPLATE).toBe(external);
     });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -47,7 +47,7 @@ import { Sun, Moon, LogOut, KeyRound, X, User, ChevronsUpDown, PanelLeftOpen, Ha
 import { NotificationToggle, MobileNotificationMenuItem } from "@/components/NotificationToggle";
 import { HapticsToggle, MobileHapticsMenuItem } from "@/components/HapticsToggle";
 import { UsageIndicator, type ProviderUsageMap } from "@/components/UsageIndicator";
-import { TerminalManager, type TerminalTab } from "@/components/TerminalManager";
+import { TerminalManager } from "@/components/TerminalManager";
 import { FileExplorer } from "@/components/FileExplorer";
 import { CombinedPanel } from "@/components/CombinedPanel";
 import {
@@ -64,6 +64,7 @@ import {
 } from "@/components/ai-elements/model-selector";
 import { HiddenModelsManager, loadHiddenModels, fetchHiddenModels, modelKey } from "@/components/HiddenModelsManager";
 import { ChangePasswordDialog } from "@/components/ChangePasswordDialog";
+import { ShortcutsDialog } from "@/components/ShortcutsDialog";
 import {
   beginInputAttempt,
   completeInputAttempt,
@@ -72,252 +73,18 @@ import {
   type InputDedupeState,
 } from "@/lib/input-dedupe";
 import { parsePendingQuestionDisplayMode, parsePendingQuestions, type QuestionDisplayMode } from "@/lib/ask-user-questions";
-
-function toRelayMessage(raw: unknown, fallbackId: string): RelayMessage | null {
-  if (!raw || typeof raw !== "object") return null;
-
-  const msg = raw as Record<string, unknown>;
-  const role = typeof msg.role === "string" ? msg.role : "message";
-  const timestamp = typeof msg.timestamp === "number" ? msg.timestamp : undefined;
-  const toolCallId = typeof msg.toolCallId === "string" ? msg.toolCallId : "";
-  const id = typeof msg.id === "string" ? msg.id : undefined;
-
-  const key = id
-    ? `${role}:id:${id}`
-    : toolCallId
-      ? `${role}:tool:${toolCallId}`
-      : timestamp !== undefined
-        ? `${role}:ts:${timestamp}`
-        : `${role}:fallback:${fallbackId}`;
-
-  const stopReason = typeof msg.stopReason === "string" ? msg.stopReason : undefined;
-  const errorMessage = typeof msg.errorMessage === "string" ? msg.errorMessage : undefined;
-
-  // Extract summary/tokensBefore for compactionSummary / branchSummary messages
-  const summary = typeof msg.summary === "string" ? msg.summary : undefined;
-  const tokensBefore = typeof msg.tokensBefore === "number" ? msg.tokensBefore : undefined;
-
-  // Preserve structured details (e.g., subagent SubagentDetails) for tool results
-  const details = msg.details !== undefined && msg.details !== null ? msg.details : undefined;
-
-  return {
-    key,
-    role,
-    timestamp,
-    content: msg.content,
-    toolName: typeof msg.toolName === "string" ? msg.toolName : undefined,
-    toolCallId: toolCallId || undefined,
-    isError: msg.isError === true || stopReason === "error",
-    stopReason,
-    errorMessage,
-    summary,
-    tokensBefore,
-    details,
-  };
-}
-
-function getAssistantToolCallIds(msg: RelayMessage): string[] {
-  if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [];
-  const ids: string[] = [];
-  for (const block of msg.content) {
-    if (!block || typeof block !== "object") continue;
-    const b = block as Record<string, unknown>;
-    if (b.type !== "toolCall") continue;
-    const id =
-      typeof b.toolCallId === "string"
-        ? b.toolCallId
-        : typeof b.id === "string"
-          ? b.id
-          : "";
-    if (id) ids.push(id);
-  }
-  return ids;
-}
-
-/** Extract concatenated text content from an assistant message for dedup comparison. */
-function extractAssistantText(msg: RelayMessage): string {
-  if (msg.role !== "assistant" || !Array.isArray(msg.content)) return "";
-  let text = "";
-  for (const block of msg.content) {
-    if (!block || typeof block !== "object") continue;
-    const b = block as Record<string, unknown>;
-    if (b.type === "text" && typeof b.text === "string") text += b.text;
-  }
-  return text;
-}
-
-/** Deduplicate assistant messages within a list. Removes no-timestamp partials
- * that are superseded by timestamped finals, even across chunk boundaries. */
-function deduplicateMessages(messages: RelayMessage[]): RelayMessage[] {
-  // Build a set of toolCallIds referenced by any timestamped assistant message.
-  const timestampedToolCallIds = new Set<string>();
-  for (const msg of messages) {
-    if (msg.role === "assistant" && msg.timestamp !== undefined) {
-      for (const id of getAssistantToolCallIds(msg)) {
-        timestampedToolCallIds.add(id);
-      }
-    }
-  }
-
-  const dropIndices = new Set<number>();
-  for (let i = 0; i < messages.length; i++) {
-    const cur = messages[i];
-    if (cur.role !== "assistant" || cur.timestamp !== undefined) continue;
-
-    // Original heuristic: immediately followed by a timestamped assistant message.
-    const next = messages[i + 1];
-    if (next?.role === "assistant" && next.timestamp !== undefined) {
-      dropIndices.add(i);
-      continue;
-    }
-
-    // Extended heuristic: shares a toolCallId with any later timestamped assistant message.
-    const ids = getAssistantToolCallIds(cur);
-    if (ids.length > 0 && ids.some((id) => timestampedToolCallIds.has(id))) {
-      dropIndices.add(i);
-      continue;
-    }
-
-    // Text-prefix heuristic: if this no-timestamp message has no toolCallIds,
-    // check if any later timestamped assistant message contains the same text
-    // (the partial is a prefix of the final). This catches text-only streaming
-    // partials that survive alongside the final message (e.g. after web_search).
-    if (ids.length === 0) {
-      const curText = extractAssistantText(cur);
-      if (curText) {
-        for (let j = i + 1; j < messages.length; j++) {
-          const candidate = messages[j];
-          if (candidate.role !== "assistant" || candidate.timestamp === undefined) continue;
-          const candidateText = extractAssistantText(candidate);
-          if (candidateText && candidateText.startsWith(curText)) {
-            dropIndices.add(i);
-            break;
-          }
-        }
-      }
-    }
-  }
-
-  if (dropIndices.size === 0) return messages;
-  return messages.filter((_, i) => !dropIndices.has(i));
-}
-
-function normalizeMessages(rawMessages: unknown[], keyOffset = 0): RelayMessage[] {
-  const all = rawMessages
-    .map((m, i) => toRelayMessage(m, `snapshot-${keyOffset + i}`))
-    .filter((m): m is RelayMessage => m !== null);
-
-  return deduplicateMessages(all);
-}
-
-interface ConfiguredModelInfo {
-  provider: string;
-  id: string;
-  name?: string;
-  reasoning?: boolean;
-  contextWindow?: number;
-}
-
-interface TokenUsageInfo {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  cost: number;
-}
-
-interface ResumeSessionOption {
-  id: string;
-  path: string;
-  name: string | null;
-  modified: string;
-  firstMessage?: string;
-}
-
-export interface TodoItem {
-  id: number;
-  text: string;
-  status: "pending" | "in_progress" | "done" | "cancelled";
-}
-
-interface SessionUiCacheEntry {
-  messages: RelayMessage[];
-  activeModel: ConfiguredModelInfo | null;
-  sessionName: string | null;
-  availableModels: ConfiguredModelInfo[];
-  availableCommands: Array<{ name: string; description?: string; source?: string }>;
-  agentActive: boolean;
-  isCompacting: boolean;
-  effortLevel: string | null;
-  planModeEnabled: boolean;
-  authSource: string | null;
-  tokenUsage: TokenUsageInfo | null;
-  providerUsage: ProviderUsageMap | null;
-  lastHeartbeatAt: number | null;
-  todoList: TodoItem[];
-  pendingQuestion: { toolCallId: string; questions: Array<{ question: string; options: string[]; type?: import("@/lib/ask-user-questions").QuestionType }>; display: QuestionDisplayMode } | null;
-  pendingPlan: {
-    toolCallId: string;
-    title: string;
-    description: string | null;
-    steps: Array<{ title: string; description?: string }>;
-  } | null;
-}
-
-function normalizeModel(raw: unknown): ConfiguredModelInfo | null {
-  if (!raw || typeof raw !== "object") return null;
-  const model = raw as Record<string, unknown>;
-  const provider = typeof model.provider === "string" ? model.provider.trim() : "";
-  // Accept both `id` (availableModels shape) and `modelId` (buildSessionContext shape)
-  const id = (typeof model.id === "string" ? model.id.trim() : "") ||
-              (typeof model.modelId === "string" ? model.modelId.trim() : "");
-  if (!provider || !id) return null;
-
-  return {
-    provider,
-    id,
-    name: typeof model.name === "string" ? model.name : undefined,
-    reasoning: typeof model.reasoning === "boolean" ? model.reasoning : undefined,
-    contextWindow: typeof model.contextWindow === "number" ? model.contextWindow : undefined,
-  };
-}
-
-function normalizeSessionName(raw: unknown): string | null {
-  if (typeof raw !== "string") return null;
-  const trimmed = raw.trim();
-  return trimmed.length > 0 ? trimmed : null;
-}
-
-/** Inject `durationSeconds` into thinking blocks that we've timed client-side. */
-function augmentThinkingDurations(message: unknown, durations: Map<number, number>): unknown {
-  if (!message || typeof message !== "object" || durations.size === 0) return message;
-  const msg = message as Record<string, unknown>;
-  if (!Array.isArray(msg.content)) return message;
-  let changed = false;
-  const content = msg.content.map((block, i) => {
-    if (!block || typeof block !== "object") return block;
-    const b = block as Record<string, unknown>;
-    if (b.type === "thinking" && durations.has(i) && b.durationSeconds === undefined) {
-      changed = true;
-      return { ...b, durationSeconds: durations.get(i) };
-    }
-    return block;
-  });
-  return changed ? { ...msg, content } : message;
-}
-
-function normalizeModelList(rawModels: unknown[]): ConfiguredModelInfo[] {
-  const deduped = new Map<string, ConfiguredModelInfo>();
-  for (const raw of rawModels) {
-    const model = normalizeModel(raw);
-    if (!model) continue;
-    deduped.set(`${model.provider}/${model.id}`, model);
-  }
-  return Array.from(deduped.values()).sort((a, b) => {
-    if (a.provider !== b.provider) return a.provider.localeCompare(b.provider);
-    return a.id.localeCompare(b.id);
-  });
-}
+import type { TodoItem, TokenUsage, ConfiguredModelInfo, ResumeSessionOption, QueuedMessage, SessionUiCacheEntry } from "@/lib/types";
+import { usePanelLayout } from "@/hooks/usePanelLayout";
+import { useMobileSidebar } from "@/hooks/useMobileSidebar";
+import {
+  toRelayMessage,
+  deduplicateMessages,
+  normalizeMessages,
+  normalizeModel,
+  normalizeSessionName,
+  augmentThinkingDurations,
+  normalizeModelList,
+} from "@/lib/message-helpers";
 
 export function App() {
   const { data: session, isPending } = useSession();
@@ -388,314 +155,24 @@ export function App() {
       .catch(() => { /* sidebar will stay with cached/empty data until RunnerManager loads */ });
     return () => { cancelled = true; };
   }, [setSidebarRunners]);
-  const [showTerminal, setShowTerminal] = React.useState(false);
-  const [terminalPosition, setTerminalPosition] = React.useState<"bottom" | "right" | "left">(() => {
-    try { return (localStorage.getItem("pp-terminal-position") as "bottom" | "right" | "left") ?? "bottom"; } catch { return "bottom"; }
-  });
-  const [terminalHeight, setTerminalHeight] = React.useState<number>(() => {
-    try {
-      const saved = localStorage.getItem("pp-terminal-height");
-      if (saved) return Math.max(120, Math.min(parseInt(saved, 10), 900));
-    } catch {}
-    return 280;
-  });
-  const [terminalWidth, setTerminalWidth] = React.useState<number>(() => {
-    try {
-      const saved = localStorage.getItem("pp-terminal-width");
-      if (saved) return Math.max(200, Math.min(parseInt(saved, 10), 1400));
-    } catch {}
-    return 480;
-  });
-  const terminalColumnRef = React.useRef<HTMLDivElement>(null);
-  // "height" = bottom panel vertical drag, "width-right" = right panel, "width-left" = left panel
-  const resizeDir = React.useRef<"height" | "width-right" | "width-left" | null>(null);
-
-  // Single handler — direction is derived from current terminalPosition at drag start
-  const handleTerminalResizeStart = React.useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    resizeDir.current = terminalPosition === "bottom" ? "height"
-      : terminalPosition === "right" ? "width-right"
-      : "width-left";
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, [terminalPosition]);
-
-  const handleTerminalResizeMove = React.useCallback((e: React.PointerEvent) => {
-    const dir = resizeDir.current;
-    if (!dir || !terminalColumnRef.current) return;
-    const rect = terminalColumnRef.current.getBoundingClientRect();
-    if (dir === "height") {
-      setTerminalHeight(Math.max(120, Math.min(rect.bottom - e.clientY, rect.height - 80)));
-    } else if (dir === "width-right") {
-      setTerminalWidth(Math.max(200, Math.min(rect.right - e.clientX, rect.width - 200)));
-    } else {
-      setTerminalWidth(Math.max(200, Math.min(e.clientX - rect.left, rect.width - 200)));
-    }
-  }, []);
-
-  const handleTerminalResizeEnd = React.useCallback(() => {
-    const dir = resizeDir.current;
-    if (!dir) return;
-    resizeDir.current = null;
-    if (dir === "height") {
-      setTerminalHeight((h) => { try { localStorage.setItem("pp-terminal-height", String(Math.round(h))); } catch {} return h; });
-    } else {
-      setTerminalWidth((w) => { try { localStorage.setItem("pp-terminal-width", String(Math.round(w))); } catch {} return w; });
-    }
-  }, []);
-
-  // Panel drag-to-reposition
-  const isPanelDragging = React.useRef(false);
-  const panelDragZoneRef = React.useRef<"bottom" | "right" | "left" | null>(null);
-  const [panelDragActive, setPanelDragActive] = React.useState(false);
-  const [panelDragZone, setPanelDragZone] = React.useState<"bottom" | "right" | "left" | null>(null);
-
-  const handleTerminalPositionChange = React.useCallback((pos: "bottom" | "right" | "left") => {
-    setTerminalPosition(pos);
-    try { localStorage.setItem("pp-terminal-position", pos); } catch {}
-  }, []);
-
-  const handlePanelDragStart = React.useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    isPanelDragging.current = true;
-    panelDragZoneRef.current = null;
-    setPanelDragActive(true);
-    setPanelDragZone(null);
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-
-  const handlePanelDragMove = React.useCallback((e: React.PointerEvent) => {
-    if (!isPanelDragging.current || !terminalColumnRef.current) return;
-    const rect = terminalColumnRef.current.getBoundingClientRect();
-    const pctX = (e.clientX - rect.left) / rect.width;
-    const pctY = (e.clientY - rect.top) / rect.height;
-    let zone: "bottom" | "right" | "left" | null = null;
-    if (pctY > 0.55) zone = "bottom";
-    else if (pctX > 0.65) zone = "right";
-    else if (pctX < 0.35) zone = "left";
-    panelDragZoneRef.current = zone;
-    setPanelDragZone(zone);
-  }, []);
-
-  // Ref to sync file explorer position when panels are combined (avoids forward-reference issues)
-  const combinedDragSyncRef = React.useRef<((zone: "bottom" | "right" | "left") => void) | null>(null);
-
-  // Drag start handler for the Terminal tab inside the combined panel.
-  // Unlike the grip handle (which moves both panels together), this only moves
-  // the terminal panel so it can be detached from the files panel.
-  const handleTerminalTabDragStart = React.useCallback((e: React.PointerEvent) => {
-    // Clear the sync ref so handlePanelDragEnd doesn't also reposition the files panel
-    combinedDragSyncRef.current = null;
-    handlePanelDragStart(e);
-  }, [handlePanelDragStart]);
-
-  const handlePanelDragEnd = React.useCallback(() => {
-    if (!isPanelDragging.current) return;
-    isPanelDragging.current = false;
-    const zone = panelDragZoneRef.current;
-    panelDragZoneRef.current = null;
-    setPanelDragActive(false);
-    setPanelDragZone(null);
-    if (zone) {
-      handleTerminalPositionChange(zone);
-      // When panels are combined (same position), also move file explorer
-      combinedDragSyncRef.current?.(zone);
-    }
-  }, [handleTerminalPositionChange]);
-
-  const handleOuterPointerMove = React.useCallback((e: React.PointerEvent) => {
-    handleTerminalResizeMove(e);
-    handlePanelDragMove(e);
-  }, [handleTerminalResizeMove, handlePanelDragMove]);
-
-  const handleOuterPointerUp = React.useCallback(() => {
-    handleTerminalResizeEnd();
-    handlePanelDragEnd();
-  }, [handleTerminalResizeEnd, handlePanelDragEnd]);
-
-  const [combinedActiveTab, setCombinedActiveTab] = React.useState<"terminal" | "files">(() => {
-    try { return (localStorage.getItem("pp-combined-tab") as "terminal" | "files") ?? "terminal"; } catch { return "terminal"; }
-  });
-  const handleCombinedTabChange = React.useCallback((tab: string) => {
-    const t = tab as "terminal" | "files";
-    setCombinedActiveTab(t);
-    try { localStorage.setItem("pp-combined-tab", t); } catch {}
-  }, []);
-
-  // ── Lifted terminal tab state ────────────────────────────────────────────
-  // Stored here (not inside TerminalManager) so tabs survive panel remounts
-  // (e.g., when the panel transitions between combined and standalone layouts).
-  const [terminalTabs, setTerminalTabs] = React.useState<TerminalTab[]>([]);
-  const [activeTerminalId, setActiveTerminalId] = React.useState<string | null>(null);
-
-  // Per-session last-active terminal: save/restore when switching sessions.
-  const sessionActiveTerminalRef = React.useRef<Map<string | null, string | null>>(new Map());
-  const prevSessionIdForTerminalRef = React.useRef<string | null>(null);
-  // Stable ref so the effect doesn't need activeTerminalId in its dep array
-  const activeTerminalIdRef = React.useRef<string | null>(null);
-  activeTerminalIdRef.current = activeTerminalId;
-
-  React.useEffect(() => {
-    const prev = prevSessionIdForTerminalRef.current;
-    if (prev === activeSessionId) return;
-    prevSessionIdForTerminalRef.current = activeSessionId;
-
-    // Save current active terminal for the outgoing session
-    sessionActiveTerminalRef.current.set(prev, activeTerminalIdRef.current);
-
-    // Restore the last-active terminal for the incoming session
-    const incoming = activeSessionId;
-    const sessionTabs = incoming != null
-      ? terminalTabs.filter((t) => t.sessionId === incoming)
-      : terminalTabs;
-    const savedActive = sessionActiveTerminalRef.current.get(incoming);
-
-    if (savedActive && sessionTabs.some((t) => t.terminalId === savedActive)) {
-      setActiveTerminalId(savedActive);
-    } else if (sessionTabs.length > 0) {
-      setActiveTerminalId(sessionTabs[sessionTabs.length - 1].terminalId);
-    } else {
-      setActiveTerminalId(null);
-    }
-  }, [activeSessionId, terminalTabs]);
-
-  const handleTerminalTabAdd = React.useCallback((tab: TerminalTab) => {
-    setTerminalTabs((prev) => [...prev, tab]);
-    setActiveTerminalId(tab.terminalId);
-  }, []);
-
-  const handleTerminalTabClose = React.useCallback((terminalId: string) => {
-    setTerminalTabs((prev) => {
-      const next = prev.filter((t) => t.terminalId !== terminalId);
-      setActiveTerminalId((current) => {
-        if (current !== terminalId) return current;
-        // Find the closest remaining tab in the same session
-        const removed = prev.find((t) => t.terminalId === terminalId);
-        const sameSess = next.filter((t) => t.sessionId === (removed?.sessionId ?? null));
-        return sameSess.length > 0 ? sameSess[sameSess.length - 1].terminalId : null;
-      });
-      return next;
-    });
-  }, []);
-
-  const [showFileExplorer, setShowFileExplorer] = React.useState(false);
-  const [filesPosition, setFilesPosition] = React.useState<"left" | "right" | "bottom">(() => {
-    try { return (localStorage.getItem("pp-files-position") as "left" | "right" | "bottom") ?? "left"; } catch { return "left"; }
-  });
-  const [filesWidth, setFilesWidth] = React.useState<number>(() => {
-    try {
-      const saved = localStorage.getItem("pp-files-width");
-      if (saved) return Math.max(160, Math.min(parseInt(saved, 10), 800));
-    } catch {}
-    return 280;
-  });
-  const [filesHeight, setFilesHeight] = React.useState<number>(() => {
-    try {
-      const saved = localStorage.getItem("pp-files-height");
-      if (saved) return Math.max(150, Math.min(parseInt(saved, 10), 800));
-    } catch {}
-    return 280;
-  });
-  const filesContainerRef = React.useRef<HTMLDivElement>(null);
-  const filesResizeDir = React.useRef<"width-right" | "width-left" | "height" | null>(null);
-
-  const handleFilesWidthLeftResizeStart = React.useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    filesResizeDir.current = "width-left";
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-  const handleFilesWidthRightResizeStart = React.useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    filesResizeDir.current = "width-right";
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-  const handleFilesHeightResizeStart = React.useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    filesResizeDir.current = "height";
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-  const handleFilesResizeMove = React.useCallback((e: React.PointerEvent) => {
-    const dir = filesResizeDir.current;
-    if (!dir || !filesContainerRef.current) return;
-    const rect = filesContainerRef.current.getBoundingClientRect();
-    if (dir === "width-right") {
-      setFilesWidth(Math.max(160, Math.min(rect.right - e.clientX, rect.width - 200)));
-    } else if (dir === "width-left") {
-      setFilesWidth(Math.max(160, Math.min(e.clientX - rect.left, rect.width - 200)));
-    } else {
-      setFilesHeight(Math.max(150, Math.min(rect.bottom - e.clientY, rect.height - 100)));
-    }
-  }, []);
-  const handleFilesResizeEnd = React.useCallback(() => {
-    const dir = filesResizeDir.current;
-    if (!dir) return;
-    filesResizeDir.current = null;
-    if (dir === "height") {
-      setFilesHeight((h) => { try { localStorage.setItem("pp-files-height", String(Math.round(h))); } catch {} return h; });
-    } else {
-      setFilesWidth((w) => { try { localStorage.setItem("pp-files-width", String(Math.round(w))); } catch {} return w; });
-    }
-  }, []);
-
-  const isFilesDragging = React.useRef(false);
-  const filesDragZoneRef = React.useRef<"left" | "right" | "bottom" | null>(null);
-  const [filesDragActive, setFilesDragActive] = React.useState(false);
-  const [filesDragZone, setFilesDragZone] = React.useState<"left" | "right" | "bottom" | null>(null);
-
-  const handleFilesPositionChange = React.useCallback((pos: "left" | "right" | "bottom") => {
-    setFilesPosition(pos);
-    try { localStorage.setItem("pp-files-position", pos); } catch {}
-  }, []);
-  const handleCombinedPositionChange = React.useCallback((pos: "left" | "right" | "bottom") => {
-    handleTerminalPositionChange(pos);
-    handleFilesPositionChange(pos);
-  }, [handleTerminalPositionChange, handleFilesPositionChange]);
-
-  // Keep the drag sync ref up-to-date so handlePanelDragEnd can sync file explorer
-  React.useEffect(() => {
-    if (showTerminal && showFileExplorer && terminalPosition === filesPosition) {
-      combinedDragSyncRef.current = handleFilesPositionChange;
-    } else {
-      combinedDragSyncRef.current = null;
-    }
-  }, [showTerminal, showFileExplorer, terminalPosition, filesPosition, handleFilesPositionChange]);
-
-  const handleFilesDragStart = React.useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    isFilesDragging.current = true;
-    filesDragZoneRef.current = null;
-    setFilesDragActive(true);
-    setFilesDragZone(null);
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-  const handleFilesDragMove = React.useCallback((e: React.PointerEvent) => {
-    if (!isFilesDragging.current || !filesContainerRef.current) return;
-    const rect = filesContainerRef.current.getBoundingClientRect();
-    const pctX = (e.clientX - rect.left) / rect.width;
-    const pctY = (e.clientY - rect.top) / rect.height;
-    let zone: "left" | "right" | "bottom" | null = null;
-    if (pctY > 0.55) zone = "bottom";
-    else if (pctX > 0.65) zone = "right";
-    else if (pctX < 0.35) zone = "left";
-    filesDragZoneRef.current = zone;
-    setFilesDragZone(zone);
-  }, []);
-  const handleFilesDragEnd = React.useCallback(() => {
-    if (!isFilesDragging.current) return;
-    isFilesDragging.current = false;
-    const zone = filesDragZoneRef.current;
-    filesDragZoneRef.current = null;
-    setFilesDragActive(false);
-    setFilesDragZone(null);
-    if (zone) handleFilesPositionChange(zone);
-  }, [handleFilesPositionChange]);
-  const handleFilesOuterPointerMove = React.useCallback((e: React.PointerEvent) => {
-    handleFilesResizeMove(e);
-    handleFilesDragMove(e);
-  }, [handleFilesResizeMove, handleFilesDragMove]);
-  const handleFilesOuterPointerUp = React.useCallback(() => {
-    handleFilesResizeEnd();
-    handleFilesDragEnd();
-  }, [handleFilesResizeEnd, handleFilesDragEnd]);
+  const panelLayout = usePanelLayout(activeSessionId);
+  const {
+    showTerminal, setShowTerminal,
+    terminalPosition, terminalHeight, terminalWidth, terminalColumnRef,
+    handleTerminalResizeStart, handleTerminalPositionChange,
+    panelDragActive, panelDragZone,
+    handlePanelDragStart, handleTerminalTabDragStart,
+    handleOuterPointerMove, handleOuterPointerUp,
+    combinedActiveTab, handleCombinedTabChange, handleCombinedPositionChange,
+    terminalTabs, activeTerminalId, setActiveTerminalId,
+    handleTerminalTabAdd, handleTerminalTabClose,
+    showFileExplorer, setShowFileExplorer,
+    filesPosition, filesWidth, filesHeight, filesContainerRef,
+    handleFilesWidthLeftResizeStart, handleFilesWidthRightResizeStart, handleFilesHeightResizeStart,
+    handleFilesPositionChange,
+    filesDragActive, filesDragZone, handleFilesDragStart,
+    handleFilesOuterPointerMove, handleFilesOuterPointerUp,
+  } = panelLayout;
 
   type RunnerInfo = { runnerId: string; name?: string | null; roots?: string[]; sessionCount: number };
   const [newSessionOpen, setNewSessionOpen] = React.useState(false);
@@ -743,7 +220,6 @@ export function App() {
   const [activeToolCalls, setActiveToolCalls] = React.useState<Map<string, string>>(new Map());
 
   // Message queue: messages sent while the agent is active
-  type QueuedMessage = { id: string; text: string; deliverAs: "steer" | "followUp"; timestamp: number };
   const [messageQueue, setMessageQueue] = React.useState<QueuedMessage[]>([]);
   const [activeModel, setActiveModel] = React.useState<ConfiguredModelInfo | null>(null);
   const [sessionName, setSessionName] = React.useState<string | null>(null);
@@ -759,7 +235,7 @@ export function App() {
   const [isCompacting, setIsCompacting] = React.useState(false);
   const [effortLevel, setEffortLevel] = React.useState<string | null>(null);
   const [planModeEnabled, setPlanModeEnabled] = React.useState(false);
-  const [tokenUsage, setTokenUsage] = React.useState<TokenUsageInfo | null>(null);
+  const [tokenUsage, setTokenUsage] = React.useState<TokenUsage | null>(null);
   const [lastHeartbeatAt, setLastHeartbeatAt] = React.useState<number | null>(null);
   const [providerUsage, setProviderUsage] = React.useState<ProviderUsageMap | null>(null);
   const [usageRefreshing, setUsageRefreshing] = React.useState(false);
@@ -821,82 +297,13 @@ export function App() {
   const [resumeSessionsLoading, setResumeSessionsLoading] = React.useState(false);
 
   // Mobile layout
-  const [sidebarOpen, setSidebarOpen] = React.useState(false);
+  const {
+    sidebarOpen, setSidebarOpen,
+    sidebarSwipeOffset, suppressOverlayClickRef,
+    handleSidebarPointerDown, handleSidebarPointerMove, handleSidebarPointerUp,
+  } = useMobileSidebar();
   const [liveSessions, setLiveSessions] = React.useState<HubSession[]>([]);
   const [sessionSwitcherOpen, setSessionSwitcherOpen] = React.useState(false);
-
-  // Swipe-left-to-close for the mobile sidebar — gesture lives on the overlay
-  // (the dim backdrop to the right of the sidebar) so it never conflicts with
-  // interactions inside the sidebar itself.
-  const sidebarSwipeRef = React.useRef<{
-    pointerId: number;
-    startX: number;
-    startY: number;
-    locked: boolean;
-    isVertical: boolean;
-    didSwipe: boolean;
-  } | null>(null);
-  const sidebarSwipeOffsetRef = React.useRef(0);
-  const [sidebarSwipeOffset, setSidebarSwipeOffset] = React.useState(0);
-  // Suppresses the click that fires immediately after a swipe pointerUp
-  const suppressOverlayClickRef = React.useRef(false);
-
-  const handleSidebarPointerDown = React.useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    if (e.button !== 0) return;
-    sidebarSwipeRef.current = {
-      pointerId: e.pointerId,
-      startX: e.clientX,
-      startY: e.clientY,
-      locked: false,
-      isVertical: false,
-      didSwipe: false,
-    };
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-
-  const handleSidebarPointerMove = React.useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    const s = sidebarSwipeRef.current;
-    if (!s || e.pointerId !== s.pointerId) return;
-    const dx = e.clientX - s.startX;
-    const dy = e.clientY - s.startY;
-    if (!s.locked && !s.isVertical) {
-      if (Math.abs(dy) > 8 && Math.abs(dy) > Math.abs(dx)) {
-        s.isVertical = true;
-        sidebarSwipeRef.current = null;
-        return;
-      }
-      if (Math.abs(dx) > 8 && Math.abs(dx) > Math.abs(dy)) {
-        s.locked = true;
-      }
-    }
-    if (s.isVertical || !s.locked) return;
-    s.didSwipe = true;
-    // Only allow leftward swipes (negative dx), with a tiny rightward overscroll
-    const clamped = Math.min(8, dx);
-    sidebarSwipeOffsetRef.current = clamped;
-    setSidebarSwipeOffset(clamped);
-    e.preventDefault();
-  }, []);
-
-  const handleSidebarPointerUp = React.useCallback((e: React.PointerEvent<HTMLDivElement>) => {
-    const s = sidebarSwipeRef.current;
-    if (!s || e.pointerId !== s.pointerId) return;
-    try { (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId); } catch { /* ignore */ }
-    const didSwipe = s.didSwipe;
-    sidebarSwipeRef.current = null;
-    const offset = sidebarSwipeOffsetRef.current;
-    sidebarSwipeOffsetRef.current = 0;
-    setSidebarSwipeOffset(0);
-    if (didSwipe) {
-      // Suppress the click that the browser fires right after pointerUp
-      suppressOverlayClickRef.current = true;
-      requestAnimationFrame(() => { suppressOverlayClickRef.current = false; });
-    }
-    // Close if dragged more than 80 px to the left
-    if (offset < -80) {
-      setSidebarOpen(false);
-    }
-  }, []);
 
   // Auto-reopen the last viewed session once live sessions arrive.
   // (restoredRef is declared here; the effect is placed after openSession is defined below)
@@ -906,15 +313,6 @@ export function App() {
   // When the session comes back live (hub sends session_added), we auto-reconnect.
   const restartPendingSessionIdRef = React.useRef<string | null>(null);
   const restartPendingTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  // Prevent the underlying content from scrolling when the mobile sidebar is open.
-  React.useEffect(() => {
-    const prev = document.body.style.overflow;
-    if (sidebarOpen) document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = prev;
-    };
-  }, [sidebarOpen]);
 
 
 
@@ -1355,7 +753,7 @@ export function App() {
         model?: { provider: string; id: string; name?: string } | null;
         sessionName?: string | null;
         thinkingLevel?: string | null;
-        tokenUsage?: TokenUsageInfo | null;
+        tokenUsage?: TokenUsage | null;
         ts?: number;
       };
 
@@ -4048,7 +3446,7 @@ export function App() {
                         id: "terminal",
                         label: "Terminal",
                         icon: <TerminalIcon className="size-3.5" />,
-                        onClose: () => { setShowTerminal(false); setCombinedActiveTab("files"); },
+                        onClose: () => { setShowTerminal(false); handleCombinedTabChange("files"); },
                         // Dragging the Terminal tab detaches it (moves only the terminal panel)
                         onDragStart: handleTerminalTabDragStart,
                         content: (
@@ -4070,7 +3468,7 @@ export function App() {
                         id: "files",
                         label: "Files",
                         icon: <FolderTree className="size-3.5" />,
-                        onClose: () => { setShowFileExplorer(false); setCombinedActiveTab("terminal"); },
+                        onClose: () => { setShowFileExplorer(false); handleCombinedTabChange("terminal"); },
                         // Dragging the Files tab detaches it (moves only the files panel)
                         onDragStart: handleFilesDragStart,
                         content: (
@@ -4328,38 +3726,7 @@ export function App() {
           </div>
         )}
 
-        {/* Keyboard shortcuts help dialog */}
-        <Dialog open={showShortcutsHelp} onOpenChange={setShowShortcutsHelp}>
-          <DialogContent className="max-w-sm">
-            <DialogHeader>
-              <DialogTitle className="flex items-center gap-2">
-                <Keyboard className="h-4 w-4" />
-                Keyboard Shortcuts
-              </DialogTitle>
-              <DialogDescription>
-                Available shortcuts for the PizzaPi web UI.
-              </DialogDescription>
-            </DialogHeader>
-            <div className="flex flex-col gap-2.5 text-sm py-1">
-              {(
-                [
-                  { key: isMac ? "⌘K" : "Ctrl+K", action: "Focus prompt" },
-                  { key: "Ctrl+`", action: "Toggle terminal" },
-                  { key: isMac ? "⌘⇧E" : "Ctrl+Shift+E", action: "Toggle file explorer" },
-                  { key: isMac ? "⌘." : "Ctrl+.", action: "Abort active agent" },
-                  { key: "?", action: "Show this dialog" },
-                ] as { key: string; action: string }[]
-              ).map(({ key, action }) => (
-                <div key={key} className="flex items-center justify-between gap-4">
-                  <span className="text-muted-foreground">{action}</span>
-                  <kbd className="inline-flex items-center rounded border bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground whitespace-nowrap">
-                    {key}
-                  </kbd>
-                </div>
-              ))}
-            </div>
-          </DialogContent>
-        </Dialog>
+        <ShortcutsDialog open={showShortcutsHelp} onOpenChange={setShowShortcutsHelp} />
       </div>
     </div>
     </TooltipProvider>

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -80,35 +80,8 @@ import { isTriggerMessage, renderTriggerCard } from "@/components/session-viewer
 
 
 export type { RelayMessage } from "@/components/session-viewer/types";
-
-export interface TodoItem {
-  id: number;
-  text: string;
-  status: "pending" | "in_progress" | "done" | "cancelled";
-}
-
-export interface TokenUsage {
-  input: number;
-  output: number;
-  cacheRead: number;
-  cacheWrite: number;
-  cost: number;
-}
-
-interface ResumeSessionOption {
-  id: string;
-  path: string;
-  name: string | null;
-  modified: string;
-  firstMessage?: string;
-}
-
-export interface QueuedMessage {
-  id: string;
-  text: string;
-  deliverAs: "steer" | "followUp";
-  timestamp: number;
-}
+export type { TodoItem, TokenUsage, QueuedMessage, ResumeSessionOption } from "@/lib/types";
+import type { TodoItem, TokenUsage, QueuedMessage, ResumeSessionOption } from "@/lib/types";
 
 export interface SessionViewerProps {
   sessionId: string | null;

--- a/packages/ui/src/components/ShortcutsDialog.tsx
+++ b/packages/ui/src/components/ShortcutsDialog.tsx
@@ -13,9 +13,13 @@ interface ShortcutsDialogProps {
   onOpenChange: (open: boolean) => void;
 }
 
-const isMac = /Mac|iPhone|iPad/i.test(navigator.platform);
+function isMacPlatform(): boolean {
+  if (typeof navigator === "undefined") return false;
+  return /Mac|iPhone|iPad/i.test(navigator.platform);
+}
 
 export function ShortcutsDialog({ open, onOpenChange }: ShortcutsDialogProps) {
+  const isMac = isMacPlatform();
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent className="max-w-sm">

--- a/packages/ui/src/components/ShortcutsDialog.tsx
+++ b/packages/ui/src/components/ShortcutsDialog.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Keyboard } from "lucide-react";
+
+interface ShortcutsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const isMac = /Mac|iPhone|iPad/i.test(navigator.platform);
+
+export function ShortcutsDialog({ open, onOpenChange }: ShortcutsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Keyboard className="h-4 w-4" />
+            Keyboard Shortcuts
+          </DialogTitle>
+          <DialogDescription>
+            Available shortcuts for the PizzaPi web UI.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2.5 text-sm py-1">
+          {(
+            [
+              { key: isMac ? "⌘K" : "Ctrl+K", action: "Focus prompt" },
+              { key: "Ctrl+`", action: "Toggle terminal" },
+              { key: isMac ? "⌘⇧E" : "Ctrl+Shift+E", action: "Toggle file explorer" },
+              { key: isMac ? "⌘." : "Ctrl+.", action: "Abort active agent" },
+              { key: "?", action: "Show this dialog" },
+            ] as { key: string; action: string }[]
+          ).map(({ key, action }) => (
+            <div key={key} className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">{action}</span>
+              <kbd className="inline-flex items-center rounded border bg-muted px-1.5 py-0.5 font-mono text-xs text-foreground whitespace-nowrap">
+                {key}
+              </kbd>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/ui/src/components/session-viewer/cards/TodoCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/TodoCard.tsx
@@ -6,12 +6,7 @@ import {
   ToolCardTitle,
 } from "@/components/ui/tool-card";
 import { PizzaProgress } from "@/components/session-viewer/cards/PizzaProgress";
-
-export interface TodoItem {
-  id: number;
-  text: string;
-  status: "pending" | "in_progress" | "done" | "cancelled";
-}
+import type { TodoItem } from "@/lib/types";
 
 export function TodoCard({ todos }: { todos: TodoItem[] }) {
   const done = todos.filter((t) => t.status === "done").length;

--- a/packages/ui/src/components/session-viewer/cards/WebSearchCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/WebSearchCard.tsx
@@ -6,7 +6,7 @@ import {
   ToolCardTitle,
   ToolCardActions,
   StatusPill,
-} from "@/components/ui/tool-card";
+} from "../../ui/tool-card";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/packages/ui/src/components/session-viewer/rendering.tsx
+++ b/packages/ui/src/components/session-viewer/rendering.tsx
@@ -24,7 +24,8 @@ import type { SubAgentTurn } from "@/components/session-viewer/types";
 
 // Re-export card components
 export { PizzaProgress, getPizzaStages, pizzaLayerLabel, stageVisual, ALL_STAGES, TOPPING_NAME_TO_IDX } from "@/components/session-viewer/cards/PizzaProgress";
-export { TodoCard, type TodoItem } from "@/components/session-viewer/cards/TodoCard";
+export { TodoCard } from "@/components/session-viewer/cards/TodoCard";
+export type { TodoItem } from "@/lib/types";
 export { SessionNameCard } from "@/components/session-viewer/cards/SessionNameCard";
 export {
   truncateSessionId,

--- a/packages/ui/src/components/session-viewer/server-tools.tsx
+++ b/packages/ui/src/components/session-viewer/server-tools.tsx
@@ -16,7 +16,7 @@ import {
   WebSearchQueryCard,
   WebSearchResultsCard,
   type WebSearchResult,
-} from "@/components/session-viewer/cards/WebSearchCard";
+} from "./cards/WebSearchCard";
 
 // ── Types for server tool metadata ──────────────────────────────────────────
 

--- a/packages/ui/src/components/session-viewer/tool-rendering.tsx
+++ b/packages/ui/src/components/session-viewer/tool-rendering.tsx
@@ -48,7 +48,8 @@ import {
 
 import { CopyableCodeBlock } from "@/components/session-viewer/cards/InterAgentCards";
 import { WriteFileCard } from "@/components/session-viewer/cards/WriteFileCard";
-import { TodoCard, type TodoItem } from "@/components/session-viewer/cards/TodoCard";
+import { TodoCard } from "@/components/session-viewer/cards/TodoCard";
+import type { TodoItem } from "@/lib/types";
 import { SessionNameCard } from "@/components/session-viewer/cards/SessionNameCard";
 import {
   truncateSessionId,

--- a/packages/ui/src/components/ui/tool-card.tsx
+++ b/packages/ui/src/components/ui/tool-card.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { cn } from "@/lib/utils";
+import { cn } from "../../lib/utils";
 import { Loader2Icon, CheckCircle2Icon, XCircleIcon } from "lucide-react";
 
 /**

--- a/packages/ui/src/hooks/useMobileSidebar.test.ts
+++ b/packages/ui/src/hooks/useMobileSidebar.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for the core logic embedded in useMobileSidebar.
+ *
+ * Because the hook requires a React renderer (DOM environment) we test the
+ * pure computational pieces extracted from the hook body. This covers the
+ * swipe gesture state-machine decisions that control whether the sidebar
+ * closes — ensuring regressions in gesture thresholds are caught early.
+ */
+
+import { describe, expect, test } from "bun:test";
+
+// ── Pure helpers mirroring hook internals ──────────────────────────────────────
+
+type AxisDecision = "vertical" | "locked-horizontal" | "undecided";
+
+/**
+ * Axis-lock decision for a running pointer move — mirrors the logic in
+ * handleSidebarPointerMove that determines when to commit to a swipe axis.
+ *
+ * @param dx  delta-X since pointer-down (positive = rightward)
+ * @param dy  delta-Y since pointer-down (positive = downward)
+ */
+function detectAxisDecision(dx: number, dy: number): AxisDecision {
+  // Mirror: if (Math.abs(dy) > 8 && Math.abs(dy) > Math.abs(dx)) → vertical abort
+  if (Math.abs(dy) > 8 && Math.abs(dy) > Math.abs(dx)) return "vertical";
+  // Mirror: if (Math.abs(dx) > 8 && Math.abs(dx) > Math.abs(dy)) → locked
+  if (Math.abs(dx) > 8 && Math.abs(dx) > Math.abs(dy)) return "locked-horizontal";
+  return "undecided";
+}
+
+/**
+ * Swipe-offset clamping — mirrors the clamped value computation in
+ * handleSidebarPointerMove: `Math.min(8, dx)`.
+ *
+ * Only leftward drags produce significant negative offsets; rightward motion
+ * is limited to a small (8 px) overscroll to give tactile feedback.
+ */
+function clampSwipeOffset(dx: number): number {
+  return Math.min(8, dx);
+}
+
+/**
+ * Close decision — mirrors the threshold check in handleSidebarPointerUp:
+ * "Close if dragged more than 80 px to the left."
+ */
+function shouldCloseSidebar(offset: number): boolean {
+  return offset < -80;
+}
+
+// ── Axis-lock detection ───────────────────────────────────────────────────────
+
+describe("detectAxisDecision", () => {
+  test("returns 'undecided' while displacement is below the 8px threshold", () => {
+    expect(detectAxisDecision(0, 0)).toBe("undecided");
+    expect(detectAxisDecision(5, 0)).toBe("undecided");
+    expect(detectAxisDecision(0, 5)).toBe("undecided");
+    expect(detectAxisDecision(4, 4)).toBe("undecided");
+  });
+
+  test("returns 'vertical' when vertical movement dominates and exceeds 8px", () => {
+    expect(detectAxisDecision(2, 20)).toBe("vertical");
+    expect(detectAxisDecision(0, 50)).toBe("vertical");
+    expect(detectAxisDecision(-3, 9)).toBe("vertical"); // dy > 8, dy > |dx|
+  });
+
+  test("returns 'locked-horizontal' when horizontal movement dominates and exceeds 8px", () => {
+    expect(detectAxisDecision(-20, 2)).toBe("locked-horizontal");
+    expect(detectAxisDecision(20, 0)).toBe("locked-horizontal");
+    expect(detectAxisDecision(-9, 3)).toBe("locked-horizontal"); // |dx| > 8, |dx| > |dy|
+  });
+
+  test("'vertical' takes precedence when both axes exceed 8px but vertical is larger", () => {
+    expect(detectAxisDecision(9, 15)).toBe("vertical");
+  });
+
+  test("'locked-horizontal' applies when both axes exceed 8px but horizontal is larger", () => {
+    expect(detectAxisDecision(15, 9)).toBe("locked-horizontal");
+  });
+
+  test("boundary: exactly 8px is NOT > 8px → undecided", () => {
+    expect(detectAxisDecision(8, 0)).toBe("undecided");
+    expect(detectAxisDecision(0, 8)).toBe("undecided");
+  });
+});
+
+// ── Swipe-offset clamping ────────────────────────────────────────────────────
+
+describe("clampSwipeOffset", () => {
+  test("passes leftward (negative) drag values through unchanged", () => {
+    expect(clampSwipeOffset(-10)).toBe(-10);
+    expect(clampSwipeOffset(-80)).toBe(-80);
+    expect(clampSwipeOffset(-200)).toBe(-200);
+  });
+
+  test("clamps rightward (positive) drag to 8px maximum", () => {
+    expect(clampSwipeOffset(0)).toBe(0);
+    expect(clampSwipeOffset(5)).toBe(5);
+    expect(clampSwipeOffset(8)).toBe(8);
+    expect(clampSwipeOffset(9)).toBe(8);
+    expect(clampSwipeOffset(100)).toBe(8);
+  });
+});
+
+// ── Close decision ───────────────────────────────────────────────────────────
+
+describe("shouldCloseSidebar", () => {
+  test("returns true when offset is more than 80px left (offset < -80)", () => {
+    expect(shouldCloseSidebar(-81)).toBe(true);
+    expect(shouldCloseSidebar(-200)).toBe(true);
+  });
+
+  test("returns false when offset is exactly -80 (boundary — not < -80)", () => {
+    expect(shouldCloseSidebar(-80)).toBe(false);
+  });
+
+  test("returns false when offset is less negative than -80", () => {
+    expect(shouldCloseSidebar(-79)).toBe(false);
+    expect(shouldCloseSidebar(0)).toBe(false);
+    expect(shouldCloseSidebar(8)).toBe(false); // rightward overscroll
+  });
+});
+
+// ── Combined gesture flow ────────────────────────────────────────────────────
+
+describe("swipe gesture state machine", () => {
+  test("aborts on vertical scroll (never reaches close threshold)", () => {
+    // Simulate a scrolling gesture: dy grows faster than dx
+    const gestures = [
+      { dx: 0, dy: 5 },   // undecided
+      { dx: -2, dy: 12 }, // vertical — abort
+    ];
+    let decision: AxisDecision = "undecided";
+    for (const { dx, dy } of gestures) {
+      decision = detectAxisDecision(dx, dy);
+      if (decision === "vertical") break;
+    }
+    expect(decision).toBe("vertical");
+    // After vertical abort the offset stays 0 (no swipe started)
+    expect(shouldCloseSidebar(0)).toBe(false);
+  });
+
+  test("closes sidebar after sufficient leftward swipe", () => {
+    // Simulate a fast leftward swipe: dx grows negative
+    const dx = -120;
+    const dy = 5;
+    expect(detectAxisDecision(dx, dy)).toBe("locked-horizontal");
+    const offset = clampSwipeOffset(dx);
+    expect(shouldCloseSidebar(offset)).toBe(true);
+  });
+
+  test("does not close sidebar on short leftward swipe", () => {
+    const dx = -50;
+    const dy = 3;
+    expect(detectAxisDecision(dx, dy)).toBe("locked-horizontal");
+    const offset = clampSwipeOffset(dx);
+    expect(shouldCloseSidebar(offset)).toBe(false);
+  });
+
+  test("does not close sidebar on rightward swipe", () => {
+    const dx = 100;
+    const dy = 0;
+    expect(detectAxisDecision(dx, dy)).toBe("locked-horizontal");
+    const offset = clampSwipeOffset(dx); // clamped to 8
+    expect(shouldCloseSidebar(offset)).toBe(false);
+  });
+});

--- a/packages/ui/src/hooks/useMobileSidebar.ts
+++ b/packages/ui/src/hooks/useMobileSidebar.ts
@@ -1,0 +1,111 @@
+import * as React from "react";
+
+export interface MobileSidebarState {
+  sidebarOpen: boolean;
+  setSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+  sidebarSwipeOffset: number;
+  suppressOverlayClickRef: React.RefObject<boolean>;
+  handleSidebarPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleSidebarPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void;
+  handleSidebarPointerUp: (e: React.PointerEvent<HTMLDivElement>) => void;
+}
+
+/**
+ * Manages mobile sidebar open/close state with swipe-left-to-close gesture
+ * and body overflow locking.
+ */
+export function useMobileSidebar(): MobileSidebarState {
+  const [sidebarOpen, setSidebarOpen] = React.useState(false);
+
+  // Swipe-left-to-close for the mobile sidebar — gesture lives on the overlay
+  // (the dim backdrop to the right of the sidebar) so it never conflicts with
+  // interactions inside the sidebar itself.
+  const sidebarSwipeRef = React.useRef<{
+    pointerId: number;
+    startX: number;
+    startY: number;
+    locked: boolean;
+    isVertical: boolean;
+    didSwipe: boolean;
+  } | null>(null);
+  const sidebarSwipeOffsetRef = React.useRef(0);
+  const [sidebarSwipeOffset, setSidebarSwipeOffset] = React.useState(0);
+  // Suppresses the click that fires immediately after a swipe pointerUp
+  const suppressOverlayClickRef = React.useRef(false);
+
+  const handleSidebarPointerDown = React.useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return;
+    sidebarSwipeRef.current = {
+      pointerId: e.pointerId,
+      startX: e.clientX,
+      startY: e.clientY,
+      locked: false,
+      isVertical: false,
+      didSwipe: false,
+    };
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const handleSidebarPointerMove = React.useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const s = sidebarSwipeRef.current;
+    if (!s || e.pointerId !== s.pointerId) return;
+    const dx = e.clientX - s.startX;
+    const dy = e.clientY - s.startY;
+    if (!s.locked && !s.isVertical) {
+      if (Math.abs(dy) > 8 && Math.abs(dy) > Math.abs(dx)) {
+        s.isVertical = true;
+        sidebarSwipeRef.current = null;
+        return;
+      }
+      if (Math.abs(dx) > 8 && Math.abs(dx) > Math.abs(dy)) {
+        s.locked = true;
+      }
+    }
+    if (s.isVertical || !s.locked) return;
+    s.didSwipe = true;
+    // Only allow leftward swipes (negative dx), with a tiny rightward overscroll
+    const clamped = Math.min(8, dx);
+    sidebarSwipeOffsetRef.current = clamped;
+    setSidebarSwipeOffset(clamped);
+    e.preventDefault();
+  }, []);
+
+  const handleSidebarPointerUp = React.useCallback((e: React.PointerEvent<HTMLDivElement>) => {
+    const s = sidebarSwipeRef.current;
+    if (!s || e.pointerId !== s.pointerId) return;
+    try { (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId); } catch { /* ignore */ }
+    const didSwipe = s.didSwipe;
+    sidebarSwipeRef.current = null;
+    const offset = sidebarSwipeOffsetRef.current;
+    sidebarSwipeOffsetRef.current = 0;
+    setSidebarSwipeOffset(0);
+    if (didSwipe) {
+      // Suppress the click that the browser fires right after pointerUp
+      suppressOverlayClickRef.current = true;
+      requestAnimationFrame(() => { suppressOverlayClickRef.current = false; });
+    }
+    // Close if dragged more than 80 px to the left
+    if (offset < -80) {
+      setSidebarOpen(false);
+    }
+  }, []);
+
+  // Prevent the underlying content from scrolling when the mobile sidebar is open.
+  React.useEffect(() => {
+    const prev = document.body.style.overflow;
+    if (sidebarOpen) document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [sidebarOpen]);
+
+  return {
+    sidebarOpen,
+    setSidebarOpen,
+    sidebarSwipeOffset,
+    suppressOverlayClickRef,
+    handleSidebarPointerDown,
+    handleSidebarPointerMove,
+    handleSidebarPointerUp,
+  };
+}

--- a/packages/ui/src/hooks/usePanelLayout.test.ts
+++ b/packages/ui/src/hooks/usePanelLayout.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Tests for the core logic embedded in usePanelLayout.
+ *
+ * Because the hook requires a React renderer (DOM environment) we test the
+ * pure computational pieces extracted from the hook body. This ensures
+ * regressions in the drag-zone detection, resize bounds, and localStorage
+ * clamping logic are caught without requiring @testing-library/react.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { PanelPosition } from "./usePanelLayout";
+
+// ── Pure helpers mirroring hook internals ──────────────────────────────────────
+
+/**
+ * Drag-zone detection — mirrors handlePanelDragMove / handleFilesDragMove.
+ * Given normalised cursor position within the container rectangle, returns
+ * the PanelPosition zone the cursor is in, or null if none.
+ */
+function detectDragZone(pctX: number, pctY: number): PanelPosition | null {
+  if (pctY > 0.55) return "bottom";
+  if (pctX > 0.65) return "right";
+  if (pctX < 0.35) return "left";
+  return null;
+}
+
+/**
+ * Terminal height clamp — mirrors handleTerminalResizeMove (height path)
+ * and the localStorage initialiser clamping.
+ */
+function clampTerminalHeight(raw: number): number {
+  return Math.max(120, Math.min(raw, 900));
+}
+
+/**
+ * Terminal width clamp — mirrors handleTerminalResizeMove (width path)
+ * and the localStorage initialiser clamping.
+ */
+function clampTerminalWidth(raw: number): number {
+  return Math.max(200, Math.min(raw, 1400));
+}
+
+/**
+ * File-explorer width clamp — mirrors handleFilesResizeMove and initialiser.
+ */
+function clampFilesWidth(raw: number): number {
+  return Math.max(160, Math.min(raw, 800));
+}
+
+/**
+ * File-explorer height clamp — mirrors handleFilesResizeMove and initialiser.
+ */
+function clampFilesHeight(raw: number): number {
+  return Math.max(150, Math.min(raw, 800));
+}
+
+/**
+ * Parse a persisted terminal height from localStorage — mirrors the hook
+ * initialiser.  Returns the default (280) when the saved value is absent or
+ * invalid.
+ */
+function parsePersistedTerminalHeight(saved: string | null): number {
+  if (saved) {
+    const parsed = parseInt(saved, 10);
+    if (!isNaN(parsed)) return clampTerminalHeight(parsed);
+  }
+  return 280; // default
+}
+
+function parsePersistedTerminalWidth(saved: string | null): number {
+  if (saved) {
+    const parsed = parseInt(saved, 10);
+    if (!isNaN(parsed)) return clampTerminalWidth(parsed);
+  }
+  return 480; // default
+}
+
+function parsePersistedFilesWidth(saved: string | null): number {
+  if (saved) {
+    const parsed = parseInt(saved, 10);
+    if (!isNaN(parsed)) return clampFilesWidth(parsed);
+  }
+  return 280; // default
+}
+
+function parsePersistedFilesHeight(saved: string | null): number {
+  if (saved) {
+    const parsed = parseInt(saved, 10);
+    if (!isNaN(parsed)) return clampFilesHeight(parsed);
+  }
+  return 280; // default
+}
+
+// ── Drag-zone detection ───────────────────────────────────────────────────────
+
+describe("detectDragZone", () => {
+  test("returns 'bottom' when cursor is in the lower portion (pctY > 0.55)", () => {
+    expect(detectDragZone(0.5, 0.6)).toBe("bottom");
+    expect(detectDragZone(0.5, 1.0)).toBe("bottom");
+    // boundary: exactly 0.55 is NOT > 0.55
+    expect(detectDragZone(0.5, 0.55)).toBeNull();
+  });
+
+  test("returns 'right' when cursor is in the right zone (pctX > 0.65, not bottom)", () => {
+    expect(detectDragZone(0.7, 0.3)).toBe("right");
+    expect(detectDragZone(1.0, 0.0)).toBe("right");
+    // boundary: exactly 0.65 is NOT > 0.65
+    expect(detectDragZone(0.65, 0.3)).toBeNull();
+  });
+
+  test("returns 'left' when cursor is in the left zone (pctX < 0.35, not bottom)", () => {
+    expect(detectDragZone(0.2, 0.3)).toBe("left");
+    expect(detectDragZone(0.0, 0.0)).toBe("left");
+    // boundary: exactly 0.35 is NOT < 0.35
+    expect(detectDragZone(0.35, 0.3)).toBeNull();
+  });
+
+  test("returns null for cursor in the centre (no zone)", () => {
+    expect(detectDragZone(0.5, 0.3)).toBeNull();
+    expect(detectDragZone(0.5, 0.0)).toBeNull();
+  });
+
+  test("'bottom' takes precedence over left/right zones", () => {
+    // pctY > 0.55 is checked first; even extreme left/right lose to bottom
+    expect(detectDragZone(0.9, 0.6)).toBe("bottom");
+    expect(detectDragZone(0.1, 0.6)).toBe("bottom");
+  });
+});
+
+// ── Terminal resize bounds ────────────────────────────────────────────────────
+
+describe("clampTerminalHeight", () => {
+  test("enforces minimum height of 120", () => {
+    expect(clampTerminalHeight(0)).toBe(120);
+    expect(clampTerminalHeight(119)).toBe(120);
+    expect(clampTerminalHeight(120)).toBe(120);
+  });
+
+  test("enforces maximum height of 900", () => {
+    expect(clampTerminalHeight(901)).toBe(900);
+    expect(clampTerminalHeight(9999)).toBe(900);
+    expect(clampTerminalHeight(900)).toBe(900);
+  });
+
+  test("passes through values in the valid range", () => {
+    expect(clampTerminalHeight(280)).toBe(280);
+    expect(clampTerminalHeight(500)).toBe(500);
+  });
+});
+
+describe("clampTerminalWidth", () => {
+  test("enforces minimum width of 200", () => {
+    expect(clampTerminalWidth(0)).toBe(200);
+    expect(clampTerminalWidth(199)).toBe(200);
+    expect(clampTerminalWidth(200)).toBe(200);
+  });
+
+  test("enforces maximum width of 1400", () => {
+    expect(clampTerminalWidth(1401)).toBe(1400);
+    expect(clampTerminalWidth(9999)).toBe(1400);
+    expect(clampTerminalWidth(1400)).toBe(1400);
+  });
+
+  test("passes through values in the valid range", () => {
+    expect(clampTerminalWidth(480)).toBe(480);
+    expect(clampTerminalWidth(800)).toBe(800);
+  });
+});
+
+// ── File-explorer resize bounds ───────────────────────────────────────────────
+
+describe("clampFilesWidth", () => {
+  test("enforces minimum width of 160", () => {
+    expect(clampFilesWidth(0)).toBe(160);
+    expect(clampFilesWidth(159)).toBe(160);
+    expect(clampFilesWidth(160)).toBe(160);
+  });
+
+  test("enforces maximum width of 800", () => {
+    expect(clampFilesWidth(801)).toBe(800);
+    expect(clampFilesWidth(9999)).toBe(800);
+    expect(clampFilesWidth(800)).toBe(800);
+  });
+
+  test("passes through values in the valid range", () => {
+    expect(clampFilesWidth(280)).toBe(280);
+  });
+});
+
+describe("clampFilesHeight", () => {
+  test("enforces minimum height of 150", () => {
+    expect(clampFilesHeight(0)).toBe(150);
+    expect(clampFilesHeight(149)).toBe(150);
+    expect(clampFilesHeight(150)).toBe(150);
+  });
+
+  test("enforces maximum height of 800", () => {
+    expect(clampFilesHeight(801)).toBe(800);
+    expect(clampFilesHeight(9999)).toBe(800);
+  });
+});
+
+// ── localStorage persisted value parsing ─────────────────────────────────────
+
+describe("parsePersistedTerminalHeight", () => {
+  test("returns default 280 when saved value is null", () => {
+    expect(parsePersistedTerminalHeight(null)).toBe(280);
+  });
+
+  test("returns parsed + clamped value for valid saved string", () => {
+    expect(parsePersistedTerminalHeight("400")).toBe(400);
+    expect(parsePersistedTerminalHeight("120")).toBe(120);
+  });
+
+  test("clamps values that are out of range", () => {
+    expect(parsePersistedTerminalHeight("50")).toBe(120); // below min
+    expect(parsePersistedTerminalHeight("1000")).toBe(900); // above max
+  });
+
+  test("returns default 280 for NaN strings", () => {
+    expect(parsePersistedTerminalHeight("not-a-number")).toBe(280);
+    expect(parsePersistedTerminalHeight("")).toBe(280);
+  });
+});
+
+describe("parsePersistedTerminalWidth", () => {
+  test("returns default 480 when saved value is null", () => {
+    expect(parsePersistedTerminalWidth(null)).toBe(480);
+  });
+
+  test("clamps to valid range", () => {
+    expect(parsePersistedTerminalWidth("100")).toBe(200); // below min
+    expect(parsePersistedTerminalWidth("2000")).toBe(1400); // above max
+    expect(parsePersistedTerminalWidth("600")).toBe(600); // valid
+  });
+});
+
+describe("parsePersistedFilesWidth", () => {
+  test("returns default 280 when saved value is null", () => {
+    expect(parsePersistedFilesWidth(null)).toBe(280);
+  });
+
+  test("clamps to valid range", () => {
+    expect(parsePersistedFilesWidth("50")).toBe(160); // below min
+    expect(parsePersistedFilesWidth("1000")).toBe(800); // above max
+    expect(parsePersistedFilesWidth("350")).toBe(350); // valid
+  });
+});
+
+describe("parsePersistedFilesHeight", () => {
+  test("returns default 280 when saved value is null", () => {
+    expect(parsePersistedFilesHeight(null)).toBe(280);
+  });
+
+  test("clamps to valid range", () => {
+    expect(parsePersistedFilesHeight("100")).toBe(150); // below min
+    expect(parsePersistedFilesHeight("1000")).toBe(800); // above max
+  });
+});
+
+// ── localStorage key validation ───────────────────────────────────────────────
+// Note: the hook's try/catch approach wraps every localStorage call so storage
+// errors (e.g., private browsing quota exceeded) degrade gracefully to defaults.
+// The persistence logic itself is tested via the parsePersistedX helpers above,
+// which mirror the initialiser clamping. Browser-side integration of localStorage
+// is tested by the Playwright E2E suite.
+
+describe("panel position type guard", () => {
+  const validPositions: PanelPosition[] = ["bottom", "right", "left"];
+
+  test("all three PanelPosition values are distinct", () => {
+    const positions = new Set(validPositions);
+    expect(positions.size).toBe(3);
+  });
+
+  test("'bottom', 'right', and 'left' are valid panel positions", () => {
+    expect(validPositions).toContain("bottom");
+    expect(validPositions).toContain("right");
+    expect(validPositions).toContain("left");
+  });
+});

--- a/packages/ui/src/hooks/usePanelLayout.ts
+++ b/packages/ui/src/hooks/usePanelLayout.ts
@@ -1,0 +1,420 @@
+import * as React from "react";
+import type { TerminalTab } from "@/components/TerminalManager";
+
+export type PanelPosition = "bottom" | "right" | "left";
+
+export interface PanelLayoutState {
+  // ── Terminal panel ──────────────────────────────────────────────────────
+  showTerminal: boolean;
+  setShowTerminal: React.Dispatch<React.SetStateAction<boolean>>;
+  terminalPosition: PanelPosition;
+  terminalHeight: number;
+  terminalWidth: number;
+  terminalColumnRef: React.RefObject<HTMLDivElement | null>;
+  handleTerminalResizeStart: (e: React.PointerEvent) => void;
+  handleTerminalPositionChange: (pos: PanelPosition) => void;
+
+  // ── Terminal drag-to-reposition ─────────────────────────────────────────
+  panelDragActive: boolean;
+  panelDragZone: PanelPosition | null;
+  handlePanelDragStart: (e: React.PointerEvent) => void;
+  handleTerminalTabDragStart: (e: React.PointerEvent) => void;
+
+  // ── Terminal outer pointer handlers (resize + drag combined) ────────────
+  handleOuterPointerMove: (e: React.PointerEvent) => void;
+  handleOuterPointerUp: () => void;
+
+  // ── Combined panel (terminal + file explorer at same position) ──────────
+  combinedActiveTab: "terminal" | "files";
+  handleCombinedTabChange: (tab: string) => void;
+  handleCombinedPositionChange: (pos: PanelPosition) => void;
+
+  // ── Lifted terminal tab state ───────────────────────────────────────────
+  terminalTabs: TerminalTab[];
+  activeTerminalId: string | null;
+  setActiveTerminalId: React.Dispatch<React.SetStateAction<string | null>>;
+  handleTerminalTabAdd: (tab: TerminalTab) => void;
+  handleTerminalTabClose: (terminalId: string) => void;
+
+  // ── File explorer panel ─────────────────────────────────────────────────
+  showFileExplorer: boolean;
+  setShowFileExplorer: React.Dispatch<React.SetStateAction<boolean>>;
+  filesPosition: PanelPosition;
+  filesWidth: number;
+  filesHeight: number;
+  filesContainerRef: React.RefObject<HTMLDivElement | null>;
+  handleFilesWidthLeftResizeStart: (e: React.PointerEvent) => void;
+  handleFilesWidthRightResizeStart: (e: React.PointerEvent) => void;
+  handleFilesHeightResizeStart: (e: React.PointerEvent) => void;
+  handleFilesPositionChange: (pos: PanelPosition) => void;
+
+  // ── File explorer drag-to-reposition ────────────────────────────────────
+  filesDragActive: boolean;
+  filesDragZone: PanelPosition | null;
+  handleFilesDragStart: (e: React.PointerEvent) => void;
+
+  // ── File explorer outer pointer handlers (resize + drag combined) ───────
+  handleFilesOuterPointerMove: (e: React.PointerEvent) => void;
+  handleFilesOuterPointerUp: () => void;
+}
+
+/**
+ * Manages the full panel layout: terminal and file explorer positioning,
+ * resizing, drag-to-reposition, combined-panel tab state, and lifted
+ * terminal tab state that survives panel remounts.
+ */
+export function usePanelLayout(activeSessionId: string | null): PanelLayoutState {
+  // ── Terminal panel state ───────────────────────────────────────────────
+  const [showTerminal, setShowTerminal] = React.useState(false);
+  const [terminalPosition, setTerminalPosition] = React.useState<PanelPosition>(() => {
+    try { return (localStorage.getItem("pp-terminal-position") as PanelPosition) ?? "bottom"; } catch { return "bottom"; }
+  });
+  const [terminalHeight, setTerminalHeight] = React.useState<number>(() => {
+    try {
+      const saved = localStorage.getItem("pp-terminal-height");
+      if (saved) return Math.max(120, Math.min(parseInt(saved, 10), 900));
+    } catch {}
+    return 280;
+  });
+  const [terminalWidth, setTerminalWidth] = React.useState<number>(() => {
+    try {
+      const saved = localStorage.getItem("pp-terminal-width");
+      if (saved) return Math.max(200, Math.min(parseInt(saved, 10), 1400));
+    } catch {}
+    return 480;
+  });
+  const terminalColumnRef = React.useRef<HTMLDivElement>(null);
+  // "height" = bottom panel vertical drag, "width-right" = right panel, "width-left" = left panel
+  const resizeDir = React.useRef<"height" | "width-right" | "width-left" | null>(null);
+
+  // Single handler — direction is derived from current terminalPosition at drag start
+  const handleTerminalResizeStart = React.useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    resizeDir.current = terminalPosition === "bottom" ? "height"
+      : terminalPosition === "right" ? "width-right"
+      : "width-left";
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, [terminalPosition]);
+
+  const handleTerminalResizeMove = React.useCallback((e: React.PointerEvent) => {
+    const dir = resizeDir.current;
+    if (!dir || !terminalColumnRef.current) return;
+    const rect = terminalColumnRef.current.getBoundingClientRect();
+    if (dir === "height") {
+      setTerminalHeight(Math.max(120, Math.min(rect.bottom - e.clientY, rect.height - 80)));
+    } else if (dir === "width-right") {
+      setTerminalWidth(Math.max(200, Math.min(rect.right - e.clientX, rect.width - 200)));
+    } else {
+      setTerminalWidth(Math.max(200, Math.min(e.clientX - rect.left, rect.width - 200)));
+    }
+  }, []);
+
+  const handleTerminalResizeEnd = React.useCallback(() => {
+    const dir = resizeDir.current;
+    if (!dir) return;
+    resizeDir.current = null;
+    if (dir === "height") {
+      setTerminalHeight((h) => { try { localStorage.setItem("pp-terminal-height", String(Math.round(h))); } catch {} return h; });
+    } else {
+      setTerminalWidth((w) => { try { localStorage.setItem("pp-terminal-width", String(Math.round(w))); } catch {} return w; });
+    }
+  }, []);
+
+  // ── Panel drag-to-reposition ──────────────────────────────────────────
+  const isPanelDragging = React.useRef(false);
+  const panelDragZoneRef = React.useRef<PanelPosition | null>(null);
+  const [panelDragActive, setPanelDragActive] = React.useState(false);
+  const [panelDragZone, setPanelDragZone] = React.useState<PanelPosition | null>(null);
+
+  const handleTerminalPositionChange = React.useCallback((pos: PanelPosition) => {
+    setTerminalPosition(pos);
+    try { localStorage.setItem("pp-terminal-position", pos); } catch {}
+  }, []);
+
+  const handlePanelDragStart = React.useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    isPanelDragging.current = true;
+    panelDragZoneRef.current = null;
+    setPanelDragActive(true);
+    setPanelDragZone(null);
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+
+  const handlePanelDragMove = React.useCallback((e: React.PointerEvent) => {
+    if (!isPanelDragging.current || !terminalColumnRef.current) return;
+    const rect = terminalColumnRef.current.getBoundingClientRect();
+    const pctX = (e.clientX - rect.left) / rect.width;
+    const pctY = (e.clientY - rect.top) / rect.height;
+    let zone: PanelPosition | null = null;
+    if (pctY > 0.55) zone = "bottom";
+    else if (pctX > 0.65) zone = "right";
+    else if (pctX < 0.35) zone = "left";
+    panelDragZoneRef.current = zone;
+    setPanelDragZone(zone);
+  }, []);
+
+  // Ref to sync file explorer position when panels are combined (avoids forward-reference issues)
+  const combinedDragSyncRef = React.useRef<((zone: PanelPosition) => void) | null>(null);
+
+  // Drag start handler for the Terminal tab inside the combined panel.
+  // Unlike the grip handle (which moves both panels together), this only moves
+  // the terminal panel so it can be detached from the files panel.
+  const handleTerminalTabDragStart = React.useCallback((e: React.PointerEvent) => {
+    // Clear the sync ref so handlePanelDragEnd doesn't also reposition the files panel
+    combinedDragSyncRef.current = null;
+    handlePanelDragStart(e);
+  }, [handlePanelDragStart]);
+
+  const handlePanelDragEnd = React.useCallback(() => {
+    if (!isPanelDragging.current) return;
+    isPanelDragging.current = false;
+    const zone = panelDragZoneRef.current;
+    panelDragZoneRef.current = null;
+    setPanelDragActive(false);
+    setPanelDragZone(null);
+    if (zone) {
+      handleTerminalPositionChange(zone);
+      // When panels are combined (same position), also move file explorer
+      combinedDragSyncRef.current?.(zone);
+    }
+  }, [handleTerminalPositionChange]);
+
+  const handleOuterPointerMove = React.useCallback((e: React.PointerEvent) => {
+    handleTerminalResizeMove(e);
+    handlePanelDragMove(e);
+  }, [handleTerminalResizeMove, handlePanelDragMove]);
+
+  const handleOuterPointerUp = React.useCallback(() => {
+    handleTerminalResizeEnd();
+    handlePanelDragEnd();
+  }, [handleTerminalResizeEnd, handlePanelDragEnd]);
+
+  // ── Combined panel tab state ──────────────────────────────────────────
+  const [combinedActiveTab, setCombinedActiveTab] = React.useState<"terminal" | "files">(() => {
+    try { return (localStorage.getItem("pp-combined-tab") as "terminal" | "files") ?? "terminal"; } catch { return "terminal"; }
+  });
+  const handleCombinedTabChange = React.useCallback((tab: string) => {
+    const t = tab as "terminal" | "files";
+    setCombinedActiveTab(t);
+    try { localStorage.setItem("pp-combined-tab", t); } catch {}
+  }, []);
+
+  // ── Lifted terminal tab state ─────────────────────────────────────────
+  // Stored here (not inside TerminalManager) so tabs survive panel remounts
+  // (e.g., when the panel transitions between combined and standalone layouts).
+  const [terminalTabs, setTerminalTabs] = React.useState<TerminalTab[]>([]);
+  const [activeTerminalId, setActiveTerminalId] = React.useState<string | null>(null);
+
+  // Per-session last-active terminal: save/restore when switching sessions.
+  const sessionActiveTerminalRef = React.useRef<Map<string | null, string | null>>(new Map());
+  const prevSessionIdForTerminalRef = React.useRef<string | null>(null);
+  // Stable ref so the effect doesn't need activeTerminalId in its dep array
+  const activeTerminalIdRef = React.useRef<string | null>(null);
+  activeTerminalIdRef.current = activeTerminalId;
+
+  React.useEffect(() => {
+    const prev = prevSessionIdForTerminalRef.current;
+    if (prev === activeSessionId) return;
+    prevSessionIdForTerminalRef.current = activeSessionId;
+
+    // Save current active terminal for the outgoing session
+    sessionActiveTerminalRef.current.set(prev, activeTerminalIdRef.current);
+
+    // Restore the last-active terminal for the incoming session
+    const incoming = activeSessionId;
+    const sessionTabs = incoming != null
+      ? terminalTabs.filter((t) => t.sessionId === incoming)
+      : terminalTabs;
+    const savedActive = sessionActiveTerminalRef.current.get(incoming);
+
+    if (savedActive && sessionTabs.some((t) => t.terminalId === savedActive)) {
+      setActiveTerminalId(savedActive);
+    } else if (sessionTabs.length > 0) {
+      setActiveTerminalId(sessionTabs[sessionTabs.length - 1].terminalId);
+    } else {
+      setActiveTerminalId(null);
+    }
+  }, [activeSessionId, terminalTabs]);
+
+  const handleTerminalTabAdd = React.useCallback((tab: TerminalTab) => {
+    setTerminalTabs((prev) => [...prev, tab]);
+    setActiveTerminalId(tab.terminalId);
+  }, []);
+
+  const handleTerminalTabClose = React.useCallback((terminalId: string) => {
+    setTerminalTabs((prev) => {
+      const next = prev.filter((t) => t.terminalId !== terminalId);
+      setActiveTerminalId((current) => {
+        if (current !== terminalId) return current;
+        // Find the closest remaining tab in the same session
+        const removed = prev.find((t) => t.terminalId === terminalId);
+        const sameSess = next.filter((t) => t.sessionId === (removed?.sessionId ?? null));
+        return sameSess.length > 0 ? sameSess[sameSess.length - 1].terminalId : null;
+      });
+      return next;
+    });
+  }, []);
+
+  // ── File explorer panel state ─────────────────────────────────────────
+  const [showFileExplorer, setShowFileExplorer] = React.useState(false);
+  const [filesPosition, setFilesPosition] = React.useState<PanelPosition>(() => {
+    try { return (localStorage.getItem("pp-files-position") as PanelPosition) ?? "left"; } catch { return "left"; }
+  });
+  const [filesWidth, setFilesWidth] = React.useState<number>(() => {
+    try {
+      const saved = localStorage.getItem("pp-files-width");
+      if (saved) return Math.max(160, Math.min(parseInt(saved, 10), 800));
+    } catch {}
+    return 280;
+  });
+  const [filesHeight, setFilesHeight] = React.useState<number>(() => {
+    try {
+      const saved = localStorage.getItem("pp-files-height");
+      if (saved) return Math.max(150, Math.min(parseInt(saved, 10), 800));
+    } catch {}
+    return 280;
+  });
+  const filesContainerRef = React.useRef<HTMLDivElement>(null);
+  const filesResizeDir = React.useRef<"width-right" | "width-left" | "height" | null>(null);
+
+  const handleFilesWidthLeftResizeStart = React.useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    filesResizeDir.current = "width-left";
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+  const handleFilesWidthRightResizeStart = React.useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    filesResizeDir.current = "width-right";
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+  const handleFilesHeightResizeStart = React.useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    filesResizeDir.current = "height";
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+  const handleFilesResizeMove = React.useCallback((e: React.PointerEvent) => {
+    const dir = filesResizeDir.current;
+    if (!dir || !filesContainerRef.current) return;
+    const rect = filesContainerRef.current.getBoundingClientRect();
+    if (dir === "width-right") {
+      setFilesWidth(Math.max(160, Math.min(rect.right - e.clientX, rect.width - 200)));
+    } else if (dir === "width-left") {
+      setFilesWidth(Math.max(160, Math.min(e.clientX - rect.left, rect.width - 200)));
+    } else {
+      setFilesHeight(Math.max(150, Math.min(rect.bottom - e.clientY, rect.height - 100)));
+    }
+  }, []);
+  const handleFilesResizeEnd = React.useCallback(() => {
+    const dir = filesResizeDir.current;
+    if (!dir) return;
+    filesResizeDir.current = null;
+    if (dir === "height") {
+      setFilesHeight((h) => { try { localStorage.setItem("pp-files-height", String(Math.round(h))); } catch {} return h; });
+    } else {
+      setFilesWidth((w) => { try { localStorage.setItem("pp-files-width", String(Math.round(w))); } catch {} return w; });
+    }
+  }, []);
+
+  const handleFilesPositionChange = React.useCallback((pos: PanelPosition) => {
+    setFilesPosition(pos);
+    try { localStorage.setItem("pp-files-position", pos); } catch {}
+  }, []);
+
+  const handleCombinedPositionChange = React.useCallback((pos: PanelPosition) => {
+    handleTerminalPositionChange(pos);
+    handleFilesPositionChange(pos);
+  }, [handleTerminalPositionChange, handleFilesPositionChange]);
+
+  // Keep the drag sync ref up-to-date so handlePanelDragEnd can sync file explorer
+  React.useEffect(() => {
+    if (showTerminal && showFileExplorer && terminalPosition === filesPosition) {
+      combinedDragSyncRef.current = handleFilesPositionChange;
+    } else {
+      combinedDragSyncRef.current = null;
+    }
+  }, [showTerminal, showFileExplorer, terminalPosition, filesPosition, handleFilesPositionChange]);
+
+  // ── File explorer drag-to-reposition ──────────────────────────────────
+  const isFilesDragging = React.useRef(false);
+  const filesDragZoneRef = React.useRef<PanelPosition | null>(null);
+  const [filesDragActive, setFilesDragActive] = React.useState(false);
+  const [filesDragZone, setFilesDragZone] = React.useState<PanelPosition | null>(null);
+
+  const handleFilesDragStart = React.useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    isFilesDragging.current = true;
+    filesDragZoneRef.current = null;
+    setFilesDragActive(true);
+    setFilesDragZone(null);
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+  }, []);
+  const handleFilesDragMove = React.useCallback((e: React.PointerEvent) => {
+    if (!isFilesDragging.current || !filesContainerRef.current) return;
+    const rect = filesContainerRef.current.getBoundingClientRect();
+    const pctX = (e.clientX - rect.left) / rect.width;
+    const pctY = (e.clientY - rect.top) / rect.height;
+    let zone: PanelPosition | null = null;
+    if (pctY > 0.55) zone = "bottom";
+    else if (pctX > 0.65) zone = "right";
+    else if (pctX < 0.35) zone = "left";
+    filesDragZoneRef.current = zone;
+    setFilesDragZone(zone);
+  }, []);
+  const handleFilesDragEnd = React.useCallback(() => {
+    if (!isFilesDragging.current) return;
+    isFilesDragging.current = false;
+    const zone = filesDragZoneRef.current;
+    filesDragZoneRef.current = null;
+    setFilesDragActive(false);
+    setFilesDragZone(null);
+    if (zone) handleFilesPositionChange(zone);
+  }, [handleFilesPositionChange]);
+  const handleFilesOuterPointerMove = React.useCallback((e: React.PointerEvent) => {
+    handleFilesResizeMove(e);
+    handleFilesDragMove(e);
+  }, [handleFilesResizeMove, handleFilesDragMove]);
+  const handleFilesOuterPointerUp = React.useCallback(() => {
+    handleFilesResizeEnd();
+    handleFilesDragEnd();
+  }, [handleFilesResizeEnd, handleFilesDragEnd]);
+
+  return {
+    showTerminal,
+    setShowTerminal,
+    terminalPosition,
+    terminalHeight,
+    terminalWidth,
+    terminalColumnRef,
+    handleTerminalResizeStart,
+    handleTerminalPositionChange,
+    panelDragActive,
+    panelDragZone,
+    handlePanelDragStart,
+    handleTerminalTabDragStart,
+    handleOuterPointerMove,
+    handleOuterPointerUp,
+    combinedActiveTab,
+    handleCombinedTabChange,
+    handleCombinedPositionChange,
+    terminalTabs,
+    activeTerminalId,
+    setActiveTerminalId,
+    handleTerminalTabAdd,
+    handleTerminalTabClose,
+    showFileExplorer,
+    setShowFileExplorer,
+    filesPosition,
+    filesWidth,
+    filesHeight,
+    filesContainerRef,
+    handleFilesWidthLeftResizeStart,
+    handleFilesWidthRightResizeStart,
+    handleFilesHeightResizeStart,
+    handleFilesPositionChange,
+    filesDragActive,
+    filesDragZone,
+    handleFilesDragStart,
+    handleFilesOuterPointerMove,
+    handleFilesOuterPointerUp,
+  };
+}

--- a/packages/ui/src/lib/message-helpers.test.ts
+++ b/packages/ui/src/lib/message-helpers.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, test } from "bun:test";
+import {
+  toRelayMessage,
+  deduplicateMessages,
+  normalizeMessages,
+  normalizeModel,
+  normalizeSessionName,
+  augmentThinkingDurations,
+  normalizeModelList,
+} from "./message-helpers";
+import type { RelayMessage } from "@/components/session-viewer/types";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function assistantMsg(
+  overrides: Partial<RelayMessage> & { key: string }
+): RelayMessage {
+  return { role: "assistant", content: null, ...overrides };
+}
+
+// ── toRelayMessage ────────────────────────────────────────────────────────────
+
+describe("toRelayMessage", () => {
+  test("returns null for null input", () => {
+    expect(toRelayMessage(null, "fallback")).toBeNull();
+  });
+
+  test("returns null for non-object input", () => {
+    expect(toRelayMessage("string", "fallback")).toBeNull();
+    expect(toRelayMessage(42, "fallback")).toBeNull();
+    expect(toRelayMessage(undefined, "fallback")).toBeNull();
+  });
+
+  test("uses id-based key when id field is present", () => {
+    const result = toRelayMessage({ role: "user", id: "abc123" }, "fallback");
+    expect(result?.key).toBe("user:id:abc123");
+  });
+
+  test("uses toolCallId-based key when id is absent but toolCallId is present", () => {
+    const result = toRelayMessage({ role: "tool_result", toolCallId: "tc1" }, "fallback");
+    expect(result?.key).toBe("tool_result:tool:tc1");
+  });
+
+  test("uses timestamp-based key when id and toolCallId are absent", () => {
+    const result = toRelayMessage({ role: "assistant", timestamp: 1234 }, "fallback");
+    expect(result?.key).toBe("assistant:ts:1234");
+  });
+
+  test("uses fallback key when no id, toolCallId, or timestamp", () => {
+    const result = toRelayMessage({ role: "user" }, "snap-0");
+    expect(result?.key).toBe("user:fallback:snap-0");
+  });
+
+  test("defaults role to 'message' if role is missing or non-string", () => {
+    const result = toRelayMessage({ role: 99 }, "x");
+    expect(result?.role).toBe("message");
+  });
+
+  test("sets isError=true when stopReason is 'error'", () => {
+    const result = toRelayMessage({ role: "assistant", stopReason: "error" }, "x");
+    expect(result?.isError).toBe(true);
+    expect(result?.stopReason).toBe("error");
+  });
+
+  test("sets isError=true when isError field is true", () => {
+    const result = toRelayMessage({ role: "tool_result", isError: true }, "x");
+    expect(result?.isError).toBe(true);
+  });
+
+  test("preserves summary and tokensBefore for compaction messages", () => {
+    const result = toRelayMessage(
+      { role: "compactionSummary", summary: "Compacted context", tokensBefore: 5000 },
+      "x"
+    );
+    expect(result?.summary).toBe("Compacted context");
+    expect(result?.tokensBefore).toBe(5000);
+  });
+
+  test("preserves structured details field", () => {
+    const details = { subagentId: "s1", status: "done" };
+    const result = toRelayMessage({ role: "tool_result", details }, "x");
+    expect(result?.details).toEqual(details);
+  });
+
+  test("omits toolCallId from output when input toolCallId is empty string", () => {
+    const result = toRelayMessage({ role: "user", toolCallId: "" }, "x");
+    expect(result?.toolCallId).toBeUndefined();
+  });
+
+  test("accepts modelId as fallback for id field in returned message", () => {
+    // toRelayMessage doesn't use modelId — verify it doesn't leak
+    const result = toRelayMessage({ role: "user", modelId: "gpt-4" }, "x");
+    expect(result?.role).toBe("user");
+  });
+});
+
+// ── deduplicateMessages ───────────────────────────────────────────────────────
+
+describe("deduplicateMessages", () => {
+  test("returns empty array unchanged", () => {
+    expect(deduplicateMessages([])).toEqual([]);
+  });
+
+  test("returns same reference when nothing is dropped", () => {
+    const msgs: RelayMessage[] = [
+      assistantMsg({ key: "a1", timestamp: 100 }),
+    ];
+    const result = deduplicateMessages(msgs);
+    expect(result).toBe(msgs); // same reference = nothing filtered
+  });
+
+  test("drops no-timestamp assistant immediately followed by timestamped assistant", () => {
+    const partial = assistantMsg({ key: "partial" }); // no timestamp
+    const final = assistantMsg({ key: "final", timestamp: 200 });
+    const result = deduplicateMessages([partial, final]);
+    expect(result).toHaveLength(1);
+    expect(result[0].key).toBe("final");
+  });
+
+  test("keeps both when no-timestamp assistant is NOT followed by a timestamped one", () => {
+    const a = assistantMsg({ key: "a" });
+    const b = assistantMsg({ key: "b" });
+    const result = deduplicateMessages([a, b]);
+    expect(result).toHaveLength(2);
+  });
+
+  test("drops partial when it shares a toolCallId with a later timestamped message", () => {
+    const partial = assistantMsg({
+      key: "partial",
+      content: [{ type: "toolCall", toolCallId: "tc1" }],
+    });
+    const final = assistantMsg({
+      key: "final",
+      timestamp: 300,
+      content: [{ type: "toolCall", toolCallId: "tc1" }],
+    });
+    // Another message in between to test the extended heuristic
+    const other: RelayMessage = { key: "user1", role: "user", content: null };
+    const result = deduplicateMessages([partial, other, final]);
+    expect(result.map((m) => m.key)).toEqual(["user1", "final"]);
+  });
+
+  test("drops text-only partial that is a prefix of a later timestamped assistant", () => {
+    const partial = assistantMsg({
+      key: "partial",
+      content: [{ type: "text", text: "Hello wor" }],
+    });
+    const final = assistantMsg({
+      key: "final",
+      timestamp: 400,
+      content: [{ type: "text", text: "Hello world!" }],
+    });
+    const result = deduplicateMessages([partial, final]);
+    expect(result.map((m) => m.key)).toEqual(["final"]);
+  });
+
+  test("keeps text partial when it is NOT a prefix of any later timestamped message (with intervening message)", () => {
+    // Note: the "immediately followed" heuristic fires for [partial, timestamped],
+    // so we need an intervening non-assistant message to bypass it.
+    const partial = assistantMsg({
+      key: "partial",
+      content: [{ type: "text", text: "Something else" }],
+    });
+    const user: RelayMessage = { key: "u1", role: "user", content: null };
+    const final = assistantMsg({
+      key: "final",
+      timestamp: 500,
+      content: [{ type: "text", text: "Completely different" }],
+    });
+    const result = deduplicateMessages([partial, user, final]);
+    expect(result).toHaveLength(3); // partial kept — no toolCallId overlap, not a text prefix
+  });
+
+  test("preserves non-assistant messages regardless", () => {
+    const user: RelayMessage = { key: "u1", role: "user", content: null };
+    const tool: RelayMessage = { key: "tr1", role: "tool_result", content: null };
+    const result = deduplicateMessages([user, tool]);
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ── normalizeMessages ─────────────────────────────────────────────────────────
+
+describe("normalizeMessages", () => {
+  test("filters out nulls from malformed raw messages", () => {
+    const raw: unknown[] = [null, undefined, 42, { role: "user" }];
+    const result = normalizeMessages(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].role).toBe("user");
+  });
+
+  test("applies keyOffset to fallback keys", () => {
+    const raw: unknown[] = [{ role: "user" }, { role: "assistant" }];
+    const result = normalizeMessages(raw, 10);
+    expect(result[0].key).toBe("user:fallback:snapshot-10");
+    expect(result[1].key).toBe("assistant:fallback:snapshot-11");
+  });
+
+  test("deduplicates after converting", () => {
+    const raw: unknown[] = [
+      { role: "assistant" }, // no timestamp — partial
+      { role: "assistant", timestamp: 1 }, // timestamped final
+    ];
+    const result = normalizeMessages(raw);
+    expect(result).toHaveLength(1);
+    expect(result[0].timestamp).toBe(1);
+  });
+});
+
+// ── normalizeModel ────────────────────────────────────────────────────────────
+
+describe("normalizeModel", () => {
+  test("returns null for null/non-object input", () => {
+    expect(normalizeModel(null)).toBeNull();
+    expect(normalizeModel("string")).toBeNull();
+    expect(normalizeModel(42)).toBeNull();
+  });
+
+  test("returns null when provider is missing", () => {
+    expect(normalizeModel({ id: "gpt-4" })).toBeNull();
+  });
+
+  test("returns null when both id and modelId are missing", () => {
+    expect(normalizeModel({ provider: "openai" })).toBeNull();
+  });
+
+  test("parses standard availableModels shape (id field)", () => {
+    const result = normalizeModel({ provider: "openai", id: "gpt-4o", name: "GPT-4o" });
+    expect(result).toEqual({
+      provider: "openai",
+      id: "gpt-4o",
+      name: "GPT-4o",
+      reasoning: undefined,
+      contextWindow: undefined,
+    });
+  });
+
+  test("parses buildSessionContext shape (modelId field)", () => {
+    const result = normalizeModel({ provider: "anthropic", modelId: "claude-opus-4" });
+    expect(result).toEqual({
+      provider: "anthropic",
+      id: "claude-opus-4",
+      name: undefined,
+      reasoning: undefined,
+      contextWindow: undefined,
+    });
+  });
+
+  test("prefers id over modelId when both present", () => {
+    const result = normalizeModel({ provider: "openai", id: "gpt-4o", modelId: "gpt-4" });
+    expect(result?.id).toBe("gpt-4o");
+  });
+
+  test("trims whitespace from provider and id", () => {
+    const result = normalizeModel({ provider: "  openai  ", id: "  gpt-4  " });
+    expect(result?.provider).toBe("openai");
+    expect(result?.id).toBe("gpt-4");
+  });
+
+  test("preserves optional fields: reasoning, contextWindow", () => {
+    const result = normalizeModel({
+      provider: "anthropic",
+      id: "claude-3-7-sonnet",
+      reasoning: true,
+      contextWindow: 200000,
+    });
+    expect(result?.reasoning).toBe(true);
+    expect(result?.contextWindow).toBe(200000);
+  });
+});
+
+// ── normalizeSessionName ──────────────────────────────────────────────────────
+
+describe("normalizeSessionName", () => {
+  test("returns null for non-string input", () => {
+    expect(normalizeSessionName(null)).toBeNull();
+    expect(normalizeSessionName(42)).toBeNull();
+    expect(normalizeSessionName(undefined)).toBeNull();
+  });
+
+  test("returns null for empty string", () => {
+    expect(normalizeSessionName("")).toBeNull();
+  });
+
+  test("returns null for whitespace-only string", () => {
+    expect(normalizeSessionName("   ")).toBeNull();
+  });
+
+  test("returns trimmed name for valid string", () => {
+    expect(normalizeSessionName("  My Session  ")).toBe("My Session");
+  });
+
+  test("returns string as-is when no surrounding whitespace", () => {
+    expect(normalizeSessionName("Session Name")).toBe("Session Name");
+  });
+});
+
+// ── augmentThinkingDurations ──────────────────────────────────────────────────
+
+describe("augmentThinkingDurations", () => {
+  test("returns original message when durations map is empty", () => {
+    const msg = { role: "assistant", content: [{ type: "thinking", text: "..." }] };
+    const result = augmentThinkingDurations(msg, new Map());
+    expect(result).toBe(msg); // same reference
+  });
+
+  test("returns original message for null/non-object input", () => {
+    const durations = new Map([[0, 3.5]]);
+    expect(augmentThinkingDurations(null, durations)).toBeNull();
+    expect(augmentThinkingDurations("string", durations)).toBe("string");
+  });
+
+  test("injects durationSeconds into thinking block at matching index", () => {
+    const msg = {
+      role: "assistant",
+      content: [
+        { type: "thinking", text: "pondering..." },
+        { type: "text", text: "answer" },
+      ],
+    };
+    const durations = new Map([[0, 2.5]]);
+    const result = augmentThinkingDurations(msg, durations) as typeof msg;
+    expect((result.content[0] as Record<string, unknown>).durationSeconds).toBe(2.5);
+    // Non-thinking block unchanged
+    expect((result.content[1] as Record<string, unknown>).durationSeconds).toBeUndefined();
+  });
+
+  test("does NOT overwrite existing durationSeconds", () => {
+    const msg = {
+      role: "assistant",
+      content: [{ type: "thinking", text: "...", durationSeconds: 1.0 }],
+    };
+    const durations = new Map([[0, 9.9]]);
+    const result = augmentThinkingDurations(msg, durations) as typeof msg;
+    expect((result.content[0] as Record<string, unknown>).durationSeconds).toBe(1.0);
+  });
+
+  test("returns new object reference when content changed", () => {
+    const msg = {
+      role: "assistant",
+      content: [{ type: "thinking", text: "..." }],
+    };
+    const durations = new Map([[0, 5.0]]);
+    const result = augmentThinkingDurations(msg, durations);
+    expect(result).not.toBe(msg); // new object
+  });
+
+  test("handles message with no content array", () => {
+    const msg = { role: "assistant", content: "string-content" };
+    const durations = new Map([[0, 1.0]]);
+    const result = augmentThinkingDurations(msg, durations);
+    expect(result).toBe(msg); // unchanged when content isn't array
+  });
+});
+
+// ── normalizeModelList ────────────────────────────────────────────────────────
+
+describe("normalizeModelList", () => {
+  test("returns empty array for empty input", () => {
+    expect(normalizeModelList([])).toEqual([]);
+  });
+
+  test("filters out invalid model entries", () => {
+    const result = normalizeModelList([null, undefined, "string", 42, { provider: "openai" }]);
+    expect(result).toHaveLength(0);
+  });
+
+  test("deduplicates models with same provider/id", () => {
+    const models: unknown[] = [
+      { provider: "openai", id: "gpt-4o" },
+      { provider: "openai", id: "gpt-4o" }, // duplicate
+      { provider: "anthropic", id: "claude-3" },
+    ];
+    const result = normalizeModelList(models);
+    expect(result).toHaveLength(2);
+  });
+
+  test("sorts by provider then id", () => {
+    const models: unknown[] = [
+      { provider: "openai", id: "gpt-4o" },
+      { provider: "anthropic", id: "claude-opus-4" },
+      { provider: "anthropic", id: "claude-haiku" },
+    ];
+    const result = normalizeModelList(models);
+    expect(result.map((m) => `${m.provider}/${m.id}`)).toEqual([
+      "anthropic/claude-haiku",
+      "anthropic/claude-opus-4",
+      "openai/gpt-4o",
+    ]);
+  });
+
+  test("keeps last entry wins when deduplicating (map behavior)", () => {
+    const models: unknown[] = [
+      { provider: "openai", id: "gpt-4o", name: "First" },
+      { provider: "openai", id: "gpt-4o", name: "Second" }, // overwrites
+    ];
+    const result = normalizeModelList(models);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe("Second");
+  });
+});

--- a/packages/ui/src/lib/message-helpers.ts
+++ b/packages/ui/src/lib/message-helpers.ts
@@ -1,0 +1,201 @@
+/**
+ * Pure helper functions for relay message normalization, deduplication,
+ * model normalization, and thinking-duration augmentation.
+ *
+ * Extracted from App.tsx — no React dependencies, fully testable.
+ */
+
+import type { RelayMessage } from "@/components/session-viewer/types";
+import type { ConfiguredModelInfo } from "@/lib/types";
+
+export function toRelayMessage(raw: unknown, fallbackId: string): RelayMessage | null {
+  if (!raw || typeof raw !== "object") return null;
+
+  const msg = raw as Record<string, unknown>;
+  const role = typeof msg.role === "string" ? msg.role : "message";
+  const timestamp = typeof msg.timestamp === "number" ? msg.timestamp : undefined;
+  const toolCallId = typeof msg.toolCallId === "string" ? msg.toolCallId : "";
+  const id = typeof msg.id === "string" ? msg.id : undefined;
+
+  const key = id
+    ? `${role}:id:${id}`
+    : toolCallId
+      ? `${role}:tool:${toolCallId}`
+      : timestamp !== undefined
+        ? `${role}:ts:${timestamp}`
+        : `${role}:fallback:${fallbackId}`;
+
+  const stopReason = typeof msg.stopReason === "string" ? msg.stopReason : undefined;
+  const errorMessage = typeof msg.errorMessage === "string" ? msg.errorMessage : undefined;
+
+  // Extract summary/tokensBefore for compactionSummary / branchSummary messages
+  const summary = typeof msg.summary === "string" ? msg.summary : undefined;
+  const tokensBefore = typeof msg.tokensBefore === "number" ? msg.tokensBefore : undefined;
+
+  // Preserve structured details (e.g., subagent SubagentDetails) for tool results
+  const details = msg.details !== undefined && msg.details !== null ? msg.details : undefined;
+
+  return {
+    key,
+    role,
+    timestamp,
+    content: msg.content,
+    toolName: typeof msg.toolName === "string" ? msg.toolName : undefined,
+    toolCallId: toolCallId || undefined,
+    isError: msg.isError === true || stopReason === "error",
+    stopReason,
+    errorMessage,
+    summary,
+    tokensBefore,
+    details,
+  };
+}
+
+function getAssistantToolCallIds(msg: RelayMessage): string[] {
+  if (msg.role !== "assistant" || !Array.isArray(msg.content)) return [];
+  const ids: string[] = [];
+  for (const block of msg.content) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as Record<string, unknown>;
+    if (b.type !== "toolCall") continue;
+    const id =
+      typeof b.toolCallId === "string"
+        ? b.toolCallId
+        : typeof b.id === "string"
+          ? b.id
+          : "";
+    if (id) ids.push(id);
+  }
+  return ids;
+}
+
+/** Extract concatenated text content from an assistant message for dedup comparison. */
+function extractAssistantText(msg: RelayMessage): string {
+  if (msg.role !== "assistant" || !Array.isArray(msg.content)) return "";
+  let text = "";
+  for (const block of msg.content) {
+    if (!block || typeof block !== "object") continue;
+    const b = block as Record<string, unknown>;
+    if (b.type === "text" && typeof b.text === "string") text += b.text;
+  }
+  return text;
+}
+
+/** Deduplicate assistant messages within a list. Removes no-timestamp partials
+ * that are superseded by timestamped finals, even across chunk boundaries. */
+export function deduplicateMessages(messages: RelayMessage[]): RelayMessage[] {
+  // Build a set of toolCallIds referenced by any timestamped assistant message.
+  const timestampedToolCallIds = new Set<string>();
+  for (const msg of messages) {
+    if (msg.role === "assistant" && msg.timestamp !== undefined) {
+      for (const id of getAssistantToolCallIds(msg)) {
+        timestampedToolCallIds.add(id);
+      }
+    }
+  }
+
+  const dropIndices = new Set<number>();
+  for (let i = 0; i < messages.length; i++) {
+    const cur = messages[i];
+    if (cur.role !== "assistant" || cur.timestamp !== undefined) continue;
+
+    // Original heuristic: immediately followed by a timestamped assistant message.
+    const next = messages[i + 1];
+    if (next?.role === "assistant" && next.timestamp !== undefined) {
+      dropIndices.add(i);
+      continue;
+    }
+
+    // Extended heuristic: shares a toolCallId with any later timestamped assistant message.
+    const ids = getAssistantToolCallIds(cur);
+    if (ids.length > 0 && ids.some((id) => timestampedToolCallIds.has(id))) {
+      dropIndices.add(i);
+      continue;
+    }
+
+    // Text-prefix heuristic: if this no-timestamp message has no toolCallIds,
+    // check if any later timestamped assistant message contains the same text
+    // (the partial is a prefix of the final). This catches text-only streaming
+    // partials that survive alongside the final message (e.g. after web_search).
+    if (ids.length === 0) {
+      const curText = extractAssistantText(cur);
+      if (curText) {
+        for (let j = i + 1; j < messages.length; j++) {
+          const candidate = messages[j];
+          if (candidate.role !== "assistant" || candidate.timestamp === undefined) continue;
+          const candidateText = extractAssistantText(candidate);
+          if (candidateText && candidateText.startsWith(curText)) {
+            dropIndices.add(i);
+            break;
+          }
+        }
+      }
+    }
+  }
+
+  if (dropIndices.size === 0) return messages;
+  return messages.filter((_, i) => !dropIndices.has(i));
+}
+
+export function normalizeMessages(rawMessages: unknown[], keyOffset = 0): RelayMessage[] {
+  const all = rawMessages
+    .map((m, i) => toRelayMessage(m, `snapshot-${keyOffset + i}`))
+    .filter((m): m is RelayMessage => m !== null);
+
+  return deduplicateMessages(all);
+}
+
+export function normalizeModel(raw: unknown): ConfiguredModelInfo | null {
+  if (!raw || typeof raw !== "object") return null;
+  const model = raw as Record<string, unknown>;
+  const provider = typeof model.provider === "string" ? model.provider.trim() : "";
+  // Accept both `id` (availableModels shape) and `modelId` (buildSessionContext shape)
+  const id = (typeof model.id === "string" ? model.id.trim() : "") ||
+              (typeof model.modelId === "string" ? model.modelId.trim() : "");
+  if (!provider || !id) return null;
+
+  return {
+    provider,
+    id,
+    name: typeof model.name === "string" ? model.name : undefined,
+    reasoning: typeof model.reasoning === "boolean" ? model.reasoning : undefined,
+    contextWindow: typeof model.contextWindow === "number" ? model.contextWindow : undefined,
+  };
+}
+
+export function normalizeSessionName(raw: unknown): string | null {
+  if (typeof raw !== "string") return null;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/** Inject `durationSeconds` into thinking blocks that we've timed client-side. */
+export function augmentThinkingDurations(message: unknown, durations: Map<number, number>): unknown {
+  if (!message || typeof message !== "object" || durations.size === 0) return message;
+  const msg = message as Record<string, unknown>;
+  if (!Array.isArray(msg.content)) return message;
+  let changed = false;
+  const content = msg.content.map((block, i) => {
+    if (!block || typeof block !== "object") return block;
+    const b = block as Record<string, unknown>;
+    if (b.type === "thinking" && durations.has(i) && b.durationSeconds === undefined) {
+      changed = true;
+      return { ...b, durationSeconds: durations.get(i) };
+    }
+    return block;
+  });
+  return changed ? { ...msg, content } : message;
+}
+
+export function normalizeModelList(rawModels: unknown[]): ConfiguredModelInfo[] {
+  const deduped = new Map<string, ConfiguredModelInfo>();
+  for (const raw of rawModels) {
+    const model = normalizeModel(raw);
+    if (!model) continue;
+    deduped.set(`${model.provider}/${model.id}`, model);
+  }
+  return Array.from(deduped.values()).sort((a, b) => {
+    if (a.provider !== b.provider) return a.provider.localeCompare(b.provider);
+    return a.id.localeCompare(b.id);
+  });
+}

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -1,0 +1,71 @@
+/**
+ * Shared UI types — canonical definitions used across App, SessionViewer,
+ * tool cards, and other components.
+ *
+ * Import from "@/lib/types" instead of defining locally.
+ */
+
+import type { QuestionType, QuestionDisplayMode } from "@/lib/ask-user-questions";
+import type { ProviderUsageMap } from "@/components/UsageIndicator";
+import type { RelayMessage } from "@/components/session-viewer/types";
+
+export interface TodoItem {
+  id: number;
+  text: string;
+  status: "pending" | "in_progress" | "done" | "cancelled";
+}
+
+export interface TokenUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cost: number;
+}
+
+export interface ConfiguredModelInfo {
+  provider: string;
+  id: string;
+  name?: string;
+  reasoning?: boolean;
+  contextWindow?: number;
+}
+
+export interface ResumeSessionOption {
+  id: string;
+  path: string;
+  name: string | null;
+  modified: string;
+  firstMessage?: string;
+}
+
+export interface QueuedMessage {
+  id: string;
+  text: string;
+  deliverAs: "steer" | "followUp";
+  timestamp: number;
+}
+
+export interface SessionUiCacheEntry {
+  messages: RelayMessage[];
+  activeModel: ConfiguredModelInfo | null;
+  sessionName: string | null;
+  availableModels: ConfiguredModelInfo[];
+  availableCommands: Array<{ name: string; description?: string; source?: string }>;
+  agentActive: boolean;
+  isCompacting: boolean;
+  effortLevel: string | null;
+  planModeEnabled: boolean;
+  authSource: string | null;
+  tokenUsage: TokenUsage | null;
+  providerUsage: ProviderUsageMap | null;
+  lastHeartbeatAt: number | null;
+  todoList: TodoItem[];
+  pendingQuestion: { toolCallId: string; questions: Array<{ question: string; options: string[]; type?: QuestionType }>; display: QuestionDisplayMode } | null;
+  pendingPlan: {
+    toolCallId: string;
+    title: string;
+    description: string | null;
+    steps: Array<{ title: string; description?: string }>;
+  } | null;
+}


### PR DESCRIPTION
## Summary

Begins decomposing the 4,368-line App.tsx god component (65 useState, 58 useCallback, 40 useRef, 14 useEffect) by extracting reusable modules.

### New files

| File | Lines | Responsibility |
|------|-------|----------------|
| `lib/types.ts` | ~75 | Canonical shared types: TodoItem, TokenUsage, ConfiguredModelInfo, ResumeSessionOption, QueuedMessage, SessionUiCacheEntry |
| `lib/message-helpers.ts` | ~190 | Pure functions: toRelayMessage, deduplicateMessages, normalizeMessages, normalizeModel, normalizeSessionName, augmentThinkingDurations, normalizeModelList |
| `hooks/usePanelLayout.ts` | ~310 | Terminal + file explorer position, resize, drag-to-reposition, combined panel tab state, lifted terminal tab management |
| `hooks/useMobileSidebar.ts` | ~100 | Swipe-left-to-close gesture, sidebar open state, body overflow locking |
| `components/ShortcutsDialog.tsx` | ~55 | Keyboard shortcuts help dialog |

### What changed

- **App.tsx**: 4,368 → 3,734 lines (**-634 lines, -15%**)
- **Type deduplication**: TodoItem was defined 3x, TokenUsage 2x, ResumeSessionOption 2x — now single source of truth in `lib/types.ts`
- **SessionViewer.tsx**: Re-exports shared types for backward compat
- **TodoCard.tsx, tool-rendering.tsx, rendering.tsx**: Import from shared types

### What is NOT in this PR (follow-up)

- NewSessionDialog extraction (tightly coupled to spawn state + fetch effects)
- ApiKeyPanel extraction
- useSocketRelay hook extraction (~1,500 lines of socket.io event handling — the biggest remaining piece)

### Verification

- `bun run typecheck` — clean (only pre-existing missing module errors)
- `bun test packages/ui` — 282/283 pass (1 pre-existing failure)
