### PR TITLE
feat: per-server oauthClientName for MCP OAuth registration

### DIFF
--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -337,18 +337,15 @@ export interface PizzaPiConfig {
     };
 
     /**
-     * Override the `client_name` sent during MCP OAuth dynamic client registration.
+     * Global default `client_name` for MCP OAuth dynamic client registration.
      *
      * Some MCP servers (e.g. Figma) restrict registration to an allowlist of
-     * known client names. Set this to a value the server accepts (e.g. `"Codex"`)
-     * to bypass such restrictions.
+     * known client names. Set this to a value the server accepts (e.g. `"Codex"`).
      *
-     * Default: `"PizzaPi"` — the real identity of this client.
+     * Can also be set per-server via `oauthClientName` in individual
+     * `mcpServers` entries — per-server values take precedence.
      *
-     * Example for Figma:
-     * ```json
-     * { "oauthClientName": "Codex" }
-     * ```
+     * Default: `"PizzaPi"`.
      */
     oauthClientName?: string;
 

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -26,8 +26,8 @@ export type McpConfig = {
   mcp?: {
     servers?: Array<
       | { name: string; transport: "stdio"; command: string; args?: string[]; env?: Record<string, string>; cwd?: string }
-      | { name: string; transport: "http"; url: string; headers?: Record<string, string> }
-      | { name: string; transport: "streamable"; url: string; headers?: Record<string, string> }
+      | { name: string; transport: "http"; url: string; headers?: Record<string, string>; oauthClientName?: string }
+      | { name: string; transport: "streamable"; url: string; headers?: Record<string, string>; oauthClientName?: string }
     >;
   };
 
@@ -35,7 +35,8 @@ export type McpConfig = {
   // {
   //   "mcpServers": {
   //     "playwright": { "command": "npx", "args": ["@playwright/mcp@latest"] },
-  //     "myserver":   { "url": "http://localhost:3000/mcp", "transport": "streamable" }
+  //     "myserver":   { "url": "http://localhost:3000/mcp", "transport": "streamable" },
+  //     "figma":      { "type": "http", "url": "https://mcp.figma.com/mcp", "oauthClientName": "Codex" }
   //   }
   // }
   //
@@ -47,7 +48,7 @@ export type McpConfig = {
   mcpServers?: Record<
     string,
     | { command: string; args?: string[]; env?: Record<string, string>; cwd?: string }
-    | { url: string; transport?: "http" | "streamable"; type?: "http" | "sse"; headers?: Record<string, string> }
+    | { url: string; transport?: "http" | "streamable"; type?: "http" | "sse"; headers?: Record<string, string>; oauthClientName?: string }
   >;
 };
 
@@ -190,7 +191,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
       const provider = new PizzaPiOAuthProvider({
         serverUrl: s.url,
         serverName: s.name,
-        clientName: oauthClientName,
+        clientName: s.oauthClientName || oauthClientName,
         deferRelayWaitTimeoutUntilAnchor: deferOAuthRelayWaitTimeoutUntilAnchor,
       });
       activeOAuthProviders.push(provider);
@@ -230,7 +231,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
     }
 
     if ("url" in def && typeof (def as any).url === "string") {
-      const d = def as { url: string; transport?: string; type?: string; headers?: Record<string, string> };
+      const d = def as { url: string; transport?: string; type?: string; headers?: Record<string, string>; oauthClientName?: string };
 
       // Domain gating for URL-based MCP servers
       if (!isMcpDomainAllowed(d.url, name)) continue;
@@ -246,7 +247,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
         const provider = new PizzaPiOAuthProvider({
           serverUrl: d.url,
           serverName: name,
-          clientName: oauthClientName,
+          clientName: d.oauthClientName || oauthClientName,
           deferRelayWaitTimeoutUntilAnchor: deferOAuthRelayWaitTimeoutUntilAnchor,
         });
         activeOAuthProviders.push(provider);

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -105,7 +105,7 @@ You can also override any setting with **environment variables**.
 | `skills` | `string[]` | `[]` | Additional skill directories. Supports `~` expansion. |
 | `allowProjectHooks` | `boolean` | `false` | Trust gate: allow project-local hooks to run. **Global config only.** |
 | `trustedPlugins` | `string[]` | `[]` | Trusted Claude Code plugin paths. **Global config only.** Managed via `pizza plugins trust`. |
-| `oauthClientName` | `string` | `"PizzaPi"` | Override the `client_name` sent during MCP OAuth dynamic client registration. Some servers (e.g. Figma) restrict registration to an allowlist of client names — set this to a name the server accepts (e.g. `"Codex"`). |
+| `oauthClientName` | `string` | `"PizzaPi"` | Global default `client_name` for MCP OAuth registration. Can also be set per-server in `mcpServers` entries. Per-server values take precedence. See [Client Name Override](/PizzaPi/customization/mcp-servers/#client-name-override). |
 | `mcpTimeout` | `number` | `30000` | Timeout (ms) for each MCP server's `tools/list` call during startup. Set to `0` to disable. See [Safe Mode](/PizzaPi/security/sandbox/). |
 | `sandbox` | `object` | *(see below)* | OS-level sandbox config. See [Agent Sandbox](/PizzaPi/security/sandbox/). |
 | `sandbox.mode` | `string` | `"basic"` | Preset: `"none"`, `"basic"`, or `"full"`. |

--- a/packages/docs/src/content/docs/customization/mcp-servers.mdx
+++ b/packages/docs/src/content/docs/customization/mcp-servers.mdx
@@ -126,19 +126,33 @@ Some HTTP MCP servers require OAuth authentication. PizzaPi handles the OAuth fl
 
 ### Client Name Override
 
-Some MCP servers (notably Figma) restrict OAuth dynamic client registration to an allowlist of known `client_name` values, rejecting unknown clients with `403 Forbidden`. You can override the name PizzaPi sends during registration with the `oauthClientName` config option:
+Some MCP servers (notably Figma) restrict OAuth dynamic client registration to an allowlist of known `client_name` values, rejecting unknown clients with `403 Forbidden`. You can override the name PizzaPi sends during registration with `oauthClientName` — either per-server or globally.
+
+**Per-server** (recommended) — only affects the server that needs it:
 
 ```jsonc
 // ~/.pizzapi/config.json
 {
-  // Override the OAuth client name for servers that restrict registration
-  "oauthClientName": "Codex",
-
   "mcpServers": {
-    "figma": { "type": "http", "url": "https://mcp.figma.com/mcp" }
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp",
+      "oauthClientName": "Codex"
+    }
   }
 }
 ```
+
+**Global** — applies to all MCP servers that don't set their own override:
+
+```jsonc
+// ~/.pizzapi/config.json
+{
+  "oauthClientName": "Codex"
+}
+```
+
+Per-server values take precedence over the global setting.
 
 <Aside type="tip">
   Figma's remote MCP server currently accepts `"Claude Code"` and `"Codex"` as client names. If you're getting `403 Forbidden` during OAuth registration, try setting `oauthClientName` to one of those values.


### PR DESCRIPTION
## Follow-up to #273

Adds per-server `oauthClientName` support so you can target specific servers without a global override affecting everything.

### Before (global only)
```jsonc
{
  "oauthClientName": "Codex",  // affects ALL servers
  "mcpServers": { ... }
}
```

### After (per-server)
```jsonc
{
  "mcpServers": {
    "figma": {
      "type": "http",
      "url": "https://mcp.figma.com/mcp",
      "oauthClientName": "Codex"  // only affects Figma
    },
    "github": {
      "type": "http",
      "url": "https://api.githubcopilot.com/mcp/"
      // uses default "PizzaPi" — no override needed
    }
  }
}
```

### Precedence
Per-server `oauthClientName` > global `oauthClientName` > default `"PizzaPi"`

### Changes
- **`registry.ts`** — Add `oauthClientName?` to both `McpConfig` format types; use `server.oauthClientName || globalOauthClientName` when constructing OAuth providers
- **`config/types.ts`** — Updated JSDoc to document per-server support
- **`mcp-servers.mdx`** — Per-server example (recommended) + global example
- **`configuration.mdx`** — Updated reference table

### Verification
- `bun run typecheck` ✅
- `bun run test` — 518 pass, 0 fail ✅