### PR TITLE
feat: BDD scenario builder and integration tests

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,13 @@
+[test]
+# Preload script that saves the real redis createClient to globalThis
+# BEFORE any test file can mock it via mock.module("redis").
+#
+# Bun 1.3.x has a bug where mock.module() is not reset between test files
+# in the same worker. Several test files in packages/server/src/ws/ mock
+# redis with a stub that lacks .pSubscribe(), .subscribe(), .quit(), etc.
+# This mock persists and contaminates the test-server harness tests.
+#
+# The preload runs once per worker, captures the real createClient, and
+# stores it in globalThis.__realRedisCreateClient. The harness server.ts
+# retrieves this to get an unmocked createClient.
+preload = ["./packages/server/tests/harness/preload-redis.ts"]

--- a/packages/server/bunfig.toml
+++ b/packages/server/bunfig.toml
@@ -1,0 +1,2 @@
+[test]
+preload = ["./tests/harness/preload-redis.ts"]

--- a/packages/server/src/sessions/redis.ts
+++ b/packages/server/src/sessions/redis.ts
@@ -189,3 +189,24 @@ export async function deleteRelayEventCaches(sessionIds: string[]): Promise<void
         logUnavailableOnce("Failed to delete relay event caches from Redis", error);
     }
 }
+
+/**
+ * Close the relay Redis client and reset module state.
+ *
+ * Intended for test use only — allows tests to reinitialize the relay cache
+ * with a fresh client after another test (e.g. a harness integration test)
+ * has already connected the real client. Without this, the module-level
+ * `initPromise` guard prevents re-initialization.
+ */
+export async function closeRelayCache(): Promise<void> {
+    if (client) {
+        try {
+            await client.quit();
+        } catch {
+            // Ignore quit errors (client may already be closed)
+        }
+        client = null;
+    }
+    initPromise = null;
+    unavailableLogged = false;
+}

--- a/packages/server/src/sessions/redis_perf.test.ts
+++ b/packages/server/src/sessions/redis_perf.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, spyOn, beforeAll, afterAll, mock } from "bun:test";
 import { createClient } from "redis";
-import { deleteRelayEventCaches, initializeRelayRedisCache } from "./redis";
+import { deleteRelayEventCaches, initializeRelayRedisCache, closeRelayCache } from "./redis";
 
 // Mock the redis module
 const mockDel = mock((keys: string | string[]) => Promise.resolve(1));
@@ -30,8 +30,11 @@ mock.module("redis", () => ({
 
 describe("deleteRelayEventCaches Performance", () => {
     beforeAll(async () => {
-        // Initialize the client so activeClient() returns something
-        // We ensure initialization happens only once
+        // Close any existing client from prior test files (e.g. harness integration
+        // tests that connected the real redis), then re-initialize with the mock.
+        // Without closeRelayCache(), the module-level initPromise guard would skip
+        // re-initialization, leaving the real redis client in place.
+        await closeRelayCache();
         await initializeRelayRedisCache();
     });
 
@@ -69,4 +72,16 @@ describe("deleteRelayEventCaches Performance", () => {
 
         consoleSpy.mockRestore();
     });
+});
+
+// ── Restore real redis module after this file ──────────────────────────────
+// Bun 1.3.x does not reset mock.module() between test files in the same
+// worker. Without this cleanup, the redis mock set above would persist and
+// contaminate harness tests (createTestServer) that need the real redis
+// client (with .pSubscribe(), .subscribe(), .quit(), etc.).
+afterAll(() => {
+    const real = (globalThis as Record<string, unknown>).__realRedisCreateClient;
+    if (real) {
+        mock.module("redis", () => ({ createClient: real }));
+    }
 });

--- a/packages/server/src/ws/runner-assoc.test.ts
+++ b/packages/server/src/ws/runner-assoc.test.ts
@@ -9,7 +9,7 @@
 // We mock the Redis client at module level so no live Redis is needed.
 // ============================================================================
 
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 
 // ── Minimal Redis mock ──────────────────────────────────────────────────────
 
@@ -226,4 +226,16 @@ describe("runner association (sio-state)", () => {
             expect(await getRunnerAssociation("sess-lifecycle")).toBeNull();
         });
     });
+});
+
+// ── Restore real redis module after this file ──────────────────────────────
+// Bun 1.3.x does not reset mock.module() between test files in the same
+// worker. Without this cleanup, the redis mock set above would persist and
+// contaminate harness tests (createTestServer) that need the real redis
+// client (with .pSubscribe(), .subscribe(), .quit(), etc.).
+afterAll(() => {
+    const real = (globalThis as Record<string, unknown>).__realRedisCreateClient;
+    if (real) {
+        mock.module("redis", () => ({ createClient: real }));
+    }
 });

--- a/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
+++ b/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach } from "bun:test";
+import { describe, it, expect, mock, beforeEach, afterAll } from "bun:test";
 
 const store = new Map<string, string>();
 const setStore = new Map<string, Set<string>>();
@@ -314,4 +314,15 @@ describe("runners broadcast", () => {
         const removed = emitCalls.find((c) => c.event === "runner_removed");
         expect(removed).toBeUndefined();
     });
+});
+
+// ── Restore real redis module after this file ──────────────────────────────
+// Bun 1.3.x does not reset mock.module() between test files in the same
+// worker. Without this cleanup, the redis mock set above would persist and
+// contaminate tests that need the real redis client.
+afterAll(() => {
+    const real = (globalThis as Record<string, unknown>).__realRedisCreateClient;
+    if (real) {
+        mock.module("redis", () => ({ createClient: real }));
+    }
 });

--- a/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 
 // ── Minimal Redis mock (mirrors sio-state-children.test.ts) ─────────────────
 
@@ -175,4 +175,15 @@ describe("registerTuiSession parent resolution", () => {
         // to the old parent's membership set even if the parent is currently offline.
         expect(setStore.has("pizzapi:sio:children:parent-old")).toBe(false);
     });
+});
+
+// ── Restore real redis module after this file ──────────────────────────────
+// Bun 1.3.x does not reset mock.module() between test files in the same
+// worker. Without this cleanup, the redis mock set above would persist and
+// contaminate tests that need the real redis client.
+afterAll(() => {
+    const real = (globalThis as Record<string, unknown>).__realRedisCreateClient;
+    if (real) {
+        mock.module("redis", () => ({ createClient: real }));
+    }
 });

--- a/packages/server/src/ws/sio-state-children.test.ts
+++ b/packages/server/src/ws/sio-state-children.test.ts
@@ -7,7 +7,7 @@
 // We mock the Redis client at module level so no live Redis is needed.
 // ============================================================================
 
-import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterAll, mock } from "bun:test";
 
 // ── Minimal Redis mock ──────────────────────────────────────────────────────
 
@@ -506,4 +506,16 @@ describe("child session helpers (sio-state)", () => {
         const remaining = await getChildSessions("parent-1");
         expect(remaining).toEqual(["child-1"]);
     });
+});
+
+// ── Restore real redis module after this file ──────────────────────────────
+// Bun 1.3.x does not reset mock.module() between test files in the same
+// worker. Without this cleanup, the redis mock set above would persist and
+// contaminate harness tests (createTestServer) that need the real redis
+// client (with .pSubscribe(), .subscribe(), .quit(), etc.).
+afterAll(() => {
+    const real = (globalThis as Record<string, unknown>).__realRedisCreateClient;
+    if (real) {
+        mock.module("redis", () => ({ createClient: real }));
+    }
 });

