### PR TITLE
🎨 Palette: Add aria-labels for icon buttons in UI

### DIFF
--- a/packages/ui/src/components/PluginsManager.tsx
+++ b/packages/ui/src/components/PluginsManager.tsx
@@ -87,6 +87,7 @@ function PluginRow({ plugin, onClick }: PluginRowProps) {
         <button
             type="button"
             onClick={onClick}
+            aria-label={`View details for ${plugin.name}`}
             className="flex items-start justify-between gap-3 w-full text-left px-3 py-2.5 rounded-lg border border-border/40 bg-muted/20 hover:bg-muted/40 transition-colors group"
         >
             <div className="flex items-start gap-2.5 min-w-0">


### PR DESCRIPTION
Added aria-label attributes to the button element in `packages/ui/src/components/PluginsManager.tsx` and verified existing aria-labels in `packages/ui/src/App.tsx`. Checked for visual and build correctness.

---
*PR created automatically by Jules for task [3539187724595779573](https://jules.google.com/task/3539187724595779573) started by @Pizzaface*