### PR TITLE
feat: mock runner client for test harness

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,6 @@
+[test]
+# Preload: captures the real redis.createClient BEFORE any mock.module("redis", ...)
+# calls from other test files replace it. The test harness (packages/server/tests/harness/)
+# reads from globalThis.__realRedisCreateClient so it always gets a genuine redis client
+# regardless of which other test files mock the redis module in the same Bun worker.
+preload = ["./packages/server/tests/harness/preload.ts"]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "dev:cli": "bun packages/cli/src/index.ts",
         "dev:runner": "bun packages/cli/src/index.ts runner",
         "test": "bun test packages/protocol packages/server/src packages/tools && bun test packages/server/tests && cd packages/cli && bun test && cd ../ui && bun test",
-        "typecheck": "tsc --build && bun run --cwd packages/protocol typecheck:tests",
+        "typecheck": "tsc --build && bun run --cwd packages/protocol typecheck:tests && bun run --cwd packages/server typecheck:tests",
         "migrate": "cd packages/server && bun run migrate",
         "clean": "bun -e \"['protocol','tools','server','ui','cli','docs'].forEach(p=>require('fs').rmSync('packages/'+p+'/dist',{recursive:true,force:true}))\"",
         "postinstall": "true"

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
         "dev:ui": "cd packages/ui && bun run dev",
         "dev:cli": "bun packages/cli/src/index.ts",
         "dev:runner": "bun packages/cli/src/index.ts runner",
