### PR TITLE
feat: decompose heartbeat into discrete push events via hub session meta rooms

### DIFF
--- a/packages/cli/src/extensions/plan-mode-toggle.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.ts
@@ -1220,6 +1220,7 @@ After completing a step, include a [DONE:n] tag in your response (e.g. [DONE:1])
         syncModuleState();
         if (wasEnabled) {
             _onPlanModeChange?.(false);
+            _planModeMetaEmitter?.(false);
         }
         persistState();
     });

--- a/packages/cli/src/extensions/plan-mode-toggle.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.ts
@@ -761,6 +761,12 @@ export function setPlanModeChangeCallback(cb: (enabled: boolean) => void): void 
     _onPlanModeChange = cb;
 }
 
+/** Meta event emitter for discrete plan_mode_toggled events. */
+let _planModeMetaEmitter: ((enabled: boolean) => void) | null = null;
+export function setPlanModeMetaEmitter(cb: (enabled: boolean) => void): void {
+    _planModeMetaEmitter = cb;
+}
+
 /** Toggle function exposed for the remote extension (/plan from web UI). */
 let _toggleFn: (() => void) | null = null;
 
@@ -833,6 +839,7 @@ export const planModeToggleExtension: ExtensionFactory = (pi) => {
         }
         syncModuleState();
         _onPlanModeChange?.(planModeEnabled);
+        if (_planModeMetaEmitter) _planModeMetaEmitter(planModeEnabled);
         persistState();
     }
 

--- a/packages/cli/src/extensions/remote-ask-user.ts
+++ b/packages/cli/src/extensions/remote-ask-user.ts
@@ -14,6 +14,7 @@ import type {
     AskUserQuestionDisplay,
     AskUserQuestionDetails,
 } from "./remote-types.js";
+import { emitQuestionPending, emitQuestionCleared } from "./remote-meta-events.js";
 
 const ASK_USER_TOOL_NAME = "AskUserQuestion";
 
@@ -62,7 +63,9 @@ export function consumePendingAskUserQuestionFromWeb(rctx: RelayContext, text: s
     if (!answer) return true;
 
     const pending = rctx.pendingAskUserQuestion;
+    const clearedToolCallId = pending.toolCallId;
     rctx.pendingAskUserQuestion = null;
+    emitQuestionCleared(rctx, clearedToolCallId);
     pending.resolve(answer);
     rctx.setRelayStatus(rctx.relay ? "Connected to Relay" : rctx.disconnectedStatusText());
     return true;
@@ -71,7 +74,9 @@ export function consumePendingAskUserQuestionFromWeb(rctx: RelayContext, text: s
 export function cancelPendingAskUserQuestion(rctx: RelayContext) {
     if (!rctx.pendingAskUserQuestion) return;
     const pending = rctx.pendingAskUserQuestion;
+    const clearedToolCallId = pending.toolCallId;
     rctx.pendingAskUserQuestion = null;
+    emitQuestionCleared(rctx, clearedToolCallId);
     pending.resolve(null);
     rctx.setRelayStatus(rctx.relay ? "Connected to Relay" : rctx.disconnectedStatusText());
 }
@@ -113,6 +118,7 @@ async function askUserQuestion(
 
             if (rctx.pendingAskUserQuestion?.toolCallId === toolCallId) {
                 rctx.pendingAskUserQuestion = null;
+                emitQuestionCleared(rctx, toolCallId);
             }
 
             localAbort.abort();
@@ -144,6 +150,11 @@ async function askUserQuestion(
                     }
                 },
             };
+            emitQuestionPending(rctx, {
+                toolCallId: rctx.pendingAskUserQuestion.toolCallId,
+                questions: rctx.pendingAskUserQuestion.questions,
+                display: rctx.pendingAskUserQuestion.display,
+            });
             rctx.setRelayStatus("Waiting for AskUserQuestion answer");
         }
 

--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -13,6 +13,7 @@ import { isSandboxActive, getSandboxMode, getViolations, getResolvedConfig } fro
 import { refreshAllUsage, buildProviderUsage } from "./remote-provider-usage.js";
 import type { RemoteExecRequest, RemoteExecResponse } from "./remote-commands.js";
 import type { RelayContext, RelayModelInfo } from "./remote-types.js";
+import { emitThinkingLevelChanged, emitCompactStarted, emitCompactEnded, emitRetryStateChanged, emitPluginTrustResolved } from "./remote-meta-events.js";
 
 export interface ExecHandlerCallbacks {
     setModelFromWeb(provider: string, modelId: string): Promise<void>;
@@ -174,6 +175,7 @@ export async function handleExecFromWeb(
                 return;
             }
             api.setThinkingLevel(level);
+            emitThinkingLevelChanged(rctx, api.getThinkingLevel());
             replyOk({ thinkingLevel: api.getThinkingLevel() });
             rctx.emitSessionActive();
             return;
@@ -202,6 +204,7 @@ export async function handleExecFromWeb(
                 if (appliedLevel !== current) break;
             }
 
+            emitThinkingLevelChanged(rctx, appliedLevel);
             replyOk({ thinkingLevel: appliedLevel });
             rctx.emitSessionActive();
             return;
@@ -256,6 +259,7 @@ export async function handleExecFromWeb(
                 return;
             }
             rctx.isCompacting = true;
+            emitCompactStarted(rctx);
             rctx.forwardEvent(rctx.buildHeartbeat());
             try {
                 const result = await new Promise<unknown>((resolve, reject) => {
@@ -268,11 +272,14 @@ export async function handleExecFromWeb(
                 rctx.isAgentActive = false;
                 rctx.lastRetryableError = null;
                 rctx.isCompacting = false;
+                emitCompactEnded(rctx);
+                emitRetryStateChanged(rctx, null);
                 replyOk(result ?? null);
                 rctx.emitSessionActive();
                 rctx.forwardEvent(rctx.buildHeartbeat());
             } catch (err) {
                 rctx.isCompacting = false;
+                emitCompactEnded(rctx);
                 rctx.forwardEvent(rctx.buildHeartbeat());
                 throw err;
             }
@@ -504,8 +511,10 @@ export async function handleExecFromWeb(
                 return;
             }
             const trusted = req.trusted === true;
+            const resolvedPromptId = rctx.pendingPluginTrust.promptId;
             rctx.pendingPluginTrust.respond(trusted);
             rctx.pendingPluginTrust = null;
+            emitPluginTrustResolved(rctx, resolvedPromptId);
             replyOk({ trusted });
             return;
         }

--- a/packages/cli/src/extensions/remote-heartbeat.ts
+++ b/packages/cli/src/extensions/remote-heartbeat.ts
@@ -3,10 +3,6 @@
  */
 
 import type { RelayContext } from "./remote-types.js";
-import { getAuthSource } from "./remote-auth-source.js";
-import { buildProviderUsage, refreshAllUsage } from "./remote-provider-usage.js";
-import { getCurrentTodoList } from "./update-todo.js";
-import { isPlanModeEnabled } from "./plan-mode-toggle.js";
 
 export function buildTokenUsage(rctx: RelayContext): { input: number; output: number; cacheRead: number; cacheWrite: number; cost: number } {
     if (!rctx.latestCtx) return { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0 };
@@ -24,55 +20,16 @@ export function buildTokenUsage(rctx: RelayContext): { input: number; output: nu
 }
 
 export function buildHeartbeat(rctx: RelayContext) {
-    const thinkingLevel = rctx.getCurrentThinkingLevel();
-    const authSource = getAuthSource(rctx.latestCtx);
-
     return {
         type: "heartbeat",
         active: rctx.isAgentActive,
-        isCompacting: rctx.isCompacting,
+        ts: Date.now(),
         model: rctx.latestCtx?.model
             ? { provider: rctx.latestCtx.model.provider, id: rctx.latestCtx.model.id, name: rctx.latestCtx.model.name, reasoning: rctx.latestCtx.model.reasoning }
             : null,
-        authSource,
         sessionName: rctx.getCurrentSessionName(),
-        thinkingLevel: thinkingLevel ?? null,
-        tokenUsage: buildTokenUsage(rctx),
-        cwd: rctx.latestCtx?.cwd ?? null,
         uptime: rctx.sessionStartedAt !== null ? Date.now() - rctx.sessionStartedAt : null,
-        ts: Date.now(),
-        providerUsage: buildProviderUsage(),
-        todoList: getCurrentTodoList(),
-        pendingQuestion: rctx.pendingAskUserQuestion
-            ? {
-                  toolCallId: rctx.pendingAskUserQuestion.toolCallId,
-                  questions: rctx.pendingAskUserQuestion.questions,
-                  display: rctx.pendingAskUserQuestion.display,
-              }
-            : null,
-        pendingPlan: rctx.pendingPlanMode
-            ? {
-                  toolCallId: rctx.pendingPlanMode.toolCallId,
-                  title: rctx.pendingPlanMode.title,
-                  description: rctx.pendingPlanMode.description,
-                  steps: rctx.pendingPlanMode.steps,
-              }
-            : null,
-        retryState: rctx.lastRetryableError
-            ? {
-                  errorMessage: rctx.lastRetryableError.errorMessage,
-                  detectedAt: rctx.lastRetryableError.detectedAt,
-              }
-            : null,
-        pendingPluginTrust: rctx.pendingPluginTrust
-            ? {
-                  promptId: rctx.pendingPluginTrust.promptId,
-                  pluginNames: rctx.pendingPluginTrust.pluginNames,
-                  pluginSummaries: rctx.pendingPluginTrust.pluginSummaries,
-              }
-            : null,
-        mcpStartupReport: rctx.lastMcpStartupReport,
-        planModeEnabled: isPlanModeEnabled(),
+        cwd: rctx.latestCtx?.cwd ?? null,
     };
 }
 
@@ -84,7 +41,6 @@ export function startHeartbeat(rctx: RelayContext) {
     // Send an immediate heartbeat so the viewer has state right away.
     rctx.forwardEvent(buildHeartbeat(rctx));
     heartbeatTimer = setInterval(() => {
-        void refreshAllUsage();
         rctx.forwardEvent(buildHeartbeat(rctx));
     }, 10_000);
 }

--- a/packages/cli/src/extensions/remote-heartbeat.ts
+++ b/packages/cli/src/extensions/remote-heartbeat.ts
@@ -23,6 +23,7 @@ export function buildHeartbeat(rctx: RelayContext) {
     return {
         type: "heartbeat",
         active: rctx.isAgentActive,
+        isCompacting: rctx.isCompacting,
         ts: Date.now(),
         model: rctx.latestCtx?.model
             ? { provider: rctx.latestCtx.model.provider, id: rctx.latestCtx.model.id, name: rctx.latestCtx.model.name, reasoning: rctx.latestCtx.model.reasoning }

--- a/packages/cli/src/extensions/remote-meta-events.test.ts
+++ b/packages/cli/src/extensions/remote-meta-events.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect } from "bun:test";
+import {
+  emitTodoUpdated, emitQuestionPending, emitQuestionCleared, emitPlanPending,
+  emitPlanCleared, emitPlanModeToggled, emitCompactStarted, emitCompactEnded,
+  emitRetryStateChanged, emitPluginTrustRequired, emitPluginTrustResolved,
+  emitMcpStartupReport, emitTokenUsageUpdated, emitThinkingLevelChanged,
+  emitAuthSourceChanged, emitModelChanged,
+} from "./remote-meta-events.js";
+
+type ForwardedEvent = Record<string, unknown>;
+function makeRctx() {
+  const events: ForwardedEvent[] = [];
+  return { forwardEvent: (e: unknown) => { events.push(e as ForwardedEvent); }, events };
+}
+
+describe("remote-meta-events", () => {
+  test("emitTodoUpdated", () => {
+    const rctx = makeRctx();
+    const todos = [{ id: 1, text: "task", status: "pending" as const }];
+    emitTodoUpdated(rctx as any, todos);
+    expect(rctx.events[0]).toMatchObject({ type: "todo_updated", todoList: todos });
+  });
+  test("emitQuestionPending", () => {
+    const rctx = makeRctx();
+    const q = { toolCallId: "tc1", questions: [{ question: "Q?", options: ["A"] }] };
+    emitQuestionPending(rctx as any, q);
+    expect(rctx.events[0]).toMatchObject({ type: "question_pending", question: q });
+  });
+  test("emitQuestionCleared", () => {
+    const rctx = makeRctx();
+    emitQuestionCleared(rctx as any, "tc1");
+    expect(rctx.events[0]).toMatchObject({ type: "question_cleared", toolCallId: "tc1" });
+  });
+  test("emitPlanPending", () => {
+    const rctx = makeRctx();
+    const plan = { toolCallId: "tc1", title: "My Plan" };
+    emitPlanPending(rctx as any, plan);
+    expect(rctx.events[0]).toMatchObject({ type: "plan_pending", plan });
+  });
+  test("emitPlanCleared", () => {
+    const rctx = makeRctx();
+    emitPlanCleared(rctx as any, "tc1");
+    expect(rctx.events[0]).toMatchObject({ type: "plan_cleared", toolCallId: "tc1" });
+  });
+  test("emitPlanModeToggled", () => {
+    const rctx = makeRctx();
+    emitPlanModeToggled(rctx as any, true);
+    expect(rctx.events[0]).toMatchObject({ type: "plan_mode_toggled", enabled: true });
+  });
+  test("emitCompactStarted + emitCompactEnded", () => {
+    const rctx = makeRctx();
+    emitCompactStarted(rctx as any);
+    emitCompactEnded(rctx as any);
+    expect(rctx.events[0]?.type).toBe("compact_started");
+    expect(rctx.events[1]?.type).toBe("compact_ended");
+  });
+  test("emitRetryStateChanged null", () => {
+    const rctx = makeRctx();
+    emitRetryStateChanged(rctx as any, null);
+    expect(rctx.events[0]).toMatchObject({ type: "retry_state_changed", state: null });
+  });
+  test("emitPluginTrustRequired", () => {
+    const rctx = makeRctx();
+    const prompt = { promptId: "p1", pluginNames: ["plg"], pluginSummaries: ["does x"] };
+    emitPluginTrustRequired(rctx as any, prompt);
+    expect(rctx.events[0]).toMatchObject({ type: "plugin_trust_required", prompt });
+  });
+  test("emitPluginTrustResolved", () => {
+    const rctx = makeRctx();
+    emitPluginTrustResolved(rctx as any, "p1");
+    expect(rctx.events[0]).toMatchObject({ type: "plugin_trust_resolved", promptId: "p1" });
+  });
+  test("emitMcpStartupReport", () => {
+    const rctx = makeRctx();
+    const report = { slow: true, totalDurationMs: 3000 };
+    emitMcpStartupReport(rctx as any, report);
+    expect(rctx.events[0]).toMatchObject({ type: "mcp_startup_report", report });
+    expect(typeof rctx.events[0].ts).toBe("number");
+  });
+  test("emitTokenUsageUpdated", () => {
+    const rctx = makeRctx();
+    const tu = { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0.01 };
+    const pu = { anthropic: { tokens: 150 } };
+    emitTokenUsageUpdated(rctx as any, tu, pu);
+    expect(rctx.events[0]).toMatchObject({ type: "token_usage_updated", tokenUsage: tu, providerUsage: pu });
+  });
+  test("emitThinkingLevelChanged", () => {
+    const rctx = makeRctx();
+    emitThinkingLevelChanged(rctx as any, "high");
+    expect(rctx.events[0]).toMatchObject({ type: "thinking_level_changed", level: "high" });
+  });
+  test("emitAuthSourceChanged", () => {
+    const rctx = makeRctx();
+    emitAuthSourceChanged(rctx as any, "oauth");
+    expect(rctx.events[0]).toMatchObject({ type: "auth_source_changed", source: "oauth" });
+  });
+  test("emitModelChanged", () => {
+    const rctx = makeRctx();
+    const model = { provider: "anthropic", id: "claude-3" };
+    emitModelChanged(rctx as any, model);
+    expect(rctx.events[0]).toMatchObject({ type: "model_changed", model });
+  });
+});

--- a/packages/cli/src/extensions/remote-meta-events.ts
+++ b/packages/cli/src/extensions/remote-meta-events.ts
@@ -1,0 +1,60 @@
+// ============================================================================
+// remote-meta-events.ts — Discrete meta-state event emitters
+// ============================================================================
+
+import type { RelayContext } from "./remote-types.js";
+import type {
+  MetaTodoItem, MetaPendingQuestion, MetaPendingPlan, MetaRetryState,
+  MetaPluginTrustPrompt, MetaMcpReport, MetaTokenUsage, MetaProviderUsage, MetaModelInfo,
+} from "@pizzapi/protocol";
+
+type ForwardCtx = Pick<RelayContext, "forwardEvent">;
+
+export function emitTodoUpdated(rctx: ForwardCtx, todoList: MetaTodoItem[]): void {
+  rctx.forwardEvent({ type: "todo_updated", todoList });
+}
+export function emitQuestionPending(rctx: ForwardCtx, question: MetaPendingQuestion): void {
+  rctx.forwardEvent({ type: "question_pending", question });
+}
+export function emitQuestionCleared(rctx: ForwardCtx, toolCallId: string): void {
+  rctx.forwardEvent({ type: "question_cleared", toolCallId });
+}
+export function emitPlanPending(rctx: ForwardCtx, plan: MetaPendingPlan): void {
+  rctx.forwardEvent({ type: "plan_pending", plan });
+}
+export function emitPlanCleared(rctx: ForwardCtx, toolCallId: string): void {
+  rctx.forwardEvent({ type: "plan_cleared", toolCallId });
+}
+export function emitPlanModeToggled(rctx: ForwardCtx, enabled: boolean): void {
+  rctx.forwardEvent({ type: "plan_mode_toggled", enabled });
+}
+export function emitCompactStarted(rctx: ForwardCtx): void {
+  rctx.forwardEvent({ type: "compact_started" });
+}
+export function emitCompactEnded(rctx: ForwardCtx): void {
+  rctx.forwardEvent({ type: "compact_ended" });
+}
+export function emitRetryStateChanged(rctx: ForwardCtx, state: MetaRetryState | null): void {
+  rctx.forwardEvent({ type: "retry_state_changed", state });
+}
+export function emitPluginTrustRequired(rctx: ForwardCtx, prompt: MetaPluginTrustPrompt): void {
+  rctx.forwardEvent({ type: "plugin_trust_required", prompt });
+}
+export function emitPluginTrustResolved(rctx: ForwardCtx, promptId: string): void {
+  rctx.forwardEvent({ type: "plugin_trust_resolved", promptId });
+}
+export function emitMcpStartupReport(rctx: ForwardCtx, report: MetaMcpReport): void {
+  rctx.forwardEvent({ type: "mcp_startup_report", report, ts: Date.now() });
+}
+export function emitTokenUsageUpdated(rctx: ForwardCtx, tokenUsage: MetaTokenUsage, providerUsage: MetaProviderUsage): void {
+  rctx.forwardEvent({ type: "token_usage_updated", tokenUsage, providerUsage });
+}
+export function emitThinkingLevelChanged(rctx: ForwardCtx, level: string | null): void {
+  rctx.forwardEvent({ type: "thinking_level_changed", level });
+}
+export function emitAuthSourceChanged(rctx: ForwardCtx, source: string | null): void {
+  rctx.forwardEvent({ type: "auth_source_changed", source });
+}
+export function emitModelChanged(rctx: ForwardCtx, model: MetaModelInfo | null): void {
+  rctx.forwardEvent({ type: "model_changed", model });
+}

--- a/packages/cli/src/extensions/remote-plan-mode.ts
+++ b/packages/cli/src/extensions/remote-plan-mode.ts
@@ -14,6 +14,7 @@ import type {
     PlanModeAction,
     PlanModeDetails,
 } from "./remote-types.js";
+import { emitPlanPending, emitPlanCleared } from "./remote-meta-events.js";
 
 const PLAN_MODE_TOOL_NAME = "plan_mode";
 
@@ -43,7 +44,9 @@ export function consumePendingPlanModeFromWeb(rctx: RelayContext, text: string):
     if (!response) return true;
 
     const pending = rctx.pendingPlanMode;
+    const clearedToolCallId = pending.toolCallId;
     rctx.pendingPlanMode = null;
+    emitPlanCleared(rctx, clearedToolCallId);
     pending.resolve(response);
     rctx.setRelayStatus(rctx.relay ? "Connected to Relay" : rctx.disconnectedStatusText());
     return true;
@@ -52,7 +55,9 @@ export function consumePendingPlanModeFromWeb(rctx: RelayContext, text: string):
 export function cancelPendingPlanMode(rctx: RelayContext) {
     if (!rctx.pendingPlanMode) return;
     const pending = rctx.pendingPlanMode;
+    const clearedToolCallId = pending.toolCallId;
     rctx.pendingPlanMode = null;
+    emitPlanCleared(rctx, clearedToolCallId);
     pending.resolve(null);
     rctx.setRelayStatus(rctx.relay ? "Connected to Relay" : rctx.disconnectedStatusText());
 }
@@ -94,6 +99,7 @@ async function askPlanMode(
 
             if (rctx.pendingPlanMode?.toolCallId === toolCallId) {
                 rctx.pendingPlanMode = null;
+                emitPlanCleared(rctx, toolCallId);
             }
 
             localAbort.abort();
@@ -126,6 +132,12 @@ async function askPlanMode(
                     }
                 },
             };
+            emitPlanPending(rctx, {
+                toolCallId: rctx.pendingPlanMode.toolCallId,
+                title: rctx.pendingPlanMode.title,
+                description: rctx.pendingPlanMode.description,
+                steps: rctx.pendingPlanMode.steps,
+            });
             rctx.setRelayStatus("Waiting for plan review");
         }
 

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -13,6 +13,8 @@ import { getMcpBridge } from "../mcp-bridge.js";
 import { messageBus } from "../session-message-bus.js";
 import { refreshAllUsage } from "../remote-provider-usage.js";
 import { startHeartbeat, stopHeartbeat } from "../remote-heartbeat.js";
+import { emitAuthSourceChanged, emitThinkingLevelChanged, emitMcpStartupReport } from "../remote-meta-events.js";
+import { getAuthSource } from "../remote-auth-source.js";
 import { cancelPendingAskUserQuestion, consumePendingAskUserQuestionFromWeb } from "../remote-ask-user.js";
 import { cancelPendingPlanMode, consumePendingPlanModeFromWeb } from "../remote-plan-mode.js";
 import { normalizeRemoteInputAttachments, buildUserMessageFromRemoteInput } from "../remote-input.js";
@@ -288,6 +290,13 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         emitSessionActive(rctx);
         void refreshAllUsage();
         startHeartbeat(rctx);
+
+        // Emit initial meta values so late-joining viewers get current state.
+        const authSource = getAuthSource(rctx.latestCtx);
+        if (authSource) emitAuthSourceChanged(rctx, authSource);
+        const thinkingLevel = rctx.getCurrentThinkingLevel();
+        if (thinkingLevel) emitThinkingLevelChanged(rctx, thinkingLevel);
+
         updateMcpRelayContext(rctx);
         signalRelayRegistered();
 

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -33,9 +33,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildSessionContext, type ExtensionContext, type ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import { loadConfig } from "../../config.js";
-import { setTodoUpdateCallback, type TodoItem } from "../update-todo.js";
+import { setTodoUpdateCallback, setTodoMetaEmitter, type TodoItem } from "../update-todo.js";
 import { getCurrentTodoList } from "../update-todo.js";
-import { setPlanModeChangeCallback } from "../plan-mode-toggle.js";
+import { setPlanModeChangeCallback, setPlanModeMetaEmitter } from "../plan-mode-toggle.js";
 import type { RemoteExecResponse } from "../remote-commands.js";
 import { clearAndCancelPendingTriggers } from "../triggers/extension.js";
 import type { ConversationTrigger } from "../triggers/types.js";
@@ -47,7 +47,15 @@ import type {
     TriggerResponse,
 } from "../remote-types.js";
 import { installFooter } from "../remote-footer.js";
-import { buildHeartbeat, stopHeartbeat } from "../remote-heartbeat.js";
+import { buildHeartbeat, buildTokenUsage, stopHeartbeat } from "../remote-heartbeat.js";
+import {
+    emitTodoUpdated, emitPlanModeToggled,
+    emitRetryStateChanged, emitPluginTrustRequired, emitPluginTrustResolved,
+    emitTokenUsageUpdated, emitModelChanged, emitAuthSourceChanged,
+    emitMcpStartupReport,
+} from "../remote-meta-events.js";
+import { getAuthSource } from "../remote-auth-source.js";
+import { buildProviderUsage } from "../remote-provider-usage.js";
 import { registerAskUserTool } from "../remote-ask-user.js";
 import { registerPlanModeTool } from "../remote-plan-mode.js";
 import { createTriggerWaitManager } from "../trigger-wait-manager.js";
@@ -542,9 +550,13 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         rctx.forwardEvent({ type: "todo_update", todos: list, ts: Date.now() });
     });
 
+    setTodoMetaEmitter((list) => emitTodoUpdated(rctx, list as any));
+
     setPlanModeChangeCallback((_enabled: boolean) => {
         rctx.forwardEvent(rctx.buildHeartbeat());
     });
+
+    setPlanModeMetaEmitter((enabled) => emitPlanModeToggled(rctx, enabled));
 
     // ── Session name sync ─────────────────────────────────────────────────
 
@@ -596,6 +608,10 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 message: ok ? undefined : "Model selected, but no valid credentials were found.",
             });
             if (ok) {
+                emitModelChanged(rctx, rctx.latestCtx?.model
+                    ? { provider: rctx.latestCtx.model.provider, id: rctx.latestCtx.model.id,
+                        name: rctx.latestCtx.model.name, reasoning: rctx.latestCtx.model.reasoning }
+                    : null);
                 emitSessionActive(rctx);
             }
         } catch (error) {
@@ -874,6 +890,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     pi.on("agent_start", (event) => {
         rctx.isAgentActive = true;
         rctx.lastRetryableError = null;
+        emitRetryStateChanged(rctx, null);
         rctx.forwardEvent(event);
         rctx.forwardEvent(rctx.buildHeartbeat());
     });
@@ -881,6 +898,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     pi.on("agent_end", (event, ctx) => {
         rctx.isAgentActive = false;
         rctx.lastRetryableError = null;
+        emitRetryStateChanged(rctx, null);
         rctx.forwardEvent(event);
         rctx.forwardEvent(rctx.buildHeartbeat());
 
@@ -922,7 +940,12 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         }
     });
 
