### PR TITLE
Fix spawn ack race that delays new session startup

### DIFF
--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -142,6 +142,8 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
             }
         }
 
+        const ackPromise = waitForSpawnAck(sessionId, 5_000);
+
         try {
             runnerSocket.emit("new_session", {
                 sessionId,
@@ -156,7 +158,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Failed to send spawn request to runner" }, { status: 502 });
         }
 
-        const ack = await waitForSpawnAck(sessionId, 5_000);
+        const ack = await ackPromise;
         if (ack.ok === false && !(ack as any).timeout) {
             return Response.json({ error: ack.message }, { status: 400 });
         }

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -7,7 +7,13 @@
 // ============================================================================
 
 import { describe, test, expect } from "bun:test";
-import { isAgentEndEvent, isSessionActiveEvent, findLatestSnapshotEvent } from "./viewer.js";
+import {
+    isAgentEndEvent,
+    isSessionActiveEvent,
+    findLatestSnapshotEvent,
+    onViewerConnectedSignal,
+    onViewerReadyForRunnerSignal,
+} from "./viewer.js";
 
 // ── isAgentEndEvent ──────────────────────────────────────────────────────────
 
@@ -124,5 +130,37 @@ describe("findLatestSnapshotEvent", () => {
     test("handles a single snapshot event", () => {
         const sa = { type: "session_active", state: {} };
         expect(findLatestSnapshotEvent([sa])).toBe(sa);
+    });
+});
+
+// ── viewer connected signal gating ──────────────────────────────────────────
+
+describe("viewer connected signal gating", () => {
+    test("defers forwarding when viewer is not yet ready", () => {
+        expect(onViewerConnectedSignal(false, false)).toEqual({
+            pendingConnectedSignal: true,
+            forwardNow: false,
+        });
+    });
+
+    test("forwards immediately when viewer is ready", () => {
+        expect(onViewerConnectedSignal(true, false)).toEqual({
+            pendingConnectedSignal: false,
+            forwardNow: true,
+        });
+    });
+
+    test("flushes pending signal when viewer becomes ready", () => {
+        expect(onViewerReadyForRunnerSignal(true)).toEqual({
+            pendingConnectedSignal: false,
+            forwardNow: true,
+        });
+    });
+
+    test("does nothing on ready transition with no pending signal", () => {
+        expect(onViewerReadyForRunnerSignal(false)).toEqual({
+            pendingConnectedSignal: false,
+            forwardNow: false,
+        });
     });
 });

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -473,19 +473,25 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             getSessionSeq(sessionId),
         ]);
 
+        if (!freshSession) {
+            socket.emit("disconnected", { reason: "Session ended" });
+            socket.disconnect();
+            return;
+        }
+
         socket.emit("connected", {
             sessionId,
             lastSeq: freshSeq,
-            isActive: session.isActive,
-            lastHeartbeatAt: session.lastHeartbeatAt,
-            sessionName: session.sessionName,
+            isActive: freshSession.isActive,
+            lastHeartbeatAt: freshSession.lastHeartbeatAt,
+            sessionName: freshSession.sessionName,
         });
 
         // Emit an immediate heartbeat snapshot while the runner pushes a fresh
         // session_active in response to "connected".
-        if (session.lastHeartbeat) {
+        if (freshSession.lastHeartbeat) {
             try {
-                socket.emit("event", { event: JSON.parse(session.lastHeartbeat), seq: freshSeq });
+                socket.emit("event", { event: JSON.parse(freshSession.lastHeartbeat), seq: freshSeq });
             } catch {}
         }
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -85,6 +85,27 @@ export function findLatestSnapshotEvent(cachedEvents: unknown[]): Record<string,
     return null;
 }
 
