### PR TITLE
chore: add missing paths to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@ Library/Caches/
 
 # Night Shift reports (local-only, not committed)
 /reports/
+
+# Tool artifacts
+.playwright-cli/
+.python-version


### PR DESCRIPTION
Added missing generated and tool paths to the root `.gitignore` to prevent tracking.

Includes:
- `reports/` for Night Shift reports
- `.playwright-cli/` for Playwright cache
- `.python-version` for pyenv config

---
*PR created automatically by Jules for task [13711926325014808749](https://jules.google.com/task/13711926325014808749) started by @Pizzaface*