### PR TITLE
fix: show full worktree name in sidebar badge

### DIFF
--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -12,7 +12,7 @@ import {
 import { cn } from "@/lib/utils";
 import { io } from "socket.io-client";
 import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/protocol";
-import { extractWorktreeName, formatPathTail } from "@/lib/path";
+import { extractWorktreeName, formatPathTail, worktreeRoots } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare, Copy } from "lucide-react";
 import { buildSessionTree, flattenSessionTree, getSessionIndent, getDescendantSessionIds, getGroupCwd } from "@/lib/session-tree";
@@ -1363,7 +1363,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             {/* Worktree badge — shown when cwd is inside a .worktrees/ directory */}
                                                             {(() => {
                                                                 const cwd = s.cwd || "";
-                                                                const knownCwds = liveSessions.map((ls) => ls.cwd || "");
+                                                                const knownCwds = worktreeRoots(liveSessions.map((ls) => ls.cwd || ""));
                                                                 const branchName = extractWorktreeName(cwd, knownCwds);
                                                                 return branchName ? (
                                                                     <div className="flex items-center gap-1 mt-0.5">

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -12,7 +12,7 @@ import {
 import { cn } from "@/lib/utils";
 import { io } from "socket.io-client";
 import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/protocol";
-import { formatPathTail } from "@/lib/path";
+import { extractWorktreeName, formatPathTail } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare, Copy } from "lucide-react";
 import { buildSessionTree, flattenSessionTree, getSessionIndent, getDescendantSessionIds, getGroupCwd } from "@/lib/session-tree";
@@ -1363,11 +1363,8 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             {/* Worktree badge — shown when cwd is inside a .worktrees/ directory */}
                                                             {(() => {
                                                                 const cwd = s.cwd || "";
-                                                                const wtMarker = "/.worktrees/";
-                                                                const wtIdx = cwd.indexOf(wtMarker);
-                                                                const branchName = wtIdx !== -1
-                                                                    ? cwd.substring(wtIdx + wtMarker.length).replace(/\/$/, "")
-                                                                    : null;
+                                                                const knownCwds = liveSessions.map((ls) => ls.cwd || "");
+                                                                const branchName = extractWorktreeName(cwd, knownCwds);
                                                                 return branchName ? (
                                                                     <div className="flex items-center gap-1 mt-0.5">
                                                                         <span

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1363,7 +1363,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             {/* Worktree badge — shown when cwd is inside a .worktrees/ directory */}
                                                             {(() => {
                                                                 const cwd = s.cwd || "";
-                                                                const match = cwd.match(/\/\.worktrees\/([^/]+)/);
+                                                                const match = cwd.match(/\/\.worktrees\/([^/]+\/[^/]+)/);
                                                                 return match ? (
                                                                     <div className="flex items-center gap-1 mt-0.5">
                                                                         <span

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1363,14 +1363,18 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             {/* Worktree badge — shown when cwd is inside a .worktrees/ directory */}
                                                             {(() => {
                                                                 const cwd = s.cwd || "";
-                                                                const match = cwd.match(/\/\.worktrees\/([^/]+\/[^/]+)/);
-                                                                return match ? (
+                                                                const wtMarker = "/.worktrees/";
+                                                                const wtIdx = cwd.indexOf(wtMarker);
+                                                                const branchName = wtIdx !== -1
+                                                                    ? cwd.substring(wtIdx + wtMarker.length).replace(/\/$/, "")
+                                                                    : null;
+                                                                return branchName ? (
                                                                     <div className="flex items-center gap-1 mt-0.5">
                                                                         <span
                                                                             className="text-[0.55rem] bg-amber-500/15 text-amber-400/80 px-1 py-0.5 rounded font-mono leading-none truncate max-w-full"
-                                                                            title={`Worktree: ${match[1]}`}
+                                                                            title={`Worktree: ${branchName}`}
                                                                         >
-                                                                            {match[1]}
+                                                                            {branchName}
                                                                         </span>
                                                                     </div>
                                                                 ) : null;

--- a/packages/ui/src/lib/path.test.ts
+++ b/packages/ui/src/lib/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { extractWorktreeName, formatPathTail } from "./path";
+import { extractWorktreeName, formatPathTail, worktreeRoots } from "./path";
 
 describe("formatPathTail", () => {
     test("returns empty string for empty input", () => {
@@ -97,5 +97,52 @@ describe("extractWorktreeName", () => {
 
     test("returns null when nothing after marker", () => {
         expect(extractWorktreeName("/repo/.worktrees/")).toBeNull();
+    });
+
+    test("ignores nested cwds when worktreeRoots filters them", () => {
+        // If raw session cwds include nested subdirs, worktreeRoots strips them
+        const rawCwds = [
+            "/repo/.worktrees/feat/login",
+            "/repo/.worktrees/feat/login/src",
+        ];
+        const roots = worktreeRoots(rawCwds);
+        expect(extractWorktreeName("/repo/.worktrees/feat/login/src", roots)).toBe("feat/login");
+    });
+});
+
+describe("worktreeRoots", () => {
+    test("filters out nested subdirectories", () => {
+        const cwds = [
+            "/repo/.worktrees/feat/login",
+            "/repo/.worktrees/feat/login/src",
+            "/repo/.worktrees/feat/login/src/lib",
+        ];
+        expect(worktreeRoots(cwds)).toEqual(["/repo/.worktrees/feat/login"]);
+    });
+
+    test("keeps multiple distinct worktree roots", () => {
+        const cwds = [
+            "/repo/.worktrees/feat/login",
+            "/repo/.worktrees/fix/bug",
+            "/repo/.worktrees/feat/login/src",
+        ];
+        const roots = worktreeRoots(cwds);
+        expect(roots).toContain("/repo/.worktrees/feat/login");
+        expect(roots).toContain("/repo/.worktrees/fix/bug");
+        expect(roots).toHaveLength(2);
+    });
+
+    test("ignores non-worktree paths", () => {
+        const cwds = ["/projects/app", "/repo/.worktrees/main"];
+        expect(worktreeRoots(cwds)).toEqual(["/repo/.worktrees/main"]);
+    });
+
+    test("returns empty array when no worktree paths", () => {
+        expect(worktreeRoots(["/home/user/code"])).toEqual([]);
+    });
+
+    test("handles trailing slashes", () => {
+        const cwds = ["/repo/.worktrees/feat/login/", "/repo/.worktrees/feat/login/src"];
+        expect(worktreeRoots(cwds)).toEqual(["/repo/.worktrees/feat/login"]);
     });
 });

--- a/packages/ui/src/lib/path.test.ts
+++ b/packages/ui/src/lib/path.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { formatPathTail } from "./path";
+import { extractWorktreeName, formatPathTail } from "./path";
 
 describe("formatPathTail", () => {
     test("returns empty string for empty input", () => {
@@ -40,5 +40,62 @@ describe("formatPathTail", () => {
 
     test("handles relative paths", () => {
         expect(formatPathTail("a/b/c/d")).toBe("…/c/d");
+    });
+});
+
+describe("extractWorktreeName", () => {
+    test("returns null for paths without .worktrees marker", () => {
+        expect(extractWorktreeName("/projects/foo/src")).toBeNull();
+        expect(extractWorktreeName("")).toBeNull();
+    });
+
+    test("extracts single-segment branch name", () => {
+        expect(extractWorktreeName("/repo/.worktrees/fix-bar")).toBe("fix-bar");
+    });
+
+    test("extracts single-segment branch when cwd is a subdir", () => {
+        expect(extractWorktreeName("/repo/.worktrees/fix-bar/src")).toBe("fix-bar");
+    });
+
+    test("extracts slashed branch name using known cwds", () => {
+        const known = ["/repo/.worktrees/feat/login"];
+        expect(extractWorktreeName("/repo/.worktrees/feat/login", known)).toBe("feat/login");
+    });
+
+    test("extracts slashed branch name when cwd is a subdir using known cwds", () => {
+        const known = ["/repo/.worktrees/feat/login"];
+        expect(extractWorktreeName("/repo/.worktrees/feat/login/src", known)).toBe("feat/login");
+    });
+
+    test("extracts deeply slashed branch name using known cwds", () => {
+        const known = ["/repo/.worktrees/a/b/c"];
+        expect(extractWorktreeName("/repo/.worktrees/a/b/c/src/lib", known)).toBe("a/b/c");
+    });
+
+    test("picks longest matching known cwd", () => {
+        const known = [
+            "/repo/.worktrees/feat",
+            "/repo/.worktrees/feat/login",
+        ];
+        expect(extractWorktreeName("/repo/.worktrees/feat/login/src", known)).toBe("feat/login");
+    });
+
+    test("falls back to first segment without known cwds", () => {
+        // Without known cwds, slashed branches fall back to first segment
+        expect(extractWorktreeName("/repo/.worktrees/feat/login/src")).toBe("feat");
+    });
+
+    test("ignores known cwds from different repos", () => {
+        const known = ["/other-repo/.worktrees/feat/login"];
+        // No match from our repo, falls back to first segment
+        expect(extractWorktreeName("/repo/.worktrees/feat/login/src", known)).toBe("feat");
+    });
+
+    test("handles trailing slashes", () => {
+        expect(extractWorktreeName("/repo/.worktrees/fix-bar/")).toBe("fix-bar");
+    });
+
+    test("returns null when nothing after marker", () => {
+        expect(extractWorktreeName("/repo/.worktrees/")).toBeNull();
     });
 });

--- a/packages/ui/src/lib/path.ts
+++ b/packages/ui/src/lib/path.ts
@@ -50,6 +50,26 @@ export function extractWorktreeName(
   return firstSlash === -1 ? afterMarker : afterMarker.substring(0, firstSlash);
 }
 
+/**
+ * Given an iterable of cwds, return only the ones that are worktree roots —
+ * i.e. the shortest path under each `/.worktrees/` prefix. This filters out
+ * nested subdirectories inside a worktree (e.g. `.worktrees/feat/login/src`)
+ * so that only the actual root (`.worktrees/feat/login`) is kept.
+ */
+export function worktreeRoots(cwds: Iterable<string>): string[] {
+  const marker = "/.worktrees/";
+  // Collect only cwds that contain the marker
+  const worktreeCwds: string[] = [];
+  for (const cwd of cwds) {
+    if (cwd.includes(marker)) worktreeCwds.push(cwd.replace(/\/$/, ""));
+  }
+
+  // Keep a cwd only if no other (shorter) cwd is a proper prefix of it
+  return worktreeCwds.filter((cwd) =>
+    !worktreeCwds.some((other) => other !== cwd && cwd.startsWith(other + "/")),
+  );
+}
+
 export function formatPathTail(path: string, maxSegments = 2): string {
   if (!path) return "";
   const normalized = path.replace(/\\/g, "/");

--- a/packages/ui/src/lib/path.ts
+++ b/packages/ui/src/lib/path.ts
@@ -1,3 +1,55 @@
+/**
+ * Extract the worktree name from a cwd that contains `/.worktrees/`.
+ *
+ * Because branch names can contain slashes (e.g. `feat/login`), we can't just
+ * split on `/` and take the first segment. Instead, we walk up from the full
+ * path after the marker, checking each prefix against a set of known worktree
+ * roots (typically other sessions' cwds). The longest matching root wins.
+ *
+ * If no known roots match, falls back to the first path segment after the
+ * marker (best-effort for single-segment branch names).
+ *
+ * @param cwd              The session's current working directory
+ * @param knownWorktreeCwds Set/array of cwds from other sessions that may be
+ *                          worktree roots (paths ending right at the worktree
+ *                          directory, e.g. `/repo/.worktrees/feat/login`)
+ * @returns The worktree/branch name, or null if cwd doesn't contain the marker
+ */
+export function extractWorktreeName(
+  cwd: string,
+  knownWorktreeCwds: Iterable<string> = [],
+): string | null {
+  const marker = "/.worktrees/";
+  const idx = cwd.indexOf(marker);
+  if (idx === -1) return null;
+
+  const repoRoot = cwd.substring(0, idx);
+  const afterMarker = cwd.substring(idx + marker.length).replace(/\/$/, "");
+  if (!afterMarker) return null;
+
+  // Check known cwds to find the longest worktree root that is a prefix of our cwd.
+  // The worktree name is the part between the marker and the root.
+  let bestName: string | null = null;
+  for (const other of knownWorktreeCwds) {
+    // A known worktree root must start with `<repoRoot>/.worktrees/`
+    if (!other.startsWith(repoRoot + marker)) continue;
+    const otherAfterMarker = other.substring(idx + marker.length).replace(/\/$/, "");
+    if (!otherAfterMarker) continue;
+    // The known cwd must be a prefix of (or equal to) our afterMarker path
+    if (afterMarker === otherAfterMarker || afterMarker.startsWith(otherAfterMarker + "/")) {
+      if (!bestName || otherAfterMarker.length > bestName.length) {
+        bestName = otherAfterMarker;
+      }
+    }
+  }
+
+  if (bestName) return bestName;
+
+  // Fallback: first path segment (works for single-segment branch names)
+  const firstSlash = afterMarker.indexOf("/");
+  return firstSlash === -1 ? afterMarker : afterMarker.substring(0, firstSlash);
+}
+
 export function formatPathTail(path: string, maxSegments = 2): string {
   if (!path) return "";
   const normalized = path.replace(/\\/g, "/");


### PR DESCRIPTION
The worktree badge in the session sidebar was only capturing the first path segment after `.worktrees/` (e.g. just `fix`), because the regex used `[^/]+`. Since worktree directories mirror branch names like `fix/plan-mode-sandbox` (two segments), the badge was truncated.

**Fix:** Updated the regex to capture two segments: `[^/]+/[^/]+`, so the badge now shows the full worktree name (e.g. `fix/plan-mode-sandbox`).