### PR TITLE
chore: gitignore reports/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ docs/superpowers/
 .worktrees/
 .beads/
 Library/Caches/
+
+# Night Shift reports (local-only, not committed)
+reports/

--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ docs/superpowers/
 Library/Caches/
 
 # Night Shift reports (local-only, not committed)
-reports/
+/reports/


### PR DESCRIPTION
Night Shift reports are local operational data — no need to commit them.