### PR TITLE
feat(cli): PizzaPi TUI header

### DIFF
--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -18,6 +18,7 @@ import { planModeToggleExtension } from "./plan-mode-toggle.js";
 import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
 import { initialPromptExtension } from "./initial-prompt.js";
+import { pizzapiHeaderExtension } from "./pizzapi-header.js";
 
 const CORE_EXTENSIONS: ExtensionFactory[] = [
     triggersExtension,  // Must be before remoteExtension (shutdown ordering)
@@ -31,6 +32,7 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     subagentExtension,
     planModeToggleExtension,
     sandboxEventsExtension,
+    pizzapiHeaderExtension,
 ];
 
 /**

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -15,6 +15,7 @@ import { subagentExtension } from "./subagent.js";
 import { planModeToggleExtension } from "./plan-mode-toggle.js";
 import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
+import { pizzapiHeaderExtension } from "./pizzapi-header.js";
 
 export interface BuildExtensionFactoriesOptions {
     cwd: string;
@@ -57,6 +58,8 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
         subagentExtension,
         planModeToggleExtension,
         sandboxEventsExtension,
+        // PizzaPi branded header — replaces pi's built-in header with box-drawing frame
+        pizzapiHeaderExtension,
     );
 
     if (options.includeInitialPrompt) {

--- a/packages/cli/src/extensions/pizzapi-header.test.ts
+++ b/packages/cli/src/extensions/pizzapi-header.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the PizzaPi branded TUI header extension.
+ *
+ * Uses a minimal Theme mock to test layout logic without needing
+ * a real TUI or pi agent context.
+ */
+
+import { describe, test, expect } from "bun:test";
+
+// ── Minimal mock theme that returns plain text (no ANSI codes) ───────────────
+// This makes it easy to check visible output without stripping escape codes.
+
+type ThemeColor =
+    | "accent"
+    | "border"
+    | "borderAccent"
+    | "borderMuted"
+    | "success"
+    | "error"
+    | "warning"
+    | "muted"
+    | "dim"
+    | "text"
+    | string;
+
+const mockTheme = {
+    fg: (_color: ThemeColor, text: string) => text,
+    bold: (text: string) => text,
+} as any;
+
+// ── Import pure helpers by re-implementing them for isolated test ─────────────
+// We test the exported `pizzapiHeaderExtension` function indirectly by
+// verifying observable render output through mock session_start registration.
+// For pure logic, we directly test the render path by calling ctx.ui.setHeader.
+
+// We capture the render function by hijacking the setHeader call.
+let capturedRender: ((width: number) => string[]) | null = null;
+
+const mockCtx = {
+    ui: {
+        setHeader: (factory: (tui: any, theme: any) => { render: (w: number) => string[]; invalidate: () => void }) => {
+            const component = factory({}, mockTheme);
+            capturedRender = component.render.bind(component);
+        },
+    },
+};
+
+const mockPi = {
+    on: (event: string, handler: (ev: any, ctx: any) => void) => {
+        if (event === "session_start") {
+            handler({}, mockCtx);
+        }
+    },
+} as any;
+
+import { pizzapiHeaderExtension } from "./pizzapi-header.js";
+
+describe("pizzapiHeaderExtension", () => {
+    test("registers on session_start and calls setHeader", () => {
+        capturedRender = null;
+        pizzapiHeaderExtension(mockPi);
+        expect(capturedRender).not.toBeNull();
+    });
+
+    test("render returns string array", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(100);
+        expect(Array.isArray(lines)).toBe(true);
+        expect(lines.length).toBeGreaterThan(0);
+    });
+
+    test("wide render (>= 80 cols) returns 7 lines with box-drawing frame", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(100);
+        // Wide mode: top border + row1 + separator + row2 + row3 + row4 + bottom border = 7
+        expect(lines.length).toBe(7);
+    });
+
+    test("narrow render (< 80 cols) returns single compact line", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(60);
+        expect(lines.length).toBe(1);
+        expect(lines[0]).toContain("🍕");
+        expect(lines[0]).toContain("PizzaPi");
+    });
+
+    test("wide top border contains PizzaPi branding", () => {
+        pizzapiHeaderExtension(mockPi);
+        const [topBorder] = capturedRender!(100);
+        expect(topBorder).toContain("PizzaPi");
+        expect(topBorder).toContain("🍕");
+    });
+
+    test("wide top border starts with ╭ and ends with ╮", () => {
+        pizzapiHeaderExtension(mockPi);
+        const [topBorder] = capturedRender!(100);
+        expect(topBorder!.startsWith("╭")).toBe(true);
+        expect(topBorder!.endsWith("╮")).toBe(true);
+    });
+
+    test("wide bottom border starts with ╰ and ends with ╯", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(100);
+        const bottom = lines[lines.length - 1]!;
+        expect(bottom.startsWith("╰")).toBe(true);
+        expect(bottom.endsWith("╯")).toBe(true);
+    });
+
+    test("content lines start with │ and end with │", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(100);
+        // Content lines are indices 1 and 3-5 (not top, mid-separator, bottom borders)
+        const contentLines = [lines[1], lines[3], lines[4], lines[5]];
+        for (const line of contentLines) {
+            expect(line!.startsWith("│")).toBe(true);
+            expect(line!.endsWith("│")).toBe(true);
+        }
+    });
+
+    test("mid-separator starts with ├ and ends with ┤", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(100);
+        const mid = lines[2]!;
+        expect(mid.startsWith("├")).toBe(true);
+        expect(mid.endsWith("┤")).toBe(true);
+    });
+
+    test("all wide lines have consistent visible width", () => {
+        pizzapiHeaderExtension(mockPi);
+        const width = 100;
+        const lines = capturedRender!(width);
+        // Each line should be exactly width chars (no ANSI in mock theme)
+        for (const line of lines) {
+            // Allow for emoji width variation (🍕 may be 2 wide)
+            // but check they're close to the target width
+            expect(line!.length).toBeGreaterThanOrEqual(width - 5);
+            expect(line!.length).toBeLessThanOrEqual(width + 5);
+        }
+    });
+
+    test("row1 contains key bindings for basic controls", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(100);
+        const row1 = lines[1]!;
+        expect(row1).toContain("Ctrl+C");
+        expect(row1).toContain("Ctrl+D");
+        expect(row1).toContain("Ctrl+Z");
+    });
+
+    test("row2 contains thinking and model hints", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(100);
+        const row2 = lines[3]!;
+        expect(row2).toContain("⇧Tab");
+        expect(row2).toContain("Ctrl+L");
+    });
+
+    test("row3 contains tools and editor hints", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(100);
+        const row3 = lines[4]!;
+        expect(row3).toContain("Ctrl+O");
+        expect(row3).toContain("Ctrl+G");
+    });
+
+    test("row4 contains special input hints", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(100);
+        const row4 = lines[5]!;
+        expect(row4).toContain("/");
+        expect(row4).toContain("!");
+        expect(row4).toContain("Ctrl+V");
+    });
+
+    test("handles very narrow width gracefully (width < 10)", () => {
+        pizzapiHeaderExtension(mockPi);
+        // Should not throw
+        expect(() => capturedRender!(5)).not.toThrow();
+        const lines = capturedRender!(5);
+        expect(Array.isArray(lines)).toBe(true);
+    });
+});

