### PR TITLE
feat: cache session metadata for fast /resume listing

### DIFF
--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -14,6 +14,7 @@ import { refreshAllUsage, buildProviderUsage } from "./remote-provider-usage.js"
 import type { RemoteExecRequest, RemoteExecResponse } from "./remote-commands.js";
 import type { RelayContext, RelayModelInfo } from "./remote-types.js";
 import { emitThinkingLevelChanged, emitCompactStarted, emitCompactEnded, emitRetryStateChanged, emitPluginTrustResolved } from "./remote-meta-events.js";
+import { listSessionsCached } from "../runner/session-list-cache.js";
 
 export interface ExecHandlerCallbacks {
     setModelFromWeb(provider: string, modelId: string): Promise<void>;
@@ -21,11 +22,8 @@ export interface ExecHandlerCallbacks {
 }
 
 function listSessionsForResume(ctx: ExtensionContext): Promise<SessionInfo[]> {
-    const cwd = ctx.sessionManager.getCwd();
     const sessionDir = ctx.sessionManager.getSessionDir();
-    return SessionManager.list(cwd, sessionDir).then(sessions =>
-        sessions.sort((a, b) => b.modified.getTime() - a.modified.getTime())
-    );
+    return listSessionsCached(sessionDir);
 }
 
 function pickResumeSession(sessions: SessionInfo[], currentPath: string | undefined, query?: string): SessionInfo | null {

--- a/packages/cli/src/runner/session-list-cache.test.ts
+++ b/packages/cli/src/runner/session-list-cache.test.ts
@@ -1,0 +1,287 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync, readFileSync, existsSync, unlinkSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir, homedir } from "node:os";
+
+// Override HOME before importing the module so cache persistence goes to a temp dir
+const originalHome = process.env.HOME;
+const fakeHome = mkdtempSync(join(tmpdir(), "slc-home-"));
+process.env.HOME = fakeHome;
+mkdirSync(join(fakeHome, ".pizzapi"), { recursive: true });
+
+// Dynamic import after HOME override
+const { listSessionsCached, invalidateSessionListCache, flushSessionListCache } = await import("./session-list-cache.js");
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeSessionDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "slc-sessions-"));
+    return dir;
+}
+
+function writeSessionFile(dir: string, filename: string, opts: {
+    id?: string;
+    cwd?: string;
+    name?: string;
+    messages?: Array<{ role: string; content: string }>;
+} = {}): string {
+    const id = opts.id ?? `session-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const cwd = opts.cwd ?? "/tmp/test-project";
+    const now = new Date().toISOString();
+
+    const lines: string[] = [];
+
+    // Header
+    lines.push(JSON.stringify({
+        type: "session",
+        version: 3,
+        id,
+        timestamp: now,
+        cwd,
+    }));
+
+    // Session name
+    if (opts.name) {
+        lines.push(JSON.stringify({
+            type: "session_info",
+            id: `info-${Date.now()}`,
+            parentId: null,
+            timestamp: now,
+            name: opts.name,
+        }));
+    }
+
+    // Messages
+    for (const msg of opts.messages ?? []) {
+        lines.push(JSON.stringify({
+            type: "message",
+            id: `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+            parentId: null,
+            timestamp: now,
+            message: {
+                role: msg.role,
+                content: msg.content,
+                timestamp: Date.now(),
+            },
+        }));
+    }
+
+    const filePath = join(dir, filename);
+    writeFileSync(filePath, lines.join("\n") + "\n");
+    return filePath;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("session-list-cache", () => {
+    let sessionDir: string;
+
+    beforeEach(() => {
+        invalidateSessionListCache();
+        sessionDir = makeSessionDir();
+    });
+
+    afterEach(() => {
+        try { rmSync(sessionDir, { recursive: true, force: true }); } catch {}
+    });
+
+    test("returns empty for nonexistent directory", async () => {
+        const results = await listSessionsCached("/tmp/does-not-exist-slc-" + Date.now());
+        expect(results).toEqual([]);
+    });
+
+    test("returns empty for empty directory", async () => {
+        const results = await listSessionsCached(sessionDir);
+        expect(results).toEqual([]);
+    });
+
+    test("parses a single session file", async () => {
+        writeSessionFile(sessionDir, "session1.jsonl", {
+            id: "test-id-1",
+            name: "Test Session",
+            messages: [
+                { role: "user", content: "Hello world" },
+                { role: "assistant", content: "Hi there" },
+            ],
+        });
+
+        const results = await listSessionsCached(sessionDir);
+        expect(results.length).toBe(1);
+        expect(results[0].id).toBe("test-id-1");
+        expect(results[0].name).toBe("Test Session");
+        expect(results[0].firstMessage).toBe("Hello world");
+        expect(results[0].messageCount).toBe(2);
+    });
+
+    test("cache hit on second call (no file changes)", async () => {
+        writeSessionFile(sessionDir, "session1.jsonl", {
+            id: "test-id-1",
+            messages: [{ role: "user", content: "First call" }],
+        });
+
+        // First call — cold cache, parses the file
+        const results1 = await listSessionsCached(sessionDir);
+        expect(results1.length).toBe(1);
+
+        // Second call — should be a cache hit (same mtime)
+        const results2 = await listSessionsCached(sessionDir);
+        expect(results2.length).toBe(1);
+        expect(results2[0].id).toBe(results1[0].id);
+        expect(results2[0].firstMessage).toBe(results1[0].firstMessage);
+    });
+
+    test("cache miss when file is modified", async () => {
+        const filePath = writeSessionFile(sessionDir, "session1.jsonl", {
+            id: "test-id-1",
+            messages: [{ role: "user", content: "Original message" }],
+        });
+
+        const results1 = await listSessionsCached(sessionDir);
+        expect(results1[0].firstMessage).toBe("Original message");
+
+        // Wait a tick to ensure mtime changes, then modify
+        await new Promise(r => setTimeout(r, 50));
+        const lines = readFileSync(filePath, "utf-8").trim().split("\n");
+        lines.push(JSON.stringify({
+            type: "message",
+            id: "msg-new",
+            parentId: null,
+            timestamp: new Date().toISOString(),
+            message: { role: "user", content: "Updated message", timestamp: Date.now() },
+        }));
+        writeFileSync(filePath, lines.join("\n") + "\n");
+
+        const results2 = await listSessionsCached(sessionDir);
+        expect(results2.length).toBe(1);
+        expect(results2[0].messageCount).toBe(2);
+    });
+
+    test("prunes deleted files from cache", async () => {
+        const f1 = writeSessionFile(sessionDir, "session1.jsonl", {
+            id: "keep-me",
+            messages: [{ role: "user", content: "Keep" }],
+        });
+        const f2 = writeSessionFile(sessionDir, "session2.jsonl", {
+            id: "delete-me",
+            messages: [{ role: "user", content: "Delete" }],
+        });
+
+        const results1 = await listSessionsCached(sessionDir);
+        expect(results1.length).toBe(2);
+
+        // Delete one file
+        unlinkSync(f2);
+
+        const results2 = await listSessionsCached(sessionDir);
+        expect(results2.length).toBe(1);
+        expect(results2[0].id).toBe("keep-me");
+    });
+
+    test("handles multiple session files sorted by modified desc", async () => {
+        writeSessionFile(sessionDir, "old.jsonl", {
+            id: "old-session",
+            messages: [{ role: "user", content: "Old message" }],
+        });
+
+        // Small delay so timestamps differ
+        await new Promise(r => setTimeout(r, 50));
+
+        writeSessionFile(sessionDir, "new.jsonl", {
+            id: "new-session",
+            messages: [{ role: "user", content: "New message" }],
+        });
+
+        const results = await listSessionsCached(sessionDir);
+        expect(results.length).toBe(2);
+        // Most recently modified should be first
+        expect(results[0].id).toBe("new-session");
+        expect(results[1].id).toBe("old-session");
+    });
+
+    test("skips non-jsonl files", async () => {
+        writeSessionFile(sessionDir, "session1.jsonl", {
+            id: "real-session",
+            messages: [{ role: "user", content: "Hello" }],
+        });
+        writeFileSync(join(sessionDir, "notes.txt"), "not a session");
+        writeFileSync(join(sessionDir, "data.json"), "{}");
+
+        const results = await listSessionsCached(sessionDir);
+        expect(results.length).toBe(1);
+        expect(results[0].id).toBe("real-session");
+    });
+
+    test("skips malformed session files", async () => {
+        writeSessionFile(sessionDir, "good.jsonl", {
+            id: "good",
+            messages: [{ role: "user", content: "Hello" }],
+        });
+        // File with no valid header
+        writeFileSync(join(sessionDir, "bad.jsonl"), '{"type":"not-a-session"}\n');
+        // Empty file
+        writeFileSync(join(sessionDir, "empty.jsonl"), "");
+
+        const results = await listSessionsCached(sessionDir);
+        expect(results.length).toBe(1);
+        expect(results[0].id).toBe("good");
+    });
+
+    test("persists cache to disk and reloads", async () => {
+        writeSessionFile(sessionDir, "session1.jsonl", {
+            id: "persist-test",
+            name: "Persistent",
+            messages: [{ role: "user", content: "Will this persist?" }],
+        });
+
+        // First call — populates cache, then flush to disk synchronously
+        const results = await listSessionsCached(sessionDir);
+        expect(results.length).toBe(1);
+        flushSessionListCache();
+
+        const cachePath = join(fakeHome, ".pizzapi", "session-list-cache.json");
+        expect(existsSync(cachePath)).toBe(true);
+
+        const cacheData = JSON.parse(readFileSync(cachePath, "utf-8"));
+        expect(cacheData.version).toBe(1);
+        expect(Object.keys(cacheData.entries).length).toBeGreaterThanOrEqual(1);
+
+        // Verify the cached entry has the right fields
+        const entry = Object.values(cacheData.entries)[0] as any;
+        expect(entry.id).toBe("persist-test");
+        expect(entry.name).toBe("Persistent");
+        expect(entry.firstMessage).toBe("Will this persist?");
+    });
+
+    test("invalidateSessionListCache clears in-memory cache", async () => {
+        writeSessionFile(sessionDir, "session1.jsonl", {
+            id: "invalidate-test",
+            messages: [{ role: "user", content: "Hello" }],
+        });
+
+        await listSessionsCached(sessionDir);
+        invalidateSessionListCache();
+
+        // After invalidation, next call should re-parse (still returns correct results)
+        const results = await listSessionsCached(sessionDir);
+        expect(results.length).toBe(1);
+        expect(results[0].id).toBe("invalidate-test");
+    });
+
+    test("session with no messages returns (no messages)", async () => {
+        writeSessionFile(sessionDir, "empty-session.jsonl", {
+            id: "no-msgs",
+            messages: [],
+        });
+
+        const results = await listSessionsCached(sessionDir);
+        expect(results.length).toBe(1);
+        expect(results[0].firstMessage).toBe("(no messages)");
+        expect(results[0].messageCount).toBe(0);
+    });
+});
+
+// Restore HOME after all tests complete
+import { afterAll } from "bun:test";
+afterAll(() => {
+    process.env.HOME = originalHome;
+});

