### PR TITLE
perf: async file existence checks in static file serving

### DIFF
--- a/packages/server/src/static.test.ts
+++ b/packages/server/src/static.test.ts
@@ -52,4 +52,13 @@ describe("serveStaticFile", () => {
         const res = await serveStaticFile("/test.map");
         expect(res?.headers.get("content-type")).toBe("application/json; charset=utf-8");
     });
+
+    test("Falls back to index.html for nonexistent SPA routes", async () => {
+        // Request a path that doesn't exist as a file — should serve index.html for SPA routing
+        const res = await serveStaticFile("/some-spa-route");
+        expect(res).not.toBeNull();
+        expect(res?.headers.get("content-type")).toBe("text/html; charset=utf-8");
+        // index.html should use no-cache control
+        expect(res?.headers.get("cache-control")).toBe("no-cache");
+    });
 });

--- a/packages/server/src/static.test.ts
+++ b/packages/server/src/static.test.ts
@@ -53,6 +53,14 @@ describe("serveStaticFile", () => {
         expect(res?.headers.get("content-type")).toBe("application/json; charset=utf-8");
     });
 
+    test("Returns null for requests matching an existing directory (no SPA fallback)", async () => {
+        // /assets maps to tests/fixtures/ui/assets which is a real directory.
+        // Bun.file(<dir>).exists() returns false, so without a directory check this
+        // would incorrectly serve index.html instead of returning null.
+        const res = await serveStaticFile("/assets");
+        expect(res).toBeNull();
+    });
+
     test("Falls back to index.html for nonexistent SPA routes", async () => {
         // Request a path that doesn't exist as a file — should serve index.html for SPA routing
         const res = await serveStaticFile("/some-spa-route");

--- a/packages/server/src/static.ts
+++ b/packages/server/src/static.ts
@@ -4,6 +4,7 @@
  */
 
 import { existsSync } from "fs";
+import { stat } from "node:fs/promises";
 import { join, extname, resolve, sep } from "path";
 
 // Resolve UI dist directory. Check in order:
@@ -86,6 +87,17 @@ export async function serveStaticFile(pathname: string): Promise<Response | null
     // Ensure the resolved path strictly resides within the configured UI_DIR
     const uiDirWithTrailingSlash = UI_DIR.endsWith(sep) ? UI_DIR : UI_DIR + sep;
     if (!filePath.startsWith(uiDirWithTrailingSlash)) return null;
+
+    // Directories must not fall through to SPA fallback — Bun.file(<dir>).exists()
+    // returns false for directories, which would incorrectly serve index.html.
+    let pathIsDir = false;
+    try {
+        const s = await stat(filePath);
+        pathIsDir = s.isDirectory();
+    } catch {
+        // Path doesn't exist or is not accessible — treat as non-directory
+    }
+    if (pathIsDir) return null;
 
     // If file doesn't exist, serve index.html for SPA routing
     if (!(await Bun.file(filePath).exists())) {

--- a/packages/server/src/static.ts
+++ b/packages/server/src/static.ts
@@ -88,7 +88,7 @@ export async function serveStaticFile(pathname: string): Promise<Response | null
     if (!filePath.startsWith(uiDirWithTrailingSlash)) return null;
 
     // If file doesn't exist, serve index.html for SPA routing
-    if (!existsSync(filePath)) {
+    if (!(await Bun.file(filePath).exists())) {
         filePath = join(UI_DIR, "index.html");
     }
 


### PR DESCRIPTION
Night Shift dish 007 — Godmother: ZxGs1TeE

Replaces blocking existsSync() with async Bun.file().exists() in the per-request static file handler. Startup-time directory resolution stays sync (runs once). Per-request checks are now non-blocking.