### PR TITLE
fix(security): improve email validation constraints and add unit tests

### DIFF
--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -71,7 +71,37 @@ describe("isValidEmail", () => {
     test("accepts standard emails", () => {
         expect(isValidEmail("test@example.com")).toBe(true);
         expect(isValidEmail("user.name+tag@sub.domain.co.uk")).toBe(true);
-        expect(isValidEmail("a@b.c")).toBe(true);
+    });
+
+    test("accepts emails with local part exactly 64 chars", () => {
+        const localPart = "a".repeat(64);
+        expect(isValidEmail(`${localPart}@example.com`)).toBe(true);
+    });
+
+    test("accepts valid emails near the 254 char limit", () => {
+        const domain = "example.com";
+        const localPartLen = 254 - domain.length - 1; // -1 for @
+        // Limit local part to 64 chars
+        const localPart = "a".repeat(Math.min(64, localPartLen));
+        const remainingDomainLen = 254 - localPart.length - 1 - 4; // -4 for .com
+        const fullDomain = "d".repeat(remainingDomainLen) + ".com";
+        expect(isValidEmail(`${localPart}@${fullDomain}`)).toBe(true);
+    });
+
+    test("rejects emails with > 64 chars in local part", () => {
+        const localPart = "a".repeat(65);
+        expect(isValidEmail(`${localPart}@example.com`)).toBe(false);
+    });
+
+    test("rejects emails > 254 chars total length", () => {
+        const localPart = "a".repeat(60);
+        // Make domain large enough to exceed 254 chars
+        const domain = "d".repeat(200) + ".com";
+        expect(isValidEmail(`${localPart}@${domain}`)).toBe(false);
+    });
+
+    test("rejects emails with single char TLD", () => {
+        expect(isValidEmail("a@b.c")).toBe(false);
     });
 
     test("rejects emails without @", () => {

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -128,6 +128,60 @@ describe("isValidEmail", () => {
     test("rejects emails without TLD dot", () => {
         expect(isValidEmail("user@domain")).toBe(false);
     });
+
+    // --- Multibyte / Unicode byte-length tests (P1) ---
+
+    test("accepts multibyte local part at exactly 64 UTF-8 bytes (32 × 'é')", () => {
+        // 'é' (U+00E9) encodes to 2 bytes in UTF-8; 32 × 2 = 64 bytes — at the RFC limit.
+        // A character-count check would see only 32 chars, well under 64.
+        const localPart = "é".repeat(32);
+        expect(isValidEmail(`${localPart}@example.com`)).toBe(true);
+    });
+
+    test("rejects multibyte local part that exceeds 64 UTF-8 bytes but not 64 characters", () => {
+        // 33 × 'é' = 66 UTF-8 bytes > 64-byte RFC limit, but only 33 JS characters.
+        // Old character-count regex {1,64} would incorrectly accept this.
+        const localPart = "é".repeat(33);
+        expect(isValidEmail(`${localPart}@example.com`)).toBe(false);
+    });
+
+    test("rejects email whose total byte length exceeds 254 but character count does not", () => {
+        // ASCII local part: 64 bytes.  '@': 1 byte.  Domain uses 'é' (2 bytes each).
+        // domain = 94 × 'é' + ".com" = 188 + 4 = 192 bytes  →  total = 257 bytes > 254.
+        // Character count: 64 + 1 + 94 + 4 = 163 — well under 254, so old code passes it.
+        const localPart = "a".repeat(64);
+        const domainLabel = "é".repeat(94);
+        expect(isValidEmail(`${localPart}@${domainLabel}.com`)).toBe(false);
+    });
+
+    test("accepts email whose total UTF-8 byte length is within 254 using multibyte domain chars", () => {
+        // ASCII local (32 bytes) + '@' (1 byte) + domain with 'é' (2 bytes each).
+        // 32 × 'é' = 64 bytes + ".com" (4 bytes) = 68 bytes → total = 32 + 1 + 68 = 101 bytes ≤ 254.
+        const localPart = "a".repeat(32);
+        const domainLabel = "é".repeat(32);
+        expect(isValidEmail(`${localPart}@${domainLabel}.com`)).toBe(true);
+    });
+
+    // --- Malformed domain tests (P2) ---
+
+    test("rejects domain with consecutive dots", () => {
+        expect(isValidEmail("a@..example.com")).toBe(false);
+        expect(isValidEmail("a@example..com")).toBe(false);
+        expect(isValidEmail("a@sub..example.com")).toBe(false);
+    });
+
+    test("rejects domain with a leading dot", () => {
+        expect(isValidEmail("a@.example.com")).toBe(false);
+    });
+
+    test("rejects domain with a trailing dot", () => {
+        expect(isValidEmail("a@example.com.")).toBe(false);
+    });
+
+    test("rejects domain that is only dots", () => {
+        expect(isValidEmail("a@...")).toBe(false);
+        expect(isValidEmail("a@.")).toBe(false);
+    });
 });
 
 describe("isValidPassword", () => {

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -79,12 +79,13 @@ describe("isValidEmail", () => {
     });
 
     test("accepts valid emails near the 254 char limit", () => {
-        const domain = "example.com";
-        const localPartLen = 254 - domain.length - 1; // -1 for @
-        // Limit local part to 64 chars
-        const localPart = "a".repeat(Math.min(64, localPartLen));
-        const remainingDomainLen = 254 - localPart.length - 1 - 4; // -4 for .com
-        const fullDomain = "d".repeat(remainingDomainLen) + ".com";
+        // Build a domain using multiple labels each ≤ 63 chars (DNS max per label).
+        // Three labels: 63 + 63 + 58 chars, plus dots and a 2-char TLD = 189 chars.
+        // localPart (64) + "@" (1) + domain (189) = 254 bytes — exactly at the RFC limit.
+        const label63 = "d".repeat(63);
+        const label58 = "d".repeat(58);
+        const fullDomain = `${label63}.${label63}.${label58}.co`;
+        const localPart = "a".repeat(64);
         expect(isValidEmail(`${localPart}@${fullDomain}`)).toBe(true);
     });
 
@@ -154,12 +155,13 @@ describe("isValidEmail", () => {
         expect(isValidEmail(`${localPart}@${domainLabel}.com`)).toBe(false);
     });
 
-    test("accepts email whose total UTF-8 byte length is within 254 using multibyte domain chars", () => {
-        // ASCII local (32 bytes) + '@' (1 byte) + domain with 'é' (2 bytes each).
-        // 32 × 'é' = 64 bytes + ".com" (4 bytes) = 68 bytes → total = 32 + 1 + 68 = 101 bytes ≤ 254.
+    test("rejects email with non-ASCII chars in domain (strict DNS label validation)", () => {
+        // DNS labels are restricted to [a-zA-Z0-9-] (RFC 1035). Non-ASCII characters
+        // such as 'é' are not valid in a literal domain label and must be rejected,
+        // regardless of whether the total byte length is within the 254-byte limit.
         const localPart = "a".repeat(32);
-        const domainLabel = "é".repeat(32);
-        expect(isValidEmail(`${localPart}@${domainLabel}.com`)).toBe(true);
+        const domainLabel = "é".repeat(32); // Total bytes well under 254, but invalid DNS chars.
+        expect(isValidEmail(`${localPart}@${domainLabel}.com`)).toBe(false);
     });
 
     // --- Malformed domain tests (P2) ---
@@ -181,6 +183,57 @@ describe("isValidEmail", () => {
     test("rejects domain that is only dots", () => {
         expect(isValidEmail("a@...")).toBe(false);
         expect(isValidEmail("a@.")).toBe(false);
+    });
+
+    // --- DNS label constraint tests (RFC 1035) ---
+
+    test("accepts domain labels up to 63 chars", () => {
+        const label = "a".repeat(63);
+        expect(isValidEmail(`user@${label}.com`)).toBe(true);
+    });
+
+    test("rejects domain label exceeding 63 chars", () => {
+        const label = "a".repeat(64);
+        expect(isValidEmail(`user@${label}.com`)).toBe(false);
+    });
+
+    test("rejects domain label starting with a hyphen", () => {
+        expect(isValidEmail("user@-label.com")).toBe(false);
+        expect(isValidEmail("user@sub.-label.com")).toBe(false);
+    });
+
+    test("rejects domain label ending with a hyphen", () => {
+        expect(isValidEmail("user@label-.com")).toBe(false);
+        expect(isValidEmail("user@sub.label-.com")).toBe(false);
+    });
+
+    test("accepts domain labels with interior hyphens", () => {
+        expect(isValidEmail("user@my-domain.com")).toBe(true);
+        expect(isValidEmail("user@my-long-domain-name.co.uk")).toBe(true);
+    });
+
+    test("rejects domain label with invalid characters (underscores, dots within label)", () => {
+        expect(isValidEmail("user@_dmarc.example.com")).toBe(false);
+        expect(isValidEmail("user@exam_ple.com")).toBe(false);
+    });
+
+    test("rejects domain total length > 253 chars", () => {
+        // 4 labels of 63 chars + dots = 63*4 + 3 = 255 > 253
+        const label = "d".repeat(63);
+        const domain = `${label}.${label}.${label}.${label}`;
+        expect(isValidEmail(`user@${domain}`)).toBe(false);
+    });
+
+    test("accepts domain near max length (252 chars) with 1-char local part", () => {
+        // A 253-char domain cannot appear in a valid email: even with the minimum
+        // 1-char local part, total = 1 + "@"(1) + 253 = 255 bytes > 254-byte RFC limit.
+        // 252-char domain with 1-char local = 254 bytes — exactly at the RFC limit.
+        // Build: 3 × 63-char labels + 1 × 60-char label + 3 dots = 63*3+60+3 = 252 chars.
+        const label63 = "d".repeat(63);
+        const label60 = "d".repeat(60);
+        const domain = `${label63}.${label63}.${label63}.${label60}`;
+        expect(domain.length).toBe(252);
+        expect(isValidEmail(`a@${domain}`)).toBe(true);
     });
 });
 

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -55,12 +55,43 @@ export class RateLimiter {
 }
 
 export function isValidEmail(email: string): boolean {
-    if (email.length > 254) {
+    const encoder = new TextEncoder();
+
+    // RFC 5321: total email address path limit is 254 bytes (measured in UTF-8 bytes,
+    // not JavaScript UTF-16 code units, to correctly handle non-ASCII characters).
+    if (encoder.encode(email).length > 254) {
         return false;
     }
-    // Regex ensuring local part is 1-64 chars, has @, domain, and TLD >= 2 chars
-    const emailRegex = /^[^\s@]{1,64}@[^\s@]+\.[^\s@.]{2,}$/;
-    return emailRegex.test(email);
+
+    // Split on the last '@' to separate local part from domain.
+    const atIndex = email.lastIndexOf("@");
+    if (atIndex <= 0 || atIndex === email.length - 1) {
+        // No '@', empty local part (@ at position 0), or empty domain (@ at end).
+        return false;
+    }
+
+    const localPart = email.slice(0, atIndex);
+    const domain = email.slice(atIndex + 1);
+
+    // Local part must not contain whitespace or a second '@'.
+    if (/[\s@]/.test(localPart)) return false;
+
+    // RFC 5321: local part must be ≤ 64 bytes (UTF-8 bytes, not character count).
+    // A multibyte character (e.g. 'é' = 2 bytes) can allow a local part that passes
+    // a character-count check but exceeds the RFC byte limit.
+    if (encoder.encode(localPart).length > 64) return false;
+
+    // Domain must not contain whitespace or '@'.
+    if (/[\s@]/.test(domain)) return false;
+
+    // Reject consecutive dots (e.g. "a@..example.com", "a@example..com").
+    if (domain.includes("..")) return false;
+
+    // Reject leading or trailing dots (e.g. "a@.example.com", "a@example.com.").
+    if (domain.startsWith(".") || domain.endsWith(".")) return false;
+
+    // Domain must have at least one dot and a TLD of ≥ 2 non-dot, non-space chars.
+    return /^[^\s@]+\.[^\s@.]{2,}$/.test(domain);
 }
 
 // Re-export from the shared protocol package so existing imports keep working.

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -55,8 +55,11 @@ export class RateLimiter {
 }
 
 export function isValidEmail(email: string): boolean {
-    // Simple but effective regex for most use cases
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+    if (email.length > 254) {
+        return false;
+    }
+    // Regex ensuring local part is 1-64 chars, has @, domain, and TLD >= 2 chars
+    const emailRegex = /^[^\s@]{1,64}@[^\s@]+\.[^\s@.]{2,}$/;
     return emailRegex.test(email);
 }
 

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -54,8 +54,11 @@ export class RateLimiter {
     }
 }
 
+// Module-level encoder avoids a new allocation on every isValidEmail call.
+const _emailEncoder = new TextEncoder();
+
 export function isValidEmail(email: string): boolean {
-    const encoder = new TextEncoder();
+    const encoder = _emailEncoder;
 
     // RFC 5321: total email address path limit is 254 bytes (measured in UTF-8 bytes,
     // not JavaScript UTF-16 code units, to correctly handle non-ASCII characters).
@@ -90,8 +93,20 @@ export function isValidEmail(email: string): boolean {
     // Reject leading or trailing dots (e.g. "a@.example.com", "a@example.com.").
     if (domain.startsWith(".") || domain.endsWith(".")) return false;
 
-    // Domain must have at least one dot and a TLD of ≥ 2 non-dot, non-space chars.
-    return /^[^\s@]+\.[^\s@.]{2,}$/.test(domain);
+    // Validate DNS structure: domain total ≤ 253 chars, each label 1–63 chars,
+    // only [a-zA-Z0-9-], no leading/trailing hyphen per label, TLD ≥ 2 chars.
+    if (domain.length > 253) return false;
+    const labels = domain.split(".");
+    if (labels.length < 2) return false;
+    // Each label must start and end with an alphanumeric character; hyphens are
+    // only permitted in interior positions (RFC 1035 §2.3.4).
+    const labelRe = /^[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/;
+    for (const label of labels) {
+        if (label.length < 1 || label.length > 63) return false;
+        if (!labelRe.test(label)) return false;
+    }
+    // TLD must be at least 2 characters.
+    return labels[labels.length - 1].length >= 2;
 }
 
 // Re-export from the shared protocol package so existing imports keep working.


### PR DESCRIPTION
This PR tightens the `isValidEmail` validation logic in `packages/server/src/security.ts` to enforce standards-compliant constraints (RFC 5321). 

Changes include:
- The total length of the email must be ≤ 254 characters.
- The local part (before the `@`) must be ≤ 64 characters.
- The top-level domain (TLD) must have at least 2 characters.
- Added comprehensive unit tests in `packages/server/src/security.test.ts` to ensure edge cases (exact 64-char local part, >254 total length, single-character TLDs) are handled appropriately.

---
*PR created automatically by Jules for task [10099998805867402857](https://jules.google.com/task/10099998805867402857) started by @Pizzaface*