### PR TITLE
fix: avoid blob CSP issues for attachments

### DIFF
--- a/packages/server/src/handler.test.ts
+++ b/packages/server/src/handler.test.ts
@@ -33,7 +33,7 @@ describe("withSecurityHeaders", () => {
         expect(csp).not.toBeNull();
         expect(csp).toContain("default-src 'self'");
         expect(csp).toContain("script-src 'self'");
-        expect(csp).toContain("connect-src 'self' ws: wss:");
+        expect(csp).toContain("connect-src 'self' ws: wss: blob:");
         expect(csp).toContain("object-src 'none'");
     });
 

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -18,7 +18,7 @@ export function withSecurityHeaders(res: Response): Response {
     headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
     headers.set(
         "Content-Security-Policy",
-        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
+        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
     );
     return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -142,7 +142,7 @@ const httpServer = createServer(async (req, res) => {
                 "referrer-policy": "strict-origin-when-cross-origin",
                 "permissions-policy": "camera=(), microphone=(), geolocation=()",
                 "content-security-policy":
-                    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
+                    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
             });
         }
         res.end(JSON.stringify({ error: "Internal server error" }));

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2279,7 +2279,7 @@ export function App() {
   const inputDedupeRef = React.useRef<InputDedupeState | null>(null);
   const inputAttemptIdRef = React.useRef(0);
 
-  const sendSessionInput = React.useCallback(async (message: { text: string; files?: Array<{ mediaType?: string; filename?: string; url?: string }>; deliverAs?: "steer" | "followUp" } | string) => {
+  const sendSessionInput = React.useCallback(async (message: { text: string; files?: Array<{ file?: File; mediaType?: string; filename?: string; url?: string }>; deliverAs?: "steer" | "followUp" } | string) => {
     const socket = viewerWsRef.current;
     const sessionId = activeSessionRef.current;
     if (!socket || !socket.connected || !sessionId) {
@@ -2310,6 +2310,7 @@ export function App() {
     const rawFiles = (payload.files ?? [])
       .filter((f) => typeof f?.url === "string" && f.url.length > 0)
       .map((f) => ({
+        file: f.file instanceof File ? f.file : undefined,
         mediaType: typeof f.mediaType === "string" ? f.mediaType : undefined,
         filename: typeof f.filename === "string" ? f.filename : undefined,
         url: f.url as string,
@@ -2326,10 +2327,18 @@ export function App() {
 
         const formData = new FormData();
         try {
-          const blob = await fetch(file.url).then((res) => res.blob());
-          const uploadFile = new File([blob], displayName, {
-            type: file.mediaType || blob.type || "application/octet-stream",
-          });
+          const uploadFile = file.file
+            ? new File([file.file], displayName, {
+                type: file.mediaType || file.file.type || "application/octet-stream",
+              })
+            : await fetch(file.url)
+                .then((res) => res.blob())
+                .then(
+                  (blob) =>
+                    new File([blob], displayName, {
+                      type: file.mediaType || blob.type || "application/octet-stream",
+                    })
+                );
           formData.append("files", uploadFile);
         } catch {
           setViewerStatus(`Failed to prepare attachment: ${displayName}`);

--- a/packages/ui/src/components/ai-elements/prompt-input.tsx
+++ b/packages/ui/src/components/ai-elements/prompt-input.tsx
@@ -78,10 +78,8 @@ import {
 // Helpers
 // ============================================================================
 
-const convertBlobUrlToDataUrl = async (url: string): Promise<string | null> => {
+const convertFileToDataUrl = async (file: Blob): Promise<string | null> => {
   try {
-    const response = await fetch(url);
-    const blob = await response.blob();
     // FileReader uses callback-based API, wrapping in Promise is necessary
     // oxlint-disable-next-line eslint-plugin-promise(avoid-new)
     return new Promise((resolve) => {
@@ -90,11 +88,16 @@ const convertBlobUrlToDataUrl = async (url: string): Promise<string | null> => {
       reader.onloadend = () => resolve(reader.result as string);
       // oxlint-disable-next-line eslint-plugin-unicorn(prefer-add-event-listener)
       reader.onerror = () => resolve(null);
-      reader.readAsDataURL(blob);
+      reader.readAsDataURL(file);
     });
   } catch {
     return null;
   }
+};
+
+export type PromptInputAttachment = FileUIPart & {
+  id: string;
+  file?: File;
 };
 
 // ============================================================================
@@ -102,7 +105,7 @@ const convertBlobUrlToDataUrl = async (url: string): Promise<string | null> => {
 // ============================================================================
 
 export interface AttachmentsContext {
-  files: (FileUIPart & { id: string })[];
+  files: PromptInputAttachment[];
   add: (files: File[] | FileList) => void;
   remove: (id: string) => void;
   clear: () => void;
@@ -177,9 +180,7 @@ export const PromptInputProvider = ({
   const clearInput = useCallback(() => setTextInput(""), []);
 
   // ----- attachments state (global when wrapped)
-  const [attachmentFiles, setAttachmentFiles] = useState<
-    (FileUIPart & { id: string })[]
-  >([]);
+  const [attachmentFiles, setAttachmentFiles] = useState<PromptInputAttachment[]>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   // oxlint-disable-next-line eslint(no-empty-function)
   const openRef = useRef<() => void>(() => {});
@@ -193,6 +194,7 @@ export const PromptInputProvider = ({
     setAttachmentFiles((prev) => [
       ...prev,
       ...incoming.map((file) => ({
+        file,
         filename: file.name,
         id: nanoid(),
         mediaType: file.type,
@@ -360,7 +362,7 @@ export const PromptInputActionAddAttachments = ({
 
 export interface PromptInputMessage {
   text: string;
-  files: FileUIPart[];
+  files: PromptInputAttachment[];
 }
 
 export type PromptInputProps = Omit<
@@ -413,7 +415,7 @@ export const PromptInput = ({
   const formRef = useRef<HTMLFormElement | null>(null);
 
   // ----- Local attachments (only used when no provider)
-  const [items, setItems] = useState<(FileUIPart & { id: string })[]>([]);
+  const [items, setItems] = useState<PromptInputAttachment[]>([]);
   const files = usingProvider ? controller.attachments.files : items;
 
   // ----- Local referenced sources (always local to PromptInput)
@@ -490,9 +492,10 @@ export const PromptInput = ({
             message: "Too many files. Some were not added.",
           });
         }
-        const next: (FileUIPart & { id: string })[] = [];
+        const next: PromptInputAttachment[] = [];
         for (const file of capped) {
           next.push({
+            file,
             filename: file.name,
             id: nanoid(),
             mediaType: file.type,
@@ -742,16 +745,17 @@ export const PromptInput = ({
 
       try {
         // Convert blob URLs to data URLs asynchronously
-        const convertedFiles: FileUIPart[] = await Promise.all(
-          files.map(async ({ id: _id, ...item }) => {
-            if (item.url?.startsWith("blob:")) {
-              const dataUrl = await convertBlobUrlToDataUrl(item.url);
-              // If conversion failed, keep the original blob URL
+        const convertedFiles: PromptInputAttachment[] = await Promise.all(
+          files.map(async ({ file, ...item }) => {
+            if (file) {
+              const dataUrl = await convertFileToDataUrl(file);
               return {
                 ...item,
+                file,
                 url: dataUrl ?? item.url,
               };
             }
+
             return item;
           })
         );


### PR DESCRIPTION
## Summary
- allow  in the server CSP  directive for attachment handling
- preserve the original  object in the prompt input so uploads no longer depend on 
- fall back to blob URL fetching only when a  object is unavailable

## Testing
- bun test v1.3.10 (30e609e0)
[static] Serving UI from /Users/jordan/Documents/Projects/PizzaPi/packages/ui/dist
- bun test v1.3.10 (30e609e0)
- 
- vite v6.4.1 building for production...
transforming...
✓ 5573 modules transformed.
rendering chunks...
computing gzip size...
dist/registerSW.js                                        0.13 kB
dist/manifest.webmanifest                                 0.53 kB
dist/index.html                                           1.20 kB │ gzip:   0.53 kB
dist/assets/index-BRzDLrt5.css                          143.96 kB │ gzip:  23.28 kB
dist/assets/clone-CDCH7X9v.js                             0.10 kB │ gzip:   0.11 kB
dist/assets/channel-DpYDCoEr.js                           0.11 kB │ gzip:   0.12 kB
dist/assets/chunk-QZHKN3VN-LG3XWcx-.js                    0.19 kB │ gzip:   0.16 kB
dist/assets/chunk-55IACEB6-CgnqbJMK.js                    0.23 kB │ gzip:   0.20 kB
dist/assets/chunk-4BX2VUAB-B8DCNdVC.js                    0.29 kB │ gzip:   0.20 kB
dist/assets/stateDiagram-v2-4FDKWEC3-BXIjoKsy.js          0.36 kB │ gzip:   0.27 kB
dist/assets/chunk-FMBD7UC4-DMK0EM9O.js                    0.36 kB │ gzip:   0.27 kB
dist/assets/init-Dmth1JHB.js                              0.38 kB │ gzip:   0.19 kB
dist/assets/highlighted-body-B3W2YXNL-BZywXQ4j.js         0.39 kB │ gzip:   0.29 kB
dist/assets/classDiagram-2ON5EDUG-C8DLDZbE.js             0.40 kB │ gzip:   0.29 kB
dist/assets/classDiagram-v2-WZHVMYZB-C8DLDZbE.js          0.40 kB │ gzip:   0.29 kB
dist/assets/chunk-QN33PNHL-DRAjpat2.js                    0.53 kB │ gzip:   0.37 kB
dist/assets/codeowners-Bp6g37R7.js                        0.55 kB │ gzip:   0.32 kB
dist/assets/infoDiagram-HS3SLOUP-CZfsodJW.js              0.66 kB │ gzip:   0.44 kB
dist/assets/shellsession-BADoaaVG.js                      0.71 kB │ gzip:   0.43 kB
dist/assets/tsv-B_m7g4N7.js                               0.74 kB │ gzip:   0.34 kB
dist/assets/html-derivative-BFtXZ54Q.js                   0.90 kB │ gzip:   0.50 kB
dist/assets/git-rebase-r7XF79zn.js                        0.98 kB │ gzip:   0.44 kB
dist/assets/qmldir-C8lEn-DE.js                            1.00 kB │ gzip:   0.45 kB
dist/assets/csv-fuZLfV_i.js                               1.14 kB │ gzip:   0.37 kB
dist/assets/ordinal-pQ88CHDN.js                           1.20 kB │ gzip:   0.58 kB
dist/assets/git-commit-F4YmCXRG.js                        1.23 kB │ gzip:   0.53 kB
dist/assets/xsl-CtQFsRM5.js                               1.39 kB │ gzip:   0.52 kB
dist/assets/dotenv-Da5cRb03.js                            1.42 kB │ gzip:   0.53 kB
dist/assets/chunk-TZMSLE5B-DDgIpzjK.js                    1.43 kB │ gzip:   0.63 kB
dist/assets/sparql-rVzFXLq3.js                            1.48 kB │ gzip:   0.82 kB
dist/assets/ini-BEwlwnbL.js                               1.53 kB │ gzip:   0.50 kB
dist/assets/band-Qk0zm9VS.js                              1.54 kB │ gzip:   0.68 kB
dist/assets/fortran-fixed-form-CkoXwp7k.js                1.67 kB │ gzip:   0.69 kB
dist/assets/docker-BcOcwvcX.js                            1.74 kB │ gzip:   0.60 kB
dist/assets/hxml-Bvhsp5Yf.js                              1.74 kB │ gzip:   0.88 kB
dist/assets/desktop-BmXAJ9_W.js                           1.83 kB │ gzip:   0.76 kB
dist/assets/wenyan-BV7otONQ.js                            2.16 kB │ gzip:   1.09 kB
dist/assets/jssm-C2t-YnRu.js                              2.24 kB │ gzip:   0.62 kB
dist/assets/reg-C-SQnVFl.js                               2.35 kB │ gzip:   0.70 kB
dist/assets/edge-BkV0erSs.js                              2.36 kB │ gzip:   0.70 kB
dist/assets/diff-D97Zzqfu.js                              2.57 kB │ gzip:   0.70 kB
dist/assets/_basePickBy-_wTtu8_m.js                       2.57 kB │ gzip:   1.28 kB
dist/assets/gleam-BspZqrRM.js                             2.58 kB │ gzip:   0.82 kB
dist/assets/erb-CgJxNhIT.js                               2.61 kB │ gzip:   0.84 kB
dist/assets/hy-DFXneXwc.js                                2.65 kB │ gzip:   1.18 kB
dist/assets/json-Cp-IABpG.js                              2.82 kB │ gzip:   0.78 kB
dist/assets/openscad-C4EeE6gA.js                          2.82 kB │ gzip:   1.01 kB
dist/assets/log-2UxHyX5q.js                               2.85 kB │ gzip:   0.90 kB
dist/assets/ron-BhRPY-oY.js                               2.87 kB │ gzip:   0.79 kB
dist/assets/cairo-KRGpt6FW.js                             2.94 kB │ gzip:   0.81 kB
dist/assets/berry-uYugtg8r.js                             3.01 kB │ gzip:   0.81 kB
dist/assets/jsonl-DcaNXYhu.js                             3.01 kB │ gzip:   0.79 kB
dist/assets/jsonc-Des-eS-w.js                             3.11 kB │ gzip:   0.80 kB
dist/assets/logo-BtOb2qkB.js                              3.13 kB │ gzip:   1.47 kB
dist/assets/po-BTJTHyun.js                                3.24 kB │ gzip:   0.91 kB
dist/assets/json5-C9tS-k6U.js                             3.25 kB │ gzip:   0.83 kB
dist/assets/mipsasm-CKIfxQSi.js                           3.26 kB │ gzip:   1.18 kB
dist/assets/tasl-QIJgUcNo.js                              3.29 kB │ gzip:   0.85 kB
dist/assets/genie-D0YGMca9.js                             3.36 kB │ gzip:   1.21 kB
dist/assets/rel-C3B-1QV4.js                               3.37 kB │ gzip:   1.11 kB
dist/assets/vala-CsfeWuGM.js                              3.37 kB │ gzip:   1.19 kB
dist/assets/arc-o1DL5ylt.js                               3.43 kB │ gzip:   1.47 kB
dist/assets/splunk-BtCnVYZw.js                            3.44 kB │ gzip:   1.52 kB
dist/assets/fluent-C4IJs8-o.js                            3.61 kB │ gzip:   0.90 kB
dist/assets/ssh-config-_ykCGR6B.js                        3.62 kB │ gzip:   1.60 kB
dist/assets/jsonnet-DFQXde-d.js                           3.62 kB │ gzip:   1.05 kB
dist/assets/kdl-DV7GczEv.js                               3.63 kB │ gzip:   1.04 kB
dist/assets/glsl-DplSGwfg.js                              3.63 kB │ gzip:   1.41 kB
dist/assets/hurl-irOxFIW8.js                              3.65 kB │ gzip:   1.16 kB
dist/assets/narrat-DRg8JJMk.js                            3.67 kB │ gzip:   1.11 kB
dist/assets/turtle-BsS91CYL.js                            3.70 kB │ gzip:   0.98 kB
dist/assets/zenscript-DVFEvuxE.js                         3.91 kB │ gzip:   1.28 kB
dist/assets/gn-n2N0HUVH.js                                4.00 kB │ gzip:   1.49 kB
dist/assets/pascal-D93ZcfNL.js                            4.15 kB │ gzip:   1.67 kB
dist/assets/diagram-S2PKOQOG-BYgD3uB2.js                  4.30 kB │ gzip:   1.89 kB
dist/assets/nextflow-BrzmwbiE.js                          4.42 kB │ gzip:   1.12 kB
dist/assets/tcl-dwOrl1Do.js                               4.43 kB │ gzip:   1.52 kB
dist/assets/rosmsg-BJDFO7_C.js                            4.52 kB │ gzip:   1.06 kB
dist/assets/http-jrhK8wxY.js                              4.55 kB │ gzip:   1.12 kB
dist/assets/polar-C0HS_06l.js                             4.67 kB │ gzip:   1.12 kB
dist/assets/defaultLocale-DX6XiGOO.js                     4.69 kB │ gzip:   2.18 kB
dist/assets/sdbl-DVxCFoDh.js                              4.70 kB │ gzip:   2.01 kB
dist/assets/fennel-BYunw83y.js                            4.77 kB │ gzip:   1.53 kB
dist/assets/bibtex-CHM0blh-.js                            4.80 kB │ gzip:   0.83 kB
dist/assets/llvm-BtvRca6l.js                              5.04 kB │ gzip:   2.01 kB
dist/assets/wgsl-Dx-B1_4e.js                              5.14 kB │ gzip:   1.39 kB
dist/assets/pieDiagram-ADFJNKIX-CGoHO6yE.js               5.23 kB │ gzip:   2.32 kB
dist/assets/gdresource-BOOCDP_w.js                        5.29 kB │ gzip:   1.34 kB
dist/assets/qml-3beO22l8.js                               5.34 kB │ gzip:   1.38 kB
dist/assets/zig-VOosw3JB.js                               5.34 kB │ gzip:   1.55 kB
dist/assets/dax-CEL-wOlO.js                               5.37 kB │ gzip:   2.23 kB
dist/assets/bicep-Bmn6On1c.js                             5.38 kB │ gzip:   1.15 kB
dist/assets/xml-sdJ4AIDG.js                               5.38 kB │ gzip:   1.21 kB
dist/assets/awk-DMzUqQB5.js                               5.46 kB │ gzip:   1.38 kB
dist/assets/coq-DkFqJrB1.js                               5.53 kB │ gzip:   1.92 kB
dist/assets/moonbit-Ba13S78F.js                           5.54 kB │ gzip:   1.54 kB
dist/assets/jinja-4LBKfQ-Z.js                             5.69 kB │ gzip:   1.40 kB
dist/assets/lean-BZvkOJ9d.js                              5.78 kB │ gzip:   1.92 kB
dist/assets/linear-CULObyyV.js                            5.80 kB │ gzip:   2.38 kB
dist/assets/powerquery-CEu0bR-o.js                        5.90 kB │ gzip:   1.52 kB
dist/assets/graph-B_nJvTFY.js                             5.91 kB │ gzip:   1.87 kB
dist/assets/shaderlab-Dg9Lc6iA.js                         5.92 kB │ gzip:   2.08 kB
dist/assets/verilog-BQ8w6xss.js                           5.93 kB │ gzip:   1.89 kB
dist/assets/cypher-COkxafJQ.js                            5.96 kB │ gzip:   1.73 kB
dist/assets/diagram-QEK2KX5R-Cb8Urfur.js                  6.02 kB │ gzip:   2.54 kB
dist/assets/vb-D17OF-Vu.js                                6.09 kB │ gzip:   2.34 kB
dist/assets/red-bN70gL4F.js                               6.26 kB │ gzip:   1.60 kB
dist/assets/min-dark-CafNBF8u.js                          6.29 kB │ gzip:   1.71 kB
dist/assets/gdshader-DkwncUOv.js                          6.33 kB │ gzip:   1.73 kB
dist/assets/prisma-Dd19v3D-.js                            6.33 kB │ gzip:   1.39 kB
dist/assets/ara-BRHolxvo.js                               6.36 kB │ gzip:   1.81 kB
dist/assets/clojure-P80f7IUj.js                           6.41 kB │ gzip:   1.42 kB
dist/assets/postcss-CXtECtnM.js                           6.42 kB │ gzip:   1.91 kB
dist/assets/toml-vGWfd6FD.js                              6.43 kB │ gzip:   1.28 kB
dist/assets/solarized-light-L9t79GZl.js                   6.48 kB │ gzip:   1.73 kB
dist/assets/r-Dspwwk_N.js                                 6.54 kB │ gzip:   1.78 kB
dist/assets/proto-C7zT0LnQ.js                             6.55 kB │ gzip:   1.42 kB
dist/assets/smalltalk-BERRCDM3.js                         6.59 kB │ gzip:   1.62 kB
dist/assets/talonscript-CkByrt1z.js                       6.76 kB │ gzip:   1.49 kB
dist/assets/solarized-dark-DXbdFlpD.js                    6.85 kB │ gzip:   1.80 kB
dist/assets/riscv-BM1_JUlF.js                             6.91 kB │ gzip:   1.98 kB
dist/assets/min-light-CTRr51gU.js                         6.97 kB │ gzip:   1.89 kB
dist/assets/soy-Brmx7dQM.js                               6.98 kB │ gzip:   1.66 kB
dist/assets/scheme-C98Dy4si.js                            7.17 kB │ gzip:   2.05 kB
dist/assets/hlsl-D3lLCCz7.js                              7.26 kB │ gzip:   2.19 kB
dist/assets/qss-IeuSbFQv.js                               7.47 kB │ gzip:   2.58 kB
dist/assets/dart-CF10PKvl.js                              7.81 kB │ gzip:   1.91 kB
dist/assets/systemd-4A_iFExJ.js                           7.87 kB │ gzip:   2.55 kB
dist/assets/monokai-D4h5O-jR.js                           7.88 kB │ gzip:   1.91 kB
dist/assets/regexp-CDVJQ6XC.js                            7.99 kB │ gzip:   1.42 kB
dist/assets/haml-B8DHNrY2.js                              8.26 kB │ gzip:   1.81 kB
dist/assets/typst-DHCkPAjA.js                             8.39 kB │ gzip:   1.67 kB
dist/assets/vue-html-AaS7Mt5G.js                          8.47 kB │ gzip:   1.68 kB
dist/assets/plsql-ChMvpjG-.js                             8.51 kB │ gzip:   3.00 kB
dist/assets/horizon-BUw7H-hv.js                           8.78 kB │ gzip:   1.96 kB
dist/assets/kotlin-BdnUsdx6.js                            8.79 kB │ gzip:   2.13 kB
dist/assets/ts-tags-zn1MmPIZ.js                           8.95 kB │ gzip:   1.22 kB
dist/assets/make-CHLpvVh8.js                              8.96 kB │ gzip:   1.77 kB
dist/assets/andromeeda-C4gqWexZ.js                        9.02 kB │ gzip:   2.36 kB
dist/assets/sas-cz2c8ADy.js                               9.06 kB │ gzip:   3.81 kB
dist/assets/dark-plus-C3mMm8J8.js                         9.10 kB │ gzip:   2.10 kB
dist/assets/slack-dark-BthQWCQV.js                        9.12 kB │ gzip:   1.97 kB
dist/assets/sass-Cj5Yp3dK.js                              9.29 kB │ gzip:   2.49 kB
dist/assets/plastic-3e1v2bzS.js                           9.30 kB │ gzip:   1.98 kB
dist/assets/slack-ochin-DqwNpetd.js                       9.43 kB │ gzip:   2.10 kB
dist/assets/tex-CvyZ59Mk.js                               9.66 kB │ gzip:   3.05 kB
dist/assets/jison-wvAkD_A8.js                             9.69 kB │ gzip:   1.85 kB
dist/assets/cmake-D1j8_8rp.js                             9.86 kB │ gzip:   3.37 kB
dist/assets/light-plus-B7mTdjB0.js                        9.94 kB │ gzip:   2.27 kB
dist/assets/hcl-BWvSN4gD.js                              10.05 kB │ gzip:   1.93 kB
dist/assets/stateDiagram-FKZM4ZOC-elxs_FdJ.js            10.35 kB │ gzip:   3.62 kB
dist/assets/pkl-u5AG7uiY.js                              10.37 kB │ gzip:   1.38 kB
dist/assets/beancount-k_qm7-4y.js                        10.37 kB │ gzip:   1.44 kB
dist/assets/dream-maker-BtqSS_iP.js                      10.47 kB │ gzip:   2.25 kB
dist/assets/raku-DXvB9xmW.js                             10.47 kB │ gzip:   2.94 kB
dist/assets/yaml-Buea-lGh.js                             10.51 kB │ gzip:   2.27 kB
dist/assets/rst-D5oM4XIm.js                              10.67 kB │ gzip:   2.41 kB
dist/assets/elm-DbKCFpqz.js                              10.97 kB │ gzip:   2.12 kB
dist/assets/github-light-DAi9KRSo.js                     11.18 kB │ gzip:   2.51 kB
dist/assets/dagre-6UL2VRFP-DXJzfnah.js                   11.23 kB │ gzip:   4.18 kB
dist/assets/prolog-CbFg5uaA.js                           11.36 kB │ gzip:   3.83 kB
dist/assets/terraform-BETggiCN.js                        11.39 kB │ gzip:   2.51 kB
dist/assets/github-dark-DHJKELXO.js                      11.41 kB │ gzip:   2.55 kB
dist/assets/puppet-BMWR74SV.js                           11.44 kB │ gzip:   2.11 kB
dist/assets/laserwave-DUszq2jm.js                        11.50 kB │ gzip:   2.58 kB
dist/assets/_baseUniq-BPMbkNey.js                        11.90 kB │ gzip:   4.65 kB
dist/assets/gherkin-DyxjwDmM.js                          11.95 kB │ gzip:   5.05 kB
dist/assets/wasm-MzD3tlZU.js                             12.01 kB │ gzip:   2.19 kB
dist/assets/hjson-D5-asLiD.js                            12.05 kB │ gzip:   1.64 kB
dist/assets/handlebars-BL8al0AC.js                       12.15 kB │ gzip:   2.38 kB
dist/assets/apache-Pmp26Uib.js                           12.46 kB │ gzip:   3.72 kB
dist/assets/vesper-DU1UobuO.js                           12.69 kB │ gzip:   1.97 kB
dist/assets/bat-BkioyH1T.js                              12.89 kB │ gzip:   3.22 kB
dist/assets/fish-BvzEVeQv.js                             13.04 kB │ gzip:   1.74 kB
dist/assets/v-BcVCzyr7.js                                13.21 kB │ gzip:   2.74 kB
dist/assets/vitesse-light-CVO1_9PV.js                    13.62 kB │ gzip:   3.04 kB
dist/assets/aurora-x-D-2ljcwZ.js                         13.66 kB │ gzip:   2.28 kB
dist/assets/vitesse-black-Bkuqu6BP.js                    13.68 kB │ gzip:   3.06 kB
dist/assets/vitesse-dark-D0r3Knsf.js                     13.76 kB │ gzip:   3.06 kB
dist/assets/pug-CGlum2m_.js                              13.84 kB │ gzip:   2.58 kB
dist/assets/luau-C-HG3fhB.js                             13.96 kB │ gzip:   3.18 kB
dist/assets/synthwave-84-CbfX1IO0.js                     14.04 kB │ gzip:   2.87 kB
dist/assets/github-light-default-D7oLnXFd.js             14.16 kB │ gzip:   3.04 kB
dist/assets/clarity-D53aC0YG.js                          14.28 kB │ gzip:   2.46 kB
dist/assets/github-light-high-contrast-BfjtVDDH.js       14.28 kB │ gzip:   3.02 kB
dist/assets/github-dark-dimmed-DH5Ifo-i.js               14.43 kB │ gzip:   3.13 kB
dist/assets/github-dark-default-Cuk6v7N8.js              14.44 kB │ gzip:   3.13 kB
dist/assets/github-dark-high-contrast-E3gJ1_iC.js        14.60 kB │ gzip:   3.09 kB
dist/assets/gnuplot-DdkO51Og.js                          14.78 kB │ gzip:   3.27 kB
dist/assets/rust-B1yitclQ.js                             15.07 kB │ gzip:   2.72 kB
dist/assets/time-K_NKLPla.js                             15.14 kB │ gzip:   4.92 kB
dist/assets/kusto-DZf3V79B.js                            15.17 kB │ gzip:   3.92 kB
dist/assets/actionscript-3-CoDkCxhg.js                   15.21 kB │ gzip:   2.66 kB
dist/assets/nix-CwoSXNpI.js                              15.51 kB │ gzip:   2.48 kB
dist/assets/lua-BaeVxFsk.js                              15.54 kB │ gzip:   3.16 kB
dist/assets/abap-BdImnpbu.js                             15.85 kB │ gzip:   5.91 kB
dist/assets/diagram-PSM6KHXK-uv8GDjuq.js                 15.95 kB │ gzip:   5.69 kB
dist/assets/solidity-rGO070M0.js                         16.07 kB │ gzip:   3.11 kB
dist/assets/matlab-D7o27uSR.js                           16.09 kB │ gzip:   3.06 kB
dist/assets/cue-D82EKSYY.js                              16.20 kB │ gzip:   2.06 kB
dist/assets/elixir-CDX3lj18.js                           16.32 kB │ gzip:   2.80 kB
dist/assets/odin-BBf5iR-q.js                             16.51 kB │ gzip:   2.94 kB
dist/assets/kanagawa-wave-DWedfzmr.js                    17.12 kB │ gzip:   2.93 kB
dist/assets/kanagawa-lotus-CfQXZHmo.js                   17.13 kB │ gzip:   2.93 kB
dist/assets/kanagawa-dragon-CkXjmgJE.js                  17.13 kB │ gzip:   2.95 kB
dist/assets/move-IF9eRakj.js                             17.51 kB │ gzip:   3.07 kB
dist/assets/graphql-ChdNCCLP.js                          18.00 kB │ gzip:   2.52 kB
dist/assets/svelte-zxCyuUbr.js                           18.05 kB │ gzip:   3.09 kB
dist/assets/liquid-DYVedYrR.js                           18.09 kB │ gzip:   3.16 kB
dist/assets/material-theme-D5KoaKCx.js                   18.62 kB │ gzip:   3.11 kB
dist/assets/material-theme-darker-BfHTSMKl.js            18.63 kB │ gzip:   3.11 kB
dist/assets/material-theme-ocean-CyktbL80.js             18.63 kB │ gzip:   3.14 kB
dist/assets/material-theme-lighter-B0m2ddpp.js           18.63 kB │ gzip:   3.11 kB
dist/assets/material-theme-palenight-Csfq5Kiy.js         18.64 kB │ gzip:   3.13 kB
dist/assets/gdscript-C5YyOfLZ.js                         18.99 kB │ gzip:   3.75 kB
dist/assets/groovy-gcz8RCvz.js                           19.18 kB │ gzip:   3.60 kB
dist/assets/mdc-DUICxH0z.js                              19.63 kB │ gzip:   6.66 kB
dist/assets/ayu-dark-CMjwMIkn.js                         19.82 kB │ gzip:   3.89 kB
dist/assets/ayu-mirage-CjoLj4QM.js                       19.82 kB │ gzip:   3.88 kB
dist/assets/ayu-light-C47S-Tmv.js                        19.88 kB │ gzip:   3.88 kB
dist/assets/glimmer-js-Rg0-pVw9.js                       20.07 kB │ gzip:   2.95 kB
dist/assets/glimmer-ts-U6CK756n.js                       20.07 kB │ gzip:   2.94 kB
dist/assets/powershell-Dpen1YoG.js                       20.15 kB │ gzip:   4.07 kB
dist/assets/viml-CJc9bBzg.js                             20.37 kB │ gzip:   6.73 kB
dist/assets/nushell-C-sUppwS.js                          20.40 kB │ gzip:   5.18 kB
dist/assets/kanban-definition-3W4ZIXB7-CNXLea7k.js       20.57 kB │ gzip:   7.23 kB
dist/assets/snazzy-light-Bw305WKR.js                     20.77 kB │ gzip:   3.83 kB
dist/assets/mindmap-definition-VGOIOE7T-DCwg8Lkz.js      21.01 kB │ gzip:   7.32 kB
dist/assets/dracula-BzJJZx-M.js                          21.07 kB │ gzip:   4.00 kB
dist/assets/dracula-soft-BXkSAIEj.js                     21.08 kB │ gzip:   4.04 kB
dist/assets/twig-ChbOoGGc.js                             21.36 kB │ gzip:   3.87 kB
dist/assets/wit-5i3qLPDT.js                              21.47 kB │ gzip:   2.89 kB
dist/assets/rose-pine-qdsjHGoJ.js                        21.74 kB │ gzip:   3.87 kB
dist/assets/rose-pine-moon-D4_iv3hh.js                   21.75 kB │ gzip:   3.89 kB
dist/assets/rose-pine-dawn-DHQR4-dF.js                   21.75 kB │ gzip:   3.89 kB
dist/assets/sankeyDiagram-TZEHDZUN-CZt3lRil.js           22.20 kB │ gzip:   8.13 kB
dist/assets/nim-CVrawwO9.js                              22.46 kB │ gzip:   3.16 kB
dist/assets/common-lisp-Cg-RD9OK.js                      22.58 kB │ gzip:   6.06 kB
dist/assets/surrealql-Bq5Q-fJD.js                        22.58 kB │ gzip:   4.32 kB
dist/assets/gruvbox-dark-hard-CFHQjOhq.js                22.63 kB │ gzip:   4.18 kB
dist/assets/gruvbox-dark-soft-CVdnzihN.js                22.63 kB │ gzip:   4.17 kB
dist/assets/gruvbox-light-hard-CH1njM8p.js               22.64 kB │ gzip:   4.18 kB
dist/assets/gruvbox-light-soft-hJgmCMqR.js               22.64 kB │ gzip:   4.18 kB
dist/assets/gruvbox-dark-medium-GsRaNv29.js              22.64 kB │ gzip:   4.18 kB
dist/assets/gruvbox-light-medium-DRw_LuNl.js             22.64 kB │ gzip:   4.18 kB
dist/assets/sql-BLtJtn59.js                              23.41 kB │ gzip:   7.40 kB
dist/assets/journeyDiagram-XKPGCS4Q-CAgkXRPs.js          23.51 kB │ gzip:   8.30 kB
dist/assets/cadence-Bv_4Rxtq.js                          23.67 kB │ gzip:   3.67 kB
dist/assets/timeline-definition-IT6M3QCI-CH13Ka1L.js     23.68 kB │ gzip:   8.26 kB
dist/assets/astro-CbQHKStN.js                            24.01 kB │ gzip:   7.54 kB
dist/assets/typespec-BGHnOYBU.js                         24.02 kB │ gzip:   2.59 kB
dist/assets/apl-dKokRX4l.js                              24.04 kB │ gzip:   4.20 kB
dist/assets/templ-P3uqSqPl.js                            24.06 kB │ gzip:   5.40 kB
dist/assets/vhdl-CeAyd5Ju.js                             24.26 kB │ gzip:   3.87 kB
dist/assets/angular-html-CU67Zn6k.js                     24.29 kB │ gzip:   4.01 kB
dist/assets/vue-DN_0RTcg.js                              24.48 kB │ gzip:   2.97 kB
dist/assets/purescript-CklMAg4u.js                       24.69 kB │ gzip:   3.25 kB
dist/assets/gitGraphDiagram-V2S2FVAM-DuKYWRH3.js         24.69 kB │ gzip:   7.59 kB
dist/assets/c3-VCDPK7BO.js                               24.89 kB │ gzip:   3.83 kB
dist/assets/one-light-C3Wv6jpd.js                        25.30 kB │ gzip:   3.67 kB
dist/assets/fsharp-CXgrBDvD.js                           25.31 kB │ gzip:   4.13 kB
dist/assets/erDiagram-Q2GNP2WA-DYE54ECX.js               25.31 kB │ gzip:   8.84 kB
dist/assets/marko-DZsq8hO1.js                            25.48 kB │ gzip:   3.57 kB
dist/assets/night-owl-light-CMTm3GFP.js                  25.90 kB │ gzip:   4.26 kB
dist/assets/system-verilog-CnnmHF94.js                   26.20 kB │ gzip:   4.85 kB
dist/assets/nord-Ddv68eIx.js                             26.72 kB │ gzip:   4.40 kB
dist/assets/codeql-DsOJ9woJ.js                           26.88 kB │ gzip:   3.79 kB
dist/assets/scss-OYdSNvt2.js                             27.20 kB │ gzip:   4.20 kB
dist/assets/java-CylS5w8V.js                             27.22 kB │ gzip:   4.26 kB
dist/assets/layout-DbXDNzQ8.js                           27.38 kB │ gzip:   9.72 kB
dist/assets/coffee-Ch7k5sss.js                           27.42 kB │ gzip:   6.35 kB
dist/assets/razor-Uh8Bk_45.js                            27.51 kB │ gzip:   3.57 kB
dist/assets/scala-C151Ov-r.js                            28.88 kB │ gzip:   3.94 kB
dist/assets/night-owl-C39BiMTA.js                        28.91 kB │ gzip:   5.16 kB
dist/assets/crystal-tKQVLTB8.js                          29.39 kB │ gzip:   4.44 kB
dist/assets/mermaid-mWjccvbQ.js                          29.51 kB │ gzip:   3.66 kB
dist/assets/applescript-Co6uUVPk.js                      29.57 kB │ gzip:   5.93 kB
dist/assets/requirementDiagram-UZGBJVZJ-RZM8Kt0M.js      30.23 kB │ gzip:   9.47 kB
dist/assets/julia-CxzCAyBv.js                            31.07 kB │ gzip:   4.33 kB
dist/assets/stylus-BEDo0Tqx.js                           31.07 kB │ gzip:   7.99 kB
dist/assets/poimandres-CS3Unz2-.js                       33.49 kB │ gzip:   5.50 kB
dist/assets/one-dark-pro-DVMEJ2y_.js                     33.79 kB │ gzip:   5.52 kB
dist/assets/bsl-BO_Y6i37.js                              33.87 kB │ gzip:   8.35 kB
dist/assets/quadrantDiagram-AYHSOK5B-Dm0NFgp9.js         34.29 kB │ gzip:  10.09 kB
dist/assets/haxe-CzTSHFRz.js                             35.16 kB │ gzip:   5.91 kB
dist/assets/nginx-BpAMiNFr.js                            35.37 kB │ gzip:   4.43 kB
dist/assets/houston-DnULxvSX.js                          35.42 kB │ gzip:   5.78 kB
dist/assets/tokyo-night-hegEt444.js                      35.67 kB │ gzip:   6.24 kB
dist/assets/chunk-DI55MBZ5-BwkLA3td.js                   36.80 kB │ gzip:  11.97 kB
dist/assets/erlang-DsQrWhSR.js                           37.48 kB │ gzip:   4.40 kB
dist/assets/xychartDiagram-PRI3JC2R-BudKFzrh.js          38.95 kB │ gzip:  10.96 kB
dist/assets/cobol-nwyudZeR.js                            39.15 kB │ gzip:  10.87 kB
dist/assets/asm-D_Q5rh1f.js                              40.72 kB │ gzip:   8.21 kB
dist/assets/shellscript-Yzrsuije.js                      41.48 kB │ gzip:   6.09 kB
dist/assets/haskell-Df6bDoY_.js                          41.49 kB │ gzip:   6.44 kB
dist/assets/perl-C0TMdlhV.js                             43.16 kB │ gzip:   4.67 kB
dist/assets/d-85-TOEBH.js                                43.80 kB │ gzip:   8.47 kB
dist/assets/chunk-B4BG7PRW-DnxTApX5.js                   45.40 kB │ gzip:  14.73 kB
dist/assets/ruby-Cw6WdidG.js                             45.91 kB │ gzip:   5.68 kB
dist/assets/go-CxLEBnE3.js                               46.81 kB │ gzip:   5.18 kB
dist/assets/apex-D8_7TLub.js                             46.99 kB │ gzip:   6.77 kB
dist/assets/catppuccin-mocha-D87Tk5Gz.js                 47.26 kB │ gzip:   8.00 kB
dist/assets/catppuccin-latte-C9dUb6Cb.js                 47.26 kB │ gzip:   8.00 kB
dist/assets/catppuccin-frappe-DFWUc33u.js                47.26 kB │ gzip:   8.02 kB
dist/assets/catppuccin-macchiato-DQyhUUbL.js             47.26 kB │ gzip:   8.01 kB
dist/assets/ada-bCR0ucgS.js                              48.08 kB │ gzip:   6.03 kB
dist/assets/css-DPfMkruS.js                              49.02 kB │ gzip:  11.85 kB
dist/assets/imba-DGztddWO.js                             49.93 kB │ gzip:   9.46 kB
dist/assets/ganttDiagram-JELNMOA3-LJo8XU1u.js            53.42 kB │ gzip:  18.61 kB
dist/assets/everforest-dark-BgDCqdQA.js                  53.75 kB │ gzip:   8.42 kB
dist/assets/everforest-light-C8M2exoo.js                 53.75 kB │ gzip:   8.42 kB
dist/assets/wikitext-BhOHFoWU.js                         55.89 kB │ gzip:   4.76 kB
dist/assets/stata-BH5u7GGu.js                            56.99 kB │ gzip:  12.36 kB
dist/assets/html-GMplVEZG.js                             57.25 kB │ gzip:  11.69 kB
dist/assets/ballerina-BFfxhgS-.js                        58.69 kB │ gzip:   8.15 kB
dist/assets/markdown-Cvjx9yec.js                         59.34 kB │ gzip:   5.64 kB
dist/assets/flowDiagram-NV44I4VS-Bki1Zglg.js             61.08 kB │ gzip:  19.57 kB
dist/assets/ocaml-C0hk2d4L.js                            62.45 kB │ gzip:   5.02 kB
dist/assets/mojo-B93PlW-d.js                             69.30 kB │ gzip:   9.19 kB
dist/assets/python-B6aJPvgy.js                           69.95 kB │ gzip:   9.13 kB
dist/assets/c4Diagram-YG6GDRKO-BBKdi2Gt.js               70.13 kB │ gzip:  19.68 kB
dist/assets/c-BIGW1oBm.js                                72.11 kB │ gzip:  10.51 kB
dist/assets/latex-DGMBWnxU.js                            72.60 kB │ gzip:   6.69 kB
dist/assets/blockDiagram-VD42YOAC-DP9i-fsp.js            73.12 kB │ gzip:  20.81 kB
dist/assets/vyper-CDx5xZoG.js                            74.65 kB │ gzip:  10.74 kB
dist/assets/hack-CaT9iCJl.js                             80.24 kB │ gzip:  26.21 kB
dist/assets/cose-bilkent-S5V4N54A-VwM4JudM.js            81.68 kB │ gzip:  22.46 kB
dist/assets/swift-Dg5xB15N.js                            86.61 kB │ gzip:  14.70 kB
dist/assets/fortran-free-form-BxgE0vQu.js                88.97 kB │ gzip:  11.27 kB
dist/assets/csharp-COcwbKMJ.js                           89.69 kB │ gzip:  10.69 kB
dist/assets/racket-BqYA7rlc.js                           92.39 kB │ gzip:  15.02 kB
dist/assets/less-B1dDrJ26.js                             97.63 kB │ gzip:  14.70 kB
dist/assets/sequenceDiagram-WL72ISMW--38CG-n5.js         98.10 kB │ gzip:  26.94 kB
dist/assets/blade-D4QpJJKB.js                           104.98 kB │ gzip:  28.20 kB
dist/assets/objective-c-DXmwc3jG.js                     105.41 kB │ gzip:  23.33 kB
dist/assets/php-Dhbhpdrm.js                             111.06 kB │ gzip:  28.52 kB
dist/assets/asciidoc-Dv7Oe6Be.js                        131.51 kB │ gzip:   9.34 kB
dist/assets/mdx-Cmh6b_Ma.js                             136.11 kB │ gzip:  23.35 kB
dist/assets/architectureDiagram-VXUJARFQ-Cc5RIpWq.js    148.93 kB │ gzip:  42.20 kB
dist/assets/objective-cpp-CLxacb5B.js                   171.97 kB │ gzip:  30.62 kB
dist/assets/javascript-wDzz0qaB.js                      174.83 kB │ gzip:  16.51 kB
dist/assets/tsx-COt5Ahok.js                             175.54 kB │ gzip:  16.51 kB
dist/assets/jsx-g9-lgVsj.js                             177.79 kB │ gzip:  16.61 kB
dist/assets/typescript-BPQ3VLAy.js                      181.08 kB │ gzip:  16.04 kB
dist/assets/angular-ts-BwZT4LLn.js                      183.82 kB │ gzip:  16.63 kB
dist/assets/vue-vine-CQOfvN7w.js                        190.05 kB │ gzip:  17.98 kB
dist/assets/wolfram-lXgVvXCa.js                         262.39 kB │ gzip:  77.14 kB
dist/assets/UsageDashboard-D4mLXI6P.js                  367.43 kB │ gzip: 104.51 kB
dist/assets/cytoscape.esm-BQaXIfA_.js                   442.44 kB │ gzip: 141.91 kB
dist/assets/treemap-GDKQZRPO-5txwrE0J.js                454.95 kB │ gzip: 107.87 kB
dist/assets/wasm-CG6Dc4jp.js                            622.34 kB │ gzip: 230.29 kB
dist/assets/cpp-CofmeUqb.js                             626.08 kB │ gzip:  44.82 kB
dist/assets/emacs-lisp-C9XAeP06.js                      779.85 kB │ gzip: 196.03 kB
dist/assets/index-D3kVlt1B.js                         2,983.09 kB │ gzip: 861.88 kB
✓ built in 10.29s

PWA v1.2.0
mode      generateSW
precache  17 entries (1215.81 KiB)
files generated
  dist/sw.js
  dist/workbox-b55cfbd3.js
