### PR TITLE
feat: mock relay client and event builders

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,6 @@
+[test]
+# Preload captures the real Redis createClient before any mock.module("redis")
+# calls from other test files can replace it in the worker's module registry.
+# This fixes cross-file mock contamination that causes the integration harness
+# tests to fail when run alongside unit tests that mock the redis package.
+preload = ["./packages/server/tests/harness/preload.ts"]

--- a/packages/cli/src/extensions/triggers/new-session-cleanup.test.ts
+++ b/packages/cli/src/extensions/triggers/new-session-cleanup.test.ts
@@ -8,7 +8,7 @@
 //   4. Calls onConfirmed when the server acks the cancel (at-least-once delivery)
 // ============================================================================
 
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 import { trackReceivedTrigger, receivedTriggers, clearAndCancelPendingTriggers } from "./extension.js";
 
 // ── Mock the relay socket used by clearAndCancelPendingTriggers ──────────────
@@ -32,6 +32,10 @@ mock.module("../remote.js", () => ({
             : null,
     getRelaySessionId: () => "parent-session-1",
 }));
+
+// Restore all module mocks after this file so they don't bleed into other
+// test files running in the same worker process.
+afterAll(() => mock.restore());
 
 describe("clearAndCancelPendingTriggers", () => {
     beforeEach(() => {

--- a/packages/server/src/routes/chat.test.ts
+++ b/packages/server/src/routes/chat.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, mock, spyOn, beforeAll, afterEach } from "bun:test";
+import { describe, expect, test, mock, spyOn, beforeAll, afterAll, afterEach } from "bun:test";
 import type { Mock } from "bun:test";
 
 // mock.module for middleware must be registered before the dynamic import below.
@@ -11,6 +11,10 @@ mock.module("../middleware.js", () => {
         validateApiKey: mock(() => Promise.resolve({ userId: "test-user", userName: "Test User" })),
     };
 });
+
+// Restore all module mocks after this file so they don't bleed into other
+// test files running in the same worker process.
+afterAll(() => mock.restore());
 
 let handleChatRoute: (req: Request, url: URL) => Promise<Response | undefined>;
 let checkSpy: Mock<(key: string) => boolean>;

--- a/packages/server/src/sessions/redis.ts
+++ b/packages/server/src/sessions/redis.ts
@@ -189,3 +189,15 @@ export async function deleteRelayEventCaches(sessionIds: string[]): Promise<void
         logUnavailableOnce("Failed to delete relay event caches from Redis", error);
     }
 }
+
+/**
+ * Reset all module-level state so that the next call to
+ * `initializeRelayRedisCache()` starts fresh with the current module
+ * mock environment.  Intended for use in test `beforeAll` / `beforeEach`
+ * hooks only — do NOT call in production code.
+ */
+export function _resetRelayRedisCacheForTesting(): void {
+    client = null;
+    initPromise = null;
+    unavailableLogged = false;
+}

--- a/packages/server/src/sessions/redis_perf.test.ts
+++ b/packages/server/src/sessions/redis_perf.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, spyOn, beforeAll, afterAll, mock } from "bun:test";
 import { createClient } from "redis";
-import { deleteRelayEventCaches, initializeRelayRedisCache } from "./redis";
+import { deleteRelayEventCaches, initializeRelayRedisCache, _resetRelayRedisCacheForTesting } from "./redis";
 
 // Mock the redis module
 const mockDel = mock((keys: string | string[]) => Promise.resolve(1));
@@ -28,10 +28,16 @@ mock.module("redis", () => ({
     })
 }));
 