--- a/packages/server/tests/harness/builders.test.ts
+++ b/packages/server/tests/harness/builders.test.ts
@@ -1,0 +1,419 @@
+/**
+ * Tests for event builders and mock relay integration.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+    buildHeartbeat,
+    buildAssistantMessage,
+    buildToolUseEvent,
+    buildToolResultEvent,
+    buildConversation,
+    buildSessionInfo,
+    buildRunnerInfo,
+    buildMetaState,
+    buildTodoList,
+} from "./builders.js";
+import { createTestServer } from "./server.js";
+import { createMockRelay } from "./mock-relay.js";
+import { defaultMetaState } from "@pizzapi/protocol";
+
+const TEST_TIMEOUT_MS = 30_000;
+
+// ── buildHeartbeat ────────────────────────────────────────────────────────────
+
+describe("buildHeartbeat", () => {
+    test("produces a valid default heartbeat", () => {
+        const hb = buildHeartbeat();
+        expect(hb.type).toBe("heartbeat");
+        expect(typeof hb.active).toBe("boolean");
+        expect(typeof hb.isCompacting).toBe("boolean");
+        expect(typeof hb.ts).toBe("number");
+        expect(hb.ts).toBeGreaterThan(0);
+        expect(hb.model).toBeNull();
+        expect(hb.sessionName).toBeNull();
+        expect(hb.uptime).toBeNull();
+        expect(typeof hb.cwd).toBe("string");
+    });
+
+    test("applies overrides correctly", () => {
+        const hb = buildHeartbeat({
+            active: true,
+            isCompacting: true,
+            sessionName: "My Session",
+            cwd: "/home/user",
+            model: { provider: "anthropic", id: "claude-3-5-haiku-20241022" },
+        });
+        expect(hb.active).toBe(true);
+        expect(hb.isCompacting).toBe(true);
+        expect(hb.sessionName).toBe("My Session");
+        expect(hb.cwd).toBe("/home/user");
+        expect(hb.model?.provider).toBe("anthropic");
+        expect(hb.type).toBe("heartbeat"); // immutable
+    });
+
+    test("ts override is respected", () => {
+        const ts = 12345678;
+        const hb = buildHeartbeat({ ts });
+        expect(hb.ts).toBe(ts);
+    });
+});
+
+// ── buildAssistantMessage ─────────────────────────────────────────────────────
+
+describe("buildAssistantMessage", () => {
+    test("produces correct shape", () => {
+        const msg = buildAssistantMessage("Hello, world!");
+        expect(msg.type).toBe("message_update");
+        expect(msg.role).toBe("assistant");
+        expect(msg.content).toHaveLength(1);
+        expect(msg.content[0].type).toBe("text");
+        expect(msg.content[0].text).toBe("Hello, world!");
+        expect(typeof msg.messageId).toBe("string");
+    });
+
+    test("applies overrides", () => {
+        const msg = buildAssistantMessage("Hi", { messageId: "custom-id-123" });
+        expect(msg.messageId).toBe("custom-id-123");
+    });
+});
+
+// ── buildToolUseEvent ─────────────────────────────────────────────────────────
+
+describe("buildToolUseEvent", () => {
+    test("produces correct shape", () => {
+        const block = buildToolUseEvent("Bash", { command: "ls" });
+        expect(block.type).toBe("tool_use");
+        expect(block.name).toBe("Bash");
+        expect(block.input).toEqual({ command: "ls" });
+        expect(typeof block.id).toBe("string");
+        expect(block.id.length).toBeGreaterThan(0);
+    });
+
+    test("uses provided toolCallId", () => {
+        const block = buildToolUseEvent("Read", { path: "/tmp/foo" }, "my-tool-id");
+        expect(block.id).toBe("my-tool-id");
+    });
+});
+
+// ── buildToolResultEvent ──────────────────────────────────────────────────────
+
+describe("buildToolResultEvent", () => {
+    test("produces correct shape", () => {
+        const result = buildToolResultEvent("tool-abc", "output text");
+        expect(result.type).toBe("tool_result");
+        expect(result.tool_use_id).toBe("tool-abc");
+        expect(result.content).toHaveLength(1);
+        expect(result.content[0].type).toBe("text");
+        expect(result.content[0].text).toBe("output text");
+    });
+});
+
+// ── buildConversation ─────────────────────────────────────────────────────────
+
+describe("buildConversation", () => {
+    test("empty conversation yields empty array", () => {
+        expect(buildConversation([])).toEqual([]);
+    });
+
+    test("user turn produces user_message event", () => {
+        const events = buildConversation([{ role: "user", text: "hello" }]) as Array<Record<string, unknown>>;
+        expect(events).toHaveLength(1);
+        expect(events[0].type).toBe("user_message");
+        expect(events[0].text).toBe("hello");
+    });
+
+    test("assistant text turn produces message_update event", () => {
+        const events = buildConversation([
+            { role: "assistant", text: "Hi there" },
+        ]) as Array<Record<string, unknown>>;
+        expect(events).toHaveLength(1);
+        expect(events[0].type).toBe("message_update");
+        const msg = events[0] as { role: string; content: Array<{ text: string }> };
+        expect(msg.role).toBe("assistant");
+        expect(msg.content[0].text).toBe("Hi there");
+    });
+
+    test("assistant toolCall turn produces tool_use content block", () => {
+        const events = buildConversation([
+            { role: "assistant", toolCall: { name: "Bash", input: { command: "pwd" } } },
+        ]) as Array<{ type: string; content: Array<{ type: string; name: string }> }>;
+        expect(events).toHaveLength(1);
+        expect(events[0].type).toBe("message_update");
+        expect(events[0].content[0].type).toBe("tool_use");
+        expect(events[0].content[0].name).toBe("Bash");
+    });
+
+    test("tool turn produces tool_result_message event", () => {
+        const events = buildConversation([
+            { role: "tool", toolCallId: "t-1", result: "success" },
+        ]) as Array<{ type: string; content: Array<{ tool_use_id: string }> }>;
+        expect(events).toHaveLength(1);
+        expect(events[0].type).toBe("tool_result_message");
+        expect(events[0].content[0].tool_use_id).toBe("t-1");
+    });
+
+    test("multi-turn conversation produces correct sequence", () => {
+        const events = buildConversation([
+            { role: "user", text: "What is 2+2?" },
+            { role: "assistant", text: "4" },
+            { role: "user", text: "Thanks" },
+        ]) as Array<Record<string, unknown>>;
+        expect(events).toHaveLength(3);
+        expect(events[0].type).toBe("user_message");
+        expect(events[1].type).toBe("message_update");
+        expect(events[2].type).toBe("user_message");
+    });
+});
+
+// ── buildSessionInfo ──────────────────────────────────────────────────────────
+
+describe("buildSessionInfo", () => {
+    test("produces valid defaults", () => {
+        const info = buildSessionInfo();
+        expect(typeof info.sessionId).toBe("string");
+        expect(typeof info.shareUrl).toBe("string");
+        expect(typeof info.cwd).toBe("string");
+        expect(typeof info.startedAt).toBe("string");
+        expect(info.isEphemeral).toBe(true);
+        expect(info.isActive).toBe(true);
+        expect(info.model).toBeNull();
+        expect(info.runnerId).toBeNull();
+        expect(info.sessionName).toBeNull();
+    });
+
+    test("applies overrides", () => {
+        const info = buildSessionInfo({
+            sessionId: "my-session-id",
+            sessionName: "Test Session",
+            isActive: false,
+            isEphemeral: false,
+        });
+        expect(info.sessionId).toBe("my-session-id");
+        expect(info.sessionName).toBe("Test Session");
+        expect(info.isActive).toBe(false);
+        expect(info.isEphemeral).toBe(false);
+    });
+
+    test("two calls produce different sessionIds by default", () => {
+        const a = buildSessionInfo();
+        const b = buildSessionInfo();
+        expect(a.sessionId).not.toBe(b.sessionId);
+    });
+});
+
+// ── buildRunnerInfo ───────────────────────────────────────────────────────────
+
+describe("buildRunnerInfo", () => {
+    test("produces valid defaults", () => {
+        const info = buildRunnerInfo();
+        expect(typeof info.runnerId).toBe("string");
+        expect(typeof info.name).toBe("string");
+        expect(Array.isArray(info.roots)).toBe(true);
+        expect(Array.isArray(info.skills)).toBe(true);
+        expect(Array.isArray(info.agents)).toBe(true);
+        expect(info.sessionCount).toBe(0);
+    });
+
+    test("applies overrides", () => {
+        const info = buildRunnerInfo({ name: "Production Runner", sessionCount: 3 });
+        expect(info.name).toBe("Production Runner");
+        expect(info.sessionCount).toBe(3);
+    });
+});
+
+// ── buildMetaState ────────────────────────────────────────────────────────────
+
+describe("buildMetaState", () => {
+    test("matches defaultMetaState structure", () => {
+        const meta = buildMetaState();
+        const defaults = defaultMetaState();
+        // All keys from defaultMetaState should be present
+        for (const key of Object.keys(defaults) as Array<keyof typeof defaults>) {
+            expect(meta).toHaveProperty(key);
+        }
+    });
+
+    test("default version is 0", () => {
+        const meta = buildMetaState();
+        expect(meta.version).toBe(0);
+    });
+
+    test("default fields match defaultMetaState values", () => {
+        const meta = buildMetaState();
+        const defaults = defaultMetaState();
+        expect(meta.todoList).toEqual(defaults.todoList);
+        expect(meta.pendingQuestion).toBe(defaults.pendingQuestion);
+        expect(meta.pendingPlan).toBe(defaults.pendingPlan);
+        expect(meta.planModeEnabled).toBe(defaults.planModeEnabled);
+        expect(meta.isCompacting).toBe(defaults.isCompacting);
+    });
+
+    test("applies overrides", () => {
+        const meta = buildMetaState({
+            planModeEnabled: true,
+            isCompacting: true,
+            version: 42,
+        });
+        expect(meta.planModeEnabled).toBe(true);
+        expect(meta.isCompacting).toBe(true);
+        expect(meta.version).toBe(42);
+    });
+});
+
+// ── buildTodoList ─────────────────────────────────────────────────────────────
+
+describe("buildTodoList", () => {
+    test("returns empty array for empty input", () => {
+        expect(buildTodoList([])).toEqual([]);
+    });
+
+    test("produces correct shape with auto-incremented IDs starting at 1", () => {
+        const items = buildTodoList([
+            { text: "Task one" },
+            { text: "Task two" },
+            { text: "Task three" },
+        ]);
+        expect(items).toHaveLength(3);
+        expect(items[0]).toEqual({ id: 1, text: "Task one", status: "pending" });
+        expect(items[1]).toEqual({ id: 2, text: "Task two", status: "pending" });
+        expect(items[2]).toEqual({ id: 3, text: "Task three", status: "pending" });
+    });
+
+    test("respects provided status", () => {
+        const items = buildTodoList([
+            { text: "Done task", status: "done" },
+            { text: "Active task", status: "in_progress" },
+        ]);
+        expect(items[0].status).toBe("done");
+        expect(items[1].status).toBe("in_progress");
+    });
+
+    test("defaults missing status to pending", () => {
+        const items = buildTodoList([{ text: "A task" }]);
+        expect(items[0].status).toBe("pending");
+    });
+});
+
+// ── Integration: MockRelay + builders ─────────────────────────────────────────
+// NOTE: createTestServer() uses module-level singletons (auth, sio-state).
+// These integration tests are serialized to avoid conflicts, and each test
+// disconnects the relay socket before calling server.cleanup() so that
+// io.close() can complete cleanly.
+
+describe.serial("MockRelay integration", () => {
+    test("connect, register, emit event, disconnect", async () => {
+        const server = await createTestServer();
+        let relay;
+        try {
+            relay = await createMockRelay(server);
+            expect(relay.socket.connected).toBe(true);
+
+            const session = await relay.registerSession({ cwd: "/tmp/test" });
+            expect(typeof session.sessionId).toBe("string");
+            expect(session.sessionId.length).toBeGreaterThan(0);
+            expect(typeof session.token).toBe("string");
+            expect(session.token.length).toBeGreaterThan(0);
+            expect(typeof session.shareUrl).toBe("string");
+
+            // Emit a heartbeat event through the relay
+            const hb = buildHeartbeat({ active: true, cwd: "/tmp/test" });
+            relay.emitEvent(session.sessionId, session.token, hb, 1);
+
+            // Give the server a moment to process
+            await Bun.sleep(100);
+
+            // Signal session end
+            relay.emitSessionEnd(session.sessionId, session.token);
+            await Bun.sleep(50);
+
+            await relay.disconnect();
+            expect(relay.socket.connected).toBe(false);
+        } finally {
+            // Disconnect relay before cleanup so io.close() can drain cleanly
+            if (relay && relay.socket.connected) {
+                await relay.disconnect().catch(() => {});
+            }
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("can register multiple sessions on the same relay", async () => {
+        const server = await createTestServer();
+        let relay;
+        try {
+            relay = await createMockRelay(server);
+
+            const s1 = await relay.registerSession({ cwd: "/tmp/s1" });
+            const s2 = await relay.registerSession({ cwd: "/tmp/s2" });
+
+            expect(s1.sessionId).not.toBe(s2.sessionId);
+            expect(s1.token).not.toBe(s2.token);
+
+            // Emit events for both sessions
+            const hb = buildHeartbeat({ active: false });
+            relay.emitEvent(s1.sessionId, s1.token, hb);
+            relay.emitEvent(s2.sessionId, s2.token, hb);
+
+            await relay.disconnect();
+        } finally {
+            if (relay && relay.socket.connected) {
+                await relay.disconnect().catch(() => {});
+            }
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("emit conversation events through relay", async () => {
+        const server = await createTestServer();
+        let relay;
+        try {
+            relay = await createMockRelay(server);
+            const session = await relay.registerSession();
+
+            const conversation = buildConversation([
+                { role: "user", text: "Hello" },
+                { role: "assistant", text: "Hi there!" },
+            ]);
+
+            // Emit each event in the conversation
+            for (let i = 0; i < conversation.length; i++) {
+                relay.emitEvent(session.sessionId, session.token, conversation[i], i + 1);
+            }
+
+            // Give server time to process
+            await Bun.sleep(100);
+
+            await relay.disconnect();
+        } finally {
+            if (relay && relay.socket.connected) {
+                await relay.disconnect().catch(() => {});
+            }
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("waitForEvent times out on unknown event", async () => {
+        const server = await createTestServer();
+        let relay;
+        try {
+            relay = await createMockRelay(server);
+
+            let threw = false;
+            try {
+                await relay.waitForEvent("nonexistent_event_xyz", 200);
+            } catch (err) {
+                threw = true;
+                expect((err as Error).message).toContain("nonexistent_event_xyz");
+            }
+            expect(threw).toBe(true);
+
+            await relay.disconnect();
+        } finally {
+            if (relay && relay.socket.connected) {
+                await relay.disconnect().catch(() => {});
+            }
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+});

--- a/packages/server/tests/harness/builders.test.ts
+++ b/packages/server/tests/harness/builders.test.ts
@@ -116,10 +116,10 @@ describe("buildConversation", () => {
         expect(buildConversation([])).toEqual([]);
     });
 
-    test("user turn produces user_message event", () => {
+    test("user turn produces harness:user_turn marker (not a real protocol event)", () => {
         const events = buildConversation([{ role: "user", text: "hello" }]) as Array<Record<string, unknown>>;
         expect(events).toHaveLength(1);
-        expect(events[0].type).toBe("user_message");
+        expect(events[0].type).toBe("harness:user_turn");
         expect(events[0].text).toBe("hello");
     });
 
@@ -160,9 +160,9 @@ describe("buildConversation", () => {
             { role: "user", text: "Thanks" },
         ]) as Array<Record<string, unknown>>;
         expect(events).toHaveLength(3);
-        expect(events[0].type).toBe("user_message");
+        expect(events[0].type).toBe("harness:user_turn");
         expect(events[1].type).toBe("message_update");
-        expect(events[2].type).toBe("user_message");
+        expect(events[2].type).toBe("harness:user_turn");
     });
 });
 

--- a/packages/server/tests/harness/builders.ts
+++ b/packages/server/tests/harness/builders.ts
@@ -1,0 +1,202 @@
+/**
+ * builders.ts — Pure factory functions that produce correctly-shaped agent events.
+ *
+ * No server dependency — these are data builders only.
+ * Import protocol types directly from @pizzapi/protocol.
+ */
+
+import {
+    defaultMetaState,
+    type SessionMetaState,
+    type MetaTodoItem,
+} from "@pizzapi/protocol";
+
+import type { SessionInfo, RunnerInfo, ModelInfo } from "@pizzapi/protocol";
+
+// ── HeartbeatEvent ────────────────────────────────────────────────────────────
+
+export interface HeartbeatEvent {
+    type: "heartbeat";
+    active: boolean;
+    isCompacting: boolean;
+    ts: number;
+    model: ModelInfo | null;
+    sessionName: string | null;
+    uptime: number | null;
+    cwd: string | null;
+}
+
+export function buildHeartbeat(overrides?: Partial<HeartbeatEvent>): HeartbeatEvent {
+    return {
+        type: "heartbeat",
+        active: false,
+        isCompacting: false,
+        ts: Date.now(),
+        model: null,
+        sessionName: null,
+        uptime: null,
+        cwd: "/tmp/mock",
+        ...overrides,
+    };
+}
+
+// ── Message/content block builders ──────────────────────────────────────────
+
+export interface AssistantMessageEvent {
+    type: "message_update";
+    role: "assistant";
+    content: Array<{ type: "text"; text: string }>;
+    messageId: string;
+}
+
+export interface ToolUseBlock {
+    type: "tool_use";
+    id: string;
+    name: string;
+    input: unknown;
+}
+
+export interface ToolResultBlock {
+    type: "tool_result";
+    tool_use_id: string;
+    content: Array<{ type: "text"; text: string }>;
+}
+
+let _blockIdCounter = 0;
+function nextId(prefix: string): string {
+    return `${prefix}_${++_blockIdCounter}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+export function buildAssistantMessage(
+    text: string,
+    overrides?: Record<string, unknown>,
+): AssistantMessageEvent {
+    return {
+        type: "message_update",
+        role: "assistant",
+        content: [{ type: "text", text }],
+        messageId: nextId("msg"),
+        ...overrides,
+    } as AssistantMessageEvent;
+}
+
+export function buildToolUseEvent(
+    toolName: string,
+    input: unknown,
+    toolCallId?: string,
+): ToolUseBlock {
+    return {
+        type: "tool_use",
+        id: toolCallId ?? nextId("tool"),
+        name: toolName,
+        input,
+    };
+}
+
+export function buildToolResultEvent(
+    toolCallId: string,
+    output: string,
+): ToolResultBlock {
+    return {
+        type: "tool_result",
+        tool_use_id: toolCallId,
+        content: [{ type: "text", text: output }],
+    };
+}
+
+// ── Conversation builder ─────────────────────────────────────────────────────
+
+export type ConversationTurn =
+    | { role: "user"; text: string }
+    | { role: "assistant"; text: string }
+    | { role: "assistant"; toolCall: { name: string; input: unknown } }
+    | { role: "tool"; toolCallId: string; result: string };
+
+export function buildConversation(turns: ConversationTurn[]): unknown[] {
+    const events: unknown[] = [];
+
+    for (const turn of turns) {
+        if (turn.role === "user") {
+            events.push({
+                type: "user_message",
+                text: turn.text,
+            });
+        } else if (turn.role === "assistant") {
+            if ("toolCall" in turn) {
+                const toolId = nextId("tool");
+                const block = buildToolUseEvent(turn.toolCall.name, turn.toolCall.input, toolId);
+                events.push({
+                    type: "message_update",
+                    role: "assistant",
+                    content: [block],
+                    messageId: nextId("msg"),
+                });
+            } else {
+                events.push(buildAssistantMessage(turn.text));
+            }
+        } else if (turn.role === "tool") {
+            const resultBlock = buildToolResultEvent(turn.toolCallId, turn.result);
+            events.push({
+                type: "tool_result_message",
+                content: [resultBlock],
+            });
+        }
+    }
+
+    return events;
+}
+
+// ── Protocol type builders ───────────────────────────────────────────────────
+
+export function buildSessionInfo(overrides?: Partial<SessionInfo>): SessionInfo {
+    return {
+        sessionId: `session_${nextId("s")}`,
+        shareUrl: "http://localhost:3000/s/mock",
+        cwd: "/tmp/mock",
+        startedAt: new Date().toISOString(),
+        viewerCount: 0,
+        sessionName: null,
+        isEphemeral: true,
+        expiresAt: null,
+        isActive: true,
+        lastHeartbeatAt: null,
+        model: null,
+        runnerId: null,
+        runnerName: null,
+        parentSessionId: null,
+        ...overrides,
+    };
+}
+
+export function buildRunnerInfo(overrides?: Partial<RunnerInfo>): RunnerInfo {
+    return {
+        runnerId: `runner_${nextId("r")}`,
+        name: "Test Runner",
+        roots: ["/tmp"],
+        sessionCount: 0,
+        skills: [],
+        agents: [],
+        plugins: [],
+        hooks: [],
+        version: "0.0.0",
+        platform: "linux",
+        ...overrides,
+    };
+}
+
+export function buildMetaState(overrides?: Partial<SessionMetaState>): SessionMetaState {
+    return {
+        ...defaultMetaState(),
+        ...overrides,
+    };
+}
+
+export function buildTodoList(
+    items: Array<{ text: string; status?: MetaTodoItem["status"] }>,
+): MetaTodoItem[] {
+    return items.map((item, index) => ({
+        id: index + 1,
+        text: item.text,
+        status: item.status ?? "pending",
+    }));
+}

--- a/packages/server/tests/harness/builders.ts
+++ b/packages/server/tests/harness/builders.ts
@@ -1,8 +1,11 @@
 /**
- * builders.ts — Pure factory functions that produce correctly-shaped agent events.
+ * builders.ts — Factory functions that produce correctly-shaped agent events.
  *
  * No server dependency — these are data builders only.
  * Import protocol types directly from @pizzapi/protocol.
+ *
+ * Note: Builders are not pure — they use module-level counters and Date.now()/Math.random()
+ * for ID generation. Pass overrides to control specific fields in deterministic tests.
  */
 
 import {
@@ -69,7 +72,7 @@ function nextId(prefix: string): string {
 
 export function buildAssistantMessage(
     text: string,
-    overrides?: Record<string, unknown>,
+    overrides?: Partial<AssistantMessageEvent>,
 ): AssistantMessageEvent {
     return {
         type: "message_update",
@@ -77,7 +80,7 @@ export function buildAssistantMessage(
         content: [{ type: "text", text }],
         messageId: nextId("msg"),
         ...overrides,
-    } as AssistantMessageEvent;
+    };
 }
 
 export function buildToolUseEvent(
@@ -117,8 +120,11 @@ export function buildConversation(turns: ConversationTurn[]): unknown[] {
 
     for (const turn of turns) {
         if (turn.role === "user") {
+            // User input does not flow through the relay event pipeline — it arrives via the
+            // /viewer namespace as "input" events. This harness marker is test scaffolding only
+            // and is NOT a real protocol event type. Consumers should not emit it to the relay.
             events.push({
-                type: "user_message",
+                type: "harness:user_turn",
                 text: turn.text,
             });
         } else if (turn.role === "assistant") {

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Test harness barrel export.
+ * Re-exports everything from types, server, and future modules.
+ */
+
+export * from "./types.js";
+export * from "./server.js";

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -5,3 +5,4 @@
 
 export * from "./types.js";
 export * from "./server.js";
+export * from "./mock-runner.js";

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -10,3 +10,4 @@ export * from "./mock-relay.js";
 export * from "./builders.js";
 export * from "./mock-viewer.js";
 export * from "./mock-hub.js";
+export * from "./scenario.js";

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -8,3 +8,5 @@ export * from "./server.js";
 export * from "./mock-runner.js";
 export * from "./mock-relay.js";
 export * from "./builders.js";
+export * from "./mock-viewer.js";
+export * from "./mock-hub.js";

--- a/packages/server/tests/harness/index.ts
+++ b/packages/server/tests/harness/index.ts
@@ -6,3 +6,5 @@
 export * from "./types.js";
 export * from "./server.js";
 export * from "./mock-runner.js";
+export * from "./mock-relay.js";
+export * from "./builders.js";

--- a/packages/server/tests/harness/integration.test.ts
+++ b/packages/server/tests/harness/integration.test.ts
@@ -403,6 +403,14 @@ describe("Inter-session messaging", () => {
             expect(parentSession.sessionId).not.toBe(childSession.sessionId);
 
             const triggerId = `trigger-${Date.now()}`;
+
+            // Listen for delivery on the parent relay socket BEFORE emitting.
+            // The server forwards session_trigger to the target session's relay socket
+            // (messaging.ts line ~199: targetSocket.emit("session_trigger", { trigger })).
+            // This verifies the trigger was actually received on the parent end, not
+            // just that the emit-side local variable was set.
+            const deliveryPromise = parentSession.relay.waitForEvent("session_trigger", 5_000);
+
             childSession.relay.emitTrigger({
                 token: childSession.token,
                 trigger: {
@@ -417,8 +425,13 @@ describe("Inter-session messaging", () => {
                 },
             });
 
-            await new Promise<void>((r) => setTimeout(r, 300));
-            expect(triggerId).toBeTruthy();
+            // Verify delivery: the trigger must arrive at the parent relay socket
+            // with the correct triggerId — confirming end-to-end routing worked.
+            const delivered = await deliveryPromise;
+            const deliveredTrigger = (delivered as Record<string, unknown>).trigger as Record<string, unknown>;
+            expect(deliveredTrigger?.triggerId).toBe(triggerId);
+            expect(deliveredTrigger?.sourceSessionId).toBe(childSession.sessionId);
+            expect(deliveredTrigger?.targetSessionId).toBe(parentSession.sessionId);
         } finally {
             await scenario.reset();
         }

--- a/packages/server/tests/harness/integration.test.ts
+++ b/packages/server/tests/harness/integration.test.ts
@@ -314,12 +314,49 @@ describe("Conversation replay", () => {
             // Request resync — server should replay stored events back to viewer
             viewer.sendResync();
 
-            // Wait for replay events to arrive
-            await new Promise<void>((r) => setTimeout(r, 800));
+            // Wait for the last stored heartbeat to arrive (event-driven, not a fixed sleep).
+            // sendSnapshotToViewer sends the most-recently stored heartbeat ("replay-session-2"),
+            // so waiting for it confirms the resync response has landed.
+            await viewer.waitForEvent(
+                (e) =>
+                    typeof e === "object" &&
+                    e !== null &&
+                    (e as Record<string, unknown>)["type"] === "heartbeat" &&
+                    (e as Record<string, unknown>)["sessionName"] === "replay-session-2",
+                5_000,
+            );
 
             const events = viewer.getReceivedEvents();
-            // Should have at least one event after resync
-            expect(events.length).toBeGreaterThan(0);
+
+            // sendSnapshotToViewer (called by resync) delivers the most-recently stored
+            // heartbeat and optionally the lastState snapshot. Verify the heartbeat event:
+            //   1. At least one heartbeat was received
+            //   2. The LAST heartbeat matches the most recent one we sent ("replay-session-2")
+            //   3. Real-time events from sendSnapshotToViewer do NOT carry replay: true
+            //      (only replayPersistedSnapshot / sendLatestSnapshotFromCache set that flag)
+
+            const heartbeatEvents = events.filter(
+                (e) =>
+                    typeof e.event === "object" &&
+                    e.event !== null &&
+                    (e.event as Record<string, unknown>)["type"] === "heartbeat",
+            );
+
+            // At least one heartbeat should have arrived via resync
+            expect(heartbeatEvents.length).toBeGreaterThanOrEqual(1);
+
+            // The LAST stored heartbeat (seq 1, "replay-session-2") should be present
+            const lastHeartbeatEntry = heartbeatEvents[heartbeatEvents.length - 1];
+            const lastHeartbeat = lastHeartbeatEntry.event as Record<string, unknown>;
+            expect(lastHeartbeat["type"]).toBe("heartbeat");
+            expect(lastHeartbeat["sessionName"]).toBe("replay-session-2");
+            expect(lastHeartbeat["active"]).toBe(false);
+
+            // sendSnapshotToViewer does NOT tag events as replay (only the persisted-
+            // snapshot replay path does). Confirm the live-session resync path.
+            for (const e of heartbeatEvents) {
+                expect(e.replay).not.toBe(true);
+            }
         } finally {
             await scenario.reset();
         }
@@ -562,7 +599,14 @@ describe("Concurrent registerSession", () => {
             ]);
             await w1;
 
-            await new Promise<void>((r) => setTimeout(r, 400));
+            // Wait for s2 and s3 to appear in the hub event-driven, not with a fixed sleep.
+            // After the first session arrives (w1), the other two may already be present
+            // or still propagating — check each individually.
+            for (const id of [s2.sessionId, s3.sessionId]) {
+                if (!hub.sessions.some((s) => s.sessionId === id)) {
+                    await hub.waitForSessionAdded((s) => s.sessionId === id, 8_000);
+                }
+            }
 
             const hubIds = hub.sessions.map((s) => s.sessionId);
             for (const id of [s1.sessionId, s2.sessionId, s3.sessionId]) {

--- a/packages/server/tests/harness/integration.test.ts
+++ b/packages/server/tests/harness/integration.test.ts
@@ -1,0 +1,580 @@
+/**
+ * Integration tests using the BDD TestScenario builder.
+ *
+ * All suites share a single TestServer (singleton constraint — only one server
+ * may be active at a time). The server is created once in a file-level
+ * beforeAll and torn down in afterAll. Each describe suite uses its own
+ * TestScenario instance (via setServer) for component isolation, with
+ * per-test cleanup in try/finally blocks.
+ *
+ * Pattern mirrors mock-viewer.test.ts — proven to be stable with the
+ * singleton server constraint.
+ *
+ * ## Hub-before-session ordering (critical)
+ *
+ * Tests that use both a hub and a relay session must:
+ *   1. Connect the hub FIRST
+ *   2. Call hub.waitForSessionAdded() BEFORE creating the session
+ *   3. Then create the session
+ *   4. Await the waitForSessionAdded promise
+ *
+ * This pattern ensures the hub receives the session_added event reliably.
+ *
+ * ## Relay Redis cache warmup (critical for Suite 1)
+ *
+ * The relay namespace has a Redis cache client that initializes asynchronously
+ * on the FIRST relay connection to a fresh server. During initialization,
+ * hub and viewer sockets may be disconnected by the server (the adapter
+ * temporarily disrupts the pub/sub setup). A warmup relay session is created
+ * in beforeAll (before any test) and held open long enough for the cache to
+ * fully initialize.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { TestScenario } from "./scenario.js";
+import { createTestServer } from "./server.js";
+import {
+    buildHeartbeat,
+    buildMetaState,
+    buildTodoList,
+} from "./builders.js";
+import type { TestServer } from "./types.js";
+
+const TIMEOUT = 30_000;
+
+// ── Single shared server ─────────────────────────────────────────────────────
+
+let server: TestServer;
+
+beforeAll(async () => {
+    server = await createTestServer();
+
+    // ── Warmup: prime the relay Redis cache ──────────────────────────────────
+    // On a fresh server, the relay namespace's Redis cache client connects
+    // asynchronously the first time a relay socket registers a session.
+    // During this window (typically < 1 s), hub and viewer sockets can be
+    // disconnected by the server. We create a warmup session, wait for the
+    // Redis cache to fully connect, then PROPERLY END the session (via
+    // emitSessionEnd) before disconnecting — this ensures server-side async
+    // cleanup completes synchronously from the relay's perspective rather
+    // than being deferred until after the first test's hub connects.
+    const warmup = new TestScenario();
+    warmup.setServer(server);
+    try {
+        const warmupSess = await warmup.addSession({ cwd: "/warmup" });
+        // Send a heartbeat to trigger full event-pipeline initialization
+        warmupSess.relay.emitEvent(
+            warmupSess.sessionId,
+            warmupSess.token,
+            buildHeartbeat({ active: true }),
+            0,
+        );
+        // Wait for the Redis cache to fully connect and all events to flush
+        await new Promise<void>((r) => setTimeout(r, 1500));
+        // Properly end the warmup session so server-side cleanup runs NOW
+        // (not deferred after our first test's hub connects)
+        warmupSess.relay.emitSessionEnd(warmupSess.sessionId, warmupSess.token);
+        await new Promise<void>((r) => setTimeout(r, 500));
+    } finally {
+        await warmup.reset();
+        // Extra settle time to ensure all server-side cleanup (session_removed
+        // broadcasts, Redis state updates) has fully propagated before tests start
+        await new Promise<void>((r) => setTimeout(r, 500));
+    }
+}, TIMEOUT);
+
+afterAll(async () => {
+    if (!server) return;
+    try {
+        await server.io.disconnectSockets(true);
+        await new Promise<void>((r) => setTimeout(r, 100));
+        const httpServer = (server.io as unknown as {
+            httpServer?: { closeAllConnections?(): void; closeIdleConnections?(): void };
+        }).httpServer;
+        if (typeof httpServer?.closeAllConnections === "function") {
+            httpServer.closeAllConnections();
+        } else if (typeof httpServer?.closeIdleConnections === "function") {
+            httpServer.closeIdleConnections();
+        }
+        await server.cleanup();
+    } catch {
+        // Ignore cleanup errors
+    }
+}, TIMEOUT);
+
+// ── Suite 1: Full session lifecycle ─────────────────────────────────────────
+
+describe("Full session lifecycle", () => {
+    test("relay → viewer receives heartbeat → session ends → viewer notified", async () => {
+        // Tests the core relay→viewer event pipeline and clean session teardown.
+        // Hub-based removal is tested in Suite 2 "hub sees both sessions" and
+        // Suite 5 meta state (where the server is past first-relay initialization).
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const session = await scenario.addSession({ cwd: "/lifecycle-test" });
+            const viewer = await scenario.addViewer(session.sessionId);
+            expect(viewer.socket.connected).toBe(true);
+
+            // Relay → viewer: heartbeat event flows through
+            const heartbeat = buildHeartbeat({ active: true, sessionName: "lifecycle-test" });
+            session.relay.emitEvent(session.sessionId, session.token, heartbeat, 0);
+
+            const received = await viewer.waitForEvent(
+                (evt) =>
+                    typeof evt === "object" &&
+                    evt !== null &&
+                    (evt as Record<string, unknown>)["type"] === "heartbeat",
+                5_000,
+            );
+            expect((received as Record<string, unknown>)["type"]).toBe("heartbeat");
+            expect((received as Record<string, unknown>)["active"]).toBe(true);
+
+            // Session ends → viewer receives disconnected notification
+            const disconnectedWaiter = viewer.waitForDisconnected(5_000);
+            session.relay.emitSessionEnd(session.sessionId, session.token);
+            const reason = await disconnectedWaiter;
+            expect(typeof reason).toBe("string");
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+
+    test("runner registers and appears in REST API", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const runner = await scenario.addRunner({ name: "lifecycle-runner" });
+            expect(runner.runnerId).toBeTruthy();
+            expect(runner.socket.connected).toBe(true);
+
+            const res = await server.fetch("/api/runners");
+            expect(res.status).toBe(200);
+            const data = (await res.json()) as { runners: Array<{ runnerId: string; name: string }> };
+            const found = data.runners.find((r) => r.runnerId === runner.runnerId);
+            expect(found).toBeTruthy();
+            expect(found?.name).toBe("lifecycle-runner");
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+});
+
+// ── Suite 2: Multi-runner environment ────────────────────────────────────────
+
+describe("Multi-runner environment", () => {
+    test("two runners connect, both appear in REST API", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const [r1, r2] = await Promise.all([
+                scenario.addRunner({ name: "runner-alpha" }),
+                scenario.addRunner({ name: "runner-beta" }),
+            ]);
+            expect(r1.runnerId).not.toBe(r2.runnerId);
+
+            const res = await server.fetch("/api/runners");
+            expect(res.status).toBe(200);
+            const data = (await res.json()) as { runners: Array<{ runnerId: string }> };
+            const ids = data.runners.map((r) => r.runnerId);
+            expect(ids).toContain(r1.runnerId);
+            expect(ids).toContain(r2.runnerId);
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+
+    test("sessions are isolated — events for one session don't bleed into another", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const sess1 = await scenario.addSession({ cwd: "/isolated-a" });
+            const sess2 = await scenario.addSession({ cwd: "/isolated-b" });
+
+            const viewer1 = await scenario.addViewer(sess1.sessionId);
+            const viewer2 = await scenario.addViewer(sess2.sessionId);
+
+            // Send event only to session 1
+            const event = buildHeartbeat({ active: true, sessionName: "isolated-a" });
+            sess1.relay.emitEvent(sess1.sessionId, sess1.token, event, 0);
+
+            // Viewer 1 should receive the event
+            const received = await viewer1.waitForEvent(
+                (e) =>
+                    typeof e === "object" &&
+                    e !== null &&
+                    (e as Record<string, unknown>)["type"] === "heartbeat",
+                3_000,
+            );
+            expect((received as Record<string, unknown>)["sessionName"]).toBe("isolated-a");
+
+            // Viewer 2 should NOT receive events from session 1
+            await new Promise<void>((r) => setTimeout(r, 200));
+            const evts2 = viewer2.getReceivedEvents();
+            const bleed = evts2.filter(
+                (e) =>
+                    typeof e.event === "object" &&
+                    e.event !== null &&
+                    (e.event as Record<string, unknown>)["sessionName"] === "isolated-a",
+            );
+            expect(bleed.length).toBe(0);
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+
+    test("hub sees both sessions (hub-before-session pattern)", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const hub = await scenario.addHub();
+
+            const added1 = hub.waitForSessionAdded(undefined, 8_000);
+            const sess1 = await scenario.addSession({ cwd: "/hub-multi-a" });
+            await added1;
+
+            const added2 = hub.waitForSessionAdded(
+                (s) => s.sessionId !== sess1.sessionId,
+                8_000,
+            );
+            const sess2 = await scenario.addSession({ cwd: "/hub-multi-b" });
+            await added2;
+
+            const ids = hub.sessions.map((s) => s.sessionId);
+            expect(ids).toContain(sess1.sessionId);
+            expect(ids).toContain(sess2.sessionId);
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+
+    test("session ends → hub sees removal", async () => {
+        // Hub-based removal test (runs after server has been through several
+        // relay connections so the relay state is fully stable)
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const hub = await scenario.addHub();
+            const addedWaiter = hub.waitForSessionAdded(undefined, 8_000);
+            const session = await scenario.addSession({ cwd: "/removal-test" });
+            await addedWaiter;
+
+            expect(hub.sessions.some((s) => s.sessionId === session.sessionId)).toBe(true);
+
+            const removalWaiter = hub.waitForSessionRemoved(session.sessionId, 5_000);
+            session.relay.emitSessionEnd(session.sessionId, session.token);
+            await removalWaiter;
+
+            expect(hub.sessions.find((s) => s.sessionId === session.sessionId)).toBeUndefined();
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+});
+
+// ── Suite 3: Conversation replay ─────────────────────────────────────────────
+
+describe("Conversation replay", () => {
+    test("sendResync delivers stored heartbeat events to viewer as replay", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            // Create session and send events BEFORE viewer connects
+            const session = await scenario.addSession({ cwd: "/replay-test" });
+
+            // Send heartbeat events (reliably stored server-side)
+            session.relay.emitEvent(
+                session.sessionId,
+                session.token,
+                buildHeartbeat({ active: true, sessionName: "replay-session" }),
+                0,
+            );
+            session.relay.emitEvent(
+                session.sessionId,
+                session.token,
+                buildHeartbeat({ active: false, sessionName: "replay-session-2" }),
+                1,
+            );
+
+            // Wait for events to be stored server-side
+            await new Promise<void>((r) => setTimeout(r, 400));
+
+            // Connect a LATE viewer, then request a resync to get stored events
+            const viewer = await scenario.addViewer(session.sessionId);
+            expect(viewer.socket.connected).toBe(true);
+            viewer.clearEvents();
+
+            // Request resync — server should replay stored events back to viewer
+            viewer.sendResync();
+
+            // Wait for replay events to arrive
+            await new Promise<void>((r) => setTimeout(r, 800));
+
+            const events = viewer.getReceivedEvents();
+            // Should have at least one event after resync
+            expect(events.length).toBeGreaterThan(0);
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+
+    test("early viewer receives real-time events (not replay-flagged)", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const session = await scenario.addSession({ cwd: "/realtime-test" });
+            const viewer = await scenario.addViewer(session.sessionId);
+            viewer.clearEvents();
+
+            const heartbeat = buildHeartbeat({ active: true, sessionName: "realtime" });
+            session.relay.emitEvent(session.sessionId, session.token, heartbeat, 0);
+
+            await viewer.waitForEvent(
+                (e) =>
+                    typeof e === "object" &&
+                    e !== null &&
+                    (e as Record<string, unknown>)["type"] === "heartbeat",
+                3_000,
+            );
+
+            const evts = viewer.getReceivedEvents();
+            const heartbeatEntry = evts.find(
+                (e) =>
+                    typeof e.event === "object" &&
+                    e.event !== null &&
+                    (e.event as Record<string, unknown>)["type"] === "heartbeat",
+            );
+            // Real-time events should NOT be flagged as replay
+            expect(heartbeatEntry?.replay).not.toBe(true);
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+
+    test("conversation events flow through relay to connected viewer", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const session = await scenario.addSession({ cwd: "/conv-test" });
+            const viewer = await scenario.addViewer(session.sessionId);
+            viewer.clearEvents();
+
+            await scenario.sendConversation(0, [
+                { role: "assistant", text: "Hello from relay!" },
+            ]);
+
+            const received = await viewer.waitForEvent(
+                (e) =>
+                    typeof e === "object" &&
+                    e !== null &&
+                    (e as Record<string, unknown>)["type"] === "message_update",
+                5_000,
+            );
+            expect((received as Record<string, unknown>)["type"]).toBe("message_update");
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+});
+
+// ── Suite 4: Inter-session messaging ─────────────────────────────────────────
+
+describe("Inter-session messaging", () => {
+    test("child session emits trigger targeting parent session", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const parentSession = await scenario.addSession({ cwd: "/parent" });
+            const childSession = await scenario.addSession({
+                cwd: "/child",
+                parentSessionId: parentSession.sessionId,
+            });
+
+            expect(parentSession.sessionId).not.toBe(childSession.sessionId);
+
+            const triggerId = `trigger-${Date.now()}`;
+            childSession.relay.emitTrigger({
+                token: childSession.token,
+                trigger: {
+                    type: "plan_review",
+                    sourceSessionId: childSession.sessionId,
+                    targetSessionId: parentSession.sessionId,
+                    payload: { steps: ["step 1", "step 2"] },
+                    deliverAs: "steer",
+                    expectsResponse: true,
+                    triggerId,
+                    ts: new Date().toISOString(),
+                },
+            });
+
+            await new Promise<void>((r) => setTimeout(r, 300));
+            expect(triggerId).toBeTruthy();
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+
+    test("hub records correct parentSessionId for child sessions", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const hub = await scenario.addHub();
+
+            const parentWaiter = hub.waitForSessionAdded(undefined, 8_000);
+            const parent = await scenario.addSession({ cwd: "/p" });
+            await parentWaiter;
+
+            const childWaiter = hub.waitForSessionAdded(
+                (s) => s.sessionId !== parent.sessionId,
+                8_000,
+            );
+            const child = await scenario.addSession({
+                cwd: "/c",
+                parentSessionId: parent.sessionId,
+            });
+            await childWaiter;
+
+            const childInfo = hub.sessions.find((s) => s.sessionId === child.sessionId);
+            expect(childInfo).toBeTruthy();
+            expect(childInfo?.parentSessionId).toBe(parent.sessionId);
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+});
+
+// ── Suite 5: Session meta state ──────────────────────────────────────────────
+
+describe("Session meta state", () => {
+    test("buildTodoList and buildMetaState produce well-formed structures", async () => {
+        const todos = buildTodoList([
+            { text: "Task 1", status: "done" },
+            { text: "Task 2", status: "in_progress" },
+            { text: "Task 3", status: "pending" },
+        ]);
+        expect(todos).toHaveLength(3);
+        expect(todos[0].status).toBe("done");
+        expect(todos[1].status).toBe("in_progress");
+        expect(todos[2].status).toBe("pending");
+
+        // SessionMetaState uses todoList (not todos)
+        const metaState = buildMetaState({ todoList: todos });
+        expect(metaState.todoList).toHaveLength(3);
+
+        const defaultMeta = buildMetaState();
+        expect(defaultMeta).toBeTruthy();
+        expect(Array.isArray(defaultMeta.todoList)).toBe(true);
+    }, TIMEOUT);
+
+    test("heartbeat event with session name triggers hub session_status update", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const hub = await scenario.addHub();
+            const addedWaiter = hub.waitForSessionAdded(undefined, 8_000);
+            const session = await scenario.addSession({ cwd: "/meta-state-test" });
+            await addedWaiter;
+
+            hub.subscribeSessionMeta(session.sessionId);
+
+            const statusPromise = hub.waitForSessionStatus(
+                session.sessionId,
+                (data) =>
+                    typeof data === "object" &&
+                    data !== null &&
+                    (data as Record<string, unknown>)["sessionId"] === session.sessionId,
+                5_000,
+            );
+
+            const heartbeat = buildHeartbeat({
+                active: true,
+                sessionName: "meta-test-session",
+            });
+            session.relay.emitEvent(session.sessionId, session.token, heartbeat, 0);
+
+            const status = await statusPromise;
+            expect((status as Record<string, unknown>)["sessionId"]).toBe(session.sessionId);
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+});
+
+// ── Suite 6: Concurrent registerSession ──────────────────────────────────────
+
+describe("Concurrent registerSession", () => {
+    test("two concurrent addSession calls produce distinct sessions", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const [sessA, sessB] = await Promise.all([
+                scenario.addSession({ cwd: "/concurrent-a" }),
+                scenario.addSession({ cwd: "/concurrent-b" }),
+            ]);
+
+            expect(sessA.sessionId).toBeTruthy();
+            expect(sessB.sessionId).toBeTruthy();
+            expect(sessA.sessionId).not.toBe(sessB.sessionId);
+            expect(sessA.token).not.toBe(sessB.token);
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+
+    test("three concurrent sessions all appear in hub", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const hub = await scenario.addHub();
+
+            const w1 = hub.waitForSessionAdded(undefined, 8_000);
+            const [s1, s2, s3] = await Promise.all([
+                scenario.addSession({ cwd: "/multi-relay-a" }),
+                scenario.addSession({ cwd: "/multi-relay-b" }),
+                scenario.addSession({ cwd: "/multi-relay-c" }),
+            ]);
+            await w1;
+
+            await new Promise<void>((r) => setTimeout(r, 400));
+
+            const hubIds = hub.sessions.map((s) => s.sessionId);
+            for (const id of [s1.sessionId, s2.sessionId, s3.sessionId]) {
+                expect(hubIds).toContain(id);
+            }
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+
+    test("registerSession called twice on same relay socket produces distinct sessions", async () => {
+        const scenario = new TestScenario();
+        scenario.setServer(server);
+
+        try {
+            const sess1 = await scenario.addSession({ cwd: "/serial-a" });
+
+            // Call registerSession a second time on the SAME relay socket
+            const sess2 = await sess1.relay.registerSession({ cwd: "/serial-b" });
+
+            expect(sess2.sessionId).toBeTruthy();
+            expect(sess2.sessionId).not.toBe(sess1.sessionId);
+            expect(sess2.token).not.toBe(sess1.token);
+        } finally {
+            await scenario.reset();
+        }
+    }, TIMEOUT);
+});

--- a/packages/server/tests/harness/mock-hub.ts
+++ b/packages/server/tests/harness/mock-hub.ts
@@ -50,13 +50,21 @@ export interface MockHubClientOptions {
 }
 
 // ---------------------------------------------------------------------------
-// Internal: single connection attempt
+// Internal: single connection attempt — builds a fully-wired MockHubClient
 // ---------------------------------------------------------------------------
 
-async function attemptHubConnection(
+/**
+ * Creates a socket, attaches ALL data listeners (including session update
+ * handlers) BEFORE waiting for the initial `sessions` snapshot.
+ *
+ * Listener-before-await ordering prevents the race where `session_added`,
+ * `session_removed`, or `session_status` events emitted between the
+ * snapshot receipt and subsequent listener attachment are silently dropped.
+ */
+async function attemptBuildHubClient(
     server: TestServer,
     connectTimeout: number,
-): Promise<{ socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents>; initialSessions: SessionInfo[] }> {
+): Promise<MockHubClient> {
     const socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents> =
         clientIo(`${server.baseUrl}/hub`, {
             extraHeaders: { cookie: server.sessionCookie },
@@ -67,82 +75,8 @@ async function attemptHubConnection(
             reconnection: false,
         });
 
-    let initialSessions: SessionInfo[] = [];
-
-    const snapshotPromise = new Promise<void>((resolve, reject) => {
-        const timer = setTimeout(() => {
-            socket.disconnect();
-            reject(
-                new Error(
-                    `MockHubClient: timeout waiting for initial sessions snapshot (${connectTimeout}ms)`,
-                ),
-            );
-        }, connectTimeout);
-
-        socket.once("sessions", (data) => {
-            clearTimeout(timer);
-            initialSessions = data.sessions;
-            resolve();
-        });
-
-        socket.once("connect_error", (err) => {
-            clearTimeout(timer);
-            socket.disconnect();
-            reject(new Error(`MockHubClient: connection error: ${err.message}`));
-        });
-    });
-
-    socket.connect();
-    await snapshotPromise;
-    return { socket, initialSessions };
-}
-
-// ---------------------------------------------------------------------------
-// Factory
-// ---------------------------------------------------------------------------
-
-/**
- * Create a MockHubClient connected to the given test server.
- *
- * The promise resolves once the server sends the initial `sessions` snapshot.
- *
- * The first connection attempt may fail with `connect_error: unauthorized`
- * due to better-auth cold-start (lazy prepared-statement caching). Up to
- * `maxAttempts` retries are made with a 150 ms delay between attempts.
- */
-export async function createMockHubClient(
-    server: TestServer,
-    opts?: MockHubClientOptions,
-): Promise<MockHubClient> {
-    const connectTimeout = opts?.connectTimeout ?? 5000;
-    const maxAttempts = opts?.maxAttempts ?? 2;
-
-    let lastError: unknown;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        if (attempt > 0) {
-            await new Promise<void>((r) => setTimeout(r, 150));
-        }
-        try {
-            const { socket, initialSessions } = await attemptHubConnection(server, connectTimeout);
-            return buildMockHubClient(socket, initialSessions);
-        } catch (err) {
-            lastError = err;
-        }
-    }
-    throw lastError;
-}
-
-// ---------------------------------------------------------------------------
-// Build MockHubClient from an already-connected socket
-// ---------------------------------------------------------------------------
-
-function buildMockHubClient(
-    socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents>,
-    initialSessions: SessionInfo[],
-): MockHubClient {
-
-    // Mutable live sessions list — seeded with the initial snapshot
-    const sessions: SessionInfo[] = [...initialSessions];
+    // Mutable live sessions list — seeded once the initial snapshot arrives
+    const sessions: SessionInfo[] = [];
 
     // Pending waitForSessionAdded resolvers
     const addedWaiters: Array<{
@@ -173,7 +107,38 @@ function buildMockHubClient(
         }>
     > = new Map();
 
-    // ── Server event handlers ──────────────────────────────────────────────
+    // Tracks whether disconnect() has been called — guards new waitFor calls
+    let isDisconnected = false;
+
+    // Rejects and clears all outstanding waiters (called on disconnect)
+    function rejectAllWaiters(reason: string): void {
+        const err = new Error(reason);
+
+        for (const w of addedWaiters.splice(0)) {
+            clearTimeout(w.timer);
+            w.reject(err);
+        }
+
+        for (const [, list] of removedWaiters) {
+            for (const w of list) {
+                clearTimeout(w.timer);
+                w.reject(err);
+            }
+        }
+        removedWaiters.clear();
+
+        for (const [, list] of statusWaiters) {
+            for (const w of list) {
+                clearTimeout(w.timer);
+                w.reject(err);
+            }
+        }
+        statusWaiters.clear();
+    }
+
+    // ── Attach ALL data listeners BEFORE waiting for the handshake ─────────
+    // This prevents the race where session update events emitted between the
+    // initial `sessions` snapshot and subsequent listener attachment are lost.
 
     // Re-snapshot (e.g. after resync) — replaces the local sessions list
     socket.on("sessions", (data) => {
@@ -246,7 +211,36 @@ function buildMockHubClient(
         }
     });
 
-    // ── MockHubClient implementation ───────────────────────────────────────
+    // ── Handshake: wait for the initial sessions snapshot ─────────────────
+
+    const snapshotPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            socket.disconnect();
+            reject(
+                new Error(
+                    `MockHubClient: timeout waiting for initial sessions snapshot (${connectTimeout}ms)`,
+                ),
+            );
+        }, connectTimeout);
+
+        // The `sessions` handler above populates the list; we just need to
+        // know when the first snapshot has arrived so we can resolve here.
+        socket.once("sessions", () => {
+            clearTimeout(timer);
+            resolve();
+        });
+
+        socket.once("connect_error", (err) => {
+            clearTimeout(timer);
+            socket.disconnect();
+            reject(new Error(`MockHubClient: connection error: ${err.message}`));
+        });
+    });
+
+    socket.connect();
+    await snapshotPromise;
+
+    // ── Build and return the MockHubClient object ──────────────────────────
 
     const client: MockHubClient = {
         socket,
@@ -256,6 +250,10 @@ function buildMockHubClient(
             predicate?: (s: SessionInfo) => boolean,
             timeout = 5000,
         ): Promise<SessionInfo> {
+            if (isDisconnected) {
+                return Promise.reject(new Error("MockHubClient.waitForSessionAdded: already disconnected"));
+            }
+
             // Check already-buffered sessions
             const existing = sessions.find((s) => !predicate || predicate(s));
             if (existing) return Promise.resolve(existing);
@@ -272,6 +270,10 @@ function buildMockHubClient(
         },
 
         waitForSessionRemoved(sessionId: string, timeout = 5000): Promise<void> {
+            if (isDisconnected) {
+                return Promise.reject(new Error("MockHubClient.waitForSessionRemoved: already disconnected"));
+            }
+
             // Already removed?
             if (!sessions.find((s) => s.sessionId === sessionId)) {
                 return Promise.resolve();
@@ -302,6 +304,10 @@ function buildMockHubClient(
             predicate?: (data: unknown) => boolean,
             timeout = 5000,
         ): Promise<unknown> {
+            if (isDisconnected) {
+                return Promise.reject(new Error("MockHubClient.waitForSessionStatus: already disconnected"));
+            }
+
             return new Promise<unknown>((resolve, reject) => {
                 const timer = setTimeout(() => {
                     const list = statusWaiters.get(sessionId);
@@ -331,6 +337,9 @@ function buildMockHubClient(
         },
 
         disconnect(): Promise<void> {
+            isDisconnected = true;
+            rejectAllWaiters("MockHubClient: disconnected");
+
             return new Promise<void>((resolve) => {
                 if (!socket.connected) {
                     resolve();
@@ -343,4 +352,38 @@ function buildMockHubClient(
     };
 
     return client;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a MockHubClient connected to the given test server.
+ *
+ * The promise resolves once the server sends the initial `sessions` snapshot.
+ *
+ * The first connection attempt may fail with `connect_error: unauthorized`
+ * due to better-auth cold-start (lazy prepared-statement caching). Up to
+ * `maxAttempts` retries are made with a 150 ms delay between attempts.
+ */
+export async function createMockHubClient(
+    server: TestServer,
+    opts?: MockHubClientOptions,
+): Promise<MockHubClient> {
+    const connectTimeout = opts?.connectTimeout ?? 5000;
+    const maxAttempts = opts?.maxAttempts ?? 2;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (attempt > 0) {
+            await new Promise<void>((r) => setTimeout(r, 150));
+        }
+        try {
+            return await attemptBuildHubClient(server, connectTimeout);
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    throw lastError;
 }

--- a/packages/server/tests/harness/mock-hub.ts
+++ b/packages/server/tests/harness/mock-hub.ts
@@ -1,0 +1,346 @@
+/**
+ * MockHubClient — test harness client for the /hub Socket.IO namespace.
+ *
+ * Connects with cookie-based auth, auto-updates session list from server
+ * broadcasts, and exposes waitFor helpers for integration tests.
+ */
+
+import { io as clientIo, type Socket as ClientSocket } from "socket.io-client";
+import type {
+    HubServerToClientEvents,
+    HubClientToServerEvents,
+    SessionInfo,
+} from "@pizzapi/protocol";
+import type { TestServer } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MockHubClient {
+    socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents>;
+    sessions: SessionInfo[];
+
+    waitForSessionAdded(
+        predicate?: (s: SessionInfo) => boolean,
+        timeout?: number,
+    ): Promise<SessionInfo>;
+    waitForSessionRemoved(sessionId: string, timeout?: number): Promise<void>;
+    waitForSessionStatus(
+        sessionId: string,
+        predicate?: (data: unknown) => boolean,
+        timeout?: number,
+    ): Promise<unknown>;
+    subscribeSessionMeta(sessionId: string): void;
+    unsubscribeSessionMeta(sessionId: string): void;
+
+    disconnect(): Promise<void>;
+}
+
+export interface MockHubClientOptions {
+    /** Timeout (ms) waiting for the initial `sessions` snapshot. Default: 5000 */
+    connectTimeout?: number;
+    /**
+     * Max connection attempts before giving up. Default: 2.
+     * The first attempt sometimes fails with `connect_error: unauthorized`
+     * due to better-auth cold-start (lazy prepared-statement caching).
+     * A retry after a short delay reliably succeeds.
+     */
+    maxAttempts?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: single connection attempt
+// ---------------------------------------------------------------------------
+
+async function attemptHubConnection(
+    server: TestServer,
+    connectTimeout: number,
+): Promise<{ socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents>; initialSessions: SessionInfo[] }> {
+    const socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents> =
+        clientIo(`${server.baseUrl}/hub`, {
+            extraHeaders: { cookie: server.sessionCookie },
+            transports: ["websocket"],
+            autoConnect: false,
+            // Disable auto-reconnect: if the connection fails, fail fast rather
+            // than silently retrying and leaving a lingering socket open.
+            reconnection: false,
+        });
+
+    let initialSessions: SessionInfo[] = [];
+
+    const snapshotPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            socket.disconnect();
+            reject(
+                new Error(
+                    `MockHubClient: timeout waiting for initial sessions snapshot (${connectTimeout}ms)`,
+                ),
+            );
+        }, connectTimeout);
+
+        socket.once("sessions", (data) => {
+            clearTimeout(timer);
+            initialSessions = data.sessions;
+            resolve();
+        });
+
+        socket.once("connect_error", (err) => {
+            clearTimeout(timer);
+            socket.disconnect();
+            reject(new Error(`MockHubClient: connection error: ${err.message}`));
+        });
+    });
+
+    socket.connect();
+    await snapshotPromise;
+    return { socket, initialSessions };
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a MockHubClient connected to the given test server.
+ *
+ * The promise resolves once the server sends the initial `sessions` snapshot.
+ *
+ * The first connection attempt may fail with `connect_error: unauthorized`
+ * due to better-auth cold-start (lazy prepared-statement caching). Up to
+ * `maxAttempts` retries are made with a 150 ms delay between attempts.
+ */
+export async function createMockHubClient(
+    server: TestServer,
+    opts?: MockHubClientOptions,
+): Promise<MockHubClient> {
+    const connectTimeout = opts?.connectTimeout ?? 5000;
+    const maxAttempts = opts?.maxAttempts ?? 2;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (attempt > 0) {
+            await new Promise<void>((r) => setTimeout(r, 150));
+        }
+        try {
+            const { socket, initialSessions } = await attemptHubConnection(server, connectTimeout);
+            return buildMockHubClient(socket, initialSessions);
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    throw lastError;
+}
+
+// ---------------------------------------------------------------------------
+// Build MockHubClient from an already-connected socket
+// ---------------------------------------------------------------------------
+
+function buildMockHubClient(
+    socket: ClientSocket<HubServerToClientEvents, HubClientToServerEvents>,
+    initialSessions: SessionInfo[],
+): MockHubClient {
+
+    // Mutable live sessions list — seeded with the initial snapshot
+    const sessions: SessionInfo[] = [...initialSessions];
+
+    // Pending waitForSessionAdded resolvers
+    const addedWaiters: Array<{
+        predicate?: (s: SessionInfo) => boolean;
+        resolve: (s: SessionInfo) => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+    }> = [];
+
+    // Pending waitForSessionRemoved resolvers: keyed by sessionId
+    const removedWaiters: Map<
+        string,
+        Array<{
+            resolve: () => void;
+            reject: (err: Error) => void;
+            timer: ReturnType<typeof setTimeout>;
+        }>
+    > = new Map();
+
+    // Pending waitForSessionStatus resolvers: keyed by sessionId
+    const statusWaiters: Map<
+        string,
+        Array<{
+            predicate?: (data: unknown) => boolean;
+            resolve: (data: unknown) => void;
+            reject: (err: Error) => void;
+            timer: ReturnType<typeof setTimeout>;
+        }>
+    > = new Map();
+
+    // ── Server event handlers ──────────────────────────────────────────────
+
+    // Re-snapshot (e.g. after resync) — replaces the local sessions list
+    socket.on("sessions", (data) => {
+        sessions.length = 0;
+        for (const s of data.sessions) sessions.push(s);
+    });
+
+    socket.on("session_added", (data) => {
+        // Upsert in case of duplicate adds
+        const idx = sessions.findIndex((s) => s.sessionId === data.sessionId);
+        if (idx === -1) {
+            sessions.push(data);
+        } else {
+            sessions[idx] = data;
+        }
+
+        // Notify waitForSessionAdded waiters
+        for (let i = addedWaiters.length - 1; i >= 0; i--) {
+            const waiter = addedWaiters[i];
+            if (!waiter.predicate || waiter.predicate(data)) {
+                clearTimeout(waiter.timer);
+                addedWaiters.splice(i, 1);
+                waiter.resolve(data);
+            }
+        }
+    });
+
+    socket.on("session_removed", (data) => {
+        const idx = sessions.findIndex((s) => s.sessionId === data.sessionId);
+        if (idx !== -1) sessions.splice(idx, 1);
+
+        // Notify waitForSessionRemoved waiters
+        const waiters = removedWaiters.get(data.sessionId);
+        if (waiters) {
+            for (const waiter of waiters) {
+                clearTimeout(waiter.timer);
+                waiter.resolve();
+            }
+            removedWaiters.delete(data.sessionId);
+        }
+    });
+
+    socket.on("session_status", (data) => {
+        // Update local session if present
+        const idx = sessions.findIndex((s) => s.sessionId === data.sessionId);
+        if (idx !== -1) {
+            sessions[idx] = {
+                ...sessions[idx],
+                isActive: data.isActive,
+                lastHeartbeatAt: data.lastHeartbeatAt,
+                sessionName: data.sessionName,
+                model: data.model,
+                runnerId: data.runnerId ?? sessions[idx].runnerId,
+                runnerName: data.runnerName ?? sessions[idx].runnerName,
+            };
+        }
+
+        // Notify waitForSessionStatus waiters
+        const waiters = statusWaiters.get(data.sessionId);
+        if (waiters) {
+            for (let i = waiters.length - 1; i >= 0; i--) {
+                const waiter = waiters[i];
+                if (!waiter.predicate || waiter.predicate(data)) {
+                    clearTimeout(waiter.timer);
+                    waiters.splice(i, 1);
+                    waiter.resolve(data);
+                }
+            }
+            if (waiters.length === 0) statusWaiters.delete(data.sessionId);
+        }
+    });
+
+    // ── MockHubClient implementation ───────────────────────────────────────
+
+    const client: MockHubClient = {
+        socket,
+        sessions,
+
+        waitForSessionAdded(
+            predicate?: (s: SessionInfo) => boolean,
+            timeout = 5000,
+        ): Promise<SessionInfo> {
+            // Check already-buffered sessions
+            const existing = sessions.find((s) => !predicate || predicate(s));
+            if (existing) return Promise.resolve(existing);
+
+            return new Promise<SessionInfo>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const idx = addedWaiters.findIndex((w) => w.resolve === resolve);
+                    if (idx !== -1) addedWaiters.splice(idx, 1);
+                    reject(new Error(`MockHubClient.waitForSessionAdded: timeout (${timeout}ms)`));
+                }, timeout);
+
+                addedWaiters.push({ predicate, resolve, reject, timer });
+            });
+        },
+
+        waitForSessionRemoved(sessionId: string, timeout = 5000): Promise<void> {
+            // Already removed?
+            if (!sessions.find((s) => s.sessionId === sessionId)) {
+                return Promise.resolve();
+            }
+
+            return new Promise<void>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const list = removedWaiters.get(sessionId);
+                    if (list) {
+                        const idx = list.findIndex((w) => w.resolve === resolve);
+                        if (idx !== -1) list.splice(idx, 1);
+                    }
+                    reject(
+                        new Error(
+                            `MockHubClient.waitForSessionRemoved: timeout (${timeout}ms) for session ${sessionId}`,
+                        ),
+                    );
+                }, timeout);
+
+                const list = removedWaiters.get(sessionId) ?? [];
+                list.push({ resolve, reject, timer });
+                removedWaiters.set(sessionId, list);
+            });
+        },
+
+        waitForSessionStatus(
+            sessionId: string,
+            predicate?: (data: unknown) => boolean,
+            timeout = 5000,
+        ): Promise<unknown> {
+            return new Promise<unknown>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const list = statusWaiters.get(sessionId);
+                    if (list) {
+                        const idx = list.findIndex((w) => w.resolve === resolve);
+                        if (idx !== -1) list.splice(idx, 1);
+                    }
+                    reject(
+                        new Error(
+                            `MockHubClient.waitForSessionStatus: timeout (${timeout}ms) for session ${sessionId}`,
+                        ),
+                    );
+                }, timeout);
+
+                const list = statusWaiters.get(sessionId) ?? [];
+                list.push({ predicate, resolve, reject, timer });
+                statusWaiters.set(sessionId, list);
+            });
+        },
+
+        subscribeSessionMeta(sessionId: string): void {
+            socket.emit("subscribe_session_meta", { sessionId });
+        },
+
+        unsubscribeSessionMeta(sessionId: string): void {
+            socket.emit("unsubscribe_session_meta", { sessionId });
+        },
+
+        disconnect(): Promise<void> {
+            return new Promise<void>((resolve) => {
+                if (!socket.connected) {
+                    resolve();
+                    return;
+                }
+                socket.once("disconnect", () => resolve());
+                socket.disconnect();
+            });
+        },
+    };
+
+    return client;
+}

--- a/packages/server/tests/harness/mock-relay.ts
+++ b/packages/server/tests/harness/mock-relay.ts
@@ -1,0 +1,165 @@
+/**
+ * MockRelay — socket.io-client connected to the /relay namespace.
+ * Provides helpers for registering sessions and emitting agent events
+ * in integration tests.
+ */
+
+import { io as connectSocket } from "socket.io-client";
+import type { TestServer } from "./types.js";
+import type { MockRelay, MockRelayOptions, MockRelaySession } from "./types.js";
+
+export async function createMockRelay(
+    server: TestServer,
+    _opts?: MockRelayOptions,
+): Promise<MockRelay> {
+    const socket = connectSocket(`${server.baseUrl}/relay`, {
+        auth: { apiKey: server.apiKey },
+        transports: ["websocket"],
+        autoConnect: true,
+        // Disable reconnection so cleanup (io.close) can complete.
+        // If reconnection is on, the client immediately reconnects after
+        // force-disconnect, preventing httpServer.close() from resolving.
+        reconnection: false,
+    });
+
+    // Wait for the socket to connect
+    await new Promise<void>((resolve, reject) => {
+        if (socket.connected) {
+            resolve();
+            return;
+        }
+        const onConnect = () => {
+            socket.off("connect_error", onError);
+            resolve();
+        };
+        const onError = (err: Error) => {
+            socket.off("connect", onConnect);
+            reject(err);
+        };
+        socket.once("connect", onConnect);
+        socket.once("connect_error", onError);
+    });
+
+    function waitForEvent(eventName: string, timeout = 5000): Promise<unknown> {
+        return new Promise<unknown>((resolve, reject) => {
+            const handler = (data: unknown) => {
+                clearTimeout(timer);
+                resolve(data);
+            };
+
+            const timer = setTimeout(() => {
+                socket.off(eventName, handler);
+                reject(new Error(`Timed out waiting for event: ${eventName}`));
+            }, timeout);
+
+            socket.once(eventName, handler);
+        });
+    }
+
+    async function registerSession(opts?: {
+        sessionId?: string;
+        cwd?: string;
+        ephemeral?: boolean;
+        collabMode?: boolean;
+        sessionName?: string | null;
+        parentSessionId?: string | null;
+    }): Promise<MockRelaySession> {
+        const registeredPromise = waitForEvent("registered");
+
+        socket.emit("register", {
+            sessionId: opts?.sessionId,
+            cwd: opts?.cwd ?? "/tmp/mock-session",
+            ephemeral: opts?.ephemeral ?? true,
+            collabMode: opts?.collabMode ?? false,
+            sessionName: opts?.sessionName ?? null,
+            parentSessionId: opts?.parentSessionId ?? null,
+        });
+
+        const data = await registeredPromise as {
+            sessionId: string;
+            token: string;
+            shareUrl: string;
+        };
+
+        return {
+            sessionId: data.sessionId,
+            token: data.token,
+            shareUrl: data.shareUrl,
+        };
+    }
+
+    function emitEvent(sessionId: string, token: string, event: unknown, seq?: number): void {
+        socket.emit("event", {
+            sessionId,
+            token,
+            event,
+            ...(seq !== undefined ? { seq } : {}),
+        });
+    }
+
+    function emitSessionEnd(sessionId: string, token: string): void {
+        socket.emit("session_end", { sessionId, token });
+    }
+
+    function emitTrigger(data: {
+        token: string;
+        trigger: {
+            type: string;
+            sourceSessionId: string;
+            targetSessionId: string;
+            payload: Record<string, unknown>;
+            deliverAs: "steer" | "followUp";
+            expectsResponse: boolean;
+            triggerId: string;
+            ts: string;
+        };
+    }): void {
+        socket.emit("session_trigger", data);
+    }
+
+    function emitTriggerResponse(data: {
+        token: string;
+        triggerId: string;
+        response: string;
+        action?: string;
+        targetSessionId: string;
+    }): void {
+        socket.emit("trigger_response", data);
+    }
+
+    function emitSessionMessage(data: {
+        token: string;
+        targetSessionId: string;
+        message: string;
+        deliverAs?: "input";
+    }): void {
+        socket.emit("session_message", data);
+    }
+
+    async function disconnect(): Promise<void> {
+        if (socket.connected) {
+            await new Promise<void>((resolve) => {
+                socket.once("disconnect", () => resolve());
+                socket.disconnect();
+            });
+        }
+        // Wait briefly for the underlying TCP connection to fully tear down.
+        // Bun's http.Server.close() waits for all open connections to drain;
+        // without this pause, httpServer.close() can hang because the WebSocket
+        // TCP connection is still in FIN_WAIT state even after the socket-level
+        // disconnect event fires.
+        await new Promise<void>((resolve) => setTimeout(resolve, 100));
+    }
+
+    return {
+        socket,
+        registerSession,
+        emitEvent,
+        emitSessionEnd,
+        emitTrigger,
+        emitTriggerResponse,
+        emitSessionMessage,
+        waitForEvent,
+        disconnect,
+    };
+}

--- a/packages/server/tests/harness/mock-relay.ts
+++ b/packages/server/tests/harness/mock-relay.ts
@@ -40,6 +40,11 @@ export async function createMockRelay(
         socket.once("connect_error", onError);
     });
 
+    // Serial queue — ensures only one registerSession call is in-flight at a time.
+    // Concurrent calls on the same socket would both receive the first "registered"
+    // event, causing one call to get wrong data and the other to be dropped.
+    let _registerLock: Promise<unknown> = Promise.resolve();
+
     function waitForEvent(eventName: string, timeout = 5000): Promise<unknown> {
         return new Promise<unknown>((resolve, reject) => {
             const handler = (data: unknown) => {
@@ -64,28 +69,38 @@ export async function createMockRelay(
         sessionName?: string | null;
         parentSessionId?: string | null;
     }): Promise<MockRelaySession> {
-        const registeredPromise = waitForEvent("registered");
+        // Serialize via _registerLock: only one registration may be in-flight at a time.
+        // Without this, concurrent calls would both listen for the first "registered" event,
+        // causing one call to receive the other's session data.
+        const doRegister = async (): Promise<MockRelaySession> => {
+            const registeredPromise = waitForEvent("registered");
 
-        socket.emit("register", {
-            sessionId: opts?.sessionId,
-            cwd: opts?.cwd ?? "/tmp/mock-session",
-            ephemeral: opts?.ephemeral ?? true,
-            collabMode: opts?.collabMode ?? false,
-            sessionName: opts?.sessionName ?? null,
-            parentSessionId: opts?.parentSessionId ?? null,
-        });
+            socket.emit("register", {
+                sessionId: opts?.sessionId,
+                cwd: opts?.cwd ?? "/tmp/mock-session",
+                ephemeral: opts?.ephemeral ?? true,
+                collabMode: opts?.collabMode ?? false,
+                sessionName: opts?.sessionName ?? null,
+                parentSessionId: opts?.parentSessionId ?? null,
+            });
 
-        const data = await registeredPromise as {
-            sessionId: string;
-            token: string;
-            shareUrl: string;
+            const data = await registeredPromise as {
+                sessionId: string;
+                token: string;
+                shareUrl: string;
+            };
+
+            return {
+                sessionId: data.sessionId,
+                token: data.token,
+                shareUrl: data.shareUrl,
+            };
         };
 
-        return {
-            sessionId: data.sessionId,
-            token: data.token,
-            shareUrl: data.shareUrl,
-        };
+        // Chain this call onto the lock; swallow errors so failures don't jam the queue.
+        const result = _registerLock.then(doRegister, doRegister);
+        _registerLock = result.then(() => {}, () => {});
+        return result;
     }
 
     function emitEvent(sessionId: string, token: string, event: unknown, seq?: number): void {

--- a/packages/server/tests/harness/mock-runner.test.ts
+++ b/packages/server/tests/harness/mock-runner.test.ts
@@ -174,37 +174,26 @@ describe("createMockRunner — emitSessionReady", () => {
     test("emitSessionReady sends session_ready to the server", async () => {
         const server = await createTestServer();
         try {
+            const sessionId = "test-session-ready-" + Date.now();
+            const receivedSessionIds: string[] = [];
+
+            // Set up server-side capture BEFORE the runner connects so the
+            // connection handler fires and attaches to the real socket (not a RemoteSocket proxy).
+            server.io.of("/runner").on("connection", (socket) => {
+                socket.on("session_ready", (data: { sessionId: string }) => {
+                    receivedSessionIds.push(data.sessionId);
+                });
+            });
+
             const runner = await createMockRunner(server);
             try {
-                const sessionId = "test-session-ready-" + Date.now();
-
-                // Capture session_ready events on the server side via the io instance.
-                const receivedSessionIds: string[] = [];
-                const runnerNs = server.io.of("/runner");
-                const captureHandler = (data: { sessionId: string }) => {
-                    if (data.sessionId === sessionId) {
-                        receivedSessionIds.push(data.sessionId);
-                    }
-                };
-                // Listen on all future connections for this event
-                runnerNs.on("connection", (socket) => {
-                    socket.on("session_ready", captureHandler);
-                });
-
-                // Also subscribe on existing sockets (the runner socket is already connected)
-                const sockets = await runnerNs.fetchSockets();
-                for (const s of sockets) {
-                    s.on("session_ready", captureHandler as (data: unknown) => void);
-                }
-
                 runner.emitSessionReady(sessionId);
 
-                // Wait a moment for the event to propagate
+                // Wait for the event to propagate to the server
                 await new Promise<void>((r) => setTimeout(r, 200));
 
-                // The session_ready event handler calls resolveSpawnReady() (no-op for unknown sessionId).
-                // We verify the socket is still alive and hasn't crashed.
-                expect(runner.socket.connected).toBe(true);
+                // P2 fix: actually assert the event was received server-side
+                expect(receivedSessionIds).toContain(sessionId);
             } finally {
                 await runner.disconnect();
             }
@@ -357,6 +346,113 @@ describe("createMockRunner — waitForEvent", () => {
             } finally {
                 await runner.disconnect();
             }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 7. Emission helpers — emitSessionError, emitSessionEvent, emitSessionEnded
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — emission helpers", () => {
+    test("emitSessionError sends session_error to the server", async () => {
+        const server = await createTestServer();
+        try {
+            const received: Array<{ sessionId: string; message: string }> = [];
+
+            // Attach server-side listener BEFORE runner connects
+            server.io.of("/runner").on("connection", (socket) => {
+                socket.on("session_error", (data: { sessionId: string; message: string }) => {
+                    received.push(data);
+                });
+            });
+
+            const runner = await createMockRunner(server);
+            try {
+                runner.emitSessionError("sess-err-1", "spawn failed");
+                await new Promise<void>((r) => setTimeout(r, 200));
+
+                expect(received.length).toBeGreaterThan(0);
+                expect(received[0].sessionId).toBe("sess-err-1");
+                expect(received[0].message).toBe("spawn failed");
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("emitSessionEvent sends runner_session_event to the server", async () => {
+        const server = await createTestServer();
+        try {
+            const received: Array<{ sessionId: string; event: unknown }> = [];
+
+            server.io.of("/runner").on("connection", (socket) => {
+                socket.on(
+                    "runner_session_event",
+                    (data: { sessionId: string; event: unknown }) => {
+                        received.push(data);
+                    },
+                );
+            });
+
+            const runner = await createMockRunner(server);
+            try {
+                runner.emitSessionEvent("sess-evt-1", { type: "output", text: "hello" });
+                await new Promise<void>((r) => setTimeout(r, 200));
+
+                expect(received.length).toBeGreaterThan(0);
+                expect(received[0].sessionId).toBe("sess-evt-1");
+                expect(received[0].event).toEqual({ type: "output", text: "hello" });
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("emitSessionEnded sends session_killed to the server", async () => {
+        const server = await createTestServer();
+        try {
+            const received: Array<{ sessionId: string }> = [];
+
+            server.io.of("/runner").on("connection", (socket) => {
+                socket.on("session_killed", (data: { sessionId: string }) => {
+                    received.push(data);
+                });
+            });
+
+            const runner = await createMockRunner(server);
+            try {
+                runner.emitSessionEnded("sess-ended-1");
+                await new Promise<void>((r) => setTimeout(r, 200));
+
+                expect(received.length).toBeGreaterThan(0);
+                expect(received[0].sessionId).toBe("sess-ended-1");
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 8. Auth failure — bad API key is rejected
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — auth failure", () => {
+    test("rejects with a bad API key", async () => {
+        const server = await createTestServer();
+        try {
+            await expect(
+                createMockRunner(server, { apiKey: "invalid-bad-key-xyz" }),
+            ).rejects.toThrow();
         } finally {
             await cleanupServer(server);
         }

--- a/packages/server/tests/harness/mock-runner.test.ts
+++ b/packages/server/tests/harness/mock-runner.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for the MockRunner test harness.
+ *
+ * Each test creates and cleans up its OWN server (following the pattern from
+ * server.test.ts).  Do NOT use beforeAll/afterAll with a shared server —
+ * module-level singletons (auth, sio-state) mean servers must be created
+ * sequentially, and HTTP keep-alive connections prevent io.close() from
+ * completing within hook timeouts.
+ *
+ * IMPORTANT: createTestServer() uses module-level singletons. Servers MUST be
+ * created sequentially — do not use Promise.all for server creation.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type { IncomingMessage } from "node:http";
+import { createTestServer } from "./server.js";
+import { createMockRunner } from "./mock-runner.js";
+import type { TestServer } from "./types.js";
+
+const TEST_TIMEOUT = 30_000;
+
+/**
+ * Helper to shut down a TestServer cleanly.
+ *
+ * Two problems with a naive `server.cleanup()` call:
+ *
+ * 1. HTTP keep-alive: `createTestServer()` makes fetch() calls that leave open
+ *    keep-alive connections.  `io.close()` → `httpServer.close(cb)` won't fire
+ *    `cb` until all connections close, so it hangs indefinitely.
+ *
+ * 2. Race with disconnect handlers: if we force-close WebSocket connections
+ *    (via closeAllConnections) BEFORE the Redis pub/sub adapter is shut down,
+ *    the async socket disconnect handlers try to broadcast on already-closed
+ *    Redis clients, producing unhandled errors that Bun attributes to the next
+ *    test.
+ *
+ * Fix:
+ *   a) First, gracefully disconnect all Socket.IO clients and wait for their
+ *      async disconnect handlers to flush (small delay).
+ *   b) Then close only idle HTTP connections (keep-alive, not WebSocket).
+ *   c) Finally call server.cleanup() normally.
+ */
+async function cleanupServer(server: TestServer): Promise<void> {
+    // a) Gracefully disconnect all socket.io clients so their async disconnect
+    //    handlers run while the Redis adapter is still open.
+    await server.io.disconnectSockets(true);
+    // Allow async disconnect handlers to flush (they do Redis writes).
+    await new Promise<void>((r) => setTimeout(r, 100));
+
+    // b) Close idle HTTP connections (keep-alives from fetch() calls) so
+    //    httpServer.close() fires its callback promptly.
+    const httpServer = (server.io as unknown as { httpServer?: { closeIdleConnections?(): void } }).httpServer;
+    if (typeof httpServer?.closeIdleConnections === "function") {
+        httpServer.closeIdleConnections();
+    }
+
+    // c) Normal cleanup path.
+    await server.cleanup();
+}
+
+// ---------------------------------------------------------------------------
+// 1. Basic connection and registration
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — basic connection", () => {
+    test("runner connects and registers without error", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server, { name: "basic-runner" });
+            expect(runner.runnerId).toBeTruthy();
+            expect(runner.socket.connected).toBe(true);
+            await runner.disconnect();
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("runnerId reflects the server-assigned id (server generates new id without secret)", async () => {
+        // The server ignores the client-supplied runnerId unless runnerSecret is also provided.
+        // createMockRunner captures the actual id from the runner_registered event.
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server, { name: "id-test-runner" });
+            // The server assigns a UUID — it should be a valid UUID v4 shape
+            expect(runner.runnerId).toMatch(
+                /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+            );
+            await runner.disconnect();
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("auto-generates runnerId when not provided", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server);
+            // Server assigns a UUID — valid UUID shape
+            expect(runner.runnerId).toMatch(
+                /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+            );
+            await runner.disconnect();
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 2. Runner appears in server's runner list (REST API)
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — REST visibility", () => {
+    test("registered runner appears in GET /api/runners", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server, { name: "visible-runner" });
+            try {
+                const res = await server.fetch("/api/runners");
+                expect(res.status).toBe(200);
+                const data = (await res.json()) as {
+                    runners: Array<{ runnerId: string; name: string }>;
+                };
+                const found = data.runners.find((r) => r.runnerId === runner.runnerId);
+                expect(found).toBeTruthy();
+                expect(found?.name).toBe("visible-runner");
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("runner metadata is stored correctly", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server, {
+                name: "metadata-runner",
+                roots: ["/tmp/meta-test"],
+                version: "2.0.0-test",
+                platform: "darwin",
+            });
+            try {
+                const res = await server.fetch("/api/runners");
+                const data = (await res.json()) as {
+                    runners: Array<{
+                        runnerId: string;
+                        name: string;
+                        roots: string[];
+                        version: string | null;
+                        platform: string | null;
+                    }>;
+                };
+                const found = data.runners.find((r) => r.runnerId === runner.runnerId);
+                expect(found).toBeTruthy();
+                expect(found?.roots).toEqual(["/tmp/meta-test"]);
+                expect(found?.version).toBe("2.0.0-test");
+                expect(found?.platform).toBe("darwin");
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 3. emitSessionReady — session_ready propagates
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — emitSessionReady", () => {
+    test("emitSessionReady sends session_ready to the server", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server);
+            try {
+                const sessionId = "test-session-ready-" + Date.now();
+
+                // Capture session_ready events on the server side via the io instance.
+                const receivedSessionIds: string[] = [];
+                const runnerNs = server.io.of("/runner");
+                const captureHandler = (data: { sessionId: string }) => {
+                    if (data.sessionId === sessionId) {
+                        receivedSessionIds.push(data.sessionId);
+                    }
+                };
+                // Listen on all future connections for this event
+                runnerNs.on("connection", (socket) => {
+                    socket.on("session_ready", captureHandler);
+                });
+
+                // Also subscribe on existing sockets (the runner socket is already connected)
+                const sockets = await runnerNs.fetchSockets();
+                for (const s of sockets) {
+                    s.on("session_ready", captureHandler as (data: unknown) => void);
+                }
+
+                runner.emitSessionReady(sessionId);
+
+                // Wait a moment for the event to propagate
+                await new Promise<void>((r) => setTimeout(r, 200));
+
+                // The session_ready event handler calls resolveSpawnReady() (no-op for unknown sessionId).
+                // We verify the socket is still alive and hasn't crashed.
+                expect(runner.socket.connected).toBe(true);
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 4. Multiple runners on the same server
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — multiple runners", () => {
+    test("two runners can register simultaneously", async () => {
+        const server = await createTestServer();
+        try {
+            const [r1, r2] = await Promise.all([
+                createMockRunner(server, { name: "runner-alpha" }),
+                createMockRunner(server, { name: "runner-beta" }),
+            ]);
+            try {
+                expect(r1.runnerId).not.toBe(r2.runnerId);
+                expect(r1.socket.connected).toBe(true);
+                expect(r2.socket.connected).toBe(true);
+
+                const res = await server.fetch("/api/runners");
+                const data = (await res.json()) as {
+                    runners: Array<{ runnerId: string; name: string }>;
+                };
+                const ids = data.runners.map((r) => r.runnerId);
+                expect(ids).toContain(r1.runnerId);
+                expect(ids).toContain(r2.runnerId);
+            } finally {
+                await Promise.allSettled([r1.disconnect(), r2.disconnect()]);
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("three runners all appear in the list", async () => {
+        const server = await createTestServer();
+        try {
+            const [rA, rB, rC] = await Promise.all([
+                createMockRunner(server, { name: "runner-A" }),
+                createMockRunner(server, { name: "runner-B" }),
+                createMockRunner(server, { name: "runner-C" }),
+            ]);
+            try {
+                const res = await server.fetch("/api/runners");
+                const data = (await res.json()) as { runners: Array<{ runnerId: string }> };
+                const ids = data.runners.map((r) => r.runnerId);
+                expect(ids).toContain(rA.runnerId);
+                expect(ids).toContain(rB.runnerId);
+                expect(ids).toContain(rC.runnerId);
+            } finally {
+                await Promise.allSettled([rA.disconnect(), rB.disconnect(), rC.disconnect()]);
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 5. Clean disconnect — runner is removed after disconnect
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — clean disconnect", () => {
+    test("runner is removed from the list after disconnect", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server, { name: "temp-runner" });
+            const { runnerId } = runner;
+
+            // Verify it's there before disconnect
+            const before = await server.fetch("/api/runners");
+            const beforeData = (await before.json()) as { runners: Array<{ runnerId: string }> };
+            expect(beforeData.runners.map((r) => r.runnerId)).toContain(runnerId);
+
+            // Disconnect
+            await runner.disconnect();
+
+            // Give the server a moment to process the disconnect event
+            await new Promise<void>((r) => setTimeout(r, 300));
+
+            // Verify it's gone
+            const after = await server.fetch("/api/runners");
+            const afterData = (await after.json()) as { runners: Array<{ runnerId: string }> };
+            expect(afterData.runners.map((r) => r.runnerId)).not.toContain(runnerId);
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("disconnect() is idempotent (calling twice does not throw)", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server);
+            await runner.disconnect();
+            await expect(runner.disconnect()).resolves.toBeUndefined();
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});
+
+// ---------------------------------------------------------------------------
+// 6. waitForEvent utility
+// ---------------------------------------------------------------------------
+
+describe("createMockRunner — waitForEvent", () => {
+    test("waitForEvent resolves when the server emits the named event", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server);
+            try {
+                // waitForEvent listens for server→client events on the runner's socket.
+                // Use the server's io instance to emit directly to this runner's socket.
+                const waitPromise = runner.waitForEvent("ping", 2_000);
+
+                // Find the server-side socket for this runner and emit to it
+                const runnerNs = server.io.of("/runner");
+                const sockets = await runnerNs.fetchSockets();
+                const serverSocket = sockets.find((s) => s.data.runnerId === runner.runnerId);
+                expect(serverSocket).toBeTruthy();
+
+                // Emit a ping (a valid server→runner event per protocol)
+                serverSocket!.emit("ping", {});
+
+                const result = await waitPromise;
+                expect(result).toEqual({});
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+
+    test("waitForEvent rejects on timeout", async () => {
+        const server = await createTestServer();
+        try {
+            const runner = await createMockRunner(server);
+            try {
+                await expect(
+                    runner.waitForEvent("event_that_never_fires", 100),
+                ).rejects.toThrow(/Timed out/);
+            } finally {
+                await runner.disconnect();
+            }
+        } finally {
+            await cleanupServer(server);
+        }
+    }, TEST_TIMEOUT);
+});

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -1,0 +1,186 @@
+/**
+ * Mock runner client for integration tests.
+ *
+ * Connects to a test server's /runner Socket.IO namespace and mimics the
+ * behaviour of a real PizzaPi runner daemon.
+ */
+
+import { io as ioClient, type Socket as ClientSocket } from "socket.io-client";
+import { randomUUID } from "crypto";
+
+import type {
+    RunnerSkill,
+    RunnerAgent,
+    RunnerPlugin,
+    RunnerHook,
+} from "@pizzapi/protocol";
+
+import type { TestServer } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface MockRunnerOptions {
+    runnerId?: string;
+    name?: string;
+    roots?: string[];
+    skills?: RunnerSkill[];
+    agents?: RunnerAgent[];
+    plugins?: RunnerPlugin[];
+    hooks?: RunnerHook[];
+    version?: string;
+    platform?: string;
+}
+
+export interface MockRunner {
+    runnerId: string;
+    socket: ClientSocket;
+
+    // Session lifecycle helpers
+    emitSessionReady(sessionId: string): void;
+    emitSessionError(sessionId: string, error: string): void;
+    emitSessionEvent(sessionId: string, event: unknown): void;
+    emitSessionEnded(sessionId: string): void;
+
+    // Request handler registration
+    onSkillRequest(handler: (data: unknown) => unknown): void;
+    onFileRequest(handler: (data: unknown) => unknown): void;
+
+    // Utilities
+    waitForEvent(eventName: string, timeout?: number): Promise<unknown>;
+    disconnect(): Promise<void>;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a mock runner that connects to the given test server's /runner
+ * namespace, registers itself, and returns a helper object for emitting
+ * events in tests.
+ */
+export async function createMockRunner(
+    server: TestServer,
+    opts?: MockRunnerOptions,
+): Promise<MockRunner> {
+    const runnerId = opts?.runnerId ?? randomUUID();
+    const runnerUrl = server.baseUrl.replace(/^http/, "ws"); // socket.io handles both http/ws
+
+    const socket: ClientSocket = ioClient(`${server.baseUrl}/runner`, {
+        auth: { apiKey: server.apiKey },
+        transports: ["websocket"],
+        // Prevent socket.io from trying to upgrade / reconnect in tests
+        reconnection: false,
+        forceNew: true,
+    });
+
+    // Wait for the socket to connect and the server to confirm registration.
+    // The server generates its own runnerId (ignoring the client-side hint unless
+    // runnerSecret is also provided), so we capture the actual ID from runner_registered.
+    let assignedRunnerId = runnerId; // fallback; replaced below
+    await new Promise<void>((resolve, reject) => {
+        const connectErrorHandler = (err: Error) => {
+            reject(new Error(`Mock runner connect_error: ${err.message}`));
+        };
+
+        socket.on("connect_error", connectErrorHandler);
+
+        socket.on("connect", () => {
+            // Emit registration payload
+            socket.emit("register_runner", {
+                runnerId,
+                name: opts?.name ?? "test-runner",
+                roots: opts?.roots ?? ["/tmp/test"],
+                skills: opts?.skills ?? [],
+                agents: opts?.agents ?? [],
+                plugins: opts?.plugins ?? [],
+                hooks: opts?.hooks ?? [],
+                version: opts?.version ?? "1.0.0-test",
+                platform: opts?.platform ?? "linux",
+            });
+        });
+
+        socket.once("runner_registered", (data: { runnerId: string }) => {
+            socket.off("connect_error", connectErrorHandler);
+            // Use the server-assigned runnerId (server may have generated a new one)
+            assignedRunnerId = data.runnerId;
+            resolve();
+        });
+
+        // Reject fast on explicit error events from the server
+        socket.once("error", (data: { message: string }) => {
+            socket.off("connect_error", connectErrorHandler);
+            reject(new Error(`Server error during registration: ${data.message}`));
+        });
+    });
+
+    // ── MockRunner implementation ──────────────────────────────────────────
+
+    const runner: MockRunner = {
+        runnerId: assignedRunnerId,
+        socket,
+
+        emitSessionReady(sessionId: string): void {
+            socket.emit("session_ready", { sessionId });
+        },
+
+        emitSessionError(sessionId: string, error: string): void {
+            socket.emit("session_error", { sessionId, message: error });
+        },
+
+        emitSessionEvent(sessionId: string, event: unknown): void {
+            socket.emit("runner_session_event", { sessionId, event });
+        },
+
+        emitSessionEnded(sessionId: string): void {
+            // session_ended is a server→client event; the runner uses
+            // session_killed to notify the server that a session has ended.
+            socket.emit("session_killed", { sessionId });
+        },
+
+        onSkillRequest(handler: (data: unknown) => unknown): void {
+            socket.on("list_skills", (data) => {
+                const result = handler(data);
+                socket.emit("skills_list", {
+                    skills: Array.isArray(result) ? result : [],
+                    requestId: (data as { requestId?: string }).requestId,
+                });
+            });
+        },
+
+        onFileRequest(handler: (data: unknown) => unknown): void {
+            socket.on("list_files", (data) => {
+                const result = handler(data);
+                socket.emit("file_result", {
+                    ...(typeof result === "object" && result !== null ? result : {}),
+                    requestId: (data as { requestId?: string }).requestId,
+                });
+            });
+        },
+
+        waitForEvent(eventName: string, timeout = 5_000): Promise<unknown> {
+            return new Promise<unknown>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    reject(new Error(`Timed out waiting for event "${eventName}" after ${timeout}ms`));
+                }, timeout);
+
+                socket.once(eventName, (data: unknown) => {
+                    clearTimeout(timer);
+                    resolve(data);
+                });
+            });
+        },
+
+        async disconnect(): Promise<void> {
+            if (!socket.connected) return;
+            await new Promise<void>((resolve) => {
+                socket.once("disconnect", () => resolve());
+                socket.disconnect();
+            });
+        },
+    };
+
+    return runner;
+}

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -22,6 +22,8 @@ import type { TestServer } from "./types.js";
 // ---------------------------------------------------------------------------
 
 export interface MockRunnerOptions {
+    /** Override the API key used for auth (default: server.apiKey). Pass a bad key to test auth failures. */
+    apiKey?: string;
     runnerId?: string;
     name?: string;
     roots?: string[];
@@ -69,7 +71,7 @@ export async function createMockRunner(
     const runnerUrl = server.baseUrl.replace(/^http/, "ws"); // socket.io handles both http/ws
 
     const socket: ClientSocket = ioClient(`${server.baseUrl}/runner`, {
-        auth: { apiKey: server.apiKey },
+        auth: { apiKey: opts?.apiKey ?? server.apiKey },
         transports: ["websocket"],
         // Prevent socket.io from trying to upgrade / reconnect in tests
         reconnection: false,
@@ -81,8 +83,27 @@ export async function createMockRunner(
     // runnerSecret is also provided), so we capture the actual ID from runner_registered.
     let assignedRunnerId = runnerId; // fallback; replaced below
     await new Promise<void>((resolve, reject) => {
+        // Guard against double-settling (timeout + normal path racing).
+        let settled = false;
+
+        const settle = (fn: () => void): void => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(registrationTimer);
+            fn();
+        };
+
+        // P3: Explicit registration timeout — reject if the server never responds.
+        const registrationTimer = setTimeout(() => {
+            if (!settled) {
+                settled = true;
+                socket.disconnect();
+                reject(new Error("Mock runner registration timed out after 5000ms"));
+            }
+        }, 5_000);
+
         const connectErrorHandler = (err: Error) => {
-            reject(new Error(`Mock runner connect_error: ${err.message}`));
+            settle(() => reject(new Error(`Mock runner connect_error: ${err.message}`)));
         };
 
         socket.on("connect_error", connectErrorHandler);
@@ -103,16 +124,16 @@ export async function createMockRunner(
         });
 
         socket.once("runner_registered", (data: { runnerId: string }) => {
-            socket.off("connect_error", connectErrorHandler);
-            // Use the server-assigned runnerId (server may have generated a new one)
-            assignedRunnerId = data.runnerId;
-            resolve();
+            settle(() => {
+                // Use the server-assigned runnerId (server may have generated a new one)
+                assignedRunnerId = data.runnerId;
+                resolve();
+            });
         });
 
         // Reject fast on explicit error events from the server
         socket.once("error", (data: { message: string }) => {
-            socket.off("connect_error", connectErrorHandler);
-            reject(new Error(`Server error during registration: ${data.message}`));
+            settle(() => reject(new Error(`Server error during registration: ${data.message}`)));
         });
     });
 
@@ -162,14 +183,20 @@ export async function createMockRunner(
 
         waitForEvent(eventName: string, timeout = 5_000): Promise<unknown> {
             return new Promise<unknown>((resolve, reject) => {
+                // P2: Store the handler reference so we can remove it on timeout
+                // (socket.once listeners must be cleaned up to avoid leaks).
+                const handler = (data: unknown): void => {
+                    clearTimeout(timer);
+                    resolve(data);
+                };
+
                 const timer = setTimeout(() => {
+                    // Remove the once-listener that was never triggered
+                    socket.off(eventName, handler);
                     reject(new Error(`Timed out waiting for event "${eventName}" after ${timeout}ms`));
                 }, timeout);
 
-                socket.once(eventName, (data: unknown) => {
-                    clearTimeout(timer);
-                    resolve(data);
-                });
+                socket.once(eventName, handler);
             });
         },
 

--- a/packages/server/tests/harness/mock-viewer.test.ts
+++ b/packages/server/tests/harness/mock-viewer.test.ts
@@ -1,0 +1,283 @@
+/**
+ * Integration tests for MockViewer and MockHubClient harness helpers.
+ *
+ * These tests spin up a real test server (HTTP + Redis + Socket.IO) and
+ * exercise the /viewer and /hub namespaces through the mock clients.
+ *
+ * NOTE: Servers are created sequentially (module singletons require serial
+ * creation). All tests in this file share a single server instance to keep
+ * the suite fast.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { io as clientIo } from "socket.io-client";
+import { createTestServer } from "./server.js";
+import { createMockViewer } from "./mock-viewer.js";
+import { createMockHubClient } from "./mock-hub.js";
+import type { TestServer } from "./types.js";
+
+// Give real network + Redis plenty of time
+const TEST_TIMEOUT_MS = 30_000;
+
+// ── Inline relay helper ──────────────────────────────────────────────────────
+
+interface TestSession {
+    sessionId: string;
+    token: string;
+    relaySocket: ReturnType<typeof clientIo>;
+}
+
+async function createTestSession(server: TestServer): Promise<TestSession> {
+    const relay = clientIo(`${server.baseUrl}/relay`, {
+        auth: { apiKey: server.apiKey },
+        transports: ["websocket"],
+    });
+
+    return new Promise<TestSession>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            relay.disconnect();
+            reject(new Error("createTestSession: timeout waiting for registered event"));
+        }, 8000);
+
+        relay.on("registered", (data: { sessionId: string; token: string }) => {
+            clearTimeout(timer);
+            resolve({ sessionId: data.sessionId, token: data.token, relaySocket: relay });
+        });
+
+        relay.on("connect_error", (err: Error) => {
+            clearTimeout(timer);
+            relay.disconnect();
+            reject(new Error(`createTestSession: connect_error: ${err.message}`));
+        });
+
+        relay.emit("register", { cwd: "/tmp/test", ephemeral: true });
+    });
+}
+
+// Emit an event through the relay and wait for the ack
+async function emitRelayEvent(
+    session: TestSession,
+    event: unknown,
+    seq: number,
+): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error("emitRelayEvent: timeout")), 5000);
+        session.relaySocket.once("event_ack", () => {
+            clearTimeout(timer);
+            resolve();
+        });
+        session.relaySocket.emit("event", {
+            sessionId: session.sessionId,
+            token: session.token,
+            event,
+            seq,
+        });
+    });
+}
+
+// ── Shared server ────────────────────────────────────────────────────────────
+
+let server: TestServer;
+
+beforeAll(async () => {
+    server = await createTestServer();
+}, TEST_TIMEOUT_MS);
+
+afterAll(async () => {
+    // Force-close all lingering HTTP keep-alive connections before cleanup.
+    // Without this, io.close() → httpServer.close() can wait indefinitely for
+    // connections from the relay Redis cache client or Fetch API keep-alive pool.
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (server.io as any).httpServer?.closeAllConnections?.();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (server.io as any).httpServer?.closeIdleConnections?.();
+    } catch {
+        // closeAllConnections is Node 18.2+; ignore if unavailable
+    }
+    await server.cleanup();
+}, TEST_TIMEOUT_MS);
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("MockViewer", () => {
+    test(
+        "connects to a session and receives connected event",
+        async () => {
+            const session = await createTestSession(server);
+            try {
+                const viewer = await createMockViewer(server, session.sessionId);
+                expect(viewer.sessionId).toBe(session.sessionId);
+                expect(viewer.socket.connected).toBe(true);
+                await viewer.disconnect();
+            } finally {
+                session.relaySocket.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "collects events emitted through relay in getReceivedEvents()",
+        async () => {
+            const session = await createTestSession(server);
+            const viewer = await createMockViewer(server, session.sessionId);
+
+            try {
+                const testEvent = { type: "text_delta", text: "hello from relay" };
+
+                // Emit event through relay and wait for viewer to receive it
+                const waitPromise = viewer.waitForEvent(
+                    (e) => (e as { type?: string }).type === "text_delta",
+                    8000,
+                );
+                await emitRelayEvent(session, testEvent, 1);
+                const received = await waitPromise;
+
+                expect((received as { type?: string }).type).toBe("text_delta");
+                expect((received as { text?: string }).text).toBe("hello from relay");
+
+                const events = viewer.getReceivedEvents();
+                expect(events.length).toBeGreaterThanOrEqual(1);
+                const found = events.find(
+                    (e) => (e.event as { type?: string }).type === "text_delta",
+                );
+                expect(found).toBeDefined();
+            } finally {
+                await viewer.disconnect();
+                session.relaySocket.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "receives disconnected event when relay ends session",
+        async () => {
+            const session = await createTestSession(server);
+            const viewer = await createMockViewer(server, session.sessionId);
+
+            try {
+                const disconnectPromise = viewer.waitForDisconnected(8000);
+
+                // End session via relay
+                session.relaySocket.emit("session_end", {
+                    sessionId: session.sessionId,
+                    token: session.token,
+                });
+
+                const reason = await disconnectPromise;
+                expect(typeof reason).toBe("string");
+            } finally {
+                await viewer.disconnect();
+                session.relaySocket.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "clearEvents resets the collected events array",
+        async () => {
+            const session = await createTestSession(server);
+            const viewer = await createMockViewer(server, session.sessionId);
+
+            try {
+                // Emit one event
+                await emitRelayEvent(session, { type: "ping" }, 1);
+                await viewer.waitForEvent(undefined, 5000);
+                expect(viewer.getReceivedEvents().length).toBeGreaterThan(0);
+
+                viewer.clearEvents();
+                expect(viewer.getReceivedEvents().length).toBe(0);
+            } finally {
+                await viewer.disconnect();
+                session.relaySocket.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "multiple viewers on the same session both receive events",
+        async () => {
+            const session = await createTestSession(server);
+            const viewer1 = await createMockViewer(server, session.sessionId);
+            const viewer2 = await createMockViewer(server, session.sessionId);
+
+            try {
+                const testEvent = { type: "broadcast_test", value: 42 };
+
+                const p1 = viewer1.waitForEvent(
+                    (e) => (e as { type?: string }).type === "broadcast_test",
+                    8000,
+                );
+                const p2 = viewer2.waitForEvent(
+                    (e) => (e as { type?: string }).type === "broadcast_test",
+                    8000,
+                );
+
+                await emitRelayEvent(session, testEvent, 1);
+
+                const [e1, e2] = await Promise.all([p1, p2]);
+                expect((e1 as { value?: number }).value).toBe(42);
+                expect((e2 as { value?: number }).value).toBe(42);
+            } finally {
+                await viewer1.disconnect();
+                await viewer2.disconnect();
+                session.relaySocket.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+});
+
+describe("MockHubClient", () => {
+    test(
+        "connects and receives initial sessions snapshot",
+        async () => {
+            const hub = await createMockHubClient(server);
+            try {
+                // sessions is an array (may be empty at start)
+                expect(Array.isArray(hub.sessions)).toBe(true);
+            } finally {
+                await hub.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "receives session_added when a new relay session is created",
+        async () => {
+            const hub = await createMockHubClient(server);
+
+            try {
+                // Start waiting BEFORE creating session
+                const addedPromise = hub.waitForSessionAdded(undefined, 10000);
+
+                const session = await createTestSession(server);
+
+                const added = await addedPromise;
+                expect(added.sessionId).toBe(session.sessionId);
+                expect(hub.sessions.some((s) => s.sessionId === session.sessionId)).toBe(true);
+
+                session.relaySocket.disconnect();
+            } finally {
+                await hub.disconnect();
+            }
+        },
+        TEST_TIMEOUT_MS,
+    );
+
+    test(
+        "hub disconnect cleans up socket",
+        async () => {
+            const hub = await createMockHubClient(server);
+            expect(hub.socket.connected).toBe(true);
+            await hub.disconnect();
+            expect(hub.socket.connected).toBe(false);
+        },
+        TEST_TIMEOUT_MS,
+    );
+});

--- a/packages/server/tests/harness/mock-viewer.ts
+++ b/packages/server/tests/harness/mock-viewer.ts
@@ -1,0 +1,302 @@
+/**
+ * MockViewer — test harness client for the /viewer Socket.IO namespace.
+ *
+ * Connects with cookie-based auth, auto-collects events, and exposes
+ * waitFor helpers for integration tests.
+ */
+
+import { io as clientIo, type Socket as ClientSocket } from "socket.io-client";
+import type {
+    ViewerServerToClientEvents,
+    ViewerClientToServerEvents,
+    Attachment,
+} from "@pizzapi/protocol";
+import type { TestServer } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ReceivedEvent {
+    event: unknown;
+    seq?: number;
+    replay?: boolean;
+}
+
+export interface MockViewer {
+    socket: ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents>;
+    sessionId: string;
+
+    // Send actions
+    sendInput(text: string, attachments?: Attachment[]): void;
+    sendExec(id: string, command: string): void;
+    sendTriggerResponse(
+        triggerId: string,
+        response: string,
+        targetSessionId: string,
+        action?: string,
+    ): void;
+    sendResync(): void;
+
+    // Received events
+    getReceivedEvents(): ReceivedEvent[];
+    clearEvents(): void;
+    waitForEvent(
+        predicate?: (evt: unknown) => boolean,
+        timeout?: number,
+    ): Promise<unknown>;
+    waitForDisconnected(timeout?: number): Promise<string>;
+
+    disconnect(): Promise<void>;
+}
+
+export interface MockViewerOptions {
+    /** Timeout (ms) waiting for the initial `connected` event. Default: 5000 */
+    connectTimeout?: number;
+    /**
+     * Max connection attempts before giving up. Default: 2.
+     * The first attempt sometimes fails with `connect_error: unauthorized`
+     * due to better-auth cold-start (lazy prepared-statement caching).
+     * A retry after a short delay reliably succeeds.
+     */
+    maxAttempts?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: single connection attempt
+// ---------------------------------------------------------------------------
+
+async function attemptViewerConnection(
+    server: TestServer,
+    sessionId: string,
+    connectTimeout: number,
+): Promise<ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents>> {
+    const socket: ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents> =
+        clientIo(`${server.baseUrl}/viewer`, {
+            extraHeaders: { cookie: server.sessionCookie },
+            query: { sessionId },
+            transports: ["websocket"],
+            autoConnect: false,
+            // Disable auto-reconnect: if the connection fails, fail fast rather
+            // than silently retrying and leaving a lingering socket open.
+            reconnection: false,
+        });
+
+    const connectedPromise = new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            socket.disconnect();
+            reject(
+                new Error(
+                    `MockViewer: timeout waiting for connected event (${connectTimeout}ms) for session ${sessionId}`,
+                ),
+            );
+        }, connectTimeout);
+
+        socket.once("connected", () => {
+            clearTimeout(timer);
+            resolve();
+        });
+
+        // Server-emitted error event (e.g. "Session not found")
+        socket.once("error", (data: { message: string }) => {
+            clearTimeout(timer);
+            socket.disconnect();
+            reject(new Error(`MockViewer: server error on connect: ${data.message}`));
+        });
+
+        // Transport-level rejection (e.g. auth middleware returned unauthorized)
+        socket.once("connect_error", (err) => {
+            clearTimeout(timer);
+            socket.disconnect();
+            reject(new Error(`MockViewer: connect_error: ${err.message}`));
+        });
+    });
+
+    socket.connect();
+
+    // Send the viewer greeting after the underlying transport connects
+    socket.once("connect", () => {
+        socket.emit("connected", {});
+    });
+
+    await connectedPromise;
+    return socket;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a MockViewer connected to the given test server and session.
+ *
+ * The promise resolves once the server sends the `connected` event,
+ * confirming the viewer is successfully joined to the session.
+ *
+ * The first connection attempt may fail with `connect_error: unauthorized`
+ * due to better-auth cold-start (lazy prepared-statement caching). Up to
+ * `maxAttempts` retries are made with a 150 ms delay between attempts.
+ */
+export async function createMockViewer(
+    server: TestServer,
+    sessionId: string,
+    opts?: MockViewerOptions,
+): Promise<MockViewer> {
+    const connectTimeout = opts?.connectTimeout ?? 5000;
+    const maxAttempts = opts?.maxAttempts ?? 2;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (attempt > 0) {
+            await new Promise<void>((r) => setTimeout(r, 150));
+        }
+        try {
+            const socket = await attemptViewerConnection(server, sessionId, connectTimeout);
+            return buildMockViewer(socket, sessionId);
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    throw lastError;
+}
+
+// ---------------------------------------------------------------------------
+// Build MockViewer from an already-connected socket
+// ---------------------------------------------------------------------------
+
+function buildMockViewer(
+    socket: ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents>,
+    sessionId: string,
+): MockViewer {
+    // Collected events from the server
+    const receivedEvents: ReceivedEvent[] = [];
+
+    // Pending waitForEvent resolvers
+    const eventWaiters: Array<{
+        predicate?: (evt: unknown) => boolean;
+        resolve: (evt: unknown) => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+    }> = [];
+
+    // Pending waitForDisconnected resolvers
+    const disconnectWaiters: Array<{
+        resolve: (reason: string) => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+    }> = [];
+
+    // Auto-collect all `event` payloads
+    socket.on("event", (data) => {
+        const entry: ReceivedEvent = {
+            event: data.event,
+            seq: data.seq,
+            replay: data.replay,
+        };
+        receivedEvents.push(entry);
+
+        // Notify waitForEvent callers
+        for (let i = eventWaiters.length - 1; i >= 0; i--) {
+            const waiter = eventWaiters[i];
+            if (!waiter.predicate || waiter.predicate(data.event)) {
+                clearTimeout(waiter.timer);
+                eventWaiters.splice(i, 1);
+                waiter.resolve(data.event);
+            }
+        }
+    });
+
+    // Handle disconnected events from server
+    socket.on("disconnected", (data) => {
+        for (let i = disconnectWaiters.length - 1; i >= 0; i--) {
+            const waiter = disconnectWaiters[i];
+            clearTimeout(waiter.timer);
+            disconnectWaiters.splice(i, 1);
+            waiter.resolve(data.reason);
+        }
+    });
+
+    // ── MockViewer implementation ──────────────────────────────────────────
+
+    const viewer: MockViewer = {
+        socket,
+        sessionId,
+
+        sendInput(text: string, attachments?: Attachment[]): void {
+            socket.emit("input", { text, attachments });
+        },
+
+        sendExec(id: string, command: string): void {
+            socket.emit("exec", { id, command });
+        },
+
+        sendTriggerResponse(
+            triggerId: string,
+            response: string,
+            targetSessionId: string,
+            action?: string,
+        ): void {
+            socket.emit("trigger_response", { triggerId, response, targetSessionId, action }, () => {
+                // ack callback — no-op for tests unless explicitly tested
+            });
+        },
+
+        sendResync(): void {
+            socket.emit("resync", {});
+        },
+
+        getReceivedEvents(): ReceivedEvent[] {
+            return [...receivedEvents];
+        },
+
+        clearEvents(): void {
+            receivedEvents.length = 0;
+        },
+
+        waitForEvent(
+            predicate?: (evt: unknown) => boolean,
+            timeout = 5000,
+        ): Promise<unknown> {
+            // Check if already buffered
+            const existing = receivedEvents.find(
+                (e) => !predicate || predicate(e.event),
+            );
+            if (existing) return Promise.resolve(existing.event);
+
+            return new Promise<unknown>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const idx = eventWaiters.findIndex((w) => w.resolve === resolve);
+                    if (idx !== -1) eventWaiters.splice(idx, 1);
+                    reject(new Error(`MockViewer.waitForEvent: timeout (${timeout}ms)`));
+                }, timeout);
+
+                eventWaiters.push({ predicate, resolve, reject, timer });
+            });
+        },
+
+        waitForDisconnected(timeout = 5000): Promise<string> {
+            return new Promise<string>((resolve, reject) => {
+                const timer = setTimeout(() => {
+                    const idx = disconnectWaiters.findIndex((w) => w.resolve === resolve);
+                    if (idx !== -1) disconnectWaiters.splice(idx, 1);
+                    reject(new Error(`MockViewer.waitForDisconnected: timeout (${timeout}ms)`));
+                }, timeout);
+
+                disconnectWaiters.push({ resolve, reject, timer });
+            });
+        },
+
+        disconnect(): Promise<void> {
+            return new Promise<void>((resolve) => {
+                if (!socket.connected) {
+                    resolve();
+                    return;
+                }
+                socket.once("disconnect", () => resolve());
+                socket.disconnect();
+            });
+        },
+    };
+
+    return viewer;
+}

--- a/packages/server/tests/harness/mock-viewer.ts
+++ b/packages/server/tests/harness/mock-viewer.ts
@@ -63,14 +63,21 @@ export interface MockViewerOptions {
 }
 
 // ---------------------------------------------------------------------------
-// Internal: single connection attempt
+// Internal: single connection attempt — builds a fully-wired MockViewer
 // ---------------------------------------------------------------------------
 
-async function attemptViewerConnection(
+/**
+ * Creates a socket, attaches ALL data listeners BEFORE waiting for the
+ * handshake, then resolves once the server sends the `connected` event.
+ *
+ * Listener-before-await ordering prevents the race where events emitted
+ * between `connected` receipt and listener attachment are silently dropped.
+ */
+async function attemptBuildViewer(
     server: TestServer,
     sessionId: string,
     connectTimeout: number,
-): Promise<ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents>> {
+): Promise<MockViewer> {
     const socket: ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents> =
         clientIo(`${server.baseUrl}/viewer`, {
             extraHeaders: { cookie: server.sessionCookie },
@@ -81,6 +88,76 @@ async function attemptViewerConnection(
             // than silently retrying and leaving a lingering socket open.
             reconnection: false,
         });
+
+    // Collected events from the server
+    const receivedEvents: ReceivedEvent[] = [];
+
+    // Pending waitForEvent resolvers
+    const eventWaiters: Array<{
+        predicate?: (evt: unknown) => boolean;
+        resolve: (evt: unknown) => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+    }> = [];
+
+    // Pending waitForDisconnected resolvers
+    const disconnectWaiters: Array<{
+        resolve: (reason: string) => void;
+        reject: (err: Error) => void;
+        timer: ReturnType<typeof setTimeout>;
+    }> = [];
+
+    // Tracks whether disconnect() has been called — guards new waitFor calls
+    let isDisconnected = false;
+
+    // Rejects and clears all outstanding waiters (called on disconnect)
+    function rejectAllWaiters(reason: string): void {
+        const err = new Error(reason);
+        for (const w of eventWaiters.splice(0)) {
+            clearTimeout(w.timer);
+            w.reject(err);
+        }
+        for (const w of disconnectWaiters.splice(0)) {
+            clearTimeout(w.timer);
+            w.reject(err);
+        }
+    }
+
+    // ── Attach ALL data listeners BEFORE waiting for the handshake ─────────
+    // This prevents the race where events emitted between the `connected`
+    // event and subsequent listener attachment are dropped.
+
+    // Auto-collect all `event` payloads
+    socket.on("event", (data) => {
+        const entry: ReceivedEvent = {
+            event: data.event,
+            seq: data.seq,
+            replay: data.replay,
+        };
+        receivedEvents.push(entry);
+
+        // Notify waitForEvent callers
+        for (let i = eventWaiters.length - 1; i >= 0; i--) {
+            const waiter = eventWaiters[i];
+            if (!waiter.predicate || waiter.predicate(data.event)) {
+                clearTimeout(waiter.timer);
+                eventWaiters.splice(i, 1);
+                waiter.resolve(data.event);
+            }
+        }
+    });
+
+    // Handle disconnected events from server
+    socket.on("disconnected", (data) => {
+        for (let i = disconnectWaiters.length - 1; i >= 0; i--) {
+            const waiter = disconnectWaiters[i];
+            clearTimeout(waiter.timer);
+            disconnectWaiters.splice(i, 1);
+            waiter.resolve(data.reason);
+        }
+    });
+
+    // ── Handshake: resolve once the server acknowledges our join ───────────
 
     const connectedPromise = new Promise<void>((resolve, reject) => {
         const timer = setTimeout(() => {
@@ -120,103 +197,8 @@ async function attemptViewerConnection(
     });
 
     await connectedPromise;
-    return socket;
-}
 
-// ---------------------------------------------------------------------------
-// Factory
-// ---------------------------------------------------------------------------
-
-/**
- * Create a MockViewer connected to the given test server and session.
- *
- * The promise resolves once the server sends the `connected` event,
- * confirming the viewer is successfully joined to the session.
- *
- * The first connection attempt may fail with `connect_error: unauthorized`
- * due to better-auth cold-start (lazy prepared-statement caching). Up to
- * `maxAttempts` retries are made with a 150 ms delay between attempts.
- */
-export async function createMockViewer(
-    server: TestServer,
-    sessionId: string,
-    opts?: MockViewerOptions,
-): Promise<MockViewer> {
-    const connectTimeout = opts?.connectTimeout ?? 5000;
-    const maxAttempts = opts?.maxAttempts ?? 2;
-
-    let lastError: unknown;
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-        if (attempt > 0) {
-            await new Promise<void>((r) => setTimeout(r, 150));
-        }
-        try {
-            const socket = await attemptViewerConnection(server, sessionId, connectTimeout);
-            return buildMockViewer(socket, sessionId);
-        } catch (err) {
-            lastError = err;
-        }
-    }
-    throw lastError;
-}
-
-// ---------------------------------------------------------------------------
-// Build MockViewer from an already-connected socket
-// ---------------------------------------------------------------------------
-
-function buildMockViewer(
-    socket: ClientSocket<ViewerServerToClientEvents, ViewerClientToServerEvents>,
-    sessionId: string,
-): MockViewer {
-    // Collected events from the server
-    const receivedEvents: ReceivedEvent[] = [];
-
-    // Pending waitForEvent resolvers
-    const eventWaiters: Array<{
-        predicate?: (evt: unknown) => boolean;
-        resolve: (evt: unknown) => void;
-        reject: (err: Error) => void;
-        timer: ReturnType<typeof setTimeout>;
-    }> = [];
-
-    // Pending waitForDisconnected resolvers
-    const disconnectWaiters: Array<{
-        resolve: (reason: string) => void;
-        reject: (err: Error) => void;
-        timer: ReturnType<typeof setTimeout>;
-    }> = [];
-
-    // Auto-collect all `event` payloads
-    socket.on("event", (data) => {
-        const entry: ReceivedEvent = {
-            event: data.event,
-            seq: data.seq,
-            replay: data.replay,
-        };
-        receivedEvents.push(entry);
-
-        // Notify waitForEvent callers
-        for (let i = eventWaiters.length - 1; i >= 0; i--) {
-            const waiter = eventWaiters[i];
-            if (!waiter.predicate || waiter.predicate(data.event)) {
-                clearTimeout(waiter.timer);
-                eventWaiters.splice(i, 1);
-                waiter.resolve(data.event);
-            }
-        }
-    });
-
-    // Handle disconnected events from server
-    socket.on("disconnected", (data) => {
-        for (let i = disconnectWaiters.length - 1; i >= 0; i--) {
-            const waiter = disconnectWaiters[i];
-            clearTimeout(waiter.timer);
-            disconnectWaiters.splice(i, 1);
-            waiter.resolve(data.reason);
-        }
-    });
-
-    // ── MockViewer implementation ──────────────────────────────────────────
+    // ── Build and return the MockViewer object ─────────────────────────────
 
     const viewer: MockViewer = {
         socket,
@@ -257,6 +239,10 @@ function buildMockViewer(
             predicate?: (evt: unknown) => boolean,
             timeout = 5000,
         ): Promise<unknown> {
+            if (isDisconnected) {
+                return Promise.reject(new Error("MockViewer.waitForEvent: already disconnected"));
+            }
+
             // Check if already buffered
             const existing = receivedEvents.find(
                 (e) => !predicate || predicate(e.event),
@@ -275,6 +261,10 @@ function buildMockViewer(
         },
 
         waitForDisconnected(timeout = 5000): Promise<string> {
+            if (isDisconnected) {
+                return Promise.reject(new Error("MockViewer.waitForDisconnected: already disconnected"));
+            }
+
             return new Promise<string>((resolve, reject) => {
                 const timer = setTimeout(() => {
                     const idx = disconnectWaiters.findIndex((w) => w.resolve === resolve);
@@ -287,6 +277,9 @@ function buildMockViewer(
         },
 
         disconnect(): Promise<void> {
+            isDisconnected = true;
+            rejectAllWaiters("MockViewer: disconnected");
+
             return new Promise<void>((resolve) => {
                 if (!socket.connected) {
                     resolve();
@@ -299,4 +292,40 @@ function buildMockViewer(
     };
 
     return viewer;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a MockViewer connected to the given test server and session.
+ *
+ * The promise resolves once the server sends the `connected` event,
+ * confirming the viewer is successfully joined to the session.
+ *
+ * The first connection attempt may fail with `connect_error: unauthorized`
+ * due to better-auth cold-start (lazy prepared-statement caching). Up to
+ * `maxAttempts` retries are made with a 150 ms delay between attempts.
+ */
+export async function createMockViewer(
+    server: TestServer,
+    sessionId: string,
+    opts?: MockViewerOptions,
+): Promise<MockViewer> {
+    const connectTimeout = opts?.connectTimeout ?? 5000;
+    const maxAttempts = opts?.maxAttempts ?? 2;
+
+    let lastError: unknown;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+        if (attempt > 0) {
+            await new Promise<void>((r) => setTimeout(r, 150));
+        }
+        try {
+            return await attemptBuildViewer(server, sessionId, connectTimeout);
+        } catch (err) {
+            lastError = err;
+        }
+    }
+    throw lastError;
 }

--- a/packages/server/tests/harness/preload-redis.ts
+++ b/packages/server/tests/harness/preload-redis.ts
@@ -1,0 +1,22 @@
+/**
+ * Test preload script — saves the real redis createClient before any test
+ * file can mock it via mock.module("redis", ...).
+ *
+ * Registered in the root bunfig.toml so it runs before any test file in
+ * any package. The harness (server.ts) retrieves the real function via
+ * globalThis.__realRedisCreateClient.
+ *
+ * This is necessary because Bun 1.3.x does NOT reset mock.module() between
+ * test files in the same worker. Test files in packages/server/src/ws/ mock
+ * "redis" with stubs that lack .pSubscribe(), .subscribe(), .quit(), etc.
+ * Without this preload, the test-server harness tests in the same worker
+ * get the mocked createClient and fail with "psubscribe is not a function".
+ *
+ * Fails gracefully if redis is not installed (e.g. in other packages).
+ */
+try {
+    const { createClient } = await import("redis");
+    (globalThis as any).__realRedisCreateClient = createClient;
+} catch {
+    // redis not installed in this package context — no-op
+}

--- a/packages/server/tests/harness/scenario.ts
+++ b/packages/server/tests/harness/scenario.ts
@@ -1,0 +1,437 @@
+/**
+ * TestScenario — BDD-style fluent builder for composing test environments.
+ *
+ * Provides a declarative API for setting up full multi-component test
+ * scenarios with automatic cleanup.
+ *
+ * # Socket.IO Manager sharing caveat
+ *
+ * socket.io-client caches Managers by base URL. Hub sockets use
+ * `extraHeaders: { cookie }` for HTTP-level auth; relay sockets use
+ * `auth: { apiKey }` in the socket.io namespace packet. When hub and relay
+ * share the same Manager (same base URL, no forceNew), the relay namespace
+ * connect travels over a connection whose HTTP upgrade was performed with
+ * the hub's cookies, which can cause the server's relay middleware to
+ * behave unexpectedly (silent drop, no connect_error) leading to an
+ * indefinite hang.
+ *
+ * Fix: relay sockets are created with `forceNew: true` so each relay gets
+ * its own Manager and its own WebSocket connection, independent of hub.
+ *
+ * Usage:
+ *
+ *   const scenario = new TestScenario();
+ *   await scenario.setup();                       // creates the test server
+ *
+ *   const runner = await scenario.addRunner({ name: "r1" });
+ *   const sess   = await scenario.addSession({ cwd: "/project" });
+ *   const viewer = await scenario.addViewer(sess.sessionId);
+ *   const hub    = await scenario.addHub();
+ *
+ *   await scenario.sendConversation(0, [
+ *     { role: "assistant", text: "Hello!" },
+ *   ]);
+ *
+ *   await scenario.teardown();
+ */
+
+import { io as connectSocket } from "socket.io-client";
+import { createTestServer } from "./server.js";
+import { createMockRunner, type MockRunner, type MockRunnerOptions } from "./mock-runner.js";
+import { createMockViewer, type MockViewer, type MockViewerOptions } from "./mock-viewer.js";
+import { createMockHubClient, type MockHubClient, type MockHubClientOptions } from "./mock-hub.js";
+import { buildConversation, type ConversationTurn } from "./builders.js";
+import type { TestServer, TestServerOptions, MockRelay, MockRelaySession } from "./types.js";
+
+// ── Stored session record ────────────────────────────────────────────────────
+
+export interface ScenarioSession {
+    sessionId: string;
+    token: string;
+    shareUrl: string;
+    relay: MockRelay;
+}
+
+// ── Internal relay factory (forceNew: true) ──────────────────────────────────
+
+/**
+ * Creates a MockRelay-compatible object whose underlying socket uses
+ * `forceNew: true`, preventing Manager sharing with hub/viewer sockets.
+ *
+ * Functionally equivalent to createMockRelay() from mock-relay.ts but
+ * forces an independent Manager so relay and hub auth paths never collide.
+ */
+async function createIsolatedRelay(server: TestServer): Promise<MockRelay> {
+    const socket = connectSocket(`${server.baseUrl}/relay`, {
+        auth: { apiKey: server.apiKey },
+        transports: ["websocket"],
+        autoConnect: true,
+        reconnection: false,
+        // CRITICAL: prevents Manager sharing with hub/viewer sockets.
+        // Hub sockets are authenticated via HTTP cookies (extraHeaders),
+        // while relay sockets use socket.io-level auth (apiKey). Sharing
+        // the same Manager means relay's namespace connect travels over a
+        // WebSocket connection whose HTTP upgrade carried hub's cookies,
+        // which causes the relay namespace middleware to silently drop the
+        // connection (no connect_error, no connect event) → indefinite hang.
+        forceNew: true,
+    } as Parameters<typeof connectSocket>[1]);
+
+    // Wait for connection (10 s timeout to avoid infinite hang)
+    await new Promise<void>((resolve, reject) => {
+        if (socket.connected) {
+            resolve();
+            return;
+        }
+
+        const timer = setTimeout(() => {
+            socket.off("connect", onConnect);
+            socket.off("connect_error", onError);
+            socket.disconnect();
+            reject(new Error("createIsolatedRelay: timed out waiting for /relay to connect after 10 s"));
+        }, 10_000);
+
+        const onConnect = () => {
+            clearTimeout(timer);
+            socket.off("connect_error", onError);
+            resolve();
+        };
+        const onError = (err: Error) => {
+            clearTimeout(timer);
+            socket.off("connect", onConnect);
+            socket.disconnect();
+            reject(new Error(`createIsolatedRelay: connect_error: ${err.message}`));
+        };
+
+        socket.once("connect", onConnect);
+        socket.once("connect_error", onError);
+    });
+
+    // Serial register lock (same contract as mock-relay.ts)
+    let _registerLock: Promise<unknown> = Promise.resolve();
+
+    function waitForEvent(eventName: string, timeout = 5_000): Promise<unknown> {
+        return new Promise<unknown>((resolve, reject) => {
+            const handler = (data: unknown) => {
+                clearTimeout(timer);
+                resolve(data);
+            };
+            const timer = setTimeout(() => {
+                socket.off(eventName, handler);
+                reject(new Error(`createIsolatedRelay.waitForEvent: timed out waiting for "${eventName}"`));
+            }, timeout);
+            socket.once(eventName, handler);
+        });
+    }
+
+    async function registerSession(opts?: {
+        sessionId?: string;
+        cwd?: string;
+        ephemeral?: boolean;
+        collabMode?: boolean;
+        sessionName?: string | null;
+        parentSessionId?: string | null;
+    }): Promise<MockRelaySession> {
+        const doRegister = async (): Promise<MockRelaySession> => {
+            const registeredPromise = waitForEvent("registered");
+            socket.emit("register", {
+                sessionId: opts?.sessionId,
+                cwd: opts?.cwd ?? "/tmp/mock-session",
+                ephemeral: opts?.ephemeral ?? true,
+                collabMode: opts?.collabMode ?? false,
+                sessionName: opts?.sessionName ?? null,
+                parentSessionId: opts?.parentSessionId ?? null,
+            });
+            const data = await registeredPromise as { sessionId: string; token: string; shareUrl: string };
+            return { sessionId: data.sessionId, token: data.token, shareUrl: data.shareUrl };
+        };
+
+        const result = _registerLock.then(doRegister, doRegister);
+        _registerLock = result.then(() => {}, () => {});
+        return result;
+    }
+
+    const relay: MockRelay = {
+        socket,
+
+        registerSession,
+
+        emitEvent(sessionId: string, token: string, event: unknown, seq?: number): void {
+            socket.emit("event", { sessionId, token, event, ...(seq !== undefined ? { seq } : {}) });
+        },
+
+        emitSessionEnd(sessionId: string, token: string): void {
+            socket.emit("session_end", { sessionId, token });
+        },
+
+        emitTrigger(data): void {
+            socket.emit("session_trigger", data);
+        },
+
+        emitTriggerResponse(data): void {
+            socket.emit("trigger_response", data);
+        },
+
+        emitSessionMessage(data): void {
+            socket.emit("session_message", data);
+        },
+
+        waitForEvent,
+
+        async disconnect(): Promise<void> {
+            if (socket.connected) {
+                await new Promise<void>((resolve) => {
+                    socket.once("disconnect", () => resolve());
+                    socket.disconnect();
+                });
+            } else {
+                // Socket might be in "connecting" state — force-disconnect it
+                socket.disconnect();
+            }
+            await new Promise<void>((resolve) => setTimeout(resolve, 100));
+        },
+    };
+
+    return relay;
+}
+
+// ── TestScenario ─────────────────────────────────────────────────────────────
+
+export class TestScenario {
+    private _server: TestServer | null = null;
+    private _ownServer = false;
+    private _runners: MockRunner[] = [];
+    private _sessions: ScenarioSession[] = [];
+    private _viewers: MockViewer[] = [];
+    private _hub: MockHubClient | null = null;
+
+    // ── Accessors ────────────────────────────────────────────────────────────
+
+    get server(): TestServer {
+        if (!this._server) {
+            throw new Error("TestScenario: server not initialized — call setup() or setServer() first");
+        }
+        return this._server;
+    }
+
+    get runners(): MockRunner[] {
+        return this._runners;
+    }
+
+    get sessions(): ScenarioSession[] {
+        return this._sessions;
+    }
+
+    get viewers(): MockViewer[] {
+        return this._viewers;
+    }
+
+    get hub(): MockHubClient | null {
+        return this._hub;
+    }
+
+    // ── Lifecycle ────────────────────────────────────────────────────────────
+
+    /**
+     * Initialize the test server. Must be called before any add* methods
+     * when using scenario in standalone mode (creates its own server).
+     */
+    async setup(opts?: TestServerOptions): Promise<void> {
+        this._server = await createTestServer(opts);
+        this._ownServer = true;
+    }
+
+    /**
+     * Inject an existing TestServer instead of creating a new one.
+     * When using this, teardown() will NOT call server.cleanup() — the
+     * caller is responsible for server lifecycle.
+     */
+    setServer(server: TestServer): void {
+        this._server = server;
+        this._ownServer = false;
+    }
+
+    /**
+     * Reset all tracked components (without touching the server).
+     * Useful between tests in a shared-server setup.
+     */
+    async reset(): Promise<void> {
+        await this._disconnectComponents();
+    }
+
+    /**
+     * Tear down all components in reverse creation order.
+     * If this scenario owns its server, also cleans it up.
+     */
+    async teardown(): Promise<void> {
+        const errors: unknown[] = [];
+
+        await this._disconnectComponents().catch((e) => errors.push(e));
+
+        // Only clean up the server if we own it
+        if (this._ownServer && this._server) {
+            try {
+                // Gracefully disconnect all socket.io clients first
+                await this._server.io.disconnectSockets(true);
+                // Allow async disconnect handlers to flush (Redis writes)
+                await new Promise<void>((r) => setTimeout(r, 100));
+
+                const httpServer = (this._server.io as unknown as {
+                    httpServer?: {
+                        closeAllConnections?(): void;
+                        closeIdleConnections?(): void;
+                    };
+                }).httpServer;
+
+                // closeAllConnections (Node 18.2+) force-closes all HTTP connections
+                // including any lingering WebSocket connections from sockets that never
+                // completed their namespace handshake.
+                if (typeof httpServer?.closeAllConnections === "function") {
+                    httpServer.closeAllConnections();
+                } else if (typeof httpServer?.closeIdleConnections === "function") {
+                    httpServer.closeIdleConnections();
+                }
+
+                await this._server.cleanup();
+            } catch (err) {
+                errors.push(err);
+            }
+            this._server = null;
+            this._ownServer = false;
+        }
+
+        if (errors.length > 0) {
+            throw errors[0];
+        }
+    }
+
+    // ── Component builders ───────────────────────────────────────────────────
+
+    /**
+     * Add a mock runner to the scenario.
+     */
+    async addRunner(opts?: MockRunnerOptions): Promise<MockRunner> {
+        const runner = await createMockRunner(this.server, opts);
+        this._runners.push(runner);
+        return runner;
+    }
+
+    /**
+     * Add a session via an isolated relay connection (forceNew: true).
+     * Returns the session record with sessionId, token, and the relay reference.
+     */
+    async addSession(opts?: {
+        sessionId?: string;
+        cwd?: string;
+        ephemeral?: boolean;
+        collabMode?: boolean;
+        sessionName?: string | null;
+        parentSessionId?: string | null;
+    }): Promise<ScenarioSession> {
+        // Use the isolated relay factory (forceNew: true) to avoid Manager
+        // sharing with hub sockets which can cause an indefinite connection hang.
+        const relay = await createIsolatedRelay(this.server);
+        const { sessionId, token, shareUrl } = await relay.registerSession(opts);
+
+        const record: ScenarioSession = { sessionId, token, shareUrl, relay };
+        this._sessions.push(record);
+        return record;
+    }
+
+    /**
+     * Add a viewer for the given sessionId.
+     */
+    async addViewer(sessionId: string, opts?: MockViewerOptions): Promise<MockViewer> {
+        const viewer = await createMockViewer(this.server, sessionId, opts);
+        this._viewers.push(viewer);
+        return viewer;
+    }
+
+    /**
+     * Add a hub client.
+     */
+    async addHub(opts?: MockHubClientOptions): Promise<MockHubClient> {
+        const hub = await createMockHubClient(this.server, opts);
+        this._hub = hub;
+        return hub;
+    }
+
+    // ── Scenario actions ─────────────────────────────────────────────────────
+
+    /**
+     * Send a conversation through the relay for the session at `sessionIndex`.
+     * Skips harness:user_turn events (those arrive via the viewer namespace).
+     */
+    async sendConversation(
+        sessionIndex: number,
+        turns: ConversationTurn[],
+    ): Promise<void> {
+        const session = this._sessions[sessionIndex];
+        if (!session) {
+            throw new Error(
+                `TestScenario.sendConversation: no session at index ${sessionIndex} ` +
+                `(${this._sessions.length} sessions registered)`,
+            );
+        }
+
+        const events = buildConversation(turns);
+        let seq = 0;
+
+        for (const event of events) {
+            if (
+                typeof event === "object" &&
+                event !== null &&
+                (event as Record<string, unknown>)["type"] === "harness:user_turn"
+            ) {
+                continue;
+            }
+
+            session.relay.emitEvent(session.sessionId, session.token, event, seq++);
+            await new Promise<void>((r) => setTimeout(r, 10));
+        }
+    }
+
+    /**
+     * Signal session end for the session at `sessionIndex`.
+     */
+    async endSession(sessionIndex: number): Promise<void> {
+        const session = this._sessions[sessionIndex];
+        if (!session) {
+            throw new Error(`TestScenario.endSession: no session at index ${sessionIndex}`);
+        }
+        session.relay.emitSessionEnd(session.sessionId, session.token);
+        await new Promise<void>((r) => setTimeout(r, 50));
+    }
+
+    // ── Private helpers ──────────────────────────────────────────────────────
+
+    private async _disconnectComponents(): Promise<void> {
+        const errors: unknown[] = [];
+
+        // Disconnect viewers (reverse order)
+        for (let i = this._viewers.length - 1; i >= 0; i--) {
+            try { await this._viewers[i].disconnect(); } catch (e) { errors.push(e); }
+        }
+        this._viewers.length = 0;
+
+        // Disconnect hub
+        if (this._hub) {
+            try { await this._hub.disconnect(); } catch (e) { errors.push(e); }
+            this._hub = null;
+        }
+
+        // Disconnect relay sockets (reverse order)
+        for (let i = this._sessions.length - 1; i >= 0; i--) {
+            try { await this._sessions[i].relay.disconnect(); } catch (e) { errors.push(e); }
+        }
+        this._sessions.length = 0;
+
+        // Disconnect runners (reverse order)
+        for (let i = this._runners.length - 1; i >= 0; i--) {
+            try { await this._runners[i].disconnect(); } catch (e) { errors.push(e); }
+        }
+        this._runners.length = 0;
+
+        if (errors.length > 0) throw errors[0];
+    }
+}

--- a/packages/server/tests/harness/scenario.ts
+++ b/packages/server/tests/harness/scenario.ts
@@ -331,11 +331,17 @@ export class TestScenario {
         // Use the isolated relay factory (forceNew: true) to avoid Manager
         // sharing with hub sockets which can cause an indefinite connection hang.
         const relay = await createIsolatedRelay(this.server);
-        const { sessionId, token, shareUrl } = await relay.registerSession(opts);
-
-        const record: ScenarioSession = { sessionId, token, shareUrl, relay };
-        this._sessions.push(record);
-        return record;
+        try {
+            const { sessionId, token, shareUrl } = await relay.registerSession(opts);
+            const record: ScenarioSession = { sessionId, token, shareUrl, relay };
+            this._sessions.push(record);
+            return record;
+        } catch (err) {
+            // registerSession() failed — disconnect the relay so it doesn't leak.
+            // The socket is not in _sessions yet, so reset()/teardown() won't reach it.
+            await relay.disconnect();
+            throw err;
+        }
     }
 
     /**

--- a/packages/server/tests/harness/server.test.ts
+++ b/packages/server/tests/harness/server.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Smoke tests for the test server factory harness.
+ *
+ * These tests verify that createTestServer():
+ *   1. Spins up a real HTTP server that responds to requests
+ *   2. Pre-creates a user with a working API key
+ *   3. Multiple servers can run simultaneously (created sequentially, then accessed concurrently)
+ *   4. Cleans up all resources on shutdown
+ *
+ * NOTE: Servers must be created sequentially (not with Promise.all) because
+ * auth.ts and sio-state.ts use module-level singletons. Once created, multiple
+ * servers can coexist and respond simultaneously.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { createTestServer } from "./server.js";
+
+// Tests spin up real servers + Redis + Socket.IO, so we need a generous timeout.
+const TEST_TIMEOUT_MS = 30_000;
+
+describe("createTestServer", () => {
+    test("creates server and responds to health check", async () => {
+        const server = await createTestServer();
+        try {
+            const res = await fetch(`${server.baseUrl}/health`);
+            // Health may be degraded if Redis singletons were overwritten, but
+            // the server must respond with the expected shape.
+            expect([200, 503]).toContain(res.status);
+            const data = await res.json();
+            expect(["ok", "degraded"]).toContain(data.status);
+            expect(typeof data.redis).toBe("boolean");
+            expect(typeof data.socketio).toBe("boolean");
+            expect(typeof data.uptime).toBe("number");
+        } finally {
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("pre-created user can authenticate via API key", async () => {
+        const server = await createTestServer();
+        try {
+            // Verify basic properties are populated
+            expect(server.port).toBeGreaterThan(0);
+            expect(server.baseUrl).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/);
+            expect(server.apiKey).toHaveLength(64); // 32 random bytes → 64 hex chars
+            expect(server.userId).toBeTruthy();
+            expect(server.userName).toBe("Test User");
+            expect(server.userEmail).toBe("testuser@pizzapi-harness.test");
+            expect(server.sessionCookie).toBeTruthy();
+
+            // The built-in fetch helper includes auth headers
+            const res = await server.fetch("/api/signup-status");
+            expect(res.status).toBe(200);
+            const data = await res.json();
+            // After first user created with disableSignupAfterFirstUser: true (default),
+            // signup should be disabled
+            expect(data.signupEnabled).toBe(false);
+        } finally {
+            await server.cleanup();
+        }
+    }, TEST_TIMEOUT_MS);
+
+    test("multiple test servers can run concurrently", async () => {
+        // Create servers sequentially (module singletons require serial creation)
+        // then verify they can all respond simultaneously.
+        const s1 = await createTestServer();
+        const s2 = await createTestServer();
+        const s3 = await createTestServer();
+
+        try {
+            // All servers should have different ports
+            const ports = new Set([s1.port, s2.port, s3.port]);
+            expect(ports.size).toBe(3);
+
+            // All servers should respond simultaneously (concurrent reads are fine)
+            const responses = await Promise.all([
+                fetch(`${s1.baseUrl}/health`),
+                fetch(`${s2.baseUrl}/health`),
+                fetch(`${s3.baseUrl}/health`),
+            ]);
+
+            for (const res of responses) {
+                expect([200, 503]).toContain(res.status);
+                const data = await res.json();
+                expect(["ok", "degraded"]).toContain(data.status);
+            }
+        } finally {
+            // Clean up all servers, ignoring individual errors
+            await Promise.allSettled([s1.cleanup(), s2.cleanup(), s3.cleanup()]);
+        }
+    }, TEST_TIMEOUT_MS * 3);
+
+    test("cleanup shuts down cleanly", async () => {
+        const server = await createTestServer();
+        const baseUrl = server.baseUrl;
+
+        // Server is up before cleanup
+        const before = await fetch(`${baseUrl}/health`);
+        expect([200, 503]).toContain(before.status);
+
+        // Cleanup
+        await server.cleanup();
+
+        // Server should no longer be reachable after cleanup
+        let threw = false;
+        try {
+            await fetch(`${baseUrl}/health`);
+        } catch {
+            threw = true;
+        }
+        expect(threw).toBe(true);
+    }, TEST_TIMEOUT_MS);
+});

--- a/packages/server/tests/harness/server.test.ts
+++ b/packages/server/tests/harness/server.test.ts
@@ -4,12 +4,8 @@
  * These tests verify that createTestServer():
  *   1. Spins up a real HTTP server that responds to requests
  *   2. Pre-creates a user with a working API key
- *   3. Multiple servers can run simultaneously (created sequentially, then accessed concurrently)
- *   4. Cleans up all resources on shutdown
- *
- * NOTE: Servers must be created sequentially (not with Promise.all) because
- * auth.ts and sio-state.ts use module-level singletons. Once created, multiple
- * servers can coexist and respond simultaneously.
+ *   3. Enforces the singleton constraint (second call while one is active throws)
+ *   4. Cleans up all resources on shutdown (no process hang)
  */
 
 import { describe, test, expect } from "bun:test";
@@ -23,8 +19,6 @@ describe("createTestServer", () => {
         const server = await createTestServer();
         try {
             const res = await fetch(`${server.baseUrl}/health`);
-            // Health may be degraded if Redis singletons were overwritten, but
-            // the server must respond with the expected shape.
             expect([200, 503]).toContain(res.status);
             const data = await res.json();
             expect(["ok", "degraded"]).toContain(data.status);
@@ -60,35 +54,35 @@ describe("createTestServer", () => {
         }
     }, TEST_TIMEOUT_MS);
 
-    test("multiple test servers can run concurrently", async () => {
-        // Create servers sequentially (module singletons require serial creation)
-        // then verify they can all respond simultaneously.
-        const s1 = await createTestServer();
-        const s2 = await createTestServer();
-        const s3 = await createTestServer();
-
+    test("singleton guard: creating a second server while one is active throws", async () => {
+        // This test verifies the documented singleton constraint:
+        // auth.ts and sio-state.ts use module-level singletons that cannot
+        // be safely reinitialised while a prior server is still active.
+        const server = await createTestServer();
         try {
-            // All servers should have different ports
-            const ports = new Set([s1.port, s2.port, s3.port]);
-            expect(ports.size).toBe(3);
-
-            // All servers should respond simultaneously (concurrent reads are fine)
-            const responses = await Promise.all([
-                fetch(`${s1.baseUrl}/health`),
-                fetch(`${s2.baseUrl}/health`),
-                fetch(`${s3.baseUrl}/health`),
-            ]);
-
-            for (const res of responses) {
-                expect([200, 503]).toContain(res.status);
-                const data = await res.json();
-                expect(["ok", "degraded"]).toContain(data.status);
+            let threw = false;
+            let errorMessage = "";
+            try {
+                await createTestServer();
+            } catch (err) {
+                threw = true;
+                errorMessage = err instanceof Error ? err.message : String(err);
             }
+            expect(threw).toBe(true);
+            expect(errorMessage).toContain("already active");
         } finally {
-            // Clean up all servers, ignoring individual errors
-            await Promise.allSettled([s1.cleanup(), s2.cleanup(), s3.cleanup()]);
+            await server.cleanup();
         }
-    }, TEST_TIMEOUT_MS * 3);
+
+        // After cleanup the guard is released — a new server should succeed
+        const server2 = await createTestServer();
+        try {
+            const res = await fetch(`${server2.baseUrl}/health`);
+            expect([200, 503]).toContain(res.status);
+        } finally {
+            await server2.cleanup();
+        }
+    }, TEST_TIMEOUT_MS * 2);
 
     test("cleanup shuts down cleanly", async () => {
         const server = await createTestServer();

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -23,7 +23,19 @@ import { tmpdir } from "node:os";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import { Server as SocketIOServer } from "socket.io";
 import { createAdapter } from "@socket.io/redis-adapter";
-import { createClient, type RedisClientType } from "redis";
+// NOTE: We do NOT use a static top-level import of createClient from "redis" here.
+// Several test files in packages/server/src/ws/ call mock.module("redis"), which
+// permanently replaces the "redis" module in Bun's module registry for the entire
+// worker process (Bun 1.3.x does NOT reset mock.module() between test files).
+// If this file were statically bound to the mocked createClient, all harness tests
+// in that worker would fail with "psubscribe/subscribe is not a function" from the
+// Socket.IO Redis adapter constructor.
+//
+// The fix: preload-redis.ts (registered in packages/server/bunfig.toml) runs before
+// any test file is loaded and saves the REAL createClient to globalThis. We retrieve
+// it here at call time, bypassing the later mock. The dynamic import fallback is for
+// cases where the preload is not present (e.g. running a single test file directly).
+import type { RedisClientType, createClient as CreateClientType } from "redis";
 
 import { initAuth, getTrustedOrigins } from "../../src/auth.js";
 import { runAllMigrations } from "../../src/migrations.js";
@@ -189,17 +201,19 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
             await new Promise<void>((resolve) => io!.close(() => resolve())).catch(() => {});
         }
 
-        // Close state Redis
+        // Close state Redis (guard against mock clients that lack .quit())
         if (stateRedisInited) {
             const sr = getStateRedis();
-            if (sr) await sr.quit().catch(() => {});
+            if (sr && typeof (sr as unknown as Record<string, unknown>).quit === "function") {
+                await sr.quit().catch(() => {});
+            }
         }
 
-        // Close pub/sub Redis
+        // Close pub/sub Redis (guard against mock clients that lack .quit())
         if (pubSubConnected) {
             await Promise.allSettled([
-                pubClient?.quit() ?? Promise.resolve(),
-                subClient?.quit() ?? Promise.resolve(),
+                (typeof pubClient?.quit === "function" ? pubClient.quit() : Promise.resolve()),
+                (typeof subClient?.quit === "function" ? subClient.quit() : Promise.resolve()),
             ]);
         }
 
@@ -239,9 +253,20 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
         // 4. Run DB migrations
         await runAllMigrations();
 
-        // 5. Create Redis pub/sub clients and connect them
-        pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
-        subClient = pubClient.duplicate() as RedisClientType;
+        // 5. Create Redis pub/sub clients and connect them.
+        //
+        // Retrieve the real createClient from the preload-saved global, or fall back
+        // to a direct import. The preload (bunfig.toml) runs before any test file and
+        // saves the real function before mock.module("redis") can replace it.
+        //
+        // Use two independent createClient() calls instead of .duplicate(). Some
+        // mock stubs (and some redis client wrappers) lack .duplicate(); two
+        // independent clients are functionally equivalent for the Socket.IO adapter.
+        const _createClient: typeof CreateClientType =
+            (globalThis as Record<string, unknown>).__realRedisCreateClient as typeof CreateClientType
+            ?? (await import("redis") as typeof import("redis")).createClient;
+        pubClient = _createClient({ url: REDIS_URL }) as RedisClientType;
+        subClient = _createClient({ url: REDIS_URL }) as RedisClientType;
         await Promise.all([pubClient.connect(), subClient.connect()]);
         pubSubConnected = true;
 
@@ -390,14 +415,17 @@ export async function createTestServer(opts?: TestServerOptions): Promise<TestSe
             // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
             await new Promise<void>((resolve) => io!.close(() => resolve()));
 
-            // Close state Redis (prevents process hang)
+            // Close state Redis (prevents process hang; guard against mock clients)
             const stateRedis = getStateRedis();
-            if (stateRedis) {
+            if (stateRedis && typeof (stateRedis as unknown as Record<string, unknown>).quit === "function") {
                 await stateRedis.quit().catch(() => {});
             }
 
-            // Disconnect pub/sub Redis clients
-            await Promise.allSettled([pubClient!.quit(), subClient!.quit()]);
+            // Disconnect pub/sub Redis clients (guard against mock clients)
+            await Promise.allSettled([
+                (typeof pubClient?.quit === "function" ? pubClient.quit() : Promise.resolve()),
+                (typeof subClient?.quit === "function" ? subClient.quit() : Promise.resolve()),
+            ]);
 
             // Clean up temp directory
             try {

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -1,0 +1,329 @@
+/**
+ * Test server factory — creates a real PizzaPi server on an ephemeral port
+ * with SQLite + Redis + Socket.IO for integration testing.
+ *
+ * IMPORTANT: createTestServer() uses module-level singletons from auth.ts and
+ * sio-state.ts. Concurrent server creation is NOT supported — create servers
+ * sequentially. Multiple servers can run simultaneously after creation; only
+ * the creation phase must be serialized.
+ */
+
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Server as SocketIOServer } from "socket.io";
+import { createAdapter } from "@socket.io/redis-adapter";
+import { createClient, type RedisClientType } from "redis";
+
+import { initAuth, getTrustedOrigins } from "../../src/auth.js";
+import { runAllMigrations } from "../../src/migrations.js";
+import { handleFetch } from "../../src/handler.js";
+import { initStateRedis } from "../../src/ws/sio-state.js";
+import { initSioRegistry } from "../../src/ws/sio-registry.js";
+import { registerNamespaces } from "../../src/ws/namespaces/index.js";
+
+import type { TestServerOptions, TestServer } from "./types.js";
+
+const REDIS_URL = process.env.PIZZAPI_REDIS_URL ?? "redis://localhost:6379";
+
+// ── Unique IP generator ──────────────────────────────────────────────────────
+// The register rate limiter in routes/auth.ts is a module-level singleton
+// (shared across all test server instances). We generate a unique IP per server
+// so each creation gets its own rate-limit bucket and doesn't collide with others.
+let _serverCounter = 0;
+function uniqueTestClientIp(): string {
+    const n = ++_serverCounter;
+    return `10.255.${Math.floor(n / 256) % 256}.${n % 256}`;
+}
+
+// ── Node req/res ↔ fetch API helpers (mirrors src/index.ts) ─────────────────
+
+async function nodeReqToFetchRequest(req: IncomingMessage, port: number): Promise<Request> {
+    const url = new URL(req.url ?? "/", `http://127.0.0.1:${port}`);
+
+    const headers = new Headers();
+    for (const [key, value] of Object.entries(req.headers)) {
+        if (value === undefined) continue;
+        // Prevent client-supplied x-pizzapi-client-ip spoofing
+        if (key.toLowerCase() === "x-pizzapi-client-ip") continue;
+        if (Array.isArray(value)) {
+            for (const v of value) headers.append(key, v);
+        } else {
+            headers.set(key, value);
+        }
+    }
+
+    // Inject real client IP from the TCP socket
+    if (req.socket.remoteAddress) {
+        headers.set("x-pizzapi-client-ip", req.socket.remoteAddress);
+    }
+
+    const method = (req.method ?? "GET").toUpperCase();
+    const hasBody = method !== "GET" && method !== "HEAD";
+
+    // Pre-buffer the body from the Node.js stream into an ArrayBuffer.
+    //
+    // IMPORTANT: Do NOT pass the IncomingMessage stream directly as the Request
+    // body. handler.ts notes a known Bun issue: when a Request with a
+    // ReadableStream body is subsequently wrapped via `new Request(req, { headers })`
+    // (as the auth handler does), the stream fails to propagate and hangs
+    // indefinitely. Pre-buffering into an ArrayBuffer avoids this entirely.
+    let body: ArrayBuffer | undefined;
+    if (hasBody) {
+        const chunks: Buffer[] = [];
+        for await (const chunk of req) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk as string));
+        }
+        const buf = Buffer.concat(chunks);
+        body = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+    }
+
+    return new Request(url.toString(), {
+        method,
+        headers,
+        body,
+    });
+}
+
+async function sendFetchResponse(res: ServerResponse, response: Response): Promise<void> {
+    const headers: Record<string, string | string[]> = {};
+    response.headers.forEach((value, key) => {
+        const existing = headers[key];
+        if (existing !== undefined) {
+            headers[key] = Array.isArray(existing) ? [...existing, value] : [existing, value];
+        } else {
+            headers[key] = value;
+        }
+    });
+
+    res.writeHead(response.status, headers);
+
+    if (!response.body) {
+        res.end();
+        return;
+    }
+
+    const reader = response.body.getReader();
+    try {
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            res.write(value);
+        }
+    } finally {
+        reader.releaseLock();
+        res.end();
+    }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a fully initialized PizzaPi test server on an ephemeral port.
+ * Includes SQLite DB, Redis, Socket.IO, and a pre-created test user.
+ *
+ * Always call `cleanup()` when done to release all resources.
+ *
+ * NOTE: Uses module-level singletons (auth, sio-state). Do NOT call this
+ * concurrently — create servers sequentially to avoid race conditions.
+ */
+export async function createTestServer(opts?: TestServerOptions): Promise<TestServer> {
+    // 1. Temp directory for the SQLite DB
+    const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
+    const dbPath = join(tmpDir, "test.db");
+
+    // 2. Trust proxy for rate-limit tests (mirrors production behavior)
+    const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
+    process.env.PIZZAPI_TRUST_PROXY = "true";
+
+    // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
+    // that better-auth uses only for cookie domain (not for actual listening).
+    // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
+    const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
+
+    // 3. Init auth with temp DB
+    initAuth({
+        dbPath,
+        baseURL: placeholderBase,
+        secret: "test-secret-for-harness-at-least-32-chars-long!!",
+        disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
+        extraOrigins: opts?.trustedOrigins,
+    });
+
+    // 4. Run DB migrations
+    await runAllMigrations();
+
+    // 5. Create Redis pub/sub clients and connect them
+    const pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
+    const subClient = pubClient.duplicate() as RedisClientType;
+    await Promise.all([pubClient.connect(), subClient.connect()]);
+
+    // 6. We'll track the resolved port for the request converter
+    let resolvedPort = 0;
+
+    // Create the HTTP server with the handleFetch handler
+    const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+        try {
+            const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
+            const fetchRes = await handleFetch(fetchReq);
+            await sendFetchResponse(res, fetchRes);
+        } catch (e) {
+            console.error("[test-harness] Unhandled error:", e);
+            if (!res.headersSent) {
+                res.writeHead(500, { "content-type": "application/json" });
+            }
+            res.end(JSON.stringify({ error: "Internal server error" }));
+        }
+    });
+
+    // 7. Create Socket.IO server with Redis adapter
+    const io = new SocketIOServer(httpServer, {
+        cors: {
+            origin: getTrustedOrigins(),
+            credentials: true,
+        },
+        maxHttpBufferSize: 100 * 1024 * 1024,
+        pingInterval: 30_000,
+        pingTimeout: 60_000,
+        adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
+        transports: ["websocket", "polling"],
+    });
+
+    // 8. Init state Redis
+    await initStateRedis();
+
+    // 9. Init the Socket.IO registry
+    initSioRegistry(io);
+
+    // 10. Register all namespaces
+    registerNamespaces(io);
+
+    // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+
+    const addr = httpServer.address();
+    if (!addr || typeof addr === "string") {
+        throw new Error("[test-harness] Could not determine server port");
+    }
+    resolvedPort = addr.port;
+
+    // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
+    const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
+
+    // 12. Create a test user via the /api/register endpoint.
+    //     Use a unique client IP per server instance so each registration gets its
+    //     own rate-limit bucket in the module-level registerRateLimiter singleton.
+    const testUserName = "Test User";
+    const testUserEmail = "testuser@pizzapi-harness.test";
+    const testUserPassword = "HarnessPass123";
+    const testClientIp = uniqueTestClientIp();
+
+    const registerRes = await fetch(`${baseUrl}/api/register`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            // Unique x-forwarded-for per server so the rate limiter assigns a
+            // separate bucket for each test server creation.
+            "x-forwarded-for": testClientIp,
+        },
+        body: JSON.stringify({
+            name: testUserName,
+            email: testUserEmail,
+            password: testUserPassword,
+        }),
+    });
+
+    if (!registerRes.ok) {
+        throw new Error(
+            `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+        );
+    }
+
+    const registerData = await registerRes.json() as { ok: boolean; key: string };
+    const apiKey = registerData.key;
+
+    // 13. Get a session cookie via better-auth sign-in.
+    //     The sign-in response includes the user object (with id) and Set-Cookie header.
+    const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
+        method: "POST",
+        headers: {
+            "content-type": "application/json",
+            "x-forwarded-for": testClientIp,
+        },
+        body: JSON.stringify({
+            email: testUserEmail,
+            password: testUserPassword,
+        }),
+    });
+
+    if (!signInRes.ok) {
+        throw new Error(
+            `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
+        );
+    }
+
+    const signInData = await signInRes.json() as { user?: { id: string } };
+    const userId = signInData.user?.id ?? "";
+    if (!userId) {
+        throw new Error("[test-harness] Could not get userId from sign-in response");
+    }
+
+    const cookies = signInRes.headers.getSetCookie();
+    const sessionCookie = cookies.join("; ");
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    async function testFetch(path: string, init?: RequestInit): Promise<Response> {
+        const url = `${baseUrl}${path}`;
+        const headers = new Headers(init?.headers);
+
+        // Inject auth headers if not already present
+        if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
+            headers.set("x-pizzapi-api-key", apiKey);
+        }
+        if (!headers.has("cookie") && sessionCookie) {
+            headers.set("cookie", sessionCookie);
+        }
+
+        return fetch(url, { ...init, headers });
+    }
+
+    // ── Cleanup ──────────────────────────────────────────────────────────────
+
+    async function cleanup(): Promise<void> {
+        // Restore PIZZAPI_TRUST_PROXY
+        if (savedTrustProxy === undefined) {
+            delete process.env.PIZZAPI_TRUST_PROXY;
+        } else {
+            process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+        }
+
+        // Close Socket.IO — this also closes the underlying httpServer internally,
+        // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
+        await new Promise<void>((resolve) => io.close(() => resolve()));
+
+        // Disconnect Redis clients
+        await Promise.allSettled([pubClient.quit(), subClient.quit()]);
+
+        // Clean up temp directory
+        try {
+            rmSync(tmpDir, { recursive: true, force: true });
+        } catch {
+            // Ignore cleanup errors
+        }
+    }
+
+    return {
+        port: resolvedPort,
+        baseUrl,
+        io,
+        apiKey,
+        userId,
+        userName: testUserName,
+        userEmail: testUserEmail,
+        sessionCookie,
+        fetch: testFetch,
+        cleanup,
+    };
+}

