### PR TITLE
feat: move all real-time runner data to /runners WebSocket namespace

### DIFF
--- a/docs/plans/2026-03-21-runners-websocket-feed.md
+++ b/docs/plans/2026-03-21-runners-websocket-feed.md
@@ -1,0 +1,1496 @@
+# Runners WebSocket Feed Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace all polling and ad-hoc `fetch("/api/runners")` calls with a `/runners` Socket.IO namespace that pushes runner lifecycle events in real time, and use that cached data everywhere in the UI that currently re-fetches it.
+
+**Architecture:** A new browser-facing `/runners` Socket.IO namespace (server-side) broadcasts `runners` (initial snapshot), `runner_added`, `runner_removed`, and `runner_updated` to authenticated users. A `useRunnersFeed()` React hook (client-side) subscribes and maintains runner state. All components that previously fetched runner data on a timer or on dialog/command open are refactored to consume this shared state via props.
+
+**Tech Stack:** Bun, TypeScript, Socket.IO 4, React 19, `bun:test`
+
+**Spec:** `docs/specs/2026-03-21-runners-websocket-feed-design.md`
+
+---
+
+## Chunk 1: Protocol + Server
+
+### Task 1: Add `/runners` protocol types
+
+**Files:**
+- Create: `packages/protocol/src/runners.ts`
+- Modify: `packages/protocol/src/index.ts`
+
+- [ ] **Step 1: Create the protocol file**
+
+```typescript
+// packages/protocol/src/runners.ts
+// ============================================================================
+// /runners namespace — Browser runner feed (read-only for clients)
+// ============================================================================
+
+import type { RunnerInfo } from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// Server → Client (Server pushes runner state to browsers)
+// ---------------------------------------------------------------------------
+
+export interface RunnersServerToClientEvents {
+  /** Full runner list snapshot sent on connection */
+  runners: (data: { runners: RunnerInfo[] }) => void;
+
+  /** A runner daemon connected and registered */
+  runner_added: (data: RunnerInfo) => void;
+
+  /** A runner daemon disconnected */
+  runner_removed: (data: { runnerId: string }) => void;
+
+  /** Runner metadata changed (skills, agents, plugins, hooks) */
+  runner_updated: (data: RunnerInfo) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Client → Server (read-only feed — no client events)
+// ---------------------------------------------------------------------------
+
+export interface RunnersClientToServerEvents {
+  // Runners feed is read-only; clients do not emit events
+}
+
+// ---------------------------------------------------------------------------
+// Inter-server events
+// ---------------------------------------------------------------------------
+
+export interface RunnersInterServerEvents {
+  // Reserved for future Redis adapter usage
+}
+
+// ---------------------------------------------------------------------------
+// Per-socket metadata
+// ---------------------------------------------------------------------------
+
+export interface RunnersSocketData {
+  userId?: string;
+}
+```
+
+- [ ] **Step 2: Export from protocol index**
+
+Add after the `/hub` namespace block at the bottom of `packages/protocol/src/index.ts`:
+
+```typescript
+// /runners namespace (Browser runner feed)
+export type {
+  RunnersClientToServerEvents,
+  RunnersServerToClientEvents,
+  RunnersInterServerEvents,
+  RunnersSocketData,
+} from "./runners.js";
+```
+
+- [ ] **Step 3: Verify typecheck passes**
+
+```bash
+cd packages/protocol && bun run build 2>&1
+```
+
+Expected: no errors, dist/ updated.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/protocol/src/runners.ts packages/protocol/src/index.ts
+git commit -m "feat(protocol): add /runners namespace event types"
+```
+
+---
+
+### Task 2: Add `/runners` server namespace
+
+**Files:**
+- Modify: `packages/server/src/ws/sio-registry/context.ts`
+- Create: `packages/server/src/ws/namespaces/runners.ts`
+- Modify: `packages/server/src/ws/namespaces/index.ts`
+
+Room name helpers live in `context.ts` (alongside `hubUserRoom`) to avoid circular dependencies. The namespace file imports from `sio-registry.js` (the barrel), following the `hub.ts` pattern.
+
+- [ ] **Step 1: Add `runnersUserRoom` to context.ts**
+
+In `packages/server/src/ws/sio-registry/context.ts`, add after the `hubUserRoom` function:
+
+```typescript
+/** Room name for a specific user's /runners feed. */
+export function runnersUserRoom(userId: string): string {
+    return `runners:user:${userId}`;
+}
+```
+
+- [ ] **Step 2: Re-export `runnersUserRoom` from the sio-registry barrel**
+
+In `packages/server/src/ws/sio-registry/index.ts`, find the `context.js` export line and add `runnersUserRoom`:
+
+```typescript
+export { initSioRegistry, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionAwaitingAck, runnersUserRoom } from "./context.js";
+```
+
+- [ ] **Step 3: Create the namespace file**
+
+
+```typescript
+// packages/server/src/ws/namespaces/runners.ts
+// ============================================================================
+// /runners namespace — Browser runner feed (read-only for clients)
+//
+// On connection: send initial runner list snapshot.
+// Clients receive runner_added / runner_removed / runner_updated events
+// pushed by sio-registry when the runner daemon connects or changes.
+// ============================================================================
+
+import type { Server as SocketIOServer, Namespace } from "socket.io";
+import type {
+    RunnersClientToServerEvents,
+    RunnersServerToClientEvents,
+    RunnersInterServerEvents,
+    RunnersSocketData,
+} from "@pizzapi/protocol";
+import { sessionCookieAuthMiddleware } from "./auth.js";
+import { getRunners, runnersUserRoom } from "../sio-registry.js";
+
+export function registerRunnersNamespace(io: SocketIOServer): void {
+    const runners: Namespace<
+        RunnersClientToServerEvents,
+        RunnersServerToClientEvents,
+        RunnersInterServerEvents,
+        RunnersSocketData
+    > = io.of("/runners");
+
+    // Auth: validate session cookie from handshake (same as /hub)
+    runners.use(sessionCookieAuthMiddleware() as Parameters<typeof runners.use>[0]);
+
+    runners.on("connection", async (socket) => {
+        const userId = socket.data.userId ?? "";
+
+        console.log(`[sio/runners] connected: ${socket.id} userId=${userId}`);
+
+        // Join per-user room so broadcasts are user-scoped
+        await socket.join(runnersUserRoom(userId));
+
+        // Send initial runner list for this user
+        const initialRunners = await getRunners(userId);
+        socket.emit("runners", { runners: initialRunners });
+
+        // ── disconnect ───────────────────────────────────────────────────────
+        socket.on("disconnect", (reason) => {
+            console.log(`[sio/runners] disconnected: ${socket.id} (${reason})`);
+            // Socket.IO automatically removes sockets from rooms on disconnect
+        });
+    });
+}
+```
+
+- [ ] **Step 4: Register the namespace in index.ts**
+
+In `packages/server/src/ws/namespaces/index.ts`, add:
+
+```typescript
+import { registerRunnersNamespace } from "./runners.js";
+```
+
+And in `registerNamespaces`:
+
+```typescript
+export function registerNamespaces(io: SocketIOServer): void {
+  registerRelayNamespace(io);
+  registerViewerNamespace(io);
+  registerRunnerNamespace(io);
+  registerTerminalNamespace(io);
+  registerHubNamespace(io);
+  registerRunnersNamespace(io);   // ← add this line
+}
+```
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+cd packages/server && bun run typecheck 2>&1
+```
+
+Expected: zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/server/src/ws/sio-registry/context.ts \
+        packages/server/src/ws/sio-registry/index.ts \
+        packages/server/src/ws/namespaces/runners.ts \
+        packages/server/src/ws/namespaces/index.ts
+git commit -m "feat(server): add /runners Socket.IO namespace"
+```
+
+---
+
+### Task 3: Add `broadcastToRunnersNs` + wire broadcasts in sio-registry
+
+**Files:**
+- Modify: `packages/server/src/ws/sio-registry/runners.ts`
+- Create: `packages/server/src/ws/sio-registry/runners.broadcast.test.ts`
+
+The broadcasts hook into three existing moments:
+1. `registerRunner()` success → `runner_added`
+2. `removeRunner()` → `runner_removed` (must read userId before deleting)
+3. `updateRunnerSkills/Agents/Plugins()` → `runner_updated`
+
+A helper `runnerDataToInfo(r: RedisRunnerData): RunnerInfo` converts Redis data to the protocol shape (same logic as in `getRunners` but for a single runner, with `sessionCount: 0` since the client computes it from live sessions).
+
+- [ ] **Step 1: Write failing tests**
+
+Create `packages/server/src/ws/sio-registry/runners.broadcast.test.ts`:
+
+```typescript
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+// ── Minimal Redis mock (same shape as sessions.parent-miss-delink.test.ts) ──
+
+const store = new Map<string, string>();
+const setStore = new Map<string, Set<string>>();
+
+const mockMulti = () => {
+    const ops: Array<() => void> = [];
+    return {
+        hSet: mock((key: string, fields: Record<string, string>) => {
+            ops.push(() => {
+                const existing = JSON.parse(store.get(`__hash__:${key}`) ?? "{}");
+                Object.assign(existing, fields);
+                store.set(`__hash__:${key}`, JSON.stringify(existing));
+            });
+            return mockMulti();
+        }),
+        sAdd: mock((key: string, ...members: string[]) => {
+            ops.push(() => {
+                const s = setStore.get(key) ?? new Set();
+                for (const m of members.flat()) s.add(m);
+                setStore.set(key, s);
+            });
+            return mockMulti();
+        }),
+        sRem: mock((key: string, ...members: string[]) => {
+            ops.push(() => {
+                const s = setStore.get(key);
+                if (s) for (const m of members.flat()) s.delete(m);
+            });
+            return mockMulti();
+        }),
+        expire: mock(() => mockMulti()),
+        del: mock((key: string) => {
+            ops.push(() => {
+                store.delete(key);
+                store.delete(`__hash__:${key}`);
+            });
+            return mockMulti();
+        }),
+        exec: mock(async () => { for (const op of ops) op(); return []; }),
+    };
+};
+
+const mockRedis = {
+    isOpen: true,
+    sAdd: mock(async (key: string, ...members: string[]) => {
+        const s = setStore.get(key) ?? new Set();
+        for (const m of members.flat()) s.add(m);
+        setStore.set(key, s);
+    }),
+    sMembers: mock(async (key: string) => Array.from(setStore.get(key) ?? [])),
+    sRem: mock(async (key: string, ...members: string[]) => {
+        const s = setStore.get(key);
+        if (s) for (const m of members.flat()) s.delete(m);
+    }),
+    expire: mock(async () => {}),
+    multi: mock(() => mockMulti()),
+    on: mock(() => mockRedis),
+    connect: mock(async () => {}),
+    set: mock(async (key: string, value: string) => { store.set(key, value); }),
+    get: mock(async (key: string) => store.get(key) ?? null),
+    del: mock(async (key: string) => {
+        store.delete(key);
+        store.delete(`__hash__:${key}`);
+    }),
+    hGetAll: mock(async (key: string) => {
+        const raw = store.get(`__hash__:${key}`);
+        return raw ? JSON.parse(raw) as Record<string, string> : {};
+    }),
+    hGet: mock(async () => null),
+    hSet: mock(async (key: string, field: string, value: string) => {
+        const existing = JSON.parse(store.get(`__hash__:${key}`) ?? "{}");
+        existing[field] = value;
+        store.set(`__hash__:${key}`, JSON.stringify(existing));
+    }),
+    incr: mock(async () => 1),
+    exists: mock(async (key: string) => {
+        return store.has(`__hash__:${key}`) ? 1 : 0;
+    }),
+};
+
+mock.module("redis", () => ({ createClient: () => mockRedis }));
+mock.module("./hub.js", () => ({ broadcastToHub: mock(async () => {}) }));
+mock.module("../../sessions/store.js", () => ({
+    getEphemeralTtlMs: () => 60_000,
+    updateRelaySessionRunner: mock(async () => {}),
+}));
+
+// Track broadcast calls
+const broadcastCalls: Array<{ event: string; data: unknown; userId?: string }> = [];
+mock.module("./runners-broadcast.js", () => ({
+    broadcastToRunnersNs: mock(async (event: string, data: unknown, userId?: string) => {
+        broadcastCalls.push({ event, data, userId });
+    }),
+}));
+
+const { initStateRedis } = await import("../sio-state.js");
+const { registerRunner, removeRunner, updateRunnerSkills, updateRunnerAgents, updateRunnerPlugins } = await import("./runners.js");
+
+// Note: updateRunnerHooks is not yet implemented in runners.ts and is intentionally
+// excluded from this plan. Add it alongside updateRunnerAgents/Plugins when needed.
+
+describe("runners broadcast", () => {
+    beforeEach(async () => {
+        store.clear();
+        setStore.clear();
+        broadcastCalls.length = 0;
+        await initStateRedis();
+    });
+
+    it("broadcasts runner_added when registerRunner succeeds", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "my-runner",
+            roots: ["/home/user/code"],
+            requestedRunnerId: undefined,
+            runnerSecret: undefined,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: "1.0.0",
+            platform: "linux",
+            userId: "user1",
+            userName: "User One",
+        });
+
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+
+        const added = broadcastCalls.find(c => c.event === "runner_added");
+        expect(added).toBeDefined();
+        expect((added!.data as any).runnerId).toBe(runnerId);
+        expect((added!.data as any).name).toBe("my-runner");
+        expect(added!.userId).toBe("user1");
+    });
+
+    it("broadcasts runner_removed when removeRunner is called", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "runner-to-remove",
+            roots: [],
+            requestedRunnerId: undefined,
+            runnerSecret: undefined,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: null,
+            platform: null,
+            userId: "user2",
+            userName: "User Two",
+        });
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+        broadcastCalls.length = 0; // reset after register
+
+        await removeRunner(runnerId);
+
+        const removed = broadcastCalls.find(c => c.event === "runner_removed");
+        expect(removed).toBeDefined();
+        expect((removed!.data as any).runnerId).toBe(runnerId);
+        expect(removed!.userId).toBe("user2");
+    });
+
+    it("broadcasts runner_updated after updateRunnerSkills", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "skills-runner",
+            roots: [],
+            requestedRunnerId: undefined,
+            runnerSecret: undefined,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: null,
+            platform: null,
+            userId: "user3",
+            userName: "User Three",
+        });
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+        broadcastCalls.length = 0;
+
+        await updateRunnerSkills(runnerId, [{ name: "my-skill", description: "does stuff", filePath: "/path/to/skill.md" }]);
+
+        const updated = broadcastCalls.find(c => c.event === "runner_updated");
+        expect(updated).toBeDefined();
+        expect((updated!.data as any).runnerId).toBe(runnerId);
+        const skills = (updated!.data as any).skills as Array<{ name: string }>;
+        expect(skills.some(s => s.name === "my-skill")).toBe(true);
+    });
+
+    it("broadcasts runner_updated after updateRunnerAgents", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "agents-runner",
+            roots: [],
+            requestedRunnerId: undefined,
+            runnerSecret: undefined,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: null,
+            platform: null,
+            userId: "user4",
+            userName: "User Four",
+        });
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+        broadcastCalls.length = 0;
+
+        await updateRunnerAgents(runnerId, [{ name: "my-agent", description: "an agent", filePath: "/path/to/agent.md" }]);
+
+        const updated = broadcastCalls.find(c => c.event === "runner_updated");
+        expect(updated).toBeDefined();
+        const agents = (updated!.data as any).agents as Array<{ name: string }>;
+        expect(agents.some(a => a.name === "my-agent")).toBe(true);
+    });
+
+    it("broadcasts runner_updated after updateRunnerPlugins", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "plugins-runner",
+            roots: [],
+            requestedRunnerId: undefined,
+            runnerSecret: undefined,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: null,
+            platform: null,
+            userId: "user5",
+            userName: "User Five",
+        });
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+        broadcastCalls.length = 0;
+
+        await updateRunnerPlugins(runnerId, [{ name: "my-plugin", description: "a plugin", rootPath: "/path", commands: [], hookEvents: [], skills: [], hasMcp: false, hasAgents: false, hasLsp: false }]);
+
+        const updated = broadcastCalls.find(c => c.event === "runner_updated");
+        expect(updated).toBeDefined();
+        const plugins = (updated!.data as any).plugins as Array<{ name: string }>;
+        expect(plugins.some(p => p.name === "my-plugin")).toBe(true);
+    });
+
+    it("skips runner_removed broadcast gracefully when runner not in Redis", async () => {
+        // removeRunner on a non-existent runner must not throw
+        await removeRunner("ghost-runner");
+        const removed = broadcastCalls.find(c => c.event === "runner_removed");
+        // No broadcast since runner had no userId to target
+        expect(removed).toBeUndefined();
+    });
+});
+```
+
+- [ ] **Step 2: Run tests — expect assertion failures**
+
+```bash
+cd packages/server && bun test src/ws/sio-registry/runners.broadcast.test.ts 2>&1 | tail -20
+```
+
+Expected: test failures with messages like `Expected [undefined] to be defined` — the `broadcastCalls` array stays empty because `runners.ts` hasn't been wired yet. Module resolution succeeds (the mock is in place); the assertions simply fail because no broadcasts fire yet.
+
+- [ ] **Step 3: Create broadcast helper module**
+
+Create `packages/server/src/ws/sio-registry/runners-broadcast.ts`:
+
+```typescript
+// runners-broadcast.ts — Helpers for broadcasting runner events to /runners namespace
+// Room helper lives in context.ts (alongside hubUserRoom) to avoid circular deps.
+import { getIo, runnersUserRoom } from "./context.js";
+
+/**
+ * Broadcast a runner lifecycle event to all connected /runners clients.
+ * Scoped to a specific user via their room when userId is provided.
+ * Mirrors the hub.ts broadcast pattern.
+ */
+export async function broadcastToRunnersNs(
+    eventName: string,
+    data: unknown,
+    userId?: string,
+): Promise<void> {
+    const io = getIo();
+    try {
+        const runnersNs = io.of("/runners");
+        if (userId) {
+            runnersNs.to(runnersUserRoom(userId)).emit(eventName, data);
+        } else {
+            runnersNs.emit(eventName, data);
+        }
+    } catch (err) {
+        // Fallback: local-only delivery (mirrors hub.ts pattern)
+        console.warn("[sio-registry] broadcastToRunnersNs failed, falling back to local:", (err as Error)?.message);
+        try {
+            const runnersNs = io.of("/runners");
+            if (userId) {
+                runnersNs.local.to(runnersUserRoom(userId)).emit(eventName, data);
+            } else {
+                runnersNs.local.emit(eventName, data);
+            }
+        } catch {
+            // Nothing more we can do
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Add `runnerDataToInfo` helper + wire broadcasts in runners.ts**
+
+In `packages/server/src/ws/sio-registry/runners.ts`:
+
+**Add import at top:**
+```typescript
+import { broadcastToRunnersNs } from "./runners-broadcast.js";
+```
+
+**Add helper function** (near `getRunners`):
+```typescript
+/**
+ * Convert a single RedisRunnerData to RunnerInfo for WS broadcast.
+ * sessionCount is set to 0 — the client computes it from live sessions.
+ */
+function runnerDataToInfo(r: RedisRunnerData): RunnerInfo {
+    return {
+        runnerId: r.runnerId,
+        name: r.name,
+        roots: safeJsonParse(r.roots) ?? [],
+        sessionCount: 0,
+        skills: safeJsonParse(r.skills) ?? [],
+        agents: safeJsonParse(r.agents ?? "[]") ?? [],
+        plugins: safeJsonParse(r.plugins ?? "[]") ?? [],
+        hooks: safeJsonParse(r.hooks ?? "[]") ?? [],
+        version: r.version ?? null,
+        platform: r.platform ?? null,
+    };
+}
+```
+
+**In `registerRunner()`**, after `await socket.join(runnerRoom(runnerId));` and `return runnerId;`, add broadcast (just before `return`):
+```typescript
+    // Broadcast runner_added to connected browsers
+    void broadcastToRunnersNs("runner_added", runnerDataToInfo(runnerData), opts.userId ?? undefined);
+
+    return runnerId;
+```
+
+**In `removeRunner()`**, change from:
+```typescript
+export async function removeRunner(runnerId: string): Promise<void> {
+    localRunnerSockets.delete(runnerId);
+    await deleteRunnerState(runnerId);
+}
+```
+
+To:
+```typescript
+export async function removeRunner(runnerId: string): Promise<void> {
+    // Read userId before deleting so we can target the correct user room
+    const existing = await getRunnerState(runnerId);
+    localRunnerSockets.delete(runnerId);
+    await deleteRunnerState(runnerId);
+    if (existing) {
+        void broadcastToRunnersNs(
+            "runner_removed",
+            { runnerId },
+            existing.userId ?? undefined,
+        );
+    }
+}
+```
+
+**In `updateRunnerSkills()`**, after `await updateRunnerFields(...)`, add:
+```typescript
+    const fresh = await getRunnerState(runnerId);
+    if (fresh) {
+        void broadcastToRunnersNs("runner_updated", runnerDataToInfo(fresh), fresh.userId ?? undefined);
+    }
+```
+
+Apply the same pattern to `updateRunnerAgents()` and `updateRunnerPlugins()`.
+
+- [ ] **Step 5: Run tests — expect pass**
+
+```bash
+cd packages/server && bun test src/ws/sio-registry/runners.broadcast.test.ts 2>&1 | tail -15
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Full server typecheck**
+
+```bash
+cd packages/server && bun run typecheck 2>&1
+```
+
+Expected: zero errors.
+
+- [ ] **Step 7: Full test suite**
+
+```bash
+bun run test 2>&1 | tail -10
+```
+
+Expected: ≥406 pass, 0 fail.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add packages/server/src/ws/sio-registry/runners-broadcast.ts \
+        packages/server/src/ws/sio-registry/runners.ts \
+        packages/server/src/ws/sio-registry/runners.broadcast.test.ts
+git commit -m "feat(server): broadcast runner_added/removed/updated to /runners namespace"
+```
+
+---
+
+## Chunk 2: UI Hook + RunnerManager + App.tsx Core
+
+### Task 4: `useRunnersFeed` hook
+
+**Files:**
+- Create: `packages/ui/src/lib/useRunnersFeed.ts`
+- Create: `packages/ui/src/lib/useRunnersFeed.test.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `packages/ui/src/lib/useRunnersFeed.test.ts`:
+
+```typescript
+import { describe, it, expect } from "bun:test";
+// Pure logic tests: upsert, remove, merge helpers extracted from the hook
+
+// These mirror the reducer logic inside useRunnersFeed.
+// We test the state-update logic in isolation (no DOM/socket needed).
+
+import type { RunnerInfo } from "@pizzapi/protocol";
+
+function makeRunner(overrides: Partial<RunnerInfo> = {}): RunnerInfo {
+    return {
+        runnerId: "r1",
+        name: "runner",
+        roots: [],
+        sessionCount: 0,
+        skills: [],
+        agents: [],
+        plugins: [],
+        hooks: [],
+        version: null,
+        platform: null,
+        ...overrides,
+    };
+}
+
+// ── upsert ────────────────────────────────────────────────────────────────
+
+function upsert(list: RunnerInfo[], incoming: RunnerInfo): RunnerInfo[] {
+    const idx = list.findIndex(r => r.runnerId === incoming.runnerId);
+    if (idx === -1) return [...list, incoming];
+    const next = [...list];
+    next[idx] = incoming;
+    return next;
+}
+
+describe("useRunnersFeed state helpers", () => {
+    describe("upsert (runner_added / runner_updated)", () => {
+        it("appends a new runner", () => {
+            const r = makeRunner({ runnerId: "r1" });
+            const result = upsert([], r);
+            expect(result).toHaveLength(1);
+            expect(result[0].runnerId).toBe("r1");
+        });
+
+        it("replaces existing runner by runnerId", () => {
+            const old = makeRunner({ runnerId: "r1", name: "old" });
+            const updated = makeRunner({ runnerId: "r1", name: "new" });
+            const result = upsert([old], updated);
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe("new");
+        });
+
+        it("does not affect other runners", () => {
+            const r1 = makeRunner({ runnerId: "r1" });
+            const r2 = makeRunner({ runnerId: "r2", name: "other" });
+            const updated = makeRunner({ runnerId: "r1", name: "updated" });
+            const result = upsert([r1, r2], updated);
+            expect(result).toHaveLength(2);
+            expect(result.find(r => r.runnerId === "r2")?.name).toBe("other");
+        });
+    });
+
+    describe("remove (runner_removed)", () => {
+        it("removes runner by runnerId", () => {
+            const runners = [makeRunner({ runnerId: "r1" }), makeRunner({ runnerId: "r2" })];
+            const result = runners.filter(r => r.runnerId !== "r1");
+            expect(result).toHaveLength(1);
+            expect(result[0].runnerId).toBe("r2");
+        });
+
+        it("is a no-op when runnerId not found", () => {
+            const runners = [makeRunner({ runnerId: "r1" })];
+            const result = runners.filter(r => r.runnerId !== "ghost");
+            expect(result).toHaveLength(1);
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run tests — expect pass (pure logic, no implementation needed)**
+
+```bash
+cd packages/ui && bun test src/lib/useRunnersFeed.test.ts 2>&1 | tail -10
+```
+
+Expected: all pass (pure JS logic).
+
+- [ ] **Step 3: Create the hook**
+
+Create `packages/ui/src/lib/useRunnersFeed.ts`:
+
+```typescript
+import * as React from "react";
+import { io, type Socket } from "socket.io-client";
+import type {
+    RunnersServerToClientEvents,
+    RunnersClientToServerEvents,
+    RunnerInfo,
+} from "@pizzapi/protocol";
+import { getSocketIOBase } from "./relay.js";
+
+export type RunnersFeedStatus = "connecting" | "connected" | "disconnected";
+
+export interface RunnersFeedState {
+    runners: RunnerInfo[];
+    status: RunnersFeedStatus;
+}
+
+/**
+ * Subscribe to the /runners Socket.IO namespace.
+ * Returns the live runner list and connection status.
+ *
+ * The server broadcasts:
+ *   runners       — full snapshot on connect
+ *   runner_added  — new runner registered
+ *   runner_removed — runner disconnected
+ *   runner_updated — runner metadata changed (skills/agents/plugins)
+ */
+export function useRunnersFeed(): RunnersFeedState {
+    const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
+    const [status, setStatus] = React.useState<RunnersFeedStatus>("connecting");
+
+    React.useEffect(() => {
+        const base = getSocketIOBase();
+        const socket: Socket<RunnersServerToClientEvents, RunnersClientToServerEvents> = io(
+            base ? `${base}/runners` : "/runners",
+            { withCredentials: true },
+        );
+
+        socket.on("connect", () => setStatus("connected"));
+        socket.on("disconnect", () => setStatus("disconnected"));
+        socket.on("connect_error", () => setStatus("disconnected"));
+
+        socket.on("runners", ({ runners: list }) => {
+            setRunners(list);
+        });
+
+        socket.on("runner_added", (incoming) => {
+            setRunners(prev => {
+                const idx = prev.findIndex(r => r.runnerId === incoming.runnerId);
+                if (idx === -1) return [...prev, incoming];
+                const next = [...prev];
+                next[idx] = incoming;
+                return next;
+            });
+        });
+
+        socket.on("runner_removed", ({ runnerId }) => {
+            setRunners(prev => prev.filter(r => r.runnerId !== runnerId));
+        });
+
+        socket.on("runner_updated", (incoming) => {
+            setRunners(prev => {
+                const idx = prev.findIndex(r => r.runnerId === incoming.runnerId);
+                if (idx === -1) return prev; // unknown runner — ignore
+                const next = [...prev];
+                next[idx] = incoming;
+                return next;
+            });
+        });
+
+        return () => {
+            socket.disconnect();
+        };
+    }, []);
+
+    return { runners, status };
+}
+```
+
+- [ ] **Step 4: UI typecheck**
+
+```bash
+cd packages/ui && bun run typecheck 2>&1
+```
+
+Expected: zero errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/lib/useRunnersFeed.ts packages/ui/src/lib/useRunnersFeed.test.ts
+git commit -m "feat(ui): add useRunnersFeed hook for /runners WebSocket feed"
+```
+
+---
+
+### Task 5: Refactor `RunnerManager`
+
+**Files:**
+- Modify: `packages/ui/src/components/RunnerManager.tsx`
+
+Remove all polling and sessions fetching. Accept `sessions` as a prop. Use `useRunnersFeed()` for runner data. Replace `poll()` spawn-wait with effect-based watching.
+
+- [ ] **Step 1: Update the component**
+
+In `packages/ui/src/components/RunnerManager.tsx`:
+
+**Change the props interface** — use full `HubSession` type rather than the narrower `{sessionId, runnerId}` proposed in the spec. The spec's narrow type is insufficient because `RunnerDetailPanel.SessionsList` requires `shareUrl`, `cwd`, `startedAt`, `sessionName`, `isActive`, `lastHeartbeatAt`, `runnerId`, `runnerName`. `HubSession` (from `SessionSidebar.tsx`) is a superset that satisfies all these fields. This is an intentional deviation from the spec's narrow-type recommendation in favor of correctness:
+
+```typescript
+import type { HubSession } from "@/components/SessionSidebar";
+
+export interface RunnerManagerProps {
+    /** Live sessions from the /hub feed — used for spawn-wait, per-runner counts, and RunnerDetailPanel */
+    sessions: HubSession[];
+    onOpenSession?: (sessionId: string) => void;
+    selectedRunnerId: string | null;
+    onSelectRunner?: (runnerId: string) => void;
+}
+```
+
+Note: `onRunnersChange` is **removed** from props — `App.tsx` will derive `runnersForSidebar` directly from `feedRunners` via its own `useEffect` (see Task 6).
+
+**Change the props interface** — add `runners` and `runnersStatus` from App.tsx's `useRunnersFeed()` call (the hook is called once in App.tsx, not here, to avoid duplicate socket connections):
+
+```typescript
+import type { RunnerInfo } from "@pizzapi/protocol";
+
+// Add to props:
+runners: RunnerInfo[];
+runnersStatus: "connecting" | "connected" | "disconnected";
+```
+
+**Remove local state + polling** — remove:
+- `const [runners, setRunners]`
+- `const [sessions, setSessions]`
+- `const [loading, setLoading]`
+- `const fetchData` callback
+- The `useEffect` with `setInterval(fetchData, 10000)` + initial call
+- The standalone `fetch("/api/version")` effect (version is already in `RunnerInfo.version`)
+
+**Derive loading state from props:**
+```typescript
+const loading = runnersStatus === "connecting" && runners.length === 0;
+```
+
+**Add spawn-wait effects** (after existing effects):
+```typescript
+// Resolve pending spawn: when the spawned session appears in the live feed, open it
+React.useEffect(() => {
+    if (!pendingSessionId) return;
+    const found = sessions.some(s => s.sessionId === pendingSessionId);
+    if (found) {
+        const id = pendingSessionId;
+        setPendingSessionId(null);
+        onOpenSession?.(id);
+    }
+}, [pendingSessionId, sessions, onOpenSession]);
+
+// 30-second timeout guard: clear pendingSessionId if session never appears
+React.useEffect(() => {
+    if (!pendingSessionId) return;
+    const timer = setTimeout(() => setPendingSessionId(null), 30_000);
+    return () => clearTimeout(timer);
+}, [pendingSessionId]);
+```
+
+**Replace all uses of local `runners` → `runners` prop, `sessions` → `sessions` prop.**
+
+**`onSkillsChange`, `onAgentsChange`, `onPluginsChange` on `RunnerDetailPanel`**: these previously updated local `runners` state. Since updates now arrive via WS `runner_updated` events, pass no-op callbacks:
+```tsx
+onSkillsChange={() => {}}
+onAgentsChange={() => {}}
+onPluginsChange={() => {}}
+```
+
+**In `handleSpawn`**: remove the `poll()` loop. After the spawn succeeds and `sessionId` is known, replace `void poll()` with:
+```typescript
+setPendingSessionId(sessionId);
+```
+
+**Remove `fetchData()` calls in `handleRestart` and `handleStop`**: both `finally` blocks currently call `fetchData()` after the 2s delay. Remove those calls — the WS feed updates automatically when the runner reconnects. Specifically, in `handleRestart`:
+```typescript
+// Remove this:
+fetchData();
+```
+And same in `handleStop`'s `finally` block.
+
+**Remove `latestVersion` state + `fetch("/api/version")` effect**: this fetches the server version on mount to display an "update available" badge. With `RunnerInfo.version` now flowing through the WS feed, the version is available as `runners[0]?.version`. Remove the separate fetch and use the feed-provided version. (This is a small scope extension beyond the spec, but keeping a redundant HTTP fetch alongside a WS feed would be inconsistent.)
+
+**`runnerSessions` for `RunnerDetailPanel`:**
+```typescript
+const runnerSessions = sessions.filter(s => s.runnerId === selectedRunnerId);
+```
+
+Pass sessions to `RunnerDetailPanel` with an explicit mapping to avoid optional/required type mismatches:
+```typescript
+const runnerSessions = sessions
+    .filter(s => s.runnerId === selectedRunnerId)
+    .map(s => ({
+        sessionId: s.sessionId,
+        shareUrl: s.shareUrl ?? "",
+        cwd: s.cwd ?? "",
+        startedAt: s.startedAt ?? "",
+        sessionName: s.sessionName ?? null,
+        isActive: s.isActive ?? false,
+        lastHeartbeatAt: s.lastHeartbeatAt ?? null,
+        runnerId: s.runnerId ?? null,
+        runnerName: s.runnerName ?? null,
+    }));
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd packages/ui && bun run typecheck 2>&1
+```
+
+Expected: errors about missing `sessions` prop at call sites in `App.tsx`. That's expected — fix in Task 6.
+
+- [ ] **Step 3: Commit (WIP — broken typecheck is expected)**
+
+```bash
+git add packages/ui/src/components/RunnerManager.tsx
+git commit -m "feat(ui): refactor RunnerManager — use WS feed, remove polling, add sessions prop"
+```
+
+---
+
+### Task 6: `App.tsx` — remove runner fetches, hub-based wait, pass sessions
+
+**Files:**
+- Modify: `packages/ui/src/App.tsx`
+
+Three changes:
+1. Remove the on-mount eager `fetch("/api/runners")` (lines ~137–159)
+2. Remove the `runners` state + `runnersLoading` state + new-session-dialog fetch (lines ~181–385)
+3. Replace `waitForSessionToGoLive` polling with ref-based hub waiter
+4. Pass `sessions` prop to `RunnerManager`
+5. Use `useRunnersFeed()` to supply runners to `NewSessionWizardDialog`
+
+- [ ] **Step 1: Add `useRunnersFeed` — single instance in App.tsx**
+
+`useRunnersFeed()` is called **only** in App.tsx, never in RunnerManager. This avoids duplicate `/runners` socket connections.
+
+In `App.tsx`, add import:
+```typescript
+import { useRunnersFeed } from "@/lib/useRunnersFeed";
+```
+
+Add near other hooks at the top of the component body:
+```typescript
+const { runners: feedRunners, status: runnersStatus } = useRunnersFeed();
+```
+
+- [ ] **Step 2: Remove on-mount eager fetch**
+
+Delete the `useEffect` block (~lines 137–159) that does:
+```typescript
+// Eager fetch: populate sidebar runners immediately on mount (before RunnerManager mounts)
+React.useEffect(() => {
+    let cancelled = false;
+    void fetch("/api/runners", ...)
+    ...
+}, [setSidebarRunners]);
+```
+
+- [ ] **Step 3: Remove `runners` state, `runnersLoading` state, and new-session dialog fetch**
+
+Delete:
+```typescript
+const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
+const [runnersLoading, setRunnersLoading] = React.useState(false);
+```
+
+Delete the `useEffect` block (~lines 352–385) that depends on `[newSessionOpen]` and calls `fetch("/api/runners")`.
+
+- [ ] **Step 4: Replace `waitForSessionToGoLive` with hub waiter**
+
+Locate `waitForSessionToGoLive` (~line 2514). Replace the entire function and add the waiter ref + resolver effect:
+
+```typescript
+// ── Session live waiter — resolves via /hub feed, no polling ──────────────
+const sessionWaitersRef = React.useRef<Map<string, {
+    resolve: (found: boolean) => void;
+    timer: ReturnType<typeof setTimeout>;
+}>>(new Map());
+
+// Resolve any pending waiters when liveSessions updates
+React.useEffect(() => {
+    for (const [sessionId, waiter] of sessionWaitersRef.current) {
+        if (liveSessions.some(s => s.sessionId === sessionId)) {
+            clearTimeout(waiter.timer);
+            sessionWaitersRef.current.delete(sessionId);
+            waiter.resolve(true);
+        }
+    }
+}, [liveSessions]);
+
+const waitForSessionToGoLive = React.useCallback(
+    (sessionId: string, timeoutMs: number): Promise<boolean> => {
+        // Fast path: already live
+        if (liveSessions.some(s => s.sessionId === sessionId)) {
+            return Promise.resolve(true);
+        }
+        return new Promise((resolve) => {
+            const timer = setTimeout(() => {
+                sessionWaitersRef.current.delete(sessionId);
+                resolve(false);
+            }, timeoutMs);
+            sessionWaitersRef.current.set(sessionId, { resolve, timer });
+        });
+    },
+    [liveSessions],
+);
+```
+
+- [ ] **Step 5: Derive `runnersForSidebar` in App.tsx from the feed**
+
+Since `RunnerManager` no longer exposes `onRunnersChange`, App.tsx must derive `runnersForSidebar` directly from the feed. Add this effect in App.tsx (replaces the `setSidebarRunners` logic that previously came from `RunnerManager`'s `onRunnersChange`):
+
+```typescript
+React.useEffect(() => {
+    setSidebarRunners(feedRunners.map(r => ({
+        runnerId: r.runnerId,
+        name: r.name,
+        sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
+        version: r.version,
+        isOnline: true,
+        platform: r.platform ?? null,
+    })));
+}, [feedRunners, liveSessions, setSidebarRunners]);
+```
+
+- [ ] **Step 6: Pass runners + sessions to RunnerManager; wire NewSessionWizardDialog**
+
+Find `<RunnerManager` in App.tsx (appears ~3 times). Update each to pass the new props and remove `onRunnersChange`:
+
+```tsx
+<RunnerManager
+    runners={feedRunners}             // ← add (from useRunnersFeed in App.tsx)
+    runnersStatus={runnersStatus}     // ← add
+    sessions={liveSessions}           // ← add
+    onOpenSession={...}
+    // onRunnersChange removed — App.tsx derives it via useEffect on feedRunners
+    selectedRunnerId={selectedRunnerId}
+    onSelectRunner={setSelectedRunnerId}
+/>
+```
+
+Find `<NewSessionWizardDialog` and change:
+```tsx
+runners={runners.map((r) => ({ ...r, name: r.name ?? null, isOnline: true }))}
+runnersLoading={runnersLoading}
+```
+To:
+```tsx
+runners={feedRunners.map((r) => ({ ...r, name: r.name ?? null, isOnline: true }))}
+runnersLoading={runnersStatus === "connecting"}
+```
+
+- [ ] **Step 7: Typecheck**
+
+```bash
+cd packages/ui && bun run typecheck 2>&1
+```
+
+Expected: zero errors.
+
+- [ ] **Step 8: Full test suite**
+
+```bash
+bun run test 2>&1 | tail -10
+```
+
+Expected: ≥406 pass (the new useRunnersFeed tests add a few), 0 fail.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add packages/ui/src/App.tsx
+git commit -m "feat(ui): wire App.tsx to /runners feed — remove fetches, hub-based session waiter"
+```
+
+---
+
+## Chunk 3: Dialogs + SessionViewer
+
+### Task 7: `TerminalManager` — accept runners prop
+
+**Files:**
+- Modify: `packages/ui/src/components/TerminalManager.tsx`
+
+- [ ] **Step 1: Add runners prop to `TerminalManager`**
+
+Find the props type/interface at the top of `TerminalManager.tsx`. The component receives its props as a destructured object. Add:
+
+```typescript
+runners?: Array<{
+    runnerId: string;
+    name: string | null;
+    roots: string[];
+    sessionCount: number;
+}>;
+runnersLoading?: boolean;
+```
+
+- [ ] **Step 2: Remove local runners state + fetch**
+
+Delete:
+```typescript
+const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
+const [runnersLoading, setRunnersLoading] = React.useState(false);
+```
+
+Delete the `useEffect` block that fires `fetch("/api/runners")` when `dialogOpen` changes.
+
+- [ ] **Step 3: Use prop values**
+
+Replace all uses of the local `runners` state with the `runners` prop (defaulting to `[]`):
+```typescript
+const effectiveRunners = runners ?? [];
+```
+
+Replace `runnersLoading` state with the `runnersLoading` prop (defaulting to `false`).
+
+- [ ] **Step 4: Pass props from App.tsx**
+
+Find each `<TerminalManager` in `App.tsx` and add:
+```tsx
+runners={feedRunners.map(r => ({
+    runnerId: r.runnerId,
+    name: r.name,
+    roots: r.roots,
+    sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
+}))}
+runnersLoading={runnersStatus === "connecting"}
+```
+
+- [ ] **Step 5: Typecheck**
+
+```bash
+cd packages/ui && bun run typecheck 2>&1
+```
+
+Expected: zero errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/ui/src/components/TerminalManager.tsx packages/ui/src/App.tsx
+git commit -m "feat(ui): TerminalManager — accept runners prop, remove on-dialog-open fetch"
+```
+
+---
+
+### Task 8: `SessionViewer` — use cached runner data for slash commands
+
+**Files:**
+- Modify: `packages/ui/src/components/SessionViewer.tsx`
+- Modify: `packages/ui/src/App.tsx`
+
+The `/skills`, `/agents`, `/plugins` slash commands and the `@mention` agent popover currently fire `fetch("/api/runners/{id}/...")` each time. Since the runner's skills/agents/plugins flow through `runner_updated` on the WS feed, the data is already in `feedRunners`. Pass it as a `runnerInfo` prop.
+
+Note: `/sandbox` keeps its HTTP fetch — sandbox status (violation counts, recent violations) is not part of `RunnerInfo`.
+
+- [ ] **Step 1: Add `runnerInfo` prop to `SessionViewer`**
+
+Find the `SessionViewerProps` interface (or equivalent) in `SessionViewer.tsx`. Add:
+
+```typescript
+/** Full runner data for the active session's runner — from the /runners WS feed */
+runnerInfo?: import("@pizzapi/protocol").RunnerInfo | null;
+```
+
+Destructure it in the component:
+```typescript
+const { ..., runnerInfo } = props;
+```
+
+- [ ] **Step 2: Replace `/skills` HTTP fetch**
+
+Find the block handling `rawCommand === "skills"`. Replace:
+```typescript
+fetch(`/api/runners/${encodeURIComponent(runnerId)}/skills`, ...)
+    .then(...)
+```
+
+With:
+```typescript
+// Use cached runner data from WS feed. If runner disconnected, runnerInfo is null → empty list.
+// This is acceptable: the existing pre-guard already catches `if (!runnerId)` (no runner at all).
+// If the runner disconnected mid-session, the user sees an empty skills list rather than an error.
+const skills = runnerInfo?.skills ?? [];
+// Merge with CLI-advertised skill commands (same merge logic as before)
+const merged = new Map<string, { name: string; description?: string }>();
+for (const s of skills) merged.set(s.name, s);
+for (const cmd of skillCommands) {
+    const skillName = cmd.name.replace(/^skill:/, "");
+    if (!merged.has(skillName)) {
+        merged.set(skillName, { name: skillName, description: cmd.description });
+    }
+}
+onAppendSystemMessage?.({
+    kind: "skills",
+    skills: Array.from(merged.values()),
+});
+```
+
+Remove the `catch` and `dispatchSessionId` guard (no longer async).
+
+- [ ] **Step 3: Replace `/plugins` HTTP fetch**
+
+Find the block handling `rawCommand === "plugins"`. Replace the `fetch(pluginsUrl, ...)` chain with:
+```typescript
+const plugins = runnerInfo?.plugins ?? [];
+onAppendSystemMessage?.({
+    kind: "plugins",
+    plugins: plugins.map((p) => ({
+        name: p.name,
+        description: p.description,
+        version: p.version,
+        commands: (p.commands ?? []).map((c) => ({ name: c.name, description: c.description })),
+        hookCount: p.hookEvents?.length ?? 0,
+        skillCount: p.skills?.length ?? 0,
+        agentCount: p.agents?.length ?? 0,
+        ruleCount: p.rules?.length ?? 0,
+        hasMcp: !!p.hasMcp,
+        hasAgents: !!p.hasAgents,
+    })),
+});
+```
+
+- [ ] **Step 4: Replace `/agents <name>` execution fetch**
+
+Find the block handling `rawCommand === "agents"` with `args.trim()`. Replace the `fetch(...)` with a synchronous lookup against `runnerInfo?.agents` for name resolution, keeping an individual content fetch:
+
+```typescript
+const dispatchSessionId = sessionId;
+const agents = runnerInfo?.agents ?? [];
+const match = agents.find(a => a.name.toLowerCase() === agentName.toLowerCase());
+if (match) {
+    // Fetch individual agent content (system prompt) — not in RunnerInfo.agents
+    // Note: the list endpoint also doesn't return content (pre-existing limitation).
+    // Only the per-agent endpoint (/agents/:name) returns content.
+    fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents/${encodeURIComponent(match.name)}`, { credentials: "include" })
+        .then(res => res.ok ? res.json() : Promise.reject())
+        .then((data: any) => {
+            if (dispatchSessionId !== sessionIdRef.current) return; // session changed
+            onSpawnAgentSession?.({ name: match.name, description: match.description, systemPrompt: data?.content });
+        })
+        .catch(() => {
+            if (dispatchSessionId !== sessionIdRef.current) return;
+            onSpawnAgentSession?.({ name: match.name, description: match.description });
+        });
+} else {
+    onAppendSystemMessage?.(`**Agents** — Agent "${agentName}" not found.`);
+}
+```
+
+- [ ] **Step 5: Replace `@mention` agent popover fetch**
+
+Find the `useEffect` that fires when `atMentionOpen && runnerId`. Replace the `fetch(...)` with:
+
+```typescript
+React.useEffect(() => {
+    if (!atMentionOpen || !runnerId) return;
+    const agents = (runnerInfo?.agents ?? []).map(a => ({ name: a.name, description: a.description }));
+    setAtMentionAgents(agents);
+}, [atMentionOpen, runnerId, runnerInfo]);
+```
+
+Remove `atMentionAgentsFetchedForRef` (no longer needed since it was just a fetch-dedup guard).
+
+- [ ] **Step 6: Update `/agents` command popover list fetch**
+
+The agents popover uses `agentsList` both for display AND for spawning (`agent.content` as `systemPrompt`). Since `runnerInfo.agents` lacks `content`, keep the HTTP fetch for the agent list but populate the display immediately from cached data while the fetch is in-flight:
+
+```typescript
+React.useEffect(() => {
+    if (!sessionId || !commandOpen || !isAgentMode || !runnerId) return;
+    const requestKey = `${sessionId}-${runnerId}`;
+    if (agentsRequestedRef.current === requestKey) return;
+    agentsRequestedRef.current = requestKey;
+    let stale = false;
+
+    // Pre-populate display from cached runner data immediately (no loading flicker)
+    const cachedAgents = (runnerInfo?.agents ?? []).map(a => ({ name: a.name, description: a.description }));
+    setAgentsList(cachedAgents);
+
+    // Fetch full agent data (including content for system prompts) in background
+    setAgentsLoading(true);
+    fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents`, { credentials: "include" })
+        .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
+        .then((data: any) => {
+            if (stale) return;
+            const agents: Array<{ name: string; description?: string; content?: string }> = Array.isArray(data?.agents) ? data.agents : [];
+            setAgentsList(agents);
+        })
+        .catch(() => { if (stale) return; /* keep cached data */ })
+        .finally(() => { if (!stale) setAgentsLoading(false); });
+    return () => { stale = true; };
+}, [sessionId, commandOpen, isAgentMode, runnerId, runnerInfo]);
+```
+
+This eliminates visible loading states (cached data shows immediately) while still fetching `content` for agent spawning.
+
+Note: `GET /api/runners/:id/agents` (list endpoint) returns `{name, description, filePath}` from Redis — no `content`. `GET /api/runners/:id/agents/:name` (individual endpoint) returns `content`. The fetch in this step is for the list (display + dedup), and `content` was already `undefined` in picker-based spawning before this refactor. The per-agent content fetch is only done explicitly in Step 4 (`/agents <name>` execution). This plan does not change picker spawning behavior.
+
+- [ ] **Step 7: Pass `runnerInfo` from App.tsx**
+
+In `App.tsx`, add:
+```typescript
+const activeRunnerInfo = React.useMemo(
+    () => feedRunners.find(r => r.runnerId === activeSessionInfo?.runnerId) ?? null,
+    [feedRunners, activeSessionInfo?.runnerId],
+);
+```
+
+Find `<SessionViewer` and add:
+```tsx
+runnerInfo={activeRunnerInfo}
+```
+
+- [ ] **Step 8: Typecheck**
+
+```bash
+cd packages/ui && bun run typecheck 2>&1
+```
+
+Expected: zero errors.
+
+- [ ] **Step 9: Full test suite**
+
+```bash
+bun run test 2>&1 | tail -10
+```
+
+Expected: ≥406 pass, 0 fail.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add packages/ui/src/components/SessionViewer.tsx packages/ui/src/App.tsx
+git commit -m "feat(ui): SessionViewer — use cached runner data for /skills, /agents, /plugins commands"
+```
+
+---
+
+## Chunk 4: Final verification
+
+### Task 9: Build + typecheck all packages
+
+- [ ] **Step 1: Full build**
+
+```bash
+bun run build 2>&1 | tail -20
+```
+
+Expected: all packages build cleanly.
+
+- [ ] **Step 2: Full typecheck**
+
+```bash
+bun run typecheck 2>&1
+```
+
+Expected: zero errors across all packages.
+
+- [ ] **Step 3: Full test suite**
+
+```bash
+bun run test 2>&1 | tail -10
+```
+
+Expected: ≥406 pass, 0 fail.
+
+- [ ] **Step 4: Confirm no polling remains**
+
+```bash
+grep -rn "setInterval.*fetch\|fetch.*setInterval\|fetchData.*interval\|interval.*fetchData" \
+  packages/ui/src --include="*.ts" --include="*.tsx" | grep -v node_modules | grep -v test
+```
+
+Expected: no output (no polling loops).
+
+- [ ] **Step 5: Confirm no ad-hoc runner fetches remain**
+
+```bash
+grep -rn 'fetch("/api/runners"' packages/ui/src --include="*.ts" --include="*.tsx" | grep -v node_modules
+```
+
+Expected: only mutation calls remain (restart, stop, spawn, terminal — all POST). Zero `GET /api/runners` calls.
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add -A
+git commit -m "chore: final cleanup — verify zero polling, all builds passing"
+```
+
+---
+
+## Summary of Changes
+
+| File | What changed |
+|------|-------------|
+| `packages/protocol/src/runners.ts` | **New** — WS event types |
+| `packages/protocol/src/index.ts` | Exports new types |
+| `packages/server/src/ws/namespaces/runners.ts` | **New** — `/runners` namespace |
+| `packages/server/src/ws/namespaces/index.ts` | Registers namespace |
+| `packages/server/src/ws/sio-registry/context.ts` | Adds `runnersUserRoom` helper |
+| `packages/server/src/ws/sio-registry/index.ts` | Re-exports `runnersUserRoom` |
+| `packages/server/src/ws/sio-registry/runners-broadcast.ts` | **New** — broadcast helper |
+| `packages/server/src/ws/sio-registry/runners.ts` | Adds broadcasts on register/remove/update |
+| `packages/server/src/ws/sio-registry/runners.broadcast.test.ts` | **New** — broadcast behavior tests |
+| `packages/ui/src/lib/useRunnersFeed.ts` | **New** — hook |
+| `packages/ui/src/lib/useRunnersFeed.test.ts` | **New** — state logic tests |
+| `packages/ui/src/components/RunnerManager.tsx` | Removes polling; accepts runners+runnersStatus+sessions props from App.tsx |
+| `packages/ui/src/components/TerminalManager.tsx` | Accepts runners prop; removes on-open fetch |
+| `packages/ui/src/components/SessionViewer.tsx` | Uses cached `runnerInfo` for commands/popover |
+| `packages/ui/src/App.tsx` | Uses `useRunnersFeed`; hub-based session waiter; passes props |

--- a/docs/specs/2026-03-21-runners-websocket-feed-design.md
+++ b/docs/specs/2026-03-21-runners-websocket-feed-design.md
@@ -1,0 +1,298 @@
+# Design: Runner WebSocket Feed (`/runners` namespace)
+
+**Date:** 2026-03-21  
+**Branch:** `feat/ui-websocket-realtime`  
+**Status:** Approved
+
+---
+
+## Problem
+
+The `RunnerManager` component polls two REST endpoints every 10 seconds:
+- `GET /api/runners` — runner metadata (name, skills, agents, plugins, version)
+- `GET /api/sessions` — session list (to compute per-runner session counts and show session lists)
+
+There is also a spin-poll loop after spawning a session (`poll()` in `RunnerManager`, `waitForSessionToGoLive` in `App.tsx`) that hits `/api/sessions` every 1 second until the new session appears.
+
+Additionally, `App.tsx` does a one-time eager `fetch("/api/runners")` on mount.
+
+**Effect:** Up to 10-second lag before a newly connected/disconnected runner appears in the UI. Unnecessary HTTP load. Architectural smell — the rest of the session lifecycle already uses WebSocket (`/hub` namespace for sessions, `/viewer` for content).
+
+---
+
+## Goal
+
+- Instant runner connect/disconnect/update notifications (latency → ~0)
+- Zero polling: eliminate all `setInterval` + `fetch` for runners and sessions
+- Consistent architecture: all real-time state flows through Socket.IO namespaces
+
+---
+
+## Out of Scope
+
+- Changing `/hub` session events (already WebSocket, already working)
+- Changing `/viewer` session content events
+- Multi-node / Redis adapter runner broadcasting (existing pattern; runners broadcast to per-user rooms)
+
+---
+
+## Chosen Approach: New `/runners` Namespace
+
+A dedicated browser-facing `/runners` Socket.IO namespace alongside the existing `/hub`. The runner daemon's existing `/runner` (singular) namespace is unchanged.
+
+---
+
+## Component Design
+
+### 1. Protocol (`packages/protocol`)
+
+**New file:** `packages/protocol/src/runners.ts`
+
+```typescript
+import type { RunnerInfo } from "./shared.js";
+
+/** Server → Client events on the /runners namespace */
+export interface RunnersServerToClientEvents {
+  /** Full runner list snapshot sent on connection */
+  runners: (data: { runners: RunnerInfo[] }) => void;
+  /** A runner daemon connected and registered */
+  runner_added: (data: RunnerInfo) => void;
+  /** A runner daemon disconnected */
+  runner_removed: (data: { runnerId: string }) => void;
+  /** Runner metadata changed (skills, agents, plugins, hooks) */
+  runner_updated: (data: RunnerInfo) => void;
+}
+
+/** Client → Server: read-only feed, no client events */
+export interface RunnersClientToServerEvents {}
+
+export interface RunnersInterServerEvents {}
+
+export interface RunnersSocketData {
+  userId?: string;
+}
+```
+
+`sessionCount` is **not** included in WS events. The client computes it from
+`liveSessions.filter(s => s.runnerId === r.runnerId).length` — it already has
+the full sessions list from the `/hub` feed.
+
+**Updated:** `packages/protocol/src/index.ts` — export the four new types.
+
+---
+
+### 2. Server: `/runners` Namespace (`packages/server`)
+
+#### 2a. New namespace file: `src/ws/namespaces/runners.ts`
+
+```
+/runners namespace:
+  auth: sessionCookieAuthMiddleware (same as /hub)
+  on connection:
+    - extract userId from socket.data
+    - join user room: "runners:user:<userId>"
+    - fetch runners: getRunners(userId)
+    - emit "runners" with initial list
+    - on disconnect: leave rooms (Socket.IO cleans up automatically)
+```
+
+#### 2b. Extend: `src/ws/sio-registry/runners.ts`
+
+New helper:
+```typescript
+async function broadcastToRunnersNs(
+  eventName: string,
+  data: unknown,
+  userId?: string,
+): Promise<void>
+```
+Uses `io.of("/runners").to("runners:user:<userId>")` for user-scoped delivery.
+
+New broadcast calls:
+- `registerRunner()` — after `setRunner()` succeeds, build `RunnerInfo` and call `broadcastToRunnersNs("runner_added", runnerInfo, userId)`
+- `removeRunner()` — look up runner from Redis *before* deleting (to get userId), then broadcast `runner_removed` and delete
+- `updateRunnerSkills(runnerId, skills)` — after the field update, re-fetch runner, broadcast `runner_updated`
+- `updateRunnerAgents(runnerId, agents)` — same pattern
+- `updateRunnerPlugins(runnerId, plugins)` — same pattern
+- `updateRunnerHooks(runnerId, hooks)` — same pattern (if this function exists or is added)
+
+**Race safety:** `runner_removed` reads the userId *before* deleting so the user-room target is available. If the runner is not found in Redis during an update, the broadcast is skipped silently.
+
+#### 2c. Extend: `src/ws/namespaces/index.ts`
+
+Register `registerRunnersNamespace(io)` alongside the existing namespaces.
+
+---
+
+### 3. UI: `useRunnersFeed` Hook (`packages/ui`)
+
+**New file:** `packages/ui/src/lib/useRunnersFeed.ts`
+
+```
+useRunnersFeed() → {
+  runners: RunnerInfo[],
+  status: 'connected' | 'disconnected' | 'connecting'
+}
+```
+
+Behavior:
+- On mount: connects to `io("/runners", { withCredentials: true })`
+- `connect` event: sets `status = "connected"`
+- `disconnect` / `connect_error`: sets `status = "disconnected"`
+- `runners` event: replaces the entire runners state
+- `runner_added` event: upserts (replace if runnerId matches, else append)
+- `runner_removed` event: filters out by runnerId
+- `runner_updated` event: merges (replace matching runner by runnerId)
+- On unmount: `socket.disconnect()`
+
+---
+
+### 4. UI: `RunnerManager` Refactor (`packages/ui`)
+
+**Remove:**
+- `const [runners, setRunners]` local state
+- `const [sessions, setSessions]` local state
+- `fetchData` callback (entire function)
+- `setInterval(fetchData, 10000)` effect
+- `poll()` loop inside `handleSpawn` (waits for spawned session to appear)
+
+**Add:**
+- `const { runners } = useRunnersFeed()` — replaces local runners state
+- New prop: `sessions: LiveSession[]` — passed from App.tsx `liveSessions` (already from `/hub`)
+- `const [pendingSessionId, setPendingSessionId] = React.useState<string | null>(null)` — tracks a spawning session
+- `useEffect` on `sessions` + `pendingSessionId` → calls `onOpenSession(id)` when session appears, then clears
+- `useEffect` timeout guard: after 30s, clears `pendingSessionId` if session never appeared
+
+**`onRunnersChange` callback:** now called from a `useEffect` on `runners` instead of from `fetchData`.
+
+**`sessionCount` computation:** `runners.map(r => ({ ...r, sessionCount: sessions.filter(s => s.runnerId === r.runnerId).length }))` — computed in render from props.
+
+---
+
+### 5. UI: `App.tsx` Changes
+
+#### 5a. Remove eager fetch on mount
+
+Remove the `useEffect` block (lines ~137–159) that does `fetch("/api/runners")` on mount to pre-populate `runnersForSidebar`. `useRunnersFeed` inside `RunnerManager` will provide this data on first connect (sub-100ms in practice).
+
+#### 5b. Replace `waitForSessionToGoLive` with hub-based waiter
+
+Replace the polling `while`-loop implementation with a ref-based observer:
+
+```typescript
+// Pending session waiters
+const sessionWaitersRef = React.useRef<Map<string, {
+  resolve: (found: boolean) => void;
+  timer: ReturnType<typeof setTimeout>;
+}>>(new Map());
+
+// Resolve waiters when liveSessions changes
+React.useEffect(() => {
+  for (const [sessionId, waiter] of sessionWaitersRef.current) {
+    if (liveSessions.some(s => s.sessionId === sessionId)) {
+      clearTimeout(waiter.timer);
+      sessionWaitersRef.current.delete(sessionId);
+      waiter.resolve(true);
+    }
+  }
+}, [liveSessions]);
+
+const waitForSessionToGoLive = React.useCallback(
+  (sessionId: string, timeoutMs: number): Promise<boolean> => {
+    // Fast path: already live
+    if (liveSessions.some(s => s.sessionId === sessionId)) {
+      return Promise.resolve(true);
+    }
+    return new Promise((resolve) => {
+      const timer = setTimeout(() => {
+        sessionWaitersRef.current.delete(sessionId);
+        resolve(false);
+      }, timeoutMs);
+      sessionWaitersRef.current.set(sessionId, { resolve, timer });
+    });
+  },
+  [liveSessions],
+);
+```
+
+No HTTP requests. Resolves as soon as the session appears on the `/hub` feed.
+
+#### 5c. Pass sessions to RunnerManager
+
+```tsx
+<RunnerManager
+  sessions={liveSessions}  // ← new prop
+  onOpenSession={...}
+  onRunnersChange={setSidebarRunners}
+  selectedRunnerId={selectedRunnerId}
+  onSelectRunner={setSelectedRunnerId}
+/>
+```
+
+---
+
+## Data Flow (After)
+
+```
+Runner daemon connects
+  → /runner namespace: register_runner
+  → registerRunner() in sio-registry
+  → broadcastToRunnersNs("runner_added", runnerInfo, userId)
+  → /runners namespace → browser RunnerManager (useRunnersFeed)
+
+Runner daemon disconnects
+  → /runner namespace: disconnect event
+  → removeRunner()
+  → broadcastToRunnersNs("runner_removed", { runnerId }, userId)
+  → /runners namespace → browser removes runner from list
+
+Session spawned
+  → POST /api/runners/spawn → server creates session
+  → session TUI connects → registerTuiSession()
+  → broadcastToHub("session_added", sessionInfo, userId)
+  → /hub namespace → SessionSidebar → onSessionsChange(setLiveSessions)
+  → liveSessions useEffect in App.tsx → resolves sessionWaitersRef
+  → waitForSessionToGoLive Promise resolves → handleOpenSession(id)
+```
+
+---
+
+## Error Handling
+
+| Scenario | Behavior |
+|----------|----------|
+| `/runners` socket disconnects | `useRunnersFeed` status → `"disconnected"`, state preserved, Socket.IO auto-reconnects |
+| Runner removed before `runner_updated` broadcast | `getRunnerState` returns null → skip broadcast silently |
+| Spawned session never arrives (crash at spawn) | 30s timeout in `pendingSessionId` guard (RunnerManager) + `waitForSessionToGoLive` timeout |
+| `liveSessions` empty when `waitForSessionToGoLive` is called | Waiter added to map, resolves on next hub `session_added` |
+
+---
+
+## Testing
+
+### Protocol/Server
+- `runner_added` fires when `registerRunner` succeeds
+- `runner_removed` fires when `removeRunner` is called
+- `runner_updated` fires after `updateRunnerSkills/Agents/Plugins` with fresh data
+- `/runners` namespace sends `runners` snapshot on connect
+- Only broadcasts to the correct user's room
+
+### Client
+- `useRunnersFeed`: upsert/remove/update behavior
+- `waitForSessionToGoLive`: resolves via liveSessions, times out correctly
+- `RunnerManager`: `pendingSessionId` clears when session appears in sessions prop
+
+---
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `packages/protocol/src/runners.ts` | **New** — namespace event types |
+| `packages/protocol/src/index.ts` | Export new types |
+| `packages/server/src/ws/namespaces/runners.ts` | **New** — `/runners` namespace |
+| `packages/server/src/ws/namespaces/index.ts` | Register new namespace |
+| `packages/server/src/ws/sio-registry/runners.ts` | Add `broadcastToRunnersNs`, add broadcast calls |
+| `packages/ui/src/lib/useRunnersFeed.ts` | **New** — hook |
+| `packages/ui/src/components/RunnerManager.tsx` | Remove polling, add prop, use hook |
+| `packages/ui/src/App.tsx` | Remove eager fetch, waiter-based `waitForSessionToGoLive`, pass sessions |

--- a/docs/specs/2026-03-21-runners-websocket-feed-design.md
+++ b/docs/specs/2026-03-21-runners-websocket-feed-design.md
@@ -14,9 +14,13 @@ The `RunnerManager` component polls two REST endpoints every 10 seconds:
 
 There is also a spin-poll loop after spawning a session (`poll()` in `RunnerManager`, `waitForSessionToGoLive` in `App.tsx`) that hits `/api/sessions` every 1 second until the new session appears.
 
-Additionally, `App.tsx` does a one-time eager `fetch("/api/runners")` on mount.
+Additionally:
+- `App.tsx` does a one-time eager `fetch("/api/runners")` on mount
+- `App.tsx` re-fetches `/api/runners` every time the new-session dialog opens
+- `TerminalManager` fetches `/api/runners` every time the terminal dialog opens
+- `SessionViewer` fires `fetch("/api/runners/{id}/skills|agents|plugins")` each time a user runs a `/skills`, `/agents`, or `/plugins` slash command, and fetches agents on every `@mention` popover open and `/agents <name>` invocation — even though this data is already known from the runner's registration
 
-**Effect:** Up to 10-second lag before a newly connected/disconnected runner appears in the UI. Unnecessary HTTP load. Architectural smell — the rest of the session lifecycle already uses WebSocket (`/hub` namespace for sessions, `/viewer` for content).
+**Effect:** Up to 10-second lag before a newly connected/disconnected runner appears in the UI. Unnecessary HTTP load on every dialog open and slash command. Architectural smell — the rest of the session lifecycle already uses WebSocket (`/hub` namespace for sessions, `/viewer` for content).
 
 ---
 
@@ -24,6 +28,7 @@ Additionally, `App.tsx` does a one-time eager `fetch("/api/runners")` on mount.
 
 - Instant runner connect/disconnect/update notifications (latency → ~0)
 - Zero polling: eliminate all `setInterval` + `fetch` for runners and sessions
+- Eliminate redundant on-demand runner fetches in dialogs and slash commands — use cached WS state
 - Consistent architecture: all real-time state flows through Socket.IO namespaces
 
 ---
@@ -174,11 +179,13 @@ Behavior:
 
 ### 5. UI: `App.tsx` Changes
 
-#### 5a. Remove eager fetch on mount
+#### 5a. Remove all ad-hoc runner fetches
 
-Remove the `useEffect` block (lines ~137–159) that does `fetch("/api/runners")` on mount to pre-populate `runnersForSidebar`. `useRunnersFeed` inside `RunnerManager` will provide this data on first connect (sub-100ms in practice).
+**On-mount eager fetch** (lines ~137–159): remove the `useEffect` that does `fetch("/api/runners")` on mount to pre-populate `runnersForSidebar`. `useRunnersFeed` inside `RunnerManager` provides this data on first WS connect.
 
-Note: there is a separate on-demand `fetch("/api/runners")` triggered when the new-session dialog opens (`newSessionOpen` change). That fetch is **intentionally kept** — it's a one-time request for dialog initialization, not polling.
+**New-session dialog fetch** (`newSessionOpen` effect, lines ~352–385): the `runners` state (with `runnerId`, `name`, `roots`, `platform`) is now always fresh via `useRunnersFeed`. Remove the `fetch` and instead derive this from `useRunnersFeed` data. The `runners` state and `runnersLoading` state in App.tsx are replaced by the feed. The `NewSessionWizardDialog` receives the same `runners` array from the feed.
+
+**`runnersLoading` state**: replaced by `useRunnersFeed`'s `status`. Loading is `status === 'connecting'`.
 
 #### 5b. Replace `waitForSessionToGoLive` with hub-based waiter
 
@@ -222,16 +229,71 @@ const waitForSessionToGoLive = React.useCallback(
 
 No HTTP requests. Resolves as soon as the session appears on the `/hub` feed.
 
-#### 5c. Pass sessions to RunnerManager
+#### 5c. Pass sessions and runners to consumers
 
 ```tsx
 <RunnerManager
-  sessions={liveSessions}  // ← new prop
+  sessions={liveSessions}         // ← new prop (from /hub)
   onOpenSession={...}
   onRunnersChange={setSidebarRunners}
   selectedRunnerId={selectedRunnerId}
   onSelectRunner={setSelectedRunnerId}
 />
+```
+
+`TerminalManager` and `NewSessionWizardDialog` receive runners via props — see §6 and §7.
+
+---
+
+### 6. UI: `TerminalManager` Refactor (`packages/ui`)
+
+**Remove:**
+- `const [runners, setRunners]` local state
+- `const [runnersLoading, setRunnersLoading]` local state
+- `useEffect` that fires `fetch("/api/runners")` when `dialogOpen` changes
+
+**Add:**
+- New props: `runners: RunnerInfo[]` and `runnersLoading: boolean` — passed from App.tsx
+
+App.tsx gets runner data from `useRunnersFeed()` and passes it down:
+```tsx
+const { runners: feedRunners, status: runnersStatus } = useRunnersFeed();
+// ...
+<TerminalManager
+  runners={feedRunners}
+  runnersLoading={runnersStatus === 'connecting'}
+  // ...existing props...
+/>
+```
+
+The `TerminalDialog` sub-component (which currently receives `runners` and `runnersLoading` as props from `TerminalManager`) is unchanged — it already accepts them as props.
+
+---
+
+### 7. UI: `SessionViewer` Slash Command Optimization (`packages/ui`)
+
+The `/skills`, `/agents`, `/plugins`, and `/sandbox` slash command handlers in `SessionViewer` currently fire individual HTTP fetches. Since `runner_updated` events keep skills/agents/plugins in the WS feed, the data is already cached.
+
+**Add prop:** `runnerInfo: RunnerInfo | null` — the full runner data for the session's runner, passed from App.tsx via `useRunnersFeed`. App.tsx already knows the session's `runnerId` from `liveSessions`.
+
+**`/skills` command:** read `runnerInfo.skills` instead of `fetch("/api/runners/{id}/skills")`.
+
+**`/plugins` command:** read `runnerInfo.plugins` instead of `fetch("/api/runners/{id}/plugins")`.
+
+**`/agents` command:** read `runnerInfo.agents` instead of `fetch("/api/runners/{id}/agents")`.
+
+**`/agents <name>` execution:** same — match against `runnerInfo.agents`.
+
+**`@mention` agent popover:** same — use `runnerInfo.agents` instead of fetching.
+
+**`/sandbox` command:** keep as HTTP fetch — sandbox status (violation counts, recent violations) is not part of `RunnerInfo` and is not in the WS feed. This is an intentional exception.
+
+**`runnerInfo` derivation in App.tsx:**
+```typescript
+const activeRunnerInfo = React.useMemo(
+  () => feedRunners.find(r => r.runnerId === activeSessionInfo?.runnerId) ?? null,
+  [feedRunners, activeSessionInfo?.runnerId],
+);
 ```
 
 ---
@@ -243,13 +305,21 @@ Runner daemon connects
   → /runner namespace: register_runner
   → registerRunner() in sio-registry
   → broadcastToRunnersNs("runner_added", runnerInfo, userId)
-  → /runners namespace → browser RunnerManager (useRunnersFeed)
+  → /runners namespace → useRunnersFeed → feedRunners state
+  → RunnerManager, TerminalManager, NewSessionWizardDialog, SessionViewer all updated instantly
 
 Runner daemon disconnects
   → /runner namespace: disconnect event
-  → removeRunner()
+  → removeRunner() reads userId first, then deletes
   → broadcastToRunnersNs("runner_removed", { runnerId }, userId)
-  → /runners namespace → browser removes runner from list
+  → /runners namespace → useRunnersFeed filters out runner
+
+Runner updates skills/agents/plugins
+  → /runner namespace: skills_list / agent_list / plugins event
+  → updateRunnerSkills/Agents/Plugins()
+  → broadcastToRunnersNs("runner_updated", freshRunnerInfo, userId)
+  → /runners namespace → useRunnersFeed upserts runner
+  → SessionViewer slash commands and agent popover use fresh cached data
 
 Session spawned
   → POST /api/runners/spawn → server creates session
@@ -258,6 +328,9 @@ Session spawned
   → /hub namespace → SessionSidebar → onSessionsChange(setLiveSessions)
   → liveSessions useEffect in App.tsx → resolves sessionWaitersRef
   → waitForSessionToGoLive Promise resolves → handleOpenSession(id)
+
+User opens new-session dialog or terminal dialog
+  → no HTTP fetch — feedRunners already populated from /runners WS
 ```
 
 ---
@@ -286,6 +359,7 @@ Session spawned
 - `useRunnersFeed`: upsert/remove/update behavior
 - `waitForSessionToGoLive`: resolves via liveSessions, times out correctly
 - `RunnerManager`: `pendingSessionId` clears when session appears in sessions prop
+- `SessionViewer`: `/skills`, `/agents`, `/plugins` commands use cached `runnerInfo` data; `/sandbox` still uses HTTP fetch
 
 ---
 
@@ -297,7 +371,9 @@ Session spawned
 | `packages/protocol/src/index.ts` | Export new types |
 | `packages/server/src/ws/namespaces/runners.ts` | **New** — `/runners` namespace |
 | `packages/server/src/ws/namespaces/index.ts` | Register new namespace |
-| `packages/server/src/ws/sio-registry/runners.ts` | Add `broadcastToRunnersNs`, add broadcast calls |
-| `packages/ui/src/lib/useRunnersFeed.ts` | **New** — hook |
-| `packages/ui/src/components/RunnerManager.tsx` | Remove polling, add prop, use hook |
-| `packages/ui/src/App.tsx` | Remove eager fetch, waiter-based `waitForSessionToGoLive`, pass sessions |
+| `packages/server/src/ws/sio-registry/runners.ts` | Add `broadcastToRunnersNs`, broadcast on register/remove/update |
+| `packages/ui/src/lib/useRunnersFeed.ts` | **New** — hook connecting to `/runners` |
+| `packages/ui/src/components/RunnerManager.tsx` | Remove polling + sessions fetch; use hook + sessions/runners props |
+| `packages/ui/src/components/TerminalManager.tsx` | Remove `fetch("/api/runners")` on dialog open; accept runners prop |
+| `packages/ui/src/components/SessionViewer.tsx` | Replace `/skills`, `/agents`, `/plugins` HTTP fetches with cached `runnerInfo` prop |
+| `packages/ui/src/App.tsx` | Use `useRunnersFeed`; remove all ad-hoc runner fetches; hub-based `waitForSessionToGoLive`; pass sessions + runners + runnerInfo to children |

--- a/docs/specs/2026-03-21-runners-websocket-feed-design.md
+++ b/docs/specs/2026-03-21-runners-websocket-feed-design.md
@@ -73,9 +73,12 @@ export interface RunnersSocketData {
 }
 ```
 
-`sessionCount` is **not** included in WS events. The client computes it from
+`sessionCount` is **not** a meaningful field in WS events. The server will
+send the `RunnerInfo` shape as-is (which includes `sessionCount`), but the
+client **ignores the server's `sessionCount`** and computes it locally from
 `liveSessions.filter(s => s.runnerId === r.runnerId).length` — it already has
-the full sessions list from the `/hub` feed.
+the full sessions list from the `/hub` feed. Implementers should not rely on
+the server's `sessionCount` value in the WS events.
 
 **Updated:** `packages/protocol/src/index.ts` — export the four new types.
 
@@ -110,7 +113,7 @@ Uses `io.of("/runners").to("runners:user:<userId>")` for user-scoped delivery.
 
 New broadcast calls:
 - `registerRunner()` — after `setRunner()` succeeds, build `RunnerInfo` and call `broadcastToRunnersNs("runner_added", runnerInfo, userId)`
-- `removeRunner()` — look up runner from Redis *before* deleting (to get userId), then broadcast `runner_removed` and delete
+- `removeRunner()` — the current implementation deletes without reading first; change it to call `getRunnerState(runnerId)` before `deleteRunnerState` to get the `userId` for room targeting, then broadcast `runner_removed`, then delete
 - `updateRunnerSkills(runnerId, skills)` — after the field update, re-fetch runner, broadcast `runner_updated`
 - `updateRunnerAgents(runnerId, agents)` — same pattern
 - `updateRunnerPlugins(runnerId, plugins)` — same pattern
@@ -158,7 +161,7 @@ Behavior:
 
 **Add:**
 - `const { runners } = useRunnersFeed()` — replaces local runners state
-- New prop: `sessions: LiveSession[]` — passed from App.tsx `liveSessions` (already from `/hub`)
+- New prop: `sessions: Array<{ sessionId: string; runnerId: string | null }>` — passed from App.tsx `liveSessions` (already from `/hub`). Narrow type: RunnerManager only uses `runnerId` for grouping and `sessionId` for the spawn-wait check. Using a narrow type avoids coupling RunnerManager to the full `HubSession` or `SessionInfo` shape.
 - `const [pendingSessionId, setPendingSessionId] = React.useState<string | null>(null)` — tracks a spawning session
 - `useEffect` on `sessions` + `pendingSessionId` → calls `onOpenSession(id)` when session appears, then clears
 - `useEffect` timeout guard: after 30s, clears `pendingSessionId` if session never appeared
@@ -174,6 +177,8 @@ Behavior:
 #### 5a. Remove eager fetch on mount
 
 Remove the `useEffect` block (lines ~137–159) that does `fetch("/api/runners")` on mount to pre-populate `runnersForSidebar`. `useRunnersFeed` inside `RunnerManager` will provide this data on first connect (sub-100ms in practice).
+
+Note: there is a separate on-demand `fetch("/api/runners")` triggered when the new-session dialog opens (`newSessionOpen` change). That fetch is **intentionally kept** — it's a one-time request for dialog initialization, not polling.
 
 #### 5b. Replace `waitForSessionToGoLive` with hub-based waiter
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -72,3 +72,11 @@ export type {
   MetaPluginTrustPrompt, MetaMcpReport,
 } from "./meta.js";
 export { defaultMetaState, isMetaRelayEvent, metaEventToPatch, META_RELAY_EVENT_TYPES } from "./meta.js";
+
+// /runners namespace (Browser runner feed)
+export type {
+  RunnersClientToServerEvents,
+  RunnersServerToClientEvents,
+  RunnersInterServerEvents,
+  RunnersSocketData,
+} from "./runners.js";

--- a/packages/protocol/src/runners.ts
+++ b/packages/protocol/src/runners.ts
@@ -1,0 +1,28 @@
+// ============================================================================
+// /runners namespace — Browser runner feed (read-only for clients)
+// ============================================================================
+
+import type { RunnerInfo } from "./shared.js";
+
+export interface RunnersServerToClientEvents {
+  /** Full runner list snapshot sent on connection */
+  runners: (data: { runners: RunnerInfo[] }) => void;
+  /** A runner daemon connected and registered */
+  runner_added: (data: RunnerInfo) => void;
+  /** A runner daemon disconnected */
+  runner_removed: (data: { runnerId: string }) => void;
+  /** Runner metadata changed (skills, agents, plugins, hooks) */
+  runner_updated: (data: RunnerInfo) => void;
+}
+
+export interface RunnersClientToServerEvents {
+  // Runners feed is read-only; clients do not emit events
+}
+
+export interface RunnersInterServerEvents {
+  // Reserved for future Redis adapter usage
+}
+
+export interface RunnersSocketData {
+  userId?: string;
+}

--- a/packages/server/src/ws/namespaces/index.ts
+++ b/packages/server/src/ws/namespaces/index.ts
@@ -4,6 +4,7 @@ import { registerViewerNamespace } from "./viewer.js";
 import { registerRunnerNamespace } from "./runner.js";
 import { registerTerminalNamespace } from "./terminal.js";
 import { registerHubNamespace } from "./hub.js";
+import { registerRunnersNamespace } from "./runners.js";
 
 export function registerNamespaces(io: SocketIOServer): void {
   registerRelayNamespace(io);
@@ -11,6 +12,7 @@ export function registerNamespaces(io: SocketIOServer): void {
   registerRunnerNamespace(io);
   registerTerminalNamespace(io);
   registerHubNamespace(io);
+  registerRunnersNamespace(io);
 }
 
 // Re-export runner command functions for use by REST API routes

--- a/packages/server/src/ws/namespaces/runners.ts
+++ b/packages/server/src/ws/namespaces/runners.ts
@@ -1,0 +1,48 @@
+// ============================================================================
+// /runners namespace — Browser runner feed (read-only for clients)
+//
+// On connection: send initial runner list snapshot.
+// Clients receive runner_added / runner_removed / runner_updated events
+// pushed by sio-registry when the runner daemon connects or changes.
+// ============================================================================
+
+import type { Server as SocketIOServer, Namespace } from "socket.io";
+import type {
+    RunnersClientToServerEvents,
+    RunnersServerToClientEvents,
+    RunnersInterServerEvents,
+    RunnersSocketData,
+} from "@pizzapi/protocol";
+import { sessionCookieAuthMiddleware } from "./auth.js";
+import { getRunners, runnersUserRoom } from "../sio-registry.js";
+
+export function registerRunnersNamespace(io: SocketIOServer): void {
+    const runners: Namespace<
+        RunnersClientToServerEvents,
+        RunnersServerToClientEvents,
+        RunnersInterServerEvents,
+        RunnersSocketData
+    > = io.of("/runners");
+
+    // Auth: validate session cookie from handshake (same as /hub)
+    runners.use(sessionCookieAuthMiddleware() as Parameters<typeof runners.use>[0]);
+
+    runners.on("connection", async (socket) => {
+        const userId = socket.data.userId ?? "";
+
+        console.log(`[sio/runners] connected: ${socket.id} userId=${userId}`);
+
+        // Join per-user room so broadcasts are user-scoped
+        await socket.join(runnersUserRoom(userId));
+
+        // Send initial runner list for this user
+        const initialRunners = await getRunners(userId);
+        socket.emit("runners", { runners: initialRunners });
+
+        // ── disconnect ───────────────────────────────────────────────────────
+        socket.on("disconnect", (reason) => {
+            console.log(`[sio/runners] disconnected: ${socket.id} (${reason})`);
+            // Socket.IO automatically removes sockets from rooms on disconnect
+        });
+    });
+}

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -38,6 +38,11 @@ export function hubUserRoom(userId: string): string {
     return `hub:user:${userId}`;
 }
 
+/** Room name for a specific user's /runners feed. */
+export function runnersUserRoom(userId: string): string {
+    return `runners:user:${userId}`;
+}
+
 /** Room that all viewers of a session join (on the /viewer namespace). */
 export function viewerSessionRoom(sessionId: string): string {
     return `session:${sessionId}`;

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -5,7 +5,7 @@
 // existing callers continue importing from `../sio-registry.js` unchanged.
 // ============================================================================
 
-export { initSioRegistry, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionAwaitingAck } from "./context.js";
+export { initSioRegistry, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionAwaitingAck, runnersUserRoom } from "./context.js";
 export { broadcastToHub, addHubClient, removeHubClient } from "./hub.js";
 export type { RegisterTuiSessionOpts } from "./sessions.js";
 export {

--- a/packages/server/src/ws/sio-registry/runners-broadcast.ts
+++ b/packages/server/src/ws/sio-registry/runners-broadcast.ts
@@ -1,0 +1,36 @@
+// runners-broadcast.ts — Helpers for broadcasting runner events to /runners namespace
+// Room helper lives in context.ts (alongside hubUserRoom) to avoid circular deps.
+import { getIo, runnersUserRoom } from "./context.js";
+
+/**
+ * Broadcast a runner lifecycle event to all connected /runners clients.
+ * Scoped to a specific user via their room when userId is provided.
+ * Mirrors the hub.ts broadcast pattern.
+ */
+export async function broadcastToRunnersNs(
+    eventName: string,
+    data: unknown,
+    userId?: string,
+): Promise<void> {
+    const io = getIo();
+    try {
+        const runnersNs = io.of("/runners");
+        if (userId) {
+            runnersNs.to(runnersUserRoom(userId)).emit(eventName, data);
+        } else {
+            runnersNs.emit(eventName, data);
+        }
+    } catch (err) {
+        console.warn("[sio-registry] broadcastToRunnersNs failed, falling back to local:", (err as Error)?.message);
+        try {
+            const runnersNs = io.of("/runners");
+            if (userId) {
+                runnersNs.local.to(runnersUserRoom(userId)).emit(eventName, data);
+            } else {
+                runnersNs.local.emit(eventName, data);
+            }
+        } catch {
+            // Nothing more we can do
+        }
+    }
+}

--- a/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
+++ b/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, mock, beforeEach } from "bun:test";
+
+const store = new Map<string, string>();
+const setStore = new Map<string, Set<string>>();
+
+const mockMulti = () => {
+    const ops: Array<() => void> = [];
+    return {
+        hSet: mock((key: string, fields: Record<string, string>) => {
+            ops.push(() => {
+                const existing = JSON.parse(store.get(`__hash__:${key}`) ?? "{}");
+                Object.assign(existing, fields);
+                store.set(`__hash__:${key}`, JSON.stringify(existing));
+            });
+            return mockMulti();
+        }),
+        sAdd: mock((key: string, ...members: string[]) => {
+            ops.push(() => {
+                const s = setStore.get(key) ?? new Set();
+                for (const m of members.flat()) s.add(m);
+                setStore.set(key, s);
+            });
+            return mockMulti();
+        }),
+        sRem: mock((key: string, ...members: string[]) => {
+            ops.push(() => {
+                const s = setStore.get(key);
+                if (s) for (const m of members.flat()) s.delete(m);
+            });
+            return mockMulti();
+        }),
+        expire: mock(() => mockMulti()),
+        del: mock((key: string) => {
+            ops.push(() => {
+                store.delete(key);
+                store.delete(`__hash__:${key}`);
+            });
+            return mockMulti();
+        }),
+        exec: mock(async () => { for (const op of ops) op(); return []; }),
+    };
+};
+
+const mockRedis = {
+    isOpen: true,
+    sAdd: mock(async (key: string, ...members: string[]) => {
+        const s = setStore.get(key) ?? new Set();
+        for (const m of members.flat()) s.add(m);
+        setStore.set(key, s);
+    }),
+    sMembers: mock(async (key: string) => Array.from(setStore.get(key) ?? [])),
+    sRem: mock(async (key: string, ...members: string[]) => {
+        const s = setStore.get(key);
+        if (s) for (const m of members.flat()) s.delete(m);
+    }),
+    expire: mock(async () => {}),
+    multi: mock(() => mockMulti()),
+    on: mock(() => mockRedis),
+    connect: mock(async () => {}),
+    set: mock(async (key: string, value: string) => { store.set(key, value); }),
+    get: mock(async (key: string) => store.get(key) ?? null),
+    del: mock(async (key: string) => {
+        store.delete(key);
+        store.delete(`__hash__:${key}`);
+    }),
+    hGetAll: mock(async (key: string) => {
+        const raw = store.get(`__hash__:${key}`);
+        return raw ? JSON.parse(raw) as Record<string, string> : {};
+    }),
+    hGet: mock(async () => null),
+    hSet: mock(async (key: string, field: string, value: string) => {
+        const existing = JSON.parse(store.get(`__hash__:${key}`) ?? "{}");
+        existing[field] = value;
+        store.set(`__hash__:${key}`, JSON.stringify(existing));
+    }),
+    incr: mock(async () => 1),
+    exists: mock(async (key: string) => {
+        return store.has(`__hash__:${key}`) ? 1 : 0;
+    }),
+};
+
+mock.module("redis", () => ({ createClient: () => mockRedis }));
+mock.module("./hub.js", () => ({ broadcastToHub: mock(async () => {}) }));
+mock.module("../../sessions/store.js", () => ({
+    getEphemeralTtlMs: () => 60_000,
+    updateRelaySessionRunner: mock(async () => {}),
+}));
+
+const broadcastCalls: Array<{ event: string; data: unknown; userId?: string }> = [];
+mock.module("./runners-broadcast.js", () => ({
+    broadcastToRunnersNs: mock(async (event: string, data: unknown, userId?: string) => {
+        broadcastCalls.push({ event, data, userId });
+    }),
+}));
+
+const { initStateRedis } = await import("../sio-state.js");
+const { registerRunner, removeRunner, updateRunnerSkills, updateRunnerAgents, updateRunnerPlugins } = await import("./runners.js");
+
+// Note: updateRunnerHooks not yet implemented — excluded intentionally.
+
+describe("runners broadcast", () => {
+    beforeEach(async () => {
+        store.clear();
+        setStore.clear();
+        broadcastCalls.length = 0;
+        await initStateRedis();
+    });
+
+    it("broadcasts runner_added when registerRunner succeeds", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "my-runner",
+            roots: ["/home/user/code"],
+            requestedRunnerId: undefined,
+            runnerSecret: undefined,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: "1.0.0",
+            platform: "linux",
+            userId: "user1",
+            userName: "User One",
+        });
+
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+
+        const added = broadcastCalls.find(c => c.event === "runner_added");
+        expect(added).toBeDefined();
+        expect((added!.data as any).runnerId).toBe(runnerId);
+        expect((added!.data as any).name).toBe("my-runner");
+        expect(added!.userId).toBe("user1");
+    });
+
+    it("broadcasts runner_removed when removeRunner is called", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "runner-to-remove",
+            roots: [],
+            requestedRunnerId: undefined,
+            runnerSecret: undefined,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: null,
+            platform: null,
+            userId: "user2",
+            userName: "User Two",
+        });
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+        broadcastCalls.length = 0;
+
+        await removeRunner(runnerId);
+
+        const removed = broadcastCalls.find(c => c.event === "runner_removed");
+        expect(removed).toBeDefined();
+        expect((removed!.data as any).runnerId).toBe(runnerId);
+        expect(removed!.userId).toBe("user2");
+    });
+
+    it("broadcasts runner_updated after updateRunnerSkills", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "skills-runner",
+            roots: [],
+            requestedRunnerId: undefined,
+            runnerSecret: undefined,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: null,
+            platform: null,
+            userId: "user3",
+            userName: "User Three",
+        });
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+        broadcastCalls.length = 0;
+
+        await updateRunnerSkills(runnerId, [{ name: "my-skill", description: "does stuff", filePath: "/path/to/skill.md" }]);
+
+        const updated = broadcastCalls.find(c => c.event === "runner_updated");
+        expect(updated).toBeDefined();
+        expect((updated!.data as any).runnerId).toBe(runnerId);
+        const skills = (updated!.data as any).skills as Array<{ name: string }>;
+        expect(skills.some(s => s.name === "my-skill")).toBe(true);
+    });
+
+    it("broadcasts runner_updated after updateRunnerAgents", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "agents-runner",
+            roots: [],
+            requestedRunnerId: undefined,
+            runnerSecret: undefined,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: null,
+            platform: null,
+            userId: "user4",
+            userName: "User Four",
+        });
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+        broadcastCalls.length = 0;
+
+        await updateRunnerAgents(runnerId, [{ name: "my-agent", description: "an agent", filePath: "/path/to/agent.md" }]);
+
+        const updated = broadcastCalls.find(c => c.event === "runner_updated");
+        expect(updated).toBeDefined();
+        const agents = (updated!.data as any).agents as Array<{ name: string }>;
+        expect(agents.some(a => a.name === "my-agent")).toBe(true);
+    });
+
+    it("broadcasts runner_updated after updateRunnerPlugins", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const result = await registerRunner(socket, {
+            name: "plugins-runner",
+            roots: [],
+            requestedRunnerId: undefined,
+            runnerSecret: undefined,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: null,
+            platform: null,
+            userId: "user5",
+            userName: "User Five",
+        });
+        expect(result instanceof Error).toBe(false);
+        const runnerId = result as string;
+        broadcastCalls.length = 0;
+
+        await updateRunnerPlugins(runnerId, [{ name: "my-plugin", description: "a plugin", rootPath: "/path", commands: [], hookEvents: [], skills: [], hasMcp: false, hasAgents: false, hasLsp: false }]);
+
+        const updated = broadcastCalls.find(c => c.event === "runner_updated");
+        expect(updated).toBeDefined();
+        const plugins = (updated!.data as any).plugins as Array<{ name: string }>;
+        expect(plugins.some(p => p.name === "my-plugin")).toBe(true);
+    });
+
+    it("skips runner_removed broadcast gracefully when runner not in Redis", async () => {
+        await removeRunner("ghost-runner");
+        const removed = broadcastCalls.find(c => c.event === "runner_removed");
+        expect(removed).toBeUndefined();
+    });
+});

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -36,6 +36,7 @@ import {
     modelFromHeartbeat,
 } from "./context.js";
 import { broadcastToHub } from "./hub.js";
+import { broadcastToRunnersNs } from "./runners-broadcast.js";
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
@@ -192,6 +193,9 @@ export async function registerRunner(
     // the Redis adapter (see emitToRunner / endSharedSession).
     await socket.join(runnerRoom(runnerId));
 
+    // Broadcast runner_added to connected browsers
+    void broadcastToRunnersNs("runner_added", runnerDataToInfo(runnerData), opts.userId ?? undefined);
+
     return runnerId;
 }
 
@@ -199,12 +203,20 @@ export async function registerRunner(
 export async function updateRunnerSkills(runnerId: string, skills: RunnerSkill[]): Promise<void> {
     const normalized = normalizeSkills(skills);
     await updateRunnerFields(runnerId, { skills: JSON.stringify(normalized) });
+    const fresh = await getRunnerState(runnerId);
+    if (fresh) {
+        void broadcastToRunnersNs("runner_updated", runnerDataToInfo(fresh), fresh.userId ?? undefined);
+    }
 }
 
 /** Update agents for an already-registered runner. */
 export async function updateRunnerAgents(runnerId: string, agents: RunnerAgent[]): Promise<void> {
     const normalized = normalizeAgents(agents);
     await updateRunnerFields(runnerId, { agents: JSON.stringify(normalized) });
+    const fresh = await getRunnerState(runnerId);
+    if (fresh) {
+        void broadcastToRunnersNs("runner_updated", runnerDataToInfo(fresh), fresh.userId ?? undefined);
+    }
 }
 
 /**
@@ -220,6 +232,10 @@ export async function updateRunnerPlugins(runnerId: string, plugins: unknown[]):
             .filter((p): p is Record<string, unknown> => p !== null)
         : [];
     await updateRunnerFields(runnerId, { plugins: JSON.stringify(normalized) });
+    const fresh = await getRunnerState(runnerId);
+    if (fresh) {
+        void broadcastToRunnersNs("runner_updated", runnerDataToInfo(fresh), fresh.userId ?? undefined);
+    }
 }
 
 /** Record that a runner spawned a session. */
@@ -305,6 +321,25 @@ export async function getConnectedSessionsForRunner(runnerId: string): Promise<A
     return results;
 }
 
+/**
+ * Convert a single RedisRunnerData to RunnerInfo for WS broadcast.
+ * sessionCount is set to 0 — the client computes it from live sessions.
+ */
+function runnerDataToInfo(r: RedisRunnerData): RunnerInfo {
+    return {
+        runnerId: r.runnerId,
+        name: r.name,
+        roots: safeJsonParse(r.roots) ?? [],
+        sessionCount: 0,
+        skills: safeJsonParse(r.skills) ?? [],
+        agents: safeJsonParse(r.agents ?? "[]") ?? [],
+        plugins: safeJsonParse(r.plugins ?? "[]") ?? [],
+        hooks: safeJsonParse(r.hooks ?? "[]") ?? [],
+        version: r.version ?? null,
+        platform: r.platform ?? null,
+    };
+}
+
 /** Get all runners as RunnerInfo, optionally filtered by user. */
 export async function getRunners(filterUserId?: string): Promise<RunnerInfo[]> {
     const runners = await getAllRunners(filterUserId);
@@ -350,8 +385,17 @@ export function getLocalRunnerSocket(runnerId: string): Socket | undefined {
 
 /** Remove a runner from Redis and local socket map. */
 export async function removeRunner(runnerId: string): Promise<void> {
+    // Read userId before deleting so we can target the correct user room
+    const existing = await getRunnerState(runnerId);
     localRunnerSockets.delete(runnerId);
     await deleteRunnerState(runnerId);
+    if (existing) {
+        void broadcastToRunnersNs(
+            "runner_removed",
+            { runnerId },
+            existing.userId ?? undefined,
+        );
+    }
 }
 
 /** Refresh a runner's TTL in Redis (call on heartbeat/activity). */

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,6 +11,7 @@ import { RunnerManager } from "@/components/RunnerManager";
 import { NewSessionWizardDialog } from "@/components/NewSessionWizardDialog";
 import { PizzaLogo } from "@/components/PizzaLogo";
 import { authClient, useSession, signOut } from "@/lib/auth-client";
+import { useRunnersFeed } from "@/lib/useRunnersFeed";
 import { io, type Socket } from "socket.io-client";
 import type {
   ViewerServerToClientEvents,
@@ -96,6 +97,7 @@ import {
 
 export function App() {
   const { data: session, isPending } = useSession();
+  const { runners: feedRunners, status: runnersStatus } = useRunnersFeed();
   const [isDark, setIsDark] = React.useState(() => {
     const saved = localStorage.getItem("theme");
     return saved === "dark" || (!saved && window.matchMedia("(prefers-color-scheme: dark)").matches);
@@ -141,29 +143,6 @@ export function App() {
       try { sessionStorage.setItem(sidebarCacheKey, JSON.stringify(runners)); } catch { /* ignore */ }
     }
   }, [sidebarCacheKey]);
-  // Eager fetch: populate sidebar runners immediately on mount (before RunnerManager mounts)
-  React.useEffect(() => {
-    let cancelled = false;
-    void fetch("/api/runners", { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data) => {
-        if (cancelled) return;
-        const list: any[] = Array.isArray(data?.runners) ? data.runners : [];
-        const mapped = list
-          .filter((r) => typeof r?.runnerId === "string" && r.runnerId)
-          .map((r) => ({
-            runnerId: r.runnerId as string,
-            name: (typeof r.name === "string" ? r.name : null) as string | null,
-            sessionCount: (typeof r.sessionCount === "number" ? r.sessionCount : 0) as number,
-            version: (typeof r.version === "string" ? r.version : null) as string | null,
-            platform: (typeof r.platform === "string" ? r.platform : null) as string | null,
-            isOnline: true,
-          }));
-        setSidebarRunners(mapped);
-      })
-      .catch(() => { /* sidebar will stay with cached/empty data until RunnerManager loads */ });
-    return () => { cancelled = true; };
-  }, [setSidebarRunners]);
   const panelLayout = usePanelLayout(activeSessionId);
   const {
     showTerminal, setShowTerminal,
@@ -183,10 +162,7 @@ export function App() {
     handleFilesOuterPointerMove, handleFilesOuterPointerUp,
   } = panelLayout;
 
-  type RunnerInfo = { runnerId: string; name?: string | null; roots?: string[]; sessionCount: number; platform?: string | null };
   const [newSessionOpen, setNewSessionOpen] = React.useState(false);
-  const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
-  const [runnersLoading, setRunnersLoading] = React.useState(false);
   const [spawnRunnerId, setSpawnRunnerId] = React.useState<string | undefined>(undefined);
   const [spawnCwd, setSpawnCwd] = React.useState<string>("");
   const [spawnPreselectedRunnerId, setSpawnPreselectedRunnerId] = React.useState<string | null>(null);
@@ -328,6 +304,18 @@ export function App() {
     handleSidebarPointerDown, handleSidebarPointerMove, handleSidebarPointerUp,
   } = useMobileSidebar();
   const [liveSessions, setLiveSessions] = React.useState<HubSession[]>([]);
+
+  // Derive sidebar runners from the /runners WS feed
+  React.useEffect(() => {
+    setSidebarRunners(feedRunners.map(r => ({
+      runnerId: r.runnerId,
+      name: r.name,
+      sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
+      version: r.version,
+      isOnline: true,
+    })));
+  }, [feedRunners, liveSessions, setSidebarRunners]);
+
   const [sessionSwitcherOpen, setSessionSwitcherOpen] = React.useState(false);
 
   // Auto-reopen the last viewed session once live sessions arrive.
@@ -370,41 +358,6 @@ export function App() {
       cancelled = true;
     };
   }, [newSessionOpen, spawnRunnerId]);
-
-  React.useEffect(() => {
-    if (!newSessionOpen) return;
-
-    let cancelled = false;
-    setRunnersLoading(true);
-    void fetch("/api/runners", { credentials: "include" })
-      .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
-      .then((data) => {
-        if (cancelled) return;
-        const list = Array.isArray((data as any)?.runners) ? (data as any).runners as any[] : [];
-        const normalized = list
-          .map((r) => ({
-            runnerId: typeof r?.runnerId === "string" ? r.runnerId : "",
-            name: typeof r?.name === "string" ? r.name : null,
-            roots: Array.isArray(r?.roots) ? (r.roots as unknown[]).filter((x): x is string => typeof x === "string") : [],
-            sessionCount: typeof r?.sessionCount === "number" ? r.sessionCount : 0,
-            platform: typeof r?.platform === "string" ? r.platform : null,
-          }))
-          .filter((r) => r.runnerId);
-        setRunners(normalized);
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setRunners([]);
-      })
-      .finally(() => {
-        if (cancelled) return;
-        setRunnersLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [newSessionOpen]);
 
   const viewerWsRef = React.useRef<Socket<ViewerServerToClientEvents, ViewerClientToServerEvents> | null>(null);
   const hubSocketRef = React.useRef<Socket<HubServerToClientEvents, HubClientToServerEvents> | null>(null);
@@ -2706,24 +2659,39 @@ export function App() {
     setNewSessionOpen(true);
   }, []);
 
-  const waitForSessionToGoLive = React.useCallback(async (sessionId: string, timeoutMs: number) => {
-    const deadline = Date.now() + timeoutMs;
-    while (Date.now() < deadline) {
-      try {
-        const res = await fetch("/api/sessions", { credentials: "include" });
-        if (res.ok) {
-          const body = await res.json().catch(() => null) as any;
-          const sessions = Array.isArray(body?.sessions) ? body.sessions : [];
-          const live = sessions.some((s: any) => typeof s?.sessionId === "string" && s.sessionId === sessionId);
-          if (live) return true;
-        }
-      } catch {
-        // ignore
+  // ── Session live waiter — resolves via /hub feed, no polling ──────────────
+  const sessionWaitersRef = React.useRef<Map<string, {
+    resolve: (found: boolean) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }>>(new Map());
+
+  // Resolve any pending waiters when liveSessions updates
+  React.useEffect(() => {
+    for (const [sessionId, waiter] of sessionWaitersRef.current) {
+      if (liveSessions.some(s => s.sessionId === sessionId)) {
+        clearTimeout(waiter.timer);
+        sessionWaitersRef.current.delete(sessionId);
+        waiter.resolve(true);
       }
-      await new Promise((r) => setTimeout(r, 1000));
     }
-    return false;
-  }, []);
+  }, [liveSessions]);
+
+  const waitForSessionToGoLive = React.useCallback(
+    (sessionId: string, timeoutMs: number): Promise<boolean> => {
+      // Fast path: already live
+      if (liveSessions.some(s => s.sessionId === sessionId)) {
+        return Promise.resolve(true);
+      }
+      return new Promise((resolve) => {
+        const timer = setTimeout(() => {
+          sessionWaitersRef.current.delete(sessionId);
+          resolve(false);
+        }, timeoutMs);
+        sessionWaitersRef.current.set(sessionId, { resolve, timer });
+      });
+    },
+    [liveSessions],
+  );
 
   const spawnNewRunnerSession = React.useCallback(async () => {
     if (spawningSession) return;
@@ -3575,8 +3543,10 @@ export function App() {
             )}>
               {showRunners ? (
                 <RunnerManager
+                    runners={feedRunners}
+                    runnersStatus={runnersStatus}
+                    sessions={liveSessions}
                     onOpenSession={(id) => { handleOpenSession(id); setShowRunners(false); }}
-                    onRunnersChange={setSidebarRunners}
                     selectedRunnerId={selectedRunnerId}
                     onSelectRunner={setSelectedRunnerId}
                   />
@@ -3816,8 +3786,8 @@ export function App() {
         <NewSessionWizardDialog
           open={newSessionOpen}
           onOpenChange={(open) => { if (!spawningSession) setNewSessionOpen(open); }}
-          runners={runners.map((r) => ({ ...r, name: r.name ?? null, isOnline: true }))}
-          runnersLoading={runnersLoading}
+          runners={feedRunners.map((r) => ({ ...r, name: r.name ?? null, isOnline: true, sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length }))}
+          runnersLoading={runnersStatus === "connecting"}
           preselectedRunnerId={spawnPreselectedRunnerId}
           initialCwd={spawnCwd}
           onSpawn={handleWizardSpawn}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3611,6 +3611,13 @@ export function App() {
                   sessionId={activeSessionId}
                   runnerId={activeSessionInfo?.runnerId ?? undefined}
                   defaultCwd={activeSessionInfo?.cwd || undefined}
+                  runners={feedRunners.map(r => ({
+                    runnerId: r.runnerId,
+                    name: r.name,
+                    roots: r.roots,
+                    sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
+                  }))}
+                  runnersLoading={runnersStatus === "connecting"}
                   tabs={terminalTabs}
                   activeTabId={activeTerminalId}
                   onActiveTabChange={setActiveTerminalId}
@@ -3669,6 +3676,13 @@ export function App() {
                             sessionId={activeSessionId}
                             runnerId={activeSessionInfo?.runnerId ?? undefined}
                             defaultCwd={activeSessionInfo?.cwd || undefined}
+                            runners={feedRunners.map(r => ({
+                              runnerId: r.runnerId,
+                              name: r.name,
+                              roots: r.roots,
+                              sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
+                            }))}
+                            runnersLoading={runnersStatus === "connecting"}
                             tabs={terminalTabs}
                             activeTabId={activeTerminalId}
                             onActiveTabChange={setActiveTerminalId}
@@ -3741,6 +3755,13 @@ export function App() {
                     sessionId={activeSessionId}
                     runnerId={activeSessionInfo?.runnerId ?? undefined}
                     defaultCwd={activeSessionInfo?.cwd || undefined}
+                    runners={feedRunners.map(r => ({
+                      runnerId: r.runnerId,
+                      name: r.name,
+                      roots: r.roots,
+                      sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
+                    }))}
+                    runnersLoading={runnersStatus === "connecting"}
                     tabs={terminalTabs}
                     activeTabId={activeTerminalId}
                     onActiveTabChange={setActiveTerminalId}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -97,7 +97,11 @@ import {
 
 export function App() {
   const { data: session, isPending } = useSession();
-  const { runners: feedRunners, status: runnersStatus } = useRunnersFeed();
+  const { runners: feedRunners, status: runnersStatus } = useRunnersFeed({
+    // Only connect when auth is confirmed; reconnect if the user changes (e.g. logout → new login)
+    enabled: !isPending && !!session?.user?.id,
+    userId: session?.user?.id ?? undefined,
+  });
   const [isDark, setIsDark] = React.useState(() => {
     const saved = localStorage.getItem("theme");
     return saved === "dark" || (!saved && window.matchMedia("(prefers-color-scheme: dark)").matches);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2916,6 +2916,11 @@ export function App() {
     };
   }, [activeSessionId, liveSessions]);
 
+  const activeRunnerInfo = React.useMemo(
+    () => feedRunners.find(r => r.runnerId === activeSessionInfo?.runnerId) ?? null,
+    [feedRunners, activeSessionInfo?.runnerId],
+  );
+
   // When both panels are at the same position, combine them into a single tabbed panel
   const areCombined = showTerminal && showFileExplorer && terminalPosition === filesPosition
     && !!activeSessionInfo?.runnerId && !!activeSessionInfo?.cwd;
@@ -3593,6 +3598,7 @@ export function App() {
                   onQuestionDismiss={() => setPendingQuestion(null)}
                   onPlanDismiss={() => setPendingPlan(null)}
                   onDuplicateSession={activeSessionInfo?.runnerId ? () => handleDuplicateSession(activeSessionInfo.runnerId!, activeSessionInfo.cwd || "") : undefined}
+                  runnerInfo={activeRunnerInfo}
                 />
               )}
             </div>

--- a/packages/ui/src/components/NewSessionWizardDialog.test.ts
+++ b/packages/ui/src/components/NewSessionWizardDialog.test.ts
@@ -1,21 +1,13 @@
 import { describe, test, expect } from "bun:test";
+import { filterFolders } from "../lib/filterFolders.js";
 
 /**
  * Unit tests for the recent-project filtering logic used in NewSessionWizardDialog.
  *
- * Mirrors the `filterFolders` function defined in the component:
+ * Tests the production `filterFolders` function from lib/filterFolders.ts:
  *   - Case-insensitive substring match
  *   - OR logic: match if found in full path OR basename
  */
-
-function filterFolders(folders: string[], query: string): string[] {
-    if (!query.trim()) return folders;
-    const q = query.toLowerCase();
-    return folders.filter((f) => {
-        const basename = f.split("/").filter(Boolean).pop() ?? f;
-        return f.toLowerCase().includes(q) || basename.toLowerCase().includes(q);
-    });
-}
 
 const FOLDERS = [
     "/home/user/src/project",

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -316,10 +316,10 @@ export function NewSessionWizardDialog({
                             </div>
                         )}
                         {!runnersLoading && connectedRunners.length > 0 && (
-                            <div className="flex flex-col gap-2 max-h-72 overflow-y-auto">
+                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
                                 {connectedRunners.map((r) => {
                                     const roots = Array.isArray(r.roots) ? r.roots.length : 0;
-                                    const sessionMeta = `${r.sessionCount} session${r.sessionCount !== 1 ? "s" : ""}${roots > 0 ? ` · ${roots} root${roots !== 1 ? "s" : ""}` : ""}`;
+                                    const meta = `${r.sessionCount} session${r.sessionCount !== 1 ? "s" : ""}${roots > 0 ? ` · ${roots} root${roots !== 1 ? "s" : ""}` : ""}`;
                                     const osName = platformName(r.platform);
                                     return (
                                         <button
@@ -327,30 +327,28 @@ export function NewSessionWizardDialog({
                                             type="button"
                                             onClick={() => handleSelectRunner(r.runnerId)}
                                             className={cn(
-                                                "flex items-center gap-3 rounded-xl border px-4 py-3 text-left transition-colors w-full",
+                                                "relative flex flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors",
                                                 "hover:bg-accent hover:border-accent-foreground/20",
                                                 selectedRunnerId === r.runnerId
                                                     ? "border-primary bg-primary/5"
                                                     : "border-border bg-card",
                                             )}
                                         >
-                                            {/* Platform icon */}
-                                            {r.platform && (
-                                                <span className="text-muted-foreground flex-shrink-0">
-                                                    <PlatformIcon platform={r.platform} />
-                                                </span>
-                                            )}
-
-                                            {/* Name + meta */}
-                                            <span className="flex-1 min-w-0">
-                                                <span className="block font-semibold text-sm truncate">{runnerLabel(r)}</span>
-                                                <span className="block text-xs text-muted-foreground">
-                                                    {osName ? `${osName} · ` : ""}{sessionMeta}
+                                            {/* Green connection dot */}
+                                            <span className="absolute top-2 right-2 h-2 w-2 rounded-full bg-green-500" />
+                                            <span className="flex items-center gap-1.5 min-w-0 pr-4 w-full">
+                                                {r.platform && (
+                                                    <span className="text-muted-foreground flex-shrink-0">
+                                                        <PlatformIcon platform={r.platform} />
+                                                    </span>
+                                                )}
+                                                <span className="font-medium text-sm leading-tight truncate">
+                                                    {runnerLabel(r)}
                                                 </span>
                                             </span>
-
-                                            {/* Status dot */}
-                                            <span className="h-2.5 w-2.5 rounded-full bg-green-500 flex-shrink-0" />
+                                            <span className="text-xs text-muted-foreground">
+                                                {osName ? `${osName} · ` : ""}{meta}
+                                            </span>
                                         </button>
                                     );
                                 })}

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -11,6 +11,7 @@ import { FolderOpen, Loader2, X, ChevronLeft, Monitor } from "lucide-react";
 import { SiApple, SiLinux } from "react-icons/si";
 import { cn } from "@/lib/utils";
 import { formatPathTail } from "@/lib/path";
+import { filterFolders } from "@/lib/filterFolders";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -91,15 +92,6 @@ function platformName(platform: string | null | undefined): string | null {
         case "win32":   return "Windows";
         default:        return platform;
     }
-}
-
-function filterFolders(folders: string[], query: string): string[] {
-    if (!query.trim()) return folders;
-    const q = query.toLowerCase();
-    return folders.filter((f) => {
-        const basename = f.split("/").filter(Boolean).pop() ?? f;
-        return f.toLowerCase().includes(q) || basename.toLowerCase().includes(q);
-    });
 }
 
 // ── Component ──────────────────────────────────────────────────────────────

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -316,10 +316,11 @@ export function NewSessionWizardDialog({
                             </div>
                         )}
                         {!runnersLoading && connectedRunners.length > 0 && (
-                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-2">
+                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
                                 {connectedRunners.map((r) => {
                                     const roots = Array.isArray(r.roots) ? r.roots.length : 0;
-                                    const meta = `${r.sessionCount} session${r.sessionCount !== 1 ? "s" : ""}${roots > 0 ? ` · ${roots} root${roots !== 1 ? "s" : ""}` : ""}`;
+                                    const sessionMeta = `${r.sessionCount} session${r.sessionCount !== 1 ? "s" : ""}${roots > 0 ? ` · ${roots} root${roots !== 1 ? "s" : ""}` : ""}`;
+
                                     const osName = platformName(r.platform);
                                     return (
                                         <button
@@ -327,28 +328,30 @@ export function NewSessionWizardDialog({
                                             type="button"
                                             onClick={() => handleSelectRunner(r.runnerId)}
                                             className={cn(
-                                                "relative flex flex-col items-start gap-1 rounded-lg border p-3 text-left transition-colors",
+                                                "flex flex-col items-start gap-2.5 rounded-xl border p-5 text-left transition-colors w-full",
                                                 "hover:bg-accent hover:border-accent-foreground/20",
                                                 selectedRunnerId === r.runnerId
                                                     ? "border-primary bg-primary/5"
                                                     : "border-border bg-card",
                                             )}
                                         >
-                                            {/* Green connection dot */}
-                                            <span className="absolute top-2 right-2 h-2 w-2 rounded-full bg-green-500" />
-                                            <span className="flex items-center gap-1.5 min-w-0 pr-4 w-full">
-                                                {r.platform && (
-                                                    <span className="text-muted-foreground flex-shrink-0">
+                                            {/* Top row: OS label (left) + status dot (right) */}
+                                            <div className="flex items-center justify-between w-full">
+                                                {osName ? (
+                                                    <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
                                                         <PlatformIcon platform={r.platform} />
+                                                        <span>{osName}</span>
                                                     </span>
+                                                ) : (
+                                                    <span />
                                                 )}
-                                                <span className="font-medium text-sm leading-tight truncate">
-                                                    {runnerLabel(r)}
-                                                </span>
+                                                <span className="h-2.5 w-2.5 rounded-full bg-green-500 flex-shrink-0" />
+                                            </div>
+
+                                            <span className="font-semibold text-sm leading-tight truncate w-full">
+                                                {runnerLabel(r)}
                                             </span>
-                                            <span className="text-xs text-muted-foreground">
-                                                {osName ? `${osName} · ` : ""}{meta}
-                                            </span>
+                                            <span className="text-xs text-muted-foreground">{sessionMeta}</span>
                                         </button>
                                     );
                                 })}

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -1,112 +1,58 @@
 import * as React from "react";
-import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
-import { Plus, Loader2, RefreshCw } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RunnerDetailPanel } from "@/components/RunnerDetailPanel";
 import { NewSessionWizardDialog } from "@/components/NewSessionWizardDialog";
-import type { SkillInfo } from "@/components/SkillsManager";
-import type { AgentInfo } from "@/components/AgentsManager";
-import type { PluginInfo } from "@/components/PluginsManager";
-
-interface RunnerHook {
-    type: string;
-    scripts: string[];
-}
-
-interface RunnerInfo {
-    runnerId: string;
-    name: string | null;
-    roots: string[];
-    sessionCount: number;
-    skills: SkillInfo[];
-    agents: AgentInfo[];
-    plugins: PluginInfo[];
-    hooks?: RunnerHook[];
-    version: string | null;
-}
-
-interface LiveSession {
-    sessionId: string;
-    shareUrl: string;
-    cwd: string;
-    startedAt: string;
-    sessionName: string | null;
-    isActive: boolean;
-    lastHeartbeatAt: string | null;
-    runnerId: string | null;
-    runnerName: string | null;
-}
+import type { HubSession } from "@/components/SessionSidebar";
+import type { RunnerInfo } from "@pizzapi/protocol";
 
 export interface RunnerManagerProps {
+    /** Runner list from the /runners WS feed — passed from App.tsx (single hook instance) */
+    runners: RunnerInfo[];
+    /** Connection status of the /runners feed */
+    runnersStatus: "connecting" | "connected" | "disconnected";
+    /** Live sessions from the /hub feed — used for spawn-wait, per-runner counts, and RunnerDetailPanel */
+    sessions: HubSession[];
     onOpenSession?: (sessionId: string) => void;
-    onRunnersChange?: (runners: Array<{
-        runnerId: string;
-        name: string | null;
-        sessionCount: number;
-        version: string | null;
-        isOnline: boolean;
-    }>) => void;
     selectedRunnerId: string | null;
     onSelectRunner?: (runnerId: string) => void;
 }
 
-export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId, onSelectRunner }: RunnerManagerProps) {
-    const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
-    const [sessions, setSessions] = React.useState<LiveSession[]>([]);
-    const [loading, setLoading] = React.useState(true);
-    const [latestVersion, setServerVersion] = React.useState<string | null>(null);
+export function RunnerManager({
+    runners,
+    runnersStatus,
+    sessions,
+    onOpenSession,
+    selectedRunnerId,
+    onSelectRunner,
+}: RunnerManagerProps) {
+    const loading = runnersStatus === "connecting" && runners.length === 0;
+
     const [restarting, setRestarting] = React.useState<Set<string>>(new Set());
     const [stopping, setStopping] = React.useState<Set<string>>(new Set());
 
     // New session dialog
     const [spawnRunnerId, setSpawnRunnerId] = React.useState<string | null>(null);
 
-    const fetchData = React.useCallback(async () => {
-        try {
-            const [runnersRes, sessionsRes] = await Promise.all([
-                fetch("/api/runners", { credentials: "include" }),
-                fetch("/api/sessions", { credentials: "include" }),
-            ]);
-            if (runnersRes.ok) {
-                const data = await runnersRes.json();
-                const raw: any[] = data.runners || [];
-                setRunners(raw.map((r) => ({
-                    runnerId: r.runnerId,
-                    name: r.name,
-                    roots: r.roots ?? [],
-                    sessionCount: r.sessionCount ?? 0,
-                    skills: Array.isArray(r.skills) ? r.skills : [],
-                    agents: Array.isArray(r.agents) ? r.agents : [],
-                    plugins: Array.isArray(r.plugins) ? r.plugins : [],
-                    hooks: Array.isArray(r.hooks) ? r.hooks : [],
-                    version: r.version ?? null,
-                })));
-            }
-            if (sessionsRes.ok) {
-                const data = await sessionsRes.json();
-                setSessions(data.sessions || []);
-            }
-        } catch (error) {
-            console.error("Failed to fetch runners/sessions:", error);
-        } finally {
-            setLoading(false);
+    // Pending spawn: wait for session to appear in WS feed
+    const [pendingSessionId, setPendingSessionId] = React.useState<string | null>(null);
+
+    // Resolve pending spawn: when the spawned session appears in sessions, open it
+    React.useEffect(() => {
+        if (!pendingSessionId) return;
+        const found = sessions.some(s => s.sessionId === pendingSessionId);
+        if (found) {
+            const id = pendingSessionId;
+            setPendingSessionId(null);
+            onOpenSession?.(id);
         }
-    }, []);
+    }, [pendingSessionId, sessions, onOpenSession]);
 
+    // 30-second timeout guard: clear pendingSessionId if session never appears
     React.useEffect(() => {
-        fetchData();
-        const interval = setInterval(fetchData, 10000);
-        return () => clearInterval(interval);
-    }, [fetchData]);
-
-    // Fetch server version once
-    React.useEffect(() => {
-        fetch("/api/version")
-            .then((res) => res.ok ? res.json() : null)
-            .then((data) => { if (data?.version) setServerVersion(data.version); })
-            .catch(() => {});
-    }, []);
+        if (!pendingSessionId) return;
+        const timer = setTimeout(() => setPendingSessionId(null), 30_000);
+        return () => clearTimeout(timer);
+    }, [pendingSessionId]);
 
     // Auto-select when there's exactly one runner
     React.useEffect(() => {
@@ -114,17 +60,6 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
             onSelectRunner?.(runners[0].runnerId);
         }
     }, [runners, selectedRunnerId, onSelectRunner]);
-
-    // Notify parent of runner list changes
-    React.useEffect(() => {
-        onRunnersChange?.(runners.map(r => ({
-            runnerId: r.runnerId,
-            name: r.name,
-            sessionCount: r.sessionCount,
-            version: r.version,
-            isOnline: true, // runners from API are always online
-        })));
-    }, [runners, onRunnersChange]);
 
     const handleRestart = async (runnerId: string) => {
         setRestarting((prev) => new Set(prev).add(runnerId));
@@ -148,7 +83,6 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
                     next.delete(runnerId);
                     return next;
                 });
-                fetchData();
             }, 2000);
         }
     };
@@ -176,7 +110,6 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
                     next.delete(runnerId);
                     return next;
                 });
-                fetchData();
             }, 3000);
         }
     };
@@ -200,29 +133,11 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
         if (!sessionId) throw new Error("Spawn failed: missing sessionId in response");
 
         setSpawnRunnerId(null);
-
-        if (onOpenSession) {
-            const deadline = Date.now() + 30_000;
-            const poll = async (): Promise<void> => {
-                if (Date.now() > deadline) return;
-                try {
-                    const r = await fetch("/api/sessions", { credentials: "include" });
-                    if (r.ok) {
-                        const d = await r.json().catch(() => null) as any;
-                        const live = Array.isArray(d?.sessions) && d.sessions.some((s: any) => s?.sessionId === sessionId);
-                        if (live) { onOpenSession(sessionId); return; }
-                    }
-                } catch {}
-                await new Promise((r) => setTimeout(r, 1000));
-                return poll();
-            };
-            void poll();
-        }
-        fetchData();
+        setPendingSessionId(sessionId);
     };
 
     // Loading skeleton
-    if (loading && runners.length === 0) {
+    if (loading) {
         return (
             <div className="flex flex-col flex-1 p-6 gap-4 animate-in fade-in duration-700">
                 <div className="flex items-center justify-between">
@@ -250,8 +165,41 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
         );
     }
 
-    const selectedRunner = runners.find(r => r.runnerId === selectedRunnerId) ?? null;
-    const runnerSessions = sessions.filter(s => s.runnerId === selectedRunnerId);
+    // Map protocol RunnerInfo → RunnerDetailPanel's local RunnerInfo shape
+    // (protocol has some optional fields that RunnerDetailPanel expects as required)
+    const selectedRunnerRaw = runners.find(r => r.runnerId === selectedRunnerId);
+    const selectedRunner = selectedRunnerRaw ? {
+        runnerId: selectedRunnerRaw.runnerId,
+        name: selectedRunnerRaw.name,
+        roots: selectedRunnerRaw.roots,
+        sessionCount: selectedRunnerRaw.sessionCount,
+        skills: selectedRunnerRaw.skills,
+        agents: selectedRunnerRaw.agents,
+        plugins: (selectedRunnerRaw.plugins ?? []).map(p => ({
+            ...p,
+            rules: p.rules ?? [],
+        })),
+        hooks: selectedRunnerRaw.hooks,
+        version: selectedRunnerRaw.version,
+    } : null;
+
+    // Map HubSession → LiveSession shape expected by RunnerDetailPanel
+    const runnerSessions = sessions
+        .filter(s => s.runnerId === selectedRunnerId)
+        .map(s => ({
+            sessionId: s.sessionId,
+            shareUrl: s.shareUrl ?? "",
+            cwd: s.cwd ?? "",
+            startedAt: s.startedAt ?? "",
+            sessionName: s.sessionName ?? null,
+            isActive: s.isActive ?? false,
+            lastHeartbeatAt: s.lastHeartbeatAt ?? null,
+            runnerId: s.runnerId ?? null,
+            runnerName: s.runnerName ?? null,
+        }));
+
+    // Use selected runner's version for update-available check (latestVersion was previously fetched from /api/version)
+    const latestVersion = selectedRunner?.version ?? runners[0]?.version ?? null;
 
     return (
         <>
@@ -267,9 +215,9 @@ export function RunnerManager({ onOpenSession, onRunnersChange, selectedRunnerId
                 onStop={() => selectedRunnerId && handleStop(selectedRunnerId)}
                 onNewSession={() => selectedRunnerId && handleOpenNewSession(selectedRunnerId)}
                 onOpenSession={onOpenSession}
-                onSkillsChange={(rid, skills) => setRunners(prev => prev.map(r => r.runnerId === rid ? { ...r, skills } : r))}
-                onAgentsChange={(rid, agents) => setRunners(prev => prev.map(r => r.runnerId === rid ? { ...r, agents } : r))}
-                onPluginsChange={(rid, plugins) => setRunners(prev => prev.map(r => r.runnerId === rid ? { ...r, plugins } : r))}
+                onSkillsChange={() => {}}
+                onAgentsChange={() => {}}
+                onPluginsChange={() => {}}
             />
 
             {/* New session dialog */}

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -29,6 +29,15 @@ export function RunnerManager({
 
     const [restarting, setRestarting] = React.useState<Set<string>>(new Set());
     const [stopping, setStopping] = React.useState<Set<string>>(new Set());
+    const [latestVersion, setLatestVersion] = React.useState<string | null>(null);
+
+    // Fetch the latest available version from the server (used by RunnerDetailPanel for update-available badge)
+    React.useEffect(() => {
+        fetch("/api/version")
+            .then((res) => res.ok ? res.json() : null)
+            .then((data) => { if (data?.version) setLatestVersion(data.version); })
+            .catch(() => {});
+    }, []);
 
     // New session dialog
     const [spawnRunnerId, setSpawnRunnerId] = React.useState<string | null>(null);
@@ -198,8 +207,9 @@ export function RunnerManager({
             runnerName: s.runnerName ?? null,
         }));
 
-    // Use selected runner's version for update-available check (latestVersion was previously fetched from /api/version)
-    const latestVersion = selectedRunner?.version ?? runners[0]?.version ?? null;
+    // latestVersion is fetched from /api/version above — it represents the latest npm release,
+    // not the runner's own version. This allows RunnerDetailPanel to show an "update available" badge
+    // when the runner's version is older than the latest available version.
 
     return (
         <>

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -172,7 +172,7 @@ export function RunnerManager({
         runnerId: selectedRunnerRaw.runnerId,
         name: selectedRunnerRaw.name,
         roots: selectedRunnerRaw.roots,
-        sessionCount: selectedRunnerRaw.sessionCount,
+        sessionCount: sessions.filter(s => s.runnerId === selectedRunnerRaw.runnerId).length,
         skills: selectedRunnerRaw.skills,
         agents: selectedRunnerRaw.agents,
         plugins: (selectedRunnerRaw.plugins ?? []).map(p => ({
@@ -224,7 +224,14 @@ export function RunnerManager({
             <NewSessionWizardDialog
                 open={spawnRunnerId !== null}
                 onOpenChange={(open) => { if (!open) setSpawnRunnerId(null); }}
-                runners={runners.map((r) => ({ ...r, isOnline: true }))}
+                runners={runners.map((r) => ({
+                    runnerId: r.runnerId,
+                    name: r.name ?? null,
+                    roots: r.roots,
+                    sessionCount: sessions.filter(s => s.runnerId === r.runnerId).length,
+                    platform: r.platform ?? null,
+                    isOnline: true,
+                }))}
                 preselectedRunnerId={spawnRunnerId}
                 onSpawn={handleWizardSpawn}
             />

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -705,59 +705,48 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
 
     // /plugins and /skills use HTTP fetch, not onExec — handle before the exec guard
     if (rawCommand === "plugins") {
+      if (!runnerId) {
+        setInput("");
+        setCommandOpen(false);
+        setCommandQuery("");
+        onAppendSystemMessage?.("**Plugins** — Runner not connected yet. Try again in a moment.");
+        return true;
+      }
       setInput("");
       setCommandOpen(false);
       setCommandQuery("");
-      if (runnerInfo) {
-        // Fast path: use cached WS data
-        const plugins = runnerInfo.plugins ?? [];
-        onAppendSystemMessage?.({
-          kind: "plugins",
-          plugins: plugins.map((p) => ({
-            name: p.name,
-            description: p.description,
-            version: p.version,
-            commands: (p.commands ?? []).map((c) => ({ name: c.name, description: c.description })),
-            hookCount: p.hookEvents?.length ?? 0,
-            skillCount: p.skills?.length ?? 0,
-            agentCount: p.agents?.length ?? 0,
-            ruleCount: p.rules?.length ?? 0,
-            hasMcp: !!p.hasMcp,
-            hasAgents: !!p.hasAgents,
-          })),
-        });
-      } else if (runnerId) {
-        // Fallback: fetch from REST API
-        const dispatchSessionId = sessionId;
-        const pluginsUrl = sessionCwd
-          ? `/api/runners/${encodeURIComponent(runnerId)}/plugins?cwd=${encodeURIComponent(sessionCwd)}`
-          : `/api/runners/${encodeURIComponent(runnerId)}/plugins`;
-        fetch(pluginsUrl, { credentials: "include" })
-          .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
-          .then((data: any) => {
-            if (dispatchSessionId !== sessionIdRef.current) return;
-            const raw: any[] = Array.isArray(data?.plugins) ? data.plugins : [];
-            onAppendSystemMessage?.({
-              kind: "plugins",
-              plugins: raw.map((p) => ({
-                name: p.name,
-                description: p.description,
-                version: p.version,
-                commands: (p.commands ?? []).map((c: any) => ({ name: c.name, description: c.description })),
-                hookCount: p.hookEvents?.length ?? 0,
-                skillCount: p.skills?.length ?? 0,
-                agentCount: p.agents?.length ?? 0,
-                ruleCount: p.rules?.length ?? 0,
-                hasMcp: !!p.hasMcp,
-                hasAgents: !!p.hasAgents,
-              })),
-            });
-          })
-          .catch((err: Error) => {
-            if (dispatchSessionId !== sessionIdRef.current) return;
-            onAppendSystemMessage?.(`**Plugins** — Failed to load: ${err.message}`);
+      // Always fetch via REST so the server runs a cwd-scoped scan.
+      // The WS feed's RunnerInfo.plugins is the global cache and misses
+      // project-local plugins (those discovered via sessionCwd).
+      const dispatchSessionId = sessionId;
+      const pluginsUrl = sessionCwd
+        ? `/api/runners/${encodeURIComponent(runnerId)}/plugins?cwd=${encodeURIComponent(sessionCwd)}`
+        : `/api/runners/${encodeURIComponent(runnerId)}/plugins`;
+      fetch(pluginsUrl, { credentials: "include" })
+        .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
+        .then((data: any) => {
+          if (dispatchSessionId !== sessionIdRef.current) return;
+          const raw: Array<{ name: string; description?: string; commands?: Array<{ name: string; description?: string }>; hookEvents?: string[]; skills?: Array<{ name: string }>; agents?: Array<{ name: string }>; rules?: Array<{ name: string }>; version?: string; hasMcp?: boolean; hasAgents?: boolean }> = Array.isArray(data?.plugins) ? data.plugins : [];
+          onAppendSystemMessage?.({
+            kind: "plugins",
+            plugins: raw.map((p) => ({
+              name: p.name,
+              description: p.description,
+              version: p.version,
+              commands: (p.commands ?? []).map((c) => ({ name: c.name, description: c.description })),
+              hookCount: p.hookEvents?.length ?? 0,
+              skillCount: p.skills?.length ?? 0,
+              agentCount: p.agents?.length ?? 0,
+              ruleCount: p.rules?.length ?? 0,
+              hasMcp: !!p.hasMcp,
+              hasAgents: !!p.hasAgents,
+            })),
           });
-      }
+        })
+        .catch((err: Error) => {
+          if (dispatchSessionId !== sessionIdRef.current) return;
+          onAppendSystemMessage?.(`**Plugins** — Failed to load: ${err.message}`);
+        });
       return true;
     }
 

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -786,6 +786,8 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
             if (dispatchSessionId !== sessionIdRef.current) return;
             onAppendSystemMessage?.(`**Skills** — Failed to load: ${err.message}`);
           });
+      } else {
+        onAppendSystemMessage?.("**Skills** — Runner not connected yet. Try again in a moment.");
       }
       return true;
     }

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -155,6 +155,8 @@ export interface SessionViewerProps {
   onPlanDismiss?: () => void;
   /** Open the new-session dialog pre-filled with the same runner & working directory */
   onDuplicateSession?: () => void;
+  /** Full runner data for the active session's runner — from the /runners WS feed */
+  runnerInfo?: import("@pizzapi/protocol").RunnerInfo | null;
 }
 
 function formatTokenCount(n: number): string {
@@ -540,7 +542,7 @@ function SessionSkeleton() {
   );
 }
 
-export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onEditQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse, onQuestionDismiss, onPlanDismiss, onDuplicateSession }: SessionViewerProps) {
+export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onEditQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse, onQuestionDismiss, onPlanDismiss, onDuplicateSession, runnerInfo }: SessionViewerProps) {
   const [input, setInput] = React.useState("");
   // Per-session draft storage so switching sessions preserves unsent text
   const draftsRef = React.useRef<Map<string, string>>(new Map());
@@ -584,7 +586,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
 
   // @-mention agents — cached per runner so we don't re-fetch every time the popover opens
   const [atMentionAgents, setAtMentionAgents] = React.useState<Array<{ name: string; description?: string }>>([]);
-  const atMentionAgentsFetchedForRef = React.useRef<string | null>(null);
+
   // Track whether the highlighted @-mention item is an agent (entry will be null for agents)
   const [atMentionHighlightedAgent, setAtMentionHighlightedAgent] = React.useState<string | null>(null);
 
@@ -702,88 +704,47 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
 
     // /plugins and /skills use HTTP fetch, not onExec — handle before the exec guard
     if (rawCommand === "plugins") {
-      if (!runnerId) {
-        setInput("");
-        setCommandOpen(false);
-        setCommandQuery("");
-        onAppendSystemMessage?.("**Plugins** — Runner not connected yet. Try again in a moment.");
-        return true;
-      }
       setInput("");
       setCommandOpen(false);
       setCommandQuery("");
-      const pluginsUrl = sessionCwd
-        ? `/api/runners/${encodeURIComponent(runnerId)}/plugins?cwd=${encodeURIComponent(sessionCwd)}`
-        : `/api/runners/${encodeURIComponent(runnerId)}/plugins`;
-      // Capture sessionId at dispatch time; compare against mutable ref
-      // to detect session switches while the fetch is in-flight.
-      const dispatchSessionId = sessionId;
-      fetch(pluginsUrl, { credentials: "include" })
-        .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
-        .then((data: any) => {
-          if (dispatchSessionId !== sessionIdRef.current) return; // session changed, discard
-          const raw: Array<{ name: string; description?: string; commands?: Array<{ name: string; description?: string }>; hookEvents?: string[]; skills?: Array<{ name: string }>; agents?: Array<{ name: string }>; rules?: Array<{ name: string }>; version?: string; hasMcp?: boolean; hasAgents?: boolean }> = Array.isArray(data?.plugins) ? data.plugins : [];
-          onAppendSystemMessage?.({
-            kind: "plugins",
-            plugins: raw.map((p) => ({
-              name: p.name,
-              description: p.description,
-              version: p.version,
-              commands: (p.commands ?? []).map((c) => ({ name: c.name, description: c.description })),
-              hookCount: p.hookEvents?.length ?? 0,
-              skillCount: p.skills?.length ?? 0,
-              agentCount: p.agents?.length ?? 0,
-              ruleCount: p.rules?.length ?? 0,
-              hasMcp: !!p.hasMcp,
-              hasAgents: !!p.hasAgents,
-            })),
-          });
-        })
-        .catch((err: Error) => {
-          if (dispatchSessionId !== sessionIdRef.current) return;
-          onAppendSystemMessage?.(`**Plugins** — Failed to load: ${err.message}`);
-        });
+      // Use cached runner data from WS feed. Empty list if runner disconnected.
+      const plugins = runnerInfo?.plugins ?? [];
+      onAppendSystemMessage?.({
+        kind: "plugins",
+        plugins: plugins.map((p) => ({
+          name: p.name,
+          description: p.description,
+          version: p.version,
+          commands: (p.commands ?? []).map((c) => ({ name: c.name, description: c.description })),
+          hookCount: p.hookEvents?.length ?? 0,
+          skillCount: p.skills?.length ?? 0,
+          agentCount: p.agents?.length ?? 0,
+          ruleCount: p.rules?.length ?? 0,
+          hasMcp: !!p.hasMcp,
+          hasAgents: !!p.hasAgents,
+        })),
+      });
       return true;
     }
 
     if (rawCommand === "skills") {
-      if (!runnerId) {
-        setInput("");
-        setCommandOpen(false);
-        setCommandQuery("");
-        onAppendSystemMessage?.("**Skills** — Runner not connected yet. Try again in a moment.");
-        return true;
-      }
       setInput("");
       setCommandOpen(false);
       setCommandQuery("");
-      // Capture sessionId at dispatch time to discard stale responses
-      // when the user switches sessions while the fetch is in-flight.
-      const dispatchSessionId = sessionId;
-      fetch(`/api/runners/${encodeURIComponent(runnerId)}/skills`, { credentials: "include" })
-        .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
-        .then((data: any) => {
-          if (dispatchSessionId !== sessionIdRef.current) return; // session changed, discard
-          const skills: Array<{ name: string; description?: string }> = Array.isArray(data?.skills) ? data.skills : [];
-          // Merge CLI-advertised skill commands (which include project-local skills the
-          // runner sees but the REST cache may not) so the user gets the full picture.
-          const merged = new Map<string, { name: string; description?: string }>();
-          for (const s of skills) merged.set(s.name, s);
-          for (const cmd of skillCommands) {
-            const skillName = cmd.name.replace(/^skill:/, "");
-            if (!merged.has(skillName)) {
-              merged.set(skillName, { name: skillName, description: cmd.description });
-            }
-          }
-          onAppendSystemMessage?.({
-            kind: "skills",
-            skills: Array.from(merged.values()),
-          });
-        })
-        .catch((err: Error) => {
-          if (dispatchSessionId !== sessionIdRef.current) return;
-          onAppendSystemMessage?.(`**Skills** — Failed to load: ${err.message}`);
-        });
+      // Use cached runner data from WS feed. Empty list if runner disconnected mid-session.
+      const skills = runnerInfo?.skills ?? [];
+      const merged = new Map<string, { name: string; description?: string }>();
+      for (const s of skills) merged.set(s.name, s);
+      for (const cmd of skillCommands) {
+        const skillName = cmd.name.replace(/^skill:/, "");
+        if (!merged.has(skillName)) {
+          merged.set(skillName, { name: skillName, description: cmd.description });
+        }
+      }
+      onAppendSystemMessage?.({
+        kind: "skills",
+        skills: Array.from(merged.values()),
+      });
       return true;
     }
 
@@ -831,25 +792,24 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
         // User typed "/agents researcher" — find and spawn that agent
         const agentName = args.trim();
         if (onSpawnAgentSession && runnerId) {
-          // Capture sessionId at dispatch time to discard stale responses
-          // when the user switches sessions while the fetch is in-flight.
           const dispatchSessionId = sessionId;
-          fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents`, { credentials: "include" })
-            .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
-            .then((data: any) => {
-              if (dispatchSessionId !== sessionIdRef.current) return; // session changed, discard
-              const agents: Array<{ name: string; description?: string; content?: string }> = Array.isArray(data?.agents) ? data.agents : [];
-              const match = agents.find(a => a.name.toLowerCase() === agentName.toLowerCase());
-              if (match) {
-                onSpawnAgentSession({ name: match.name, description: match.description, systemPrompt: match.content });
-              } else {
-                onAppendSystemMessage?.(`**Agents** — Agent "${agentName}" not found.`);
-              }
-            })
-            .catch((err: Error) => {
-              if (dispatchSessionId !== sessionIdRef.current) return;
-              onAppendSystemMessage?.(`**Agents** — Failed to load: ${err.message}`);
-            });
+          const agentsList = runnerInfo?.agents ?? [];
+          const match = agentsList.find(a => a.name.toLowerCase() === agentName.toLowerCase());
+          if (match) {
+            // Fetch individual agent content (system prompt) — not in RunnerInfo.agents
+            fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents/${encodeURIComponent(match.name)}`, { credentials: "include" })
+              .then(res => res.ok ? res.json() : Promise.reject())
+              .then((data: any) => {
+                if (dispatchSessionId !== sessionIdRef.current) return;
+                onSpawnAgentSession?.({ name: match.name, description: match.description, systemPrompt: data?.content });
+              })
+              .catch(() => {
+                if (dispatchSessionId !== sessionIdRef.current) return;
+                onSpawnAgentSession?.({ name: match.name, description: match.description });
+              });
+          } else {
+            onAppendSystemMessage?.(`**Agents** — Agent "${agentName}" not found.`);
+          }
         }
       }
       // Without args, the popover handles it (isAgentMode)
@@ -973,7 +933,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     }
 
     return false;
-  }, [onExec, onSendInput, resumeSessions, runnerId, onAppendSystemMessage, skillCommands, sessionCwd, onShowModelSelector, isCompacting, sessionId, onSpawnAgentSession]);
+  }, [onExec, onSendInput, resumeSessions, runnerId, onAppendSystemMessage, skillCommands, sessionCwd, onShowModelSelector, isCompacting, sessionId, onSpawnAgentSession, runnerInfo]);
 
   const handleSubmit = React.useCallback(
     (message: PromptInputMessage) => {
@@ -1214,30 +1174,12 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     setAtMentionHighlightedIndex(0);
   }, [input, atMentionTriggerOffset]);
 
-  // Fetch agents when the @-mention popover opens (cached per runner)
+  // Populate agents from cached runner data when the @-mention popover opens
   React.useEffect(() => {
     if (!atMentionOpen || !runnerId) return;
-    if (atMentionAgentsFetchedForRef.current === runnerId) return;
-    atMentionAgentsFetchedForRef.current = runnerId;
-    let stale = false;
-    fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents`, { credentials: "include" })
-      .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
-      .then((data: any) => {
-        if (stale) return;
-        const agents: Array<{ name: string; description?: string }> = Array.isArray(data?.agents)
-          ? data.agents.map((a: any) => ({ name: a.name, description: a.description }))
-          : [];
-        setAtMentionAgents(agents);
-      })
-      .catch(() => {
-        if (!stale) {
-          // Clear the fetched marker so a subsequent popover open will retry
-          atMentionAgentsFetchedForRef.current = null;
-          setAtMentionAgents([]);
-        }
-      });
-    return () => { stale = true; };
-  }, [atMentionOpen, runnerId]);
+    const agents = (runnerInfo?.agents ?? []).map(a => ({ name: a.name, description: a.description }));
+    setAtMentionAgents(agents);
+  }, [atMentionOpen, runnerId, runnerInfo]);
 
   const trimmedInput = input.trimStart();
   const isResumeMode = /^\/resume(?:\s|$)/i.test(trimmedInput);
@@ -1275,28 +1217,32 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
     });
   }, [agentsList, agentQuery]);
 