--- a/packages/cli/src/extensions/pizzapi-header.test.ts
+++ b/packages/cli/src/extensions/pizzapi-header.test.ts
@@ -214,4 +214,14 @@ describe("pizzapiHeaderExtension", () => {
         const lines = capturedRender!(5);
         expect(Array.isArray(lines)).toBe(true);
     });
+
+    test("wide top border visible width equals terminal width", () => {
+        pizzapiHeaderExtension(mockPi);
+        for (const width of [100, 120, 160]) {
+            const lines = capturedRender!(width);
+            const topBorder = lines[0]!;
+            const actual = visibleWidth(topBorder);
+            expect(actual).toBe(width);
+        }
+    });
 });

--- a/packages/cli/src/extensions/pizzapi-header.test.ts
+++ b/packages/cli/src/extensions/pizzapi-header.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { describe, test, expect } from "bun:test";
+import { visibleWidth } from "@mariozechner/pi-tui";
 
 // ── Minimal mock theme that returns plain text (no ANSI codes) ───────────────
 // This makes it easy to check visible output without stripping escape codes.
@@ -69,19 +70,53 @@ describe("pizzapiHeaderExtension", () => {
         expect(lines.length).toBeGreaterThan(0);
     });
 
-    test("wide render (>= 80 cols) returns 7 lines with box-drawing frame", () => {
+    test("wide render (>= 100 cols) returns 7 lines with box-drawing frame", () => {
         pizzapiHeaderExtension(mockPi);
         const lines = capturedRender!(100);
         // Wide mode: top border + row1 + separator + row2 + row3 + row4 + bottom border = 7
         expect(lines.length).toBe(7);
     });
 
-    test("narrow render (< 80 cols) returns single compact line", () => {
+    test("narrow render (< 100 cols) returns single compact line", () => {
         pizzapiHeaderExtension(mockPi);
         const lines = capturedRender!(60);
         expect(lines.length).toBe(1);
         expect(lines[0]).toContain("🍕");
         expect(lines[0]).toContain("PizzaPi");
+    });
+
+    test("width=99 is narrow (< 100 threshold)", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(99);
+        expect(lines.length).toBe(1);
+    });
+
+    test("width=100 is wide (>= 100 threshold)", () => {
+        pizzapiHeaderExtension(mockPi);
+        const lines = capturedRender!(100);
+        expect(lines.length).toBe(7);
+    });
+
+    test("narrow mode: line visible width does not exceed given width", () => {
+        pizzapiHeaderExtension(mockPi);
+        for (const width of [5, 10, 17, 20, 40, 60, 80, 99]) {
+            const lines = capturedRender!(width);
+            for (const line of lines) {
+                const lw = visibleWidth(line!);
+                expect(lw).toBeLessThanOrEqual(width);
+            }
+        }
+    });
+
+    test("wide mode: all lines visible width does not exceed given width", () => {
+        pizzapiHeaderExtension(mockPi);
+        for (const width of [100, 120, 160, 200]) {
+            const lines = capturedRender!(width);
+            for (const line of lines) {
+                const lw = visibleWidth(line!);
+                expect(lw).toBeLessThanOrEqual(width);
+            }
+        }
     });
 
     test("wide top border contains PizzaPi branding", () => {

--- a/packages/cli/src/extensions/pizzapi-header.ts
+++ b/packages/cli/src/extensions/pizzapi-header.ts
@@ -172,12 +172,36 @@ export function pizzapiHeaderExtension(pi: ExtensionAPI): void {
                 render(width: number): string[] {
                     const innerWidth = width - 4;
 
-                    // ── Narrow fallback (< 80 cols) ──────────────────────────
-                    if (width < 80) {
-                        return [
-                            theme.fg("accent", `🍕 PizzaPi v${version}`) +
-                            theme.fg("dim", "  Ctrl+C clear · Ctrl+D exit · Ctrl+Z suspend"),
-                        ];
+                    // ── Narrow fallback (< 100 cols) ─────────────────────────
+                    if (width < 100) {
+                        if (width <= 0) return [];
+
+                        // Build title, truncating to fit within width
+                        const titleRaw = `🍕 PizzaPi v${version}`;
+                        let titleFit = "";
+                        let titleFitWidth = 0;
+                        for (const char of titleRaw) {
+                            const cw = visibleWidth(char);
+                            if (titleFitWidth + cw > width) break;
+                            titleFit += char;
+                            titleFitWidth += cw;
+                        }
+
+                        const titleStyled = theme.fg("accent", titleFit);
+
+                        // Remaining space after title and 2-char separator ("  ")
+                        const hintSpace = width - titleFitWidth - 2;
+                        if (hintSpace <= 0) {
+                            return [titleStyled];
+                        }
+
+                        const hintsLine = buildHintLine(theme, [
+                            hint(theme, KEYS.clear, "clear"),
+                            hint(theme, KEYS.exit, "exit"),
+                            hint(theme, KEYS.suspend, "suspend"),
+                        ], hintSpace);
+
+                        return [hintsLine ? titleStyled + "  " + hintsLine : titleStyled];
                     }
 
                     // ── Wide layout with box-drawing frame ───────────────────

--- a/packages/cli/src/extensions/pizzapi-header.ts
+++ b/packages/cli/src/extensions/pizzapi-header.ts
@@ -119,20 +119,25 @@ function topBorder(
     version: string,
     width: number,
 ): string {
-    const titleRaw = ` 🍕 PizzaPi v${version} `;
+    // The rendered title zone is: "🍕 PizzaPi v${version}" + " " (1 trailing space before right dashes).
+    // We must use visibleWidth() here because the emoji occupies 2 terminal columns
+    // and we need exact column counts, not JS string lengths.
+    const titleText = `🍕 PizzaPi v${version}`;
+    // +1 for the trailing space between the title and the right dashes
+    const titleZoneWidth = visibleWidth(titleText) + 1;
     // +2 for the corner chars; the title sits inside the horizontal rule
     const ruleWidth = width - 2;
-    if (ruleWidth <= titleRaw.length) {
+    if (ruleWidth <= titleZoneWidth) {
         // Too narrow: just horizontal rule
         return theme.fg("border", "╭" + "─".repeat(Math.max(0, ruleWidth)) + "╮");
     }
-    const remaining = ruleWidth - titleRaw.length;
+    const remaining = ruleWidth - titleZoneWidth;
     const leftDashes = Math.floor(remaining / 2);
     const rightDashes = remaining - leftDashes;
-    // Rebuild: corner + dashes + styled-title + dashes + corner
+    // Rebuild: corner + dashes + styled-title + space + dashes + corner
     return (
         theme.fg("border", "╭" + "─".repeat(leftDashes)) +
-        theme.fg("accent", `🍕 PizzaPi v${version}`) +
+        theme.fg("accent", titleText) +
         theme.fg("border", " " + "─".repeat(rightDashes) + "╮")
     );
 }

--- a/packages/cli/src/extensions/pizzapi-header.ts
+++ b/packages/cli/src/extensions/pizzapi-header.ts
@@ -1,0 +1,230 @@
+/**
+ * PizzaPi branded TUI header with box-drawing frame.
+ *
+ * Replaces pi's built-in header with a "balanced control panel" layout:
+ * a box-drawing frame containing the PizzaPi title centered in the top border
+ * and keybinding hints organised by category.
+ *
+ * For narrow terminals (< 80 cols), falls back to a compact text-only header.
+ */
+
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import type { Theme } from "@mariozechner/pi-coding-agent";
+import { visibleWidth } from "@mariozechner/pi-tui";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+// ── Version ──────────────────────────────────────────────────────────────────
+
+function getPizzaPiVersion(): string {
+    try {
+        const require = createRequire(import.meta.url);
+        const __filename = fileURLToPath(import.meta.url);
+        const __dirname = dirname(__filename);
+        // Works whether running from src/ or dist/
+        const pkgPath = join(__dirname, "..", "..", "package.json");
+        const pkg = require(pkgPath) as { version: string };
+        return pkg.version ?? "0.0.0";
+    } catch {
+        return "0.0.0";
+    }
+}
+
+// ── Default keybinding display strings ───────────────────────────────────────
+// These mirror DEFAULT_APP_KEYBINDINGS from pi-coding-agent/dist/core/keybindings.js
+// Since extensions don't receive a KeybindingsManager, we hardcode defaults here.
+
+const KEYS = {
+    interrupt: "Esc",
+    clear: "Ctrl+C",
+    exit: "Ctrl+D",
+    suspend: "Ctrl+Z",
+    cycleThinkingLevel: "⇧Tab",
+    cycleModelForward: "Ctrl+P",
+    cycleModelBackward: "⇧Ctrl+P",
+    selectModel: "Ctrl+L",
+    expandTools: "Ctrl+O",
+    toggleThinking: "Ctrl+T",
+    externalEditor: "Ctrl+G",
+    followUp: "Alt+↩",
+    dequeue: "Alt+↑",
+    pasteImage: "Ctrl+V",
+} as const;
+
+// ── Layout helpers ────────────────────────────────────────────────────────────
+
+/** Pad a string (which may contain ANSI codes) to exactly `width` visible chars. */
+function padToWidth(s: string, width: number): string {
+    const vis = visibleWidth(s);
+    if (vis >= width) return s;
+    return s + " ".repeat(width - vis);
+}
+
+/**
+ * Build a hint segment: styled key + styled description.
+ * key in "muted", description in "dim".
+ */
+function hint(
+    theme: Theme,
+    key: string,
+    desc: string,
+): { text: string; rawLen: number } {
+    const raw = `${key} ${desc}`;
+    const text = theme.fg("muted", key) + theme.fg("dim", ` ${desc}`);
+    return { text, rawLen: raw.length };
+}
+
+/**
+ * Join hint segments with a " · " separator, truncating to fit `innerWidth`.
+ * Returns the composed line (may contain ANSI codes).
+ */
+function buildHintLine(
+    theme: Theme,
+    hints: Array<{ text: string; rawLen: number }>,
+    innerWidth: number,
+): string {
+    const sep = " · ";
+    const sepRaw = sep.length;
+    const sepStyled = theme.fg("dim", sep);
+
+    let line = "";
+    let usedRaw = 0;
+
+    for (let i = 0; i < hints.length; i++) {
+        const h = hints[i]!;
+        const addLen = (i === 0 ? 0 : sepRaw) + h.rawLen;
+        if (usedRaw + addLen > innerWidth) break;
+        if (i > 0) line += sepStyled;
+        line += h.text;
+        usedRaw += addLen;
+    }
+    return line;
+}
+
+/** Render a box content line: `│ <padded-content> │` */
+function boxLine(
+    theme: Theme,
+    content: string,
+    width: number,
+): string {
+    const innerWidth = width - 4; // 2 for "│ " prefix + 2 for " │" suffix
+    const padded = padToWidth(content, Math.max(0, innerWidth));
+    return theme.fg("border", "│") + " " + padded + " " + theme.fg("border", "│");
+}
+
+/** Build the top border: `╭──── 🍕 PizzaPi v0.4.0 ────╮` */
+function topBorder(
+    theme: Theme,
+    version: string,
+    width: number,
+): string {
+    const titleRaw = ` 🍕 PizzaPi v${version} `;
+    // +2 for the corner chars; the title sits inside the horizontal rule
+    const ruleWidth = width - 2;
+    if (ruleWidth <= titleRaw.length) {
+        // Too narrow: just horizontal rule
+        return theme.fg("border", "╭" + "─".repeat(Math.max(0, ruleWidth)) + "╮");
+    }
+    const remaining = ruleWidth - titleRaw.length;
+    const leftDashes = Math.floor(remaining / 2);
+    const rightDashes = remaining - leftDashes;
+    // Rebuild: corner + dashes + styled-title + dashes + corner
+    return (
+        theme.fg("border", "╭" + "─".repeat(leftDashes)) +
+        theme.fg("accent", `🍕 PizzaPi v${version}`) +
+        theme.fg("border", " " + "─".repeat(rightDashes) + "╮")
+    );
+}
+
+/** Middle separator: `├──...──┤` */
+function midBorder(
+    theme: Theme,
+    width: number,
+): string {
+    return theme.fg("border", "├" + "─".repeat(Math.max(0, width - 2)) + "┤");
+}
+
+/** Bottom border: `╰──...──╯` */
+function bottomBorder(
+    theme: Theme,
+    width: number,
+): string {
+    return theme.fg("border", "╰" + "─".repeat(Math.max(0, width - 2)) + "╯");
+}
+
+// ── Extension factory ─────────────────────────────────────────────────────────
+
+/**
+ * ExtensionFactory that installs the PizzaPi branded TUI header.
+ *
+ * Registers on "session_start" and calls ctx.ui.setHeader() to replace
+ * pi's built-in header with the branded box-drawing frame.
+ */
+export function pizzapiHeaderExtension(pi: ExtensionAPI): void {
+    const version = getPizzaPiVersion();
+
+    pi.on("session_start", (_event, ctx) => {
+        ctx.ui.setHeader((_tui, theme) => {
+            return {
+                invalidate() {},
+
+                render(width: number): string[] {
+                    const innerWidth = width - 4;
+
+                    // ── Narrow fallback (< 80 cols) ──────────────────────────
+                    if (width < 80) {
+                        return [
+                            theme.fg("accent", `🍕 PizzaPi v${version}`) +
+                            theme.fg("dim", "  Ctrl+C clear · Ctrl+D exit · Ctrl+Z suspend"),
+                        ];
+                    }
+
+                    // ── Wide layout with box-drawing frame ───────────────────
+
+                    // Row 1 — basic controls
+                    const row1 = buildHintLine(theme, [
+                        hint(theme, KEYS.clear, "interrupt"),
+                        hint(theme, KEYS.exit, "exit"),
+                        hint(theme, KEYS.suspend, "suspend"),
+                    ], innerWidth);
+
+                    // Row 2 — thinking / model
+                    const row2 = buildHintLine(theme, [
+                        hint(theme, KEYS.cycleThinkingLevel, "thinking"),
+                        hint(theme, KEYS.toggleThinking, "toggle thinking"),
+                        hint(theme, `${KEYS.cycleModelForward}/${KEYS.cycleModelBackward}`, "cycle models"),
+                        hint(theme, KEYS.selectModel, "select model"),
+                    ], innerWidth);
+
+                    // Row 3 — tools / nav
+                    const row3 = buildHintLine(theme, [
+                        hint(theme, KEYS.expandTools, "tools"),
+                        hint(theme, KEYS.externalEditor, "editor"),
+                        hint(theme, KEYS.followUp, "follow-up"),
+                        hint(theme, KEYS.dequeue, "dequeue"),
+                    ], innerWidth);
+
+                    // Row 4 — special inputs
+                    const row4 = buildHintLine(theme, [
+                        hint(theme, "/", "commands"),
+                        hint(theme, "!", "bash"),
+                        hint(theme, "!!", "bash (no ctx)"),
+                        hint(theme, KEYS.pasteImage, "paste"),
+                        { text: theme.fg("dim", "drop files"), rawLen: "drop files".length },
+                    ], innerWidth);
+
+                    return [
+                        topBorder(theme, version, width),
+                        boxLine(theme, row1, width),
+                        midBorder(theme, width),
+                        boxLine(theme, row2, width),
+                        boxLine(theme, row3, width),
+                        boxLine(theme, row4, width),
+                        bottomBorder(theme, width),
+                    ];
+                },
+            };
+        });
+    });
+}


### PR DESCRIPTION
Night Shift dish 002 — Custom balanced control panel header with box-drawing frame, 🍕 PizzaPi branding, and categorized keybinding hints.

## What this adds

A new `pizzapiHeaderExtension` that replaces pi's built-in header with a branded box-drawing panel:

```
╭─────────────────────────── 🍕 PizzaPi v0.4.0 ───────────────────────────╮
│ Ctrl+C interrupt · Ctrl+D exit · Ctrl+Z suspend                         │
├──────────────────────────────────────────────────────────────────────────┤
│ ⇧Tab thinking · Ctrl+T toggle thinking · Ctrl+P/⇧Ctrl+P cycle models    │
│ Ctrl+O tools · Ctrl+G editor · Alt+↩ follow-up · Alt+↑ dequeue          │
│ / commands · ! bash · !! bash (no ctx) · Ctrl+V paste · drop files       │
╰──────────────────────────────────────────────────────────────────────────╯
```

- Responsive: full box-drawing frame for ≥80 cols, compact single-line for <80 cols
- Reads version from `packages/cli/package.json` at runtime
- Uses actual pi default keybindings (hardcoded per task spec)
- Registered as a core extension in `buildPizzaPiExtensionFactories`

## Files changed

- `packages/cli/src/extensions/pizzapi-header.ts` — new extension
- `packages/cli/src/extensions/pizzapi-header.test.ts` — 15 unit tests
- `packages/cli/src/extensions/factories.ts` — registration
- `packages/cli/src/extensions/factories.test.ts` — updated to include new core extension

## Testing

- 15 new unit tests for header rendering (all pass)
- 11 existing factories tests updated and passing
- Typecheck clean (no new errors)