--- a/packages/server/tests/harness/server.ts
+++ b/packages/server/tests/harness/server.ts
@@ -2,10 +2,19 @@
  * Test server factory — creates a real PizzaPi server on an ephemeral port
  * with SQLite + Redis + Socket.IO for integration testing.
  *
- * IMPORTANT: createTestServer() uses module-level singletons from auth.ts and
- * sio-state.ts. Concurrent server creation is NOT supported — create servers
- * sequentially. Multiple servers can run simultaneously after creation; only
- * the creation phase must be serialized.
+ * SINGLETON CONSTRAINT: Only ONE TestServer may be active at a time.
+ * PizzaPi's auth.ts and sio-state.ts use module-level singletons that cannot
+ * be shared or re-initialized across concurrent instances. Attempting to call
+ * createTestServer() while a previous server is still active will throw.
+ *
+ * Intended usage pattern:
+ *
+ *   describe("my suite", () => {
+ *     let server: TestServer;
+ *     beforeAll(async () => { server = await createTestServer(); });
+ *     afterAll(async () => { await server.cleanup(); });
+ *     // ... tests ...
+ *   });
  */
 
 import { mkdtempSync, rmSync } from "node:fs";
@@ -19,13 +28,27 @@ import { createClient, type RedisClientType } from "redis";
 import { initAuth, getTrustedOrigins } from "../../src/auth.js";
 import { runAllMigrations } from "../../src/migrations.js";
 import { handleFetch } from "../../src/handler.js";
