### PR TITLE
feat(cli): PizzaPi terminal title

### DIFF
--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -17,6 +17,7 @@ import { subagentExtension } from "./subagent.js";
 import { planModeToggleExtension } from "./plan-mode-toggle.js";
 import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
+import { pizzapiTitleExtension } from "./pizzapi-title.js";
 import { initialPromptExtension } from "./initial-prompt.js";
 
 const CORE_EXTENSIONS: ExtensionFactory[] = [
@@ -31,6 +32,7 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     subagentExtension,
     planModeToggleExtension,
     sandboxEventsExtension,
+    pizzapiTitleExtension,
 ];
 
 /**

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -15,6 +15,7 @@ import { subagentExtension } from "./subagent.js";
 import { planModeToggleExtension } from "./plan-mode-toggle.js";
 import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
+import { pizzapiTitleExtension } from "./pizzapi-title.js";
 
 export interface BuildExtensionFactoriesOptions {
     cwd: string;
@@ -57,6 +58,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
         subagentExtension,
         planModeToggleExtension,
         sandboxEventsExtension,
+        pizzapiTitleExtension,
     );
 
     if (options.includeInitialPrompt) {

--- a/packages/cli/src/extensions/pizzapi-title.test.ts
+++ b/packages/cli/src/extensions/pizzapi-title.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { buildPizzapiTitle } from "./pizzapi-title.js";
+
+describe("buildPizzapiTitle", () => {
+    test("includes session name when provided", () => {
+        const title = buildPizzapiTitle("Fix login bug", "/Users/jordan/Projects/MyApp");
+        expect(title).toBe("🍕 PizzaPi — Fix login bug — MyApp");
+    });
+
+    test("omits session name when undefined", () => {
+        const title = buildPizzapiTitle(undefined, "/Users/jordan/Projects/MyApp");
+        expect(title).toBe("🍕 PizzaPi — MyApp");
+    });
+
+    test("uses basename of cwd", () => {
+        const title = buildPizzapiTitle(undefined, "/home/user/deep/nested/path");
+        expect(title).toBe("🍕 PizzaPi — path");
+    });
+
+    test("handles root cwd", () => {
+        const title = buildPizzapiTitle(undefined, "/");
+        // basename("/") === "" on POSIX
+        expect(title).toBe("🍕 PizzaPi — ");
+    });
+
+    test("uses em-dash separator (—)", () => {
+        const title = buildPizzapiTitle("My Session", "/tmp/work");
+        expect(title).toContain("—");
+        expect(title).toMatch(/^🍕 PizzaPi — .+ — .+$/);
+    });
+});

--- a/packages/cli/src/extensions/pizzapi-title.ts
+++ b/packages/cli/src/extensions/pizzapi-title.ts
@@ -1,0 +1,50 @@
+import { basename } from "node:path";
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import type { ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+/**
+ * Build the PizzaPi terminal title string.
+ *
+ * Format: `🍕 PizzaPi — <sessionName> — <cwdBasename>`
+ * When no session name:  `🍕 PizzaPi — <cwdBasename>`
+ */
+export function buildPizzapiTitle(sessionName: string | undefined, cwd: string): string {
+    const cwdBasename = basename(cwd);
+    if (sessionName) {
+        return `🍕 PizzaPi — ${sessionName} — ${cwdBasename}`;
+    }
+    return `🍕 PizzaPi — ${cwdBasename}`;
+}
+
+/**
+ * PizzaPi terminal title extension.
+ *
+ * Overrides pi's default terminal title (`π - sessionName - cwd`) with
+ * PizzaPi branding.  Updates the title:
+ *  - On session start (initial title, name not yet known)
+ *  - On session switch (handles resumed sessions that already have a name)
+ *  - When the set_session_name tool fires (model has just named the session)
+ */
+export const pizzapiTitleExtension: ExtensionFactory = (pi) => {
+    function updateTitle(ctx: ExtensionContext): void {
+        if (!ctx.hasUI) return;
+        const title = buildPizzapiTitle(pi.getSessionName(), ctx.cwd);
+        ctx.ui.setTitle(title);
+    }
+
+    pi.on("session_start", (_event, ctx) => {
+        updateTitle(ctx);
+    });
+
+    pi.on("session_switch", (_event, ctx) => {
+        updateTitle(ctx);
+    });
+
+    // React to the model calling set_session_name so the title updates immediately
+    // after the session is named without waiting for the next event.
+    pi.on("tool_execution_end", (event, ctx) => {
+        if (event.toolName === "set_session_name") {
+            updateTitle(ctx);
+        }
+    });
+};


### PR DESCRIPTION
Night Shift dish 004 — Override pi's terminal title to show 🍕 PizzaPi branding in tab bars.

## Changes

- **New**: `packages/cli/src/extensions/pizzapi-title.ts` — Extension that overrides the terminal title with PizzaPi branding
- **Updated**: `packages/cli/src/extensions/factories.ts` — Registers the new extension
- **Updated**: `packages/cli/src/extensions/factories.test.ts` — Adds `pizzapiTitleExtension` to `CORE_EXTENSIONS`
- **New**: `packages/cli/src/extensions/pizzapi-title.test.ts` — Unit tests for title formatting

## Title Format

- With session name: `🍕 PizzaPi — <sessionName> — <cwdBasename>`
- Without session name: `🍕 PizzaPi — <cwdBasename>`

## Implementation

Uses `ctx.ui.setTitle()` (the proper extension API method) rather than raw OSC escape sequences. Updates the title on:
1. `session_start` — sets initial title (no name yet)
2. `session_switch` — handles resumed sessions with existing names
3. `tool_execution_end` for `set_session_name` — updates title immediately after the model names the session