### PR TITLE
feat: session dot-chase border indicators

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -180,6 +180,9 @@ export function App() {
 
   const [pendingQuestion, setPendingQuestion] = React.useState<{ toolCallId: string; questions: Array<{ question: string; options: string[]; type?: import("@/lib/ask-user-questions").QuestionType }>; display: QuestionDisplayMode } | null>(null);
 
+  /** Set of session IDs that currently have a pending AskUserQuestion. */
+  const [sessionsWithPendingQuestion, setSessionsWithPendingQuestion] = React.useState<Set<string>>(new Set());
+
   /** Pending plan mode prompt from the worker — shown as a plan review panel in the viewer. */
   const [pendingPlan, setPendingPlan] = React.useState<{
     toolCallId: string;
@@ -414,7 +417,20 @@ export function App() {
     evictLruIfNeeded(sessionUiCacheRef.current, sessionId, MAX_SESSION_UI_CACHE_SIZE, activeSessionRef.current);
 
     sessionUiCacheRef.current.set(sessionId, next);
-  }, []);
+
+    // Keep the sidebar indicator in sync: track which sessions are awaiting input.
+    if (Object.prototype.hasOwnProperty.call(patch, "pendingQuestion")) {
+      setSessionsWithPendingQuestion((prev) => {
+        const next = new Set(prev);
+        if (patch.pendingQuestion) {
+          next.add(sessionId);
+        } else {
+          next.delete(sessionId);
+        }
+        return next;
+      });
+    }
+  }, [setSessionsWithPendingQuestion]);
 
   // Debounce streaming delta updates (toolcall_delta, text_delta, thinking_delta) so we
   // flush at most once per animation frame instead of once per character.