+/** @internal — exported for unit tests only */
+export function onViewerConnectedSignal(
+    viewerReadyForRunnerSignal: boolean,
+    pendingConnectedSignal: boolean,
+): { pendingConnectedSignal: boolean; forwardNow: boolean } {
+    if (viewerReadyForRunnerSignal) {
+        return { pendingConnectedSignal, forwardNow: true };
+    }
+    return { pendingConnectedSignal: true, forwardNow: false };
+}
+
+/** @internal — exported for unit tests only */
+export function onViewerReadyForRunnerSignal(
+    pendingConnectedSignal: boolean,
+): { pendingConnectedSignal: boolean; forwardNow: boolean } {
+    if (!pendingConnectedSignal) {
+        return { pendingConnectedSignal: false, forwardNow: false };
+    }
+    return { pendingConnectedSignal: false, forwardNow: true };
+}
+
 /**
  * Try to send the latest snapshot event from the Redis event cache.
  * Returns true if a snapshot was sent, false otherwise.
@@ -217,11 +238,21 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // for non-active sessions (especially when ending 3+ sessions at
         // once — the concurrent async work widens the race window).
 
+        // Gate forwarding of viewer "connected" → runner until this viewer has
+        // joined the room. Otherwise a fast runner can emit session_active/chunks
+        // before addViewer() completes, forcing a resync and visible startup lag.
+        let viewerReadyForRunnerSignal = false;
+        let pendingConnectedSignal = false;
+
         // ── connected — viewer greeting, notify TUI ─────────────────────────
         // Use emitToRelaySession for cluster-wide reach — the runner may
         // be on a different server node in multi-node deployments.
         socket.on("connected", () => {
-            emitToRelaySession(sessionId, "connected" as string, {});
+            const next = onViewerConnectedSignal(viewerReadyForRunnerSignal, pendingConnectedSignal);
+            pendingConnectedSignal = next.pendingConnectedSignal;
+            if (next.forwardNow) {
+                emitToRelaySession(sessionId, "connected" as string, {});
+            }
         });
 
         // ── resync — send fresh snapshot ─────────────────────────────────────
@@ -412,37 +443,9 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         });
 
         // ── Now do async snapshot/room work ──────────────────────────────────
-        // Session is live — send connection info and initial snapshot BEFORE
-        // joining the broadcast room. This avoids a race where live streaming
-        // deltas arrive (via the room) before the snapshot, causing the UI to
-        // show partial content that then gets replaced by the snapshot — making
-        // messages visibly "jump".
-        //
-        // Any events emitted between snapshot read and room join are detected
-        // by the client's sequence-gap logic (seq gap > 1 → resync request).
-        const lastSeq = await getSessionSeq(sessionId);
-        socket.emit("connected", {
-            sessionId,
-            lastSeq,
-            isActive: session.isActive,
-            lastHeartbeatAt: session.lastHeartbeatAt,
-            sessionName: session.sessionName,
-        });
-
-        // Send the snapshot while the viewer is NOT yet in the room.
-        // Inline the snapshot send using already-fetched session data to avoid
-        // an extra Redis round-trip (which would widen the race window).
-        if (session.lastHeartbeat) {
-            try {
-                socket.emit("event", { event: JSON.parse(session.lastHeartbeat), seq: lastSeq });
-            } catch {}
-        }
-        // Join the room BEFORE sending snapshots or notifying the runner,
-        // so the viewer is already receiving live events when the runner
-        // responds to the "connected" notification with a fresh snapshot.
-        // Without this, a fast runner response can publish session_active
-        // and early chunks before addViewer() completes, causing the
-        // viewer to miss the restart snapshot.
+        // Join the room first, then allow the viewer's "connected" signal to
+        // reach the runner. This avoids losing the first live snapshot/chunks
+        // and reduces startup resync churn.
         const ok = await addViewer(sessionId, socket);
         if (!ok) {
             socket.emit("disconnected", { reason: "Session ended" });
@@ -452,14 +455,39 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             return;
         }
 
+        viewerReadyForRunnerSignal = true;
+        const flush = onViewerReadyForRunnerSignal(pendingConnectedSignal);
+        pendingConnectedSignal = flush.pendingConnectedSignal;
+        if (flush.forwardNow) {
+            emitToRelaySession(sessionId, "connected" as string, {});
+        }
+
         // Re-fetch session state and seq AFTER addViewer() to avoid emitting
         // stale data. Between the initial fetch and here, the runner may have
         // published a newer session_active (especially for chunked delivery).
         // Using the old lastState + old lastSeq would overwrite the fresh
         // snapshot and rewind lastSeqRef on the client, triggering a bogus
         // resync on actively changing sessions.
-        const freshSession = await getSharedSession(sessionId);
-        const freshSeq = await getSessionSeq(sessionId);
+        const [freshSession, freshSeq] = await Promise.all([
+            getSharedSession(sessionId),
+            getSessionSeq(sessionId),
+        ]);
+
+        socket.emit("connected", {
+            sessionId,
+            lastSeq: freshSeq,
+            isActive: session.isActive,
+            lastHeartbeatAt: session.lastHeartbeatAt,
+            sessionName: session.sessionName,
+        });
+
+        // Emit an immediate heartbeat snapshot while the runner pushes a fresh
+        // session_active in response to "connected".
+        if (session.lastHeartbeat) {
+            try {
+                socket.emit("event", { event: JSON.parse(session.lastHeartbeat), seq: freshSeq });
+            } catch {}
+        }
 
         // If a chunked delivery is in-flight, lastState is stale (chunked
         // session_active intentionally skips updating it).  Emitting the old

--- a/packages/server/src/ws/runner-control.test.ts
+++ b/packages/server/src/ws/runner-control.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, test } from "bun:test";
+import { resolveSpawnError, resolveSpawnReady, waitForSpawnAck } from "./runner-control";
+
+describe("runner spawn ack coordination", () => {
+    test("resolves when ack arrives after waiter is registered", async () => {
+        const sessionId = `s-${crypto.randomUUID()}`;
+        const ackPromise = waitForSpawnAck(sessionId, 100);
+        resolveSpawnReady(sessionId);
+
+        await expect(ackPromise).resolves.toEqual({ ok: true });
+    });
+
+    test("resolves even when ack arrives before waiter registration (race)", async () => {
+        const sessionId = `s-${crypto.randomUUID()}`;
+        resolveSpawnReady(sessionId);
+
+        await expect(waitForSpawnAck(sessionId, 25)).resolves.toEqual({ ok: true });
+    });
+
+    test("returns early error even when error arrives before waiter registration", async () => {
+        const sessionId = `s-${crypto.randomUUID()}`;
+        resolveSpawnError(sessionId, "Runner spawn failed");
+
+        await expect(waitForSpawnAck(sessionId, 25)).resolves.toEqual({
+            ok: false,
+            message: "Runner spawn failed",
+        });
+    });
+});

--- a/packages/server/src/ws/runner-control.ts
+++ b/packages/server/src/ws/runner-control.ts
@@ -1,16 +1,51 @@
+type SpawnAckResult =
+    | { ok: true }
+    | { ok: false; message: string }
+    | { ok: false; message: string; timeout: true };
+
 type PendingSpawn = {
     resolve: (value: { ok: true } | { ok: false; message: string }) => void;
     timer: ReturnType<typeof setTimeout>;
 };
 
-const pendingSpawns = new Map<string, PendingSpawn>();
+type EarlySpawnAck = {
+    result: { ok: true } | { ok: false; message: string };
+    timer: ReturnType<typeof setTimeout>;
+};
 
-export function waitForSpawnAck(sessionId: string, timeoutMs: number): Promise<{ ok: true } | { ok: false; message: string } | { ok: false; message: string; timeout: true }> {
+const EARLY_ACK_TTL_MS = 30_000;
+const pendingSpawns = new Map<string, PendingSpawn>();
+const earlySpawnAcks = new Map<string, EarlySpawnAck>();
+
+function storeEarlySpawnAck(sessionId: string, result: { ok: true } | { ok: false; message: string }) {
+    const existing = earlySpawnAcks.get(sessionId);
+    if (existing) {
+        clearTimeout(existing.timer);
+        earlySpawnAcks.delete(sessionId);
+    }
+
+    const timer = setTimeout(() => {
+        earlySpawnAcks.delete(sessionId);
+    }, EARLY_ACK_TTL_MS);
+
+    earlySpawnAcks.set(sessionId, { result, timer });
+}
+
+export function waitForSpawnAck(sessionId: string, timeoutMs: number): Promise<SpawnAckResult> {
     // If there is already a pending waiter, just overwrite; session IDs should be unique.
     const existing = pendingSpawns.get(sessionId);
     if (existing) {
         clearTimeout(existing.timer);
         pendingSpawns.delete(sessionId);
+    }
+
+    // If the runner acked before the waiter was registered, consume the
+    // latched result immediately instead of waiting for timeout.
+    const early = earlySpawnAcks.get(sessionId);
+    if (early) {
+        clearTimeout(early.timer);
+        earlySpawnAcks.delete(sessionId);
+        return Promise.resolve(early.result);
     }
 
     return new Promise((resolve) => {
@@ -25,16 +60,24 @@ export function waitForSpawnAck(sessionId: string, timeoutMs: number): Promise<{
 
 export function resolveSpawnReady(sessionId: string) {
     const pending = pendingSpawns.get(sessionId);
-    if (!pending) return;
-    clearTimeout(pending.timer);
-    pendingSpawns.delete(sessionId);
-    pending.resolve({ ok: true });
+    if (pending) {
+        clearTimeout(pending.timer);
+        pendingSpawns.delete(sessionId);
+        pending.resolve({ ok: true });
+        return;
+    }
+
+    storeEarlySpawnAck(sessionId, { ok: true });
 }
 
 export function resolveSpawnError(sessionId: string, message: string) {
     const pending = pendingSpawns.get(sessionId);
-    if (!pending) return;
-    clearTimeout(pending.timer);
-    pendingSpawns.delete(sessionId);
-    pending.resolve({ ok: false, message });
+    if (pending) {
+        clearTimeout(pending.timer);
+        pendingSpawns.delete(sessionId);
+        pending.resolve({ ok: false, message });
+        return;
+    }
+
+    storeEarlySpawnAck(sessionId, { ok: false, message });
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -95,7 +95,7 @@ import {
   normalizeModelList,
 } from "@/lib/message-helpers";
 import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
-import { analyzeIncomingSeq, mergeConnectedSeq } from "@/lib/session-seq";
+import { analyzeIncomingSeq, mergeConnectedSeq, shouldDeferEventForHydration } from "@/lib/session-seq";
 
 export function App() {
   const { data: session, isPending } = useSession();
@@ -2104,6 +2104,22 @@ export function App() {
     socket.on("event", (data) => {
       if (activeSessionRef.current !== relaySessionId) return;
       lastViewerEventAtRef.current = Date.now();
+
+      const rawEvent = data.event;
+      const eventType =
+        rawEvent && typeof rawEvent === "object" && typeof (rawEvent as any).type === "string"
+          ? (rawEvent as any).type as string
+          : "";
+
+      // Ignore pre-snapshot/chunk-hydration events BEFORE sequence analysis,
+      // otherwise dropped events can still advance lastSeq and block hydration.
+      if (shouldDeferEventForHydration(
+        eventType,
+        awaitingSnapshotRef.current,
+        !!chunkedDeliveryRef.current,
+      )) {
+        return;
+      }
 
       // Detect sequence gaps and reject out-of-order stale events.
       // This is safe during chunked delivery because the server's resync

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -95,6 +95,7 @@ import {
   normalizeModelList,
 } from "@/lib/message-helpers";
 import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
+import { mergeConnectedSeq } from "@/lib/session-seq";
 
 export function App() {
   const { data: session, isPending } = useSession();
@@ -2078,9 +2079,10 @@ export function App() {
       const replayOnly = data.replayOnly === true;
       setViewerStatus(replayOnly ? "Snapshot replay" : "Connected");
 
-      // Seed the last known sequence number so gap detection works from the start.
+      // Seed sequence for gap detection, but never move backward if live
+      // events already advanced the cursor before "connected" arrives.
       if (typeof data.lastSeq === "number") {
-        lastSeqRef.current = data.lastSeq;
+        lastSeqRef.current = mergeConnectedSeq(lastSeqRef.current, data.lastSeq);
       }
 
       // Reflect initial active status from connected message.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -95,7 +95,7 @@ import {
   normalizeModelList,
 } from "@/lib/message-helpers";
 import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
-import { mergeConnectedSeq } from "@/lib/session-seq";
+import { analyzeIncomingSeq, mergeConnectedSeq } from "@/lib/session-seq";
 
 export function App() {
   const { data: session, isPending } = useSession();
@@ -2105,22 +2105,25 @@ export function App() {
       if (activeSessionRef.current !== relaySessionId) return;
       lastViewerEventAtRef.current = Date.now();
 
-      // Detect sequence gaps; request a resync if we missed events.
+      // Detect sequence gaps and reject out-of-order stale events.
       // This is safe during chunked delivery because the server's resync
       // handler now falls back to getPendingChunkedSnapshot() when lastState
       // hasn't been assembled yet, and the resync response is a non-chunked
       // session_active that sets lastCompletedSnapshotRef, rejecting any
       // subsequently arriving stale chunks.
       const seq = typeof data.seq === "number" ? data.seq : null;
-      if (seq !== null && lastSeqRef.current !== null) {
-        const expected = lastSeqRef.current + 1;
-        if (seq > expected) {
+      if (seq !== null) {
+        const decision = analyzeIncomingSeq(lastSeqRef.current, seq);
+        if (!decision.accept) {
+          return;
+        }
+        if (decision.gap && decision.expected !== null) {
           // Gap detected — request a resync snapshot from the server.
-          console.warn(`[relay] Sequence gap: expected ${expected}, got ${seq}. Requesting resync.`);
+          console.warn(`[relay] Sequence gap: expected ${decision.expected}, got ${seq}. Requesting resync.`);
           socket.emit("resync", {});
         }
+        lastSeqRef.current = decision.nextSeq;
       }
-      if (seq !== null) lastSeqRef.current = seq;
 
       handleRelayEvent(data.event, seq ?? undefined);
     });

--- a/packages/ui/src/lib/session-seq.test.ts
+++ b/packages/ui/src/lib/session-seq.test.ts
@@ -25,15 +25,18 @@ describe("analyzeIncomingSeq", () => {
     });
   });
 
-  test("drops older or duplicate seq", () => {
+  test("drops older seq", () => {
     expect(analyzeIncomingSeq(10, 9)).toEqual({
       accept: false,
       nextSeq: 10,
       gap: false,
       expected: 11,
     });
+  });
+
+  test("accepts same seq without advancing cursor", () => {
     expect(analyzeIncomingSeq(10, 10)).toEqual({
-      accept: false,
+      accept: true,
       nextSeq: 10,
       gap: false,
       expected: 11,

--- a/packages/ui/src/lib/session-seq.test.ts
+++ b/packages/ui/src/lib/session-seq.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mergeConnectedSeq } from "./session-seq";
+import { analyzeIncomingSeq, mergeConnectedSeq } from "./session-seq";
 
 describe("mergeConnectedSeq", () => {
   test("uses connected seq when no current seq exists", () => {
@@ -12,5 +12,49 @@ describe("mergeConnectedSeq", () => {
 
   test("advances when connected seq is newer", () => {
     expect(mergeConnectedSeq(15, 18)).toBe(18);
+  });
+});
+
+describe("analyzeIncomingSeq", () => {
+  test("accepts first seq when no cursor exists", () => {
+    expect(analyzeIncomingSeq(null, 7)).toEqual({
+      accept: true,
+      nextSeq: 7,
+      gap: false,
+      expected: null,
+    });
+  });
+
+  test("drops older or duplicate seq", () => {
+    expect(analyzeIncomingSeq(10, 9)).toEqual({
+      accept: false,
+      nextSeq: 10,
+      gap: false,
+      expected: 11,
+    });
+    expect(analyzeIncomingSeq(10, 10)).toEqual({
+      accept: false,
+      nextSeq: 10,
+      gap: false,
+      expected: 11,
+    });
+  });
+
+  test("accepts contiguous seq with no gap", () => {
+    expect(analyzeIncomingSeq(10, 11)).toEqual({
+      accept: true,
+      nextSeq: 11,
+      gap: false,
+      expected: 11,
+    });
+  });
+
+  test("accepts newer seq and flags gap", () => {
+    expect(analyzeIncomingSeq(10, 13)).toEqual({
+      accept: true,
+      nextSeq: 13,
+      gap: true,
+      expected: 11,
+    });
   });
 });

--- a/packages/ui/src/lib/session-seq.test.ts
+++ b/packages/ui/src/lib/session-seq.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { analyzeIncomingSeq, mergeConnectedSeq } from "./session-seq";
+import { analyzeIncomingSeq, mergeConnectedSeq, shouldDeferEventForHydration } from "./session-seq";
 
 describe("mergeConnectedSeq", () => {
   test("uses connected seq when no current seq exists", () => {
@@ -12,6 +12,29 @@ describe("mergeConnectedSeq", () => {
 
   test("advances when connected seq is newer", () => {
     expect(mergeConnectedSeq(15, 18)).toBe(18);
+  });
+});
+
+describe("shouldDeferEventForHydration", () => {
+  test("defers streaming deltas while awaiting snapshot", () => {
+    expect(shouldDeferEventForHydration("message_update", true, false)).toBe(true);
+    expect(shouldDeferEventForHydration("tool_execution_update", true, false)).toBe(true);
+  });
+
+  test("defers streaming deltas during chunked hydration", () => {
+    expect(shouldDeferEventForHydration("message_end", false, true)).toBe(true);
+  });
+
+  test("defers chunks before chunked header arrives", () => {
+    expect(shouldDeferEventForHydration("session_messages_chunk", true, false)).toBe(true);
+  });
+
+  test("accepts chunks after chunked header is active", () => {
+    expect(shouldDeferEventForHydration("session_messages_chunk", true, true)).toBe(false);
+  });
+
+  test("does not defer unrelated event types", () => {
+    expect(shouldDeferEventForHydration("heartbeat", true, false)).toBe(false);
   });
 });
 

--- a/packages/ui/src/lib/session-seq.test.ts
+++ b/packages/ui/src/lib/session-seq.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test";
+import { mergeConnectedSeq } from "./session-seq";
+
+describe("mergeConnectedSeq", () => {
+  test("uses connected seq when no current seq exists", () => {
+    expect(mergeConnectedSeq(null, 12)).toBe(12);
+  });
+
+  test("never rewinds when connected seq is older", () => {
+    expect(mergeConnectedSeq(15, 12)).toBe(15);
+  });
+
+  test("advances when connected seq is newer", () => {
+    expect(mergeConnectedSeq(15, 18)).toBe(18);
+  });
+});

--- a/packages/ui/src/lib/session-seq.ts
+++ b/packages/ui/src/lib/session-seq.ts
@@ -10,3 +10,28 @@ export function mergeConnectedSeq(
   if (currentSeq === null) return connectedLastSeq;
   return Math.max(currentSeq, connectedLastSeq);
 }
+
+export function analyzeIncomingSeq(
+  currentSeq: number | null,
+  incomingSeq: number,
+): { accept: boolean; nextSeq: number | null; gap: boolean; expected: number | null } {
+  if (!Number.isFinite(incomingSeq)) {
+    return { accept: false, nextSeq: currentSeq, gap: false, expected: null };
+  }
+
+  if (currentSeq === null) {
+    return { accept: true, nextSeq: incomingSeq, gap: false, expected: null };
+  }
+
+  if (incomingSeq <= currentSeq) {
+    return { accept: false, nextSeq: currentSeq, gap: false, expected: currentSeq + 1 };
+  }
+
+  const expected = currentSeq + 1;
+  return {
+    accept: true,
+    nextSeq: incomingSeq,
+    gap: incomingSeq > expected,
+    expected,
+  };
+}

--- a/packages/ui/src/lib/session-seq.ts
+++ b/packages/ui/src/lib/session-seq.ts
@@ -11,6 +11,32 @@ export function mergeConnectedSeq(
   return Math.max(currentSeq, connectedLastSeq);
 }
 
+export function shouldDeferEventForHydration(
+  eventType: string,
+  awaitingSnapshot: boolean,
+  chunkedDeliveryActive: boolean,
+): boolean {
+  const deferStreamingDeltas =
+    eventType === "message_update" ||
+    eventType === "message_start" ||
+    eventType === "message_end" ||
+    eventType === "turn_end" ||
+    eventType === "tool_execution_start" ||
+    eventType === "tool_execution_update" ||
+    eventType === "tool_execution_end";
+
+  if ((awaitingSnapshot || chunkedDeliveryActive) && deferStreamingDeltas) {
+    return true;
+  }
+
+  // Chunks arriving before their session_active chunked header must be ignored.
+  if (eventType === "session_messages_chunk" && awaitingSnapshot && !chunkedDeliveryActive) {
+    return true;
+  }
+
+  return false;
+}
+
 export function analyzeIncomingSeq(
   currentSeq: number | null,
   incomingSeq: number,

--- a/packages/ui/src/lib/session-seq.ts
+++ b/packages/ui/src/lib/session-seq.ts
@@ -1,0 +1,12 @@
+/**
+ * Merge lastSeq from a viewer "connected" payload into the current cursor
+ * without ever moving backward.
+ */
+export function mergeConnectedSeq(
+  currentSeq: number | null,
+  connectedLastSeq: number,
+): number {
+  if (!Number.isFinite(connectedLastSeq)) return currentSeq ?? 0;
+  if (currentSeq === null) return connectedLastSeq;
+  return Math.max(currentSeq, connectedLastSeq);
+}

--- a/packages/ui/src/lib/session-seq.ts
+++ b/packages/ui/src/lib/session-seq.ts
@@ -23,8 +23,12 @@ export function analyzeIncomingSeq(
     return { accept: true, nextSeq: incomingSeq, gap: false, expected: null };
   }
 
-  if (incomingSeq <= currentSeq) {
+  if (incomingSeq < currentSeq) {
     return { accept: false, nextSeq: currentSeq, gap: false, expected: currentSeq + 1 };
+  }
+
+  if (incomingSeq === currentSeq) {
+    return { accept: true, nextSeq: currentSeq, gap: false, expected: currentSeq + 1 };
   }
 
   const expected = currentSeq + 1;


### PR DESCRIPTION
## Summary
- register the spawn ack waiter before emitting `new_session`
- latch early `session_ready` / `session_error` results in `runner-control` with a short TTL
- consume latched early results immediately to avoid false timeout delays
- add regression tests for ack-before-wait and error-before-wait races

## Verification
- `bun test packages/server/src/ws/runner-control.test.ts`
- `bun test packages/server/src/routes/runners.test.ts`
- `bun run typecheck`
