### PR TITLE
feat: fire session_error trigger to parent on usage limit errors

### DIFF
--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -117,6 +117,7 @@ export function waitForRelayRegistration(timeoutMs: number = 10_000): Promise<vo
 export const remoteExtension: ExtensionFactory = (pi) => {
     // ── Orchestrator-local state (NOT in RelayContext) ─────────────────────
     let sessionCompleteFired = false;
+    let sessionErrorFired = false;
     // Set when /new fires so we can retry delink_children on reconnect if
     // the initial emit is lost.  Cleared by the server ack callback.
     let pendingDelink = false;
@@ -870,6 +871,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
 
     pi.on("turn_start", (event) => {
         sessionCompleteFired = false;
+        sessionErrorFired = false;
         rctx.wasAborted = false;
         clearFollowUpGrace();
         rctx.forwardEvent(event);
@@ -937,6 +939,42 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             }
             const exitReason = rctx.wasAborted ? "killed" : lastError ? "error" : "completed";
             fireSessionComplete(summary, fullOutputPath, exitReason);
+            // Fire session_error for terminal usage-limit errors (one-shot, only at agent_end)
+            if (
+                !sessionErrorFired &&
+                lastError &&
+                rctx.isChildSession &&
+                rctx.parentSessionId &&
+                rctx.sioSocket?.connected &&
+                rctx.relay
+            ) {
+                const errText = lastError.errorMessage;
+                const lower = errText.toLowerCase();
+                const isUsageLimitError =
+                    lower.includes("usage") ||
+                    lower.includes("limit") ||
+                    lower.includes("rate") ||
+                    lower.includes("quota");
+                if (isUsageLimitError) {
+                    sessionErrorFired = true;
+                    rctx.sioSocket.emit("session_trigger" as any, {
+                        token: rctx.relay.token,
+                        trigger: {
+                            type: "session_error",
+                            sourceSessionId: rctx.relay.sessionId,
+                            sourceSessionName: undefined,
+                            targetSessionId: rctx.parentSessionId,
+                            payload: {
+                                message: errText,
+                            },
+                            deliverAs: "steer" as const,
+                            expectsResponse: true,
+                            triggerId: crypto.randomUUID(),
+                            ts: new Date().toISOString(),
+                        },
+                    });
+                }
+            }
             if (rctx.isChildSession) {
                 startFollowUpGrace(ctx);
             }
@@ -960,25 +998,6 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             emitRetryStateChanged(rctx, rctx.lastRetryableError);
             rctx.forwardEvent({ type: "cli_error", message: errorText, source: "provider", ts: Date.now() });
             rctx.forwardEvent(rctx.buildHeartbeat());
-            if (rctx.isChildSession && rctx.parentSessionId && rctx.sioSocket?.connected && rctx.relay) {
-                rctx.sioSocket.emit("session_trigger" as any, {
-                    token: rctx.relay.token,
-                    trigger: {
-                        type: "session_error",
-                        sourceSessionId: rctx.relay.sessionId,
-                        sourceSessionName: undefined,
-                        targetSessionId: rctx.parentSessionId,
-                        payload: {
-                            message: errorText,
-                            error: errorText,
-                        },
-                        deliverAs: "steer" as const,
-                        expectsResponse: true,
-                        triggerId: crypto.randomUUID(),
-                        ts: new Date().toISOString(),
-                    },
-                });
-            }
         }
     });
     pi.on("tool_execution_start", (event) => rctx.forwardEvent(event));

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -48,7 +48,7 @@ import type {
 } from "../remote-types.js";
 import { installFooter } from "../remote-footer.js";
 import { buildHeartbeat, buildTokenUsage, stopHeartbeat } from "../remote-heartbeat.js";