@@ -3442,6 +3458,7 @@ export function App() {
               selectedRunnerId={selectedRunnerId}
               onSelectRunner={setSelectedRunnerId}
               onShowSessions={() => setShowRunners(false)}
+              sessionsWithPendingQuestion={sessionsWithPendingQuestion}
             />
           </ErrorBoundary>
         </div>

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -102,6 +102,8 @@ export interface SessionSidebarProps {
     selectedRunnerId?: string | null;
     /** Called when a runner is selected */
     onSelectRunner?: (runnerId: string) => void;
+    /** Set of session IDs that currently have a pending AskUserQuestion (awaiting user input). */
+    sessionsWithPendingQuestion?: Set<string>;
 }
 
 function formatRelativeDate(isoString: string): string {
@@ -187,8 +189,13 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     selectedRunnerId,
     onSelectRunner,
     onShowSessions,
+    sessionsWithPendingQuestion,
 }: SessionSidebarProps) {
     const [collapsed, setCollapsed] = React.useState(false);
+
+    // Track sessions that completed (isActive: true→false) but haven't been viewed yet.
+    const [completedUnreadSessions, setCompletedUnreadSessions] = React.useState<Set<string>>(new Set());
+    const prevActiveMapRef = React.useRef<Map<string, boolean>>(new Map());
 
     // Multi-select mode state
     const [selectMode, setSelectMode] = React.useState(false);
@@ -542,6 +549,38 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     React.useEffect(() => {
         onSessionsChange?.(liveSessions);
     }, [liveSessions, onSessionsChange]);
+
+    // Detect isActive: true → false transitions to mark sessions as completed+unread.
+    React.useEffect(() => {
+        const prev = prevActiveMapRef.current;
+        const nowCompleted: string[] = [];
+        for (const s of liveSessions) {
+            const wasActive = prev.get(s.sessionId) ?? false;
+            const isNowActive = s.isActive ?? false;
+            if (wasActive && !isNowActive) {
+                nowCompleted.push(s.sessionId);
+            }
+            prev.set(s.sessionId, isNowActive);
+        }
+        if (nowCompleted.length > 0) {
+            setCompletedUnreadSessions((prev) => {
+                const next = new Set(prev);
+                for (const id of nowCompleted) next.add(id);
+                return next;
+            });
+        }
+    }, [liveSessions]);
+
+    // Clear completed-unread when the user navigates to a session.
+    React.useEffect(() => {
+        if (!activeSessionId) return;
+        setCompletedUnreadSessions((prev) => {
+            if (!prev.has(activeSessionId)) return prev;
+            const next = new Set(prev);
+            next.delete(activeSessionId);
+            return next;
+        });
+    }, [activeSessionId]);
 
     React.useEffect(() => {
         const socket = io("/hub", { withCredentials: true });
@@ -1228,8 +1267,14 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             selectMode && isChecked
                                                                 ? "bg-sidebar-accent text-sidebar-accent-foreground"
                                                                 : isActiveSession
-                                                                    ? "bg-sidebar-accent text-sidebar-accent-foreground border border-yellow-400/40 animate-border-glow"
-                                                                    : "bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent/50",
+                                                                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
+                                                                    : sessionsWithPendingQuestion?.has(s.sessionId)
+                                                                        ? "text-sidebar-foreground animate-awaiting-chase"
+                                                                        : s.isActive
+                                                                            ? "text-sidebar-foreground animate-working-chase"
+                                                                            : completedUnreadSessions.has(s.sessionId)
+                                                                                ? "text-sidebar-foreground animate-completed-chase"
+                                                                                : "bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent/50",
                                                         )}
                                                         style={{
                                                             transform: !selectMode && hasOffset ? `translateX(${swipeOffset}px)` : undefined,

--- a/packages/ui/src/style.css
+++ b/packages/ui/src/style.css
@@ -48,6 +48,100 @@
   50% { border-color: oklch(0.85 0.15 85 / 0.7); box-shadow: 0 0 8px oklch(0.85 0.15 85 / 0.3); }
 }
 
+/* ── Conic dot-chase: shared @property + keyframe ── */
+@property --chase-angle {
+  syntax: '<angle>';
+  inherits: false;
+  initial-value: 0deg;
+}
+
+@keyframes chase-spin {
+  from { --chase-angle: 0deg; }
+  to   { --chase-angle: 360deg; }
+}
+
+/* Shared inner bg mask so the conic gradient only shows on the border */
+.animate-working-chase,
+.animate-awaiting-chase,
+.animate-completed-chase {
+  isolation: isolate;
+}
+
+.animate-working-chase::after,
+.animate-awaiting-chase::after,
+.animate-completed-chase::after {
+  content: '';
+  position: absolute;
+  inset: 1.5px;
+  border-radius: 5px;
+  background: var(--sidebar);
+  z-index: -1;
+  pointer-events: none;
+}
+
+/* Working — blue dot chase */
+.animate-working-chase::before {
+  content: '';
+  position: absolute;
+  inset: -1.5px;
+  border-radius: 8px;
+  background: conic-gradient(from var(--chase-angle),
+    transparent                  0deg,
+    transparent                  290deg,
+    oklch(0.5  0.22 220 / 0)     290deg,
+    oklch(0.6  0.25 220 / 0.4)   310deg,
+    oklch(0.75 0.28 215 / 0.8)   330deg,
+    oklch(0.92 0.2  205 / 1)     345deg,
+    oklch(0.75 0.28 215 / 0.5)   355deg,
+    oklch(0.5  0.22 220 / 0)     360deg
+  );
+  animation: chase-spin 2s linear infinite;
+  z-index: -1;
+  pointer-events: none;
+}
+
+/* Awaiting input — purple dot chase */
+.animate-awaiting-chase::before {
+  content: '';
+  position: absolute;
+  inset: -1.5px;
+  border-radius: 8px;
+  background: conic-gradient(from var(--chase-angle),
+    transparent                  0deg,
+    transparent                  290deg,
+    oklch(0.5  0.28 280 / 0)     290deg,
+    oklch(0.6  0.32 283 / 0.4)   310deg,
+    oklch(0.72 0.35 285 / 0.85)  330deg,
+    oklch(0.9  0.25 292 / 1)     345deg,
+    oklch(0.72 0.35 285 / 0.5)   355deg,
+    oklch(0.5  0.28 280 / 0)     360deg
+  );
+  animation: chase-spin 2s linear infinite;
+  z-index: -1;
+  pointer-events: none;
+}
+
+/* Completed unread — green dot chase */
+.animate-completed-chase::before {
+  content: '';
+  position: absolute;
+  inset: -1.5px;
+  border-radius: 8px;
+  background: conic-gradient(from var(--chase-angle),
+    transparent                  0deg,
+    transparent                  290deg,
+    oklch(0.5  0.22 145 / 0)     290deg,
+    oklch(0.6  0.25 147 / 0.4)   310deg,
+    oklch(0.72 0.28 148 / 0.85)  330deg,
+    oklch(0.9  0.2  152 / 1)     345deg,
+    oklch(0.72 0.28 148 / 0.5)   355deg,
+    oklch(0.5  0.22 145 / 0)     360deg
+  );
+  animation: chase-spin 2s linear infinite;
+  z-index: -1;
+  pointer-events: none;
+}
+
 :root {
   --radius: 0.625rem;
   --checker-dark: #e4e4e7;


### PR DESCRIPTION
## Summary

Replaces the pulsing yellow border on the active session with a cleaner set of conic-gradient dot-chase indicators that communicate session state at a glance.

## Changes

### Active session
- Removed pulsing `animate-border-glow` border
- Now just uses `bg-sidebar-accent` highlight — no border, no animation

### New dot-chase indicators (non-active sessions only)

| State | Color | Trigger |
|-------|-------|---------|
| Working / generating | 🔵 Blue | `isActive === true` |
| Awaiting user input | 🟣 Purple | `AskUserQuestion` pending |
| Completed + unread | 🟢 Green | `isActive` flipped false, not yet viewed |

The green indicator clears automatically when you navigate to the session (on any screen).

## Implementation

- **`style.css`**: `@property --chase-angle` + `@keyframes chase-spin` + three `.animate-*-chase` classes using conic-gradient with `::before`/`::after` pseudo-elements and `isolation: isolate`
- **`App.tsx`**: Tracks `sessionsWithPendingQuestion: Set<string>` via `patchSessionCache` — adds/removes session IDs as `pendingQuestion` is set/cleared
- **`SessionSidebar.tsx`**: Detects `isActive: true→false` transitions for completed-unread tracking; clears on `activeSessionId` change