### PR TITLE
fix: use Web Animations API for true animation sync

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { initAnimationSync } from "@/lib/synced-animation";
 import { SessionSidebar, type DotState, type HubSession } from "@/components/SessionSidebar";
 import { SessionViewer, type RelayMessage } from "@/components/SessionViewer";
 import type { CommandResultData } from "@/components/session-viewer/rendering";
@@ -22,7 +23,6 @@ import type {
 } from "@pizzapi/protocol";
 import { isMetaRelayEvent } from "@pizzapi/protocol";
 import { cn } from "@/lib/utils";
-import { syncedPulse } from "@/lib/synced-animation";
 import { pulseStreamingHaptic, cancelHaptic, startToolHaptic, stopToolHaptic } from "@/lib/haptics";
 import { Button } from "@/components/ui/button";
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
@@ -100,6 +100,9 @@ import {
 } from "@/lib/message-helpers";
 import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
 import { analyzeIncomingSeq, mergeConnectedSeq, shouldDeferEventForHydration } from "@/lib/session-seq";
+
+// Sync all CSS animations (pulse, chase-spin, etc.) to the same phase globally.
+initAnimationSync();
 
 export function App() {
   const { data: session, isPending } = useSession();
@@ -3334,7 +3337,6 @@ export function App() {
                 >
                   <span
                     className={`inline-block h-1.5 w-1.5 rounded-full flex-shrink-0 transition-colors ${agentActive ? "bg-green-400 shadow-[0_0_5px_#4ade8080] animate-pulse" : "bg-slate-400"}`}
-                    style={agentActive ? syncedPulse() : undefined}
                   />
                   {activeModel?.provider && (
                     <ProviderIcon provider={activeModel.provider} className="size-3.5 flex-shrink-0" />
@@ -3387,7 +3389,6 @@ export function App() {
                           <span
                             className={`absolute -top-0.5 -right-0.5 inline-block h-2 w-2 rounded-full border-2 border-popover ${s.isActive ? "bg-blue-400 animate-pulse" : "bg-green-600"}`}
                             title={s.isActive ? "Generating" : "Idle"}
-                            style={s.isActive ? syncedPulse() : undefined}
                           />
                         </div>
                         {/* Name + path */}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2605,6 +2605,20 @@ export function App() {
       setViewerStatus("Ending session…");
     } else if (command === "compact") {
       setViewerStatus("Compacting…");
+    } else if (command === "abort") {
+      // Optimistically mark as inactive so the UI updates immediately
+      // instead of waiting for the next heartbeat cycle.
+      setAgentActive(false);
+      patchSessionCache({ agentActive: false });
+      // Also update the sidebar's live session list so the session row
+      // transitions from "active" to "completed unread" without waiting
+      // for the hub's next session_status heartbeat.
+      const sid = activeSessionRef.current;
+      if (sid) {
+        setLiveSessions((prev) =>
+          prev.map((s) => (s.sessionId === sid ? { ...s, isActive: false } : s)),
+        );
+      }
     }
     try {
       const { type: _type, ...rest } = payload;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -186,7 +186,7 @@ export function App() {
   const [pendingQuestion, setPendingQuestion] = React.useState<{ toolCallId: string; questions: Array<{ question: string; options: string[]; type?: import("@/lib/ask-user-questions").QuestionType }>; display: QuestionDisplayMode } | null>(null);
 
   /** Set of session IDs that currently have a pending AskUserQuestion. */
-  const [sessionsWithPendingQuestion, setSessionsWithPendingQuestion] = React.useState<Set<string>>(new Set());
+  const [sessionsAwaitingInput, setSessionsAwaitingInput] = React.useState<Set<string>>(new Set());
 
   /** Pending plan mode prompt from the worker — shown as a plan review panel in the viewer. */
   const [pendingPlan, setPendingPlan] = React.useState<{
@@ -423,19 +423,21 @@ export function App() {
 
     sessionUiCacheRef.current.set(sessionId, next);
 
-    // Keep the sidebar indicator in sync: track which sessions are awaiting input.
-    if (Object.prototype.hasOwnProperty.call(patch, "pendingQuestion")) {
-      setSessionsWithPendingQuestion((prev) => {
+    // Keep the sidebar indicator in sync: track which sessions are awaiting input
+    // (either a pending question or a pending plan review).
+    if (Object.prototype.hasOwnProperty.call(patch, "pendingQuestion") ||
+        Object.prototype.hasOwnProperty.call(patch, "pendingPlan")) {
+      setSessionsAwaitingInput((prev) => {
         const next = new Set(prev);
-        if (patch.pendingQuestion) {
+        if (patch.pendingQuestion || patch.pendingPlan) {
           next.add(sessionId);
-        } else {
+        } else if (!patch.pendingQuestion && !patch.pendingPlan) {
           next.delete(sessionId);
         }
         return next;
       });
     }
-  }, [setSessionsWithPendingQuestion]);
+  }, [setSessionsAwaitingInput]);
 
   // Debounce streaming delta updates (toolcall_delta, text_delta, thinking_delta) so we
   // flush at most once per animation frame instead of once per character.
@@ -1993,14 +1995,15 @@ export function App() {
     const handleStateSnapshot = ({ sessionId, state }: { sessionId: string; state: SessionMetaState }) => {
       const currentSessionId = activeSessionRef.current;
 
-      // For background sessions: extract pendingQuestion from the initial
-      // state_snapshot so badges are correct on load/reconnect even when the
-      // session is already blocked waiting for user input.
+      // For background sessions: extract pendingQuestion/pendingPlan from the
+      // initial state_snapshot so badges are correct on load/reconnect even
+      // when the session is already blocked waiting for user input.
       if (sessionId !== currentSessionId) {
-        if (Object.prototype.hasOwnProperty.call(state, "pendingQuestion")) {
-          setSessionsWithPendingQuestion((prev) => {
+        if (Object.prototype.hasOwnProperty.call(state, "pendingQuestion") ||
+            Object.prototype.hasOwnProperty.call(state, "pendingPlan")) {
+          setSessionsAwaitingInput((prev) => {
             const next = new Set(prev);
-            if (state.pendingQuestion) {
+            if (state.pendingQuestion || state.pendingPlan) {
               next.add(sessionId);
             } else {
               next.delete(sessionId);
@@ -2020,11 +2023,13 @@ export function App() {
     const handleMetaEvent = (payload: { sessionId: string; version: number } & Record<string, unknown>) => {
       // Update the sidebar pending-question badge for ANY session's meta event,
       // not just the active one.  Background sessions emit pendingQuestion
-      // updates into their own meta rooms; the badge must reflect all of them.
-      if (Object.prototype.hasOwnProperty.call(payload, "pendingQuestion")) {
-        setSessionsWithPendingQuestion((prev) => {
+      // and pendingPlan updates into their own meta rooms; the badge must
+      // reflect all of them.
+      if (Object.prototype.hasOwnProperty.call(payload, "pendingQuestion") ||
+          Object.prototype.hasOwnProperty.call(payload, "pendingPlan")) {
+        setSessionsAwaitingInput((prev) => {
           const next = new Set(prev);
-          if (payload.pendingQuestion) {
+          if (payload.pendingQuestion || payload.pendingPlan) {
             next.add(payload.sessionId);
           } else {
             next.delete(payload.sessionId);
@@ -3589,7 +3594,7 @@ export function App() {
               selectedRunnerId={selectedRunnerId}
               onSelectRunner={setSelectedRunnerId}
               onShowSessions={() => setShowRunners(false)}
-              sessionsWithPendingQuestion={sessionsWithPendingQuestion}
+              sessionsAwaitingInput={sessionsAwaitingInput}
             />
           </ErrorBoundary>
         </div>

--- a/packages/ui/src/components/RunnerDetailPanel.tsx
+++ b/packages/ui/src/components/RunnerDetailPanel.tsx
@@ -8,7 +8,7 @@ import {
     TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { syncedPulse } from "@/lib/synced-animation";
+
 import { formatPathTail } from "@/lib/path";
 import { SkillsManager, type SkillInfo } from "@/components/SkillsManager";
 import { AgentsManager, type AgentInfo } from "@/components/AgentsManager";
@@ -152,7 +152,6 @@ function SessionsList({
                                     ? "bg-blue-400 shadow-[0_0_5px_#60a5fa80] animate-pulse"
                                     : "bg-green-500/70",
                             )}
-                            style={active ? syncedPulse() : undefined}
                         />
 
                         {/* Name + cwd */}

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -10,7 +10,6 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-import { syncedPulse } from "@/lib/synced-animation";
 import { io } from "socket.io-client";
 import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/protocol";
 import { extractWorktreeName, formatPathTail, worktreeRoots } from "@/lib/path";
@@ -1298,9 +1297,6 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         style={{
                                                             transform: !selectMode && hasOffset ? `translateX(${swipeOffset}px)` : undefined,
                                                             touchAction: selectMode ? undefined : "pan-y",
-                                                            ...(visualState === "active" || visualState === "selectedActive" || visualState === "awaiting" || visualState === "completedUnread"
-                                                                ? syncedPulse(visualState === "active" || visualState === "selectedActive" ? 2000 : 2500)
-                                                                : undefined),
                                                         }}
                                                     >
                                                         {/* Expand/collapse toggle for parent sessions */}
@@ -1379,7 +1375,6 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                                 visualState === "completedUnread" && "bg-green-500/20 shadow-[0_0_8px_#22c55e60]",
                                                                 (visualState === "idle" || visualState === "selected") && "bg-sidebar-accent/50",
                                                             )}
-                                                            style={visualState === "active" || visualState === "selectedActive" ? syncedPulse() : undefined}
                                                         >
                                                             <ProviderIcon
                                                                 provider={provider}

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -103,8 +103,8 @@ export interface SessionSidebarProps {
     selectedRunnerId?: string | null;
     /** Called when a runner is selected */
     onSelectRunner?: (runnerId: string) => void;
-    /** Set of session IDs that currently have a pending AskUserQuestion (awaiting user input). */
-    sessionsWithPendingQuestion?: Set<string>;
+    /** Set of session IDs that currently have a pending AskUserQuestion or plan_mode review. */
+    sessionsAwaitingInput?: Set<string>;
 }
 
 function formatRelativeDate(isoString: string): string {
@@ -190,7 +190,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     selectedRunnerId,
     onSelectRunner,
     onShowSessions,
-    sessionsWithPendingQuestion,
+    sessionsAwaitingInput,
 }: SessionSidebarProps) {
     const [collapsed, setCollapsed] = React.useState(false);
 
@@ -1158,7 +1158,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                             const isChecked = selectedSessionIds.has(s.sessionId);
                                             const visualState = getSessionVisualState({
                                                 isSelected: isActiveSession || (selectMode && isChecked),
-                                                isAwaiting: !!sessionsWithPendingQuestion?.has(s.sessionId),
+                                                isAwaiting: !!sessionsAwaitingInput?.has(s.sessionId),
                                                 isActive: !!s.isActive,
                                                 isCompletedUnread: completedUnreadSessions.has(s.sessionId),
                                             });

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -66,7 +66,6 @@ import {
 } from "@/components/ui/command";
 import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
-import { syncedPulse } from "@/lib/synced-animation";
 import { formatPathTail } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { MultipleChoiceQuestions } from "@/components/ai-elements/multiple-choice";
@@ -1487,7 +1486,6 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                     ? "bg-slate-400"
                     : "bg-slate-600",
             )}
-            style={(isCompacting || agentActive) ? syncedPulse() : undefined}
             title={
               isCompacting ? "Compacting context…"
               : agentActive ? "Agent active"
@@ -1669,7 +1667,7 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
             <ConversationEmptyState
               icon={
                 <span className="inline-flex items-center justify-center h-10 w-10 rounded-full bg-muted/60 border border-border/60">
-                  <span className="inline-block h-2.5 w-2.5 rounded-full bg-slate-400 animate-pulse" style={syncedPulse()} />
+                  <span className="inline-block h-2.5 w-2.5 rounded-full bg-slate-400 animate-pulse" />
                 </span>
               }
               title="Waiting for session events"

--- a/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/TriggerCard.tsx
@@ -75,12 +75,12 @@ function AskUserQuestionCard({
   );
 
   return (
-    <ToolCardShell>
-      <ToolCardHeader className="py-2.5">
+    <ToolCardShell className="border-blue-500/40 bg-blue-950/20 shadow-[0_0_12px_-3px_rgba(59,130,246,0.25)]">
+      <ToolCardHeader className="py-2.5 border-blue-500/20 bg-blue-950/30">
         <ToolCardTitle
-          icon={<Zap className="size-3.5 shrink-0 text-blue-400" />}
+          icon={<Zap className="size-3.5 shrink-0 text-blue-400 animate-pulse" />}
         >
-          <span className="text-sm font-medium text-zinc-300">
+          <span className="text-sm font-medium text-blue-200">
             Question from Child {childName ? `"${childName}"` : ""}
           </span>
         </ToolCardTitle>
@@ -195,12 +195,12 @@ function PlanReviewCard({
   isResponding?: boolean;
 }) {
   return (
-    <ToolCardShell>
-      <ToolCardHeader className="py-2.5">
+    <ToolCardShell className="border-amber-500/40 bg-amber-950/20 shadow-[0_0_12px_-3px_rgba(245,158,11,0.25)]">
+      <ToolCardHeader className="py-2.5 border-amber-500/20 bg-amber-950/30">
         <ToolCardTitle
-          icon={<Clock className="size-3.5 shrink-0 text-amber-400" />}
+          icon={<Clock className="size-3.5 shrink-0 text-amber-400 animate-pulse" />}
         >
-          <span className="text-sm font-medium text-zinc-300">
+          <span className="text-sm font-medium text-amber-200">
             Plan Review from {childName ? `"${childName}"` : "Child"}
           </span>
         </ToolCardTitle>
@@ -226,7 +226,7 @@ function PlanReviewCard({
         </ToolCardSection>
       )}
 
-      <div className="flex flex-wrap gap-2 px-4 py-3 border-t border-zinc-800 bg-zinc-900/50">
+      <div className="flex flex-wrap gap-2 px-4 py-3 border-t border-amber-500/20 bg-amber-950/20">
         <Button
           size="sm"
           variant="default"

--- a/packages/ui/src/lib/synced-animation.ts
+++ b/packages/ui/src/lib/synced-animation.ts
@@ -1,27 +1,51 @@
 /**
- * Returns style props that anchor a CSS animation to a shared global epoch
- * so every element using the same cycle duration pulses in perfect sync —
- * regardless of when it mounts.
+ * Synchronize CSS animations across elements using the Web Animations API.
  *
- * Sets both `animationDelay` (for animations on the element itself, e.g.
- * Tailwind `animate-pulse`) and `--sync-delay` (a CSS custom property that
- * pseudo-element animations like `::before` can reference).
+ * CSS animations start when an element mounts, so elements added at different
+ * times pulse out of phase. Pure CSS cannot fix this — MDN confirms "it is
+ * impossible to sync two separate animations with CSS animations."
  *
- * Usage:
- *   <span style={syncedPulse()} className="animate-pulse" />
- *   <div  style={syncedPulse(2000)} className="animate-working-chase" />
+ * This module listens for `animationstart` events and forces every matching
+ * animation's `startTime` to 0 on the document timeline, so they all share
+ * the same phase regardless of when they mounted.
  */
 
-/** Default Tailwind `animate-pulse` / chase-spin duration (ms). */
-const DEFAULT_CYCLE_MS = 2000;
+/** Animation names we want to keep in lockstep. */
+const SYNCED_NAMES = new Set([
+  "pulse",           // Tailwind animate-pulse
+  "chase-spin",      // Sidebar active row chase border
+  "awaiting-pulse",  // Sidebar awaiting-input row
+  "completed-pulse", // Sidebar completed-unread row
+]);
 
-export function syncedPulse(
-  cycleMs: number = DEFAULT_CYCLE_MS,
-): React.CSSProperties {
-  const delay = `${-(Date.now() % cycleMs)}ms`;
-  return {
-    animationDelay: delay,
-    // Custom property for pseudo-element animations (::before, ::after)
-    "--sync-delay": delay,
-  } as React.CSSProperties;
+let initialized = false;
+
+/**
+ * Call once at app startup. Installs a global `animationstart` listener that
+ * forces all matching CSS animations to `startTime = 0`, anchoring them to
+ * the document timeline origin so every instance beats in unison.
+ */
+export function initAnimationSync(): void {
+  if (initialized) return;
+  initialized = true;
+
+  document.addEventListener(
+    "animationstart",
+    (e: AnimationEvent) => {
+      if (!SYNCED_NAMES.has(e.animationName)) return;
+
+      // Use rAF so we don't mutate animations mid-style-recalc
+      requestAnimationFrame(() => {
+        for (const anim of document.getAnimations()) {
+          if (
+            anim instanceof CSSAnimation &&
+            SYNCED_NAMES.has(anim.animationName)
+          ) {
+            anim.startTime = 0;
+          }
+        }
+      });
+    },
+    true, // capture phase — catches pseudo-element events that bubble
+  );
 }

--- a/packages/ui/src/lib/synced-animation.ts
+++ b/packages/ui/src/lib/synced-animation.ts
@@ -39,7 +39,8 @@ export function initAnimationSync(): void {
         for (const anim of document.getAnimations()) {
           if (
             anim instanceof CSSAnimation &&
-            SYNCED_NAMES.has(anim.animationName)
+            SYNCED_NAMES.has(anim.animationName) &&
+            anim.startTime !== 0
           ) {
             anim.startTime = 0;
           }

--- a/packages/ui/src/style.css
+++ b/packages/ui/src/style.css
@@ -92,7 +92,6 @@
     oklch(0.5  0.22 220 / 0)     360deg
   );
   animation: chase-spin 2s linear infinite;
-  animation-delay: var(--sync-delay, 0ms);
   z-index: -1;
   pointer-events: none;
 }
@@ -128,7 +127,6 @@
     oklch(0.5  0.22 220 / 0)     360deg
   );
   animation: chase-spin 2s linear infinite;
-  animation-delay: var(--sync-delay, 0ms);
   z-index: -1;
   pointer-events: none;
 }
@@ -145,7 +143,6 @@
 
 .animate-awaiting-pulse {
   animation: awaiting-pulse 2.5s ease-in-out infinite;
-  animation-delay: var(--sync-delay, 0ms);
   border-radius: 6px;
 }
 
@@ -161,7 +158,6 @@
 
 .animate-completed-pulse {
   animation: completed-pulse 2.5s ease-in-out infinite;
-  animation-delay: var(--sync-delay, 0ms);
   border-radius: 6px;
 }
 


### PR DESCRIPTION
Follows up on #282 — the CSS `animationDelay` approach didn't actually work because elements render in different React commits with different `Date.now()` values.

## The problem

CSS animations start when elements mount. Elements that mount at different times pulse out of phase. MDN confirms: *"it is impossible to sync two separate animations with CSS animations."*

## The fix

Use the **Web Animations API** instead. A global `animationstart` listener calls `document.getAnimations()` and sets `startTime = 0` on every matching `CSSAnimation`, anchoring them all to the document timeline origin. This guarantees every dot/chase beats in perfect lockstep regardless of when the element mounted.

```ts
// Runs once at app boot
document.addEventListener('animationstart', (e) => {
  if (!SYNCED_NAMES.has(e.animationName)) return;
  requestAnimationFrame(() => {
    for (const anim of document.getAnimations()) {
      if (anim instanceof CSSAnimation && SYNCED_NAMES.has(anim.animationName)) {
        anim.startTime = 0;
      }
    }
  });
}, true);
```

## What changed

- **Rewrote** `synced-animation.ts` — replaced `syncedPulse()` CSS hack with `initAnimationSync()` using Web Animations API
- **Removed** all `syncedPulse()` inline styles from App.tsx, SessionViewer, SessionSidebar, RunnerDetailPanel
- **Removed** all `--sync-delay` CSS custom property usage from style.css
- **Added** `initAnimationSync()` call at module scope in App.tsx

Synced animation names: `pulse`, `chase-spin`, `awaiting-pulse`, `completed-pulse`