### PR TITLE
feat(cli): themed TUI rendering for spawn_session

### DIFF
--- a/packages/cli/src/extensions/spawn-session.ts
+++ b/packages/cli/src/extensions/spawn-session.ts
@@ -237,26 +237,27 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
             );
         },
         renderResult: (result: any, _opts: any, theme: any) => {
-            try {
-                const text: string = result?.content?.[0]?.text ?? "";
-                if (text.startsWith("Error:") || text.startsWith("{\"error\"")) {
-                    const msg = text.length > 80 ? text.slice(0, 77) + "..." : text;
-                    return new Text(theme.fg("error", "✗ ") + theme.fg("muted", msg), 0, 0);
-                }
-                const data = JSON.parse(text);
-                const rawId: string = data.sessionId ?? "";
-                const sessionId = rawId.length > 8 ? rawId.slice(-8) : rawId || "?";
-                const url: string = data.shareUrl ? " " + data.shareUrl : "";
-                return new Text(
-                    theme.fg("success", "✓") + " " +
-                    theme.fg("muted", "session ") +
-                    theme.fg("accent", sessionId) +
-                    theme.fg("dim", url),
-                    0, 0
-                );
-            } catch {
-                return new Text(theme.fg("success", "✓ ") + theme.fg("muted", "session spawned"), 0, 0);
+            const details = result?.details as Record<string, unknown> | undefined;
+            const text: string = result?.content?.[0]?.text ?? "";
+
+            // Error: details has an "error" key, or text starts with "Error"
+            if (details?.error || text.startsWith("Error")) {
+                const msg = (typeof details?.error === "string" ? details.error : text);
+                const display = msg.length > 80 ? msg.slice(0, 77) + "..." : msg;
+                return new Text(theme.fg("error", "✗ " + display), 0, 0);
             }
+
+            // Success: use details.sessionId and details.shareUrl
+            const rawId = typeof details?.sessionId === "string" ? details.sessionId : "";
+            const sessionId = rawId.length > 8 ? rawId.slice(-8) : rawId || "?";
+            const url = typeof details?.shareUrl === "string" ? " " + details.shareUrl : "";
+            return new Text(
+                theme.fg("success", "✓") + " " +
+                theme.fg("muted", "session ") +
+                theme.fg("accent", sessionId) +
+                theme.fg("dim", url),
+                0, 0
+            );
         },
     });
 

--- a/packages/cli/src/extensions/spawn-session.ts
+++ b/packages/cli/src/extensions/spawn-session.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
 import { loadConfig } from "../config.js";
 import { getRelaySessionId } from "./remote.js";
 import { buildProviderUsage, refreshAllUsage } from "./remote-provider-usage.js";
@@ -224,8 +225,39 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
             }
         },
 
-        renderCall: () => silent,
-        renderResult: () => silent,
+        renderCall: (args: any, theme: any) => {
+            const model = args.model ? ` [${args.model.provider}/${args.model.id}]` : "";
+            const rawCwd = args.cwd ?? "";
+            const cwdDisplay = rawCwd ? ` in ${rawCwd.split("/").slice(-2).join("/")}` : "";
+            return new Text(
+                theme.fg("accent", "⟳") + " " +
+                theme.fg("muted", "spawning session") +
+                theme.fg("dim", model + cwdDisplay),
+                0, 0
+            );
+        },
+        renderResult: (result: any, _opts: any, theme: any) => {
+            try {
+                const text: string = result?.content?.[0]?.text ?? "";
+                if (text.startsWith("Error:") || text.startsWith("{\"error\"")) {
+                    const msg = text.length > 80 ? text.slice(0, 77) + "..." : text;
+                    return new Text(theme.fg("error", "✗ ") + theme.fg("muted", msg), 0, 0);
+                }
+                const data = JSON.parse(text);
+                const rawId: string = data.sessionId ?? "";
+                const sessionId = rawId.length > 8 ? rawId.slice(-8) : rawId || "?";
+                const url: string = data.shareUrl ? " " + data.shareUrl : "";
+                return new Text(
+                    theme.fg("success", "✓") + " " +
+                    theme.fg("muted", "session ") +
+                    theme.fg("accent", sessionId) +
+                    theme.fg("dim", url),
+                    0, 0
+                );
+            } catch {
+                return new Text(theme.fg("success", "✓ ") + theme.fg("muted", "session spawned"), 0, 0);
+            }
+        },
     });
 
     pi.registerTool({


### PR DESCRIPTION
Night Shift 2 dish 002 — spawn_session now shows a themed status line in the TUI: ⟳ spawning session + session ID on completion.

## Changes

- **`packages/cli/src/extensions/spawn-session.ts`**: Added `import { Text } from "@mariozechner/pi-tui"` and replaced silent `renderCall`/`renderResult` for the `spawn_session` tool with themed output.

### renderCall
```
⟳ spawning session  [provider/model]  in last/two/segments/of/cwd
```
Uses `theme.fg("accent")` for the spinner, `theme.fg("muted")` for the label, and `theme.fg("dim")` for the model/cwd metadata.

### renderResult
- **Success**: `✓ session <last-8-chars-of-id> <shareUrl>` using success/accent/dim theme tokens
- **Error**: `✗ <truncated error message>` using error token
- **Parse fallback**: `✓ session spawned` (catch-all)

### Unchanged
- `list_models` — keeps silent `renderCall`/`renderResult` (utility call, not user-facing)
- `set_session_name` — not touched