--- a/packages/cli/src/runner/session-list-cache.ts
+++ b/packages/cli/src/runner/session-list-cache.ts
@@ -1,0 +1,353 @@
+/**
+ * Session list cache — avoids re-parsing every .jsonl session file on each
+ * /resume listing.  Caches SessionInfo metadata keyed by file path + mtime.
+ *
+ * On each scan:
+ *  1. stat() every .jsonl file in the session directory
+ *  2. If mtime matches the cached entry → cache hit (skip parsing)
+ *  3. If mtime differs or entry is missing → parse the file (cache miss)
+ *  4. Prune cache entries whose files no longer exist
+ *  5. Persist the cache to ~/.pizzapi/session-list-cache.json
+ *
+ * The upstream SessionManager.list() reads & parses every file every time,
+ * which is O(total-session-bytes).  This makes it O(number-of-files) for
+ * the common case where most sessions haven't changed.
+ */
+
+import { existsSync, mkdirSync, readFileSync, writeFileSync, statSync, readdirSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { homedir } from "node:os";
+import { readFile, stat, readdir } from "node:fs/promises";
+
+/** Resolve home directory (respects $HOME override for tests). */
+function resolveHome(): string {
+    return process.env.HOME || homedir();
+}
+import type { SessionInfo } from "@mariozechner/pi-coding-agent";
+
+// ── Cache file format ────────────────────────────────────────────────────────
+
+const CACHE_VERSION = 1;
+
+interface CachedSessionEntry {
+    mtimeMs: number;
+    sizeBytes: number;
+    id: string;
+    cwd: string;
+    name: string | undefined;
+    parentSessionPath: string | undefined;
+    created: string;          // ISO string
+    modified: string;         // ISO string
+    messageCount: number;
+    firstMessage: string;
+    allMessagesText: string;
+}
+
+interface CacheFile {
+    version: number;
+    entries: Record<string, CachedSessionEntry>;
+}
+
+// ── In-memory state ──────────────────────────────────────────────────────────
+
+let cache: Map<string, CachedSessionEntry> = new Map();
+let cacheLoaded = false;
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * List sessions from a directory using the stat-based cache.
+ * Drop-in replacement for SessionManager.list() in the resume context.
+ */
+export async function listSessionsCached(
+    sessionDir: string,
+): Promise<SessionInfo[]> {
+    if (!cacheLoaded) {
+        loadCacheFromDisk();
+        cacheLoaded = true;
+    }
+
+    if (!existsSync(sessionDir)) return [];
+
+    let files: string[];
+    try {
+        const entries = await readdir(sessionDir);
+        files = entries.filter(f => f.endsWith(".jsonl")).map(f => join(sessionDir, f));
+    } catch {
+        return [];
+    }
+
+    // Track which paths exist this scan (for pruning)
+    const livePathsInDir = new Set<string>();
+    const results: SessionInfo[] = [];
+
+    // Process files with concurrency control to avoid fd exhaustion
+    const BATCH_SIZE = 50;
+    for (let i = 0; i < files.length; i += BATCH_SIZE) {
+        const batch = files.slice(i, i + BATCH_SIZE);
+        const batchResults = await Promise.all(batch.map(async (filePath) => {
+            const resolved = resolve(filePath);
+            livePathsInDir.add(resolved);
+
+            try {
+                const stats = await stat(resolved);
+                const cached = cache.get(resolved);
+
+                if (cached && cached.mtimeMs === stats.mtimeMs && cached.sizeBytes === stats.size) {
+                    // Cache hit — reconstruct SessionInfo from cached data
+                    return cachedEntryToSessionInfo(resolved, cached);
+                }
+
+                // Cache miss — parse the file
+                const info = await parseSessionFile(resolved, stats);
+                if (info) {
+                    const entry = sessionInfoToCachedEntry(info, stats);
+                    cache.set(resolved, entry);
+                    return info;
+                }
+                return null;
+            } catch {
+                return null;
+            }
+        }));
+
+        for (const info of batchResults) {
+            if (info) results.push(info);
+        }
+    }
+
+    // Prune deleted files from this directory
+    for (const path of cache.keys()) {
+        if (path.startsWith(sessionDir) && !livePathsInDir.has(path)) {
+            cache.delete(path);
+        }
+    }
+
+    // Persist asynchronously (best-effort, coalesced)
+    persistCache();
+
+    results.sort((a, b) => b.modified.getTime() - a.modified.getTime());
+    return results;
+}
+
+/**
+ * Force a full cache invalidation (e.g. after session deletion).
+ */
+export function invalidateSessionListCache(): void {
+    cache.clear();
+    cacheLoaded = false;
+    if (persistTimer !== null) {
+        clearTimeout(persistTimer);
+        persistTimer = null;
+    }
+}
+
+// ── Parsing (mirrors upstream buildSessionInfo) ──────────────────────────────
+
+interface RawEntry {
+    type: string;
+    id?: string;
+    timestamp?: string;
+    message?: { role?: string; content?: unknown; timestamp?: number };
+    name?: string;
+    cwd?: string;
+    parentSession?: string;
+}
+
+function isMessageWithContent(msg: any): boolean {
+    if (!msg || typeof msg !== "object") return false;
+    const content = msg.content;
+    if (typeof content === "string") return content.length > 0;
+    if (Array.isArray(content)) return content.length > 0;
+    return false;
+}
+
+function extractTextContent(msg: any): string {
+    if (!msg || typeof msg !== "object") return "";
+    const content = msg.content;
+    if (typeof content === "string") return content.slice(0, 500);
+    if (Array.isArray(content)) {
+        for (const part of content) {
+            if (part && typeof part === "object" && part.type === "text" && typeof part.text === "string") {
+                return part.text.slice(0, 500);
+            }
+        }
+    }
+    return "";
+}
+
+async function parseSessionFile(filePath: string, stats: { mtime: Date }): Promise<SessionInfo | null> {
+    try {
+        const content = await readFile(filePath, "utf8");
+        const lines = content.trim().split("\n");
+        const entries: RawEntry[] = [];
+        for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+                entries.push(JSON.parse(line));
+            } catch {
+                // Skip malformed lines
+            }
+        }
+        if (entries.length === 0) return null;
+        const header = entries[0];
+        if (header.type !== "session") return null;
+
+        let messageCount = 0;
+        let firstMessage = "";
+        const allMessages: string[] = [];
+        let name: string | undefined;
+        let lastActivityTime: number | undefined;
+
+        for (const entry of entries) {
+            if (entry.type === "session_info") {
+                const n = (entry as any).name;
+                if (typeof n === "string" && n.trim()) {
+                    name = n.trim();
+                }
+            }
+            if (entry.type !== "message") continue;
+            const message = entry.message;
+            if (!isMessageWithContent(message)) continue;
+            if (message!.role !== "user" && message!.role !== "assistant") continue;
+            messageCount++;
+
+            // Track last activity time
+            const msgTimestamp = message!.timestamp;
+            if (typeof msgTimestamp === "number") {
+                lastActivityTime = Math.max(lastActivityTime ?? 0, msgTimestamp);
+            } else if (typeof entry.timestamp === "string") {
+                const t = new Date(entry.timestamp).getTime();
+                if (!Number.isNaN(t)) {
+                    lastActivityTime = Math.max(lastActivityTime ?? 0, t);
+                }
+            }
+
+            const textContent = extractTextContent(message);
+            if (!textContent) continue;
+            allMessages.push(textContent);
+            if (!firstMessage && message!.role === "user") {
+                firstMessage = textContent;
+            }
+        }
+
+        const cwd = typeof header.cwd === "string" ? header.cwd : "";
+        const parentSessionPath = header.parentSession;
+
+        // Compute modified date (mirrors upstream getSessionModifiedDate)
+        let modified: Date;
+        if (typeof lastActivityTime === "number" && lastActivityTime > 0) {
+            modified = new Date(lastActivityTime);
+        } else {
+            const headerTime = typeof header.timestamp === "string"
+                ? new Date(header.timestamp).getTime()
+                : NaN;
+            modified = !Number.isNaN(headerTime) ? new Date(headerTime) : stats.mtime;
+        }
+
+        return {
+            path: filePath,
+            id: header.id ?? "",
+            cwd,
+            name,
+            parentSessionPath,
+            created: new Date(header.timestamp ?? stats.mtime),
+            modified,
+            messageCount,
+            firstMessage: firstMessage || "(no messages)",
+            allMessagesText: allMessages.join(" "),
+        };
+    } catch {
+        return null;
+    }
+}
+
+// ── Conversion helpers ───────────────────────────────────────────────────────
+
+function cachedEntryToSessionInfo(path: string, entry: CachedSessionEntry): SessionInfo {
+    return {
+        path,
+        id: entry.id,
+        cwd: entry.cwd,
+        name: entry.name,
+        parentSessionPath: entry.parentSessionPath,
+        created: new Date(entry.created),
+        modified: new Date(entry.modified),
+        messageCount: entry.messageCount,
+        firstMessage: entry.firstMessage,
+        allMessagesText: entry.allMessagesText,
+    };
+}
+
+function sessionInfoToCachedEntry(info: SessionInfo, stats: { mtimeMs: number; size: number }): CachedSessionEntry {
+    return {
+        mtimeMs: stats.mtimeMs,
+        sizeBytes: stats.size,
+        id: info.id,
+        cwd: info.cwd,
+        name: info.name,
+        parentSessionPath: info.parentSessionPath,
+        created: info.created.toISOString(),
+        modified: info.modified.toISOString(),
+        messageCount: info.messageCount,
+        firstMessage: info.firstMessage,
+        allMessagesText: info.allMessagesText,
+    };
+}
+
+// ── Disk persistence ─────────────────────────────────────────────────────────
+
+function cacheFilePath(): string {
+    return join(resolveHome(), ".pizzapi", "session-list-cache.json");
+}
+
+function loadCacheFromDisk(): void {
+    try {
+        const path = cacheFilePath();
+        if (!existsSync(path)) return;
+        const raw = JSON.parse(readFileSync(path, "utf-8")) as CacheFile;
+        if (raw.version !== CACHE_VERSION) return;
+        cache = new Map(Object.entries(raw.entries ?? {}));
+    } catch {
+        cache = new Map();
+    }
+}
+
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+
+function persistCache(): void {
+    if (persistTimer !== null) return; // coalesce rapid writes
+    persistTimer = setTimeout(() => {
+        persistTimer = null;
+        try {
+            const dir = join(resolveHome(), ".pizzapi");
+            if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+            const data: CacheFile = {
+                version: CACHE_VERSION,
+                entries: Object.fromEntries(cache),
+            };
+            writeFileSync(cacheFilePath(), JSON.stringify(data), { encoding: "utf-8", mode: 0o600 });
+        } catch {
+            // Non-fatal
+        }
+    }, 100);
+}
+
+/** Flush any pending cache write immediately (for testing). */
+export function flushSessionListCache(): void {
+    if (persistTimer !== null) {
+        clearTimeout(persistTimer);
+        persistTimer = null;
+        try {
+            const dir = join(resolveHome(), ".pizzapi");
+            if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+            const data: CacheFile = {
+                version: CACHE_VERSION,
+                entries: Object.fromEntries(cache),
+            };
+            writeFileSync(cacheFilePath(), JSON.stringify(data), { encoding: "utf-8", mode: 0o600 });
+        } catch {
+            // Non-fatal
+        }
+    }
+}


