### PR TITLE
fix(ui): remove !e.shiftKey from ? shortcut — was dead code on standard layouts

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2828,7 +2828,6 @@ export function App() {
         !e.metaKey &&
         !e.ctrlKey &&
         !e.altKey &&
-        !e.shiftKey &&
         !document.querySelector('[role="dialog"]')
       ) {
         setShowShortcutsHelp(true);


### PR DESCRIPTION
## Problem

The `?` keyboard shortcut to show help is dead code on standard US keyboard layouts.

Typing `?` requires `Shift+/`, so `e.key === "?"` is only true when `e.shiftKey === true`. The handler simultaneously required `!e.shiftKey`, making these two conditions mutually exclusive.

## Fix

Removed the `!e.shiftKey` guard from the `?` shortcut handler. The other modifier guards (`!e.metaKey`, `!e.ctrlKey`, `!e.altKey`) remain to prevent firing during Cmd+Shift+? etc.

Fixes Godmother bug: Oj8CXyzM