### PR TITLE
build: pin Bun version in Dockerfile to 1.3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # ── Shared dependency layer ──────────────────────────────────────────────────
 # Installs node_modules and copies configs shared by both build stages.
 # The docker/compose.yml dev profile targets this stage (target: builder).
-FROM oven/bun:1 AS builder
+FROM oven/bun:1.3.10 AS builder
 WORKDIR /app
 
 # Copy patches and lockfile first for layer caching
@@ -64,7 +64,7 @@ RUN if [ "$PREBUILT_UI" = "true" ] && [ -d packages/ui/dist ]; then \
     fi
 
 # ── Production image ─────────────────────────────────────────────────────────
-FROM oven/bun:1-slim
+FROM oven/bun:1.3.10-slim
 WORKDIR /app
 
 COPY --from=build-server /app/node_modules ./node_modules


### PR DESCRIPTION
### What
Pins the floating `oven/bun:1` and `oven/bun:1-slim` Docker image tags in the root `Dockerfile` to explicitly use `1.3.10`.

### Why
Floating tags silently pick up new versions (like `1.3.x` to `1.4.x`) on rebuilds, which can cause unpredictable breakages. Pinning to `1.3.10` aligns the Dockerfile with the explicit versions used in the project's CI (`ci.yml` and `release.yml`) for reliable, deterministic builds.

---
*PR created automatically by Jules for task [12053272347173913712](https://jules.google.com/task/12053272347173913712) started by @Pizzaface*