### PR TITLE
fix(ui): resolve JSON parse error badge on AskUserQuestion tool results

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1622,6 +1622,9 @@ export function App() {
             toolName,
             content: syntheticContent,
             isError: false,
+            // Mark as a streaming partial so deduplication logic does not
+            // treat it as a terminal tool result (the tool is still in-flight).
+            isStreamingPartial: true,
           });
           scheduleToolStreamFlush();
         }

--- a/packages/ui/src/components/session-viewer/grouping.test.ts
+++ b/packages/ui/src/components/session-viewer/grouping.test.ts
@@ -326,6 +326,72 @@ describe("groupToolExecutionMessages", () => {
         expect(tc2Tool!.content).toBeTruthy();
     });
 
+    test("matches id-less tool results when preferring non-errored snapshots", () => {
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Let me ask you something" },
+                    { type: "toolCall", name: "AskUserQuestion", id: "tc1",
+                      arguments: { questions: [{ question: "Color?", options: ["Red", "Blue"] }] } },
+                ],
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "JSON Parse error: Expected '}'",
+                content: [
+                    { type: "text", text: "Let me ask you something" },
+                    { type: "toolCall", name: "AskUserQuestion", id: "tc1",
+                      arguments: '{"questions": [{"question": "Color?", "options": ["Red"' },
+                ],
+            }),
+            msg({
+                key: "r1",
+                role: "toolResult",
+                toolName: "AskUserQuestion",
+                content: [{ type: "text", text: "User answered: Red" }],
+            }),
+        ];
+
+        const result = groupToolExecutionMessages(messages);
+        const tools = result.filter((m) => m.role === "tool");
+        expect(tools).toHaveLength(1);
+        expect(tools[0].toolCallId).toBe("tc1");
+        expect(tools[0].content).toBeTruthy();
+        expect(result.filter((m) => m.role === "assistant" && m.stopReason === "error")).toHaveLength(0);
+    });
+
+    test("drops stale partial-only tool IDs removed from the final snapshot", () => {
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Running tools" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                    { type: "toolCall", name: "read_file", id: "tc2", arguments: { path: "/tmp/a.txt" } },
+                ],
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "Stream error",
+                content: [
+                    { type: "text", text: "Running tools" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+            }),
+        ];
+
+        const result = groupToolExecutionMessages(messages);
+        expect(result.filter((m) => m.role === "assistant")).toHaveLength(1);
+        expect(result.filter((m) => m.role === "tool" && m.toolCallId === "tc2")).toHaveLength(0);
+    });
+
     test("incomplete tool args fall back to empty object (not raw string)", () => {
         // When the only version of an assistant message is the errored one
         // (no streaming partial), parseToolArguments must return {} rather than

--- a/packages/ui/src/components/session-viewer/grouping.test.ts
+++ b/packages/ui/src/components/session-viewer/grouping.test.ts
@@ -241,6 +241,65 @@ describe("groupToolExecutionMessages", () => {
         const textParts = result.filter((m) => m.role === "assistant");
         expect(textParts).toHaveLength(1);
         expect(textParts[0].stopReason).toBeUndefined();
+        // Preserve the newer (timestamped) snapshot's timestamp so the assistant
+        // text doesn't sort to the end of the transcript.
+        expect(textParts[0].timestamp).toBe(12345);
+    });
+
+    test("P2: preserves assistant blocks that only exist in the newer errored snapshot", () => {
+        // Scenario: a non-errored partial contains [text, tc1], but the newer
+        // errored snapshot contains additional assistant content after the tool
+        // call. When tc1 completes successfully, we still want to keep that
+        // trailing assistant content (it is real transcript text).
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Let me ask you something" },
+                    { type: "toolCall", name: "AskUserQuestion", id: "tc1",
+                      arguments: { questions: [{ question: "Color?", options: ["Red", "Blue"] }] } },
+                ],
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "JSON Parse error: Expected '}'",
+                content: [
+                    { type: "text", text: "Let me ask you something" },
+                    { type: "toolCall", name: "AskUserQuestion", id: "tc1",
+                      arguments: '{"questions": [{"question": "Color?", "options": ["Red"' },
+                    { type: "text", text: "Trailing text that should not be lost" },
+                ],
+                timestamp: 12345,
+            }),
+            msg({
+                key: "r1",
+                role: "toolResult",
+                toolCallId: "tc1",
+                toolName: "AskUserQuestion",
+                content: [{ type: "text", text: "User answered: Red" }],
+            }),
+        ];
+
+        const result = groupToolExecutionMessages(messages);
+
+        const tools = result.filter((m) => m.role === "tool");
+        expect(tools).toHaveLength(1);
+        expect(tools[0].content).toBeTruthy();
+
+        // One assistant part before the tool call, one after it (trailing text)
+        const assistantParts = result.filter((m) => m.role === "assistant");
+        expect(assistantParts).toHaveLength(2);
+        expect(assistantParts[0].stopReason).toBeUndefined();
+        expect(assistantParts[1].stopReason).toBeUndefined();
+
+        expect(assistantParts[1].content).toEqual([
+            { type: "text", text: "Trailing text that should not be lost" },
+        ]);
+        // Timestamp should come from the newer snapshot so sorting stays correct.
+        expect(assistantParts[1].timestamp).toBe(12345);
     });
 
     test("P1: keeps errored snapshot when no tool result follows (no non-errored partial)", () => {

--- a/packages/ui/src/components/session-viewer/grouping.test.ts
+++ b/packages/ui/src/components/session-viewer/grouping.test.ts
@@ -823,6 +823,106 @@ describe("groupToolExecutionMessages", () => {
         const errorParts = assistantParts.filter((m) => m.stopReason === "error");
         expect(errorParts).toHaveLength(0);
     });
+
+    test("P2 regression: keeps latest-only tool calls when a clean snapshot wins", () => {
+        // Scenario: partial (non-errored) = [text, tc1], final (error) = [text, tc1, tc2]
+        // Result for tc1 arrives → final wins (has both IDs). But current merge
+        // logic only iterates through winner blocks and doesn't add tool calls
+        // that exist only in latest. tc2 should still be added to the transcript.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Let me run these" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+            }),
+            msg({
+                key: "a2",
+                role: "assistant",
+                stopReason: "error",
+                content: [
+                    { type: "text", text: "Let me run these" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                    { type: "toolCall", name: "bash", id: "tc2", arguments: { command: "pwd" } },
+                ],
+            }),
+            msg({
+                key: "r1",
+                role: "toolResult",
+                toolCallId: "tc1",
+                toolName: "bash",
+                content: [{ type: "text", text: "file1\nfile2" }],
+            }),
+        ];
+        const result = groupToolExecutionMessages(messages);
+        // Both tc1 and tc2 must be present as grouped tools, even though only tc1
+        // has a result. tc2 should appear as a pending tool card.
+        const tools = result.filter(
+            (m) => m.role === "tool" && (m.toolCallId === "tc1" || m.toolCallId === "tc2")
+        );
+        expect(tools.length).toBeGreaterThanOrEqual(1); // At least tc1
+        const tc2Tools = result.filter((m) => m.role === "tool" && m.toolCallId === "tc2");
+        expect(tc2Tools.length).toBeGreaterThan(0);
+    });
+
+    test("P2 regression: preserves winner-only assistant text after first tool call", () => {
+        // Scenario: partial (non-errored) = [text, tc1, "Between", tc2]
+        //          final (error) = [text, tc1, tc2]
+        // Results for both tools arrive.
+        // The merge should keep the "Between" text from the winner even though
+        // it doesn't exist in the final snapshot.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Let me run two things" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                    { type: "text", text: "Between the tools" },
+                    { type: "toolCall", name: "bash", id: "tc2", arguments: { command: "pwd" } },
+                ],
+            }),
+            msg({
+                key: "a2",
+                role: "assistant",
+                stopReason: "error",
+                content: [
+                    { type: "text", text: "Let me run two things" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                    { type: "toolCall", name: "bash", id: "tc2", arguments: { command: "pwd" } },
+                ],
+            }),
+            msg({
+                key: "r1",
+                role: "toolResult",
+                toolCallId: "tc1",
+                toolName: "bash",
+                content: [{ type: "text", text: "file1" }],
+            }),
+            msg({
+                key: "r2",
+                role: "toolResult",
+                toolCallId: "tc2",
+                toolName: "bash",
+                content: [{ type: "text", text: "/home" }],
+            }),
+        ];
+        const result = groupToolExecutionMessages(messages);
+        // The merged assistant block should include both "Let me run two things"
+        // and "Between the tools" text.
+        const assistantParts = result.filter((m) => m.role === "assistant");
+        expect(assistantParts.length).toBeGreaterThan(0);
+        const assistant = assistantParts[0];
+        expect(assistant.content).toBeDefined();
+        const content = assistant.content as unknown[];
+        const textBlocks = content.filter((b) => !b || typeof b !== "object" ? false : (b as Record<string, unknown>).type === "text");
+        const allText = textBlocks.map((b) => (b as Record<string, unknown>).text || "").join(" ");
+        // Should contain both the intro and the "Between" text
+        expect(allText).toContain("Let me run two things");
+        expect(allText).toContain("Between the tools");
+    });
 });
 
 // ── groupSubAgentConversations ──────────────────────────────────────────────

