### PR TITLE
fix: CSP wasm-unsafe-eval + review loop fixes

### DIFF
--- a/packages/cli/src/extensions/remote/usage-limit-error.test.ts
+++ b/packages/cli/src/extensions/remote/usage-limit-error.test.ts
@@ -53,22 +53,6 @@ describe("isUsageLimitError", () => {
             expect(isUsageLimitError("Your quota has been exhausted")).toBe(true);
         });
 
-        test("'capacity' standalone", () => {
-            expect(isUsageLimitError("Service capacity exceeded for this region")).toBe(true);
-        });
-
-        test("'overloaded'", () => {
-            expect(isUsageLimitError("The model is currently overloaded, please try again")).toBe(true);
-        });
-
-        test("'throttled'", () => {
-            expect(isUsageLimitError("Request throttled due to high traffic")).toBe(true);
-        });
-
-        test("'throttling'", () => {
-            expect(isUsageLimitError("Server is throttling your requests")).toBe(true);
-        });
-
         test("OpenAI rate limit message", () => {
             expect(isUsageLimitError("Rate limit reached for gpt-4 in organization org-xxx on tokens per minute")).toBe(true);
         });
@@ -123,6 +107,22 @@ describe("isUsageLimitError", () => {
         test("'accumulated' — contains 'quota' infix? No, 'quota' uses word boundary", () => {
             // \bquota\b would not match inside a longer word
             expect(isUsageLimitError("errors accumulated during processing")).toBe(false);
+        });
+
+        test("'overloaded' — transient provider saturation, not a quota error", () => {
+            expect(isUsageLimitError("The model is currently overloaded, please try again")).toBe(false);
+        });
+
+        test("'throttled' — transient backpressure, not a quota error", () => {
+            expect(isUsageLimitError("Request throttled due to high traffic")).toBe(false);
+        });
+
+        test("'throttling' — transient backpressure, not a quota error", () => {
+            expect(isUsageLimitError("Server is throttling your requests")).toBe(false);
+        });
+
+        test("'capacity' standalone — transient saturation, not a quota error", () => {
+            expect(isUsageLimitError("Service capacity exceeded for this region")).toBe(false);
         });
 
         test("model not found error", () => {

--- a/packages/cli/src/extensions/remote/usage-limit-error.ts
+++ b/packages/cli/src/extensions/remote/usage-limit-error.ts
@@ -28,9 +28,6 @@ const USAGE_LIMIT_PHRASES: ReadonlyArray<RegExp> = [
     /context\s+window/i,
     // Single-word patterns with word boundaries
     /\bquota\b/i,
-    /\bcapacity\b/i,
-    /\boverloaded\b/i,
-    /\bthrottl/i, // throttle / throttled / throttling
 ];
 
 /**

--- a/packages/server/src/handler.test.ts
+++ b/packages/server/src/handler.test.ts
@@ -316,7 +316,7 @@ describe("withSecurityHeaders", () => {
         const csp = res.headers.get("Content-Security-Policy");
         expect(csp).not.toBeNull();
         expect(csp).toContain("default-src 'self'");
-        expect(csp).toContain("script-src 'self'");
+        expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval'");
         expect(csp).toContain("connect-src 'self' ws: wss: blob:");
         expect(csp).toContain("object-src 'none'");
     });

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -135,7 +135,7 @@ export function withSecurityHeaders(res: Response): Response {
     headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
     headers.set(
         "Content-Security-Policy",
-        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
+        "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
     );
     return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
 }

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -150,7 +150,7 @@ const httpServer = createServer(async (req, res) => {
                 "referrer-policy": "strict-origin-when-cross-origin",
                 "permissions-policy": "camera=(), microphone=(), geolocation=()",
                 "content-security-policy":
-                    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
+                    "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
             });
         }
         res.end(JSON.stringify({ error: "Internal server error" }));

--- a/packages/server/src/routes/index.test.ts
+++ b/packages/server/src/routes/index.test.ts
@@ -77,7 +77,7 @@ describe("handleApi — global endpoints", () => {
 
         const res = await handleApi(req, url);
         expect(res).toBeTruthy();
-        expect(res!.status).toBe(503);
+        expect(res!.status).toBe(200);
         const data = await res!.json();
         expect(data.status).toBe("degraded");
         expect(data.redis).toBe(false);

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -42,15 +42,12 @@ export async function handleApi(req: Request, url: URL): Promise<Response | unde
     if (url.pathname === "/health") {
         const { redis, socketio, startedAt } = serverHealth;
         const ok = redis && socketio;
-        return Response.json(
-            {
-                status: ok ? "ok" : "degraded",
-                redis,
-                socketio,
-                uptime: Math.floor((Date.now() - startedAt) / 1000),
-            },
-            { status: ok ? 200 : 503 },
-        );
+        return Response.json({
+            status: ok ? "ok" : "degraded",
+            redis,
+            socketio,
+            uptime: Math.floor((Date.now() - startedAt) / 1000),
+        });
     }
 
     if (url.pathname === "/api/version" && req.method === "GET") {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1938,7 +1938,25 @@ export function App() {
 
     const handleStateSnapshot = ({ sessionId, state }: { sessionId: string; state: SessionMetaState }) => {
       const currentSessionId = activeSessionRef.current;
-      if (sessionId !== currentSessionId) return;
+
+      // For background sessions: extract pendingQuestion from the initial
+      // state_snapshot so badges are correct on load/reconnect even when the
+      // session is already blocked waiting for user input.
+      if (sessionId !== currentSessionId) {
+        if (Object.prototype.hasOwnProperty.call(state, "pendingQuestion")) {
+          setSessionsWithPendingQuestion((prev) => {
+            const next = new Set(prev);
+            if (state.pendingQuestion) {
+              next.add(sessionId);
+            } else {
+              next.delete(sessionId);
+            }
+            return next;
+          });
+        }
+        return;
+      }
+
       const seen = metaVersionsRef.current.get(sessionId) ?? 0;
       if (state.version < seen) return;
       metaVersionsRef.current.set(sessionId, state.version);
@@ -1980,18 +1998,23 @@ export function App() {
       }
     };
 
-    // Re-subscribe to the current session's meta room after non-recovered reconnects
-    // (e.g., server restart). Without this, the client stops receiving meta_event
-    // updates until the user switches sessions or reloads.
-    // Also clear the stored meta version so that the first state_snapshot/meta_event
-    // arriving after reconnect (version ≥ 1) is not dropped as "stale" — the server
-    // resets its version counter to 0 on restart, so any previously-seen version
-    // would cause all new events to be silently ignored.
+    // Re-subscribe to ALL meta rooms after non-recovered reconnects (e.g., server
+    // restart). Without this, the client stops receiving meta_event updates until
+    // the user switches sessions or reloads.
+    // Also clear stored meta versions so the first state_snapshot/meta_event
+    // arriving after reconnect is not dropped as "stale" — the server resets its
+    // version counter to 0 on restart, so any previously-seen version would cause
+    // all new events to be silently ignored.
     const handleReconnect = () => {
       const currentSessionId = activeSessionRef.current;
       if (currentSessionId) {
         metaVersionsRef.current.delete(currentSessionId);
         socket.emit("subscribe_session_meta", { sessionId: currentSessionId });
+      }
+      // Re-subscribe background sessions and clear their version state.
+      for (const id of backgroundMetaIdsRef.current) {
+        metaVersionsRef.current.delete(id);
+        socket.emit("subscribe_session_meta", { sessionId: id });
       }
     };
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2072,9 +2072,15 @@ export function App() {
     const prev = backgroundMetaIdsRef.current;
 
     // Unsubscribe from sessions that are no longer in the live list.
+    // Do NOT unsubscribe the active session — it may have just been promoted
+    // from background and its subscription is now managed by the active-session
+    // effect above. Emitting unsubscribe here would silently break all meta
+    // updates for the newly-opened session.
     for (const id of prev) {
       if (!currentIds.has(id)) {
-        hubSock.emit("unsubscribe_session_meta", { sessionId: id });
+        if (id !== activeSessionId) {
+          hubSock.emit("unsubscribe_session_meta", { sessionId: id });
+        }
         prev.delete(id);
       }
     }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1946,6 +1946,21 @@ export function App() {
     };
 
     const handleMetaEvent = (payload: { sessionId: string; version: number } & Record<string, unknown>) => {
+      // Update the sidebar pending-question badge for ANY session's meta event,
+      // not just the active one.  Background sessions emit pendingQuestion
+      // updates into their own meta rooms; the badge must reflect all of them.
+      if (Object.prototype.hasOwnProperty.call(payload, "pendingQuestion")) {
+        setSessionsWithPendingQuestion((prev) => {
+          const next = new Set(prev);
+          if (payload.pendingQuestion) {
+            next.add(payload.sessionId);
+          } else {
+            next.delete(payload.sessionId);
+          }
+          return next;
+        });
+      }
+
       const currentSessionId = activeSessionRef.current;
       if (payload.sessionId !== currentSessionId) return;
       const { sessionId, version, ...event } = payload;
@@ -2018,6 +2033,37 @@ export function App() {
       prevMetaSessionRef.current = null;
     }
   }, [activeSessionId]);
+
+  // Subscribe to meta rooms for ALL live sessions (not just the active one) so
+  // that background sessions can update the sidebar pending-question badge.
+  // The active session's subscription is managed by the effect above; this
+  // effect handles every other live session.
+  const backgroundMetaIdsRef = React.useRef<Set<string>>(new Set());
+  React.useEffect(() => {
+    const hubSock = hubSocketRef.current;
+    if (!hubSock) return;
+
+    const currentIds = new Set(
+      liveSessions.map((s) => s.sessionId).filter((id) => id !== activeSessionId),
+    );
+    const prev = backgroundMetaIdsRef.current;
+
+    // Unsubscribe from sessions that are no longer in the live list.
+    for (const id of prev) {
+      if (!currentIds.has(id)) {
+        hubSock.emit("unsubscribe_session_meta", { sessionId: id });
+        prev.delete(id);
+      }
+    }
+
+    // Subscribe to newly-appeared background sessions.
+    for (const id of currentIds) {
+      if (!prev.has(id)) {
+        hubSock.emit("subscribe_session_meta", { sessionId: id });
+        prev.add(id);
+      }
+    }
+  }, [liveSessions, activeSessionId]);
 
   const openSession = React.useCallback((relaySessionId: string) => {
     // Flush/cancel any pending RAF queues (streaming deltas & tool-stream

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -551,8 +551,17 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     }, [liveSessions, onSessionsChange]);
 
     // Detect isActive: true → false transitions to mark sessions as completed+unread.
+    // Also prune stale entries for sessions no longer in the live list to avoid
+    // unbounded growth of both tracking structures over time.
     React.useEffect(() => {
         const prev = prevActiveMapRef.current;
+        const liveIds = new Set(liveSessions.map((s) => s.sessionId));
+
+        // Prune sessions that are no longer present in the live list.
+        for (const id of prev.keys()) {
+            if (!liveIds.has(id)) prev.delete(id);
+        }
+
         const nowCompleted: string[] = [];
         for (const s of liveSessions) {
             const wasActive = prev.get(s.sessionId) ?? false;
@@ -569,6 +578,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                 return next;
             });
         }
+        // Also prune completedUnreadSessions for sessions no longer live.
+        setCompletedUnreadSessions((prev) => {
+            const pruned = new Set([...prev].filter((id) => liveIds.has(id)));
+            if (pruned.size === prev.size) return prev;
+            return pruned;
+        });
     }, [liveSessions]);
 
     // Clear completed-unread when the user navigates to a session.


### PR DESCRIPTION
## Summary

### CSP: add `'wasm-unsafe-eval'` to `script-src`
Shiki loads language grammars via WebAssembly. The browser was blocking instantiation because `'wasm-unsafe-eval'` was missing from the CSP `script-src` directive, causing `Failed to highlight code: CompileError: WebAssembly.instantiate()` in the console. Updated both `handler.ts` and `index.ts`.

---

### Bugs caught by review loop (all pre-existing on branch)

**`/health` always returns 200**
Returning 503 in degraded mode (Redis/Socket.IO unavailable) was triggering liveness probe restart loops. The server intentionally continues serving HTTP in degraded mode — the status is now reflected in the JSON body only (`status: "degraded"`).

**SessionSidebar: prune stale session IDs**
`prevActiveMapRef` and `completedUnreadSessions` only ever grew; sessions removed from the live list were never pruned, causing unbounded Map/Set growth on long-running dashboards.

**`isUsageLimitError`: remove transient terms**
`overloaded`, `throttled/throttling`, and bare `capacity` were classified as hard quota errors, causing parent sessions to cancel children on temporary provider saturation (HTTP 529 / backpressure).

**Background session pending-question badge**
`sessionsWithPendingQuestion` was only ever updated for the active session. Background sessions entering `AskUserQuestion` while not viewed never showed the sidebar badge. Fixed by:
- Subscribing to meta rooms for all live sessions (not just active)
- Extracting `pendingQuestion` from `meta_event` before the active-session guard
- Processing `state_snapshot` for background sessions on load/reconnect
- Replaying background subscriptions on hub reconnect
- Not emitting `unsubscribe_session_meta` for a session being promoted to active