### PR TITLE
🎨 Palette: Use Tooltip for Image Viewer actions in File Explorer

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-03-23 - Replaced Native Titles with Tooltips in ImageViewer
+**Learning:** The native `title` HTML attribute creates an inconsistent and often delayed visual feedback experience compared to the rest of the application.
+**Action:** Always favor using the standard Radix/Shadcn UI `Tooltip` components instead of `title` attributes for icon-only buttons to ensure immediate, styled, and predictable tooltips. Ensure `aria-label` remains on the button for screen readers.

--- a/packages/ui/src/components/FileExplorer.tsx
+++ b/packages/ui/src/components/FileExplorer.tsx
@@ -390,51 +390,67 @@ function ImageViewer({
       {/* Toolbar */}
       {dataUrl && (
         <div className="flex items-center gap-1 px-3 py-1.5 border-b border-border/50 bg-muted/30">
-          <button
-            type="button"
-            onClick={zoomOut}
-            className="p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-            title="Zoom out"
-            aria-label="Zoom out"
-          >
-            <ZoomOut className="size-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={zoomOut}
+                className="p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+                aria-label="Zoom out"
+              >
+                <ZoomOut className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Zoom out</TooltipContent>
+          </Tooltip>
           <span className="text-[0.65rem] text-muted-foreground tabular-nums w-12 text-center">
             {Math.round(zoom * 100)}%
           </span>
-          <button
-            type="button"
-            onClick={zoomIn}
-            className="p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-            title="Zoom in"
-            aria-label="Zoom in"
-          >
-            <ZoomIn className="size-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={zoomIn}
+                className="p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+                aria-label="Zoom in"
+              >
+                <ZoomIn className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Zoom in</TooltipContent>
+          </Tooltip>
           <div className="w-px h-4 bg-border mx-1" />
-          <button
-            type="button"
-            onClick={toggleFit}
-            className={cn(
-              "p-1 rounded transition-colors",
-              fitMode === "actual"
-                ? "text-foreground bg-accent"
-                : "text-muted-foreground hover:text-foreground hover:bg-accent",
-            )}
-            title={fitMode === "contain" ? "Show actual size" : "Fit to view"}
-            aria-label={fitMode === "contain" ? "Show actual size" : "Fit to view"}
-          >
-            <Maximize2 className="size-3.5" />
-          </button>
-          <button
-            type="button"
-            onClick={resetZoom}
-            className="p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
-            title="Reset zoom"
-            aria-label="Reset zoom"
-          >
-            <RotateCw className="size-3.5" />
-          </button>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={toggleFit}
+                className={cn(
+                  "p-1 rounded transition-colors",
+                  fitMode === "actual"
+                    ? "text-foreground bg-accent"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                )}
+                aria-label={fitMode === "contain" ? "Show actual size" : "Fit to view"}
+              >
+                <Maximize2 className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>{fitMode === "contain" ? "Show actual size" : "Fit to view"}</TooltipContent>
+          </Tooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={resetZoom}
+                className="p-1 text-muted-foreground hover:text-foreground hover:bg-accent rounded transition-colors"
+                aria-label="Reset zoom"
+              >
+                <RotateCw className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Reset zoom</TooltipContent>
+          </Tooltip>
         </div>
       )}
 


### PR DESCRIPTION
💡 **What:** The UX enhancement added: Replaced native HTML `title` attributes with the Shadcn `Tooltip` component for icon-only zoom and fit controls in the `FileExplorer` component's image viewer toolbar.
🎯 **Why:** The user problem it solves: Native `title` attributes can be inconsistent across browsers/OSs and have an unchangeable visual delay, so utilizing a dedicated `Tooltip` component is a great way to add visual polish while maintaining accessibility.
📸 **Before/After:** No visual screenshot for hover interactions, but Tooltips now appear faster and match the app's visual style.
♿ **Accessibility:** Any a11y improvements made: Ensured `aria-label` remains on the button for screen readers.

---
*PR created automatically by Jules for task [15749305619893372417](https://jules.google.com/task/15749305619893372417) started by @Pizzaface*