### PR TITLE
fix: sidebar child session scaling + clearer status indicators

### DIFF
--- a/docs/superpowers/plans/2026-03-23-sidebar-session-status.md
+++ b/docs/superpowers/plans/2026-03-23-sidebar-session-status.md
@@ -1,0 +1,399 @@
+# Sidebar Session Status Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the overloaded chase animations and inline pin/dot elements with a cleaner three-state status system where only active sessions spin, awaiting sessions pulse amber, completed-unread sessions pulse green, and the provider icon itself is the sole status indicator.
+
+**Architecture:** Extract a pure `getSessionVisualState()` helper that maps sidebar inputs to one of four visual states. Update the session row class logic, the provider icon container, and the CSS animations. Remove the inline pin icon and the activity dot overlay.
+
+**Tech Stack:** React, TailwindCSS v4, CSS custom properties + keyframes (oklch color space)
+
+---
+
+## Task 1: Extract `getSessionVisualState` helper
+
+**Files:**
+- Create: `packages/ui/src/lib/session-visual-state.ts`
+- Create: `packages/ui/src/lib/session-visual-state.test.ts`
+
+This is a pure function — no React, no DOM. It encodes the priority logic that currently lives inline in the session row's `cn()` chain.
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// packages/ui/src/lib/session-visual-state.test.ts
+import { describe, test, expect } from "bun:test";
+import { getSessionVisualState } from "./session-visual-state";
+
+describe("getSessionVisualState", () => {
+  test("returns 'active' when session is active and not awaiting", () => {
+    expect(getSessionVisualState({
+      isActive: true,
+      isAwaiting: false,
+      isCompletedUnread: false,
+      isSelected: false,
+    })).toBe("active");
+  });
+
+  test("returns 'awaiting' when session has pending question", () => {
+    expect(getSessionVisualState({
+      isActive: true,
+      isAwaiting: true,
+      isCompletedUnread: false,
+      isSelected: false,
+    })).toBe("awaiting");
+  });
+
+  test("awaiting wins over active (priority)", () => {
+    expect(getSessionVisualState({
+      isActive: true,
+      isAwaiting: true,
+      isCompletedUnread: false,
+      isSelected: false,
+    })).toBe("awaiting");
+  });
+
+  test("returns 'completedUnread' for completed unread session", () => {
+    expect(getSessionVisualState({
+      isActive: false,
+      isAwaiting: false,
+      isCompletedUnread: true,
+      isSelected: false,
+    })).toBe("completedUnread");
+  });
+
+  test("returns 'idle' when none of the above", () => {
+    expect(getSessionVisualState({
+      isActive: false,
+      isAwaiting: false,
+      isCompletedUnread: false,
+      isSelected: false,
+    })).toBe("idle");
+  });
+
+  test("returns 'selected' when isSelected is true (overrides all)", () => {
+    expect(getSessionVisualState({
+      isActive: true,
+      isAwaiting: true,
+      isCompletedUnread: true,
+      isSelected: true,
+    })).toBe("selected");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `bun test packages/ui/src/lib/session-visual-state.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Write the implementation**
+
+```typescript
+// packages/ui/src/lib/session-visual-state.ts
+export type SessionVisualState = "selected" | "awaiting" | "active" | "completedUnread" | "idle";
+
+export interface SessionVisualStateInput {
+  isSelected: boolean;
+  isAwaiting: boolean;
+  isActive: boolean;
+  isCompletedUnread: boolean;
+}
+
+/**
+ * Determine the visual state of a sidebar session row.
+ * Priority: selected > awaiting > active > completedUnread > idle.
+ */
+export function getSessionVisualState(input: SessionVisualStateInput): SessionVisualState {
+  if (input.isSelected) return "selected";
+  if (input.isAwaiting) return "awaiting";
+  if (input.isActive) return "active";
+  if (input.isCompletedUnread) return "completedUnread";
+  return "idle";
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `bun test packages/ui/src/lib/session-visual-state.test.ts`
+Expected: PASS — all 6 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/lib/session-visual-state.ts packages/ui/src/lib/session-visual-state.test.ts
+git commit -m "feat: extract getSessionVisualState pure helper with tests"
+```
+
+---
+
+## Task 2: Replace CSS chase animations with new status treatments
+
+**Files:**
+- Modify: `packages/ui/src/style.css` (lines ~58–145, the chase animation section)
+
+Replace the three identical chase animations with:
+- `animate-working-chase` — keep the blue conic spinning chase (active work)
+- `animate-awaiting-pulse` — new soft amber pulse (no spin)
+- `animate-completed-pulse` — new soft green pulse (no spin)
+
+- [ ] **Step 1: Replace awaiting chase with amber pulse**
+
+In `packages/ui/src/style.css`, replace the `.animate-awaiting-chase::before` block (lines ~104–124) with a soft amber pulse keyframe and class. Remove `.animate-awaiting-chase` from the shared chase blocks (lines ~64–82).
+
+New CSS for awaiting:
+```css
+@keyframes awaiting-pulse {
+  0%, 100% {
+    box-shadow: inset 0 0 0 1.5px oklch(0.78 0.16 70 / 0.25);
+  }
+  50% {
+    box-shadow: inset 0 0 0 1.5px oklch(0.78 0.16 70 / 0.6);
+  }
+}
+
+.animate-awaiting-pulse {
+  animation: awaiting-pulse 2.5s ease-in-out infinite;
+  border-radius: 6px;
+}
+```
+
+- [ ] **Step 2: Replace completed chase with green pulse**
+
+Replace the `.animate-completed-chase::before` block (lines ~125–145) with a soft green pulse.
+
+New CSS for completed:
+```css
+@keyframes completed-pulse {
+  0%, 100% {
+    box-shadow: inset 0 0 0 1.5px oklch(0.72 0.19 152 / 0.25);
+  }
+  50% {
+    box-shadow: inset 0 0 0 1.5px oklch(0.72 0.19 152 / 0.6);
+  }
+}
+
+.animate-completed-pulse {
+  animation: completed-pulse 2.5s ease-in-out infinite;
+  border-radius: 6px;
+}
+```
+
+- [ ] **Step 3: Clean up shared chase blocks**
+
+Update the shared selectors (lines ~64–82) so only `.animate-working-chase` uses the `isolation`, `::after` inner mask, and `::before` conic gradient. Remove `.animate-awaiting-chase` and `.animate-completed-chase` from those shared selectors entirely.
+
+- [ ] **Step 4: Verify no other files reference the old class names**
+
+Run: `rg "animate-awaiting-chase|animate-completed-chase" packages/ui/src -g '*.tsx' -g '*.ts'`
+
+Any references to the old names need to be updated in Task 3 (the session row). Note them for that task.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/ui/src/style.css
+git commit -m "feat: replace awaiting/completed chase with pulse animations"
+```
+
+---
+
+## Task 3: Update session row to use new visual state + animations
+
+**Files:**
+- Modify: `packages/ui/src/components/SessionSidebar.tsx`
+
+Use `getSessionVisualState` and the new animation class names in the session row's `cn()` chain.
+
+- [ ] **Step 1: Import the new helper**
+
+At the top of `SessionSidebar.tsx`, add:
+```typescript
+import { getSessionVisualState } from "@/lib/session-visual-state";
+```
+
+- [ ] **Step 2: Replace the inline state logic in the session button's className**
+
+Find the `cn()` block on the session `<button>` that currently reads (approximately):
+```
+selectMode && isChecked
+  ? "bg-sidebar-accent ..."
+  : isActiveSession
+    ? "bg-sidebar-accent ..."
+    : sessionsWithPendingQuestion?.has(s.sessionId)
+      ? "... animate-awaiting-chase"
+      : s.isActive
+        ? "... animate-working-chase"
+        : completedUnreadSessions.has(s.sessionId)
+          ? "... animate-completed-chase"
+          : "bg-sidebar ..."
+```
+
+Replace with a call to `getSessionVisualState`:
+```typescript
+const visualState = getSessionVisualState({
+  isSelected: isActiveSession || (selectMode && isChecked),
+  isAwaiting: !!sessionsWithPendingQuestion?.has(s.sessionId),
+  isActive: !!s.isActive,
+  isCompletedUnread: completedUnreadSessions.has(s.sessionId),
+});
+```
+
+Then use the result in `cn()`:
+```typescript
+cn(
+  "relative flex items-center gap-2.5 w-full min-w-0 px-2.5 py-3 md:py-2.5 text-left rounded-md",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+  !hasOffset && "transition-transform duration-200 ease-out",
+  visualState === "selected" && "bg-sidebar-accent text-sidebar-accent-foreground",
+  visualState === "awaiting" && "text-sidebar-foreground animate-awaiting-pulse",
+  visualState === "active" && "text-sidebar-foreground animate-working-chase",
+  visualState === "completedUnread" && "text-sidebar-foreground animate-completed-pulse",
+  visualState === "idle" && "bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent/50",
+)
+```
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: clean exit
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/components/SessionSidebar.tsx
+git commit -m "feat: use getSessionVisualState for session row styling"
+```
+
+---
+
+## Task 4: Update provider icon to be the sole status indicator
+
+**Files:**
+- Modify: `packages/ui/src/components/SessionSidebar.tsx`
+
+Remove the small activity dot (`<span>` overlaying the provider icon) and instead apply status-aware styling to the icon container itself.
+
+- [ ] **Step 1: Remove the activity dot**
+
+Find and delete the `<span>` element that renders the activity dot overlay. It looks like:
+```tsx
+<span
+  className={cn(
+    "absolute -top-0.5 -right-0.5 inline-block h-2 w-2 rounded-full border border-sidebar ring-1 ring-sidebar transition-colors",
+    s.isActive
+      ? "bg-blue-400 shadow-[0_0_4px_#60a5fa80] animate-pulse ring-blue-400/20"
+      : "bg-green-600 ring-green-600/20",
+  )}
+  title={s.isActive ? "Actively generating" : "Session idle"}
+/>
+```
+
+Delete this entire `<span>`.
+
+- [ ] **Step 2: Apply status-aware styling to the provider icon container**
+
+The provider icon container is currently:
+```tsx
+<div className="relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md bg-sidebar-accent/50">
+```
+
+Use the `visualState` variable (already computed in Task 3) to style it:
+```tsx
+<div className={cn(
+  "relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md transition-all duration-300",
+  visualState === "active" && "bg-blue-500/20 shadow-[0_0_8px_#3b82f680] animate-pulse",
+  visualState === "awaiting" && "bg-amber-500/20 shadow-[0_0_8px_#f59e0b60]",
+  visualState === "completedUnread" && "bg-green-500/20 shadow-[0_0_8px_#22c55e60]",
+  (visualState === "idle" || visualState === "selected") && "bg-sidebar-accent/50",
+)}>
+```
+
+For the awaiting and completedUnread states, add a subtle CSS pulse on the container using the existing Tailwind `animate-pulse` or use a custom gentler animation — try `animate-pulse` first and adjust if it's too strong.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: clean exit
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/components/SessionSidebar.tsx
+git commit -m "feat: provider icon as sole status indicator, remove activity dot"
+```
+
+---
+
+## Task 5: Remove inline pin icon
+
+**Files:**
+- Modify: `packages/ui/src/components/SessionSidebar.tsx`
+
+- [ ] **Step 1: Remove the inline pin toggle element**
+
+Find and delete the `<span role="button">` block that renders the always-visible pin icon inside the session button. It looks like:
+```tsx
+{!selectMode && (
+  <span
+    role="button"
+    tabIndex={-1}
+    className={cn(
+      "flex-shrink-0 flex items-center justify-center w-5 h-5 rounded transition-colors",
+      isPinned
+        ? "text-blue-400 hover:text-blue-300"
+        : "text-sidebar-foreground/20 hover:text-sidebar-foreground/40",
+      isPinPending && "opacity-50 pointer-events-none",
+    )}
+    onClick={...}
+    onPointerDown={...}
+    aria-label={isPinned ? "Unpin session" : "Pin session"}
+    title={isPinned ? "Unpin" : "Pin"}
+  >
+    <Pin className={cn("h-3.5 w-3.5", isPinned && "fill-blue-400/30")} />
+  </span>
+)}
+```
+
+Delete this entire block. **Keep** the keyboard handler (`onKeyDown` with `e.key.toLowerCase() === "p"`) on the parent button so keyboard pinning still works. **Keep** the Pin button in the swipe-reveal action area.
+
+- [ ] **Step 2: Remove the Pin import if unused**
+
+Check if `Pin` and `PinOff` from lucide-react are still used elsewhere in the file (swipe-reveal buttons, ended-pinned section). Only remove from the import if completely unused.
+
+- [ ] **Step 3: Run typecheck**
+
+Run: `bun run typecheck`
+Expected: clean exit
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/ui/src/components/SessionSidebar.tsx
+git commit -m "feat: remove inline pin icon from session row"
+```
+
+---
+
+## Task 6: Run full verification
+
+- [ ] **Step 1: Run full UI test suite**
+
+Run: `bun test packages/ui`
+Expected: all tests pass
+
+- [ ] **Step 2: Run full typecheck**
+
+Run: `bun run typecheck`
+Expected: clean exit
+
+- [ ] **Step 3: Verify no stale references**
+
+Run: `rg "animate-awaiting-chase|animate-completed-chase" packages/ui/src`
+Expected: no results (all references replaced)
+
+- [ ] **Step 4: Final commit if any cleanup was needed**
+
+```bash
+git add -A && git commit -m "chore: cleanup stale animation references" || true
+```

--- a/docs/superpowers/specs/2026-03-23-sidebar-session-status-design.md
+++ b/docs/superpowers/specs/2026-03-23-sidebar-session-status-design.md
@@ -24,7 +24,7 @@ The sidebar currently makes "waiting for a trigger" and "completed" feel too sim
 **Visual treatment:**
 - This remains the only clearly busy state.
 - Keep the stronger working animation (`spin` / `chase` / equivalent active motion).
-- Use the existing active/working color family unless implementation details suggest a nearby variant is clearer.
+- Keep the existing blue/working color family unless implementation details show a very close variant reads better.
 
 **User impression:** “This session is currently running.”
 
@@ -39,7 +39,7 @@ The sidebar currently makes "waiting for a trigger" and "completed" feel too sim
 
 **User impression:** “This session needs something before it can continue.”
 
-### 3. Complete
+### 3. Completed (Unread)
 
 **Meaning:** The session completed since the user last viewed it.
 
@@ -50,6 +50,16 @@ The sidebar currently makes "waiting for a trigger" and "completed" feel too sim
 
 **User impression:** “This session is finished and ready to review.”
 
+### 4. Idle
+
+**Meaning:** The session is neither actively working, nor waiting on a trigger, nor newly completed/unread.
+
+**Visual treatment:**
+- Keep this subdued and largely static.
+- It should not compete visually with the three attention-worthy states above.
+
+**User impression:** “This session is inactive right now.”
+
 ## UI Surface Areas
 
 ### Session row styling
@@ -57,17 +67,22 @@ The sidebar currently makes "waiting for a trigger" and "completed" feel too sim
 Update the session row state styling so:
 - **Active** keeps the stronger working animation.
 - **Awaiting** gets a lighter pulse-based pending treatment.
-- **Complete** gets a lighter pulse-based resolved treatment.
+- **Completed (Unread)** gets a lighter pulse-based resolved treatment.
+- **Idle** remains subdued.
 
 Avoid making awaiting and completed rows feel identical; the distinction should come from both motion and color semantics.
+
+Priority note: if multiple booleans could apply at once, preserve the existing semantic priority used by the current sidebar logic unless a real bug is found. In particular, awaiting should continue to win over active if both appear true at render time.
 
 ### Provider/activity dot
 
 Update the small dot on the provider badge so it communicates state consistently:
 - **Active:** animated working indicator
 - **Awaiting:** amber pulse
-- **Complete/unread:** green pulse
+- **Completed (Unread):** green pulse
 - **Idle/default:** subdued static indicator
+
+Implementation note: the current dot logic only branches on `s.isActive`, so this change requires threading the same awaiting/completed state information used by the row styling into the dot styling logic as well.
 
 ## Constraints
 
@@ -78,10 +93,19 @@ Update the small dot on the provider badge so it communicates state consistently
 
 ## Testing Strategy
 
-Prefer focused testing of state-to-style mapping if the mapping can be extracted cleanly into a pure helper without unnecessary abstraction. Otherwise:
+Prefer focused testing of state-to-style mapping if the mapping can be extracted cleanly into a pure helper without unnecessary abstraction. A good target would be a helper that maps the sidebar inputs to a visual state such as:
+
+- `active`
+- `awaiting`
+- `completedUnread`
+- `idle`
+
+Otherwise:
 - run UI package tests,
 - run typecheck,
 - and verify the affected sidebar behavior manually or via targeted UI tests if available.
+
+If the implementation changes custom animation classes, update the existing sidebar animation definitions rather than introducing redundant near-duplicates unless that materially improves clarity.
 
 ## Non-Goals
 

--- a/docs/superpowers/specs/2026-03-23-sidebar-session-status-design.md
+++ b/docs/superpowers/specs/2026-03-23-sidebar-session-status-design.md
@@ -1,0 +1,91 @@
+# Sidebar Session Status Design
+
+**Date:** 2026-03-23
+**Scope:** Clarify visual differentiation between active, awaiting, and completed session states in the sidebar tree.
+
+## Goal
+
+Make session status easier to read at a glance by ensuring only actively working sessions use a busy/spinning treatment, while awaiting and completed sessions use lighter pulse treatments with distinct meanings.
+
+## Current Problem
+
+The sidebar currently makes "waiting for a trigger" and "completed" feel too similar to "actively working," especially because motion treatments are overloaded. This makes it harder to tell whether a session is:
+
+- still doing work,
+- blocked on user input / trigger response, or
+- finished and ready for review.
+
+## Desired State Model
+
+### 1. Active
+
+**Meaning:** The agent is currently doing work.
+
+**Visual treatment:**
+- This remains the only clearly busy state.
+- Keep the stronger working animation (`spin` / `chase` / equivalent active motion).
+- Use the existing active/working color family unless implementation details suggest a nearby variant is clearer.
+
+**User impression:** “This session is currently running.”
+
+### 2. Awaiting
+
+**Meaning:** The session is blocked and waiting for a trigger, user input, or plan response.
+
+**Visual treatment:**
+- Remove any spin/busy treatment.
+- Use a soft amber pulse.
+- Make the state feel paused/pending rather than active.
+
+**User impression:** “This session needs something before it can continue.”
+
+### 3. Complete
+
+**Meaning:** The session completed since the user last viewed it.
+
+**Visual treatment:**
+- Remove any spin/busy treatment.
+- Use a soft green pulse or similarly completion-coded resolved treatment.
+- If practical within the existing compact layout, give this state a subtle “done” cue distinct from awaiting.
+
+**User impression:** “This session is finished and ready to review.”
+
+## UI Surface Areas
+
+### Session row styling
+
+Update the session row state styling so:
+- **Active** keeps the stronger working animation.
+- **Awaiting** gets a lighter pulse-based pending treatment.
+- **Complete** gets a lighter pulse-based resolved treatment.
+
+Avoid making awaiting and completed rows feel identical; the distinction should come from both motion and color semantics.
+
+### Provider/activity dot
+
+Update the small dot on the provider badge so it communicates state consistently:
+- **Active:** animated working indicator
+- **Awaiting:** amber pulse
+- **Complete/unread:** green pulse
+- **Idle/default:** subdued static indicator
+
+## Constraints
+
+- Keep the sidebar compact; do not add bulky labels or large badges unless clearly necessary.
+- Do not change session-state semantics unless a genuine classification bug is discovered.
+- Ensure nested child sessions continue to render correctly after any styling changes.
+- Be mindful of narrow sidebar widths and mobile layouts.
+
+## Testing Strategy
+
+Prefer focused testing of state-to-style mapping if the mapping can be extracted cleanly into a pure helper without unnecessary abstraction. Otherwise:
+- run UI package tests,
+- run typecheck,
+- and verify the affected sidebar behavior manually or via targeted UI tests if available.
+
+## Non-Goals
+
+- Redesigning the full sidebar information hierarchy
+- Changing session lifecycle semantics
+- Adding new backend session statuses
+- Reworking swipe actions or tree expansion behavior

--- a/docs/superpowers/specs/2026-03-23-sidebar-session-status-design.md
+++ b/docs/superpowers/specs/2026-03-23-sidebar-session-status-design.md
@@ -75,15 +75,25 @@ Avoid making awaiting and completed rows feel identical; the distinction should 
 
 Priority note: if multiple booleans could apply at once, preserve the existing semantic priority used by the current sidebar logic unless a real bug is found. In particular, awaiting should continue to win over active if both appear true at render time.
 
-### Provider/activity dot
+### Provider icon as sole status indicator
 
-Update the small dot on the provider badge so it communicates state consistently:
-- **Active:** animated working indicator
-- **Awaiting:** amber pulse
-- **Completed (Unread):** green pulse
-- **Idle/default:** subdued static indicator
+**Remove the small activity dot** that currently overlays the provider badge. Instead, the provider icon container itself becomes the status indicator:
 
-Implementation note: the current dot logic only branches on `s.isActive`, so this change requires threading the same awaiting/completed state information used by the row styling into the dot styling logic as well. The idle dot should be dimmed relative to the completed-unread green pulse so the completed state remains the more attention-grabbing of the two.
+- **Active:** the provider icon gets the spin/chase animation — it is the "working" indicator.
+- **Awaiting:** the provider icon gets a soft amber pulse/glow.
+- **Completed (Unread):** the provider icon gets a soft green pulse/glow.
+- **Idle:** the provider icon is static/subdued (no animation, no glow).
+
+This requires threading `sessionsWithPendingQuestion` and `completedUnreadSessions` into the icon container's class logic, which currently only branches on `s.isActive`.
+
+### Remove inline pin icon
+
+Remove the always-visible pin toggle icon from the session row. Pinning remains accessible via:
+- Swipe-reveal action buttons
+- Long-press context action
+- Keyboard shortcut (`P`)
+
+This declutters the compact row layout and lets the status indicator and session text take more space.
 
 ## Constraints
 

--- a/docs/superpowers/specs/2026-03-23-sidebar-session-status-design.md
+++ b/docs/superpowers/specs/2026-03-23-sidebar-session-status-design.md
@@ -35,6 +35,7 @@ The sidebar currently makes "waiting for a trigger" and "completed" feel too sim
 **Visual treatment:**
 - Remove any spin/busy treatment.
 - Use a soft amber pulse.
+- Replace the existing purple/chase-style awaiting treatment with the new amber pending treatment.
 - Make the state feel paused/pending rather than active.
 
 **User impression:** “This session needs something before it can continue.”
@@ -82,7 +83,7 @@ Update the small dot on the provider badge so it communicates state consistently
 - **Completed (Unread):** green pulse
 - **Idle/default:** subdued static indicator
 
-Implementation note: the current dot logic only branches on `s.isActive`, so this change requires threading the same awaiting/completed state information used by the row styling into the dot styling logic as well.
+Implementation note: the current dot logic only branches on `s.isActive`, so this change requires threading the same awaiting/completed state information used by the row styling into the dot styling logic as well. The idle dot should be dimmed relative to the completed-unread green pulse so the completed state remains the more attention-grabbing of the two.
 
 ## Constraints
 

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1385,31 +1385,6 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             />
                                                         </div>
 
-                                                        {/* Pin toggle */}
-                                                        {!selectMode && (
-                                                            <span
-                                                                role="button"
-                                                                tabIndex={-1}
-                                                                className={cn(
-                                                                    "flex-shrink-0 flex items-center justify-center w-5 h-5 rounded transition-colors",
-                                                                    isPinned
-                                                                        ? "text-blue-400 hover:text-blue-300"
-                                                                        : "text-sidebar-foreground/20 hover:text-sidebar-foreground/40",
-                                                                    isPinPending && "opacity-50 pointer-events-none",
-                                                                )}
-                                                                onClick={(e) => {
-                                                                    e.stopPropagation();
-                                                                    e.preventDefault();
-                                                                    if (!isPinPending) togglePinSession(s.sessionId, isPinned);
-                                                                }}
-                                                                onPointerDown={(e) => e.stopPropagation()}
-                                                                aria-label={isPinned ? "Unpin session" : "Pin session"}
-                                                                title={isPinned ? "Unpin" : "Pin"}
-                                                            >
-                                                                <Pin className={cn("h-3.5 w-3.5", isPinned && "fill-blue-400/30")} />
-                                                            </span>
-                                                        )}
-
                                                         {/* Text info */}
                                                         <div className="flex-1 min-w-0">
                                                             <div className="flex items-baseline justify-between gap-1 min-w-0">

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1364,8 +1364,14 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             </div>
                                                         )}
 
-                                                        {/* Provider icon + activity dot */}
-                                                        <div className="relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md bg-sidebar-accent/50">
+                                                        {/* Provider icon — status indicated via background/glow */}
+                                                        <div className={cn(
+                                                            "relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md transition-all duration-300",
+                                                            visualState === "active" && "bg-blue-500/20 shadow-[0_0_8px_#3b82f680] animate-pulse",
+                                                            visualState === "awaiting" && "bg-amber-500/20 shadow-[0_0_8px_#f59e0b60]",
+                                                            visualState === "completedUnread" && "bg-green-500/20 shadow-[0_0_8px_#22c55e60]",
+                                                            (visualState === "idle" || visualState === "selected") && "bg-sidebar-accent/50",
+                                                        )}>
                                                             <ProviderIcon
                                                                 provider={provider}
                                                                 className="size-4 text-sidebar-foreground/70"
@@ -1376,15 +1382,6 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                                           ? `${activeModel.provider} · ${activeModel.name ?? activeModel.id}`
                                                                           : "unknown"
                                                                 }
-                                                            />
-                                                            <span
-                                                                className={cn(
-                                                                    "absolute -top-0.5 -right-0.5 inline-block h-2 w-2 rounded-full border border-sidebar ring-1 ring-sidebar transition-colors",
-                                                                    s.isActive
-                                                                        ? "bg-blue-400 shadow-[0_0_4px_#60a5fa80] animate-pulse ring-blue-400/20"
-                                                                        : "bg-green-600 ring-green-600/20",
-                                                                )}
-                                                                title={s.isActive ? "Actively generating" : "Session idle"}
                                                             />
                                                         </div>
 

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -17,6 +17,7 @@ import { ProviderIcon } from "@/components/ProviderIcon";
 import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare, Copy } from "lucide-react";
 import { buildSessionTree, flattenSessionTree, getSessionIndent, getDescendantSessionIds, getGroupCwd } from "@/lib/session-tree";
 import { pruneSwipeOffsets } from "@/lib/swipe-reveal";
+import { getSessionVisualState } from "@/lib/session-visual-state";
 
 interface HubSession {
     sessionId: string;
@@ -1155,6 +1156,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                             const showCwd = runnerGroup.projects.length === 1;
                                             const isActiveSession = !showRunners && activeSessionId === s.sessionId;
                                             const isChecked = selectedSessionIds.has(s.sessionId);
+                                            const visualState = getSessionVisualState({
+                                                isSelected: isActiveSession || (selectMode && isChecked),
+                                                isAwaiting: !!sessionsWithPendingQuestion?.has(s.sessionId),
+                                                isActive: !!s.isActive,
+                                                isCompletedUnread: completedUnreadSessions.has(s.sessionId),
+                                            });
                                             const provider = s.model?.provider ??
                                                 (activeSessionId === s.sessionId ? activeModel?.provider : undefined) ??
                                                 "unknown";
@@ -1280,17 +1287,11 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             "relative flex items-center gap-2.5 w-full min-w-0 px-2.5 py-3 md:py-2.5 text-left rounded-md",
                                                             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
                                                             !hasOffset && "transition-transform duration-200 ease-out",
-                                                            selectMode && isChecked
-                                                                ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                                                                : isActiveSession
-                                                                    ? "bg-sidebar-accent text-sidebar-accent-foreground"
-                                                                    : sessionsWithPendingQuestion?.has(s.sessionId)
-                                                                        ? "text-sidebar-foreground animate-awaiting-chase"
-                                                                        : s.isActive
-                                                                            ? "text-sidebar-foreground animate-working-chase"
-                                                                            : completedUnreadSessions.has(s.sessionId)
-                                                                                ? "text-sidebar-foreground animate-completed-chase"
-                                                                                : "bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent/50",
+                                                            visualState === "selected" && "bg-sidebar-accent text-sidebar-accent-foreground",
+                                                            visualState === "awaiting" && "text-sidebar-foreground animate-awaiting-pulse",
+                                                            visualState === "active" && "text-sidebar-foreground animate-working-chase",
+                                                            visualState === "completedUnread" && "text-sidebar-foreground animate-completed-pulse",
+                                                            visualState === "idle" && "bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent/50",
                                                         )}
                                                         style={{
                                                             transform: !selectMode && hasOffset ? `translateX(${swipeOffset}px)` : undefined,

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1171,6 +1171,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                 <div
                                                     key={s.sessionId}
                                                     className="relative overflow-hidden rounded-md"
+                                                    style={depth > 0 ? { marginLeft: `${getSessionIndent(depth)}px` } : undefined}
                                                 >
                                                     {/* "Duplicate" + "Pin" + "End" actions behind the card — only rendered during swipe/reveal (not in select mode) */}
                                                     {/* Width adapts: 3 buttons when session has a runner, 2 buttons otherwise */}
@@ -1294,7 +1295,6 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         style={{
                                                             transform: !selectMode && hasOffset ? `translateX(${swipeOffset}px)` : undefined,
                                                             touchAction: selectMode ? undefined : "pan-y",
-                                                            marginLeft: `${getSessionIndent(depth)}px`,
                                                         }}
                                                     >
                                                         {/* Expand/collapse toggle for parent sessions */}

--- a/packages/ui/src/lib/session-tree.test.ts
+++ b/packages/ui/src/lib/session-tree.test.ts
@@ -187,6 +187,31 @@ describe("session-tree", () => {
       expect(flattened[2].session.sessionId).toBe("level2");
     });
 
+    test("assigns monotonically increasing depth for arbitrarily deep nesting", () => {
+      // Builds a 5-level chain (0 → 1 → 2 → 3 → 4) and verifies depths are
+      // exactly [0, 1, 2, 3, 4] when all nodes are expanded.
+      // This is the invariant the sidebar's outer-wrapper marginLeft approach relies on:
+      // each level should receive its own distinct indent, not be clamped or repeated.
+      const now = Date.now();
+      const sessions = [
+        { ...createSession("d0"),           startedAt: new Date(now - 5000).toISOString() },
+        { ...createSession("d1", "d0"),     startedAt: new Date(now - 4000).toISOString() },
+        { ...createSession("d2", "d1"),     startedAt: new Date(now - 3000).toISOString() },
+        { ...createSession("d3", "d2"),     startedAt: new Date(now - 2000).toISOString() },
+        { ...createSession("d4", "d3"),     startedAt: new Date(now - 1000).toISOString() },
+      ];
+
+      const tree = buildSessionTree(sessions);
+      const allIds = new Set(sessions.map((s) => s.sessionId));
+      const flattened = flattenSessionTree(tree, allIds);
+
+      expect(flattened).toHaveLength(5);
+      for (let i = 0; i < 5; i++) {
+        expect(flattened[i].depth).toBe(i);
+        expect(flattened[i].session.sessionId).toBe(`d${i}`);
+      }
+    });
+
     test("returns empty array for empty tree", () => {
       const flattened = flattenSessionTree([], new Set());
       expect(flattened).toHaveLength(0);
@@ -206,6 +231,17 @@ describe("session-tree", () => {
 
     test("handles large depth values", () => {
       expect(getSessionIndent(10)).toBe(160);
+    });
+
+    test("indent is always strictly positive for depth > 0 (wrapper must receive nonzero margin)", () => {
+      // This directly guards the sidebar layout fix: the outer wrapper <div> receives
+      // marginLeft = getSessionIndent(depth) for depth > 0.  If indent were 0 for any
+      // depth > 0, child sessions would visually overlap their parents.
+      for (let d = 1; d <= 8; d++) {
+        expect(getSessionIndent(d)).toBeGreaterThan(0);
+        // Also verify it's strictly larger than the previous level
+        expect(getSessionIndent(d)).toBeGreaterThan(getSessionIndent(d - 1));
+      }
     });
   });
 

--- a/packages/ui/src/lib/session-visual-state.test.ts
+++ b/packages/ui/src/lib/session-visual-state.test.ts
@@ -1,0 +1,58 @@
+import { describe, test, expect } from "bun:test";
+import { getSessionVisualState } from "./session-visual-state";
+
+describe("getSessionVisualState", () => {
+  test("returns 'active' when session is active and not awaiting", () => {
+    expect(getSessionVisualState({
+      isActive: true,
+      isAwaiting: false,
+      isCompletedUnread: false,
+      isSelected: false,
+    })).toBe("active");
+  });
+
+  test("returns 'awaiting' when session has pending question", () => {
+    expect(getSessionVisualState({
+      isActive: true,
+      isAwaiting: true,
+      isCompletedUnread: false,
+      isSelected: false,
+    })).toBe("awaiting");
+  });
+
+  test("awaiting wins over active (priority)", () => {
+    expect(getSessionVisualState({
+      isActive: true,
+      isAwaiting: true,
+      isCompletedUnread: false,
+      isSelected: false,
+    })).toBe("awaiting");
+  });
+
+  test("returns 'completedUnread' for completed unread session", () => {
+    expect(getSessionVisualState({
+      isActive: false,
+      isAwaiting: false,
+      isCompletedUnread: true,
+      isSelected: false,
+    })).toBe("completedUnread");
+  });
+
+  test("returns 'idle' when none of the above", () => {
+    expect(getSessionVisualState({
+      isActive: false,
+      isAwaiting: false,
+      isCompletedUnread: false,
+      isSelected: false,
+    })).toBe("idle");
+  });
+
+  test("returns 'selected' when isSelected is true (overrides all)", () => {
+    expect(getSessionVisualState({
+      isActive: true,
+      isAwaiting: true,
+      isCompletedUnread: true,
+      isSelected: true,
+    })).toBe("selected");
+  });
+});

--- a/packages/ui/src/lib/session-visual-state.ts
+++ b/packages/ui/src/lib/session-visual-state.ts
@@ -1,0 +1,20 @@
+export type SessionVisualState = "selected" | "awaiting" | "active" | "completedUnread" | "idle";
+
+export interface SessionVisualStateInput {
+  isSelected: boolean;
+  isAwaiting: boolean;
+  isActive: boolean;
+  isCompletedUnread: boolean;
+}
+
+/**
+ * Determine the visual state of a sidebar session row.
+ * Priority: selected > awaiting > active > completedUnread > idle.
+ */
+export function getSessionVisualState(input: SessionVisualStateInput): SessionVisualState {
+  if (input.isSelected) return "selected";
+  if (input.isAwaiting) return "awaiting";
+  if (input.isActive) return "active";
+  if (input.isCompletedUnread) return "completedUnread";
+  return "idle";
+}

--- a/packages/ui/src/style.css
+++ b/packages/ui/src/style.css
@@ -61,15 +61,11 @@
 }
 
 /* Shared inner bg mask so the conic gradient only shows on the border */
-.animate-working-chase,
-.animate-awaiting-chase,
-.animate-completed-chase {
+.animate-working-chase {
   isolation: isolate;
 }
 
-.animate-working-chase::after,
-.animate-awaiting-chase::after,
-.animate-completed-chase::after {
+.animate-working-chase::after {
   content: '';
   position: absolute;
   inset: 1.5px;
@@ -100,46 +96,34 @@
   pointer-events: none;
 }
 
-/* Awaiting input — purple dot chase */
-.animate-awaiting-chase::before {
-  content: '';
-  position: absolute;
-  inset: -1.5px;
-  border-radius: 8px;
-  background: conic-gradient(from var(--chase-angle),
-    transparent                  0deg,
-    transparent                  290deg,
-    oklch(0.5  0.28 280 / 0)     290deg,
-    oklch(0.6  0.32 283 / 0.4)   310deg,
-    oklch(0.72 0.35 285 / 0.85)  330deg,
-    oklch(0.9  0.25 292 / 1)     345deg,
-    oklch(0.72 0.35 285 / 0.5)   355deg,
-    oklch(0.5  0.28 280 / 0)     360deg
-  );
-  animation: chase-spin 2s linear infinite;
-  z-index: -1;
-  pointer-events: none;
+/* Awaiting input — soft amber pulse */
+@keyframes awaiting-pulse {
+  0%, 100% {
+    box-shadow: inset 0 0 0 1.5px oklch(0.78 0.16 70 / 0.25);
+  }
+  50% {
+    box-shadow: inset 0 0 0 1.5px oklch(0.78 0.16 70 / 0.6);
+  }
 }
 
-/* Completed unread — green dot chase */
-.animate-completed-chase::before {
-  content: '';
-  position: absolute;
-  inset: -1.5px;
-  border-radius: 8px;
-  background: conic-gradient(from var(--chase-angle),
-    transparent                  0deg,
-    transparent                  290deg,
-    oklch(0.5  0.22 145 / 0)     290deg,
-    oklch(0.6  0.25 147 / 0.4)   310deg,
-    oklch(0.72 0.28 148 / 0.85)  330deg,
-    oklch(0.9  0.2  152 / 1)     345deg,
-    oklch(0.72 0.28 148 / 0.5)   355deg,
-    oklch(0.5  0.22 145 / 0)     360deg
-  );
-  animation: chase-spin 2s linear infinite;
-  z-index: -1;
-  pointer-events: none;
+.animate-awaiting-pulse {
+  animation: awaiting-pulse 2.5s ease-in-out infinite;
+  border-radius: 6px;
+}
+
+/* Completed unread — soft green pulse */
+@keyframes completed-pulse {
+  0%, 100% {
+    box-shadow: inset 0 0 0 1.5px oklch(0.72 0.19 152 / 0.25);
+  }
+  50% {
+    box-shadow: inset 0 0 0 1.5px oklch(0.72 0.19 152 / 0.6);
+  }
+}
+
+.animate-completed-pulse {
+  animation: completed-pulse 2.5s ease-in-out infinite;
+  border-radius: 6px;
 }
 
 :root {


### PR DESCRIPTION
## Summary

Fixes sidebar child session rendering and overhauls session status indicators for clarity.

### Child session nesting fix
- Moved left indent from the inner `<button>` to the outer wrapper `<div>` so `overflow-hidden` no longer clips nested session rows
- Supports arbitrary nesting depth

### Session status indicator overhaul
- **Active** (agent working): blue spinning chase animation — the only state that spins
- **Awaiting** (blocked on user/trigger): soft amber pulse — replaces the old purple chase
- **Completed (unread)**: soft green pulse — replaces the old green chase  
- **Idle**: static/subdued — no animation

### Provider icon as sole status indicator
- Removed the small activity dot overlay on the provider badge
- The provider icon container itself now glows/pulses per status state

### Inline pin icon removed
- Removed the always-visible pin toggle from session rows
- Pin remains accessible via swipe-reveal, long-press, and keyboard (`P`)
- Declutters the compact row layout

### New code
- `getSessionVisualState()` pure helper with full test coverage (6 tests)
- Encodes priority: selected > awaiting > active > completedUnread > idle

### Verification
- 597 tests pass, 0 fail
- Typecheck clean
- No stale animation class references

### Related
- Logged flaky pin/unpin bug investigation to Godmother (`m1fFXhUb`, P2)