### PR TITLE
fix: sessionUiCacheRef LRU eviction (memory leak)

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -95,6 +95,8 @@ import {
   normalizeModelList,
 } from "@/lib/message-helpers";
 
+const MAX_SESSION_UI_CACHE_SIZE = 50;
+
 export function App() {
   const { data: session, isPending } = useSession();
   const { runners: feedRunners, status: runnersStatus } = useRunnersFeed({
@@ -392,8 +394,24 @@ export function App() {
       todoList: prev?.todoList ?? [],
       pendingQuestion: prev?.pendingQuestion ?? null,
       pendingPlan: prev?.pendingPlan ?? null,
+      lastAccessed: Date.now(),
       ...patch,
     };
+
+    // Evict the least-recently-accessed entry if we're over the size limit.
+    if (!sessionUiCacheRef.current.has(sessionId) && sessionUiCacheRef.current.size >= MAX_SESSION_UI_CACHE_SIZE) {
+      let lruKey: string | null = null;
+      let lruTime = Infinity;
+      for (const [key, entry] of sessionUiCacheRef.current) {
+        if (entry.lastAccessed < lruTime) {
+          lruTime = entry.lastAccessed;
+          lruKey = key;
+        }
+      }
+      if (lruKey !== null) {
+        sessionUiCacheRef.current.delete(lruKey);
+      }
+    }
 
     sessionUiCacheRef.current.set(sessionId, next);
   }, []);
@@ -2022,6 +2040,10 @@ export function App() {
     setResumeSessionsLoading(false);
 
     const cached = sessionUiCacheRef.current.get(relaySessionId);
+    // Update lastAccessed so this entry is not evicted while actively being viewed.
+    if (cached) {
+      sessionUiCacheRef.current.set(relaySessionId, { ...cached, lastAccessed: Date.now() });
+    }
     setMessages(cached?.messages ?? []);
     setActiveModel(cached?.activeModel ?? null);
     setSessionName(cached?.sessionName ?? null);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -394,8 +394,8 @@ export function App() {
       todoList: prev?.todoList ?? [],
       pendingQuestion: prev?.pendingQuestion ?? null,
       pendingPlan: prev?.pendingPlan ?? null,
-      lastAccessed: Date.now(),
       ...patch,
+      lastAccessed: Date.now(),
     };
 
     // Evict the least-recently-accessed entry if we're over the size limit.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -94,8 +94,7 @@ import {
   augmentThinkingDurations,
   normalizeModelList,
 } from "@/lib/message-helpers";
-
-const MAX_SESSION_UI_CACHE_SIZE = 50;
+import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
 
 export function App() {
   const { data: session, isPending } = useSession();
@@ -399,19 +398,7 @@ export function App() {
     };
 
     // Evict the least-recently-accessed entry if we're over the size limit.
-    if (!sessionUiCacheRef.current.has(sessionId) && sessionUiCacheRef.current.size >= MAX_SESSION_UI_CACHE_SIZE) {
-      let lruKey: string | null = null;
-      let lruTime = Infinity;
-      for (const [key, entry] of sessionUiCacheRef.current) {
-        if (entry.lastAccessed < lruTime) {
-          lruTime = entry.lastAccessed;
-          lruKey = key;
-        }
-      }
-      if (lruKey !== null) {
-        sessionUiCacheRef.current.delete(lruKey);
-      }
-    }
+    evictLruIfNeeded(sessionUiCacheRef.current, sessionId, MAX_SESSION_UI_CACHE_SIZE, activeSessionRef.current);
 
     sessionUiCacheRef.current.set(sessionId, next);
   }, []);
