### PR TITLE
feat: optimize pizza web build times

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,25 @@
 node_modules
 */node_modules
-**/dist
+packages/protocol/dist
+packages/tools/dist
+packages/server/dist
+packages/cli/dist
+packages/docs/dist
 **/*.tsbuildinfo
 .git
 .env
 *.log
+
+# Packages not needed for the web hub Docker image
+packages/cli
+packages/docs
+packages/npm
+
+# Dev / CI artifacts
+docker
+certs
+.windsurf
+.github
+.vscode
+*.md
+LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
+# syntax=docker/dockerfile:1
+
+# ── Shared dependency layer ──────────────────────────────────────────────────
+# Installs node_modules and copies configs shared by both build stages.
+# The docker/compose.yml dev profile targets this stage (target: builder).
 FROM oven/bun:1 AS builder
 WORKDIR /app
 
@@ -13,6 +18,7 @@ RUN cat /tmp/full-package.json | bun -e ' \
     const slim = { \
         name: f.name, version: f.version, \
         workspaces: ["packages/protocol","packages/tools","packages/server","packages/ui"], \
+        devDependencies: { typescript: f.devDependencies?.typescript ?? "^5.7.0" }, \
         patchedDependencies: f.patchedDependencies \
     }; \
     await Bun.write("/app/package.json", JSON.stringify(slim, null, 2));'
@@ -25,38 +31,53 @@ COPY packages/ui/package.json packages/ui/
 # --ignore-scripts skips native builds (better-sqlite3 from @better-auth/cli)
 # that aren't needed at runtime since the server uses bun:sqlite.
 # Can't use --frozen-lockfile since we trimmed the workspace list.
-RUN bun install --ignore-scripts
+RUN --mount=type=cache,target=/root/.bun/install/cache \
+    bun install --ignore-scripts
 
-# Copy source for needed packages only
-COPY tsconfig.base.json ./
+# Root tsconfigs needed by tsc --build project references
+COPY tsconfig.base.json tsconfig.json ./
+
+# Protocol source is shared by both server (tsc reference) and UI (bundled dep)
 COPY packages/protocol/ packages/protocol/
+
+# ── Build server (runs in parallel with build-ui) ───────────────────────────
+# tsc --build follows project references: protocol → tools → server
+FROM builder AS build-server
 COPY packages/tools/ packages/tools/
 COPY packages/server/ packages/server/
+RUN node_modules/typescript/bin/tsc --build packages/server/tsconfig.json
+
+# ── Build UI ─────────────────────────────────────────────────────────────────
+# When PREBUILT_UI=true (default), `pizza web` builds the UI on the host first
+# (native speed, ~15s) and the Dockerfile just copies the dist from context.
+# Set PREBUILT_UI=false to build inside Docker (slow on Docker Desktop VMs).
+ARG PREBUILT_UI=false
+FROM builder AS build-ui
+ARG PREBUILT_UI
+COPY packages/tools/ packages/tools/
 COPY packages/ui/ packages/ui/
+RUN if [ "$PREBUILT_UI" = "true" ] && [ -d packages/ui/dist ]; then \
+        echo "Using pre-built UI dist from host"; \
+    else \
+        node_modules/typescript/bin/tsc --build packages/protocol/tsconfig.json \
+        && cd packages/ui && bun run build; \
+    fi
 
-# Copy root tsconfig (needed for tsc --build project references)
-COPY tsconfig.json ./
-
-# tsc --build follows project references to resolve workspace deps
-# that bun doesn't symlink in node_modules.
-RUN bunx tsc --build packages/server/tsconfig.json \
-    && cd /app/packages/ui && bun run build
-
-# --- Production image ---
+# ── Production image ─────────────────────────────────────────────────────────
 FROM oven/bun:1-slim
 WORKDIR /app
 
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/packages/protocol/dist ./packages/protocol/dist
-COPY --from=builder /app/packages/protocol/package.json ./packages/protocol/
-COPY --from=builder /app/packages/tools/dist ./packages/tools/dist
-COPY --from=builder /app/packages/tools/package.json ./packages/tools/
-COPY --from=builder /app/packages/tools/node_modules ./packages/tools/node_modules
-COPY --from=builder /app/packages/server/dist ./packages/server/dist
-COPY --from=builder /app/packages/server/package.json ./packages/server/
-COPY --from=builder /app/packages/server/node_modules ./packages/server/node_modules
-COPY --from=builder /app/packages/ui/dist ./packages/ui/dist
-COPY --from=builder /app/package.json ./
+COPY --from=build-server /app/node_modules ./node_modules
+COPY --from=build-server /app/packages/protocol/dist ./packages/protocol/dist
+COPY --from=build-server /app/packages/protocol/package.json ./packages/protocol/
+COPY --from=build-server /app/packages/tools/dist ./packages/tools/dist
+COPY --from=build-server /app/packages/tools/package.json ./packages/tools/
+COPY --from=build-server /app/packages/tools/node_modules ./packages/tools/node_modules
+COPY --from=build-server /app/packages/server/dist ./packages/server/dist
+COPY --from=build-server /app/packages/server/package.json ./packages/server/
+COPY --from=build-server /app/packages/server/node_modules ./packages/server/node_modules
+COPY --from=build-ui /app/packages/ui/dist ./packages/ui/dist
+COPY --from=build-server /app/package.json ./
 
 ENV PIZZAPI_UI_DIR=/app/packages/ui/dist
 ENV AUTH_DB_PATH=/app/data/auth.db

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.2.6-dev.2",
+      "version": "0.3.1-dev.3",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
@@ -139,7 +139,7 @@
         "@tailwindcss/vite": "^4.2.0",
         "@types/react-resizable": "^3.0.8",
         "@vite-pwa/assets-generator": "^1.0.2",
-        "@vitejs/plugin-react": "^5.1.4",
+        "@vitejs/plugin-react-swc": "^4.3.0",
         "@xterm/addon-fit": "^0.11.0",
         "@xterm/addon-web-links": "^0.12.0",
         "@xterm/xterm": "^6.0.0",
@@ -434,10 +434,6 @@
     "@babel/plugin-transform-react-jsx": ["@babel/plugin-transform-react-jsx@7.28.6", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.3", "@babel/helper-module-imports": "^7.28.6", "@babel/helper-plugin-utils": "^7.28.6", "@babel/plugin-syntax-jsx": "^7.28.6", "@babel/types": "^7.28.6" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow=="],
 
     "@babel/plugin-transform-react-jsx-development": ["@babel/plugin-transform-react-jsx-development@7.27.1", "", { "dependencies": { "@babel/plugin-transform-react-jsx": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ykDdF5yI4f1WrAolLqeF3hmYU12j9ntLQl/AOG1HAS21jxyg1Q0/J/tpREuYLfatGdGmXp/3yS0ZA76kOlVq9Q=="],
-
-    "@babel/plugin-transform-react-jsx-self": ["@babel/plugin-transform-react-jsx-self@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw=="],
-
-    "@babel/plugin-transform-react-jsx-source": ["@babel/plugin-transform-react-jsx-source@7.27.1", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw=="],
 
     "@babel/plugin-transform-react-pure-annotations": ["@babel/plugin-transform-react-pure-annotations@7.27.1", "", { "dependencies": { "@babel/helper-annotate-as-pure": "^7.27.1", "@babel/helper-plugin-utils": "^7.27.1" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-JfuinvDOsD9FVMTHpzA/pBLisxpv1aSf+OIV8lgH3MuWrks19R27e6a6DipIg4aX1Zm9Wpb04p8wljfKrVSnPA=="],
 
@@ -927,7 +923,7 @@
 
     "@redis/time-series": ["@redis/time-series@1.1.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g=="],
 
-    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
     "@rollup/plugin-babel": ["@rollup/plugin-babel@5.3.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.10.4", "@rollup/pluginutils": "^3.1.0" }, "peerDependencies": { "@babel/core": "^7.0.0", "@types/babel__core": "^7.1.9", "rollup": "^1.20.0||^2.0.0" }, "optionalPeers": ["@types/babel__core"] }, "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q=="],
 
@@ -1129,6 +1125,32 @@
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
 
+    "@swc/core": ["@swc/core@1.15.18", "", { "dependencies": { "@swc/counter": "^0.1.3", "@swc/types": "^0.1.25" }, "optionalDependencies": { "@swc/core-darwin-arm64": "1.15.18", "@swc/core-darwin-x64": "1.15.18", "@swc/core-linux-arm-gnueabihf": "1.15.18", "@swc/core-linux-arm64-gnu": "1.15.18", "@swc/core-linux-arm64-musl": "1.15.18", "@swc/core-linux-x64-gnu": "1.15.18", "@swc/core-linux-x64-musl": "1.15.18", "@swc/core-win32-arm64-msvc": "1.15.18", "@swc/core-win32-ia32-msvc": "1.15.18", "@swc/core-win32-x64-msvc": "1.15.18" }, "peerDependencies": { "@swc/helpers": ">=0.5.17" }, "optionalPeers": ["@swc/helpers"] }, "sha512-z87aF9GphWp//fnkRsqvtY+inMVPgYW3zSlXH1kJFvRT5H/wiAn+G32qW5l3oEk63KSF1x3Ov0BfHCObAmT8RA=="],
+
+    "@swc/core-darwin-arm64": ["@swc/core-darwin-arm64@1.15.18", "", { "os": "darwin", "cpu": "arm64" }, "sha512-+mIv7uBuSaywN3C9LNuWaX1jJJ3SKfiJuE6Lr3bd+/1Iv8oMU7oLBjYMluX1UrEPzwN2qCdY6Io0yVicABoCwQ=="],
+
+    "@swc/core-darwin-x64": ["@swc/core-darwin-x64@1.15.18", "", { "os": "darwin", "cpu": "x64" }, "sha512-wZle0eaQhnzxWX5V/2kEOI6Z9vl/lTFEC6V4EWcn+5pDjhemCpQv9e/TDJ0GIoiClX8EDWRvuZwh+Z3dhL1NAg=="],
+
+    "@swc/core-linux-arm-gnueabihf": ["@swc/core-linux-arm-gnueabihf@1.15.18", "", { "os": "linux", "cpu": "arm" }, "sha512-ao61HGXVqrJFHAcPtF4/DegmwEkVCo4HApnotLU8ognfmU8x589z7+tcf3hU+qBiU1WOXV5fQX6W9Nzs6hjxDw=="],
+
+    "@swc/core-linux-arm64-gnu": ["@swc/core-linux-arm64-gnu@1.15.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-3xnctOBLIq3kj8PxOCgPrGjBLP/kNOddr6f5gukYt/1IZxsITQaU9TDyjeX6jG+FiCIHjCuWuffsyQDL5Ew1bg=="],
+
+    "@swc/core-linux-arm64-musl": ["@swc/core-linux-arm64-musl@1.15.18", "", { "os": "linux", "cpu": "arm64" }, "sha512-0a+Lix+FSSHBSBOA0XznCcHo5/1nA6oLLjcnocvzXeqtdjnPb+SvchItHI+lfeiuj1sClYPDvPMLSLyXFaiIKw=="],
+
+    "@swc/core-linux-x64-gnu": ["@swc/core-linux-x64-gnu@1.15.18", "", { "os": "linux", "cpu": "x64" }, "sha512-wG9J8vReUlpaHz4KOD/5UE1AUgirimU4UFT9oZmupUDEofxJKYb1mTA/DrMj0s78bkBiNI+7Fo2EgPuvOJfuAA=="],
+
+    "@swc/core-linux-x64-musl": ["@swc/core-linux-x64-musl@1.15.18", "", { "os": "linux", "cpu": "x64" }, "sha512-4nwbVvCphKzicwNWRmvD5iBaZj8JYsRGa4xOxJmOyHlMDpsvvJ2OR2cODlvWyGFH6BYL1MfIAK3qph3hp0Az6g=="],
+
+    "@swc/core-win32-arm64-msvc": ["@swc/core-win32-arm64-msvc@1.15.18", "", { "os": "win32", "cpu": "arm64" }, "sha512-zk0RYO+LjiBCat2RTMHzAWaMky0cra9loH4oRrLKLLNuL+jarxKLFDA8xTZWEkCPLjUTwlRN7d28eDLLMgtUcQ=="],
+
+    "@swc/core-win32-ia32-msvc": ["@swc/core-win32-ia32-msvc@1.15.18", "", { "os": "win32", "cpu": "ia32" }, "sha512-yVuTrZ0RccD5+PEkpcLOBAuPbYBXS6rslENvIXfvJGXSdX5QGi1ehC4BjAMl5FkKLiam4kJECUI0l7Hq7T1vwg=="],
+
+    "@swc/core-win32-x64-msvc": ["@swc/core-win32-x64-msvc@1.15.18", "", { "os": "win32", "cpu": "x64" }, "sha512-7NRmE4hmUQNCbYU3Hn9Tz57mK9Qq4c97ZS+YlamlK6qG9Fb5g/BB3gPDe0iLlJkns/sYv2VWSkm8c3NmbEGjbg=="],
+
+    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
+
+    "@swc/types": ["@swc/types@0.1.25", "", { "dependencies": { "@swc/counter": "^0.1.3" } }, "sha512-iAoY/qRhNH8a/hBvm3zKj9qQ4oc2+3w1unPJa2XvTK3XjeLXtzcCingVPw/9e5mn1+0yPqxcBGp9Jf0pkfMb1g=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.2.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.31.1", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.0" } }, "sha512-Yv+fn/o2OmL5fh/Ir62VXItdShnUxfpkMA4Y7jdeC8O81WPB8Kf6TT6GSHvnqgSwDzlB5iT7kDpeXxLsUS0T6Q=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.0", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.0", "@tailwindcss/oxide-darwin-arm64": "4.2.0", "@tailwindcss/oxide-darwin-x64": "4.2.0", "@tailwindcss/oxide-freebsd-x64": "4.2.0", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.0", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.0", "@tailwindcss/oxide-linux-arm64-musl": "4.2.0", "@tailwindcss/oxide-linux-x64-gnu": "4.2.0", "@tailwindcss/oxide-linux-x64-musl": "4.2.0", "@tailwindcss/oxide-wasm32-wasi": "4.2.0", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.0", "@tailwindcss/oxide-win32-x64-msvc": "4.2.0" } }, "sha512-AZqQzADaj742oqn2xjl5JbIOzZB/DGCYF/7bpvhA8KvjUj9HJkag6bBuwZvH1ps6dfgxNHyuJVlzSr2VpMgdTQ=="],
@@ -1307,7 +1329,7 @@
 
     "@vite-pwa/assets-generator": ["@vite-pwa/assets-generator@1.0.2", "", { "dependencies": { "cac": "^6.7.14", "colorette": "^2.0.20", "consola": "^3.4.2", "sharp": "^0.33.5", "sharp-ico": "^0.1.5", "unconfig": "^7.3.1" }, "bin": { "pwa-assets-generator": "bin/pwa-assets-generator.mjs" } }, "sha512-MCbrb508JZHqe7bUibmZj/lyojdhLRnfkmyXnkrCM2zVrjTgL89U8UEfInpKTvPeTnxsw2hmyZxnhsdNR6yhwg=="],
 
-    "@vitejs/plugin-react": ["@vitejs/plugin-react@5.1.4", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA=="],
+    "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@4.3.0", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7", "@swc/core": "^1.15.11" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-mOkXCII839dHyAt/gpoSlm28JIVDwhZ6tnG6wJxUy2bmOx7UaPjvOyIDf3SFv5s7Eo7HVaq6kRcu6YMEzt5Z7w=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
@@ -2726,8 +2748,6 @@
     "react-icons": ["react-icons@5.5.0", "", { "peerDependencies": { "react": "*" } }, "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw=="],
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
-
-    "react-refresh": ["react-refresh@0.18.0", "", {}, "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw=="],
 
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 

--- a/packages/cli/src/templates/compose.yml.template
+++ b/packages/cli/src/templates/compose.yml.template
@@ -10,6 +10,8 @@ services:
     build:
       context: {{REPO_PATH}}
       dockerfile: Dockerfile
+      args:
+        PREBUILT_UI: "{{PREBUILT_UI}}"
     ports:
       - "{{PORT}}:7492"
     environment:

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -27,6 +27,8 @@ services:
     build:
       context: {{REPO_PATH}}
       dockerfile: Dockerfile
+      args:
+        PREBUILT_UI: "{{PREBUILT_UI}}"
     ports:
       - "{{PORT}}:7492"
     environment:
@@ -62,6 +64,7 @@ describe("web.ts compose template", () => {
         expect(COMPOSE_TEMPLATE).toContain("{{VAPID_PRIVATE_KEY}}");
         expect(COMPOSE_TEMPLATE).toContain("{{VAPID_SUBJECT}}");
         expect(COMPOSE_TEMPLATE).toContain("{{EXTRA_ORIGINS_LINE}}");
+        expect(COMPOSE_TEMPLATE).toContain("{{PREBUILT_UI}}");
     });
 
     test("template substitution produces valid compose structure", () => {
@@ -75,7 +78,8 @@ describe("web.ts compose template", () => {
             .replace(/\{\{VAPID_SUBJECT}}/g, "mailto:admin@pizzapi.local")
             .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, "      - PIZZAPI_EXTRA_ORIGINS=https://example.com\n")
             .replace(/\{\{TRUST_PROXY_LINE}}/g, "      # - PIZZAPI_TRUST_PROXY=\n")
-            .replace(/\{\{PROXY_DEPTH_LINE}}/g, "      # - PIZZAPI_PROXY_DEPTH=\n");
+            .replace(/\{\{PROXY_DEPTH_LINE}}/g, "      # - PIZZAPI_PROXY_DEPTH=\n")
+            .replace(/\{\{PREBUILT_UI}}/g, "true");
 
         // No unsubstituted placeholders remain
         expect(composed).not.toContain("{{");
@@ -93,6 +97,7 @@ describe("web.ts compose template", () => {
         expect(composed).toContain("VAPID_SUBJECT=mailto:admin@pizzapi.local");
         expect(composed).toContain("PIZZAPI_EXTRA_ORIGINS=https://example.com");
         expect(composed).toContain("/home/user/.pizzapi/web/data:/app/data:Z");
+        expect(composed).toContain('PREBUILT_UI: "true"');
     });
 
     test("template with no extra origins produces commented-out line", () => {
@@ -106,7 +111,8 @@ describe("web.ts compose template", () => {
             .replace(/\{\{VAPID_SUBJECT}}/g, "mailto:test@test.com")
             .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, "      # - PIZZAPI_EXTRA_ORIGINS=\n")
             .replace(/\{\{TRUST_PROXY_LINE}}/g, "      # - PIZZAPI_TRUST_PROXY=\n")
-            .replace(/\{\{PROXY_DEPTH_LINE}}/g, "      # - PIZZAPI_PROXY_DEPTH=\n");
+            .replace(/\{\{PROXY_DEPTH_LINE}}/g, "      # - PIZZAPI_PROXY_DEPTH=\n")
+            .replace(/\{\{PREBUILT_UI}}/g, "false");
 
         expect(composed).toContain("# - PIZZAPI_EXTRA_ORIGINS=");
         expect(composed).not.toContain("{{");

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -6,6 +6,9 @@ import {
     extractSettingsFromCompose,
     resolveBetterAuthSecret,
     resolveMissingProxySettings,
+    shouldInstallDependencies,
+    shouldRebuildHostUi,
+    readBooleanEnv,
 } from "./web";
 
 /**
@@ -54,6 +57,90 @@ describe("web.ts compose template", () => {
         const external = readFileSync(externalPath, "utf-8");
         expect(COMPOSE_TEMPLATE).toBe(external);
     });
+
+describe("shouldInstallDependencies", () => {
+    test("requires install when node_modules missing", () => {
+        expect(
+            shouldInstallDependencies({
+                nodeModulesPresent: false,
+                currentLockHash: "abc",
+                lastLockHash: "abc",
+            })
+        ).toBe(true);
+    });
+
+    test("skips install when hashes match", () => {
+        expect(
+            shouldInstallDependencies({
+                nodeModulesPresent: true,
+                currentLockHash: "abc",
+                lastLockHash: "abc",
+            })
+        ).toBe(false);
+    });
+
+    test("installs when lock hash changed", () => {
+        expect(
+            shouldInstallDependencies({
+                nodeModulesPresent: true,
+                currentLockHash: "new",
+                lastLockHash: "old",
+            })
+        ).toBe(true);
+    });
+});
+
+describe("shouldRebuildHostUi", () => {
+    test("rebuilds when dist missing", () => {
+        expect(
+            shouldRebuildHostUi({
+                distReady: false,
+                currentSignature: "sig",
+                lastSignature: "sig",
+            })
+        ).toBe(true);
+    });
+
+    test("skips rebuild when signature unchanged", () => {
+        expect(
+            shouldRebuildHostUi({
+                distReady: true,
+                currentSignature: "sig",
+                lastSignature: "sig",
+            })
+        ).toBe(false);
+    });
+
+    test("rebuilds when signature missing", () => {
+        expect(
+            shouldRebuildHostUi({
+                distReady: true,
+                currentSignature: null,
+                lastSignature: "sig",
+            })
+        ).toBe(true);
+    });
+});
+
+describe("readBooleanEnv", () => {
+    test("falls back to default when undefined", () => {
+        expect(readBooleanEnv(undefined, true)).toBe(true);
+    });
+
+    test("parses truthy strings", () => {
+        expect(readBooleanEnv("YES", false)).toBe(true);
+        expect(readBooleanEnv("1", false)).toBe(true);
+    });
+
+    test("parses falsy strings", () => {
+        expect(readBooleanEnv("no", true)).toBe(false);
+        expect(readBooleanEnv("0", true)).toBe(false);
+    });
+
+    test("returns default for unknown values", () => {
+        expect(readBooleanEnv("maybe", true)).toBe(true);
+    });
+});
 
     test("template contains all required placeholders", () => {
         expect(COMPOSE_TEMPLATE).toContain("{{REPO_PATH}}");

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -13,7 +13,7 @@
  */
 
 import { execFileSync, spawn } from "child_process";
