### PR TITLE
fix(ui): replace deprecated navigator.platform with navigator.userAgentData?.platform

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -246,7 +246,10 @@ export function App() {
   const [authSource, setAuthSource] = React.useState<string | null>(null);
 
   // Keyboard shortcuts
-  const isMac = React.useMemo(() => /Mac|iPhone|iPad/i.test(navigator.platform), []);
+  const isMac = React.useMemo(() => {
+    const platform = navigator.userAgentData?.platform ?? navigator.platform ?? "";
+    return /Mac|iPhone|iPad/i.test(platform);
+  }, []);
   const [showShortcutsHelp, setShowShortcutsHelp] = React.useState(false);
 
   // Sequence tracking for gap detection

--- a/packages/ui/src/components/ShortcutsDialog.tsx
+++ b/packages/ui/src/components/ShortcutsDialog.tsx
@@ -15,7 +15,8 @@ interface ShortcutsDialogProps {
 
 function isMacPlatform(): boolean {
   if (typeof navigator === "undefined") return false;
-  return /Mac|iPhone|iPad/i.test(navigator.platform);
+  const platform = navigator.userAgentData?.platform ?? navigator.platform ?? "";
+  return /Mac|iPhone|iPad/i.test(platform);
 }
 
 export function ShortcutsDialog({ open, onOpenChange }: ShortcutsDialogProps) {

--- a/packages/ui/src/vite-env.d.ts
+++ b/packages/ui/src/vite-env.d.ts
@@ -8,3 +8,9 @@ interface ImportMetaEnv {
 interface ImportMeta {
     readonly env: ImportMetaEnv;
 }
+
+interface Navigator {
+    userAgentData?: {
+        platform: string;
+    };
+}


### PR DESCRIPTION
**What**: Replaced deprecated `navigator.platform` with `navigator.userAgentData?.platform` (with a legacy fallback) across the UI package.
**Why**: The `navigator.platform` property is deprecated and can trigger warnings in modern browsers or dev tools. Replacing it with `userAgentData` maintains the existing logic (checking for Mac/iOS platforms) while using a more modern, supported API.
**How**:
- Updated `isMac` check in `packages/ui/src/App.tsx`.
- Updated `isMacPlatform()` check in `packages/ui/src/components/ShortcutsDialog.tsx`.
- Added `userAgentData` optional property to the `Navigator` interface in `packages/ui/src/vite-env.d.ts` to ensure TypeScript compilation (`bun run typecheck`) succeeds.

---
*PR created automatically by Jules for task [9920367778636327719](https://jules.google.com/task/9920367778636327719) started by @Pizzaface*