### PR TITLE
fix(daemon): fix pid template literal and replace per-session TTL timers with sweep

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -145,8 +145,19 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         // disconnect).  Entries auto-expire after 5 min — must be comfortably
         // longer than the relay's sweep interval (default 60 s) to avoid
         // re-logging on the next sweep cycle.
-        const endedSessionIds = new Set<string>();
+        // Map of sessionId → timestamp (ms) when the entry was recorded.
+        // A single shared sweep interval purges stale entries rather than
+        // scheduling one setTimeout per session (which scales linearly with
+        // session churn under high load).
+        const endedSessionIds = new Map<string, number>();
         const ENDED_SESSION_TTL_MS = 5 * 60_000;
+        const ENDED_SESSION_SWEEP_MS = 60_000; // sweep every 60 s
+        const endedSessionSweep = setInterval(() => {
+            const now = Date.now();
+            for (const [id, ts] of endedSessionIds) {
+                if (now - ts >= ENDED_SESSION_TTL_MS) endedSessionIds.delete(id);
+            }
+        }, ENDED_SESSION_SWEEP_MS);
         const runnerName = process.env.PIZZAPI_RUNNER_NAME?.trim() || hostname();
         let runnerId: string | null = null;
         let isFirstConnect = true;
@@ -171,6 +182,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         const shutdown = (code: number) => {
             if (isShuttingDown) return;
             isShuttingDown = true;
+            clearInterval(endedSessionSweep);
             killAllTerminals();
             stopUsageRefreshLoop();
             releaseStateLock(statePath);
@@ -390,13 +402,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     return;
                 }
                 runningSessions.delete(sessionId);
-                endedSessionIds.add(sessionId);
-                setTimeout(() => endedSessionIds.delete(sessionId), ENDED_SESSION_TTL_MS);
+                endedSessionIds.set(sessionId, Date.now());
                 logInfo(`session ${sessionId} ended on relay${entry.adopted ? " (adopted)" : ""}${reason ? ` (${reason})` : ""}`);
             } else if (!endedSessionIds.has(sessionId)) {
                 // First duplicate — log once then suppress subsequent copies
-                endedSessionIds.add(sessionId);
-                setTimeout(() => endedSessionIds.delete(sessionId), ENDED_SESSION_TTL_MS);
+                endedSessionIds.set(sessionId, Date.now());
                 logInfo(`session_ended for unknown/already-removed session ${sessionId}`);
             }
             // else: duplicate session_ended for a session we already handled — silently ignore

--- a/packages/cli/src/runner/runner-state.ts
+++ b/packages/cli/src/runner/runner-state.ts
@@ -63,7 +63,7 @@ export function acquireStateAndIdentity(statePath: string): { runnerId: string; 
             if (Number.isFinite(pid) && pid > 0) {
                 if (isPidRunning(pid)) {
                     logError(`pizzapi runner already running (pid ${pid}, state: ${statePath}).`);
-                    logError("   Stop the existing runner process first, e.g.: kill ${pid}");
+                    logError(`   Stop the existing runner process first, e.g.: kill ${pid}`);
                     process.exit(1);
                 }
                 // PID is gone or belongs to an unrelated process — stale lock.


### PR DESCRIPTION
## Fixes

### Bug 1: Literal \${pid} in error message
Runner lock error printed `kill ${pid}` literally instead of the actual PID. Fixed by using backtick template literals.

### Bug 2: Per-session TTL timer accumulation
Each ended session scheduled its own `setTimeout(..., 5min)` to clear its dedup entry. Under high churn, timer count scaled linearly with session turnover.

**Fix:** Replaced with a single shared `setInterval` sweep (every 60s) that purges entries older than 5 minutes. Uses `Map<string, number>` (session ID → timestamp) instead of `Set`. Sweep interval is properly cleaned up in `shutdown()`.

**Godmother:** closes WlWQUIk0 (P3), AMaXZH9u (P4)