### PR TITLE
Show runners as rows in single-column layout

### DIFF
--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -308,7 +308,10 @@ export function NewSessionWizardDialog({
                             </div>
                         )}
                         {!runnersLoading && connectedRunners.length > 0 && (
-                            <div className="grid grid-cols-2 sm:grid-cols-3 gap-4">
+                            <div className={cn(
+                                "flex flex-col gap-2",
+                                connectedRunners.length > 5 && "max-h-96 overflow-y-auto"
+                            )}>
                                 {connectedRunners.map((r) => {
                                     const roots = Array.isArray(r.roots) ? r.roots.length : 0;
                                     const sessionMeta = `${r.sessionCount} session${r.sessionCount !== 1 ? "s" : ""}${roots > 0 ? ` · ${roots} root${roots !== 1 ? "s" : ""}` : ""}`;
@@ -320,30 +323,31 @@ export function NewSessionWizardDialog({
                                             type="button"
                                             onClick={() => handleSelectRunner(r.runnerId)}
                                             className={cn(
-                                                "flex flex-col items-start gap-2.5 rounded-xl border p-5 text-left transition-colors w-full",
+                                                "flex flex-row items-center gap-3 rounded-lg border p-4 text-left transition-colors w-full",
                                                 "hover:bg-accent hover:border-accent-foreground/20",
                                                 selectedRunnerId === r.runnerId
                                                     ? "border-primary bg-primary/5"
                                                     : "border-border bg-card",
                                             )}
                                         >
-                                            {/* Top row: OS label (left) + status dot (right) */}
-                                            <div className="flex items-center justify-between w-full">
-                                                {osName ? (
-                                                    <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                                                        <PlatformIcon platform={r.platform} />
-                                                        <span>{osName}</span>
-                                                    </span>
-                                                ) : (
-                                                    <span />
-                                                )}
-                                                <span className="h-2.5 w-2.5 rounded-full bg-green-500 flex-shrink-0" />
+                                            {/* Status dot */}
+                                            <span className="h-2.5 w-2.5 rounded-full bg-green-500 flex-shrink-0" />
+
+                                            {/* Content */}
+                                            <div className="flex flex-col min-w-0 flex-1">
+                                                <span className="font-semibold text-sm leading-tight truncate">
+                                                    {runnerLabel(r)}
+                                                </span>
+                                                <span className="text-xs text-muted-foreground">{sessionMeta}</span>
                                             </div>
 
-                                            <span className="font-semibold text-sm leading-tight truncate w-full">
-                                                {runnerLabel(r)}
-                                            </span>
-                                            <span className="text-xs text-muted-foreground">{sessionMeta}</span>
+                                            {/* OS icon */}
+                                            {osName && (
+                                                <span className="flex items-center gap-1.5 text-xs text-muted-foreground flex-shrink-0">
+                                                    <span>{osName}</span>
+                                                    <PlatformIcon platform={r.platform} />
+                                                </span>
+                                            )}
                                         </button>
                                     );
                                 })}


### PR DESCRIPTION
## Summary

Changes the runner selector in the New Session dialog to display runners as a single-column list instead of a multi-column grid.

## Changes

- **Layout**: Changed from  to single-column flexbox
- **Scrolling**: Added scrollable container with  when more than 5 runners
- **Card design**: Converted runner cards from vertical to horizontal row layout
  - Status dot now on the left
  - Runner name and session count in the middle
  - OS badge on the right
- **Spacing**: Adjusted padding and gaps for better row presentation

## Why

Single-column layout works better across all screen sizes, especially mobile. Users can scan runners more naturally as a list, and the horizontal layout makes better use of screen width.

## Testing

- ✅ TypeScript typecheck passes
- ✅ Build passes
- ✅ UI renders correctly with both few (<5) and many (>5) runners
- ✅ Scrolling appears when runner count exceeds 5