### PR TITLE
🎨 Palette: Add skip-to-content link for keyboard users

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3374,6 +3374,7 @@ export function App() {
           >
             <div
               id="main-content"
+              tabIndex={-1}
               className={cn(
               "flex flex-col flex-1 min-h-0",
               showTerminal && "overflow-hidden",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2769,7 +2769,7 @@ export function App() {
   }
 
   if (!session) {
-    return <AuthPage onAuthenticated={() => authClient.$store.notify("$sessionSignal")} />;
+    return <AuthPage onAuthenticated={() => authClient.$store.notify("$sessionSignal")} />
   }
 
   const rawUser = session && typeof session === "object" ? (session as any).user : undefined;
@@ -2809,6 +2809,12 @@ export function App() {
   return (
     <TooltipProvider delayDuration={0}>
     <div className="flex h-[100dvh] w-full flex-col overflow-hidden bg-background pp-safe-left pp-safe-right">
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:z-50 focus:p-4 focus:bg-background focus:text-foreground"
+      >
+        Skip to content
+      </a>
       {/* ── Desktop header ────────────────────────────────────────────── */}
       <header className="hidden md:flex items-center justify-between gap-3 border-b bg-background px-4 pb-2 pt-[calc(0.5rem_+_env(safe-area-inset-top))] flex-shrink-0">
         <div className="flex items-center gap-3 flex-shrink-0">
@@ -3366,7 +3372,9 @@ export function App() {
             onPointerUp={showTerminal ? handleOuterPointerUp : undefined}
             onPointerCancel={showTerminal ? handleOuterPointerUp : undefined}
           >
-            <div className={cn(
+            <div
+              id="main-content"
+              className={cn(
               "flex flex-col flex-1 min-h-0",
               showTerminal && "overflow-hidden",
               showTerminal && terminalPosition !== "bottom" && "min-w-0",


### PR DESCRIPTION
Fixes an accessibility issue where keyboard users had no mechanism to skip the sidebar and header navigation to jump straight to the main application content. 

Changes:
* Adds a `<a href="#main-content">Skip to content</a>` link immediately inside the root container.
* Uses Tailwind CSS v4 classes (`sr-only focus:not-sr-only focus:absolute ...`) to keep it visually hidden until focused.
* Adds the corresponding `id="main-content"` to the container wrapping `RunnerManager` and `SessionViewer`.

Verified via local testing and a Playwright test script verifying visual appearance and anchor target.

---
*PR created automatically by Jules for task [3901312165530415362](https://jules.google.com/task/3901312165530415362) started by @Pizzaface*