### PR TITLE
fix(ui): make runner tab bar horizontally scrollable on mobile

### DIFF
--- a/packages/ui/src/components/RunnerDetailPanel.tsx
+++ b/packages/ui/src/components/RunnerDetailPanel.tsx
@@ -267,32 +267,34 @@ function TabBar({
     runner: RunnerInfo;
 }) {
     return (
-        <div className="flex gap-1 border-b border-border/40">
-            {TABS.map((tab) => {
-                const isActive = activeTab === tab.key;
-                const countSource = tab.countKey ? runner[tab.countKey] : null;
-                const count = countSource != null ? (Array.isArray(countSource) ? countSource.length : 0) : null;
-                return (
-                    <button
-                        key={tab.key}
-                        type="button"
-                        onClick={() => onTabChange(tab.key)}
-                        className={cn(
-                            "px-3 py-2 text-xs font-medium transition-all flex items-center gap-1.5",
-                            isActive
-                                ? "border-b-2 border-blue-500 text-blue-300"
-                                : "opacity-40 hover:opacity-70",
-                        )}
-                    >
-                        {tab.label}
-                        {count !== null && (
-                            <span className="text-[9px] font-mono bg-muted/60 px-1.5 py-0.5 rounded-full">
-                                {count}
-                            </span>
-                        )}
-                    </button>
-                );
-            })}
+        <div className="overflow-x-auto -mx-4 sm:-mx-6 px-4 sm:px-6">
+            <div className="flex gap-1 border-b border-border/40 min-w-max">
+                {TABS.map((tab) => {
+                    const isActive = activeTab === tab.key;
+                    const countSource = tab.countKey ? runner[tab.countKey] : null;
+                    const count = countSource != null ? (Array.isArray(countSource) ? countSource.length : 0) : null;
+                    return (
+                        <button
+                            key={tab.key}
+                            type="button"
+                            onClick={() => onTabChange(tab.key)}
+                            className={cn(
+                                "px-3 py-2 text-xs font-medium transition-all flex items-center gap-1.5 whitespace-nowrap shrink-0",
+                                isActive
+                                    ? "border-b-2 border-blue-500 text-blue-300"
+                                    : "opacity-40 hover:opacity-70",
+                            )}
+                        >
+                            {tab.label}
+                            {count !== null && (
+                                <span className="text-[9px] font-mono bg-muted/60 px-1.5 py-0.5 rounded-full">
+                                    {count}
+                                </span>
+                            )}
+                        </button>
+                    );
+                })}
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Problem

On narrow mobile screens the runner detail panel has 6 tabs (Sessions, Skills, Agents, Plugins, Hooks, Sandbox) that are too wide to fit. This caused the **entire panel** to scroll horizontally instead of just the tab strip itself.

## Fix

- Wrap the `TabBar` buttons in an `overflow-x-auto` outer div with a `min-w-max` inner row so only the tab strip scrolls horizontally.
- Negative margin / positive padding (`-mx-4 sm:-mx-6 / px-4 sm:px-6`) makes the scrollable area bleed to the panel edges for a clean look.
- Added `whitespace-nowrap shrink-0` to each tab button so they never wrap or shrink.

The panel content and the rest of the page remain unaffected.