--- a/packages/ui/src/components/session-viewer/grouping.test.ts
+++ b/packages/ui/src/components/session-viewer/grouping.test.ts
@@ -191,11 +191,11 @@ describe("groupToolExecutionMessages", () => {
     });
 
     test("deduplication prefers non-errored message over errored one with same toolCallId", () => {
-        // Scenario: streaming partial arrives first (no error), then a final
-        // message with stopReason: "error" and the same toolCallId arrives.
-        // Dedup keeps the LAST one. After tool result merges, the tool card
-        // shows completed but the error assistant message remains.
-        // This test documents the current behavior.
+        // Scenario: streaming partial arrives first (no error, complete args),
+        // then a final message with stopReason: "error" and the same toolCallId
+        // arrives (truncated JSON args).  Dedup should PREFER the non-errored
+        // partial so the tool card shows completed and NO error banner appears
+        // on the assistant text bubble.
         const messages: RelayMessage[] = [
             msg({
                 key: "a1-partial",
@@ -231,6 +231,41 @@ describe("groupToolExecutionMessages", () => {
         const tools = result.filter((m) => m.role === "tool");
         expect(tools).toHaveLength(1);
         expect(tools[0].content).toBeTruthy();
+        // No error banner: the errored message was dropped in favour of the
+        // non-errored partial, so no assistant part inherits stopReason "error".
+        const errorParts = result.filter(
+            (m) => m.role === "assistant" && m.stopReason === "error",
+        );
+        expect(errorParts).toHaveLength(0);
+        // The assistant text bubble should come from the non-errored partial
+        const textParts = result.filter((m) => m.role === "assistant");
+        expect(textParts).toHaveLength(1);
+        expect(textParts[0].stopReason).toBeUndefined();
+    });
+
+    test("incomplete tool args fall back to empty object (not raw string)", () => {
+        // When the only version of an assistant message is the errored one
+        // (no streaming partial), parseToolArguments must return {} rather than
+        // the raw incomplete JSON string so downstream card components always
+        // receive an object-shaped toolInput.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "JSON Parse error: Expected '}'",
+                content: [
+                    { type: "toolCall", name: "AskUserQuestion", id: "tc1",
+                      arguments: '{"questions": [{"question": "Color?", "options": ["Red"' },
+                ],
+                timestamp: 99999,
+            }),
+        ];
+        const result = groupToolExecutionMessages(messages);
+        const tools = result.filter((m) => m.role === "tool");
+        expect(tools).toHaveLength(1);
+        // toolInput must be an object (not the raw string)
+        expect(tools[0].toolInput).toEqual({});
     });
 
     test("passes through compactionSummary messages unchanged", () => {

--- a/packages/ui/src/components/session-viewer/grouping.test.ts
+++ b/packages/ui/src/components/session-viewer/grouping.test.ts
@@ -417,6 +417,111 @@ describe("groupToolExecutionMessages", () => {
         expect(tools[0].toolInput).toEqual({});
     });
 
+    test("P1 regression: streaming partial (isStreamingPartial) is not counted as a terminal result", () => {
+        // Scenario (mirrors the runtime state during a failed tool invocation):
+        //   1. Non-errored assistant partial references tc1.
+        //   2. A synthetic toolResult for tc1 arrives from tool_execution_update
+        //      (isStreamingPartial: true) — the tool is still in-flight.
+        //   3. The turn errors out; a final errored snapshot for tc1 is written.
+        //   4. No real/terminal toolResult ever arrives for tc1.
+        //
+        // Without the fix, collectToolCallIdsWithResult counts the streaming
+        // partial as proof that tc1 completed, causing the non-errored partial
+        // to be preferred and the error banner to be silently dropped.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+            }),
+            // Synthetic streaming partial — in-flight, NOT a terminal result.
+            msg({
+                key: "toolResult:tool:tc1",
+                role: "toolResult",
+                toolCallId: "tc1",
+                toolName: "bash",
+                content: [{ type: "text", text: "partial output..." }],
+                isStreamingPartial: true,
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "Stream disconnected mid-tool",
+                content: [
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+                timestamp: 12345,
+            }),
+            // No real toolResult — the stream died before the tool finished.
+        ];
+        const result = groupToolExecutionMessages(messages);
+        // The errored final must be kept so the failure banner is visible.
+        const errorParts = result.filter(
+            (m) => m.role === "assistant" && m.stopReason === "error",
+        );
+        expect(errorParts).toHaveLength(1);
+        // The non-errored partial must be dropped (it looks "pending" which is wrong).
+        const nonErroredParts = result.filter(
+            (m) => m.role === "assistant" && !m.stopReason,
+        );
+        expect(nonErroredParts).toHaveLength(0);
+    });
+
+    test("P2 regression: non-errored partial [tc1] + errored final [tc1,tc2] with tc1 result does not duplicate text", () => {
+        // Scenario: a non-errored partial covers [text, tc1]; then the stream
+        // continues and issues tc2, dying before tc2 finishes.  The errored
+        // final covers [text, tc1, tc2].  A real toolResult exists for tc1.
+        //
+        // Without the fix, the "keep if it wins for any ID" rule keeps BOTH
+        // snapshots (partial wins for tc1 via lastNonErroredIndex; final wins
+        // for tc2 via lastIndex) — the same assistant text is rendered twice.
+        //
+        // With the fix, the component has exactly ONE winner (the errored final,
+        // because the tie goes to the latest snapshot), so text appears once.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Running tools" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "Stream error",
+                content: [
+                    { type: "text", text: "Running tools" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                    { type: "toolCall", name: "read_file", id: "tc2", arguments: { path: "/a.ts" } },
+                ],
+                timestamp: 12345,
+            }),
+            // Real terminal result for tc1 only — tc2 never ran.
+            msg({
+                key: "r1",
+                role: "toolResult",
+                toolCallId: "tc1",
+                toolName: "bash",
+                content: [{ type: "text", text: "file1.txt" }],
+            }),
+        ];
+        const result = groupToolExecutionMessages(messages);
+        // Exactly one assistant text bubble — no duplication.
+        const assistantParts = result.filter((m) => m.role === "assistant");
+        expect(assistantParts).toHaveLength(1);
+        // Both tool cards must be present (tc1 with result, tc2 pending).
+        const tools = result.filter((m) => m.role === "tool");
+        expect(tools).toHaveLength(2);
+        expect(tools.find((t) => t.toolCallId === "tc1")?.content).toBeTruthy();
+        expect(tools.find((t) => t.toolCallId === "tc2")).toBeDefined();
+    });
+
     test("passes through compactionSummary messages unchanged", () => {
         const messages: RelayMessage[] = [
             msg({

--- a/packages/ui/src/components/session-viewer/grouping.test.ts
+++ b/packages/ui/src/components/session-viewer/grouping.test.ts
@@ -243,6 +243,89 @@ describe("groupToolExecutionMessages", () => {
         expect(textParts[0].stopReason).toBeUndefined();
     });
 
+    test("P1: keeps errored snapshot when no tool result follows (no non-errored partial)", () => {
+        // Scenario: partial arrives (non-errored), then stream dies producing an
+        // errored final for the same toolCallId with NO tool result ever arriving.
+        // The errored snapshot must be kept so the failure banner is visible;
+        // the non-errored partial should be dropped (it looks "pending" which is wrong).
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "toolCall", name: "AskUserQuestion", id: "tc1",
+                      arguments: { questions: [{ question: "Color?", options: ["Red"] }] } },
+                ],
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "Stream disconnected",
+                content: [
+                    { type: "toolCall", name: "AskUserQuestion", id: "tc1",
+                      arguments: '{"questions": [{"question": "Color?", "options": ["Red"' },
+                ],
+                timestamp: 12345,
+            }),
+            // No toolResult message — stream died before the tool ran.
+        ];
+        const result = groupToolExecutionMessages(messages);
+        // The errored final should be kept (not the non-errored partial),
+        // because no tool result ever arrived.
+        const errorParts = result.filter(
+            (m) => m.role === "assistant" && m.stopReason === "error",
+        );
+        expect(errorParts).toHaveLength(1);
+        // The non-errored partial should have been dropped.
+        const nonErroredParts = result.filter(
+            (m) => m.role === "assistant" && !m.stopReason,
+        );
+        expect(nonErroredParts).toHaveLength(0);
+    });
+
+    test("P2: keeps errored snapshot that introduces new tool call IDs", () => {
+        // Scenario: a non-errored partial carries [tc1], then an errored final
+        // carries [tc1, tc2].  The current "all IDs must agree" filter would
+        // discard the errored final (because tc1 prefers the partial), silently
+        // orphaning tc2.  With the "any ID" fix the errored final is kept so
+        // tc2's tool entry is created and any subsequent toolResult for tc2 can
+        // be matched.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "Stream error",
+                content: [
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                    { type: "toolCall", name: "read_file", id: "tc2", arguments: { path: "/a.ts" } },
+                ],
+                timestamp: 12345,
+            }),
+            msg({
+                key: "r2",
+                role: "toolResult",
+                toolCallId: "tc2",
+                toolName: "read_file",
+                content: [{ type: "text", text: "file content" }],
+            }),
+        ];
+        const result = groupToolExecutionMessages(messages);
+        // tc2's tool item must exist and have its result filled in.
+        const tools = result.filter((m) => m.role === "tool");
+        const tc2Tool = tools.find((t) => t.toolCallId === "tc2");
+        expect(tc2Tool).toBeDefined();
+        expect(tc2Tool!.content).toBeTruthy();
+    });
+
     test("incomplete tool args fall back to empty object (not raw string)", () => {
         // When the only version of an assistant message is the errored one
         // (no streaming partial), parseToolArguments must return {} rather than

--- a/packages/ui/src/components/session-viewer/grouping.test.ts
+++ b/packages/ui/src/components/session-viewer/grouping.test.ts
@@ -924,6 +924,78 @@ describe("groupToolExecutionMessages", () => {
         expect(allText).toContain("Let me run two things");
         expect(allText).toContain("Between the tools");
     });
+
+    test("P2: preserves latest-only text between tool calls (thread cZR)", () => {
+        // partial (non-errored) = [text, tc1]
+        // final (error) = [text, tc1, "Between", tc2] with results for both
+        // The "Between" text from the latest must survive the merge.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Start" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+            }),
+            msg({
+                key: "a2",
+                role: "assistant",
+                stopReason: "error",
+                content: [
+                    { type: "text", text: "Start" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                    { type: "text", text: "Between" },
+                    { type: "toolCall", name: "bash", id: "tc2", arguments: { command: "pwd" } },
+                ],
+            }),
+            msg({ key: "r1", role: "toolResult", toolCallId: "tc1", toolName: "bash", content: [{ type: "text", text: "out1" }] }),
+            msg({ key: "r2", role: "toolResult", toolCallId: "tc2", toolName: "bash", content: [{ type: "text", text: "out2" }] }),
+        ];
+        const result = groupToolExecutionMessages(messages);
+        const assistantParts = result.filter((m) => m.role === "assistant");
+        const allText = assistantParts
+            .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
+            .filter((b) => b && typeof b === "object" && (b as Record<string, unknown>).type === "text")
+            .map((b) => (b as Record<string, unknown>).text || "")
+            .join(" ");
+        expect(allText).toContain("Between");
+    });
+
+    test("P2: prefers latest revision of shared assistant text (thread cZU)", () => {
+        // partial (non-errored) = ["Let me ask", tc1]
+        // final (error) = ["Let me ask you something", tc1] with result for tc1
+        // The merged text should be the latest version.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Let me ask" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+            }),
+            msg({
+                key: "a2",
+                role: "assistant",
+                stopReason: "error",
+                content: [
+                    { type: "text", text: "Let me ask you something" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+            }),
+            msg({ key: "r1", role: "toolResult", toolCallId: "tc1", toolName: "bash", content: [{ type: "text", text: "out" }] }),
+        ];
+        const result = groupToolExecutionMessages(messages);
+        const assistantParts = result.filter((m) => m.role === "assistant");
+        const allText = assistantParts
+            .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
+            .filter((b) => b && typeof b === "object" && (b as Record<string, unknown>).type === "text")
+            .map((b) => (b as Record<string, unknown>).text || "")
+            .join(" ");
+        expect(allText).toContain("Let me ask you something");
+        expect(allText).not.toContain("Let me ask you something Let me ask you something");
+    });
 });
 
 // ── groupSubAgentConversations ──────────────────────────────────────────────

--- a/packages/ui/src/components/session-viewer/grouping.test.ts
+++ b/packages/ui/src/components/session-viewer/grouping.test.ts
@@ -910,15 +910,16 @@ describe("groupToolExecutionMessages", () => {
             }),
         ];
         const result = groupToolExecutionMessages(messages);