-import { initStateRedis } from "../../src/ws/sio-state.js";
+import { initStateRedis, getStateRedis } from "../../src/ws/sio-state.js";
 import { initSioRegistry } from "../../src/ws/sio-registry.js";
 import { registerNamespaces } from "../../src/ws/namespaces/index.js";
 
 import type { TestServerOptions, TestServer } from "./types.js";
 
 const REDIS_URL = process.env.PIZZAPI_REDIS_URL ?? "redis://localhost:6379";
+
+// ── Singleton guard ──────────────────────────────────────────────────────────
+// auth.ts and sio-state.ts hold module-level singletons. Re-initializing them
+// while a previous TestServer is active causes the older server to operate
+// against the newer globals, producing SQLiteError disk I/O errors when the
+// newer server's temp DB is removed on cleanup.
+let _activeServer = false;
+
+// ── Module-level env capture ─────────────────────────────────────────────────
+// Capture PIZZAPI_TRUST_PROXY at module load (once) so that cleanup() always
+// restores the genuine pre-test value — not an intermediate value written by
+// a previous createTestServer() call. Per-server save/restore would drift if
+// cleanup order ever diverged from creation order.
+const _originalTrustProxy: string | undefined = process.env.PIZZAPI_TRUST_PROXY;
 
 // ── Unique IP generator ──────────────────────────────────────────────────────
 // The register rate limiter in routes/auth.ts is a module-level singleton
