### PR TITLE
fix(auth): prevent user enumeration via /api/register when signups disabled

### DIFF
--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -18,6 +18,7 @@ export type {
 
 // Password validation (shared across server, UI, CLI)
 export {
+  MAX_PASSWORD_LENGTH,
   PASSWORD_REQUIREMENTS,
   PASSWORD_REQUIREMENTS_SUMMARY,
   validatePassword,

--- a/packages/protocol/src/password.ts
+++ b/packages/protocol/src/password.ts
@@ -2,6 +2,16 @@
 // Password validation — shared across server, UI, and CLI
 // ============================================================================
 
+/**
+ * Maximum password length (in characters) accepted by the server.
+ *
+ * Better Auth uses scrypt for hashing, which — unlike bcrypt — does NOT truncate
+ * input. Arbitrarily long passwords translate to proportionally expensive hashing,
+ * creating a DoS vector. 128 characters is generous for any real password/passphrase
+ * while bounding scrypt cost.
+ */
+export const MAX_PASSWORD_LENGTH = 128;
+
 /** Human-readable description of each password requirement. */
 export const PASSWORD_REQUIREMENTS = [
   "At least 8 characters",

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -9,6 +9,7 @@
 import { getApiKeyRateLimitConfig, getAuth, getKysely, isSignupAllowed } from "../auth.js";
 import { RateLimiter, isValidEmail, isValidPassword, getClientIp } from "../security.js";
 import { PASSWORD_REQUIREMENTS_SUMMARY } from "@pizzapi/protocol";
+import { hashPassword as betterAuthHashPassword } from "better-auth/crypto";
 import type { RouteHandler } from "./types.js";
 
 // 5 requests per 15 minutes
@@ -85,11 +86,12 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
             // Block new account creation when signups are disabled.
             const signupAllowed = await isSignupAllowed();
             if (!signupAllowed) {
-                // Run a constant-time dummy hash to equalize response latency with
-                // the "account exists" branch above (which runs bcrypt via signInEmail).
-                // Without this, an attacker can distinguish registered from unregistered
-                // emails by measuring timing differences even though both paths return 403.
-                await Bun.password.hash(password);
+                // Run a dummy hash using Better Auth's own scrypt-based hasher to
+                // equalize response latency with the "account exists" branch above
+                // (which runs the same scrypt verifier via signInEmail). Without this,
+                // an attacker can distinguish registered from unregistered emails by
+                // measuring timing differences even though both paths return 403.
+                await betterAuthHashPassword(password);
                 return SIGNUPS_DISABLED_RESPONSE();
             }
             if (!name) {

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -58,6 +58,13 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
             .where("email", "=", email)
             .executeTakeFirst();
 
+        // Constant response used when signups are disabled, regardless of
+        // whether the email already exists. Returning the same status + body
+        // for both "email not found" and "email found but wrong password"
+        // prevents user-enumeration via differing error responses.
+        const SIGNUPS_DISABLED_RESPONSE = () =>
+            Response.json({ error: "Registration is not available." }, { status: 403 });
+
         let userId: string;
         if (existing) {
             // Verify password by attempting sign-in
@@ -65,6 +72,12 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
                 .api.signInEmail({ body: { email, password } })
                 .catch(() => null);
             if (!signIn?.user?.id) {
+                // When signups are disabled return the same 403 as "no account"
+                // so callers cannot distinguish existing vs non-existing emails.
+                const allowed = await isSignupAllowed();
+                if (!allowed) {
+                    return SIGNUPS_DISABLED_RESPONSE();
+                }
                 return Response.json({ error: "Invalid credentials" }, { status: 401 });
             }
             userId = signIn.user.id;
@@ -72,10 +85,7 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
             // Block new account creation when signups are disabled.
             const allowed = await isSignupAllowed();
             if (!allowed) {
-                return Response.json(
-                    { error: "Signups are disabled. Contact the administrator." },
-                    { status: 403 },
-                );
+                return SIGNUPS_DISABLED_RESPONSE();
             }
             if (!name) {
                 return Response.json(

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -52,9 +52,6 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: PASSWORD_REQUIREMENTS_SUMMARY }, { status: 400 });
         }
 
-        // Check signup status once, before the per-branch logic below.
-        const signupAllowed = await isSignupAllowed();
-
         const existing = await getKysely()
             .selectFrom("user")
             .select("id")
@@ -77,6 +74,7 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
             if (!signIn?.user?.id) {
                 // When signups are disabled return the same 403 as "no account"
                 // so callers cannot distinguish existing vs non-existing emails.
+                const signupAllowed = await isSignupAllowed();
                 if (!signupAllowed) {
                     return SIGNUPS_DISABLED_RESPONSE();
                 }
@@ -85,6 +83,7 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
             userId = signIn.user.id;
         } else {
             // Block new account creation when signups are disabled.
+            const signupAllowed = await isSignupAllowed();
             if (!signupAllowed) {
                 // Run a constant-time dummy hash to equalize response latency with
                 // the "account exists" branch above (which runs bcrypt via signInEmail).

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -8,7 +8,7 @@
 
 import { getApiKeyRateLimitConfig, getAuth, getKysely, isSignupAllowed } from "../auth.js";
 import { RateLimiter, isValidEmail, isValidPassword, getClientIp } from "../security.js";
-import { PASSWORD_REQUIREMENTS_SUMMARY } from "@pizzapi/protocol";
+import { PASSWORD_REQUIREMENTS_SUMMARY, MAX_PASSWORD_LENGTH } from "@pizzapi/protocol";
 import { hashPassword as betterAuthHashPassword } from "better-auth/crypto";
 import type { RouteHandler } from "./types.js";
 
@@ -47,6 +47,10 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
 
         if (!isValidEmail(email)) {
             return Response.json({ error: "Invalid email format" }, { status: 400 });
+        }
+
+        if (password.length > MAX_PASSWORD_LENGTH) {
+            return Response.json({ error: PASSWORD_REQUIREMENTS_SUMMARY }, { status: 400 });
         }
 
         if (!isValidPassword(password)) {

--- a/packages/server/src/routes/auth.ts
+++ b/packages/server/src/routes/auth.ts
@@ -52,6 +52,9 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: PASSWORD_REQUIREMENTS_SUMMARY }, { status: 400 });
         }
 
+        // Check signup status once, before the per-branch logic below.
+        const signupAllowed = await isSignupAllowed();
+
         const existing = await getKysely()
             .selectFrom("user")
             .select("id")
@@ -74,8 +77,7 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
             if (!signIn?.user?.id) {
                 // When signups are disabled return the same 403 as "no account"
                 // so callers cannot distinguish existing vs non-existing emails.
-                const allowed = await isSignupAllowed();
-                if (!allowed) {
+                if (!signupAllowed) {
                     return SIGNUPS_DISABLED_RESPONSE();
                 }
                 return Response.json({ error: "Invalid credentials" }, { status: 401 });
@@ -83,8 +85,12 @@ export const handleAuthRoute: RouteHandler = async (req, url) => {
             userId = signIn.user.id;
         } else {
             // Block new account creation when signups are disabled.
-            const allowed = await isSignupAllowed();
-            if (!allowed) {
+            if (!signupAllowed) {
+                // Run a constant-time dummy hash to equalize response latency with
+                // the "account exists" branch above (which runs bcrypt via signInEmail).
+                // Without this, an attacker can distinguish registered from unregistered
+                // emails by measuring timing differences even though both paths return 403.
+                await Bun.password.hash(password);
                 return SIGNUPS_DISABLED_RESPONSE();
             }
             if (!name) {

--- a/packages/server/tests/e2e/signup.test.ts
+++ b/packages/server/tests/e2e/signup.test.ts
@@ -242,7 +242,7 @@ describe("E2E: API key authenticates HTTP requests", () => {
 
 // ── Signup gating ─────────────────────────────────────────────────────────────
 
-describe("E2E: signup gating (disable after first user)", () => {
+describe.serial("E2E: signup gating (disable after first user)", () => {
     test("when gating is enabled, second user registration is blocked", async () => {
         // Set up a fresh DB with gating enabled
         const gatedDir = mkdtempSync(join(tmpdir(), "pizzapi-e2e-gated-"));
@@ -296,7 +296,7 @@ describe("E2E: signup gating (disable after first user)", () => {
 
 // ── User enumeration prevention ──────────────────────────────────────────────
 
-describe("E2E: /api/register does not leak account existence when signups disabled", () => {
+describe.serial("E2E: /api/register does not leak account existence when signups disabled", () => {
     test("existing email + wrong password and unknown email both return identical 403", async () => {
         // Set up a fresh DB with one user and gating enabled
         const enumDir = mkdtempSync(join(tmpdir(), "pizzapi-e2e-enum-"));

--- a/packages/server/tests/e2e/signup.test.ts
+++ b/packages/server/tests/e2e/signup.test.ts
@@ -275,7 +275,7 @@ describe("E2E: signup gating (disable after first user)", () => {
             }, { "x-forwarded-for": "10.0.3.2" });
             expect(res2.status).toBe(403);
             const data2 = await res2.json();
-            expect(data2.error).toContain("disabled");
+            expect(data2.error).toBe("Registration is not available.");
 
             // Signup status should reflect disabled state
             const statusRes = await req("GET", "/api/signup-status");
@@ -290,6 +290,109 @@ describe("E2E: signup gating (disable after first user)", () => {
                 disableSignupAfterFirstUser: false,
             });
             try { rmSync(gatedDir, { recursive: true, force: true }); } catch {}
+        }
+    });
+});
+
+// ── User enumeration prevention ──────────────────────────────────────────────
+
+describe("E2E: /api/register does not leak account existence when signups disabled", () => {
+    test("existing email + wrong password and unknown email both return identical 403", async () => {
+        // Set up a fresh DB with one user and gating enabled
+        const enumDir = mkdtempSync(join(tmpdir(), "pizzapi-e2e-enum-"));
+        const enumDbPath = join(enumDir, "enum.db");
+
+        try {
+            initAuth({
+                dbPath: enumDbPath,
+                baseURL: BASE,
+                secret: "test-secret-for-e2e-at-least-32-chars-long!!",
+                disableSignupAfterFirstUser: true,
+            });
+            await runAllMigrations();
+
+            // Register first (and only) user — signups now effectively disabled
+            const reg = await req("POST", "/api/register", {
+                name: "Enum Test User",
+                email: "enumtest@example.com",
+                password: "EnumPass123",
+            }, { "x-forwarded-for": "10.0.5.1" });
+            expect(reg.status).toBe(200);
+
+            // Path A: existing email with wrong password
+            const resExisting = await req("POST", "/api/register", {
+                name: "Enum Test User",
+                email: "enumtest@example.com",   // ← known email
+                password: "WrongPassword999",
+            }, { "x-forwarded-for": "10.0.5.2" });
+
+            // Path B: unknown email (new registration attempt, blocked)
+            const resUnknown = await req("POST", "/api/register", {
+                name: "Unknown User",
+                email: "nobody@example.com",     // ← unknown email
+                password: "SomePass123",
+            }, { "x-forwarded-for": "10.0.5.3" });
+
+            // Both paths MUST return the same status code
+            expect(resExisting.status).toBe(403);
+            expect(resUnknown.status).toBe(403);
+
+            // Both paths MUST return the same error body
+            const bodyExisting = await resExisting.json();
+            const bodyUnknown = await resUnknown.json();
+            expect(bodyExisting.error).toBe("Registration is not available.");
+            expect(bodyUnknown.error).toBe("Registration is not available.");
+            expect(bodyExisting.error).toBe(bodyUnknown.error);
+        } finally {
+            initAuth({
+                dbPath,
+                baseURL: BASE,
+                secret: "test-secret-for-e2e-at-least-32-chars-long!!",
+                disableSignupAfterFirstUser: false,
+            });
+            try { rmSync(enumDir, { recursive: true, force: true }); } catch {}
+        }
+    });
+
+    test("existing email + correct password still succeeds when signups disabled", async () => {
+        // Set up a fresh DB with gating enabled
+        const enumDir2 = mkdtempSync(join(tmpdir(), "pizzapi-e2e-enum2-"));
+        const enumDbPath2 = join(enumDir2, "enum2.db");
+
+        try {
+            initAuth({
+                dbPath: enumDbPath2,
+                baseURL: BASE,
+                secret: "test-secret-for-e2e-at-least-32-chars-long!!",
+                disableSignupAfterFirstUser: true,
+            });
+            await runAllMigrations();
+
+            // Register the first user
+            const reg = await req("POST", "/api/register", {
+                name: "Returning User",
+                email: "returning@example.com",
+                password: "ReturnPass123",
+            }, { "x-forwarded-for": "10.0.6.1" });
+            expect(reg.status).toBe(200);
+
+            // Re-register with correct credentials — should succeed (key rotation)
+            const reReg = await req("POST", "/api/register", {
+                email: "returning@example.com",
+                password: "ReturnPass123",
+            }, { "x-forwarded-for": "10.0.6.2" });
+            expect(reReg.status).toBe(200);
+            const data = await reReg.json();
+            expect(data.ok).toBe(true);
+            expect(typeof data.key).toBe("string");
+        } finally {
+            initAuth({
+                dbPath,
+                baseURL: BASE,
+                secret: "test-secret-for-e2e-at-least-32-chars-long!!",
+                disableSignupAfterFirstUser: false,
+            });
+            try { rmSync(enumDir2, { recursive: true, force: true }); } catch {}
         }
     });
 });


### PR DESCRIPTION
## Problem
`/api/register` leaked account existence when signups were disabled:
- Existing email + wrong password → 401 "Invalid credentials"
- Non-existing email → 403 "Signups are disabled"

Different responses enabled user enumeration.

## Fix
When signups are disabled, both paths now return identical `403 "Registration is not available."` responses, preventing attackers from distinguishing existing vs non-existing accounts.

Existing users with correct credentials still authenticate successfully.

## Tests
Added tests verifying both paths return identical status + body when signups disabled.

**Godmother:** closes xgjL0sA5 (P3 security bug)