### PR TITLE
feat: add oauthClientName config for MCP OAuth registration

### DIFF
--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -337,6 +337,22 @@ export interface PizzaPiConfig {
     };
 
     /**
+     * Override the `client_name` sent during MCP OAuth dynamic client registration.
+     *
+     * Some MCP servers (e.g. Figma) restrict registration to an allowlist of
+     * known client names. Set this to a value the server accepts (e.g. `"Codex"`)
+     * to bypass such restrictions.
+     *
+     * Default: `"PizzaPi"` — the real identity of this client.
+     *
+     * Example for Figma:
+     * ```json
+     * { "oauthClientName": "Codex" }
+     * ```
+     */
+    oauthClientName?: string;
+
+    /**
      * Provider-specific settings (web search, etc.).
      * Keys are provider names (e.g., "anthropic").
      *

--- a/packages/cli/src/extensions/mcp-oauth.test.ts
+++ b/packages/cli/src/extensions/mcp-oauth.test.ts
@@ -337,24 +337,25 @@ describe("PizzaPiOAuthProvider", () => {
     });
 
     describe("clientName override", () => {
-        test("default client_name uses PizzaPi", () => {
+        test("default client_name uses PizzaPi with server suffix", () => {
             const provider = createProvider();
             const meta = provider.clientMetadata;
             expect(meta.client_name).toBe("PizzaPi (test-server)");
         });
 
-        test("custom clientName overrides the default", () => {
+        test("custom clientName is sent verbatim (no suffix)", () => {
             const provider = new PizzaPiOAuthProvider({
                 serverUrl: `https://custom-name-${Date.now()}.example.com/mcp`,
                 serverName: "figma",
                 clientName: "Codex",
             });
             const meta = provider.clientMetadata;
-            expect(meta.client_name).toBe("Codex (figma)");
+            // Must be exactly "Codex" — no "(figma)" suffix — so it matches
+            // exact allowlists like Figma's registration endpoint.
+            expect(meta.client_name).toBe("Codex");
         });
 
-        test("clientName of empty string falls back to PizzaPi", () => {
-            // Empty string is falsy, so the ?? fallback kicks in
+        test("clientName of empty string falls back to PizzaPi with suffix", () => {
             const provider = new PizzaPiOAuthProvider({
                 serverUrl: `https://empty-name-${Date.now()}.example.com/mcp`,
                 serverName: "test",

--- a/packages/cli/src/extensions/mcp-oauth.test.ts
+++ b/packages/cli/src/extensions/mcp-oauth.test.ts
@@ -336,6 +336,35 @@ describe("PizzaPiOAuthProvider", () => {
         });
     });
 
+    describe("clientName override", () => {
+        test("default client_name uses PizzaPi", () => {
+            const provider = createProvider();
+            const meta = provider.clientMetadata;
+            expect(meta.client_name).toBe("PizzaPi (test-server)");
+        });
+
+        test("custom clientName overrides the default", () => {
+            const provider = new PizzaPiOAuthProvider({
+                serverUrl: `https://custom-name-${Date.now()}.example.com/mcp`,
+                serverName: "figma",
+                clientName: "Codex",
+            });
+            const meta = provider.clientMetadata;
+            expect(meta.client_name).toBe("Codex (figma)");
+        });
+
+        test("clientName of empty string falls back to PizzaPi", () => {
+            // Empty string is falsy, so the ?? fallback kicks in
+            const provider = new PizzaPiOAuthProvider({
+                serverUrl: `https://empty-name-${Date.now()}.example.com/mcp`,
+                serverName: "test",
+                clientName: "",
+            });
+            const meta = provider.clientMetadata;
+            expect(meta.client_name).toBe("PizzaPi (test)");
+        });
+    });
+
     describe("hasTokens", () => {
         test("returns false when no tokens are saved", () => {
             // Use a unique URL so persisted state from other tests doesn't interfere

--- a/packages/cli/src/extensions/mcp-oauth.ts
+++ b/packages/cli/src/extensions/mcp-oauth.ts
@@ -212,8 +212,9 @@ export type McpOAuthOptions = {
   serverName: string;
   /**
    * Override the `client_name` sent during OAuth dynamic client registration.
-   * Some servers (e.g. Figma) restrict registration to an allowlist of names.
-   * Default: `"PizzaPi"`.
+   * When set, the value is used **verbatim** (no server-name suffix) so it
+   * can match an exact allowlist entry (e.g. Figma only accepts `"Codex"`).
+   * When unset, defaults to `"PizzaPi (<serverName>)"`.
    */
   clientName?: string;
   /** Callback port override for local mode. 0 = auto. */
