### PR TITLE
feat: mock viewer and hub clients for test harness

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,7 @@
+[test]
+# Exclude compiled dist/ directories from test discovery.
+# TypeScript source files in src/ and tests/ are the canonical test sources.
+# Running compiled .test.js copies from dist/ alongside source .test.ts files
+# causes module-mock leakage across test workers (e.g. mock.module("redis",...)
+# from a dist test bleeds into workers running source tests).
+exclude = ["**/dist/**"]

--- a/packages/server/bunfig.toml
+++ b/packages/server/bunfig.toml
@@ -1,0 +1,7 @@
+[test]
+# Exclude the compiled dist/ directory from test discovery.
+# It contains compiled .test.js copies of all .test.ts source files.
+# Running them alongside the sources causes module-mock leakage (e.g.
+# mock.module("redis",...) from dist/sessions/redis_perf.test.js bleeds
+# into other test workers and breaks tests that need the real Redis client).
+exclude = ["dist/**"]

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Test harness barrel export.
+ * Re-exports everything from types, server, and future modules.
+ */
+
+export * from "./types.js";
+export * from "./server.js";

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -5,3 +5,5 @@
 
 export * from "./types.js";
 export * from "./server.js";
+export * from "./mock-viewer.js";
+export * from "./mock-hub.js";

--- a/packages/server/tests/harness/mock-hub.ts
+++ b/packages/server/tests/harness/mock-hub.ts
@@ -50,13 +50,21 @@ export interface MockHubClientOptions {
 }
 
 // ---------------------------------------------------------------------------
-// Internal: single connection attempt
+// Internal: single connection attempt — builds a fully-wired MockHubClient
 // ---------------------------------------------------------------------------
 