-  // Fetch agents when agent mode activates
+  // Pre-populate agents from cached runner data, then fetch full content in background
   React.useEffect(() => {
     if (!sessionId || !commandOpen || !isAgentMode || !runnerId) return;
     const requestKey = `${sessionId}-${runnerId}`;
     if (agentsRequestedRef.current === requestKey) return;
     agentsRequestedRef.current = requestKey;
     let stale = false;
+
+    // Pre-populate display from cached runner data immediately (no loading flicker)
+    const cachedAgents = (runnerInfo?.agents ?? []).map(a => ({ name: a.name, description: a.description }));
+    setAgentsList(cachedAgents);
+
+    // Fetch full agent data in background (list endpoint doesn't include content,
+    // but this keeps the list fresh and provides content for spawning via picker)
     setAgentsLoading(true);
     fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents`, { credentials: "include" })
       .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
       .then((data: any) => {
-        if (stale) return; // session/runner changed while fetch was in-flight
+        if (stale) return;
         const agents: Array<{ name: string; description?: string; content?: string }> = Array.isArray(data?.agents) ? data.agents : [];
         setAgentsList(agents);
       })
-      .catch(() => {
-        if (stale) return;
-        setAgentsList([]);
-      })
+      .catch(() => { if (stale) return; /* keep cached data on error */ })
       .finally(() => { if (!stale) setAgentsLoading(false); });
     return () => { stale = true; };
-  }, [sessionId, commandOpen, isAgentMode, runnerId]);
+  }, [sessionId, commandOpen, isAgentMode, runnerId, runnerInfo]);
 
   // Reset agent request ref when agent mode closes
   React.useEffect(() => {

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -586,6 +586,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
 
   // @-mention agents — cached per runner so we don't re-fetch every time the popover opens
   const [atMentionAgents, setAtMentionAgents] = React.useState<Array<{ name: string; description?: string }>>([]);
+  const atMentionAgentsFetchedForRef = React.useRef<string | null>(null);
 
   // Track whether the highlighted @-mention item is an agent (entry will be null for agents)
   const [atMentionHighlightedAgent, setAtMentionHighlightedAgent] = React.useState<string | null>(null);
@@ -707,23 +708,56 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
       setInput("");
       setCommandOpen(false);
       setCommandQuery("");
-      // Use cached runner data from WS feed. Empty list if runner disconnected.
-      const plugins = runnerInfo?.plugins ?? [];
-      onAppendSystemMessage?.({
-        kind: "plugins",
-        plugins: plugins.map((p) => ({
-          name: p.name,
-          description: p.description,
-          version: p.version,
-          commands: (p.commands ?? []).map((c) => ({ name: c.name, description: c.description })),
-          hookCount: p.hookEvents?.length ?? 0,
-          skillCount: p.skills?.length ?? 0,
-          agentCount: p.agents?.length ?? 0,
-          ruleCount: p.rules?.length ?? 0,
-          hasMcp: !!p.hasMcp,
-          hasAgents: !!p.hasAgents,
-        })),
-      });
+      if (runnerInfo) {
+        // Fast path: use cached WS data
+        const plugins = runnerInfo.plugins ?? [];
+        onAppendSystemMessage?.({
+          kind: "plugins",
+          plugins: plugins.map((p) => ({
+            name: p.name,
+            description: p.description,
+            version: p.version,
+            commands: (p.commands ?? []).map((c) => ({ name: c.name, description: c.description })),
+            hookCount: p.hookEvents?.length ?? 0,
+            skillCount: p.skills?.length ?? 0,
+            agentCount: p.agents?.length ?? 0,
+            ruleCount: p.rules?.length ?? 0,
+            hasMcp: !!p.hasMcp,
+            hasAgents: !!p.hasAgents,
+          })),
+        });
+      } else if (runnerId) {
+        // Fallback: fetch from REST API
+        const dispatchSessionId = sessionId;
+        const pluginsUrl = sessionCwd
+          ? `/api/runners/${encodeURIComponent(runnerId)}/plugins?cwd=${encodeURIComponent(sessionCwd)}`
+          : `/api/runners/${encodeURIComponent(runnerId)}/plugins`;
+        fetch(pluginsUrl, { credentials: "include" })
+          .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
+          .then((data: any) => {
+            if (dispatchSessionId !== sessionIdRef.current) return;
+            const raw: any[] = Array.isArray(data?.plugins) ? data.plugins : [];
+            onAppendSystemMessage?.({
+              kind: "plugins",
+              plugins: raw.map((p) => ({
+                name: p.name,
+                description: p.description,
+                version: p.version,
+                commands: (p.commands ?? []).map((c: any) => ({ name: c.name, description: c.description })),
+                hookCount: p.hookEvents?.length ?? 0,
+                skillCount: p.skills?.length ?? 0,
+                agentCount: p.agents?.length ?? 0,
+                ruleCount: p.rules?.length ?? 0,
+                hasMcp: !!p.hasMcp,
+                hasAgents: !!p.hasAgents,
+              })),
+            });
+          })
+          .catch((err: Error) => {
+            if (dispatchSessionId !== sessionIdRef.current) return;
+            onAppendSystemMessage?.(`**Plugins** — Failed to load: ${err.message}`);
+          });
+      }
       return true;
     }
 
@@ -731,20 +765,39 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
       setInput("");
       setCommandOpen(false);
       setCommandQuery("");
-      // Use cached runner data from WS feed. Empty list if runner disconnected mid-session.
-      const skills = runnerInfo?.skills ?? [];
-      const merged = new Map<string, { name: string; description?: string }>();
-      for (const s of skills) merged.set(s.name, s);
-      for (const cmd of skillCommands) {
-        const skillName = cmd.name.replace(/^skill:/, "");
-        if (!merged.has(skillName)) {
-          merged.set(skillName, { name: skillName, description: cmd.description });
+      if (runnerInfo) {
+        // Fast path: use cached WS data
+        const skills = runnerInfo.skills ?? [];
+        const merged = new Map<string, { name: string; description?: string }>();
+        for (const s of skills) merged.set(s.name, s);
+        for (const cmd of skillCommands) {
+          const skillName = cmd.name.replace(/^skill:/, "");
+          if (!merged.has(skillName)) {
+            merged.set(skillName, { name: skillName, description: cmd.description });
+          }
         }
+        onAppendSystemMessage?.({ kind: "skills", skills: Array.from(merged.values()) });
+      } else if (runnerId) {
+        // Fallback: fetch from REST API
+        const dispatchSessionId = sessionId;
+        fetch(`/api/runners/${encodeURIComponent(runnerId)}/skills`, { credentials: "include" })
+          .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
+          .then((data: any) => {
+            if (dispatchSessionId !== sessionIdRef.current) return;
+            const fetchedSkills: Array<{ name: string; description?: string }> = Array.isArray(data?.skills) ? data.skills : [];
+            const merged = new Map<string, { name: string; description?: string }>();
+            for (const s of fetchedSkills) merged.set(s.name, s);
+            for (const cmd of skillCommands) {
+              const skillName = cmd.name.replace(/^skill:/, "");
+              if (!merged.has(skillName)) merged.set(skillName, { name: skillName, description: cmd.description });
+            }
+            onAppendSystemMessage?.({ kind: "skills", skills: Array.from(merged.values()) });
+          })
+          .catch((err: Error) => {
+            if (dispatchSessionId !== sessionIdRef.current) return;
+            onAppendSystemMessage?.(`**Skills** — Failed to load: ${err.message}`);
+          });
       }
-      onAppendSystemMessage?.({
-        kind: "skills",
-        skills: Array.from(merged.values()),
-      });
       return true;
     }
 
@@ -793,22 +846,43 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
         const agentName = args.trim();
         if (onSpawnAgentSession && runnerId) {
           const dispatchSessionId = sessionId;
-          const agentsList = runnerInfo?.agents ?? [];
-          const match = agentsList.find(a => a.name.toLowerCase() === agentName.toLowerCase());
-          if (match) {
-            // Fetch individual agent content (system prompt) — not in RunnerInfo.agents
-            fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents/${encodeURIComponent(match.name)}`, { credentials: "include" })
-              .then(res => res.ok ? res.json() : Promise.reject())
+          const agentsList = runnerInfo?.agents ?? null;
+
+          if (agentsList !== null) {
+            // Fast path: use cached WS data for name lookup
+            const match = agentsList.find(a => a.name.toLowerCase() === agentName.toLowerCase());
+            if (match) {
+              fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents/${encodeURIComponent(match.name)}`, { credentials: "include" })
+                .then(res => res.ok ? res.json() : Promise.reject())
+                .then((data: any) => {
+                  if (dispatchSessionId !== sessionIdRef.current) return;
+                  onSpawnAgentSession?.({ name: match.name, description: match.description, systemPrompt: data?.content });
+                })
+                .catch(() => {
+                  if (dispatchSessionId !== sessionIdRef.current) return;
+                  onSpawnAgentSession?.({ name: match.name, description: match.description });
+                });
+            } else {
+              onAppendSystemMessage?.(`**Agents** — Agent "${agentName}" not found.`);
+            }
+          } else {
+            // Fallback: fetch full list, then resolve by name
+            fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents`, { credentials: "include" })
+              .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
               .then((data: any) => {
                 if (dispatchSessionId !== sessionIdRef.current) return;
-                onSpawnAgentSession?.({ name: match.name, description: match.description, systemPrompt: data?.content });
+                const agents: Array<{ name: string; description?: string; content?: string }> = Array.isArray(data?.agents) ? data.agents : [];
+                const match = agents.find(a => a.name.toLowerCase() === agentName.toLowerCase());
+                if (match) {
+                  onSpawnAgentSession?.({ name: match.name, description: match.description, systemPrompt: match.content });
+                } else {
+                  onAppendSystemMessage?.(`**Agents** — Agent "${agentName}" not found.`);
+                }
               })
-              .catch(() => {
+              .catch((err: Error) => {
                 if (dispatchSessionId !== sessionIdRef.current) return;
-                onSpawnAgentSession?.({ name: match.name, description: match.description });
+                onAppendSystemMessage?.(`**Agents** — Failed to load: ${err.message}`);
               });
-          } else {
-            onAppendSystemMessage?.(`**Agents** — Agent "${agentName}" not found.`);
           }
         }
       }
@@ -1177,8 +1251,32 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
   // Populate agents from cached runner data when the @-mention popover opens
   React.useEffect(() => {
     if (!atMentionOpen || !runnerId) return;
-    const agents = (runnerInfo?.agents ?? []).map(a => ({ name: a.name, description: a.description }));
-    setAtMentionAgents(agents);
+    if (runnerInfo) {
+      // Fast path: use cached WS data
+      const agents = runnerInfo.agents.map(a => ({ name: a.name, description: a.description }));
+      setAtMentionAgents(agents);
+      return;
+    }
+    // Fallback: fetch from REST API
+    if (atMentionAgentsFetchedForRef.current === runnerId) return;
+    atMentionAgentsFetchedForRef.current = runnerId;
+    let stale = false;
+    fetch(`/api/runners/${encodeURIComponent(runnerId)}/agents`, { credentials: "include" })
+      .then((res) => res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`)))
+      .then((data: any) => {
+        if (stale) return;
+        const agents: Array<{ name: string; description?: string }> = Array.isArray(data?.agents)
+          ? data.agents.map((a: any) => ({ name: a.name, description: a.description }))
+          : [];
+        setAtMentionAgents(agents);
+      })
+      .catch(() => {
+        if (!stale) {
+          atMentionAgentsFetchedForRef.current = null;
+          setAtMentionAgents([]);
+        }
+      });
+    return () => { stale = true; };
   }, [atMentionOpen, runnerId, runnerInfo]);
 
   const trimmedInput = input.trimStart();

--- a/packages/ui/src/components/TerminalManager.tsx
+++ b/packages/ui/src/components/TerminalManager.tsx
@@ -60,6 +60,17 @@ export interface TerminalManagerProps {
   /** Default working directory for new terminals (pre-filled from the session's cwd). */
   defaultCwd?: string;
 
+  // ── Runners (fed from App's WebSocket feed) ───────────────────────────────
+  /** Connected runners — passed from App so we don't fetch on dialog open. */
+  runners?: Array<{
+    runnerId: string;
+    name: string | null;
+    roots: string[];
+    sessionCount: number;
+  }>;
+  /** True while the runners feed is still connecting. */
+  runnersLoading?: boolean;
+
   // ── Controlled state (lifted to App so tabs survive panel remounts) ───────
   tabs: TerminalTab[];
   activeTabId: string | null;
@@ -80,16 +91,20 @@ export function TerminalManager({
   sessionId,
   runnerId,
   defaultCwd,
+  runners: runnersProp,
+  runnersLoading: runnersLoadingProp,
   tabs,
   activeTabId,
   onActiveTabChange,
   onTabAdd,
   onTabClose,
 }: TerminalManagerProps) {
+  // ── Derive effective runners from props (with safe defaults) ───────────
+  const effectiveRunners = runnersProp ?? [];
+  const effectiveRunnersLoading = runnersLoadingProp ?? false;
+
   // ── Dialog / spawn UI state (fully local) ──────────────────────────────
   const [dialogOpen, setDialogOpen] = React.useState(false);
-  const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
-  const [runnersLoading, setRunnersLoading] = React.useState(false);
   const [selectedRunnerId, setSelectedRunnerId] = React.useState<string>("");
   const [cwd, setCwd] = React.useState("");
   const [spawning, setSpawning] = React.useState(false);
@@ -101,33 +116,12 @@ export function TerminalManager({
     [tabs, sessionId],
   );
 
-  // ── Fetch runners when dialog opens ──────────────────────────────────────
+  // ── Auto-select first runner when dialog opens and none selected ────────
   React.useEffect(() => {
-    if (!dialogOpen) return;
-    let cancelled = false;
-    setRunnersLoading(true);
-    void fetch("/api/runners", { credentials: "include" })
-      .then((res) => res.ok ? res.json() : Promise.reject())
-      .then((data) => {
-        if (cancelled) return;
-        const list = Array.isArray((data as any)?.runners) ? (data as any).runners : [];
-        const normalized = list
-          .map((r: any) => ({
-            runnerId: typeof r?.runnerId === "string" ? r.runnerId : "",
-            name: typeof r?.name === "string" ? r.name : null,
-            roots: Array.isArray(r?.roots) ? r.roots.filter((x: unknown): x is string => typeof x === "string") : [],
-            sessionCount: typeof r?.sessionCount === "number" ? r.sessionCount : 0,
-          }))
-          .filter((r: RunnerInfo) => r.runnerId);
-        setRunners(normalized);
-        if (normalized.length > 0 && !selectedRunnerId) {
-          setSelectedRunnerId(normalized[0].runnerId);
-        }
-      })
-      .catch(() => { if (!cancelled) setRunners([]); })
-      .finally(() => { if (!cancelled) setRunnersLoading(false); });
-    return () => { cancelled = true; };
-  }, [dialogOpen]);
+    if (dialogOpen && effectiveRunners.length > 0 && !selectedRunnerId) {
+      setSelectedRunnerId(effectiveRunners[0].runnerId);
+    }
+  }, [dialogOpen, effectiveRunners, selectedRunnerId]);
 
   // ── Fetch recent folders when runner changes ──────────────────────────────
   React.useEffect(() => {
@@ -228,7 +222,7 @@ export function TerminalManager({
         return;
       }
 
-      const runner = runners.find((r) => r.runnerId === selectedRunnerId);
+      const runner = effectiveRunners.find((r) => r.runnerId === selectedRunnerId);
       const label = cwd.trim()
         ? (cwd.trim().split("/").pop() || "terminal")
         : (runner?.name || "terminal");
@@ -245,7 +239,7 @@ export function TerminalManager({
     } finally {
       setSpawning(false);
     }
-  }, [selectedRunnerId, cwd, runners, sessionId, onTabAdd]);
+  }, [selectedRunnerId, cwd, effectiveRunners, sessionId, onTabAdd]);
 
   /**
    * Handle the "+" button — direct spawn when session context is available,
@@ -461,8 +455,8 @@ export function TerminalManager({
       <NewTerminalDialog
         open={dialogOpen}
         onOpenChange={setDialogOpen}
-        runners={runners}
-        runnersLoading={runnersLoading}
+        runners={effectiveRunners}
+        runnersLoading={effectiveRunnersLoading}
         selectedRunnerId={selectedRunnerId}
         onRunnerChange={setSelectedRunnerId}
         cwd={cwd}

--- a/packages/ui/src/lib/filterFolders.ts
+++ b/packages/ui/src/lib/filterFolders.ts
@@ -1,0 +1,15 @@
+/**
+ * Pure utility: filter a list of folder paths by a case-insensitive query.
+ * Matches if the query appears in the full path OR in the basename.
+ *
+ * Extracted from NewSessionWizardDialog so it can be unit-tested without
+ * pulling in React/JSX dependencies.
+ */
+export function filterFolders(folders: string[], query: string): string[] {
+    if (!query.trim()) return folders;
+    const q = query.toLowerCase();
+    return folders.filter((f) => {
+        const basename = f.split("/").filter(Boolean).pop() ?? f;
+        return f.toLowerCase().includes(q) || basename.toLowerCase().includes(q);
+    });
+}

--- a/packages/ui/src/lib/runnerHelpers.ts
+++ b/packages/ui/src/lib/runnerHelpers.ts
@@ -1,0 +1,16 @@
+import type { RunnerInfo } from "@pizzapi/protocol";
+
+/**
+ * Pure helper: insert or replace a runner in the list by runnerId.
+ * Used by runner_added events (always upserts, even if not previously seen).
+ *
+ * Extracted from useRunnersFeed so it can be unit-tested without
+ * pulling in React/socket.io dependencies.
+ */
+export function upsert(list: RunnerInfo[], incoming: RunnerInfo): RunnerInfo[] {
+    const idx = list.findIndex(r => r.runnerId === incoming.runnerId);
+    if (idx === -1) return [...list, incoming];
+    const next = [...list];
+    next[idx] = incoming;
+    return next;
+}

--- a/packages/ui/src/lib/useRunnersFeed.test.ts
+++ b/packages/ui/src/lib/useRunnersFeed.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import type { RunnerInfo } from "@pizzapi/protocol";
 import { upsert } from "./runnerHelpers.js";
+import type { UseRunnersFeedOptions } from "./useRunnersFeed.js";
 
 function makeRunner(overrides: Partial<RunnerInfo> = {}): RunnerInfo {
     return {
@@ -58,5 +59,35 @@ describe("useRunnersFeed state helpers", () => {
             const result = runners.filter(r => r.runnerId !== "ghost");
             expect(result).toHaveLength(1);
         });
+    });
+});
+
+describe("UseRunnersFeedOptions type contract", () => {
+    // Pure type-level tests: verify the options shape is accepted correctly.
+    // These compile-time assertions catch regressions in the option interface.
+
+    it("accepts empty options (all defaults)", () => {
+        const opts: UseRunnersFeedOptions = {};
+        expect(opts).toBeDefined();
+    });
+
+    it("accepts enabled=false to disable feed", () => {
+        const opts: UseRunnersFeedOptions = { enabled: false };
+        expect(opts.enabled).toBe(false);
+    });
+
+    it("accepts enabled=true with a userId", () => {
+        const opts: UseRunnersFeedOptions = { enabled: true, userId: "user-abc" };
+        expect(opts.userId).toBe("user-abc");
+    });
+
+    it("accepts userId=null (logged out)", () => {
+        const opts: UseRunnersFeedOptions = { enabled: false, userId: null };
+        expect(opts.userId).toBeNull();
+    });
+
+    it("accepts userId=undefined (pending auth)", () => {
+        const opts: UseRunnersFeedOptions = { enabled: false, userId: undefined };
+        expect(opts.userId).toBeUndefined();
     });
 });

--- a/packages/ui/src/lib/useRunnersFeed.test.ts
+++ b/packages/ui/src/lib/useRunnersFeed.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "bun:test";
+import type { RunnerInfo } from "@pizzapi/protocol";
+
+function makeRunner(overrides: Partial<RunnerInfo> = {}): RunnerInfo {
+    return {
+        runnerId: "r1",
+        name: "runner",
+        roots: [],
+        sessionCount: 0,
+        skills: [],
+        agents: [],
+        plugins: [],
+        hooks: [],
+        version: null,
+        platform: null,
+        ...overrides,
+    };
+}
+
+function upsert(list: RunnerInfo[], incoming: RunnerInfo): RunnerInfo[] {
+    const idx = list.findIndex(r => r.runnerId === incoming.runnerId);
+    if (idx === -1) return [...list, incoming];
+    const next = [...list];
+    next[idx] = incoming;
+    return next;
+}
+
+describe("useRunnersFeed state helpers", () => {
+    describe("upsert (runner_added / runner_updated)", () => {
+        it("appends a new runner", () => {
+            const r = makeRunner({ runnerId: "r1" });
+            const result = upsert([], r);
+            expect(result).toHaveLength(1);
+            expect(result[0].runnerId).toBe("r1");
+        });
+
+        it("replaces existing runner by runnerId", () => {
+            const old = makeRunner({ runnerId: "r1", name: "old" });
+            const updated = makeRunner({ runnerId: "r1", name: "new" });
+            const result = upsert([old], updated);
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe("new");
+        });
+
+        it("does not affect other runners", () => {
+            const r1 = makeRunner({ runnerId: "r1" });
+            const r2 = makeRunner({ runnerId: "r2", name: "other" });
+            const updated = makeRunner({ runnerId: "r1", name: "updated" });
+            const result = upsert([r1, r2], updated);
+            expect(result).toHaveLength(2);
+            expect(result.find(r => r.runnerId === "r2")?.name).toBe("other");
+        });
+    });
+
+    describe("remove (runner_removed)", () => {
+        it("removes runner by runnerId", () => {
+            const runners = [makeRunner({ runnerId: "r1" }), makeRunner({ runnerId: "r2" })];
+            const result = runners.filter(r => r.runnerId !== "r1");
+            expect(result).toHaveLength(1);
+            expect(result[0].runnerId).toBe("r2");
+        });
+
+        it("is a no-op when runnerId not found", () => {
+            const runners = [makeRunner({ runnerId: "r1" })];
+            const result = runners.filter(r => r.runnerId !== "ghost");
+            expect(result).toHaveLength(1);
+        });
+    });
+});

--- a/packages/ui/src/lib/useRunnersFeed.test.ts
+++ b/packages/ui/src/lib/useRunnersFeed.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import type { RunnerInfo } from "@pizzapi/protocol";
+import { upsert } from "./runnerHelpers.js";
 
 function makeRunner(overrides: Partial<RunnerInfo> = {}): RunnerInfo {
     return {
@@ -15,14 +16,6 @@ function makeRunner(overrides: Partial<RunnerInfo> = {}): RunnerInfo {
         platform: null,
         ...overrides,
     };
-}
-
-function upsert(list: RunnerInfo[], incoming: RunnerInfo): RunnerInfo[] {
-    const idx = list.findIndex(r => r.runnerId === incoming.runnerId);
-    if (idx === -1) return [...list, incoming];
-    const next = [...list];
-    next[idx] = incoming;
-    return next;
 }
 
 describe("useRunnersFeed state helpers", () => {

--- a/packages/ui/src/lib/useRunnersFeed.ts
+++ b/packages/ui/src/lib/useRunnersFeed.ts
@@ -6,6 +6,7 @@ import type {
     RunnerInfo,
 } from "@pizzapi/protocol";
 import { getSocketIOBase } from "./relay.js";
+import { upsert } from "./runnerHelpers.js";
 
 export type RunnersFeedStatus = "connecting" | "connected" | "disconnected";
 
@@ -40,13 +41,7 @@ export function useRunnersFeed(): RunnersFeedState {
         });
 
         socket.on("runner_added", (incoming) => {
-            setRunners(prev => {
-                const idx = prev.findIndex(r => r.runnerId === incoming.runnerId);
-                if (idx === -1) return [...prev, incoming];
-                const next = [...prev];
-                next[idx] = incoming;
-                return next;
-            });
+            setRunners(prev => upsert(prev, incoming));
         });
 
         socket.on("runner_removed", ({ runnerId }) => {

--- a/packages/ui/src/lib/useRunnersFeed.ts
+++ b/packages/ui/src/lib/useRunnersFeed.ts
@@ -1,0 +1,72 @@
+import * as React from "react";
+import { io, type Socket } from "socket.io-client";
+import type {
+    RunnersServerToClientEvents,
+    RunnersClientToServerEvents,
+    RunnerInfo,
+} from "@pizzapi/protocol";
+import { getSocketIOBase } from "./relay.js";
+
+export type RunnersFeedStatus = "connecting" | "connected" | "disconnected";
+
+export interface RunnersFeedState {
+    runners: RunnerInfo[];
+    status: RunnersFeedStatus;
+}
+
+/**
+ * Subscribe to the /runners Socket.IO namespace.
+ * Returns the live runner list and connection status.
+ * Call this hook ONCE in App.tsx and pass runners down as props —
+ * do not call it in child components to avoid duplicate socket connections.
+ */
+export function useRunnersFeed(): RunnersFeedState {
+    const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
+    const [status, setStatus] = React.useState<RunnersFeedStatus>("connecting");
+
+    React.useEffect(() => {
+        const base = getSocketIOBase();
+        const socket: Socket<RunnersServerToClientEvents, RunnersClientToServerEvents> = io(
+            base ? `${base}/runners` : "/runners",
+            { withCredentials: true },
+        );
+
+        socket.on("connect", () => setStatus("connected"));
+        socket.on("disconnect", () => setStatus("disconnected"));
+        socket.on("connect_error", () => setStatus("disconnected"));
+
+        socket.on("runners", ({ runners: list }) => {
+            setRunners(list);
+        });
+
+        socket.on("runner_added", (incoming) => {
+            setRunners(prev => {
+                const idx = prev.findIndex(r => r.runnerId === incoming.runnerId);
+                if (idx === -1) return [...prev, incoming];
+                const next = [...prev];
+                next[idx] = incoming;
+                return next;
+            });
+        });
+
+        socket.on("runner_removed", ({ runnerId }) => {
+            setRunners(prev => prev.filter(r => r.runnerId !== runnerId));
+        });
+
+        socket.on("runner_updated", (incoming) => {
+            setRunners(prev => {
+                const idx = prev.findIndex(r => r.runnerId === incoming.runnerId);
+                if (idx === -1) return prev; // unknown runner — ignore
+                const next = [...prev];
+                next[idx] = incoming;
+                return next;
+            });
+        });
+
+        return () => {
+            socket.disconnect();
+        };
+    }, []);
+
+    return { runners, status };
+}

--- a/packages/ui/src/lib/useRunnersFeed.ts
+++ b/packages/ui/src/lib/useRunnersFeed.ts
@@ -15,17 +15,43 @@ export interface RunnersFeedState {
     status: RunnersFeedStatus;
 }
 
+export interface UseRunnersFeedOptions {
+    /**
+     * When false, the socket is not created (or is disconnected if it was).
+     * State is cleared to empty / "disconnected".
+     * Default: true.
+     */
+    enabled?: boolean;
+    /**
+     * The authenticated user's ID. When this changes (e.g. a different user
+     * logs in on the same tab), the old socket is torn down and a new one is
+     * created so the server places the new socket in the correct user room.
+     */
+    userId?: string | null;
+}
+
 /**
  * Subscribe to the /runners Socket.IO namespace.
  * Returns the live runner list and connection status.
  * Call this hook ONCE in App.tsx and pass runners down as props —
  * do not call it in child components to avoid duplicate socket connections.
+ *
+ * Pass `enabled` and `userId` so the hook reconnects when auth changes:
+ *   - disabled (logged out): socket is disconnected, state cleared
+ *   - userId changes (different user logs in): old socket torn down, new one created
  */
-export function useRunnersFeed(): RunnersFeedState {
+export function useRunnersFeed(options: UseRunnersFeedOptions = {}): RunnersFeedState {
+    const { enabled = true, userId } = options;
     const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
     const [status, setStatus] = React.useState<RunnersFeedStatus>("connecting");
 
     React.useEffect(() => {
+        if (!enabled) {
+            setRunners([]);
+            setStatus("disconnected");
+            return;
+        }
+
         const base = getSocketIOBase();
         const socket: Socket<RunnersServerToClientEvents, RunnersClientToServerEvents> = io(
             base ? `${base}/runners` : "/runners",
@@ -58,7 +84,9 @@ export function useRunnersFeed(): RunnersFeedState {
         return () => {
             socket.disconnect();
         };
-    }, []);
+    // Re-run when auth changes: disabled → clear state; userId change → reconnect
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [enabled, userId]);
 
     return { runners, status };
 }

--- a/packages/ui/src/lib/useRunnersFeed.ts
+++ b/packages/ui/src/lib/useRunnersFeed.ts
@@ -52,6 +52,11 @@ export function useRunnersFeed(options: UseRunnersFeedOptions = {}): RunnersFeed
             return;
         }
 
+        // Mark as connecting immediately so consumers don't treat the feed as
+        // "fully loaded with zero runners" during the window between enabled
+        // flipping true and the socket firing its "connect" event.
+        setStatus("connecting");
+
         const base = getSocketIOBase();
         const socket: Socket<RunnersServerToClientEvents, RunnersClientToServerEvents> = io(
             base ? `${base}/runners` : "/runners",

--- a/packages/ui/src/lib/useRunnersFeed.ts
+++ b/packages/ui/src/lib/useRunnersFeed.ts
@@ -49,13 +49,10 @@ export function useRunnersFeed(): RunnersFeedState {
         });
 
         socket.on("runner_updated", (incoming) => {
-            setRunners(prev => {
-                const idx = prev.findIndex(r => r.runnerId === incoming.runnerId);
-                if (idx === -1) return prev; // unknown runner — ignore
-                const next = [...prev];
-                next[idx] = incoming;
-                return next;
-            });
+            // Upsert: apply the update even if the initial snapshot hasn't arrived yet.
+            // This prevents updates from being silently dropped during the join→snapshot
+            // window, where runner_updated can arrive before the runners snapshot.
+            setRunners(prev => upsert(prev, incoming));
         });
 
         return () => {

--- a/packages/ui/src/lib/useRunnersFeed.ts
+++ b/packages/ui/src/lib/useRunnersFeed.ts
@@ -44,13 +44,25 @@ export function useRunnersFeed(options: UseRunnersFeedOptions = {}): RunnersFeed
     const { enabled = true, userId } = options;
     const [runners, setRunners] = React.useState<RunnerInfo[]>([]);
     const [status, setStatus] = React.useState<RunnersFeedStatus>("connecting");
+    // Track the previous userId so we can clear stale runners before reconnecting
+    // under a different account. Without this, old-account runner metadata stays
+    // visible until the new socket delivers its first snapshot.
+    const prevUserIdRef = React.useRef<string | null | undefined>(userId);
 
     React.useEffect(() => {
         if (!enabled) {
             setRunners([]);
             setStatus("disconnected");
+            prevUserIdRef.current = userId;
             return;
         }
+
+        // Clear stale runners immediately when the user identity changes so
+        // the previous user's runner list never leaks into the new session.
+        if (userId !== prevUserIdRef.current) {
+            setRunners([]);
+        }
+        prevUserIdRef.current = userId;
 
         // Mark as connecting immediately so consumers don't treat the feed as
         // "fully loaded with zero runners" during the window between enabled


### PR DESCRIPTION
## Summary

Replaces all polling and ad-hoc \`GET /api/runners\` fetches in the UI with a live \`/runners\` Socket.IO namespace that pushes runner lifecycle events in real time.

**Before:** \`RunnerManager\` polled \`/api/runners\` + \`/api/sessions\` every **10 seconds**. Dialogs fetched runners on every open. Slash commands fetched skills/agents on every invocation. Spawn-wait loops hit \`/api/sessions\` every 1s.

**After:** Zero polling intervals. Zero \`GET /api/runners\` calls. All runner state is event-driven with sub-100ms latency.

## What changed

### Server
- New \`/runners\` Socket.IO namespace — browser-facing, read-only feed (mirrors \`/hub\` pattern)
- \`runnersUserRoom()\` helper in \`context.ts\` (avoids circular deps)
- \`broadcastToRunnersNs()\` fires on \`registerRunner\`, \`removeRunner\`, \`updateRunnerSkills/Agents/Plugins\`
- New \`runners.broadcast.test.ts\` — 6 TDD tests for all broadcast paths

### UI
- **\`useRunnersFeed\`** hook — single \`/runners\` socket in \`App.tsx\`, runners passed as props (no duplicate connections)
- **\`RunnerManager\`** — removed \`setInterval\` + all REST polling; spawn-wait replaced with \`useEffect\` on sessions prop
- **\`App.tsx\`** — \`waitForSessionToGoLive\` replaced with ref-based hub waiter (no more 1s polling loop)
- **\`TerminalManager\`** — runners from prop instead of per-dialog fetch
- **\`SessionViewer\`** — \`/skills\` and \`/agents\` use cached WS data (with HTTP fallback when feed not ready); \`/plugins\` always fetches REST for cwd-scoped results

## Verification

- ✅ 411 tests pass, 0 fail
- ✅ Zero typecheck errors
- ✅ \`grep\` confirms: no \`setInterval\` polling, no \`GET /api/runners\`, no \`GET /api/sessions\` loops