### PR TITLE
fix(api): handle malformed JSON in /api/chat

### DIFF
--- a/packages/server/src/routes/chat.test.ts
+++ b/packages/server/src/routes/chat.test.ts
@@ -1,12 +1,24 @@
-import { describe, expect, test, mock } from "bun:test";
-import { handleChatRoute } from "./chat";
-import * as middleware from "../middleware.js";
+import { describe, expect, test, mock, beforeAll } from "bun:test";
 
+// mock.module MUST be registered before any import of the module under test
+// (or modules that transitively import the mocked dependency).
+// Static imports are hoisted and resolved before module-level code runs,
+// so we register the mock here — at the very top — and then dynamically
+// import the module under test inside beforeAll().
 mock.module("../middleware.js", () => {
     return {
         requireSession: mock(() => Promise.resolve({ userId: "test-user", userName: "Test User" })),
         validateApiKey: mock(() => Promise.resolve({ userId: "test-user", userName: "Test User" })),
     };
+});
+
+let handleChatRoute: (req: Request, url: URL) => Promise<Response | undefined>;
+
+beforeAll(async () => {
+    // Dynamic import ensures the mock above is already in place when
+    // ./chat.js (and its transitive dependency ../middleware.js) are loaded.
+    const mod = await import("./chat.js");
+    handleChatRoute = mod.handleChatRoute;
 });
 
 describe("handleChatRoute", () => {

--- a/packages/server/src/routes/chat.test.ts
+++ b/packages/server/src/routes/chat.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test, mock } from "bun:test";
+import { handleChatRoute } from "./chat";
+import * as middleware from "../middleware.js";
+
+mock.module("../middleware.js", () => {
+    return {
+        requireSession: mock(() => Promise.resolve({ userId: "test-user", userName: "Test User" })),
+        validateApiKey: mock(() => Promise.resolve({ userId: "test-user", userName: "Test User" })),
+    };
+});
+
+describe("handleChatRoute", () => {
+    test("returns 400 for malformed JSON body", async () => {
+        const url = new URL("http://localhost/api/chat");
+        const req = new Request(url, {
+            method: "POST",
+            body: "{ malformed ",
+        });
+
+        const res = await handleChatRoute(req, url);
+        expect(res).toBeDefined();
+        expect(res!.status).toBe(400);
+
+        const data = await res!.json();
+        expect(data).toEqual({ error: "Invalid JSON body" });
+    });
+
+    test("returns 400 for valid JSON body with missing fields", async () => {
+        const url = new URL("http://localhost/api/chat");
+        const req = new Request(url, {
+            method: "POST",
+            body: JSON.stringify({ message: "Hello", provider: "mock-provider" }),
+        });
+
+        const res = await handleChatRoute(req, url);
+        expect(res).toBeDefined();
+        expect(res!.status).toBe(400);
+
+        const data = await res!.json();
+        expect(data).toEqual({ error: "Missing required fields: message, provider, model" });
+    });
+});

--- a/packages/server/src/routes/chat.test.ts
+++ b/packages/server/src/routes/chat.test.ts
@@ -25,6 +25,51 @@ describe("handleChatRoute", () => {
         expect(data).toEqual({ error: "Invalid JSON body" });
     });
 
+    test("returns 400 for valid JSON null body", async () => {
+        const url = new URL("http://localhost/api/chat");
+        const req = new Request(url, {
+            method: "POST",
+            body: JSON.stringify(null),
+        });
+
+        const res = await handleChatRoute(req, url);
+        expect(res).toBeDefined();
+        expect(res!.status).toBe(400);
+
+        const data = await res!.json();
+        expect(data).toEqual({ error: "Invalid JSON body" });
+    });
+
+    test("returns 400 for valid JSON array body", async () => {
+        const url = new URL("http://localhost/api/chat");
+        const req = new Request(url, {
+            method: "POST",
+            body: JSON.stringify([]),
+        });
+
+        const res = await handleChatRoute(req, url);
+        expect(res).toBeDefined();
+        expect(res!.status).toBe(400);
+
+        const data = await res!.json();
+        expect(data).toEqual({ error: "Invalid JSON body" });
+    });
+
+    test("returns 400 for valid JSON primitive body", async () => {
+        const url = new URL("http://localhost/api/chat");
+        const req = new Request(url, {
+            method: "POST",
+            body: JSON.stringify(42),
+        });
+
+        const res = await handleChatRoute(req, url);
+        expect(res).toBeDefined();
+        expect(res!.status).toBe(400);
+
+        const data = await res!.json();
+        expect(data).toEqual({ error: "Invalid JSON body" });
+    });
+
     test("returns 400 for valid JSON body with missing fields", async () => {
         const url = new URL("http://localhost/api/chat");
         const req = new Request(url, {

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -21,6 +21,10 @@ export const handleChatRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Invalid JSON body" }, { status: 400 });
         }
 
+        if (body === null || typeof body !== "object" || Array.isArray(body)) {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+        }
+
         const { message, provider, model: modelId } = body;
 
         if (!message || !provider || !modelId) {

--- a/packages/server/src/routes/chat.ts
+++ b/packages/server/src/routes/chat.ts
@@ -13,7 +13,14 @@ export const handleChatRoute: RouteHandler = async (req, url) => {
     if (url.pathname === "/api/chat" && req.method === "POST") {
         const identity = await requireSession(req);
         if (identity instanceof Response) return identity;
-        const body = await req.json();
+
+        let body;
+        try {
+            body = await req.json();
+        } catch (error) {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+        }
+
         const { message, provider, model: modelId } = body;
 
         if (!message || !provider || !modelId) {


### PR DESCRIPTION
Fixes an issue where sending malformed JSON to `/api/chat` via POST would throw an unhandled internal server error instead of returning a proper 400 Bad Request error. Added a new unit test suite to verify the route behavior.

---
*PR created automatically by Jules for task [16394393567445361740](https://jules.google.com/task/16394393567445361740) started by @Pizzaface*