@@ -2041,9 +2028,7 @@ export function App() {
 
     const cached = sessionUiCacheRef.current.get(relaySessionId);
     // Update lastAccessed so this entry is not evicted while actively being viewed.
-    if (cached) {
-      sessionUiCacheRef.current.set(relaySessionId, { ...cached, lastAccessed: Date.now() });
-    }
+    touchSessionCache(sessionUiCacheRef.current, relaySessionId);
     setMessages(cached?.messages ?? []);
     setActiveModel(cached?.activeModel ?? null);
     setSessionName(cached?.sessionName ?? null);

--- a/packages/ui/src/lib/session-ui-cache.test.ts
+++ b/packages/ui/src/lib/session-ui-cache.test.ts
@@ -1,0 +1,280 @@
+import { describe, test, expect } from "bun:test";
+import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "./session-ui-cache.js";
+import type { SessionUiCacheEntry } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Build a minimal SessionUiCacheEntry with a controlled lastAccessed time. */
+function makeEntry(lastAccessed: number): SessionUiCacheEntry {
+  return {
+    messages: [],
+    activeModel: null,
+    sessionName: null,
+    availableModels: [],
+    availableCommands: [],
+    agentActive: false,
+    isCompacting: false,
+    effortLevel: null,
+    planModeEnabled: false,
+    authSource: null,
+    tokenUsage: null,
+    providerUsage: null,
+    lastHeartbeatAt: null,
+    todoList: [],
+    pendingQuestion: null,
+    pendingPlan: null,
+    lastAccessed,
+  };
+}
+
+/**
+ * Populate a map with `count` entries whose keys are "s0", "s1", …
+ * and whose `lastAccessed` values are 1000, 2000, … (oldest = "s0").
+ */
+function makeCache(count: number): Map<string, SessionUiCacheEntry> {
+  const cache = new Map<string, SessionUiCacheEntry>();
+  for (let i = 0; i < count; i++) {
+    cache.set(`s${i}`, makeEntry((i + 1) * 1000));
+  }
+  return cache;
+}
+
+// ---------------------------------------------------------------------------
+// MAX_SESSION_UI_CACHE_SIZE constant
+// ---------------------------------------------------------------------------
+
+describe("MAX_SESSION_UI_CACHE_SIZE", () => {
+  test("is 50", () => {
+    expect(MAX_SESSION_UI_CACHE_SIZE).toBe(50);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// evictLruIfNeeded
+// ---------------------------------------------------------------------------
+
+describe("evictLruIfNeeded — no-op cases", () => {
+  test("does not evict when cache is below capacity", () => {
+    const cache = makeCache(3);
+    evictLruIfNeeded(cache, "new-session", 5);
+    expect(cache.size).toBe(3); // still 3; nothing evicted
+  });
+
+  test("does not evict when cache is exactly at capacity but key already exists (update, not insert)", () => {
+    const cache = makeCache(5);
+    // "s0" is already in the map — this is an update, not a new insertion.
+    evictLruIfNeeded(cache, "s0", 5);
+    expect(cache.size).toBe(5);
+    expect(cache.has("s0")).toBe(true);
+  });
+
+  test("does not evict when cache size is one below the limit", () => {
+    const cache = makeCache(4);
+    evictLruIfNeeded(cache, "new-session", 5);
+    expect(cache.size).toBe(4);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("evictLruIfNeeded — size limit enforcement", () => {
+  test("evicts exactly one entry when cache is at capacity and a new key is inserted", () => {
+    const cache = makeCache(5);
+    evictLruIfNeeded(cache, "new-session", 5);
+    // One entry should have been removed to make room.
+    expect(cache.size).toBe(4);
+  });
+
+  test("does not evict more than one entry per call", () => {
+    // Even if the cache is far over the theoretical limit (shouldn't happen in
+    // normal usage but the function should remain stable).
+    const cache = makeCache(10);
+    evictLruIfNeeded(cache, "new-session", 5);
+    expect(cache.size).toBe(9); // exactly one eviction
+  });
+
+  test("new key is NOT inserted by evictLruIfNeeded (caller's responsibility)", () => {
+    const cache = makeCache(5);
+    evictLruIfNeeded(cache, "new-session", 5);
+    // The utility only evicts; inserting the new entry is the caller's job.
+    expect(cache.has("new-session")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("evictLruIfNeeded — LRU selection", () => {
+  test("evicts the entry with the smallest lastAccessed value", () => {
+    const cache = makeCache(5);
+    // s0 → lastAccessed=1000 (oldest/LRU)
+    // s1 → 2000, s2 → 3000, s3 → 4000, s4 → 5000 (newest/MRU)
+    evictLruIfNeeded(cache, "new-session", 5);
+    expect(cache.has("s0")).toBe(false); // oldest evicted
+    expect(cache.has("s1")).toBe(true);
+    expect(cache.has("s4")).toBe(true);
+  });
+
+  test("evicts the correct entry when lastAccessed values are not in insertion order", () => {
+    const cache = new Map<string, SessionUiCacheEntry>();
+    cache.set("alpha", makeEntry(9000)); // newest
+    cache.set("beta", makeEntry(1000));  // oldest → should be evicted
+    cache.set("gamma", makeEntry(5000));
+    cache.set("delta", makeEntry(3000));
+    cache.set("epsilon", makeEntry(7000));
+
+    evictLruIfNeeded(cache, "new-session", 5);
+    expect(cache.has("beta")).toBe(false);
+    expect(cache.size).toBe(4);
+  });
+
+  test("when two entries share the smallest lastAccessed, one of them (the first encountered) is evicted", () => {
+    const cache = new Map<string, SessionUiCacheEntry>();
+    cache.set("a", makeEntry(1000)); // tied for oldest
+    cache.set("b", makeEntry(1000)); // tied for oldest
+    cache.set("c", makeEntry(2000));
+    cache.set("d", makeEntry(3000));
+    cache.set("e", makeEntry(4000));
+
+    evictLruIfNeeded(cache, "new-session", 5);
+    expect(cache.size).toBe(4);
+    // Either "a" or "b" may be gone, but not both.
+    const evictedCount = ["a", "b"].filter((k) => !cache.has(k)).length;
+    expect(evictedCount).toBe(1);
+    expect(cache.has("c")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("evictLruIfNeeded — active session protection", () => {
+  test("does not evict the activeKey even if it is the LRU", () => {
+    // "s0" is the LRU (lastAccessed=1000) but it is the active session.
+    const cache = makeCache(5);
+    evictLruIfNeeded(cache, "new-session", 5, "s0");
+    expect(cache.has("s0")).toBe(true); // active session protected
+    expect(cache.size).toBe(4);        // something else was evicted
+    // "s1" is the next oldest (2000) and should have been evicted.
+    expect(cache.has("s1")).toBe(false);
+  });
+
+  test("evicts the true LRU when activeKey is the second-oldest", () => {
+    const cache = makeCache(5);
+    // s1 (lastAccessed=2000) is active; s0 (1000) is older and can be evicted.
+    evictLruIfNeeded(cache, "new-session", 5, "s1");
+    expect(cache.has("s0")).toBe(false);
+    expect(cache.has("s1")).toBe(true);
+  });
+
+  test("evicts correctly when activeKey is not in the cache", () => {
+    const cache = makeCache(5);
+    evictLruIfNeeded(cache, "new-session", 5, "ghost-session");
+    // "ghost-session" is not in the cache so it doesn't affect selection.
+    expect(cache.has("s0")).toBe(false); // s0 is still evicted as LRU
+    expect(cache.size).toBe(4);
+  });
+
+  test("no eviction is skipped when activeKey is null", () => {
+    const cache = makeCache(5);
+    evictLruIfNeeded(cache, "new-session", 5, null);
+    expect(cache.size).toBe(4);
+    expect(cache.has("s0")).toBe(false);
+  });
+
+  test("no eviction is skipped when activeKey is undefined", () => {
+    const cache = makeCache(5);
+    evictLruIfNeeded(cache, "new-session", 5, undefined);
+    expect(cache.size).toBe(4);
+    expect(cache.has("s0")).toBe(false);
+  });
+
+  test("no entry is evicted if all entries are the activeKey (single-entry cache at capacity)", () => {
+    // Edge case: only one entry in cache and it is the active session.
+    const cache = new Map<string, SessionUiCacheEntry>();
+    cache.set("only", makeEntry(1000));
+    evictLruIfNeeded(cache, "new-session", 1, "only");
+    // There is no non-active candidate, so nothing is evicted.
+    expect(cache.size).toBe(1);
+    expect(cache.has("only")).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+
+describe("evictLruIfNeeded — edge cases", () => {
+  test("empty cache: no-op, no error", () => {
+    const cache = new Map<string, SessionUiCacheEntry>();
+    expect(() => evictLruIfNeeded(cache, "new-session", 0)).not.toThrow();
+    expect(cache.size).toBe(0);
+  });
+
+  test("maxSize of 1 evicts the only existing entry when a new key is inserted", () => {
+    const cache = new Map<string, SessionUiCacheEntry>();
+    cache.set("old", makeEntry(1000));
+    evictLruIfNeeded(cache, "fresh", 1);
+    expect(cache.has("old")).toBe(false);
+    expect(cache.size).toBe(0);
+  });
+
+  test("works correctly with the default MAX_SESSION_UI_CACHE_SIZE of 50", () => {
+    const cache = makeCache(50);
+    evictLruIfNeeded(cache, "s50"); // uses default maxSize
+    expect(cache.size).toBe(49);
+    expect(cache.has("s0")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// touchSessionCache
+// ---------------------------------------------------------------------------
+
+describe("touchSessionCache", () => {
+  test("updates lastAccessed for an existing entry", () => {
+    const cache = new Map<string, SessionUiCacheEntry>();
+    cache.set("x", makeEntry(1000));
+
+    touchSessionCache(cache, "x", 9999);
+    expect(cache.get("x")?.lastAccessed).toBe(9999);
+  });
+
+  test("does not mutate other fields of the entry", () => {
+    const cache = new Map<string, SessionUiCacheEntry>();
+    const entry = { ...makeEntry(1000), sessionName: "My Session", agentActive: true };
+    cache.set("x", entry);
+
+    touchSessionCache(cache, "x", 5000);
+    const updated = cache.get("x")!;
+    expect(updated.sessionName).toBe("My Session");
+    expect(updated.agentActive).toBe(true);
+    expect(updated.lastAccessed).toBe(5000);
+  });
+
+  test("is a no-op when the session is not in the cache", () => {
+    const cache = makeCache(3);
+    const sizeBefore = cache.size;
+    expect(() => touchSessionCache(cache, "ghost", 9999)).not.toThrow();
+    expect(cache.size).toBe(sizeBefore);
+    expect(cache.has("ghost")).toBe(false);
+  });
+
+  test("after touching the LRU entry it is no longer the eviction candidate", () => {
+    // s0 starts as oldest (1000). After touch it becomes newest.
+    const cache = makeCache(5);
+    touchSessionCache(cache, "s0", 99999);
+
+    evictLruIfNeeded(cache, "new-session", 5);
+
+    // s0 is now the MRU — s1 (lastAccessed=2000) should be evicted instead.
+    expect(cache.has("s0")).toBe(true);
+    expect(cache.has("s1")).toBe(false);
+  });
+
+  test("uses Date.now() by default (smoke test — just checks it does not throw)", () => {
+    const cache = new Map<string, SessionUiCacheEntry>();
+    cache.set("y", makeEntry(1000));
+    expect(() => touchSessionCache(cache, "y")).not.toThrow();
+    // lastAccessed should have been updated to a reasonable epoch value.
+    expect((cache.get("y")?.lastAccessed ?? 0)).toBeGreaterThan(1000);
+  });
+});

--- a/packages/ui/src/lib/session-ui-cache.ts
+++ b/packages/ui/src/lib/session-ui-cache.ts
@@ -1,0 +1,69 @@
+/**
+ * Utilities for managing the per-session UI state cache (sessionUiCacheRef).
+ *
+ * Extracted from App.tsx so the eviction logic can be unit-tested in isolation.
+ */
+
+import type { SessionUiCacheEntry } from "./types.js";
+
+/** Maximum number of sessions kept in the UI state cache. */
+export const MAX_SESSION_UI_CACHE_SIZE = 50;
+
+/**
+ * Evict the least-recently-accessed entry from `cache` when a *new* key is
+ * about to be inserted and the cache is already at capacity.
+ *
+ * Rules:
+ * - No-op if `newKey` already exists in the map (we're updating, not inserting).
+ * - No-op if `cache.size < maxSize` (there is still room).
+ * - Otherwise, delete the entry whose `lastAccessed` timestamp is smallest.
+ *   The `activeKey`, if provided, is excluded from eviction candidates so the
+ *   currently-visible session is never evicted (it may still lose to a fresher
+ *   LRU candidate in practice, but callers keep its `lastAccessed` current by
+ *   refreshing it on open — see App.tsx:2045).
+ *
+ * @param cache     The live cache map (mutated in place).
+ * @param newKey    The session ID about to be inserted.
+ * @param maxSize   Upper bound on cache entries.
+ * @param activeKey Optional session ID to protect from eviction.
+ */
+export function evictLruIfNeeded(
+  cache: Map<string, SessionUiCacheEntry>,
+  newKey: string,
+  maxSize: number = MAX_SESSION_UI_CACHE_SIZE,
+  activeKey?: string | null,
+): void {
+  // Only evict when adding a brand-new key and we're at or above capacity.
+  if (cache.has(newKey) || cache.size < maxSize) return;
+
+  let lruKey: string | null = null;
+  let lruTime = Infinity;
+  for (const [key, entry] of cache) {
+    if (key === activeKey) continue; // never evict the active session
+    if (entry.lastAccessed < lruTime) {
+      lruTime = entry.lastAccessed;
+      lruKey = key;
+    }
+  }
+  if (lruKey !== null) {
+    cache.delete(lruKey);
+  }
+}
+
+/**
+ * Refresh the `lastAccessed` timestamp for a session already in the cache.
+ * Called when the user opens / switches to a session so it won't be selected
+ * as the LRU candidate while it is actively being viewed.
+ *
+ * No-op when the session is not in the cache.
+ */
+export function touchSessionCache(
+  cache: Map<string, SessionUiCacheEntry>,
+  sessionId: string,
+  now: number = Date.now(),
+): void {
+  const entry = cache.get(sessionId);
+  if (entry) {
+    cache.set(sessionId, { ...entry, lastAccessed: now });
+  }
+}

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -68,4 +68,5 @@ export interface SessionUiCacheEntry {
     description: string | null;
     steps: Array<{ title: string; description?: string }>;
   } | null;
+  lastAccessed: number;
 }


### PR DESCRIPTION
Night Shift dish 004 — Godmother: Hjsibp2R

Adds LRU eviction policy to the session UI cache. Cache is capped at 50 entries with least-recently-accessed eviction to prevent unbounded memory growth.