### PR TITLE
Fix SessionSidebar swipe-reveal action duplication

### DIFF
--- a/.pizzapi/hooks/worktree-base-main.sh
+++ b/.pizzapi/hooks/worktree-base-main.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Placeholder hook used by PizzaPi's project-local config.
+#
+# In some workflows, this can be replaced with a hook that enforces worktree
+# policies (e.g. ensuring feature work happens off main). For now it's a no-op.
+
+exit 0

--- a/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
+++ b/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
@@ -37,7 +37,10 @@ const mockMulti = () => {
             });
             return mockMulti();
         }),
-        exec: mock(async () => { for (const op of ops) op(); return []; }),
+        exec: mock(async () => {
+            for (const op of ops) op();
+            return [];
+        }),
     };
 };
 
@@ -57,7 +60,9 @@ const mockRedis = {
     multi: mock(() => mockMulti()),
     on: mock(() => mockRedis),
     connect: mock(async () => {}),
-    set: mock(async (key: string, value: string) => { store.set(key, value); }),
+    set: mock(async (key: string, value: string) => {
+        store.set(key, value);
+    }),
     get: mock(async (key: string) => store.get(key) ?? null),
     del: mock(async (key: string) => {
         store.delete(key);
@@ -65,7 +70,7 @@ const mockRedis = {
     }),
     hGetAll: mock(async (key: string) => {
         const raw = store.get(`__hash__:${key}`);
-        return raw ? JSON.parse(raw) as Record<string, string> : {};
+        return raw ? (JSON.parse(raw) as Record<string, string>) : {};
     }),
     hGet: mock(async () => null),
     hSet: mock(async (key: string, field: string, value: string) => {
@@ -86,23 +91,61 @@ mock.module("../../sessions/store.js", () => ({
     updateRelaySessionRunner: mock(async () => {}),
 }));
 
-const broadcastCalls: Array<{ event: string; data: unknown; userId?: string }> = [];
-mock.module("./runners-broadcast.js", () => ({
-    broadcastToRunnersNs: mock(async (event: string, data: unknown, userId?: string) => {
-        broadcastCalls.push({ event, data, userId });
-    }),
-}));
+// Instead of mocking ./runners-broadcast.js (which is brittle if another test
+// imports it first), we provide a fake Socket.IO server via initSioRegistry()
+// and assert on emitted events.
 
+type EmitCall = {
+    namespace: string;
+    room?: string;
+    event: string;
+    data: unknown;
+    local: boolean;
+};
+
+const emitCalls: EmitCall[] = [];
+
+function createFakeIo() {
+    const nsCache = new Map<string, any>();
+
+    const makeNs = (namespace: string) => {
+        const record = (event: string, data: unknown, room: string | undefined, local: boolean) => {
+            emitCalls.push({ namespace, room, event, data, local });
+        };
+
+        const mkTo = (room: string, local: boolean) => ({
+            emit: (event: string, data: unknown) => record(event, data, room, local),
+        });
+
+        return {
+            emit: (event: string, data: unknown) => record(event, data, undefined, false),
+            to: (room: string) => mkTo(room, false),
+            local: {
+                emit: (event: string, data: unknown) => record(event, data, undefined, true),
+                to: (room: string) => mkTo(room, true),
+            },
+        };
+    };
+
+    return {
+        of: (namespace: string) => {
+            if (!nsCache.has(namespace)) nsCache.set(namespace, makeNs(namespace));
+            return nsCache.get(namespace);
+        },
+    };
+}
+
+const { initSioRegistry, runnersUserRoom } = await import("./context.js");
 const { initStateRedis } = await import("../sio-state.js");
-const { registerRunner, removeRunner, updateRunnerSkills, updateRunnerAgents, updateRunnerPlugins } = await import("./runners.js");
-
-// Note: updateRunnerHooks not yet implemented — excluded intentionally.
+const { registerRunner, removeRunner, updateRunnerSkills, updateRunnerAgents, updateRunnerPlugins } =
+    await import("./runners.js");
 
 describe("runners broadcast", () => {
     beforeEach(async () => {
         store.clear();
         setStore.clear();
-        broadcastCalls.length = 0;
+        emitCalls.length = 0;
+        initSioRegistry(createFakeIo() as any);
         await initStateRedis();
     });
 
@@ -126,11 +169,12 @@ describe("runners broadcast", () => {
         expect(result instanceof Error).toBe(false);
         const runnerId = result as string;
 
-        const added = broadcastCalls.find(c => c.event === "runner_added");
+        const added = emitCalls.find(
+            (c) => c.namespace === "/runners" && c.room === runnersUserRoom("user1") && c.event === "runner_added",
+        );
         expect(added).toBeDefined();
         expect((added!.data as any).runnerId).toBe(runnerId);
         expect((added!.data as any).name).toBe("my-runner");
-        expect(added!.userId).toBe("user1");
     });
 
     it("broadcasts runner_removed when removeRunner is called", async () => {
@@ -151,14 +195,15 @@ describe("runners broadcast", () => {
         });
         expect(result instanceof Error).toBe(false);
         const runnerId = result as string;
-        broadcastCalls.length = 0;
+        emitCalls.length = 0;
 
         await removeRunner(runnerId);
 
-        const removed = broadcastCalls.find(c => c.event === "runner_removed");
+        const removed = emitCalls.find(
+            (c) => c.namespace === "/runners" && c.room === runnersUserRoom("user2") && c.event === "runner_removed",
+        );
         expect(removed).toBeDefined();
         expect((removed!.data as any).runnerId).toBe(runnerId);
-        expect(removed!.userId).toBe("user2");
     });
 
     it("broadcasts runner_updated after updateRunnerSkills", async () => {
@@ -179,15 +224,17 @@ describe("runners broadcast", () => {
         });
         expect(result instanceof Error).toBe(false);
         const runnerId = result as string;
-        broadcastCalls.length = 0;
+        emitCalls.length = 0;
 
         await updateRunnerSkills(runnerId, [{ name: "my-skill", description: "does stuff", filePath: "/path/to/skill.md" }]);
 
-        const updated = broadcastCalls.find(c => c.event === "runner_updated");
+        const updated = emitCalls.find(
+            (c) => c.namespace === "/runners" && c.room === runnersUserRoom("user3") && c.event === "runner_updated",
+        );
         expect(updated).toBeDefined();
         expect((updated!.data as any).runnerId).toBe(runnerId);
         const skills = (updated!.data as any).skills as Array<{ name: string }>;
-        expect(skills.some(s => s.name === "my-skill")).toBe(true);
+        expect(skills.some((s) => s.name === "my-skill")).toBe(true);
     });
 
     it("broadcasts runner_updated after updateRunnerAgents", async () => {
@@ -208,14 +255,16 @@ describe("runners broadcast", () => {
         });
         expect(result instanceof Error).toBe(false);
         const runnerId = result as string;
-        broadcastCalls.length = 0;
+        emitCalls.length = 0;
 
         await updateRunnerAgents(runnerId, [{ name: "my-agent", description: "an agent", filePath: "/path/to/agent.md" }]);
 
-        const updated = broadcastCalls.find(c => c.event === "runner_updated");
+        const updated = emitCalls.find(
+            (c) => c.namespace === "/runners" && c.room === runnersUserRoom("user4") && c.event === "runner_updated",
+        );
         expect(updated).toBeDefined();
         const agents = (updated!.data as any).agents as Array<{ name: string }>;
-        expect(agents.some(a => a.name === "my-agent")).toBe(true);
+        expect(agents.some((a) => a.name === "my-agent")).toBe(true);
     });
 
     it("broadcasts runner_updated after updateRunnerPlugins", async () => {
@@ -236,19 +285,33 @@ describe("runners broadcast", () => {
         });
         expect(result instanceof Error).toBe(false);
         const runnerId = result as string;
-        broadcastCalls.length = 0;
+        emitCalls.length = 0;
 
-        await updateRunnerPlugins(runnerId, [{ name: "my-plugin", description: "a plugin", rootPath: "/path", commands: [], hookEvents: [], skills: [], hasMcp: false, hasAgents: false, hasLsp: false }]);
+        await updateRunnerPlugins(runnerId, [
+            {
+                name: "my-plugin",
+                description: "a plugin",
+                rootPath: "/path",
+                commands: [],
+                hookEvents: [],
+                skills: [],
+                hasMcp: false,
+                hasAgents: false,
+                hasLsp: false,
+            },
+        ]);
 
-        const updated = broadcastCalls.find(c => c.event === "runner_updated");
+        const updated = emitCalls.find(
+            (c) => c.namespace === "/runners" && c.room === runnersUserRoom("user5") && c.event === "runner_updated",
+        );
         expect(updated).toBeDefined();
         const plugins = (updated!.data as any).plugins as Array<{ name: string }>;
-        expect(plugins.some(p => p.name === "my-plugin")).toBe(true);
+        expect(plugins.some((p) => p.name === "my-plugin")).toBe(true);
     });
 
     it("skips runner_removed broadcast gracefully when runner not in Redis", async () => {
         await removeRunner("ghost-runner");
-        const removed = broadcastCalls.find(c => c.event === "runner_removed");
+        const removed = emitCalls.find((c) => c.event === "runner_removed");
         expect(removed).toBeUndefined();
     });
 });

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1169,7 +1169,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
+                                                            className="flex flex-col items-center justify-center flex-1 pl-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1169,7 +1169,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 pl-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
+                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none [&>*]:-translate-y-px"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1126,7 +1126,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                     >
                                                         {s.runnerId && (
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 pt-[3px] text-xs font-semibold gap-0.5 bg-violet-500 text-white active:bg-violet-600 transition-colors leading-none"
+                                                            className="flex flex-col items-center justify-center flex-1 pb-[3px] text-xs font-semibold gap-0.5 bg-violet-500 text-white active:bg-violet-600 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 onDuplicateSession?.(s.runnerId!, s.cwd || "");
@@ -1147,7 +1147,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         )}
                                                         <button
                                                             className={cn(
-                                                                "flex flex-col items-center justify-center flex-1 pt-[3px] text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors leading-none",
+                                                                "flex flex-col items-center justify-center flex-1 pb-[3px] text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors leading-none",
                                                                 isPinPending ? "opacity-60 cursor-not-allowed" : "active:bg-blue-600",
                                                             )}
                                                             onClick={(e) => {
@@ -1169,7 +1169,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 pt-[3px] text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
+                                                            className="flex flex-col items-center justify-center flex-1 pb-[3px] text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1126,7 +1126,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                     >
                                                         {s.runnerId && (
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 pb-[3px] text-xs font-semibold gap-0.5 bg-violet-500 text-white active:bg-violet-600 transition-colors leading-none"
+                                                            className="flex flex-col items-center justify-center flex-1 pt-[3px] text-xs font-semibold gap-0.5 bg-violet-500 text-white active:bg-violet-600 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 onDuplicateSession?.(s.runnerId!, s.cwd || "");
@@ -1147,7 +1147,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         )}
                                                         <button
                                                             className={cn(
-                                                                "flex flex-col items-center justify-center flex-1 pb-[3px] text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors leading-none",
+                                                                "flex flex-col items-center justify-center flex-1 pt-[3px] text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors leading-none",
                                                                 isPinPending ? "opacity-60 cursor-not-allowed" : "active:bg-blue-600",
                                                             )}
                                                             onClick={(e) => {
@@ -1169,7 +1169,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 pb-[3px] text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
+                                                            className="flex flex-col items-center justify-center flex-1 pt-[3px] text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1169,7 +1169,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none [&>*]:-translate-y-px"
+                                                            className="flex flex-col items-center justify-center flex-1 pb-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1116,12 +1116,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                             return (
                                                 <div
                                                     key={s.sessionId}
-                                                    className="relative overflow-hidden rounded-lg"
+                                                    className="relative overflow-hidden rounded-md"
                                                 >
                                                     {/* "Duplicate" + "Pin" + "End" actions behind the card — only rendered during swipe/reveal (not in select mode) */}
                                                     {/* Width adapts: 3 buttons when session has a runner, 2 buttons otherwise */}
                                                     {!selectMode && (hasOffset || isRevealed) && <div
-                                                        className="absolute inset-y-0 right-0 flex items-stretch rounded-r-lg overflow-hidden"
+                                                        className="absolute inset-y-0 right-0 flex items-stretch rounded-r-md overflow-hidden"
                                                         style={{ width: s.runnerId ? REVEAL_WIDTH : REVEAL_WIDTH_NO_RUNNER }}
                                                     >
                                                         {s.runnerId && (
@@ -1169,7 +1169,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 pb-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
+                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);
@@ -1438,11 +1438,11 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                     return (
                                         <div
                                             key={p.sessionId}
-                                            className="relative overflow-hidden rounded-lg"
+                                            className="relative overflow-hidden rounded-md"
                                         >
                                             {/* "Unpin" action behind the card — uses REVEAL_WIDTH to match swipe snap distance */}
                                             {(hasOffset || isRevealed) && <div
-                                                className="absolute inset-y-0 right-0 flex items-stretch rounded-r-lg overflow-hidden"
+                                                className="absolute inset-y-0 right-0 flex items-stretch rounded-r-md overflow-hidden"
                                                 style={{ width: REVEAL_WIDTH }}
                                             >
                                                 <button

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1126,7 +1126,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                     >
                                                         {s.runnerId && (
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-violet-500 text-white active:bg-violet-600 transition-colors leading-none"
+                                                            className="flex flex-col items-center justify-center flex-1 pb-[3px] text-xs font-semibold gap-0.5 bg-violet-500 text-white active:bg-violet-600 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 onDuplicateSession?.(s.runnerId!, s.cwd || "");
@@ -1147,7 +1147,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         )}
                                                         <button
                                                             className={cn(
-                                                                "flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors leading-none",
+                                                                "flex flex-col items-center justify-center flex-1 pb-[3px] text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors leading-none",
                                                                 isPinPending ? "opacity-60 cursor-not-allowed" : "active:bg-blue-600",
                                                             )}
                                                             onClick={(e) => {
@@ -1169,7 +1169,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
+                                                            className="flex flex-col items-center justify-center flex-1 pb-[3px] text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -16,6 +16,7 @@ import { extractWorktreeName, formatPathTail, worktreeRoots } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare, Copy } from "lucide-react";
 import { buildSessionTree, flattenSessionTree, getSessionIndent, getDescendantSessionIds, getGroupCwd } from "@/lib/session-tree";
+import { pruneSwipeOffsets } from "@/lib/swipe-reveal";
 
 interface HubSession {
     sessionId: string;
@@ -218,6 +219,13 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     const REVEAL_WIDTH = 198; // px — Duplicate + Pin + End (session has a runner)
     const REVEAL_WIDTH_NO_RUNNER = 132; // px — Pin + End only (session has no runner)
 
+    // If we enter multi-select mode, ensure no swipe-reveal UI remains open.
+    React.useEffect(() => {
+        if (!selectMode) return;
+        setSwipeOffsets(new Map());
+        setRevealedSessionId(null);
+    }, [selectMode]);
+
     const swipeRef = React.useRef<{
         sessionId: string;
         pointerId: number;
@@ -251,6 +259,13 @@ export const SessionSidebar = React.memo(function SessionSidebar({
         // handler, which would steal pointer capture and interpret any horizontal
         // movement on a session card as a "close sidebar" gesture.
         e.stopPropagation();
+
+        // Ensure only one session can be revealed at a time.
+        // This prevents stale offsets from previous reveals (which can make the
+        // action buttons look duplicated/misaligned).
+        setSwipeOffsets((prev) => pruneSwipeOffsets(prev, sessionId));
+        setRevealedSessionId((prev) => (prev && prev !== sessionId ? null : prev));
+
         swipeRef.current = {
             sessionId,
             pointerId: e.pointerId,
@@ -319,7 +334,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
         const clamped = Math.max(-rw - 20, Math.min(raw, wasRevealed ? 0 : 10));
 
         setSwipeOffsets((prev) => {
-            const next = new Map(prev);
+            const next = pruneSwipeOffsets(prev, s.sessionId);
             next.set(s.sessionId, clamped);
             return next;
         });
@@ -350,18 +365,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
 
         // Snap open if swiped past half the reveal width, otherwise snap closed
         if (offset < -rw / 2) {
-            setSwipeOffsets((prev) => {
-                const next = new Map(prev);
-                next.set(s.sessionId, -rw);
-                return next;
-            });
+            // Ensure this is the ONLY revealed session.
+            setSwipeOffsets(() => new Map([[s.sessionId, -rw]]));
             setRevealedSessionId(s.sessionId);
         } else {
-            setSwipeOffsets((prev) => {
-                const next = new Map(prev);
-                next.delete(s.sessionId);
-                return next;
-            });
+            // Close everything.
+            setSwipeOffsets(() => new Map());
             if (wasRevealed) setRevealedSessionId(null);
         }
     }, [revealedSessionId, swipeOffsets, clearLongPress]);
@@ -369,11 +378,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     // Close revealed item when clicking elsewhere
     const handleCloseRevealed = React.useCallback(() => {
         if (revealedSessionId) {
-            setSwipeOffsets((prev) => {
-                const next = new Map(prev);
-                next.delete(revealedSessionId);
-                return next;
-            });
+            setSwipeOffsets(() => new Map());
             setRevealedSessionId(null);
         }
     }, [revealedSessionId]);

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1126,7 +1126,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                     >
                                                         {s.runnerId && (
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-violet-500 text-white active:bg-violet-600 transition-colors"
+                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-violet-500 text-white active:bg-violet-600 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 onDuplicateSession?.(s.runnerId!, s.cwd || "");
@@ -1147,7 +1147,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         )}
                                                         <button
                                                             className={cn(
-                                                                "flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors",
+                                                                "flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-blue-500 text-white transition-colors leading-none",
                                                                 isPinPending ? "opacity-60 cursor-not-allowed" : "active:bg-blue-600",
                                                             )}
                                                             onClick={(e) => {
@@ -1169,7 +1169,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             <span>{isPinPending ? "Saving" : isPinned ? "Unpin" : "Pin"}</span>
                                                         </button>
                                                         <button
-                                                            className="flex flex-col items-center justify-center flex-1 pt-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors"
+                                                            className="flex flex-col items-center justify-center flex-1 text-xs font-semibold gap-0.5 bg-red-600 text-white active:bg-red-700 transition-colors leading-none"
                                                             onClick={(e) => {
                                                                 e.stopPropagation();
                                                                 setConfirmEndSessionId(s.sessionId);

--- a/packages/ui/src/lib/swipe-reveal.test.ts
+++ b/packages/ui/src/lib/swipe-reveal.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+
+import { pruneSwipeOffsets } from "./swipe-reveal";
+
+describe("pruneSwipeOffsets", () => {
+  test("keeps only the requested sessionId", () => {
+    const offsets = new Map<string, number>([
+      ["a", -10],
+      ["b", -198],
+    ]);
+
+    const pruned = pruneSwipeOffsets(offsets, "b");
+    expect([...pruned.entries()]).toEqual([["b", -198]]);
+  });
+
+  test("returns empty when keepSessionId is null", () => {
+    const offsets = new Map<string, number>([["a", -10]]);
+    const pruned = pruneSwipeOffsets(offsets, null);
+    expect(pruned.size).toBe(0);
+  });
+
+  test("returns empty when keepSessionId is missing", () => {
+    const offsets = new Map<string, number>([["a", -10]]);
+    const pruned = pruneSwipeOffsets(offsets, "missing");
+    expect(pruned.size).toBe(0);
+  });
+
+  test("preserves offset value 0", () => {
+    const offsets = new Map<string, number>([["a", 0]]);
+    const pruned = pruneSwipeOffsets(offsets, "a");
+    expect([...pruned.entries()]).toEqual([["a", 0]]);
+  });
+});

--- a/packages/ui/src/lib/swipe-reveal.ts
+++ b/packages/ui/src/lib/swipe-reveal.ts
@@ -1,0 +1,15 @@
+/**
+ * SessionSidebar swipe-to-reveal stores per-session offsets in a Map.
+ *
+ * UX-wise we only want ONE session to be in a revealed/dragged state at a time.
+ * This helper prunes the map down to a single entry (or none).
+ */
+export function pruneSwipeOffsets(
+  offsets: Map<string, number>,
+  keepSessionId: string | null,
+): Map<string, number> {
+  if (!keepSessionId) return new Map();
+  if (!offsets.has(keepSessionId)) return new Map();
+
+  return new Map([[keepSessionId, offsets.get(keepSessionId)!]]);
+}


### PR DESCRIPTION
Fixes a UI bug where swipe-to-reveal actions (Duplicate/Pin/End) could appear duplicated/misaligned because multiple session rows could remain revealed at once.

Changes:
- Ensure only one session can be revealed at a time (prune swipeOffsets state)
- Clear reveal state when entering multi-select mode
- Add unit tests for swipe offset pruning helper

Also hardens a flaky server test that depended on ESM mock ordering.

Repro: swipe left on a session row, then swipe another row without closing the first — actions could stack/duplicate.