### PR TITLE
fix: BETTER_AUTH_SECRET startup validation

### DIFF
--- a/packages/server/src/auth.test.ts
+++ b/packages/server/src/auth.test.ts
@@ -38,12 +38,14 @@ describe("secret validation", () => {
         process.env.NODE_ENV = "production";
         delete process.env.BETTER_AUTH_SECRET;
 
-        const dbPath = join(mkdtempSync(join(tmpdir(), "auth-secret-test-")), "test.db");
+        const tmpD = mkdtempSync(join(tmpdir(), "auth-secret-test-"));
+        const dbPath = join(tmpD, "test.db");
         try {
             expect(() => initAuth({ dbPath })).toThrow(/BETTER_AUTH_SECRET is not set/);
         } finally {
             process.env.NODE_ENV = origEnv;
             if (origSecret !== undefined) process.env.BETTER_AUTH_SECRET = origSecret;
+            rmSync(tmpD, { recursive: true, force: true });
         }
     });
 

--- a/packages/server/src/auth.test.ts
+++ b/packages/server/src/auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll, spyOn } from "bun:test";
 import { getDisableSignupAfterFirstUser, isSignupAllowed, getKysely, initAuth } from "./auth";
 import { sql } from "kysely";
 import { mkdtempSync, rmSync } from "fs";
@@ -31,7 +31,106 @@ afterAll(() => {
     rmSync(tmpDir, { recursive: true, force: true });
 });
 
