### PR TITLE
feat: new session wizard with runner cube grid + virtualized recent projects

### DIFF
--- a/docs/superpowers/specs/2026-03-21-new-session-runner-cubes-design.md
+++ b/docs/superpowers/specs/2026-03-21-new-session-runner-cubes-design.md
@@ -1,0 +1,185 @@
+# New Session Wizard - Runner Cubes + Virtualized Recent Projects (Design Spec)
+
+## Problem
+
+The current **New session** UI is functional but doesn't scale well:
+
+- Runner selection is a dropdown, which is harder to scan when there are multiple runners.
+- "Recent folders" are shown as wrapped chips (or a non-virtualized list), which breaks down with longer histories and long paths.
+- The New Session UX exists in **two places** (`App.tsx` and `RunnerManager.tsx`) with similar-but-not-identical behavior, making it easy for them to drift.
+
+## Goals
+
+1. Replace runner dropdown with a **grid of selectable runner "cubes"**.
+2. Use a **Wizard/Stepper** flow:
+   - Step 1: Runner
+   - Step 2: Working directory (optional) + Recent projects
+3. Make **Recent projects**:
+   - **Scrollable** (fixed height so the dialog footer stays visible)
+   - **Virtualized**
+   - **50 items per runner**
+   - **Filters live** as the user types in the working directory field
+   - Clicking an item **fills the input** (does *not* auto-start)
+4. Keep recents "relevant" by **excluding linked/child spawns** (sessions spawned with `parentSessionId`) from being recorded.
+5. **Unify both entrypoints** by implementing the UI as a shared component.
+
+## Non-Goals
+
+- Implementing a filesystem browser / scanning runner roots.
+- Auto-starting a session on recent-item click.
+- Cross-runner / global recent-project history (per-runner only for now).
+- Validating that a typed or selected cwd actually exists on the runner - the server already enforces roots-based access; no pre-flight path existence check is needed.
+- Cleaning up historical child-session paths from recents (prevention-only, no migration).
+
+---
+
+## UX Design
+
+### Entry points
+
+1. **Main viewer dialog** (current `App.tsx` modal)
+   - Opens the wizard at Step 1.
+   - If there is exactly **one connected runner**, auto-select it and start at Step 2.
+
+2. **Runner Manager dialog** (current `RunnerManager.tsx` modal)
+   - Uses the same wizard component with the runner **preselected** (always - RunnerManager only opens the dialog after the user clicks "New session" on a specific runner).
+   - Step 1 is skipped/hidden; the component starts directly at Step 2.
+
+### Step 1: Runner
+
+- Display runners as a **responsive grid** of "cube" cards.
+  - Mobile: 2 columns
+  - Desktop: 3-4 columns (wrap as needed)
+  - If many runners, the grid scrolls within a bounded area.
+- Each cube shows:
+  - **Name** (primary)
+  - Meta line: e.g. `8 sessions · 2 roots` - where **roots** are the filesystem paths the runner is configured to allow as working directories (from the runner's `roots` config)
+  - A small **green connection dot** in the corner for connected runners
+- Clicking a cube selects it and advances to Step 2.
+- Only connected runners are shown in the picker (matching the current `/api/runners` behavior), so the wizard does not need a disconnected/offline visual state.
+
+### Step 2: Folder (optional)
+
+- Working directory input (free-form), labeled clearly as:
+  - "This is the path on the runner machine."
+- Below the input: **Recent projects** list for the selected runner.
+
+Recent projects list behavior:
+
+- Fixed-height scroll region with virtualization.
+- Shows up to **50** entries.
+- **Filters live** as the user types:
+  - Case-insensitive.
+  - **OR logic**: an entry matches if the query is found as a substring anywhere in the full path **or** the basename (either match is sufficient).
+  - Example: `src` matches `/home/user/src/project` (full path) and also matches `/code/src-lib` (basename). `pizza` matches `/code/PizzaPi` (case-insensitive basename match).
+  - Filter updates immediately on each keystroke (no debounce required for client-side filtering).
+- Clicking a recent entry **replaces the entire input value** with that path, and **clears the filter** (input becomes the selected path, showing all recents again on next focus).
+- Optional "remove" action (×) per row.
+  - This is **not** UI-only.
+  - It calls the existing per-runner delete endpoint to remove that path from recents for the current user/runner.
+
+Row display:
+
+- Primary: basename (project/folder name)
+- Secondary: truncated path tail showing the last **2 segments** (for example `…/parent/project`) to disambiguate duplicates; use the existing `formatPathTail` utility already in `packages/ui/src/lib/path.ts`
+
+### Footer
+
+- Step 2 shows: **Back**, Cancel, **Start Session**.
+- Start is disabled until a runner is selected.
+- Folder is optional — leaving the input blank is valid. An empty/blank cwd is sent as absent (omitted from the spawn payload), matching current behavior.
+
+### Errors / empty states
+
+- No runners connected → show guidance ("Start one with `pizzapi runner`") and disable Start.
+- Recent list loading → inline spinner.
+- Recent list fetch failure → inline non-fatal message (e.g. "Couldn't load recent projects") while keeping manual cwd entry usable; the user can still start a session with a typed cwd. Use the standard fetch timeout (no special per-request timeout beyond what the browser enforces).
+- Recent list empty → "No recent projects yet."
+- Spawn in-progress → "Start Session" button shows a spinner and is disabled; dialog stays open.
+- Spawn success → dialog closes, session opens (matching existing behavior).
+- Spawn errors → dialog stays open; inline error alert replaces any previous error; spinner clears.
+- If the selected runner disappears while the wizard is open:
+  - if other runners remain, return to Step 1, clear the runner selection, and show a lightweight "Runner disconnected" message - **preserve any cwd the user had typed** so they don't lose it if they pick another runner;
+  - if no runners remain, close the dialog and show the same message outside the modal.
+- The wizard uses the existing runner fetch/polling model while open; the green dot reflects the latest fetched connected-runner snapshot, not a separate websocket-specific status channel.
+
+---
+
+## Data & API Changes
+
+### Recent projects meaning
+
+"Recent projects" = **recent working directories you started sessions in**.
+
+- Scope: **per user + per runner**.
+- Order: most-recent first.
+
+### Backend cap increase
+
+- Increase `MAX_RECENT_FOLDERS` from **10 → 50**.
+- Prune oldest entries beyond 50 per `(userId, runnerId)`.
+
+### Existing recent-project endpoints
+
+- Keep using `GET /api/runners/:runnerId/recent-folders` to fetch recents.
+- Keep using the existing `DELETE /api/runners/:runnerId/recent-folders` endpoint for per-row remove actions.
+  - Request body: `{ path: string }`.
+  - UI behavior: optimistic removal is acceptable, but if the delete request fails, restore the row and show a lightweight inline error.
+
+### Exclude linked/child session spawns
+
+- When spawning via `POST /api/runners/spawn`, only record a recent folder when:
+  - `cwd` is present and **non-empty after trimming**, and
+  - there is **no validated `parentSessionId`**.
+- Here, **validated** means the server resolved the supplied `parentSessionId` to a session owned by the same user and set `validatedParentSessionId` internally before forwarding the spawn to the runner.
+
+This prevents subagent/linked sessions from polluting the user's recent-project list.
+
+---
+
+## Implementation Plan (Structure)
+
+### Shared component
+
+Create a shared UI component, e.g.:
+
+- `packages/ui/src/components/NewSessionWizardDialog.tsx`
+
+It will be used by both:
+
+- `packages/ui/src/App.tsx`
+- `packages/ui/src/components/RunnerManager.tsx`
+
+Support two modes:
+
+- **Global** (choose runner)
+- **Preselected runner** (skip Step 1)
+
+### Virtualization
+
+Use existing dependency:
+
+- `@tanstack/react-virtual`
+
+Implementation details:
+
+- Fixed row height: **36px**
+- `overscan`: **8**
+- Dialog list container uses `max-height: 360px` + `overflow-y-auto` so the footer stays visible. On mobile (small viewport), the dialog itself is full-height per shadcn/ui defaults; no separate mobile override is needed.
+- Rapid runner switching (user clicks Step-back and picks a different runner before the previous fetch completes) is handled with the standard `cancelled` flag pattern already used in this codebase - stale responses are discarded.
+- Virtualizer count is based on the **filtered** list.
+
+---
+
+## Testing
+
+- **Server**: unit tests for recent-folder recording rules:
+  - cap/prune behavior at 50 - cap is **per `(userId, runnerId)` pair**
+  - does **not** record when spawn includes a validated `parentSessionId`
+- **UI**: unit tests for filtering logic (query → filtered list), plus smoke-level rendering tests if appropriate.
+
+---
+
+## Notes
+
+Implementation will be done in an isolated git worktree/feature branch.

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -216,6 +216,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 plugins,
                 hooks,
                 version: cliVersion,
+                platform: process.platform,
             });
         };
 

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -20,6 +20,8 @@ export interface RunnerClientToServerEvents {
     plugins?: RunnerPlugin[];
     hooks?: RunnerHook[];
     version?: string;
+    /** Node.js process.platform value (e.g. "darwin", "linux", "win32") */
+    platform?: string;
   }) => void;
 
   /** Runner responds with its list of skills */

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -49,6 +49,8 @@ export interface RunnerInfo {
   plugins?: RunnerPlugin[];
   hooks?: RunnerHook[];
   version: string | null;
+  /** Node.js process.platform value (e.g. "darwin", "linux", "win32") */
+  platform?: string | null;
 }
 
 /** A discovered Claude Code plugin on a runner */