-        // The merged assistant block should include both "Let me run two things"
-        // and "Between the tools" text.
+        // After grouping, text blocks are split across multiple assistant parts
+        // (one before each tool call). Both texts must appear somewhere in the
+        // result — check all assistant parts combined.
         const assistantParts = result.filter((m) => m.role === "assistant");
         expect(assistantParts.length).toBeGreaterThan(0);
-        const assistant = assistantParts[0];
-        expect(assistant.content).toBeDefined();
-        const content = assistant.content as unknown[];
-        const textBlocks = content.filter((b) => !b || typeof b !== "object" ? false : (b as Record<string, unknown>).type === "text");
-        const allText = textBlocks.map((b) => (b as Record<string, unknown>).text || "").join(" ");
+        const allText = assistantParts
+            .flatMap((m) => (Array.isArray(m.content) ? (m.content as unknown[]) : []))
+            .filter((b) => b && typeof b === "object" && (b as Record<string, unknown>).type === "text")
+            .map((b) => (b as Record<string, unknown>).text || "")
+            .join(" ");
         // Should contain both the intro and the "Between" text
         expect(allText).toContain("Let me run two things");
         expect(allText).toContain("Between the tools");

--- a/packages/ui/src/components/session-viewer/grouping.test.ts
+++ b/packages/ui/src/components/session-viewer/grouping.test.ts
@@ -451,6 +451,49 @@ describe("groupToolExecutionMessages", () => {
         expect(result.filter((m) => m.role === "tool" && m.toolCallId === "tc2")).toHaveLength(0);
     });
 
