### PR TITLE
fix: replace alert/confirm in RunnerManager with proper dialogs

### DIFF
--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -2,6 +2,17 @@ import * as React from "react";
 import { Skeleton } from "@/components/ui/skeleton";
 import { RunnerDetailPanel } from "@/components/RunnerDetailPanel";
 import { NewSessionWizardDialog } from "@/components/NewSessionWizardDialog";
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { ErrorAlert } from "@/components/ui/error-alert";
 import type { HubSession } from "@/components/SessionSidebar";
 import type { RunnerInfo } from "@pizzapi/protocol";
 
@@ -31,6 +42,12 @@ export function RunnerManager({
     const [stopping, setStopping] = React.useState<Set<string>>(new Set());
     const [latestVersion, setLatestVersion] = React.useState<string | null>(null);
 
+    // Error state for inline error display
+    const [error, setError] = React.useState<string | null>(null);
+
+    // Stop confirmation dialog state
+    const [stopConfirmRunnerId, setStopConfirmRunnerId] = React.useState<string | null>(null);
+
     // Fetch the latest available version from the server (used by RunnerDetailPanel for update-available badge)
     React.useEffect(() => {
         fetch("/api/version")
@@ -38,6 +55,13 @@ export function RunnerManager({
             .then((data) => { if (data?.version) setLatestVersion(data.version); })
             .catch(() => {});
     }, []);
+
+    // Auto-dismiss error after 5 seconds
+    React.useEffect(() => {
+        if (!error) return;
+        const timer = setTimeout(() => setError(null), 5000);
+        return () => clearTimeout(timer);
+    }, [error]);
 
     // New session dialog
     const [spawnRunnerId, setSpawnRunnerId] = React.useState<string | null>(null);
@@ -81,10 +105,10 @@ export function RunnerManager({
             });
             if (!res.ok) {
                 const data = await res.json();
-                alert(`Failed to restart runner: ${data.error || "Unknown error"}`);
+                setError(`Failed to restart runner: ${data.error || "Unknown error"}`);
             }
-        } catch (error) {
-            console.error("Failed to restart runner:", error);
+        } catch (err) {
+            console.error("Failed to restart runner:", err);
         } finally {
             setTimeout(() => {
                 setRestarting((prev) => {
@@ -96,8 +120,15 @@ export function RunnerManager({
         }
     };
 
-    const handleStop = async (runnerId: string) => {
-        if (!confirm("Stop this runner? It will shut down completely and won't restart automatically.")) return;
+    const handleStopRequest = (runnerId: string) => {
+        setStopConfirmRunnerId(runnerId);
+    };
+
+    const handleStopConfirm = async () => {
+        const runnerId = stopConfirmRunnerId;
+        setStopConfirmRunnerId(null);
+        if (!runnerId) return;
+
         setStopping((prev) => new Set(prev).add(runnerId));
         try {
             const res = await fetch("/api/runners/stop", {
@@ -108,10 +139,10 @@ export function RunnerManager({
             });
             if (!res.ok) {
                 const data = await res.json();
-                alert(`Failed to stop runner: ${data.error || "Unknown error"}`);
+                setError(`Failed to stop runner: ${data.error || "Unknown error"}`);
             }
-        } catch (error) {
-            console.error("Failed to stop runner:", error);
+        } catch (err) {
+            console.error("Failed to stop runner:", err);
         } finally {
             setTimeout(() => {
                 setStopping((prev) => {
@@ -213,6 +244,13 @@ export function RunnerManager({
 
     return (
         <>
+            {/* Inline error banner — auto-dismisses after 5 seconds */}
+            {error && (
+                <div className="px-4 pt-3">
+                    <ErrorAlert>{error}</ErrorAlert>
+                </div>
+            )}
+
             <RunnerDetailPanel
                 runner={selectedRunner}
                 hasRunners={runners.length > 0}
@@ -222,7 +260,7 @@ export function RunnerManager({
                 isStopping={stopping.has(selectedRunnerId ?? "")}
                 isOffline={!selectedRunner}
                 onRestart={() => selectedRunnerId && handleRestart(selectedRunnerId)}
-                onStop={() => selectedRunnerId && handleStop(selectedRunnerId)}
+                onStop={() => selectedRunnerId && handleStopRequest(selectedRunnerId)}
                 onNewSession={() => selectedRunnerId && handleOpenNewSession(selectedRunnerId)}
                 onOpenSession={onOpenSession}
                 onSkillsChange={() => {}}
@@ -245,6 +283,25 @@ export function RunnerManager({
                 preselectedRunnerId={spawnRunnerId}
                 onSpawn={handleWizardSpawn}
             />
+
+            {/* Stop runner confirmation dialog */}
+            <AlertDialog
+                open={stopConfirmRunnerId !== null}
+                onOpenChange={(open) => { if (!open) setStopConfirmRunnerId(null); }}
+            >
+                <AlertDialogContent>
+                    <AlertDialogHeader>
+                        <AlertDialogTitle>Stop runner?</AlertDialogTitle>
+                        <AlertDialogDescription>
+                            This runner will shut down completely and won&apos;t restart automatically.
+                        </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                        <AlertDialogCancel>Cancel</AlertDialogCancel>
+                        <AlertDialogAction onClick={handleStopConfirm}>Stop runner</AlertDialogAction>
+                    </AlertDialogFooter>
+                </AlertDialogContent>
+            </AlertDialog>
         </>
     );
 }

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,143 @@
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[70] bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[70] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 outline-none sm:max-w-lg",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </AlertDialogPrimitive.Content>
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({ className, children, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel asChild>
+      <Button variant="outline" {...props} />
+    </AlertDialogPrimitive.Cancel>
+  )
+}
+
+function AlertDialogAction({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action asChild>
+      <Button variant="destructive" {...props} />
+    </AlertDialogPrimitive.Action>
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}


### PR DESCRIPTION
Night Shift dish 005 — Godmother: SivhU2C0

Replaces native alert() and confirm() calls in RunnerManager.tsx with Radix AlertDialog and toast notifications. No longer blocks the main thread.