-import { createECDH, randomBytes } from "crypto";
+import { createECDH, createHash, randomBytes } from "crypto";
 import { existsSync, mkdirSync, writeFileSync, readFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
@@ -41,7 +41,77 @@ export interface WebConfig {
 
 const WEB_DIR = join(homedir(), ".pizzapi", "web");
 const CONFIG_PATH = join(WEB_DIR, "config.json");
+const HOST_BUILD_STATE_PATH = join(WEB_DIR, "host-build.json");
 const REPO_URL = "https://github.com/Pizzaface/PizzaPi.git";
+
+interface HostBuildState {
+    lastLockHash?: string | null;
+    lastUiSignature?: string | null;
+}
+
+function loadHostBuildState(): HostBuildState {
+    try {
+        return JSON.parse(readFileSync(HOST_BUILD_STATE_PATH, "utf-8"));
+    } catch {
+        return {};
+    }
+}
+
+function saveHostBuildState(state: HostBuildState): void {
+    mkdirSync(WEB_DIR, { recursive: true });
+    writeFileSync(HOST_BUILD_STATE_PATH, JSON.stringify(state, null, 2) + "\n");
+}
+
+function hashFile(path: string): string | null {
+    try {
+        return createHash("sha256").update(readFileSync(path)).digest("hex");
+    } catch {
+        return null;
+    }
+}
+
+function computeUiSignature(repoPath: string): string | null {
+    try {
+        const head = execFileSync("git", ["-C", repoPath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
+        const status = execFileSync(
+            "git",
+            ["-C", repoPath, "status", "--short", "packages/ui", "packages/protocol"],
+            { encoding: "utf-8" }
+        ).trim();
+        const lockHash = hashFile(join(repoPath, "bun.lock")) ?? "";
+        return createHash("sha256").update(head).update("\n").update(status).update("\n").update(lockHash).digest("hex");
+    } catch {
+        return null;
+    }
+}
+
+export function shouldInstallDependencies(opts: {
+    nodeModulesPresent: boolean;
+    currentLockHash: string | null;
+    lastLockHash: string | null | undefined;
+}): boolean {
+    if (!opts.nodeModulesPresent) return true;
+    if (!opts.currentLockHash) return false;
+    return opts.currentLockHash !== (opts.lastLockHash ?? null);
+}
+
+export function shouldRebuildHostUi(opts: {
+    distReady: boolean;
+    currentSignature: string | null;
+    lastSignature: string | null | undefined;
+}): boolean {
+    if (!opts.distReady) return true;
+    if (!opts.currentSignature) return true;
+    return opts.currentSignature !== (opts.lastSignature ?? null);
+}
+
+export function readBooleanEnv(value: string | undefined, defaultValue: boolean): boolean {
+    if (value === undefined) return defaultValue;
+    const normalized = value.trim().toLowerCase();
+    if (["1", "true", "yes", "on"].includes(normalized)) return true;
+    if (["0", "false", "no", "off"].includes(normalized)) return false;
+    return defaultValue;
+}
 
 // ─── VAPID key generation ─────────────────────────────────────────────────────
 
@@ -518,8 +588,10 @@ services:
  */
 function prebuildUI(repoPath: string): boolean {
     const uiDist = join(repoPath, "packages", "ui", "dist");
+    const uiDistIndex = join(uiDist, "index.html");
+    const nodeModulesPath = join(repoPath, "node_modules");
+    const protocolDist = join(repoPath, "packages", "protocol", "dist");
 
-    // Check if bun is available on the host
     try {
         execFileSync("bun", ["--version"], { stdio: "ignore" });
     } catch {
@@ -528,32 +600,62 @@ function prebuildUI(repoPath: string): boolean {
     }
 
     console.log("Pre-building UI on host for faster Docker build...");
+
+    const state = loadHostBuildState();
+    let stateDirty = false;
+
+    const lockHash = hashFile(join(repoPath, "bun.lock"));
+    const needsInstall = shouldInstallDependencies({
+        nodeModulesPresent: existsSync(nodeModulesPath),
+        currentLockHash: lockHash,
+        lastLockHash: state.lastLockHash,
+    });
+
     try {
-        // Install deps if node_modules is missing
-        if (!existsSync(join(repoPath, "node_modules"))) {
-            console.log("  Installing dependencies...");
+        if (needsInstall) {
+            console.log("  Installing dependencies (bun install)...");
             execFileSync("bun", ["install"], { cwd: repoPath, stdio: "inherit" });
+            state.lastLockHash = lockHash ?? null;
+            stateDirty = true;
         }
 
-        // Build protocol (UI imports @pizzapi/protocol which needs dist/)
-        const protocolDist = join(repoPath, "packages", "protocol", "dist");
-        if (!existsSync(protocolDist)) {
-            console.log("  Building protocol...");
-            execFileSync("bun", ["run", "build:protocol"], { cwd: repoPath, stdio: "inherit" });
+        const uiSignature = computeUiSignature(repoPath);
+        const distReady = existsSync(uiDistIndex);
+        const needsUiBuild = shouldRebuildHostUi({
+            distReady,
+            currentSignature: uiSignature,
+            lastSignature: state.lastUiSignature,
+        });
+
+        if (!needsUiBuild && distReady) {
+            console.log("  Host UI build is up to date (reusing dist/).");
+            if (stateDirty) saveHostBuildState(state);
+            return true;
         }
 
-        // Build UI
+        console.log("  Building protocol...");
+        execFileSync("bun", ["run", "build:protocol"], { cwd: repoPath, stdio: "inherit" });
+
         console.log("  Building UI...");
         execFileSync("bun", ["run", "build:ui"], { cwd: repoPath, stdio: "inherit" });
 
-        if (existsSync(join(uiDist, "index.html"))) {
+        if (existsSync(uiDistIndex)) {
             console.log("  ✓ UI pre-built successfully.");
+            if (uiSignature) {
+                state.lastUiSignature = uiSignature;
+                stateDirty = true;
+            }
+            if (stateDirty) saveHostBuildState(state);
             return true;
         }
     } catch (err) {
         console.warn("Warning: Host UI build failed, falling back to Docker build.");
         if (err instanceof Error) console.warn(`  ${err.message}`);
+        if (stateDirty) saveHostBuildState(state);
+        return false;
     }
+
+    if (stateDirty) saveHostBuildState(state);
     return false;
 }
 
@@ -898,9 +1000,13 @@ export async function runWeb(args: string[]): Promise<void> {
 
     const repoPath = getRepoPath();
 
-    // Pre-build UI on the host for much faster Docker builds.
-    // Falls back to building inside Docker if bun is not available.
-    const prebuiltUi = prebuildUI(repoPath);
+    const useHostPrebuild = readBooleanEnv(process.env.PIZZAPI_PREBUILD_UI, true);
+    if (!useHostPrebuild) {
+        console.log("Skipping host UI pre-build (PIZZAPI_PREBUILD_UI=false).");
+    }
+
+    // Pre-build UI on the host for much faster Docker builds when enabled.
+    const prebuiltUi = useHostPrebuild ? prebuildUI(repoPath) : false;
     const composePath = generateComposeFile(repoPath, config, prebuiltUi);
 
     console.log(`Starting PizzaPi web on port ${config.port}...`);

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -487,6 +487,8 @@ services:
     build:
       context: {{REPO_PATH}}
       dockerfile: Dockerfile
+      args:
+        PREBUILT_UI: "{{PREBUILT_UI}}"
     ports:
       - "{{PORT}}:7492"
     environment:
@@ -503,7 +505,59 @@ services:
     restart: unless-stopped
 `;
 
-function generateComposeFile(repoPath: string, config: WebConfig): string {
+// ─── Host-side UI pre-build ──────────────────────────────────────────────────
+
+/**
+ * Attempt to build the UI on the host using bun (native speed, ~15s) instead
+ * of inside Docker (minutes on Docker Desktop VMs).  Returns true if the
+ * pre-built dist is ready in `repoPath/packages/ui/dist`.
+ *
+ * Gracefully falls back to false (Docker will build it) when:
+ *   - `bun` is not on PATH (e.g. npm-installed binary without bun)
+ *   - `bun install` or `bun run build` fails for any reason
+ */
+function prebuildUI(repoPath: string): boolean {
+    const uiDist = join(repoPath, "packages", "ui", "dist");
+
+    // Check if bun is available on the host
+    try {
+        execFileSync("bun", ["--version"], { stdio: "ignore" });
+    } catch {
+        console.log("bun not found on host — UI will be built inside Docker (slower).");
+        return false;
+    }
+
+    console.log("Pre-building UI on host for faster Docker build...");
+    try {
+        // Install deps if node_modules is missing
+        if (!existsSync(join(repoPath, "node_modules"))) {
+            console.log("  Installing dependencies...");
+            execFileSync("bun", ["install"], { cwd: repoPath, stdio: "inherit" });
+        }
+
+        // Build protocol (UI imports @pizzapi/protocol which needs dist/)
+        const protocolDist = join(repoPath, "packages", "protocol", "dist");
+        if (!existsSync(protocolDist)) {
+            console.log("  Building protocol...");
+            execFileSync("bun", ["run", "build:protocol"], { cwd: repoPath, stdio: "inherit" });
+        }
+
+        // Build UI
+        console.log("  Building UI...");
+        execFileSync("bun", ["run", "build:ui"], { cwd: repoPath, stdio: "inherit" });
+
+        if (existsSync(join(uiDist, "index.html"))) {
+            console.log("  ✓ UI pre-built successfully.");
+            return true;
+        }
+    } catch (err) {
+        console.warn("Warning: Host UI build failed, falling back to Docker build.");
+        if (err instanceof Error) console.warn(`  ${err.message}`);
+    }
+    return false;
+}
+
+function generateComposeFile(repoPath: string, config: WebConfig, prebuiltUi: boolean): string {
     const composePath = join(WEB_DIR, "compose.yml");
     mkdirSync(WEB_DIR, { recursive: true });
 
@@ -563,7 +617,8 @@ function generateComposeFile(repoPath: string, config: WebConfig): string {
         .replace(/\{\{BETTER_AUTH_SECRET}}/g, config.betterAuthSecret)
         .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, extraOriginsLine)
         .replace(/\{\{TRUST_PROXY_LINE}}/g, trustProxyLine)
-        .replace(/\{\{PROXY_DEPTH_LINE}}/g, proxyDepthLine);
+        .replace(/\{\{PROXY_DEPTH_LINE}}/g, proxyDepthLine)
+        .replace(/\{\{PREBUILT_UI}}/g, prebuiltUi ? "true" : "false");
 
     // Only write if changed
     const existing = existsSync(composePath) ? readFileSync(composePath, "utf-8") : null;
@@ -842,7 +897,11 @@ export async function runWeb(args: string[]): Promise<void> {
     }
 
     const repoPath = getRepoPath();
-    const composePath = generateComposeFile(repoPath, config);
+
+    // Pre-build UI on the host for much faster Docker builds.
+    // Falls back to building inside Docker if bun is not available.
+    const prebuiltUi = prebuildUI(repoPath);
+    const composePath = generateComposeFile(repoPath, config, prebuiltUi);
 
     console.log(`Starting PizzaPi web on port ${config.port}...`);
     console.log(`  Repo:    ${repoPath}`);

--- a/packages/docs/src/content/docs/deployment/self-hosting.mdx
+++ b/packages/docs/src/content/docs/deployment/self-hosting.mdx
@@ -20,7 +20,8 @@ pizzapi web
 This automatically:
 1. Clones the PizzaPi repo (if not already present) to `~/.pizzapi/web/repo`
 2. Generates required secrets (including `BETTER_AUTH_SECRET` and VAPID keys) and a Docker Compose file in `~/.pizzapi/web/`
-3. Builds and starts Redis + the relay server
+3. Builds the UI on your host with Bun (cached between runs unless sources change)
+4. Builds and starts Redis + the relay server
 4. Serves the web UI at **http://localhost:7492**
 
 On subsequent runs, it pulls the latest changes and rebuilds if needed.
@@ -51,7 +52,7 @@ All settings are persisted in `~/.pizzapi/web/config.json` and applied on every 
 Persistent data (SQLite database) is stored in `~/.pizzapi/web/data/`.
 
 <Aside type="tip">
-  `pizza web` is ideal for personal use or quick evaluation. For production deployments with custom domains and TLS, see the manual Docker Compose setup below. See the [CLI Reference](/PizzaPi/running/cli-reference/#pizzapi-web) for the full list of commands and config keys.
+  `pizza web` is ideal for personal use or quick evaluation. For production deployments with custom domains and TLS, see the manual Docker Compose setup below. See the [CLI Reference](/PizzaPi/running/cli-reference/#pizzapi-web) for the full list of commands and config keys. Set `PIZZAPI_PREBUILD_UI=false` if you would rather have Docker perform the UI build.
 </Aside>
 
 ---

--- a/packages/docs/src/content/docs/running/cli-reference.mdx
+++ b/packages/docs/src/content/docs/running/cli-reference.mdx
@@ -148,6 +148,12 @@ Flags:
   -f, --foreground    Run in the foreground (don't detach)
   -h, --help          Show this help
 
+Host build:
+  PIZZAPI_PREBUILD_UI=false   Skip the host-side UI build and let Docker build it instead
+
+Docker build args:
+  PREBUILT_UI (auto)    Set by pizza web based on the host prebuild result
+
 Configuration (~/.pizzapi/web/config.json):
   port            Host port (default: 7492)
   vapidSubject    VAPID subject for push notifications
@@ -175,6 +181,10 @@ pizzapi web status
 
 <Aside type="note">
   Requires **Docker** with Docker Compose installed. If you're not running from the PizzaPi repository, the command will automatically clone it to `~/.pizzapi/web/repo`.
+</Aside>
+
+<Aside type="tip">
+  On each start `pizza web` attempts to build the UI on the host using Bun (typically ~15 seconds) and injects the result into the Docker build. Set `PIZZAPI_PREBUILD_UI=false` if you prefer Docker to perform the UI build or if Bun is unavailable on the host.
 </Aside>
 
 | Subcommand | Description |

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -52,7 +52,7 @@
     "@tailwindcss/vite": "^4.2.0",
     "@types/react-resizable": "^3.0.8",
     "@vite-pwa/assets-generator": "^1.0.2",
-    "@vitejs/plugin-react": "^5.1.4",
+    "@vitejs/plugin-react-swc": "^4.3.0",
     "@xterm/addon-fit": "^0.11.0",
     "@xterm/addon-web-links": "^0.12.0",
     "@xterm/xterm": "^6.0.0",

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from "vite";
-import react from "@vitejs/plugin-react";
+import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
 import { VitePWA } from "vite-plugin-pwa";
 import path from "path";


### PR DESCRIPTION
## Summary

Dramatically reduces `pizza web` Docker build times by pre-building the UI on the host and parallelizing Docker stages.

## Changes

- **Split Dockerfile into parallel BuildKit stages** — server `tsc` and UI `vite` build run concurrently
- **Pre-build UI on host** when `bun` is available on PATH (~15s native vs ~6min in Docker VM)
  - `PREBUILT_UI` build arg controls behavior (`true` = skip Vite in Docker)
  - Graceful fallback for npm installs where `bun` may not be on PATH
- **Swap `@vitejs/plugin-react` (Babel) → `@vitejs/plugin-react-swc` (SWC)** — ~6x faster JSX transforms
- **Replace `bunx tsc`** with direct `node_modules/typescript/bin/tsc` (no download overhead)
- **Add BuildKit cache mount** for `bun install`
- **Expand `.dockerignore`** — exclude cli/docs/npm packages, allow `packages/ui/dist` through

## Performance

| Scenario | Before | After |
|----------|--------|-------|
| Host has `bun` (dev) | ~6 min | **~15s UI + ~55s server tsc** |
| npm install (no bun) | ~6 min | ~6 min (fallback, SWC still helps) |
| Local Vite build | 78s (Babel) | **13s (SWC)** |

## Testing

- All 414 tests pass
- Typecheck clean
- Docker build verified with `PREBUILT_UI=true` and `PREBUILT_UI=false`