### PR TITLE
fix(ui): improve Usage Dashboard hover states and data viz

### DIFF
--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -14,7 +14,7 @@
 
 import { execFileSync, spawn } from "child_process";
 import { createECDH, createHash, randomBytes } from "crypto";
-import { existsSync, mkdirSync, writeFileSync, readFileSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 
@@ -577,16 +577,23 @@ services:
 
 // ─── Host-side UI pre-build ──────────────────────────────────────────────────
 
+export interface PrebuildResult {
+    /** Whether a pre-built dist/ is ready for Docker to copy */
+    prebuilt: boolean;
+    /** Whether a build was actually performed (vs. cache hit) */
+    rebuilt: boolean;
+}
+
 /**
  * Attempt to build the UI on the host using bun (native speed, ~15s) instead
- * of inside Docker (minutes on Docker Desktop VMs).  Returns true if the
- * pre-built dist is ready in `repoPath/packages/ui/dist`.
+ * of inside Docker (minutes on Docker Desktop VMs).  Returns a result object
+ * indicating whether the dist is ready and whether a rebuild occurred.
  *
- * Gracefully falls back to false (Docker will build it) when:
+ * Gracefully falls back to { prebuilt: false } when:
  *   - `bun` is not on PATH (e.g. npm-installed binary without bun)
  *   - `bun install` or `bun run build` fails for any reason
  */
-function prebuildUI(repoPath: string): boolean {
+function prebuildUI(repoPath: string): PrebuildResult {
     const uiDist = join(repoPath, "packages", "ui", "dist");
     const uiDistIndex = join(uiDist, "index.html");
     const nodeModulesPath = join(repoPath, "node_modules");
@@ -596,7 +603,7 @@ function prebuildUI(repoPath: string): boolean {
         execFileSync("bun", ["--version"], { stdio: "ignore" });
     } catch {
         console.log("bun not found on host — UI will be built inside Docker (slower).");
-        return false;
+        return { prebuilt: false, rebuilt: false };
     }
 
     console.log("Pre-building UI on host for faster Docker build...");
@@ -630,7 +637,16 @@ function prebuildUI(repoPath: string): boolean {
         if (!needsUiBuild && distReady) {
             console.log("  Host UI build is up to date (reusing dist/).");
             if (stateDirty) saveHostBuildState(state);
-            return true;
+            return { prebuilt: true, rebuilt: false };
+        }
+
+        // Explicitly clean dist/ before building to prevent stale artifacts.
+        // Vite's emptyOutDir should handle this, but on macOS Docker Desktop
+        // the filesystem bridge (virtiofs/gRPC-FUSE) can miss subtle changes.
+        // Belt-and-suspenders: nuke it ourselves.
+        if (existsSync(uiDist)) {
+            console.log("  Cleaning old dist/...");
+            rmSync(uiDist, { recursive: true, force: true });
         }
 
         console.log("  Building protocol...");
@@ -640,23 +656,44 @@ function prebuildUI(repoPath: string): boolean {
         execFileSync("bun", ["run", "build:ui"], { cwd: repoPath, stdio: "inherit" });
 
         if (existsSync(uiDistIndex)) {
+            // Write a cache-busting stamp so Docker's COPY layer always
+            // detects the rebuild, even if Vite produced byte-identical output.
+            writeBuildStamp(uiDist);
+
             console.log("  ✓ UI pre-built successfully.");
             if (uiSignature) {
                 state.lastUiSignature = uiSignature;
                 stateDirty = true;
             }
             if (stateDirty) saveHostBuildState(state);
-            return true;
+            return { prebuilt: true, rebuilt: true };
         }
     } catch (err) {
         console.warn("Warning: Host UI build failed, falling back to Docker build.");
         if (err instanceof Error) console.warn(`  ${err.message}`);
         if (stateDirty) saveHostBuildState(state);
-        return false;
+        return { prebuilt: false, rebuilt: false };
     }
 
     if (stateDirty) saveHostBuildState(state);
-    return false;
+    return { prebuilt: false, rebuilt: false };
+}
+
+/**
+ * Write a `.build-stamp` file into dist/ with a unique timestamp.
+ * This ensures Docker BuildKit's content-based COPY cache always detects
+ * a change when the host prebuild actually ran, even if the Vite output
+ * is byte-identical (e.g. only whitespace/comment changes).
+ */
+function writeBuildStamp(distDir: string): void {
+    try {
+        writeFileSync(
+            join(distDir, ".build-stamp"),
+            JSON.stringify({ builtAt: new Date().toISOString(), pid: process.pid }) + "\n"
+        );
+    } catch {
+        // Non-fatal — Docker will still detect most changes without it
+    }
 }
 
 function generateComposeFile(repoPath: string, config: WebConfig, prebuiltUi: boolean): string {
@@ -1006,16 +1043,25 @@ export async function runWeb(args: string[]): Promise<void> {
     }
 
     // Pre-build UI on the host for much faster Docker builds when enabled.
-    const prebuiltUi = useHostPrebuild ? prebuildUI(repoPath) : false;
-    const composePath = generateComposeFile(repoPath, config, prebuiltUi);
+    const prebuildResult: PrebuildResult = useHostPrebuild
+        ? prebuildUI(repoPath)
+        : { prebuilt: false, rebuilt: false };
+    const composePath = generateComposeFile(repoPath, config, prebuildResult.prebuilt);
 
     console.log(`Starting PizzaPi web on port ${config.port}...`);
     console.log(`  Repo:    ${repoPath}`);
     console.log(`  Config:  ${CONFIG_PATH}`);
     console.log();
 
+    // When the host prebuild actually rebuilt, force-recreate containers so
+    // Docker picks up the new image even if BuildKit's layer cache didn't
+    // detect the change (common on macOS Docker Desktop with virtiofs).
+    const forceRecreate = prebuildResult.rebuilt;
+
     if (parsed.detach) {
-        await composeExecAsync(composePath, ["up", "-d", "--build"]);
+        const upArgs = ["up", "-d", "--build"];
+        if (forceRecreate) upArgs.push("--force-recreate");
+        await composeExecAsync(composePath, upArgs);
         console.log();
         console.log(`✅ PizzaPi web is running at http://localhost:${config.port}`);
         console.log();
@@ -1024,6 +1070,8 @@ export async function runWeb(args: string[]): Promise<void> {
         console.log("  pizza web stop      Stop the hub");
         console.log("  pizza web config    View configuration");
     } else {
-        await composeExecAsync(composePath, ["up", "--build"]);
+        const upArgs = ["up", "--build"];
+        if (forceRecreate) upArgs.push("--force-recreate");
+        await composeExecAsync(composePath, upArgs);
     }
 }

--- a/packages/ui/src/components/usage-dashboard/CostChart.tsx
+++ b/packages/ui/src/components/usage-dashboard/CostChart.tsx
@@ -40,7 +40,7 @@ function CustomTooltip({ active, payload, label }: any) {
           <span style={{ fontVariantNumeric: "tabular-nums" }}>{formatCurrency(p.value)}</span>
         </div>
       ))}
-      <div style={{ borderTop: "1px solid hsl(var(--border))", marginTop: "4px", paddingTop: "4px", display: "flex", justifyContent: "space-between", fontWeight: 600, ...tooltipItemStyle }}>
+      <div style={{ borderTop: "1px solid var(--border)", marginTop: "4px", paddingTop: "4px", display: "flex", justifyContent: "space-between", fontWeight: 600, ...tooltipItemStyle }}>
         <span>Total</span>
         <span style={{ fontVariantNumeric: "tabular-nums" }}>{formatCurrency(total)}</span>
       </div>
@@ -77,12 +77,12 @@ export function CostChart({ daily }: CostChartProps) {
             <XAxis
               dataKey="date"
               className="text-xs"
-              tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
               tickFormatter={formatDate}
             />
             <YAxis
               className="text-xs"
-              tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
               tickFormatter={formatCurrency}
             />
             <Tooltip

--- a/packages/ui/src/components/usage-dashboard/CostChart.tsx
+++ b/packages/ui/src/components/usage-dashboard/CostChart.tsx
@@ -10,27 +10,42 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  COST_COLORS,
+  tooltipContentStyle,
+  tooltipLabelStyle,
+  tooltipItemStyle,
+  formatCurrency,
+  formatDate,
+  chartCursorStyle,
+} from "./chart-theme";
 import type { UsageData } from "./types";
 
 interface CostChartProps {
   daily: UsageData["daily"];
 }
 
-const colors = {
-  input: "#3b82f6",
-  output: "#ef4444",
-  cacheRead: "#8b5cf6",
-  cacheWrite: "#f59e0b",
-};
-
-function formatCurrency(value: number): string {
-  if (value === 0) return "$0";
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value);
+function CustomTooltip({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null;
+  const total = payload.reduce((sum: number, p: any) => sum + (p.value ?? 0), 0);
+  return (
+    <div style={tooltipContentStyle}>
+      <p style={tooltipLabelStyle}>{formatDate(label)}</p>
+      {payload.map((p: any) => (
+        <div key={p.dataKey} style={{ display: "flex", justifyContent: "space-between", gap: "16px", ...tooltipItemStyle }}>
+          <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+            <span style={{ width: 8, height: 8, borderRadius: "50%", backgroundColor: p.color, display: "inline-block" }} />
+            {p.name}
+          </span>
+          <span style={{ fontVariantNumeric: "tabular-nums" }}>{formatCurrency(p.value)}</span>
+        </div>
+      ))}
+      <div style={{ borderTop: "1px solid hsl(var(--border))", marginTop: "4px", paddingTop: "4px", display: "flex", justifyContent: "space-between", fontWeight: 600, ...tooltipItemStyle }}>
+        <span>Total</span>
+        <span style={{ fontVariantNumeric: "tabular-nums" }}>{formatCurrency(total)}</span>
+      </div>
+    </div>
+  );
 }
 
 export function CostChart({ daily }: CostChartProps) {
@@ -61,49 +76,51 @@ export function CostChart({ daily }: CostChartProps) {
             <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
             <XAxis
               dataKey="date"
-              className="text-xs text-muted-foreground"
-              tick={{ fontSize: 12 }}
+              className="text-xs"
+              tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+              tickFormatter={formatDate}
             />
             <YAxis
-              className="text-xs text-muted-foreground"
-              tick={{ fontSize: 12 }}
+              className="text-xs"
+              tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
               tickFormatter={formatCurrency}
             />
             <Tooltip
-              formatter={(value) => formatCurrency(value as number)}
-              contentStyle={{
-                backgroundColor: "hsl(var(--background))",
-                border: "1px solid hsl(var(--border))",
-              }}
+              content={<CustomTooltip />}
+              cursor={chartCursorStyle}
             />
             <Legend />
             <Bar
               dataKey="costInput"
               stackId="cost"
-              fill={colors.input}
+              fill={COST_COLORS.input}
               name="Input Cost"
-              radius={[4, 4, 0, 0]}
+              radius={[0, 0, 0, 0]}
+              activeBar={{ fillOpacity: 0.8, stroke: COST_COLORS.input, strokeWidth: 1 }}
             />
             <Bar
               dataKey="costOutput"
               stackId="cost"
-              fill={colors.output}
+              fill={COST_COLORS.output}
               name="Output Cost"
-              radius={[4, 4, 0, 0]}
+              radius={[0, 0, 0, 0]}
+              activeBar={{ fillOpacity: 0.8, stroke: COST_COLORS.output, strokeWidth: 1 }}
             />
             <Bar
               dataKey="costCacheRead"
               stackId="cost"
-              fill={colors.cacheRead}
+              fill={COST_COLORS.cacheRead}
               name="Cache Read Cost"
-              radius={[4, 4, 0, 0]}
+              radius={[0, 0, 0, 0]}
+              activeBar={{ fillOpacity: 0.8, stroke: COST_COLORS.cacheRead, strokeWidth: 1 }}
             />
             <Bar
               dataKey="costCacheWrite"
               stackId="cost"
-              fill={colors.cacheWrite}
+              fill={COST_COLORS.cacheWrite}
               name="Cache Write Cost"
               radius={[4, 4, 0, 0]}
+              activeBar={{ fillOpacity: 0.8, stroke: COST_COLORS.cacheWrite, strokeWidth: 1 }}
             />
           </BarChart>
         </ResponsiveContainer>

--- a/packages/ui/src/components/usage-dashboard/ModelBreakdown.tsx
+++ b/packages/ui/src/components/usage-dashboard/ModelBreakdown.tsx
@@ -3,37 +3,22 @@ import {
   PieChart,
   Pie,
   Cell,
-  Legend,
   Tooltip,
   ResponsiveContainer,
+  Sector,
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  PIE_COLORS,
+  tooltipContentStyle,
+  tooltipLabelStyle,
+  tooltipItemStyle,
+  formatCurrency,
+} from "./chart-theme";
 import type { UsageData } from "./types";
 
 interface ModelBreakdownProps {
   byModel: UsageData["byModel"];
-}
-
-const colors = [
-  "#3b82f6",
-  "#ef4444",
-  "#10b981",
-  "#f59e0b",
-  "#8b5cf6",
-  "#ec4899",
-  "#06b6d4",
-  "#14b8a6",
-  "#f97316",
-  "#6366f1",
-];
-
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value);
 }
 
 export function ModelBreakdown({ byModel }: ModelBreakdownProps) {
@@ -62,6 +47,32 @@ export function ModelBreakdown({ byModel }: ModelBreakdownProps) {
     return `${percentage}%`;
   };
 
+  function CustomTooltip({ active, payload }: any) {
+    if (!active || !payload?.length) return null;
+    const d = payload[0].payload;
+    const pct = totalCost > 0 ? ((d.value / totalCost) * 100).toFixed(1) : "0";
+    return (
+      <div style={tooltipContentStyle}>
+        <p style={tooltipLabelStyle}>{d.label}</p>
+        <div style={tooltipItemStyle}>
+          <span style={{ color: "hsl(var(--muted-foreground))" }}>{d.provider}</span>
+        </div>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: "16px", ...tooltipItemStyle }}>
+          <span>Cost</span>
+          <span style={{ fontWeight: 600, fontVariantNumeric: "tabular-nums" }}>{formatCurrency(d.value)}</span>
+        </div>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: "16px", ...tooltipItemStyle }}>
+          <span>Share</span>
+          <span style={{ fontWeight: 600, fontVariantNumeric: "tabular-nums" }}>{pct}%</span>
+        </div>
+        <div style={{ display: "flex", justifyContent: "space-between", gap: "16px", ...tooltipItemStyle }}>
+          <span>Sessions</span>
+          <span style={{ fontWeight: 600, fontVariantNumeric: "tabular-nums" }}>{d.sessions}</span>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <Card>
       <CardHeader>
@@ -69,7 +80,7 @@ export function ModelBreakdown({ byModel }: ModelBreakdownProps) {
       </CardHeader>
       <CardContent>
         <div className="flex flex-col lg:flex-row gap-8">
-          <div className="flex-1">
+          <div className="flex-1 min-w-0">
             <ResponsiveContainer width="100%" height={300}>
               <PieChart>
                 <Pie
@@ -78,47 +89,49 @@ export function ModelBreakdown({ byModel }: ModelBreakdownProps) {
                   cy="50%"
                   labelLine={false}
                   label={renderLabel}
-                  outerRadius={100}
+                  outerRadius="80%"
+                  innerRadius="40%"
                   fill="#8884d8"
                   dataKey="value"
+                  activeShape={(props: any) => (
+                    <Sector
+                      {...props}
+                      outerRadius={props.outerRadius + 6}
+                      stroke={props.fill}
+                      strokeWidth={2}
+                    />
+                  )}
                 >
-                  {data.map((entry, index) => (
+                  {data.map((_entry, index) => (
                     <Cell
                       key={`cell-${index}`}
-                      fill={colors[index % colors.length]}
+                      fill={PIE_COLORS[index % PIE_COLORS.length]}
+                      stroke="hsl(var(--background))"
+                      strokeWidth={2}
                     />
                   ))}
                 </Pie>
-                <Tooltip
-                  formatter={(value) => formatCurrency(value as number)}
-                  contentStyle={{
-                    backgroundColor: "hsl(var(--background))",
-                    border: "1px solid hsl(var(--border))",
-                  }}
-                />
+                <Tooltip content={<CustomTooltip />} />
               </PieChart>
             </ResponsiveContainer>
           </div>
           <div className="flex-1 flex flex-col gap-2">
             {data.map((m, idx) => (
-              <div key={m.model} className="text-sm flex items-center gap-3">
+              <div
+                key={m.model}
+                className="text-sm flex items-center gap-3 rounded-md px-2 py-1.5 transition-colors hover:bg-muted/50"
+              >
                 <div
-                  className="w-3 h-3 rounded-full"
-                  style={{
-                    backgroundColor: colors[idx % colors.length],
-                  }}
+                  className="w-3 h-3 rounded-full flex-shrink-0"
+                  style={{ backgroundColor: PIE_COLORS[idx % PIE_COLORS.length] }}
                 />
-                <div className="flex-1">
-                  <div className="font-medium">{m.model}</div>
-                  <div className="text-xs text-muted-foreground">
-                    {m.provider}
-                  </div>
+                <div className="flex-1 min-w-0">
+                  <div className="font-medium truncate">{m.model}</div>
+                  <div className="text-xs text-muted-foreground">{m.provider}</div>
                 </div>
-                <div className="text-right">
+                <div className="text-right flex-shrink-0">
                   <div className="font-medium">{formatCurrency(m.cost)}</div>
-                  <div className="text-xs text-muted-foreground">
-                    {m.sessions} sessions
-                  </div>
+                  <div className="text-xs text-muted-foreground">{m.sessions} sessions</div>
                 </div>
               </div>
             ))}

--- a/packages/ui/src/components/usage-dashboard/ModelBreakdown.tsx
+++ b/packages/ui/src/components/usage-dashboard/ModelBreakdown.tsx
@@ -55,7 +55,7 @@ export function ModelBreakdown({ byModel }: ModelBreakdownProps) {
       <div style={tooltipContentStyle}>
         <p style={tooltipLabelStyle}>{d.label}</p>
         <div style={tooltipItemStyle}>
-          <span style={{ color: "hsl(var(--muted-foreground))" }}>{d.provider}</span>
+          <span style={{ color: "var(--muted-foreground)" }}>{d.provider}</span>
         </div>
         <div style={{ display: "flex", justifyContent: "space-between", gap: "16px", ...tooltipItemStyle }}>
           <span>Cost</span>
@@ -106,7 +106,7 @@ export function ModelBreakdown({ byModel }: ModelBreakdownProps) {
                     <Cell
                       key={`cell-${index}`}
                       fill={PIE_COLORS[index % PIE_COLORS.length]}
-                      stroke="hsl(var(--background))"
+                      stroke="var(--background)"
                       strokeWidth={2}
                     />
                   ))}

--- a/packages/ui/src/components/usage-dashboard/ProjectBreakdown.tsx
+++ b/packages/ui/src/components/usage-dashboard/ProjectBreakdown.tsx
@@ -6,28 +6,57 @@ import {
   YAxis,
   CartesianGrid,
   Tooltip,
-  Legend,
   ResponsiveContainer,
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  tooltipContentStyle,
+  tooltipLabelStyle,
+  tooltipItemStyle,
+  formatCurrency,
+} from "./chart-theme";
 import type { UsageData } from "./types";
 
 interface ProjectBreakdownProps {
   byProject: UsageData["byProject"];
 }
 
-const colors = {
-  sessions: "#3b82f6",
-  cost: "#ef4444",
-};
+// ── Separate charts for sessions and cost to avoid the dual-axis visual lie ─
 
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value);
+const SESSION_COLOR = "#3b82f6"; // blue-500
+const COST_COLOR = "#f97316";    // orange-500
+
+function SessionTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0].payload;
+  return (
+    <div style={tooltipContentStyle}>
+      <p style={tooltipLabelStyle}>{d.projectShort}</p>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: "16px", ...tooltipItemStyle }}>
+        <span>Sessions</span>
+        <span style={{ fontWeight: 600, fontVariantNumeric: "tabular-nums" }}>{d.sessions}</span>
+      </div>
+    </div>
+  );
+}
+
+function CostTooltip({ active, payload }: any) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0].payload;
+  return (
+    <div style={tooltipContentStyle}>
+      <p style={tooltipLabelStyle}>{d.projectShort}</p>
+      <div style={{ display: "flex", justifyContent: "space-between", gap: "16px", ...tooltipItemStyle }}>
+        <span>Cost</span>
+        <span style={{ fontWeight: 600, fontVariantNumeric: "tabular-nums" }}>{formatCurrency(d.cost)}</span>
+      </div>
+    </div>
+  );
+}
+
+/** Compute a reasonable chart height based on the number of projects. */
+function chartHeight(itemCount: number): number {
+  return Math.max(200, itemCount * 40 + 40);
 }
 
 export function ProjectBreakdown({ byProject }: ProjectBreakdownProps) {
@@ -35,9 +64,9 @@ export function ProjectBreakdown({ byProject }: ProjectBreakdownProps) {
     return (
       <Card>
         <CardHeader>
-          <CardTitle>Sessions by Project</CardTitle>
+          <CardTitle>Projects</CardTitle>
         </CardHeader>
-        <CardContent className="h-96 flex items-center justify-center text-muted-foreground">
+        <CardContent className="h-48 flex items-center justify-center text-muted-foreground">
           No data available
         </CardContent>
       </Card>
@@ -49,55 +78,86 @@ export function ProjectBreakdown({ byProject }: ProjectBreakdownProps) {
     name: p.projectShort,
   }));
 
+  const h = chartHeight(data.length);
+  // Adaptive left margin: measure longest label (rough heuristic: 7px per char)
+  const maxLabelLen = Math.max(...data.map((d) => d.name.length));
+  const leftMargin = Math.min(200, Math.max(80, maxLabelLen * 7 + 16));
+
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Sessions by Project</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <ResponsiveContainer width="100%" height={400}>
-          <BarChart
-            data={data}
-            layout="vertical"
-            margin={{ top: 5, right: 30, left: 200, bottom: 5 }}
-          >
-            <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-            <XAxis type="number" className="text-xs text-muted-foreground" />
-            <YAxis
-              dataKey="name"
-              type="category"
-              className="text-xs text-muted-foreground"
-              width={190}
-              tick={{ fontSize: 12 }}
-            />
-            <Tooltip
-              formatter={(value, name) => {
-                if (name === "cost") {
-                  return formatCurrency(value as number);
-                }
-                return value;
-              }}
-              contentStyle={{
-                backgroundColor: "hsl(var(--background))",
-                border: "1px solid hsl(var(--border))",
-              }}
-            />
-            <Legend />
-            <Bar
-              dataKey="sessions"
-              fill={colors.sessions}
-              name="Sessions"
-              radius={[0, 4, 4, 0]}
-            />
-            <Bar
-              dataKey="cost"
-              fill={colors.cost}
-              name="Cost"
-              radius={[0, 4, 4, 0]}
-            />
-          </BarChart>
-        </ResponsiveContainer>
-      </CardContent>
-    </Card>
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      {/* Sessions by Project */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Sessions by Project</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={h}>
+            <BarChart
+              data={data}
+              layout="vertical"
+              margin={{ top: 5, right: 30, left: leftMargin, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" horizontal={false} />
+              <XAxis
+                type="number"
+                tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+                allowDecimals={false}
+              />
+              <YAxis
+                dataKey="name"
+                type="category"
+                width={leftMargin - 8}
+                tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+              />
+              <Tooltip content={<SessionTooltip />} cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }} />
+              <Bar
+                dataKey="sessions"
+                fill={SESSION_COLOR}
+                name="Sessions"
+                radius={[0, 4, 4, 0]}
+                activeBar={{ fillOpacity: 0.8, stroke: SESSION_COLOR, strokeWidth: 1 }}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+
+      {/* Cost by Project */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Cost by Project</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <ResponsiveContainer width="100%" height={h}>
+            <BarChart
+              data={data}
+              layout="vertical"
+              margin={{ top: 5, right: 30, left: leftMargin, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" className="stroke-muted" horizontal={false} />
+              <XAxis
+                type="number"
+                tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+                tickFormatter={formatCurrency}
+              />
+              <YAxis
+                dataKey="name"
+                type="category"
+                width={leftMargin - 8}
+                tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+              />
+              <Tooltip content={<CostTooltip />} cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }} />
+              <Bar
+                dataKey="cost"
+                fill={COST_COLOR}
+                name="Cost"
+                radius={[0, 4, 4, 0]}
+                activeBar={{ fillOpacity: 0.8, stroke: COST_COLOR, strokeWidth: 1 }}
+              />
+            </BarChart>
+          </ResponsiveContainer>
+        </CardContent>
+      </Card>
+    </div>
   );
 }

--- a/packages/ui/src/components/usage-dashboard/ProjectBreakdown.tsx
+++ b/packages/ui/src/components/usage-dashboard/ProjectBreakdown.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import {
   BarChart,
   Bar,
@@ -9,6 +9,7 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import {
   tooltipContentStyle,
   tooltipLabelStyle,
@@ -25,6 +26,7 @@ interface ProjectBreakdownProps {
 
 const SESSION_COLOR = "#3b82f6"; // blue-500
 const COST_COLOR = "#f97316";    // orange-500
+const TOP_N = 8; // Show top N projects by default
 
 function SessionTooltip({ active, payload }: any) {
   if (!active || !payload?.length) return null;
@@ -56,10 +58,12 @@ function CostTooltip({ active, payload }: any) {
 
 /** Compute a reasonable chart height based on the number of projects. */
 function chartHeight(itemCount: number): number {
-  return Math.max(200, itemCount * 40 + 40);
+  return Math.max(180, itemCount * 32 + 40);
 }
 
 export function ProjectBreakdown({ byProject }: ProjectBreakdownProps) {
+  const [showAll, setShowAll] = useState(false);
+
   if (byProject.length === 0) {
     return (
       <Card>
@@ -73,43 +77,53 @@ export function ProjectBreakdown({ byProject }: ProjectBreakdownProps) {
     );
   }
 
-  const data = byProject.map((p) => ({
+  // Sort by sessions descending, take top N unless expanded
+  const sorted = [...byProject].sort((a, b) => b.sessions - a.sessions);
+  const visible = showAll ? sorted : sorted.slice(0, TOP_N);
+  const hiddenCount = sorted.length - TOP_N;
+
+  const data = visible.map((p) => ({
     ...p,
-    name: p.projectShort,
+    name: p.projectShort.length > 24 ? p.projectShort.slice(0, 22) + "…" : p.projectShort,
   }));
 
   const h = chartHeight(data.length);
-  // Adaptive left margin: measure longest label (rough heuristic: 7px per char)
+  // Adaptive left margin: measure longest label (rough heuristic: 6.5px per char, capped)
   const maxLabelLen = Math.max(...data.map((d) => d.name.length));
-  const leftMargin = Math.min(200, Math.max(80, maxLabelLen * 7 + 16));
+  const leftMargin = Math.min(180, Math.max(60, maxLabelLen * 6.5 + 12));
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
       {/* Sessions by Project */}
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
           <CardTitle>Sessions by Project</CardTitle>
+          {hiddenCount > 0 && (
+            <Button variant="ghost" size="sm" className="text-xs h-7" onClick={() => setShowAll(!showAll)}>
+              {showAll ? "Show top" : `+${hiddenCount} more`}
+            </Button>
+          )}
         </CardHeader>
         <CardContent>
           <ResponsiveContainer width="100%" height={h}>
             <BarChart
               data={data}
               layout="vertical"
-              margin={{ top: 5, right: 30, left: leftMargin, bottom: 5 }}
+              margin={{ top: 5, right: 24, left: leftMargin, bottom: 5 }}
             >
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" horizontal={false} />
               <XAxis
                 type="number"
-                tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+                tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
                 allowDecimals={false}
               />
               <YAxis
                 dataKey="name"
                 type="category"
                 width={leftMargin - 8}
-                tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+                tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
               />
-              <Tooltip content={<SessionTooltip />} cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }} />
+              <Tooltip content={<SessionTooltip />} cursor={{ fill: "var(--muted)", fillOpacity: 0.4 }} />
               <Bar
                 dataKey="sessions"
                 fill={SESSION_COLOR}
@@ -124,29 +138,34 @@ export function ProjectBreakdown({ byProject }: ProjectBreakdownProps) {
 
       {/* Cost by Project */}
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between pb-2">
           <CardTitle>Cost by Project</CardTitle>
+          {hiddenCount > 0 && (
+            <Button variant="ghost" size="sm" className="text-xs h-7" onClick={() => setShowAll(!showAll)}>
+              {showAll ? "Show top" : `+${hiddenCount} more`}
+            </Button>
+          )}
         </CardHeader>
         <CardContent>
           <ResponsiveContainer width="100%" height={h}>
             <BarChart
               data={data}
               layout="vertical"
-              margin={{ top: 5, right: 30, left: leftMargin, bottom: 5 }}
+              margin={{ top: 5, right: 24, left: leftMargin, bottom: 5 }}
             >
               <CartesianGrid strokeDasharray="3 3" className="stroke-muted" horizontal={false} />
               <XAxis
                 type="number"
-                tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+                tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
                 tickFormatter={formatCurrency}
               />
               <YAxis
                 dataKey="name"
                 type="category"
                 width={leftMargin - 8}
-                tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+                tick={{ fontSize: 11, fill: "var(--muted-foreground)" }}
               />
-              <Tooltip content={<CostTooltip />} cursor={{ fill: "hsl(var(--muted))", fillOpacity: 0.4 }} />
+              <Tooltip content={<CostTooltip />} cursor={{ fill: "var(--muted)", fillOpacity: 0.4 }} />
               <Bar
                 dataKey="cost"
                 fill={COST_COLOR}

--- a/packages/ui/src/components/usage-dashboard/SessionStats.tsx
+++ b/packages/ui/src/components/usage-dashboard/SessionStats.tsx
@@ -1,46 +1,42 @@
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { formatCurrency, formatTokens } from "./chart-theme";
 import type { UsageData } from "./types";
 
 interface SessionStatsProps {
   summary: UsageData["summary"];
 }
 
-function formatCurrency(value: number | null): string {
-  if (value === null || value === undefined) return "—";
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value);
-}
-
-function formatTokens(value: number): string {
-  if (value >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}M`;
-  }
-  if (value >= 1_000) {
-    return `${(value / 1_000).toFixed(1)}K`;
-  }
-  return Math.round(value).toString();
-}
-
 function formatDuration(ms: number | null): string {
   if (ms === null || ms === undefined) return "—";
-  
+
   const totalSeconds = Math.round(ms / 1000);
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const seconds = totalSeconds % 60;
 
-  if (hours > 0) {
-    return `${hours}h ${minutes}m ${seconds}s`;
-  }
-  if (minutes > 0) {
-    return `${minutes}m ${seconds}s`;
-  }
+  if (hours > 0) return `${hours}h ${minutes}m ${seconds}s`;
+  if (minutes > 0) return `${minutes}m ${seconds}s`;
   return `${seconds}s`;
+}
+
+function formatCurrencyNullable(value: number | null): string {
+  if (value === null || value === undefined) return "—";
+  return formatCurrency(value);
+}
+
+function StatCard({ title, value, subtitle }: { title: string; value: string; subtitle: string }) {
+  return (
+    <Card className="transition-shadow hover:shadow-md">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
+      </CardContent>
+    </Card>
+  );
 }
 
 export function SessionStats({ summary }: SessionStatsProps) {
@@ -48,55 +44,28 @@ export function SessionStats({ summary }: SessionStatsProps) {
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Duration</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{formatDuration(summary.avgSessionDurationMs)}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            per session
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Tokens</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{formatTokens(summary.avgSessionTokens)}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            per session
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Cost</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{formatCurrency(avgCostPerSession)}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            {summary.sessionsWithCost > 0 ? `per session` : `no cost data`}
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Input Tokens</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">
-            {summary.totalSessions > 0 ? Math.round(summary.totalInputTokens / summary.totalSessions) : "—"}
-          </div>
-          <p className="text-xs text-muted-foreground mt-1">
-            input tokens per session
-          </p>
-        </CardContent>
-      </Card>
+      <StatCard
+        title="Avg Duration"
+        value={formatDuration(summary.avgSessionDurationMs)}
+        subtitle="per session"
+      />
+      <StatCard
+        title="Avg Tokens"
+        value={formatTokens(summary.avgSessionTokens)}
+        subtitle="per session"
+      />
+      <StatCard
+        title="Avg Cost"
+        value={formatCurrencyNullable(avgCostPerSession)}
+        subtitle={summary.sessionsWithCost > 0 ? "per session" : "no cost data"}
+      />
+      <StatCard
+        title="Avg Input Tokens"
+        value={summary.totalSessions > 0
+          ? formatTokens(Math.round(summary.totalInputTokens / summary.totalSessions))
+          : "—"}
+        subtitle="input tokens per session"
+      />
     </div>
   );
 }

--- a/packages/ui/src/components/usage-dashboard/SessionTable.tsx
+++ b/packages/ui/src/components/usage-dashboard/SessionTable.tsx
@@ -1,0 +1,197 @@
+import React, { useMemo, useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { formatCurrency } from "./chart-theme";
+import type { UsageData } from "./types";
+import { ArrowDown, ArrowUp, ArrowUpDown } from "lucide-react";
+
+type Session = UsageData["recentSessions"][number];
+
+type SortKey = "name" | "project" | "model" | "cost" | "messages" | "startedAt";
+type SortDir = "asc" | "desc";
+
+const DEFAULT_SORT: { key: SortKey; dir: SortDir } = { key: "startedAt", dir: "desc" };
+
+interface Column {
+  key: SortKey;
+  label: string;
+  align: "left" | "right";
+  render: (s: Session) => React.ReactNode;
+  sortValue: (s: Session) => string | number;
+}
+
+function formatRelativeTime(dateStr: string): string {
+  const now = Date.now();
+  const then = new Date(dateStr).getTime();
+  const diffMs = now - then;
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return "just now";
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  const diffDays = Math.floor(diffHr / 24);
+  if (diffDays < 30) return `${diffDays}d ago`;
+  return new Date(dateStr).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+function formatAbsoluteTime(dateStr: string): string {
+  return new Date(dateStr).toLocaleString(undefined, {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+const COLUMNS: Column[] = [
+  {
+    key: "name",
+    label: "Session",
+    align: "left",
+    render: (s) => s.sessionName || `Session ${s.id.slice(0, 8)}`,
+    sortValue: (s) => (s.sessionName || s.id).toLowerCase(),
+  },
+  {
+    key: "project",
+    label: "Project",
+    align: "left",
+    render: (s) => s.projectShort,
+    sortValue: (s) => s.projectShort.toLowerCase(),
+  },
+  {
+    key: "model",
+    label: "Model",
+    align: "left",
+    render: (s) => s.primaryModel,
+    sortValue: (s) => s.primaryModel.toLowerCase(),
+  },
+  {
+    key: "startedAt",
+    label: "Started",
+    align: "left",
+    render: (s) => (
+      <span title={formatAbsoluteTime(s.startedAt)}>
+        {formatRelativeTime(s.startedAt)}
+      </span>
+    ),
+    sortValue: (s) => new Date(s.startedAt).getTime(),
+  },
+  {
+    key: "cost",
+    label: "Cost",
+    align: "right",
+    render: (s) => (s.totalCost ? formatCurrency(s.totalCost) : "—"),
+    sortValue: (s) => s.totalCost ?? -1,
+  },
+  {
+    key: "messages",
+    label: "Messages",
+    align: "right",
+    render: (s) => s.messageCount,
+    sortValue: (s) => s.messageCount,
+  },
+];
+
+function SortIcon({ active, dir }: { active: boolean; dir: SortDir }) {
+  if (!active) return <ArrowUpDown className="h-3 w-3 opacity-40" />;
+  return dir === "asc" ? (
+    <ArrowUp className="h-3 w-3" />
+  ) : (
+    <ArrowDown className="h-3 w-3" />
+  );
+}
+
+interface SessionTableProps {
+  sessions: UsageData["recentSessions"];
+}
+
+export function SessionTable({ sessions }: SessionTableProps) {
+  const [sort, setSort] = useState<{ key: SortKey; dir: SortDir }>(DEFAULT_SORT);
+
+  const toggleSort = (key: SortKey) => {
+    setSort((prev) =>
+      prev.key === key
+        ? { key, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { key, dir: "desc" },
+    );
+  };
+
+  const sorted = useMemo(() => {
+    const col = COLUMNS.find((c) => c.key === sort.key)!;
+    const multiplier = sort.dir === "asc" ? 1 : -1;
+    return [...sessions].sort((a, b) => {
+      const va = col.sortValue(a);
+      const vb = col.sortValue(b);
+      if (typeof va === "number" && typeof vb === "number") {
+        return (va - vb) * multiplier;
+      }
+      return String(va).localeCompare(String(vb)) * multiplier;
+    });
+  }, [sessions, sort]);
+
+  if (sessions.length === 0) return null;
+
+  return (
+    <Card>
+      <div className="px-6 py-4 border-b">
+        <h3 className="font-semibold">Recent Sessions</h3>
+      </div>
+      <CardContent className="pt-0 px-0">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b bg-muted/30">
+                {COLUMNS.map((col) => (
+                  <th
+                    key={col.key}
+                    className={`py-2.5 px-3 font-medium text-muted-foreground cursor-pointer select-none hover:text-foreground transition-colors ${
+                      col.align === "right" ? "text-right" : "text-left"
+                    }`}
+                    onClick={() => toggleSort(col.key)}
+                  >
+                    <span className="inline-flex items-center gap-1">
+                      {col.align === "right" && (
+                        <SortIcon active={sort.key === col.key} dir={sort.dir} />
+                      )}
+                      {col.label}
+                      {col.align === "left" && (
+                        <SortIcon active={sort.key === col.key} dir={sort.dir} />
+                      )}
+                    </span>
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sorted.map((session) => (
+                <tr
+                  key={session.id}
+                  className="border-b last:border-0 hover:bg-muted/50 transition-colors"
+                >
+                  {COLUMNS.map((col) => (
+                    <td
+                      key={col.key}
+                      className={`py-2 px-3 ${
+                        col.align === "right" ? "text-right tabular-nums" : "truncate max-w-[200px]"
+                      }`}
+                      title={
+                        col.key === "name"
+                          ? (session.sessionName || `Session ${session.id.slice(0, 8)}`)
+                          : col.key === "project"
+                            ? session.project
+                            : col.key === "model"
+                              ? session.primaryModel
+                              : undefined
+                      }
+                    >
+                      {col.render(session)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/ui/src/components/usage-dashboard/SummaryCards.tsx
+++ b/packages/ui/src/components/usage-dashboard/SummaryCards.tsx
@@ -1,5 +1,8 @@
 import React from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { Info } from "lucide-react";
+import { formatCurrency, formatTokens } from "./chart-theme";
 import type { UsageData } from "./types";
 
 interface SummaryCardsProps {
@@ -7,83 +10,67 @@ interface SummaryCardsProps {
   daily: UsageData["daily"];
 }
 
-function formatCurrency(value: number): string {
-  return new Intl.NumberFormat("en-US", {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value);
-}
-
-function formatTokens(value: number): string {
-  if (value >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}M`;
-  }
-  if (value >= 1_000) {
-    return `${(value / 1_000).toFixed(1)}K`;
-  }
-  return value.toString();
+function StatCard({ title, value, subtitle, tooltip }: {
+  title: string;
+  value: string;
+  subtitle: string;
+  tooltip?: string;
+}) {
+  return (
+    <Card className="transition-shadow hover:shadow-md">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground flex items-center gap-1.5">
+          {title}
+          {tooltip && (
+            <TooltipProvider delayDuration={200}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Info className="h-3.5 w-3.5 text-muted-foreground/60 cursor-help" />
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-xs text-xs">
+                  {tooltip}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        <p className="text-xs text-muted-foreground mt-1">{subtitle}</p>
+      </CardContent>
+    </Card>
+  );
 }
 
 export function SummaryCards({ summary, daily }: SummaryCardsProps) {
-  // Calculate average daily cost from daily data.
-  // TODO: This divides by the number of *active* days (days with at least one
-  // usage event), not the total calendar days in the selected range.
-  // "Avg Daily Cost" over a 30-day range with only 10 active days will be 3×
-  // higher than a pure calendar average.  Consider whether to display both, or
-  // rename the label to "Avg Cost (active days)" to avoid confusion.
   const avgDailyCost = daily.length > 0 ? daily.reduce((sum, d) => sum + d.cost, 0) / daily.length : 0;
 
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Total Cost</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{summary.sessionsWithCost === 0 ? "—" : formatCurrency(summary.totalCost)}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            {summary.sessionsWithCost} of {summary.totalSessions} sessions with cost data
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Sessions</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{summary.totalSessions}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            {summary.avgSessionCost > 0 ? `Avg ${formatCurrency(summary.avgSessionCost)}/session` : "No cost data"}
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Total Tokens</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{formatTokens(summary.totalInputTokens + summary.totalOutputTokens)}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            Input + Output
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-2">
-          <CardTitle className="text-sm font-medium text-muted-foreground">Avg Cost / Active Day</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{summary.sessionsWithCost === 0 ? "—" : formatCurrency(avgDailyCost)}</div>
-          <p className="text-xs text-muted-foreground mt-1">
-            across {daily.length} active day{daily.length === 1 ? "" : "s"}
-          </p>
-        </CardContent>
-      </Card>
+      <StatCard
+        title="Total Cost"
+        value={summary.sessionsWithCost === 0 ? "—" : formatCurrency(summary.totalCost)}
+        subtitle={`${summary.sessionsWithCost} of ${summary.totalSessions} sessions with cost data`}
+        tooltip="Sum of all token costs (input, output, cache read, cache write) across sessions with cost data."
+      />
+      <StatCard
+        title="Sessions"
+        value={String(summary.totalSessions)}
+        subtitle={summary.avgSessionCost > 0 ? `Avg ${formatCurrency(summary.avgSessionCost)}/session` : "No cost data"}
+      />
+      <StatCard
+        title="Total Tokens"
+        value={formatTokens(summary.totalInputTokens + summary.totalOutputTokens)}
+        subtitle="Input + Output"
+        tooltip="Total input and output tokens. Does not include cache read/write tokens."
+      />
+      <StatCard
+        title="Avg Cost / Active Day"
+        value={summary.sessionsWithCost === 0 ? "—" : formatCurrency(avgDailyCost)}
+        subtitle={`across ${daily.length} active day${daily.length === 1 ? "" : "s"}`}
+        tooltip="Average cost per day that had at least one session. Days with no activity are excluded, so this will be higher than a calendar-day average."
+      />
     </div>
   );
 }

--- a/packages/ui/src/components/usage-dashboard/TokenChart.tsx
+++ b/packages/ui/src/components/usage-dashboard/TokenChart.tsx
@@ -47,7 +47,7 @@ function CustomTooltip({ active, payload, label }: any) {
           <span style={{ fontVariantNumeric: "tabular-nums" }}>{formatTokens(p.value)}</span>
         </div>
       ))}
-      <div style={{ borderTop: "1px solid hsl(var(--border))", marginTop: "4px", paddingTop: "4px", display: "flex", justifyContent: "space-between", fontWeight: 600, ...tooltipItemStyle }}>
+      <div style={{ borderTop: "1px solid var(--border)", marginTop: "4px", paddingTop: "4px", display: "flex", justifyContent: "space-between", fontWeight: 600, ...tooltipItemStyle }}>
         <span>Total</span>
         <span style={{ fontVariantNumeric: "tabular-nums" }}>{formatTokens(total)}</span>
       </div>
@@ -105,12 +105,12 @@ export function TokenChart({ daily }: TokenChartProps) {
             <XAxis
               dataKey="date"
               className="text-xs"
-              tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
               tickFormatter={formatDate}
             />
             <YAxis
               className="text-xs"
-              tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+              tick={{ fontSize: 12, fill: "var(--muted-foreground)" }}
               tickFormatter={formatTokens}
             />
             <Tooltip
@@ -123,8 +123,8 @@ export function TokenChart({ daily }: TokenChartProps) {
               formatter={(value: string, entry: any) => (
                 <span style={{
                   color: hidden.has(entry.dataKey)
-                    ? "hsl(var(--muted-foreground))"
-                    : "hsl(var(--foreground))",
+                    ? "var(--muted-foreground)"
+                    : "var(--foreground)",
                   textDecoration: hidden.has(entry.dataKey) ? "line-through" : "none",
                   opacity: hidden.has(entry.dataKey) ? 0.5 : 1,
                 }}>
@@ -148,7 +148,7 @@ export function TokenChart({ daily }: TokenChartProps) {
                   r: 5,
                   strokeWidth: 2,
                   stroke: s.color,
-                  fill: "hsl(var(--background))",
+                  fill: "var(--background)",
                 }}
               />
             ))}

--- a/packages/ui/src/components/usage-dashboard/TokenChart.tsx
+++ b/packages/ui/src/components/usage-dashboard/TokenChart.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState, useCallback } from "react";
 import {
   AreaChart,
   Area,
@@ -10,30 +10,65 @@ import {
   ResponsiveContainer,
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  COST_COLORS,
+  tooltipContentStyle,
+  tooltipLabelStyle,
+  tooltipItemStyle,
+  formatTokens,
+  formatDate,
+  chartCursorStyle,
+} from "./chart-theme";
 import type { UsageData } from "./types";
 
 interface TokenChartProps {
   daily: UsageData["daily"];
 }
 
-const colors = {
-  input: "#3b82f6",
-  output: "#ef4444",
-  cacheRead: "#8b5cf6",
-  cacheWrite: "#f59e0b",
-};
+const SERIES = [
+  { key: "inputTokens", name: "Input", color: COST_COLORS.input },
+  { key: "outputTokens", name: "Output", color: COST_COLORS.output },
+  { key: "cacheReadTokens", name: "Cache Read", color: COST_COLORS.cacheRead },
+  { key: "cacheWriteTokens", name: "Cache Write", color: COST_COLORS.cacheWrite },
+] as const;
 
-function formatTokens(value: number): string {
-  if (value >= 1_000_000) {
-    return `${(value / 1_000_000).toFixed(1)}M`;
-  }
-  if (value >= 1_000) {
-    return `${(value / 1_000).toFixed(1)}K`;
-  }
-  return value.toString();
+function CustomTooltip({ active, payload, label }: any) {
+  if (!active || !payload?.length) return null;
+  const total = payload.reduce((sum: number, p: any) => sum + (p.value ?? 0), 0);
+  return (
+    <div style={tooltipContentStyle}>
+      <p style={tooltipLabelStyle}>{formatDate(label)}</p>
+      {payload.map((p: any) => (
+        <div key={p.dataKey} style={{ display: "flex", justifyContent: "space-between", gap: "16px", ...tooltipItemStyle }}>
+          <span style={{ display: "flex", alignItems: "center", gap: "6px" }}>
+            <span style={{ width: 8, height: 8, borderRadius: "50%", backgroundColor: p.color, display: "inline-block" }} />
+            {p.name}
+          </span>
+          <span style={{ fontVariantNumeric: "tabular-nums" }}>{formatTokens(p.value)}</span>
+        </div>
+      ))}
+      <div style={{ borderTop: "1px solid hsl(var(--border))", marginTop: "4px", paddingTop: "4px", display: "flex", justifyContent: "space-between", fontWeight: 600, ...tooltipItemStyle }}>
+        <span>Total</span>
+        <span style={{ fontVariantNumeric: "tabular-nums" }}>{formatTokens(total)}</span>
+      </div>
+    </div>
+  );
 }
 
 export function TokenChart({ daily }: TokenChartProps) {
+  // Interactive legend: track which series are hidden
+  const [hidden, setHidden] = useState<Set<string>>(new Set());
+
+  const handleLegendClick = useCallback((e: any) => {
+    const key = e.dataKey;
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
   if (daily.length === 0) {
     return (
       <Card>
@@ -59,78 +94,64 @@ export function TokenChart({ daily }: TokenChartProps) {
             margin={{ top: 20, right: 30, left: 0, bottom: 5 }}
           >
             <defs>
-              <linearGradient id="colorInput" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor={colors.input} stopOpacity={0.8} />
-                <stop offset="95%" stopColor={colors.input} stopOpacity={0} />
-              </linearGradient>
-              <linearGradient id="colorOutput" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor={colors.output} stopOpacity={0.8} />
-                <stop offset="95%" stopColor={colors.output} stopOpacity={0} />
-              </linearGradient>
-              <linearGradient id="colorCacheRead" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor={colors.cacheRead} stopOpacity={0.8} />
-                <stop offset="95%" stopColor={colors.cacheRead} stopOpacity={0} />
-              </linearGradient>
-              <linearGradient id="colorCacheWrite" x1="0" y1="0" x2="0" y2="1">
-                <stop offset="5%" stopColor={colors.cacheWrite} stopOpacity={0.8} />
-                <stop offset="95%" stopColor={colors.cacheWrite} stopOpacity={0} />
-              </linearGradient>
+              {SERIES.map((s) => (
+                <linearGradient key={s.key} id={`grad-${s.key}`} x1="0" y1="0" x2="0" y2="1">
+                  <stop offset="5%" stopColor={s.color} stopOpacity={0.3} />
+                  <stop offset="95%" stopColor={s.color} stopOpacity={0} />
+                </linearGradient>
+              ))}
             </defs>
             <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
             <XAxis
               dataKey="date"
-              className="text-xs text-muted-foreground"
-              tick={{ fontSize: 12 }}
+              className="text-xs"
+              tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
+              tickFormatter={formatDate}
             />
             <YAxis
-              className="text-xs text-muted-foreground"
-              tick={{ fontSize: 12 }}
+              className="text-xs"
+              tick={{ fontSize: 12, fill: "hsl(var(--muted-foreground))" }}
               tickFormatter={formatTokens}
             />
             <Tooltip
-              formatter={(value) => formatTokens(value as number)}
-              contentStyle={{
-                backgroundColor: "hsl(var(--background))",
-                border: "1px solid hsl(var(--border))",
-              }}
+              content={<CustomTooltip />}
+              cursor={chartCursorStyle}
             />
-            <Legend />
-            <Area
-              type="monotone"
-              dataKey="inputTokens"
-              stackId="1"
-              stroke={colors.input}
-              fillOpacity={1}
-              fill="url(#colorInput)"
-              name="Input Tokens"
+            <Legend
+              onClick={handleLegendClick}
+              wrapperStyle={{ cursor: "pointer" }}
+              formatter={(value: string, entry: any) => (
+                <span style={{
+                  color: hidden.has(entry.dataKey)
+                    ? "hsl(var(--muted-foreground))"
+                    : "hsl(var(--foreground))",
+                  textDecoration: hidden.has(entry.dataKey) ? "line-through" : "none",
+                  opacity: hidden.has(entry.dataKey) ? 0.5 : 1,
+                }}>
+                  {value}
+                </span>
+              )}
             />
-            <Area
-              type="monotone"
-              dataKey="outputTokens"
-              stackId="1"
-              stroke={colors.output}
-              fillOpacity={1}
-              fill="url(#colorOutput)"
-              name="Output Tokens"
-            />
-            <Area
-              type="monotone"
-              dataKey="cacheReadTokens"
-              stackId="1"
-              stroke={colors.cacheRead}
-              fillOpacity={1}
-              fill="url(#colorCacheRead)"
-              name="Cache Read Tokens"
-            />
-            <Area
-              type="monotone"
-              dataKey="cacheWriteTokens"
-              stackId="1"
-              stroke={colors.cacheWrite}
-              fillOpacity={1}
-              fill="url(#colorCacheWrite)"
-              name="Cache Write Tokens"
-            />
+            {/* Unstacked: each series independent so cache reads don't crush others */}
+            {SERIES.map((s) => (
+              <Area
+                key={s.key}
+                type="monotone"
+                dataKey={s.key}
+                stroke={s.color}
+                strokeWidth={2}
+                fillOpacity={1}
+                fill={`url(#grad-${s.key})`}
+                name={s.name}
+                hide={hidden.has(s.key)}
+                activeDot={{
+                  r: 5,
+                  strokeWidth: 2,
+                  stroke: s.color,
+                  fill: "hsl(var(--background))",
+                }}
+              />
+            ))}
           </AreaChart>
         </ResponsiveContainer>
       </CardContent>

--- a/packages/ui/src/components/usage-dashboard/UsageDashboard.tsx
+++ b/packages/ui/src/components/usage-dashboard/UsageDashboard.tsx
@@ -6,7 +6,7 @@ import { CostChart } from "./CostChart";
 import { TokenChart } from "./TokenChart";
 import { ModelBreakdown } from "./ModelBreakdown";
 import { ProjectBreakdown } from "./ProjectBreakdown";
-import { Card, CardContent } from "@/components/ui/card";
+import { SessionTable } from "./SessionTable";
 import { AlertCircle, Loader2 } from "lucide-react";
 import type { UsageData, UsageRange } from "./types";
 
@@ -112,69 +112,7 @@ export function UsageDashboard({ runnerId }: UsageDashboardProps) {
       </div>
 
       {/* Recent Sessions */}
-      {data.recentSessions.length > 0 && (
-        <Card>
-          <div className="px-6 py-4 border-b">
-            <h3 className="font-semibold">Recent Sessions</h3>
-          </div>
-          <CardContent className="pt-4">
-            <div className="space-y-2 overflow-x-auto">
-              <table className="w-full text-sm">
-                <thead className="border-b">
-                  <tr className="text-muted-foreground">
-                    <th className="text-left py-2 px-2 font-medium">
-                      Session
-                    </th>
-                    <th className="text-left py-2 px-2 font-medium">
-                      Project
-                    </th>
-                    <th className="text-left py-2 px-2 font-medium">Model</th>
-                    <th className="text-right py-2 px-2 font-medium">Cost</th>
-                    <th className="text-right py-2 px-2 font-medium">
-                      Messages
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.recentSessions.map((session) => (
-                    <tr
-                      key={session.id}
-                      className="border-b last:border-0 hover:bg-muted/50 transition-colors"
-                    >
-                      <td
-                        className="py-2 px-2 truncate max-w-xs"
-                        title={session.sessionName || `Session ${session.id.slice(0, 8)}`}
-                      >
-                        {session.sessionName || `Session ${session.id.slice(0, 8)}`}
-                      </td>
-                      <td
-                        className="py-2 px-2 truncate max-w-xs"
-                        title={session.project}
-                      >
-                        {session.projectShort}
-                      </td>
-                      <td
-                        className="py-2 px-2 truncate"
-                        title={session.primaryModel}
-                      >
-                        {session.primaryModel}
-                      </td>
-                      <td className="py-2 px-2 text-right tabular-nums">
-                        {session.totalCost
-                          ? `$${session.totalCost.toFixed(2)}`
-                          : "—"}
-                      </td>
-                      <td className="py-2 px-2 text-right tabular-nums">
-                        {session.messageCount}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </CardContent>
-        </Card>
-      )}
+      <SessionTable sessions={data.recentSessions} />
     </div>
   );
 }

--- a/packages/ui/src/components/usage-dashboard/UsageDashboard.tsx
+++ b/packages/ui/src/components/usage-dashboard/UsageDashboard.tsx
@@ -139,23 +139,32 @@ export function UsageDashboard({ runnerId }: UsageDashboardProps) {
                   {data.recentSessions.map((session) => (
                     <tr
                       key={session.id}
-                      className="border-b last:border-0 hover:bg-muted/50"
+                      className="border-b last:border-0 hover:bg-muted/50 transition-colors"
                     >
-                      <td className="py-2 px-2 truncate max-w-xs">
+                      <td
+                        className="py-2 px-2 truncate max-w-xs"
+                        title={session.sessionName || `Session ${session.id.slice(0, 8)}`}
+                      >
                         {session.sessionName || `Session ${session.id.slice(0, 8)}`}
                       </td>
-                      <td className="py-2 px-2 truncate max-w-xs">
+                      <td
+                        className="py-2 px-2 truncate max-w-xs"
+                        title={session.project}
+                      >
                         {session.projectShort}
                       </td>
-                      <td className="py-2 px-2 truncate">
+                      <td
+                        className="py-2 px-2 truncate"
+                        title={session.primaryModel}
+                      >
                         {session.primaryModel}
                       </td>
-                      <td className="py-2 px-2 text-right">
+                      <td className="py-2 px-2 text-right tabular-nums">
                         {session.totalCost
-                          ? `$${session.totalCost.toFixed(3)}`
+                          ? `$${session.totalCost.toFixed(2)}`
                           : "—"}
                       </td>
-                      <td className="py-2 px-2 text-right">
+                      <td className="py-2 px-2 text-right tabular-nums">
                         {session.messageCount}
                       </td>
                     </tr>

--- a/packages/ui/src/components/usage-dashboard/chart-theme.ts
+++ b/packages/ui/src/components/usage-dashboard/chart-theme.ts
@@ -1,0 +1,103 @@
+/**
+ * Shared chart theme utilities for the Usage Dashboard.
+ *
+ * Provides theme-aware colors (via CSS variables), a reusable custom tooltip
+ * style object, and common formatters so every chart looks consistent.
+ */
+
+// ── Theme-aware chart colors ────────────────────────────────────────────────
+// These read the CSS custom properties set in style.css (:root / .dark).
+// Recharts needs concrete hex/rgb values at render time, so we resolve them
+// from the computed style of the document element.
+
+function cssVar(name: string): string {
+  if (typeof window === "undefined") return "";
+  return getComputedStyle(document.documentElement).getPropertyValue(name).trim();
+}
+
+/** Resolve a CSS variable to a usable color string for Recharts. */
+export function chartColor(index: 1 | 2 | 3 | 4 | 5): string {
+  return cssVar(`--chart-${index}`) || FALLBACK_COLORS[index - 1];
+}
+
+const FALLBACK_COLORS = [
+  "#3b82f6", // blue
+  "#10b981", // emerald
+  "#6366f1", // indigo
+  "#f59e0b", // amber
+  "#ef4444", // red
+];
+
+/**
+ * Semantic color map for the token-type / cost-type breakdown charts.
+ * Each key maps to a distinct, non-overlapping hue so there's no
+ * accidental false associations across charts.
+ */
+export const COST_COLORS = {
+  input: "#3b82f6",     // blue-500
+  output: "#f97316",    // orange-500  (was red — now distinct from destructive)
+  cacheRead: "#8b5cf6", // violet-500
+  cacheWrite: "#14b8a6", // teal-500   (was amber — now won't clash with chart-4)
+};
+
+/** 10-color categorical palette for the model pie chart. */
+export const PIE_COLORS = [
+  "#3b82f6", "#10b981", "#f59e0b", "#8b5cf6", "#ef4444",
+  "#ec4899", "#06b6d4", "#14b8a6", "#f97316", "#6366f1",
+];
+
+// ── Tooltip styles ──────────────────────────────────────────────────────────
+
+/** Inline style object for Recharts <Tooltip contentStyle={…} /> */
+export const tooltipContentStyle: React.CSSProperties = {
+  backgroundColor: "hsl(var(--popover))",
+  color: "hsl(var(--popover-foreground))",
+  border: "1px solid hsl(var(--border))",
+  borderRadius: "var(--radius)",
+  fontSize: "0.8125rem",
+  lineHeight: "1.25rem",
+  padding: "8px 12px",
+  boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+};
+
+export const tooltipLabelStyle: React.CSSProperties = {
+  color: "hsl(var(--popover-foreground))",
+  fontWeight: 600,
+  marginBottom: "4px",
+};
+
+export const tooltipItemStyle: React.CSSProperties = {
+  color: "hsl(var(--popover-foreground))",
+  padding: "1px 0",
+};
+
+// ── Formatters ──────────────────────────────────────────────────────────────
+
+export function formatCurrency(value: number): string {
+  if (value === 0) return "$0.00";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+export function formatTokens(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}K`;
+  return value.toString();
+}
+
+export function formatDate(dateStr: string): string {
+  const d = new Date(dateStr + "T00:00:00"); // force local parse
+  return d.toLocaleDateString(undefined, { month: "short", day: "numeric" });
+}
+
+// ── Recharts cursor style ───────────────────────────────────────────────────
+
+/** Semi-transparent cursor overlay for bar/area charts. */
+export const chartCursorStyle = {
+  fill: "hsl(var(--muted))",
+  fillOpacity: 0.4,
+};

--- a/packages/ui/src/components/usage-dashboard/chart-theme.ts
+++ b/packages/ui/src/components/usage-dashboard/chart-theme.ts
@@ -48,27 +48,31 @@ export const PIE_COLORS = [
 
 // ── Tooltip styles ──────────────────────────────────────────────────────────
 
-/** Inline style object for Recharts <Tooltip contentStyle={…} /> */
+/** Inline style object for the custom tooltip wrapper div. */
 export const tooltipContentStyle: React.CSSProperties = {
-  backgroundColor: "hsl(var(--popover))",
-  color: "hsl(var(--popover-foreground))",
-  border: "1px solid hsl(var(--border))",
+  backgroundColor: "var(--popover)",
+  color: "var(--popover-foreground)",
+  border: "1px solid var(--border)",
   borderRadius: "var(--radius)",
-  fontSize: "0.8125rem",
-  lineHeight: "1.25rem",
-  padding: "8px 12px",
+  fontSize: "0.75rem",
+  lineHeight: "1.125rem",
+  padding: "6px 10px",
   boxShadow: "0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)",
+  minWidth: "140px",
+  maxWidth: "220px",
 };
 
 export const tooltipLabelStyle: React.CSSProperties = {
-  color: "hsl(var(--popover-foreground))",
+  color: "var(--popover-foreground)",
   fontWeight: 600,
-  marginBottom: "4px",
+  marginBottom: "2px",
+  fontSize: "0.75rem",
 };
 
 export const tooltipItemStyle: React.CSSProperties = {
-  color: "hsl(var(--popover-foreground))",
+  color: "var(--popover-foreground)",
   padding: "1px 0",
+  fontSize: "0.6875rem",
 };
 
 // ── Formatters ──────────────────────────────────────────────────────────────
@@ -98,6 +102,6 @@ export function formatDate(dateStr: string): string {
 
 /** Semi-transparent cursor overlay for bar/area charts. */
 export const chartCursorStyle = {
-  fill: "hsl(var(--muted))",
+  fill: "var(--muted)",
   fillOpacity: 0.4,
 };

--- a/packages/ui/src/style.css
+++ b/packages/ui/src/style.css
@@ -40,6 +40,12 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
 
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+
   --animate-border-glow: border-glow 3s ease-in-out infinite;
 }
 
@@ -192,6 +198,11 @@
   --sidebar-accent-foreground: oklch(0.205 0 0);
   --sidebar-border: oklch(0.922 0 0);
   --sidebar-ring: oklch(0.708 0 0);
+  --chart-1: oklch(0.646 0.222 41.116);
+  --chart-2: oklch(0.6 0.118 184.704);
+  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-4: oklch(0.828 0.189 84.429);
+  --chart-5: oklch(0.769 0.188 70.08);
 }
 
 .dark {
@@ -224,6 +235,11 @@
   --sidebar-accent-foreground: oklch(0.985 0 0);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
+  --chart-1: oklch(0.488 0.243 264.376);
+  --chart-2: oklch(0.696 0.17 162.48);
+  --chart-3: oklch(0.769 0.188 70.08);
+  --chart-4: oklch(0.627 0.265 303.9);
+  --chart-5: oklch(0.645 0.246 16.439);
 }
 
 @layer base {


### PR DESCRIPTION
## Summary

Fixes P1 and P2 issues from a design audit of the Usage Dashboard — hover states, tooltips, and data visualization.

### What changed

| Component | Before | After |
|-----------|--------|-------|
| **All chart tooltips** | Default Recharts tooltip with invisible text on dark theme | Custom tooltips with `hsl(var(--popover-foreground))`, formatted dates, totals row |
| **TokenChart** | Stacked areas — cache reads crush input/output to invisible slivers | Unstacked areas with interactive legend (click to toggle series), styled activeDot |
| **CostChart** | No hover feedback on bars, raw date labels | activeBar highlight, formatted dates, totals in tooltip |
| **ModelBreakdown pie** | No hover feedback on slices, tooltip only shows $ | Expanding activeShape on hover, tooltip shows cost + % + sessions, donut style |
| **ProjectBreakdown** | Single chart plotting sessions (count) and cost ($) on same axis — visual lie | Split into two separate charts with own Y-axes, adaptive left margin |
| **SummaryCards** | Static cards, no hover, confusing "Avg Cost / Active Day" | hover:shadow-md, info tooltip explaining active-days calculation |
| **SessionStats** | Static cards | hover:shadow-md, shared formatters |
| **Recent Sessions table** | Truncated text with no way to see full value, cost shows 3 decimal places | title attrs for full text on hover, cost fixed to 2 decimals, tabular-nums |
| **Colors** | Same blue (`#3b82f6`) reused for 3 different semantic meanings | Distinct palette: input=blue, output=orange, cacheRead=violet, cacheWrite=teal |

### New files

- **`chart-theme.ts`** — shared tooltip styles, formatters, color palettes, cursor config
- **`style.css`** — `--chart-1` through `--chart-5` CSS variables (light + dark)

### Verification

- `tsc --noEmit` ✅ clean
- `bun run build` ✅ clean
