### PR TITLE
refactor(cli): extract AskUserQuestion prompt fragment from BUILTIN_SYSTEM_PROMPT

### DIFF
--- a/packages/cli/src/config/system-prompt.test.ts
+++ b/packages/cli/src/config/system-prompt.test.ts
@@ -1,0 +1,55 @@
+import { describe, test, expect } from "bun:test";
+import { BUILTIN_SYSTEM_PROMPT } from "./system-prompt.js";
+import { ASK_USER_QUESTION_PROMPT_FRAGMENT } from "../prompts/ask-user-question.js";
+
+describe("BUILTIN_SYSTEM_PROMPT", () => {
+    test("contains the full AskUserQuestion fragment verbatim", () => {
+        const fragmentText = ASK_USER_QUESTION_PROMPT_FRAGMENT.join(" ");
+        expect(BUILTIN_SYSTEM_PROMPT).toContain(fragmentText);
+    });
+
+    test("fragment is flanked by Toggle Plan Mode section and Sandbox section", () => {
+        // Verify the fragment sits in the right place in the prompt
+        const beforeFragment = "Do not exit plan mode without first submitting a plan via `plan_mode` unless the task is trivial.\n";
+        const firstFragmentLine = "## Asking Questions — AskUserQuestion\n";
+        const lastFragmentLine = "If you are a child session, keep AskUserQuestion calls simple: one question with radio-style options.\n";
+        const afterFragment = "## Sandbox\n";
+
+        const beforeIdx = BUILTIN_SYSTEM_PROMPT.indexOf(beforeFragment);
+        const firstIdx = BUILTIN_SYSTEM_PROMPT.indexOf(firstFragmentLine);
+        const lastIdx = BUILTIN_SYSTEM_PROMPT.indexOf(lastFragmentLine);
+        const afterIdx = BUILTIN_SYSTEM_PROMPT.indexOf(afterFragment);
+
+        expect(beforeIdx).toBeGreaterThan(-1);
+        expect(firstIdx).toBeGreaterThan(beforeIdx);
+        expect(lastIdx).toBeGreaterThan(firstIdx);
+        expect(afterIdx).toBeGreaterThan(lastIdx);
+    });
+
+    test("fragment includes all three question type descriptions", () => {
+        const fragmentText = ASK_USER_QUESTION_PROMPT_FRAGMENT.join(" ");
+        expect(fragmentText).toContain('"radio"');
+        expect(fragmentText).toContain('"checkbox"');
+        expect(fragmentText).toContain('"ranked"');
+    });
+
+    test("composed prompt is a non-empty string", () => {
+        expect(typeof BUILTIN_SYSTEM_PROMPT).toBe("string");
+        expect(BUILTIN_SYSTEM_PROMPT.length).toBeGreaterThan(0);
+    });
+
+    test("prompt still contains all major sections", () => {
+        const sections = [
+            "## Spawning Sessions & Linked Sessions",
+            "## Subagent Tool",
+            "## Plan Mode",
+            "## Toggle Plan Mode",
+            "## Asking Questions — AskUserQuestion",
+            "## Sandbox",
+            "## PizzaPi Configuration",
+        ];
+        for (const section of sections) {
+            expect(BUILTIN_SYSTEM_PROMPT).toContain(section);
+        }
+    });
+});