@@ -125,205 +148,282 @@ async function sendFetchResponse(res: ServerResponse, response: Response): Promi
  *
  * Always call `cleanup()` when done to release all resources.
  *
- * NOTE: Uses module-level singletons (auth, sio-state). Do NOT call this
- * concurrently — create servers sequentially to avoid race conditions.
+ * SINGLETON: Only one TestServer may be active at a time. Calling this while
+ * a previous server is still running throws immediately. Call cleanup() on the
+ * existing server first.
  */
 export async function createTestServer(opts?: TestServerOptions): Promise<TestServer> {
-    // 1. Temp directory for the SQLite DB
-    const tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
-    const dbPath = join(tmpDir, "test.db");
-
-    // 2. Trust proxy for rate-limit tests (mirrors production behavior)
-    const savedTrustProxy = process.env.PIZZAPI_TRUST_PROXY;
-    process.env.PIZZAPI_TRUST_PROXY = "true";
-
-    // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
-    // that better-auth uses only for cookie domain (not for actual listening).
-    // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
-    const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
-
-    // 3. Init auth with temp DB
-    initAuth({
-        dbPath,
-        baseURL: placeholderBase,
-        secret: "test-secret-for-harness-at-least-32-chars-long!!",
-        disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
-        extraOrigins: opts?.trustedOrigins,
-    });
-
-    // 4. Run DB migrations
-    await runAllMigrations();
-
-    // 5. Create Redis pub/sub clients and connect them
-    const pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
-    const subClient = pubClient.duplicate() as RedisClientType;
-    await Promise.all([pubClient.connect(), subClient.connect()]);
-
-    // 6. We'll track the resolved port for the request converter
-    let resolvedPort = 0;
-
-    // Create the HTTP server with the handleFetch handler
-    const httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
-        try {
-            const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
-            const fetchRes = await handleFetch(fetchReq);
-            await sendFetchResponse(res, fetchRes);
-        } catch (e) {
-            console.error("[test-harness] Unhandled error:", e);
-            if (!res.headersSent) {
-                res.writeHead(500, { "content-type": "application/json" });
-            }
-            res.end(JSON.stringify({ error: "Internal server error" }));
-        }
-    });
-
-    // 7. Create Socket.IO server with Redis adapter
-    const io = new SocketIOServer(httpServer, {
-        cors: {
-            origin: getTrustedOrigins(),
-            credentials: true,
-        },
-        maxHttpBufferSize: 100 * 1024 * 1024,
-        pingInterval: 30_000,
-        pingTimeout: 60_000,
-        adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
-        transports: ["websocket", "polling"],
-    });
-
-    // 8. Init state Redis
-    await initStateRedis();
-
-    // 9. Init the Socket.IO registry
-    initSioRegistry(io);
-
-    // 10. Register all namespaces
-    registerNamespaces(io);
-
-    // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
-    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
-
-    const addr = httpServer.address();
-    if (!addr || typeof addr === "string") {
-        throw new Error("[test-harness] Could not determine server port");
-    }
-    resolvedPort = addr.port;
-
-    // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
-    const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
-
-    // 12. Create a test user via the /api/register endpoint.
-    //     Use a unique client IP per server instance so each registration gets its
-    //     own rate-limit bucket in the module-level registerRateLimiter singleton.
-    const testUserName = "Test User";
-    const testUserEmail = "testuser@pizzapi-harness.test";
-    const testUserPassword = "HarnessPass123";
-    const testClientIp = uniqueTestClientIp();
-
-    const registerRes = await fetch(`${baseUrl}/api/register`, {
-        method: "POST",
-        headers: {
-            "content-type": "application/json",
-            // Unique x-forwarded-for per server so the rate limiter assigns a
-            // separate bucket for each test server creation.
-            "x-forwarded-for": testClientIp,
-        },
-        body: JSON.stringify({
-            name: testUserName,
-            email: testUserEmail,
-            password: testUserPassword,
-        }),
-    });
-
-    if (!registerRes.ok) {
+    // ── Singleton guard ──────────────────────────────────────────────────────
+    if (_activeServer) {
         throw new Error(
-            `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+            "[test-harness] A TestServer is already active. " +
+            "Call cleanup() on the existing server before creating another. " +
+            "auth.ts and sio-state.ts use module-level singletons that cannot " +
+            "be shared across concurrent TestServer instances.",
         );
     }
+    _activeServer = true;
 
-    const registerData = await registerRes.json() as { ok: boolean; key: string };
-    const apiKey = registerData.key;
+    // ── Setup with rollback on failure ───────────────────────────────────────
+    // Track resources opened so far so we can close them if setup throws.
+    let tmpDir: string | null = null;
+    let pubClient: RedisClientType | null = null;
+    let subClient: RedisClientType | null = null;
+    let pubSubConnected = false;
+    let httpServer: ReturnType<typeof createServer> | null = null;
+    let io: SocketIOServer | null = null;
+    let stateRedisInited = false;
 
-    // 13. Get a session cookie via better-auth sign-in.
-    //     The sign-in response includes the user object (with id) and Set-Cookie header.
-    const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
-        method: "POST",
-        headers: {
-            "content-type": "application/json",
-            "x-forwarded-for": testClientIp,
-        },
-        body: JSON.stringify({
-            email: testUserEmail,
-            password: testUserPassword,
-        }),
-    });
+    async function rollback(): Promise<void> {
+        _activeServer = false;
 
-    if (!signInRes.ok) {
-        throw new Error(
-            `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
-        );
-    }
-
-    const signInData = await signInRes.json() as { user?: { id: string } };
-    const userId = signInData.user?.id ?? "";
-    if (!userId) {
-        throw new Error("[test-harness] Could not get userId from sign-in response");
-    }
-
-    const cookies = signInRes.headers.getSetCookie();
-    const sessionCookie = cookies.join("; ");
-
-    // ── Helpers ──────────────────────────────────────────────────────────────
-
-    async function testFetch(path: string, init?: RequestInit): Promise<Response> {
-        const url = `${baseUrl}${path}`;
-        const headers = new Headers(init?.headers);
-
-        // Inject auth headers if not already present
-        if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
-            headers.set("x-pizzapi-api-key", apiKey);
-        }
-        if (!headers.has("cookie") && sessionCookie) {
-            headers.set("cookie", sessionCookie);
-        }
-
-        return fetch(url, { ...init, headers });
-    }
-
-    // ── Cleanup ──────────────────────────────────────────────────────────────
-
-    async function cleanup(): Promise<void> {
-        // Restore PIZZAPI_TRUST_PROXY
-        if (savedTrustProxy === undefined) {
+        // Restore env (use the module-level original, not a per-server snapshot)
+        if (_originalTrustProxy === undefined) {
             delete process.env.PIZZAPI_TRUST_PROXY;
         } else {
-            process.env.PIZZAPI_TRUST_PROXY = savedTrustProxy;
+            process.env.PIZZAPI_TRUST_PROXY = _originalTrustProxy;
         }
 
-        // Close Socket.IO — this also closes the underlying httpServer internally,
-        // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
-        await new Promise<void>((resolve) => io.close(() => resolve()));
+        // Close Socket.IO (also closes httpServer)
+        if (io) {
+            await new Promise<void>((resolve) => io!.close(() => resolve())).catch(() => {});
+        }
 
-        // Disconnect Redis clients
-        await Promise.allSettled([pubClient.quit(), subClient.quit()]);
+        // Close state Redis
+        if (stateRedisInited) {
+            const sr = getStateRedis();
+            if (sr) await sr.quit().catch(() => {});
+        }
+
+        // Close pub/sub Redis
+        if (pubSubConnected) {
+            await Promise.allSettled([
+                pubClient?.quit() ?? Promise.resolve(),
+                subClient?.quit() ?? Promise.resolve(),
+            ]);
+        }
 
         // Clean up temp directory
-        try {
-            rmSync(tmpDir, { recursive: true, force: true });
-        } catch {
-            // Ignore cleanup errors
+        if (tmpDir) {
+            try {
+                rmSync(tmpDir, { recursive: true, force: true });
+            } catch {
+                // ignore
+            }
         }
     }
 
-    return {
-        port: resolvedPort,
-        baseUrl,
-        io,
-        apiKey,
-        userId,
-        userName: testUserName,
-        userEmail: testUserEmail,
-        sessionCookie,
-        fetch: testFetch,
-        cleanup,
-    };
+    try {
+        // 1. Temp directory for the SQLite DB
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-test-"));
+        const dbPath = join(tmpDir, "test.db");
+
+        // 2. Trust proxy for rate-limit tests (mirrors production behavior).
+        //    Set process-wide; cleanup() will restore _originalTrustProxy.
+        process.env.PIZZAPI_TRUST_PROXY = "true";
+
+        // We need a placeholder baseURL for initAuth. We'll use a temp placeholder
+        // that better-auth uses only for cookie domain (not for actual listening).
+        // Using http://127.0.0.1 avoids port-0 issues and works for cookie matching.
+        const placeholderBase = opts?.baseUrl ?? "http://127.0.0.1";
+
+        // 3. Init auth with temp DB
+        initAuth({
+            dbPath,
+            baseURL: placeholderBase,
+            secret: "test-secret-for-harness-at-least-32-chars-long!!",
+            disableSignupAfterFirstUser: opts?.disableSignupAfterFirstUser ?? true,
+            extraOrigins: opts?.trustedOrigins,
+        });
+
+        // 4. Run DB migrations
+        await runAllMigrations();
+
+        // 5. Create Redis pub/sub clients and connect them
+        pubClient = createClient({ url: REDIS_URL }) as RedisClientType;
+        subClient = pubClient.duplicate() as RedisClientType;
+        await Promise.all([pubClient.connect(), subClient.connect()]);
+        pubSubConnected = true;
+
+        // 6. We'll track the resolved port for the request converter
+        let resolvedPort = 0;
+
+        // Create the HTTP server with the handleFetch handler
+        httpServer = createServer(async (req: IncomingMessage, res: ServerResponse) => {
+            try {
+                const fetchReq = await nodeReqToFetchRequest(req, resolvedPort);
+                const fetchRes = await handleFetch(fetchReq);
+                await sendFetchResponse(res, fetchRes);
+            } catch (e) {
+                console.error("[test-harness] Unhandled error:", e);
+                if (!res.headersSent) {
+                    res.writeHead(500, { "content-type": "application/json" });
+                }
+                res.end(JSON.stringify({ error: "Internal server error" }));
+            }
+        });
+
+        // 7. Create Socket.IO server with Redis adapter
+        io = new SocketIOServer(httpServer, {
+            cors: {
+                origin: getTrustedOrigins(),
+                credentials: true,
+            },
+            maxHttpBufferSize: 100 * 1024 * 1024,
+            pingInterval: 30_000,
+            pingTimeout: 60_000,
+            adapter: createAdapter(pubClient, subClient, { key: "pizzapi-sio-test" }),
+            transports: ["websocket", "polling"],
+        });
+
+        // 8. Init state Redis
+        await initStateRedis();
+        stateRedisInited = true;
+
+        // 9. Init the Socket.IO registry
+        initSioRegistry(io);
+
+        // 10. Register all namespaces
+        registerNamespaces(io);
+
+        // 11. Listen on port 0 (OS assigns an ephemeral port) on IPv4 loopback
+        await new Promise<void>((resolve) => httpServer!.listen(0, "127.0.0.1", resolve));
+
+        const addr = httpServer.address();
+        if (!addr || typeof addr === "string") {
+            throw new Error("[test-harness] Could not determine server port");
+        }
+        resolvedPort = addr.port;
+
+        // Use 127.0.0.1 explicitly (not localhost) to avoid IPv6 resolution on macOS
+        const baseUrl = opts?.baseUrl ?? `http://127.0.0.1:${resolvedPort}`;
+
+        // 12. Create a test user via the /api/register endpoint.
+        //     Use a unique client IP per server instance so each registration gets its
+        //     own rate-limit bucket in the module-level registerRateLimiter singleton.
+        const testUserName = "Test User";
+        const testUserEmail = "testuser@pizzapi-harness.test";
+        const testUserPassword = "HarnessPass123";
+        const testClientIp = uniqueTestClientIp();
+
+        const registerRes = await fetch(`${baseUrl}/api/register`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                // Unique x-forwarded-for per server so the rate limiter assigns a
+                // separate bucket for each test server creation.
+                "x-forwarded-for": testClientIp,
+            },
+            body: JSON.stringify({
+                name: testUserName,
+                email: testUserEmail,
+                password: testUserPassword,
+            }),
+        });
+
+        if (!registerRes.ok) {
+            throw new Error(
+                `[test-harness] Failed to create test user: ${registerRes.status} ${await registerRes.text()}`,
+            );
+        }
+
+        const registerData = await registerRes.json() as { ok: boolean; key: string };
+        const apiKey = registerData.key;
+
+        // 13. Get a session cookie via better-auth sign-in.
+        //     The sign-in response includes the user object (with id) and Set-Cookie header.
+        const signInRes = await fetch(`${baseUrl}/api/auth/sign-in/email`, {
+            method: "POST",
+            headers: {
+                "content-type": "application/json",
+                "x-forwarded-for": testClientIp,
+            },
+            body: JSON.stringify({
+                email: testUserEmail,
+                password: testUserPassword,
+            }),
+        });
+
+        if (!signInRes.ok) {
+            throw new Error(
+                `[test-harness] Failed to sign in test user: ${signInRes.status} ${await signInRes.text()}`,
+            );
+        }
+
+        const signInData = await signInRes.json() as { user?: { id: string } };
+        const userId = signInData.user?.id ?? "";
+        if (!userId) {
+            throw new Error("[test-harness] Could not get userId from sign-in response");
+        }
+
+        const cookies = signInRes.headers.getSetCookie();
+        const sessionCookie = cookies.join("; ");
+
+        // ── Helpers ──────────────────────────────────────────────────────────────
+
+        async function testFetch(path: string, init?: RequestInit): Promise<Response> {
+            const url = `${baseUrl}${path}`;
+            const headers = new Headers(init?.headers);
+
+            // Inject auth headers if not already present
+            if (!headers.has("x-pizzapi-api-key") && !headers.has("x-api-key")) {
+                headers.set("x-pizzapi-api-key", apiKey);
+            }
+            if (!headers.has("cookie") && sessionCookie) {
+                headers.set("cookie", sessionCookie);
+            }
+
+            return fetch(url, { ...init, headers });
+        }
+
+        // ── Cleanup ──────────────────────────────────────────────────────────────
+
+        async function cleanup(): Promise<void> {
+            // Restore PIZZAPI_TRUST_PROXY to the original pre-test value
+            if (_originalTrustProxy === undefined) {
+                delete process.env.PIZZAPI_TRUST_PROXY;
+            } else {
+                process.env.PIZZAPI_TRUST_PROXY = _originalTrustProxy;
+            }
+
+            // Close Socket.IO — this also closes the underlying httpServer internally,
+            // so we do NOT call httpServer.close() separately (it would throw ERR_SERVER_NOT_RUNNING).
+            await new Promise<void>((resolve) => io!.close(() => resolve()));
+
+            // Close state Redis (prevents process hang)
+            const stateRedis = getStateRedis();
+            if (stateRedis) {
+                await stateRedis.quit().catch(() => {});
+            }
+
+            // Disconnect pub/sub Redis clients
+            await Promise.allSettled([pubClient!.quit(), subClient!.quit()]);
+
+            // Clean up temp directory
+            try {
+                rmSync(tmpDir!, { recursive: true, force: true });
+            } catch {
+                // Ignore cleanup errors
+            }
+
+            // Release the singleton guard so a new TestServer can be created
+            _activeServer = false;
+        }
+
+        return {
+            port: resolvedPort,
+            baseUrl,
+            io,
+            apiKey,
+            userId,
+            userName: testUserName,
+            userEmail: testUserEmail,
+            sessionCookie,
+            fetch: testFetch,
+            cleanup,
+        };
+    } catch (err) {
+        await rollback();
+        throw err;
+    }
 }

