### PR TITLE
fix(push): remove || true from unsubscribePush return value

### DIFF
--- a/packages/server/src/push.test.ts
+++ b/packages/server/src/push.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeAll, afterEach } from "bun:test";
+import { getKysely } from "./auth.js";
+import { unsubscribePush } from "./push.js";
+
+beforeAll(async () => {
+    await getKysely().schema
+        .createTable("push_subscription")
+        .ifNotExists()
+        .addColumn("id", "text", (col) => col.primaryKey())
+        .addColumn("userId", "text", (col) => col.notNull())
+        .addColumn("endpoint", "text", (col) => col.notNull())
+        .addColumn("keys", "text", (col) => col.notNull())
+        .addColumn("createdAt", "text", (col) => col.notNull())
+        .addColumn("enabledEvents", "text", (col) => col.notNull().defaultTo("*"))
+        .execute();
+});
+
+afterEach(async () => {
+    await getKysely().deleteFrom("push_subscription" as any).execute();
+});
+
+describe("unsubscribePush", () => {
+    it("returns true when a matching subscription is deleted", async () => {
+        const db = getKysely();
+        const now = new Date().toISOString();
+        await db
+            .insertInto("push_subscription" as any)
+            .values({
+                id: "sub-1",
+                userId: "user-1",
+                endpoint: "https://example.com/push/1",
+                keys: "{}",
+                createdAt: now,
+                enabledEvents: "*",
+            })
+            .execute();
+
+        const result = await unsubscribePush("user-1", "https://example.com/push/1");
+        expect(result).toBe(true);
+    });
+
+    it("returns false when no matching subscription exists", async () => {
+        const result = await unsubscribePush("user-1", "https://example.com/push/nonexistent");
+        expect(result).toBe(false);
+    });
+
+    it("returns false when userId does not match", async () => {
+        const db = getKysely();
+        const now = new Date().toISOString();
+        await db
+            .insertInto("push_subscription" as any)
+            .values({
+                id: "sub-2",
+                userId: "user-1",
+                endpoint: "https://example.com/push/2",
+                keys: "{}",
+                createdAt: now,
+                enabledEvents: "*",
+            })
+            .execute();
+
+        const result = await unsubscribePush("wrong-user", "https://example.com/push/2");
+        expect(result).toBe(false);
+    });
+});

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -137,7 +137,7 @@ export async function unsubscribePush(userId: string, endpoint: string): Promise
         .where("endpoint", "=", endpoint)
         .execute();
 
-    return (result as any)[0]?.numDeletedRows > 0 || true;
+    return (result as any)[0]?.numDeletedRows > 0;
 }
 
 export async function unsubscribePushById(userId: string, subscriptionId: string): Promise<void> {


### PR DESCRIPTION
## Problem
`unsubscribePush()` always returned `true` due to `|| true` in the return expression:
```ts
return (result as any)[0]?.numDeletedRows > 0 || true
```

## Fix
Removed `|| true` so the function correctly returns whether rows were actually deleted.

## Tests
Added 3 tests covering: successful deletion returns true, no-match returns false, wrong userId returns false.

**Godmother:** closes xgjL0sA5 (P4 bug)