### PR TITLE
fix: code-block tokensCache FIFO eviction (memory leak)

### DIFF
--- a/packages/ui/src/components/ai-elements/code-block-cache.test.ts
+++ b/packages/ui/src/components/ai-elements/code-block-cache.test.ts
@@ -1,0 +1,228 @@
+import { describe, expect, test } from "bun:test";
+import {
+  evictOldestIfNeeded,
+  getTokensCacheKey,
+  MAX_HIGHLIGHTER_CACHE_SIZE,
+  MAX_TOKENS_CACHE_SIZE,
+} from "./code-block-cache";
+
+// ---------------------------------------------------------------------------
+// evictOldestIfNeeded
+// ---------------------------------------------------------------------------
+
+describe("evictOldestIfNeeded", () => {
+  test("does not evict when map is below capacity", () => {
+    const map = new Map<string, number>();
+    map.set("a", 1);
+    map.set("b", 2);
+
+    evictOldestIfNeeded(map, 3);
+
+    expect(map.size).toBe(2);
+    expect(map.has("a")).toBe(true);
+    expect(map.has("b")).toBe(true);
+  });
+
+  test("does not evict when map is empty", () => {
+    const map = new Map<string, number>();
+    evictOldestIfNeeded(map, 1);
+    expect(map.size).toBe(0);
+  });
+
+  test("evicts the oldest (first-inserted) entry when at capacity", () => {
+    const map = new Map<string, number>([
+      ["first", 1],
+      ["second", 2],
+      ["third", 3],
+    ]);
+
+    // Map has 3 entries; maxSize is 3 → evict before adding a 4th
+    evictOldestIfNeeded(map, 3);
+
+    expect(map.size).toBe(2);
+    expect(map.has("first")).toBe(false); // oldest evicted
+    expect(map.has("second")).toBe(true);
+    expect(map.has("third")).toBe(true);
+  });
+
+  test("evicts the oldest entry when map exceeds capacity", () => {
+    const map = new Map<string, number>([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+      ["d", 4],
+    ]);
+
+    // size(4) >= maxSize(3) → evict "a"
+    evictOldestIfNeeded(map, 3);
+
+    expect(map.size).toBe(3);
+    expect(map.has("a")).toBe(false);
+  });
+
+  test("evicts only one entry per call even when multiple exceed capacity", () => {
+    const map = new Map<string, number>([
+      ["x", 1],
+      ["y", 2],
+      ["z", 3],
+    ]);
+
+    // maxSize is 1; only one eviction per call
+    evictOldestIfNeeded(map, 1);
+
+    expect(map.size).toBe(2); // one removed, two remain
+    expect(map.has("x")).toBe(false);
+  });
+
+  test("maintains FIFO order across multiple insertions and evictions", () => {
+    const maxSize = 3;
+    const map = new Map<string, number>();
+
+    // Insert 5 entries one at a time, evicting before each insertion
+    for (let i = 1; i <= 5; i++) {
+      evictOldestIfNeeded(map, maxSize);
+      map.set(`key${i}`, i);
+    }
+
+    // After 5 insertions with maxSize=3:
+    // After key4: evicted key1 → {key2, key3, key4}  → insert key4 → {key2,key3,key4}
+    // After key5: evicted key2 → {key3, key4, key5}
+    expect(map.size).toBe(3);
+    expect(map.has("key1")).toBe(false);
+    expect(map.has("key2")).toBe(false);
+    expect(map.has("key3")).toBe(true);
+    expect(map.has("key4")).toBe(true);
+    expect(map.has("key5")).toBe(true);
+  });
+
+  test("works with numeric keys", () => {
+    const map = new Map<number, string>([
+      [1, "one"],
+      [2, "two"],
+    ]);
+
+    evictOldestIfNeeded(map, 2);
+
+    expect(map.size).toBe(1);
+    expect(map.has(1)).toBe(false);
+    expect(map.has(2)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cache size bounds — constants are present and sensible
+// ---------------------------------------------------------------------------
+
+describe("cache size constants", () => {
+  test("MAX_TOKENS_CACHE_SIZE is a positive integer", () => {
+    expect(typeof MAX_TOKENS_CACHE_SIZE).toBe("number");
+    expect(Number.isInteger(MAX_TOKENS_CACHE_SIZE)).toBe(true);
+    expect(MAX_TOKENS_CACHE_SIZE).toBeGreaterThan(0);
+  });
+
+  test("MAX_HIGHLIGHTER_CACHE_SIZE is a positive integer", () => {
+    expect(typeof MAX_HIGHLIGHTER_CACHE_SIZE).toBe("number");
+    expect(Number.isInteger(MAX_HIGHLIGHTER_CACHE_SIZE)).toBe(true);
+    expect(MAX_HIGHLIGHTER_CACHE_SIZE).toBeGreaterThan(0);
+  });
+
+  test("cache cannot grow beyond MAX_TOKENS_CACHE_SIZE", () => {
+    const cache = new Map<string, number>();
+    const limit = MAX_TOKENS_CACHE_SIZE;
+
+    for (let i = 0; i < limit + 10; i++) {
+      evictOldestIfNeeded(cache, limit);
+      cache.set(`entry-${i}`, i);
+    }
+
+    expect(cache.size).toBeLessThanOrEqual(limit);
+  });
+
+  test("cache cannot grow beyond MAX_HIGHLIGHTER_CACHE_SIZE", () => {
+    const cache = new Map<string, number>();
+    const limit = MAX_HIGHLIGHTER_CACHE_SIZE;
+
+    for (let i = 0; i < limit + 5; i++) {
+      evictOldestIfNeeded(cache, limit);
+      cache.set(`lang-${i}`, i);
+    }
+
+    expect(cache.size).toBeLessThanOrEqual(limit);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTokensCacheKey
+// ---------------------------------------------------------------------------
+
+describe("getTokensCacheKey", () => {
+  test("returns a string", () => {
+    expect(typeof getTokensCacheKey("const x = 1;", "typescript")).toBe("string");
+  });
+
+  test("includes the language in the key", () => {
+    const key = getTokensCacheKey("hello", "python");
+    expect(key).toContain("python");
+  });
+
+  test("different languages produce different keys for the same code", () => {
+    const ts = getTokensCacheKey("const x = 1;", "typescript");
+    const js = getTokensCacheKey("const x = 1;", "javascript");
+    expect(ts).not.toBe(js);
+  });
+
+  test("different code lengths produce different keys", () => {
+    const k1 = getTokensCacheKey("abc", "text");
+    const k2 = getTokensCacheKey("abcd", "text");
+    expect(k1).not.toBe(k2);
+  });
+
+  test("same code and language produce the same key (stable/idempotent)", () => {
+    const code = "function hello() { return 42; }";
+    const k1 = getTokensCacheKey(code, "javascript");
+    const k2 = getTokensCacheKey(code, "javascript");
+    expect(k1).toBe(k2);
+  });
+
+  test("short code (≤100 chars) produces a consistent key", () => {
+    const short = "x = 1";
+    const key = getTokensCacheKey(short, "python");
+    expect(key).toContain(short);
+  });
+
+  test("long code key includes first and last 100 chars", () => {
+    const prefix = "A".repeat(100);
+    const middle = "B".repeat(300);
+    const suffix = "C".repeat(100);
+    const code = prefix + middle + suffix;
+
+    const key = getTokensCacheKey(code, "text");
+
+    expect(key).toContain(prefix);
+    expect(key).toContain(suffix);
+    // The middle section is not directly embedded (too long for inclusion)
+    // The total length is encoded, so two codes of the same prefix/suffix but
+    // different total length still differ.
+    expect(key).toContain(String(code.length));
+  });
+
+  test("two codes with same prefix/suffix but different length have different keys", () => {
+    const prefix = "A".repeat(100);
+    const suffix = "Z".repeat(100);
+    const code1 = prefix + "X" + suffix;
+    const code2 = prefix + "XYZXYZ" + suffix;
+
+    const k1 = getTokensCacheKey(code1, "text");
+    const k2 = getTokensCacheKey(code2, "text");
+
+    expect(k1).not.toBe(k2);
+  });
+
+  test("empty string produces a stable key", () => {
+    const key = getTokensCacheKey("", "text");
+    expect(typeof key).toBe("string");
+    expect(key.length).toBeGreaterThan(0);
+    // Calling it twice is idempotent
+    expect(getTokensCacheKey("", "text")).toBe(key);
+  });
+});

--- a/packages/ui/src/components/ai-elements/code-block-cache.ts
+++ b/packages/ui/src/components/ai-elements/code-block-cache.ts
@@ -1,0 +1,42 @@
+/**
+ * Cache utilities for code-block syntax highlighting.
+ *
+ * Extracted as a separate module so the FIFO eviction logic and cache-key
+ * generation can be unit-tested independently of React / Shiki.
+ */
+
+// Cache size limits — prevent unbounded memory growth in long sessions
+export const MAX_HIGHLIGHTER_CACHE_SIZE = 50;
+export const MAX_TOKENS_CACHE_SIZE = 200;
+
+/**
+ * Evict the oldest (first-inserted) entry when the cache has reached its
+ * capacity.  JavaScript Maps preserve insertion order, so `keys().next()`
+ * always returns the oldest key — this is what gives us FIFO semantics.
+ *
+ * The eviction happens *before* the new entry is inserted so that the map
+ * never exceeds `maxSize` entries.
+ */
+export function evictOldestIfNeeded<K, V>(map: Map<K, V>, maxSize: number): void {
+  if (map.size >= maxSize) {
+    const oldest = map.keys().next().value;
+    if (oldest !== undefined) {
+      map.delete(oldest);
+    }
+  }
+}
+
+/**
+ * Derive a stable cache key for a (code, language) pair.
+ *
+ * Using the full code string as a key is wasteful for very large snippets.
+ * Instead we capture: language, total length, the first 100 chars, and the
+ * last 100 chars.  Two snippets that differ only in the middle (e.g. a
+ * growing streamed response) will get different keys once the length changes,
+ * which is the normal case during streaming.
+ */
+export function getTokensCacheKey(code: string, language: string): string {
+  const start = code.slice(0, 100);
+  const end = code.length > 100 ? code.slice(-100) : "";
+  return `${language}:${code.length}:${start}:${end}`;
+}

--- a/packages/ui/src/components/ai-elements/code-block.tsx
+++ b/packages/ui/src/components/ai-elements/code-block.tsx
@@ -120,19 +120,14 @@ const CodeBlockContext = createContext<CodeBlockContextType>({
   code: "",
 });
 
-// Cache size limits — prevent unbounded memory growth in long sessions
-const MAX_HIGHLIGHTER_CACHE_SIZE = 50;
-const MAX_TOKENS_CACHE_SIZE = 200;
-
-/** Evict the oldest (first-inserted) entry when the cache exceeds its limit. */
-function evictOldestIfNeeded<K, V>(map: Map<K, V>, maxSize: number): void {
-  if (map.size >= maxSize) {
-    const oldest = map.keys().next().value;
-    if (oldest !== undefined) {
-      map.delete(oldest);
-    }
-  }
-}
+// Cache size limits and FIFO eviction logic — imported from shared utility so
+// they can be unit-tested independently of React / Shiki.
+import {
+  evictOldestIfNeeded,
+  getTokensCacheKey,
+  MAX_HIGHLIGHTER_CACHE_SIZE,
+  MAX_TOKENS_CACHE_SIZE,
+} from "./code-block-cache";
 
 // Highlighter cache (singleton per language)
 const highlighterCache = new Map<
@@ -145,12 +140,6 @@ const tokensCache = new Map<string, TokenizedCode>();
 
 // Subscribers for async token updates
 const subscribers = new Map<string, Set<(result: TokenizedCode) => void>>();
-
-const getTokensCacheKey = (code: string, language: BundledLanguage) => {
-  const start = code.slice(0, 100);
-  const end = code.length > 100 ? code.slice(-100) : "";
-  return `${language}:${code.length}:${start}:${end}`;
-};
 
 const getHighlighter = (
   language: BundledLanguage

--- a/packages/ui/src/components/ai-elements/code-block.tsx
+++ b/packages/ui/src/components/ai-elements/code-block.tsx
@@ -120,6 +120,20 @@ const CodeBlockContext = createContext<CodeBlockContextType>({
   code: "",
 });
 
+// Cache size limits — prevent unbounded memory growth in long sessions
+const MAX_HIGHLIGHTER_CACHE_SIZE = 50;
+const MAX_TOKENS_CACHE_SIZE = 200;
+
+/** Evict the oldest (first-inserted) entry when the cache exceeds its limit. */
+function evictOldestIfNeeded<K, V>(map: Map<K, V>, maxSize: number): void {
+  if (map.size >= maxSize) {
+    const oldest = map.keys().next().value;
+    if (oldest !== undefined) {
+      map.delete(oldest);
+    }
+  }
+}
+
 // Highlighter cache (singleton per language)
 const highlighterCache = new Map<
   string,
@@ -151,6 +165,7 @@ const getHighlighter = (
     themes: ["github-light", "github-dark"],
   });
 
+  evictOldestIfNeeded(highlighterCache, MAX_HIGHLIGHTER_CACHE_SIZE);
   highlighterCache.set(language, highlighterPromise);
   return highlighterPromise;
 };
@@ -215,7 +230,8 @@ export const highlightCode = (
         tokens: result.tokens,
       };
 
-      // Cache the result
+      // Cache the result (evict oldest entry if at capacity)
+      evictOldestIfNeeded(tokensCache, MAX_TOKENS_CACHE_SIZE);
       tokensCache.set(tokensCacheKey, tokenized);
 
       // Notify all subscribers


### PR DESCRIPTION
Night Shift dish 011 — Godmother: p02fgrfW

Adds FIFO eviction to the tokensCache Map in code-block.tsx. Cache is capped at 200 entries. Prevents unbounded memory growth in long sessions with many code blocks.