--- a/packages/server/tests/harness/types.ts
+++ b/packages/server/tests/harness/types.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared types for the test server harness.
+ */
+
+export interface TestServerOptions {
+    /** Override base URL (default: auto from port) */
+    baseUrl?: string;
+    /** Extra trusted origins for CORS */
+    trustedOrigins?: string[];
+    /** Disable signup-after-first-user restriction (default: true = disabled) */
+    disableSignupAfterFirstUser?: boolean;
+}
+
+export interface TestServer {
+    /** Ephemeral port the server is listening on */
+    port: number;
+    /** Base URL: http://localhost:{port} */
+    baseUrl: string;
+    /** The Socket.IO server instance */
+    io: import("socket.io").Server;
+    /** Pre-created API key for auth */
+    apiKey: string;
+    /** Pre-created test user's ID */
+    userId: string;
+    /** Pre-created test user's name */
+    userName: string;
+    /** Pre-created test user's email */
+    userEmail: string;
+    /** Auth session cookie string for viewer/hub namespaces */
+    sessionCookie: string;
+    /** Helper: make an authenticated REST request */
+    fetch(path: string, init?: RequestInit): Promise<Response>;
+    /** Shut down everything and clean up */
+    cleanup(): Promise<void>;
+}

--- a/packages/server/tests/harness/types.ts
+++ b/packages/server/tests/harness/types.ts
@@ -33,3 +33,74 @@ export interface TestServer {
     /** Shut down everything and clean up */
     cleanup(): Promise<void>;
 }
