### PR TITLE
fix(tools): remove fragile search.test.ts assertion that fails on paths containing 'usage'

### DIFF
--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -246,8 +246,6 @@ describe("searchTool", () => {
             type: "files",
         });
         const text = result.content[0].text;
-        // Must NOT contain help/usage output from find
-        expect(text.toLowerCase()).not.toContain("usage");
         // Should be either "No matches found" or "Search failed: ..." (path doesn't exist)
         expect(text === "No matches found" || text.startsWith("Search failed:")).toBe(true);
     });


### PR DESCRIPTION
## Problem

In `packages/tools/src/search.test.ts`, the assertion:
```ts
expect(text.toLowerCase()).not.toContain("usage");
```
will false-fail if the cwd path contains 'usage' (e.g. nightshift worktrees).

## Fix

Removed the fragile assertion. The next assertion already covers the intent precisely:
```ts
expect(text === "No matches found" || text.startsWith("Search failed:")).toBe(true);
```

Fixes Godmother bug: MCBL0VIN