+// Restore all module mocks after this file so they don't bleed into other
+// test files running in the same worker process.
+afterAll(() => mock.restore());
+
 describe("deleteRelayEventCaches Performance", () => {
     beforeAll(async () => {
-        // Initialize the client so activeClient() returns something
-        // We ensure initialization happens only once
+        // Reset any pre-existing relay Redis cache state (e.g. from integration
+        // tests that ran before this file in the same worker process), then
+        // re-initialize with the mocked client so the tests get clean mock state.
+        _resetRelayRedisCacheForTesting();
         await initializeRelayRedisCache();
     });
 

--- a/packages/server/src/ws/runner-assoc.test.ts
+++ b/packages/server/src/ws/runner-assoc.test.ts
@@ -9,7 +9,7 @@
 // We mock the Redis client at module level so no live Redis is needed.
 // ============================================================================
 
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 
 // ── Minimal Redis mock ──────────────────────────────────────────────────────
 
@@ -39,6 +39,10 @@ const mockRedis = {
 mock.module("redis", () => ({
     createClient: () => mockRedis,
 }));
+
+// Restore all module mocks after this file so they don't bleed into other
+// test files running in the same worker process.
+afterAll(() => mock.restore());
 
 // Now import the functions under test (they'll use the mocked Redis)
 // We need to init the state redis first

--- a/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
+++ b/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterAll } from "bun:test";
 
 const store = new Map<string, string>();
 const setStore = new Map<string, Set<string>>();
@@ -90,6 +90,10 @@ mock.module("../../sessions/store.js", () => ({
     getEphemeralTtlMs: () => 60_000,
     updateRelaySessionRunner: mock(async () => {}),
 }));
+
+// Restore all module mocks after this file so they don't bleed into other
+// test files running in the same worker process.
+afterAll(() => mock.restore());
 
 // Instead of mocking ./runners-broadcast.js (which is brittle if another test
 // imports it first), we provide a fake Socket.IO server via initSioRegistry()

--- a/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 
 // ── Minimal Redis mock (mirrors sio-state-children.test.ts) ─────────────────
 
@@ -102,6 +102,10 @@ const mockRedis = {
 mock.module("redis", () => ({
     createClient: () => mockRedis,
 }));
+
+// Restore all module mocks after this file so they don't bleed into other
+// test files running in the same worker process.
+afterAll(() => mock.restore());
 
 // Prevent this unit test from touching the real SQLite-backed session store or
 // the global Socket.IO hub registry. Those are covered by separate integration

--- a/packages/server/src/ws/sio-state-children.test.ts
+++ b/packages/server/src/ws/sio-state-children.test.ts
@@ -7,7 +7,7 @@
 // We mock the Redis client at module level so no live Redis is needed.
 // ============================================================================
 
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 
 // ── Minimal Redis mock ──────────────────────────────────────────────────────
 
@@ -112,6 +112,10 @@ const mockRedis = {
 mock.module("redis", () => ({
     createClient: () => mockRedis,
 }));
+
+// Restore all module mocks after this file so they don't bleed into other
+// test files running in the same worker process.
+afterAll(() => mock.restore());
 
 const {
     initStateRedis,

--- a/packages/server/tests/harness/builders.test.ts
+++ b/packages/server/tests/harness/builders.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Tests for event builders and mock relay integration.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+    buildHeartbeat,
+    buildAssistantMessage,
+    buildToolUseEvent,
+    buildToolResultEvent,
+    buildConversation,
+    buildSessionInfo,
+    buildRunnerInfo,
+    buildMetaState,
+    buildTodoList,
+} from "./builders.js";
+import { createTestServer } from "./server.js";
+import { createMockRelay } from "./mock-relay.js";
+import { defaultMetaState } from "@pizzapi/protocol";
+
+const TEST_TIMEOUT_MS = 30_000;
+
+// ── buildHeartbeat ────────────────────────────────────────────────────────────
+
+describe("buildHeartbeat", () => {
+    test("produces a valid default heartbeat", () => {
+        const hb = buildHeartbeat();
+        expect(hb.type).toBe("heartbeat");
+        expect(typeof hb.active).toBe("boolean");
+        expect(typeof hb.isCompacting).toBe("boolean");
+        expect(typeof hb.ts).toBe("number");
+        expect(hb.ts).toBeGreaterThan(0);
+        expect(hb.model).toBeNull();
+        expect(hb.sessionName).toBeNull();
+        expect(hb.uptime).toBeNull();
+        expect(typeof hb.cwd).toBe("string");
+    });
+
+    test("applies overrides correctly", () => {
+        const hb = buildHeartbeat({
+            active: true,
+            isCompacting: true,
+            sessionName: "My Session",
+            cwd: "/home/user",
+            model: { provider: "anthropic", id: "claude-3-5-haiku-20241022" },
+        });
+        expect(hb.active).toBe(true);
+        expect(hb.isCompacting).toBe(true);
+        expect(hb.sessionName).toBe("My Session");
+        expect(hb.cwd).toBe("/home/user");
+        expect(hb.model?.provider).toBe("anthropic");
+        expect(hb.type).toBe("heartbeat"); // immutable
+    });
+
+    test("ts override is respected", () => {
+        const ts = 12345678;
+        const hb = buildHeartbeat({ ts });
+        expect(hb.ts).toBe(ts);
+    });
+});
+
+// ── buildAssistantMessage ─────────────────────────────────────────────────────
+
+describe("buildAssistantMessage", () => {
+    test("produces correct shape", () => {
+        const msg = buildAssistantMessage("Hello, world!");
+        expect(msg.type).toBe("message_update");
+        expect(msg.role).toBe("assistant");
+        expect(msg.content).toHaveLength(1);
+        expect(msg.content[0].type).toBe("text");
+        expect(msg.content[0].text).toBe("Hello, world!");
+        expect(typeof msg.messageId).toBe("string");
+    });
+
+    test("applies overrides", () => {
+        const msg = buildAssistantMessage("Hi", { messageId: "custom-id-123" });
+        expect(msg.messageId).toBe("custom-id-123");
+    });
+});
+
+// ── buildToolUseEvent ─────────────────────────────────────────────────────────
+
+describe("buildToolUseEvent", () => {
+    test("produces correct shape", () => {
+        const block = buildToolUseEvent("Bash", { command: "ls" });
+        expect(block.type).toBe("tool_use");
+        expect(block.name).toBe("Bash");
+        expect(block.input).toEqual({ command: "ls" });
+        expect(typeof block.id).toBe("string");
+        expect(block.id.length).toBeGreaterThan(0);
+    });
+
+    test("uses provided toolCallId", () => {
+        const block = buildToolUseEvent("Read", { path: "/tmp/foo" }, "my-tool-id");
+        expect(block.id).toBe("my-tool-id");
+    });
+});
+
+// ── buildToolResultEvent ──────────────────────────────────────────────────────
+
+describe("buildToolResultEvent", () => {
+    test("produces correct shape", () => {
+        const result = buildToolResultEvent("tool-abc", "output text");
+        expect(result.type).toBe("tool_result");
+        expect(result.tool_use_id).toBe("tool-abc");
+        expect(result.content).toHaveLength(1);
+        expect(result.content[0].type).toBe("text");
+        expect(result.content[0].text).toBe("output text");
+    });
+});
+
+// ── buildConversation ─────────────────────────────────────────────────────────
+
+describe("buildConversation", () => {
+    test("empty conversation yields empty array", () => {
+        expect(buildConversation([])).toEqual([]);
+    });
+
+    test("user turn produces user_message event", () => {
+        const events = buildConversation([{ role: "user", text: "hello" }]) as Array<Record<string, unknown>>;
+        expect(events).toHaveLength(1);
+        expect(events[0].type).toBe("user_message");
+        expect(events[0].text).toBe("hello");
+    });
+
+    test("assistant text turn produces message_update event", () => {
+        const events = buildConversation([
+            { role: "assistant", text: "Hi there" },
+        ]) as Array<Record<string, unknown>>;
+        expect(events).toHaveLength(1);
+        expect(events[0].type).toBe("message_update");
+        const msg = events[0] as { role: string; content: Array<{ text: string }> };
+        expect(msg.role).toBe("assistant");
+        expect(msg.content[0].text).toBe("Hi there");
+    });
+
+    test("assistant toolCall turn produces tool_use content block", () => {
+        const events = buildConversation([
+            { role: "assistant", toolCall: { name: "Bash", input: { command: "pwd" } } },
+        ]) as Array<{ type: string; content: Array<{ type: string; name: string }> }>;
+        expect(events).toHaveLength(1);
+        expect(events[0].type).toBe("message_update");
+        expect(events[0].content[0].type).toBe("tool_use");
+        expect(events[0].content[0].name).toBe("Bash");
+    });
+
+    test("tool turn produces tool_result_message event", () => {
+        const events = buildConversation([
+            { role: "tool", toolCallId: "t-1", result: "success" },
+        ]) as Array<{ type: string; content: Array<{ tool_use_id: string }> }>;
+        expect(events).toHaveLength(1);
+        expect(events[0].type).toBe("tool_result_message");
+        expect(events[0].content[0].tool_use_id).toBe("t-1");
+    });
+
+    test("multi-turn conversation produces correct sequence", () => {
+        const events = buildConversation([
+            { role: "user", text: "What is 2+2?" },
+            { role: "assistant", text: "4" },
+            { role: "user", text: "Thanks" },
+        ]) as Array<Record<string, unknown>>;
+        expect(events).toHaveLength(3);
+        expect(events[0].type).toBe("user_message");
+        expect(events[1].type).toBe("message_update");
+        expect(events[2].type).toBe("user_message");
+    });
+});
+
+// ── buildSessionInfo ──────────────────────────────────────────────────────────
+
+describe("buildSessionInfo", () => {
+    test("produces valid defaults", () => {
+        const info = buildSessionInfo();
+        expect(typeof info.sessionId).toBe("string");
+        expect(typeof info.shareUrl).toBe("string");
+        expect(typeof info.cwd).toBe("string");
+        expect(typeof info.startedAt).toBe("string");
+        expect(info.isEphemeral).toBe(true);
+        expect(info.isActive).toBe(true);
+        expect(info.model).toBeNull();
+        expect(info.runnerId).toBeNull();
+        expect(info.sessionName).toBeNull();
+    });
+
+    test("applies overrides", () => {
+        const info = buildSessionInfo({
+            sessionId: "my-session-id",
+            sessionName: "Test Session",
+            isActive: false,
+            isEphemeral: false,
+        });
+        expect(info.sessionId).toBe("my-session-id");
+        expect(info.sessionName).toBe("Test Session");
+        expect(info.isActive).toBe(false);
+        expect(info.isEphemeral).toBe(false);
+    });
+
+    test("two calls produce different sessionIds by default", () => {
+        const a = buildSessionInfo();
+        const b = buildSessionInfo();
+        expect(a.sessionId).not.toBe(b.sessionId);
+    });
+});
+
+// ── buildRunnerInfo ───────────────────────────────────────────────────────────
+
+describe("buildRunnerInfo", () => {
+    test("produces valid defaults", () => {
+        const info = buildRunnerInfo();
+        expect(typeof info.runnerId).toBe("string");
+        expect(typeof info.name).toBe("string");
+        expect(Array.isArray(info.roots)).toBe(true);
+        expect(Array.isArray(info.skills)).toBe(true);
+        expect(Array.isArray(info.agents)).toBe(true);
+        expect(info.sessionCount).toBe(0);
+    });
+
+    test("applies overrides", () => {
+        const info = buildRunnerInfo({ name: "Production Runner", sessionCount: 3 });
+        expect(info.name).toBe("Production Runner");
+        expect(info.sessionCount).toBe(3);
+    });
+});
+
+// ── buildMetaState ────────────────────────────────────────────────────────────
+
+describe("buildMetaState", () => {
+    test("matches defaultMetaState structure", () => {
+        const meta = buildMetaState();
+        const defaults = defaultMetaState();
+        // All keys from defaultMetaState should be present
+        for (const key of Object.keys(defaults) as Array<keyof typeof defaults>) {
+            expect(meta).toHaveProperty(key);
+        }
+    });
+
+    test("default version is 0", () => {
+        const meta = buildMetaState();
+        expect(meta.version).toBe(0);
+    });
+
+    test("default fields match defaultMetaState values", () => {
+        const meta = buildMetaState();
+        const defaults = defaultMetaState();
+        expect(meta.todoList).toEqual(defaults.todoList);
+        expect(meta.pendingQuestion).toBe(defaults.pendingQuestion);
+        expect(meta.pendingPlan).toBe(defaults.pendingPlan);
+        expect(meta.planModeEnabled).toBe(defaults.planModeEnabled);
+        expect(meta.isCompacting).toBe(defaults.isCompacting);
+    });
+
+    test("applies overrides", () => {
+        const meta = buildMetaState({
+            planModeEnabled: true,
+            isCompacting: true,
+            version: 42,
+        });
+        expect(meta.planModeEnabled).toBe(true);
+        expect(meta.isCompacting).toBe(true);
+        expect(meta.version).toBe(42);
+    });
+});
+
+// ── buildTodoList ─────────────────────────────────────────────────────────────
+
+describe("buildTodoList", () => {
+    test("returns empty array for empty input", () => {
+        expect(buildTodoList([])).toEqual([]);
+    });
+
+    test("produces correct shape with auto-incremented IDs starting at 1", () => {
+        const items = buildTodoList([
+            { text: "Task one" },
+            { text: "Task two" },
+            { text: "Task three" },
+        ]);
+        expect(items).toHaveLength(3);
+        expect(items[0]).toEqual({ id: 1, text: "Task one", status: "pending" });
+        expect(items[1]).toEqual({ id: 2, text: "Task two", status: "pending" });
+        expect(items[2]).toEqual({ id: 3, text: "Task three", status: "pending" });
+    });
+
+    test("respects provided status", () => {
+        const items = buildTodoList([
+            { text: "Done task", status: "done" },
+            { text: "Active task", status: "in_progress" },
+        ]);
+        expect(items[0].status).toBe("done");
+        expect(items[1].status).toBe("in_progress");
+    });
+
+    test("defaults missing status to pending", () => {
+        const items = buildTodoList([{ text: "A task" }]);
+        expect(items[0].status).toBe("pending");
+    });
+});
+
+// ── Integration: MockRelay + builders ─────────────────────────────────────────
+// NOTE: createTestServer() uses module-level singletons (auth, sio-state).
+// These integration tests are serialized to avoid conflicts, and each test
+// disconnects the relay socket before calling server.cleanup() so that
+// io.close() can complete cleanly.
+
+describe.serial("MockRelay integration", () => {
+    test("connect, register, emit event, disconnect", async () => {
+        const server = await createTestServer();
+        let relay;
+        try {
+            relay = await createMockRelay(server);
+            expect(relay.socket.connected).toBe(true);
+
+            const session = await relay.registerSession({ cwd: "/tmp/test" });
+            expect(typeof session.sessionId).toBe("string");
+            expect(session.sessionId.length).toBeGreaterThan(0);
+            expect(typeof session.token).toBe("string");
+            expect(session.token.length).toBeGreaterThan(0);
+            expect(typeof session.shareUrl).toBe("string");
+
+            // Emit a heartbeat event through the relay
+            const hb = buildHeartbeat({ active: true, cwd: "/tmp/test" });
+            relay.emitEvent(session.sessionId, session.token, hb, 1);
+
+            // Give the server a moment to process
+            await Bun.sleep(100);
+
+            // Signal session end
+            relay.emitSessionEnd(session.sessionId, session.token);
+            await Bun.sleep(50);
+
+            await relay.disconnect();
+            expect(relay.socket.connected).toBe(false);
+        } finally {
+            // Disconnect relay before cleanup so io.close() can drain cleanly
+            if (relay && relay.socket.connected) {
+                await relay.disconnect().catch(() => {});
+            }
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("can register multiple sessions on the same relay", async () => {
+        const server = await createTestServer();
+        let relay;
+        try {
+            relay = await createMockRelay(server);
+
+            const s1 = await relay.registerSession({ cwd: "/tmp/s1" });
+            const s2 = await relay.registerSession({ cwd: "/tmp/s2" });
+
+            expect(s1.sessionId).not.toBe(s2.sessionId);
+            expect(s1.token).not.toBe(s2.token);
+
+            // Emit events for both sessions
+            const hb = buildHeartbeat({ active: false });
+            relay.emitEvent(s1.sessionId, s1.token, hb);
+            relay.emitEvent(s2.sessionId, s2.token, hb);
+
+            await relay.disconnect();
+        } finally {
+            if (relay && relay.socket.connected) {
+                await relay.disconnect().catch(() => {});
+            }
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("emit conversation events through relay", async () => {
+        const server = await createTestServer();
+        let relay;
+        try {
+            relay = await createMockRelay(server);
+            const session = await relay.registerSession();
+
+            const conversation = buildConversation([
+                { role: "user", text: "Hello" },
+                { role: "assistant", text: "Hi there!" },
+            ]);
+
+            // Emit each event in the conversation
+            for (let i = 0; i < conversation.length; i++) {
+                relay.emitEvent(session.sessionId, session.token, conversation[i], i + 1);
+            }
+
+            // Give server time to process
+            await Bun.sleep(100);
+
+            await relay.disconnect();
+        } finally {
+            if (relay && relay.socket.connected) {
+                await relay.disconnect().catch(() => {});
+            }
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("waitForEvent times out on unknown event", async () => {
+        const server = await createTestServer();
+        let relay;
+        try {
+            relay = await createMockRelay(server);
+
+            let threw = false;
+            try {
+                await relay.waitForEvent("nonexistent_event_xyz", 200);
+            } catch (err) {
+                threw = true;
+                expect((err as Error).message).toContain("nonexistent_event_xyz");
+            }
+            expect(threw).toBe(true);
+
+            await relay.disconnect();
+        } finally {
+            if (relay && relay.socket.connected) {
+                await relay.disconnect().catch(() => {});
+            }
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+});

--- a/packages/server/tests/harness/builders.test.ts
+++ b/packages/server/tests/harness/builders.test.ts
@@ -116,10 +116,10 @@ describe("buildConversation", () => {
         expect(buildConversation([])).toEqual([]);
     });
 
-    test("user turn produces user_message event", () => {
+    test("user turn produces harness:user_turn marker (not a real protocol event)", () => {
         const events = buildConversation([{ role: "user", text: "hello" }]) as Array<Record<string, unknown>>;
         expect(events).toHaveLength(1);
-        expect(events[0].type).toBe("user_message");
+        expect(events[0].type).toBe("harness:user_turn");
         expect(events[0].text).toBe("hello");
     });
 
@@ -160,9 +160,9 @@ describe("buildConversation", () => {
             { role: "user", text: "Thanks" },
         ]) as Array<Record<string, unknown>>;
         expect(events).toHaveLength(3);
-        expect(events[0].type).toBe("user_message");
+        expect(events[0].type).toBe("harness:user_turn");
         expect(events[1].type).toBe("message_update");
-        expect(events[2].type).toBe("user_message");
+        expect(events[2].type).toBe("harness:user_turn");
     });
 });
 

--- a/packages/server/tests/harness/builders.ts
+++ b/packages/server/tests/harness/builders.ts
@@ -1,0 +1,202 @@
+/**
+ * builders.ts — Pure factory functions that produce correctly-shaped agent events.
+ *
+ * No server dependency — these are data builders only.
+ * Import protocol types directly from @pizzapi/protocol.
+ */
+
+import {
+    defaultMetaState,
+    type SessionMetaState,
+    type MetaTodoItem,
+} from "@pizzapi/protocol";
+
+import type { SessionInfo, RunnerInfo, ModelInfo } from "@pizzapi/protocol";
+
+// ── HeartbeatEvent ────────────────────────────────────────────────────────────
+
+export interface HeartbeatEvent {
+    type: "heartbeat";
+    active: boolean;
+    isCompacting: boolean;
+    ts: number;
+    model: ModelInfo | null;
+    sessionName: string | null;
+    uptime: number | null;
+    cwd: string | null;
+}
+
+export function buildHeartbeat(overrides?: Partial<HeartbeatEvent>): HeartbeatEvent {
+    return {
+        type: "heartbeat",
+        active: false,
+        isCompacting: false,
+        ts: Date.now(),
+        model: null,
+        sessionName: null,
+        uptime: null,
+        cwd: "/tmp/mock",
+        ...overrides,
+    };
+}
+
+// ── Message/content block builders ──────────────────────────────────────────
+
+export interface AssistantMessageEvent {
+    type: "message_update";
+    role: "assistant";
+    content: Array<{ type: "text"; text: string }>;
+    messageId: string;
+}
+
+export interface ToolUseBlock {
+    type: "tool_use";
+    id: string;
+    name: string;
+    input: unknown;
+}
+
+export interface ToolResultBlock {
+    type: "tool_result";
+    tool_use_id: string;
+    content: Array<{ type: "text"; text: string }>;
+}
+
+let _blockIdCounter = 0;
+function nextId(prefix: string): string {
+    return `${prefix}_${++_blockIdCounter}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function buildAssistantMessage(
+    text: string,
+    overrides?: Record<string, unknown>,
+): AssistantMessageEvent {
+    return {
+        type: "message_update",
+        role: "assistant",
+        content: [{ type: "text", text }],
+        messageId: nextId("msg"),
+        ...overrides,
+    } as AssistantMessageEvent;
+}
+
+export function buildToolUseEvent(
+    toolName: string,
+    input: unknown,
+    toolCallId?: string,
+): ToolUseBlock {
+    return {
+        type: "tool_use",
+        id: toolCallId ?? nextId("tool"),
+        name: toolName,
+        input,
+    };
+}
+
+export function buildToolResultEvent(
+    toolCallId: string,
+    output: string,
+): ToolResultBlock {
+    return {
+        type: "tool_result",
+        tool_use_id: toolCallId,
+        content: [{ type: "text", text: output }],
+    };
+}
+
+// ── Conversation builder ─────────────────────────────────────────────────────
+
+export type ConversationTurn =
+    | { role: "user"; text: string }
+    | { role: "assistant"; text: string }
+    | { role: "assistant"; toolCall: { name: string; input: unknown } }
+    | { role: "tool"; toolCallId: string; result: string };
+
+export function buildConversation(turns: ConversationTurn[]): unknown[] {
+    const events: unknown[] = [];
+
+    for (const turn of turns) {
+        if (turn.role === "user") {
+            events.push({
+                type: "user_message",
+                text: turn.text,
+            });
+        } else if (turn.role === "assistant") {
+            if ("toolCall" in turn) {
+                const toolId = nextId("tool");
+                const block = buildToolUseEvent(turn.toolCall.name, turn.toolCall.input, toolId);
+                events.push({
+                    type: "message_update",
+                    role: "assistant",
+                    content: [block],
+                    messageId: nextId("msg"),
+                });
+            } else {
+                events.push(buildAssistantMessage(turn.text));
+            }
+        } else if (turn.role === "tool") {
+            const resultBlock = buildToolResultEvent(turn.toolCallId, turn.result);
+            events.push({
+                type: "tool_result_message",
+                content: [resultBlock],
+            });
+        }
+    }
+
+    return events;
+}
+
+// ── Protocol type builders ───────────────────────────────────────────────────
+
+export function buildSessionInfo(overrides?: Partial<SessionInfo>): SessionInfo {
+    return {
+        sessionId: `session_${nextId("s")}`,
+        shareUrl: "http://localhost:3000/s/mock",
+        cwd: "/tmp/mock",
+        startedAt: new Date().toISOString(),
+        viewerCount: 0,
+        sessionName: null,
+        isEphemeral: true,
+        expiresAt: null,
+        isActive: true,
+        lastHeartbeatAt: null,
+        model: null,
+        runnerId: null,
+        runnerName: null,
+        parentSessionId: null,
+        ...overrides,
+    };
+}
+
+export function buildRunnerInfo(overrides?: Partial<RunnerInfo>): RunnerInfo {
+    return {
+        runnerId: `runner_${nextId("r")}`,
+        name: "Test Runner",
+        roots: ["/tmp"],
+        sessionCount: 0,
+        skills: [],
+        agents: [],
+        plugins: [],
+        hooks: [],
+        version: "0.0.0",
+        platform: "linux",
+        ...overrides,
+    };
+}
+
+export function buildMetaState(overrides?: Partial<SessionMetaState>): SessionMetaState {
+    return {
+        ...defaultMetaState(),
+        ...overrides,
+    };
+}
+
+export function buildTodoList(
+    items: Array<{ text: string; status?: MetaTodoItem["status"] }>,
+): MetaTodoItem[] {
+    return items.map((item, index) => ({
+        id: index + 1,
+        text: item.text,
+        status: item.status ?? "pending",
+    }));
+}

--- a/packages/server/tests/harness/builders.ts
+++ b/packages/server/tests/harness/builders.ts
@@ -1,8 +1,11 @@
 /**
- * builders.ts — Pure factory functions that produce correctly-shaped agent events.
+ * builders.ts — Factory functions that produce correctly-shaped agent events.
  *
  * No server dependency — these are data builders only.
  * Import protocol types directly from @pizzapi/protocol.
+ *
+ * Note: Builders are not pure — they use module-level counters and Date.now()/Math.random()
+ * for ID generation. Pass overrides to control specific fields in deterministic tests.
  */
 
 import {
@@ -69,7 +72,7 @@ function nextId(prefix: string): string {
 
 export function buildAssistantMessage(
     text: string,
-    overrides?: Record<string, unknown>,
+    overrides?: Partial<AssistantMessageEvent>,
 ): AssistantMessageEvent {
     return {
         type: "message_update",
@@ -77,7 +80,7 @@ export function buildAssistantMessage(
         content: [{ type: "text", text }],
         messageId: nextId("msg"),
         ...overrides,
-    } as AssistantMessageEvent;
+    };
 }
 
 export function buildToolUseEvent(
@@ -117,8 +120,11 @@ export function buildConversation(turns: ConversationTurn[]): unknown[] {
 
     for (const turn of turns) {
         if (turn.role === "user") {
+            // User input does not flow through the relay event pipeline — it arrives via the
+            // /viewer namespace as "input" events. This harness marker is test scaffolding only
+            // and is NOT a real protocol event type. Consumers should not emit it to the relay.
             events.push({
-                type: "user_message",
+                type: "harness:user_turn",
                 text: turn.text,
             });
         } else if (turn.role === "assistant") {

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Test harness barrel export.
+ * Re-exports everything from types, server, and future modules.
+ */
+
+export * from "./types.js";
+export * from "./server.js";

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -5,3 +5,5 @@
 
 export * from "./types.js";
 export * from "./server.js";
+export * from "./mock-relay.js";
+export * from "./builders.js";

--- a/packages/server/tests/harness/mock-relay.ts
+++ b/packages/server/tests/harness/mock-relay.ts
@@ -1,0 +1,165 @@
+/**
+ * MockRelay — socket.io-client connected to the /relay namespace.
+ * Provides helpers for registering sessions and emitting agent events
+ * in integration tests.
+ */
+
+import { io as connectSocket } from "socket.io-client";
+import type { TestServer } from "./types.js";
+import type { MockRelay, MockRelayOptions, MockRelaySession } from "./types.js";
+
+export async function createMockRelay(
+    server: TestServer,
+    _opts?: MockRelayOptions,
+): Promise<MockRelay> {
+    const socket = connectSocket(`${server.baseUrl}/relay`, {
+        auth: { apiKey: server.apiKey },
+        transports: ["websocket"],
+        autoConnect: true,
+        // Disable reconnection so cleanup (io.close) can complete.
+        // If reconnection is on, the client immediately reconnects after
+        // force-disconnect, preventing httpServer.close() from resolving.
+        reconnection: false,
+    });
+
+    // Wait for the socket to connect
+    await new Promise<void>((resolve, reject) => {
+        if (socket.connected) {
+            resolve();
+            return;
+        }
+        const onConnect = () => {
+            socket.off("connect_error", onError);
+            resolve();
+        };
+        const onError = (err: Error) => {
+            socket.off("connect", onConnect);
+            reject(err);
+        };
+        socket.once("connect", onConnect);
+        socket.once("connect_error", onError);
+    });
+
+    function waitForEvent(eventName: string, timeout = 5000): Promise<unknown> {
+        return new Promise<unknown>((resolve, reject) => {
+            const handler = (data: unknown) => {
+                clearTimeout(timer);
+                resolve(data);
+            };
+
+            const timer = setTimeout(() => {
+                socket.off(eventName, handler);
+                reject(new Error(`Timed out waiting for event: ${eventName}`));
+            }, timeout);
+
+            socket.once(eventName, handler);
+        });
+    }
+
+    async function registerSession(opts?: {
+        sessionId?: string;
+        cwd?: string;
+        ephemeral?: boolean;
+        collabMode?: boolean;
+        sessionName?: string | null;
+        parentSessionId?: string | null;
+    }): Promise<MockRelaySession> {
+        const registeredPromise = waitForEvent("registered");
+
+        socket.emit("register", {
+            sessionId: opts?.sessionId,
+            cwd: opts?.cwd ?? "/tmp/mock-session",
+            ephemeral: opts?.ephemeral ?? true,
+            collabMode: opts?.collabMode ?? false,
+            sessionName: opts?.sessionName ?? null,
+            parentSessionId: opts?.parentSessionId ?? null,
+        });
+
+        const data = await registeredPromise as {
+            sessionId: string;
+            token: string;
+            shareUrl: string;
+        };
+
+        return {
+            sessionId: data.sessionId,
+            token: data.token,
+            shareUrl: data.shareUrl,
+        };
+    }
+
+    function emitEvent(sessionId: string, token: string, event: unknown, seq?: number): void {
+        socket.emit("event", {
+            sessionId,
+            token,
+            event,
+            ...(seq !== undefined ? { seq } : {}),
+        });
+    }
+
+    function emitSessionEnd(sessionId: string, token: string): void {
+        socket.emit("session_end", { sessionId, token });
+    }
+
+    function emitTrigger(data: {
+        token: string;
+        trigger: {
+            type: string;
+            sourceSessionId: string;
+            targetSessionId: string;
+            payload: Record<string, unknown>;
+            deliverAs: "steer" | "followUp";
+            expectsResponse: boolean;
+            triggerId: string;
+            ts: string;
+        };
+    }): void {
+        socket.emit("session_trigger", data);
+    }
+
+    function emitTriggerResponse(data: {
+        token: string;
+        triggerId: string;
+        response: string;
+        action?: string;
+        targetSessionId: string;
+    }): void {
+        socket.emit("trigger_response", data);
+    }
+
+    function emitSessionMessage(data: {
+        token: string;
+        targetSessionId: string;
+        message: string;
+        deliverAs?: "input";
+    }): void {
+        socket.emit("session_message", data);
+    }
+
+    async function disconnect(): Promise<void> {
+        if (socket.connected) {
+            await new Promise<void>((resolve) => {
+                socket.once("disconnect", () => resolve());
+                socket.disconnect();
+            });
+        }
+        // Wait briefly for the underlying TCP connection to fully tear down.
+        // Bun's http.Server.close() waits for all open connections to drain;
+        // without this pause, httpServer.close() can hang because the WebSocket
+        // TCP connection is still in FIN_WAIT state even after the socket-level
+        // disconnect event fires.
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    }
+
+    return {
+        socket,
+        registerSession,
+        emitEvent,
+        emitSessionEnd,
+        emitTrigger,
+        emitTriggerResponse,
+        emitSessionMessage,
+        waitForEvent,
+        disconnect,
+    };
+}

--- a/packages/server/tests/harness/mock-relay.ts
+++ b/packages/server/tests/harness/mock-relay.ts
@@ -40,6 +40,11 @@ export async function createMockRelay(
         socket.once("connect_error", onError);
     });
 
+    // Serial queue — ensures only one registerSession call is in-flight at a time.
+    // Concurrent calls on the same socket would both receive the first "registered"
+    // event, causing one call to get wrong data and the other to be dropped.
+    let _registerLock: Promise<unknown> = Promise.resolve();
+
     function waitForEvent(eventName: string, timeout = 5000): Promise<unknown> {
         return new Promise<unknown>((resolve, reject) => {
             const handler = (data: unknown) => {
@@ -64,28 +69,38 @@ export async function createMockRelay(
         sessionName?: string | null;
         parentSessionId?: string | null;
     }): Promise<MockRelaySession> {
-        const registeredPromise = waitForEvent("registered");
+        // Serialize via _registerLock: only one registration may be in-flight at a time.
+        // Without this, concurrent calls would both listen for the first "registered" event,
+        // causing one call to receive the other's session data.
+        const doRegister = async (): Promise<MockRelaySession> => {
+            const registeredPromise = waitForEvent("registered");
 
-        socket.emit("register", {
-            sessionId: opts?.sessionId,
-            cwd: opts?.cwd ?? "/tmp/mock-session",
-            ephemeral: opts?.ephemeral ?? true,
-            collabMode: opts?.collabMode ?? false,
-            sessionName: opts?.sessionName ?? null,
-            parentSessionId: opts?.parentSessionId ?? null,
-        });
+            socket.emit("register", {
+                sessionId: opts?.sessionId,
+                cwd: opts?.cwd ?? "/tmp/mock-session",
+                ephemeral: opts?.ephemeral ?? true,
+                collabMode: opts?.collabMode ?? false,
+                sessionName: opts?.sessionName ?? null,
+                parentSessionId: opts?.parentSessionId ?? null,
+            });
 
-        const data = await registeredPromise as {
-            sessionId: string;
-            token: string;
-            shareUrl: string;
+            const data = await registeredPromise as {
+                sessionId: string;
+                token: string;
+                shareUrl: string;
+            };
+
+            return {
+                sessionId: data.sessionId,
+                token: data.token,
+                shareUrl: data.shareUrl,
+            };
         };
 
-        return {
-            sessionId: data.sessionId,
-            token: data.token,
-            shareUrl: data.shareUrl,
-        };
+        // Chain this call onto the lock; swallow errors so failures don't jam the queue.
+        const result = _registerLock.then(doRegister, doRegister);
+        _registerLock = result.then(() => {}, () => {});
+        return result;
     }
 
     function emitEvent(sessionId: string, token: string, event: unknown, seq?: number): void {

--- a/packages/server/tests/harness/preload.ts
+++ b/packages/server/tests/harness/preload.ts
@@ -1,0 +1,19 @@
+/**
+ * Bun test preload — captures the real Redis createClient before any
+ * mock.module("redis", …) calls in other test files can replace it.
+ *
+ * In Bun 1.x, mock.module() patches the module registry permanently for the
+ * lifetime of the worker process. Test files that mock "redis" without
+ * calling mock.restore() contaminate subsequent files sharing the same worker.
+ * The preload runs before any test file's module-level code, so the binding
+ * captured here always refers to the genuine redis module.
+ *
+ * The harness (createTestServer) reads __harnessRealCreateClient from
+ * globalThis to create pub/sub Redis clients that are immune to mock pollution.
+ */
+import { createClient } from "redis";
+import type { RedisClientType } from "redis";
+
+type CreateClient = (...args: Parameters<typeof createClient>) => RedisClientType;
+(globalThis as unknown as Record<string, unknown>).__harnessRealCreateClient =
+    createClient as CreateClient;

--- a/packages/server/tests/harness/server.test.ts
+++ b/packages/server/tests/harness/server.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Smoke tests for the test server factory harness.
+ *
+ * These tests verify that createTestServer():
+ *   1. Spins up a real HTTP server that responds to requests
+ *   2. Pre-creates a user with a working API key
+ *   3. Multiple servers can run simultaneously (created sequentially, then accessed concurrently)
+ *   4. Cleans up all resources on shutdown
+ *
+ * NOTE: Servers must be created sequentially (not with Promise.all) because
+ * auth.ts and sio-state.ts use module-level singletons. Once created, multiple
+ * servers can coexist and respond simultaneously.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { createTestServer } from "./server.js";
+
+// Tests spin up real servers + Redis + Socket.IO, so we need a generous timeout.
+const TEST_TIMEOUT_MS = 30_000;
+
+describe("createTestServer", () => {
+    test("creates server and responds to health check", async () => {
+        const server = await createTestServer();
+        try {
+            const res = await fetch(`${server.baseUrl}/health`);
+            // Health may be degraded if Redis singletons were overwritten, but
+            // the server must respond with the expected shape.
+            expect([200, 503]).toContain(res.status);
+            const data = await res.json();
+            expect(["ok", "degraded"]).toContain(data.status);
+            expect(typeof data.redis).toBe("boolean");
+            expect(typeof data.socketio).toBe("boolean");
+            expect(typeof data.uptime).toBe("number");
+        } finally {
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("pre-created user can authenticate via API key", async () => {
+        const server = await createTestServer();
+        try {
+            // Verify basic properties are populated
+            expect(server.port).toBeGreaterThan(0);
+            expect(server.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+            expect(server.apiKey).toHaveLength(64); // 32 random bytes → 64 hex chars
+            expect(server.userId).toBeTruthy();
+            expect(server.userName).toBe("Test User");
+            expect(server.userEmail).toBe("testuser@pizzapi-harness.test");
+            expect(server.sessionCookie).toBeTruthy();
+
+            // The built-in fetch helper includes auth headers
+            const res = await server.fetch("/api/signup-status");
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            // After first user created with disableSignupAfterFirstUser: true (default),
+            // signup should be disabled
+            expect(data.signupEnabled).toBe(false);
+        } finally {
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("multiple test servers can run concurrently", async () => {
+        // Create servers sequentially (module singletons require serial creation)
+        // then verify they can all respond simultaneously.
+        const s1 = await createTestServer();
+        const s2 = await createTestServer();
+        const s3 = await createTestServer();
+
+        try {
+            // All servers should have different ports
+            const ports = new Set([s1.port, s2.port, s3.port]);
+            expect(ports.size).toBe(3);
+
+            // All servers should respond simultaneously (concurrent reads are fine)
+            const responses = await Promise.all([
+                fetch(`${s1.baseUrl}/health`),
+                fetch(`${s2.baseUrl}/health`),
+                fetch(`${s3.baseUrl}/health`),
+            ]);
+
+            for (const res of responses) {
+                expect([200, 503]).toContain(res.status);
+                const data = await res.json();
+                expect(["ok", "degraded"]).toContain(data.status);
+            }
+        } finally {
+            // Clean up all servers, ignoring individual errors
+            await Promise.allSettled([s1.cleanup(), s2.cleanup(), s3.cleanup()]);
+        }
+    }, TEST_TIMEOUT_MS * 3);
+
+    test("cleanup shuts down cleanly", async () => {
+        const server = await createTestServer();
+        const baseUrl = server.baseUrl;
+
+        // Server is up before cleanup
+        const before = await fetch(`${baseUrl}/health`);
+        expect([200, 503]).toContain(before.status);
+
+        // Cleanup
+        await server.cleanup();
+
+        // Server should no longer be reachable after cleanup
+        let threw = false;
+        try {
+            await fetch(`${baseUrl}/health`);
+        } catch {
+            threw = true;
+        }
+        expect(threw).toBe(true);
+    }, TEST_TIMEOUT_MS);
+});

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -11,10 +11,12 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { randomBytes } from "node:crypto";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Server as SocketIOServer } from "socket.io";
 import { createAdapter } from "@socket.io/redis-adapter";
-import { createClient, type RedisClientType } from "redis";
+// Type-only import — erased at compile time, no runtime module registry lookup.
+import type { RedisClientType } from "redis";
 
 import { initAuth, getTrustedOrigins } from "../../src/auth.js";
 import { runAllMigrations } from "../../src/migrations.js";
@@ -137,10 +139,34 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
     const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
     process.env.PIZZAPI_TRUST_PROXY = "true";
 
+    // Shared helper — restores PIZZAPI_TRUST_PROXY to its original value.
+    // Called both from cleanup() on success and from the catch block on failure
+    // so that a throw during setup never leaves a mutated env var behind.
+    function restoreEnv(): void {
+        if (savedTrustProxy === undefined) {
+            delete process.env.PIZZAPI_TRUST_PROXY;
+        } else {
+            process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+        }
+    }
+
     // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
     // that better-auth uses only for cookie domain (not for actual listening).
     // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
     const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
+
+    try {
+
+    // Retrieve the real Redis createClient captured by the test preload
+    // (packages/server/tests/harness/preload.ts).  Using the global avoids
+    // the module-registry lookup entirely, which is immune to contamination
+    // from mock.module("redis", …) calls in other test files sharing the
+    // same Bun worker process.
+    type CreateClientFn = typeof import("redis").createClient;
+    const createClient = (
+        (globalThis as unknown as Record<string, unknown>).__harnessRealCreateClient as CreateClientFn | undefined
+        ?? (await import("redis")).createClient
+    );
 
     // 3. Init auth with temp DB
     initAuth({
@@ -186,7 +212,7 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
         maxHttpBufferSize: 100 * 1024 * 1024,
         pingInterval: 30_000,
         pingTimeout: 60_000,
-        adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
+        adapter: createAdapter(pubClient, subClient, { key: `pizzapi-sio-test-${randomBytes(8).toString("hex")}` }),
         transports: ["websocket", "polling"],
     });
 
@@ -293,11 +319,7 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
 
     async function cleanup(): Promise<void> {
         // Restore PIZZAPI_TRUST_PROXY
-        if (savedTrustProxy === undefined) {
-            delete process.env.PIZZAPI_TRUST_PROXY;
-        } else {
-            process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
-        }
+        restoreEnv();
 
         // Close Socket.IO — this also closes the underlying httpServer internally,
         // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
@@ -326,4 +348,16 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
         fetch: testFetch,
         cleanup,
     };
+
+    } catch (err) {
+        // Setup failed — restore env var and clean up temp dir so that the
+        // mutated PIZZAPI_TRUST_PROXY doesn't contaminate subsequent tests.
+        restoreEnv();
+        try {
+            rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+            // Ignore cleanup errors
+        }
+        throw err;
+    }
 }

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -1,0 +1,329 @@
+/**
+ * Test server factory — creates a real PizzaPi server on an ephemeral port
+ * with SQLite + Redis + Socket.IO for integration testing.
+ *
+ * IMPORTANT: createTestServer() uses module-level singletons from auth.ts and
+ * sio-state.ts. Concurrent server creation is NOT supported — create servers
+ * sequentially. Multiple servers can run simultaneously after creation; only
+ * the creation phase must be serialized.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Server as SocketIOServer } from "socket.io";
+import { createAdapter } from "@socket.io/redis-adapter";
+import { createClient, type RedisClientType } from "redis";
+
+import { initAuth, getTrustedOrigins } from "../../src/auth.js";
+import { runAllMigrations } from "../../src/migrations.js";
+import { handleFetch } from "../../src/handler.js";
+import { initStateRedis } from "../../src/ws/sio-state.js";
+import { initSioRegistry } from "../../src/ws/sio-registry.js";
+import { registerNamespaces } from "../../src/ws/namespaces/index.js";
+
+import type { TestServerOptions, TestServer } from "./types.js";
+
+const REDIS_URL = process.env.PIZZAPI_REDIS_URL ?? "redis://localhost:6379";
+
+// ── Unique IP generator ──────────────────────────────────────────────────────
+// The register rate limiter in routes/auth.ts is a module-level singleton
+// (shared across all test server instances). We generate a unique IP per server
+// so each creation gets its own rate-limit bucket and doesn't collide with others.
+let _serverCounter = 0;
+function uniqueTestClientIp(): string {
+    const n = ++_serverCounter;
+    return `10.255.${Math.floor(n / 256) % 256}.${n % 256}`;
+}
+
+// ── Node req/res ↔ fetch API helpers (mirrors src/index.ts) ─────────────────
+
+async function nodeReqToFetchRequest(req: IncomingMessage, port: number): Promise<Request> {
+    const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+        if (value === undefined) continue;
+        // Prevent client-supplied x-pizzapi-client-ip spoofing
+        if (key.toLowerCase() === "x-pizzapi-client-ip") continue;
+        if (Array.isArray(value)) {
+            for (const v of value) headers.append(key, v);
+        } else {
+            headers.set(key, value);
+        }
+    }
+
+    // Inject real client IP from the TCP socket
+    if (req.socket.remoteAddress) {
+        headers.set("x-pizzapi-client-ip", req.socket.remoteAddress);
+    }
+
+    const method = (req.method ?? "GET").toUpperCase();
+    const hasBody = method !== "GET" && method !== "HEAD";
+
+    // Pre-buffer the body from the Node.js stream into an ArrayBuffer.
+    //
+    // IMPORTANT: Do NOT pass the IncomingMessage stream directly as the Request
+    // body. handler.ts notes a known Bun issue: when a Request with a
+    // ReadableStream body is subsequently wrapped via `new Request(req, { headers })`
+    // (as the auth handler does), the stream fails to propagate and hangs
+    // indefinitely. Pre-buffering into an ArrayBuffer avoids this entirely.
+    let body: ArrayBuffer | undefined;
+    if (hasBody) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+        }
+        const buf = Buffer.concat(chunks);
+        body = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+    }
+
+    return new Request(url.toString(), {
+        method,
+        headers,
+        body,
+    });
+}
+
+async function sendFetchResponse(res: ServerResponse, response: Response): Promise<void> {
+    const headers: Record<string, string | string[]> = {};
+    response.headers.forEach((value, key) => {
+        const existing = headers[key];
+        if (existing !== undefined) {
+            headers[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+        } else {
+            headers[key] = value;
+        }
+    });
+
+    res.writeHead(response.status, headers);
+
+    if (!response.body) {
+        res.end();
+        return;
+    }
+
+    const reader = response.body.getReader();
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            res.write(value);
+        }
+    } finally {
+        reader.releaseLock();
+        res.end();
+    }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a fully initialized PizzaPi test server on an ephemeral port.
+ * Includes SQLite DB, Redis, Socket.IO, and a pre-created test user.
+ *
+ * Always call `cleanup()` when done to release all resources.
+ *
+ * NOTE: Uses module-level singletons (auth, sio-state). Do NOT call this
+ * concurrently — create servers sequentially to avoid race conditions.
+ */
+export async function createTestServer(opts?: TestServerOptions): Promise<TestServer> {
+    // 1. Temp directory for the SQLite DB
+    const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
+    const dbPath = join(tmpDir, "test.db");
+
+    // 2. Trust proxy for rate-limit tests (mirrors production behavior)
+    const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
+    process.env.PIZZAPI_TRUST_PROXY = "true";
+
+    // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
+    // that better-auth uses only for cookie domain (not for actual listening).
+    // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
+    const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
+
+    // 3. Init auth with temp DB
+    initAuth({
+        dbPath,
+        baseURL: placeholderBase,
+        secret: "test-secret-for-harness-at-least-32-chars-long!!",
+        disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
+        extraOrigins: opts?.trustedOrigins,
+    });
+
+    // 4. Run DB migrations
+    await runAllMigrations();
+
+    // 5. Create Redis pub/sub clients and connect them
+    const pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
+    const subClient = pubClient.duplicate() as RedisClientType;
+    await Promise.all([pubClient.connect(), subClient.connect()]);
+
+    // 6. We'll track the resolved port for the request converter
+    let resolvedPort = 0;
+
+    // Create the HTTP server with the handleFetch handler
+    const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+        try {
+            const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
+            const fetchRes = await handleFetch(fetchReq);
+            await sendFetchResponse(res, fetchRes);
+        } catch (e) {
+            console.error("[test-harness] Unhandled error:", e);
+            if (!res.headersSent) {
+                res.writeHead(500, { "content-type": "application/json" });
+            }
+            res.end(JSON.stringify({ error: "Internal server error" }));
+        }
+    });
+
+    // 7. Create Socket.IO server with Redis adapter
+    const io = new SocketIOServer(httpServer, {
+        cors: {
+            origin: getTrustedOrigins(),
+            credentials: true,
+        },
+        maxHttpBufferSize: 100 * 1024 * 1024,
+        pingInterval: 30_000,
+        pingTimeout: 60_000,
+        adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
+        transports: ["websocket", "polling"],
+    });
+
+    // 8. Init state Redis
+    await initStateRedis();
+
+    // 9. Init the Socket.IO registry
+    initSioRegistry(io);
+
+    // 10. Register all namespaces
+    registerNamespaces(io);
+
+    // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === "string") {
+        throw new Error("[test-harness] Could not determine server port");
+    }
+    resolvedPort = addr.port;
+
+    // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
+    const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
+
+    // 12. Create a test user via the /api/register endpoint.
+    //     Use a unique client IP per server instance so each registration gets its
+    //     own rate-limit bucket in the module-level registerRateLimiter singleton.
+    const testUserName = "Test User";
+    const testUserEmail = "testuser@pizzapi-harness.test";
+    const testUserPassword = "HarnessPass123";
+    const testClientIp = uniqueTestClientIp();
+
+    const registerRes = await fetch(`${baseUrl}/api/register`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            // Unique x-forwarded-for per server so the rate limiter assigns a
+            // separate bucket for each test server creation.
+            "x-forwarded-for": testClientIp,
+        },
+        body: JSON.stringify({
+            name: testUserName,
+            email: testUserEmail,
+            password: testUserPassword,
+        }),
+    });
+
+    if (!registerRes.ok) {
+        throw new Error(
+            `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+        );
+    }
+
+    const registerData = await registerRes.json() as { ok: boolean; key: string };
+    const apiKey = registerData.key;
+
+    // 13. Get a session cookie via better-auth sign-in.
+    //     The sign-in response includes the user object (with id) and Set-Cookie header.
+    const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            "x-forwarded-for": testClientIp,
+        },
+        body: JSON.stringify({
+            email: testUserEmail,
+            password: testUserPassword,
+        }),
+    });
+
+    if (!signInRes.ok) {
+        throw new Error(
+            `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
+        );
+    }
+
+    const signInData = await signInRes.json() as { user?: { id: string } };
+    const userId = signInData.user?.id ?? "";
+    if (!userId) {
+        throw new Error("[test-harness] Could not get userId from sign-in response");
+    }
+
+    const cookies = signInRes.headers.getSetCookie();
+    const sessionCookie = cookies.join("; ");
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    async function testFetch(path: string, init?: RequestInit): Promise<Response> {
+        const url = `${baseUrl}${path}`;
+        const headers = new Headers(init?.headers);
+
+        // Inject auth headers if not already present
+        if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
+            headers.set("x-pizzapi-api-key", apiKey);
+        }
+        if (!headers.has("cookie") && sessionCookie) {
+            headers.set("cookie", sessionCookie);
+        }
+
+        return fetch(url, { ...init, headers });
+    }
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+
+    async function cleanup(): Promise<void> {
+        // Restore PIZZAPI_TRUST_PROXY
+        if (savedTrustProxy === undefined) {
+            delete process.env.PIZZAPI_TRUST_PROXY;
+        } else {
+            process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+        }
+
+        // Close Socket.IO — this also closes the underlying httpServer internally,
+        // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
+        await new Promise<void>((resolve) => io.close(() => resolve()));
+
+        // Disconnect Redis clients
+        await Promise.allSettled([pubClient.quit(), subClient.quit()]);
+
+        // Clean up temp directory
+        try {
+            rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+            // Ignore cleanup errors
+        }
+    }
+
+    return {
+        port: resolvedPort,
+        baseUrl,
+        io,
+        apiKey,
+        userId,
+        userName: testUserName,
+        userEmail: testUserEmail,
+        sessionCookie,
+        fetch: testFetch,
+        cleanup,
+    };
+}

--- a/packages/server/tests/harness/types.ts
+++ b/packages/server/tests/harness/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types for the test server harness.
+ */
+
+export interface TestServerOptions {
+    /** Override base URL (default: auto from port) */
+    baseUrl?: string;
+    /** Extra trusted origins for CORS */
+    trustedOrigins?: string[];
+    /** Disable signup-after-first-user restriction (default: true = disabled) */
+    disableSignupAfterFirstUser?: boolean;
+}
+
+export interface TestServer {
+    /** Ephemeral port the server is listening on */
+    port: number;
+    /** Base URL: http://localhost:{port} */
+    baseUrl: string;
+    /** The Socket.IO server instance */
+    io: import("socket.io").Server;
+    /** Pre-created API key for auth */
+    apiKey: string;
+    /** Pre-created test user's ID */
+    userId: string;
+    /** Pre-created test user's name */
+    userName: string;
+    /** Pre-created test user's email */
+    userEmail: string;
+    /** Auth session cookie string for viewer/hub namespaces */
+    sessionCookie: string;
+    /** Helper: make an authenticated REST request */
+    fetch(path: string, init?: RequestInit): Promise<Response>;
+    /** Shut down everything and clean up */
+    cleanup(): Promise<void>;
+}

--- a/packages/server/tests/harness/types.ts
+++ b/packages/server/tests/harness/types.ts
@@ -33,3 +33,74 @@ export interface TestServer {
     /** Shut down everything and clean up */
     cleanup(): Promise<void>;
 }
+
+// ── MockRelay types ──────────────────────────────────────────────────────────
+
+import type { Socket as ClientSocket } from "socket.io-client";
+
+export interface MockRelayOptions {
+    // Future options
+}
+
+export interface MockRelaySession {
+    sessionId: string;
+    token: string;
+    shareUrl: string;
+}
+
+export interface MockRelay {
+    socket: ClientSocket;
+
+    /** Register a new session. Returns { sessionId, token, shareUrl } */
+    registerSession(opts?: {
+        sessionId?: string;
+        cwd?: string;
+        ephemeral?: boolean;
+        collabMode?: boolean;
+        sessionName?: string | null;
+        parentSessionId?: string | null;
+    }): Promise<MockRelaySession>;
+
+    /** Send an agent event through the relay */
+    emitEvent(sessionId: string, token: string, event: unknown, seq?: number): void;
+
+    /** Signal session end */
+    emitSessionEnd(sessionId: string, token: string): void;
+
+    /** Fire a session trigger (child → parent) */
+    emitTrigger(data: {
+        token: string;
+        trigger: {
+            type: string;
+            sourceSessionId: string;
+            targetSessionId: string;
+            payload: Record<string, unknown>;
+            deliverAs: "steer" | "followUp";
+            expectsResponse: boolean;
+            triggerId: string;
+            ts: string;
+        };
+    }): void;
+
+    /** Fire a trigger response (parent → child) */
+    emitTriggerResponse(data: {
+        token: string;
+        triggerId: string;
+        response: string;
+        action?: string;
+        targetSessionId: string;
+    }): void;
+
+    /** Send an inter-session message */
+    emitSessionMessage(data: {
+        token: string;
+        targetSessionId: string;
+        message: string;
+        deliverAs?: "input";
+    }): void;
+
+    /** Wait for a specific event */
+    waitForEvent(eventName: string, timeout?: number): Promise<unknown>;
+
+    disconnect(): Promise<void>;
+}


### PR DESCRIPTION
Night Shift dish 003: MockRelay client + event builder factories (heartbeat, conversation, meta state, etc.) for BDD-style integration testing.

## What's added

### `packages/server/tests/harness/mock-relay.ts`
- `createMockRelay(server)` — connects `socket.io-client` to `/relay` with API key auth
- Full `MockRelay` interface: `registerSession()`, `emitEvent()`, `emitSessionEnd()`, trigger/message emitters, `waitForEvent()`, `disconnect()`
- `reconnection: false` + 100ms TCP drain delay ensures `server.cleanup()` completes cleanly (Bun `httpServer.close()` compatibility fix)

### `packages/server/tests/harness/builders.ts`
- `buildHeartbeat()`, `buildAssistantMessage()`, `buildToolUseEvent()`, `buildToolResultEvent()`
- `buildConversation(turns)` — multi-turn conversation from typed `ConversationTurn` array
- `buildSessionInfo()`, `buildRunnerInfo()`, `buildMetaState()`, `buildTodoList()`

### `packages/server/tests/harness/builders.test.ts`
31 tests: 27 unit tests (all builders) + 4 MockRelay integration tests

### Updated
- `types.ts` — `MockRelayOptions`, `MockRelaySession`, `MockRelay` interfaces
- `index.ts` — exports new modules

## Test results
```
31 pass, 0 fail
```