### PR TITLE
fix(tools): wrap read_file/write_file fs operations in try/catch for graceful errors

### DIFF
--- a/packages/tools/src/read-file.test.ts
+++ b/packages/tools/src/read-file.test.ts
@@ -92,6 +92,24 @@ describe("readFileTool", () => {
         });
     });
 
+    describe("fs error handling", () => {
+        test("returns graceful error for nonexistent file", async () => {
+            const result = await execRead(join(tmpDir, "does-not-exist.txt"));
+            expect(result.content[0].text).toContain("❌");
+            expect(result.content[0].text).toContain("File not found");
+            expect(result.details.size).toBe(0);
+            expect(result.details.error).toBe("ENOENT");
+        });
+
+        test("returns graceful error when reading a directory as a file", async () => {
+            const result = await execRead(tmpDir);
+            expect(result.content[0].text).toContain("❌");
+            // EISDIR on most platforms, or a generic fs error — either is acceptable
+            expect(result.details.size).toBe(0);
+            expect(result.details.error).toBeTruthy();
+        });
+    });
+
     test("has correct tool metadata", () => {
         expect(readFileTool.name).toBe("read_file");
         expect(readFileTool.label).toBe("Read File");

--- a/packages/tools/src/read-file.ts
+++ b/packages/tools/src/read-file.ts
@@ -20,7 +20,24 @@ export const readFileTool: AgentTool = {
                 details: { path: params.path, size: 0, sandboxBlocked: true },
             };
         }
-        const content = await readFile(params.path, "utf-8");
+        let content: string;
+        try {
+            content = await readFile(params.path, "utf-8");
+        } catch (err: any) {
+            const code: string = err.code ?? "";
+            const reason =
+                code === "ENOENT"
+                    ? `File not found: ${params.path}`
+                    : code === "EACCES"
+                      ? `Permission denied: ${params.path}`
+                      : code === "EISDIR"
+                        ? `Path is a directory, not a file: ${params.path}`
+                        : `Failed to read ${params.path}: ${err.message ?? String(err)}`;
+            return {
+                content: [{ type: "text" as const, text: `❌ ${reason}` }],
+                details: { path: params.path, size: 0, error: code || err.message },
+            };
+        }
         return {
             content: [{ type: "text" as const, text: content }],
             details: { path: params.path, size: content.length },

--- a/packages/tools/src/write-file.test.ts
+++ b/packages/tools/src/write-file.test.ts
@@ -91,6 +91,25 @@ describe("writeFileTool", () => {
         });
     });
 
+    describe("fs error handling", () => {
+        test("returns graceful error when writing to a path whose parent cannot be created (root-owned)", async () => {
+            // /proc is always present and non-writable on Linux; use a clearly inaccessible path on macOS too
+            const unwritablePath = "/root/pizzapi-test-canary/out.txt";
+            const result = await execWrite(unwritablePath, "content");
+            expect(result.content[0].text).toContain("❌");
+            expect(result.details.size).toBe(0);
+            expect(result.details.error).toBeTruthy();
+        });
+
+        test("returns graceful error when writing to a directory path", async () => {
+            // Attempt to write to a path that already exists as a directory
+            const result = await execWrite(tmpDir, "content");
+            expect(result.content[0].text).toContain("❌");
+            expect(result.details.size).toBe(0);
+            expect(result.details.error).toBeTruthy();
+        });
+    });
+
     test("has correct tool metadata", () => {
         expect(writeFileTool.name).toBe("write_file");
         expect(writeFileTool.label).toBe("Write File");

--- a/packages/tools/src/write-file.ts
+++ b/packages/tools/src/write-file.ts
@@ -22,8 +22,26 @@ export const writeFileTool: AgentTool = {
                 details: { path: params.path, size: 0, sandboxBlocked: true },
             };
         }
-        await mkdir(dirname(params.path), { recursive: true });
-        await writeFile(params.path, params.content, "utf-8");
+        try {
+            await mkdir(dirname(params.path), { recursive: true });
+            await writeFile(params.path, params.content, "utf-8");
+        } catch (err: any) {
+            const code: string = err.code ?? "";
+            const reason =
+                code === "EACCES"
+                    ? `Permission denied: ${params.path}`
+                    : code === "ENOSPC"
+                      ? `No space left on device while writing: ${params.path}`
+                      : code === "EISDIR"
+                        ? `Path is a directory, not a file: ${params.path}`
+                        : code === "ENOENT"
+                          ? `Parent directory could not be created for: ${params.path}`
+                          : `Failed to write ${params.path}: ${err.message ?? String(err)}`;
+            return {
+                content: [{ type: "text" as const, text: `❌ ${reason}` }],
+                details: { path: params.path, size: 0, error: code || err.message },
+            };
+        }
         return {
             content: [{ type: "text" as const, text: `Wrote ${params.content.length} bytes to ${params.path}` }],
             details: { path: params.path, size: params.content.length },


### PR DESCRIPTION
## Problem
`read_file` and `write_file` tools propagated raw fs/promises exceptions (ENOENT, EACCES, etc.) directly, causing tool exceptions instead of user-friendly error output.

## Fix
Wrapped filesystem operations in try/catch blocks. Returns structured error content with human-readable messages mapped from error codes:
- ENOENT → "File not found"
- EACCES → "Permission denied"
- EISDIR → "Path is a directory"
- ENOSPC → "No space left on device"

## Tests
Added tests for error cases: nonexistent file read, directory read, unwritable path, directory-as-file write.

137 pass, 1 skip (expected), 0 fail.

**Godmother:** closes m5asses3 (P3 bug)