### PR TITLE
fix: patch CONFIG_DIR_NAME to .pizzapi for correct session storage

### DIFF
--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -107,6 +107,17 @@ describe("pi-coding-agent patch application", () => {
         expect(source).not.toContain("async checkForNewVersion()");
         expect(source).not.toContain("showNewVersionNotification");
     });
+
+    test("config.js: CONFIG_DIR_NAME is overridden to .pizzapi", async () => {
+        const source = await Bun.file(
+            piCodingAgentPath("dist/config.js"),
+        ).text();
+
+        // Must hardcode .pizzapi, not read from upstream package.json
+        expect(source).toContain('CONFIG_DIR_NAME = ".pizzapi"');
+        expect(source).not.toContain('CONFIG_DIR_NAME = pkg.piConfig');
+        expect(source).toContain("PATCH(pizzapi)");
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -172,6 +183,22 @@ describe("pi-coding-agent patched runtime behavior", () => {
         expect(regex.test("rate limit exceeded")).toBe(true);
         expect(regex.test("Error 529: overloaded")).toBe(true);
         expect(regex.test("fetch failed")).toBe(true);
+    });
+
+    test("CONFIG_DIR_NAME exports as .pizzapi at runtime", async () => {
+        const { CONFIG_DIR_NAME } = await import(
+            piCodingAgentPath("dist/config.js")
+        );
+        expect(CONFIG_DIR_NAME).toBe(".pizzapi");
+    });
+
+    test("getSessionsDir uses .pizzapi path", async () => {
+        const { getSessionsDir } = await import(
+            piCodingAgentPath("dist/config.js")
+        );
+        const dir = getSessionsDir();
+        expect(dir).toContain(".pizzapi");
+        expect(dir).not.toMatch(/\/\.pi\//);
     });
 
     test("runtime.newSession/switchSession are assignable (runner can bind them)", async () => {

--- a/patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch
+++ b/patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch
@@ -1,6 +1,24 @@
 diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-337ecc0e082ff23b b/.bun-tag-337ecc0e082ff23b
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-8164784f1eb34c4d b/.bun-tag-8164784f1eb34c4d
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/config.js b/dist/config.js
+index 51cdae907f8cda750b66dd361b3acc7143ae22a2..f9e667986119c512aa1d222f2a171c08d9570323 100644
+--- a/dist/config.js
++++ b/dist/config.js
+@@ -138,7 +138,9 @@ export function getChangelogPath() {
+ // =============================================================================
+ const pkg = JSON.parse(readFileSync(getPackageJsonPath(), "utf-8"));
+ export const APP_NAME = pkg.piConfig?.name || "pi";
+-export const CONFIG_DIR_NAME = pkg.piConfig?.configDir || ".pi";
++// PATCH(pizzapi): override configDir — upstream reads its own package.json
++// which has ".pi", but PizzaPi stores everything under ~/.pizzapi/.
++export const CONFIG_DIR_NAME = ".pizzapi";
+ export const VERSION = pkg.version;
+ // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
+ export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
 index a9d04699e9b49fa7dafcddc3a15250916e393eff..7cdc9d7e841ad80981b5dda67e1f5e9898c5274c 100644
 --- a/dist/core/agent-session.js

--- a/patches/README.md
+++ b/patches/README.md
@@ -6,7 +6,7 @@ every `bun install` — no postinstall script is needed.
 
 ## @mariozechner/pi-coding-agent@0.58.3
 
-**Purpose:** Four changes:
+**Purpose:** Five changes:
 
 1. **Session control on extension API:** Expose `newSession()` and
    `switchSession()` on the extension runtime so the PizzaPi remote extension
@@ -20,7 +20,13 @@ every `bun install` — no postinstall script is needed.
    instead of the hardcoded default, so the login message is accurate when
    PizzaPi overrides the auth file location.
 
-4. **Retryable JSON parse errors:** Add `json.?parse.?error` and
+4. **Override configDir to `.pizzapi`:** Hardcode `CONFIG_DIR_NAME` to
+   `".pizzapi"` so that all session storage, auth, settings, and agent data
+   lives under `~/.pizzapi/` instead of the upstream default `~/.pi/`. The
+   upstream code reads `configDir` from its own `package.json` (which has
+   `".pi"`), not the consuming CLI's `package.json`.
+
+5. **Retryable JSON parse errors:** Add `json.?parse.?error` and
    `unexpected.?end.?of.?json` to the retryable error regex so transient
    Anthropic SSE stream truncations are automatically retried instead of
    showing an opaque ERROR badge to the user.
@@ -36,6 +42,7 @@ work from anywhere in the extension.
 
 | File | Change |
 |------|--------|
+| `dist/config.js` — `CONFIG_DIR_NAME` | Hardcodes `".pizzapi"` instead of reading `pkg.piConfig?.configDir` (which resolves to `".pi"` from the upstream package.json) |
 | `dist/core/extensions/loader.js` — `createExtensionRuntime()` | Adds `newSession` and `switchSession` stubs (reject before init) |
 | `dist/core/extensions/loader.js` — `createExtensionAPI()` | Adds `newSession(options)` and `switchSession(sessionPath)` wrappers delegating to the runtime |
 | `dist/core/extensions/runner.js` — `bindCommandContext()` | Copies real `newSessionHandler` / `switchSessionHandler` onto the runtime object |


### PR DESCRIPTION
## Problem

Upstream `pi-coding-agent` reads `configDir` from its own `package.json` (which has `.pi`), not the consuming CLI's `package.json`. This caused all new sessions to be created under `~/.pi/agent/sessions/` instead of `~/.pizzapi/agent/sessions/`.

## Changes

- Patch `CONFIG_DIR_NAME = ".pizzapi"` in the upstream package so all session storage, auth, settings, and agent data lives under `~/.pizzapi/`
- Added patch application and runtime tests for the override

## Files Changed

- `patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch` — extended with CONFIG_DIR_NAME override
- `patches/README.md` — documented the new patch
- `packages/cli/src/patches.test.ts` — tests for patch application and runtime behavior

## Stack

This PR is stacked on #292 (`fix/workspace-symlinks-and-clean`).