+    test("P2 regression: older partial winner does not resurrect tool calls dropped by latest snapshot", () => {
+        // Scenario: older partial has [text, tc1, tc2], latest errored has [text, tc1].
+        // tc1 gets a real result, so the vote picks the non-errored partial as winner.
+        // The merge must NOT copy tc2 from the winner since the server dropped it.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Running tools" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                    { type: "toolCall", name: "read_file", id: "tc2", arguments: { path: "/tmp/x" } },
+                ],
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "Stream error",
+                timestamp: 100,
+                content: [
+                    { type: "text", text: "Running tools" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+            }),
+            msg({
+                key: "r1",
+                role: "tool",
+                toolCallId: "tc1",
+                content: "file1.txt\nfile2.txt",
+                timestamp: 101,
+            }),
+        ];
+
+        const result = groupToolExecutionMessages(messages);
+        // tc2 should NOT appear — the latest snapshot intentionally removed it
+        const tc2Tools = result.filter((m) => m.role === "tool" && m.toolCallId === "tc2");
+        expect(tc2Tools).toHaveLength(0);
+        // tc1 should still have its result
+        const tc1Tools = result.filter((m) => m.role === "tool" && m.toolCallId === "tc1");
+        expect(tc1Tools).toHaveLength(1);
+    });
+
     test("incomplete tool args fall back to empty object (not raw string)", () => {
         // When the only version of an assistant message is the errored one
         // (no streaming partial), parseToolArguments must return {} rather than

--- a/packages/ui/src/components/session-viewer/grouping.test.ts
+++ b/packages/ui/src/components/session-viewer/grouping.test.ts
@@ -671,6 +671,158 @@ describe("groupToolExecutionMessages", () => {
         expect(result[2].role).toBe("user");
         expect(result[3].role).toBe("assistant");
     });
+
+    test("P2 regression: preserves trailing text from winner when blocks are merged", () => {
+        // Scenario: A non-errored partial has [text, tc1], an errored final has
+        // [text, tc1, trailing_text]. When tc1 completes, we prefer the partial
+        // but must preserve the trailing text from the final.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Starting task" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                ],
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "Stream error",
+                content: [
+                    { type: "text", text: "Starting task" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "ls" } },
+                    { type: "text", text: "Task in progress (tool still running)" },
+                ],
+                timestamp: 12345,
+            }),
+            msg({
+                key: "r1",
+                role: "toolResult",
+                toolCallId: "tc1",
+                toolName: "bash",
+                content: [{ type: "text", text: "output" }],
+            }),
+        ];
+        const result = groupToolExecutionMessages(messages);
+        // Should have leading text, tool card, and trailing text
+        const assistantParts = result.filter((m) => m.role === "assistant");
+        expect(assistantParts.length).toBeGreaterThanOrEqual(2);
+        // Check that trailing text is preserved
+        const trailingPart = assistantParts[assistantParts.length - 1];
+        const content = Array.isArray(trailingPart.content) ? trailingPart.content : [];
+        const trailingText = content.find((b: unknown) => {
+            if (!b || typeof b !== "object") return false;
+            const block = b as Record<string, unknown>;
+            return block.type === "text" && typeof block.text === "string" && block.text.includes("in progress");
+        });
+        expect(trailingText).toBeDefined();
+    });
+
+    test("P2 regression: deduplicates pending calls so id-less result matches correctly", () => {
+        // Scenario: partial = [bash tc1], final(error) = [bash tc1, bash tc2],
+        // result for tc1 arrives, then id-less bash result for tc2 arrives.
+        // Without dedup, pending list has stale [bash/tc1 from partial, bash/tc1
+        // from final, bash/tc2 from final], so the id-less result matches the
+        // stale tc1 entry instead of tc2. With dedup, it matches tc2 correctly.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "echo a" } },
+                ],
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "Stream error",
+                content: [
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "echo a" } },
+                    { type: "toolCall", name: "bash", id: "tc2", arguments: { command: "echo b" } },
+                ],
+                timestamp: 12345,
+            }),
+            // Real result for tc1
+            msg({
+                key: "r1",
+                role: "toolResult",
+                toolCallId: "tc1",
+                toolName: "bash",
+                content: [{ type: "text", text: "a" }],
+            }),
+            // Id-less result for bash (should match tc2, not tc1)
+            msg({
+                key: "r2",
+                role: "toolResult",
+                toolName: "bash",
+                content: [{ type: "text", text: "b" }],
+            }),
+        ];
+        const result = groupToolExecutionMessages(messages);
+        // Both tool calls should be completed with correct results
+        const tools = result.filter((m) => m.role === "tool");
+        expect(tools).toHaveLength(2);
+        const tc1Tool = tools.find((t) => t.toolCallId === "tc1");
+        const tc2Tool = tools.find((t) => t.toolCallId === "tc2");
+        expect(tc1Tool?.content).toBeTruthy();
+        expect(tc2Tool?.content).toBeTruthy();
+    });
+
+    test("P2 regression: prefers non-errored snapshot when all tools complete (tie-break)", () => {
+        // Scenario: partial = [text, tc1], final(error) = [text, tc1, tc2],
+        // results for both tc1 and tc2 arrive. Without the fix, the vote ties
+        // (tc1 votes partial, tc2 votes final) and the tie-break picks latest
+        // (errored final), so ERROR badge persists. With the fix, when all
+        // tools complete, we prefer the non-errored partial.
+        const messages: RelayMessage[] = [
+            msg({
+                key: "a1-partial",
+                role: "assistant",
+                content: [
+                    { type: "text", text: "Running both tools" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "cmd1" } },
+                ],
+            }),
+            msg({
+                key: "a1-final",
+                role: "assistant",
+                stopReason: "error",
+                errorMessage: "Stream error",
+                content: [
+                    { type: "text", text: "Running both tools" },
+                    { type: "toolCall", name: "bash", id: "tc1", arguments: { command: "cmd1" } },
+                    { type: "toolCall", name: "bash", id: "tc2", arguments: { command: "cmd2" } },
+                ],
+                timestamp: 12345,
+            }),
+            // Result for tc1
+            msg({
+                key: "r1",
+                role: "toolResult",
+                toolCallId: "tc1",
+                toolName: "bash",
+                content: [{ type: "text", text: "out1" }],
+            }),
+            // Result for tc2
+            msg({
+                key: "r2",
+                role: "toolResult",
+                toolCallId: "tc2",
+                toolName: "bash",
+                content: [{ type: "text", text: "out2" }],
+            }),
+        ];
+        const result = groupToolExecutionMessages(messages);
+        // The assistant text should come from the non-errored partial
+        const assistantParts = result.filter((m) => m.role === "assistant");
+        expect(assistantParts.length).toBeGreaterThan(0);
+        // Should NOT have error badge since all tools completed
+        const errorParts = assistantParts.filter((m) => m.stopReason === "error");
+        expect(errorParts).toHaveLength(0);
+    });
 });
 
 // ── groupSubAgentConversations ──────────────────────────────────────────────

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -54,21 +54,84 @@ function shouldGroupToolCall(_toolName: string): boolean {
 function extractGroupedToolCallIds(message: RelayMessage): Set<string> {
   const ids = new Set<string>();
   if (message.role !== "assistant" || !Array.isArray(message.content)) return ids;
+  for (const pending of extractGroupedPendingToolCalls(message)) {
+    if (pending.toolCallId) ids.add(pending.toolCallId);
+  }
+  return ids;
+}
+
+function extractGroupedPendingToolCalls(message: RelayMessage): PendingToolCall[] {
+  const pending: PendingToolCall[] = [];
+  if (message.role !== "assistant" || !Array.isArray(message.content)) return pending;
+
   for (const block of message.content) {
     if (!block || typeof block !== "object") continue;
     const b = block as Record<string, unknown>;
     if (b.type !== "toolCall") continue;
+
     const toolName = typeof b.name === "string" ? b.name : "unknown";
     if (!shouldGroupToolCall(toolName)) continue;
-    const id =
+
+    const toolCallId =
       typeof b.toolCallId === "string"
         ? b.toolCallId
         : typeof b.id === "string"
           ? b.id
           : "";
-    if (id) ids.add(id);
+
+    pending.push({
+      toolCallId,
+      toolName,
+      args: parseToolArguments(b.arguments),
+    });
   }
-  return ids;
+
+  return pending;
+}
+
+function collectToolCallIdsWithResult(messages: RelayMessage[]): Set<string> {
+  const toolCallIdsWithResult = new Set<string>();
+  const pendingToolCalls: PendingToolCall[] = [];
+
+  for (const message of messages) {
+    if (message.role === "assistant") {
+      pendingToolCalls.push(...extractGroupedPendingToolCalls(message));
+      continue;
+    }
+
+    if (message.role !== "toolResult" && message.role !== "tool") continue;
+
+    let matchedPendingIndex = -1;
+
+    if (message.toolCallId) {
+      matchedPendingIndex = pendingToolCalls.findIndex(
+        (pending) => pending.toolCallId && pending.toolCallId === message.toolCallId
+      );
+    }
+
+    if (matchedPendingIndex < 0) {
+      const normalizedName = normalizeToolName(message.toolName);
+      matchedPendingIndex = pendingToolCalls.findIndex(
+        (pending) => normalizeToolName(pending.toolName) === normalizedName
+      );
+    }
+
+    if (matchedPendingIndex < 0 && pendingToolCalls.length > 0) {
+      matchedPendingIndex = 0;
+    }
+
+    const matched =
+      matchedPendingIndex >= 0
+        ? pendingToolCalls.splice(matchedPendingIndex, 1)[0]
+        : undefined;
+    const matchedToolCallId = message.toolCallId ?? matched?.toolCallId;
+
+    if (matchedToolCallId) {
+      toolCallIdsWithResult.add(matchedToolCallId);
+    }
+  }
+
+  return toolCallIdsWithResult;
 }
 
 /**
@@ -93,60 +156,93 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
   const lastNonErroredIndexForToolCallId = new Map<string, number>();
   // Cache the extracted IDs for each message index to avoid re-parsing the content during the filter pass.
   const messageIdsMap = new Map<number, Set<string>>();
+  const assistantIndexes: number[] = [];
 
   // Pre-collect tool call IDs that have a corresponding tool result in the
-  // transcript.  We only prefer a non-errored partial over an errored final
-  // when the tool actually ran (i.e. a result exists); otherwise the errored
-  // snapshot is the most informative version and should be kept.
-  const toolCallIdsWithResult = new Set<string>();
-  for (const msg of messages) {
-    if ((msg.role === "toolResult" || msg.role === "tool") && msg.toolCallId) {
-      toolCallIdsWithResult.add(msg.toolCallId);
-    }
-  }
+  // transcript, including legacy toolResult messages that only match back to a
+  // pending tool call by tool name / order.
+  const toolCallIdsWithResult = collectToolCallIdsWithResult(messages);
 
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
     if (msg.role !== "assistant") continue;
     const ids = extractGroupedToolCallIds(msg);
-    if (ids.size > 0) {
-      messageIdsMap.set(i, ids);
-      for (const id of ids) {
-        lastIndexForToolCallId.set(id, i);
-        // Only record the non-errored index when a tool result exists for this
-        // ID.  If no result ever arrives the errored snapshot is the right one
-        // to surface (it carries the failure state); recording a non-errored
-        // partial here would cause the filter below to prefer the partial and
-        // silently drop the error banner.
-        if (msg.stopReason !== "error" && toolCallIdsWithResult.has(id)) {
-          lastNonErroredIndexForToolCallId.set(id, i);
-        }
+    if (ids.size === 0) continue;
+
+    assistantIndexes.push(i);
+    messageIdsMap.set(i, ids);
+
+    for (const id of ids) {
+      lastIndexForToolCallId.set(id, i);
+      // Only record the non-errored index when a tool result exists for this
+      // ID.  If no result ever arrives the errored snapshot is the right one
+      // to surface (it carries the failure state); recording a non-errored
+      // partial here would cause the filter below to prefer the partial and
+      // silently drop the error banner.
+      if (msg.stopReason !== "error" && toolCallIdsWithResult.has(id)) {
+        lastNonErroredIndexForToolCallId.set(id, i);
       }
     }
   }
 
   if (lastIndexForToolCallId.size === 0) return messages;
 
+  // Assistant snapshots that share toolCallIds represent alternate versions of
+  // the same turn.  When a later snapshot drops one of the earlier IDs, that
+  // dropped ID is stale and should not keep the earlier partial alive.
+  const componentValidIdsByMessageIndex = new Map<number, Set<string>>();
+  const visitedAssistantIndexes = new Set<number>();
+
+  for (const startIndex of assistantIndexes) {
+    if (visitedAssistantIndexes.has(startIndex)) continue;
+
+    const queue = [startIndex];
+    const component: number[] = [];
+    visitedAssistantIndexes.add(startIndex);
+
+    while (queue.length > 0) {
+      const currentIndex = queue.shift()!;
+      component.push(currentIndex);
+      const currentIds = messageIdsMap.get(currentIndex)!;
+
+      for (const candidateIndex of assistantIndexes) {
+        if (visitedAssistantIndexes.has(candidateIndex)) continue;
+        const candidateIds = messageIdsMap.get(candidateIndex)!;
+        const overlaps = [...candidateIds].some((id) => currentIds.has(id));
+        if (!overlaps) continue;
+        visitedAssistantIndexes.add(candidateIndex);
+        queue.push(candidateIndex);
+      }
+    }
+
+    const latestIndex = Math.max(...component);
+    const validIds = new Set(messageIdsMap.get(latestIndex)!);
+    for (const index of component) {
+      componentValidIdsByMessageIndex.set(index, validIds);
+    }
+  }
+
   // For each assistant message, determine the "preferred" index for each of
-  // its tool call IDs:
+  // its still-relevant tool call IDs:
   //   - If a non-errored version exists for this ID AND a tool result arrived,
   //     prefer the last non-errored version (avoids a spurious error badge on
   //     a successfully-completed tool).
   //   - Otherwise fall back to the last version overall (errored or not) so
   //     that the failure state is visible when no result ever arrived.
   //
-  // A message is kept when it is the preferred version for AT LEAST ONE of its
-  // IDs.  Using "any" rather than "all" ensures a later errored snapshot that
-  // introduced new tool call IDs (absent from any earlier message) is never
-  // silently dropped — without it, the only assistant message carrying those
-  // new IDs would be discarded, orphaning any later toolResult messages.
+  // A message is kept when it is the preferred version for at least one ID that
+  // still appears in the latest snapshot of its turn. This preserves newer IDs
+  // introduced by later snapshots while dropping stale partial-only IDs that a
+  // later snapshot removed.
   return messages.filter((msg, i) => {
     if (msg.role !== "assistant") return true;
-    // Use cached IDs if available; otherwise (e.g. if empty) treat as having no IDs.
+
     const ids = messageIdsMap.get(i);
     if (!ids || ids.size === 0) return true;
-    // Keep if this is the preferred version for at least one tool call ID.
+
+    const validIds = componentValidIdsByMessageIndex.get(i) ?? ids;
     for (const id of ids) {
+      if (!validIds.has(id)) continue;
       const preferredIdx = lastNonErroredIndexForToolCallId.has(id)
         ? lastNonErroredIndexForToolCallId.get(id)!
         : lastIndexForToolCallId.get(id)!;

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -441,7 +441,19 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
             }
           }
 
-          // Append any tool calls that exist only in the latest snapshot
+          // Collect text content from winner blocks so we can skip duplicates
+          // when appending new content from the latest snapshot.
+          const winnerTexts = new Set<string>();
+          for (const block of winnerBlocks) {
+            if (!block || typeof block !== "object") continue;
+            const b = block as Record<string, unknown>;
+            if (b.type === "text" && typeof b.text === "string") winnerTexts.add(b.text);
+          }
+
+          // Append any tool calls that exist only in the latest snapshot, and
+          // any non-toolCall blocks (e.g. trailing text) that don't appear in
+          // the winner — these represent content the model emitted after the
+          // errored stream ended that the winner (partial) never received.
           for (const block of latestBlocks) {
             if (!block || typeof block !== "object") continue;
             const b = block as Record<string, unknown>;
@@ -454,6 +466,11 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
                     : "";
               // Only add if this tool ID doesn't already exist in the winner
               if (id && !winnerToolIds.has(id)) {
+                mergedBlocks.push(block);
+              }
+            } else if (b.type === "text" && typeof b.text === "string") {
+              // Append text blocks that are unique to the latest snapshot
+              if (!winnerTexts.has(b.text)) {
                 mergedBlocks.push(block);
               }
             }

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -93,9 +93,25 @@ function collectToolCallIdsWithResult(messages: RelayMessage[]): Set<string> {
   const toolCallIdsWithResult = new Set<string>();
   const pendingToolCalls: PendingToolCall[] = [];
 
+  // Track which assistant indices have been seen so we can skip duplicates.
+  // When the same turn appears multiple times (partial + final), we only want
+  // to queue pending calls from the unique turns, not duplicate tool calls.
+  const seenTurns = new Map<string, number>(); // turnKey -> last assistant index
+
   for (const message of messages) {
     if (message.role === "assistant") {
-      pendingToolCalls.push(...extractGroupedPendingToolCalls(message));
+      // Build a signature of this turn (ordered tool call IDs) to detect duplicates.
+      const calls = extractGroupedPendingToolCalls(message);
+      const turnKey = calls.map((c) => c.toolCallId || `unnamed_${c.toolName}`).sort().join("|");
+
+      // If we've seen this exact turn before (same tool calls), skip it to avoid
+      // queueing duplicate pending entries that will confuse id-less result matching.
+      if (seenTurns.has(turnKey)) {
+        continue;
+      }
+      seenTurns.set(turnKey, messages.indexOf(message));
+
+      pendingToolCalls.push(...calls);
       continue;
     }
 
@@ -328,9 +344,18 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
       }
 
       // Pick the snapshot with the most votes; tie-break: prefer the latest index.
+      // UNLESS all tools have completed results, in which case prefer non-errored
+      // over errored when vote counts tie.
       let maxWins = winCount.get(latestIndex) ?? 0;
       for (const [idx, count] of winCount) {
-        if (count > maxWins || (count === maxWins && idx > winner)) {
+        const shouldUpdate =
+          count > maxWins ||
+          (count === maxWins &&
+            ((allValidIdsHaveResult &&
+              messages[idx]?.stopReason !== "error" &&
+              messages[winner]?.stopReason === "error") ||
+              (!allValidIdsHaveResult && idx > winner)));
+        if (shouldUpdate) {
           maxWins = count;
           winner = idx;
         }
@@ -346,13 +371,84 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
       const winnerBlocks = Array.isArray(winnerMsg.content) ? (winnerMsg.content as unknown[]) : null;
       const latestBlocks = Array.isArray(latestMsg.content) ? (latestMsg.content as unknown[]) : null;
 
-      // Always use the latest snapshot's block array as the authoritative tool-call
-      // set. The older (winner) snapshot may contain tool calls that the server
-      // intentionally dropped; using the longer array would resurrect them as
-      // dangling pending cards.
-      const mergedBlocks = latestBlocks ?? winnerBlocks;
+      // The authoritative tool-call set comes from the latest snapshot to avoid
+      // resurrecting tool calls that the server intentionally dropped. However,
+      // we must preserve non-toolCall blocks from the winner (text, thinking, etc.)
+      // that may not exist in the truncated latest snapshot.
+      const mergedBlocks: unknown[] = [];
+      if (latestBlocks) {
+        // Extract tool call IDs from the latest snapshot so we can preserve only
+        // those tool calls while merging in winner's non-toolCall content.
+        const latestToolIds = new Set<string>();
+        for (const block of latestBlocks) {
+          if (!block || typeof block !== "object") continue;
+          const b = block as Record<string, unknown>;
+          if (b.type === "toolCall") {
+            const id =
+              typeof b.toolCallId === "string"
+                ? b.toolCallId
+                : typeof b.id === "string"
+                  ? b.id
+                  : "";
+            if (id) latestToolIds.add(id);
+          }
+        }
 
-      if (mergedBlocks) {
+        // Merge: preserve winner's blocks up to the first tool call, then use
+        // latest's blocks (which contain the authoritative tool calls and any
+        // trailing content).
+        if (winnerBlocks) {
+          let foundFirstToolCall = false;
+          for (const block of winnerBlocks) {
+            if (!block || typeof block !== "object") {
+              if (!foundFirstToolCall) mergedBlocks.push(block);
+              continue;
+            }
+            const b = block as Record<string, unknown>;
+            if (b.type === "toolCall") {
+              foundFirstToolCall = true;
+              // Only preserve if this tool call exists in the latest snapshot.
+              const id =
+                typeof b.toolCallId === "string"
+                  ? b.toolCallId
+                  : typeof b.id === "string"
+                    ? b.id
+                    : "";
+              if (!id || latestToolIds.has(id)) {
+                // Preserve winner's version for better parsed args
+                mergedBlocks.push(block);
+              }
+            } else if (!foundFirstToolCall) {
+              // Keep non-toolCall blocks before the first tool call
+              mergedBlocks.push(block);
+            }
+          }
+
+          // Append any trailing content from the latest snapshot
+          let latestFoundFirstToolCall = false;
+          let skippedToFirstToolCall = false;
+          for (const block of latestBlocks) {
+            if (!block || typeof block !== "object") {
+              if (skippedToFirstToolCall) mergedBlocks.push(block);
+              continue;
+            }
+            const b = block as Record<string, unknown>;
+            if (b.type === "toolCall") {
+              latestFoundFirstToolCall = true;
+              skippedToFirstToolCall = true;
+            } else if (skippedToFirstToolCall) {
+              // Only append trailing non-toolCall blocks from latest
+              mergedBlocks.push(block);
+            }
+          }
+        } else {
+          mergedBlocks.push(...latestBlocks);
+        }
+      } else if (winnerBlocks) {
+        mergedBlocks.push(...winnerBlocks);
+      }
+
+      if (mergedBlocks.length > 0) {
         const argsById = collectValidToolArgsByCallId(winnerMsg);
         const patchedBlocks = argsById.size > 0 ? patchToolCallArguments(mergedBlocks, argsById) : mergedBlocks;
 

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -101,6 +101,11 @@ function collectToolCallIdsWithResult(messages: RelayMessage[]): Set<string> {
 
     if (message.role !== "toolResult" && message.role !== "tool") continue;
 
+    // Synthetic streaming partials (from tool_execution_update) are in-flight
+    // tool output — they are NOT terminal results and must not be counted as
+    // proof that a tool call completed.
+    if (message.isStreamingPartial) continue;
+
     let matchedPendingIndex = -1;
 
     if (message.toolCallId) {
@@ -187,10 +192,21 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
 
   if (lastIndexForToolCallId.size === 0) return messages;
 
-  // Assistant snapshots that share toolCallIds represent alternate versions of
-  // the same turn.  When a later snapshot drops one of the earlier IDs, that
-  // dropped ID is stale and should not keep the earlier partial alive.
-  const componentValidIdsByMessageIndex = new Map<number, Set<string>>();
+  // Group assistant snapshots that share toolCallIds into "components" — all
+  // members of a component represent alternate versions of the same turn.
+  // We pick exactly ONE winner per component to avoid rendering the same
+  // assistant text and tool cards multiple times.
+  //
+  // Winner selection per component:
+  //   - validIds = IDs present in the *latest* snapshot of the component
+  //     (earlier-only IDs were dropped by a later snapshot and are stale).
+  //   - For each valid ID, find the "preferred" snapshot:
+  //       • A non-errored snapshot wins when a tool result arrived for that ID
+  //         (prevents a spurious ERROR badge on a tool that completed fine).
+  //       • Otherwise the last snapshot wins (carries the failure state).
+  //   - Tally wins per snapshot.  The snapshot with the most wins is the
+  //     component winner; ties go to the latest snapshot (most complete).
+  const componentWinnerByIndex = new Map<number, number>();
   const visitedAssistantIndexes = new Set<number>();
 
   for (const startIndex of assistantIndexes) {
@@ -216,39 +232,43 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
     }
 
     const latestIndex = Math.max(...component);
-    const validIds = new Set(messageIdsMap.get(latestIndex)!);
-    for (const index of component) {
-      componentValidIdsByMessageIndex.set(index, validIds);
+    const validIds = messageIdsMap.get(latestIndex)!;
+    const componentSet = new Set(component);
+
+    // Tally wins: each valid ID votes for its preferred snapshot.
+    const winCount = new Map<number, number>();
+    for (const id of validIds) {
+      const preferredIdx = lastNonErroredIndexForToolCallId.has(id)
+        ? lastNonErroredIndexForToolCallId.get(id)!
+        : lastIndexForToolCallId.get(id)!;
+      // Only count if the preferred snapshot is actually in this component.
+      const resolvedIdx = componentSet.has(preferredIdx) ? preferredIdx : latestIndex;
+      winCount.set(resolvedIdx, (winCount.get(resolvedIdx) ?? 0) + 1);
+    }
+
+    // Pick the snapshot with the most votes; tie-break: prefer the latest index.
+    let winner = latestIndex;
+    let maxWins = winCount.get(latestIndex) ?? 0;
+    for (const [idx, count] of winCount) {
+      if (count > maxWins || (count === maxWins && idx > winner)) {
+        maxWins = count;
+        winner = idx;
+      }
+    }
+
+    for (const idx of component) {
+      componentWinnerByIndex.set(idx, winner);
     }
   }
 
-  // For each assistant message, determine the "preferred" index for each of
-  // its still-relevant tool call IDs:
-  //   - If a non-errored version exists for this ID AND a tool result arrived,
-  //     prefer the last non-errored version (avoids a spurious error badge on
-  //     a successfully-completed tool).
-  //   - Otherwise fall back to the last version overall (errored or not) so
-  //     that the failure state is visible when no result ever arrived.
-  //
-  // A message is kept when it is the preferred version for at least one ID that
-  // still appears in the latest snapshot of its turn. This preserves newer IDs
-  // introduced by later snapshots while dropping stale partial-only IDs that a
-  // later snapshot removed.
+  // Keep only the single winner for each component of same-turn snapshots.
   return messages.filter((msg, i) => {
     if (msg.role !== "assistant") return true;
 
     const ids = messageIdsMap.get(i);
     if (!ids || ids.size === 0) return true;
 
-    const validIds = componentValidIdsByMessageIndex.get(i) ?? ids;
-    for (const id of ids) {
-      if (!validIds.has(id)) continue;
-      const preferredIdx = lastNonErroredIndexForToolCallId.has(id)
-        ? lastNonErroredIndexForToolCallId.get(id)!
-        : lastIndexForToolCallId.get(id)!;
-      if (preferredIdx === i) return true;
-    }
-    return false;
+    return componentWinnerByIndex.get(i) === i;
   });
 }
 

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -132,13 +132,15 @@ function collectToolCallIdsWithResult(messages: RelayMessage[]): Set<string> {
 
     if (matchedPendingIndex < 0) {
       const normalizedName = normalizeToolName(message.toolName);
-      matchedPendingIndex = pendingToolCalls.findIndex(
+      // Prefer the *latest* pending call with this name so stale earlier calls
+      // don't consume results meant for newer invocations (PR #220 thread cZf_-).
+      matchedPendingIndex = pendingToolCalls.findLastIndex(
         (pending) => normalizeToolName(pending.toolName) === normalizedName
       );
     }
 
     if (matchedPendingIndex < 0 && pendingToolCalls.length > 0) {
-      matchedPendingIndex = 0;
+      matchedPendingIndex = pendingToolCalls.length - 1;
     }
 
     const matched =
@@ -443,13 +445,32 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
             mergeToolCalls.push(tc);
           }
 
-          // Add winner-only tool calls that have completed results
-          for (const tc of wSeg.tcs) {
+          // Add winner-only tool calls that have completed results,
+          // inserting at their original position from the winner snapshot
+          // rather than appending at the end (PR #220 thread cZf__).
+          for (let wi = 0; wi < wSeg.tcs.length; wi++) {
+            const tc = wSeg.tcs[wi];
             const id = tcId(tc);
-            if (id && !mergeToolIdx.has(id) && toolCallIdsWithResult.has(id)) {
-              mergeToolIdx.set(id, mergeToolCalls.length);
-              mergeToolCalls.push(tc);
+            if (!id || mergeToolIdx.has(id) || !toolCallIdsWithResult.has(id)) continue;
+
+            // Find the insertion point: after the last preceding winner TC
+            // that is already in mergeToolCalls.
+            let insertAfter = -1; // -1 means "insert at the beginning"
+            for (let j = wi - 1; j >= 0; j--) {
+              const prevId = tcId(wSeg.tcs[j]);
+              if (prevId && mergeToolIdx.has(prevId)) {
+                insertAfter = mergeToolIdx.get(prevId)!;
+                break;
+              }
             }
+
+            const insertAt = insertAfter + 1;
+            mergeToolCalls.splice(insertAt, 0, tc);
+            // Update all indices >= insertAt
+            for (const [k, v] of mergeToolIdx) {
+              if (v >= insertAt) mergeToolIdx.set(k, v + 1);
+            }
+            mergeToolIdx.set(id, insertAt);
           }
 
           // For each gap between tool calls, merge non-tool segments.
@@ -749,13 +770,15 @@ export function groupToolExecutionMessages(messages: RelayMessage[]): RelayMessa
 
       if (matchedPendingIndex < 0) {
         const normalizedName = normalizeToolName(message.toolName);
-        matchedPendingIndex = pendingToolCalls.findIndex(
+        // Prefer the *latest* pending call with this name so stale earlier
+        // calls don't consume results meant for newer invocations.
+        matchedPendingIndex = pendingToolCalls.findLastIndex(
           (p) => normalizeToolName(p.toolName) === normalizedName
         );
       }
 
       if (matchedPendingIndex < 0 && pendingToolCalls.length > 0) {
-        matchedPendingIndex = 0;
+        matchedPendingIndex = pendingToolCalls.length - 1;
       }
 
       const matched =

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -23,7 +23,10 @@ function parseToolArguments(argumentsValue: unknown): unknown {
     try {
       return JSON.parse(argumentsValue) as unknown;
     } catch {
-      return argumentsValue;
+      // Incomplete / malformed JSON (e.g. stream truncation) — return an empty
+      // object rather than the raw string so downstream code always gets an
+      // object-shaped toolInput, consistent with rendering.tsx's own fallback.
+      return {};
     }
   }
 
@@ -75,10 +78,19 @@ function extractGroupedToolCallIds(message: RelayMessage): Set<string> {
  *
  * Two assistant messages are considered duplicates of the same turn when they
  * share at least one grouped-tool toolCallId.
+ *
+ * If a non-errored version and an errored version both reference the same
+ * toolCallId, we prefer the non-errored one.  This avoids propagating
+ * stopReason="error" / errorMessage onto the content parts that are split off
+ * during grouping — which would otherwise show a spurious ERROR badge on the
+ * assistant text bubble even though the tool completed successfully.
  */
 function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] {
-  // Build a map: toolCallId → last index of an assistant message that references it.
+  // Build two maps:
+  //   toolCallId → last index of ANY assistant message that references it
+  //   toolCallId → last index of a NON-ERRORED assistant message that references it
   const lastIndexForToolCallId = new Map<string, number>();
+  const lastNonErroredIndexForToolCallId = new Map<string, number>();
   // Cache the extracted IDs for each message index to avoid re-parsing the content during the filter pass.
   const messageIdsMap = new Map<number, Set<string>>();
 
@@ -90,22 +102,30 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
       messageIdsMap.set(i, ids);
       for (const id of ids) {
         lastIndexForToolCallId.set(id, i);
+        if (msg.stopReason !== "error") {
+          lastNonErroredIndexForToolCallId.set(id, i);
+        }
       }
     }
   }
 
   if (lastIndexForToolCallId.size === 0) return messages;
 
