### PR TITLE
⚡ Bolt: Optimize socket presence check in emitToRelaySessionAwaitingAck

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -6,3 +6,6 @@
 ## 2025-04-18 - Use adapter.sockets() for presence/count checks
 **Learning:** Using `allSockets()` or `fetchSockets()` pulls full `RemoteSocket` objects across the cluster via the Redis adapter. When only the presence of sockets or the count is needed, directly querying the adapter via `adapter.sockets(new Set([roomName]))` avoids this expensive network overhead.
 **Action:** Use `await io.of("namespace").adapter.sockets(new Set([roomName]))` to check for room presence or socket count instead of `fetchSockets()`.
+## 2024-05-20 - Fast Socket.IO presence checks
+**Learning:** In Socket.IO, using `fetchSockets()` to verify if clients are in a room incurs expensive network overhead because it pulls full `RemoteSocket` objects across the Redis cluster.
+**Action:** Query the adapter directly using `await io.of('...').adapter.sockets(new Set([room]))` to return a `Set` of socket IDs quickly.

--- a/packages/server/src/ws/sio-registry.delink.test.ts
+++ b/packages/server/src/ws/sio-registry.delink.test.ts
@@ -48,9 +48,9 @@ describe("sio-registry delink helpers", () => {
 
     it("confirms parent_delinked delivery when a relay socket acks", async () => {
         const relayNamespace = {
-            in: (_room: string) => ({
-                fetchSockets: async () => [{ id: "socket-1" }],
-            }),
+            adapter: {
+                sockets: async (_rooms: Set<string>) => new Set(["socket-1"]),
+            },
             to: (_room: string) => ({
                 timeout: (_timeoutMs: number) => ({
                     emit: (_eventName: string, _data: unknown, ack: (err: unknown, responses?: unknown[]) => void) => {
@@ -72,9 +72,9 @@ describe("sio-registry delink helpers", () => {
 
     it("reports failure when listeners exist but none ack parent_delinked", async () => {
         const relayNamespace = {
-            in: (_room: string) => ({
-                fetchSockets: async () => [{ id: "socket-1" }],
-            }),
+            adapter: {
+                sockets: async (_rooms: Set<string>) => new Set(["socket-1"]),
+            },
             to: (_room: string) => ({
                 timeout: (_timeoutMs: number) => ({
                     emit: (_eventName: string, _data: unknown, ack: (err: unknown, responses?: unknown[]) => void) => {

--- a/packages/server/src/ws/sio-registry.delink.test.ts
+++ b/packages/server/src/ws/sio-registry.delink.test.ts
@@ -70,6 +70,30 @@ describe("sio-registry delink helpers", () => {
         });
     });
 
+    it("returns hadListeners:false immediately when no relay sockets are present (empty set)", async () => {
+        let emitCalled = false;
+        const relayNamespace = {
+            adapter: {
+                sockets: async (_rooms: Set<string>) => new Set<string>(),
+            },
+            to: (_room: string) => ({
+                timeout: (_timeoutMs: number) => ({
+                    emit: (_eventName: string, _data: unknown, _ack: (err: unknown, responses?: unknown[]) => void) => {
+                        emitCalled = true;
+                    },
+                }),
+            }),
+        };
+
+        initSioRegistry({
+            of: () => relayNamespace,
+        } as any);
+
+        const result = await emitToRelaySessionAwaitingAck("child-1", "parent_delinked", { parentSessionId: "parent-1" });
+        expect(result).toEqual({ hadListeners: false, acked: false });
+        expect(emitCalled).toBe(false);
+    });
+
     it("reports failure when listeners exist but none ack parent_delinked", async () => {
         const relayNamespace = {
             adapter: {

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -208,8 +208,9 @@ export async function emitToRelaySessionAwaitingAck(
     if (!io) return { hadListeners: false, acked: false };
     const room = relaySessionRoom(sessionId);
     try {
-        const sockets = await io.of("/relay").in(room).fetchSockets();
-        if (sockets.length === 0) return { hadListeners: false, acked: false };
+        // ⚡ Bolt: Fast socket presence check via adapter.sockets() avoids expensive cluster-wide network overhead of fetchSockets()
+        const sockets = await io.of("/relay").adapter.sockets(new Set([room]));
+        if (sockets.size === 0) return { hadListeners: false, acked: false };
 
         const relayNs = io.of("/relay") as any;
         const responses = await new Promise<unknown[]>((resolve, reject) => {


### PR DESCRIPTION
💡 What: Changed the slow `fetchSockets()` operation (which gathers full socket objects across the Redis cluster) to the lightweight `adapter.sockets(new Set([room]))` operation which only retrieves socket IDs in `emitToRelaySessionAwaitingAck`.

🎯 Why: To reduce expensive cluster-wide network overhead.

📊 Impact: Significantly improves performance and reduces network calls when a relay socket acks a parent delinked message.

🔬 Measurement: Verifiable by checking the reduced network latency when confirming `parent_delinked` events. Tests run and verify identical behavior using `bun test packages/server/src/ws/sio-registry.delink.test.ts`.

---
*PR created automatically by Jules for task [14302131403950611619](https://jules.google.com/task/14302131403950611619) started by @Pizzaface*