### PR TITLE
feat(ui): open session from /session/<id> deep-link URL

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -326,6 +326,16 @@ export function App() {
   // (restoredRef is declared here; the effect is placed after openSession is defined below)
   const restoredRef = React.useRef(false);
 
+  // Deep-link: if the page was loaded with a /session/<id> URL, capture the
+  // session ID on mount so we can open it once auth + liveSessions are ready.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const deepLinkSessionIdRef = React.useRef<string | null>(
+    (() => {
+      const m = window.location.pathname.match(/^\/session\/([0-9a-f-]{36})(?:\/|$)/i);
+      return m ? m[1] : null;
+    })(),
+  );
+
   // Tracks a session that was restarted via the remote exec "restart" command.
   // When the session comes back live (hub sends session_added), we auto-reconnect.
   const restartPendingSessionIdRef = React.useRef<string | null>(null);
@@ -2197,15 +2207,26 @@ export function App() {
   }, [handleRelayEvent, patchSessionCache, cancelPendingDeltas]);
 
   // Auto-reopen the last viewed session once live sessions arrive.
+  // Deep-links (/session/<id>) take priority over the stored lastSessionId.
   React.useEffect(() => {
     if (restoredRef.current) return;
     if (liveSessions.length === 0) return;
-    const lastId = localStorage.getItem("pp.lastSessionId");
-    if (!lastId) return;
-    const still_live = liveSessions.some((s) => s.sessionId === lastId);
+
+    // Prefer the deep-link session ID from the URL over the stored last session.
+    const deepLinkId = deepLinkSessionIdRef.current;
+    const targetId = deepLinkId ?? localStorage.getItem("pp.lastSessionId");
+    if (!targetId) return;
+    const still_live = liveSessions.some((s) => s.sessionId === targetId);
     if (!still_live) return;
+
     restoredRef.current = true;
-    openSession(lastId);
+    // Clear the deep-link ref so it doesn't interfere with future navigation,
+    // and replace the URL so a reload doesn't re-trigger the deep-link.
+    if (deepLinkId) {
+      deepLinkSessionIdRef.current = null;
+      history.replaceState(null, "", "/");
+    }
+    openSession(targetId);
   }, [liveSessions, openSession]);
 
   // When a restarted session comes back live, automatically reconnect to it.

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -331,8 +331,8 @@ export function App() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   const deepLinkSessionIdRef = React.useRef<string | null>(
     (() => {
-      const m = window.location.pathname.match(/^\/session\/([0-9a-f-]{36})(?:\/|$)/i);
-      return m ? m[1] : null;
+      const m = window.location.pathname.match(/^\/session\/([^/]+)(?:\/|$)/);
+      return m ? decodeURIComponent(m[1]) : null;
     })(),
   );
 


### PR DESCRIPTION
## What

When the app loads at a `/session/<uuid>` URL (e.g. a shared link like `https://jordans-mac-mini.tail65556b.ts.net/session/72038cb3-933a-480c-9241-f438f623a067`), it now automatically opens that session once auth and live sessions are ready.

## Why it was broken

The auto-restore effect only read `pp.lastSessionId` from localStorage, completely ignoring the URL path. Deep-link URLs were silently discarded.

## How it works

- On mount, parse `window.location.pathname` for `/session/<uuid>` and stash the ID in a ref — synchronously, before any render or auth redirect
- In the auto-restore effect, prefer the deep-link session ID over the stored `lastSessionId`
- After opening, call `history.replaceState(null, '', '/')` so a reload doesn't re-trigger the deep-link

## Auth scoping

No extra UI work needed — the viewer WebSocket subscription goes through `requireSession` middleware with the auth cookie. A user navigating to another user's session URL simply won't receive a `session_active` event.