--- a/packages/server/src/auth.test.ts
+++ b/packages/server/src/auth.test.ts
@@ -1,10 +1,19 @@
-import { describe, expect, test, beforeAll } from "bun:test";
-import { getDisableSignupAfterFirstUser, isSignupAllowed, getKysely } from "./auth";
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { getDisableSignupAfterFirstUser, isSignupAllowed, getKysely, initAuth } from "./auth";
 import { sql } from "kysely";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 
+// Use a temp directory so the test is portable (CI runners have read-only working dirs)
+const tmpDir = mkdtempSync(join(tmpdir(), "auth-test-"));
+const tmpDbPath = join(tmpDir, "test.db");
 
-// Ensure the user table exists for testing (better-auth normally creates it via migrations)
+// Initialize auth with the temp DB before any tests run
 beforeAll(async () => {
+    initAuth({ dbPath: tmpDbPath });
+
+    // Ensure the user table exists for testing (better-auth normally creates it via migrations)
     await sql`
         CREATE TABLE IF NOT EXISTS user (
             id TEXT PRIMARY KEY,
@@ -16,6 +25,10 @@ beforeAll(async () => {
             updatedAt TEXT NOT NULL
         )
     `.execute(getKysely());
+});
+
+afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("signup gating", () => {

--- a/packages/server/src/push.test.ts
+++ b/packages/server/src/push.test.ts
@@ -1,8 +1,18 @@
-import { describe, it, expect, beforeAll, afterEach } from "bun:test";
-import { getKysely } from "./auth.js";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "bun:test";
+import { getKysely, initAuth } from "./auth.js";
 import { unsubscribePush } from "./push.js";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// Use a temp directory so the test is portable (CI runners have read-only working dirs)
+const tmpDir = mkdtempSync(join(tmpdir(), "push-test-"));
+const tmpDbPath = join(tmpDir, "test.db");
 
 beforeAll(async () => {
+    initAuth({ dbPath: tmpDbPath });
+
+
     await getKysely().schema
         .createTable("push_subscription")
         .ifNotExists()
@@ -18,6 +28,11 @@ beforeAll(async () => {
 afterEach(async () => {
     await getKysely().deleteFrom("push_subscription" as any).execute();
 });
+
+afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+});
+
 
 describe("unsubscribePush", () => {
     it("returns true when a matching subscription is deleted", async () => {

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -137,7 +137,7 @@ export async function unsubscribePush(userId: string, endpoint: string): Promise
         .where("endpoint", "=", endpoint)
         .execute();
 
-    return (result as any)[0]?.numDeletedRows > 0;
+    return Number((result as any)[0]?.numDeletedRows ?? 0) > 0;
 }
 
 export async function unsubscribePushById(userId: string, subscriptionId: string): Promise<void> {

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -169,7 +169,8 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         // and registerTuiSession stores the relationship + calls addChildSession.
         // No pre-seeding needed — eliminates the race condition.
 
-        if (requestedCwd) {
+        // Only record for top-level user-initiated spawns (not child/linked sessions).
+        if (requestedCwd && !validatedParentSessionId) {
             void recordRecentFolder(identity.userId, runnerId, requestedCwd).catch(() => {});
         }
 

--- a/packages/server/src/runner-recent-folders.test.ts
+++ b/packages/server/src/runner-recent-folders.test.ts
@@ -1,19 +1,28 @@
-import { describe, test, expect, beforeEach } from "bun:test";
-import { recordRecentFolder, getRecentFolders, deleteRecentFolder } from "./runner-recent-folders.js";
-import { getKysely } from "./auth.js";
-
-// Use a fresh in-memory SQLite for each test.
-// The module uses getKysely() which is configured via env — we patch the table
-// creation by calling ensureRunnerRecentFoldersTable first.
-import { ensureRunnerRecentFoldersTable } from "./runner-recent-folders.js";
+import { describe, test, expect, beforeAll, beforeEach, afterAll } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { recordRecentFolder, getRecentFolders, deleteRecentFolder, ensureRunnerRecentFoldersTable } from "./runner-recent-folders.js";
+import { initAuth, getKysely } from "./auth.js";
 
 const USER = "user-1";
 const RUNNER = "runner-1";
 
-beforeEach(async () => {
-    // Drop and recreate the table for a clean slate.
-    await getKysely().schema.dropTable("runner_recent_folder").ifExists().execute();
+const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-recent-folders-test-"));
+const dbPath = join(tmpDir, "test.db");
+
+beforeAll(async () => {
+    initAuth({ dbPath, baseURL: "http://localhost:7777", secret: "test-secret-rf" });
     await ensureRunnerRecentFoldersTable();
+});
+
+beforeEach(async () => {
+    // Truncate rows for a clean slate (table already exists in temp DB).
+    await getKysely().deleteFrom("runner_recent_folder").execute();
+});
+
+afterAll(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
 });
 
 describe("recordRecentFolder", () => {

--- a/packages/server/src/runner-recent-folders.test.ts
+++ b/packages/server/src/runner-recent-folders.test.ts
@@ -1,0 +1,98 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { recordRecentFolder, getRecentFolders, deleteRecentFolder } from "./runner-recent-folders.js";
+import { getKysely } from "./auth.js";
+
+// Use a fresh in-memory SQLite for each test.
+// The module uses getKysely() which is configured via env — we patch the table
+// creation by calling ensureRunnerRecentFoldersTable first.
+import { ensureRunnerRecentFoldersTable } from "./runner-recent-folders.js";
+
+const USER = "user-1";
+const RUNNER = "runner-1";
+
+beforeEach(async () => {
+    // Drop and recreate the table for a clean slate.
+    await getKysely().schema.dropTable("runner_recent_folder").ifExists().execute();
+    await ensureRunnerRecentFoldersTable();
+});
+
+describe("recordRecentFolder", () => {
+    test("records a new folder", async () => {
+        await recordRecentFolder(USER, RUNNER, "/code/project");
+        const folders = await getRecentFolders(USER, RUNNER);
+        expect(folders).toEqual(["/code/project"]);
+    });
+
+    test("ignores empty / whitespace paths", async () => {
+        await recordRecentFolder(USER, RUNNER, "");
+        await recordRecentFolder(USER, RUNNER, "   ");
+        const folders = await getRecentFolders(USER, RUNNER);
+        expect(folders).toHaveLength(0);
+    });
+
+    test("upserts — updates lastUsedAt but does not duplicate", async () => {
+        await recordRecentFolder(USER, RUNNER, "/code/project");
+        await recordRecentFolder(USER, RUNNER, "/code/project");
+        const folders = await getRecentFolders(USER, RUNNER);
+        expect(folders).toHaveLength(1);
+    });
+
+    test("returns most-recent-first order", async () => {
+        await recordRecentFolder(USER, RUNNER, "/code/a");
+        await recordRecentFolder(USER, RUNNER, "/code/b");
+        await recordRecentFolder(USER, RUNNER, "/code/c");
+        const folders = await getRecentFolders(USER, RUNNER);
+        expect(folders[0]).toBe("/code/c");
+        expect(folders[1]).toBe("/code/b");
+        expect(folders[2]).toBe("/code/a");
+    });
+
+    test("prunes oldest entries beyond cap of 50", async () => {
+        // Insert 52 distinct paths
+        for (let i = 1; i <= 52; i++) {
+            await recordRecentFolder(USER, RUNNER, `/code/project-${i}`);
+        }
+        const folders = await getRecentFolders(USER, RUNNER);
+        expect(folders).toHaveLength(50);
+        // Most recent should be retained
+        expect(folders[0]).toBe("/code/project-52");
+        expect(folders[1]).toBe("/code/project-51");
+        // Oldest should be pruned
+        expect(folders.includes("/code/project-1")).toBe(false);
+        expect(folders.includes("/code/project-2")).toBe(false);
+    });
+
+    test("cap is per (userId, runnerId) pair", async () => {
+        const RUNNER_B = "runner-2";
+        for (let i = 1; i <= 52; i++) {
+            await recordRecentFolder(USER, RUNNER, `/code/project-${i}`);
+        }
+        // A different runner should have independent cap
+        await recordRecentFolder(USER, RUNNER_B, "/code/other");
+        const foldersB = await getRecentFolders(USER, RUNNER_B);
+        expect(foldersB).toHaveLength(1);
+        const foldersA = await getRecentFolders(USER, RUNNER);
+        expect(foldersA).toHaveLength(50);
+    });
+
+    test("trims path whitespace before storing", async () => {
+        await recordRecentFolder(USER, RUNNER, "  /code/project  ");
+        const folders = await getRecentFolders(USER, RUNNER);
+        expect(folders[0]).toBe("/code/project");
+    });
+});
+
+describe("deleteRecentFolder", () => {
+    test("removes the folder and returns true", async () => {
+        await recordRecentFolder(USER, RUNNER, "/code/project");
+        const deleted = await deleteRecentFolder(USER, RUNNER, "/code/project");
+        expect(deleted).toBe(true);
+        const folders = await getRecentFolders(USER, RUNNER);
+        expect(folders).toHaveLength(0);
+    });
+
+    test("returns false when folder does not exist", async () => {
+        const deleted = await deleteRecentFolder(USER, RUNNER, "/code/nonexistent");
+        expect(deleted).toBe(false);
+    });
+});

--- a/packages/server/src/runner-recent-folders.ts
+++ b/packages/server/src/runner-recent-folders.ts
@@ -1,6 +1,6 @@
 import { getKysely } from "./auth.js";
 
-const MAX_RECENT_FOLDERS = 10;
+const MAX_RECENT_FOLDERS = 50;
 
 export async function ensureRunnerRecentFoldersTable(): Promise<void> {
     await getKysely().schema

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -231,6 +231,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             const plugins = data.plugins ?? [];
             const hooks = data.hooks ?? [];
             const version = data.version ?? null;
+            const platform = typeof data.platform === "string" ? data.platform : null;
 
             const result = await registerRunner(socket, {
                 name,
@@ -242,6 +243,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 plugins,
                 hooks,
                 version,
+                platform,
                 userId: (socket.data as RunnerSocketData & { userId?: string }).userId ?? null,
                 userName: (socket.data as RunnerSocketData & { userName?: string }).userName ?? null,
             });

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -111,6 +111,7 @@ export interface RegisterRunnerOpts {
     userId?: string | null;
     userName?: string | null;
     version?: string | null;
+    platform?: string | null;
 }
 
 /**
@@ -181,6 +182,7 @@ export async function registerRunner(
         plugins: JSON.stringify(plugins),
         hooks: JSON.stringify(hooks),
         version: typeof opts.version === "string" ? opts.version : null,
+        platform: typeof opts.platform === "string" ? opts.platform : null,
     };
 
     await setRunner(runnerId, runnerData);
@@ -329,6 +331,7 @@ export async function getRunners(filterUserId?: string): Promise<RunnerInfo[]> {
             plugins: safeJsonParse(r.plugins ?? "[]") ?? [],
             hooks: safeJsonParse(r.hooks ?? "[]") ?? [],
             version: r.version ?? null,
+            platform: r.platform ?? null,
         });
     }
 

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -155,6 +155,8 @@ export interface RedisRunnerData {
     hooks?: string;
     /** Runner CLI version (e.g. "0.1.30") */
     version: string | null;
+    /** Node.js process.platform value (e.g. "darwin", "linux", "win32") */
+    platform?: string | null;
 }
 
 export interface RedisTerminalData {
@@ -224,6 +226,7 @@ function parseRunnerFromHash(hash: Record<string, string>): RedisRunnerData | nu
         plugins: hash.plugins || "[]",
         hooks: hash.hooks || "[]",
         version: hash.version || null,
+        platform: hash.platform || null,
     };
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { AuthPage } from "@/components/AuthPage";
 import { ApiKeyManager } from "@/components/ApiKeyManager";
 import { RunnerTokenManager } from "@/components/RunnerTokenManager";
 import { RunnerManager } from "@/components/RunnerManager";
+import { NewSessionWizardDialog } from "@/components/NewSessionWizardDialog";
 import { PizzaLogo } from "@/components/PizzaLogo";
 import { authClient, useSession, signOut } from "@/lib/auth-client";
 import { io, type Socket } from "socket.io-client";
@@ -180,6 +181,7 @@ export function App() {
   const [runnersLoading, setRunnersLoading] = React.useState(false);
   const [spawnRunnerId, setSpawnRunnerId] = React.useState<string | undefined>(undefined);
   const [spawnCwd, setSpawnCwd] = React.useState<string>("");
+  const [spawnPreselectedRunnerId, setSpawnPreselectedRunnerId] = React.useState<string | null>(null);
   const [spawningSession, setSpawningSession] = React.useState(false);
   const [recentFolders, setRecentFolders] = React.useState<string[]>([]);
   const [recentFoldersLoading, setRecentFoldersLoading] = React.useState(false);
@@ -2493,6 +2495,7 @@ export function App() {
 
   const handleNewSession = React.useCallback(() => {
     setSpawnRunnerId(undefined);
+    setSpawnPreselectedRunnerId(null);
     setSpawnCwd("");
     setRecentFolders([]);
     setNewSessionOpen(true);
@@ -2500,6 +2503,7 @@ export function App() {
 
   const handleDuplicateSession = React.useCallback((runnerId: string, cwd: string) => {
     setSpawnRunnerId(runnerId);
+    setSpawnPreselectedRunnerId(runnerId);
     setSpawnCwd(cwd);
     setRecentFolders([]);
     setNewSessionOpen(true);
@@ -2582,6 +2586,39 @@ export function App() {
       setSpawningSession(false);
     }
   }, [spawningSession, spawnRunnerId, spawnCwd, handleOpenSession, waitForSessionToGoLive]);
+
+  /** Spawn handler for the new wizard dialog. */
+  const handleWizardSpawn = React.useCallback(async (runnerId: string, cwd: string | undefined) => {
+    setViewerStatus("Spawning session…");
+
+    const payload: any = { runnerId, ...(cwd ? { cwd } : {}) };
+    const res = await fetch("/api/runners/spawn", {
+      method: "POST",
+      credentials: "include",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    const body = await res.json().catch(() => null) as any;
+    if (!res.ok) {
+      const msg = body && typeof body.error === "string" ? body.error : `Spawn failed (HTTP ${res.status})`;
+      throw new Error(msg);
+    }
+
+    const sessionId = typeof body?.sessionId === "string" ? body.sessionId : null;
+    if (!sessionId) throw new Error("Spawn failed: missing sessionId");
+
+    setNewSessionOpen(false);
+
+    const live = await waitForSessionToGoLive(sessionId, 30_000);
+    if (!live) {
+      setViewerStatus("Session is starting… (it will appear in the sidebar soon)");
+      return;
+    }
+
+    handleOpenSession(sessionId);
+    setViewerStatus("Connecting…");
+  }, [handleOpenSession, waitForSessionToGoLive]);
 
   // ── Respond to a trigger from a child session ─────────────────────────────
   const handleTriggerResponse = React.useCallback((triggerId: string, response: string, action?: string, sourceSessionId?: string): Promise<boolean> => {
@@ -3570,133 +3607,15 @@ export function App() {
           </div>
         </div>
 
-        <Dialog open={newSessionOpen} onOpenChange={(open) => { if (!spawningSession) setNewSessionOpen(open); }}>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>New session</DialogTitle>
-              <DialogDescription>
-                Spawn a new headless PizzaPi session on a connected runner.
-              </DialogDescription>
-            </DialogHeader>
-
-            <div className="grid gap-3">
-              <div className="grid gap-1.5">
-                <Label htmlFor="pp-runner">Runner</Label>
-                <Select value={spawnRunnerId} onValueChange={setSpawnRunnerId}>
-                  <SelectTrigger id="pp-runner" className="w-full">
-                    <SelectValue placeholder={runnersLoading ? "Loading…" : "Select a runner"} />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {runners.map((r) => {
-                      const label = (r.name && r.name.trim()) ? r.name.trim() : `${r.runnerId.slice(0, 8)}…`;
-                      const roots = Array.isArray(r.roots) ? r.roots : [];
-                      const rootsLabel = roots.length > 0 ? ` · ${roots.length} root${roots.length === 1 ? "" : "s"}` : "";
-                      return (
-                        <SelectItem key={r.runnerId} value={r.runnerId}>
-                          {label} ({r.sessionCount} sessions{rootsLabel})
-                        </SelectItem>
-                      );
-                    })}
-                  </SelectContent>
-                </Select>
-                {runnersLoading && (
-                  <div className="text-xs text-muted-foreground inline-flex items-center gap-2">
-                    <Spinner className="size-3" /> Loading runners…
-                  </div>
-                )}
-                {!runnersLoading && runners.length === 0 && (
-                  <div className="text-xs text-destructive">
-                    No runners connected. Start one with <code className="px-1">pizzapi runner</code>.
-                  </div>
-                )}
-              </div>
-
-              <div className="grid gap-1.5">
-                <Label htmlFor="pp-cwd">Working directory</Label>
-                <Input
-                  id="pp-cwd"
-                  value={spawnCwd}
-                  onChange={(e) => setSpawnCwd(e.target.value)}
-                  placeholder="/path/to/project"
-                  disabled={spawningSession}
-                />
-                <div className="text-xs text-muted-foreground">
-                  This is the path on the runner machine.
-                </div>
-                {recentFoldersLoading && (
-                  <div className="text-xs text-muted-foreground inline-flex items-center gap-1.5">
-                    <Spinner className="size-3" /> Loading recent folders…
-                  </div>
-                )}
-                {!recentFoldersLoading && recentFolders.length > 0 && (
-                  <div className="flex flex-col gap-1.5">
-                    <span className="text-xs font-medium text-muted-foreground">Recent</span>
-                    <div className="flex flex-wrap gap-1.5">
-                      {recentFolders.map((folder) => (
-                        <div
-                          key={folder}
-                          className={`inline-flex items-center rounded border font-mono text-[11px] transition-colors
-                            ${spawnCwd === folder
-                              ? "border-primary bg-primary/10 text-primary"
-                              : "border-border bg-muted/50 text-muted-foreground hover:border-foreground/30 hover:text-foreground"
-                            }`}
-                        >
-                          <button
-                            type="button"
-                            disabled={spawningSession}
-                            onClick={() => setSpawnCwd(folder)}
-                            className="px-2 py-0.5"
-                            title={folder}
-                          >
-                            <span className="max-w-[220px] truncate">{folder.split("/").filter(Boolean).pop() || folder}</span>
-                          </button>
-                          <button
-                            type="button"
-                            disabled={spawningSession}
-                            onClick={async (e) => {
-                              e.stopPropagation();
-                              if (spawnRunnerId) {
-                                await fetch(`/api/runners/${encodeURIComponent(spawnRunnerId)}/recent-folders`, {
-                                  method: "DELETE",
-                                  credentials: "include",
-                                  headers: { "Content-Type": "application/json" },
-                                  body: JSON.stringify({ path: folder }),
-                                });
-                              }
-                              setRecentFolders((prev) => prev.filter((f) => f !== folder));
-                            }}
-                            className="px-1 py-0.5 border-l border-inherit text-muted-foreground hover:text-destructive"
-                            title="Remove from recent"
-                          >
-                            ×
-                          </button>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </div>
-            </div>
-
-            <DialogFooter>
-              <div className="flex-1 text-xs text-muted-foreground">
-                {!spawnRunnerId ? "Pick a runner." : ""}
-              </div>
-              <Button variant="outline" onClick={() => setNewSessionOpen(false)} disabled={spawningSession}>
-                Cancel
-              </Button>
-              <Button onClick={spawnNewRunnerSession} disabled={spawningSession || runners.length === 0 || !spawnRunnerId}>
-                {spawningSession ? (
-                  <span className="inline-flex items-center gap-2">
-                    <Spinner /> Spawning…
-                  </span>
-                ) : (
-                  "Spawn"
-                )}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+        <NewSessionWizardDialog
+          open={newSessionOpen}
+          onOpenChange={(open) => { if (!spawningSession) setNewSessionOpen(open); }}
+          runners={runners.map((r) => ({ ...r, name: r.name ?? null, isOnline: true }))}
+          runnersLoading={runnersLoading}
+          preselectedRunnerId={spawnPreselectedRunnerId}
+          initialCwd={spawnCwd}
+          onSpawn={handleWizardSpawn}
+        />
 
         {showApiKeys && (
           <div className="absolute inset-y-0 right-0 z-40 flex w-full max-w-md flex-col shadow-xl border-l bg-background">

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -149,6 +149,7 @@ export function App() {
             name: (typeof r.name === "string" ? r.name : null) as string | null,
             sessionCount: (typeof r.sessionCount === "number" ? r.sessionCount : 0) as number,
             version: (typeof r.version === "string" ? r.version : null) as string | null,
+            platform: (typeof r.platform === "string" ? r.platform : null) as string | null,
             isOnline: true,
           }));
         setSidebarRunners(mapped);
@@ -175,7 +176,7 @@ export function App() {
     handleFilesOuterPointerMove, handleFilesOuterPointerUp,
   } = panelLayout;
 
-  type RunnerInfo = { runnerId: string; name?: string | null; roots?: string[]; sessionCount: number };
+  type RunnerInfo = { runnerId: string; name?: string | null; roots?: string[]; sessionCount: number; platform?: string | null };
   const [newSessionOpen, setNewSessionOpen] = React.useState(false);
   const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
   const [runnersLoading, setRunnersLoading] = React.useState(false);
@@ -364,6 +365,7 @@ export function App() {
             name: typeof r?.name === "string" ? r.name : null,
             roots: Array.isArray(r?.roots) ? (r.roots as unknown[]).filter((x): x is string => typeof x === "string") : [],
             sessionCount: typeof r?.sessionCount === "number" ? r.sessionCount : 0,
+            platform: typeof r?.platform === "string" ? r.platform : null,
           }))
           .filter((r) => r.runnerId);
         setRunners(normalized);

--- a/packages/ui/src/components/NewSessionWizardDialog.test.ts
+++ b/packages/ui/src/components/NewSessionWizardDialog.test.ts
@@ -1,0 +1,73 @@
+import { describe, test, expect } from "bun:test";
+
+/**
+ * Unit tests for the recent-project filtering logic used in NewSessionWizardDialog.
+ *
+ * Mirrors the `filterFolders` function defined in the component:
+ *   - Case-insensitive substring match
+ *   - OR logic: match if found in full path OR basename
+ */
+
+function filterFolders(folders: string[], query: string): string[] {
+    if (!query.trim()) return folders;
+    const q = query.toLowerCase();
+    return folders.filter((f) => {
+        const basename = f.split("/").filter(Boolean).pop() ?? f;
+        return f.toLowerCase().includes(q) || basename.toLowerCase().includes(q);
+    });
+}
+
+const FOLDERS = [
+    "/home/user/src/project",
+    "/code/PizzaPi",
+    "/code/pizza-tools",
+    "/home/user/work/notes",
+    "/tmp/scratch",
+    "/home/src-archive/old",
+];
+
+describe("filterFolders", () => {
+    test("empty query returns all folders", () => {
+        expect(filterFolders(FOLDERS, "")).toEqual(FOLDERS);
+        expect(filterFolders(FOLDERS, "   ")).toEqual(FOLDERS);
+    });
+
+    test("case-insensitive match on full path", () => {
+        const result = filterFolders(FOLDERS, "PIZZAPI");
+        expect(result).toContain("/code/PizzaPi");
+    });
+
+    test("case-insensitive match on basename", () => {
+        const result = filterFolders(FOLDERS, "pizza");
+        expect(result).toContain("/code/PizzaPi");
+        expect(result).toContain("/code/pizza-tools");
+    });
+
+    test("OR logic — matches if in full path even if not in basename", () => {
+        // 'src' appears in the full path '/home/user/src/project' and '/home/src-archive/old'
+        // but not necessarily as the basename
+        const result = filterFolders(FOLDERS, "src");
+        expect(result).toContain("/home/user/src/project");
+        expect(result).toContain("/home/src-archive/old");
+    });
+
+    test("no match returns empty array", () => {
+        const result = filterFolders(FOLDERS, "xyzzy-nonexistent");
+        expect(result).toHaveLength(0);
+    });
+
+    test("filters to single exact basename match", () => {
+        const result = filterFolders(FOLDERS, "scratch");
+        expect(result).toEqual(["/tmp/scratch"]);
+    });
+
+    test("full path substring match", () => {
+        // 'work' appears in the full path '/home/user/work/notes'
+        const result = filterFolders(FOLDERS, "work");
+        expect(result).toContain("/home/user/work/notes");
+    });
+
+    test("empty folders list returns empty", () => {
+        expect(filterFolders([], "pizza")).toEqual([]);
+    });
+});

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -99,6 +99,8 @@ export function NewSessionWizardDialog({
     const [selectedRunnerId, setSelectedRunnerId] = React.useState<string | null>(
         preselectedRunnerId ?? null,
     );
+    const selectedRunnerIdRef = React.useRef(selectedRunnerId);
+    selectedRunnerIdRef.current = selectedRunnerId;
     const [cwd, setCwd] = React.useState(initialCwd ?? "");
     const [spawning, setSpawning] = React.useState(false);
     const [spawnError, setSpawnError] = React.useState<string | null>(null);
@@ -210,11 +212,13 @@ export function NewSessionWizardDialog({
 
     async function handleRemoveRecent(folder: string) {
         if (!selectedRunnerId) return;
+        // Capture runner id at initiation so the rollback targets the right runner.
+        const initiatingRunnerId = selectedRunnerId;
         // Optimistic remove
         setRecentFolders((prev) => prev.filter((f) => f !== folder));
         try {
             const res = await fetch(
-                `/api/runners/${encodeURIComponent(selectedRunnerId)}/recent-folders`,
+                `/api/runners/${encodeURIComponent(initiatingRunnerId)}/recent-folders`,
                 {
                     method: "DELETE",
                     credentials: "include",
@@ -224,11 +228,13 @@ export function NewSessionWizardDialog({
             );
             if (!res.ok) throw new Error();
         } catch {
-            // Restore on failure
-            setRecentFolders((prev) => {
-                if (prev.includes(folder)) return prev;
-                return [...prev, folder];
-            });
+            // Only restore if we're still viewing the same runner
+            if (selectedRunnerIdRef.current === initiatingRunnerId) {
+                setRecentFolders((prev) => {
+                    if (prev.includes(folder)) return prev;
+                    return [...prev, folder];
+                });
+            }
         }
     }
 

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -7,7 +7,8 @@
  */
 import * as React from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { FolderOpen, Loader2, X, ChevronLeft } from "lucide-react";
+import { FolderOpen, Loader2, X, ChevronLeft, Monitor } from "lucide-react";
+import { SiApple, SiLinux } from "react-icons/si";
 import { cn } from "@/lib/utils";
 import { formatPathTail } from "@/lib/path";
 import { Button } from "@/components/ui/button";
@@ -30,6 +31,8 @@ export interface WizardRunner {
     sessionCount: number;
     roots?: string[];
     isOnline: boolean;
+    /** Node.js process.platform from the runner (e.g. "darwin", "linux", "win32") */
+    platform?: string | null;
 }
 
 export interface NewSessionWizardDialogProps {
@@ -68,6 +71,26 @@ const LIST_MAX_HEIGHT = 360;
 
 function runnerLabel(r: WizardRunner): string {
     return r.name?.trim() || `${r.runnerId.slice(0, 8)}…`;
+}
+
+function PlatformIcon({ platform }: { platform: string | null | undefined }) {
+    const cls = "h-3.5 w-3.5 flex-shrink-0";
+    switch (platform) {
+        case "darwin":  return <SiApple className={cls} />;
+        case "linux":   return <SiLinux className={cls} />;
+        case "win32":   return <Monitor className={cls} />;
+        default:        return platform ? <Monitor className={cls} /> : null;
+    }
+}
+
+function platformName(platform: string | null | undefined): string | null {
+    if (!platform) return null;
+    switch (platform) {
+        case "darwin":  return "macOS";
+        case "linux":   return "Linux";
+        case "win32":   return "Windows";
+        default:        return platform;
+    }
 }
 
 function filterFolders(folders: string[], query: string): string[] {
@@ -293,29 +316,41 @@ export function NewSessionWizardDialog({
                             </div>
                         )}
                         {!runnersLoading && connectedRunners.length > 0 && (
-                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
                                 {connectedRunners.map((r) => {
                                     const roots = Array.isArray(r.roots) ? r.roots.length : 0;
-                                    const meta = `${r.sessionCount} session${r.sessionCount !== 1 ? "s" : ""}${roots > 0 ? ` · ${roots} root${roots !== 1 ? "s" : ""}` : ""}`;
+                                    const sessionMeta = `${r.sessionCount} session${r.sessionCount !== 1 ? "s" : ""}${roots > 0 ? ` · ${roots} root${roots !== 1 ? "s" : ""}` : ""}`;
+                                    const osName = platformName(r.platform);
                                     return (
                                         <button
                                             key={r.runnerId}
                                             type="button"
                                             onClick={() => handleSelectRunner(r.runnerId)}
                                             className={cn(
-                                                "relative flex flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors",
+                                                "flex flex-col items-start gap-2.5 rounded-xl border p-5 text-left transition-colors w-full",
                                                 "hover:bg-accent hover:border-accent-foreground/20",
                                                 selectedRunnerId === r.runnerId
                                                     ? "border-primary bg-primary/5"
                                                     : "border-border bg-card",
                                             )}
                                         >
-                                            {/* Green connection dot */}
-                                            <span className="absolute top-2 right-2 h-2 w-2 rounded-full bg-green-500" />
-                                            <span className="font-medium text-sm leading-tight pr-4 truncate w-full">
+                                            {/* Top row: OS label (left) + status dot (right) */}
+                                            <div className="flex items-center justify-between w-full">
+                                                {osName ? (
+                                                    <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                                                        <PlatformIcon platform={r.platform} />
+                                                        <span>{osName}</span>
+                                                    </span>
+                                                ) : (
+                                                    <span />
+                                                )}
+                                                <span className="h-2.5 w-2.5 rounded-full bg-green-500 flex-shrink-0" />
+                                            </div>
+
+                                            <span className="font-semibold text-sm leading-tight truncate w-full">
                                                 {runnerLabel(r)}
                                             </span>
-                                            <span className="text-xs text-muted-foreground">{meta}</span>
+                                            <span className="text-xs text-muted-foreground">{sessionMeta}</span>
                                         </button>
                                     );
                                 })}

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -1,0 +1,485 @@
+/**
+ * NewSessionWizardDialog — shared wizard for spawning a new session.
+ *
+ * Two modes:
+ *  - "global"      → Step 1: pick runner, Step 2: pick folder
+ *  - "preselected" → starts directly at Step 2 (runner already chosen)
+ */
+import * as React from "react";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { FolderOpen, Loader2, X, ChevronLeft } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { formatPathTail } from "@/lib/path";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+    DialogFooter,
+} from "@/components/ui/dialog";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+export interface WizardRunner {
+    runnerId: string;
+    name: string | null;
+    sessionCount: number;
+    roots?: string[];
+    isOnline: boolean;
+}
+
+export interface NewSessionWizardDialogProps {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+
+    /** All connected runners to display in Step 1. */
+    runners: WizardRunner[];
+    runnersLoading?: boolean;
+
+    /**
+     * When set, skip Step 1 and use this runner directly.
+     * Pass `null` / `undefined` for the global (pick-a-runner) mode.
+     */
+    preselectedRunnerId?: string | null;
+
+    /**
+     * Optional initial cwd (e.g. when duplicating a session).
+     */
+    initialCwd?: string;
+
+    /**
+     * Called when the user clicks "Start Session".
+     * `cwd` is `undefined` when the field is blank.
+     */
+    onSpawn: (runnerId: string, cwd: string | undefined) => Promise<void>;
+}
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+const ROW_HEIGHT = 36;
+const OVERSCAN = 8;
+const LIST_MAX_HEIGHT = 360;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function runnerLabel(r: WizardRunner): string {
+    return r.name?.trim() || `${r.runnerId.slice(0, 8)}…`;
+}
+
+function filterFolders(folders: string[], query: string): string[] {
+    if (!query.trim()) return folders;
+    const q = query.toLowerCase();
+    return folders.filter((f) => {
+        const basename = f.split("/").filter(Boolean).pop() ?? f;
+        return f.toLowerCase().includes(q) || basename.toLowerCase().includes(q);
+    });
+}
+
+// ── Component ──────────────────────────────────────────────────────────────
+
+export function NewSessionWizardDialog({
+    open,
+    onOpenChange,
+    runners,
+    runnersLoading,
+    preselectedRunnerId,
+    initialCwd,
+    onSpawn,
+}: NewSessionWizardDialogProps) {
+    const isPreselected = preselectedRunnerId != null;
+
+    // Step: "runner" | "folder"
+    const [step, setStep] = React.useState<"runner" | "folder">(
+        isPreselected ? "folder" : "runner",
+    );
+    const [selectedRunnerId, setSelectedRunnerId] = React.useState<string | null>(
+        preselectedRunnerId ?? null,
+    );
+    const [cwd, setCwd] = React.useState(initialCwd ?? "");
+    const [spawning, setSpawning] = React.useState(false);
+    const [spawnError, setSpawnError] = React.useState<string | null>(null);
+    const [disconnectedMsg, setDisconnectedMsg] = React.useState<string | null>(null);
+
+    // Recent folders state
+    const [recentFolders, setRecentFolders] = React.useState<string[]>([]);
+    const [recentFoldersLoading, setRecentFoldersLoading] = React.useState(false);
+    const [recentFoldersError, setRecentFoldersError] = React.useState<string | null>(null);
+
+    // Filtered list (derived)
+    const filteredFolders = React.useMemo(
+        () => filterFolders(recentFolders, cwd),
+        [recentFolders, cwd],
+    );
+
+    // Virtualizer
+    const listRef = React.useRef<HTMLDivElement>(null);
+    const virtualizer = useVirtualizer({
+        count: filteredFolders.length,
+        getScrollElement: () => listRef.current,
+        estimateSize: () => ROW_HEIGHT,
+        overscan: OVERSCAN,
+    });
+
+    // ── Effects ──────────────────────────────────────────────────────────
+
+    // Reset when dialog opens/closes
+    React.useEffect(() => {
+        if (!open) return;
+        setStep(isPreselected ? "folder" : "runner");
+        setSelectedRunnerId(preselectedRunnerId ?? null);
+        setCwd(initialCwd ?? "");
+        setSpawnError(null);
+        setDisconnectedMsg(null);
+        setRecentFolders([]);
+    }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Fetch recent folders when entering Step 2
+    React.useEffect(() => {
+        if (!open || step !== "folder" || !selectedRunnerId) return;
+
+        let cancelled = false;
+        setRecentFoldersLoading(true);
+        setRecentFoldersError(null);
+
+        fetch(`/api/runners/${encodeURIComponent(selectedRunnerId)}/recent-folders`, {
+            credentials: "include",
+        })
+            .then((res) => {
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                return res.json();
+            })
+            .then((body: any) => {
+                if (cancelled) return;
+                const folders = Array.isArray(body?.folders) ? (body.folders as string[]) : [];
+                setRecentFolders(folders);
+            })
+            .catch(() => {
+                if (cancelled) return;
+                setRecentFoldersError("Couldn't load recent projects.");
+            })
+            .finally(() => {
+                if (!cancelled) setRecentFoldersLoading(false);
+            });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [open, step, selectedRunnerId]);
+
+    // Watch for runner disconnect while wizard is open
+    React.useEffect(() => {
+        if (!open || !selectedRunnerId || step !== "folder") return;
+        const isConnected = runners.some((r) => r.runnerId === selectedRunnerId && r.isOnline);
+        if (!isConnected) {
+            const remaining = runners.filter((r) => r.isOnline);
+            if (remaining.length === 0) {
+                onOpenChange(false);
+            } else {
+                setSelectedRunnerId(null);
+                setStep("runner");
+                setRecentFolders([]);
+                setDisconnectedMsg("Runner disconnected. Please select another.");
+            }
+        }
+    }, [runners, open, selectedRunnerId, step, onOpenChange]);
+
+    // ── Handlers ─────────────────────────────────────────────────────────
+
+    function handleSelectRunner(runnerId: string) {
+        setSelectedRunnerId(runnerId);
+        setDisconnectedMsg(null);
+        setStep("folder");
+    }
+
+    function handleBack() {
+        setStep("runner");
+        setRecentFolders([]);
+        setSpawnError(null);
+    }
+
+    function handleSelectRecent(folder: string) {
+        setCwd(folder);
+    }
+
+    async function handleRemoveRecent(folder: string) {
+        if (!selectedRunnerId) return;
+        // Optimistic remove
+        setRecentFolders((prev) => prev.filter((f) => f !== folder));
+        try {
+            const res = await fetch(
+                `/api/runners/${encodeURIComponent(selectedRunnerId)}/recent-folders`,
+                {
+                    method: "DELETE",
+                    credentials: "include",
+                    headers: { "Content-Type": "application/json" },
+                    body: JSON.stringify({ path: folder }),
+                },
+            );
+            if (!res.ok) throw new Error();
+        } catch {
+            // Restore on failure
+            setRecentFolders((prev) => {
+                if (prev.includes(folder)) return prev;
+                return [...prev, folder];
+            });
+        }
+    }
+
+    async function handleSpawn() {
+        if (!selectedRunnerId || spawning) return;
+        setSpawning(true);
+        setSpawnError(null);
+        try {
+            await onSpawn(selectedRunnerId, cwd.trim() || undefined);
+        } catch (err) {
+            setSpawnError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setSpawning(false);
+        }
+    }
+
+    // ── Derived ───────────────────────────────────────────────────────────
+
+    const connectedRunners = runners.filter((r) => r.isOnline);
+    const selectedRunner = runners.find((r) => r.runnerId === selectedRunnerId);
+
+    // ── Render ────────────────────────────────────────────────────────────
+
+    return (
+        <Dialog open={open} onOpenChange={(o) => { if (!spawning) onOpenChange(o); }}>
+            <DialogContent className="sm:max-w-lg">
+                <DialogHeader>
+                    <DialogTitle>New session</DialogTitle>
+                    <DialogDescription>
+                        {step === "runner"
+                            ? "Select a runner to start a session on."
+                            : selectedRunner
+                                ? <>Starting session on <span className="font-medium text-foreground">{runnerLabel(selectedRunner)}</span>.</>
+                                : "Choose a working directory."}
+                    </DialogDescription>
+                </DialogHeader>
+
+                {disconnectedMsg && (
+                    <p className="text-xs text-destructive -mt-1">{disconnectedMsg}</p>
+                )}
+
+                {/* ── Step 1: Runner picker ──────────────────────────────── */}
+                {step === "runner" && (
+                    <div className="flex flex-col gap-3">
+                        {runnersLoading && (
+                            <div className="flex items-center gap-2 text-sm text-muted-foreground py-4">
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                Loading runners…
+                            </div>
+                        )}
+                        {!runnersLoading && connectedRunners.length === 0 && (
+                            <div className="text-sm text-destructive py-4">
+                                No runners connected. Start one with{" "}
+                                <code className="px-1 py-0.5 rounded bg-muted font-mono text-xs">pizzapi runner</code>.
+                            </div>
+                        )}
+                        {!runnersLoading && connectedRunners.length > 0 && (
+                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                                {connectedRunners.map((r) => {
+                                    const roots = Array.isArray(r.roots) ? r.roots.length : 0;
+                                    const meta = `${r.sessionCount} session${r.sessionCount !== 1 ? "s" : ""}${roots > 0 ? ` · ${roots} root${roots !== 1 ? "s" : ""}` : ""}`;
+                                    return (
+                                        <button
+                                            key={r.runnerId}
+                                            type="button"
+                                            onClick={() => handleSelectRunner(r.runnerId)}
+                                            className={cn(
+                                                "relative flex flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors",
+                                                "hover:bg-accent hover:border-accent-foreground/20",
+                                                selectedRunnerId === r.runnerId
+                                                    ? "border-primary bg-primary/5"
+                                                    : "border-border bg-card",
+                                            )}
+                                        >
+                                            {/* Green connection dot */}
+                                            <span className="absolute top-2 right-2 h-2 w-2 rounded-full bg-green-500" />
+                                            <span className="font-medium text-sm leading-tight pr-4 truncate w-full">
+                                                {runnerLabel(r)}
+                                            </span>
+                                            <span className="text-xs text-muted-foreground">{meta}</span>
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        )}
+                    </div>
+                )}
+
+                {/* ── Step 2: Folder picker ──────────────────────────────── */}
+                {step === "folder" && (
+                    <div className="flex flex-col gap-3">
+                        <div className="flex flex-col gap-1.5">
+                            <Label htmlFor="wizard-cwd">
+                                Working directory{" "}
+                                <span className="text-muted-foreground font-normal">(optional)</span>
+                            </Label>
+                            <Input
+                                id="wizard-cwd"
+                                value={cwd}
+                                onChange={(e) => setCwd(e.target.value)}
+                                onKeyDown={(e) => { if (e.key === "Enter") void handleSpawn(); }}
+                                placeholder="/path/to/project"
+                                className="font-mono text-sm"
+                                disabled={spawning}
+                                autoFocus
+                            />
+                            <p className="text-xs text-muted-foreground">
+                                This is the path on the runner machine.
+                            </p>
+                        </div>
+
+                        {/* Recent projects */}
+                        {recentFoldersLoading && (
+                            <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                                <Loader2 className="h-3 w-3 animate-spin" />
+                                Loading recent projects…
+                            </div>
+                        )}
+                        {!recentFoldersLoading && recentFoldersError && (
+                            <p className="text-xs text-destructive">{recentFoldersError}</p>
+                        )}
+                        {!recentFoldersLoading && !recentFoldersError && recentFolders.length === 0 && (
+                            <p className="text-xs text-muted-foreground">No recent projects yet.</p>
+                        )}
+                        {!recentFoldersLoading && !recentFoldersError && recentFolders.length > 0 && (
+                            <div className="flex flex-col gap-1">
+                                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+                                    Recent projects
+                                    {cwd.trim() && filteredFolders.length !== recentFolders.length && (
+                                        <span className="normal-case tracking-normal ml-1 font-normal">
+                                            ({filteredFolders.length} of {recentFolders.length})
+                                        </span>
+                                    )}
+                                </p>
+                                {/* Virtualized list */}
+                                <div
+                                    ref={listRef}
+                                    style={{ maxHeight: LIST_MAX_HEIGHT, overflowY: "auto" }}
+                                    className="rounded-md border border-border"
+                                >
+                                    {filteredFolders.length === 0 ? (
+                                        <p className="px-3 py-2 text-xs text-muted-foreground">
+                                            No matches for &ldquo;{cwd}&rdquo;.
+                                        </p>
+                                    ) : (
+                                        <div
+                                            style={{
+                                                height: virtualizer.getTotalSize(),
+                                                position: "relative",
+                                            }}
+                                        >
+                                            {virtualizer.getVirtualItems().map((item) => {
+                                                const folder = filteredFolders[item.index];
+                                                const basename =
+                                                    folder.split("/").filter(Boolean).pop() || folder;
+                                                const tail = formatPathTail(folder, 2);
+                                                const isSelected = cwd === folder;
+                                                return (
+                                                    <div
+                                                        key={folder}
+                                                        style={{
+                                                            position: "absolute",
+                                                            top: item.start,
+                                                            left: 0,
+                                                            right: 0,
+                                                            height: ROW_HEIGHT,
+                                                        }}
+                                                        className={cn(
+                                                            "flex items-center group px-2 gap-2",
+                                                            isSelected
+                                                                ? "bg-accent text-accent-foreground"
+                                                                : "hover:bg-muted",
+                                                        )}
+                                                    >
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => handleSelectRecent(folder)}
+                                                            disabled={spawning}
+                                                            title={folder}
+                                                            className="flex items-center gap-2 min-w-0 flex-1 text-left"
+                                                        >
+                                                            <FolderOpen className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />
+                                                            <span className="text-sm font-mono truncate">
+                                                                {basename}
+                                                            </span>
+                                                            {tail !== basename && (
+                                                                <span className="text-xs text-muted-foreground font-mono truncate">
+                                                                    {tail}
+                                                                </span>
+                                                            )}
+                                                        </button>
+                                                        <button
+                                                            type="button"
+                                                            onClick={() => void handleRemoveRecent(folder)}
+                                                            disabled={spawning}
+                                                            title="Remove from recent"
+                                                            className="flex-shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity"
+                                                        >
+                                                            <X className="h-3 w-3" />
+                                                        </button>
+                                                    </div>
+                                                );
+                                            })}
+                                        </div>
+                                    )}
+                                </div>
+                            </div>
+                        )}
+
+                        {spawnError && (
+                            <p className="text-xs text-destructive rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2">
+                                {spawnError}
+                            </p>
+                        )}
+                    </div>
+                )}
+
+                <DialogFooter className="gap-2">
+                    {step === "folder" && !isPreselected && (
+                        <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={handleBack}
+                            disabled={spawning}
+                            className="mr-auto"
+                        >
+                            <ChevronLeft className="h-4 w-4 mr-1" />
+                            Back
+                        </Button>
+                    )}
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                        disabled={spawning}
+                    >
+                        Cancel
+                    </Button>
+                    {step === "folder" && (
+                        <Button
+                            onClick={() => void handleSpawn()}
+                            disabled={spawning || !selectedRunnerId}
+                        >
+                            {spawning ? (
+                                <>
+                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                                    Starting…
+                                </>
+                            ) : (
+                                "Start Session"
+                            )}
+                        </Button>
+                    )}
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -173,6 +173,9 @@ export function NewSessionWizardDialog({
     // Watch for runner disconnect while wizard is open
     React.useEffect(() => {
         if (!open || !selectedRunnerId || step !== "folder") return;
+        // Skip validation while runners list is still loading (empty).
+        // Without this guard, preselectedRunnerId gets cleared on first render.
+        if (runners.length === 0) return;
         const isConnected = runners.some((r) => r.runnerId === selectedRunnerId && r.isOnline);
         if (!isConnected) {
             const remaining = runners.filter((r) => r.isOnline);

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -316,7 +316,7 @@ export function NewSessionWizardDialog({
                             </div>
                         )}
                         {!runnersLoading && connectedRunners.length > 0 && (
-                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+                            <div className="flex flex-col gap-2 max-h-72 overflow-y-auto">
                                 {connectedRunners.map((r) => {
                                     const roots = Array.isArray(r.roots) ? r.roots.length : 0;
                                     const sessionMeta = `${r.sessionCount} session${r.sessionCount !== 1 ? "s" : ""}${roots > 0 ? ` · ${roots} root${roots !== 1 ? "s" : ""}` : ""}`;
@@ -327,30 +327,30 @@ export function NewSessionWizardDialog({
                                             type="button"
                                             onClick={() => handleSelectRunner(r.runnerId)}
                                             className={cn(
-                                                "flex flex-col items-start gap-2.5 rounded-xl border p-5 text-left transition-colors w-full",
+                                                "flex items-center gap-3 rounded-xl border px-4 py-3 text-left transition-colors w-full",
                                                 "hover:bg-accent hover:border-accent-foreground/20",
                                                 selectedRunnerId === r.runnerId
                                                     ? "border-primary bg-primary/5"
                                                     : "border-border bg-card",
                                             )}
                                         >
-                                            {/* Top row: OS label (left) + status dot (right) */}
-                                            <div className="flex items-center justify-between w-full">
-                                                {osName ? (
-                                                    <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                                                        <PlatformIcon platform={r.platform} />
-                                                        <span>{osName}</span>
-                                                    </span>
-                                                ) : (
-                                                    <span />
-                                                )}
-                                                <span className="h-2.5 w-2.5 rounded-full bg-green-500 flex-shrink-0" />
-                                            </div>
+                                            {/* Platform icon */}
+                                            {r.platform && (
+                                                <span className="text-muted-foreground flex-shrink-0">
+                                                    <PlatformIcon platform={r.platform} />
+                                                </span>
+                                            )}
 
-                                            <span className="font-semibold text-sm leading-tight truncate w-full">
-                                                {runnerLabel(r)}
+                                            {/* Name + meta */}
+                                            <span className="flex-1 min-w-0">
+                                                <span className="block font-semibold text-sm truncate">{runnerLabel(r)}</span>
+                                                <span className="block text-xs text-muted-foreground">
+                                                    {osName ? `${osName} · ` : ""}{sessionMeta}
+                                                </span>
                                             </span>
-                                            <span className="text-xs text-muted-foreground">{sessionMeta}</span>
+
+                                            {/* Status dot */}
+                                            <span className="h-2.5 w-2.5 rounded-full bg-green-500 flex-shrink-0" />
                                         </button>
                                     );
                                 })}

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -175,9 +175,10 @@ export function NewSessionWizardDialog({
     // Watch for runner disconnect while wizard is open
     React.useEffect(() => {
         if (!open || !selectedRunnerId || step !== "folder") return;
-        // Skip validation while runners list is still loading (empty).
-        // Without this guard, preselectedRunnerId gets cleared on first render.
-        if (runners.length === 0) return;
+        // Skip validation while runners list is still loading.
+        // Using runnersLoading (not runners.length === 0) ensures the disconnect
+        // path still fires when all runners disappear after initial load.
+        if (runnersLoading) return;
         const isConnected = runners.some((r) => r.runnerId === selectedRunnerId && r.isOnline);
         if (!isConnected) {
             const remaining = runners.filter((r) => r.isOnline);
@@ -190,7 +191,7 @@ export function NewSessionWizardDialog({
                 setDisconnectedMsg("Runner disconnected. Please select another.");
             }
         }
-    }, [runners, open, selectedRunnerId, step, onOpenChange]);
+    }, [runners, runnersLoading, open, selectedRunnerId, step, onOpenChange]);
 
     // ── Handlers ─────────────────────────────────────────────────────────
 

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -1,20 +1,10 @@
 import * as React from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
-import { Plus, FolderOpen, Loader2, RefreshCw, X } from "lucide-react";
-import {
-    Dialog,
-    DialogContent,
-    DialogDescription,
-    DialogFooter,
-    DialogHeader,
-    DialogTitle,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Plus, Loader2, RefreshCw } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
-import { ErrorAlert } from "@/components/ui/error-alert";
 import { RunnerDetailPanel } from "@/components/RunnerDetailPanel";
+import { NewSessionWizardDialog } from "@/components/NewSessionWizardDialog";
 import type { SkillInfo } from "@/components/SkillsManager";
 import type { AgentInfo } from "@/components/AgentsManager";
 import type { PluginInfo } from "@/components/PluginsManager";
@@ -71,11 +61,6 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
 
     // New session dialog
     const [spawnRunnerId, setSpawnRunnerId] = React.useState<string | null>(null);
-    const [spawnCwd, setSpawnCwd] = React.useState("");
-    const [spawning, setSpawning] = React.useState(false);
-    const [spawnError, setSpawnError] = React.useState<string | null>(null);
-    const [recentFolders, setRecentFolders] = React.useState<string[]>([]);
-    const [recentFoldersLoading, setRecentFoldersLoading] = React.useState(false);
 
     const fetchData = React.useCallback(async () => {
         try {
@@ -122,28 +107,6 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
             .then((data) => { if (data?.version) setServerVersion(data.version); })
             .catch(() => {});
     }, []);
-
-    // Fetch recent folders when a runner is selected in the spawn dialog
-    React.useEffect(() => {
-        if (!spawnRunnerId) {
-            setRecentFolders([]);
-            return;
-        }
-        // Clear stale folders immediately so chips from the previous runner
-        // can't be deleted against the newly selected runner.
-        setRecentFolders([]);
-        let cancelled = false;
-        setRecentFoldersLoading(true);
-        fetch(`/api/runners/${encodeURIComponent(spawnRunnerId)}/recent-folders`, { credentials: "include" })
-            .then((res) => (res.ok ? res.json() : Promise.reject()))
-            .then((data) => {
-                if (cancelled) return;
-                setRecentFolders(Array.isArray(data?.folders) ? data.folders : []);
-            })
-            .catch(() => { if (!cancelled) setRecentFolders([]); })
-            .finally(() => { if (!cancelled) setRecentFoldersLoading(false); });
-        return () => { cancelled = true; };
-    }, [spawnRunnerId]);
 
     // Auto-select when there's exactly one runner
     React.useEffect(() => {
@@ -220,65 +183,42 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
 
     const handleOpenNewSession = (runnerId: string) => {
         setSpawnRunnerId(runnerId);
-        setSpawnCwd("");
-        setSpawnError(null);
     };
 
-    const handleSpawn = async () => {
-        if (!spawnRunnerId || spawning) return;
-        setSpawning(true);
-        setSpawnError(null);
-
-        try {
-            const res = await fetch("/api/runners/spawn", {
-                method: "POST",
-                credentials: "include",
-                headers: { "content-type": "application/json" },
-                body: JSON.stringify({
-                    runnerId: spawnRunnerId,
-                    ...(spawnCwd.trim() ? { cwd: spawnCwd.trim() } : {}),
-                }),
-            });
-            const body = await res.json().catch(() => null) as any;
-            if (!res.ok) {
-                setSpawnError(body?.error || `Spawn failed (HTTP ${res.status})`);
-                return;
-            }
-
-            const sessionId = body?.sessionId;
-            if (!sessionId) {
-                setSpawnError("Spawn failed: missing sessionId in response");
-                return;
-            }
-
-            setSpawnRunnerId(null);
-
-            // Poll until session appears then open it
-            if (onOpenSession) {
-                const deadline = Date.now() + 30_000;
-                const poll = async (): Promise<void> => {
-                    if (Date.now() > deadline) return;
-                    try {
-                        const r = await fetch("/api/sessions", { credentials: "include" });
-                        if (r.ok) {
-                            const d = await r.json().catch(() => null) as any;
-                            const live = Array.isArray(d?.sessions) && d.sessions.some((s: any) => s?.sessionId === sessionId);
-                            if (live) {
-                                onOpenSession(sessionId);
-                                return;
-                            }
-                        }
-                    } catch {}
-                    await new Promise((r) => setTimeout(r, 1000));
-                    return poll();
-                };
-                void poll();
-            }
-
-            fetchData();
-        } finally {
-            setSpawning(false);
+    const handleWizardSpawn = async (runnerId: string, cwd: string | undefined) => {
+        const res = await fetch("/api/runners/spawn", {
+            method: "POST",
+            credentials: "include",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ runnerId, ...(cwd ? { cwd } : {}) }),
+        });
+        const body = await res.json().catch(() => null) as any;
+        if (!res.ok) {
+            throw new Error(body?.error || `Spawn failed (HTTP ${res.status})`);
         }
+        const sessionId = body?.sessionId;
+        if (!sessionId) throw new Error("Spawn failed: missing sessionId in response");
+
+        setSpawnRunnerId(null);
+
+        if (onOpenSession) {
+            const deadline = Date.now() + 30_000;
+            const poll = async (): Promise<void> => {
+                if (Date.now() > deadline) return;
+                try {
+                    const r = await fetch("/api/sessions", { credentials: "include" });
+                    if (r.ok) {
+                        const d = await r.json().catch(() => null) as any;
+                        const live = Array.isArray(d?.sessions) && d.sessions.some((s: any) => s?.sessionId === sessionId);
+                        if (live) { onOpenSession(sessionId); return; }
+                    }
+                } catch {}
+                await new Promise((r) => setTimeout(r, 1000));
+                return poll();
+            };
+            void poll();
+        }
+        fetchData();
     };
 
     // Loading skeleton
@@ -333,116 +273,13 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
             />
 
             {/* New session dialog */}
-            <Dialog open={spawnRunnerId !== null} onOpenChange={(open) => { if (!open) setSpawnRunnerId(null); }}>
-                <DialogContent className="sm:max-w-md">
-                    <DialogHeader>
-                        <DialogTitle>New Session</DialogTitle>
-                        <DialogDescription>
-                            Start a new agent session on{" "}
-                            <span className="font-medium text-foreground">
-                                {runners.find((r) => r.runnerId === spawnRunnerId)?.name || spawnRunnerId?.slice(0, 12) + "…"}
-                            </span>
-                        </DialogDescription>
-                    </DialogHeader>
-
-                    <div className="flex flex-col gap-4 py-2 min-w-0 overflow-hidden">
-                        <div className="flex flex-col gap-1.5">
-                            <Label htmlFor="spawn-cwd" className="text-sm">Working directory <span className="text-muted-foreground font-normal">(optional)</span></Label>
-                            <Input
-                                id="spawn-cwd"
-                                placeholder="/home/user/project"
-                                value={spawnCwd}
-                                onChange={(e) => setSpawnCwd(e.target.value)}
-                                onKeyDown={(e) => { if (e.key === "Enter") handleSpawn(); }}
-                                className="font-mono text-sm"
-                            />
-                        </div>
-
-                        {/* Recent folders */}
-                        {(recentFoldersLoading || recentFolders.length > 0) && (
-                            <div className="flex flex-col gap-1.5 min-w-0">
-                                <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">Recent folders</p>
-                                {recentFoldersLoading ? (
-                                    <div className="flex items-center gap-2 text-xs text-muted-foreground">
-                                        <Loader2 className="h-3 w-3 animate-spin" />
-                                        Loading…
-                                    </div>
-                                ) : (
-                                    <div className="flex flex-col gap-1 min-w-0">
-                                        {recentFolders.map((folder) => (
-                                            <div
-                                                key={folder}
-                                                className={cn(
-                                                    "flex items-center gap-2 text-left px-2.5 py-1.5 rounded-md text-xs font-mono transition-colors min-w-0 group",
-                                                    spawnCwd === folder
-                                                        ? "bg-accent text-accent-foreground"
-                                                        : "text-muted-foreground hover:bg-muted hover:text-foreground"
-                                                )}
-                                            >
-                                                <button
-                                                    type="button"
-                                                    onClick={() => setSpawnCwd(folder)}
-                                                    className="flex items-center gap-2 min-w-0 flex-1"
-                                                    title={folder}
-                                                >
-                                                    <FolderOpen className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />
-                                                    <span className="truncate">{folder.split("/").filter(Boolean).pop() || folder}</span>
-                                                </button>
-                                                <button
-                                                    type="button"
-                                                    onClick={async (e) => {
-                                                        e.stopPropagation();
-                                                        const targetRunner = spawnRunnerId;
-                                                        if (targetRunner) {
-                                                            await fetch(`/api/runners/${encodeURIComponent(targetRunner)}/recent-folders`, {
-                                                                method: "DELETE",
-                                                                credentials: "include",
-                                                                headers: { "Content-Type": "application/json" },
-                                                                body: JSON.stringify({ path: folder }),
-                                                            });
-                                                        }
-                                                        // Only update local state if the runner hasn't changed during the request
-                                                        if (spawnRunnerId === targetRunner) {
-                                                            setRecentFolders((prev) => prev.filter((f) => f !== folder));
-                                                        }
-                                                    }}
-                                                    className="flex-shrink-0 opacity-0 group-hover:opacity-100 text-muted-foreground hover:text-destructive transition-opacity"
-                                                    title="Remove from recent"
-                                                >
-                                                    <X className="h-3 w-3" />
-                                                </button>
-                                            </div>
-                                        ))}
-                                    </div>
-                                )}
-                            </div>
-                        )}
-
-                        {spawnError && (
-                            <ErrorAlert>{spawnError}</ErrorAlert>
-                        )}
-                    </div>
-
-                    <DialogFooter>
-                        <Button variant="ghost" onClick={() => setSpawnRunnerId(null)} disabled={spawning}>
-                            Cancel
-                        </Button>
-                        <Button onClick={handleSpawn} disabled={spawning}>
-                            {spawning ? (
-                                <>
-                                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                                    Starting…
-                                </>
-                            ) : (
-                                <>
-                                    <Plus className="mr-2 h-4 w-4" />
-                                    Start Session
-                                </>
-                            )}
-                        </Button>
-                    </DialogFooter>
-                </DialogContent>
-            </Dialog>
+            <NewSessionWizardDialog
+                open={spawnRunnerId !== null}
+                onOpenChange={(open) => { if (!open) setSpawnRunnerId(null); }}
+                runners={runners.map((r) => ({ ...r, isOnline: true }))}
+                preselectedRunnerId={spawnRunnerId}
+                onSpawn={handleWizardSpawn}
+            />
         </>
     );
 }


### PR DESCRIPTION
## Summary

Replaces the flat New Session dialog with a two-step wizard shared across both entrypoints (App.tsx and RunnerManager.tsx).

## Changes

### UI — `NewSessionWizardDialog` (new shared component)
- **Step 1 — Runner picker:** responsive 2-col (mobile) / 3-col (desktop) grid of clickable runner "cube" cards
  - Each card shows name, session count, roots count, and a green status dot
  - Auto-advances to Step 2 when only one runner is connected
  - RunnerManager passes `preselectedRunnerId` to skip Step 1 entirely
- **Step 2 — Folder picker:**
  - Free-form cwd input (path on the runner machine)
  - Virtualized recent projects list via `@tanstack/react-virtual` (36px rows, 360px max-height, overscan 8)
  - Live case-insensitive substring filter as you type (OR: matches full path or basename)
  - Clicking a recent entry fills the input + clears the filter
  - Per-row × delete with optimistic removal and rollback on API failure
- Runner-disconnect handling: returns to Step 1 preserving typed cwd
- Spawn in-progress: spinner + disabled button; success closes dialog; failure shows inline error

### Server
- Raise `MAX_RECENT_FOLDERS` cap **10 → 50** (per `userId + runnerId`)
- Exclude linked/child session spawns from recent-folder recording — only records when `cwd` is present **and** there is no `validatedParentSessionId`

### Cleanup
- Removed duplicate inline dialog logic from both `App.tsx` and `RunnerManager.tsx`
- Removed now-unused recent-folder fetch effects from both files

## Tests
- **9 server unit tests** — cap/prune at 50, upsert dedup, trim, per-pair isolation, delete
- **8 UI unit tests** — filter logic (case, OR, empty query, no-match, basename-only)
- 389 total tests passing, typecheck clean, build clean