-  // Drop any assistant message that contains grouped tool calls but is NOT the
-  // last message to reference all of those tool call IDs.
+  // For each assistant message, determine the "preferred" index for each of
+  // its tool call IDs:
+  //   - If a non-errored version exists for this ID, prefer the last such version.
+  //   - Otherwise fall back to the last version (errored or not).
   return messages.filter((msg, i) => {
     if (msg.role !== "assistant") return true;
     // Use cached IDs if available; otherwise (e.g. if empty) treat as having no IDs.
     const ids = messageIdsMap.get(i);
     if (!ids || ids.size === 0) return true;
-    // Keep only if this index is the last for every id it contains.
+    // Keep only if this index is the preferred version for every id it contains.
     for (const id of ids) {
-      if (lastIndexForToolCallId.get(id) !== i) return false;
+      const preferredIdx = lastNonErroredIndexForToolCallId.has(id)
+        ? lastNonErroredIndexForToolCallId.get(id)!
+        : lastIndexForToolCallId.get(id)!;
+      if (preferredIdx !== i) return false;
     }
     return true;
   });

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -192,6 +192,77 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
 
   if (lastIndexForToolCallId.size === 0) return messages;
 
+  const parseToolArgumentsIfValid = (argumentsValue: unknown): unknown | null => {
+    if (argumentsValue && typeof argumentsValue === "object") return argumentsValue;
+    if (typeof argumentsValue === "string") {
+      try {
+        return JSON.parse(argumentsValue) as unknown;
+      } catch {
+        return null;
+      }
+    }
+    return null;
+  };
+
+  const collectValidToolArgsByCallId = (msg: RelayMessage): Map<string, unknown> => {
+    const argsById = new Map<string, unknown>();
+    if (msg.role !== "assistant" || !Array.isArray(msg.content)) return argsById;
+
+    for (const block of msg.content) {
+      if (!block || typeof block !== "object") continue;
+      const b = block as Record<string, unknown>;
+      if (b.type !== "toolCall") continue;
+
+      const toolName = typeof b.name === "string" ? b.name : "unknown";
+      if (!shouldGroupToolCall(toolName)) continue;
+
+      const toolCallId =
+        typeof b.toolCallId === "string"
+          ? b.toolCallId
+          : typeof b.id === "string"
+            ? b.id
+            : "";
+      if (!toolCallId) continue;
+
+      const parsed = parseToolArgumentsIfValid(b.arguments);
+      if (parsed !== null) argsById.set(toolCallId, parsed);
+    }
+
+    return argsById;
+  };
+
+  const patchToolCallArguments = (blocks: unknown[], argsById: Map<string, unknown>): unknown[] => {
+    let changed = false;
+
+    const next = blocks.map((block) => {
+      if (!block || typeof block !== "object") return block;
+      const b = block as Record<string, unknown>;
+      if (b.type !== "toolCall") return block;
+
+      const toolName = typeof b.name === "string" ? b.name : "unknown";
+      if (!shouldGroupToolCall(toolName)) return block;
+
+      const toolCallId =
+        typeof b.toolCallId === "string"
+          ? b.toolCallId
+          : typeof b.id === "string"
+            ? b.id
+            : "";
+      if (!toolCallId) return block;
+
+      if (!argsById.has(toolCallId)) return block;
+      const nextArgs = argsById.get(toolCallId);
+
+      // Avoid cloning when already equal (common when winner is also the content source).
+      if (b.arguments === nextArgs) return block;
+
+      changed = true;
+      return { ...b, arguments: nextArgs };
+    });
+
+    return changed ? next : blocks;
+  };
+
   // Group assistant snapshots that share toolCallIds into "components" — all
   // members of a component represent alternate versions of the same turn.
   // We pick exactly ONE winner per component to avoid rendering the same