-import { isUsageLimitError } from "./usage-limit-error.js";
+import { maybeFireSessionError } from "./session-error-trigger.js";
 import {
     emitTodoUpdated, emitPlanModeToggled,
     emitRetryStateChanged, emitPluginTrustRequired, emitPluginTrustResolved,
@@ -941,34 +941,19 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             const exitReason = rctx.wasAborted ? "killed" : lastError ? "error" : "completed";
             fireSessionComplete(summary, fullOutputPath, exitReason);
             // Fire session_error for terminal usage-limit errors (one-shot, only at agent_end)
-            if (
-                !sessionErrorFired &&
-                lastError &&
-                rctx.isChildSession &&
-                rctx.parentSessionId &&
-                rctx.sioSocket?.connected &&
-                rctx.relay
-            ) {
-                const errText = lastError.errorMessage;
-                if (isUsageLimitError(errText)) {
-                    sessionErrorFired = true;
-                    rctx.sioSocket.emit("session_trigger" as any, {
-                        token: rctx.relay.token,
-                        trigger: {
-                            type: "session_error",
-                            sourceSessionId: rctx.relay.sessionId,
-                            sourceSessionName: undefined,
-                            targetSessionId: rctx.parentSessionId,
-                            payload: {
-                                message: errText,
-                            },
-                            deliverAs: "steer" as const,
-                            expectsResponse: true,
-                            triggerId: crypto.randomUUID(),
-                            ts: new Date().toISOString(),
-                        },
-                    });
-                }
+            if (maybeFireSessionError({
+                sessionErrorFired,
+                errorMessage: lastError?.errorMessage,
+                isChildSession: rctx.isChildSession,
+                parentSessionId: rctx.parentSessionId,
+                socketConnected: rctx.sioSocket?.connected ?? false,
+                emitFn: rctx.sioSocket
+                    ? (event, payload) => (rctx.sioSocket as any).emit(event, payload)
+                    : null,
+                relayToken: rctx.relay?.token,
+                relaySessionId: rctx.relay?.sessionId,
+            })) {
+                sessionErrorFired = true;
             }
             if (rctx.isChildSession) {
                 startFollowUpGrace(ctx);

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -48,6 +48,7 @@ import type {
 } from "../remote-types.js";
 import { installFooter } from "../remote-footer.js";
 import { buildHeartbeat, buildTokenUsage, stopHeartbeat } from "../remote-heartbeat.js";
+import { isUsageLimitError } from "./usage-limit-error.js";
 import {
     emitTodoUpdated, emitPlanModeToggled,
     emitRetryStateChanged, emitPluginTrustRequired, emitPluginTrustResolved,
@@ -949,13 +950,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 rctx.relay
             ) {
                 const errText = lastError.errorMessage;
-                const lower = errText.toLowerCase();
-                const isUsageLimitError =
-                    lower.includes("usage") ||
-                    lower.includes("limit") ||
-                    lower.includes("rate") ||
-                    lower.includes("quota");
-                if (isUsageLimitError) {
+                if (isUsageLimitError(errText)) {
                     sessionErrorFired = true;
                     rctx.sioSocket.emit("session_trigger" as any, {
                         token: rctx.relay.token,
@@ -992,12 +987,19 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     pi.on("message_end", (event) => {
         rctx.forwardEvent(event);
         const msg = (event as any).message;
-        if (msg && msg.role === "assistant" && msg.stopReason === "error" && msg.errorMessage) {
-            const errorText = String(msg.errorMessage);
-            rctx.lastRetryableError = { errorMessage: errorText, detectedAt: Date.now() };
-            emitRetryStateChanged(rctx, rctx.lastRetryableError);
-            rctx.forwardEvent({ type: "cli_error", message: errorText, source: "provider", ts: Date.now() });
-            rctx.forwardEvent(rctx.buildHeartbeat());
+        if (msg && msg.role === "assistant") {
+            if (msg.stopReason === "error" && msg.errorMessage) {
+                const errorText = String(msg.errorMessage);
+                rctx.lastRetryableError = { errorMessage: errorText, detectedAt: Date.now() };
+                emitRetryStateChanged(rctx, rctx.lastRetryableError);
+                rctx.forwardEvent({ type: "cli_error", message: errorText, source: "provider", ts: Date.now() });
+                rctx.forwardEvent(rctx.buildHeartbeat());
+            } else if (msg.stopReason !== "error" && rctx.lastRetryableError) {
+                // Agent recovered successfully after a retryable error — clear
+                // the latch so we don't report a false-positive error exit.
+                rctx.lastRetryableError = null;
+                emitRetryStateChanged(rctx, null);
+            }
         }
     });
     pi.on("tool_execution_start", (event) => rctx.forwardEvent(event));

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -881,7 +881,8 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         stopHeartbeat();
         stopSessionNameSync();
         _ctx = null;
-        fireSessionComplete(undefined, undefined, rctx.wasAborted ? "killed" : "completed");
+        const shutdownExitReason = rctx.wasAborted ? "killed" : rctx.lastRetryableError ? "error" : "completed";
+        fireSessionComplete(undefined, undefined, shutdownExitReason);
         doDisconnect();
     });
 
@@ -897,6 +898,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
 
     pi.on("agent_end", (event, ctx) => {
         rctx.isAgentActive = false;
+        const lastError = rctx.lastRetryableError;
         rctx.lastRetryableError = null;
         emitRetryStateChanged(rctx, null);
         rctx.forwardEvent(event);
@@ -933,7 +935,8 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                     }
                 }
             }
-            fireSessionComplete(summary, fullOutputPath, rctx.wasAborted ? "killed" : "completed");
+            const exitReason = rctx.wasAborted ? "killed" : lastError ? "error" : "completed";
+            fireSessionComplete(summary, fullOutputPath, exitReason);
             if (rctx.isChildSession) {
                 startFollowUpGrace(ctx);
             }
@@ -957,6 +960,25 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             emitRetryStateChanged(rctx, rctx.lastRetryableError);
             rctx.forwardEvent({ type: "cli_error", message: errorText, source: "provider", ts: Date.now() });
             rctx.forwardEvent(rctx.buildHeartbeat());
+            if (rctx.isChildSession && rctx.parentSessionId && rctx.sioSocket?.connected && rctx.relay) {
+                rctx.sioSocket.emit("session_trigger" as any, {
+                    token: rctx.relay.token,
+                    trigger: {
+                        type: "session_error",
+                        sourceSessionId: rctx.relay.sessionId,
+                        sourceSessionName: undefined,
+                        targetSessionId: rctx.parentSessionId,
+                        payload: {
+                            message: errorText,
+                            error: errorText,
+                        },
+                        deliverAs: "steer" as const,
+                        expectsResponse: true,
+                        triggerId: crypto.randomUUID(),
+                        ts: new Date().toISOString(),
+                    },
+                });
+            }
         }
     });
     pi.on("tool_execution_start", (event) => rctx.forwardEvent(event));

--- a/packages/cli/src/extensions/remote/session-error-trigger.test.ts
+++ b/packages/cli/src/extensions/remote/session-error-trigger.test.ts
@@ -1,0 +1,233 @@
+import { describe, test, expect, mock } from "bun:test";
+import { maybeFireSessionError, type SessionErrorParams } from "./session-error-trigger.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+type EmitFn = (event: string, payload: unknown) => void;
+
+function makeEmitFn(): ReturnType<typeof mock<EmitFn>> {
+    return mock<EmitFn>(() => {});
+}
+
+function makeParams(overrides: Partial<SessionErrorParams> = {}): SessionErrorParams {
+    return {
+        sessionErrorFired: false,
+        errorMessage: "You have exceeded your usage limit",
+        isChildSession: true,
+        parentSessionId: "parent-session-123",
+        socketConnected: true,
+        emitFn: makeEmitFn(),
+        relayToken: "relay-token-abc",
+        relaySessionId: "relay-session-xyz",
+        ...overrides,
+    };
+}
+
+// ── Happy path: trigger IS emitted ───────────────────────────────────────────
+
+describe("maybeFireSessionError — happy path", () => {
+    test("emits session_trigger when all conditions are met", () => {
+        const emitFn = makeEmitFn();
+        const params = makeParams({ emitFn });
+
+        const result = maybeFireSessionError(params);
+
+        expect(result).toBe(true);
+        expect(emitFn).toHaveBeenCalledTimes(1);
+    });
+
+    test("emits to the 'session_trigger' event name", () => {
+        const emitFn = makeEmitFn();
+        maybeFireSessionError(makeParams({ emitFn }));
+
+        expect(emitFn.mock.calls[0][0]).toBe("session_trigger");
+    });
+
+    test("payload contains correct type, relayToken, and targetSessionId", () => {
+        const emitFn = makeEmitFn();
+        const params = makeParams({
+            emitFn,
+            relayToken: "tok-123",
+            parentSessionId: "parent-456",
+            relaySessionId: "source-789",
+        });
+
+        maybeFireSessionError(params);
+
+        const payload = emitFn.mock.calls[0][1] as any;
+        expect(payload.token).toBe("tok-123");
+        expect(payload.trigger.type).toBe("session_error");
+        expect(payload.trigger.targetSessionId).toBe("parent-456");
+        expect(payload.trigger.sourceSessionId).toBe("source-789");
+        expect(payload.trigger.deliverAs).toBe("steer");
+        expect(payload.trigger.expectsResponse).toBe(true);
+    });
+
+    test("payload.trigger.payload.message contains the error message", () => {
+        const emitFn = makeEmitFn();
+        const errMsg = "Rate limit reached for your plan";
+        maybeFireSessionError(makeParams({ emitFn, errorMessage: errMsg }));
+
+        const payload = emitFn.mock.calls[0][1] as any;
+        expect(payload.trigger.payload.message).toBe(errMsg);
+    });
+
+    test("payload includes a triggerId (UUID) and ts (ISO string)", () => {
+        const emitFn = makeEmitFn();
+        maybeFireSessionError(makeParams({ emitFn }));
+
+        const payload = emitFn.mock.calls[0][1] as any;
+        expect(typeof payload.trigger.triggerId).toBe("string");
+        expect(payload.trigger.triggerId.length).toBeGreaterThan(0);
+        expect(typeof payload.trigger.ts).toBe("string");
+        expect(() => new Date(payload.trigger.ts)).not.toThrow();
+    });
+
+    test("works with gRPC RESOURCE_EXHAUSTED (underscore)", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({
+            emitFn,
+            errorMessage: "grpc status RESOURCE_EXHAUSTED",
+        }));
+
+        expect(result).toBe(true);
+        expect(emitFn).toHaveBeenCalledTimes(1);
+    });
+
+    test("works with gRPC QUOTA_EXCEEDED (underscore)", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({
+            emitFn,
+            errorMessage: "grpc status QUOTA_EXCEEDED",
+        }));
+
+        expect(result).toBe(true);
+        expect(emitFn).toHaveBeenCalledTimes(1);
+    });
+});
+
+// ── Guard conditions: trigger must NOT fire ───────────────────────────────────
+
+describe("maybeFireSessionError — guard conditions", () => {
+    test("returns false and does not emit when sessionErrorFired is already true", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({ emitFn, sessionErrorFired: true }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+
+    test("returns false and does not emit when errorMessage is undefined", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({ emitFn, errorMessage: undefined }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+
+    test("returns false and does not emit when errorMessage is null", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({ emitFn, errorMessage: null }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+
+    test("returns false and does not emit when errorMessage is empty string", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({ emitFn, errorMessage: "" }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+
+    test("returns false and does not emit when not a child session", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({ emitFn, isChildSession: false }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+
+    test("returns false and does not emit when parentSessionId is null", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({ emitFn, parentSessionId: null }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+
+    test("returns false and does not emit when socket is not connected", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({ emitFn, socketConnected: false }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+
+    test("returns false and does not emit when emitFn is null", () => {
+        const result = maybeFireSessionError(makeParams({ emitFn: null }));
+
+        expect(result).toBe(false);
+    });
+
+    test("returns false and does not emit when relayToken is missing", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({ emitFn, relayToken: null }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+
+    test("returns false and does not emit when relaySessionId is missing", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({ emitFn, relaySessionId: null }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+
+    test("returns false and does not emit when error is not a usage-limit error", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({
+            emitFn,
+            errorMessage: "Connection reset by peer",
+        }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+
+    test("returns false and does not emit for generic server errors", () => {
+        const emitFn = makeEmitFn();
+        const result = maybeFireSessionError(makeParams({
+            emitFn,
+            errorMessage: "Internal server error (500)",
+        }));
+
+        expect(result).toBe(false);
+        expect(emitFn).not.toHaveBeenCalled();
+    });
+});
+
+// ── One-shot guard behaviour ──────────────────────────────────────────────────
+
+describe("maybeFireSessionError — one-shot semantics", () => {
+    test("caller is responsible for setting sessionErrorFired after return", () => {
+        // Simulate the agent_end pattern from index.ts:
+        //   if (maybeFireSessionError(...)) { sessionErrorFired = true; }
+        let sessionErrorFired = false;
+        const emitFn = makeEmitFn();
+
+        // First call: fires and caller sets the flag
+        if (maybeFireSessionError(makeParams({ emitFn, sessionErrorFired }))) {
+            sessionErrorFired = true;
+        }
+
+        // Second call with updated flag: must NOT fire again
+        const secondResult = maybeFireSessionError(makeParams({ emitFn, sessionErrorFired }));
+
+        expect(secondResult).toBe(false);
+        expect(emitFn).toHaveBeenCalledTimes(1); // only the first call emitted
+    });
+});

--- a/packages/cli/src/extensions/remote/session-error-trigger.ts
+++ b/packages/cli/src/extensions/remote/session-error-trigger.ts
@@ -1,0 +1,91 @@
+/**
+ * session-error-trigger.ts
+ *
+ * Pure helper that encapsulates the `session_error` trigger emission logic
+ * that runs at `agent_end`. Extracted from index.ts so it can be unit-tested
+ * independently of the pi extension lifecycle.
+ */
+
+import { isUsageLimitError } from "./usage-limit-error.js";
+
+export interface SessionErrorParams {
+    /** Whether a session_error trigger has already been fired this session. */
+    sessionErrorFired: boolean;
+    /** The error message from the last retryable error, if any. */
+    errorMessage: string | undefined | null;
+    /** Whether this session is a child of another session. */
+    isChildSession: boolean;
+    /** The parent session ID, or null/undefined if not a child. */
+    parentSessionId: string | null | undefined;
+    /** Whether the Socket.IO socket is currently connected. */
+    socketConnected: boolean;
+    /**
+     * Function that emits an event on the Socket.IO socket.
+     * Null when the socket is unavailable.
+     */
+    emitFn: ((event: string, payload: unknown) => void) | null;
+    /** Relay auth token. */
+    relayToken: string | undefined | null;
+    /** Relay session ID (source of the trigger). */
+    relaySessionId: string | undefined | null;
+}
+
+/**
+ * Fires a `session_error` trigger to the parent session if all preconditions
+ * are met and the error message is a known usage-limit error.
+ *
+ * Preconditions (all must hold):
+ *  - `sessionErrorFired` is false (one-shot guard)
+ *  - `errorMessage` is a non-empty string
+ *  - `isChildSession` is true
+ *  - `parentSessionId` is set
+ *  - `socketConnected` is true
+ *  - `emitFn` is available
+ *  - `relayToken` and `relaySessionId` are set
+ *  - `isUsageLimitError(errorMessage)` returns true
+ *
+ * @returns `true` if the trigger was fired; `false` if any precondition failed.
+ */
+export function maybeFireSessionError(params: SessionErrorParams): boolean {
+    const {
+        sessionErrorFired,
+        errorMessage,
+        isChildSession,
+        parentSessionId,
+        socketConnected,
+        emitFn,
+        relayToken,
+        relaySessionId,
+    } = params;
+
+    if (
+        !sessionErrorFired &&
+        errorMessage &&
+        isChildSession &&
+        parentSessionId &&
+        socketConnected &&
+        emitFn &&
+        relayToken &&
+        relaySessionId &&
+        isUsageLimitError(errorMessage)
+    ) {
+        emitFn("session_trigger", {
+            token: relayToken,
+            trigger: {
+                type: "session_error",
+                sourceSessionId: relaySessionId,
+                sourceSessionName: undefined,
+                targetSessionId: parentSessionId,
+                payload: {
+                    message: errorMessage,
+                },
+                deliverAs: "steer" as const,
+                expectsResponse: true,
+                triggerId: crypto.randomUUID(),
+                ts: new Date().toISOString(),
+            },
+        });
+        return true;
+    }
+    return false;
+}

--- a/packages/cli/src/extensions/remote/usage-limit-error.test.ts
+++ b/packages/cli/src/extensions/remote/usage-limit-error.test.ts
@@ -29,8 +29,12 @@ describe("isUsageLimitError", () => {
             expect(isUsageLimitError("Resource exhausted: RESOURCE_EXHAUSTED")).toBe(true);
         });
 
-        test("'RESOURCE_EXHAUSTED' uppercase", () => {
-            expect(isUsageLimitError("grpc status RESOURCE_EXHAUSTED")).toBe(false); // "resource exhausted" requires space not underscore
+        test("'RESOURCE_EXHAUSTED' gRPC/Gemini style (underscore)", () => {
+            expect(isUsageLimitError("grpc status RESOURCE_EXHAUSTED")).toBe(true);
+        });
+
+        test("'QUOTA_EXCEEDED' gRPC style (underscore)", () => {
+            expect(isUsageLimitError("grpc status QUOTA_EXCEEDED")).toBe(true);
         });
 
         test("'resource exhausted' lowercase", () => {

--- a/packages/cli/src/extensions/remote/usage-limit-error.test.ts
+++ b/packages/cli/src/extensions/remote/usage-limit-error.test.ts
@@ -1,0 +1,136 @@
+import { describe, test, expect } from "bun:test";
+import { isUsageLimitError } from "./usage-limit-error.js";
+
+describe("isUsageLimitError", () => {
+    // ── True positives ────────────────────────────────────────────────────
+
+    describe("matches known usage-limit phrases", () => {
+        test("'usage limit' (Anthropic Claude)", () => {
+            expect(isUsageLimitError("You have exceeded your usage limit")).toBe(true);
+        });
+
+        test("'usage limit' case-insensitive", () => {
+            expect(isUsageLimitError("USAGE LIMIT reached")).toBe(true);
+        });
+
+        test("'rate limit'", () => {
+            expect(isUsageLimitError("Rate limit reached for your plan")).toBe(true);
+        });
+
+        test("'rate limit' mixed case", () => {
+            expect(isUsageLimitError("Rate Limit Exceeded")).toBe(true);
+        });
+
+        test("'quota exceeded'", () => {
+            expect(isUsageLimitError("Quota exceeded for your current subscription")).toBe(true);
+        });
+
+        test("'resource exhausted'", () => {
+            expect(isUsageLimitError("Resource exhausted: RESOURCE_EXHAUSTED")).toBe(true);
+        });
+
+        test("'RESOURCE_EXHAUSTED' uppercase", () => {
+            expect(isUsageLimitError("grpc status RESOURCE_EXHAUSTED")).toBe(false); // "resource exhausted" requires space not underscore
+        });
+
+        test("'resource exhausted' lowercase", () => {
+            expect(isUsageLimitError("resource exhausted: out of capacity")).toBe(true);
+        });
+
+        test("'tokens per minute'", () => {
+            expect(isUsageLimitError("Tokens per minute limit reached for your tier")).toBe(true);
+        });
+
+        test("'requests per minute'", () => {
+            expect(isUsageLimitError("Requests per minute exceeded")).toBe(true);
+        });
+
+        test("'quota' standalone", () => {
+            expect(isUsageLimitError("Your quota has been exhausted")).toBe(true);
+        });
+
+        test("'capacity' standalone", () => {
+            expect(isUsageLimitError("Service capacity exceeded for this region")).toBe(true);
+        });
+
+        test("'overloaded'", () => {
+            expect(isUsageLimitError("The model is currently overloaded, please try again")).toBe(true);
+        });
+
+        test("'throttled'", () => {
+            expect(isUsageLimitError("Request throttled due to high traffic")).toBe(true);
+        });
+
+        test("'throttling'", () => {
+            expect(isUsageLimitError("Server is throttling your requests")).toBe(true);
+        });
+
+        test("OpenAI rate limit message", () => {
+            expect(isUsageLimitError("Rate limit reached for gpt-4 in organization org-xxx on tokens per minute")).toBe(true);
+        });
+
+        test("Gemini quota message", () => {
+            expect(isUsageLimitError("You've exceeded your current quota. Please check your plan and billing.")).toBe(true);
+        });
+    });
+
+    // ── False positives (must NOT match) ──────────────────────────────────
+
+    describe("does NOT match unrelated errors", () => {
+        test("'generate' — contains 'rate' as infix", () => {
+            expect(isUsageLimitError("Failed to generate a response")).toBe(false);
+        });
+
+        test("'elaborate' — contains 'rate' as infix", () => {
+            expect(isUsageLimitError("Please elaborate on the topic")).toBe(false);
+        });
+
+        test("'moderate' — contains 'rate' as infix", () => {
+            expect(isUsageLimitError("Content failed moderate check")).toBe(false);
+        });
+
+        test("'demonstrate' — contains 'rate' as infix", () => {
+            expect(isUsageLimitError("Unable to demonstrate behavior")).toBe(false);
+        });
+
+        test("generic network error", () => {
+            expect(isUsageLimitError("Connection reset by peer")).toBe(false);
+        });
+
+        test("generic timeout error", () => {
+            expect(isUsageLimitError("Request timed out after 30 seconds")).toBe(false);
+        });
+
+        test("empty string", () => {
+            expect(isUsageLimitError("")).toBe(false);
+        });
+
+        test("'limited' — adjective, not a limit phrase", () => {
+            // 'rate limit' pattern requires both words; 'limited' alone has no phrase match
+            // and 'limit' pattern requires 'rate' or 'usage' before it as a phrase
+            expect(isUsageLimitError("Limited functionality available")).toBe(false);
+        });
+
+        test("'usability' — contains 'usage' as infix would be wrong, but 'usage' pattern checks for 'usage limit'", () => {
+            // The 'usage limit' phrase is required; 'usability' doesn't contain 'usage limit'
+            expect(isUsageLimitError("There is a usability issue with this API")).toBe(false);
+        });
+
+        test("'accumulated' — contains 'quota' infix? No, 'quota' uses word boundary", () => {
+            // \bquota\b would not match inside a longer word
+            expect(isUsageLimitError("errors accumulated during processing")).toBe(false);
+        });
+
+        test("model not found error", () => {
+            expect(isUsageLimitError("Model not found: claude-opus-4-5")).toBe(false);
+        });
+
+        test("authentication error", () => {
+            expect(isUsageLimitError("Invalid API key provided")).toBe(false);
+        });
+
+        test("server error", () => {
+            expect(isUsageLimitError("Internal server error (500)")).toBe(false);
+        });
+    });
+});

--- a/packages/cli/src/extensions/remote/usage-limit-error.ts
+++ b/packages/cli/src/extensions/remote/usage-limit-error.ts
@@ -1,0 +1,59 @@
+/**
+ * Usage-limit error classifier.
+ *
+ * Identifies provider errors that indicate the session has hit a hard usage
+ * ceiling — as opposed to transient/retryable errors or unrelated failures.
+ *
+ * Design constraints:
+ *  - No bare `includes("rate")` — that matches "generate", "elaborate", etc.
+ *  - All matching is case-insensitive.
+ *  - Phrase patterns are matched as full sub-phrases (not word-by-word) to
+ *    avoid split false-positives.
+ *  - Single-word patterns use word boundaries (\b) to avoid infix matches.
+ */
+
+/**
+ * Known phrases that indicate a hard usage / quota limit from a provider.
+ * Ordered from most specific to least specific.
+ */
+const USAGE_LIMIT_PHRASES: ReadonlyArray<RegExp> = [
+    // Multi-word phrases — match literally (no \b needed; they're long enough)
+    /usage\s+limit/i,
+    /rate\s+limit/i,
+    /quota\s+exceeded/i,
+    /resource\s+exhausted/i,
+    /tokens\s+per\s+minute/i,
+    /requests\s+per\s+minute/i,
+    /output\s+tokens\s+per/i,
+    /context\s+window/i,
+    // Single-word patterns with word boundaries
+    /\bquota\b/i,
+    /\bcapacity\b/i,
+    /\boverloaded\b/i,
+    /\bthrottl/i, // throttle / throttled / throttling
+];
+
+/**
+ * Returns true if the error message indicates a hard provider usage limit.
+ *
+ * Examples that should match:
+ *   "You have exceeded your usage limit"
+ *   "Rate limit reached for requests per minute"
+ *   "Quota exceeded for your current plan"
+ *   "Resource exhausted: RESOURCE_EXHAUSTED"
+ *   "Tokens per minute limit reached"
+ *   "Service capacity exceeded"
+ *
+ * Examples that must NOT match:
+ *   "Failed to generate a response"   — contains "rate" as infix of "generate"
+ *   "Elaborate on the topic"          — contains "rate" as infix of "elaborate"
+ *   "Error processing request"        — generic error, no quota meaning
+ */
+export function isUsageLimitError(message: string): boolean {
+    for (const pattern of USAGE_LIMIT_PHRASES) {
+        if (pattern.test(message)) {
+            return true;
+        }
+    }
+    return false;
+}

--- a/packages/cli/src/extensions/remote/usage-limit-error.ts
+++ b/packages/cli/src/extensions/remote/usage-limit-error.ts
@@ -20,8 +20,8 @@ const USAGE_LIMIT_PHRASES: ReadonlyArray<RegExp> = [
     // Multi-word phrases — match literally (no \b needed; they're long enough)
     /usage\s+limit/i,
     /rate\s+limit/i,
-    /quota\s+exceeded/i,
-    /resource\s+exhausted/i,
+    /quota[\s_]+exceeded/i, // matches "quota exceeded" and gRPC "QUOTA_EXCEEDED"
+    /resource[\s_]+exhausted/i, // matches "resource exhausted" and gRPC "RESOURCE_EXHAUSTED"
     /tokens\s+per\s+minute/i,
     /requests\s+per\s+minute/i,
     /output\s+tokens\s+per/i,
@@ -41,6 +41,8 @@ const USAGE_LIMIT_PHRASES: ReadonlyArray<RegExp> = [
  *   "Rate limit reached for requests per minute"
  *   "Quota exceeded for your current plan"
  *   "Resource exhausted: RESOURCE_EXHAUSTED"
+ *   "grpc status RESOURCE_EXHAUSTED"          — gRPC/Gemini quota error
+ *   "grpc status QUOTA_EXCEEDED"              — gRPC quota variant
  *   "Tokens per minute limit reached"
  *   "Service capacity exceeded"
  *


### PR DESCRIPTION
Night Shift dish 007 — When a child session hits a usage limit or provider error, immediately fires a session_error trigger to the parent and sets exitReason to 'error' in the session_complete trigger.