### PR TITLE
fix: sync all active-state pulse animations to shared phase

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -22,6 +22,7 @@ import type {
 } from "@pizzapi/protocol";
 import { isMetaRelayEvent } from "@pizzapi/protocol";
 import { cn } from "@/lib/utils";
+import { syncedPulse } from "@/lib/synced-animation";
 import { pulseStreamingHaptic, cancelHaptic, startToolHaptic, stopToolHaptic } from "@/lib/haptics";
 import { Button } from "@/components/ui/button";
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -3333,6 +3334,7 @@ export function App() {
                 >
                   <span
                     className={`inline-block h-1.5 w-1.5 rounded-full flex-shrink-0 transition-colors ${agentActive ? "bg-green-400 shadow-[0_0_5px_#4ade8080] animate-pulse" : "bg-slate-400"}`}
+                    style={agentActive ? syncedPulse() : undefined}
                   />
                   {activeModel?.provider && (
                     <ProviderIcon provider={activeModel.provider} className="size-3.5 flex-shrink-0" />
@@ -3385,6 +3387,7 @@ export function App() {
                           <span
                             className={`absolute -top-0.5 -right-0.5 inline-block h-2 w-2 rounded-full border-2 border-popover ${s.isActive ? "bg-blue-400 animate-pulse" : "bg-green-600"}`}
                             title={s.isActive ? "Generating" : "Idle"}
+                            style={s.isActive ? syncedPulse() : undefined}
                           />
                         </div>
                         {/* Name + path */}

--- a/packages/ui/src/components/RunnerDetailPanel.tsx
+++ b/packages/ui/src/components/RunnerDetailPanel.tsx
@@ -8,6 +8,7 @@ import {
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { syncedPulse } from "@/lib/synced-animation";
 import { formatPathTail } from "@/lib/path";
 import { SkillsManager, type SkillInfo } from "@/components/SkillsManager";
 import { AgentsManager, type AgentInfo } from "@/components/AgentsManager";
@@ -151,6 +152,7 @@ function SessionsList({
                                     ? "bg-blue-400 shadow-[0_0_5px_#60a5fa80] animate-pulse"
                                     : "bg-green-500/70",
                             )}
+                            style={active ? syncedPulse() : undefined}
                         />
 
                         {/* Name + cwd */}

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -10,6 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
+import { syncedPulse } from "@/lib/synced-animation";
 import { io } from "socket.io-client";
 import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/protocol";
 import { extractWorktreeName, formatPathTail, worktreeRoots } from "@/lib/path";
@@ -1296,6 +1297,9 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         style={{
                                                             transform: !selectMode && hasOffset ? `translateX(${swipeOffset}px)` : undefined,
                                                             touchAction: selectMode ? undefined : "pan-y",
+                                                            ...(visualState === "active" || visualState === "awaiting" || visualState === "completedUnread"
+                                                                ? syncedPulse(visualState === "active" ? 2000 : 2500)
+                                                                : undefined),
                                                         }}
                                                     >
                                                         {/* Expand/collapse toggle for parent sessions */}
@@ -1365,13 +1369,16 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         )}
 
                                                         {/* Provider icon — status indicated via background/glow */}
-                                                        <div className={cn(
-                                                            "relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md transition-all duration-300",
-                                                            visualState === "active" && "bg-blue-500/20 shadow-[0_0_8px_#3b82f680] animate-pulse",
-                                                            visualState === "awaiting" && "bg-amber-500/20 shadow-[0_0_8px_#f59e0b60]",
-                                                            visualState === "completedUnread" && "bg-green-500/20 shadow-[0_0_8px_#22c55e60]",
-                                                            (visualState === "idle" || visualState === "selected") && "bg-sidebar-accent/50",
-                                                        )}>
+                                                        <div
+                                                            className={cn(
+                                                                "relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md transition-all duration-300",
+                                                                visualState === "active" && "bg-blue-500/20 shadow-[0_0_8px_#3b82f680] animate-pulse",
+                                                                visualState === "awaiting" && "bg-amber-500/20 shadow-[0_0_8px_#f59e0b60]",
+                                                                visualState === "completedUnread" && "bg-green-500/20 shadow-[0_0_8px_#22c55e60]",
+                                                                (visualState === "idle" || visualState === "selected") && "bg-sidebar-accent/50",
+                                                            )}
+                                                            style={visualState === "active" ? syncedPulse() : undefined}
+                                                        >
                                                             <ProviderIcon
                                                                 provider={provider}
                                                                 className="size-4 text-sidebar-foreground/70"

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1289,6 +1289,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
                                                             !hasOffset && "transition-transform duration-200 ease-out",
                                                             visualState === "selected" && "bg-sidebar-accent text-sidebar-accent-foreground",
+                                                            visualState === "selectedActive" && "bg-sidebar-accent text-sidebar-accent-foreground animate-selected-active-chase",
                                                             visualState === "awaiting" && "text-sidebar-foreground animate-awaiting-pulse",
                                                             visualState === "active" && "text-sidebar-foreground animate-working-chase",
                                                             visualState === "completedUnread" && "text-sidebar-foreground animate-completed-pulse",
@@ -1297,8 +1298,8 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         style={{
                                                             transform: !selectMode && hasOffset ? `translateX(${swipeOffset}px)` : undefined,
                                                             touchAction: selectMode ? undefined : "pan-y",
-                                                            ...(visualState === "active" || visualState === "awaiting" || visualState === "completedUnread"
-                                                                ? syncedPulse(visualState === "active" ? 2000 : 2500)
+                                                            ...(visualState === "active" || visualState === "selectedActive" || visualState === "awaiting" || visualState === "completedUnread"
+                                                                ? syncedPulse(visualState === "active" || visualState === "selectedActive" ? 2000 : 2500)
                                                                 : undefined),
                                                         }}
                                                     >
@@ -1373,11 +1374,12 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             className={cn(
                                                                 "relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md transition-all duration-300",
                                                                 visualState === "active" && "bg-blue-500/20 shadow-[0_0_8px_#3b82f680] animate-pulse",
+                                                                visualState === "selectedActive" && "bg-blue-500/10 shadow-[0_0_6px_#3b82f640] animate-pulse",
                                                                 visualState === "awaiting" && "bg-amber-500/20 shadow-[0_0_8px_#f59e0b60]",
                                                                 visualState === "completedUnread" && "bg-green-500/20 shadow-[0_0_8px_#22c55e60]",
                                                                 (visualState === "idle" || visualState === "selected") && "bg-sidebar-accent/50",
                                                             )}
-                                                            style={visualState === "active" ? syncedPulse() : undefined}
+                                                            style={visualState === "active" || visualState === "selectedActive" ? syncedPulse() : undefined}
                                                         >
                                                             <ProviderIcon
                                                                 provider={provider}

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -66,6 +66,7 @@ import {
 } from "@/components/ui/command";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { syncedPulse } from "@/lib/synced-animation";
 import { formatPathTail } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { MultipleChoiceQuestions } from "@/components/ai-elements/multiple-choice";
@@ -1486,6 +1487,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                     ? "bg-slate-400"
                     : "bg-slate-600",
             )}
+            style={(isCompacting || agentActive) ? syncedPulse() : undefined}
             title={
               isCompacting ? "Compacting context…"
               : agentActive ? "Agent active"
@@ -1667,7 +1669,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
             <ConversationEmptyState
               icon={
                 <span className="inline-flex items-center justify-center h-10 w-10 rounded-full bg-muted/60 border border-border/60">
-                  <span className="inline-block h-2.5 w-2.5 rounded-full bg-slate-400 animate-pulse" />
+                  <span className="inline-block h-2.5 w-2.5 rounded-full bg-slate-400 animate-pulse" style={syncedPulse()} />
                 </span>
               }
               title="Waiting for session events"

--- a/packages/ui/src/lib/session-visual-state.ts
+++ b/packages/ui/src/lib/session-visual-state.ts
@@ -1,4 +1,4 @@
-export type SessionVisualState = "selected" | "awaiting" | "active" | "completedUnread" | "idle";
+export type SessionVisualState = "selected" | "selectedActive" | "awaiting" | "active" | "completedUnread" | "idle";
 
 export interface SessionVisualStateInput {
   isSelected: boolean;
@@ -9,9 +9,10 @@ export interface SessionVisualStateInput {
 
 /**
  * Determine the visual state of a sidebar session row.
- * Priority: selected > awaiting > active > completedUnread > idle.
+ * Priority: selected (+ active variant) > awaiting > active > completedUnread > idle.
  */
 export function getSessionVisualState(input: SessionVisualStateInput): SessionVisualState {
+  if (input.isSelected && input.isActive) return "selectedActive";
   if (input.isSelected) return "selected";
   if (input.isAwaiting) return "awaiting";
   if (input.isActive) return "active";

--- a/packages/ui/src/lib/synced-animation.ts
+++ b/packages/ui/src/lib/synced-animation.ts
@@ -1,0 +1,18 @@
+/**
+ * Returns a negative `animationDelay` that anchors a CSS animation to a
+ * shared global epoch so every element using the same cycle duration pulses
+ * in perfect sync — regardless of when it mounts.
+ *
+ * Usage:
+ *   <span style={syncedPulse()} className="animate-pulse" />
+ *   <span style={syncedPulse(2500)} className="animate-awaiting-pulse" />
+ */
+
+/** Default Tailwind `animate-pulse` duration (ms). */
+const DEFAULT_CYCLE_MS = 2000;
+
+export function syncedPulse(
+  cycleMs: number = DEFAULT_CYCLE_MS,
+): React.CSSProperties {
+  return { animationDelay: `${-(Date.now() % cycleMs)}ms` };
+}

--- a/packages/ui/src/lib/synced-animation.ts
+++ b/packages/ui/src/lib/synced-animation.ts
@@ -1,18 +1,27 @@
 /**
- * Returns a negative `animationDelay` that anchors a CSS animation to a
- * shared global epoch so every element using the same cycle duration pulses
- * in perfect sync — regardless of when it mounts.
+ * Returns style props that anchor a CSS animation to a shared global epoch
+ * so every element using the same cycle duration pulses in perfect sync —
+ * regardless of when it mounts.
+ *
+ * Sets both `animationDelay` (for animations on the element itself, e.g.
+ * Tailwind `animate-pulse`) and `--sync-delay` (a CSS custom property that
+ * pseudo-element animations like `::before` can reference).
  *
  * Usage:
  *   <span style={syncedPulse()} className="animate-pulse" />
- *   <span style={syncedPulse(2500)} className="animate-awaiting-pulse" />
+ *   <div  style={syncedPulse(2000)} className="animate-working-chase" />
  */
 
-/** Default Tailwind `animate-pulse` duration (ms). */
+/** Default Tailwind `animate-pulse` / chase-spin duration (ms). */
 const DEFAULT_CYCLE_MS = 2000;
 
 export function syncedPulse(
   cycleMs: number = DEFAULT_CYCLE_MS,
 ): React.CSSProperties {
-  return { animationDelay: `${-(Date.now() % cycleMs)}ms` };
+  const delay = `${-(Date.now() % cycleMs)}ms`;
+  return {
+    animationDelay: delay,
+    // Custom property for pseudo-element animations (::before, ::after)
+    "--sync-delay": delay,
+  } as React.CSSProperties;
 }

--- a/packages/ui/src/style.css
+++ b/packages/ui/src/style.css
@@ -92,6 +92,7 @@
     oklch(0.5  0.22 220 / 0)     360deg
   );
   animation: chase-spin 2s linear infinite;
+  animation-delay: var(--sync-delay, 0ms);
   z-index: -1;
   pointer-events: none;
 }
@@ -127,6 +128,7 @@
     oklch(0.5  0.22 220 / 0)     360deg
   );
   animation: chase-spin 2s linear infinite;
+  animation-delay: var(--sync-delay, 0ms);
   z-index: -1;
   pointer-events: none;
 }
@@ -143,6 +145,7 @@
 
 .animate-awaiting-pulse {
   animation: awaiting-pulse 2.5s ease-in-out infinite;
+  animation-delay: var(--sync-delay, 0ms);
   border-radius: 6px;
 }
 
@@ -158,6 +161,7 @@
 
 .animate-completed-pulse {
   animation: completed-pulse 2.5s ease-in-out infinite;
+  animation-delay: var(--sync-delay, 0ms);
   border-radius: 6px;
 }
 

--- a/packages/ui/src/style.css
+++ b/packages/ui/src/style.css
@@ -96,6 +96,41 @@
   pointer-events: none;
 }
 
+/* Selected+Active — subtle blue dot chase (lighter than .animate-working-chase) */
+.animate-selected-active-chase {
+  isolation: isolate;
+}
+
+.animate-selected-active-chase::after {
+  content: '';
+  position: absolute;
+  inset: 1.5px;
+  border-radius: 5px;
+  background: var(--sidebar-accent);
+  z-index: -1;
+  pointer-events: none;
+}
+
+.animate-selected-active-chase::before {
+  content: '';
+  position: absolute;
+  inset: -1.5px;
+  border-radius: 8px;
+  background: conic-gradient(from var(--chase-angle),
+    transparent                  0deg,
+    transparent                  290deg,
+    oklch(0.5  0.22 220 / 0)     290deg,
+    oklch(0.6  0.25 220 / 0.2)   310deg,
+    oklch(0.75 0.28 215 / 0.4)   330deg,
+    oklch(0.92 0.2  205 / 0.5)   345deg,
+    oklch(0.75 0.28 215 / 0.25)  355deg,
+    oklch(0.5  0.22 220 / 0)     360deg
+  );
+  animation: chase-spin 2s linear infinite;
+  z-index: -1;
+  pointer-events: none;
+}
+
 /* Awaiting input — soft amber pulse */
 @keyframes awaiting-pulse {
   0%, 100% {


### PR DESCRIPTION
## Problem

CSS animations start when elements mount, so status dots that appear at different times pulse out of phase — like unsynchronized turn signals.

## Fix

A tiny `syncedPulse()` utility that computes a negative `animationDelay` anchored to `Date.now() % cycleDuration`. Every element calling it gets snapped to the same beat, regardless of when it mounted.

```ts
export function syncedPulse(cycleMs = 2000): React.CSSProperties {
  return { animationDelay: `${-(Date.now() % cycleMs)}ms` };
}
```

## Applied to all 7 pulsing indicators

- **App.tsx** — header session pill dot + session switcher dropdown badges
- **SessionViewer.tsx** — status dot (active & compacting) + waiting-for-events dot
- **SessionSidebar.tsx** — row animations (chase 2s / awaiting 2.5s / completed 2.5s) + icon background glow
- **RunnerDetailPanel.tsx** — session activity dot