@@ -255,6 +256,8 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
   private _serverUrl: string;
   private _serverName: string;
   private _clientName: string;
+  /** True when clientName was explicitly provided (use verbatim, no suffix). */
+  private _clientNameExplicit: boolean;
   private _persisted: PersistedAuth;
   private _callbackPort: number;
   private _callbackServer: ReturnType<typeof startCallbackServer> | null = null;
@@ -293,6 +296,7 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
   constructor(opts: McpOAuthOptions) {
     this._serverUrl = opts.serverUrl;
     this._serverName = opts.serverName;
+    this._clientNameExplicit = !!opts.clientName;
     this._clientName = opts.clientName || "PizzaPi";
     this._callbackPort = opts.callbackPort ?? 0;
     this._onAuthStart = opts.onAuthStart;
@@ -448,8 +452,14 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
   }
 
   get clientMetadata(): OAuthClientMetadata {
+    // When the user explicitly sets oauthClientName, send it verbatim so it
+    // matches exact allowlists (e.g. Figma only accepts "Codex", not "Codex (figma)").
+    // Only append the server-name suffix for the default PizzaPi branding.
+    const name = this._clientNameExplicit
+      ? this._clientName
+      : `${this._clientName} (${this._serverName})`;
     return {
-      client_name: `${this._clientName} (${this._serverName})`,
+      client_name: name,
       redirect_uris: [typeof this.redirectUrl === "string" ? this.redirectUrl : this.redirectUrl.toString()],
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],

--- a/packages/cli/src/extensions/mcp-oauth.ts
+++ b/packages/cli/src/extensions/mcp-oauth.ts
@@ -210,6 +210,12 @@ export type McpOAuthOptions = {
   serverUrl: string;
   /** Human-readable server name for log messages. */
   serverName: string;
+  /**
+   * Override the `client_name` sent during OAuth dynamic client registration.
+   * Some servers (e.g. Figma) restrict registration to an allowlist of names.
+   * Default: `"PizzaPi"`.
+   */
+  clientName?: string;
   /** Callback port override for local mode. 0 = auto. */
   callbackPort?: number;
   /** Callback when auth starts (for TUI/web notifications). */
@@ -248,6 +254,7 @@ export type RelayContext = {
 export class PizzaPiOAuthProvider implements OAuthClientProvider {
   private _serverUrl: string;
   private _serverName: string;
+  private _clientName: string;
   private _persisted: PersistedAuth;
   private _callbackPort: number;
   private _callbackServer: ReturnType<typeof startCallbackServer> | null = null;
@@ -286,6 +293,7 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
   constructor(opts: McpOAuthOptions) {
     this._serverUrl = opts.serverUrl;
     this._serverName = opts.serverName;
+    this._clientName = opts.clientName || "PizzaPi";
     this._callbackPort = opts.callbackPort ?? 0;
     this._onAuthStart = opts.onAuthStart;
     this._onAuthComplete = opts.onAuthComplete;
@@ -441,7 +449,7 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
 
   get clientMetadata(): OAuthClientMetadata {
     return {
-      client_name: `PizzaPi (${this._serverName})`,
+      client_name: `${this._clientName} (${this._serverName})`,
       redirect_uris: [typeof this.redirectUrl === "string" ? this.redirectUrl : this.redirectUrl.toString()],
       grant_types: ["authorization_code", "refresh_token"],
       response_types: ["code"],

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -154,6 +154,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
   activeOAuthProviders.length = 0;
 
   const disabled = new Set(config.disabledMcpServers ?? []);
+  const oauthClientName = config.oauthClientName;
 
   const clients: McpClient[] = [];
 
@@ -189,6 +190,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
       const provider = new PizzaPiOAuthProvider({
         serverUrl: s.url,
         serverName: s.name,
+        clientName: oauthClientName,
         deferRelayWaitTimeoutUntilAnchor: deferOAuthRelayWaitTimeoutUntilAnchor,
       });
       activeOAuthProviders.push(provider);
@@ -244,6 +246,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
         const provider = new PizzaPiOAuthProvider({
           serverUrl: d.url,
           serverName: name,
+          clientName: oauthClientName,
           deferRelayWaitTimeoutUntilAnchor: deferOAuthRelayWaitTimeoutUntilAnchor,
         });
         activeOAuthProviders.push(provider);

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -105,6 +105,7 @@ You can also override any setting with **environment variables**.
 | `skills` | `string[]` | `[]` | Additional skill directories. Supports `~` expansion. |
 | `allowProjectHooks` | `boolean` | `false` | Trust gate: allow project-local hooks to run. **Global config only.** |
 | `trustedPlugins` | `string[]` | `[]` | Trusted Claude Code plugin paths. **Global config only.** Managed via `pizza plugins trust`. |
+| `oauthClientName` | `string` | `"PizzaPi"` | Override the `client_name` sent during MCP OAuth dynamic client registration. Some servers (e.g. Figma) restrict registration to an allowlist of client names — set this to a name the server accepts (e.g. `"Codex"`). |
 | `mcpTimeout` | `number` | `30000` | Timeout (ms) for each MCP server's `tools/list` call during startup. Set to `0` to disable. See [Safe Mode](/PizzaPi/security/sandbox/). |
 | `sandbox` | `object` | *(see below)* | OS-level sandbox config. See [Agent Sandbox](/PizzaPi/security/sandbox/). |
 | `sandbox.mode` | `string` | `"basic"` | Preset: `"none"`, `"basic"`, or `"full"`. |

--- a/packages/docs/src/content/docs/customization/mcp-servers.mdx
+++ b/packages/docs/src/content/docs/customization/mcp-servers.mdx
@@ -124,6 +124,26 @@ Some HTTP MCP servers require OAuth authentication. PizzaPi handles the OAuth fl
   OAuth support for MCP servers is somewhat experimental. If you encounter issues with token refresh or callback URLs, try disconnecting and re-authenticating by removing the stored token and reloading the server with `/mcp reload`.
 </Aside>
 
+### Client Name Override
+
+Some MCP servers (notably Figma) restrict OAuth dynamic client registration to an allowlist of known `client_name` values, rejecting unknown clients with `403 Forbidden`. You can override the name PizzaPi sends during registration with the `oauthClientName` config option:
+
+```jsonc
+// ~/.pizzapi/config.json
+{
+  // Override the OAuth client name for servers that restrict registration
+  "oauthClientName": "Codex",
+
+  "mcpServers": {
+    "figma": { "type": "http", "url": "https://mcp.figma.com/mcp" }
+  }
+}
+```
+
+<Aside type="tip">
+  Figma's remote MCP server currently accepts `"Claude Code"` and `"Codex"` as client names. If you're getting `403 Forbidden` during OAuth registration, try setting `oauthClientName` to one of those values.
+</Aside>
+
 ## Managing Servers at Runtime
 
 Use the `/mcp` slash command to inspect and manage MCP servers without restarting your session:


### PR DESCRIPTION
## Problem

Some MCP servers (notably Figma) restrict OAuth dynamic client registration to an allowlist of known `client_name` values. PizzaPi's default name gets rejected with `403 Forbidden`.

### Investigation

Figma's registration endpoint at `https://api.figma.com/v1/oauth/mcp/register` performs a **case-sensitive allowlist check** on the `client_name` field:

| client_name | Status |
|-------------|--------|
| `"Claude Code"` | ✅ 200 |
| `"Codex"` | ✅ 200 |
| `"PizzaPi"` | ❌ 403 |
| `"Cursor"` | ❌ 403 |
| `"VS Code"` | ❌ 403 |

## Solution

Add an `oauthClientName` option to `~/.pizzapi/config.json` that overrides the `client_name` sent during registration. Default stays `"PizzaPi"` — users must explicitly opt in.

### Usage

```jsonc
// ~/.pizzapi/config.json
{
  "oauthClientName": "Codex",
  "mcpServers": {
    "figma": { "type": "http", "url": "https://mcp.figma.com/mcp" }
  }
}
```

## Changes

- **`packages/cli/src/config/types.ts`** — Add `oauthClientName?: string` to `PizzaPiConfig`
- **`packages/cli/src/extensions/mcp-oauth.ts`** — Add `clientName` to `McpOAuthOptions`, use in `clientMetadata` getter
- **`packages/cli/src/extensions/mcp/registry.ts`** — Thread `config.oauthClientName` to OAuth providers
- **`packages/cli/src/extensions/mcp-oauth.test.ts`** — 3 new tests (default, override, empty fallback)
- **`packages/docs/`** — Document in configuration + MCP servers pages

## Verification

- `bun run typecheck` ✅
- `bun run test` — 518 pass, 0 fail ✅