### PR TITLE
feat: runner usage dashboard

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -129,6 +129,7 @@
         "react-dom": "^19.2.4",
         "react-icons": "^5.5.0",
         "react-resizable": "^3.0.5",
+        "recharts": "^3.8.0",
         "shiki": "^3.22.0",
         "socket.io-client": "^4.8.1",
         "streamdown": "^2.3.0",
@@ -923,6 +924,8 @@
 
     "@redis/time-series": ["@redis/time-series@1.1.0", "", { "peerDependencies": { "@redis/client": "^1.0.0" } }, "sha512-c1Q99M5ljsIuc4YdaCwfUEXsofakb9c8+Zse2qxTadu8TalLXuAESzLvFAvNVbkmSlvlzIQOLpBCmWI9wTOt+g=="],
 
+    "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
     "@rollup/plugin-babel": ["@rollup/plugin-babel@5.3.1", "", { "dependencies": { "@babel/helper-module-imports": "^7.10.4", "@rollup/pluginutils": "^3.1.0" }, "peerDependencies": { "@babel/core": "^7.0.0", "@types/babel__core": "^7.1.9", "rollup": "^1.20.0||^2.0.0" }, "optionalPeers": ["@types/babel__core"] }, "sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q=="],
@@ -1114,6 +1117,8 @@
     "@socket.io/redis-adapter": ["@socket.io/redis-adapter@8.3.0", "", { "dependencies": { "debug": "~4.3.1", "notepack.io": "~3.0.1", "uid2": "1.0.0" }, "peerDependencies": { "socket.io-adapter": "^2.5.4" } }, "sha512-ly0cra+48hDmChxmIpnESKrc94LjRL80TEmZVscuQ/WWkRP81nNj8W8cCGMqbI4L6NCuAaPRSzZF1a9GlAxxnA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@streamdown/cjk": ["@streamdown/cjk@1.0.2", "", { "dependencies": { "remark-cjk-friendly": "^1.2.3", "remark-cjk-friendly-gfm-strikethrough": "^1.2.3", "unist-util-visit": "^5.0.0" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-5OOuZjj2Lnae92Zmg2gA5hloSbcKj25gv+QY4iKbYI+iRsiGWbgmYxmgxNUSO9SR6BKOCy783UHN1HM/QEUpdw=="],
 
@@ -1316,6 +1321,8 @@
     "@types/trusted-types": ["@types/trusted-types@2.0.7", "", {}, "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@types/use-sync-external-store": ["@types/use-sync-external-store@0.0.6", "", {}, "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="],
 
     "@types/validate-npm-package-name": ["@types/validate-npm-package-name@4.0.2", "", {}, "sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw=="],
 
@@ -1691,6 +1698,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
+
     "decode-bmp": ["decode-bmp@0.2.1", "", { "dependencies": { "@canvas/image-data": "^1.0.0", "to-data-view": "^1.1.0" } }, "sha512-NiOaGe+GN0KJqi2STf24hfMkFitDUaIoUU3eKvP/wAbLe8o6FuW5n/x7MHPR0HKvBokp6MQY/j7w8lewEeVCIA=="],
 
     "decode-ico": ["decode-ico@0.4.1", "", { "dependencies": { "@canvas/image-data": "^1.0.0", "decode-bmp": "^0.2.0", "to-data-view": "^1.1.0" } }, "sha512-69NZfbKIzux1vBOd31al3XnMnH+2mqDhEgLdpygErm4d60N+UwA5Sq5WFjmEDQzumgB9fElojGwWG0vybVfFmA=="],
@@ -1806,6 +1815,8 @@
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "^1.2.7", "is-date-object": "^1.0.5", "is-symbol": "^1.0.4" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "es-toolkit": ["es-toolkit@1.45.1", "", {}, "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw=="],
 
     "esast-util-from-estree": ["esast-util-from-estree@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "unist-util-position-from-estree": "^2.0.0" } }, "sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ=="],
 
@@ -2088,6 +2099,8 @@
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+
+    "immer": ["immer@10.2.0", "", {}, "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -2749,6 +2762,8 @@
 
     "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "react-redux": ["react-redux@9.2.0", "", { "dependencies": { "@types/use-sync-external-store": "^0.0.6", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "@types/react": "^18.2.25 || ^19", "react": "^18.0 || ^19", "redux": "^5.0.0" }, "optionalPeers": ["@types/react", "redux"] }, "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g=="],
+
     "react-remove-scroll": ["react-remove-scroll@2.7.2", "", { "dependencies": { "react-remove-scroll-bar": "^2.3.7", "react-style-singleton": "^2.2.3", "tslib": "^2.1.0", "use-callback-ref": "^1.3.3", "use-sidecar": "^1.1.3" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q=="],
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
@@ -2763,6 +2778,8 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
+    "recharts": ["recharts@3.8.0", "", { "dependencies": { "@reduxjs/toolkit": "^1.9.0 || 2.x.x", "clsx": "^2.1.1", "decimal.js-light": "^2.5.1", "es-toolkit": "^1.39.3", "eventemitter3": "^5.0.1", "immer": "^10.1.1", "react-redux": "8.x.x || 9.x.x", "reselect": "5.1.1", "tiny-invariant": "^1.3.3", "use-sync-external-store": "^1.2.2", "victory-vendor": "^37.0.2" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Z/m38DX3L73ExO4Tpc9/iZWHmHnlzWG4njQbxsF5aSjwqmHNDDIm0rdEBArkwsBvR8U6EirlEHiQNYWCVh9sGQ=="],
+
     "recma-build-jsx": ["recma-build-jsx@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-build-jsx": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew=="],
 
     "recma-jsx": ["recma-jsx@1.0.1", "", { "dependencies": { "acorn-jsx": "^5.0.0", "estree-util-to-js": "^2.0.0", "recma-parse": "^1.0.0", "recma-stringify": "^1.0.0", "unified": "^11.0.0" }, "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-huSIy7VU2Z5OLv6oFLosQGGDqPqdO1iq6bWNAdhzMxSJP7RAso4fCZ1cKu8j9YHCZf3TPrq4dw3okhrylgcd7w=="],
@@ -2772,6 +2789,10 @@
     "recma-stringify": ["recma-stringify@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "estree-util-to-js": "^2.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-cjwII1MdIIVloKvC9ErQ+OgAtwHBmcZ0Bg4ciz78FtbT8In39aAYbaA7zvxQ61xVMSPE8WxhLwLbhif4Js2C+g=="],
 
     "redis": ["redis@4.7.1", "", { "dependencies": { "@redis/bloom": "1.2.0", "@redis/client": "1.6.1", "@redis/graph": "1.1.1", "@redis/json": "1.0.7", "@redis/search": "1.2.0", "@redis/time-series": "1.1.0" } }, "sha512-S1bJDnqLftzHXHP8JsT5II/CtHWQrASX5K96REjWjlmWKrviSOLWmM7QnRLstAWsu1VBBV1ffV6DzCvxNP0UJQ=="],
+
+    "redux": ["redux@5.0.1", "", {}, "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w=="],
+
+    "redux-thunk": ["redux-thunk@3.1.0", "", { "peerDependencies": { "redux": "^5.0.0" } }, "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -2840,6 +2861,8 @@
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
@@ -3211,6 +3234,8 @@
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "victory-vendor": ["victory-vendor@37.3.6", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ=="],
+
     "vite": ["vite@6.4.1", "", { "dependencies": { "esbuild": "^0.25.0", "fdir": "^6.4.4", "picomatch": "^4.0.2", "postcss": "^8.5.3", "rollup": "^4.34.9", "tinyglobby": "^0.2.13" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0", "jiti": ">=1.21.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g=="],
 
     "vite-plugin-pwa": ["vite-plugin-pwa@1.2.0", "", { "dependencies": { "debug": "^4.3.6", "pretty-bytes": "^6.1.1", "tinyglobby": "^0.2.10", "workbox-build": "^7.4.0", "workbox-window": "^7.4.0" }, "peerDependencies": { "@vite-pwa/assets-generator": "^1.0.0", "vite": "^3.1.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@vite-pwa/assets-generator"] }, "sha512-a2xld+SJshT9Lgcv8Ji4+srFJL4k/1bVbd1x06JIkvecpQkwkvCncD1+gSzcdm3s+owWLpMJerG3aN5jupJEVw=="],
@@ -3414,6 +3439,8 @@
     "@radix-ui/react-toolbar/@radix-ui/react-separator": ["@radix-ui/react-separator@1.1.7", "", { "dependencies": { "@radix-ui/react-primitive": "2.1.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA=="],
 
     "@radix-ui/react-tooltip/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
+
+    "@reduxjs/toolkit/immer": ["immer@11.1.4", "", {}, "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw=="],
 
     "@rollup/plugin-babel/@rollup/pluginutils": ["@rollup/pluginutils@3.1.0", "", { "dependencies": { "@types/estree": "0.0.39", "estree-walker": "^1.0.1", "picomatch": "^2.2.2" }, "peerDependencies": { "rollup": "^1.20.0||^2.0.0" } }, "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,6 +2,9 @@
   "name": "@pizzapi/cli",
   "version": "0.3.1-dev.3",
   "type": "module",
+  "piConfig": {
+    "configDir": ".pizzapi"
+  },
   "bin": {
     "pizza": "src/index.ts",
     "pizzapi": "src/index.ts"

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -66,7 +66,24 @@ function migrateSessionStorage(): void {
     // Skip if old dir doesn't exist or new sessions dir already exists
     if (!existsSync(oldDir) || existsSync(newSessions)) return;
 
-    mkdirSync(newDir, { recursive: true });
+    // Ensure the parent directory exists but do NOT pre-create newDir itself —
+    // renameSync requires the target to not exist, or on some platforms it will
+    // fail with EEXIST/ENOTEMPTY when renaming onto an existing directory.
+    mkdirSync(join(newDir, ".."), { recursive: true });
+
+    if (existsSync(newDir)) {
+        // newDir already exists (e.g. a fresh install created it) but newSessions
+        // does not — merge any files from oldDir into newDir and remove oldDir.
+        try {
+            cpSync(oldDir, newDir, { recursive: true });
+            rmSync(oldDir, { recursive: true, force: true });
+            logInfo(`Merged session data from ~/.pi/agent into ~/.pizzapi/agent`);
+        } catch (e: any) {
+            logWarn(`Failed to merge session storage: ${e.message}`);
+        }
+        return;
+    }
+
     try {
         renameSync(oldDir, newDir);
         logInfo(`Migrated session data from ~/.pi/agent to ~/.pizzapi/agent`);

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -4,7 +4,8 @@ import { promisify } from "node:util";
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 import { readdir, stat } from "node:fs/promises";
-import { hostname } from "node:os";
+import { existsSync, mkdirSync, renameSync, cpSync, rmSync } from "node:fs";
+import { hostname, homedir } from "node:os";
 import {
     spawnTerminal,
     writeTerminalInput,
@@ -45,6 +46,42 @@ import {
     scanAllPluginInfo,
 } from "../plugins.js";
 
+import {
+    initUsage,
+    triggerScan,
+    getData as getUsageData,
+    closeUsage,
+} from "../usage/index.js";
+import type { UsageRange } from "../usage/types.js";
+
+/**
+ * Migrate session storage from ~/.pi/agent to ~/.pizzapi/agent.
+ * Runs on daemon startup and is idempotent (safe to call repeatedly).
+ */
+function migrateSessionStorage(): void {
+    const oldDir = join(homedir(), ".pi", "agent");
+    const newDir = join(homedir(), ".pizzapi", "agent");
+    const newSessions = join(newDir, "sessions");
+
+    // Skip if old dir doesn't exist or new sessions dir already exists
+    if (!existsSync(oldDir) || existsSync(newSessions)) return;
+
+    mkdirSync(newDir, { recursive: true });
+    try {
+        renameSync(oldDir, newDir);
+        logInfo(`Migrated session data from ~/.pi/agent to ~/.pizzapi/agent`);
+    } catch (e: any) {
+        if (e.code === "EXDEV") {
+            // Cross-device move failed — fall back to copy
+            cpSync(oldDir, newDir, { recursive: true });
+            rmSync(oldDir, { recursive: true, force: true });
+            logInfo(`Migrated session data from ~/.pi/agent to ~/.pizzapi/agent (cross-device copy)`);
+        } else {
+            logWarn(`Failed to migrate session storage: ${e.message}`);
+        }
+    }
+}
+
 /**
  * Read the `relayUrl` from ~/.pizzapi/config.json, returning undefined
  * if not set or set to "off".  Used as a fallback when PIZZAPI_RELAY_URL
@@ -75,6 +112,12 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
     setLogComponent("daemon");
     const statePath = defaultStatePath();
     const identity = acquireStateAndIdentity(statePath);
+
+    // Migrate session storage from ~/.pi to ~/.pizzapi on startup
+    migrateSessionStorage();
+
+    // Initialize usage tracking
+    initUsage();
 
     // Read CLI version for reporting to the server.
     // Use module import instead of filesystem path math so this works in:
@@ -179,12 +222,19 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
         logInfo(`connecting to relay at ${sioUrl}/runner…`);
 
+        // Start periodic usage scan (every 5 minutes)
+        const usageScanInterval = setInterval(() => {
+            triggerScan();
+        }, 5 * 60 * 1000);
+
         const shutdown = (code: number) => {
             if (isShuttingDown) return;
             isShuttingDown = true;
             clearInterval(endedSessionSweep);
+            clearInterval(usageScanInterval);
             killAllTerminals();
             stopUsageRefreshLoop();
+            closeUsage();
             releaseStateLock(statePath);
             socket.disconnect();
             resolve(code);
@@ -1149,6 +1199,30 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     requestId,
                     ok: false,
                     message: err instanceof Error ? err.message : String(err),
+                });
+            }
+        });
+
+        // ── Usage dashboard ───────────────────────────────────────────────
+
+        socket.on("get_usage", (data: any) => {
+            if (isShuttingDown) return;
+            const requestId = data.requestId ?? "";
+            try {
+                const range = (data.range as UsageRange) || "90d";
+                const usageData = getUsageData(range);
+                if (!usageData) {
+                    socket.emit("usage_error", {
+                        requestId,
+                        error: "Usage data not available yet — initial scan in progress",
+                    });
+                    return;
+                }
+                socket.emit("usage_data", { requestId, data: usageData });
+            } catch (e: any) {
+                socket.emit("usage_error", {
+                    requestId,
+                    error: e.message ?? "Unknown error",
                 });
             }
         });

--- a/packages/cli/src/usage/aggregator.test.ts
+++ b/packages/cli/src/usage/aggregator.test.ts
@@ -1,0 +1,384 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { Database } from "bun:sqlite";
+import { getUsageData } from "./aggregator.js";
+import type { UsageRange } from "./types.js";
+
+function createTestDb(): Database {
+  const db = new Database(":memory:");
+  db.run("PRAGMA journal_mode=WAL");
+
+  db.run(`
+    CREATE TABLE usage_events (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL,
+      project TEXT NOT NULL,
+      timestamp INTEGER NOT NULL,
+      provider TEXT NOT NULL,
+      model TEXT NOT NULL,
+      input_tokens INTEGER DEFAULT 0,
+      output_tokens INTEGER DEFAULT 0,
+      cache_read_tokens INTEGER DEFAULT 0,
+      cache_write_tokens INTEGER DEFAULT 0,
+      cost_usd REAL,
+      cost_input REAL,
+      cost_output REAL,
+      cost_cache_read REAL,
+      cost_cache_write REAL,
+      UNIQUE(session_id, timestamp, model)
+    )
+  `);
+
+  db.run(`
+    CREATE TABLE sessions (
+      id TEXT PRIMARY KEY,
+      project TEXT NOT NULL,
+      session_name TEXT,
+      started_at INTEGER NOT NULL,
+      ended_at INTEGER,
+      message_count INTEGER DEFAULT 0,
+      total_input INTEGER DEFAULT 0,
+      total_output INTEGER DEFAULT 0,
+      total_cache_read INTEGER DEFAULT 0,
+      total_cache_write INTEGER DEFAULT 0,
+      total_cost REAL,
+      primary_model TEXT,
+      primary_provider TEXT
+    )
+  `);
+
+  db.run("CREATE INDEX idx_events_timestamp ON usage_events(timestamp)");
+  db.run("CREATE INDEX idx_events_project ON usage_events(project)");
+  db.run("CREATE INDEX idx_events_model ON usage_events(model)");
+  db.run("CREATE INDEX idx_sessions_started ON sessions(started_at)");
+  db.run("CREATE INDEX idx_sessions_project ON sessions(project)");
+
+  return db;
+}
+
+describe("Aggregator", () => {
+  test("empty database returns zeroed summary", () => {
+    const db = createTestDb();
+    const data = getUsageData(db, "90d");
+
+    expect(data.summary.totalSessions).toBe(0);
+    expect(data.summary.totalCost).toBe(0);
+    expect(data.summary.totalInputTokens).toBe(0);
+    expect(data.daily).toHaveLength(0);
+    expect(data.byModel).toHaveLength(0);
+    expect(data.byProject).toHaveLength(0);
+
+    db.close();
+  });
+
+  test("daily rollups group by date", () => {
+    const db = createTestDb();
+    const now = Date.now();
+    const oneDay = 24 * 60 * 60 * 1000;
+
+    // Insert events on 3 different days
+    const session1StartMs = now - 2 * oneDay;
+    const session2StartMs = now - oneDay;
+    const session3StartMs = now;
+
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/proj1", null, session1StartMs, session1StartMs + 60000, 1, 100, 50, 0, 0, 0.5, "claude-opus", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/proj2", null, session2StartMs, session2StartMs + 60000, 1, 200, 100, 0, 0, 1.0, "claude-sonnet", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s3", "/proj1", null, session3StartMs, session3StartMs + 60000, 1, 150, 75, 0, 0, 0.75, "claude-opus", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/proj1", session1StartMs, "anthropic", "claude-opus", 100, 50, 0, 0, 0.5, 0.3, 0.2, 0, 0]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/proj2", session2StartMs, "anthropic", "claude-sonnet", 200, 100, 0, 0, 1.0, 0.6, 0.4, 0, 0]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s3", "/proj1", session3StartMs, "anthropic", "claude-opus", 150, 75, 0, 0, 0.75, 0.45, 0.3, 0, 0]
+    );
+
+    const data = getUsageData(db, "all");
+
+    expect(data.daily.length).toBe(3);
+    expect(data.daily[0].sessions).toBe(1);
+    expect(data.daily[1].sessions).toBe(1);
+    expect(data.daily[2].sessions).toBe(1);
+
+    // Verify costs are summed per day
+    expect(data.daily[0].cost).toBeCloseTo(0.5, 5);
+    expect(data.daily[1].cost).toBeCloseTo(1.0, 5);
+    expect(data.daily[2].cost).toBeCloseTo(0.75, 5);
+
+    db.close();
+  });
+
+  test("model breakdown shows top models by cost", () => {
+    const db = createTestDb();
+    const now = Date.now();
+
+    // Insert sessions with different models
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/proj1", null, now, now + 60000, 1, 100, 50, 0, 0, 2.0, "claude-opus", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/proj2", null, now, now + 60000, 1, 200, 100, 0, 0, 1.0, "claude-sonnet", "anthropic"]
+    );
+
+    // Insert usage events
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/proj1", now, "anthropic", "claude-opus", 100, 50, 0, 0, 2.0, 1.2, 0.8, 0, 0]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/proj2", now, "anthropic", "claude-sonnet", 200, 100, 0, 0, 1.0, 0.6, 0.4, 0, 0]
+    );
+
+    const data = getUsageData(db, "all");
+
+    expect(data.byModel.length).toBe(2);
+    expect(data.byModel[0].model).toBe("claude-opus");
+    expect(data.byModel[0].cost).toBeCloseTo(2.0, 5);
+    expect(data.byModel[0].sessions).toBe(1);
+    expect(data.byModel[1].model).toBe("claude-sonnet");
+    expect(data.byModel[1].cost).toBeCloseTo(1.0, 5);
+
+    db.close();
+  });
+
+  test("project breakdown shows top projects", () => {
+    const db = createTestDb();
+    const now = Date.now();
+
+    // Insert sessions for different projects
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/home/user/projects/pizzapi", null, now, now + 60000, 1, 100, 50, 0, 0, 2.0, "claude-opus", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/home/user/projects/other", null, now, now + 60000, 1, 200, 100, 0, 0, 1.0, "claude-sonnet", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/home/user/projects/pizzapi", now, "anthropic", "claude-opus", 100, 50, 0, 0, 2.0, 1.2, 0.8, 0, 0]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/home/user/projects/other", now, "anthropic", "claude-sonnet", 200, 100, 0, 0, 1.0, 0.6, 0.4, 0, 0]
+    );
+
+    const data = getUsageData(db, "all");
+
+    expect(data.byProject.length).toBe(2);
+    expect(data.byProject[0].projectShort).toBe("pizzapi");
+    expect(data.byProject[0].cost).toBeCloseTo(2.0, 5);
+    expect(data.byProject[1].projectShort).toBe("other");
+    expect(data.byProject[1].cost).toBeCloseTo(1.0, 5);
+
+    db.close();
+  });
+
+  test("summary excludes null costs", () => {
+    const db = createTestDb();
+    const now = Date.now();
+
+    // One session with cost, one without
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/proj1", null, now, now + 60000, 1, 100, 50, 0, 0, 2.0, "claude-opus", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/proj2", null, now, now + 60000, 1, 200, 100, 0, 0, null, "claude-sonnet", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/proj1", now, "anthropic", "claude-opus", 100, 50, 0, 0, 2.0, 1.2, 0.8, 0, 0]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/proj2", now, "anthropic", "claude-sonnet", 200, 100, 0, 0, null, null, null, null, null]
+    );
+
+    const data = getUsageData(db, "all");
+
+    expect(data.summary.totalSessions).toBe(2);
+    expect(data.summary.sessionsWithCost).toBe(1);
+    expect(data.summary.totalCost).toBeCloseTo(2.0, 5);
+    expect(data.summary.avgSessionCost).toBeCloseTo(2.0, 5); // Only s1 has cost
+
+    db.close();
+  });
+
+  test("avgSessionDurationMs excludes sessions without ended_at", () => {
+    const db = createTestDb();
+    const now = Date.now();
+
+    // One session with ended_at, one without
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/proj1", null, now, now + 60000, 1, 100, 50, 0, 0, 1.0, "claude-opus", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/proj2", null, now, null, 1, 200, 100, 0, 0, 1.0, "claude-sonnet", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/proj1", now, "anthropic", "claude-opus", 100, 50, 0, 0, 1.0, 0.6, 0.4, 0, 0]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/proj2", now, "anthropic", "claude-sonnet", 200, 100, 0, 0, 1.0, 0.6, 0.4, 0, 0]
+    );
+
+    const data = getUsageData(db, "all");
+
+    expect(data.summary.avgSessionDurationMs).toBe(60000);
+
+    db.close();
+  });
+
+  test("date range filtering respects 'all'", () => {
+    const db = createTestDb();
+    const now = Date.now();
+    const oneDay = 24 * 60 * 60 * 1000;
+    const oldSession = now - 1000 * oneDay; // 1000 days ago
+
+    // Old session
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/proj1", null, oldSession, oldSession + 60000, 1, 100, 50, 0, 0, 1.0, "claude-opus", "anthropic"]
+    );
+
+    // Recent session
+    db.run(
+      `INSERT INTO sessions (id, project, session_name, started_at, ended_at, 
+       message_count, total_input, total_output, total_cache_read, total_cache_write,
+       total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/proj2", null, now, now + 60000, 1, 200, 100, 0, 0, 1.0, "claude-sonnet", "anthropic"]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s1", "/proj1", oldSession, "anthropic", "claude-opus", 100, 50, 0, 0, 1.0, 0.6, 0.4, 0, 0]
+    );
+
+    db.run(
+      `INSERT INTO usage_events (session_id, project, timestamp, provider, model,
+       input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+       cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ["s2", "/proj2", now, "anthropic", "claude-sonnet", 200, 100, 0, 0, 1.0, 0.6, 0.4, 0, 0]
+    );
+
+    const data = getUsageData(db, "all");
+
+    // "all" should include both old and new sessions
+    expect(data.summary.totalSessions).toBe(2);
+    expect(data.daily.length).toBe(2); // Both dates should be included
+
+    db.close();
+  });
+});

--- a/packages/cli/src/usage/aggregator.ts
+++ b/packages/cli/src/usage/aggregator.ts
@@ -1,0 +1,261 @@
+import { Database } from "bun:sqlite";
+import type { UsageData, UsageRange } from "./types.js";
+
+export function getUsageData(db: Database, range: UsageRange = "90d"): UsageData {
+  const now = Date.now();
+  const oneDay = 24 * 60 * 60 * 1000;
+
+  // Calculate date range
+  let fromTimestamp = now;
+  switch (range) {
+    case "7d":
+      fromTimestamp = now - 7 * oneDay;
+      break;
+    case "30d":
+      fromTimestamp = now - 30 * oneDay;
+      break;
+    case "90d":
+      fromTimestamp = now - 90 * oneDay;
+      break;
+    case "all":
+      fromTimestamp = 0;
+      break;
+  }
+
+  // Get total date range in DB (min and max session starts)
+  const totalRange = db.query<
+    { minStart: number | null; maxStart: number | null },
+    []
+  >(
+    `SELECT MIN(started_at) as minStart, MAX(started_at) as maxStart FROM sessions`
+  ).get() || { minStart: null, maxStart: null };
+
+  const totalDateRangeStart = totalRange.minStart || now;
+  const totalDateRangeEnd = totalRange.maxStart || now;
+
+  // Summary statistics
+  const summary = db.query<
+    {
+      totalSessions: number;
+      totalCost: number;
+      totalInputTokens: number;
+      totalOutputTokens: number;
+      totalCacheReadTokens: number;
+      totalCacheWriteTokens: number;
+      sessionsWithCost: number;
+      avgCost: number;
+      avgTokens: number;
+      sessionsWithDuration: number;
+      totalDurationMs: number;
+    },
+    [number]
+  >(
+    `
+    SELECT
+      COUNT(DISTINCT s.id) as totalSessions,
+      COALESCE(SUM(s.total_cost), 0) as totalCost,
+      COALESCE(SUM(s.total_input), 0) as totalInputTokens,
+      COALESCE(SUM(s.total_output), 0) as totalOutputTokens,
+      COALESCE(SUM(s.total_cache_read), 0) as totalCacheReadTokens,
+      COALESCE(SUM(s.total_cache_write), 0) as totalCacheWriteTokens,
+      COUNT(CASE WHEN s.total_cost IS NOT NULL THEN 1 END) as sessionsWithCost,
+      COALESCE(AVG(CASE WHEN s.total_cost IS NOT NULL THEN s.total_cost END), 0) as avgCost,
+      CASE WHEN COUNT(DISTINCT s.id) > 0 
+        THEN COALESCE(SUM(s.total_input + s.total_output + s.total_cache_read + s.total_cache_write), 0) / COUNT(DISTINCT s.id)
+        ELSE 0
+      END as avgTokens,
+      COUNT(CASE WHEN s.ended_at IS NOT NULL THEN 1 END) as sessionsWithDuration,
+      COALESCE(SUM(CASE WHEN s.ended_at IS NOT NULL THEN s.ended_at - s.started_at ELSE 0 END), 0) as totalDurationMs
+    FROM sessions s
+    WHERE s.started_at >= ?
+  `,
+  ).get(fromTimestamp) || {
+    totalSessions: 0,
+    totalCost: 0,
+    totalInputTokens: 0,
+    totalOutputTokens: 0,
+    totalCacheReadTokens: 0,
+    totalCacheWriteTokens: 0,
+    sessionsWithCost: 0,
+    avgCost: 0,
+    avgTokens: 0,
+    sessionsWithDuration: 0,
+    totalDurationMs: 0,
+  };
+
+  const avgSessionDurationMs =
+    summary.sessionsWithDuration > 0
+      ? summary.totalDurationMs / summary.sessionsWithDuration
+      : null;
+
+  // Daily rollups
+  const daily = db.query<
+    {
+      date: string;
+      sessions: number;
+      cost: number;
+      costInput: number;
+      costOutput: number;
+      costCacheRead: number;
+      costCacheWrite: number;
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens: number;
+      cacheWriteTokens: number;
+    },
+    [number]
+  >(
+    `
+    SELECT
+      DATE(u.timestamp / 1000, 'unixepoch') as date,
+      COUNT(DISTINCT u.session_id) as sessions,
+      COALESCE(SUM(u.cost_usd), 0) as cost,
+      COALESCE(SUM(u.cost_input), 0) as costInput,
+      COALESCE(SUM(u.cost_output), 0) as costOutput,
+      COALESCE(SUM(u.cost_cache_read), 0) as costCacheRead,
+      COALESCE(SUM(u.cost_cache_write), 0) as costCacheWrite,
+      COALESCE(SUM(u.input_tokens), 0) as inputTokens,
+      COALESCE(SUM(u.output_tokens), 0) as outputTokens,
+      COALESCE(SUM(u.cache_read_tokens), 0) as cacheReadTokens,
+      COALESCE(SUM(u.cache_write_tokens), 0) as cacheWriteTokens
+    FROM usage_events u
+    WHERE u.timestamp >= ?
+    GROUP BY DATE(u.timestamp / 1000, 'unixepoch')
+    ORDER BY date ASC
+  `,
+  ).all(fromTimestamp);
+
+  // By model breakdown (top 20 by cost)
+  const byModel = db.query<
+    {
+      provider: string;
+      model: string;
+      sessions: number;
+      cost: number;
+      inputTokens: number;
+      outputTokens: number;
+    },
+    [number]
+  >(
+    `
+    SELECT
+      u.provider,
+      u.model,
+      COUNT(DISTINCT u.session_id) as sessions,
+      COALESCE(SUM(u.cost_usd), 0) as cost,
+      COALESCE(SUM(u.input_tokens), 0) as inputTokens,
+      COALESCE(SUM(u.output_tokens), 0) as outputTokens
+    FROM usage_events u
+    WHERE u.timestamp >= ?
+    GROUP BY u.provider, u.model
+    ORDER BY cost DESC
+    LIMIT 20
+  `,
+  ).all(fromTimestamp);
+
+  // By project breakdown (top 20 by cost)
+  const byProjectRaw = db.query<
+    {
+      project: string;
+      sessions: number;
+      cost: number;
+      inputTokens: number;
+      outputTokens: number;
+    },
+    [number]
+  >(
+    `
+    SELECT
+      u.project,
+      COUNT(DISTINCT u.session_id) as sessions,
+      COALESCE(SUM(u.cost_usd), 0) as cost,
+      COALESCE(SUM(u.input_tokens), 0) as inputTokens,
+      COALESCE(SUM(u.output_tokens), 0) as outputTokens
+    FROM usage_events u
+    WHERE u.timestamp >= ?
+    GROUP BY u.project
+    ORDER BY cost DESC
+    LIMIT 20
+  `,
+  ).all(fromTimestamp);
+
+  const byProject = byProjectRaw.map((p) => ({
+    project: p.project,
+    projectShort: p.project.split("/").pop() || p.project,
+    sessions: p.sessions,
+    cost: p.cost,
+    inputTokens: p.inputTokens,
+    outputTokens: p.outputTokens,
+  }));
+
+  // Recent sessions (last 50 in date range)
+  const recentSessionsRaw = db.query<
+    {
+      id: string;
+      project: string;
+      sessionName: string | null;
+      startedAt: number;
+      endedAt: number | null;
+      messageCount: number;
+      totalCost: number | null;
+      primaryModel: string;
+    },
+    [number]
+  >(
+    `
+    SELECT
+      id,
+      project,
+      session_name as sessionName,
+      started_at as startedAt,
+      ended_at as endedAt,
+      message_count as messageCount,
+      total_cost as totalCost,
+      primary_model as primaryModel
+    FROM sessions
+    WHERE started_at >= ?
+    ORDER BY started_at DESC
+    LIMIT 50
+  `,
+  ).all(fromTimestamp);
+
+  const recentSessions = recentSessionsRaw.map((s) => ({
+    id: s.id,
+    project: s.project,
+    projectShort: s.project.split("/").pop() || s.project,
+    sessionName: s.sessionName,
+    startedAt: new Date(s.startedAt).toISOString(),
+    endedAt: s.endedAt ? new Date(s.endedAt).toISOString() : null,
+    messageCount: s.messageCount,
+    totalCost: s.totalCost,
+    primaryModel: s.primaryModel,
+  }));
+
+  return {
+    generatedAt: new Date().toISOString(),
+    dateRange: {
+      from: new Date(fromTimestamp).toISOString(),
+      to: new Date(now).toISOString(),
+    },
+    totalDateRange: {
+      from: new Date(totalDateRangeStart).toISOString(),
+      to: new Date(totalDateRangeEnd).toISOString(),
+    },
+    summary: {
+      totalSessions: summary.totalSessions,
+      totalCost: summary.totalCost,
+      totalInputTokens: summary.totalInputTokens,
+      totalOutputTokens: summary.totalOutputTokens,
+      totalCacheReadTokens: summary.totalCacheReadTokens,
+      totalCacheWriteTokens: summary.totalCacheWriteTokens,
+      avgSessionCost: summary.avgCost,
+      avgSessionTokens: summary.avgTokens,
+      avgSessionDurationMs,
+      sessionsWithCost: summary.sessionsWithCost,
+    },
+    daily,
+    byModel,
+    byProject,
+    recentSessions,
+  };
+}

--- a/packages/cli/src/usage/aggregator.ts
+++ b/packages/cli/src/usage/aggregator.ts
@@ -179,7 +179,7 @@ export function getUsageData(db: Database, range: UsageRange = "90d"): UsageData
   `,
   ).all(fromTimestamp);
 
-  const byProject = byProjectRaw.map((p) => ({
+  const byProject = byProjectRaw.map((p: (typeof byProjectRaw)[number]) => ({
     project: p.project,
     projectShort: p.project.split("/").pop() || p.project,
     sessions: p.sessions,
@@ -219,7 +219,7 @@ export function getUsageData(db: Database, range: UsageRange = "90d"): UsageData
   `,
   ).all(fromTimestamp);
 
-  const recentSessions = recentSessionsRaw.map((s) => ({
+  const recentSessions = recentSessionsRaw.map((s: (typeof recentSessionsRaw)[number]) => ({
     id: s.id,
     project: s.project,
     projectShort: s.project.split("/").pop() || s.project,

--- a/packages/cli/src/usage/index.ts
+++ b/packages/cli/src/usage/index.ts
@@ -1,0 +1,40 @@
+import { openUsageDb } from "./schema.js";
+import { scanSessions } from "./scanner.js";
+import { getUsageData } from "./aggregator.js";
+import type { UsageData, UsageRange } from "./types.js";
+import type { Database } from "bun:sqlite";
+
+let db: Database | null = null;
+let lastScanAt = 0;
+let scanning = false;
+
+export function initUsage(): void {
+  db = openUsageDb();
+  // Initial scan in background
+  triggerScan();
+}
+
+export async function triggerScan(): Promise<void> {
+  if (!db || scanning) return;
+  scanning = true;
+  try {
+    await scanSessions(db);
+    lastScanAt = Date.now();
+  } finally {
+    scanning = false;
+  }
+}
+
+export function getData(range: UsageRange = "90d"): UsageData | null {
+  if (!db) return null;
+  // Trigger scan if stale (> 1 min)
+  if (Date.now() - lastScanAt > 60_000) {
+    triggerScan(); // fire and forget — return current data
+  }
+  return getUsageData(db, range);
+}
+
+export function closeUsage(): void {
+  db?.close();
+  db = null;
+}

--- a/packages/cli/src/usage/scanner.test.ts
+++ b/packages/cli/src/usage/scanner.test.ts
@@ -1,0 +1,653 @@
+import { describe, test, expect } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { writeFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { Database } from "bun:sqlite";
+import { openUsageDb } from "./schema.js";
+import { processFile, parseSessionHeader, extractSessionName } from "./scanner.js";
+
+describe("Scanner", () => {
+  test("parseSessionHeader parses valid session header", () => {
+    const line = JSON.stringify({
+      type: "session",
+      version: 1,
+      id: "session-123",
+      timestamp: "2026-03-23T12:00:00Z",
+      cwd: "/home/user/projects/pizzapi",
+    });
+
+    const result = parseSessionHeader(line);
+    expect(result).toBeTruthy();
+    expect(result?.id).toBe("session-123");
+    expect(result?.cwd).toBe("/home/user/projects/pizzapi");
+  });
+
+  test("parseSessionHeader returns null for non-session lines", () => {
+    const line = JSON.stringify({
+      type: "message",
+      id: "msg-123",
+    });
+
+    const result = parseSessionHeader(line);
+    expect(result).toBeNull();
+  });
+
+  test("extractSessionName finds set_session_name in tool calls", () => {
+    const line = JSON.stringify({
+      type: "message",
+      timestamp: "2026-03-23T12:00:00Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus",
+        tool_calls: [
+          {
+            tool_call_id: "call-123",
+            name: "set_session_name",
+            arguments: JSON.stringify({
+              name: "My Test Session",
+            }),
+          },
+        ],
+      },
+    });
+
+    const result = extractSessionName(line);
+    expect(result).toBe("My Test Session");
+  });
+
+  test("extractSessionName returns null when no session name found", () => {
+    const line = JSON.stringify({
+      type: "message",
+      timestamp: "2026-03-23T12:00:00Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus",
+      },
+    });
+
+    const result = extractSessionName(line);
+    expect(result).toBeNull();
+  });
+
+  test("processFile correctly parses JSONL with usage data", () => {
+    // Create temp directory
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const dbPath = join(tmpDir, "test.db");
+    const filePath = join(tmpDir, "session.jsonl");
+
+    // Create JSONL file
+    const sessionHeader = {
+      type: "session",
+      version: 1,
+      id: "session-001",
+      timestamp: "2026-03-23T12:00:00Z",
+      cwd: "/project/test",
+    } as const;
+
+    const usageMessage = {
+      type: "message",
+      id: "msg-001",
+      timestamp: "2026-03-23T12:05:00Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus",
+        usage: {
+          input: 100,
+          output: 50,
+          cacheRead: 10,
+          cacheWrite: 5,
+          totalTokens: 165,
+          cost: {
+            total: 0.001,
+            input: 0.0005,
+            output: 0.0004,
+            cacheRead: 0.00005,
+            cacheWrite: 0.000001,
+          },
+        },
+      },
+    };
+
+    const content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage)}\n`;
+    writeFileSync(filePath, content);
+
+    // Process the file
+    const db = new Database(dbPath);
+    db.run("PRAGMA journal_mode=WAL");
+    db.run(`
+      CREATE TABLE usage_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        project TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        cache_read_tokens INTEGER DEFAULT 0,
+        cache_write_tokens INTEGER DEFAULT 0,
+        cost_usd REAL,
+        cost_input REAL,
+        cost_output REAL,
+        cost_cache_read REAL,
+        cost_cache_write REAL,
+        UNIQUE(session_id, timestamp, model)
+      )
+    `);
+    db.run(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        project TEXT NOT NULL,
+        session_name TEXT,
+        started_at INTEGER NOT NULL,
+        ended_at INTEGER,
+        message_count INTEGER DEFAULT 0,
+        total_input INTEGER DEFAULT 0,
+        total_output INTEGER DEFAULT 0,
+        total_cache_read INTEGER DEFAULT 0,
+        total_cache_write INTEGER DEFAULT 0,
+        total_cost REAL,
+        primary_model TEXT,
+        primary_provider TEXT
+      )
+    `);
+    db.run(`
+      CREATE TABLE processing_state (
+        file_path TEXT PRIMARY KEY,
+        last_offset INTEGER DEFAULT 0,
+        last_modified INTEGER
+      )
+    `);
+
+    processFile(db, filePath, "session.jsonl", sessionHeader);
+
+    // Verify usage_events was inserted
+    const events = db.query<any, []>("SELECT * FROM usage_events").all();
+    expect(events.length).toBe(1);
+    expect(events[0].session_id).toBe("session-001");
+    expect(events[0].project).toBe("/project/test");
+    expect(events[0].model).toBe("claude-opus");
+    expect(events[0].input_tokens).toBe(100);
+    expect(events[0].output_tokens).toBe(50);
+    expect(events[0].cost_usd).toBeCloseTo(0.001, 6);
+
+    // Verify sessions was upserted
+    const sessions = db.query<any, []>("SELECT * FROM sessions").all();
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].id).toBe("session-001");
+    expect(sessions[0].message_count).toBe(1);
+    expect(sessions[0].total_input).toBe(100);
+
+    db.close();
+  });
+
+  test("processFile skips malformed JSON lines without crashing", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const dbPath = join(tmpDir, "test.db");
+    const filePath = join(tmpDir, "session.jsonl");
+
+    const sessionHeader = {
+      type: "session",
+      version: 1,
+      id: "session-002",
+      timestamp: "2026-03-23T12:00:00Z",
+      cwd: "/project/test",
+    } as const;
+
+    // Content with a malformed JSON line
+    const content = `${JSON.stringify(sessionHeader)}\nmalformed json line\n`;
+    writeFileSync(filePath, content);
+
+    const db = new Database(dbPath);
+    db.run("PRAGMA journal_mode=WAL");
+    db.run(`
+      CREATE TABLE usage_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        project TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        cache_read_tokens INTEGER DEFAULT 0,
+        cache_write_tokens INTEGER DEFAULT 0,
+        cost_usd REAL,
+        cost_input REAL,
+        cost_output REAL,
+        cost_cache_read REAL,
+        cost_cache_write REAL,
+        UNIQUE(session_id, timestamp, model)
+      )
+    `);
+    db.run(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        project TEXT NOT NULL,
+        session_name TEXT,
+        started_at INTEGER NOT NULL,
+        ended_at INTEGER,
+        message_count INTEGER DEFAULT 0,
+        total_input INTEGER DEFAULT 0,
+        total_output INTEGER DEFAULT 0,
+        total_cache_read INTEGER DEFAULT 0,
+        total_cache_write INTEGER DEFAULT 0,
+        total_cost REAL,
+        primary_model TEXT,
+        primary_provider TEXT
+      )
+    `);
+    db.run(`
+      CREATE TABLE processing_state (
+        file_path TEXT PRIMARY KEY,
+        last_offset INTEGER DEFAULT 0,
+        last_modified INTEGER
+      )
+    `);
+
+    // Should not throw
+    processFile(db, filePath, "session.jsonl", sessionHeader);
+
+    // Should have no events (malformed line was skipped)
+    const events = db.query<any, []>("SELECT * FROM usage_events").all();
+    expect(events.length).toBe(0);
+
+    db.close();
+  });
+
+  test("processFile handles sessions with no cost data", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const dbPath = join(tmpDir, "test.db");
+    const filePath = join(tmpDir, "session.jsonl");
+
+    const sessionHeader = {
+      type: "session",
+      version: 1,
+      id: "session-003",
+      timestamp: "2026-03-23T12:00:00Z",
+      cwd: "/project/test",
+    } as const;
+
+    const usageMessage = {
+      type: "message",
+      id: "msg-001",
+      timestamp: "2026-03-23T12:05:00Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus",
+        usage: {
+          input: 100,
+          output: 50,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 150,
+          // No cost field
+        },
+      },
+    };
+
+    const content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage)}\n`;
+    writeFileSync(filePath, content);
+
+    const db = new Database(dbPath);
+    db.run("PRAGMA journal_mode=WAL");
+    db.run(`
+      CREATE TABLE usage_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        project TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        cache_read_tokens INTEGER DEFAULT 0,
+        cache_write_tokens INTEGER DEFAULT 0,
+        cost_usd REAL,
+        cost_input REAL,
+        cost_output REAL,
+        cost_cache_read REAL,
+        cost_cache_write REAL,
+        UNIQUE(session_id, timestamp, model)
+      )
+    `);
+    db.run(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        project TEXT NOT NULL,
+        session_name TEXT,
+        started_at INTEGER NOT NULL,
+        ended_at INTEGER,
+        message_count INTEGER DEFAULT 0,
+        total_input INTEGER DEFAULT 0,
+        total_output INTEGER DEFAULT 0,
+        total_cache_read INTEGER DEFAULT 0,
+        total_cache_write INTEGER DEFAULT 0,
+        total_cost REAL,
+        primary_model TEXT,
+        primary_provider TEXT
+      )
+    `);
+    db.run(`
+      CREATE TABLE processing_state (
+        file_path TEXT PRIMARY KEY,
+        last_offset INTEGER DEFAULT 0,
+        last_modified INTEGER
+      )
+    `);
+
+    processFile(db, filePath, "session.jsonl", sessionHeader);
+
+    // Verify event was inserted with NULL cost
+    const events = db.query<any, []>("SELECT * FROM usage_events").all();
+    expect(events.length).toBe(1);
+    expect(events[0].cost_usd).toBeNull();
+
+    db.close();
+  });
+
+  test("processFile handles incremental processing correctly", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const dbPath = join(tmpDir, "test.db");
+    const filePath = join(tmpDir, "session.jsonl");
+
+    const sessionHeader = {
+      type: "session",
+      version: 1,
+      id: "session-004",
+      timestamp: "2026-03-23T12:00:00Z",
+      cwd: "/project/test",
+    } as const;
+
+    const usageMessage1 = {
+      type: "message",
+      id: "msg-001",
+      timestamp: "2026-03-23T12:05:00Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus",
+        usage: {
+          input: 100,
+          output: 50,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 150,
+          cost: {
+            total: 0.001,
+            input: 0.0005,
+            output: 0.0004,
+            cacheRead: 0.00005,
+            cacheWrite: 0.000001,
+          },
+        },
+      },
+    };
+
+    // Write initial file with header + one message
+    let content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage1)}\n`;
+    writeFileSync(filePath, content);
+
+    // Set up database
+    const db = new Database(dbPath);
+    db.run("PRAGMA journal_mode=WAL");
+    db.run(`
+      CREATE TABLE usage_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        project TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        cache_read_tokens INTEGER DEFAULT 0,
+        cache_write_tokens INTEGER DEFAULT 0,
+        cost_usd REAL,
+        cost_input REAL,
+        cost_output REAL,
+        cost_cache_read REAL,
+        cost_cache_write REAL,
+        UNIQUE(session_id, timestamp, model)
+      )
+    `);
+    db.run(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        project TEXT NOT NULL,
+        session_name TEXT,
+        started_at INTEGER NOT NULL,
+        ended_at INTEGER,
+        message_count INTEGER DEFAULT 0,
+        total_input INTEGER DEFAULT 0,
+        total_output INTEGER DEFAULT 0,
+        total_cache_read INTEGER DEFAULT 0,
+        total_cache_write INTEGER DEFAULT 0,
+        total_cost REAL,
+        primary_model TEXT,
+        primary_provider TEXT
+      )
+    `);
+    db.run(`
+      CREATE TABLE processing_state (
+        file_path TEXT PRIMARY KEY,
+        last_offset INTEGER DEFAULT 0,
+        last_modified INTEGER
+      )
+    `);
+
+    // First scan: process initial file
+    processFile(db, filePath, "session.jsonl", sessionHeader, content);
+
+    // Verify first message was processed
+    let events = db.query<any, []>("SELECT * FROM usage_events").all();
+    expect(events.length).toBe(1);
+    let sessions = db.query<any, []>("SELECT * FROM sessions").all();
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].message_count).toBe(1);
+    expect(sessions[0].total_input).toBe(100);
+
+    // Get the stored offset
+    const state = db
+      .query<{ last_offset: number }, []>("SELECT last_offset FROM processing_state")
+      .get();
+    expect(state).toBeTruthy();
+    const firstScanOffset = state!.last_offset;
+
+    // Append a second message
+    const usageMessage2 = {
+      type: "message",
+      id: "msg-002",
+      timestamp: "2026-03-23T12:10:00Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus",
+        usage: {
+          input: 200,
+          output: 100,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 300,
+          cost: {
+            total: 0.002,
+            input: 0.001,
+            output: 0.0008,
+            cacheRead: 0.0001,
+            cacheWrite: 0.000002,
+          },
+        },
+      },
+    };
+
+    content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage1)}\n${JSON.stringify(usageMessage2)}\n`;
+    writeFileSync(filePath, content);
+
+    // Second scan: incremental processing with lastOffset
+    processFile(db, filePath, "session.jsonl", sessionHeader, content, firstScanOffset);
+
+    // Verify both messages are now in the database
+    events = db.query<any, []>("SELECT * FROM usage_events").all();
+    expect(events.length).toBe(2);
+
+    sessions = db.query<any, []>("SELECT * FROM sessions").all();
+    expect(sessions.length).toBe(1);
+    expect(sessions[0].message_count).toBe(2);
+    expect(sessions[0].total_input).toBe(300); // 100 + 200
+    expect(sessions[0].total_output).toBe(150); // 50 + 100
+
+    db.close();
+  });
+
+  test("processFile handles partial lines correctly", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const dbPath = join(tmpDir, "test.db");
+    const filePath = join(tmpDir, "session.jsonl");
+
+    const sessionHeader = {
+      type: "session",
+      version: 1,
+      id: "session-005",
+      timestamp: "2026-03-23T12:00:00Z",
+      cwd: "/project/test",
+    } as const;
+
+    const usageMessage1 = {
+      type: "message",
+      id: "msg-001",
+      timestamp: "2026-03-23T12:05:00Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus",
+        usage: {
+          input: 100,
+          output: 50,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 150,
+          cost: {
+            total: 0.001,
+            input: 0.0005,
+            output: 0.0004,
+            cacheRead: 0.00005,
+            cacheWrite: 0.000001,
+          },
+        },
+      },
+    };
+
+    const usageMessage2 = {
+      type: "message",
+      id: "msg-002",
+      timestamp: "2026-03-23T12:10:00Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus",
+        usage: {
+          input: 200,
+          output: 100,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 300,
+          cost: {
+            total: 0.002,
+            input: 0.001,
+            output: 0.0008,
+            cacheRead: 0.0001,
+            cacheWrite: 0.000002,
+          },
+        },
+      },
+    };
+
+    // Write file with one complete message and a partial line (cut mid-JSON)
+    const completeMsg = JSON.stringify(usageMessage2);
+    const partialLine = completeMsg.slice(0, 50); // Cut the message mid-way, no newline
+    let content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage1)}\n${partialLine}`;
+    writeFileSync(filePath, content);
+
+    // Set up database
+    const db = new Database(dbPath);
+    db.run("PRAGMA journal_mode=WAL");
+    db.run(`
+      CREATE TABLE usage_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        project TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        cache_read_tokens INTEGER DEFAULT 0,
+        cache_write_tokens INTEGER DEFAULT 0,
+        cost_usd REAL,
+        cost_input REAL,
+        cost_output REAL,
+        cost_cache_read REAL,
+        cost_cache_write REAL,
+        UNIQUE(session_id, timestamp, model)
+      )
+    `);
+    db.run(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        project TEXT NOT NULL,
+        session_name TEXT,
+        started_at INTEGER NOT NULL,
+        ended_at INTEGER,
+        message_count INTEGER DEFAULT 0,
+        total_input INTEGER DEFAULT 0,
+        total_output INTEGER DEFAULT 0,
+        total_cache_read INTEGER DEFAULT 0,
+        total_cache_write INTEGER DEFAULT 0,
+        total_cost REAL,
+        primary_model TEXT,
+        primary_provider TEXT
+      )
+    `);
+    db.run(`
+      CREATE TABLE processing_state (
+        file_path TEXT PRIMARY KEY,
+        last_offset INTEGER DEFAULT 0,
+        last_modified INTEGER
+      )
+    `);
+
+    // First scan: should process complete message but skip partial line (no trailing newline)
+    processFile(db, filePath, "session.jsonl", sessionHeader, content);
+
+    // Verify only the complete message was processed (not the partial line)
+    let events = db.query<any, []>("SELECT * FROM usage_events").all();
+    expect(events.length).toBe(1); // Only message1 should be processed
+    let sessions = db.query<any, []>("SELECT * FROM sessions").all();
+    expect(sessions[0].message_count).toBe(1);
+
+    // Get the stored offset (should be after the first complete message's newline)
+    const state = db
+      .query<{ last_offset: number }, []>("SELECT last_offset FROM processing_state")
+      .get();
+    const firstScanOffset = state!.last_offset;
+
+    // Now complete the partial line and add a new complete line
+    content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage1)}\n${JSON.stringify(usageMessage2)}\n`;
+    writeFileSync(filePath, content);
+
+    // Second scan: should process message2 (which completes the partial line)
+    processFile(db, filePath, "session.jsonl", sessionHeader, content, firstScanOffset);
+
+    // Verify message2 was processed
+    events = db.query<any, []>("SELECT * FROM usage_events").all();
+    expect(events.length).toBe(2); // message1 from first scan + message2 from second scan
+    sessions = db.query<any, []>("SELECT * FROM sessions").all();
+    expect(sessions[0].message_count).toBe(2);
+
+    db.close();
+  });
+});

--- a/packages/cli/src/usage/scanner.ts
+++ b/packages/cli/src/usage/scanner.ts
@@ -1,0 +1,410 @@
+import { Database } from "bun:sqlite";
+import { readFileSync, statSync, existsSync } from "node:fs";
+import { readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import type { SessionHeader, UsageMessage } from "./types.js";
+import { getSessionsDir } from "./schema.js";
+
+export interface ParsedSessionHeader extends SessionHeader {}
+
+/**
+ * Parse a JSONL line as a session header.
+ * Returns the header if it's a valid session header, null otherwise.
+ */
+export function parseSessionHeader(line: string): ParsedSessionHeader | null {
+  try {
+    const obj = JSON.parse(line);
+    if (obj.type === "session" && obj.id && obj.cwd) {
+      return obj as ParsedSessionHeader;
+    }
+  } catch {
+    // JSON parse error — skip
+  }
+  return null;
+}
+
+/**
+ * Extract session name from a message line containing set_session_name tool call.
+ */
+export function extractSessionName(line: string): string | null {
+  try {
+    const obj = JSON.parse(line);
+    if (obj.type !== "message" || !obj.message) return null;
+
+    const msg = obj.message;
+    if (!msg.tool_calls || !Array.isArray(msg.tool_calls)) return null;
+
+    for (const call of msg.tool_calls) {
+      if (call.name === "set_session_name" && call.arguments) {
+        try {
+          const args = typeof call.arguments === "string" 
+            ? JSON.parse(call.arguments) 
+            : call.arguments;
+          if (args.name && typeof args.name === "string") {
+            return args.name;
+          }
+        } catch {
+          // Skip if arguments can't be parsed
+        }
+      }
+    }
+  } catch {
+    // JSON parse error — skip
+  }
+  return null;
+}
+
+/**
+ * Process a single JSONL file and insert/update usage events and sessions.
+ * Called with a session header that was already parsed from the file.
+ * If fullContent is provided, it will be used instead of reading from disk.
+ * If lastOffset is provided, will process only new lines after that byte offset.
+ */
+export function processFile(
+  db: Database,
+  filePath: string,
+  relativePath: string,
+  sessionHeader: SessionHeader,
+  fullContent?: string,
+  lastOffset?: number,
+): void {
+  const sessionId = sessionHeader.id;
+  const project = sessionHeader.cwd;
+  const startedAtMs = new Date(sessionHeader.timestamp).getTime();
+
+  // Read the full file if content wasn't provided
+  if (!fullContent) {
+    fullContent = readFileSync(filePath, "utf-8");
+  }
+
+  // Handle incremental processing: if we have a lastOffset, process only new lines
+  let linesToProcess: string[];
+  if (lastOffset !== undefined && lastOffset > 0) {
+    // lastOffset points to the byte position we've already processed up to
+    // If lastOffset >= fullContent.length, there's no new content
+    if (lastOffset >= fullContent.length) {
+      linesToProcess = [];
+    } else {
+      // Start from lastOffset
+      // If there's a newline at lastOffset (shouldn't happen), skip it
+      let startPos = lastOffset;
+      if (startPos < fullContent.length && fullContent[startPos] === "\n") {
+        startPos++;
+      }
+      // Process only the new content
+      const newContent = fullContent.slice(startPos);
+      linesToProcess = newContent.split("\n");
+    }
+  } else {
+    // First scan: process all lines (skip the header in the processing loop)
+    linesToProcess = fullContent.split("\n");
+  }
+
+  // Track usage data
+  interface UsageEvent {
+    timestamp: number;
+    provider: string;
+    model: string;
+    input_tokens: number;
+    output_tokens: number;
+    cache_read_tokens: number;
+    cache_write_tokens: number;
+    cost_usd: number | null;
+    cost_input: number | null;
+    cost_output: number | null;
+    cost_cache_read: number | null;
+    cost_cache_write: number | null;
+  }
+
+  const events: UsageEvent[] = [];
+  let sessionName: string | null = null;
+  let lastMessageTimestamp = startedAtMs;
+  let messageCount = 0;
+
+  // Model usage tracking (by count)
+  const modelUsage = new Map<string, number>();
+
+  // For incremental scans, we need to get existing session data to merge with
+  let existingSession: any = null;
+  if (lastOffset !== undefined && lastOffset > 0) {
+    existingSession = db
+      .query<any, [string]>("SELECT * FROM sessions WHERE id = ?")
+      .get(sessionId);
+  }
+
+  // Track the byte position of the last complete line we process
+  let lastCompleteLineOffset = lastOffset ?? 0;
+
+  // Process each line
+  for (let i = 0; i < linesToProcess.length; i++) {
+    const line = linesToProcess[i];
+    if (!line.trim()) continue;
+
+    try {
+      const obj = JSON.parse(line);
+
+      // Skip the session header (already have it)
+      if (obj.type === "session") {
+        // Mark this line as successfully processed
+        lastCompleteLineOffset += Buffer.byteLength(line, "utf-8") + 1; // +1 for newline
+        continue;
+      }
+
+      // Check for session name
+      if (obj.type === "message" && !sessionName) {
+        const name = extractSessionName(line);
+        if (name) sessionName = name;
+      }
+
+      // Extract usage from assistant messages
+      if (
+        obj.type === "message" &&
+        obj.message &&
+        obj.message.role === "assistant" &&
+        obj.message.usage
+      ) {
+        const msg = obj.message as any;
+        const usage = msg.usage;
+        const timestamp = new Date(obj.timestamp).getTime();
+
+        lastMessageTimestamp = Math.max(lastMessageTimestamp, timestamp);
+        messageCount++;
+
+        const provider = msg.provider || "unknown";
+        const model = msg.model || "unknown";
+
+        // Track model usage
+        modelUsage.set(model, (modelUsage.get(model) || 0) + 1);
+
+        const event: UsageEvent = {
+          timestamp,
+          provider,
+          model,
+          input_tokens: usage.input || 0,
+          output_tokens: usage.output || 0,
+          cache_read_tokens: usage.cacheRead || 0,
+          cache_write_tokens: usage.cacheWrite || 0,
+          cost_usd: usage.cost?.total ?? null,
+          cost_input: usage.cost?.input ?? null,
+          cost_output: usage.cost?.output ?? null,
+          cost_cache_read: usage.cost?.cacheRead ?? null,
+          cost_cache_write: usage.cost?.cacheWrite ?? null,
+        };
+
+        events.push(event);
+
+        // Mark this line as successfully processed
+        lastCompleteLineOffset += Buffer.byteLength(line, "utf-8") + 1; // +1 for newline
+      } else {
+        // For other valid JSON types (like message without usage), still mark as processed
+        lastCompleteLineOffset += Buffer.byteLength(line, "utf-8") + 1; // +1 for newline
+      }
+    } catch {
+      // Skip malformed lines — don't update lastCompleteLineOffset for malformed lines
+    }
+  }
+
+  // Determine primary model (most used by count)
+  let primaryModel = "unknown";
+  let primaryProvider = "unknown";
+  if (modelUsage.size > 0) {
+    primaryModel = [...modelUsage.entries()].sort((a, b) => b[1] - a[1])[0][0];
+    // Extract provider from first matching event
+    const firstEvent = events.find((e) => e.model === primaryModel);
+    if (firstEvent) {
+      primaryProvider = firstEvent.provider;
+    }
+  }
+
+  // Aggregate totals
+  let totalInput = 0;
+  let totalOutput = 0;
+  let totalCacheRead = 0;
+  let totalCacheWrite = 0;
+  let totalCost: number | null = null;
+
+  for (const event of events) {
+    totalInput += event.input_tokens;
+    totalOutput += event.output_tokens;
+    totalCacheRead += event.cache_read_tokens;
+    totalCacheWrite += event.cache_write_tokens;
+
+    // Sum cost (skip null values)
+    if (event.cost_usd !== null) {
+      totalCost = (totalCost ?? 0) + event.cost_usd;
+    }
+  }
+
+  // For incremental scans, merge with existing data
+  if (existingSession && messageCount > 0) {
+    totalInput += existingSession.total_input || 0;
+    totalOutput += existingSession.total_output || 0;
+    totalCacheRead += existingSession.total_cache_read || 0;
+    totalCacheWrite += existingSession.total_cache_write || 0;
+    if (existingSession.total_cost !== null) {
+      totalCost = (totalCost ?? 0) + existingSession.total_cost;
+    }
+    messageCount += existingSession.message_count || 0;
+  }
+
+  // Use transaction for atomicity
+  db.transaction(() => {
+    // Insert usage events
+    for (const event of events) {
+      db.run(
+        `INSERT OR IGNORE INTO usage_events 
+         (session_id, project, timestamp, provider, model, 
+          input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+          cost_usd, cost_input, cost_output, cost_cache_read, cost_cache_write)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          sessionId,
+          project,
+          event.timestamp,
+          event.provider,
+          event.model,
+          event.input_tokens,
+          event.output_tokens,
+          event.cache_read_tokens,
+          event.cache_write_tokens,
+          event.cost_usd,
+          event.cost_input,
+          event.cost_output,
+          event.cost_cache_read,
+          event.cost_cache_write,
+        ],
+      );
+    }
+
+    // Upsert session summary
+    db.run(
+      `INSERT INTO sessions 
+       (id, project, session_name, started_at, ended_at, message_count,
+        total_input, total_output, total_cache_read, total_cache_write,
+        total_cost, primary_model, primary_provider)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+       session_name = COALESCE(excluded.session_name, session_name),
+       ended_at = CASE WHEN excluded.ended_at IS NULL THEN ended_at ELSE MAX(ended_at, excluded.ended_at) END,
+       message_count = excluded.message_count,
+       total_input = excluded.total_input,
+       total_output = excluded.total_output,
+       total_cache_read = excluded.total_cache_read,
+       total_cache_write = excluded.total_cache_write,
+       total_cost = excluded.total_cost,
+       primary_model = excluded.primary_model,
+       primary_provider = excluded.primary_provider`,
+      [
+        sessionId,
+        project,
+        sessionName,
+        startedAtMs,
+        messageCount > 0 ? lastMessageTimestamp : null,
+        messageCount,
+        totalInput,
+        totalOutput,
+        totalCacheRead,
+        totalCacheWrite,
+        totalCost,
+        primaryModel,
+        primaryProvider,
+      ],
+    );
+
+    // Update processing state with byte offset (only for the lines we actually processed)
+    const fileStats = statSync(filePath);
+    db.run(
+      `INSERT INTO processing_state (file_path, last_offset, last_modified)
+       VALUES (?, ?, ?)
+       ON CONFLICT(file_path) DO UPDATE SET
+       last_offset = excluded.last_offset,
+       last_modified = excluded.last_modified`,
+      [relativePath, lastCompleteLineOffset, fileStats.mtimeMs],
+    );
+  })();
+}
+
+/**
+ * Scan all session directories and process new/changed JSONL files.
+ * Idempotent — can be called repeatedly.
+ */
+export async function scanSessions(db: Database): Promise<void> {
+  const primaryDir = getSessionsDir();
+  const piDir = join(homedir(), ".pi", "agent", "sessions");
+
+  const dirsToScan = [];
+  if (existsSync(primaryDir)) {
+    dirsToScan.push(primaryDir);
+  }
+  if (existsSync(piDir) && piDir !== primaryDir) {
+    dirsToScan.push(piDir);
+  }
+
+  for (const sessionsDir of dirsToScan) {
+    let sessionDirs: string[];
+    try {
+      sessionDirs = await readdir(sessionsDir);
+    } catch {
+      // Directory doesn't exist or can't be read
+      continue;
+    }
+
+    for (const sessionDirName of sessionDirs) {
+      const sessionPath = join(sessionsDir, sessionDirName);
+      let files: string[];
+
+      try {
+        files = await readdir(sessionPath);
+      } catch {
+        // Can't read directory
+        continue;
+      }
+
+      for (const fileName of files) {
+        if (!fileName.endsWith(".jsonl")) continue;
+
+        const filePath = join(sessionPath, fileName);
+        const relativePath = join(sessionDirName, fileName);
+
+        // Check if we need to process this file
+        const state = db
+          .query<{ last_offset: number; last_modified: number }, [string]>(
+            "SELECT last_offset, last_modified FROM processing_state WHERE file_path = ?",
+          )
+          .get(relativePath);
+
+        let fileStats: ReturnType<typeof statSync>;
+        try {
+          fileStats = statSync(filePath);
+        } catch {
+          // File doesn't exist anymore
+          continue;
+        }
+
+        // Skip if file hasn't changed
+        if (state && state.last_modified === fileStats.mtimeMs) {
+          continue;
+        }
+
+        // Read the file once
+        const content = readFileSync(filePath, "utf-8");
+        const firstLine = content.split("\n")[0];
+        const sessionHeader = parseSessionHeader(firstLine);
+
+        if (!sessionHeader) {
+          // Skip files without valid session header
+          continue;
+        }
+
+        // Process the file, passing content to avoid double read
+        // and passing lastOffset for incremental processing
+        try {
+          processFile(db, filePath, relativePath, sessionHeader, content, state?.last_offset);
+        } catch (e) {
+          console.error(`Error processing ${filePath}:`, e);
+        }
+      }
+    }
+  }
+}

--- a/packages/cli/src/usage/scanner.ts
+++ b/packages/cli/src/usage/scanner.ts
@@ -81,19 +81,21 @@ export function processFile(
   // Handle incremental processing: if we have a lastOffset, process only new lines
   let linesToProcess: string[];
   if (lastOffset !== undefined && lastOffset > 0) {
-    // lastOffset points to the byte position we've already processed up to
-    // If lastOffset >= fullContent.length, there's no new content
-    if (lastOffset >= fullContent.length) {
+    // lastOffset is a UTF-8 byte count. We must use Buffer-based slicing so
+    // that multi-byte Unicode characters in cwd/session names don't cause
+    // offset drift (JS string .slice() counts UTF-16 code units, not bytes).
+    const fullBuf = Buffer.from(fullContent, "utf-8");
+    if (lastOffset >= fullBuf.length) {
       linesToProcess = [];
     } else {
-      // Start from lastOffset
-      // If there's a newline at lastOffset (shouldn't happen), skip it
+      // Start from lastOffset (byte position)
+      // If there's a newline byte at lastOffset (shouldn't happen), skip it
       let startPos = lastOffset;
-      if (startPos < fullContent.length && fullContent[startPos] === "\n") {
+      if (startPos < fullBuf.length && fullBuf[startPos] === 0x0a /* '\n' */) {
         startPos++;
       }
-      // Process only the new content
-      const newContent = fullContent.slice(startPos);
+      // Slice by bytes then decode — correctly handles multi-byte characters
+      const newContent = fullBuf.slice(startPos).toString("utf-8");
       linesToProcess = newContent.split("\n");
     }
   } else {
@@ -277,40 +279,45 @@ export function processFile(
       );
     }
 
-    // Upsert session summary
-    db.run(
-      `INSERT INTO sessions 
-       (id, project, session_name, started_at, ended_at, message_count,
-        total_input, total_output, total_cache_read, total_cache_write,
-        total_cost, primary_model, primary_provider)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-       ON CONFLICT(id) DO UPDATE SET
-       session_name = COALESCE(excluded.session_name, session_name),
-       ended_at = CASE WHEN excluded.ended_at IS NULL THEN ended_at ELSE MAX(ended_at, excluded.ended_at) END,
-       message_count = excluded.message_count,
-       total_input = excluded.total_input,
-       total_output = excluded.total_output,
-       total_cache_read = excluded.total_cache_read,
-       total_cache_write = excluded.total_cache_write,
-       total_cost = excluded.total_cost,
-       primary_model = excluded.primary_model,
-       primary_provider = excluded.primary_provider`,
-      [
-        sessionId,
-        project,
-        sessionName,
-        startedAtMs,
-        messageCount > 0 ? lastMessageTimestamp : null,
-        messageCount,
-        totalInput,
-        totalOutput,
-        totalCacheRead,
-        totalCacheWrite,
-        totalCost,
-        primaryModel,
-        primaryProvider,
-      ],
-    );
+    // Only upsert session summary when we have new usage events to write.
+    // Skipping when events.length === 0 prevents an incremental rescan from
+    // zeroing out existing aggregates (message_count, totals, primary_model)
+    // on files that contain no new assistant-usage entries.
+    if (events.length > 0) {
+      db.run(
+        `INSERT INTO sessions 
+         (id, project, session_name, started_at, ended_at, message_count,
+          total_input, total_output, total_cache_read, total_cache_write,
+          total_cost, primary_model, primary_provider)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+         session_name = COALESCE(excluded.session_name, session_name),
+         ended_at = CASE WHEN excluded.ended_at IS NULL THEN ended_at ELSE MAX(ended_at, excluded.ended_at) END,
+         message_count = excluded.message_count,
+         total_input = excluded.total_input,
+         total_output = excluded.total_output,
+         total_cache_read = excluded.total_cache_read,
+         total_cache_write = excluded.total_cache_write,
+         total_cost = excluded.total_cost,
+         primary_model = excluded.primary_model,
+         primary_provider = excluded.primary_provider`,
+        [
+          sessionId,
+          project,
+          sessionName,
+          startedAtMs,
+          messageCount > 0 ? lastMessageTimestamp : null,
+          messageCount,
+          totalInput,
+          totalOutput,
+          totalCacheRead,
+          totalCacheWrite,
+          totalCost,
+          primaryModel,
+          primaryProvider,
+        ],
+      );
+    }
 
     // Update processing state with byte offset (only for the lines we actually processed)
     const fileStats = statSync(filePath);

--- a/packages/cli/src/usage/schema.ts
+++ b/packages/cli/src/usage/schema.ts
@@ -1,0 +1,92 @@
+import { Database } from "bun:sqlite";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { mkdirSync } from "node:fs";
+
+const SCHEMA_VERSION = 1;
+
+export function getUsageDbPath(): string {
+  return join(homedir(), ".pizzapi", "agent", "usage.db");
+}
+
+export function getSessionsDir(): string {
+  // Primary directory — scanner also checks piDir as fallback
+  return join(homedir(), ".pizzapi", "agent", "sessions");
+}
+
+export function openUsageDb(): Database {
+  const dbPath = getUsageDbPath();
+  mkdirSync(join(dbPath, ".."), { recursive: true });
+
+  const db = new Database(dbPath);
+
+  // Enable WAL for concurrent read/write
+  db.run("PRAGMA journal_mode=WAL");
+
+  const currentVersion = db.query<{ user_version: number }, []>(
+    "PRAGMA user_version"
+  ).get()?.user_version ?? 0;
+
+  if (currentVersion < SCHEMA_VERSION) {
+    db.transaction(() => {
+      if (currentVersion < 1) {
+        db.run(`
+          CREATE TABLE IF NOT EXISTS usage_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL,
+            project TEXT NOT NULL,
+            timestamp INTEGER NOT NULL,
+            provider TEXT NOT NULL,
+            model TEXT NOT NULL,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            cost_usd REAL,
+            cost_input REAL,
+            cost_output REAL,
+            cost_cache_read REAL,
+            cost_cache_write REAL,
+            UNIQUE(session_id, timestamp, model)
+          )
+        `);
+
+        db.run(`
+          CREATE TABLE IF NOT EXISTS sessions (
+            id TEXT PRIMARY KEY,
+            project TEXT NOT NULL,
+            session_name TEXT,
+            started_at INTEGER NOT NULL,
+            ended_at INTEGER,
+            message_count INTEGER DEFAULT 0,
+            total_input INTEGER DEFAULT 0,
+            total_output INTEGER DEFAULT 0,
+            total_cache_read INTEGER DEFAULT 0,
+            total_cache_write INTEGER DEFAULT 0,
+            total_cost REAL,
+            primary_model TEXT,
+            primary_provider TEXT
+          )
+        `);
+
+        db.run(`
+          CREATE TABLE IF NOT EXISTS processing_state (
+            file_path TEXT PRIMARY KEY,
+            last_offset INTEGER DEFAULT 0,
+            last_modified INTEGER
+          )
+        `);
+
+        db.run("CREATE INDEX IF NOT EXISTS idx_events_timestamp ON usage_events(timestamp)");
+        db.run("CREATE INDEX IF NOT EXISTS idx_events_project ON usage_events(project)");
+        db.run("CREATE INDEX IF NOT EXISTS idx_events_model ON usage_events(model)");
+        db.run("CREATE INDEX IF NOT EXISTS idx_sessions_started ON sessions(started_at)");
+        db.run("CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project)");
+      }
+
+      db.run(`PRAGMA user_version = ${SCHEMA_VERSION}`);
+    })();
+  }
+
+  return db;
+}

--- a/packages/cli/src/usage/types.ts
+++ b/packages/cli/src/usage/types.ts
@@ -1,0 +1,108 @@
+/** JSONL session header (first line of every session file) */
+export interface SessionHeader {
+  type: "session";
+  version: number;
+  id: string;
+  timestamp: string;
+  cwd: string;
+}
+
+/** JSONL assistant message with usage data */
+export interface UsageMessage {
+  type: "message";
+  id: string;
+  timestamp: string;
+  message: {
+    role: "assistant";
+    provider: string;
+    model: string;
+    usage?: {
+      input: number;
+      output: number;
+      cacheRead: number;
+      cacheWrite: number;
+      totalTokens: number;
+      cost?: {
+        input?: number;
+        output?: number;
+        cacheRead?: number;
+        cacheWrite?: number;
+        total: number;
+      };
+    };
+  };
+}
+
+/** JSONL model change event */
+export interface ModelChangeEvent {
+  type: "model_change";
+  timestamp: string;
+  provider: string;
+  modelId: string;
+}
+
+/** API response shape */
+export interface UsageData {
+  generatedAt: string;
+  dateRange: { from: string; to: string };
+  totalDateRange: { from: string; to: string };
+
+  summary: {
+    totalSessions: number;
+    totalCost: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalCacheReadTokens: number;
+    totalCacheWriteTokens: number;
+    avgSessionCost: number;
+    avgSessionTokens: number;
+    avgSessionDurationMs: number | null;
+    sessionsWithCost: number;
+  };
+
+  daily: Array<{
+    date: string;
+    sessions: number;
+    cost: number;
+    costInput: number;
+    costOutput: number;
+    costCacheRead: number;
+    costCacheWrite: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+  }>;
+
+  byModel: Array<{
+    provider: string;
+    model: string;
+    sessions: number;
+    cost: number;
+    inputTokens: number;
+    outputTokens: number;
+  }>;
+
+  byProject: Array<{
+    project: string;
+    projectShort: string;
+    sessions: number;
+    cost: number;
+    inputTokens: number;
+    outputTokens: number;
+  }>;
+
+  recentSessions: Array<{
+    id: string;
+    project: string;
+    projectShort: string;
+    sessionName: string | null;
+    startedAt: string;
+    endedAt: string | null;
+    messageCount: number;
+    totalCost: number | null;
+    primaryModel: string;
+  }>;
+}
+
+export type UsageRange = "7d" | "30d" | "90d" | "all";

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -74,6 +74,18 @@ export interface RunnerClientToServerEvents {
     [key: string]: unknown;
   }) => void;
 
+  /** Runner responds with usage dashboard data */
+  usage_data: (data: {
+    requestId?: string;
+    data: unknown; // UsageData shape — typed as unknown here to avoid protocol depending on CLI types
+  }) => void;
+
+  /** Runner reports a usage data error */
+  usage_error: (data: {
+    requestId?: string;
+    error: string;
+  }) => void;
+
   /** Runner forwards a session event from a worker */
   runner_session_event: (data: {
     sessionId: string;
@@ -327,6 +339,12 @@ export interface RunnerServerToClientEvents {
   sandbox_update_config: (data: {
     requestId?: string;
     config: Record<string, unknown>;
+  }) => void;
+
+  /** Requests usage dashboard data from the runner */
+  get_usage: (data: {
+    requestId?: string;
+    range?: "7d" | "30d" | "90d" | "all";
   }) => void;
 
   /** Generic error */

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -757,5 +757,33 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         }
     }
 
+    // GET /api/runners/:id/usage
+    const usageMatch = url.pathname.match(/^\/api\/runners\/([^/]+)\/usage$/);
+    if (usageMatch && req.method === "GET") {
+        const identity = await requireSession(req);
+        if (identity instanceof Response) return identity;
+
+        const runnerId = decodeURIComponent(usageMatch[1]);
+        const runner = await getRunnerData(runnerId);
+        if (!runner) return Response.json({ error: "Runner not found" }, { status: 404 });
+        if (runner.userId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
+
+        const range = url.searchParams.get("range") || "90d";
+        const validRanges = ["7d", "30d", "90d", "all"];
+        if (!validRanges.includes(range)) {
+            return Response.json({ error: "Invalid range parameter" }, { status: 400 });
+        }
+
+        try {
+            const result = await sendRunnerCommand(runnerId, { type: "get_usage", range }, 30_000) as any;
+            if (result && result.error) {
+                return Response.json({ error: result.error }, { status: 502 });
+            }
+            return Response.json(result);
+        } catch (err) {
+            return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 502 });
+        }
+    }
+
     return undefined;
 };

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -154,6 +154,7 @@ export async function sendAgentCommand(
 
 interface PendingRunnerCommand {
     resolve: (result: Record<string, unknown>) => void;
+    reject: (err: Error) => void;
     timer: ReturnType<typeof setTimeout>;
 }
 
@@ -184,7 +185,7 @@ export async function sendRunnerCommand(
             reject(new Error("Runner command timed out"));
         }, timeoutMs);
 
-        pendingRunnerCommands.set(requestId, { resolve, timer });
+        pendingRunnerCommands.set(requestId, { resolve, reject, timer });
 
         try {
             const { type: _type, ...rest } = command;
@@ -396,6 +397,32 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                     pendingRunnerCommands.delete(requestId);
                     const { requestId: _rid, ...rest } = data;
                     pending.resolve(rest);
+                }
+            }
+        });
+
+        // ── usage_data — respond with usage dashboard data ────────────────────
+        socket.on("usage_data", (data) => {
+            const requestId = data.requestId;
+            if (requestId) {
+                const pending = pendingRunnerCommands.get(requestId);
+                if (pending) {
+                    clearTimeout(pending.timer);
+                    pendingRunnerCommands.delete(requestId);
+                    pending.resolve((data.data as Record<string, unknown>) ?? {});
+                }
+            }
+        });
+
+        // ── usage_error — usage data request failed ──────────────────────────
+        socket.on("usage_error", (data) => {
+            const requestId = data.requestId;
+            if (requestId) {
+                const pending = pendingRunnerCommands.get(requestId);
+                if (pending) {
+                    clearTimeout(pending.timer);
+                    pendingRunnerCommands.delete(requestId);
+                    pending.reject(new Error(data.error ?? "Unknown usage error"));
                 }
             }
         });

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,6 +41,7 @@
     "react-dom": "^19.2.4",
     "react-icons": "^5.5.0",
     "react-resizable": "^3.0.5",
+    "recharts": "^3.8.0",
     "shiki": "^3.22.0",
     "streamdown": "^2.3.0",
     "tailwind-merge": "^3.5.0",

--- a/packages/ui/src/components/RunnerDetailPanel.tsx
+++ b/packages/ui/src/components/RunnerDetailPanel.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState, useEffect } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { Button } from "@/components/ui/button";
 import {
     Tooltip,
@@ -13,6 +13,11 @@ import { SkillsManager, type SkillInfo } from "@/components/SkillsManager";
 import { AgentsManager, type AgentInfo } from "@/components/AgentsManager";
 import { PluginsManager, type PluginInfo } from "@/components/PluginsManager";
 import { SandboxManager } from "@/components/SandboxManager";
+const UsageDashboard = React.lazy(() =>
+    import("@/components/usage-dashboard/UsageDashboard").then((m) => ({
+        default: m.UsageDashboard,
+    }))
+);
 import {
     Plus,
     RefreshCw,
@@ -30,7 +35,7 @@ import {
 // Types
 // ---------------------------------------------------------------------------
 
-export type RunnerTab = "sessions" | "skills" | "agents" | "plugins" | "sandbox" | "hooks";
+export type RunnerTab = "sessions" | "skills" | "agents" | "plugins" | "sandbox" | "hooks" | "usage";
 
 interface RunnerHook {
     type: string;
@@ -254,6 +259,7 @@ const TABS: { key: RunnerTab; label: string; countKey?: "skills" | "agents" | "p
     { key: "agents", label: "Agents", countKey: "agents" },
     { key: "plugins", label: "Plugins", countKey: "plugins" },
     { key: "hooks", label: "Hooks", countKey: "hooks" },
+    { key: "usage", label: "Usage" },
     { key: "sandbox", label: "Sandbox" },
 ];
 
@@ -403,6 +409,20 @@ export function RunnerDetailPanel({
             break;
         case "hooks":
             tabContent = <HooksList hooks={runner.hooks} />;
+            break;
+        case "usage":
+            tabContent = (
+                <Suspense
+                    fallback={
+                        <div className="flex items-center justify-center p-8">
+                            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                            <span className="ml-2 text-muted-foreground">Loading usage dashboard...</span>
+                        </div>
+                    }
+                >
+                    <UsageDashboard runnerId={runner.runnerId} />
+                </Suspense>
+            );
             break;
         case "sandbox":
             tabContent = <SandboxManager runnerId={runner.runnerId} bare />;

--- a/packages/ui/src/components/usage-dashboard/CostChart.tsx
+++ b/packages/ui/src/components/usage-dashboard/CostChart.tsx
@@ -1,0 +1,113 @@
+import React from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { UsageData } from "./types";
+
+interface CostChartProps {
+  daily: UsageData["daily"];
+}
+
+const colors = {
+  input: "#3b82f6",
+  output: "#ef4444",
+  cacheRead: "#8b5cf6",
+  cacheWrite: "#f59e0b",
+};
+
+function formatCurrency(value: number): string {
+  if (value === 0) return "$0";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function CostChart({ daily }: CostChartProps) {
+  if (daily.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Cost Over Time</CardTitle>
+        </CardHeader>
+        <CardContent className="h-96 flex items-center justify-center text-muted-foreground">
+          No data available
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Cost Over Time</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={400}>
+          <BarChart
+            data={daily}
+            margin={{ top: 20, right: 30, left: 0, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+            <XAxis
+              dataKey="date"
+              className="text-xs text-muted-foreground"
+              tick={{ fontSize: 12 }}
+            />
+            <YAxis
+              className="text-xs text-muted-foreground"
+              tick={{ fontSize: 12 }}
+              tickFormatter={formatCurrency}
+            />
+            <Tooltip
+              formatter={(value) => formatCurrency(value as number)}
+              contentStyle={{
+                backgroundColor: "hsl(var(--background))",
+                border: "1px solid hsl(var(--border))",
+              }}
+            />
+            <Legend />
+            <Bar
+              dataKey="costInput"
+              stackId="cost"
+              fill={colors.input}
+              name="Input Cost"
+              radius={[4, 4, 0, 0]}
+            />
+            <Bar
+              dataKey="costOutput"
+              stackId="cost"
+              fill={colors.output}
+              name="Output Cost"
+              radius={[4, 4, 0, 0]}
+            />
+            <Bar
+              dataKey="costCacheRead"
+              stackId="cost"
+              fill={colors.cacheRead}
+              name="Cache Read Cost"
+              radius={[4, 4, 0, 0]}
+            />
+            <Bar
+              dataKey="costCacheWrite"
+              stackId="cost"
+              fill={colors.cacheWrite}
+              name="Cache Write Cost"
+              radius={[4, 4, 0, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/ui/src/components/usage-dashboard/ModelBreakdown.tsx
+++ b/packages/ui/src/components/usage-dashboard/ModelBreakdown.tsx
@@ -1,0 +1,130 @@
+import React from "react";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Legend,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { UsageData } from "./types";
+
+interface ModelBreakdownProps {
+  byModel: UsageData["byModel"];
+}
+
+const colors = [
+  "#3b82f6",
+  "#ef4444",
+  "#10b981",
+  "#f59e0b",
+  "#8b5cf6",
+  "#ec4899",
+  "#06b6d4",
+  "#14b8a6",
+  "#f97316",
+  "#6366f1",
+];
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function ModelBreakdown({ byModel }: ModelBreakdownProps) {
+  if (byModel.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Usage by Model</CardTitle>
+        </CardHeader>
+        <CardContent className="h-96 flex items-center justify-center text-muted-foreground">
+          No data available
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const totalCost = byModel.reduce((sum, m) => sum + m.cost, 0);
+  const data = byModel.map((m) => ({
+    ...m,
+    label: m.model,
+    value: m.cost,
+  }));
+
+  const renderLabel = (entry: any) => {
+    const percentage = totalCost > 0 ? ((entry.value / totalCost) * 100).toFixed(1) : "0";
+    return `${percentage}%`;
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Usage by Model</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="flex flex-col lg:flex-row gap-8">
+          <div className="flex-1">
+            <ResponsiveContainer width="100%" height={300}>
+              <PieChart>
+                <Pie
+                  data={data}
+                  cx="50%"
+                  cy="50%"
+                  labelLine={false}
+                  label={renderLabel}
+                  outerRadius={100}
+                  fill="#8884d8"
+                  dataKey="value"
+                >
+                  {data.map((entry, index) => (
+                    <Cell
+                      key={`cell-${index}`}
+                      fill={colors[index % colors.length]}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip
+                  formatter={(value) => formatCurrency(value as number)}
+                  contentStyle={{
+                    backgroundColor: "hsl(var(--background))",
+                    border: "1px solid hsl(var(--border))",
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+          </div>
+          <div className="flex-1 flex flex-col gap-2">
+            {data.map((m, idx) => (
+              <div key={m.model} className="text-sm flex items-center gap-3">
+                <div
+                  className="w-3 h-3 rounded-full"
+                  style={{
+                    backgroundColor: colors[idx % colors.length],
+                  }}
+                />
+                <div className="flex-1">
+                  <div className="font-medium">{m.model}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {m.provider}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="font-medium">{formatCurrency(m.cost)}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {m.sessions} sessions
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/ui/src/components/usage-dashboard/PeriodSelector.tsx
+++ b/packages/ui/src/components/usage-dashboard/PeriodSelector.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import { Button } from "@/components/ui/button";
+import type { UsageRange } from "./types";
+
+interface PeriodSelectorProps {
+  value: UsageRange;
+  onChange: (range: UsageRange) => void;
+}
+
+const periods: { label: string; value: UsageRange }[] = [
+  { label: "7 days", value: "7d" },
+  { label: "30 days", value: "30d" },
+  { label: "90 days", value: "90d" },
+  { label: "All time", value: "all" },
+];
+
+export function PeriodSelector({ value, onChange }: PeriodSelectorProps) {
+  return (
+    <div className="flex gap-2 flex-wrap">
+      {periods.map((period) => (
+        <Button
+          key={period.value}
+          variant={value === period.value ? "default" : "outline"}
+          size="sm"
+          onClick={() => onChange(period.value)}
+        >
+          {period.label}
+        </Button>
+      ))}
+    </div>
+  );
+}

--- a/packages/ui/src/components/usage-dashboard/ProjectBreakdown.tsx
+++ b/packages/ui/src/components/usage-dashboard/ProjectBreakdown.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { UsageData } from "./types";
+
+interface ProjectBreakdownProps {
+  byProject: UsageData["byProject"];
+}
+
+const colors = {
+  sessions: "#3b82f6",
+  cost: "#ef4444",
+};
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function ProjectBreakdown({ byProject }: ProjectBreakdownProps) {
+  if (byProject.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Sessions by Project</CardTitle>
+        </CardHeader>
+        <CardContent className="h-96 flex items-center justify-center text-muted-foreground">
+          No data available
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const data = byProject.map((p) => ({
+    ...p,
+    name: p.projectShort,
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Sessions by Project</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={400}>
+          <BarChart
+            data={data}
+            layout="vertical"
+            margin={{ top: 5, right: 30, left: 200, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+            <XAxis type="number" className="text-xs text-muted-foreground" />
+            <YAxis
+              dataKey="name"
+              type="category"
+              className="text-xs text-muted-foreground"
+              width={190}
+              tick={{ fontSize: 12 }}
+            />
+            <Tooltip
+              formatter={(value, name) => {
+                if (name === "cost") {
+                  return formatCurrency(value as number);
+                }
+                return value;
+              }}
+              contentStyle={{
+                backgroundColor: "hsl(var(--background))",
+                border: "1px solid hsl(var(--border))",
+              }}
+            />
+            <Legend />
+            <Bar
+              dataKey="sessions"
+              fill={colors.sessions}
+              name="Sessions"
+              radius={[0, 4, 4, 0]}
+            />
+            <Bar
+              dataKey="cost"
+              fill={colors.cost}
+              name="Cost"
+              radius={[0, 4, 4, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/ui/src/components/usage-dashboard/SessionStats.tsx
+++ b/packages/ui/src/components/usage-dashboard/SessionStats.tsx
@@ -86,14 +86,14 @@ export function SessionStats({ summary }: SessionStatsProps) {
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Turns</CardTitle>
+          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Input Tokens</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">
             {summary.totalSessions > 0 ? Math.round(summary.totalInputTokens / summary.totalSessions) : "—"}
           </div>
           <p className="text-xs text-muted-foreground mt-1">
-            messages per session
+            input tokens per session
           </p>
         </CardContent>
       </Card>

--- a/packages/ui/src/components/usage-dashboard/SessionStats.tsx
+++ b/packages/ui/src/components/usage-dashboard/SessionStats.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { UsageData } from "./types";
+
+interface SessionStatsProps {
+  summary: UsageData["summary"];
+}
+
+function formatCurrency(value: number | null): string {
+  if (value === null || value === undefined) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatTokens(value: number): string {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}K`;
+  }
+  return Math.round(value).toString();
+}
+
+function formatDuration(ms: number | null): string {
+  if (ms === null || ms === undefined) return "—";
+  
+  const totalSeconds = Math.round(ms / 1000);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const seconds = totalSeconds % 60;
+
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${seconds}s`;
+  }
+  if (minutes > 0) {
+    return `${minutes}m ${seconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+export function SessionStats({ summary }: SessionStatsProps) {
+  const avgCostPerSession = summary.sessionsWithCost > 0 ? summary.avgSessionCost : null;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Duration</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{formatDuration(summary.avgSessionDurationMs)}</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            per session
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Tokens</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{formatTokens(summary.avgSessionTokens)}</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            per session
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Cost</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{formatCurrency(avgCostPerSession)}</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            {summary.sessionsWithCost > 0 ? `per session` : `no cost data`}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Turns</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">
+            {summary.totalSessions > 0 ? Math.round(summary.totalInputTokens / summary.totalSessions) : "—"}
+          </div>
+          <p className="text-xs text-muted-foreground mt-1">
+            messages per session
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/ui/src/components/usage-dashboard/SummaryCards.tsx
+++ b/packages/ui/src/components/usage-dashboard/SummaryCards.tsx
@@ -27,7 +27,12 @@ function formatTokens(value: number): string {
 }
 
 export function SummaryCards({ summary, daily }: SummaryCardsProps) {
-  // Calculate average daily cost from daily data
+  // Calculate average daily cost from daily data.
+  // TODO: This divides by the number of *active* days (days with at least one
+  // usage event), not the total calendar days in the selected range.
+  // "Avg Daily Cost" over a 30-day range with only 10 active days will be 3×
+  // higher than a pure calendar average.  Consider whether to display both, or
+  // rename the label to "Avg Cost (active days)" to avoid confusion.
   const avgDailyCost = daily.length > 0 ? daily.reduce((sum, d) => sum + d.cost, 0) / daily.length : 0;
 
   return (

--- a/packages/ui/src/components/usage-dashboard/SummaryCards.tsx
+++ b/packages/ui/src/components/usage-dashboard/SummaryCards.tsx
@@ -75,12 +75,12 @@ export function SummaryCards({ summary, daily }: SummaryCardsProps) {
 
       <Card>
         <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Daily Cost</CardTitle>
+          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Cost / Active Day</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="text-2xl font-bold">{summary.sessionsWithCost === 0 ? "—" : formatCurrency(avgDailyCost)}</div>
           <p className="text-xs text-muted-foreground mt-1">
-            {daily.length} days of data
+            across {daily.length} active day{daily.length === 1 ? "" : "s"}
           </p>
         </CardContent>
       </Card>

--- a/packages/ui/src/components/usage-dashboard/SummaryCards.tsx
+++ b/packages/ui/src/components/usage-dashboard/SummaryCards.tsx
@@ -1,0 +1,84 @@
+import React from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { UsageData } from "./types";
+
+interface SummaryCardsProps {
+  summary: UsageData["summary"];
+  daily: UsageData["daily"];
+}
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatTokens(value: number): string {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}K`;
+  }
+  return value.toString();
+}
+
+export function SummaryCards({ summary, daily }: SummaryCardsProps) {
+  // Calculate average daily cost from daily data
+  const avgDailyCost = daily.length > 0 ? daily.reduce((sum, d) => sum + d.cost, 0) / daily.length : 0;
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Total Cost</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{summary.sessionsWithCost === 0 ? "—" : formatCurrency(summary.totalCost)}</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            {summary.sessionsWithCost} of {summary.totalSessions} sessions with cost data
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Sessions</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{summary.totalSessions}</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            {summary.avgSessionCost > 0 ? `Avg ${formatCurrency(summary.avgSessionCost)}/session` : "No cost data"}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Total Tokens</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{formatTokens(summary.totalInputTokens + summary.totalOutputTokens)}</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            Input + Output
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Daily Cost</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{summary.sessionsWithCost === 0 ? "—" : formatCurrency(avgDailyCost)}</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            {daily.length} days of data
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/packages/ui/src/components/usage-dashboard/TokenChart.tsx
+++ b/packages/ui/src/components/usage-dashboard/TokenChart.tsx
@@ -1,0 +1,139 @@
+import React from "react";
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { UsageData } from "./types";
+
+interface TokenChartProps {
+  daily: UsageData["daily"];
+}
+
+const colors = {
+  input: "#3b82f6",
+  output: "#ef4444",
+  cacheRead: "#8b5cf6",
+  cacheWrite: "#f59e0b",
+};
+
+function formatTokens(value: number): string {
+  if (value >= 1_000_000) {
+    return `${(value / 1_000_000).toFixed(1)}M`;
+  }
+  if (value >= 1_000) {
+    return `${(value / 1_000).toFixed(1)}K`;
+  }
+  return value.toString();
+}
+
+export function TokenChart({ daily }: TokenChartProps) {
+  if (daily.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Token Usage Over Time</CardTitle>
+        </CardHeader>
+        <CardContent className="h-96 flex items-center justify-center text-muted-foreground">
+          No data available
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Token Usage Over Time</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={400}>
+          <AreaChart
+            data={daily}
+            margin={{ top: 20, right: 30, left: 0, bottom: 5 }}
+          >
+            <defs>
+              <linearGradient id="colorInput" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={colors.input} stopOpacity={0.8} />
+                <stop offset="95%" stopColor={colors.input} stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="colorOutput" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={colors.output} stopOpacity={0.8} />
+                <stop offset="95%" stopColor={colors.output} stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="colorCacheRead" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={colors.cacheRead} stopOpacity={0.8} />
+                <stop offset="95%" stopColor={colors.cacheRead} stopOpacity={0} />
+              </linearGradient>
+              <linearGradient id="colorCacheWrite" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor={colors.cacheWrite} stopOpacity={0.8} />
+                <stop offset="95%" stopColor={colors.cacheWrite} stopOpacity={0} />
+              </linearGradient>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+            <XAxis
+              dataKey="date"
+              className="text-xs text-muted-foreground"
+              tick={{ fontSize: 12 }}
+            />
+            <YAxis
+              className="text-xs text-muted-foreground"
+              tick={{ fontSize: 12 }}
+              tickFormatter={formatTokens}
+            />
+            <Tooltip
+              formatter={(value) => formatTokens(value as number)}
+              contentStyle={{
+                backgroundColor: "hsl(var(--background))",
+                border: "1px solid hsl(var(--border))",
+              }}
+            />
+            <Legend />
+            <Area
+              type="monotone"
+              dataKey="inputTokens"
+              stackId="1"
+              stroke={colors.input}
+              fillOpacity={1}
+              fill="url(#colorInput)"
+              name="Input Tokens"
+            />
+            <Area
+              type="monotone"
+              dataKey="outputTokens"
+              stackId="1"
+              stroke={colors.output}
+              fillOpacity={1}
+              fill="url(#colorOutput)"
+              name="Output Tokens"
+            />
+            <Area
+              type="monotone"
+              dataKey="cacheReadTokens"
+              stackId="1"
+              stroke={colors.cacheRead}
+              fillOpacity={1}
+              fill="url(#colorCacheRead)"
+              name="Cache Read Tokens"
+            />
+            <Area
+              type="monotone"
+              dataKey="cacheWriteTokens"
+              stackId="1"
+              stroke={colors.cacheWrite}
+              fillOpacity={1}
+              fill="url(#colorCacheWrite)"
+              name="Cache Write Tokens"
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/ui/src/components/usage-dashboard/UsageDashboard.tsx
+++ b/packages/ui/src/components/usage-dashboard/UsageDashboard.tsx
@@ -1,0 +1,170 @@
+import React, { useState, useEffect } from "react";
+import { PeriodSelector } from "./PeriodSelector";
+import { SummaryCards } from "./SummaryCards";
+import { SessionStats } from "./SessionStats";
+import { CostChart } from "./CostChart";
+import { TokenChart } from "./TokenChart";
+import { ModelBreakdown } from "./ModelBreakdown";
+import { ProjectBreakdown } from "./ProjectBreakdown";
+import { Card, CardContent } from "@/components/ui/card";
+import { AlertCircle, Loader2 } from "lucide-react";
+import type { UsageData, UsageRange } from "./types";
+
+interface UsageDashboardProps {
+  runnerId: string;
+}
+
+export function UsageDashboard({ runnerId }: UsageDashboardProps) {
+  const [range, setRange] = useState<UsageRange>("90d");
+  const [data, setData] = useState<UsageData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchUsageData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch(
+          `/api/runners/${encodeURIComponent(runnerId)}/usage?range=${range}`,
+          {
+            headers: {
+              Accept: "application/json",
+            },
+          },
+        );
+
+        if (!response.ok) {
+          const errorData = await response.json();
+          throw new Error(errorData.error || "Failed to fetch usage data");
+        }
+
+        const usageData = await response.json();
+        setData(usageData);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "An unexpected error occurred",
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUsageData();
+  }, [runnerId, range]);
+
+  if (error) {
+    return (
+      <div className="space-y-4">
+        <div className="flex items-center gap-3 p-4 border border-red-500/30 bg-red-500/5 rounded-lg">
+          <AlertCircle className="h-5 w-5 text-red-600" />
+          <div>
+            <h3 className="font-medium text-red-900 dark:text-red-200">
+              Error loading usage data
+            </h3>
+            <p className="text-sm text-red-800 dark:text-red-300">{error}</p>
+          </div>
+        </div>
+        <PeriodSelector value={range} onChange={setRange} />
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        <span className="ml-2 text-muted-foreground">Loading usage data...</span>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <p className="text-muted-foreground">No usage data available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Period Selector */}
+      <PeriodSelector value={range} onChange={setRange} />
+
+      {/* Summary Cards */}
+      <SummaryCards summary={data.summary} daily={data.daily} />
+
+      {/* Session Stats */}
+      <SessionStats summary={data.summary} />
+
+      {/* Charts Grid */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <CostChart daily={data.daily} />
+        <TokenChart daily={data.daily} />
+      </div>
+
+      {/* Breakdowns */}
+      <div className="grid grid-cols-1 gap-4">
+        <ModelBreakdown byModel={data.byModel} />
+        <ProjectBreakdown byProject={data.byProject} />
+      </div>
+
+      {/* Recent Sessions */}
+      {data.recentSessions.length > 0 && (
+        <Card>
+          <div className="px-6 py-4 border-b">
+            <h3 className="font-semibold">Recent Sessions</h3>
+          </div>
+          <CardContent className="pt-4">
+            <div className="space-y-2 overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead className="border-b">
+                  <tr className="text-muted-foreground">
+                    <th className="text-left py-2 px-2 font-medium">
+                      Session
+                    </th>
+                    <th className="text-left py-2 px-2 font-medium">
+                      Project
+                    </th>
+                    <th className="text-left py-2 px-2 font-medium">Model</th>
+                    <th className="text-right py-2 px-2 font-medium">Cost</th>
+                    <th className="text-right py-2 px-2 font-medium">
+                      Messages
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.recentSessions.map((session) => (
+                    <tr
+                      key={session.id}
+                      className="border-b last:border-0 hover:bg-muted/50"
+                    >
+                      <td className="py-2 px-2 truncate max-w-xs">
+                        {session.sessionName || `Session ${session.id.slice(0, 8)}`}
+                      </td>
+                      <td className="py-2 px-2 truncate max-w-xs">
+                        {session.projectShort}
+                      </td>
+                      <td className="py-2 px-2 truncate">
+                        {session.primaryModel}
+                      </td>
+                      <td className="py-2 px-2 text-right">
+                        {session.totalCost
+                          ? `$${session.totalCost.toFixed(3)}`
+                          : "—"}
+                      </td>
+                      <td className="py-2 px-2 text-right">
+                        {session.messageCount}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/components/usage-dashboard/types.ts
+++ b/packages/ui/src/components/usage-dashboard/types.ts
@@ -1,0 +1,65 @@
+/** API response shape */
+export interface UsageData {
+  generatedAt: string;
+  dateRange: { from: string; to: string };
+  totalDateRange: { from: string; to: string };
+
+  summary: {
+    totalSessions: number;
+    totalCost: number;
+    totalInputTokens: number;
+    totalOutputTokens: number;
+    totalCacheReadTokens: number;
+    totalCacheWriteTokens: number;
+    avgSessionCost: number;
+    avgSessionTokens: number;
+    avgSessionDurationMs: number | null;
+    sessionsWithCost: number;
+  };
+
+  daily: Array<{
+    date: string;
+    sessions: number;
+    cost: number;
+    costInput: number;
+    costOutput: number;
+    costCacheRead: number;
+    costCacheWrite: number;
+    inputTokens: number;
+    outputTokens: number;
+    cacheReadTokens: number;
+    cacheWriteTokens: number;
+  }>;
+
+  byModel: Array<{
+    provider: string;
+    model: string;
+    sessions: number;
+    cost: number;
+    inputTokens: number;
+    outputTokens: number;
+  }>;
+
+  byProject: Array<{
+    project: string;
+    projectShort: string;
+    sessions: number;
+    cost: number;
+    inputTokens: number;
+    outputTokens: number;
+  }>;
+
+  recentSessions: Array<{
+    id: string;
+    project: string;
+    projectShort: string;
+    sessionName: string | null;
+    startedAt: string;
+    endedAt: string | null;
+    messageCount: number;
+    totalCost: number | null;
+    primaryModel: string;
+  }>;
+}
+
+export type UsageRange = "7d" | "30d" | "90d" | "all";


### PR DESCRIPTION
## Usage Dashboard

Adds a runner-side usage analytics dashboard that processes JSONL session files into SQLite and renders interactive charts in the web UI.

### What's included

- **Config dir migration**: `~/.pi/agent/` → `~/.pizzapi/agent/` with one-time auto-migration
- **SQLite usage database**: WAL mode, incremental JSONL scanning, idempotent inserts
- **Runner-side scanner**: processes session JSONL files into daily rollups, model/project breakdowns
- **Server REST endpoint**: `GET /api/runners/:id/usage?range=7d|30d|90d|all`
- **Web UI dashboard**: recharts visualizations (cost chart, token chart, model pie, project bars), summary cards, session stats, period selector

### Dashboard features

- Token usage over time (input/output/cache, by day)
- Cost over time with component breakdown
- Usage by model (pie chart)
- Sessions by project (horizontal bar chart)
- Average session stats (duration, tokens, cost, turns)
- Period selector (7d / 30d / 90d / all)

### Technical details

- Scanner uses byte-offset incremental processing with partial-line safety
- SQLite WAL mode for concurrent read/write
- Idempotent inserts via `UNIQUE(session_id, timestamp, model)`
- Dashboard lazy-loaded via `React.lazy` to keep recharts out of main bundle
- 16 tests covering scanner, aggregator, and edge cases

### Design spec

`docs/superpowers/specs/2026-03-23-usage-dashboard-design.md` (local, gitignored)