+
+// ── MockRelay types ──────────────────────────────────────────────────────────
+
+import type { Socket as ClientSocket } from "socket.io-client";
+
+export interface MockRelayOptions {
+    // Future options
+}
+
+export interface MockRelaySession {
+    sessionId: string;
+    token: string;
+    shareUrl: string;
+}
+
+export interface MockRelay {
+    socket: ClientSocket;
+
+    /** Register a new session. Returns { sessionId, token, shareUrl } */
+    registerSession(opts?: {
+        sessionId?: string;
+        cwd?: string;
+        ephemeral?: boolean;
+        collabMode?: boolean;
+        sessionName?: string | null;
+        parentSessionId?: string | null;
+    }): Promise<MockRelaySession>;
+
+    /** Send an agent event through the relay */
+    emitEvent(sessionId: string, token: string, event: unknown, seq?: number): void;
+
+    /** Signal session end */
+    emitSessionEnd(sessionId: string, token: string): void;
+
+    /** Fire a session trigger (child → parent) */
+    emitTrigger(data: {
+        token: string;
+        trigger: {
+            type: string;
+            sourceSessionId: string;
+            targetSessionId: string;
+            payload: Record<string, unknown>;
+            deliverAs: "steer" | "followUp";
+            expectsResponse: boolean;
+            triggerId: string;
+            ts: string;
+        };
+    }): void;
+
+    /** Fire a trigger response (parent → child) */
+    emitTriggerResponse(data: {
+        token: string;
+        triggerId: string;
+        response: string;
+        action?: string;
+        targetSessionId: string;
+    }): void;
+
+    /** Send an inter-session message */
+    emitSessionMessage(data: {
+        token: string;
+        targetSessionId: string;
+        message: string;
+        deliverAs?: "input";
+    }): void;
+
+    /** Wait for a specific event */
+    waitForEvent(eventName: string, timeout?: number): Promise<unknown>;
+
+    disconnect(): Promise<void>;
+}