@@ -207,6 +278,7 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
   //   - Tally wins per snapshot.  The snapshot with the most wins is the
   //     component winner; ties go to the latest snapshot (most complete).
   const componentWinnerByIndex = new Map<number, number>();
+  const patchedAssistantByIndex = new Map<number, RelayMessage>();
   const visitedAssistantIndexes = new Set<number>();
 
   for (const startIndex of assistantIndexes) {
@@ -235,24 +307,64 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
     const validIds = messageIdsMap.get(latestIndex)!;
     const componentSet = new Set(component);
 
+    const latestMsg = messages[latestIndex]!;
+    const allValidIdsHaveResult = [...validIds].every((id) => toolCallIdsWithResult.has(id));
+
     // Tally wins: each valid ID votes for its preferred snapshot.
-    const winCount = new Map<number, number>();
-    for (const id of validIds) {
-      const preferredIdx = lastNonErroredIndexForToolCallId.has(id)
-        ? lastNonErroredIndexForToolCallId.get(id)!
-        : lastIndexForToolCallId.get(id)!;
-      // Only count if the preferred snapshot is actually in this component.
-      const resolvedIdx = componentSet.has(preferredIdx) ? preferredIdx : latestIndex;
-      winCount.set(resolvedIdx, (winCount.get(resolvedIdx) ?? 0) + 1);
+    // If the latest snapshot is errored AND any tool never produced a terminal
+    // result, force the latest snapshot to win so we don't silently drop the
+    // failure state.
+    let winner = latestIndex;
+
+    if (!(latestMsg.stopReason === "error" && !allValidIdsHaveResult)) {
+      const winCount = new Map<number, number>();
+      for (const id of validIds) {
+        const preferredIdx = lastNonErroredIndexForToolCallId.has(id)
+          ? lastNonErroredIndexForToolCallId.get(id)!
+          : lastIndexForToolCallId.get(id)!;
+        // Only count if the preferred snapshot is actually in this component.
+        const resolvedIdx = componentSet.has(preferredIdx) ? preferredIdx : latestIndex;
+        winCount.set(resolvedIdx, (winCount.get(resolvedIdx) ?? 0) + 1);
+      }
+
+      // Pick the snapshot with the most votes; tie-break: prefer the latest index.
+      let maxWins = winCount.get(latestIndex) ?? 0;
+      for (const [idx, count] of winCount) {
+        if (count > maxWins || (count === maxWins && idx > winner)) {
+          maxWins = count;
+          winner = idx;
+        }
+      }
     }
 
-    // Pick the snapshot with the most votes; tie-break: prefer the latest index.
-    let winner = latestIndex;
-    let maxWins = winCount.get(latestIndex) ?? 0;
-    for (const [idx, count] of winCount) {
-      if (count > maxWins || (count === maxWins && idx > winner)) {
-        maxWins = count;
-        winner = idx;
+    // If we pick an older non-errored snapshot, preserve the newer snapshot's
+    // timestamp and any additional assistant blocks, while keeping the older
+    // snapshot's non-error stopReason/isError and toolCall arguments.
+    if (winner !== latestIndex) {
+      const winnerMsg = messages[winner]!;
+
+      const winnerBlocks = Array.isArray(winnerMsg.content) ? (winnerMsg.content as unknown[]) : null;
+      const latestBlocks = Array.isArray(latestMsg.content) ? (latestMsg.content as unknown[]) : null;
+
+      const mergedBlocks =
+        winnerBlocks && latestBlocks
+          ? (latestBlocks.length >= winnerBlocks.length ? latestBlocks : winnerBlocks)
+          : latestBlocks ?? winnerBlocks;
+
+      if (mergedBlocks) {
+        const argsById = collectValidToolArgsByCallId(winnerMsg);
+        const patchedBlocks = argsById.size > 0 ? patchToolCallArguments(mergedBlocks, argsById) : mergedBlocks;
+
+        patchedAssistantByIndex.set(winner, {
+          ...winnerMsg,
+          timestamp: latestMsg.timestamp ?? winnerMsg.timestamp,
+          content: patchedBlocks,
+        });
+      } else if (latestMsg.timestamp !== undefined && winnerMsg.timestamp === undefined) {
+        patchedAssistantByIndex.set(winner, {
+          ...winnerMsg,
+          timestamp: latestMsg.timestamp,
+        });
       }
     }
 
@@ -261,15 +373,22 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
     }
   }
 
-  // Keep only the single winner for each component of same-turn snapshots.
-  return messages.filter((msg, i) => {
-    if (msg.role !== "assistant") return true;
+  const result: RelayMessage[] = [];
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i]!;
+    if (msg.role === "assistant") {
+      const ids = messageIdsMap.get(i);
+      if (ids && ids.size > 0) {
+        if (componentWinnerByIndex.get(i) !== i) continue;
+        result.push(patchedAssistantByIndex.get(i) ?? msg);
+        continue;
+      }
+    }
 
-    const ids = messageIdsMap.get(i);
-    if (!ids || ids.size === 0) return true;
+    result.push(msg);
+  }
 
-    return componentWinnerByIndex.get(i) === i;
-  });
+  return result;
 }
 
 function getThinkingContent(buf: unknown[]): { thinking: string; duration: number } | null {

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -94,6 +94,17 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
   // Cache the extracted IDs for each message index to avoid re-parsing the content during the filter pass.
   const messageIdsMap = new Map<number, Set<string>>();
 
+  // Pre-collect tool call IDs that have a corresponding tool result in the
+  // transcript.  We only prefer a non-errored partial over an errored final
+  // when the tool actually ran (i.e. a result exists); otherwise the errored
+  // snapshot is the most informative version and should be kept.
+  const toolCallIdsWithResult = new Set<string>();
+  for (const msg of messages) {
+    if ((msg.role === "toolResult" || msg.role === "tool") && msg.toolCallId) {
+      toolCallIdsWithResult.add(msg.toolCallId);
+    }
+  }
+
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
     if (msg.role !== "assistant") continue;
@@ -102,7 +113,12 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
       messageIdsMap.set(i, ids);
       for (const id of ids) {
         lastIndexForToolCallId.set(id, i);
-        if (msg.stopReason !== "error") {
+        // Only record the non-errored index when a tool result exists for this
+        // ID.  If no result ever arrives the errored snapshot is the right one
+        // to surface (it carries the failure state); recording a non-errored
+        // partial here would cause the filter below to prefer the partial and
+        // silently drop the error banner.
+        if (msg.stopReason !== "error" && toolCallIdsWithResult.has(id)) {
           lastNonErroredIndexForToolCallId.set(id, i);
         }
       }
@@ -113,21 +129,30 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
 
   // For each assistant message, determine the "preferred" index for each of
   // its tool call IDs:
-  //   - If a non-errored version exists for this ID, prefer the last such version.
-  //   - Otherwise fall back to the last version (errored or not).
+  //   - If a non-errored version exists for this ID AND a tool result arrived,
+  //     prefer the last non-errored version (avoids a spurious error badge on
+  //     a successfully-completed tool).
+  //   - Otherwise fall back to the last version overall (errored or not) so
+  //     that the failure state is visible when no result ever arrived.
+  //
+  // A message is kept when it is the preferred version for AT LEAST ONE of its
+  // IDs.  Using "any" rather than "all" ensures a later errored snapshot that
+  // introduced new tool call IDs (absent from any earlier message) is never
+  // silently dropped — without it, the only assistant message carrying those
+  // new IDs would be discarded, orphaning any later toolResult messages.
   return messages.filter((msg, i) => {
     if (msg.role !== "assistant") return true;
     // Use cached IDs if available; otherwise (e.g. if empty) treat as having no IDs.
     const ids = messageIdsMap.get(i);
     if (!ids || ids.size === 0) return true;
-    // Keep only if this index is the preferred version for every id it contains.
+    // Keep if this is the preferred version for at least one tool call ID.
     for (const id of ids) {
       const preferredIdx = lastNonErroredIndexForToolCallId.has(id)
         ? lastNonErroredIndexForToolCallId.get(id)!
         : lastIndexForToolCallId.get(id)!;
-      if (preferredIdx !== i) return false;
+      if (preferredIdx === i) return true;
     }
-    return true;
+    return false;
   });
 }
 

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -346,10 +346,11 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
       const winnerBlocks = Array.isArray(winnerMsg.content) ? (winnerMsg.content as unknown[]) : null;
       const latestBlocks = Array.isArray(latestMsg.content) ? (latestMsg.content as unknown[]) : null;
 
-      const mergedBlocks =
-        winnerBlocks && latestBlocks
-          ? (latestBlocks.length >= winnerBlocks.length ? latestBlocks : winnerBlocks)
-          : latestBlocks ?? winnerBlocks;
+      // Always use the latest snapshot's block array as the authoritative tool-call
+      // set. The older (winner) snapshot may contain tool calls that the server
+      // intentionally dropped; using the longer array would resurrect them as
+      // dangling pending cards.
+      const mergedBlocks = latestBlocks ?? winnerBlocks;
 
       if (mergedBlocks) {
         const argsById = collectValidToolArgsByCallId(winnerMsg);

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -416,7 +416,7 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
           }
 
           // Preserve all non-toolCall blocks from winner and tool calls that
-          // exist in both winner and latest.
+          // exist in both winner and latest, or that have a completed result.
           for (const block of winnerBlocks) {
             if (!block || typeof block !== "object") {
               mergedBlocks.push(block);
@@ -424,15 +424,15 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
             }
             const b = block as Record<string, unknown>;
             if (b.type === "toolCall") {
-              // Only preserve if this tool call exists in the latest snapshot.
               const id =
                 typeof b.toolCallId === "string"
                   ? b.toolCallId
                   : typeof b.id === "string"
                     ? b.id
                     : "";
-              if (!id || latestToolIds.has(id)) {
-                // Preserve winner's version for better parsed args
+              // Keep if present in latest, OR if a terminal toolResult exists
+              // (the latest snapshot may have truncated it, but the call ran).
+              if (!id || latestToolIds.has(id) || toolCallIdsWithResult.has(id)) {
                 mergedBlocks.push(block);
               }
             } else {
@@ -441,20 +441,22 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
             }
           }
 
-          // Collect text content from winner blocks so we can skip duplicates
-          // when appending new content from the latest snapshot.
-          const winnerTexts = new Set<string>();
-          for (const block of winnerBlocks) {
-            if (!block || typeof block !== "object") continue;
-            const b = block as Record<string, unknown>;
-            if (b.type === "text" && typeof b.text === "string") winnerTexts.add(b.text);
+          // Find the index of the last toolCall in the latest snapshot — only
+          // blocks after this position are "trailing" content unique to latest.
+          let lastToolCallIdx = -1;
+          for (let li = latestBlocks.length - 1; li >= 0; li--) {
+            const lb = latestBlocks[li];
+            if (lb && typeof lb === "object" && (lb as Record<string, unknown>).type === "toolCall") {
+              lastToolCallIdx = li;
+              break;
+            }
           }
 
-          // Append any tool calls that exist only in the latest snapshot, and
-          // any non-toolCall blocks (e.g. trailing text) that don't appear in
-          // the winner — these represent content the model emitted after the
-          // errored stream ended that the winner (partial) never received.
-          for (const block of latestBlocks) {
+          // Append tool calls that exist only in the latest snapshot, and
+          // trailing non-toolCall blocks (after the last tool call) that aren't
+          // already at the end of the merged result.
+          for (let li = 0; li < latestBlocks.length; li++) {
+            const block = latestBlocks[li];
             if (!block || typeof block !== "object") continue;
             const b = block as Record<string, unknown>;
             if (b.type === "toolCall") {
@@ -468,9 +470,18 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
               if (id && !winnerToolIds.has(id)) {
                 mergedBlocks.push(block);
               }
-            } else if (b.type === "text" && typeof b.text === "string") {
-              // Append text blocks that are unique to the latest snapshot
-              if (!winnerTexts.has(b.text)) {
+            } else if (li > lastToolCallIdx && b.type === "text" && typeof b.text === "string") {
+              // This is trailing text (after the last tool call in the latest
+              // snapshot). Only skip if this exact text is already at the tail
+              // of the merged result — comparing by position prevents conflating
+              // identical text that appears at different positions.
+              const lastMerged = mergedBlocks.length > 0 ? mergedBlocks[mergedBlocks.length - 1] : null;
+              const lastIsMatch =
+                lastMerged &&
+                typeof lastMerged === "object" &&
+                (lastMerged as Record<string, unknown>).type === "text" &&
+                (lastMerged as Record<string, unknown>).text === b.text;
+              if (!lastIsMatch) {
                 mergedBlocks.push(block);
               }
             }
@@ -483,7 +494,15 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
       }
 
       if (mergedBlocks.length > 0) {
+        // For each shared tool call, prefer the latest parseable args over the
+        // winner's — the latest snapshot may have a more complete version of
+        // the arguments even if the message itself errored.
         const argsById = collectValidToolArgsByCallId(winnerMsg);
+        const latestArgsById = collectValidToolArgsByCallId(latestMsg);
+        // Overlay: latest valid args win over winner's args
+        for (const [id, args] of latestArgsById) {
+          argsById.set(id, args);
+        }
         const patchedBlocks = argsById.size > 0 ? patchToolCallArguments(mergedBlocks, argsById) : mergedBlocks;
 
         patchedAssistantByIndex.set(winner, {

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -394,96 +394,119 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
           }
         }
 
-        // Merge: preserve winner's assistant blocks (text, thinking, etc.) and use
-        // latest's tool calls as the authoritative set. We also need to add any
-        // tool calls that exist only in the latest snapshot.
+        // Merge strategy: segment both winner and latest by tool-call
+        // boundaries, then merge each segment preferring the latest's
+        // non-tool blocks (thread cZU) while preserving winner-only blocks
+        // (existing behaviour) and latest-only blocks between tool calls
+        // (thread cZR).
         if (winnerBlocks) {
-          // Build a set of tool IDs from the winner so we can identify which
-          // tool calls we've already added.
-          const winnerToolIds = new Set<string>();
-          for (const block of winnerBlocks) {
-            if (!block || typeof block !== "object") continue;
+          // Helper: extract tool call ID from a block
+          const tcId = (block: unknown): string => {
+            if (!block || typeof block !== "object") return "";
             const b = block as Record<string, unknown>;
-            if (b.type === "toolCall") {
-              const id =
-                typeof b.toolCallId === "string"
-                  ? b.toolCallId
-                  : typeof b.id === "string"
-                    ? b.id
-                    : "";
-              if (id) winnerToolIds.add(id);
+            if (b.type !== "toolCall") return "";
+            return typeof b.toolCallId === "string"
+              ? b.toolCallId
+              : typeof b.id === "string"
+                ? b.id
+                : "";
+          };
+
+          // Segment blocks into alternating non-tool segments and tool calls.
+          // Result: segments[0], toolCalls[0], segments[1], toolCalls[1], ...
+          const segment = (blocks: unknown[]): { segs: unknown[][]; tcs: unknown[] } => {
+            const segs: unknown[][] = [[]];
+            const tcs: unknown[] = [];
+            for (const block of blocks) {
+              if (block && typeof block === "object" && (block as Record<string, unknown>).type === "toolCall") {
+                tcs.push(block);
+                segs.push([]);
+              } else {
+                segs[segs.length - 1].push(block);
+              }
+            }
+            return { segs, tcs };
+          };
+
+          const wSeg = segment(winnerBlocks);
+          const lSeg = segment(latestBlocks);
+
+          // Determine which tool calls make it into the merge (in latest OR has result)
+          const mergeToolCalls: unknown[] = [];
+          // Map from tool-call ID to its index in mergeToolCalls
+          const mergeToolIdx = new Map<string, number>();
+
+          // Start with latest's tool calls (preserves latest ordering)
+          for (const tc of lSeg.tcs) {
+            const id = tcId(tc);
+            mergeToolIdx.set(id, mergeToolCalls.length);
+            mergeToolCalls.push(tc);
+          }
+
+          // Add winner-only tool calls that have completed results
+          for (const tc of wSeg.tcs) {
+            const id = tcId(tc);
+            if (id && !mergeToolIdx.has(id) && toolCallIdsWithResult.has(id)) {
+              mergeToolIdx.set(id, mergeToolCalls.length);
+              mergeToolCalls.push(tc);
             }
           }
 
-          // Preserve all non-toolCall blocks from winner and tool calls that
-          // exist in both winner and latest, or that have a completed result.
-          for (const block of winnerBlocks) {
-            if (!block || typeof block !== "object") {
-              mergedBlocks.push(block);
-              continue;
+          // For each gap between tool calls, merge non-tool segments.
+          // Map winner tool calls to their position so we can align segments.
+          const wTcPositions = new Map<string, number>();
+          for (let i = 0; i < wSeg.tcs.length; i++) {
+            wTcPositions.set(tcId(wSeg.tcs[i]), i);
+          }
+          const lTcPositions = new Map<string, number>();
+          for (let i = 0; i < lSeg.tcs.length; i++) {
+            lTcPositions.set(tcId(lSeg.tcs[i]), i);
+          }
+
+          // For each gap position in the merge (0 = before first TC, 1 = after first TC, etc.),
+          // find the corresponding segment from winner and latest by matching
+          // surrounding tool call IDs.
+          const numGaps = mergeToolCalls.length + 1;
+          for (let g = 0; g < numGaps; g++) {
+            // Determine which segment index in winner/latest corresponds to gap g
+            // Gap g is after mergeToolCalls[g-1] and before mergeToolCalls[g]
+            const prevTcId = g > 0 ? tcId(mergeToolCalls[g - 1]) : null;
+            const nextTcId = g < mergeToolCalls.length ? tcId(mergeToolCalls[g]) : null;
+
+            // Winner segment: the segment after prevTcId (or segment 0 if no prevTcId)
+            let wSegIdx = -1;
+            if (prevTcId === null) {
+              wSegIdx = 0;
+            } else if (wTcPositions.has(prevTcId)) {
+              wSegIdx = wTcPositions.get(prevTcId)! + 1;
             }
-            const b = block as Record<string, unknown>;
-            if (b.type === "toolCall") {
-              const id =
-                typeof b.toolCallId === "string"
-                  ? b.toolCallId
-                  : typeof b.id === "string"
-                    ? b.id
-                    : "";
-              // Keep if present in latest, OR if a terminal toolResult exists
-              // (the latest snapshot may have truncated it, but the call ran).
-              if (!id || latestToolIds.has(id) || toolCallIdsWithResult.has(id)) {
-                mergedBlocks.push(block);
+
+            // Latest segment: the segment after prevTcId (or segment 0 if no prevTcId)
+            let lSegIdx = -1;
+            if (prevTcId === null) {
+              lSegIdx = 0;
+            } else if (lTcPositions.has(prevTcId)) {
+              lSegIdx = lTcPositions.get(prevTcId)! + 1;
+            }
+
+            const wBlocks = wSegIdx >= 0 && wSegIdx < wSeg.segs.length ? wSeg.segs[wSegIdx] : [];
+            const lBlocks = lSegIdx >= 0 && lSegIdx < lSeg.segs.length ? lSeg.segs[lSegIdx] : [];
+
+            // Merge: prefer latest blocks (thread cZU), then append any
+            // winner-only extras (preserves winner-only text like "Between").
+            if (lBlocks.length > 0) {
+              mergedBlocks.push(...lBlocks);
+              // Append winner blocks beyond the latest's count at this position
+              for (let i = lBlocks.length; i < wBlocks.length; i++) {
+                mergedBlocks.push(wBlocks[i]);
               }
             } else {
-              // Keep all non-toolCall blocks (text, thinking, etc.) from winner
-              mergedBlocks.push(block);
+              mergedBlocks.push(...wBlocks);
             }
-          }
 
-          // Find the index of the last toolCall in the latest snapshot — only
-          // blocks after this position are "trailing" content unique to latest.
-          let lastToolCallIdx = -1;
-          for (let li = latestBlocks.length - 1; li >= 0; li--) {
-            const lb = latestBlocks[li];
-            if (lb && typeof lb === "object" && (lb as Record<string, unknown>).type === "toolCall") {
-              lastToolCallIdx = li;
-              break;
-            }
-          }
-
-          // Append tool calls that exist only in the latest snapshot, and
-          // trailing non-toolCall blocks (after the last tool call) that aren't
-          // already at the end of the merged result.
-          for (let li = 0; li < latestBlocks.length; li++) {
-            const block = latestBlocks[li];
-            if (!block || typeof block !== "object") continue;
-            const b = block as Record<string, unknown>;
-            if (b.type === "toolCall") {
-              const id =
-                typeof b.toolCallId === "string"
-                  ? b.toolCallId
-                  : typeof b.id === "string"
-                    ? b.id
-                    : "";
-              // Only add if this tool ID doesn't already exist in the winner
-              if (id && !winnerToolIds.has(id)) {
-                mergedBlocks.push(block);
-              }
-            } else if (li > lastToolCallIdx && b.type === "text" && typeof b.text === "string") {
-              // This is trailing text (after the last tool call in the latest
-              // snapshot). Only skip if this exact text is already at the tail
-              // of the merged result — comparing by position prevents conflating
-              // identical text that appears at different positions.
-              const lastMerged = mergedBlocks.length > 0 ? mergedBlocks[mergedBlocks.length - 1] : null;
-              const lastIsMatch =
-                lastMerged &&
-                typeof lastMerged === "object" &&
-                (lastMerged as Record<string, unknown>).type === "text" &&
-                (lastMerged as Record<string, unknown>).text === b.text;
-              if (!lastIsMatch) {
-                mergedBlocks.push(block);
-              }
+            // Emit the tool call for this gap (if not the last gap)
+            if (g < mergeToolCalls.length) {
+              mergedBlocks.push(mergeToolCalls[g]);
             }
           }
         } else {

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -132,15 +132,16 @@ function collectToolCallIdsWithResult(messages: RelayMessage[]): Set<string> {
 
     if (matchedPendingIndex < 0) {
       const normalizedName = normalizeToolName(message.toolName);
-      // Prefer the *latest* pending call with this name so stale earlier calls
-      // don't consume results meant for newer invocations (PR #220 thread cZf_-).
-      matchedPendingIndex = pendingToolCalls.findLastIndex(
+      // Use FIFO (findIndex) so results map to pending calls in invocation
+      // order. Stale streaming-partial duplicates are already excluded at
+      // enqueue time via message.key dedup, so LIFO is not needed here.
+      matchedPendingIndex = pendingToolCalls.findIndex(
         (pending) => normalizeToolName(pending.toolName) === normalizedName
       );
     }
 
     if (matchedPendingIndex < 0 && pendingToolCalls.length > 0) {
-      matchedPendingIndex = pendingToolCalls.length - 1;
+      matchedPendingIndex = 0;
     }
 
     const matched =
@@ -770,15 +771,16 @@ export function groupToolExecutionMessages(messages: RelayMessage[]): RelayMessa
 
       if (matchedPendingIndex < 0) {
         const normalizedName = normalizeToolName(message.toolName);
-        // Prefer the *latest* pending call with this name so stale earlier
-        // calls don't consume results meant for newer invocations.
-        matchedPendingIndex = pendingToolCalls.findLastIndex(
+        // Use FIFO (findIndex) so results map to pending calls in invocation
+        // order. Stale streaming-partial duplicates are excluded at enqueue
+        // time via message.key dedup, so LIFO is not needed here.
+        matchedPendingIndex = pendingToolCalls.findIndex(
           (p) => normalizeToolName(p.toolName) === normalizedName
         );
       }
 
       if (matchedPendingIndex < 0 && pendingToolCalls.length > 0) {
-        matchedPendingIndex = pendingToolCalls.length - 1;
+        matchedPendingIndex = 0;
       }
 
       const matched =

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -394,19 +394,36 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
           }
         }
 
-        // Merge: preserve winner's blocks up to the first tool call, then use
-        // latest's blocks (which contain the authoritative tool calls and any
-        // trailing content).
+        // Merge: preserve winner's assistant blocks (text, thinking, etc.) and use
+        // latest's tool calls as the authoritative set. We also need to add any
+        // tool calls that exist only in the latest snapshot.
         if (winnerBlocks) {
-          let foundFirstToolCall = false;
+          // Build a set of tool IDs from the winner so we can identify which
+          // tool calls we've already added.
+          const winnerToolIds = new Set<string>();
+          for (const block of winnerBlocks) {
+            if (!block || typeof block !== "object") continue;
+            const b = block as Record<string, unknown>;
+            if (b.type === "toolCall") {
+              const id =
+                typeof b.toolCallId === "string"
+                  ? b.toolCallId
+                  : typeof b.id === "string"
+                    ? b.id
+                    : "";
+              if (id) winnerToolIds.add(id);
+            }
+          }
+
+          // Preserve all non-toolCall blocks from winner and tool calls that
+          // exist in both winner and latest.
           for (const block of winnerBlocks) {
             if (!block || typeof block !== "object") {
-              if (!foundFirstToolCall) mergedBlocks.push(block);
+              mergedBlocks.push(block);
               continue;
             }
             const b = block as Record<string, unknown>;
             if (b.type === "toolCall") {
-              foundFirstToolCall = true;
               // Only preserve if this tool call exists in the latest snapshot.
               const id =
                 typeof b.toolCallId === "string"
@@ -418,27 +435,27 @@ function deduplicateAssistantMessages(messages: RelayMessage[]): RelayMessage[] 
                 // Preserve winner's version for better parsed args
                 mergedBlocks.push(block);
               }
-            } else if (!foundFirstToolCall) {
-              // Keep non-toolCall blocks before the first tool call
+            } else {
+              // Keep all non-toolCall blocks (text, thinking, etc.) from winner
               mergedBlocks.push(block);
             }
           }
 
-          // Append any trailing content from the latest snapshot
-          let latestFoundFirstToolCall = false;
-          let skippedToFirstToolCall = false;
+          // Append any tool calls that exist only in the latest snapshot
           for (const block of latestBlocks) {
-            if (!block || typeof block !== "object") {
-              if (skippedToFirstToolCall) mergedBlocks.push(block);
-              continue;
-            }
+            if (!block || typeof block !== "object") continue;
             const b = block as Record<string, unknown>;
             if (b.type === "toolCall") {
-              latestFoundFirstToolCall = true;
-              skippedToFirstToolCall = true;
-            } else if (skippedToFirstToolCall) {
-              // Only append trailing non-toolCall blocks from latest
-              mergedBlocks.push(block);
+              const id =
+                typeof b.toolCallId === "string"
+                  ? b.toolCallId
+                  : typeof b.id === "string"
+                    ? b.id
+                    : "";
+              // Only add if this tool ID doesn't already exist in the winner
+              if (id && !winnerToolIds.has(id)) {
+                mergedBlocks.push(block);
+              }
             }
           }
         } else {

--- a/packages/ui/src/components/session-viewer/types.ts
+++ b/packages/ui/src/components/session-viewer/types.ts
@@ -21,6 +21,12 @@ export interface RelayMessage {
   tokensBefore?: number;
   /** Structured details from tool results (e.g., subagent SubagentDetails) */
   details?: unknown;
+  /**
+   * True when this toolResult message is a synthetic streaming partial produced
+   * by a `tool_execution_update` event (i.e. the tool is still in-flight).
+   * These must NOT be treated as terminal results by deduplication logic.
+   */
+  isStreamingPartial?: boolean;
 }
 
 // ── Sub-agent conversation types ─────────────────────────────────────────────

--- a/packages/ui/src/lib/message-helpers.ts
+++ b/packages/ui/src/lib/message-helpers.ts
@@ -48,6 +48,7 @@ export function toRelayMessage(raw: unknown, fallbackId: string): RelayMessage |
     summary,
     tokensBefore,
     details,
+    isStreamingPartial: msg.isStreamingPartial === true ? true : undefined,
   };
 }
 


### PR DESCRIPTION
## Problem
When an AskUserQuestion tool call completed in the web UI, the assistant message showed an ERROR badge with "JSON Parse error: Expected '}'". The tool itself completed successfully but the message was incorrectly marked as errored.

## Root Cause
Anthropic's SSE stream truncation during tool calls saved two messages for the same turn:
1. A non-errored streaming snapshot with complete tool args
2. A final errored message with truncated (incomplete JSON) args

The deduplication logic kept the errored version, propagating the error badge to the text bubble.

## Fix
1. **`deduplicateAssistantMessages`**: When both errored and non-errored versions exist for the same turn, prefer the non-errored version
2. **`parseToolArguments`**: Return `{}` instead of raw incomplete JSON string on parse failure — downstream components expect object-shaped `toolInput`

## Tests
Updated dedup test to assert no error badge, added test for `{}` fallback on incomplete args.

**Godmother:** closes El1R2Svt (P2 bug)