+describe("secret validation", () => {
+    test("throws in production when secret is missing", () => {
+        const origEnv = process.env.NODE_ENV;
+        const origSecret = process.env.BETTER_AUTH_SECRET;
+        process.env.NODE_ENV = "production";
+        delete process.env.BETTER_AUTH_SECRET;
+
+        const dbPath = join(mkdtempSync(join(tmpdir(), "auth-secret-test-")), "test.db");
+        try {
+            expect(() => initAuth({ dbPath })).toThrow(/BETTER_AUTH_SECRET is not set/);
+        } finally {
+            process.env.NODE_ENV = origEnv;
+            if (origSecret !== undefined) process.env.BETTER_AUTH_SECRET = origSecret;
+        }
+    });
+
+    test("uses random fallback in development when secret is missing", () => {
+        const origEnv = process.env.NODE_ENV;
+        const origSecret = process.env.BETTER_AUTH_SECRET;
+        process.env.NODE_ENV = "development";
+        delete process.env.BETTER_AUTH_SECRET;
+
+        const tmpD = mkdtempSync(join(tmpdir(), "auth-secret-test-"));
+        const dbPath = join(tmpD, "test.db");
+        const warnSpy = spyOn(console, "warn");
+        try {
+            // Should not throw — generates a random fallback
+            expect(() => initAuth({ dbPath })).not.toThrow();
+            const warnCalls = warnSpy.mock.calls.map((args) => args.join(" "));
+            const found = warnCalls.some((msg) => msg.includes("BETTER_AUTH_SECRET") && msg.includes("random ephemeral secret"));
+            expect(found).toBe(true);
+        } finally {
+            warnSpy.mockRestore();
+            process.env.NODE_ENV = origEnv;
+            if (origSecret !== undefined) process.env.BETTER_AUTH_SECRET = origSecret;
+            rmSync(tmpD, { recursive: true, force: true });
+        }
+    });
+
+    test("warns when secret is shorter than 32 characters", () => {
+        const origEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = "development";
+
+        const tmpD = mkdtempSync(join(tmpdir(), "auth-secret-test-"));
+        const dbPath = join(tmpD, "test.db");
+        const warnSpy = spyOn(console, "warn");
+        try {
+            expect(() => initAuth({ dbPath, secret: "short" })).not.toThrow();
+            const warnCalls = warnSpy.mock.calls.map((args) => args.join(" "));
+            const found = warnCalls.some((msg) => msg.includes("shorter than 32 characters"));
+            expect(found).toBe(true);
+        } finally {
+            warnSpy.mockRestore();
+            process.env.NODE_ENV = origEnv;
+            rmSync(tmpD, { recursive: true, force: true });
+        }
+    });
+
+    test("accepts a valid secret without warnings", () => {
+        const origEnv = process.env.NODE_ENV;
+        process.env.NODE_ENV = "development";
+
+        const tmpD = mkdtempSync(join(tmpdir(), "auth-secret-test-"));
+        const dbPath = join(tmpD, "test.db");
+        const warnSpy = spyOn(console, "warn");
+        const goodSecret = "a".repeat(32);
+        try {
+            expect(() => initAuth({ dbPath, secret: goodSecret })).not.toThrow();
+            const warnCalls = warnSpy.mock.calls.map((args) => args.join(" "));
+            const foundSecretWarn = warnCalls.some(
+                (msg) => msg.includes("BETTER_AUTH_SECRET") || msg.includes("shorter than 32"),
+            );
+            expect(foundSecretWarn).toBe(false);
+        } finally {
+            warnSpy.mockRestore();
+            process.env.NODE_ENV = origEnv;
+            rmSync(tmpD, { recursive: true, force: true });
+        }
+    });
+});
+
 describe("signup gating", () => {
+    // Re-initialize with the test DB because the secret validation tests above
+    // call initAuth() with different temp DBs, resetting global auth state.
+    beforeAll(async () => {
+        initAuth({ dbPath: tmpDbPath });
+
+        await sql`
+            CREATE TABLE IF NOT EXISTS user (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL,
+                email TEXT NOT NULL UNIQUE,
+                emailVerified INTEGER NOT NULL DEFAULT 0,
+                image TEXT,
+                createdAt TEXT NOT NULL,
+                updatedAt TEXT NOT NULL
+            )
+        `.execute(getKysely());
+    });
+
     test("disableSignupAfterFirstUser defaults to true", () => {
         // The env var PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER is not set in
         // the test environment, so it should fall back to the default (true).

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -239,7 +239,28 @@ let _initialized = false;
 export function initAuth(config: AuthConfig = {}): void {
     const dbPath = config.dbPath ?? process.env.AUTH_DB_PATH ?? "auth.db";
     const baseURL = config.baseURL ?? process.env.BETTER_AUTH_BASE_URL ?? `http://localhost:${process.env.PORT ?? "7492"}`;
-    const secret = config.secret ?? process.env.BETTER_AUTH_SECRET;
+    let secret = config.secret ?? process.env.BETTER_AUTH_SECRET;
+
+    // Validate the auth secret
+    const isProd = process.env.NODE_ENV === "production";
+    if (!secret || secret.trim() === "") {
+        const msg =
+            "BETTER_AUTH_SECRET is not set. Sessions will be signed with an insecure key.\n" +
+            "  Set it via the BETTER_AUTH_SECRET environment variable (min 32 characters).\n" +
+            "  Example: BETTER_AUTH_SECRET=$(openssl rand -hex 32)";
+        if (isProd) {
+            throw new Error(`[auth] ${msg}`);
+        } else {
+            const fallback = crypto.randomUUID().replace(/-/g, "") + crypto.randomUUID().replace(/-/g, "");
+            console.warn(`[auth] WARNING: ${msg}\n  Using a random ephemeral secret for this development session.`);
+            secret = fallback;
+        }
+    } else if (secret.length < 32) {
+        console.warn(
+            `[auth] WARNING: BETTER_AUTH_SECRET is shorter than 32 characters (got ${secret.length}). ` +
+            "A longer secret is strongly recommended for security.",
+        );
+    }
 
     _disableSignupAfterFirstUser = config.disableSignupAfterFirstUser ??
         parseBooleanEnv(process.env.PIZZAPI_DISABLE_SIGNUP_AFTER_FIRST_USER, true);


### PR DESCRIPTION
Night Shift dish 009 — Godmother: jekGK4zm

Validates BETTER_AUTH_SECRET at startup. In production, throws if missing. In development, generates a random fallback with a warning. Also warns if secret is shorter than 32 characters.