### PR DESCRIPTION
## Problem

The web UI's `/resume` picker calls `SessionManager.list()` which reads and parses **every** `.jsonl` session file on each invocation. With 2,375+ sessions totaling 774MB, this is a significant I/O and CPU hit every time the picker opens.

## Solution

Add a stat-based session metadata cache (`session-list-cache.ts`) that:

- **Stats** each `.jsonl` file and compares `mtimeMs` + `size` against cached entries
- **Cache hit** → returns cached `SessionInfo` without reading file contents
- **Cache miss** → parses the file, caches the result
- **Prunes** deleted files from the cache automatically
- **Persists** to `~/.pizzapi/session-list-cache.json` with coalesced writes (100ms debounce)
- Processes files in batches of 50 to avoid fd exhaustion

### Performance impact

| | Before | After (warm cache) |
|---|---|---|
| I/O | Read + parse all 774MB | 2,375 `stat()` calls (~few ms) |
| First call | Same as before | Same as before (cold cache) |
| Subsequent calls | Same as before | Near-instant |

## Changes

- **New:** `packages/cli/src/runner/session-list-cache.ts` — the cache module
- **New:** `packages/cli/src/runner/session-list-cache.test.ts` — 12 tests covering hits, misses, pruning, persistence, edge cases
- **Modified:** `packages/cli/src/extensions/remote-exec-handler.ts` — `listSessionsForResume()` now uses `listSessionsCached()`

## Testing

- 12 new tests, all passing
- Full suite: 597 tests, 0 failures
- Typecheck clean