### PR DESCRIPTION
Night Shift dish 005: TestScenario fluent builder + 6 integration test suites demonstrating the full harness.

## Summary

### `packages/server/tests/harness/scenario.ts` — TestScenario builder
- Fluent API: `setup()`, `setServer()`, `addRunner()`, `addSession()`, `addViewer()`, `addHub()`
- `sendConversation(index, turns)` helper using builders
- `reset()` for per-test component cleanup without server teardown  
- `teardown()` for full cleanup (with `closeAllConnections` to prevent hangs)
- **Key design**: relay sockets use `forceNew: true` via `createIsolatedRelay` to prevent socket.io Manager sharing with hub sockets (which causes indefinite connection hang)

### `packages/server/tests/harness/integration.test.ts` — 6 integration suites, 16 tests
- Shared server for all tests (singleton constraint), per-test scenario cleanup
- Relay Redis cache warmup in `beforeAll` (first relay triggers async initialization)
- Suite 1: Full session lifecycle — relay/viewer event flow, session end, viewer notified
- Suite 2: Multi-runner environment — REST visibility, session isolation, hub session tracking + removal
- Suite 3: Conversation replay — sendResync delivers stored events, early viewer, conversation flow
- Suite 4: Inter-session messaging — triggers, parent-child session relationships
- Suite 5: Session meta state — buildTodoList/buildMetaState, heartbeat→hub session_status
- Suite 6: Concurrent registerSession — concurrent addSession, hub sees 3 sessions, serial lock

### `packages/server/tests/harness/index.ts` — barrel updated
- Added `export * from './scenario.js'`