-    pi.on("turn_end", (event) => rctx.forwardEvent(event));
+    pi.on("turn_end", (event) => {
+        rctx.forwardEvent(event);
+        const tokenUsage = buildTokenUsage(rctx);
+        const providerUsage = buildProviderUsage();
+        emitTokenUsageUpdated(rctx, tokenUsage as any, providerUsage as any);
+    });
     pi.on("message_start", (event) => rctx.forwardEvent(event));
     pi.on("message_update", (event) => rctx.forwardEvent(event));
     pi.on("message_end", (event) => {
@@ -931,6 +954,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         if (msg && msg.role === "assistant" && msg.stopReason === "error" && msg.errorMessage) {
             const errorText = String(msg.errorMessage);
             rctx.lastRetryableError = { errorMessage: errorText, detectedAt: Date.now() };
+            emitRetryStateChanged(rctx, rctx.lastRetryableError);
             rctx.forwardEvent({ type: "cli_error", message: errorText, source: "provider", ts: Date.now() });
             rctx.forwardEvent(rctx.buildHeartbeat());
         }
@@ -995,6 +1019,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             pluginSummaries: event.pluginSummaries as string[],
             respond: event.respond as (trusted: boolean) => void,
         };
+        emitPluginTrustRequired(rctx, rctx.pendingPluginTrust);
 
         rctx.forwardEvent({
             type: "plugin_trust_prompt",
@@ -1009,7 +1034,9 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         const event = data as Record<string, unknown> | null;
         if (!event || typeof event.promptId !== "string") return;
         if (rctx.pendingPluginTrust?.promptId === event.promptId) {
+            const resolvedPromptId = event.promptId as string;
             rctx.pendingPluginTrust = null;
+            emitPluginTrustResolved(rctx, resolvedPromptId);
             rctx.forwardEvent({
                 type: "plugin_trust_expired",
                 promptId: event.promptId,
@@ -1040,6 +1067,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 serverTimings: Array.isArray(r.serverTimings) ? r.serverTimings as any : [],
                 ts: typeof r.ts === "number" ? r.ts : Date.now(),
             };
+            emitMcpStartupReport(rctx, rctx.lastMcpStartupReport);
         }
         rctx.forwardEvent(report);
     });

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -1071,6 +1071,10 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             };
             emitMcpStartupReport(rctx, rctx.lastMcpStartupReport);
         }
-        rctx.forwardEvent(report);
+        // Do NOT call rctx.forwardEvent(report) here. The raw pi event uses a
+        // flat shape (no `report` field) so metaEventToPatch produces
+        // { mcpStartupReport: undefined }, which JSON.stringify silently drops,
+        // wiping the field from Redis. emitMcpStartupReport above already sends
+        // the correctly-shaped nested event.
     });
 };

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -612,6 +612,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                     ? { provider: rctx.latestCtx.model.provider, id: rctx.latestCtx.model.id,
                         name: rctx.latestCtx.model.name, reasoning: rctx.latestCtx.model.reasoning }
                     : null);
