### PR TITLE
fix(ui): cap mobile height of question/plan panels so options are always scrollable

### DIFF
--- a/packages/ui/src/components/ai-elements/multiple-choice.tsx
+++ b/packages/ui/src/components/ai-elements/multiple-choice.tsx
@@ -520,15 +520,15 @@ export function MultipleChoiceQuestions({
   };
 
   return (
-    <div className={cn("overflow-hidden rounded-lg border border-violet-500/30 bg-gradient-to-b from-violet-500/[0.08] to-violet-500/[0.03] shadow-sm shadow-violet-500/5", className)}>
-      <div className="flex items-center gap-2 border-b border-violet-500/15 px-3 py-2">
+    <div className={cn("flex flex-col overflow-hidden rounded-lg border border-violet-500/30 bg-gradient-to-b from-violet-500/[0.08] to-violet-500/[0.03] shadow-sm shadow-violet-500/5 max-h-[65dvh]", className)}>
+      <div className="flex shrink-0 items-center gap-2 border-b border-violet-500/15 px-3 py-2">
         <div className="flex size-6 items-center justify-center rounded-full bg-violet-500/15">
           <MessageCircleQuestion className="size-3.5 text-violet-400" />
         </div>
         <span className="text-xs font-medium text-violet-300">Question {currentStep + 1} of {questions.length}</span>
       </div>
 
-      <div className="px-3 pt-2.5">
+      <div className="shrink-0 px-3 pt-2.5">
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-violet-500/15">
           <div
             className="h-full rounded-full bg-violet-500/60 transition-all"
@@ -537,9 +537,11 @@ export function MultipleChoiceQuestions({
         </div>
       </div>
 
-      {questions.length > 0 && renderQuestion(questions[currentStep]!, currentStep)}
+      <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
+        {questions.length > 0 && renderQuestion(questions[currentStep]!, currentStep)}
+      </div>
 
-      <div className="flex items-center gap-2 border-t border-violet-500/15 px-3 py-2.5">
+      <div className="flex shrink-0 items-center gap-2 border-t border-violet-500/15 px-3 py-2.5">
         <Button
           size="sm"
           variant="outline"

--- a/packages/ui/src/components/ai-elements/plan-mode.tsx
+++ b/packages/ui/src/components/ai-elements/plan-mode.tsx
@@ -118,7 +118,7 @@ export function PlanModePanel({
       </div>
 
       {/* Scrollable plan content */}
-      <div className="flex-1 overflow-y-auto min-h-0">
+      <div className="flex-1 overflow-y-auto min-h-0 overscroll-contain">
         <div className="px-3 py-3 space-y-2.5">
           {/* Title */}
           <h3 className="text-sm font-semibold text-foreground/90 leading-snug">


### PR DESCRIPTION
## Problem

On mobile, when an `AskUserQuestion` prompt has long question text, the answer choices are pushed off-screen with no way to scroll to them. The composer area has no height cap, so the component grows taller than the viewport and the options become unreachable.

## Changes

### `MultipleChoiceQuestions` (`multiple-choice.tsx`)
- Outer container changed to `flex-col overflow-hidden max-h-[65dvh]`
- Header (icon + step counter), progress bar, and footer buttons get `shrink-0` — always pinned and visible
- Question text + options wrapped in `min-h-0 flex-1 overflow-y-auto overscroll-contain`
- Covers all question types: **radio**, **checkbox**, and **ranked** (all flow through the same `renderQuestion` wrapper)

### `PlanModePanel` (`plan-mode.tsx`)
- Already had `flex-col`, `max-h-[50vh] sm:max-h-[60vh]`, and `overflow-y-auto min-h-0`
- Added `overscroll-contain` to the scrollable body div for consistency / scroll bleed-through prevention

## Not affected
- Command palette — already has `max-h-56` on `CommandList`
- `AtMentionPopover` — already has `max-h-[50vh] overflow-y-auto`
- `TriggerCard` legacy option buttons — live in the scrollable message stream, not the fixed bottom bar