### PR TITLE
feat: add security response headers

### DIFF
--- a/packages/server/src/handler.test.ts
+++ b/packages/server/src/handler.test.ts
@@ -1,0 +1,50 @@
+import { describe, test, expect } from "bun:test";
+import { withSecurityHeaders } from "./handler.js";
+
+describe("withSecurityHeaders", () => {
+    test("injects X-Content-Type-Options: nosniff", () => {
+        const res = withSecurityHeaders(new Response("ok", { status: 200 }));
+        expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    });
+
+    test("injects X-Frame-Options: DENY", () => {
+        const res = withSecurityHeaders(new Response("ok", { status: 200 }));
+        expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+    });
+
+    test("injects X-XSS-Protection: 0", () => {
+        const res = withSecurityHeaders(new Response("ok", { status: 200 }));
+        expect(res.headers.get("X-XSS-Protection")).toBe("0");
+    });
+
+    test("injects Referrer-Policy: strict-origin-when-cross-origin", () => {
+        const res = withSecurityHeaders(new Response("ok", { status: 200 }));
+        expect(res.headers.get("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+    });
+
+    test("injects Permissions-Policy", () => {
+        const res = withSecurityHeaders(new Response("ok", { status: 200 }));
+        expect(res.headers.get("Permissions-Policy")).toBe("camera=(), microphone=(), geolocation=()");
+    });
+
+    test("preserves existing headers", () => {
+        const original = new Response("hello", {
+            status: 201,
+            headers: { "Content-Type": "application/json" },
+        });
+        const res = withSecurityHeaders(original);
+        expect(res.headers.get("Content-Type")).toBe("application/json");
+        expect(res.status).toBe(201);
+    });
+
+    test("preserves response body", async () => {
+        const res = withSecurityHeaders(new Response("body text", { status: 200 }));
+        expect(await res.text()).toBe("body text");
+    });
+
+    test("preserves statusText", () => {
+        const res = withSecurityHeaders(new Response(null, { status: 404, statusText: "Not Found" }));
+        expect(res.status).toBe(404);
+        expect(res.statusText).toBe("Not Found");
+    });
+});

--- a/packages/server/src/handler.test.ts
+++ b/packages/server/src/handler.test.ts
@@ -27,6 +27,16 @@ describe("withSecurityHeaders", () => {
         expect(res.headers.get("Permissions-Policy")).toBe("camera=(), microphone=(), geolocation=()");
     });
 
+    test("injects Content-Security-Policy", () => {
+        const res = withSecurityHeaders(new Response("ok", { status: 200 }));
+        const csp = res.headers.get("Content-Security-Policy");
+        expect(csp).not.toBeNull();
+        expect(csp).toContain("default-src 'self'");
+        expect(csp).toContain("script-src 'self'");
+        expect(csp).toContain("connect-src 'self' ws: wss:");
+        expect(csp).toContain("object-src 'none'");
+    });
+
     test("preserves existing headers", () => {
         const original = new Response("hello", {
             status: 201,
@@ -74,5 +84,6 @@ describe("withSecurityHeaders", () => {
         expect(collected["x-xss-protection"]).toBe("0");
         expect(collected["referrer-policy"]).toBe("strict-origin-when-cross-origin");
         expect(collected["permissions-policy"]).toBe("camera=(), microphone=(), geolocation=()");
+        expect(typeof collected["content-security-policy"]).toBe("string");
     });
 });

--- a/packages/server/src/handler.test.ts
+++ b/packages/server/src/handler.test.ts
@@ -47,4 +47,32 @@ describe("withSecurityHeaders", () => {
         expect(res.status).toBe(404);
         expect(res.statusText).toBe("Not Found");
     });
+
+    test("no duplicate security headers when response is collected via sendFetchResponse-style merging", () => {
+        // Regression test for the P0 bug where sendFetchResponse had its own hardcoded
+        // security headers AND withSecurityHeaders also set them, producing header arrays.
+        // After the fix, sendFetchResponse starts with an empty map and only populates it
+        // from the Response headers — so each security header must appear exactly once.
+        const response = withSecurityHeaders(new Response("ok", { status: 200 }));
+
+        // Simulate the sendFetchResponse header-collection loop
+        const collected: Record<string, string | string[]> = {};
+        response.headers.forEach((value, key) => {
+            const existing = collected[key];
+            if (existing !== undefined) {
+                collected[key] = Array.isArray(existing)
+                    ? [...existing, value]
+                    : [existing, value];
+            } else {
+                collected[key] = value;
+            }
+        });
+
+        // Each security header must be a plain string, not an array
+        expect(collected["x-content-type-options"]).toBe("nosniff");
+        expect(collected["x-frame-options"]).toBe("DENY");
+        expect(collected["x-xss-protection"]).toBe("0");
+        expect(collected["referrer-policy"]).toBe("strict-origin-when-cross-origin");
+        expect(collected["permissions-policy"]).toBe("camera=(), microphone=(), geolocation=()");
+    });
 });

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -16,6 +16,10 @@ export function withSecurityHeaders(res: Response): Response {
     headers.set("X-XSS-Protection", "0");
     headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
     headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+    headers.set(
+        "Content-Security-Policy",
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
+    );
     return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
 }
 

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -5,10 +5,30 @@ import { serveStaticFile } from "./static.js";
 import { getClientIp } from "./security.js";
 
 /**
+ * Clone a Response and inject the standard security headers.
+ * Called on every response returned by handleFetch.
+ * Exported for testing.
+ */
+export function withSecurityHeaders(res: Response): Response {
+    const headers = new Headers(res.headers);
+    headers.set("X-Content-Type-Options", "nosniff");
+    headers.set("X-Frame-Options", "DENY");
+    headers.set("X-XSS-Protection", "0");
+    headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+    headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
+    return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
+}
+
+/**
  * Fetch-style request handler (REST + auth + static).
  * Extracted so it can be used both by the production server and integration tests.
  */
 export async function handleFetch(req: Request): Promise<Response> {
+    const res = await _handleFetch(req);
+    return withSecurityHeaders(res);
+}
+
+async function _handleFetch(req: Request): Promise<Response> {
     const url = new URL(req.url);
 
     // ── better-auth handler ────────────────────────────────────────────────

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -141,6 +141,8 @@ const httpServer = createServer(async (req, res) => {
                 "x-xss-protection": "0",
                 "referrer-policy": "strict-origin-when-cross-origin",
                 "permissions-policy": "camera=(), microphone=(), geolocation=()",
+                "content-security-policy":
+                    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
             });
         }
         res.end(JSON.stringify({ error: "Internal server error" }));

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -82,12 +82,9 @@ function nodeReqToFetchRequest(req: IncomingMessage): Request {
 }
 
 async function sendFetchResponse(res: ServerResponse, response: Response): Promise<void> {
-    const headers: Record<string, string | string[]> = {
-        "x-content-type-options": "nosniff",
-        "x-frame-options": "DENY",
-        "x-xss-protection": "0",
-        "referrer-policy": "strict-origin-when-cross-origin"
-    };
+    // Security headers are already injected by withSecurityHeaders in handleFetch.
+    // Do NOT add them here — duplicating would produce header arrays on the wire.
+    const headers: Record<string, string | string[]> = {};
     response.headers.forEach((value, key) => {
         const existing = headers[key];
         if (existing !== undefined) {
@@ -142,7 +139,8 @@ const httpServer = createServer(async (req, res) => {
                 "x-content-type-options": "nosniff",
                 "x-frame-options": "DENY",
                 "x-xss-protection": "0",
-                "referrer-policy": "strict-origin-when-cross-origin"
+                "referrer-policy": "strict-origin-when-cross-origin",
+                "permissions-policy": "camera=(), microphone=(), geolocation=()",
             });
         }
         res.end(JSON.stringify({ error: "Internal server error" }));


### PR DESCRIPTION
Night Shift dish 004 — Adds X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Referrer-Policy, and Permissions-Policy headers to all server responses.