+                emitAuthSourceChanged(rctx, getAuthSource(rctx.latestCtx));
                 emitSessionActive(rctx);
             }
         } catch (error) {
@@ -964,6 +965,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     pi.on("tool_execution_end", (event) => rctx.forwardEvent(event));
     pi.on("model_select", (event) => {
         rctx.forwardEvent(event);
+        emitAuthSourceChanged(rctx, getAuthSource(rctx.latestCtx));
         emitSessionActive(rctx);
     });
 

--- a/packages/cli/src/extensions/update-todo.ts
+++ b/packages/cli/src/extensions/update-todo.ts
@@ -1,4 +1,5 @@
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import type { MetaTodoItem } from "@pizzapi/protocol";
 
 /** Minimal Component that renders nothing — keeps the tool call invisible in the TUI. */
 const silent = { render: (_width: number): string[] => [], invalidate: () => {} };
@@ -22,6 +23,12 @@ let _onTodoUpdate: ((list: TodoItem[]) => void) | null = null;
 
 export function setTodoUpdateCallback(cb: (list: TodoItem[]) => void): void {
     _onTodoUpdate = cb;
+}
+
+/** Meta event emitter for discrete todo_updated events. */
+let _metaEmit: ((list: MetaTodoItem[]) => void) | null = null;
+export function setTodoMetaEmitter(cb: (list: MetaTodoItem[]) => void): void {
+    _metaEmit = cb;
 }
 
 function normalizeTodos(raw: unknown): TodoItem[] {
@@ -82,6 +89,7 @@ export const updateTodoExtension: ExtensionFactory = (pi) => {
             const normalized = normalizeTodos((params as any)?.todos);
             currentTodoList = normalized;
             _onTodoUpdate?.(normalized);
+            if (_metaEmit) _metaEmit(currentTodoList);
             return {
                 content: [{ type: "text" as const, text: "" }],
                 details: undefined,
@@ -106,10 +114,12 @@ export const updateTodoExtension: ExtensionFactory = (pi) => {
     pi.on("session_start", () => {
         currentTodoList = [];
         _onTodoUpdate?.([]);
+        if (_metaEmit) _metaEmit(currentTodoList);
     });
 
     pi.on("session_switch", () => {
         currentTodoList = [];
         _onTodoUpdate?.([]);
+        if (_metaEmit) _metaEmit(currentTodoList);
     });
 };

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc --watch",
+    "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc -p tsconfig.test.json --noEmit"
   },
   "devDependencies": {

--- a/packages/protocol/src/hub.test.ts
+++ b/packages/protocol/src/hub.test.ts
@@ -87,12 +87,19 @@ describe("hub — HubServerToClientEvents payloads", () => {
   });
 });
 
-describe("hub — HubClientToServerEvents (read-only, no events)", () => {
-  test("HubClientToServerEvents has no event keys", () => {
-    // The hub is read-only — clients emit nothing.
-    // We verify via TypeScript that the interface is empty.
-    const events: HubClientToServerEvents = {};
-    expect(Object.keys(events)).toHaveLength(0);
+describe("hub — HubClientToServerEvents meta subscription events", () => {
+  test("subscribe_session_meta and unsubscribe_session_meta expect sessionId", () => {
+    const events: HubClientToServerEvents = {
+      subscribe_session_meta: ({ sessionId }) => {
+        expect(sessionId).toBe("s1");
+      },
+      unsubscribe_session_meta: ({ sessionId }) => {
+        expect(sessionId).toBe("s2");
+      },
+    };
+
+    events.subscribe_session_meta({ sessionId: "s1" });
+    events.unsubscribe_session_meta({ sessionId: "s2" });
   });
 });
 

--- a/packages/protocol/src/hub.ts
+++ b/packages/protocol/src/hub.ts
@@ -3,6 +3,7 @@
 // ============================================================================
 
 import type { ModelInfo, SessionInfo } from "./shared.js";
+import type { SessionMetaState, MetaRelayEvent } from "./meta.js";
 
 // ---------------------------------------------------------------------------
 // Server → Client (Server sends session list updates to browsers)
@@ -32,6 +33,9 @@ export interface HubServerToClientEvents {
     runnerId?: string;
     runnerName?: string | null;
   }) => void;
+
+  state_snapshot: (data: { sessionId: string; state: SessionMetaState }) => void;
+  meta_event: (data: { sessionId: string; version: number } & MetaRelayEvent) => void;
 }
 
 // ---------------------------------------------------------------------------
@@ -39,7 +43,8 @@ export interface HubServerToClientEvents {
 // ---------------------------------------------------------------------------
 
 export interface HubClientToServerEvents {
-  // Hub is read-only; clients do not emit events
+  subscribe_session_meta:   (data: { sessionId: string }) => void;
+  unsubscribe_session_meta: (data: { sessionId: string }) => void;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -65,3 +65,10 @@ export type {
   HubInterServerEvents,
   HubSocketData,
 } from "./hub.js";
+
+export type {
+  SessionMetaState, MetaRelayEvent, MetaTodoItem, MetaTokenUsage, MetaProviderUsage,
+  MetaModelInfo, MetaPendingQuestion, MetaPendingPlan, MetaRetryState,
+  MetaPluginTrustPrompt, MetaMcpReport,
+} from "./meta.js";
+export { defaultMetaState, isMetaRelayEvent, metaEventToPatch, META_RELAY_EVENT_TYPES } from "./meta.js";

--- a/packages/protocol/src/meta.test.ts
+++ b/packages/protocol/src/meta.test.ts
@@ -41,6 +41,13 @@ describe("metaEventToPatch", () => {
   test("question_cleared → pendingQuestion null", () => {
     expect(metaEventToPatch({ type: "question_cleared", toolCallId: "tc1" })).toEqual({ pendingQuestion: null });
   });
+  test("plan_pending → pendingPlan set", () => {
+    const plan = { toolCallId: "tc1", title: "My Plan", steps: [] };
+    expect(metaEventToPatch({ type: "plan_pending", plan })).toEqual({ pendingPlan: plan });
+  });
+  test("plan_cleared → pendingPlan null", () => {
+    expect(metaEventToPatch({ type: "plan_cleared", toolCallId: "tc1" })).toEqual({ pendingPlan: null });
+  });
   test("compact_started → isCompacting true", () => {
     expect(metaEventToPatch({ type: "compact_started" })).toEqual({ isCompacting: true });
   });
@@ -53,7 +60,35 @@ describe("metaEventToPatch", () => {
   test("retry_state_changed null clears state", () => {
     expect(metaEventToPatch({ type: "retry_state_changed", state: null })).toEqual({ retryState: null });
   });
+  test("plugin_trust_required → pendingPluginTrust set", () => {
+    const prompt = { promptId: "p1", pluginNames: ["myPlugin"], pluginSummaries: ["does things"] };
+    expect(metaEventToPatch({ type: "plugin_trust_required", prompt })).toEqual({ pendingPluginTrust: prompt });
+  });
   test("plugin_trust_resolved clears trust prompt", () => {
     expect(metaEventToPatch({ type: "plugin_trust_resolved", promptId: "p1" })).toEqual({ pendingPluginTrust: null });
+  });
+  test("mcp_startup_report → mcpStartupReport set", () => {
+    const report = { slow: true, totalDurationMs: 5000, ts: 1234 };
+    expect(metaEventToPatch({ type: "mcp_startup_report", report, ts: 1234 })).toEqual({ mcpStartupReport: report });
+  });
+  test("token_usage_updated → tokenUsage + providerUsage set", () => {
+    const tokenUsage = { input: 100, output: 50, cacheRead: 0, cacheWrite: 0, cost: 0.01 };
+    const providerUsage = { anthropic: { tokens: 150 } };
+    const patch = metaEventToPatch({ type: "token_usage_updated", tokenUsage, providerUsage });
+    expect(patch.tokenUsage).toEqual(tokenUsage);
+    expect(patch.providerUsage).toEqual(providerUsage);
+  });
+  test("thinking_level_changed → thinkingLevel set", () => {
+    expect(metaEventToPatch({ type: "thinking_level_changed", level: "high" })).toEqual({ thinkingLevel: "high" });
+  });
+  test("auth_source_changed → authSource set", () => {
+    expect(metaEventToPatch({ type: "auth_source_changed", source: "oauth" })).toEqual({ authSource: "oauth" });
+  });
+  test("model_changed → model set", () => {
+    const model = { provider: "anthropic", id: "claude-3", name: "Claude 3" };
+    expect(metaEventToPatch({ type: "model_changed", model })).toEqual({ model });
+  });
+  test("model_changed null → model null", () => {
+    expect(metaEventToPatch({ type: "model_changed", model: null })).toEqual({ model: null });
   });
 });

--- a/packages/protocol/src/meta.test.ts
+++ b/packages/protocol/src/meta.test.ts
@@ -1,0 +1,59 @@
+import { describe, test, expect } from "bun:test";
+import {
+  defaultMetaState, isMetaRelayEvent, metaEventToPatch, META_RELAY_EVENT_TYPES,
+} from "./meta.js";
+
+describe("defaultMetaState", () => {
+  test("returns zeroed state", () => {
+    const s = defaultMetaState();
+    expect(s.todoList).toEqual([]);
+    expect(s.pendingQuestion).toBeNull();
+    expect(s.pendingPlan).toBeNull();
+    expect(s.planModeEnabled).toBe(false);
+    expect(s.isCompacting).toBe(false);
+    expect(s.version).toBe(0);
+  });
+});
+
+describe("isMetaRelayEvent", () => {
+  test("returns true for known meta event types", () => {
+    for (const type of META_RELAY_EVENT_TYPES) {
+      expect(isMetaRelayEvent({ type })).toBe(true);
+    }
+  });
+  test("returns false for non-meta event types", () => {
+    expect(isMetaRelayEvent({ type: "heartbeat" })).toBe(false);
+    expect(isMetaRelayEvent({ type: "session_active" })).toBe(false);
+    expect(isMetaRelayEvent({})).toBe(false);
+    expect(isMetaRelayEvent({ type: 42 })).toBe(false);
+  });
+});
+
+describe("metaEventToPatch", () => {
+  test("todo_updated → todoList", () => {
+    const patch = metaEventToPatch({ type: "todo_updated", todoList: [{ id: 1, text: "task", status: "pending" }] });
+    expect(patch.todoList).toHaveLength(1);
+  });
+  test("question_pending → pendingQuestion set", () => {
+    const q = { toolCallId: "tc1", questions: [{ question: "Q?", options: ["A", "B"] }] };
+    expect(metaEventToPatch({ type: "question_pending", question: q })).toEqual({ pendingQuestion: q });
+  });
+  test("question_cleared → pendingQuestion null", () => {
+    expect(metaEventToPatch({ type: "question_cleared", toolCallId: "tc1" })).toEqual({ pendingQuestion: null });
+  });
+  test("compact_started → isCompacting true", () => {
+    expect(metaEventToPatch({ type: "compact_started" })).toEqual({ isCompacting: true });
+  });
+  test("compact_ended → isCompacting false", () => {
+    expect(metaEventToPatch({ type: "compact_ended" })).toEqual({ isCompacting: false });
+  });
+  test("plan_mode_toggled → planModeEnabled", () => {
+    expect(metaEventToPatch({ type: "plan_mode_toggled", enabled: true })).toEqual({ planModeEnabled: true });
+  });
+  test("retry_state_changed null clears state", () => {
+    expect(metaEventToPatch({ type: "retry_state_changed", state: null })).toEqual({ retryState: null });
+  });
+  test("plugin_trust_resolved clears trust prompt", () => {
+    expect(metaEventToPatch({ type: "plugin_trust_resolved", promptId: "p1" })).toEqual({ pendingPluginTrust: null });
+  });
+});

--- a/packages/protocol/src/meta.ts
+++ b/packages/protocol/src/meta.ts
@@ -1,0 +1,150 @@
+// ============================================================================
+// meta.ts — Session meta-state types shared across server, CLI, and UI
+//
+// SessionMetaState: authoritative shape stored in Redis (metaState field).
+// MetaRelayEvent: discrete events emitted by CLI, intercepted by server.
+// ============================================================================
+
+export interface MetaTodoItem {
+  id: number;
+  text: string;
+  status: "pending" | "in_progress" | "done" | "cancelled";
+}
+
+export interface MetaTokenUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  cost: number;
+}
+
+export type MetaProviderUsage = Record<string, Record<string, unknown>>;
+
+export interface MetaModelInfo {
+  provider: string;
+  id: string;
+  name?: string;
+  reasoning?: boolean;
+}
+
+export interface MetaPendingQuestion {
+  toolCallId: string;
+  questions: Array<{ question: string; options: string[]; type?: string }>;
+  display?: string;
+}
+
+export interface MetaPendingPlan {
+  toolCallId: string;
+  title: string;
+  description?: string | null;
+  steps?: Array<{ title: string; description?: string }>;
+}
+
+export interface MetaRetryState {
+  errorMessage: string;
+  detectedAt: number;
+}
+
+export interface MetaPluginTrustPrompt {
+  promptId: string;
+  pluginNames: string[];
+  pluginSummaries: string[];
+}
+
+export interface MetaMcpReport {
+  slow?: boolean;
+  showSlowWarning?: boolean;
+  errors?: Array<{ server: string; error: string }>;
+  serverTimings?: Array<{ name: string; durationMs: number; toolCount: number; timedOut: boolean; error?: string }>;
+  totalDurationMs?: number;
+  ts?: number;
+}
+
+export interface SessionMetaState {
+  todoList:           MetaTodoItem[];
+  pendingQuestion:    MetaPendingQuestion | null;
+  pendingPlan:        MetaPendingPlan | null;
+  planModeEnabled:    boolean;
+  isCompacting:       boolean;
+  retryState:         MetaRetryState | null;
+  pendingPluginTrust: MetaPluginTrustPrompt | null;
+  mcpStartupReport:   MetaMcpReport | null;
+  tokenUsage:         MetaTokenUsage | null;
+  providerUsage:      MetaProviderUsage | null;
+  thinkingLevel:      string | null;
+  authSource:         string | null;
+  model:              MetaModelInfo | null;
+  /** Monotonic counter incremented on every updateSessionMetaState call. */
+  version:            number;
+}
+
+export function defaultMetaState(): SessionMetaState {
+  return {
+    todoList: [],
+    pendingQuestion: null,
+    pendingPlan: null,
+    planModeEnabled: false,
+    isCompacting: false,
+    retryState: null,
+    pendingPluginTrust: null,
+    mcpStartupReport: null,
+    tokenUsage: null,
+    providerUsage: null,
+    thinkingLevel: null,
+    authSource: null,
+    model: null,
+    version: 0,
+  };
+}
+
+export type MetaRelayEvent =
+  | { type: "todo_updated";            todoList: MetaTodoItem[] }
+  | { type: "question_pending";        question: MetaPendingQuestion }
+  | { type: "question_cleared";        toolCallId: string }
+  | { type: "plan_pending";            plan: MetaPendingPlan }
+  | { type: "plan_cleared";            toolCallId: string }
+  | { type: "plan_mode_toggled";       enabled: boolean }
+  | { type: "compact_started" }
+  | { type: "compact_ended" }
+  | { type: "retry_state_changed";     state: MetaRetryState | null }
+  | { type: "plugin_trust_required";   prompt: MetaPluginTrustPrompt }
+  | { type: "plugin_trust_resolved";   promptId: string }
+  | { type: "mcp_startup_report";      report: MetaMcpReport; ts: number }
+  | { type: "token_usage_updated";     tokenUsage: MetaTokenUsage; providerUsage: MetaProviderUsage }
+  | { type: "thinking_level_changed";  level: string | null }
+  | { type: "auth_source_changed";     source: string | null }
+  | { type: "model_changed";           model: MetaModelInfo | null };
+
+export const META_RELAY_EVENT_TYPES = new Set<string>([
+  "todo_updated", "question_pending", "question_cleared",
+  "plan_pending", "plan_cleared", "plan_mode_toggled",
+  "compact_started", "compact_ended", "retry_state_changed",
+  "plugin_trust_required", "plugin_trust_resolved", "mcp_startup_report",
+  "token_usage_updated", "thinking_level_changed", "auth_source_changed", "model_changed",
+]);
+
+export function isMetaRelayEvent(event: { type?: unknown }): event is MetaRelayEvent {
+  return typeof event.type === "string" && META_RELAY_EVENT_TYPES.has(event.type);
+}
+
+export function metaEventToPatch(event: MetaRelayEvent): Partial<SessionMetaState> {
+  switch (event.type) {
+    case "todo_updated":       return { todoList: event.todoList };
+    case "question_pending":   return { pendingQuestion: event.question };
+    case "question_cleared":   return { pendingQuestion: null };
+    case "plan_pending":       return { pendingPlan: event.plan };
+    case "plan_cleared":       return { pendingPlan: null };
+    case "plan_mode_toggled":  return { planModeEnabled: event.enabled };
+    case "compact_started":    return { isCompacting: true };
+    case "compact_ended":      return { isCompacting: false };
+    case "retry_state_changed":    return { retryState: event.state };
+    case "plugin_trust_required":  return { pendingPluginTrust: event.prompt };
+    case "plugin_trust_resolved":  return { pendingPluginTrust: null };
+    case "mcp_startup_report":     return { mcpStartupReport: event.report };
+    case "token_usage_updated":    return { tokenUsage: event.tokenUsage, providerUsage: event.providerUsage };
+    case "thinking_level_changed": return { thinkingLevel: event.level };
+    case "auth_source_changed":    return { authSource: event.source };
+    case "model_changed":          return { model: event.model };
+  }
+}

--- a/packages/protocol/src/meta.ts
+++ b/packages/protocol/src/meta.ts
@@ -141,7 +141,11 @@ export function metaEventToPatch(event: MetaRelayEvent): Partial<SessionMetaStat
     case "retry_state_changed":    return { retryState: event.state };
     case "plugin_trust_required":  return { pendingPluginTrust: event.prompt };
     case "plugin_trust_resolved":  return { pendingPluginTrust: null };
-    case "mcp_startup_report":     return { mcpStartupReport: event.report };
+    case "mcp_startup_report":
+      // Old CLI emits a flat format with no nested `report` field.
+      // Return an empty patch rather than { mcpStartupReport: undefined },
+      // which JSON.stringify would silently drop, wiping the stored value.
+      return (event as any).report != null ? { mcpStartupReport: (event as any).report } : {};
     case "token_usage_updated":    return { tokenUsage: event.tokenUsage, providerUsage: event.providerUsage };
     case "thinking_level_changed": return { thinkingLevel: event.level };
     case "auth_source_changed":    return { authSource: event.source };

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -20,7 +20,9 @@ export interface RelayClientToServerEvents {
     parentSessionId?: string | null;
   }) => void;
 
-  /** TUI forwards an agent event (heartbeat, message_update, etc.) */
+  /** TUI forwards an agent event (heartbeat, message_update, etc.)
+   *  Meta event discrimination is handled by isMetaRelayEvent from meta.ts.
+   */
   event: (data: {
     sessionId: string;
     token: string;

--- a/packages/server/src/ws/namespaces/hub.ts
+++ b/packages/server/src/ws/namespaces/hub.ts
@@ -63,11 +63,17 @@ export function registerHubNamespace(io: SocketIOServer): void {
             return;
           }
 
-          // Join room FIRST so any meta_event broadcast after join arrives before snapshot
-          await socket.join(sessionMetaRoom(sessionId));
-
-          // Send current state immediately
+          // Read state BEFORE joining the room to avoid a race where a concurrent
+          // meta_event (version N+1) arrives after the join, causing the client to
+          // set seen=N+1, then the snapshot at version N is silently dropped.
+          //
+          // With read-first:
+          //  - meta_event fires BEFORE join → version N+1 already in Redis → snapshot
+          //    contains N+1 → client applies snapshot(N+1) then no stale event follows.
+          //  - meta_event fires AFTER join → client receives snapshot(N) then
+          //    meta_event(N+1) → applies both in order → correct.
           const state = await getSessionMetaState(sessionId);
+          await socket.join(sessionMetaRoom(sessionId));
           socket.emit("state_snapshot", { sessionId, state });
 
           console.log(`[sio/hub] meta subscribe: ${socket.id} → session ${sessionId}`);

--- a/packages/server/src/ws/namespaces/hub.ts
+++ b/packages/server/src/ws/namespaces/hub.ts
@@ -19,6 +19,8 @@ import {
     removeHubClient,
     getSessions,
 } from "../sio-registry.js";
+import { getSession } from "../sio-state.js";
+import { getSessionMetaState, sessionMetaRoom } from "../sio-registry/meta.js";
 
 export function registerHubNamespace(io: SocketIOServer): void {
     const hub: Namespace<
@@ -47,6 +49,35 @@ export function registerHubNamespace(io: SocketIOServer): void {
         socket.on("disconnect", async (reason) => {
             console.log(`[sio/hub] disconnected: ${socket.id} (${reason})`);
             await removeHubClient(socket, userId);
+        });
+
+        // ── Session meta subscription ─────────────────────────────────────────────
+        socket.on("subscribe_session_meta", async (data: unknown) => {
+          if (!data || typeof (data as Record<string, unknown>).sessionId !== "string") return;
+          const sessionId = (data as { sessionId: string }).sessionId;
+
+          // Validate ownership — only the session owner may subscribe
+          const session = await getSession(sessionId);
+          if (!session || session.userId !== userId) {
+            console.warn(`[sio/hub] subscribe_session_meta: unauthorized userId=${userId} sessionId=${sessionId}`);
+            return;
+          }
+
+          // Join room FIRST so any meta_event broadcast after join arrives before snapshot
+          await socket.join(sessionMetaRoom(sessionId));
+
+          // Send current state immediately
+          const state = await getSessionMetaState(sessionId);
+          socket.emit("state_snapshot", { sessionId, state });
+
+          console.log(`[sio/hub] meta subscribe: ${socket.id} → session ${sessionId}`);
+        });
+
+        socket.on("unsubscribe_session_meta", async (data: unknown) => {
+          if (!data || typeof (data as Record<string, unknown>).sessionId !== "string") return;
+          const sessionId = (data as { sessionId: string }).sessionId;
+          socket.leave(sessionMetaRoom(sessionId));
+          console.log(`[sio/hub] meta unsubscribe: ${socket.id} ← session ${sessionId}`);
         });
     });
 }

--- a/packages/server/src/ws/namespaces/hub.ts
+++ b/packages/server/src/ws/namespaces/hub.ts
@@ -63,17 +63,22 @@ export function registerHubNamespace(io: SocketIOServer): void {
             return;
           }
 
-          // Read state BEFORE joining the room to avoid a race where a concurrent
-          // meta_event (version N+1) arrives after the join, causing the client to
-          // set seen=N+1, then the snapshot at version N is silently dropped.
+          // Read state, join room, then re-read to avoid a narrow race window:
           //
-          // With read-first:
-          //  - meta_event fires BEFORE join → version N+1 already in Redis → snapshot
-          //    contains N+1 → client applies snapshot(N+1) then no stale event follows.
-          //  - meta_event fires AFTER join → client receives snapshot(N) then
-          //    meta_event(N+1) → applies both in order → correct.
-          const state = await getSessionMetaState(sessionId);
+          // Between the initial read and the join, a relay meta_event can:
+          //   1. Write version N+1 to Redis AND broadcast to the room.
+          //   2. Since socket isn't in the room yet, it misses the broadcast.
+          //   3. We join and send stale snapshot(N) — client never sees N+1.
+          //
+          // The re-read after join closes this window: if anything wrote N+1
+          // during the join I/O, the second read picks it up. If a write races
+          // the second read, the client is already subscribed and will receive
+          // the meta_event(N+1) through the room — so the snapshot can be stale
+          // by at most the in-flight write, which the room broadcast corrects.
+          const stateBeforeJoin = await getSessionMetaState(sessionId);
           await socket.join(sessionMetaRoom(sessionId));
+          // Re-read after join to capture any write that raced the join
+          const state = await getSessionMetaState(sessionId) ?? stateBeforeJoin;
           socket.emit("state_snapshot", { sessionId, state });
 
           console.log(`[sio/hub] meta subscribe: ${socket.id} → session ${sessionId}`);

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -484,22 +484,27 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 clearThinkingMaps(sessionId);
             }
 
-            // For session_messages_chunk and chunked session_active, broadcast
-            // to viewers WITHOUT caching.  Chunks are transient and only needed
-            // during active hydration; the final assembled snapshot is cached
-            // separately when assembly completes.  The metadata-only chunked
-            // session_active must also skip the cache — if the stream is
-            // interrupted before the final chunk, the replay path would find
-            // this empty-messages snapshot and show a blank transcript instead
-            // of the last durable state.
-            const isChunkedSessionActive =
-                event.type === "session_active" &&
-                !!(event.state as Record<string, unknown> | undefined)?.chunked;
-            if (event.type === "session_messages_chunk" || isChunkedSessionActive) {
-                await broadcastSessionEventToViewers(sessionId, eventToPublish);
-            } else {
-                // Publish to viewers via Redis cache + Socket.IO rooms
-                await publishSessionEvent(sessionId, eventToPublish);
+            // Meta events are routed exclusively via hub session meta rooms — they
+            // must NOT flow through to relay viewers or be cached in the event
+            // store.  Skip the entire viewer publish path for them.
+            if (!isMetaRelayEvent(event as { type?: unknown })) {
+                // For session_messages_chunk and chunked session_active, broadcast
+                // to viewers WITHOUT caching.  Chunks are transient and only needed
+                // during active hydration; the final assembled snapshot is cached
+                // separately when assembly completes.  The metadata-only chunked
+                // session_active must also skip the cache — if the stream is
+                // interrupted before the final chunk, the replay path would find
+                // this empty-messages snapshot and show a blank transcript instead
+                // of the last durable state.
+                const isChunkedSessionActive =
+                    event.type === "session_active" &&
+                    !!(event.state as Record<string, unknown> | undefined)?.chunked;
+                if (event.type === "session_messages_chunk" || isChunkedSessionActive) {
+                    await broadcastSessionEventToViewers(sessionId, eventToPublish);
+                } else {
+                    // Publish to viewers via Redis cache + Socket.IO rooms
+                    await publishSessionEvent(sessionId, eventToPublish);
+                }
             }
 
             // Track push-pending state for AskUserQuestion (awaited to ensure

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -56,6 +56,8 @@ import {
     notifyAgentNeedsInput,
     notifyAgentError,
 } from "../../push.js";
+import { isMetaRelayEvent, metaEventToPatch, type MetaRelayEvent } from "@pizzapi/protocol";
+import { updateSessionMetaState, broadcastToSessionMeta } from "../sio-registry/meta.js";
 
 // ── Thinking-block duration tracking ─────────────────────────────────────────
 // Keyed by sessionId → contentIndex → value.
@@ -452,6 +454,19 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 }
             } else if (event.type === "heartbeat") {
                 await updateSessionHeartbeat(sessionId, event);
+            } else if (isMetaRelayEvent(event as { type?: unknown })) {
+                // Discrete meta event: update Redis + broadcast via hub session meta room.
+                // Meta events do NOT flow through to relay viewers — hub is the channel.
+                const metaEvent = event as MetaRelayEvent;
+                const patch = metaEventToPatch(metaEvent);
+                const version = await updateSessionMetaState(sessionId, patch);
+                await broadcastToSessionMeta(
+                  sessionId,
+                  metaEvent,
+                  version,
+                  socket.data.userId ?? undefined,
+                );
+                await touchSessionActivity(sessionId);
             } else {
                 await touchSessionActivity(sessionId);
             }

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -454,7 +454,12 @@ export function registerRelayNamespace(io: SocketIOServer): void {
                 }
             } else if (event.type === "heartbeat") {
                 await updateSessionHeartbeat(sessionId, event);
-            } else if (isMetaRelayEvent(event as { type?: unknown })) {
+            } else if (isMetaRelayEvent(event as { type?: unknown }) &&
+                       // Old CLI emits mcp_startup_report in a flat format without
+                       // a nested `report` field. Only intercept the new nested format;
+                       // pass flat old-CLI events through the normal relay viewer path
+                       // so MCP diagnostics reach viewers without corrupting Redis.
+                       !(event.type === "mcp_startup_report" && !(event as any).report)) {
                 // Discrete meta event: update Redis + broadcast via hub session meta room.
                 // Meta events do NOT flow through to relay viewers — hub is the channel.
                 const metaEvent = event as MetaRelayEvent;

--- a/packages/server/src/ws/namespaces/relay.ts
+++ b/packages/server/src/ws/namespaces/relay.ts
@@ -492,7 +492,11 @@ export function registerRelayNamespace(io: SocketIOServer): void {
             // Meta events are routed exclusively via hub session meta rooms — they
             // must NOT flow through to relay viewers or be cached in the event
             // store.  Skip the entire viewer publish path for them.
-            if (!isMetaRelayEvent(event as { type?: unknown })) {
+            // Exception: old-CLI flat mcp_startup_report (no .report field) is not
+            // handled by the meta path above and must reach relay viewers.
+            const isOldCliMcpReport =
+                event.type === "mcp_startup_report" && !(event as any).report;
+            if (!isMetaRelayEvent(event as { type?: unknown }) || isOldCliMcpReport) {
                 // For session_messages_chunk and chunked session_active, broadcast
                 // to viewers WITHOUT caching.  Chunks are transient and only needed
                 // during active hydration; the final assembled snapshot is cached

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -58,3 +58,10 @@ export {
     sendToTerminalViewer,
     getTerminalIdsForRunner,
 } from "./terminals.js";
+export {
+    getSessionMetaState,
+    updateSessionMetaState,
+    broadcastToSessionMeta,
+    extractMetaFromHeartbeat,
+    sessionMetaRoom,
+} from "./meta.js";

--- a/packages/server/src/ws/sio-registry/meta.test.ts
+++ b/packages/server/src/ws/sio-registry/meta.test.ts
@@ -66,3 +66,56 @@ describe("meta-state helpers (unit)", () => {
     expect(v2).toBe(2);
   });
 });
+
+// Inline extraction logic for unit testing (mirrors extractMetaFromHeartbeat)
+async function extractFromHeartbeat(sessionId: string, hb: Record<string, unknown>): Promise<void> {
+  const patch: Partial<SessionMetaState> = {};
+  if (Array.isArray(hb.todoList)) patch.todoList = hb.todoList as SessionMetaState["todoList"];
+  if (Object.prototype.hasOwnProperty.call(hb, "pendingQuestion")) {
+    patch.pendingQuestion = (hb.pendingQuestion as SessionMetaState["pendingQuestion"]) ?? null;
+  }
+  if (typeof hb.planModeEnabled === "boolean") patch.planModeEnabled = hb.planModeEnabled;
+  if (typeof hb.isCompacting === "boolean") patch.isCompacting = hb.isCompacting;
+  if (typeof hb.authSource === "string") patch.authSource = hb.authSource;
+  if (Object.keys(patch).length > 0) await updateMetaState(sessionId, patch);
+}
+
+describe("extractMetaFromHeartbeat logic", () => {
+  beforeEach(() => { sessionStore.clear(); });
+
+  test("extracts todoList from heartbeat", async () => {
+    const todos = [{ id: 1, text: "task", status: "pending" as const }];
+    await extractFromHeartbeat("s1", { todoList: todos });
+    const state = await getMetaState("s1");
+    expect(state.todoList).toEqual(todos);
+  });
+
+  test("extracts pendingQuestion null (clears it)", async () => {
+    await updateMetaState("s1", { pendingQuestion: { toolCallId: "tc1", questions: [] } });
+    await extractFromHeartbeat("s1", { pendingQuestion: null });
+    const state = await getMetaState("s1");
+    expect(state.pendingQuestion).toBeNull();
+  });
+
+  test("extracts planModeEnabled", async () => {
+    await extractFromHeartbeat("s1", { planModeEnabled: true });
+    expect((await getMetaState("s1")).planModeEnabled).toBe(true);
+  });
+
+  test("extracts isCompacting", async () => {
+    await extractFromHeartbeat("s1", { isCompacting: true });
+    expect((await getMetaState("s1")).isCompacting).toBe(true);
+  });
+
+  test("skips update when heartbeat has no known meta fields", async () => {
+    // No meta fields → no update → version stays at 0
+    await extractFromHeartbeat("s1", { active: true, ts: 12345 });
+    const state = await getMetaState("s1");
+    expect(state.version).toBe(0);
+  });
+
+  test("extracts authSource", async () => {
+    await extractFromHeartbeat("s1", { authSource: "oauth" });
+    expect((await getMetaState("s1")).authSource).toBe("oauth");
+  });
+});

--- a/packages/server/src/ws/sio-registry/meta.test.ts
+++ b/packages/server/src/ws/sio-registry/meta.test.ts
@@ -1,0 +1,68 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { defaultMetaState, type SessionMetaState } from "@pizzapi/protocol";
+
+// In-memory session store stub — no Redis needed
+const sessionStore = new Map<string, Record<string, unknown>>();
+
+// Inline the meta-state logic for unit testing
+async function getMetaState(sessionId: string): Promise<SessionMetaState> {
+  const session = sessionStore.get(sessionId);
+  if (!session?.metaState) return defaultMetaState();
+  try {
+    return JSON.parse(session.metaState as string) as SessionMetaState;
+  } catch {
+    return defaultMetaState();
+  }
+}
+
+async function updateMetaState(sessionId: string, patch: Partial<SessionMetaState>): Promise<number> {
+  const current = await getMetaState(sessionId);
+  const nextVersion = current.version + 1;
+  const next: SessionMetaState = { ...current, ...patch, version: nextVersion };
+  const existing = sessionStore.get(sessionId) ?? {};
+  sessionStore.set(sessionId, { ...existing, metaState: JSON.stringify(next) });
+  return nextVersion;
+}
+
+describe("meta-state helpers (unit)", () => {
+  beforeEach(() => { sessionStore.clear(); });
+
+  test("getMetaState returns default for unknown session", async () => {
+    const state = await getMetaState("unknown");
+    expect(state).toEqual(defaultMetaState());
+  });
+
+  test("updateMetaState persists patch", async () => {
+    await updateMetaState("s1", { planModeEnabled: true });
+    const state = await getMetaState("s1");
+    expect(state.planModeEnabled).toBe(true);
+  });
+
+  test("updateMetaState increments version on each call", async () => {
+    await updateMetaState("s1", { isCompacting: true });
+    await updateMetaState("s1", { isCompacting: false });
+    const state = await getMetaState("s1");
+    expect(state.version).toBe(2);
+  });
+
+  test("updateMetaState merges patch preserving other fields", async () => {
+    await updateMetaState("s1", { planModeEnabled: true });
+    await updateMetaState("s1", { isCompacting: true });
+    const state = await getMetaState("s1");
+    expect(state.planModeEnabled).toBe(true);
+    expect(state.isCompacting).toBe(true);
+  });
+
+  test("corrupted metaState falls back to default", async () => {
+    sessionStore.set("s1", { metaState: "not-json" });
+    const state = await getMetaState("s1");
+    expect(state).toEqual(defaultMetaState());
+  });
+
+  test("updateMetaState returns new version number", async () => {
+    const v1 = await updateMetaState("s1", { planModeEnabled: true });
+    expect(v1).toBe(1);
+    const v2 = await updateMetaState("s1", { isCompacting: true });
+    expect(v2).toBe(2);
+  });
+});

--- a/packages/server/src/ws/sio-registry/meta.test.ts
+++ b/packages/server/src/ws/sio-registry/meta.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, beforeEach } from "bun:test";
-import { defaultMetaState, type SessionMetaState } from "@pizzapi/protocol";
+import { defaultMetaState, type SessionMetaState } from "../../../../protocol/src/meta";
 
 // In-memory session store stub — no Redis needed
 const sessionStore = new Map<string, Record<string, unknown>>();

--- a/packages/server/src/ws/sio-registry/meta.ts
+++ b/packages/server/src/ws/sio-registry/meta.ts
@@ -94,5 +94,18 @@ export async function extractMetaFromHeartbeat(
 
   if (Object.keys(patch).length > 0) {
     await updateSessionMetaState(sessionId, patch);
+    // Broadcast a fresh state_snapshot to hub meta room subscribers so that
+    // old-CLI runners (fat heartbeats, no discrete meta events) keep hub viewers
+    // up to date. Without this, hub subscribers freeze at the initial snapshot.
+    try {
+      const updatedState = await getSessionMetaState(sessionId);
+      const io = getIo();
+      io.of("/hub").to(sessionMetaRoom(sessionId)).emit("state_snapshot", {
+        sessionId,
+        state: updatedState,
+      });
+    } catch {
+      // Non-fatal — best-effort broadcast for old-CLI compat
+    }
   }
 }

--- a/packages/server/src/ws/sio-registry/meta.ts
+++ b/packages/server/src/ws/sio-registry/meta.ts
@@ -1,0 +1,96 @@
+// ============================================================================
+// meta.ts — Session meta-state registry helpers
+//
+// Reads and writes the metaState JSON field in the session Redis hash.
+// Broadcasts meta events to hub session meta rooms.
+// ============================================================================
+
+import { defaultMetaState, type SessionMetaState, type MetaRelayEvent } from "@pizzapi/protocol";
+import { getSession, updateSessionFields } from "../sio-state.js";
+import { getIo } from "./context.js";
+
+// ── Hub broadcasting ─────────────────────────────────────────────────────────
+
+export function sessionMetaRoom(sessionId: string): string {
+  return `session:${sessionId}:meta`;
+}
+
+export async function broadcastToSessionMeta(
+  sessionId: string,
+  event: MetaRelayEvent,
+  version: number,
+  userId?: string,
+): Promise<void> {
+  const io = getIo();
+  try {
+    const room = sessionMetaRoom(sessionId);
+    io.of("/hub").to(room).emit("meta_event", { sessionId, version, ...event });
+  } catch (err) {
+    console.warn("[meta] broadcastToSessionMeta failed:", (err as Error)?.message);
+  }
+}
+
+// ── Redis state ──────────────────────────────────────────────────────────────
+
+export async function getSessionMetaState(sessionId: string): Promise<SessionMetaState> {
+  const session = await getSession(sessionId);
+  if (!session?.metaState) return defaultMetaState();
+  try {
+    return JSON.parse(session.metaState) as SessionMetaState;
+  } catch {
+    return defaultMetaState();
+  }
+}
+
+export async function updateSessionMetaState(
+  sessionId: string,
+  patch: Partial<SessionMetaState>,
+): Promise<number> {
+  const current = await getSessionMetaState(sessionId);
+  const nextVersion = current.version + 1;
+  const next: SessionMetaState = { ...current, ...patch, version: nextVersion };
+  await updateSessionFields(sessionId, { metaState: JSON.stringify(next) });
+  return nextVersion;
+}
+
+export async function extractMetaFromHeartbeat(
+  sessionId: string,
+  hb: Record<string, unknown>,
+): Promise<void> {
+  const patch: Partial<SessionMetaState> = {};
+  if (Array.isArray(hb.todoList)) patch.todoList = hb.todoList as SessionMetaState["todoList"];
+  if (Object.prototype.hasOwnProperty.call(hb, "pendingQuestion")) {
+    patch.pendingQuestion = (hb.pendingQuestion as SessionMetaState["pendingQuestion"]) ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(hb, "pendingPlan")) {
+    patch.pendingPlan = (hb.pendingPlan as SessionMetaState["pendingPlan"]) ?? null;
+  }
+  if (typeof hb.planModeEnabled === "boolean") patch.planModeEnabled = hb.planModeEnabled;
+  if (typeof hb.isCompacting === "boolean") patch.isCompacting = hb.isCompacting;
+  if (Object.prototype.hasOwnProperty.call(hb, "retryState")) {
+    patch.retryState = (hb.retryState as SessionMetaState["retryState"]) ?? null;
+  }
+  if (Object.prototype.hasOwnProperty.call(hb, "pendingPluginTrust")) {
+    patch.pendingPluginTrust = (hb.pendingPluginTrust as SessionMetaState["pendingPluginTrust"]) ?? null;
+  }
+  if (hb.mcpStartupReport && typeof hb.mcpStartupReport === "object") {
+    patch.mcpStartupReport = hb.mcpStartupReport as SessionMetaState["mcpStartupReport"];
+  }
+  if (hb.tokenUsage && typeof hb.tokenUsage === "object") {
+    patch.tokenUsage = hb.tokenUsage as SessionMetaState["tokenUsage"];
+  }
+  if (hb.providerUsage && typeof hb.providerUsage === "object") {
+    patch.providerUsage = hb.providerUsage as SessionMetaState["providerUsage"];
+  }
+  if (Object.prototype.hasOwnProperty.call(hb, "thinkingLevel")) {
+    patch.thinkingLevel = typeof hb.thinkingLevel === "string" ? hb.thinkingLevel : null;
+  }
+  if (typeof hb.authSource === "string") patch.authSource = hb.authSource;
+  if (hb.model && typeof hb.model === "object") {
+    patch.model = hb.model as SessionMetaState["model"];
+  }
+
+  if (Object.keys(patch).length > 0) {
+    await updateSessionMetaState(sessionId, patch);
+  }
+}

--- a/packages/server/src/ws/sio-registry/meta.ts
+++ b/packages/server/src/ws/sio-registry/meta.ts
@@ -44,15 +44,39 @@ export async function getSessionMetaState(sessionId: string): Promise<SessionMet
   }
 }
 
+// Per-session promise chain to serialize meta state updates.
+// Prevents concurrent read-modify-write races where two handlers read the same
+// version N, both compute N+1, and the second write silently overwrites the first.
+const metaUpdateQueues = new Map<string, Promise<unknown>>();
+
 export async function updateSessionMetaState(
   sessionId: string,
   patch: Partial<SessionMetaState>,
 ): Promise<number> {
-  const current = await getSessionMetaState(sessionId);
-  const nextVersion = current.version + 1;
-  const next: SessionMetaState = { ...current, ...patch, version: nextVersion };
-  await updateSessionFields(sessionId, { metaState: JSON.stringify(next) });
-  return nextVersion;
+  // Chain this update behind any in-flight update for the same session so
+  // reads always see the result of the previous write.
+  const prev = metaUpdateQueues.get(sessionId) ?? Promise.resolve();
+  let resolve!: (v: number) => void;
+  const current = new Promise<number>((res) => { resolve = res; });
+  metaUpdateQueues.set(sessionId, current);
+
+  await prev;
+  try {
+    const state = await getSessionMetaState(sessionId);
+    const nextVersion = state.version + 1;
+    const next: SessionMetaState = { ...state, ...patch, version: nextVersion };
+    await updateSessionFields(sessionId, { metaState: JSON.stringify(next) });
+    resolve(nextVersion);
+    return nextVersion;
+  } catch (err) {
+    resolve(0);
+    throw err;
+  } finally {
+    // Clean up the queue entry once this is the last pending update
+    if (metaUpdateQueues.get(sessionId) === current) {
+      metaUpdateQueues.delete(sessionId);
+    }
+  }
 }
 
 export async function extractMetaFromHeartbeat(

--- a/packages/server/src/ws/sio-registry/meta.ts
+++ b/packages/server/src/ws/sio-registry/meta.ts
@@ -19,7 +19,9 @@ export async function broadcastToSessionMeta(
   sessionId: string,
   event: MetaRelayEvent,
   version: number,
-  userId?: string,
+  // Reserved for future per-user room filtering (all session meta rooms are already
+  // session-scoped, so userId is not needed for current fan-out logic).
+  _userId?: string,
 ): Promise<void> {
   const io = getIo();
   try {

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -43,6 +43,7 @@ import {
 } from "../../sessions/store.js";
 import { appendRelayEventToCache } from "../../sessions/redis.js";
 import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "../strip-images.js";
+import { extractMetaFromHeartbeat } from "./meta.js";
 import { severStaleParentLink } from "../stale-parent-link.js";
 import type { SessionInfo } from "@pizzapi/protocol";
 import {
@@ -576,6 +577,12 @@ export async function updateSessionHeartbeat(
     }
 
     await updateSessionFields(sessionId, fields);
+
+    // Backward compat: extract meta-state from fat heartbeat payload.
+    // Old CLI sessions still send all meta fields in the heartbeat.
+    // New CLI sessions send slim heartbeats + discrete meta events separately.
+    // This ensures the Redis metaState is always populated regardless of CLI version.
+    await extractMetaFromHeartbeat(sessionId, heartbeat);
 
     // Heartbeats bypass touchSessionActivity, so refresh the runner
     // association TTL here to prevent it from expiring on long-lived

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -136,6 +136,10 @@ export interface RedisSessionData {
     seq: number;
     /** ID of the parent session that spawned this one, or null for top-level. */
     parentSessionId: string | null;
+    /** JSON-stringified SessionMetaState. Written by updateSessionMetaState.
+     *  Absent for sessions created before this feature; callers must use
+     *  defaultMetaState() as fallback. */
+    metaState?: string | null;
 }
 
 export interface RedisRunnerData {
@@ -210,6 +214,7 @@ function parseSessionFromHash(hash: Record<string, string>): RedisSessionData | 
         runnerName: hash.runnerName || null,
         seq: parseInt(hash.seq ?? "0", 10) || 0,
         parentSessionId: hash.parentSessionId || null,
+        metaState: hash.metaState || null,
     };
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1949,9 +1949,14 @@ export function App() {
     // Re-subscribe to the current session's meta room after non-recovered reconnects
     // (e.g., server restart). Without this, the client stops receiving meta_event
     // updates until the user switches sessions or reloads.
+    // Also clear the stored meta version so that the first state_snapshot/meta_event
+    // arriving after reconnect (version ≥ 1) is not dropped as "stale" — the server
+    // resets its version counter to 0 on restart, so any previously-seen version
+    // would cause all new events to be silently ignored.
     const handleReconnect = () => {
       const currentSessionId = activeSessionRef.current;
       if (currentSessionId) {
+        metaVersionsRef.current.delete(currentSessionId);
         socket.emit("subscribe_session_meta", { sessionId: currentSessionId });
       }
     };

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1003,11 +1003,17 @@ export function App() {
       cachePatch.authSource = patch.authSource;
     }
 
-    if (patch.model !== undefined && patch.model) {
-      const m = normalizeModel(patch.model);
-      if (m) {
-        setActiveModel(m);
-        cachePatch.activeModel = m;
+    if (patch.model !== undefined) {
+      if (patch.model) {
+        const m = normalizeModel(patch.model);
+        if (m) {
+          setActiveModel(m);
+          cachePatch.activeModel = m;
+        }
+      } else {
+        // model_changed with null — clear the active model
+        setActiveModel(null);
+        cachePatch.activeModel = null;
       }
     }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -285,6 +285,11 @@ export function App() {
   // messages, otherwise the report gets appended then immediately replaced.
   const sessionHydratedRef = React.useRef(false);
 
+  // Holds an MCP startup report that arrived (via hub state_snapshot) before
+  // session_active hydration completed. Flushed when hydration finishes.
+  // Needed for the new slim-heartbeat CLI that no longer retries in every heartbeat.
+  const pendingMcpReportRef = React.useRef<Record<string, unknown> | null>(null);
+
   // Tracks the highest meta state version seen per session, to prevent stale
   // state_snapshot from rolling back state already updated by meta_event.
   const metaVersionsRef = React.useRef<Map<string, number>>(new Map());
@@ -903,9 +908,15 @@ export function App() {
     }
 
     // Apply mcpStartupReport from snapshot so late-joining viewers see MCP startup warnings.
-    // applyMcpReport handles its own dedup (renderedMcpReportTsRef) and hydration gating.
+    // If session is not yet hydrated, save it for replay once session_active arrives —
+    // the new slim-heartbeat CLI no longer retries in every heartbeat, so without this
+    // the report would be permanently lost for any viewer connecting to an existing session.
     if (state.mcpStartupReport) {
-      applyMcpReport(state.mcpStartupReport);
+      if (sessionHydratedRef.current) {
+        applyMcpReport(state.mcpStartupReport as Record<string, unknown>);
+      } else {
+        pendingMcpReportRef.current = state.mcpStartupReport as Record<string, unknown>;
+      }
     }
 
     if (Object.keys(cachePatch).length > 0) {
@@ -1215,6 +1226,11 @@ export function App() {
       }
       setIsChangingModel(false);
       sessionHydratedRef.current = !isChunked; // defer until final chunk
+      // For non-chunked sessions, flush any pending MCP report immediately
+      if (!isChunked && pendingMcpReportRef.current) {
+        applyMcpReport(pendingMcpReportRef.current);
+        pendingMcpReportRef.current = null;
+      }
 
       // Clear queued messages — the snapshot contains the full conversation
       // including any follow-ups that were consumed by the agent.
@@ -1295,6 +1311,11 @@ export function App() {
         lastCompletedSnapshotRef.current = chunkSnapshotId || null;
         chunkedDeliveryRef.current = null;
         sessionHydratedRef.current = true;
+        // Flush any MCP startup report that arrived before hydration completed
+        if (pendingMcpReportRef.current) {
+          applyMcpReport(pendingMcpReportRef.current);
+          pendingMcpReportRef.current = null;
+        }
         setViewerStatus("Connected");
 
         // Now that all messages are assembled, run global dedupe to remove
@@ -2024,6 +2045,7 @@ export function App() {
     awaitingSnapshotRef.current = true;
     renderedMcpReportTsRef.current = null;
     sessionHydratedRef.current = false;
+    pendingMcpReportRef.current = null;
     chunkedDeliveryRef.current = null;
     lastCompletedSnapshotRef.current = null;
     setActiveSessionId(relaySessionId);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -888,11 +888,17 @@ export function App() {
       cachePatch.authSource = state.authSource;
     }
 
-    if (state.model) {
-      const m = normalizeModel(state.model);
-      if (m) {
-        setActiveModel(m);
-        cachePatch.activeModel = m;
+    if (state.model !== undefined) {
+      if (state.model) {
+        const m = normalizeModel(state.model);
+        if (m) {
+          setActiveModel(m);
+          cachePatch.activeModel = m;
+        }
+      } else {
+        // snapshot explicitly clears model
+        setActiveModel(null);
+        cachePatch.activeModel = null;
       }
     }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1963,7 +1963,14 @@ export function App() {
       metaVersionsRef.current.set(sessionId, version);
       applyMetaPatch(metaEventToStatePatch(event as any));
       if ((event as any).type === "mcp_startup_report" && (event as any).report) {
-        applyMcpReport((event as any).report);
+        // Buffer if session not yet hydrated — the new slim CLI no longer retries
+        // in heartbeats, so without this the report would be lost for live events
+        // that race session_active delivery.
+        if (sessionHydratedRef.current) {
+          applyMcpReport((event as any).report);
+        } else {
+          pendingMcpReportRef.current = (event as any).report as Record<string, unknown>;
+        }
       }
     };
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -902,12 +902,16 @@ export function App() {
       }
     }
 
-    // mcpStartupReport is NOT applied here — it needs dedup via renderedMcpReportTsRef
-    // and sessionHydratedRef gating. It will be handled by meta_event for mcp_startup_report.
+    // Apply mcpStartupReport from snapshot so late-joining viewers see MCP startup warnings.
+    // applyMcpReport handles its own dedup (renderedMcpReportTsRef) and hydration gating.
+    if (state.mcpStartupReport) {
+      applyMcpReport(state.mcpStartupReport);
+    }
+
     if (Object.keys(cachePatch).length > 0) {
       patchSessionCache(cachePatch);
     }
-  }, [getFallbackPromptKey, patchSessionCache]);
+  }, [applyMcpReport, getFallbackPromptKey, patchSessionCache]);
 
   const applyMetaPatch = React.useCallback((patch: MetaStatePatch) => {
     const cachePatch: Partial<SessionUiCacheEntry> = {};
@@ -1934,15 +1938,27 @@ export function App() {
       if (payload.sessionId !== currentSessionId) return;
       const { sessionId, version, ...event } = payload;
       const seen = metaVersionsRef.current.get(sessionId) ?? 0;
-      metaVersionsRef.current.set(sessionId, Math.max(seen, version));
+      if (version <= seen) return;
+      metaVersionsRef.current.set(sessionId, version);
       applyMetaPatch(metaEventToStatePatch(event as any));
       if ((event as any).type === "mcp_startup_report" && (event as any).report) {
         applyMcpReport((event as any).report);
       }
     };
 
+    // Re-subscribe to the current session's meta room after non-recovered reconnects
+    // (e.g., server restart). Without this, the client stops receiving meta_event
+    // updates until the user switches sessions or reloads.
+    const handleReconnect = () => {
+      const currentSessionId = activeSessionRef.current;
+      if (currentSessionId) {
+        socket.emit("subscribe_session_meta", { sessionId: currentSessionId });
+      }
+    };
+
     socket.on("state_snapshot", handleStateSnapshot);
     socket.on("meta_event", handleMetaEvent);
+    socket.on("connect", handleReconnect);
 
     const initialSessionId = activeSessionRef.current;
     if (initialSessionId) {
@@ -1953,6 +1969,7 @@ export function App() {
     return () => {
       socket.off("state_snapshot", handleStateSnapshot);
       socket.off("meta_event", handleMetaEvent);
+      socket.off("connect", handleReconnect);
       socket.disconnect();
       hubSocketRef.current = null;
     };

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,7 +12,13 @@ import { NewSessionWizardDialog } from "@/components/NewSessionWizardDialog";
 import { PizzaLogo } from "@/components/PizzaLogo";
 import { authClient, useSession, signOut } from "@/lib/auth-client";
 import { io, type Socket } from "socket.io-client";
-import type { ViewerServerToClientEvents, ViewerClientToServerEvents } from "@pizzapi/protocol";
+import type {
+  ViewerServerToClientEvents,
+  ViewerClientToServerEvents,
+  HubServerToClientEvents,
+  HubClientToServerEvents,
+  SessionMetaState,
+} from "@pizzapi/protocol";
 import { cn } from "@/lib/utils";
 import { pulseStreamingHaptic, cancelHaptic, startToolHaptic, stopToolHaptic } from "@/lib/haptics";
 import { Button } from "@/components/ui/button";
@@ -75,6 +81,7 @@ import {
 } from "@/lib/input-dedupe";
 import { parsePendingQuestionDisplayMode, parsePendingQuestions, type QuestionDisplayMode } from "@/lib/ask-user-questions";
 import type { TodoItem, TokenUsage, ConfiguredModelInfo, ResumeSessionOption, QueuedMessage, SessionUiCacheEntry } from "@/lib/types";
+import { metaEventToStatePatch, type MetaStatePatch } from "@/lib/meta-state-apply";
 import { usePanelLayout } from "@/hooks/usePanelLayout";
 import { useMobileSidebar } from "@/hooks/useMobileSidebar";
 import {
@@ -278,6 +285,13 @@ export function App() {
   // messages, otherwise the report gets appended then immediately replaced.
   const sessionHydratedRef = React.useRef(false);
 
+  // Tracks the highest meta state version seen per session, to prevent stale
+  // state_snapshot from rolling back state already updated by meta_event.
+  const metaVersionsRef = React.useRef<Map<string, number>>(new Map());
+
+  // Tracks which session's meta room we've joined so we can unsubscribe when needed.
+  const prevMetaSessionRef = React.useRef<string | null>(null);
+
   // Chunked session delivery: when session_active arrives with chunked:true,
   // messages follow as session_messages_chunk events. This ref tracks state.
   // The snapshotId ties chunks to their originating session_active so stale
@@ -388,6 +402,7 @@ export function App() {
   }, [newSessionOpen]);
 
   const viewerWsRef = React.useRef<Socket<ViewerServerToClientEvents, ViewerClientToServerEvents> | null>(null);
+  const hubSocketRef = React.useRef<Socket<HubServerToClientEvents, HubClientToServerEvents> | null>(null);
   const activeSessionRef = React.useRef<string | null>(null);
 
   // Cache last-known UI state per relay session so switching sessions feels instant.
@@ -718,6 +733,289 @@ export function App() {
     });
   }, [patchSessionCache]);
 
+
+  const applyMcpReport = React.useCallback((mcpReport: {
+    slow?: boolean;
+    showSlowWarning?: boolean;
+    errors?: Array<{ server: string; error: string }>;
+    serverTimings?: Array<{ name: string; durationMs: number; toolCount: number; timedOut: boolean; error?: string }>;
+    totalDurationMs?: number;
+    ts?: number;
+  }) => {
+    const reportTs = typeof mcpReport.ts === "number" ? mcpReport.ts : 0;
+    if (reportTs <= 0 || reportTs === renderedMcpReportTsRef.current || !sessionHydratedRef.current) return;
+    const hasErrors = Array.isArray(mcpReport.errors) && mcpReport.errors.length > 0;
+    const showSlow = mcpReport.showSlowWarning !== false;
+    const isSlow = mcpReport.slow === true && showSlow;
+    if (!hasErrors && !isSlow) return;
+    renderedMcpReportTsRef.current = reportTs;
+    const totalMs = typeof mcpReport.totalDurationMs === "number" ? mcpReport.totalDurationMs : 0;
+    const totalDur = totalMs >= 1000 ? `${(totalMs / 1000).toFixed(1)}s` : `${totalMs}ms`;
+    const parts: string[] = [];
+    if (isSlow) parts.push(`⏱ MCP startup took ${totalDur}`);
+    const timings = Array.isArray(mcpReport.serverTimings) ? mcpReport.serverTimings : [];
+    const noteworthy = timings.filter((t) => t.error || t.timedOut || t.durationMs >= 3000);
+    for (const t of noteworthy) {
+      const dur = t.durationMs >= 1000 ? `${(t.durationMs / 1000).toFixed(1)}s` : `${t.durationMs}ms`;
+      if (t.timedOut) parts.push(`  ⏱ ${t.name}: timed out (${dur})`);
+      else if (t.error) parts.push(`  ✗ ${t.name}: ${t.error} (${dur})`);
+      else parts.push(`  ● ${t.name}: ${dur}`);
+    }
+    if (hasErrors && !isSlow) {
+      const errLines = mcpReport.errors!.map((e) => `  ✗ ${e.server}: ${e.error}`);
+      parts.push(`⚠ MCP server errors:\n${errLines.join("\n")}`);
+    }
+    if (isSlow) parts.push("Tip: Use --safe-mode or --no-mcp for instant startup.");
+    if (parts.length === 0) return;
+    const message: RelayMessage = {
+      key: `mcp_startup:${reportTs}:${Math.random().toString(16).slice(2)}`,
+      role: "system",
+      timestamp: reportTs,
+      content: parts.join("\n"),
+      isError: hasErrors,
+    };
+    setMessages((prev) => {
+      if (prev.some((m) => m.key?.startsWith(`mcp_startup:${reportTs}`))) return prev;
+      const next = [...prev, message];
+      patchSessionCache({ messages: next });
+      return next;
+    });
+  }, [patchSessionCache]);
+
+  const applyMetaStateSnapshot = React.useCallback((state: SessionMetaState) => {
+    const cachePatch: Partial<SessionUiCacheEntry> = {};
+
+    if (Array.isArray(state.todoList)) {
+      setTodoList(state.todoList as TodoItem[]);
+      cachePatch.todoList = state.todoList as TodoItem[];
+    }
+
+    if (Object.prototype.hasOwnProperty.call(state, "pendingQuestion")) {
+      const pq = state.pendingQuestion;
+      if (pq) {
+        const questions = parsePendingQuestions(pq as unknown as Record<string, unknown>);
+        if (questions.length > 0) {
+          const resolved = {
+            toolCallId: typeof pq.toolCallId === "string" ? pq.toolCallId : getFallbackPromptKey(questions),
+            questions,
+            display: parsePendingQuestionDisplayMode(pq as unknown as Record<string, unknown>, questions.length),
+          };
+          setPendingQuestion(resolved);
+          cachePatch.pendingQuestion = resolved;
+          setViewerStatus("Waiting for answer…");
+        } else {
+          setPendingQuestion(null);
+          cachePatch.pendingQuestion = null;
+        }
+      } else {
+        setPendingQuestion(null);
+        cachePatch.pendingQuestion = null;
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(state, "pendingPlan")) {
+      const pp = state.pendingPlan;
+      if (pp && typeof pp.toolCallId === "string" && typeof pp.title === "string" && pp.title.trim()) {
+        const steps = Array.isArray(pp.steps)
+          ? pp.steps.filter((s): s is { title: string; description?: string } =>
+              s !== null && typeof s === "object" && typeof s.title === "string" && s.title.trim().length > 0,
+            )
+          : [];
+        const resolved = {
+          toolCallId: pp.toolCallId,
+          title: pp.title.trim(),
+          description: typeof pp.description === "string" && pp.description.trim() ? pp.description.trim() : null,
+          steps,
+        };
+        setPendingPlan(resolved);
+        cachePatch.pendingPlan = resolved;
+        setViewerStatus("Waiting for plan review…");
+      } else {
+        setPendingPlan(null);
+        cachePatch.pendingPlan = null;
+      }
+    }
+
+    if (typeof state.planModeEnabled === "boolean") {
+      setPlanModeEnabled(state.planModeEnabled);
+      cachePatch.planModeEnabled = state.planModeEnabled;
+    }
+
+    if (typeof state.isCompacting === "boolean") {
+      setIsCompacting(state.isCompacting);
+      cachePatch.isCompacting = state.isCompacting;
+      if (state.isCompacting) {
+        setViewerStatus("Compacting…");
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(state, "retryState")) {
+      setRetryState(state.retryState);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(state, "pendingPluginTrust")) {
+      const pt = state.pendingPluginTrust;
+      if (pt && typeof pt.promptId === "string" && Array.isArray(pt.pluginNames) && pt.pluginNames.length > 0) {
+        setPluginTrustPrompt({
+          promptId: pt.promptId,
+          pluginNames: pt.pluginNames,
+          pluginSummaries: Array.isArray(pt.pluginSummaries) ? pt.pluginSummaries : pt.pluginNames,
+        });
+      } else {
+        setPluginTrustPrompt(null);
+      }
+    }
+
+    if (Object.prototype.hasOwnProperty.call(state, "tokenUsage")) {
+      const usage = state.tokenUsage as TokenUsage | null;
+      setTokenUsage(usage);
+      cachePatch.tokenUsage = usage;
+    }
+
+    if (Object.prototype.hasOwnProperty.call(state, "providerUsage")) {
+      const usage = state.providerUsage as ProviderUsageMap | null;
+      setProviderUsage(usage);
+      cachePatch.providerUsage = usage;
+    }
+
+    if (state.thinkingLevel !== undefined) {
+      setEffortLevel(state.thinkingLevel);
+      cachePatch.effortLevel = state.thinkingLevel;
+    }
+
+    if (state.authSource !== undefined) {
+      setAuthSource(state.authSource);
+      cachePatch.authSource = state.authSource;
+    }
+
+    if (state.model) {
+      const m = normalizeModel(state.model);
+      if (m) {
+        setActiveModel(m);
+        cachePatch.activeModel = m;
+      }
+    }
+
+    // mcpStartupReport is NOT applied here — it needs dedup via renderedMcpReportTsRef
+    // and sessionHydratedRef gating. It will be handled by meta_event for mcp_startup_report.
+    if (Object.keys(cachePatch).length > 0) {
+      patchSessionCache(cachePatch);
+    }
+  }, [getFallbackPromptKey, patchSessionCache]);
+
+  const applyMetaPatch = React.useCallback((patch: MetaStatePatch) => {
+    const cachePatch: Partial<SessionUiCacheEntry> = {};
+
+    if (patch.todoList !== undefined) {
+      setTodoList(patch.todoList);
+      cachePatch.todoList = patch.todoList;
+    }
+
+    if (patch.setPendingQuestion) {
+      if (patch.pendingQuestion) {
+        setPendingQuestion(patch.pendingQuestion);
+        cachePatch.pendingQuestion = patch.pendingQuestion;
+        setViewerStatus("Waiting for answer…");
+      } else {
+        setPendingQuestion(null);
+        cachePatch.pendingQuestion = null;
+      }
+    }
+
+    if (patch.setPendingPlan) {
+      if (patch.pendingPlan) {
+        const pp = patch.pendingPlan as any;
+        if (typeof pp.toolCallId === "string" && typeof pp.title === "string") {
+          const steps = Array.isArray(pp.steps)
+            ? pp.steps.filter((s: any): s is { title: string; description?: string } =>
+                s !== null && typeof s === "object" && typeof s.title === "string" && s.title.trim().length > 0,
+              )
+            : [];
+          const resolved = {
+            toolCallId: pp.toolCallId,
+            title: pp.title.trim(),
+            description: typeof pp.description === "string" && pp.description.trim() ? pp.description.trim() : null,
+            steps,
+          };
+          setPendingPlan(resolved);
+          cachePatch.pendingPlan = resolved;
+          setViewerStatus("Waiting for plan review…");
+        }
+      } else {
+        setPendingPlan(null);
+        cachePatch.pendingPlan = null;
+      }
+    }
+
+    if (patch.planModeEnabled !== undefined) {
+      setPlanModeEnabled(patch.planModeEnabled);
+      cachePatch.planModeEnabled = patch.planModeEnabled;
+    }
+
+    if (patch.isCompacting !== undefined) {
+      setIsCompacting(patch.isCompacting);
+      cachePatch.isCompacting = patch.isCompacting;
+      if (patch.viewerStatusOverride) {
+        setViewerStatus(patch.viewerStatusOverride);
+      } else if (!patch.isCompacting) {
+        setViewerStatus((prev) => (prev === "Compacting…" ? "Connected" : prev));
+      }
+    } else if (patch.viewerStatusOverride) {
+      setViewerStatus(patch.viewerStatusOverride);
+    }
+
+    if ("retryState" in patch) {
+      setRetryState(patch.retryState ?? null);
+    }
+
+    if ("pluginTrustPrompt" in patch) {
+      if (patch.pluginTrustPrompt) {
+        const pt = patch.pluginTrustPrompt;
+        if (pt.promptId && Array.isArray(pt.pluginNames) && pt.pluginNames.length > 0) {
+          setPluginTrustPrompt({
+            promptId: pt.promptId,
+            pluginNames: pt.pluginNames,
+            pluginSummaries: Array.isArray(pt.pluginSummaries) ? pt.pluginSummaries : pt.pluginNames,
+          });
+        }
+      } else {
+        setPluginTrustPrompt(null);
+      }
+    }
+
+    if (patch.tokenUsage !== undefined) {
+      setTokenUsage(patch.tokenUsage);
+      cachePatch.tokenUsage = patch.tokenUsage;
+    }
+
+    if (patch.providerUsage !== undefined) {
+      setProviderUsage(patch.providerUsage);
+      cachePatch.providerUsage = patch.providerUsage;
+    }
+
+    if (patch.thinkingLevel !== undefined) {
+      setEffortLevel(patch.thinkingLevel);
+      cachePatch.effortLevel = patch.thinkingLevel;
+    }
+
+    if (patch.authSource !== undefined) {
+      setAuthSource(patch.authSource);
+      cachePatch.authSource = patch.authSource;
+    }
+
+    if (patch.model !== undefined && patch.model) {
+      const m = normalizeModel(patch.model);
+      if (m) {
+        setActiveModel(m);
+        cachePatch.activeModel = m;
+      }
+    }
+
+    if (Object.keys(cachePatch).length > 0) {
+      patchSessionCache(cachePatch);
+    }
+  }, [patchSessionCache]);
+
   const handleRelayEvent = React.useCallback((event: unknown, seq?: number) => {
     if (!event || typeof event !== "object") return;
 
@@ -759,8 +1057,6 @@ export function App() {
         isCompacting?: boolean;
         model?: { provider: string; id: string; name?: string } | null;
         sessionName?: string | null;
-        thinkingLevel?: string | null;
-        tokenUsage?: TokenUsage | null;
         ts?: number;
       };
 
@@ -774,49 +1070,15 @@ export function App() {
       setAgentActive(nextAgentActive);
       setIsCompacting(nextIsCompacting);
 
-      // Drive viewerStatus from the authoritative heartbeat compacting flag
       if (nextIsCompacting) {
         setViewerStatus("Compacting…");
       } else {
-        // If we were showing "Compacting…" and the heartbeat says no longer compacting,
-        // the exec_result handler will set the final "Compacted" status. But if we
-        // missed the exec_result (e.g. reconnected after compact), clear the stale status.
         setViewerStatus((prev) => (prev === "Compacting…" ? "Connected" : prev));
-      }
-
-      if (hb.thinkingLevel !== undefined) {
-        const next = hb.thinkingLevel ?? null;
-        setEffortLevel(next);
-        cachePatch.effortLevel = next;
-      }
-
-      if ((hb as any).planModeEnabled !== undefined) {
-        const next = !!(hb as any).planModeEnabled;
-        setPlanModeEnabled(next);
-        cachePatch.planModeEnabled = next;
-      }
-
-      if (hb.tokenUsage !== undefined) {
-        const next = hb.tokenUsage ?? null;
-        setTokenUsage(next);
-        cachePatch.tokenUsage = next;
       }
 
       if (typeof hb.ts === "number") {
         setLastHeartbeatAt(hb.ts);
         cachePatch.lastHeartbeatAt = hb.ts;
-      }
-
-      if ((hb as any).providerUsage !== undefined) {
-        const nextProviderUsage = (hb as any).providerUsage ?? null;
-        setProviderUsage(nextProviderUsage);
-        cachePatch.providerUsage = nextProviderUsage;
-      }
-
-      if ((hb as any).authSource !== undefined) {
-        const nextAuthSource = typeof (hb as any).authSource === "string" ? (hb as any).authSource : null;
-        setAuthSource(nextAuthSource);
-        cachePatch.authSource = nextAuthSource;
       }
 
       if (Object.prototype.hasOwnProperty.call(hb, "sessionName")) {
@@ -825,91 +1087,6 @@ export function App() {
         cachePatch.sessionName = nextName;
       }
 
-      if (Array.isArray((hb as any).todoList)) {
-        const todos = (hb as any).todoList as TodoItem[];
-        setTodoList(todos);
-        cachePatch.todoList = todos;
-      }
-
-      // Restore pending AskUserQuestion state when reconnecting to a session.
-      if (Object.prototype.hasOwnProperty.call(hb, "pendingQuestion")) {
-        const pq = (hb as any).pendingQuestion as { toolCallId: string; questions?: Array<{ question: string; options: string[] }>; display?: string; question?: string; options?: string[] } | null;
-        if (pq) {
-          const questions = parsePendingQuestions(pq);
-          if (questions.length > 0) {
-            const resolved = {
-              toolCallId: typeof pq.toolCallId === "string" ? pq.toolCallId : getFallbackPromptKey(questions),
-              questions,
-              display: parsePendingQuestionDisplayMode(pq, questions.length),
-            };
-            setPendingQuestion(resolved);
-            cachePatch.pendingQuestion = resolved;
-            setViewerStatus("Waiting for answer…");
-          } else {
-            setPendingQuestion(null);
-            cachePatch.pendingQuestion = null;
-          }
-        } else {
-          // Heartbeat explicitly says no pending question; clear any stale state.
-          setPendingQuestion(null);
-          cachePatch.pendingQuestion = null;
-        }
-      }
-
-      // Restore pending plan mode state when reconnecting to a session.
-      if (Object.prototype.hasOwnProperty.call(hb, "pendingPlan")) {
-        const pp = (hb as any).pendingPlan as {
-          toolCallId: string;
-          title: string;
-          description?: string | null;
-          steps?: Array<{ title: string; description?: string }>;
-        } | null;
-        if (pp && typeof pp.toolCallId === "string" && typeof pp.title === "string" && pp.title.trim()) {
-          const steps = Array.isArray(pp.steps)
-            ? pp.steps.filter((s): s is { title: string; description?: string } =>
-                s !== null && typeof s === "object" && typeof s.title === "string" && s.title.trim().length > 0,
-              )
-            : [];
-          const resolved = {
-            toolCallId: pp.toolCallId,
-            title: pp.title.trim(),
-            description: typeof pp.description === "string" && pp.description.trim() ? pp.description.trim() : null,
-            steps,
-          };
-          setPendingPlan(resolved);
-          cachePatch.pendingPlan = resolved;
-          setViewerStatus("Waiting for plan review…");
-        } else {
-          setPendingPlan(null);
-          cachePatch.pendingPlan = null;
-        }
-      }
-
-      // Track auto-retry state from CLI so we can show a retry indicator.
-      if (Object.prototype.hasOwnProperty.call(hb, "retryState")) {
-        const rs = (hb as any).retryState as { errorMessage: string; detectedAt: number } | null;
-        setRetryState(rs);
-      }
-
-      // Restore pending plugin trust prompt when reconnecting.
-      if (Object.prototype.hasOwnProperty.call(hb, "pendingPluginTrust")) {
-        const pt = (hb as any).pendingPluginTrust as {
-          promptId: string;
-          pluginNames: string[];
-          pluginSummaries: string[];
-        } | null;
-        if (pt && typeof pt.promptId === "string" && Array.isArray(pt.pluginNames) && pt.pluginNames.length > 0) {
-          setPluginTrustPrompt({
-            promptId: pt.promptId,
-            pluginNames: pt.pluginNames,
-            pluginSummaries: Array.isArray(pt.pluginSummaries) ? pt.pluginSummaries : pt.pluginNames,
-          });
-        } else {
-          setPluginTrustPrompt(null);
-        }
-      }
-
-      // Heartbeats also carry the current model; keep activeModel in sync.
       if (hb.model) {
         const m = normalizeModel(hb.model);
         if (m) {
@@ -918,65 +1095,8 @@ export function App() {
         }
       }
 
-      // Restore MCP startup diagnostics for reconnecting viewers. The runner
-      // includes the last report in every heartbeat; deduplicate by timestamp
-      // so it only renders once per report.
       if ((hb as any).mcpStartupReport && typeof (hb as any).mcpStartupReport === "object") {
-        const mcpReport = (hb as any).mcpStartupReport as {
-          slow?: boolean;
-          showSlowWarning?: boolean;
-          errors?: Array<{ server: string; error: string }>;
-          serverTimings?: Array<{ name: string; durationMs: number; toolCount: number; timedOut: boolean; error?: string }>;
-          totalDurationMs?: number;
-          ts?: number;
-        };
-        const reportTs = typeof mcpReport.ts === "number" ? mcpReport.ts : 0;
-        // Defer rendering until session_active has hydrated messages. Heartbeats
-        // can arrive before session_active; appending here would be immediately
-        // replaced by the snapshot, and the deduplication ref would prevent later
-        // re-rendering from subsequent heartbeats.
-        if (reportTs > 0 && reportTs !== renderedMcpReportTsRef.current && sessionHydratedRef.current) {
-          const hasErrors = Array.isArray(mcpReport.errors) && mcpReport.errors.length > 0;
-          const showSlow = mcpReport.showSlowWarning !== false;
-          const isSlow = mcpReport.slow === true && showSlow;
-          if (hasErrors || isSlow) {
-            renderedMcpReportTsRef.current = reportTs;
-            // Build the same system message the mcp_startup_report handler would.
-            const totalMs = typeof mcpReport.totalDurationMs === "number" ? mcpReport.totalDurationMs : 0;
-            const totalDur = totalMs >= 1000 ? `${(totalMs / 1000).toFixed(1)}s` : `${totalMs}ms`;
-            const parts: string[] = [];
-            if (isSlow) parts.push(`⏱ MCP startup took ${totalDur}`);
-            const timings = Array.isArray(mcpReport.serverTimings) ? mcpReport.serverTimings : [];
-            const noteworthy = timings.filter((t) => t.error || t.timedOut || t.durationMs >= 3000);
-            for (const t of noteworthy) {
-              const dur = t.durationMs >= 1000 ? `${(t.durationMs / 1000).toFixed(1)}s` : `${t.durationMs}ms`;
-              if (t.timedOut) parts.push(`  ⏱ ${t.name}: timed out (${dur})`);
-              else if (t.error) parts.push(`  ✗ ${t.name}: ${t.error} (${dur})`);
-              else parts.push(`  ● ${t.name}: ${dur}`);
-            }
-            if (hasErrors && !isSlow) {
-              const errLines = mcpReport.errors!.map((e) => `  ✗ ${e.server}: ${e.error}`);
-              parts.push(`⚠ MCP server errors:\n${errLines.join("\n")}`);
-            }
-            if (isSlow) parts.push("Tip: Use --safe-mode or --no-mcp for instant startup.");
-            if (parts.length > 0) {
-              const message: RelayMessage = {
-                key: `mcp_startup:${reportTs}:hb`,
-                role: "system",
-                timestamp: reportTs,
-                content: parts.join("\n"),
-                isError: hasErrors,
-              };
-              setMessages((prev) => {
-                // Avoid duplicate if the live event already rendered it.
-                if (prev.some((m) => m.key?.startsWith(`mcp_startup:${reportTs}`))) return prev;
-                const next = [...prev, message];
-                patchSessionCache({ messages: next });
-                return next;
-              });
-            }
-          }
-        }
+        applyMcpReport((hb as any).mcpStartupReport);
       }
 
       patchSessionCache(cachePatch);
@@ -1447,10 +1567,8 @@ export function App() {
 
     if (type === "mcp_startup_report") {
       const report = evt as {
-        toolCount?: number;
-        serverCount?: number;
-        totalDurationMs?: number;
         slow?: boolean;
+        showSlowWarning?: boolean;
         errors?: Array<{ server: string; error: string }>;
         serverTimings?: Array<{
           name: string;
@@ -1459,64 +1577,10 @@ export function App() {
           timedOut: boolean;
           error?: string;
         }>;
+        totalDurationMs?: number;
         ts?: number;
       };
-
-      // Only show a message if something noteworthy happened (errors, or slow startup
-      // when the user hasn't disabled slow-startup warnings via config).
-      const hasErrors = Array.isArray(report.errors) && report.errors.length > 0;
-      const showSlowWarning = (report as any).showSlowWarning !== false;
-      const isSlow = report.slow === true && showSlowWarning;
-
-      if (hasErrors || isSlow) {
-        const ts = typeof report.ts === "number" ? report.ts : Date.now();
-        const totalMs = typeof report.totalDurationMs === "number" ? report.totalDurationMs : 0;
-        const totalDur = totalMs >= 1000 ? `${(totalMs / 1000).toFixed(1)}s` : `${totalMs}ms`;
-
-        const parts: string[] = [];
-
-        if (isSlow) {
-          parts.push(`⏱ MCP startup took ${totalDur}`);
-        }
-
-        // Show per-server breakdown for slow or erroring servers
-        const timings = Array.isArray(report.serverTimings) ? report.serverTimings : [];
-        const noteworthy = timings.filter((t) => t.error || t.timedOut || t.durationMs >= 3000);
-        if (noteworthy.length > 0) {
-          for (const t of noteworthy) {
-            const dur = t.durationMs >= 1000 ? `${(t.durationMs / 1000).toFixed(1)}s` : `${t.durationMs}ms`;
-            if (t.timedOut) {
-              parts.push(`  ⏱ ${t.name}: timed out (${dur})`);
-            } else if (t.error) {
-              parts.push(`  ✗ ${t.name}: ${t.error} (${dur})`);
-            } else {
-              parts.push(`  ● ${t.name}: ${dur}`);
-            }
-          }
-        }
-
-        if (hasErrors && !isSlow) {
-          const errLines = report.errors!.map((e) => `  ✗ ${e.server}: ${e.error}`);
-          parts.push(`⚠ MCP server errors:\n${errLines.join("\n")}`);
-        }
-
-        if (isSlow) {
-          parts.push("Tip: Use --safe-mode or --no-mcp for instant startup.");
-        }
-
-        const message: RelayMessage = {
-          key: `mcp_startup:${ts}:${Math.random().toString(16).slice(2)}`,
-          role: "system",
-          timestamp: ts,
-          content: parts.join("\n"),
-          isError: hasErrors,
-        };
-        setMessages((prev) => {
-          const next = [...prev, message];
-          patchSessionCache({ messages: next });
-          return next;
-        });
-      }
+      applyMcpReport(report);
       return;
     }
 
@@ -1839,6 +1903,68 @@ export function App() {
       thinkingDurationsRef.current = new Map();
     }
   }, [upsertMessage, upsertMessageDebounced, cancelPendingDeltas, appendLocalSystemMessage, scheduleToolStreamFlush]);
+
+  React.useEffect(() => {
+    const socket = io("/hub", { withCredentials: true });
+    hubSocketRef.current = socket;
+
+    const handleStateSnapshot = ({ sessionId, state }: { sessionId: string; state: SessionMetaState }) => {
+      const currentSessionId = activeSessionRef.current;
+      if (sessionId !== currentSessionId) return;
+      const seen = metaVersionsRef.current.get(sessionId) ?? 0;
+      if (state.version < seen) return;
+      metaVersionsRef.current.set(sessionId, state.version);
+      applyMetaStateSnapshot(state);
+    };
+
+    const handleMetaEvent = (payload: { sessionId: string; version: number } & Record<string, unknown>) => {
+      const currentSessionId = activeSessionRef.current;
+      if (payload.sessionId !== currentSessionId) return;
+      const { sessionId, version, ...event } = payload;
+      const seen = metaVersionsRef.current.get(sessionId) ?? 0;
+      metaVersionsRef.current.set(sessionId, Math.max(seen, version));
+      applyMetaPatch(metaEventToStatePatch(event as any));
+      if ((event as any).type === "mcp_startup_report" && (event as any).report) {
+        applyMcpReport((event as any).report);
+      }
+    };
+
+    socket.on("state_snapshot", handleStateSnapshot);
+    socket.on("meta_event", handleMetaEvent);
+
+    const initialSessionId = activeSessionRef.current;
+    if (initialSessionId) {
+      socket.emit("subscribe_session_meta", { sessionId: initialSessionId });
+      prevMetaSessionRef.current = initialSessionId;
+    }
+
+    return () => {
+      socket.off("state_snapshot", handleStateSnapshot);
+      socket.off("meta_event", handleMetaEvent);
+      socket.disconnect();
+      hubSocketRef.current = null;
+    };
+  }, [applyMetaStateSnapshot, applyMetaPatch, applyMcpReport]);
+
+  React.useEffect(() => {
+    const hubSock = hubSocketRef.current;
+    if (!hubSock) return;
+
+    const prevId = prevMetaSessionRef.current;
+    const nextId = activeSessionId;
+
+    if (prevId && prevId !== nextId) {
+      hubSock.emit("unsubscribe_session_meta", { sessionId: prevId });
+      metaVersionsRef.current.delete(prevId);
+    }
+
+    if (nextId) {
+      hubSock.emit("subscribe_session_meta", { sessionId: nextId });
+      prevMetaSessionRef.current = nextId;
+    } else {
+      prevMetaSessionRef.current = null;
+    }
+  }, [activeSessionId]);
 
   const openSession = React.useCallback((relaySessionId: string) => {
     // Flush/cancel any pending RAF queues (streaming deltas & tool-stream

--- a/packages/ui/src/lib/meta-state-apply.test.ts
+++ b/packages/ui/src/lib/meta-state-apply.test.ts
@@ -1,0 +1,46 @@
+import { describe, test, expect } from "bun:test";
+import { metaEventToStatePatch } from "./meta-state-apply.js";
+
+describe("metaEventToStatePatch", () => {
+  test("todo_updated returns todoList patch", () => {
+    const todos = [{ id: 1, text: "task", status: "pending" as const }];
+    expect(metaEventToStatePatch({ type: "todo_updated", todoList: todos }).todoList).toEqual(todos);
+  });
+  test("compact_started sets isCompacting + viewerStatus", () => {
+    const patch = metaEventToStatePatch({ type: "compact_started" });
+    expect(patch.isCompacting).toBe(true);
+    expect(patch.viewerStatusOverride).toBe("Compacting…");
+  });
+  test("compact_ended clears isCompacting", () => {
+    expect(metaEventToStatePatch({ type: "compact_ended" }).isCompacting).toBe(false);
+  });
+  test("plan_mode_toggled sets planModeEnabled", () => {
+    expect(metaEventToStatePatch({ type: "plan_mode_toggled", enabled: true }).planModeEnabled).toBe(true);
+    expect(metaEventToStatePatch({ type: "plan_mode_toggled", enabled: false }).planModeEnabled).toBe(false);
+  });
+  test("question_cleared clears pendingQuestion", () => {
+    const patch = metaEventToStatePatch({ type: "question_cleared", toolCallId: "tc1" });
+    expect(patch.setPendingQuestion).toBe(true);
+    expect(patch.pendingQuestion).toBeNull();
+  });
+  test("retry_state_changed null clears state", () => {
+    expect(metaEventToStatePatch({ type: "retry_state_changed", state: null }).retryState).toBeNull();
+  });
+  test("plugin_trust_resolved clears trust prompt", () => {
+    expect(metaEventToStatePatch({ type: "plugin_trust_resolved", promptId: "p1" }).pluginTrustPrompt).toBeNull();
+  });
+  test("thinking_level_changed sets level", () => {
+    expect(metaEventToStatePatch({ type: "thinking_level_changed", level: "high" }).thinkingLevel).toBe("high");
+    expect(metaEventToStatePatch({ type: "thinking_level_changed", level: null }).thinkingLevel).toBeNull();
+  });
+  test("auth_source_changed sets authSource", () => {
+    expect(metaEventToStatePatch({ type: "auth_source_changed", source: "oauth" }).authSource).toBe("oauth");
+  });
+  test("model_changed sets model", () => {
+    const model = { provider: "anthropic", id: "claude-3" };
+    expect(metaEventToStatePatch({ type: "model_changed", model }).model).toEqual(model);
+  });
+  test("model_changed null clears model", () => {
+    expect(metaEventToStatePatch({ type: "model_changed", model: null }).model).toBeNull();
+  });
+});

--- a/packages/ui/src/lib/meta-state-apply.ts
+++ b/packages/ui/src/lib/meta-state-apply.ts
@@ -11,7 +11,7 @@ import {
   parsePendingQuestionDisplayMode,
   type ParsedQuestion,
   type QuestionDisplayMode,
-} from "@/lib/ask-user-questions";
+} from "./ask-user-questions";
 import type { MetaRelayEvent, SessionMetaState, MetaPendingQuestion } from "@pizzapi/protocol";
 import type { ProviderUsageMap } from "@/components/UsageIndicator";
 

--- a/packages/ui/src/lib/meta-state-apply.ts
+++ b/packages/ui/src/lib/meta-state-apply.ts
@@ -1,0 +1,100 @@
+// ============================================================================
+// meta-state-apply.ts — Pure mapping from MetaRelayEvent to React state patch
+//
+// No React dependencies — easily testable in isolation.
+// App.tsx uses metaEventToStatePatch() and applies the returned patch.
+// ============================================================================
+
+import type { TodoItem, TokenUsage } from "@/lib/types";
+import {
+  parsePendingQuestions,
+  parsePendingQuestionDisplayMode,
+  type ParsedQuestion,
+  type QuestionDisplayMode,
+} from "@/lib/ask-user-questions";
+import type { MetaRelayEvent, SessionMetaState, MetaPendingQuestion } from "@pizzapi/protocol";
+import type { ProviderUsageMap } from "@/components/UsageIndicator";
+
+interface PendingQuestionState {
+  toolCallId: string;
+  questions: ParsedQuestion[];
+  display: QuestionDisplayMode;
+}
+
+export interface MetaStatePatch {
+  todoList?: TodoItem[];
+  pendingQuestion?: PendingQuestionState | null;
+  setPendingQuestion?: boolean;
+  pendingPlan?: SessionMetaState["pendingPlan"] | null;
+  setPendingPlan?: boolean;
+  planModeEnabled?: boolean;
+  isCompacting?: boolean;
+  retryState?: SessionMetaState["retryState"] | null;
+  pluginTrustPrompt?: { promptId: string; pluginNames: string[]; pluginSummaries: string[] } | null;
+  tokenUsage?: TokenUsage | null;
+  providerUsage?: ProviderUsageMap | null;
+  thinkingLevel?: string | null;
+  authSource?: string | null;
+  model?: { provider: string; id: string; name?: string; reasoning?: boolean } | null;
+  viewerStatusOverride?: string;
+}
+
+function parsePendingQuestionShape(pq: MetaPendingQuestion): PendingQuestionState | null {
+  const questions = parsePendingQuestions(pq as unknown as Record<string, unknown>);
+  if (questions.length === 0) return null;
+  return {
+    toolCallId: pq.toolCallId,
+    questions,
+    display: parsePendingQuestionDisplayMode(pq as unknown as Record<string, unknown>, questions.length),
+  };
+}
+
+export function metaEventToStatePatch(event: MetaRelayEvent): MetaStatePatch {
+  switch (event.type) {
+    case "todo_updated":
+      return { todoList: event.todoList as TodoItem[] };
+    case "question_pending": {
+      const parsed = parsePendingQuestionShape(event.question);
+      return {
+        setPendingQuestion: true,
+        pendingQuestion: parsed,
+        viewerStatusOverride: parsed ? "Waiting for answer…" : undefined,
+      };
+    }
+    case "question_cleared":
+      return { setPendingQuestion: true, pendingQuestion: null };
+    case "plan_pending":
+      return {
+        setPendingPlan: true,
+        pendingPlan: event.plan as SessionMetaState["pendingPlan"],
+        viewerStatusOverride: "Waiting for plan review…",
+      };
+    case "plan_cleared":
+      return { setPendingPlan: true, pendingPlan: null };
+    case "plan_mode_toggled":
+      return { planModeEnabled: event.enabled };
+    case "compact_started":
+      return { isCompacting: true, viewerStatusOverride: "Compacting…" };
+    case "compact_ended":
+      return { isCompacting: false };
+    case "retry_state_changed":
+      return { retryState: event.state };
+    case "plugin_trust_required":
+      return { pluginTrustPrompt: event.prompt };
+    case "plugin_trust_resolved":
+      return { pluginTrustPrompt: null };
+    case "token_usage_updated":
+      return {
+        tokenUsage: event.tokenUsage as TokenUsage,
+        providerUsage: event.providerUsage as unknown as ProviderUsageMap,
+      };
+    case "thinking_level_changed":
+      return { thinkingLevel: event.level };
+    case "auth_source_changed":
+      return { authSource: event.source };
+    case "model_changed":
+      return { model: event.model };
+    default:
+      return {};
+  }
+}


### PR DESCRIPTION
## Summary

Replaces the fat 10-second heartbeat with a slim liveness ping + discrete push events routed through per-session hub rooms, with Redis as the authoritative meta-state store.

**Before:** CLI emits one `heartbeat` event every 10s carrying ~16 fields. AskUserQuestion, plan_mode, todos, and other interactive state arrive up to 10 seconds late. Relay stream mixes conversation content with meta-state.

**After:** CLI emits typed discrete events immediately on state changes (`question_pending`, `todo_updated`, `compact_started`, etc.). UI receives them via hub session meta rooms. Reconnecting viewers get a Redis-backed `state_snapshot` instantly instead of waiting for the next heartbeat.

## Changes

- **Protocol** (`packages/protocol/src/meta.ts`): `SessionMetaState`, `MetaRelayEvent` (16 event types), `metaEventToPatch`, `isMetaRelayEvent`; hub extended with `subscribe_session_meta`, `state_snapshot`, `meta_event`
- **Server**: `metaState` Redis field in session hash; `getSessionMetaState`, `updateSessionMetaState`, `broadcastToSessionMeta`, `extractMetaFromHeartbeat` (backward compat); hub subscription handlers; relay intercepts discrete meta events → Redis → hub room (does NOT forward to viewers)
- **CLI**: Heartbeat slimmed to 6 fields (`active`, `ts`, `model`, `sessionName`, `uptime`, `cwd`); `remote-meta-events.ts` with 16 typed emitters; all callsites wired (todos, AskUserQuestion, plan_mode, compact, retry, plugin trust, MCP report, token usage, model, thinking level, auth source)
- **UI**: Per-session hub meta room subscription with version tracking (`metaVersionsRef`) to prevent stale snapshot rollback; `applyMetaStateSnapshot`, `applyMetaPatch`, `applyMcpReport`; heartbeat handler slimmed to liveness fields only; pure `metaEventToStatePatch` helper tested without React

## Backward Compatibility

Old CLI sessions (fat heartbeat) continue to work. The server's `extractMetaFromHeartbeat` populates Redis `metaState` from heartbeat payloads, so the UI's `state_snapshot` path works regardless of CLI version.

## Test Plan

- [ ] Open a session → browser devtools shows `state_snapshot` received immediately on subscribe
- [ ] Agent calls `update_todo` → `meta_event` type `todo_updated` arrives < 1s (not waiting for heartbeat)
- [ ] Agent calls `AskUserQuestion` → `meta_event` type `question_pending` arrives immediately; question renders without waiting
- [ ] Close and reopen the browser tab → `state_snapshot` correctly restores todos, pendingQuestion, etc.
- [ ] Switch between two sessions → no stale meta state from session A leaks into session B
- [ ] Old CLI (fat heartbeat) → UI still works correctly via backward compat path