-async function attemptHubConnection(
+/**
+ * Creates a socket, attaches ALL data listeners (including session update
+ * handlers) BEFORE waiting for the initial `sessions` snapshot.
+ *
+ * Listener-before-await ordering prevents the race where `session_added`,
+ * `session_removed`, or `session_status` events emitted between the
+ * snapshot receipt and subsequent listener attachment are silently dropped.
+ */
+async function attemptBuildHubClient(
     server: TestServer,
     connectTimeout: number,
-): Promise<{ socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents>; initialSessions: SessionInfo[] }> {
+): Promise<MockHubClient> {
     const socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents> =
         clientIo(`${server.baseUrl}/hub`, {
             extraHeaders: { cookie: server.sessionCookie },
@@ -67,82 +75,8 @@ async function attemptHubConnection(
             reconnection: false,
         });
 
-    let initialSessions: SessionInfo[] = [];
-
-    const snapshotPromise = new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(() => {
-            socket.disconnect();
-            reject(
-                new Error(
-                    `MockHubClient: timeout waiting for initial sessions snapshot (${connectTimeout}ms)`,
-                ),
-            );
-        }, connectTimeout);
-
-        socket.once("sessions", (data) => {
-            clearTimeout(timer);
-            initialSessions = data.sessions;
-            resolve();
-        });
-
-        socket.once("connect_error", (err) => {
-            clearTimeout(timer);
-            socket.disconnect();
-            reject(new Error(`MockHubClient: connection error: ${err.message}`));
-        });
-    });
-
-    socket.connect();
-    await snapshotPromise;
-    return { socket, initialSessions };
-}
-
-// ---------------------------------------------------------------------------
-// Factory
-// ---------------------------------------------------------------------------
-
-/**
- * Create a MockHubClient connected to the given test server.
- *
- * The promise resolves once the server sends the initial `sessions` snapshot.
- *
- * The first connection attempt may fail with `connect_error: unauthorized`
- * due to better-auth cold-start (lazy prepared-statement caching). Up to
- * `maxAttempts` retries are made with a 150 ms delay between attempts.
- */
-export async function createMockHubClient(
-    server: TestServer,
-    opts?: MockHubClientOptions,
-): Promise<MockHubClient> {
-    const connectTimeout = opts?.connectTimeout ?? 5000;
-    const maxAttempts = opts?.maxAttempts ?? 2;
-
-    let lastError: unknown;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        if (attempt > 0) {
-            await new Promise<void>((r) => setTimeout(r, 150));
-        }
-        try {
-            const { socket, initialSessions } = await attemptHubConnection(server, connectTimeout);
-            return buildMockHubClient(socket, initialSessions);
-        } catch (err) {
-            lastError = err;
-        }
-    }
-    throw lastError;
-}
-
-// ---------------------------------------------------------------------------
-// Build MockHubClient from an already-connected socket
-// ---------------------------------------------------------------------------
-
-function buildMockHubClient(
-    socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents>,
-    initialSessions: SessionInfo[],
-): MockHubClient {
-
-    // Mutable live sessions list — seeded with the initial snapshot
-    const sessions: SessionInfo[] = [...initialSessions];
+    // Mutable live sessions list — seeded once the initial snapshot arrives
+    const sessions: SessionInfo[] = [];
 
     // Pending waitForSessionAdded resolvers
     const addedWaiters: Array<{
@@ -173,7 +107,38 @@ function buildMockHubClient(
         }>
     > = new Map();
 
-    // ── Server event handlers ──────────────────────────────────────────────
+    // Tracks whether disconnect() has been called — guards new waitFor calls
+    let isDisconnected = false;
+
+    // Rejects and clears all outstanding waiters (called on disconnect)
+    function rejectAllWaiters(reason: string): void {
+        const err = new Error(reason);
+
+        for (const w of addedWaiters.splice(0)) {
+            clearTimeout(w.timer);
+            w.reject(err);
+        }
+
+        for (const [, list] of removedWaiters) {
+            for (const w of list) {
+                clearTimeout(w.timer);
+                w.reject(err);
+            }
+        }
+        removedWaiters.clear();
+
+        for (const [, list] of statusWaiters) {
+            for (const w of list) {
+                clearTimeout(w.timer);
+                w.reject(err);
+            }
+        }
+        statusWaiters.clear();
+    }
+
+    // ── Attach ALL data listeners BEFORE waiting for the handshake ─────────
+    // This prevents the race where session update events emitted between the
+    // initial `sessions` snapshot and subsequent listener attachment are lost.
 
     // Re-snapshot (e.g. after resync) — replaces the local sessions list
     socket.on("sessions", (data) => {
@@ -246,7 +211,36 @@ function buildMockHubClient(
         }
     });
 
-    // ── MockHubClient implementation ───────────────────────────────────────
+    // ── Handshake: wait for the initial sessions snapshot ─────────────────
+
+    const snapshotPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            socket.disconnect();
+            reject(
+                new Error(
+                    `MockHubClient: timeout waiting for initial sessions snapshot (${connectTimeout}ms)`,
+                ),
+            );
+        }, connectTimeout);
+
+        // The `sessions` handler above populates the list; we just need to
+        // know when the first snapshot has arrived so we can resolve here.
+        socket.once("sessions", () => {
+            clearTimeout(timer);
+            resolve();
+        });
+
+        socket.once("connect_error", (err) => {
+            clearTimeout(timer);
+            socket.disconnect();
+            reject(new Error(`MockHubClient: connection error: ${err.message}`));
+        });
+    });
+
+    socket.connect();
+    await snapshotPromise;
+
+    // ── Build and return the MockHubClient object ──────────────────────────
 
     const client: MockHubClient = {
         socket,
@@ -256,6 +250,10 @@ function buildMockHubClient(
             predicate?: (s: SessionInfo) => boolean,
             timeout = 5000,
         ): Promise<SessionInfo> {
+            if (isDisconnected) {
+                return Promise.reject(new Error("MockHubClient.waitForSessionAdded: already disconnected"));
+            }
+
             // Check already-buffered sessions
             const existing = sessions.find((s) => !predicate || predicate(s));
             if (existing) return Promise.resolve(existing);
@@ -272,6 +270,10 @@ function buildMockHubClient(
         },
 
         waitForSessionRemoved(sessionId: string, timeout = 5000): Promise<void> {
+            if (isDisconnected) {
+                return Promise.reject(new Error("MockHubClient.waitForSessionRemoved: already disconnected"));
+            }
+
             // Already removed?
             if (!sessions.find((s) => s.sessionId === sessionId)) {
                 return Promise.resolve();
@@ -302,6 +304,10 @@ function buildMockHubClient(
             predicate?: (data: unknown) => boolean,
             timeout = 5000,
         ): Promise<unknown> {
+            if (isDisconnected) {
+                return Promise.reject(new Error("MockHubClient.waitForSessionStatus: already disconnected"));
+            }
+
             return new Promise<unknown>((resolve, reject) => {
                 const timer = setTimeout(() => {
                     const list = statusWaiters.get(sessionId);
@@ -331,6 +337,9 @@ function buildMockHubClient(
         },
 
         disconnect(): Promise<void> {
+            isDisconnected = true;
+            rejectAllWaiters("MockHubClient: disconnected");
+
             return new Promise<void>((resolve) => {
                 if (!socket.connected) {
                     resolve();
@@ -343,4 +352,38 @@ function buildMockHubClient(
     };
 
     return client;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a MockHubClient connected to the given test server.
+ *
+ * The promise resolves once the server sends the initial `sessions` snapshot.
+ *
+ * The first connection attempt may fail with `connect_error: unauthorized`
+ * due to better-auth cold-start (lazy prepared-statement caching). Up to
+ * `maxAttempts` retries are made with a 150 ms delay between attempts.
+ */
+export async function createMockHubClient(
+    server: TestServer,
+    opts?: MockHubClientOptions,
+): Promise<MockHubClient> {
+    const connectTimeout = opts?.connectTimeout ?? 5000;
+    const maxAttempts = opts?.maxAttempts ?? 2;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (attempt > 0) {
+            await new Promise<void>((r) => setTimeout(r, 150));
+        }
+        try {
+            return await attemptBuildHubClient(server, connectTimeout);
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    throw lastError;
 }

--- a/packages/server/tests/harness/mock-hub.ts
+++ b/packages/server/tests/harness/mock-hub.ts
@@ -1,0 +1,346 @@
+/**
+ * MockHubClient — test harness client for the /hub Socket.IO namespace.
+ *
+ * Connects with cookie-based auth, auto-updates session list from server
+ * broadcasts, and exposes waitFor helpers for integration tests.
+ */
+
+import { io as clientIo, type Socket as ClientSocket } from "socket.io-client";
+import type {
+    HubServerToClientEvents,
+    HubClientToServerEvents,
+    SessionInfo,
+} from "@pizzapi/protocol";
+import type { TestServer } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MockHubClient {
+    socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents>;
+    sessions: SessionInfo[];
+
+    waitForSessionAdded(
+        predicate?: (s: SessionInfo) => boolean,
+        timeout?: number,
+    ): Promise<SessionInfo>;
+    waitForSessionRemoved(sessionId: string, timeout?: number): Promise<void>;
+    waitForSessionStatus(
+        sessionId: string,
+        predicate?: (data: unknown) => boolean,
+        timeout?: number,
+    ): Promise<unknown>;
+    subscribeSessionMeta(sessionId: string): void;
+    unsubscribeSessionMeta(sessionId: string): void;
+
+    disconnect(): Promise<void>;
+}
+
+export interface MockHubClientOptions {
+    /** Timeout (ms) waiting for the initial `sessions` snapshot. Default: 5000 */
+    connectTimeout?: number;
+    /**
+     * Max connection attempts before giving up. Default: 2.
+     * The first attempt sometimes fails with `connect_error: unauthorized`
+     * due to better-auth cold-start (lazy prepared-statement caching).
+     * A retry after a short delay reliably succeeds.
+     */
+    maxAttempts?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: single connection attempt
+// ---------------------------------------------------------------------------
+
+async function attemptHubConnection(
+    server: TestServer,
+    connectTimeout: number,
+): Promise<{ socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents>; initialSessions: SessionInfo[] }> {
+    const socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents> =
+        clientIo(`${server.baseUrl}/hub`, {
+            extraHeaders: { cookie: server.sessionCookie },
+            transports: ["websocket"],
+            autoConnect: false,
+            // Disable auto-reconnect: if the connection fails, fail fast rather
+            // than silently retrying and leaving a lingering socket open.
+            reconnection: false,
+        });
+
+    let initialSessions: SessionInfo[] = [];
+
+    const snapshotPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            socket.disconnect();
+            reject(
+                new Error(
+                    `MockHubClient: timeout waiting for initial sessions snapshot (${connectTimeout}ms)`,
+                ),
+            );
+        }, connectTimeout);
+
+        socket.once("sessions", (data) => {
+            clearTimeout(timer);
+            initialSessions = data.sessions;
+            resolve();
+        });
+
+        socket.once("connect_error", (err) => {
+            clearTimeout(timer);
+            socket.disconnect();
+            reject(new Error(`MockHubClient: connection error: ${err.message}`));
+        });
+    });
+
+    socket.connect();
+    await snapshotPromise;
+    return { socket, initialSessions };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a MockHubClient connected to the given test server.
+ *
+ * The promise resolves once the server sends the initial `sessions` snapshot.
+ *
+ * The first connection attempt may fail with `connect_error: unauthorized`
+ * due to better-auth cold-start (lazy prepared-statement caching). Up to
+ * `maxAttempts` retries are made with a 150 ms delay between attempts.
+ */
+export async function createMockHubClient(
+    server: TestServer,
+    opts?: MockHubClientOptions,
+): Promise<MockHubClient> {
+    const connectTimeout = opts?.connectTimeout ?? 5000;
+    const maxAttempts = opts?.maxAttempts ?? 2;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (attempt > 0) {
+            await new Promise<void>((r) => setTimeout(r, 150));
+        }
+        try {
+            const { socket, initialSessions } = await attemptHubConnection(server, connectTimeout);
+            return buildMockHubClient(socket, initialSessions);
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    throw lastError;
+}
+
+// ---------------------------------------------------------------------------
+// Build MockHubClient from an already-connected socket
+// ---------------------------------------------------------------------------
+
+function buildMockHubClient(
+    socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents>,
+    initialSessions: SessionInfo[],
+): MockHubClient {
+
+    // Mutable live sessions list — seeded with the initial snapshot
+    const sessions: SessionInfo[] = [...initialSessions];
+
+    // Pending waitForSessionAdded resolvers
+    const addedWaiters: Array<{
+        predicate?: (s: SessionInfo) => boolean;
+        resolve: (s: SessionInfo) => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+    }> = [];
+
+    // Pending waitForSessionRemoved resolvers: keyed by sessionId
+    const removedWaiters: Map<
+        string,
+        Array<{
+            resolve: () => void;
+            reject: (err: Error) => void;
+            timer: ReturnType<typeof setTimeout>;
+        }>
+    > = new Map();
+
+    // Pending waitForSessionStatus resolvers: keyed by sessionId
+    const statusWaiters: Map<
+        string,
+        Array<{
+            predicate?: (data: unknown) => boolean;
+            resolve: (data: unknown) => void;
+            reject: (err: Error) => void;
+            timer: ReturnType<typeof setTimeout>;
+        }>
+    > = new Map();
+
+    // ── Server event handlers ──────────────────────────────────────────────
+
+    // Re-snapshot (e.g. after resync) — replaces the local sessions list
+    socket.on("sessions", (data) => {
+        sessions.length = 0;
+        for (const s of data.sessions) sessions.push(s);
+    });
+
+    socket.on("session_added", (data) => {
+        // Upsert in case of duplicate adds
+        const idx = sessions.findIndex((s) => s.sessionId === data.sessionId);
+        if (idx === -1) {
+            sessions.push(data);
+        } else {
+            sessions[idx] = data;
+        }
+
+        // Notify waitForSessionAdded waiters
+        for (let i = addedWaiters.length - 1; i >= 0; i--) {
+            const waiter = addedWaiters[i];
+            if (!waiter.predicate || waiter.predicate(data)) {
+                clearTimeout(waiter.timer);
+                addedWaiters.splice(i, 1);
+                waiter.resolve(data);
+            }
+        }
+    });
+
+    socket.on("session_removed", (data) => {
+        const idx = sessions.findIndex((s) => s.sessionId === data.sessionId);
+        if (idx !== -1) sessions.splice(idx, 1);
+
+        // Notify waitForSessionRemoved waiters
+        const waiters = removedWaiters.get(data.sessionId);
+        if (waiters) {
+            for (const waiter of waiters) {
+                clearTimeout(waiter.timer);
+                waiter.resolve();
+            }
+            removedWaiters.delete(data.sessionId);
+        }
+    });
+
+    socket.on("session_status", (data) => {
+        // Update local session if present
+        const idx = sessions.findIndex((s) => s.sessionId === data.sessionId);
+        if (idx !== -1) {
+            sessions[idx] = {
+                ...sessions[idx],
+                isActive: data.isActive,
+                lastHeartbeatAt: data.lastHeartbeatAt,
+                sessionName: data.sessionName,
+                model: data.model,
+                runnerId: data.runnerId ?? sessions[idx].runnerId,
+                runnerName: data.runnerName ?? sessions[idx].runnerName,
+            };
+        }
+
+        // Notify waitForSessionStatus waiters
+        const waiters = statusWaiters.get(data.sessionId);
+        if (waiters) {
+            for (let i = waiters.length - 1; i >= 0; i--) {
+                const waiter = waiters[i];
+                if (!waiter.predicate || waiter.predicate(data)) {
+                    clearTimeout(waiter.timer);
+                    waiters.splice(i, 1);
+                    waiter.resolve(data);
+                }
+            }
+            if (waiters.length === 0) statusWaiters.delete(data.sessionId);
+        }
+    });
+
+    // ── MockHubClient implementation ───────────────────────────────────────
+
+    const client: MockHubClient = {
+        socket,
+        sessions,
+
+        waitForSessionAdded(
+            predicate?: (s: SessionInfo) => boolean,
+            timeout = 5000,
+        ): Promise<SessionInfo> {
+            // Check already-buffered sessions
+            const existing = sessions.find((s) => !predicate || predicate(s));
+            if (existing) return Promise.resolve(existing);
+
+            return new Promise<SessionInfo>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const idx = addedWaiters.findIndex((w) => w.resolve === resolve);
+                    if (idx !== -1) addedWaiters.splice(idx, 1);
+                    reject(new Error(`MockHubClient.waitForSessionAdded: timeout (${timeout}ms)`));
+                }, timeout);
+
+                addedWaiters.push({ predicate, resolve, reject, timer });
+            });
+        },
+
+        waitForSessionRemoved(sessionId: string, timeout = 5000): Promise<void> {
+            // Already removed?
+            if (!sessions.find((s) => s.sessionId === sessionId)) {
+                return Promise.resolve();
+            }
+
+            return new Promise<void>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const list = removedWaiters.get(sessionId);
+                    if (list) {
+                        const idx = list.findIndex((w) => w.resolve === resolve);
+                        if (idx !== -1) list.splice(idx, 1);
+                    }
+                    reject(
+                        new Error(
+                            `MockHubClient.waitForSessionRemoved: timeout (${timeout}ms) for session ${sessionId}`,
+                        ),
+                    );
+                }, timeout);
+
+                const list = removedWaiters.get(sessionId) ?? [];
+                list.push({ resolve, reject, timer });
+                removedWaiters.set(sessionId, list);
+            });
+        },
+
+        waitForSessionStatus(
+            sessionId: string,
+            predicate?: (data: unknown) => boolean,
+            timeout = 5000,
+        ): Promise<unknown> {
+            return new Promise<unknown>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const list = statusWaiters.get(sessionId);
+                    if (list) {
+                        const idx = list.findIndex((w) => w.resolve === resolve);
+                        if (idx !== -1) list.splice(idx, 1);
+                    }
+                    reject(
+                        new Error(
+                            `MockHubClient.waitForSessionStatus: timeout (${timeout}ms) for session ${sessionId}`,
+                        ),
+                    );
+                }, timeout);
+
+                const list = statusWaiters.get(sessionId) ?? [];
+                list.push({ predicate, resolve, reject, timer });
+                statusWaiters.set(sessionId, list);
+            });
+        },
+
+        subscribeSessionMeta(sessionId: string): void {
+            socket.emit("subscribe_session_meta", { sessionId });
+        },
+
+        unsubscribeSessionMeta(sessionId: string): void {
+            socket.emit("unsubscribe_session_meta", { sessionId });
+        },
+
+        disconnect(): Promise<void> {
+            return new Promise<void>((resolve) => {
+                if (!socket.connected) {
+                    resolve();
+                    return;
+                }
+                socket.once("disconnect", () => resolve());
+                socket.disconnect();
+            });
+        },
+    };
+
+    return client;
+}

--- a/packages/server/tests/harness/mock-viewer.test.ts
+++ b/packages/server/tests/harness/mock-viewer.test.ts
@@ -77,13 +77,21 @@ async function emitRelayEvent(
 
 // ── Shared server ────────────────────────────────────────────────────────────
 
-let server: TestServer;
+// Definite-assignment assertion: server is always set if beforeAll succeeds.
+// afterAll does a runtime guard to handle the case where beforeAll itself threw.
+let server!: TestServer;
 
 beforeAll(async () => {
     server = await createTestServer();
 }, TEST_TIMEOUT_MS);
 
 afterAll(async () => {
+    // Guard: if beforeAll threw, server is still undefined at runtime — skip cleanup.
+    // The definite-assignment assertion above keeps the type clean for test bodies,
+    // which only run after a successful beforeAll.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+    if (!server) return;
+
     // Force-close all lingering HTTP keep-alive connections before cleanup.
     // Without this, io.close() → httpServer.close() can wait indefinitely for
     // connections from the relay Redis cache client or Fetch API keep-alive pool.

--- a/packages/server/tests/harness/mock-viewer.test.ts
+++ b/packages/server/tests/harness/mock-viewer.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Integration tests for MockViewer and MockHubClient harness helpers.
+ *
+ * These tests spin up a real test server (HTTP + Redis + Socket.IO) and
+ * exercise the /viewer and /hub namespaces through the mock clients.
+ *
+ * NOTE: Servers are created sequentially (module singletons require serial
+ * creation). All tests in this file share a single server instance to keep
+ * the suite fast.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { io as clientIo } from "socket.io-client";
+import { createTestServer } from "./server.js";
+import { createMockViewer } from "./mock-viewer.js";
+import { createMockHubClient } from "./mock-hub.js";
+import type { TestServer } from "./types.js";
+
+// Give real network + Redis plenty of time
+const TEST_TIMEOUT_MS = 30_000;
+
+// ── Inline relay helper ──────────────────────────────────────────────────────
+
+interface TestSession {
+    sessionId: string;
+    token: string;
+    relaySocket: ReturnType<typeof clientIo>;
+}
+
+async function createTestSession(server: TestServer): Promise<TestSession> {
+    const relay = clientIo(`${server.baseUrl}/relay`, {
+        auth: { apiKey: server.apiKey },
+        transports: ["websocket"],
+    });
+
+    return new Promise<TestSession>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            relay.disconnect();
+            reject(new Error("createTestSession: timeout waiting for registered event"));
+        }, 8000);
+
+        relay.on("registered", (data: { sessionId: string; token: string }) => {
+            clearTimeout(timer);
+            resolve({ sessionId: data.sessionId, token: data.token, relaySocket: relay });
+        });
+
+        relay.on("connect_error", (err: Error) => {
+            clearTimeout(timer);
+            relay.disconnect();
+            reject(new Error(`createTestSession: connect_error: ${err.message}`));
+        });
+
+        relay.emit("register", { cwd: "/tmp/test", ephemeral: true });
+    });
+}
+
+// Emit an event through the relay and wait for the ack
+async function emitRelayEvent(
+    session: TestSession,
+    event: unknown,
+    seq: number,
+): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("emitRelayEvent: timeout")), 5000);
+        session.relaySocket.once("event_ack", () => {
+            clearTimeout(timer);
+            resolve();
+        });
+        session.relaySocket.emit("event", {
+            sessionId: session.sessionId,
+            token: session.token,
+            event,
+            seq,
+        });
+    });
+}
+
+// ── Shared server ────────────────────────────────────────────────────────────
+
+let server: TestServer;
+
+beforeAll(async () => {
+    server = await createTestServer();
+}, TEST_TIMEOUT_MS);
+
+afterAll(async () => {
+    // Force-close all lingering HTTP keep-alive connections before cleanup.
+    // Without this, io.close() → httpServer.close() can wait indefinitely for
+    // connections from the relay Redis cache client or Fetch API keep-alive pool.
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (server.io as any).httpServer?.closeAllConnections?.();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (server.io as any).httpServer?.closeIdleConnections?.();
+    } catch {
+        // closeAllConnections is Node 18.2+; ignore if unavailable
+    }
+    await server.cleanup();
+}, TEST_TIMEOUT_MS);
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("MockViewer", () => {
+    test(
+        "connects to a session and receives connected event",
+        async () => {
+            const session = await createTestSession(server);
+            try {
+                const viewer = await createMockViewer(server, session.sessionId);
+                expect(viewer.sessionId).toBe(session.sessionId);
+                expect(viewer.socket.connected).toBe(true);
+                await viewer.disconnect();
+            } finally {
+                session.relaySocket.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "collects events emitted through relay in getReceivedEvents()",
+        async () => {
+            const session = await createTestSession(server);
+            const viewer = await createMockViewer(server, session.sessionId);
+
+            try {
+                const testEvent = { type: "text_delta", text: "hello from relay" };
+
+                // Emit event through relay and wait for viewer to receive it
+                const waitPromise = viewer.waitForEvent(
+                    (e) => (e as { type?: string }).type === "text_delta",
+                    8000,
+                );
+                await emitRelayEvent(session, testEvent, 1);
+                const received = await waitPromise;
+
+                expect((received as { type?: string }).type).toBe("text_delta");
+                expect((received as { text?: string }).text).toBe("hello from relay");
+
+                const events = viewer.getReceivedEvents();
+                expect(events.length).toBeGreaterThanOrEqual(1);
+                const found = events.find(
+                    (e) => (e.event as { type?: string }).type === "text_delta",
+                );
+                expect(found).toBeDefined();
+            } finally {
+                await viewer.disconnect();
+                session.relaySocket.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "receives disconnected event when relay ends session",
+        async () => {
+            const session = await createTestSession(server);
+            const viewer = await createMockViewer(server, session.sessionId);
+
+            try {
+                const disconnectPromise = viewer.waitForDisconnected(8000);
+
+                // End session via relay
+                session.relaySocket.emit("session_end", {
+                    sessionId: session.sessionId,
+                    token: session.token,
+                });
+
+                const reason = await disconnectPromise;
+                expect(typeof reason).toBe("string");
+            } finally {
+                await viewer.disconnect();
+                session.relaySocket.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "clearEvents resets the collected events array",
+        async () => {
+            const session = await createTestSession(server);
+            const viewer = await createMockViewer(server, session.sessionId);
+
+            try {
+                // Emit one event
+                await emitRelayEvent(session, { type: "ping" }, 1);
+                await viewer.waitForEvent(undefined, 5000);
+                expect(viewer.getReceivedEvents().length).toBeGreaterThan(0);
+
+                viewer.clearEvents();
+                expect(viewer.getReceivedEvents().length).toBe(0);
+            } finally {
+                await viewer.disconnect();
+                session.relaySocket.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "multiple viewers on the same session both receive events",
+        async () => {
+            const session = await createTestSession(server);
+            const viewer1 = await createMockViewer(server, session.sessionId);
+            const viewer2 = await createMockViewer(server, session.sessionId);
+
+            try {
+                const testEvent = { type: "broadcast_test", value: 42 };
+
+                const p1 = viewer1.waitForEvent(
+                    (e) => (e as { type?: string }).type === "broadcast_test",
+                    8000,
+                );
+                const p2 = viewer2.waitForEvent(
+                    (e) => (e as { type?: string }).type === "broadcast_test",
+                    8000,
+                );
+
+                await emitRelayEvent(session, testEvent, 1);
+
+                const [e1, e2] = await Promise.all([p1, p2]);
+                expect((e1 as { value?: number }).value).toBe(42);
+                expect((e2 as { value?: number }).value).toBe(42);
+            } finally {
+                await viewer1.disconnect();
+                await viewer2.disconnect();
+                session.relaySocket.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+});
+
+describe("MockHubClient", () => {
+    test(
+        "connects and receives initial sessions snapshot",
+        async () => {
+            const hub = await createMockHubClient(server);
+            try {
+                // sessions is an array (may be empty at start)
+                expect(Array.isArray(hub.sessions)).toBe(true);
+            } finally {
+                await hub.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "receives session_added when a new relay session is created",
+        async () => {
+            const hub = await createMockHubClient(server);
+
+            try {
+                // Start waiting BEFORE creating session
+                const addedPromise = hub.waitForSessionAdded(undefined, 10000);
+
+                const session = await createTestSession(server);
+
+                const added = await addedPromise;
+                expect(added.sessionId).toBe(session.sessionId);
+                expect(hub.sessions.some((s) => s.sessionId === session.sessionId)).toBe(true);
+
+                session.relaySocket.disconnect();
+            } finally {
+                await hub.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "hub disconnect cleans up socket",
+        async () => {
+            const hub = await createMockHubClient(server);
+            expect(hub.socket.connected).toBe(true);
+            await hub.disconnect();
+            expect(hub.socket.connected).toBe(false);
+        },
+        TEST_TIMEOUT_MS,
+    );
+});

--- a/packages/server/tests/harness/mock-viewer.ts
+++ b/packages/server/tests/harness/mock-viewer.ts
@@ -1,0 +1,302 @@
+/**
+ * MockViewer — test harness client for the /viewer Socket.IO namespace.
+ *
+ * Connects with cookie-based auth, auto-collects events, and exposes
+ * waitFor helpers for integration tests.
+ */
+
+import { io as clientIo, type Socket as ClientSocket } from "socket.io-client";
+import type {
+    ViewerServerToClientEvents,
+    ViewerClientToServerEvents,
+    Attachment,
+} from "@pizzapi/protocol";
+import type { TestServer } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReceivedEvent {
+    event: unknown;
+    seq?: number;
+    replay?: boolean;
+}
+
+export interface MockViewer {
+    socket: ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents>;
+    sessionId: string;
+
+    // Send actions
+    sendInput(text: string, attachments?: Attachment[]): void;
+    sendExec(id: string, command: string): void;
+    sendTriggerResponse(
+        triggerId: string,
+        response: string,
+        targetSessionId: string,
+        action?: string,
+    ): void;
+    sendResync(): void;
+
+    // Received events
+    getReceivedEvents(): ReceivedEvent[];
+    clearEvents(): void;
+    waitForEvent(
+        predicate?: (evt: unknown) => boolean,
+        timeout?: number,
+    ): Promise<unknown>;
+    waitForDisconnected(timeout?: number): Promise<string>;
+
+    disconnect(): Promise<void>;
+}
+
+export interface MockViewerOptions {
+    /** Timeout (ms) waiting for the initial `connected` event. Default: 5000 */
+    connectTimeout?: number;
+    /**
+     * Max connection attempts before giving up. Default: 2.
+     * The first attempt sometimes fails with `connect_error: unauthorized`
+     * due to better-auth cold-start (lazy prepared-statement caching).
+     * A retry after a short delay reliably succeeds.
+     */
+    maxAttempts?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: single connection attempt
+// ---------------------------------------------------------------------------
+
+async function attemptViewerConnection(
+    server: TestServer,
+    sessionId: string,
+    connectTimeout: number,
+): Promise<ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents>> {
+    const socket: ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents> =
+        clientIo(`${server.baseUrl}/viewer`, {
+            extraHeaders: { cookie: server.sessionCookie },
+            query: { sessionId },
+            transports: ["websocket"],
+            autoConnect: false,
+            // Disable auto-reconnect: if the connection fails, fail fast rather
+            // than silently retrying and leaving a lingering socket open.
+            reconnection: false,
+        });
+
+    const connectedPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            socket.disconnect();
+            reject(
+                new Error(
+                    `MockViewer: timeout waiting for connected event (${connectTimeout}ms) for session ${sessionId}`,
+                ),
+            );
+        }, connectTimeout);
+
+        socket.once("connected", () => {
+            clearTimeout(timer);
+            resolve();
+        });
+
+        // Server-emitted error event (e.g. "Session not found")
+        socket.once("error", (data: { message: string }) => {
+            clearTimeout(timer);
+            socket.disconnect();
+            reject(new Error(`MockViewer: server error on connect: ${data.message}`));
+        });
+
+        // Transport-level rejection (e.g. auth middleware returned unauthorized)
+        socket.once("connect_error", (err) => {
+            clearTimeout(timer);
+            socket.disconnect();
+            reject(new Error(`MockViewer: connect_error: ${err.message}`));
+        });
+    });
+
+    socket.connect();
+
+    // Send the viewer greeting after the underlying transport connects
+    socket.once("connect", () => {
+        socket.emit("connected", {});
+    });
+
+    await connectedPromise;
+    return socket;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a MockViewer connected to the given test server and session.
+ *
+ * The promise resolves once the server sends the `connected` event,
+ * confirming the viewer is successfully joined to the session.
+ *
+ * The first connection attempt may fail with `connect_error: unauthorized`
+ * due to better-auth cold-start (lazy prepared-statement caching). Up to
+ * `maxAttempts` retries are made with a 150 ms delay between attempts.
+ */
+export async function createMockViewer(
+    server: TestServer,
+    sessionId: string,
+    opts?: MockViewerOptions,
+): Promise<MockViewer> {
+    const connectTimeout = opts?.connectTimeout ?? 5000;
+    const maxAttempts = opts?.maxAttempts ?? 2;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (attempt > 0) {
+            await new Promise<void>((r) => setTimeout(r, 150));
+        }
+        try {
+            const socket = await attemptViewerConnection(server, sessionId, connectTimeout);
+            return buildMockViewer(socket, sessionId);
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    throw lastError;
+}
+
+// ---------------------------------------------------------------------------
+// Build MockViewer from an already-connected socket
+// ---------------------------------------------------------------------------
+
+function buildMockViewer(
+    socket: ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents>,
+    sessionId: string,
+): MockViewer {
+    // Collected events from the server
+    const receivedEvents: ReceivedEvent[] = [];
+
+    // Pending waitForEvent resolvers
+    const eventWaiters: Array<{
+        predicate?: (evt: unknown) => boolean;
+        resolve: (evt: unknown) => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+    }> = [];
+
+    // Pending waitForDisconnected resolvers
+    const disconnectWaiters: Array<{
+        resolve: (reason: string) => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+    }> = [];
+
+    // Auto-collect all `event` payloads
+    socket.on("event", (data) => {
+        const entry: ReceivedEvent = {
+            event: data.event,
+            seq: data.seq,
+            replay: data.replay,
+        };
+        receivedEvents.push(entry);
+
+        // Notify waitForEvent callers
+        for (let i = eventWaiters.length - 1; i >= 0; i--) {
+            const waiter = eventWaiters[i];
+            if (!waiter.predicate || waiter.predicate(data.event)) {
+                clearTimeout(waiter.timer);
+                eventWaiters.splice(i, 1);
+                waiter.resolve(data.event);
+            }
+        }
+    });
+
+    // Handle disconnected events from server
+    socket.on("disconnected", (data) => {
+        for (let i = disconnectWaiters.length - 1; i >= 0; i--) {
+            const waiter = disconnectWaiters[i];
+            clearTimeout(waiter.timer);
+            disconnectWaiters.splice(i, 1);
+            waiter.resolve(data.reason);
+        }
+    });
+
+    // ── MockViewer implementation ──────────────────────────────────────────
+
+    const viewer: MockViewer = {
+        socket,
+        sessionId,
+
+        sendInput(text: string, attachments?: Attachment[]): void {
+            socket.emit("input", { text, attachments });
+        },
+
+        sendExec(id: string, command: string): void {
+            socket.emit("exec", { id, command });
+        },
+
+        sendTriggerResponse(
+            triggerId: string,
+            response: string,
+            targetSessionId: string,
+            action?: string,
+        ): void {
+            socket.emit("trigger_response", { triggerId, response, targetSessionId, action }, () => {
+                // ack callback — no-op for tests unless explicitly tested
+            });
+        },
+
+        sendResync(): void {
+            socket.emit("resync", {});
+        },
+
+        getReceivedEvents(): ReceivedEvent[] {
+            return [...receivedEvents];
+        },
+
+        clearEvents(): void {
+            receivedEvents.length = 0;
+        },
+
+        waitForEvent(
+            predicate?: (evt: unknown) => boolean,
+            timeout = 5000,
+        ): Promise<unknown> {
+            // Check if already buffered
+            const existing = receivedEvents.find(
+                (e) => !predicate || predicate(e.event),
+            );
+            if (existing) return Promise.resolve(existing.event);
+
+            return new Promise<unknown>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const idx = eventWaiters.findIndex((w) => w.resolve === resolve);
+                    if (idx !== -1) eventWaiters.splice(idx, 1);
+                    reject(new Error(`MockViewer.waitForEvent: timeout (${timeout}ms)`));
+                }, timeout);
+
+                eventWaiters.push({ predicate, resolve, reject, timer });
+            });
+        },
+
+        waitForDisconnected(timeout = 5000): Promise<string> {
+            return new Promise<string>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const idx = disconnectWaiters.findIndex((w) => w.resolve === resolve);
+                    if (idx !== -1) disconnectWaiters.splice(idx, 1);
+                    reject(new Error(`MockViewer.waitForDisconnected: timeout (${timeout}ms)`));
+                }, timeout);
+
+                disconnectWaiters.push({ resolve, reject, timer });
+            });
+        },
+
+        disconnect(): Promise<void> {
+            return new Promise<void>((resolve) => {
+                if (!socket.connected) {
+                    resolve();
+                    return;
+                }
+                socket.once("disconnect", () => resolve());
+                socket.disconnect();
+            });
+        },
+    };
+
+    return viewer;
+}

--- a/packages/server/tests/harness/mock-viewer.ts
+++ b/packages/server/tests/harness/mock-viewer.ts
@@ -63,14 +63,21 @@ export interface MockViewerOptions {
 }
 
 // ---------------------------------------------------------------------------
-// Internal: single connection attempt
+// Internal: single connection attempt — builds a fully-wired MockViewer
 // ---------------------------------------------------------------------------
 
-async function attemptViewerConnection(
+/**
+ * Creates a socket, attaches ALL data listeners BEFORE waiting for the
+ * handshake, then resolves once the server sends the `connected` event.
+ *
+ * Listener-before-await ordering prevents the race where events emitted
+ * between `connected` receipt and listener attachment are silently dropped.
+ */
+async function attemptBuildViewer(
     server: TestServer,
     sessionId: string,
     connectTimeout: number,
-): Promise<ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents>> {
+): Promise<MockViewer> {
     const socket: ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents> =
         clientIo(`${server.baseUrl}/viewer`, {
             extraHeaders: { cookie: server.sessionCookie },
@@ -81,6 +88,76 @@ async function attemptViewerConnection(
             // than silently retrying and leaving a lingering socket open.
             reconnection: false,
         });
+
+    // Collected events from the server
+    const receivedEvents: ReceivedEvent[] = [];
+
+    // Pending waitForEvent resolvers
+    const eventWaiters: Array<{
+        predicate?: (evt: unknown) => boolean;
+        resolve: (evt: unknown) => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+    }> = [];
+
+    // Pending waitForDisconnected resolvers
+    const disconnectWaiters: Array<{
+        resolve: (reason: string) => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+    }> = [];
+
+    // Tracks whether disconnect() has been called — guards new waitFor calls
+    let isDisconnected = false;
+
+    // Rejects and clears all outstanding waiters (called on disconnect)
+    function rejectAllWaiters(reason: string): void {
+        const err = new Error(reason);
+        for (const w of eventWaiters.splice(0)) {
+            clearTimeout(w.timer);
+            w.reject(err);
+        }
+        for (const w of disconnectWaiters.splice(0)) {
+            clearTimeout(w.timer);
+            w.reject(err);
+        }
+    }
+
+    // ── Attach ALL data listeners BEFORE waiting for the handshake ─────────
+    // This prevents the race where events emitted between the `connected`
+    // event and subsequent listener attachment are dropped.
+
+    // Auto-collect all `event` payloads
+    socket.on("event", (data) => {
+        const entry: ReceivedEvent = {
+            event: data.event,
+            seq: data.seq,
+            replay: data.replay,
+        };
+        receivedEvents.push(entry);
+
+        // Notify waitForEvent callers
+        for (let i = eventWaiters.length - 1; i >= 0; i--) {
+            const waiter = eventWaiters[i];
+            if (!waiter.predicate || waiter.predicate(data.event)) {
+                clearTimeout(waiter.timer);
+                eventWaiters.splice(i, 1);
+                waiter.resolve(data.event);
+            }
+        }
+    });
+
+    // Handle disconnected events from server
+    socket.on("disconnected", (data) => {
+        for (let i = disconnectWaiters.length - 1; i >= 0; i--) {
+            const waiter = disconnectWaiters[i];
+            clearTimeout(waiter.timer);
+            disconnectWaiters.splice(i, 1);
+            waiter.resolve(data.reason);
+        }
+    });
+
+    // ── Handshake: resolve once the server acknowledges our join ───────────
 
     const connectedPromise = new Promise<void>((resolve, reject) => {
         const timer = setTimeout(() => {
@@ -120,103 +197,8 @@ async function attemptViewerConnection(
     });
 
     await connectedPromise;
-    return socket;
-}
 
-// ---------------------------------------------------------------------------
-// Factory
-// ---------------------------------------------------------------------------
-
-/**
- * Create a MockViewer connected to the given test server and session.
- *
- * The promise resolves once the server sends the `connected` event,
- * confirming the viewer is successfully joined to the session.
- *
- * The first connection attempt may fail with `connect_error: unauthorized`
- * due to better-auth cold-start (lazy prepared-statement caching). Up to
- * `maxAttempts` retries are made with a 150 ms delay between attempts.
- */
-export async function createMockViewer(
-    server: TestServer,
-    sessionId: string,
-    opts?: MockViewerOptions,
-): Promise<MockViewer> {
-    const connectTimeout = opts?.connectTimeout ?? 5000;
-    const maxAttempts = opts?.maxAttempts ?? 2;
-
-    let lastError: unknown;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        if (attempt > 0) {
-            await new Promise<void>((r) => setTimeout(r, 150));
-        }
-        try {
-            const socket = await attemptViewerConnection(server, sessionId, connectTimeout);
-            return buildMockViewer(socket, sessionId);
-        } catch (err) {
-            lastError = err;
-        }
-    }
-    throw lastError;
-}
-
-// ---------------------------------------------------------------------------
-// Build MockViewer from an already-connected socket
-// ---------------------------------------------------------------------------
-
-function buildMockViewer(
-    socket: ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents>,
-    sessionId: string,
-): MockViewer {
-    // Collected events from the server
-    const receivedEvents: ReceivedEvent[] = [];
-
-    // Pending waitForEvent resolvers
-    const eventWaiters: Array<{
-        predicate?: (evt: unknown) => boolean;
-        resolve: (evt: unknown) => void;
-        reject: (err: Error) => void;
-        timer: ReturnType<typeof setTimeout>;
-    }> = [];
-
-    // Pending waitForDisconnected resolvers
-    const disconnectWaiters: Array<{
-        resolve: (reason: string) => void;
-        reject: (err: Error) => void;
-        timer: ReturnType<typeof setTimeout>;
-    }> = [];
-
-    // Auto-collect all `event` payloads
-    socket.on("event", (data) => {
-        const entry: ReceivedEvent = {
-            event: data.event,
-            seq: data.seq,
-            replay: data.replay,
-        };
-        receivedEvents.push(entry);
-
-        // Notify waitForEvent callers
-        for (let i = eventWaiters.length - 1; i >= 0; i--) {
-            const waiter = eventWaiters[i];
-            if (!waiter.predicate || waiter.predicate(data.event)) {
-                clearTimeout(waiter.timer);
-                eventWaiters.splice(i, 1);
-                waiter.resolve(data.event);
-            }
-        }
-    });
-
-    // Handle disconnected events from server
-    socket.on("disconnected", (data) => {
-        for (let i = disconnectWaiters.length - 1; i >= 0; i--) {
-            const waiter = disconnectWaiters[i];
-            clearTimeout(waiter.timer);
-            disconnectWaiters.splice(i, 1);
-            waiter.resolve(data.reason);
-        }
-    });
-
-    // ── MockViewer implementation ──────────────────────────────────────────
+    // ── Build and return the MockViewer object ─────────────────────────────
 
     const viewer: MockViewer = {
         socket,
@@ -257,6 +239,10 @@ function buildMockViewer(
             predicate?: (evt: unknown) => boolean,
             timeout = 5000,
         ): Promise<unknown> {
+            if (isDisconnected) {
+                return Promise.reject(new Error("MockViewer.waitForEvent: already disconnected"));
+            }
+
             // Check if already buffered
             const existing = receivedEvents.find(
                 (e) => !predicate || predicate(e.event),
@@ -275,6 +261,10 @@ function buildMockViewer(
         },
 
         waitForDisconnected(timeout = 5000): Promise<string> {
+            if (isDisconnected) {
+                return Promise.reject(new Error("MockViewer.waitForDisconnected: already disconnected"));
+            }
+
             return new Promise<string>((resolve, reject) => {
                 const timer = setTimeout(() => {
                     const idx = disconnectWaiters.findIndex((w) => w.resolve === resolve);
@@ -287,6 +277,9 @@ function buildMockViewer(
         },
 
         disconnect(): Promise<void> {
+            isDisconnected = true;
+            rejectAllWaiters("MockViewer: disconnected");
+
             return new Promise<void>((resolve) => {
                 if (!socket.connected) {
                     resolve();
@@ -299,4 +292,40 @@ function buildMockViewer(
     };
 
     return viewer;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a MockViewer connected to the given test server and session.
+ *
+ * The promise resolves once the server sends the `connected` event,
+ * confirming the viewer is successfully joined to the session.
+ *
+ * The first connection attempt may fail with `connect_error: unauthorized`
+ * due to better-auth cold-start (lazy prepared-statement caching). Up to
+ * `maxAttempts` retries are made with a 150 ms delay between attempts.
+ */
+export async function createMockViewer(
+    server: TestServer,
+    sessionId: string,
+    opts?: MockViewerOptions,
+): Promise<MockViewer> {
+    const connectTimeout = opts?.connectTimeout ?? 5000;
+    const maxAttempts = opts?.maxAttempts ?? 2;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (attempt > 0) {
+            await new Promise<void>((r) => setTimeout(r, 150));
+        }
+        try {
+            return await attemptBuildViewer(server, sessionId, connectTimeout);
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    throw lastError;
 }

--- a/packages/server/tests/harness/server.test.ts
+++ b/packages/server/tests/harness/server.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Smoke tests for the test server factory harness.
+ *
+ * These tests verify that createTestServer():
+ *   1. Spins up a real HTTP server that responds to requests
+ *   2. Pre-creates a user with a working API key
+ *   3. Multiple servers can run simultaneously (created sequentially, then accessed concurrently)
+ *   4. Cleans up all resources on shutdown
+ *
+ * NOTE: Servers must be created sequentially (not with Promise.all) because
+ * auth.ts and sio-state.ts use module-level singletons. Once created, multiple
+ * servers can coexist and respond simultaneously.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { createTestServer } from "./server.js";
+
+// Tests spin up real servers + Redis + Socket.IO, so we need a generous timeout.
+const TEST_TIMEOUT_MS = 30_000;
+
+describe("createTestServer", () => {
+    test("creates server and responds to health check", async () => {
+        const server = await createTestServer();
+        try {
+            const res = await fetch(`${server.baseUrl}/health`);
+            // Health may be degraded if Redis singletons were overwritten, but
+            // the server must respond with the expected shape.
+            expect([200, 503]).toContain(res.status);
+            const data = await res.json();
+            expect(["ok", "degraded"]).toContain(data.status);
+            expect(typeof data.redis).toBe("boolean");
+            expect(typeof data.socketio).toBe("boolean");
+            expect(typeof data.uptime).toBe("number");
+        } finally {
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("pre-created user can authenticate via API key", async () => {
+        const server = await createTestServer();
+        try {
+            // Verify basic properties are populated
+            expect(server.port).toBeGreaterThan(0);
+            expect(server.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+            expect(server.apiKey).toHaveLength(64); // 32 random bytes → 64 hex chars
+            expect(server.userId).toBeTruthy();
+            expect(server.userName).toBe("Test User");
+            expect(server.userEmail).toBe("testuser@pizzapi-harness.test");
+            expect(server.sessionCookie).toBeTruthy();
+
+            // The built-in fetch helper includes auth headers
+            const res = await server.fetch("/api/signup-status");
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            // After first user created with disableSignupAfterFirstUser: true (default),
+            // signup should be disabled
+            expect(data.signupEnabled).toBe(false);
+        } finally {
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("multiple test servers can run concurrently", async () => {
+        // Create servers sequentially (module singletons require serial creation)
+        // then verify they can all respond simultaneously.
+        const s1 = await createTestServer();
+        const s2 = await createTestServer();
+        const s3 = await createTestServer();
+
+        try {
+            // All servers should have different ports
+            const ports = new Set([s1.port, s2.port, s3.port]);
+            expect(ports.size).toBe(3);
+
+            // All servers should respond simultaneously (concurrent reads are fine)
+            const responses = await Promise.all([
+                fetch(`${s1.baseUrl}/health`),
+                fetch(`${s2.baseUrl}/health`),
+                fetch(`${s3.baseUrl}/health`),
+            ]);
+
+            for (const res of responses) {
+                expect([200, 503]).toContain(res.status);
+                const data = await res.json();
+                expect(["ok", "degraded"]).toContain(data.status);
+            }
+        } finally {
+            // Clean up all servers, ignoring individual errors
+            await Promise.allSettled([s1.cleanup(), s2.cleanup(), s3.cleanup()]);
+        }
+    }, TEST_TIMEOUT_MS * 3);
+
+    test("cleanup shuts down cleanly", async () => {
+        const server = await createTestServer();
+        const baseUrl = server.baseUrl;
+
+        // Server is up before cleanup
+        const before = await fetch(`${baseUrl}/health`);
+        expect([200, 503]).toContain(before.status);
+
+        // Cleanup
+        await server.cleanup();
+
+        // Server should no longer be reachable after cleanup
+        let threw = false;
+        try {
+            await fetch(`${baseUrl}/health`);
+        } catch {
+            threw = true;
+        }
+        expect(threw).toBe(true);
+    }, TEST_TIMEOUT_MS);
+});

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -37,6 +37,38 @@ function uniqueTestClientIp(): string {
     return `10.255.${Math.floor(n / 256) % 256}.${n % 256}`;
 }
 
+// ── PIZZAPI_TRUST_PROXY env management ───────────────────────────────────────
+// All test servers need PIZZAPI_TRUST_PROXY=true. To avoid env-restoration races
+// when multiple servers are cleaned up concurrently (Promise.allSettled), we
+// track the original value once at module load time and restore it only after
+// the last active server is torn down.
+//
+// JS is single-threaded, so the _activeServers decrement + conditional restore
+// in cleanup() is always atomic with respect to other cleanup() invocations.
+
+const _trustProxyOriginal: string | undefined = process.env.PIZZAPI_TRUST_PROXY;
+let _activeServers = 0;
+
+function acquireTrustProxy(): void {
+    if (_activeServers === 0) {
+        // First server — set the env var
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+    }
+    _activeServers++;
+}
+
+function releaseTrustProxy(): void {
+    _activeServers = Math.max(0, _activeServers - 1);
+    if (_activeServers === 0) {
+        // Last server cleaned up — restore original value
+        if (_trustProxyOriginal === undefined) {
+            delete process.env.PIZZAPI_TRUST_PROXY;
+        } else {
+            process.env.PIZZAPI_TRUST_PROXY = _trustProxyOriginal;
+        }
+    }
+}
+
 // ── Node req/res ↔ fetch API helpers (mirrors src/index.ts) ─────────────────
 
 async function nodeReqToFetchRequest(req: IncomingMessage, port: number): Promise<Request> {
@@ -129,201 +161,237 @@ async function sendFetchResponse(res: ServerResponse, response: Response): Promi
  * concurrently — create servers sequentially to avoid race conditions.
  */
 export async function createTestServer(opts?: TestServerOptions): Promise<TestServer> {
-    // 1. Temp directory for the SQLite DB
-    const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
-    const dbPath = join(tmpDir, "test.db");
+    // Acquire PIZZAPI_TRUST_PROXY — shared across all active test servers.
+    // Must be matched by a releaseTrustProxy() call in cleanup() or error path.
+    acquireTrustProxy();
 
-    // 2. Trust proxy for rate-limit tests (mirrors production behavior)
-    const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
-    process.env.PIZZAPI_TRUST_PROXY = "true";
+    // Track all allocated resources so we can clean up on partial failure.
+    let tmpDir: string | undefined;
+    let pubClient: RedisClientType | undefined;
+    let subClient: RedisClientType | undefined;
+    let httpServer: ReturnType<typeof createServer> | undefined;
+    let io: SocketIOServer | undefined;
 
-    // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
-    // that better-auth uses only for cookie domain (not for actual listening).
-    // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
-    const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
+    try {
+        // 1. Temp directory for the SQLite DB
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
+        const dbPath = join(tmpDir, "test.db");
 
-    // 3. Init auth with temp DB
-    initAuth({
-        dbPath,
-        baseURL: placeholderBase,
-        secret: "test-secret-for-harness-at-least-32-chars-long!!",
-        disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
-        extraOrigins: opts?.trustedOrigins,
-    });
+        // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
+        // that better-auth uses only for cookie domain (not for actual listening).
+        // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
+        const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
 
-    // 4. Run DB migrations
-    await runAllMigrations();
+        // 2. Init auth with temp DB
+        initAuth({
+            dbPath,
+            baseURL: placeholderBase,
+            secret: "test-secret-for-harness-at-least-32-chars-long!!",
+            disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
+            extraOrigins: opts?.trustedOrigins,
+        });
 
-    // 5. Create Redis pub/sub clients and connect them
-    const pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
-    const subClient = pubClient.duplicate() as RedisClientType;
-    await Promise.all([pubClient.connect(), subClient.connect()]);
+        // 3. Run DB migrations
+        await runAllMigrations();
 
-    // 6. We'll track the resolved port for the request converter
-    let resolvedPort = 0;
+        // 4. Create Redis pub/sub clients.
+        //    IMPORTANT: Do NOT use pubClient.duplicate() here. Other test files in
+        //    the suite may mock the "redis" module (e.g. redis_perf.test.ts uses
+        //    mock.module("redis", ...)), and mock objects typically omit .duplicate().
+        //    Creating each client independently via createClient() avoids this
+        //    dependency entirely.
+        pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
+        subClient = createClient({ url: REDIS_URL }) as RedisClientType;
+        await Promise.all([pubClient.connect(), subClient.connect()]);
 
-    // Create the HTTP server with the handleFetch handler
-    const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-        try {
-            const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
-            const fetchRes = await handleFetch(fetchReq);
-            await sendFetchResponse(res, fetchRes);
-        } catch (e) {
-            console.error("[test-harness] Unhandled error:", e);
-            if (!res.headersSent) {
-                res.writeHead(500, { "content-type": "application/json" });
+        // 5. We'll track the resolved port for the request converter
+        let resolvedPort = 0;
+
+        // Create the HTTP server with the handleFetch handler
+        httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+            try {
+                const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
+                const fetchRes = await handleFetch(fetchReq);
+                await sendFetchResponse(res, fetchRes);
+            } catch (e) {
+                console.error("[test-harness] Unhandled error:", e);
+                if (!res.headersSent) {
+                    res.writeHead(500, { "content-type": "application/json" });
+                }
+                res.end(JSON.stringify({ error: "Internal server error" }));
             }
-            res.end(JSON.stringify({ error: "Internal server error" }));
+        });
+
+        // 6. Create Socket.IO server with Redis adapter
+        io = new SocketIOServer(httpServer, {
+            cors: {
+                origin: getTrustedOrigins(),
+                credentials: true,
+            },
+            maxHttpBufferSize: 100 * 1024 * 1024,
+            pingInterval: 30_000,
+            pingTimeout: 60_000,
+            adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
+            transports: ["websocket", "polling"],
+        });
+
+        // 7. Init state Redis
+        await initStateRedis();
+
+        // 8. Init the Socket.IO registry
+        initSioRegistry(io);
+
+        // 9. Register all namespaces
+        registerNamespaces(io);
+
+        // 10. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
+        await new Promise<void>((resolve) => httpServer!.listen(0, "127.0.0.1", resolve));
+
+        const addr = httpServer.address();
+        if (!addr || typeof addr === "string") {
+            throw new Error("[test-harness] Could not determine server port");
         }
-    });
+        resolvedPort = addr.port;
 
-    // 7. Create Socket.IO server with Redis adapter
-    const io = new SocketIOServer(httpServer, {
-        cors: {
-            origin: getTrustedOrigins(),
-            credentials: true,
-        },
-        maxHttpBufferSize: 100 * 1024 * 1024,
-        pingInterval: 30_000,
-        pingTimeout: 60_000,
-        adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
-        transports: ["websocket", "polling"],
-    });
+        // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
+        const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
 
-    // 8. Init state Redis
-    await initStateRedis();
+        // 11. Create a test user via the /api/register endpoint.
+        //     Use a unique client IP per server instance so each registration gets its
+        //     own rate-limit bucket in the module-level registerRateLimiter singleton.
+        const testUserName = "Test User";
+        const testUserEmail = "testuser@pizzapi-harness.test";
+        const testUserPassword = "HarnessPass123";
+        const testClientIp = uniqueTestClientIp();
 
-    // 9. Init the Socket.IO registry
-    initSioRegistry(io);
+        const registerRes = await fetch(`${baseUrl}/api/register`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                // Unique x-forwarded-for per server so the rate limiter assigns a
+                // separate bucket for each test server creation.
+                "x-forwarded-for": testClientIp,
+            },
+            body: JSON.stringify({
+                name: testUserName,
+                email: testUserEmail,
+                password: testUserPassword,
+            }),
+        });
 
-    // 10. Register all namespaces
-    registerNamespaces(io);
-
-    // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
-    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
-
-    const addr = httpServer.address();
-    if (!addr || typeof addr === "string") {
-        throw new Error("[test-harness] Could not determine server port");
-    }
-    resolvedPort = addr.port;
-
-    // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
-    const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
-
-    // 12. Create a test user via the /api/register endpoint.
-    //     Use a unique client IP per server instance so each registration gets its
-    //     own rate-limit bucket in the module-level registerRateLimiter singleton.
-    const testUserName = "Test User";
-    const testUserEmail = "testuser@pizzapi-harness.test";
-    const testUserPassword = "HarnessPass123";
-    const testClientIp = uniqueTestClientIp();
-
-    const registerRes = await fetch(`${baseUrl}/api/register`, {
-        method: "POST",
-        headers: {
-            "content-type": "application/json",
-            // Unique x-forwarded-for per server so the rate limiter assigns a
-            // separate bucket for each test server creation.
-            "x-forwarded-for": testClientIp,
-        },
-        body: JSON.stringify({
-            name: testUserName,
-            email: testUserEmail,
-            password: testUserPassword,
-        }),
-    });
-
-    if (!registerRes.ok) {
-        throw new Error(
-            `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
-        );
-    }
-
-    const registerData = await registerRes.json() as { ok: boolean; key: string };
-    const apiKey = registerData.key;
-
-    // 13. Get a session cookie via better-auth sign-in.
-    //     The sign-in response includes the user object (with id) and Set-Cookie header.
-    const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
-        method: "POST",
-        headers: {
-            "content-type": "application/json",
-            "x-forwarded-for": testClientIp,
-        },
-        body: JSON.stringify({
-            email: testUserEmail,
-            password: testUserPassword,
-        }),
-    });
-
-    if (!signInRes.ok) {
-        throw new Error(
-            `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
-        );
-    }
-
-    const signInData = await signInRes.json() as { user?: { id: string } };
-    const userId = signInData.user?.id ?? "";
-    if (!userId) {
-        throw new Error("[test-harness] Could not get userId from sign-in response");
-    }
-
-    const cookies = signInRes.headers.getSetCookie();
-    const sessionCookie = cookies.join("; ");
-
-    // ── Helpers ──────────────────────────────────────────────────────────────
-
-    async function testFetch(path: string, init?: RequestInit): Promise<Response> {
-        const url = `${baseUrl}${path}`;
-        const headers = new Headers(init?.headers);
-
-        // Inject auth headers if not already present
-        if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
-            headers.set("x-pizzapi-api-key", apiKey);
-        }
-        if (!headers.has("cookie") && sessionCookie) {
-            headers.set("cookie", sessionCookie);
+        if (!registerRes.ok) {
+            throw new Error(
+                `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+            );
         }
 
-        return fetch(url, { ...init, headers });
-    }
+        const registerData = await registerRes.json() as { ok: boolean; key: string };
+        const apiKey = registerData.key;
 
-    // ── Cleanup ──────────────────────────────────────────────────────────────
+        // 12. Get a session cookie via better-auth sign-in.
+        //     The sign-in response includes the user object (with id) and Set-Cookie header.
+        const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "x-forwarded-for": testClientIp,
+            },
+            body: JSON.stringify({
+                email: testUserEmail,
+                password: testUserPassword,
+            }),
+        });
 
-    async function cleanup(): Promise<void> {
-        // Restore PIZZAPI_TRUST_PROXY
-        if (savedTrustProxy === undefined) {
-            delete process.env.PIZZAPI_TRUST_PROXY;
-        } else {
-            process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+        if (!signInRes.ok) {
+            throw new Error(
+                `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
+            );
         }
 
-        // Close Socket.IO — this also closes the underlying httpServer internally,
-        // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
-        await new Promise<void>((resolve) => io.close(() => resolve()));
-
-        // Disconnect Redis clients
-        await Promise.allSettled([pubClient.quit(), subClient.quit()]);
-
-        // Clean up temp directory
-        try {
-            rmSync(tmpDir, { recursive: true, force: true });
-        } catch {
-            // Ignore cleanup errors
+        const signInData = await signInRes.json() as { user?: { id: string } };
+        const userId = signInData.user?.id ?? "";
+        if (!userId) {
+            throw new Error("[test-harness] Could not get userId from sign-in response");
         }
-    }
 
-    return {
-        port: resolvedPort,
-        baseUrl,
-        io,
-        apiKey,
-        userId,
-        userName: testUserName,
-        userEmail: testUserEmail,
-        sessionCookie,
-        fetch: testFetch,
-        cleanup,
-    };
+        const cookies = signInRes.headers.getSetCookie();
+        const sessionCookie = cookies.join("; ");
+
+        // ── Helpers ──────────────────────────────────────────────────────────────
+
+        async function testFetch(path: string, init?: RequestInit): Promise<Response> {
+            const url = `${baseUrl}${path}`;
+            const headers = new Headers(init?.headers);
+
+            // Inject auth headers if not already present
+            if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
+                headers.set("x-pizzapi-api-key", apiKey);
+            }
+            if (!headers.has("cookie") && sessionCookie) {
+                headers.set("cookie", sessionCookie);
+            }
+
+            return fetch(url, { ...init, headers });
+        }
+
+        // ── Cleanup ──────────────────────────────────────────────────────────────
+
+        async function cleanup(): Promise<void> {
+            // Release our hold on PIZZAPI_TRUST_PROXY. This is atomic (JS is
+            // single-threaded) — the last cleanup() call to run restores the
+            // original value; concurrent cleanups via Promise.allSettled are safe.
+            releaseTrustProxy();
+
+            // Close Socket.IO — this also closes the underlying httpServer internally,
+            // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
+            await new Promise<void>((resolve) => io!.close(() => resolve()));
+
+            // Disconnect Redis clients
+            await Promise.allSettled([pubClient!.quit(), subClient!.quit()]);
+
+            // Clean up temp directory
+            try {
+                rmSync(tmpDir!, { recursive: true, force: true });
+            } catch {
+                // Ignore cleanup errors
+            }
+        }
+
+        return {
+            port: resolvedPort,
+            baseUrl,
+            io,
+            apiKey,
+            userId,
+            userName: testUserName,
+            userEmail: testUserEmail,
+            sessionCookie,
+            fetch: testFetch,
+            cleanup,
+        };
+
+    } catch (err) {
+        // ── Failure-safe teardown ────────────────────────────────────────────────
+        // If setup fails at any point, clean up every resource that was allocated
+        // before the failure, then re-throw so the caller sees the real error.
+
+        releaseTrustProxy();
+
+        // io.close() also closes the httpServer, so prefer it when available.
+        if (io) {
+            try { await new Promise<void>((resolve) => io!.close(() => resolve())); } catch { /* ignore */ }
+        } else if (httpServer) {
+            // io not yet created; close the bare HTTP server
+            try { await new Promise<void>((resolve) => httpServer!.close(() => resolve())); } catch { /* ignore */ }
+        }
+
+        if (pubClient) { try { await pubClient.quit(); } catch { /* ignore */ } }
+        if (subClient) { try { await subClient.quit(); } catch { /* ignore */ } }
+
+        if (tmpDir) {
+            try { rmSync(tmpDir, { recursive: true, force: true }); } catch { /* ignore */ }
+        }
+
+        throw err;
+    }
 }

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -1,0 +1,329 @@
+/**
+ * Test server factory — creates a real PizzaPi server on an ephemeral port
+ * with SQLite + Redis + Socket.IO for integration testing.
+ *
+ * IMPORTANT: createTestServer() uses module-level singletons from auth.ts and
+ * sio-state.ts. Concurrent server creation is NOT supported — create servers
+ * sequentially. Multiple servers can run simultaneously after creation; only
+ * the creation phase must be serialized.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Server as SocketIOServer } from "socket.io";
+import { createAdapter } from "@socket.io/redis-adapter";
+import { createClient, type RedisClientType } from "redis";
+
+import { initAuth, getTrustedOrigins } from "../../src/auth.js";
+import { runAllMigrations } from "../../src/migrations.js";
+import { handleFetch } from "../../src/handler.js";
+import { initStateRedis } from "../../src/ws/sio-state.js";
+import { initSioRegistry } from "../../src/ws/sio-registry.js";
+import { registerNamespaces } from "../../src/ws/namespaces/index.js";
+
+import type { TestServerOptions, TestServer } from "./types.js";
+
+const REDIS_URL = process.env.PIZZAPI_REDIS_URL ?? "redis://localhost:6379";
+
+// ── Unique IP generator ──────────────────────────────────────────────────────
+// The register rate limiter in routes/auth.ts is a module-level singleton
+// (shared across all test server instances). We generate a unique IP per server
+// so each creation gets its own rate-limit bucket and doesn't collide with others.
+let _serverCounter = 0;
+function uniqueTestClientIp(): string {
+    const n = ++_serverCounter;
+    return `10.255.${Math.floor(n / 256) % 256}.${n % 256}`;
+}
+
+// ── Node req/res ↔ fetch API helpers (mirrors src/index.ts) ─────────────────
+
+async function nodeReqToFetchRequest(req: IncomingMessage, port: number): Promise<Request> {
+    const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+        if (value === undefined) continue;
+        // Prevent client-supplied x-pizzapi-client-ip spoofing
+        if (key.toLowerCase() === "x-pizzapi-client-ip") continue;
+        if (Array.isArray(value)) {
+            for (const v of value) headers.append(key, v);
+        } else {
+            headers.set(key, value);
+        }
+    }
+
+    // Inject real client IP from the TCP socket
+    if (req.socket.remoteAddress) {
+        headers.set("x-pizzapi-client-ip", req.socket.remoteAddress);
+    }
+
+    const method = (req.method ?? "GET").toUpperCase();
+    const hasBody = method !== "GET" && method !== "HEAD";
+
+    // Pre-buffer the body from the Node.js stream into an ArrayBuffer.
+    //
+    // IMPORTANT: Do NOT pass the IncomingMessage stream directly as the Request
+    // body. handler.ts notes a known Bun issue: when a Request with a
+    // ReadableStream body is subsequently wrapped via `new Request(req, { headers })`
+    // (as the auth handler does), the stream fails to propagate and hangs
+    // indefinitely. Pre-buffering into an ArrayBuffer avoids this entirely.
+    let body: ArrayBuffer | undefined;
+    if (hasBody) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+        }
+        const buf = Buffer.concat(chunks);
+        body = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+    }
+
+    return new Request(url.toString(), {
+        method,
+        headers,
+        body,
+    });
+}
+
+async function sendFetchResponse(res: ServerResponse, response: Response): Promise<void> {
+    const headers: Record<string, string | string[]> = {};
+    response.headers.forEach((value, key) => {
+        const existing = headers[key];
+        if (existing !== undefined) {
+            headers[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+        } else {
+            headers[key] = value;
+        }
+    });
+
+    res.writeHead(response.status, headers);
+
+    if (!response.body) {
+        res.end();
+        return;
+    }
+
+    const reader = response.body.getReader();
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            res.write(value);
+        }
+    } finally {
+        reader.releaseLock();
+        res.end();
+    }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a fully initialized PizzaPi test server on an ephemeral port.
+ * Includes SQLite DB, Redis, Socket.IO, and a pre-created test user.
+ *
+ * Always call `cleanup()` when done to release all resources.
+ *
+ * NOTE: Uses module-level singletons (auth, sio-state). Do NOT call this
+ * concurrently — create servers sequentially to avoid race conditions.
+ */
+export async function createTestServer(opts?: TestServerOptions): Promise<TestServer> {
+    // 1. Temp directory for the SQLite DB
+    const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
+    const dbPath = join(tmpDir, "test.db");
+
+    // 2. Trust proxy for rate-limit tests (mirrors production behavior)
+    const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
+    process.env.PIZZAPI_TRUST_PROXY = "true";
+
+    // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
+    // that better-auth uses only for cookie domain (not for actual listening).
+    // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
+    const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
+
+    // 3. Init auth with temp DB
+    initAuth({
+        dbPath,
+        baseURL: placeholderBase,
+        secret: "test-secret-for-harness-at-least-32-chars-long!!",
+        disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
+        extraOrigins: opts?.trustedOrigins,
+    });
+
+    // 4. Run DB migrations
+    await runAllMigrations();
+
+    // 5. Create Redis pub/sub clients and connect them
+    const pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
+    const subClient = pubClient.duplicate() as RedisClientType;
+    await Promise.all([pubClient.connect(), subClient.connect()]);
+
+    // 6. We'll track the resolved port for the request converter
+    let resolvedPort = 0;
+
+    // Create the HTTP server with the handleFetch handler
+    const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+        try {
+            const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
+            const fetchRes = await handleFetch(fetchReq);
+            await sendFetchResponse(res, fetchRes);
+        } catch (e) {
+            console.error("[test-harness] Unhandled error:", e);
+            if (!res.headersSent) {
+                res.writeHead(500, { "content-type": "application/json" });
+            }
+            res.end(JSON.stringify({ error: "Internal server error" }));
+        }
+    });
+
+    // 7. Create Socket.IO server with Redis adapter
+    const io = new SocketIOServer(httpServer, {
+        cors: {
+            origin: getTrustedOrigins(),
+            credentials: true,
+        },
+        maxHttpBufferSize: 100 * 1024 * 1024,
+        pingInterval: 30_000,
+        pingTimeout: 60_000,
+        adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
+        transports: ["websocket", "polling"],
+    });
+
+    // 8. Init state Redis
+    await initStateRedis();
+
+    // 9. Init the Socket.IO registry
+    initSioRegistry(io);
+
+    // 10. Register all namespaces
+    registerNamespaces(io);
+
+    // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === "string") {
+        throw new Error("[test-harness] Could not determine server port");
+    }
+    resolvedPort = addr.port;
+
+    // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
+    const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
+
+    // 12. Create a test user via the /api/register endpoint.
+    //     Use a unique client IP per server instance so each registration gets its
+    //     own rate-limit bucket in the module-level registerRateLimiter singleton.
+    const testUserName = "Test User";
+    const testUserEmail = "testuser@pizzapi-harness.test";
+    const testUserPassword = "HarnessPass123";
+    const testClientIp = uniqueTestClientIp();
+
+    const registerRes = await fetch(`${baseUrl}/api/register`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            // Unique x-forwarded-for per server so the rate limiter assigns a
+            // separate bucket for each test server creation.
+            "x-forwarded-for": testClientIp,
+        },
+        body: JSON.stringify({
+            name: testUserName,
+            email: testUserEmail,
+            password: testUserPassword,
+        }),
+    });
+
+    if (!registerRes.ok) {
+        throw new Error(
+            `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+        );
+    }
+
+    const registerData = await registerRes.json() as { ok: boolean; key: string };
+    const apiKey = registerData.key;
+
+    // 13. Get a session cookie via better-auth sign-in.
+    //     The sign-in response includes the user object (with id) and Set-Cookie header.
+    const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            "x-forwarded-for": testClientIp,
+        },
+        body: JSON.stringify({
+            email: testUserEmail,
+            password: testUserPassword,
+        }),
+    });
+
+    if (!signInRes.ok) {
+        throw new Error(
+            `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
+        );
+    }
+
+    const signInData = await signInRes.json() as { user?: { id: string } };
+    const userId = signInData.user?.id ?? "";
+    if (!userId) {
+        throw new Error("[test-harness] Could not get userId from sign-in response");
+    }
+
+    const cookies = signInRes.headers.getSetCookie();
+    const sessionCookie = cookies.join("; ");
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    async function testFetch(path: string, init?: RequestInit): Promise<Response> {
+        const url = `${baseUrl}${path}`;
+        const headers = new Headers(init?.headers);
+
+        // Inject auth headers if not already present
+        if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
+            headers.set("x-pizzapi-api-key", apiKey);
+        }
+        if (!headers.has("cookie") && sessionCookie) {
+            headers.set("cookie", sessionCookie);
+        }
+
+        return fetch(url, { ...init, headers });
+    }
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+
+    async function cleanup(): Promise<void> {
+        // Restore PIZZAPI_TRUST_PROXY
+        if (savedTrustProxy === undefined) {
+            delete process.env.PIZZAPI_TRUST_PROXY;
+        } else {
+            process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+        }
+
+        // Close Socket.IO — this also closes the underlying httpServer internally,
+        // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
+        await new Promise<void>((resolve) => io.close(() => resolve()));
+
+        // Disconnect Redis clients
+        await Promise.allSettled([pubClient.quit(), subClient.quit()]);
+
+        // Clean up temp directory
+        try {
+            rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+            // Ignore cleanup errors
+        }
+    }
+
+    return {
+        port: resolvedPort,
+        baseUrl,
+        io,
+        apiKey,
+        userId,
+        userName: testUserName,
+        userEmail: testUserEmail,
+        sessionCookie,
+        fetch: testFetch,
+        cleanup,
+    };
+}

--- a/packages/server/tests/harness/types.ts
+++ b/packages/server/tests/harness/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types for the test server harness.
+ */
+
+export interface TestServerOptions {
+    /** Override base URL (default: auto from port) */
+    baseUrl?: string;
+    /** Extra trusted origins for CORS */
+    trustedOrigins?: string[];
+    /** Disable signup-after-first-user restriction (default: true = disabled) */
+    disableSignupAfterFirstUser?: boolean;
+}
+
+export interface TestServer {
+    /** Ephemeral port the server is listening on */
+    port: number;
+    /** Base URL: http://localhost:{port} */
+    baseUrl: string;
+    /** The Socket.IO server instance */
+    io: import("socket.io").Server;
+    /** Pre-created API key for auth */
+    apiKey: string;
+    /** Pre-created test user's ID */
+    userId: string;
+    /** Pre-created test user's name */
+    userName: string;
+    /** Pre-created test user's email */
+    userEmail: string;
+    /** Auth session cookie string for viewer/hub namespaces */
+    sessionCookie: string;
+    /** Helper: make an authenticated REST request */
+    fetch(path: string, init?: RequestInit): Promise<Response>;
+    /** Shut down everything and clean up */
+    cleanup(): Promise<void>;
+}

--- a/packages/server/tsconfig.json
+++ b/packages/server/tsconfig.json
@@ -5,5 +5,6 @@
         "rootDir": "src"
     },
     "references": [{ "path": "../tools" }, { "path": "../protocol" }],
-    "include": ["src"]
+    "include": ["src"],
+    "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }


### PR DESCRIPTION
Night Shift dish 004: MockViewer + MockHubClient for /viewer and /hub Socket.IO namespaces. Cookie-based auth, auto-event collection, waitFor helpers.

## What's in this PR

### `packages/server/tests/harness/mock-viewer.ts`
- `createMockViewer(server, sessionId, opts?)` — connects to `/viewer` with cookie auth
- Retry logic (2 attempts, 150ms delay) handles better-auth cold-start on first connection
- Auto-collects all `event` payloads with `getReceivedEvents()`
- `waitForEvent(predicate, timeout)` — waits for a matching event
- `waitForDisconnected(timeout)` — waits for server-sent `disconnected` event
- `sendInput`, `sendExec`, `sendTriggerResponse`, `sendResync` action helpers
- `reconnection: false` prevents lingering sockets after test failures

### `packages/server/tests/harness/mock-hub.ts`
- `createMockHubClient(server, opts?)` — connects to `/hub` with cookie auth
- Same retry logic for cold-start robustness
- Maintains live `sessions` list from server broadcasts
- `waitForSessionAdded`, `waitForSessionRemoved`, `waitForSessionStatus` helpers
- `subscribeSessionMeta` / `unsubscribeSessionMeta` pass-through

### `packages/server/tests/harness/mock-viewer.test.ts`
Integration tests (8 tests, all pass):
1. Viewer connects and receives connected event
2. Relay events forwarded to viewer getReceivedEvents()
3. Session end → viewer gets disconnected event
4. clearEvents resets collected events
5. Multiple viewers on same session both receive events
6. Hub connects and receives initial sessions snapshot
7. Hub receives session_added on new relay session
8. Hub disconnect cleans up socket