### PR TITLE
feat: test server factory — harness foundation

### DIFF
--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Test harness barrel export.
+ * Re-exports everything from types, server, and future modules.
+ */
+
+export * from "./types.js";
+export * from "./server.js";

--- a/packages/server/tests/harness/server.test.ts
+++ b/packages/server/tests/harness/server.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Smoke tests for the test server factory harness.
+ *
+ * These tests verify that createTestServer():
+ *   1. Spins up a real HTTP server that responds to requests
+ *   2. Pre-creates a user with a working API key
+ *   3. Multiple servers can run simultaneously (created sequentially, then accessed concurrently)
+ *   4. Cleans up all resources on shutdown
+ *
+ * NOTE: Servers must be created sequentially (not with Promise.all) because
+ * auth.ts and sio-state.ts use module-level singletons. Once created, multiple
+ * servers can coexist and respond simultaneously.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { createTestServer } from "./server.js";
+
+// Tests spin up real servers + Redis + Socket.IO, so we need a generous timeout.
+const TEST_TIMEOUT_MS = 30_000;
+
+describe("createTestServer", () => {
+    test("creates server and responds to health check", async () => {
+        const server = await createTestServer();
+        try {
+            const res = await fetch(`${server.baseUrl}/health`);
+            // Health may be degraded if Redis singletons were overwritten, but
+            // the server must respond with the expected shape.
+            expect([200, 503]).toContain(res.status);
+            const data = await res.json();
+            expect(["ok", "degraded"]).toContain(data.status);
+            expect(typeof data.redis).toBe("boolean");
+            expect(typeof data.socketio).toBe("boolean");
+            expect(typeof data.uptime).toBe("number");
+        } finally {
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("pre-created user can authenticate via API key", async () => {
+        const server = await createTestServer();
+        try {
+            // Verify basic properties are populated
+            expect(server.port).toBeGreaterThan(0);
+            expect(server.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+            expect(server.apiKey).toHaveLength(64); // 32 random bytes → 64 hex chars
+            expect(server.userId).toBeTruthy();
+            expect(server.userName).toBe("Test User");
+            expect(server.userEmail).toBe("testuser@pizzapi-harness.test");
+            expect(server.sessionCookie).toBeTruthy();
+
+            // The built-in fetch helper includes auth headers
+            const res = await server.fetch("/api/signup-status");
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            // After first user created with disableSignupAfterFirstUser: true (default),
+            // signup should be disabled
+            expect(data.signupEnabled).toBe(false);
+        } finally {
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("multiple test servers can run concurrently", async () => {
+        // Create servers sequentially (module singletons require serial creation)
+        // then verify they can all respond simultaneously.
+        const s1 = await createTestServer();
+        const s2 = await createTestServer();
+        const s3 = await createTestServer();
+
+        try {
+            // All servers should have different ports
+            const ports = new Set([s1.port, s2.port, s3.port]);
+            expect(ports.size).toBe(3);
+
+            // All servers should respond simultaneously (concurrent reads are fine)
+            const responses = await Promise.all([
+                fetch(`${s1.baseUrl}/health`),
+                fetch(`${s2.baseUrl}/health`),
+                fetch(`${s3.baseUrl}/health`),
+            ]);
+
+            for (const res of responses) {
+                expect([200, 503]).toContain(res.status);
+                const data = await res.json();
+                expect(["ok", "degraded"]).toContain(data.status);
+            }
+        } finally {
+            // Clean up all servers, ignoring individual errors
+            await Promise.allSettled([s1.cleanup(), s2.cleanup(), s3.cleanup()]);
+        }
+    }, TEST_TIMEOUT_MS * 3);
+
+    test("cleanup shuts down cleanly", async () => {
+        const server = await createTestServer();
+        const baseUrl = server.baseUrl;
+
+        // Server is up before cleanup
+        const before = await fetch(`${baseUrl}/health`);
+        expect([200, 503]).toContain(before.status);
+
+        // Cleanup
+        await server.cleanup();
+
+        // Server should no longer be reachable after cleanup
+        let threw = false;
+        try {
+            await fetch(`${baseUrl}/health`);
+        } catch {
+            threw = true;
+        }
+        expect(threw).toBe(true);
+    }, TEST_TIMEOUT_MS);
+});

--- a/packages/server/tests/harness/server.test.ts
+++ b/packages/server/tests/harness/server.test.ts
@@ -8,14 +8,75 @@
  *   4. Cleans up all resources on shutdown (no process hang)
  */
 
+import { createConnection } from "node:net";
+import { createClient } from "redis";
 import { describe, test, expect } from "bun:test";
 import { createTestServer } from "./server.js";
 
 // Tests spin up real servers + Redis + Socket.IO, so we need a generous timeout.
 const TEST_TIMEOUT_MS = 30_000;
 
+// ── Redis availability + mock detection ──────────────────────────────────────
+// Two-stage check before any tests are defined:
+//
+//   Stage 1 (TCP probe): Uses node:net — completely immune to mock.module("redis", ...).
+//                        Checks if the Redis port is open at all.
+//
+//   Stage 2 (module check): If the TCP port is open, verify the redis module is real
+//                            (not mocked by another test file in the same worker).
+//                            Real clients have .ping(); mocks typically omit it.
+//
+// If either check fails, all tests use test.skip for clear CI output instead of
+// failing with a cryptic TypeError.
+const REDIS_URL_FOR_PROBE = process.env.PIZZAPI_REDIS_URL ?? "redis://localhost:6379";
+
+function probeRedisViaTcp(url: string, timeoutMs = 3000): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+        let settled = false;
+        const settle = (ok: boolean) => {
+            if (settled) return;
+            settled = true;
+            try { socket.destroy(); } catch { /* ignore */ }
+            resolve(ok);
+        };
+        const { hostname, port } = new URL(url);
+        const socket = createConnection({ host: hostname, port: parseInt(port, 10) || 6379 });
+        socket.setTimeout(timeoutMs);
+        socket.once("connect", () => settle(true));
+        socket.once("error", () => settle(false));
+        socket.once("timeout", () => settle(false));
+    });
+}
+
+// Stage 1: TCP probe
+const redisPortOpen = await probeRedisViaTcp(REDIS_URL_FOR_PROBE);
+
+// Stage 2: Module mock detection — createClient() in a mocked environment returns
+// an object without .ping(); real clients always have it.
+let redisModuleIsReal = false;
+if (redisPortOpen) {
+    // Intentionally uses the (potentially mocked) redis module: if it IS mocked,
+    // the returned object lacks .ping() and we skip rather than fail.
+    const probeClient = createClient({ url: REDIS_URL_FOR_PROBE }) as { ping?: unknown };
+    redisModuleIsReal = typeof probeClient.ping === "function";
+}
+
+if (!redisPortOpen) {
+    console.log(
+        `[harness] Redis not reachable at ${REDIS_URL_FOR_PROBE} — ` +
+        `all harness tests will be skipped.`,
+    );
+} else if (!redisModuleIsReal) {
+    console.log(
+        `[harness] Redis module is mocked (mock.module("redis", ...) is active in this worker) — ` +
+        `all harness tests will be skipped. Run harness tests in isolation to avoid this.`,
+    );
+}
+
+const testFn: typeof test = redisPortOpen && redisModuleIsReal ? test : test.skip;
+
 describe("createTestServer", () => {
-    test("creates server and responds to health check", async () => {
+    testFn("creates server and responds to health check", async () => {
         const server = await createTestServer();
         try {
             const res = await fetch(`${server.baseUrl}/health`);
@@ -30,7 +91,7 @@ describe("createTestServer", () => {
         }
     }, TEST_TIMEOUT_MS);
 
-    test("pre-created user can authenticate via API key", async () => {
+    testFn("pre-created user can authenticate via API key", async () => {
         const server = await createTestServer();
         try {
             // Verify basic properties are populated
@@ -54,7 +115,7 @@ describe("createTestServer", () => {
         }
     }, TEST_TIMEOUT_MS);
 
-    test("singleton guard: creating a second server while one is active throws", async () => {
+    testFn("singleton guard: creating a second server while one is active throws", async () => {
         // This test verifies the documented singleton constraint:
         // auth.ts and sio-state.ts use module-level singletons that cannot
         // be safely reinitialised while a prior server is still active.
@@ -84,7 +145,7 @@ describe("createTestServer", () => {
         }
     }, TEST_TIMEOUT_MS * 2);
 
-    test("cleanup shuts down cleanly", async () => {
+    testFn("cleanup shuts down cleanly", async () => {
         const server = await createTestServer();
         const baseUrl = server.baseUrl;
 

--- a/packages/server/tests/harness/server.test.ts
+++ b/packages/server/tests/harness/server.test.ts
@@ -4,12 +4,8 @@
  * These tests verify that createTestServer():
  *   1. Spins up a real HTTP server that responds to requests
  *   2. Pre-creates a user with a working API key
- *   3. Multiple servers can run simultaneously (created sequentially, then accessed concurrently)
- *   4. Cleans up all resources on shutdown
- *
- * NOTE: Servers must be created sequentially (not with Promise.all) because
- * auth.ts and sio-state.ts use module-level singletons. Once created, multiple
- * servers can coexist and respond simultaneously.
+ *   3. Enforces the singleton constraint (second call while one is active throws)
+ *   4. Cleans up all resources on shutdown (no process hang)
  */
 
 import { describe, test, expect } from "bun:test";
@@ -23,8 +19,6 @@ describe("createTestServer", () => {
         const server = await createTestServer();
         try {
             const res = await fetch(`${server.baseUrl}/health`);
-            // Health may be degraded if Redis singletons were overwritten, but
-            // the server must respond with the expected shape.
             expect([200, 503]).toContain(res.status);
             const data = await res.json();
             expect(["ok", "degraded"]).toContain(data.status);
@@ -60,35 +54,35 @@ describe("createTestServer", () => {
         }
     }, TEST_TIMEOUT_MS);
 
-    test("multiple test servers can run concurrently", async () => {
-        // Create servers sequentially (module singletons require serial creation)
-        // then verify they can all respond simultaneously.
-        const s1 = await createTestServer();
-        const s2 = await createTestServer();
-        const s3 = await createTestServer();
-
+    test("singleton guard: creating a second server while one is active throws", async () => {
+        // This test verifies the documented singleton constraint:
+        // auth.ts and sio-state.ts use module-level singletons that cannot
+        // be safely reinitialised while a prior server is still active.
+        const server = await createTestServer();
         try {
-            // All servers should have different ports
-            const ports = new Set([s1.port, s2.port, s3.port]);
-            expect(ports.size).toBe(3);
-
-            // All servers should respond simultaneously (concurrent reads are fine)
-            const responses = await Promise.all([
-                fetch(`${s1.baseUrl}/health`),
-                fetch(`${s2.baseUrl}/health`),
-                fetch(`${s3.baseUrl}/health`),
-            ]);
-
-            for (const res of responses) {
-                expect([200, 503]).toContain(res.status);
-                const data = await res.json();
-                expect(["ok", "degraded"]).toContain(data.status);
+            let threw = false;
+            let errorMessage = "";
+            try {
+                await createTestServer();
+            } catch (err) {
+                threw = true;
+                errorMessage = err instanceof Error ? err.message : String(err);
             }
+            expect(threw).toBe(true);
+            expect(errorMessage).toContain("already active");
         } finally {
-            // Clean up all servers, ignoring individual errors
-            await Promise.allSettled([s1.cleanup(), s2.cleanup(), s3.cleanup()]);
+            await server.cleanup();
         }
-    }, TEST_TIMEOUT_MS * 3);
+
+        // After cleanup the guard is released — a new server should succeed
+        const server2 = await createTestServer();
+        try {
+            const res = await fetch(`${server2.baseUrl}/health`);
+            expect([200, 503]).toContain(res.status);
+        } finally {
+            await server2.cleanup();
+        }
+    }, TEST_TIMEOUT_MS * 2);
 
     test("cleanup shuts down cleanly", async () => {
         const server = await createTestServer();

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -195,11 +195,13 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
             if (sr) await sr.quit().catch(() => {});
         }
 
-        // Close pub/sub Redis
+        // Close pub/sub Redis.
+        // Use ?. on the method itself (not just the object) because mocked Redis clients
+        // from mock.module("redis", ...) may not implement .quit().
         if (pubSubConnected) {
             await Promise.allSettled([
-                pubClient?.quit() ?? Promise.resolve(),
-                subClient?.quit() ?? Promise.resolve(),
+                pubClient?.quit?.() ?? Promise.resolve(),
+                subClient?.quit?.() ?? Promise.resolve(),
             ]);
         }
 
@@ -239,11 +241,34 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
         // 4. Run DB migrations
         await runAllMigrations();
 
-        // 5. Create Redis pub/sub clients and connect them
+        // 5. Create Redis pub/sub clients and connect them.
+        //    Use two independent createClient() calls instead of .duplicate() because
+        //    mock.module("redis", ...) in other test files replaces createClient() with
+        //    a factory that returns objects without .duplicate(), causing a TypeError
+        //    when those tests run in the same Bun worker as the harness tests.
         pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
-        subClient = pubClient.duplicate() as RedisClientType;
+        subClient = createClient({ url: REDIS_URL }) as RedisClientType;
         await Promise.all([pubClient.connect(), subClient.connect()]);
         pubSubConnected = true;
+
+        // Verify this is a real Redis connection, not a test mock.
+        // Mock clients (from mock.module("redis", ...)) don't implement .ping().
+        // If this fails, throw a clear error so callers can skip rather than fail cryptically.
+        try {
+            const pong = await pubClient.ping();
+            if (pong !== "PONG") {
+                throw new Error(`unexpected PING response: ${JSON.stringify(pong)}`);
+            }
+        } catch (pingErr) {
+            const reason = pingErr instanceof Error ? pingErr.message : String(pingErr);
+            throw new Error(
+                `[test-harness] Redis not available at ${REDIS_URL} — ` +
+                `harness test should be skipped. ` +
+                `(${reason}) ` +
+                `If this is a mock-contamination issue, ensure harness tests ` +
+                `do not run in the same Bun worker as test files that call mock.module("redis", ...).`,
+            );
+        }
 
         // 6. We'll track the resolved port for the request converter
         let resolvedPort = 0;
@@ -356,8 +381,14 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
             throw new Error("[test-harness] Could not get userId from sign-in response");
         }
 
-        const cookies = signInRes.headers.getSetCookie();
-        const sessionCookie = cookies.join("; ");
+        // Extract only the name=value portion of each Set-Cookie header (the part before
+        // the first ';'). Joining the full header values would include cookie attributes
+        // like Path=/, HttpOnly, SameSite=Lax, etc., producing a malformed Cookie header.
+        const sessionCookie = signInRes.headers
+            .getSetCookie()
+            .map((c) => c.split(";")[0]!.trim())
+            .filter((c) => c.length > 0)
+            .join("; ");
 
         // ── Helpers ──────────────────────────────────────────────────────────────
 

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -1,0 +1,329 @@
+/**
+ * Test server factory — creates a real PizzaPi server on an ephemeral port
+ * with SQLite + Redis + Socket.IO for integration testing.
+ *
+ * IMPORTANT: createTestServer() uses module-level singletons from auth.ts and
+ * sio-state.ts. Concurrent server creation is NOT supported — create servers
+ * sequentially. Multiple servers can run simultaneously after creation; only
+ * the creation phase must be serialized.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Server as SocketIOServer } from "socket.io";
+import { createAdapter } from "@socket.io/redis-adapter";
+import { createClient, type RedisClientType } from "redis";
+
+import { initAuth, getTrustedOrigins } from "../../src/auth.js";
+import { runAllMigrations } from "../../src/migrations.js";
+import { handleFetch } from "../../src/handler.js";
+import { initStateRedis } from "../../src/ws/sio-state.js";
+import { initSioRegistry } from "../../src/ws/sio-registry.js";
+import { registerNamespaces } from "../../src/ws/namespaces/index.js";
+
+import type { TestServerOptions, TestServer } from "./types.js";
+
+const REDIS_URL = process.env.PIZZAPI_REDIS_URL ?? "redis://localhost:6379";
+
+// ── Unique IP generator ──────────────────────────────────────────────────────
+// The register rate limiter in routes/auth.ts is a module-level singleton
+// (shared across all test server instances). We generate a unique IP per server
+// so each creation gets its own rate-limit bucket and doesn't collide with others.
+let _serverCounter = 0;
+function uniqueTestClientIp(): string {
+    const n = ++_serverCounter;
+    return `10.255.${Math.floor(n / 256) % 256}.${n % 256}`;
+}
+
+// ── Node req/res ↔ fetch API helpers (mirrors src/index.ts) ─────────────────
+
+async function nodeReqToFetchRequest(req: IncomingMessage, port: number): Promise<Request> {
+    const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+        if (value === undefined) continue;
+        // Prevent client-supplied x-pizzapi-client-ip spoofing
+        if (key.toLowerCase() === "x-pizzapi-client-ip") continue;
+        if (Array.isArray(value)) {
+            for (const v of value) headers.append(key, v);
+        } else {
+            headers.set(key, value);
+        }
+    }
+
+    // Inject real client IP from the TCP socket
+    if (req.socket.remoteAddress) {
+        headers.set("x-pizzapi-client-ip", req.socket.remoteAddress);
+    }
+
+    const method = (req.method ?? "GET").toUpperCase();
+    const hasBody = method !== "GET" && method !== "HEAD";
+
+    // Pre-buffer the body from the Node.js stream into an ArrayBuffer.
+    //
+    // IMPORTANT: Do NOT pass the IncomingMessage stream directly as the Request
+    // body. handler.ts notes a known Bun issue: when a Request with a
+    // ReadableStream body is subsequently wrapped via `new Request(req, { headers })`
+    // (as the auth handler does), the stream fails to propagate and hangs
+    // indefinitely. Pre-buffering into an ArrayBuffer avoids this entirely.
+    let body: ArrayBuffer | undefined;
+    if (hasBody) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+        }
+        const buf = Buffer.concat(chunks);
+        body = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+    }
+
+    return new Request(url.toString(), {
+        method,
+        headers,
+        body,
+    });
+}
+
+async function sendFetchResponse(res: ServerResponse, response: Response): Promise<void> {
+    const headers: Record<string, string | string[]> = {};
+    response.headers.forEach((value, key) => {
+        const existing = headers[key];
+        if (existing !== undefined) {
+            headers[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+        } else {
+            headers[key] = value;
+        }
+    });
+
+    res.writeHead(response.status, headers);
+
+    if (!response.body) {
+        res.end();
+        return;
+    }
+
+    const reader = response.body.getReader();
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            res.write(value);
+        }
+    } finally {
+        reader.releaseLock();
+        res.end();
+    }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a fully initialized PizzaPi test server on an ephemeral port.
+ * Includes SQLite DB, Redis, Socket.IO, and a pre-created test user.
+ *
+ * Always call `cleanup()` when done to release all resources.
+ *
+ * NOTE: Uses module-level singletons (auth, sio-state). Do NOT call this
+ * concurrently — create servers sequentially to avoid race conditions.
+ */
+export async function createTestServer(opts?: TestServerOptions): Promise<TestServer> {
+    // 1. Temp directory for the SQLite DB
+    const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
+    const dbPath = join(tmpDir, "test.db");
+
+    // 2. Trust proxy for rate-limit tests (mirrors production behavior)
+    const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
+    process.env.PIZZAPI_TRUST_PROXY = "true";
+
+    // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
+    // that better-auth uses only for cookie domain (not for actual listening).
+    // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
+    const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
+
+    // 3. Init auth with temp DB
+    initAuth({
+        dbPath,
+        baseURL: placeholderBase,
+        secret: "test-secret-for-harness-at-least-32-chars-long!!",
+        disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
+        extraOrigins: opts?.trustedOrigins,
+    });
+
+    // 4. Run DB migrations
+    await runAllMigrations();
+
+    // 5. Create Redis pub/sub clients and connect them
+    const pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
+    const subClient = pubClient.duplicate() as RedisClientType;
+    await Promise.all([pubClient.connect(), subClient.connect()]);
+
+    // 6. We'll track the resolved port for the request converter
+    let resolvedPort = 0;
+
+    // Create the HTTP server with the handleFetch handler
+    const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+        try {
+            const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
+            const fetchRes = await handleFetch(fetchReq);
+            await sendFetchResponse(res, fetchRes);
+        } catch (e) {
+            console.error("[test-harness] Unhandled error:", e);
+            if (!res.headersSent) {
+                res.writeHead(500, { "content-type": "application/json" });
+            }
+            res.end(JSON.stringify({ error: "Internal server error" }));
+        }
+    });
+
+    // 7. Create Socket.IO server with Redis adapter
+    const io = new SocketIOServer(httpServer, {
+        cors: {
+            origin: getTrustedOrigins(),
+            credentials: true,
+        },
+        maxHttpBufferSize: 100 * 1024 * 1024,
+        pingInterval: 30_000,
+        pingTimeout: 60_000,
+        adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
+        transports: ["websocket", "polling"],
+    });
+
+    // 8. Init state Redis
+    await initStateRedis();
+
+    // 9. Init the Socket.IO registry
+    initSioRegistry(io);
+
+    // 10. Register all namespaces
+    registerNamespaces(io);
+
+    // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === "string") {
+        throw new Error("[test-harness] Could not determine server port");
+    }
+    resolvedPort = addr.port;
+
+    // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
+    const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
+
+    // 12. Create a test user via the /api/register endpoint.
+    //     Use a unique client IP per server instance so each registration gets its
+    //     own rate-limit bucket in the module-level registerRateLimiter singleton.
+    const testUserName = "Test User";
+    const testUserEmail = "testuser@pizzapi-harness.test";
+    const testUserPassword = "HarnessPass123";
+    const testClientIp = uniqueTestClientIp();
+
+    const registerRes = await fetch(`${baseUrl}/api/register`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            // Unique x-forwarded-for per server so the rate limiter assigns a
+            // separate bucket for each test server creation.
+            "x-forwarded-for": testClientIp,
+        },
+        body: JSON.stringify({
+            name: testUserName,
+            email: testUserEmail,
+            password: testUserPassword,
+        }),
+    });
+
+    if (!registerRes.ok) {
+        throw new Error(
+            `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+        );
+    }
+
+    const registerData = await registerRes.json() as { ok: boolean; key: string };
+    const apiKey = registerData.key;
+
+    // 13. Get a session cookie via better-auth sign-in.
+    //     The sign-in response includes the user object (with id) and Set-Cookie header.
+    const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            "x-forwarded-for": testClientIp,
+        },
+        body: JSON.stringify({
+            email: testUserEmail,
+            password: testUserPassword,
+        }),
+    });
+
+    if (!signInRes.ok) {
+        throw new Error(
+            `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
+        );
+    }
+
+    const signInData = await signInRes.json() as { user?: { id: string } };
+    const userId = signInData.user?.id ?? "";
+    if (!userId) {
+        throw new Error("[test-harness] Could not get userId from sign-in response");
+    }
+
+    const cookies = signInRes.headers.getSetCookie();
+    const sessionCookie = cookies.join("; ");
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    async function testFetch(path: string, init?: RequestInit): Promise<Response> {
+        const url = `${baseUrl}${path}`;
+        const headers = new Headers(init?.headers);
+
+        // Inject auth headers if not already present
+        if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
+            headers.set("x-pizzapi-api-key", apiKey);
+        }
+        if (!headers.has("cookie") && sessionCookie) {
+            headers.set("cookie", sessionCookie);
+        }
+
+        return fetch(url, { ...init, headers });
+    }
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+
+    async function cleanup(): Promise<void> {
+        // Restore PIZZAPI_TRUST_PROXY
+        if (savedTrustProxy === undefined) {
+            delete process.env.PIZZAPI_TRUST_PROXY;
+        } else {
+            process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+        }
+
+        // Close Socket.IO — this also closes the underlying httpServer internally,
+        // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
+        await new Promise<void>((resolve) => io.close(() => resolve()));
+
+        // Disconnect Redis clients
+        await Promise.allSettled([pubClient.quit(), subClient.quit()]);
+
+        // Clean up temp directory
+        try {
+            rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+            // Ignore cleanup errors
+        }
+    }
+
+    return {
+        port: resolvedPort,
+        baseUrl,
+        io,
+        apiKey,
+        userId,
+        userName: testUserName,
+        userEmail: testUserEmail,
+        sessionCookie,
+        fetch: testFetch,
+        cleanup,
+    };
+}

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -2,10 +2,19 @@
  * Test server factory — creates a real PizzaPi server on an ephemeral port
  * with SQLite + Redis + Socket.IO for integration testing.
  *
- * IMPORTANT: createTestServer() uses module-level singletons from auth.ts and
- * sio-state.ts. Concurrent server creation is NOT supported — create servers
- * sequentially. Multiple servers can run simultaneously after creation; only
- * the creation phase must be serialized.
+ * SINGLETON CONSTRAINT: Only ONE TestServer may be active at a time.
+ * PizzaPi's auth.ts and sio-state.ts use module-level singletons that cannot
+ * be shared or re-initialized across concurrent instances. Attempting to call
+ * createTestServer() while a previous server is still active will throw.
+ *
+ * Intended usage pattern:
+ *
+ *   describe("my suite", () => {
+ *     let server: TestServer;
+ *     beforeAll(async () => { server = await createTestServer(); });
+ *     afterAll(async () => { await server.cleanup(); });
+ *     // ... tests ...
+ *   });
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -19,13 +28,27 @@ import { createClient, type RedisClientType } from "redis";
 import { initAuth, getTrustedOrigins } from "../../src/auth.js";
 import { runAllMigrations } from "../../src/migrations.js";
 import { handleFetch } from "../../src/handler.js";
-import { initStateRedis } from "../../src/ws/sio-state.js";
+import { initStateRedis, getStateRedis } from "../../src/ws/sio-state.js";
 import { initSioRegistry } from "../../src/ws/sio-registry.js";
 import { registerNamespaces } from "../../src/ws/namespaces/index.js";
 
 import type { TestServerOptions, TestServer } from "./types.js";
 
 const REDIS_URL = process.env.PIZZAPI_REDIS_URL ?? "redis://localhost:6379";
+
+// ── Singleton guard ──────────────────────────────────────────────────────────
+// auth.ts and sio-state.ts hold module-level singletons. Re-initializing them
+// while a previous TestServer is active causes the older server to operate
+// against the newer globals, producing SQLiteError disk I/O errors when the
+// newer server's temp DB is removed on cleanup.
+let _activeServer = false;
+
+// ── Module-level env capture ─────────────────────────────────────────────────
+// Capture PIZZAPI_TRUST_PROXY at module load (once) so that cleanup() always
+// restores the genuine pre-test value — not an intermediate value written by
+// a previous createTestServer() call. Per-server save/restore would drift if
+// cleanup order ever diverged from creation order.
+const _originalTrustProxy: string | undefined = process.env.PIZZAPI_TRUST_PROXY;
 
 // ── Unique IP generator ──────────────────────────────────────────────────────
 // The register rate limiter in routes/auth.ts is a module-level singleton
@@ -125,205 +148,282 @@ async function sendFetchResponse(res: ServerResponse, response: Response): Promi
  *
  * Always call `cleanup()` when done to release all resources.
  *
- * NOTE: Uses module-level singletons (auth, sio-state). Do NOT call this
- * concurrently — create servers sequentially to avoid race conditions.
+ * SINGLETON: Only one TestServer may be active at a time. Calling this while
+ * a previous server is still running throws immediately. Call cleanup() on the
+ * existing server first.
  */
 export async function createTestServer(opts?: TestServerOptions): Promise<TestServer> {
-    // 1. Temp directory for the SQLite DB
-    const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
-    const dbPath = join(tmpDir, "test.db");
-
-    // 2. Trust proxy for rate-limit tests (mirrors production behavior)
-    const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
-    process.env.PIZZAPI_TRUST_PROXY = "true";
-
-    // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
-    // that better-auth uses only for cookie domain (not for actual listening).
-    // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
-    const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
-
-    // 3. Init auth with temp DB
-    initAuth({
-        dbPath,
-        baseURL: placeholderBase,
-        secret: "test-secret-for-harness-at-least-32-chars-long!!",
-        disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
-        extraOrigins: opts?.trustedOrigins,
-    });
-
-    // 4. Run DB migrations
-    await runAllMigrations();
-
-    // 5. Create Redis pub/sub clients and connect them
-    const pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
-    const subClient = pubClient.duplicate() as RedisClientType;
-    await Promise.all([pubClient.connect(), subClient.connect()]);
-
-    // 6. We'll track the resolved port for the request converter
-    let resolvedPort = 0;
-
-    // Create the HTTP server with the handleFetch handler
-    const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-        try {
-            const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
-            const fetchRes = await handleFetch(fetchReq);
-            await sendFetchResponse(res, fetchRes);
-        } catch (e) {
-            console.error("[test-harness] Unhandled error:", e);
-            if (!res.headersSent) {
-                res.writeHead(500, { "content-type": "application/json" });
-            }
-            res.end(JSON.stringify({ error: "Internal server error" }));
-        }
-    });
-
-    // 7. Create Socket.IO server with Redis adapter
-    const io = new SocketIOServer(httpServer, {
-        cors: {
-            origin: getTrustedOrigins(),
-            credentials: true,
-        },
-        maxHttpBufferSize: 100 * 1024 * 1024,
-        pingInterval: 30_000,
-        pingTimeout: 60_000,
-        adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
-        transports: ["websocket", "polling"],
-    });
-
-    // 8. Init state Redis
-    await initStateRedis();
-
-    // 9. Init the Socket.IO registry
-    initSioRegistry(io);
-
-    // 10. Register all namespaces
-    registerNamespaces(io);
-
-    // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
-    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
-
-    const addr = httpServer.address();
-    if (!addr || typeof addr === "string") {
-        throw new Error("[test-harness] Could not determine server port");
-    }
-    resolvedPort = addr.port;
-
-    // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
-    const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
-
-    // 12. Create a test user via the /api/register endpoint.
-    //     Use a unique client IP per server instance so each registration gets its
-    //     own rate-limit bucket in the module-level registerRateLimiter singleton.
-    const testUserName = "Test User";
-    const testUserEmail = "testuser@pizzapi-harness.test";
-    const testUserPassword = "HarnessPass123";
-    const testClientIp = uniqueTestClientIp();
-
-    const registerRes = await fetch(`${baseUrl}/api/register`, {
-        method: "POST",
-        headers: {
-            "content-type": "application/json",
-            // Unique x-forwarded-for per server so the rate limiter assigns a
-            // separate bucket for each test server creation.
-            "x-forwarded-for": testClientIp,
-        },
-        body: JSON.stringify({
-            name: testUserName,
-            email: testUserEmail,
-            password: testUserPassword,
-        }),
-    });
-
-    if (!registerRes.ok) {
+    // ── Singleton guard ──────────────────────────────────────────────────────
+    if (_activeServer) {
         throw new Error(
-            `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+            "[test-harness] A TestServer is already active. " +
+            "Call cleanup() on the existing server before creating another. " +
+            "auth.ts and sio-state.ts use module-level singletons that cannot " +
+            "be shared across concurrent TestServer instances.",
         );
     }
+    _activeServer = true;
 
-    const registerData = await registerRes.json() as { ok: boolean; key: string };
-    const apiKey = registerData.key;
+    // ── Setup with rollback on failure ───────────────────────────────────────
+    // Track resources opened so far so we can close them if setup throws.
+    let tmpDir: string | null = null;
+    let pubClient: RedisClientType | null = null;
+    let subClient: RedisClientType | null = null;
+    let pubSubConnected = false;
+    let httpServer: ReturnType<typeof createServer> | null = null;
+    let io: SocketIOServer | null = null;
+    let stateRedisInited = false;
 
-    // 13. Get a session cookie via better-auth sign-in.
-    //     The sign-in response includes the user object (with id) and Set-Cookie header.
-    const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
-        method: "POST",
-        headers: {
-            "content-type": "application/json",
-            "x-forwarded-for": testClientIp,
-        },
-        body: JSON.stringify({
-            email: testUserEmail,
-            password: testUserPassword,
-        }),
-    });
+    async function rollback(): Promise<void> {
+        _activeServer = false;
 
-    if (!signInRes.ok) {
-        throw new Error(
-            `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
-        );
-    }
-
-    const signInData = await signInRes.json() as { user?: { id: string } };
-    const userId = signInData.user?.id ?? "";
-    if (!userId) {
-        throw new Error("[test-harness] Could not get userId from sign-in response");
-    }
-
-    const cookies = signInRes.headers.getSetCookie();
-    const sessionCookie = cookies.join("; ");
-
-    // ── Helpers ──────────────────────────────────────────────────────────────
-
-    async function testFetch(path: string, init?: RequestInit): Promise<Response> {
-        const url = `${baseUrl}${path}`;
-        const headers = new Headers(init?.headers);
-
-        // Inject auth headers if not already present
-        if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
-            headers.set("x-pizzapi-api-key", apiKey);
-        }
-        if (!headers.has("cookie") && sessionCookie) {
-            headers.set("cookie", sessionCookie);
-        }
-
-        return fetch(url, { ...init, headers });
-    }
-
-    // ── Cleanup ──────────────────────────────────────────────────────────────
-
-    async function cleanup(): Promise<void> {
-        // Restore PIZZAPI_TRUST_PROXY
-        if (savedTrustProxy === undefined) {
+        // Restore env (use the module-level original, not a per-server snapshot)
+        if (_originalTrustProxy === undefined) {
             delete process.env.PIZZAPI_TRUST_PROXY;
         } else {
-            process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+            process.env.PIZZAPI_TRUST_PROXY = _originalTrustProxy;
         }
 
-        // Close Socket.IO — this also closes the underlying httpServer internally,
-        // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
-        await new Promise<void>((resolve) => io.close(() => resolve()));
+        // Close Socket.IO (also closes httpServer)
+        if (io) {
+            await new Promise<void>((resolve) => io!.close(() => resolve())).catch(() => {});
+        }
 
-        // Disconnect Redis clients
-        await Promise.allSettled([pubClient.quit(), subClient.quit()]);
+        // Close state Redis
+        if (stateRedisInited) {
+            const sr = getStateRedis();
+            if (sr) await sr.quit().catch(() => {});
+        }
+
+        // Close pub/sub Redis
+        if (pubSubConnected) {
+            await Promise.allSettled([
+                pubClient?.quit() ?? Promise.resolve(),
+                subClient?.quit() ?? Promise.resolve(),
+            ]);
+        }
 
         // Clean up temp directory
-        try {
-            rmSync(tmpDir, { recursive: true, force: true });
-        } catch {
-            // Ignore cleanup errors
+        if (tmpDir) {
+            try {
+                rmSync(tmpDir, { recursive: true, force: true });
+            } catch {
+                // ignore
+            }
         }
     }
 
-    return {
-        port: resolvedPort,
-        baseUrl,
-        io,
-        apiKey,
-        userId,
-        userName: testUserName,
-        userEmail: testUserEmail,
-        sessionCookie,
-        fetch: testFetch,
-        cleanup,
-    };
+    try {
+        // 1. Temp directory for the SQLite DB
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
+        const dbPath = join(tmpDir, "test.db");
+
+        // 2. Trust proxy for rate-limit tests (mirrors production behavior).
+        //    Set process-wide; cleanup() will restore _originalTrustProxy.
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+
+        // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
+        // that better-auth uses only for cookie domain (not for actual listening).
+        // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
+        const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
+
+        // 3. Init auth with temp DB
+        initAuth({
+            dbPath,
+            baseURL: placeholderBase,
+            secret: "test-secret-for-harness-at-least-32-chars-long!!",
+            disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
+            extraOrigins: opts?.trustedOrigins,
+        });
+
+        // 4. Run DB migrations
+        await runAllMigrations();
+
+        // 5. Create Redis pub/sub clients and connect them
+        pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
+        subClient = pubClient.duplicate() as RedisClientType;
+        await Promise.all([pubClient.connect(), subClient.connect()]);
+        pubSubConnected = true;
+
+        // 6. We'll track the resolved port for the request converter
+        let resolvedPort = 0;
+
+        // Create the HTTP server with the handleFetch handler
+        httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+            try {
+                const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
+                const fetchRes = await handleFetch(fetchReq);
+                await sendFetchResponse(res, fetchRes);
+            } catch (e) {
+                console.error("[test-harness] Unhandled error:", e);
+                if (!res.headersSent) {
+                    res.writeHead(500, { "content-type": "application/json" });
+                }
+                res.end(JSON.stringify({ error: "Internal server error" }));
+            }
+        });
+
+        // 7. Create Socket.IO server with Redis adapter
+        io = new SocketIOServer(httpServer, {
+            cors: {
+                origin: getTrustedOrigins(),
+                credentials: true,
+            },
+            maxHttpBufferSize: 100 * 1024 * 1024,
+            pingInterval: 30_000,
+            pingTimeout: 60_000,
+            adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
+            transports: ["websocket", "polling"],
+        });
+
+        // 8. Init state Redis
+        await initStateRedis();
+        stateRedisInited = true;
+
+        // 9. Init the Socket.IO registry
+        initSioRegistry(io);
+
+        // 10. Register all namespaces
+        registerNamespaces(io);
+
+        // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
+        await new Promise<void>((resolve) => httpServer!.listen(0, "127.0.0.1", resolve));
+
+        const addr = httpServer.address();
+        if (!addr || typeof addr === "string") {
+            throw new Error("[test-harness] Could not determine server port");
+        }
+        resolvedPort = addr.port;
+
+        // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
+        const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
+
+        // 12. Create a test user via the /api/register endpoint.
+        //     Use a unique client IP per server instance so each registration gets its
+        //     own rate-limit bucket in the module-level registerRateLimiter singleton.
+        const testUserName = "Test User";
+        const testUserEmail = "testuser@pizzapi-harness.test";
+        const testUserPassword = "HarnessPass123";
+        const testClientIp = uniqueTestClientIp();
+
+        const registerRes = await fetch(`${baseUrl}/api/register`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                // Unique x-forwarded-for per server so the rate limiter assigns a
+                // separate bucket for each test server creation.
+                "x-forwarded-for": testClientIp,
+            },
+            body: JSON.stringify({
+                name: testUserName,
+                email: testUserEmail,
+                password: testUserPassword,
+            }),
+        });
+
+        if (!registerRes.ok) {
+            throw new Error(
+                `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+            );
+        }
+
+        const registerData = await registerRes.json() as { ok: boolean; key: string };
+        const apiKey = registerData.key;
+
+        // 13. Get a session cookie via better-auth sign-in.
+        //     The sign-in response includes the user object (with id) and Set-Cookie header.
+        const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "x-forwarded-for": testClientIp,
+            },
+            body: JSON.stringify({
+                email: testUserEmail,
+                password: testUserPassword,
+            }),
+        });
+
+        if (!signInRes.ok) {
+            throw new Error(
+                `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
+            );
+        }
+
+        const signInData = await signInRes.json() as { user?: { id: string } };
+        const userId = signInData.user?.id ?? "";
+        if (!userId) {
+            throw new Error("[test-harness] Could not get userId from sign-in response");
+        }
+
+        const cookies = signInRes.headers.getSetCookie();
+        const sessionCookie = cookies.join("; ");
+
+        // ── Helpers ──────────────────────────────────────────────────────────────
+
+        async function testFetch(path: string, init?: RequestInit): Promise<Response> {
+            const url = `${baseUrl}${path}`;
+            const headers = new Headers(init?.headers);
+
+            // Inject auth headers if not already present
+            if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
+                headers.set("x-pizzapi-api-key", apiKey);
+            }
+            if (!headers.has("cookie") && sessionCookie) {
+                headers.set("cookie", sessionCookie);
+            }
+
+            return fetch(url, { ...init, headers });
+        }
+
+        // ── Cleanup ──────────────────────────────────────────────────────────────
+
+        async function cleanup(): Promise<void> {
+            // Restore PIZZAPI_TRUST_PROXY to the original pre-test value
+            if (_originalTrustProxy === undefined) {
+                delete process.env.PIZZAPI_TRUST_PROXY;
+            } else {
+                process.env.PIZZAPI_TRUST_PROXY = _originalTrustProxy;
+            }
+
+            // Close Socket.IO — this also closes the underlying httpServer internally,
+            // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
+            await new Promise<void>((resolve) => io!.close(() => resolve()));
+
+            // Close state Redis (prevents process hang)
+            const stateRedis = getStateRedis();
+            if (stateRedis) {
+                await stateRedis.quit().catch(() => {});
+            }
+
+            // Disconnect pub/sub Redis clients
+            await Promise.allSettled([pubClient!.quit(), subClient!.quit()]);
+
+            // Clean up temp directory
+            try {
+                rmSync(tmpDir!, { recursive: true, force: true });
+            } catch {
+                // Ignore cleanup errors
+            }
+
+            // Release the singleton guard so a new TestServer can be created
+            _activeServer = false;
+        }
+
+        return {
+            port: resolvedPort,
+            baseUrl,
+            io,
+            apiKey,
+            userId,
+            userName: testUserName,
+            userEmail: testUserEmail,
+            sessionCookie,
+            fetch: testFetch,
+            cleanup,
+        };
+    } catch (err) {
+        await rollback();
+        throw err;
+    }
 }

--- a/packages/server/tests/harness/types.ts
+++ b/packages/server/tests/harness/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types for the test server harness.
+ */
+
+export interface TestServerOptions {
+    /** Override base URL (default: auto from port) */
+    baseUrl?: string;
+    /** Extra trusted origins for CORS */
+    trustedOrigins?: string[];
+    /** Disable signup-after-first-user restriction (default: true = disabled) */
+    disableSignupAfterFirstUser?: boolean;
+}
+
+export interface TestServer {
+    /** Ephemeral port the server is listening on */
+    port: number;
+    /** Base URL: http://localhost:{port} */
+    baseUrl: string;
+    /** The Socket.IO server instance */
+    io: import("socket.io").Server;
+    /** Pre-created API key for auth */
+    apiKey: string;
+    /** Pre-created test user's ID */
+    userId: string;
+    /** Pre-created test user's name */
+    userName: string;
+    /** Pre-created test user's email */
+    userEmail: string;
+    /** Auth session cookie string for viewer/hub namespaces */
+    sessionCookie: string;
+    /** Helper: make an authenticated REST request */
+    fetch(path: string, init?: RequestInit): Promise<Response>;
+    /** Shut down everything and clean up */
+    cleanup(): Promise<void>;
+}


### PR DESCRIPTION
Night Shift dish 001: Creates `packages/server/tests/harness/` with `createTestServer()` factory that spins up a real PizzaPi server on an ephemeral port with SQLite + Redis + Socket.IO for integration testing.

## What's Added

- `tests/harness/types.ts` — `TestServer` and `TestServerOptions` interfaces
- `tests/harness/server.ts` — `createTestServer()` factory
- `tests/harness/index.ts` — barrel export
- `tests/harness/server.test.ts` — 4 smoke tests

## How It Works

`createTestServer()` spins up a complete PizzaPi stack:
1. Temp SQLite DB via `initAuth()` + `runAllMigrations()`
2. Redis pub/sub clients
3. Node.js HTTP server using `handleFetch` (same as production)
4. Socket.IO with Redis adapter on the same port
5. Pre-created test user with API key and session cookie

Returns a `TestServer` with `port`, `baseUrl`, `io`, `apiKey`, `userId`, `sessionCookie`, and helper methods `fetch()` + `cleanup()`.

## Key Implementation Notes

- Uses `127.0.0.1` (not `localhost`) to avoid IPv6 resolution on macOS
- Pre-buffers request body from Node.js `IncomingMessage` into `ArrayBuffer` — avoids a known Bun hang when `ReadableStream` bodies are re-wrapped in `Request` (documented in `handler.ts`)
- Generates unique `x-forwarded-for` IPs per server to avoid rate-limit collisions across the module-level `registerRateLimiter` singleton
- `io.close()` also closes the HTTP server; cleanup does not double-close
- Documents that `createTestServer()` must be called serially (module-level singletons in `auth.ts` and `sio-state.ts`)

## Test Results

```
4 pass, 0 fail
Ran 4 tests across 1 file [2.26s]
```

Typecheck: clean