### PR TITLE
Add health checks to docker compose services

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -7,6 +7,11 @@ services:
     # ports:
     #   - "6379:6379"
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   server:
     build:
@@ -28,8 +33,14 @@ services:
     volumes:
       - pizzapi-data:/app/data
     depends_on:
-      - redis
+      redis:
+        condition: service_healthy
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:7492/health').then(r => process.exit(r.ok ? 0 : 1))"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   dev:
     build:


### PR DESCRIPTION
Fixes missing healthchecks in `docker/compose.yml`.
- Adds `redis-cli ping` check to the Redis service.
- Adds `bun` HTTP fetch check to the Server service (testing the `/health` endpoint).
- Updates the Server service to `depends_on` Redis with `condition: service_healthy`.

---
*PR created automatically by Jules for task [6111135823373583890](https://jules.google.com/task/6111135823373583890) started by @Pizzaface*