### PR TITLE
fix(cli): remove delink_children retry guard console.log

### DIFF
--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -180,7 +180,6 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             pendingDelink = false;
             pendingDelinkEpoch = null;
             staleChildIds.clear();
-            console.log("pizzapi: delink_children confirmed by server — retry guard cleared");
         });
     }
 


### PR DESCRIPTION
Removes the noisy `pizzapi: delink_children confirmed by server — retry guard cleared` log message from the CLI output.