-        "test": "bun test packages/protocol packages/server packages/tools && cd packages/cli && bun test && cd ../ui && bun test",
+        "test": "bun test packages/protocol packages/server/src packages/tools && bun test packages/server/tests && cd packages/cli && bun test && cd ../ui && bun test",
         "typecheck": "tsc --build && bun run --cwd packages/protocol typecheck:tests",
         "migrate": "cd packages/server && bun run migrate",
         "clean": "bun -e \"['protocol','tools','server','ui','cli','docs'].forEach(p=>require('fs').rmSync('packages/'+p+'/dist',{recursive:true,force:true}))\"",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -6,6 +6,7 @@
     "types": "dist/index.d.ts",
     "scripts": {
         "build": "tsc",
+        "typecheck:tests": "tsc -p tsconfig.test.json --noEmit",
         "dev": "bun --watch src/index.ts",
         "start": "bun dist/index.js",
         "migrate": "bun src/migrate.ts"

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Test harness barrel export.
+ * Re-exports everything from types, server, and future modules.
+ */
+
+export * from "./types.js";
+export * from "./server.js";

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -5,3 +5,4 @@
 
 export * from "./types.js";
 export * from "./server.js";
+export * from "./mock-runner.js";

--- a/packages/server/tests/harness/mock-runner.test.ts
+++ b/packages/server/tests/harness/mock-runner.test.ts
@@ -177,11 +177,16 @@ describe("createMockRunner — emitSessionReady", () => {
             const sessionId = "test-session-ready-" + Date.now();
             const receivedSessionIds: string[] = [];
 
+            // Resolve this promise the moment the server receives session_ready.
+            let resolveReady!: () => void;
+            const readyReceived = new Promise<void>((resolve) => { resolveReady = resolve; });
+
             // Set up server-side capture BEFORE the runner connects so the
             // connection handler fires and attaches to the real socket (not a RemoteSocket proxy).
             server.io.of("/runner").on("connection", (socket) => {
                 socket.on("session_ready", (data: { sessionId: string }) => {
                     receivedSessionIds.push(data.sessionId);
+                    resolveReady();
                 });
             });
 
@@ -189,10 +194,9 @@ describe("createMockRunner — emitSessionReady", () => {
             try {
                 runner.emitSessionReady(sessionId);
 
-                // Wait for the event to propagate to the server
-                await new Promise<void>((r) => setTimeout(r, 200));
+                // Wait for the server to actually receive the event (event-driven, not time-based).
+                await readyReceived;
 
-                // P2 fix: actually assert the event was received server-side
                 expect(receivedSessionIds).toContain(sessionId);
             } finally {
                 await runner.disconnect();
@@ -278,12 +282,20 @@ describe("createMockRunner — clean disconnect", () => {
             // Disconnect
             await runner.disconnect();
 
-            // Give the server a moment to process the disconnect event
-            await new Promise<void>((r) => setTimeout(r, 300));
+            // Poll until the server removes the runner from its registry, rather than
+            // waiting a fixed duration (which is flaky under CI load).
+            const deadline = Date.now() + 5_000;
+            let afterData: { runners: Array<{ runnerId: string }> } = { runners: [{ runnerId }] };
+            while (
+                Date.now() < deadline &&
+                afterData.runners.some((r) => r.runnerId === runnerId)
+            ) {
+                await new Promise<void>((r) => setTimeout(r, 50));
+                const after = await server.fetch("/api/runners");
+                afterData = (await after.json()) as { runners: Array<{ runnerId: string }> };
+            }
 
             // Verify it's gone
-            const after = await server.fetch("/api/runners");
-            const afterData = (await after.json()) as { runners: Array<{ runnerId: string }> };
             expect(afterData.runners.map((r) => r.runnerId)).not.toContain(runnerId);
         } finally {
             await cleanupServer(server);
@@ -362,17 +374,21 @@ describe("createMockRunner — emission helpers", () => {
         try {
             const received: Array<{ sessionId: string; message: string }> = [];
 
+            let resolveError!: () => void;
+            const errorReceived = new Promise<void>((resolve) => { resolveError = resolve; });
+
             // Attach server-side listener BEFORE runner connects
             server.io.of("/runner").on("connection", (socket) => {
                 socket.on("session_error", (data: { sessionId: string; message: string }) => {
                     received.push(data);
+                    resolveError();
                 });
             });
 
             const runner = await createMockRunner(server);
             try {
                 runner.emitSessionError("sess-err-1", "spawn failed");
-                await new Promise<void>((r) => setTimeout(r, 200));
+                await errorReceived;
 
                 expect(received.length).toBeGreaterThan(0);
                 expect(received[0].sessionId).toBe("sess-err-1");
@@ -390,11 +406,15 @@ describe("createMockRunner — emission helpers", () => {
         try {
             const received: Array<{ sessionId: string; event: unknown }> = [];
 
+            let resolveEvent!: () => void;
+            const eventReceived = new Promise<void>((resolve) => { resolveEvent = resolve; });
+
             server.io.of("/runner").on("connection", (socket) => {
                 socket.on(
                     "runner_session_event",
                     (data: { sessionId: string; event: unknown }) => {
                         received.push(data);
+                        resolveEvent();
                     },
                 );
             });
@@ -402,7 +422,7 @@ describe("createMockRunner — emission helpers", () => {
             const runner = await createMockRunner(server);
             try {
                 runner.emitSessionEvent("sess-evt-1", { type: "output", text: "hello" });
-                await new Promise<void>((r) => setTimeout(r, 200));
+                await eventReceived;
 
                 expect(received.length).toBeGreaterThan(0);
                 expect(received[0].sessionId).toBe("sess-evt-1");
@@ -420,16 +440,20 @@ describe("createMockRunner — emission helpers", () => {
         try {
             const received: Array<{ sessionId: string }> = [];
 
+            let resolveKilled!: () => void;
+            const killedReceived = new Promise<void>((resolve) => { resolveKilled = resolve; });
+
             server.io.of("/runner").on("connection", (socket) => {
                 socket.on("session_killed", (data: { sessionId: string }) => {
                     received.push(data);
+                    resolveKilled();
                 });
             });
 
             const runner = await createMockRunner(server);
             try {
                 runner.emitSessionEnded("sess-ended-1");
-                await new Promise<void>((r) => setTimeout(r, 200));
+                await killedReceived;
 
                 expect(received.length).toBeGreaterThan(0);
                 expect(received[0].sessionId).toBe("sess-ended-1");

--- a/packages/server/tests/harness/mock-runner.test.ts
+++ b/packages/server/tests/harness/mock-runner.test.ts
@@ -174,37 +174,26 @@ describe("createMockRunner — emitSessionReady", () => {
     test("emitSessionReady sends session_ready to the server", async () => {
         const server = await createTestServer();
         try {
+            const sessionId = "test-session-ready-" + Date.now();
+            const receivedSessionIds: string[] = [];
+
+            // Set up server-side capture BEFORE the runner connects so the
+            // connection handler fires and attaches to the real socket (not a RemoteSocket proxy).
+            server.io.of("/runner").on("connection", (socket) => {
+                socket.on("session_ready", (data: { sessionId: string }) => {
+                    receivedSessionIds.push(data.sessionId);
+                });
+            });
+
             const runner = await createMockRunner(server);
             try {
-                const sessionId = "test-session-ready-" + Date.now();
-
-                // Capture session_ready events on the server side via the io instance.
-                const receivedSessionIds: string[] = [];
-                const runnerNs = server.io.of("/runner");
-                const captureHandler = (data: { sessionId: string }) => {
-                    if (data.sessionId === sessionId) {
-                        receivedSessionIds.push(data.sessionId);
-                    }
-                };
-                // Listen on all future connections for this event
-                runnerNs.on("connection", (socket) => {
-                    socket.on("session_ready", captureHandler);
-                });
-
-                // Also subscribe on existing sockets (the runner socket is already connected)
-                const sockets = await runnerNs.fetchSockets();
-                for (const s of sockets) {
-                    s.on("session_ready", captureHandler as (data: unknown) => void);
-                }
-
                 runner.emitSessionReady(sessionId);
 
-                // Wait a moment for the event to propagate
+                // Wait for the event to propagate to the server
                 await new Promise<void>((r) => setTimeout(r, 200));
 
-                // The session_ready event handler calls resolveSpawnReady() (no-op for unknown sessionId).
-                // We verify the socket is still alive and hasn't crashed.
-                expect(runner.socket.connected).toBe(true);
+                // P2 fix: actually assert the event was received server-side
+                expect(receivedSessionIds).toContain(sessionId);
             } finally {
                 await runner.disconnect();
             }
@@ -357,6 +346,113 @@ describe("createMockRunner — waitForEvent", () => {
             } finally {
                 await runner.disconnect();
             }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 7. Emission helpers — emitSessionError, emitSessionEvent, emitSessionEnded
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — emission helpers", () => {
+    test("emitSessionError sends session_error to the server", async () => {
+        const server = await createTestServer();
+        try {
+            const received: Array<{ sessionId: string; message: string }> = [];
+
+            // Attach server-side listener BEFORE runner connects
+            server.io.of("/runner").on("connection", (socket) => {
+                socket.on("session_error", (data: { sessionId: string; message: string }) => {
+                    received.push(data);
+                });
+            });
+
+            const runner = await createMockRunner(server);
+            try {
+                runner.emitSessionError("sess-err-1", "spawn failed");
+                await new Promise<void>((r) => setTimeout(r, 200));
+
+                expect(received.length).toBeGreaterThan(0);
+                expect(received[0].sessionId).toBe("sess-err-1");
+                expect(received[0].message).toBe("spawn failed");
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("emitSessionEvent sends runner_session_event to the server", async () => {
+        const server = await createTestServer();
+        try {
+            const received: Array<{ sessionId: string; event: unknown }> = [];
+
+            server.io.of("/runner").on("connection", (socket) => {
+                socket.on(
+                    "runner_session_event",
+                    (data: { sessionId: string; event: unknown }) => {
+                        received.push(data);
+                    },
+                );
+            });
+
+            const runner = await createMockRunner(server);
+            try {
+                runner.emitSessionEvent("sess-evt-1", { type: "output", text: "hello" });
+                await new Promise<void>((r) => setTimeout(r, 200));
+
+                expect(received.length).toBeGreaterThan(0);
+                expect(received[0].sessionId).toBe("sess-evt-1");
+                expect(received[0].event).toEqual({ type: "output", text: "hello" });
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("emitSessionEnded sends session_killed to the server", async () => {
+        const server = await createTestServer();
+        try {
+            const received: Array<{ sessionId: string }> = [];
+
+            server.io.of("/runner").on("connection", (socket) => {
+                socket.on("session_killed", (data: { sessionId: string }) => {
+                    received.push(data);
+                });
+            });
+
+            const runner = await createMockRunner(server);
+            try {
+                runner.emitSessionEnded("sess-ended-1");
+                await new Promise<void>((r) => setTimeout(r, 200));
+
+                expect(received.length).toBeGreaterThan(0);
+                expect(received[0].sessionId).toBe("sess-ended-1");
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 8. Auth failure — bad API key is rejected
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — auth failure", () => {
+    test("rejects with a bad API key", async () => {
+        const server = await createTestServer();
+        try {
+            await expect(
+                createMockRunner(server, { apiKey: "invalid-bad-key-xyz" }),
+            ).rejects.toThrow();
         } finally {
             await cleanupServer(server);
         }

--- a/packages/server/tests/harness/mock-runner.test.ts
+++ b/packages/server/tests/harness/mock-runner.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for the MockRunner test harness.
+ *
+ * Each test creates and cleans up its OWN server (following the pattern from
+ * server.test.ts).  Do NOT use beforeAll/afterAll with a shared server —
+ * module-level singletons (auth, sio-state) mean servers must be created
+ * sequentially, and HTTP keep-alive connections prevent io.close() from
+ * completing within hook timeouts.
+ *
+ * IMPORTANT: createTestServer() uses module-level singletons. Servers MUST be
+ * created sequentially — do not use Promise.all for server creation.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type { IncomingMessage } from "node:http";
+import { createTestServer } from "./server.js";
+import { createMockRunner } from "./mock-runner.js";
+import type { TestServer } from "./types.js";
+
+const TEST_TIMEOUT = 30_000;
+
+/**
+ * Helper to shut down a TestServer cleanly.
+ *
+ * Two problems with a naive `server.cleanup()` call:
+ *
+ * 1. HTTP keep-alive: `createTestServer()` makes fetch() calls that leave open
+ *    keep-alive connections.  `io.close()` → `httpServer.close(cb)` won't fire
+ *    `cb` until all connections close, so it hangs indefinitely.
+ *
+ * 2. Race with disconnect handlers: if we force-close WebSocket connections
+ *    (via closeAllConnections) BEFORE the Redis pub/sub adapter is shut down,
+ *    the async socket disconnect handlers try to broadcast on already-closed
+ *    Redis clients, producing unhandled errors that Bun attributes to the next
+ *    test.
+ *
+ * Fix:
+ *   a) First, gracefully disconnect all Socket.IO clients and wait for their
+ *      async disconnect handlers to flush (small delay).
+ *   b) Then close only idle HTTP connections (keep-alive, not WebSocket).
+ *   c) Finally call server.cleanup() normally.
+ */
+async function cleanupServer(server: TestServer): Promise<void> {
+    // a) Gracefully disconnect all socket.io clients so their async disconnect
+    //    handlers run while the Redis adapter is still open.
+    await server.io.disconnectSockets(true);
+    // Allow async disconnect handlers to flush (they do Redis writes).
+    await new Promise<void>((r) => setTimeout(r, 100));
+
+    // b) Close idle HTTP connections (keep-alives from fetch() calls) so
+    //    httpServer.close() fires its callback promptly.
+    const httpServer = (server.io as unknown as { httpServer?: { closeIdleConnections?(): void } }).httpServer;
+    if (typeof httpServer?.closeIdleConnections === "function") {
+        httpServer.closeIdleConnections();
+    }
+
+    // c) Normal cleanup path.
+    await server.cleanup();
+}
+
+// ---------------------------------------------------------------------------
+// 1. Basic connection and registration
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — basic connection", () => {
+    test("runner connects and registers without error", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server, { name: "basic-runner" });
+            expect(runner.runnerId).toBeTruthy();
+            expect(runner.socket.connected).toBe(true);
+            await runner.disconnect();
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("runnerId reflects the server-assigned id (server generates new id without secret)", async () => {
+        // The server ignores the client-supplied runnerId unless runnerSecret is also provided.
+        // createMockRunner captures the actual id from the runner_registered event.
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server, { name: "id-test-runner" });
+            // The server assigns a UUID — it should be a valid UUID v4 shape
+            expect(runner.runnerId).toMatch(
+                /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+            );
+            await runner.disconnect();
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("auto-generates runnerId when not provided", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server);
+            // Server assigns a UUID — valid UUID shape
+            expect(runner.runnerId).toMatch(
+                /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+            );
+            await runner.disconnect();
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Runner appears in server's runner list (REST API)
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — REST visibility", () => {
+    test("registered runner appears in GET /api/runners", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server, { name: "visible-runner" });
+            try {
+                const res = await server.fetch("/api/runners");
+                expect(res.status).toBe(200);
+                const data = (await res.json()) as {
+                    runners: Array<{ runnerId: string; name: string }>;
+                };
+                const found = data.runners.find((r) => r.runnerId === runner.runnerId);
+                expect(found).toBeTruthy();
+                expect(found?.name).toBe("visible-runner");
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("runner metadata is stored correctly", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server, {
+                name: "metadata-runner",
+                roots: ["/tmp/meta-test"],
+                version: "2.0.0-test",
+                platform: "darwin",
+            });
+            try {
+                const res = await server.fetch("/api/runners");
+                const data = (await res.json()) as {
+                    runners: Array<{
+                        runnerId: string;
+                        name: string;
+                        roots: string[];
+                        version: string | null;
+                        platform: string | null;
+                    }>;
+                };
+                const found = data.runners.find((r) => r.runnerId === runner.runnerId);
+                expect(found).toBeTruthy();
+                expect(found?.roots).toEqual(["/tmp/meta-test"]);
+                expect(found?.version).toBe("2.0.0-test");
+                expect(found?.platform).toBe("darwin");
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 3. emitSessionReady — session_ready propagates
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — emitSessionReady", () => {
+    test("emitSessionReady sends session_ready to the server", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server);
+            try {
+                const sessionId = "test-session-ready-" + Date.now();
+
+                // Capture session_ready events on the server side via the io instance.
+                const receivedSessionIds: string[] = [];
+                const runnerNs = server.io.of("/runner");
+                const captureHandler = (data: { sessionId: string }) => {
+                    if (data.sessionId === sessionId) {
+                        receivedSessionIds.push(data.sessionId);
+                    }
+                };
+                // Listen on all future connections for this event
+                runnerNs.on("connection", (socket) => {
+                    socket.on("session_ready", captureHandler);
+                });
+
+                // Also subscribe on existing sockets (the runner socket is already connected)
+                const sockets = await runnerNs.fetchSockets();
+                for (const s of sockets) {
+                    s.on("session_ready", captureHandler as (data: unknown) => void);
+                }
+
+                runner.emitSessionReady(sessionId);
+
+                // Wait a moment for the event to propagate
+                await new Promise<void>((r) => setTimeout(r, 200));
+
+                // The session_ready event handler calls resolveSpawnReady() (no-op for unknown sessionId).
+                // We verify the socket is still alive and hasn't crashed.
+                expect(runner.socket.connected).toBe(true);
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Multiple runners on the same server
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — multiple runners", () => {
+    test("two runners can register simultaneously", async () => {
+        const server = await createTestServer();
+        try {
+            const [r1, r2] = await Promise.all([
+                createMockRunner(server, { name: "runner-alpha" }),
+                createMockRunner(server, { name: "runner-beta" }),
+            ]);
+            try {
+                expect(r1.runnerId).not.toBe(r2.runnerId);
+                expect(r1.socket.connected).toBe(true);
+                expect(r2.socket.connected).toBe(true);
+
+                const res = await server.fetch("/api/runners");
+                const data = (await res.json()) as {
+                    runners: Array<{ runnerId: string; name: string }>;
+                };
+                const ids = data.runners.map((r) => r.runnerId);
+                expect(ids).toContain(r1.runnerId);
+                expect(ids).toContain(r2.runnerId);
+            } finally {
+                await Promise.allSettled([r1.disconnect(), r2.disconnect()]);
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("three runners all appear in the list", async () => {
+        const server = await createTestServer();
+        try {
+            const [rA, rB, rC] = await Promise.all([
+                createMockRunner(server, { name: "runner-A" }),
+                createMockRunner(server, { name: "runner-B" }),
+                createMockRunner(server, { name: "runner-C" }),
+            ]);
+            try {
+                const res = await server.fetch("/api/runners");
+                const data = (await res.json()) as { runners: Array<{ runnerId: string }> };
+                const ids = data.runners.map((r) => r.runnerId);
+                expect(ids).toContain(rA.runnerId);
+                expect(ids).toContain(rB.runnerId);
+                expect(ids).toContain(rC.runnerId);
+            } finally {
+                await Promise.allSettled([rA.disconnect(), rB.disconnect(), rC.disconnect()]);
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 5. Clean disconnect — runner is removed after disconnect
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — clean disconnect", () => {
+    test("runner is removed from the list after disconnect", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server, { name: "temp-runner" });
+            const { runnerId } = runner;
+
+            // Verify it's there before disconnect
+            const before = await server.fetch("/api/runners");
+            const beforeData = (await before.json()) as { runners: Array<{ runnerId: string }> };
+            expect(beforeData.runners.map((r) => r.runnerId)).toContain(runnerId);
+
+            // Disconnect
+            await runner.disconnect();
+
+            // Give the server a moment to process the disconnect event
+            await new Promise<void>((r) => setTimeout(r, 300));
+
+            // Verify it's gone
+            const after = await server.fetch("/api/runners");
+            const afterData = (await after.json()) as { runners: Array<{ runnerId: string }> };
+            expect(afterData.runners.map((r) => r.runnerId)).not.toContain(runnerId);
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("disconnect() is idempotent (calling twice does not throw)", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server);
+            await runner.disconnect();
+            await expect(runner.disconnect()).resolves.toBeUndefined();
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 6. waitForEvent utility
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — waitForEvent", () => {
+    test("waitForEvent resolves when the server emits the named event", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server);
+            try {
+                // waitForEvent listens for server→client events on the runner's socket.
+                // Use the server's io instance to emit directly to this runner's socket.
+                const waitPromise = runner.waitForEvent("ping", 2_000);
+
+                // Find the server-side socket for this runner and emit to it
+                const runnerNs = server.io.of("/runner");
+                const sockets = await runnerNs.fetchSockets();
+                const serverSocket = sockets.find((s) => s.data.runnerId === runner.runnerId);
+                expect(serverSocket).toBeTruthy();
+
+                // Emit a ping (a valid server→runner event per protocol)
+                serverSocket!.emit("ping", {});
+
+                const result = await waitPromise;
+                expect(result).toEqual({});
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("waitForEvent rejects on timeout", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server);
+            try {
+                await expect(
+                    runner.waitForEvent("event_that_never_fires", 100),
+                ).rejects.toThrow(/Timed out/);
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -68,7 +68,6 @@ export async function createMockRunner(
     opts?: MockRunnerOptions,
 ): Promise<MockRunner> {
     const runnerId = opts?.runnerId ?? randomUUID();
-    const runnerUrl = server.baseUrl.replace(/^http/, "ws"); // socket.io handles both http/ws
 
     const socket: ClientSocket = ioClient(`${server.baseUrl}/runner`, {
         auth: { apiKey: opts?.apiKey ?? server.apiKey },

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -1,0 +1,186 @@
+/**
+ * Mock runner client for integration tests.
+ *
+ * Connects to a test server's /runner Socket.IO namespace and mimics the
+ * behaviour of a real PizzaPi runner daemon.
+ */
+
+import { io as ioClient, type Socket as ClientSocket } from "socket.io-client";
+import { randomUUID } from "crypto";
+
+import type {
+    RunnerSkill,
+    RunnerAgent,
+    RunnerPlugin,
+    RunnerHook,
+} from "@pizzapi/protocol";
+
+import type { TestServer } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface MockRunnerOptions {
+    runnerId?: string;
+    name?: string;
+    roots?: string[];
+    skills?: RunnerSkill[];
+    agents?: RunnerAgent[];
+    plugins?: RunnerPlugin[];
+    hooks?: RunnerHook[];
+    version?: string;
+    platform?: string;
+}
+
+export interface MockRunner {
+    runnerId: string;
+    socket: ClientSocket;
+
+    // Session lifecycle helpers
+    emitSessionReady(sessionId: string): void;
+    emitSessionError(sessionId: string, error: string): void;
+    emitSessionEvent(sessionId: string, event: unknown): void;
+    emitSessionEnded(sessionId: string): void;
+
+    // Request handler registration
+    onSkillRequest(handler: (data: unknown) => unknown): void;
+    onFileRequest(handler: (data: unknown) => unknown): void;
+
+    // Utilities
+    waitForEvent(eventName: string, timeout?: number): Promise<unknown>;
+    disconnect(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a mock runner that connects to the given test server's /runner
+ * namespace, registers itself, and returns a helper object for emitting
+ * events in tests.
+ */
+export async function createMockRunner(
+    server: TestServer,
+    opts?: MockRunnerOptions,
+): Promise<MockRunner> {
+    const runnerId = opts?.runnerId ?? randomUUID();
+    const runnerUrl = server.baseUrl.replace(/^http/, "ws"); // socket.io handles both http/ws
+
+    const socket: ClientSocket = ioClient(`${server.baseUrl}/runner`, {
+        auth: { apiKey: server.apiKey },
+        transports: ["websocket"],
+        // Prevent socket.io from trying to upgrade / reconnect in tests
+        reconnection: false,
+        forceNew: true,
+    });
+
+    // Wait for the socket to connect and the server to confirm registration.
+    // The server generates its own runnerId (ignoring the client-side hint unless
+    // runnerSecret is also provided), so we capture the actual ID from runner_registered.
+    let assignedRunnerId = runnerId; // fallback; replaced below
+    await new Promise<void>((resolve, reject) => {
+        const connectErrorHandler = (err: Error) => {
+            reject(new Error(`Mock runner connect_error: ${err.message}`));
+        };
+
+        socket.on("connect_error", connectErrorHandler);
+
+        socket.on("connect", () => {
+            // Emit registration payload
+            socket.emit("register_runner", {
+                runnerId,
+                name: opts?.name ?? "test-runner",
+                roots: opts?.roots ?? ["/tmp/test"],
+                skills: opts?.skills ?? [],
+                agents: opts?.agents ?? [],
+                plugins: opts?.plugins ?? [],
+                hooks: opts?.hooks ?? [],
+                version: opts?.version ?? "1.0.0-test",
+                platform: opts?.platform ?? "linux",
+            });
+        });
+
+        socket.once("runner_registered", (data: { runnerId: string }) => {
+            socket.off("connect_error", connectErrorHandler);
+            // Use the server-assigned runnerId (server may have generated a new one)
+            assignedRunnerId = data.runnerId;
+            resolve();
+        });
+
+        // Reject fast on explicit error events from the server
+        socket.once("error", (data: { message: string }) => {
+            socket.off("connect_error", connectErrorHandler);
+            reject(new Error(`Server error during registration: ${data.message}`));
+        });
+    });
+
+    // ── MockRunner implementation ──────────────────────────────────────────
+
+    const runner: MockRunner = {
+        runnerId: assignedRunnerId,
+        socket,
+
+        emitSessionReady(sessionId: string): void {
+            socket.emit("session_ready", { sessionId });
+        },
+
+        emitSessionError(sessionId: string, error: string): void {
+            socket.emit("session_error", { sessionId, message: error });
+        },
+
+        emitSessionEvent(sessionId: string, event: unknown): void {
+            socket.emit("runner_session_event", { sessionId, event });
+        },
+
+        emitSessionEnded(sessionId: string): void {
+            // session_ended is a server→client event; the runner uses
+            // session_killed to notify the server that a session has ended.
+            socket.emit("session_killed", { sessionId });
+        },
+
+        onSkillRequest(handler: (data: unknown) => unknown): void {
+            socket.on("list_skills", (data) => {
+                const result = handler(data);
+                socket.emit("skills_list", {
+                    skills: Array.isArray(result) ? result : [],
+                    requestId: (data as { requestId?: string }).requestId,
+                });
+            });
+        },
+
+        onFileRequest(handler: (data: unknown) => unknown): void {
+            socket.on("list_files", (data) => {
+                const result = handler(data);
+                socket.emit("file_result", {
+                    ...(typeof result === "object" && result !== null ? result : {}),
+                    requestId: (data as { requestId?: string }).requestId,
+                });
+            });
+        },
+
+        waitForEvent(eventName: string, timeout = 5_000): Promise<unknown> {
+            return new Promise<unknown>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    reject(new Error(`Timed out waiting for event "${eventName}" after ${timeout}ms`));
+                }, timeout);
+
+                socket.once(eventName, (data: unknown) => {
+                    clearTimeout(timer);
+                    resolve(data);
+                });
+            });
+        },
+
+        async disconnect(): Promise<void> {
+            if (!socket.connected) return;
+            await new Promise<void>((resolve) => {
+                socket.once("disconnect", () => resolve());
+                socket.disconnect();
+            });
+        },
+    };
+
+    return runner;
+}

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -22,6 +22,8 @@ import type { TestServer } from "./types.js";
 // ---------------------------------------------------------------------------
 
 export interface MockRunnerOptions {
+    /** Override the API key used for auth (default: server.apiKey). Pass a bad key to test auth failures. */
+    apiKey?: string;
     runnerId?: string;
     name?: string;
     roots?: string[];
@@ -69,7 +71,7 @@ export async function createMockRunner(
     const runnerUrl = server.baseUrl.replace(/^http/, "ws"); // socket.io handles both http/ws
 
     const socket: ClientSocket = ioClient(`${server.baseUrl}/runner`, {
-        auth: { apiKey: server.apiKey },
+        auth: { apiKey: opts?.apiKey ?? server.apiKey },
         transports: ["websocket"],
         // Prevent socket.io from trying to upgrade / reconnect in tests
         reconnection: false,
@@ -81,8 +83,27 @@ export async function createMockRunner(
     // runnerSecret is also provided), so we capture the actual ID from runner_registered.
     let assignedRunnerId = runnerId; // fallback; replaced below
     await new Promise<void>((resolve, reject) => {
+        // Guard against double-settling (timeout + normal path racing).
+        let settled = false;
+
+        const settle = (fn: () => void): void => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(registrationTimer);
+            fn();
+        };
+
+        // P3: Explicit registration timeout — reject if the server never responds.
+        const registrationTimer = setTimeout(() => {
+            if (!settled) {
+                settled = true;
+                socket.disconnect();
+                reject(new Error("Mock runner registration timed out after 5000ms"));
+            }
+        }, 5_000);
+
         const connectErrorHandler = (err: Error) => {
-            reject(new Error(`Mock runner connect_error: ${err.message}`));
+            settle(() => reject(new Error(`Mock runner connect_error: ${err.message}`)));
         };
 
         socket.on("connect_error", connectErrorHandler);
@@ -103,16 +124,16 @@ export async function createMockRunner(
         });
 
         socket.once("runner_registered", (data: { runnerId: string }) => {
-            socket.off("connect_error", connectErrorHandler);
-            // Use the server-assigned runnerId (server may have generated a new one)
-            assignedRunnerId = data.runnerId;
-            resolve();
+            settle(() => {
+                // Use the server-assigned runnerId (server may have generated a new one)
+                assignedRunnerId = data.runnerId;
+                resolve();
+            });
         });
 
         // Reject fast on explicit error events from the server
         socket.once("error", (data: { message: string }) => {
-            socket.off("connect_error", connectErrorHandler);
-            reject(new Error(`Server error during registration: ${data.message}`));
+            settle(() => reject(new Error(`Server error during registration: ${data.message}`)));
         });
     });
 
@@ -162,14 +183,20 @@ export async function createMockRunner(
 
         waitForEvent(eventName: string, timeout = 5_000): Promise<unknown> {
             return new Promise<unknown>((resolve, reject) => {
+                // P2: Store the handler reference so we can remove it on timeout
+                // (socket.once listeners must be cleaned up to avoid leaks).
+                const handler = (data: unknown): void => {
+                    clearTimeout(timer);
+                    resolve(data);
+                };
+
                 const timer = setTimeout(() => {
+                    // Remove the once-listener that was never triggered
+                    socket.off(eventName, handler);
                     reject(new Error(`Timed out waiting for event "${eventName}" after ${timeout}ms`));
                 }, timeout);
 
-                socket.once(eventName, (data: unknown) => {
-                    clearTimeout(timer);
-                    resolve(data);
-                });
+                socket.once(eventName, handler);
             });
         },
 

--- a/packages/server/tests/harness/preload.ts
+++ b/packages/server/tests/harness/preload.ts
@@ -1,0 +1,23 @@
+/**
+ * Bun test preload script — captures the real redis createClient before any
+ * mock.module("redis", ...) calls replace it.
+ *
+ * Bun runs this file BEFORE evaluating any test file (including before the
+ * hoisted mock.module() calls in test files). By saving the real createClient
+ * to globalThis here, the test harness can always access the genuine redis
+ * client factory regardless of what other test files mock.
+ *
+ * Referenced from bunfig.toml:
+ *   [test]
+ *   preload = ["./packages/server/tests/harness/preload.ts"]
+ */
+
+import { createClient } from "redis";
+
+// Type augmentation so TypeScript knows about the global
+declare global {
+    // eslint-disable-next-line no-var
+    var __realRedisCreateClient: typeof createClient | undefined;
+}
+
+globalThis.__realRedisCreateClient = createClient;

--- a/packages/server/tests/harness/server.test.ts
+++ b/packages/server/tests/harness/server.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Smoke tests for the test server factory harness.
+ *
+ * These tests verify that createTestServer():
+ *   1. Spins up a real HTTP server that responds to requests
+ *   2. Pre-creates a user with a working API key
+ *   3. Multiple servers can run simultaneously (created sequentially, then accessed concurrently)
+ *   4. Cleans up all resources on shutdown
+ *
+ * NOTE: Servers must be created sequentially (not with Promise.all) because
+ * auth.ts and sio-state.ts use module-level singletons. Once created, multiple
+ * servers can coexist and respond simultaneously.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { createTestServer } from "./server.js";
+
+// Tests spin up real servers + Redis + Socket.IO, so we need a generous timeout.
+const TEST_TIMEOUT_MS = 30_000;
+
+describe("createTestServer", () => {
+    test("creates server and responds to health check", async () => {
+        const server = await createTestServer();
+        try {
+            const res = await fetch(`${server.baseUrl}/health`);
+            // Health may be degraded if Redis singletons were overwritten, but
+            // the server must respond with the expected shape.
+            expect([200, 503]).toContain(res.status);
+            const data = await res.json();
+            expect(["ok", "degraded"]).toContain(data.status);
+            expect(typeof data.redis).toBe("boolean");
+            expect(typeof data.socketio).toBe("boolean");
+            expect(typeof data.uptime).toBe("number");
+        } finally {
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("pre-created user can authenticate via API key", async () => {
+        const server = await createTestServer();
+        try {
+            // Verify basic properties are populated
+            expect(server.port).toBeGreaterThan(0);
+            expect(server.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+            expect(server.apiKey).toHaveLength(64); // 32 random bytes → 64 hex chars
+            expect(server.userId).toBeTruthy();
+            expect(server.userName).toBe("Test User");
+            expect(server.userEmail).toBe("testuser@pizzapi-harness.test");
+            expect(server.sessionCookie).toBeTruthy();
+
+            // The built-in fetch helper includes auth headers
+            const res = await server.fetch("/api/signup-status");
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            // After first user created with disableSignupAfterFirstUser: true (default),
+            // signup should be disabled
+            expect(data.signupEnabled).toBe(false);
+        } finally {
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("multiple test servers can run concurrently", async () => {
+        // Create servers sequentially (module singletons require serial creation)
+        // then verify they can all respond simultaneously.
+        const s1 = await createTestServer();
+        const s2 = await createTestServer();
+        const s3 = await createTestServer();
+
+        try {
+            // All servers should have different ports
+            const ports = new Set([s1.port, s2.port, s3.port]);
+            expect(ports.size).toBe(3);
+
+            // All servers should respond simultaneously (concurrent reads are fine)
+            const responses = await Promise.all([
+                fetch(`${s1.baseUrl}/health`),
+                fetch(`${s2.baseUrl}/health`),
+                fetch(`${s3.baseUrl}/health`),
+            ]);
+
+            for (const res of responses) {
+                expect([200, 503]).toContain(res.status);
+                const data = await res.json();
+                expect(["ok", "degraded"]).toContain(data.status);
+            }
+        } finally {
+            // Clean up all servers, ignoring individual errors
+            await Promise.allSettled([s1.cleanup(), s2.cleanup(), s3.cleanup()]);
+        }
+    }, TEST_TIMEOUT_MS * 3);
+
+    test("cleanup shuts down cleanly", async () => {
+        const server = await createTestServer();
+        const baseUrl = server.baseUrl;
+
+        // Server is up before cleanup
+        const before = await fetch(`${baseUrl}/health`);
+        expect([200, 503]).toContain(before.status);
+
+        // Cleanup
+        await server.cleanup();
+
+        // Server should no longer be reachable after cleanup
+        let threw = false;
+        try {
+            await fetch(`${baseUrl}/health`);
+        } catch {
+            threw = true;
+        }
+        expect(threw).toBe(true);
+    }, TEST_TIMEOUT_MS);
+});

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -14,7 +14,17 @@ import { tmpdir } from "node:os";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Server as SocketIOServer } from "socket.io";
 import { createAdapter } from "@socket.io/redis-adapter";
-import { createClient, type RedisClientType } from "redis";
+import type { RedisClientType, createClient as CreateClientType } from "redis";
+
+// Bun test preload (bunfig.toml) saves the real createClient to globalThis BEFORE
+// any mock.module("redis", ...) calls from other test files can replace it.
+// We use that saved reference here so the harness always gets a genuine redis client.
+// Falls back to the module-level import only if the preload didn't run (e.g., direct
+// `import` outside of `bun test`), in which case mock contamination is not a concern.
+declare global {
+    // eslint-disable-next-line no-var
+    var __realRedisCreateClient: typeof CreateClientType | undefined;
+}
 
 import { initAuth, getTrustedOrigins } from "../../src/auth.js";
 import { runAllMigrations } from "../../src/migrations.js";
@@ -163,16 +173,18 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
 
         // 5. Create Redis pub/sub clients and connect them.
         //
-        // Guard against mock.module("redis", ...) from other test files running in the
-        // same Bun worker: the real redis client from redis@4.x always has .duplicate(),
-        // whereas mock clients typically omit it. If .duplicate is absent, create an
-        // independent client for the sub role instead of crashing.
-        pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
-        subClient = (
-            typeof pubClient.duplicate === "function"
-                ? pubClient.duplicate()
-                : createClient({ url: REDIS_URL })
-        ) as RedisClientType;
+        // ALWAYS use the real createClient saved by the preload script. The preload runs
+        // before any mock.module("redis", ...) can activate, so globalThis.__realRedisCreateClient
+        // is the genuine redis factory regardless of what other test files mock.
+        //
+        // If the preload didn't run (e.g., this module was imported outside bun test), fall
+        // back to a dynamic import of redis. In that case, mock contamination is not an issue.
+        const realCreate =
+            globalThis.__realRedisCreateClient ??
+            ((await import("redis")) as unknown as { createClient: typeof CreateClientType }).createClient;
+
+        pubClient = realCreate({ url: REDIS_URL }) as RedisClientType;
+        subClient = pubClient.duplicate() as RedisClientType;
         await Promise.all([pubClient.connect(), subClient.connect()]);
 
         // 6. We'll track the resolved port for the request converter

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -137,193 +137,246 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
     const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
     process.env.PIZZAPI_TRUST_PROXY = "true";
 
-    // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
-    // that better-auth uses only for cookie domain (not for actual listening).
-    // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
-    const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
+    // Track partially-created resources so the catch block can roll back
+    // whatever was allocated before the failure.
+    let pubClient: RedisClientType | undefined;
+    let subClient: RedisClientType | undefined;
+    let io: SocketIOServer | undefined;
 
-    // 3. Init auth with temp DB
-    initAuth({
-        dbPath,
-        baseURL: placeholderBase,
-        secret: "test-secret-for-harness-at-least-32-chars-long!!",
-        disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
-        extraOrigins: opts?.trustedOrigins,
-    });
+    try {
+        // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
+        // that better-auth uses only for cookie domain (not for actual listening).
+        // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
+        const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
 
-    // 4. Run DB migrations
-    await runAllMigrations();
+        // 3. Init auth with temp DB
+        initAuth({
+            dbPath,
+            baseURL: placeholderBase,
+            secret: "test-secret-for-harness-at-least-32-chars-long!!",
+            disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
+            extraOrigins: opts?.trustedOrigins,
+        });
 
-    // 5. Create Redis pub/sub clients and connect them
-    const pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
-    const subClient = pubClient.duplicate() as RedisClientType;
-    await Promise.all([pubClient.connect(), subClient.connect()]);
+        // 4. Run DB migrations
+        await runAllMigrations();
 
-    // 6. We'll track the resolved port for the request converter
-    let resolvedPort = 0;
+        // 5. Create Redis pub/sub clients and connect them.
+        //
+        // Guard against mock.module("redis", ...) from other test files running in the
+        // same Bun worker: the real redis client from redis@4.x always has .duplicate(),
+        // whereas mock clients typically omit it. If .duplicate is absent, create an
+        // independent client for the sub role instead of crashing.
+        pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
+        subClient = (
+            typeof pubClient.duplicate === "function"
+                ? pubClient.duplicate()
+                : createClient({ url: REDIS_URL })
+        ) as RedisClientType;
+        await Promise.all([pubClient.connect(), subClient.connect()]);
 
-    // Create the HTTP server with the handleFetch handler
-    const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-        try {
-            const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
-            const fetchRes = await handleFetch(fetchReq);
-            await sendFetchResponse(res, fetchRes);
-        } catch (e) {
-            console.error("[test-harness] Unhandled error:", e);
-            if (!res.headersSent) {
-                res.writeHead(500, { "content-type": "application/json" });
+        // 6. We'll track the resolved port for the request converter
+        let resolvedPort = 0;
+
+        // Create the HTTP server with the handleFetch handler
+        const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+            try {
+                const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
+                const fetchRes = await handleFetch(fetchReq);
+                await sendFetchResponse(res, fetchRes);
+            } catch (e) {
+                console.error("[test-harness] Unhandled error:", e);
+                if (!res.headersSent) {
+                    res.writeHead(500, { "content-type": "application/json" });
+                }
+                res.end(JSON.stringify({ error: "Internal server error" }));
             }
-            res.end(JSON.stringify({ error: "Internal server error" }));
+        });
+
+        // 7. Create Socket.IO server with Redis adapter
+        io = new SocketIOServer(httpServer, {
+            cors: {
+                origin: getTrustedOrigins(),
+                credentials: true,
+            },
+            maxHttpBufferSize: 100 * 1024 * 1024,
+            pingInterval: 30_000,
+            pingTimeout: 60_000,
+            adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
+            transports: ["websocket", "polling"],
+        });
+
+        // 8. Init state Redis
+        await initStateRedis();
+
+        // 9. Init the Socket.IO registry
+        initSioRegistry(io);
+
+        // 10. Register all namespaces
+        registerNamespaces(io);
+
+        // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
+        await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+
+        const addr = httpServer.address();
+        if (!addr || typeof addr === "string") {
+            throw new Error("[test-harness] Could not determine server port");
         }
-    });
+        resolvedPort = addr.port;
 
-    // 7. Create Socket.IO server with Redis adapter
-    const io = new SocketIOServer(httpServer, {
-        cors: {
-            origin: getTrustedOrigins(),
-            credentials: true,
-        },
-        maxHttpBufferSize: 100 * 1024 * 1024,
-        pingInterval: 30_000,
-        pingTimeout: 60_000,
-        adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
-        transports: ["websocket", "polling"],
-    });
+        // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
+        const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
 
-    // 8. Init state Redis
-    await initStateRedis();
+        // 12. Create a test user via the /api/register endpoint.
+        //     Use a unique client IP per server instance so each registration gets its
+        //     own rate-limit bucket in the module-level registerRateLimiter singleton.
+        const testUserName = "Test User";
+        const testUserEmail = "testuser@pizzapi-harness.test";
+        const testUserPassword = "HarnessPass123";
+        const testClientIp = uniqueTestClientIp();
 
-    // 9. Init the Socket.IO registry
-    initSioRegistry(io);
+        const registerRes = await fetch(`${baseUrl}/api/register`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                // Unique x-forwarded-for per server so the rate limiter assigns a
+                // separate bucket for each test server creation.
+                "x-forwarded-for": testClientIp,
+            },
+            body: JSON.stringify({
+                name: testUserName,
+                email: testUserEmail,
+                password: testUserPassword,
+            }),
+        });
 
-    // 10. Register all namespaces
-    registerNamespaces(io);
-
-    // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
-    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
-
-    const addr = httpServer.address();
-    if (!addr || typeof addr === "string") {
-        throw new Error("[test-harness] Could not determine server port");
-    }
-    resolvedPort = addr.port;
-
-    // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
-    const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
-
-    // 12. Create a test user via the /api/register endpoint.
-    //     Use a unique client IP per server instance so each registration gets its
-    //     own rate-limit bucket in the module-level registerRateLimiter singleton.
-    const testUserName = "Test User";
-    const testUserEmail = "testuser@pizzapi-harness.test";
-    const testUserPassword = "HarnessPass123";
-    const testClientIp = uniqueTestClientIp();
-
-    const registerRes = await fetch(`${baseUrl}/api/register`, {
-        method: "POST",
-        headers: {
-            "content-type": "application/json",
-            // Unique x-forwarded-for per server so the rate limiter assigns a
-            // separate bucket for each test server creation.
-            "x-forwarded-for": testClientIp,
-        },
-        body: JSON.stringify({
-            name: testUserName,
-            email: testUserEmail,
-            password: testUserPassword,
-        }),
-    });
-
-    if (!registerRes.ok) {
-        throw new Error(
-            `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
-        );
-    }
-
-    const registerData = await registerRes.json() as { ok: boolean; key: string };
-    const apiKey = registerData.key;
-
-    // 13. Get a session cookie via better-auth sign-in.
-    //     The sign-in response includes the user object (with id) and Set-Cookie header.
-    const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
-        method: "POST",
-        headers: {
-            "content-type": "application/json",
-            "x-forwarded-for": testClientIp,
-        },
-        body: JSON.stringify({
-            email: testUserEmail,
-            password: testUserPassword,
-        }),
-    });
-
-    if (!signInRes.ok) {
-        throw new Error(
-            `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
-        );
-    }
-
-    const signInData = await signInRes.json() as { user?: { id: string } };
-    const userId = signInData.user?.id ?? "";
-    if (!userId) {
-        throw new Error("[test-harness] Could not get userId from sign-in response");
-    }
-
-    const cookies = signInRes.headers.getSetCookie();
-    const sessionCookie = cookies.join("; ");
-
-    // ── Helpers ──────────────────────────────────────────────────────────────
-
-    async function testFetch(path: string, init?: RequestInit): Promise<Response> {
-        const url = `${baseUrl}${path}`;
-        const headers = new Headers(init?.headers);
-
-        // Inject auth headers if not already present
-        if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
-            headers.set("x-pizzapi-api-key", apiKey);
-        }
-        if (!headers.has("cookie") && sessionCookie) {
-            headers.set("cookie", sessionCookie);
+        if (!registerRes.ok) {
+            throw new Error(
+                `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+            );
         }
 
-        return fetch(url, { ...init, headers });
-    }
+        const registerData = await registerRes.json() as { ok: boolean; key: string };
+        const apiKey = registerData.key;
 
-    // ── Cleanup ──────────────────────────────────────────────────────────────
+        // 13. Get a session cookie via better-auth sign-in.
+        //     The sign-in response includes the user object (with id) and Set-Cookie header.
+        const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "x-forwarded-for": testClientIp,
+            },
+            body: JSON.stringify({
+                email: testUserEmail,
+                password: testUserPassword,
+            }),
+        });
 
-    async function cleanup(): Promise<void> {
-        // Restore PIZZAPI_TRUST_PROXY
+        if (!signInRes.ok) {
+            throw new Error(
+                `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
+            );
+        }
+
+        const signInData = await signInRes.json() as { user?: { id: string } };
+        const userId = signInData.user?.id ?? "";
+        if (!userId) {
+            throw new Error("[test-harness] Could not get userId from sign-in response");
+        }
+
+        const cookies = signInRes.headers.getSetCookie();
+        const sessionCookie = cookies.join("; ");
+
+        // ── Helpers ──────────────────────────────────────────────────────────────
+
+        async function testFetch(path: string, init?: RequestInit): Promise<Response> {
+            const url = `${baseUrl}${path}`;
+            const headers = new Headers(init?.headers);
+
+            // Inject auth headers if not already present
+            if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
+                headers.set("x-pizzapi-api-key", apiKey);
+            }
+            if (!headers.has("cookie") && sessionCookie) {
+                headers.set("cookie", sessionCookie);
+            }
+
+            return fetch(url, { ...init, headers });
+        }
+
+        // ── Cleanup ──────────────────────────────────────────────────────────────
+
+        async function cleanup(): Promise<void> {
+            // Restore PIZZAPI_TRUST_PROXY
+            if (savedTrustProxy === undefined) {
+                delete process.env.PIZZAPI_TRUST_PROXY;
+            } else {
+                process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+            }
+
+            // Close Socket.IO — this also closes the underlying httpServer internally,
+            // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
+            await new Promise<void>((resolve) => io!.close(() => resolve()));
+
+            // Disconnect Redis clients
+            await Promise.allSettled([pubClient!.quit(), subClient!.quit()]);
+
+            // Clean up temp directory
+            try {
+                rmSync(tmpDir, { recursive: true, force: true });
+            } catch {
+                // Ignore cleanup errors
+            }
+        }
+
+        return {
+            port: resolvedPort,
+            baseUrl,
+            io: io!,
+            apiKey,
+            userId,
+            userName: testUserName,
+            userEmail: testUserEmail,
+            sessionCookie,
+            fetch: testFetch,
+            cleanup,
+        };
+    } catch (err) {
+        // ── Setup rollback ────────────────────────────────────────────────────
+        // An exception occurred before we could return a TestServer with a cleanup()
+        // function. Release whatever was partially created to prevent global/env/resource
+        // state from leaking into subsequent tests.
+
+        // Restore PIZZAPI_TRUST_PROXY env var
         if (savedTrustProxy === undefined) {
             delete process.env.PIZZAPI_TRUST_PROXY;
         } else {
             process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
         }
 
-        // Close Socket.IO — this also closes the underlying httpServer internally,
-        // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
-        await new Promise<void>((resolve) => io.close(() => resolve()));
+        // Close Socket.IO (also closes the underlying httpServer)
+        if (io) {
+            await new Promise<void>((resolve) => io!.close(() => resolve()));
+        }
 
-        // Disconnect Redis clients
-        await Promise.allSettled([pubClient.quit(), subClient.quit()]);
+        // Disconnect Redis clients (only if they were opened and have a real quit()).
+        // The typeof guard prevents a crash if an unexpected mock slips through.
+        if (pubClient ?? subClient) {
+            const safeQuit = (c: RedisClientType | undefined): Promise<unknown> => {
+                if (!c || !c.isOpen || typeof c.quit !== "function") return Promise.resolve();
+                return c.quit();
+            };
+            await Promise.allSettled([safeQuit(pubClient), safeQuit(subClient)]);
+        }
 
-        // Clean up temp directory
+        // Remove temp directory
         try {
             rmSync(tmpDir, { recursive: true, force: true });
         } catch {
             // Ignore cleanup errors
         }
-    }
 
-    return {
-        port: resolvedPort,
-        baseUrl,
-        io,
-        apiKey,
-        userId,
-        userName: testUserName,
-        userEmail: testUserEmail,
-        sessionCookie,
-        fetch: testFetch,
-        cleanup,
-    };
+        throw err;
+    }
 }

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -1,0 +1,329 @@
+/**
+ * Test server factory — creates a real PizzaPi server on an ephemeral port
+ * with SQLite + Redis + Socket.IO for integration testing.
+ *
+ * IMPORTANT: createTestServer() uses module-level singletons from auth.ts and
+ * sio-state.ts. Concurrent server creation is NOT supported — create servers
+ * sequentially. Multiple servers can run simultaneously after creation; only
+ * the creation phase must be serialized.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Server as SocketIOServer } from "socket.io";
+import { createAdapter } from "@socket.io/redis-adapter";
+import { createClient, type RedisClientType } from "redis";
+
+import { initAuth, getTrustedOrigins } from "../../src/auth.js";
+import { runAllMigrations } from "../../src/migrations.js";
+import { handleFetch } from "../../src/handler.js";
+import { initStateRedis } from "../../src/ws/sio-state.js";
+import { initSioRegistry } from "../../src/ws/sio-registry.js";
+import { registerNamespaces } from "../../src/ws/namespaces/index.js";
+
+import type { TestServerOptions, TestServer } from "./types.js";
+
+const REDIS_URL = process.env.PIZZAPI_REDIS_URL ?? "redis://localhost:6379";
+
+// ── Unique IP generator ──────────────────────────────────────────────────────
+// The register rate limiter in routes/auth.ts is a module-level singleton
+// (shared across all test server instances). We generate a unique IP per server
+// so each creation gets its own rate-limit bucket and doesn't collide with others.
+let _serverCounter = 0;
+function uniqueTestClientIp(): string {
+    const n = ++_serverCounter;
+    return `10.255.${Math.floor(n / 256) % 256}.${n % 256}`;
+}
+
+// ── Node req/res ↔ fetch API helpers (mirrors src/index.ts) ─────────────────
+
+async function nodeReqToFetchRequest(req: IncomingMessage, port: number): Promise<Request> {
+    const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+        if (value === undefined) continue;
+        // Prevent client-supplied x-pizzapi-client-ip spoofing
+        if (key.toLowerCase() === "x-pizzapi-client-ip") continue;
+        if (Array.isArray(value)) {
+            for (const v of value) headers.append(key, v);
+        } else {
+            headers.set(key, value);
+        }
+    }
+
+    // Inject real client IP from the TCP socket
+    if (req.socket.remoteAddress) {
+        headers.set("x-pizzapi-client-ip", req.socket.remoteAddress);
+    }
+
+    const method = (req.method ?? "GET").toUpperCase();
+    const hasBody = method !== "GET" && method !== "HEAD";
+
+    // Pre-buffer the body from the Node.js stream into an ArrayBuffer.
+    //
+    // IMPORTANT: Do NOT pass the IncomingMessage stream directly as the Request
+    // body. handler.ts notes a known Bun issue: when a Request with a
+    // ReadableStream body is subsequently wrapped via `new Request(req, { headers })`
+    // (as the auth handler does), the stream fails to propagate and hangs
+    // indefinitely. Pre-buffering into an ArrayBuffer avoids this entirely.
+    let body: ArrayBuffer | undefined;
+    if (hasBody) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+        }
+        const buf = Buffer.concat(chunks);
+        body = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+    }
+
+    return new Request(url.toString(), {
+        method,
+        headers,
+        body,
+    });
+}
+
+async function sendFetchResponse(res: ServerResponse, response: Response): Promise<void> {
+    const headers: Record<string, string | string[]> = {};
+    response.headers.forEach((value, key) => {
+        const existing = headers[key];
+        if (existing !== undefined) {
+            headers[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+        } else {
+            headers[key] = value;
+        }
+    });
+
+    res.writeHead(response.status, headers);
+
+    if (!response.body) {
+        res.end();
+        return;
+    }
+
+    const reader = response.body.getReader();
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            res.write(value);
+        }
+    } finally {
+        reader.releaseLock();
+        res.end();
+    }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a fully initialized PizzaPi test server on an ephemeral port.
+ * Includes SQLite DB, Redis, Socket.IO, and a pre-created test user.
+ *
+ * Always call `cleanup()` when done to release all resources.
+ *
+ * NOTE: Uses module-level singletons (auth, sio-state). Do NOT call this
+ * concurrently — create servers sequentially to avoid race conditions.
+ */
+export async function createTestServer(opts?: TestServerOptions): Promise<TestServer> {
+    // 1. Temp directory for the SQLite DB
+    const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
+    const dbPath = join(tmpDir, "test.db");
+
+    // 2. Trust proxy for rate-limit tests (mirrors production behavior)
+    const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
+    process.env.PIZZAPI_TRUST_PROXY = "true";
+
+    // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
+    // that better-auth uses only for cookie domain (not for actual listening).
+    // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
+    const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
+
+    // 3. Init auth with temp DB
+    initAuth({
+        dbPath,
+        baseURL: placeholderBase,
+        secret: "test-secret-for-harness-at-least-32-chars-long!!",
+        disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
+        extraOrigins: opts?.trustedOrigins,
+    });
+
+    // 4. Run DB migrations
+    await runAllMigrations();
+
+    // 5. Create Redis pub/sub clients and connect them
+    const pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
+    const subClient = pubClient.duplicate() as RedisClientType;
+    await Promise.all([pubClient.connect(), subClient.connect()]);
+
+    // 6. We'll track the resolved port for the request converter
+    let resolvedPort = 0;
+
+    // Create the HTTP server with the handleFetch handler
+    const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+        try {
+            const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
+            const fetchRes = await handleFetch(fetchReq);
+            await sendFetchResponse(res, fetchRes);
+        } catch (e) {
+            console.error("[test-harness] Unhandled error:", e);
+            if (!res.headersSent) {
+                res.writeHead(500, { "content-type": "application/json" });
+            }
+            res.end(JSON.stringify({ error: "Internal server error" }));
+        }
+    });
+
+    // 7. Create Socket.IO server with Redis adapter
+    const io = new SocketIOServer(httpServer, {
+        cors: {
+            origin: getTrustedOrigins(),
+            credentials: true,
+        },
+        maxHttpBufferSize: 100 * 1024 * 1024,
+        pingInterval: 30_000,
+        pingTimeout: 60_000,
+        adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
+        transports: ["websocket", "polling"],
+    });
+
+    // 8. Init state Redis
+    await initStateRedis();
+
+    // 9. Init the Socket.IO registry
+    initSioRegistry(io);
+
+    // 10. Register all namespaces
+    registerNamespaces(io);
+
+    // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === "string") {
+        throw new Error("[test-harness] Could not determine server port");
+    }
+    resolvedPort = addr.port;
+
+    // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
+    const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
+
+    // 12. Create a test user via the /api/register endpoint.
+    //     Use a unique client IP per server instance so each registration gets its
+    //     own rate-limit bucket in the module-level registerRateLimiter singleton.
+    const testUserName = "Test User";
+    const testUserEmail = "testuser@pizzapi-harness.test";
+    const testUserPassword = "HarnessPass123";
+    const testClientIp = uniqueTestClientIp();
+
+    const registerRes = await fetch(`${baseUrl}/api/register`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            // Unique x-forwarded-for per server so the rate limiter assigns a
+            // separate bucket for each test server creation.
+            "x-forwarded-for": testClientIp,
+        },
+        body: JSON.stringify({
+            name: testUserName,
+            email: testUserEmail,
+            password: testUserPassword,
+        }),
+    });
+
+    if (!registerRes.ok) {
+        throw new Error(
+            `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+        );
+    }
+
+    const registerData = await registerRes.json() as { ok: boolean; key: string };
+    const apiKey = registerData.key;
+
+    // 13. Get a session cookie via better-auth sign-in.
+    //     The sign-in response includes the user object (with id) and Set-Cookie header.
+    const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            "x-forwarded-for": testClientIp,
+        },
+        body: JSON.stringify({
+            email: testUserEmail,
+            password: testUserPassword,
+        }),
+    });
+
+    if (!signInRes.ok) {
+        throw new Error(
+            `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
+        );
+    }
+
+    const signInData = await signInRes.json() as { user?: { id: string } };
+    const userId = signInData.user?.id ?? "";
+    if (!userId) {
+        throw new Error("[test-harness] Could not get userId from sign-in response");
+    }
+
+    const cookies = signInRes.headers.getSetCookie();
+    const sessionCookie = cookies.join("; ");
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    async function testFetch(path: string, init?: RequestInit): Promise<Response> {
+        const url = `${baseUrl}${path}`;
+        const headers = new Headers(init?.headers);
+
+        // Inject auth headers if not already present
+        if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
+            headers.set("x-pizzapi-api-key", apiKey);
+        }
+        if (!headers.has("cookie") && sessionCookie) {
+            headers.set("cookie", sessionCookie);
+        }
+
+        return fetch(url, { ...init, headers });
+    }
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+
+    async function cleanup(): Promise<void> {
+        // Restore PIZZAPI_TRUST_PROXY
+        if (savedTrustProxy === undefined) {
+            delete process.env.PIZZAPI_TRUST_PROXY;
+        } else {
+            process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+        }
+
+        // Close Socket.IO — this also closes the underlying httpServer internally,
+        // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
+        await new Promise<void>((resolve) => io.close(() => resolve()));
+
+        // Disconnect Redis clients
+        await Promise.allSettled([pubClient.quit(), subClient.quit()]);
+
+        // Clean up temp directory
+        try {
+            rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+            // Ignore cleanup errors
+        }
+    }
+
+    return {
+        port: resolvedPort,
+        baseUrl,
+        io,
+        apiKey,
+        userId,
+        userName: testUserName,
+        userEmail: testUserEmail,
+        sessionCookie,
+        fetch: testFetch,
+        cleanup,
+    };
+}

--- a/packages/server/tests/harness/types.ts
+++ b/packages/server/tests/harness/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types for the test server harness.
+ */
+
+export interface TestServerOptions {
+    /** Override base URL (default: auto from port) */
+    baseUrl?: string;
+    /** Extra trusted origins for CORS */
+    trustedOrigins?: string[];
+    /** Disable signup-after-first-user restriction (default: true = disabled) */
+    disableSignupAfterFirstUser?: boolean;
+}
+
+export interface TestServer {
+    /** Ephemeral port the server is listening on */
+    port: number;
+    /** Base URL: http://localhost:{port} */
+    baseUrl: string;
+    /** The Socket.IO server instance */
+    io: import("socket.io").Server;
+    /** Pre-created API key for auth */
+    apiKey: string;
+    /** Pre-created test user's ID */
+    userId: string;
+    /** Pre-created test user's name */
+    userName: string;
+    /** Pre-created test user's email */
+    userEmail: string;
+    /** Auth session cookie string for viewer/hub namespaces */
+    sessionCookie: string;
+    /** Helper: make an authenticated REST request */
+    fetch(path: string, init?: RequestInit): Promise<Response>;
+    /** Shut down everything and clean up */
+    cleanup(): Promise<void>;
+}

--- a/packages/server/tsconfig.test.json
+++ b/packages/server/tsconfig.test.json
@@ -5,5 +5,5 @@
         "rootDir": "."
     },
     "references": [{ "path": "../tools" }, { "path": "../protocol" }],
-    "include": ["src", "tests/harness"]
+    "include": ["src", "tests"]
 }

--- a/packages/server/tsconfig.test.json
+++ b/packages/server/tsconfig.test.json
@@ -1,10 +1,9 @@
 {
     "extends": "../../tsconfig.base.json",
     "compilerOptions": {
-        "outDir": "dist",
-        "rootDir": "src"
+        "noEmit": true,
+        "rootDir": "."
     },
     "references": [{ "path": "../tools" }, { "path": "../protocol" }],
-    "include": ["src"],
-    "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
+    "include": ["src", "tests/harness"]
 }


### PR DESCRIPTION
Night Shift dish 002: MockRunner client that connects to /runner namespace, emits runner events, and supports test scenarios.

## What's included

- `packages/server/tests/harness/mock-runner.ts` — `createMockRunner(server, opts?)` factory that:
  - Connects to the test server's `/runner` Socket.IO namespace with API key auth
  - Emits `register_runner` and waits for `runner_registered` (capturing the server-assigned runnerId)
  - Returns a `MockRunner` with helpers: `emitSessionReady`, `emitSessionError`, `emitSessionEvent`, `emitSessionEnded`, `onSkillRequest`, `onFileRequest`, `waitForEvent`, `disconnect`

- `packages/server/tests/harness/mock-runner.test.ts` — 12 tests covering:
  - Basic connection and registration
  - REST API visibility (`GET /api/runners`)
  - Session lifecycle events
  - Multiple simultaneous runners
  - Clean disconnect (runner removed from list)
  - `waitForEvent` utility (resolves + timeout)

- `packages/server/tests/harness/index.ts` — barrel updated to export `mock-runner.js`

## Key implementation notes

- Server-assigned runnerId: the server generates its own UUID unless `runnerSecret` is also provided — the mock runner captures the actual ID from the `runner_registered` event
- Clean test teardown: uses `io.disconnectSockets(true)` + 100ms flush before closing idle HTTP connections, preventing unhandled Redis errors from async disconnect handlers

## Verification

```
bun test tests/harness/mock-runner.test.ts  → 12 pass, 0 fail
bun run typecheck                           → clean
```