--- a/packages/cli/src/config/system-prompt.ts
+++ b/packages/cli/src/config/system-prompt.ts
@@ -1,3 +1,5 @@
+import { ASK_USER_QUESTION_PROMPT_FRAGMENT } from "../prompts/ask-user-question.js";
+
 /**
  * Built-in system prompt additions — always appended by the CLI.
  * User config `appendSystemPrompt` is concatenated after this.
@@ -51,19 +53,7 @@ export const BUILTIN_SYSTEM_PROMPT = [
     "plan mode exits automatically when the user approves the plan ('Clear Context & Begin' or 'Begin'),",
     "so you do NOT need to call `toggle_plan_mode` after approval — just proceed with execution.",
     "Do not exit plan mode without first submitting a plan via `plan_mode` unless the task is trivial.\n",
-    "## Asking Questions — AskUserQuestion\n",
-    "Use `AskUserQuestion` when you need user input to proceed.",
-    "It renders interactive UI elements (buttons, checkboxes, drag-to-rank) that are much easier to interact with than plain-text questions, especially on mobile.\n",
-    "Each question has a `type` field:\n",
-    "- `\"radio\"` (default) — Single-select. User picks exactly one option. Best for simple either/or decisions, choosing between approaches, or yes/no confirmations.\n",
-    "- `\"checkbox\"` — Multi-select. User must pick at least one option. Best for feature selection, choosing which items to include, or any \"select all that apply\" scenario. If \"none\" is a valid answer, include an explicit \"None\" option.\n",
-    "- `\"ranked\"` — Ranked-choice ordering. User drags options into priority order. Best for prioritization questions like \"which of these should we tackle first?\"\n",
-    "Always provide pre-defined `options` for every question. The UI automatically adds a \"Write your own...\" free-form option, so you don't need to include one. Good options save the user time.\n",
-    "Use the `questions` array to ask multiple questions at once — the UI renders them as a stepper (one at a time).",
-    "Batch related questions together rather than making multiple separate tool calls.\n",
-    "**Note:** In linked child sessions (spawned via `spawn_session`), the full multi-question, checkbox, and ranked UI is NOT available.",
-    "The trigger system flattens questions into a single prompt with a flat option list for the parent agent.",
-    "If you are a child session, keep AskUserQuestion calls simple: one question with radio-style options.\n",
+    ...ASK_USER_QUESTION_PROMPT_FRAGMENT,
     "## Sandbox\n",
     "This session may run with OS-level sandbox restrictions that control which files you can read/write",
     "and which network domains are accessible. If a tool call is blocked by the sandbox,",

--- a/packages/cli/src/prompts/ask-user-question.ts
+++ b/packages/cli/src/prompts/ask-user-question.ts
@@ -1,0 +1,24 @@
+/**
+ * Prompt fragment: AskUserQuestion guidance.
+ *
+ * Extracted from BUILTIN_SYSTEM_PROMPT for maintainability.
+ * Composed back into the system prompt via spread in system-prompt.ts.
+ *
+ * When updating AskUserQuestion type guidance or UI behaviour, edit here only —
+ * changes are automatically included in BUILTIN_SYSTEM_PROMPT.
+ */
+export const ASK_USER_QUESTION_PROMPT_FRAGMENT: string[] = [
+    "## Asking Questions — AskUserQuestion\n",
+    "Use `AskUserQuestion` when you need user input to proceed.",
+    "It renders interactive UI elements (buttons, checkboxes, drag-to-rank) that are much easier to interact with than plain-text questions, especially on mobile.\n",
+    "Each question has a `type` field:\n",
+    "- `\"radio\"` (default) — Single-select. User picks exactly one option. Best for simple either/or decisions, choosing between approaches, or yes/no confirmations.\n",
+    "- `\"checkbox\"` — Multi-select. User must pick at least one option. Best for feature selection, choosing which items to include, or any \"select all that apply\" scenario. If \"none\" is a valid answer, include an explicit \"None\" option.\n",
+    "- `\"ranked\"` — Ranked-choice ordering. User drags options into priority order. Best for prioritization questions like \"which of these should we tackle first?\"\n",
+    "Always provide pre-defined `options` for every question. The UI automatically adds a \"Write your own...\" free-form option, so you don't need to include one. Good options save the user time.\n",
+    "Use the `questions` array to ask multiple questions at once — the UI renders them as a stepper (one at a time).",
+    "Batch related questions together rather than making multiple separate tool calls.\n",
+    "**Note:** In linked child sessions (spawned via `spawn_session`), the full multi-question, checkbox, and ranked UI is NOT available.",
+    "The trigger system flattens questions into a single prompt with a flat option list for the parent agent.",
+    "If you are a child session, keep AskUserQuestion calls simple: one question with radio-style options.\n",
+];


### PR DESCRIPTION
## Problem
The AskUserQuestion type guidance (radio/checkbox/ranked descriptions) was hardcoded inline in `BUILTIN_SYSTEM_PROMPT` in config.ts, making it hard to maintain.

## Fix
- Created `packages/cli/src/prompts/ask-user-question.ts` with the extracted fragment
- Imported and composed it back into `BUILTIN_SYSTEM_PROMPT` via spread
- Output is byte-for-byte identical — pure refactor

## Tests
5 new tests verifying: fragment appears verbatim, correct section ordering, all type descriptions present, non-empty output, all major sections preserved.

**Godmother:** closes CvyocyPJ (P3 refactor)