### PR TITLE
feat(tunnel): HTTP port tunnel service — Runner Service System Phase 4

### DIFF
--- a/packages/cli/src/cli-colors.test.ts
+++ b/packages/cli/src/cli-colors.test.ts
@@ -125,6 +125,23 @@ describe("cli-colors helpers (logic)", () => {
         }
     });
 
+    test("colorRemaining shows correct remaining % (not used %)", async () => {
+        const origNoColor = process.env["NO_COLOR"];
+        process.env["NO_COLOR"] = "1";
+        try {
+            const mod = await import(`./cli-colors.ts?remaining=${Date.now()}`);
+            // 90% remaining → should display "90.0%", not "10.0%"
+            expect(mod.colorRemaining(90)).toBe("90.0%");
+            // 10% remaining → should display "10.0%", not "90.0%"
+            expect(mod.colorRemaining(10)).toBe("10.0%");
+            // 50% remaining → should display "50.0%"
+            expect(mod.colorRemaining(50)).toBe("50.0%");
+        } finally {
+            if (origNoColor === undefined) delete process.env["NO_COLOR"];
+            else process.env["NO_COLOR"] = origNoColor;
+        }
+    });
+
     test("c helpers are identity functions when NO_COLOR is set", async () => {
         const origNoColor = process.env["NO_COLOR"];
         process.env["NO_COLOR"] = "1";

--- a/packages/cli/src/cli-colors.test.ts
+++ b/packages/cli/src/cli-colors.test.ts
@@ -25,6 +25,21 @@ describe("cli-colors (NO_COLOR / non-TTY)", () => {
         }
     });
 
+    test("usageBar returns plain text when NO_COLOR is empty string (presence-based spec)", async () => {
+        const orig = process.env["NO_COLOR"];
+        // NO_COLOR="" — present but empty — must still disable colors per no-color.org
+        process.env["NO_COLOR"] = "";
+        try {
+            const mod = await import(`./cli-colors.ts?nocolor_empty=${Date.now()}`);
+            const result = mod.usageBar(75);
+            expect(result).toBe(stripAnsi(result));
+            expect(result).toContain("75.0%");
+        } finally {
+            if (orig === undefined) delete process.env["NO_COLOR"];
+            else process.env["NO_COLOR"] = orig;
+        }
+    });
+
     test("colorPct returns plain percentage string when NO_COLOR is set", async () => {
         const orig = process.env["NO_COLOR"];
         process.env["NO_COLOR"] = "1";
@@ -33,6 +48,19 @@ describe("cli-colors (NO_COLOR / non-TTY)", () => {
             expect(mod.colorPct(42)).toBe("42.0%");
             expect(mod.colorPct(60)).toBe("60.0%");
             expect(mod.colorPct(90)).toBe("90.0%");
+        } finally {
+            if (orig === undefined) delete process.env["NO_COLOR"];
+            else process.env["NO_COLOR"] = orig;
+        }
+    });
+
+    test("colorPct returns plain percentage string when NO_COLOR is empty string", async () => {
+        const orig = process.env["NO_COLOR"];
+        process.env["NO_COLOR"] = "";
+        try {
+            const mod = await import(`./cli-colors.ts?nocolor_empty2=${Date.now()}`);
+            expect(mod.colorPct(42)).toBe("42.0%");
+            expect(mod.colorPct(80)).toBe("80.0%");
         } finally {
             if (orig === undefined) delete process.env["NO_COLOR"];
             else process.env["NO_COLOR"] = orig;
@@ -55,6 +83,26 @@ describe("cli-colors helpers (logic)", () => {
             // 50% → 5 filled + 5 empty
             const half = mod.usageBar(50, 10);
             expect(half).toContain("█".repeat(5) + "░".repeat(5));
+        } finally {
+            if (origNoColor === undefined) delete process.env["NO_COLOR"];
+            else process.env["NO_COLOR"] = origNoColor;
+        }
+    });
+
+    test("colorPct 80% boundary is amber not red (spec: red is >80, not >=80)", async () => {
+        const origNoColor = process.env["NO_COLOR"];
+        // Need colors enabled — delete NO_COLOR and simulate TTY via module internals
+        // We can't easily fake isTTY, so we test with NO_COLOR set and check plain output,
+        // then verify the threshold logic via a color-enabled import using FORCE_COLOR workaround.
+        // Since we can't fake isTTY in bun:test, we verify the logic path is correct by
+        // checking that the no-color fallback returns plain text at all boundaries.
+        process.env["NO_COLOR"] = "1";
+        try {
+            const mod = await import(`./cli-colors.ts?boundary=${Date.now()}`);
+            // In no-color mode all return plain text — ensures no crashes at boundary values
+            expect(mod.colorPct(79.9)).toBe("79.9%");
+            expect(mod.colorPct(80.0)).toBe("80.0%");
+            expect(mod.colorPct(80.1)).toBe("80.1%");
         } finally {
             if (origNoColor === undefined) delete process.env["NO_COLOR"];
             else process.env["NO_COLOR"] = origNoColor;

--- a/packages/cli/src/cli-colors.test.ts
+++ b/packages/cli/src/cli-colors.test.ts
@@ -1,0 +1,100 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+
+// We test the module behaviour by controlling the TTY + env state before import.
+// Because Bun caches modules we use dynamic imports with cache-busting.
+
+describe("cli-colors (NO_COLOR / non-TTY)", () => {
+    // Strip ANSI escape sequences from a string
+    const stripAnsi = (s: string) => s.replace(/\x1b\[[0-9;]*m/g, "");
+
+    test("usageBar returns plain text when NO_COLOR is set", async () => {
+        const orig = process.env["NO_COLOR"];
+        process.env["NO_COLOR"] = "1";
+        try {
+            // Re-import so the module re-evaluates isColorEnabled
+            const mod = await import(`./cli-colors.ts?nocolor=${Date.now()}`);
+            const result = mod.usageBar(75);
+            // Should not contain ANSI codes
+            expect(result).toBe(stripAnsi(result));
+            expect(result).toContain("75.0%");
+            expect(result).toContain("[");
+            expect(result).toContain("]");
+        } finally {
+            if (orig === undefined) delete process.env["NO_COLOR"];
+            else process.env["NO_COLOR"] = orig;
+        }
+    });
+
+    test("colorPct returns plain percentage string when NO_COLOR is set", async () => {
+        const orig = process.env["NO_COLOR"];
+        process.env["NO_COLOR"] = "1";
+        try {
+            const mod = await import(`./cli-colors.ts?nocolor2=${Date.now()}`);
+            expect(mod.colorPct(42)).toBe("42.0%");
+            expect(mod.colorPct(60)).toBe("60.0%");
+            expect(mod.colorPct(90)).toBe("90.0%");
+        } finally {
+            if (orig === undefined) delete process.env["NO_COLOR"];
+            else process.env["NO_COLOR"] = orig;
+        }
+    });
+});
+
+describe("cli-colors helpers (logic)", () => {
+    test("usageBar fills correct number of blocks", async () => {
+        const origNoColor = process.env["NO_COLOR"];
+        process.env["NO_COLOR"] = "1";
+        try {
+            const mod = await import(`./cli-colors.ts?fill=${Date.now()}`);
+            // 0% → all empty
+            const empty = mod.usageBar(0, 10);
+            expect(empty).toContain("░".repeat(10));
+            // 100% → all filled
+            const full = mod.usageBar(100, 10);
+            expect(full).toContain("█".repeat(10));
+            // 50% → 5 filled + 5 empty
+            const half = mod.usageBar(50, 10);
+            expect(half).toContain("█".repeat(5) + "░".repeat(5));
+        } finally {
+            if (origNoColor === undefined) delete process.env["NO_COLOR"];
+            else process.env["NO_COLOR"] = origNoColor;
+        }
+    });
+
+    test("usageBar clamps values outside 0-100", async () => {
+        const origNoColor = process.env["NO_COLOR"];
+        process.env["NO_COLOR"] = "1";
+        try {
+            const mod = await import(`./cli-colors.ts?clamp=${Date.now()}`);
+            // Should not throw and should clamp correctly
+            const over = mod.usageBar(150, 10);
+            expect(over).toContain("100.0%");
+            const under = mod.usageBar(-10, 10);
+            expect(under).toContain("0.0%");
+        } finally {
+            if (origNoColor === undefined) delete process.env["NO_COLOR"];
+            else process.env["NO_COLOR"] = origNoColor;
+        }
+    });
+
+    test("c helpers are identity functions when NO_COLOR is set", async () => {
+        const origNoColor = process.env["NO_COLOR"];
+        process.env["NO_COLOR"] = "1";
+        try {
+            const mod = await import(`./cli-colors.ts?identity=${Date.now()}`);
+            const { c } = mod;
+            expect(c.brand("hello")).toBe("hello");
+            expect(c.cmd("pizza")).toBe("pizza");
+            expect(c.label("Commands")).toBe("Commands");
+            expect(c.flag("--help")).toBe("--help");
+            expect(c.success("✓")).toBe("✓");
+            expect(c.error("✗")).toBe("✗");
+            expect(c.dim("secondary")).toBe("secondary");
+            expect(c.bold("bold text")).toBe("bold text");
+            expect(c.accent("accent")).toBe("accent");
+        } finally {
+            if (origNoColor === undefined) delete process.env["NO_COLOR"];
+            else process.env["NO_COLOR"] = origNoColor;
+        }
+    });
+});

--- a/packages/cli/src/cli-colors.ts
+++ b/packages/cli/src/cli-colors.ts
@@ -96,3 +96,16 @@ export function colorPct(pct: number): string {
     if (pct <= 80) return `\x1b[33m${s}\x1b[39m`;
     return `\x1b[31m${s}\x1b[39m`;
 }
+
+/**
+ * Return a colored remaining-percentage string.
+ * Coloring is based on remaining (high remaining = green, low remaining = red):
+ * Green >50%, amber 20-50%, red ≤20%.
+ */
+export function colorRemaining(pct: number): string {
+    const s = `${pct.toFixed(1)}%`;
+    if (!isColorEnabled) return s;
+    if (pct > 50) return `\x1b[32m${s}\x1b[39m`;
+    if (pct > 20) return `\x1b[33m${s}\x1b[39m`;
+    return `\x1b[31m${s}\x1b[39m`;
+}

--- a/packages/cli/src/cli-colors.ts
+++ b/packages/cli/src/cli-colors.ts
@@ -1,0 +1,98 @@
+/**
+ * CLI color utilities for PizzaPi — "Warm Confidence" palette.
+ *
+ * Respects NO_COLOR env var and non-TTY output (pipes, redirects).
+ * All helpers are no-ops when color is disabled, so --json and piped
+ * output are never polluted with escape sequences.
+ */
+
+const isColorEnabled =
+    process.stdout.isTTY === true &&
+    !process.env["NO_COLOR"] &&
+    process.env["TERM"] !== "dumb";
+
+const esc = (code: string, s: string, reset: string) =>
+    isColorEnabled ? `\x1b[${code}m${s}\x1b[${reset}m` : s;
+
+export const c = {
+    /** Bold bright plum — pizza logo / product name */
+    brand: (s: string) => esc("1;35", s, "0"),
+
+    /** Bold bright magenta — command names */
+    cmd: (s: string) => esc("1;35", s, "0"),
+
+    /** Light purple — section headers ("Commands", "Flags") */
+    label: (s: string) => (isColorEnabled ? `\x1b[38;2;196;167;224m${s}\x1b[39m` : s),
+
+    /** Soft lavender — accent / highlight */
+    accent: (s: string) => (isColorEnabled ? `\x1b[38;2;232;180;248m${s}\x1b[39m` : s),
+
+    /** Light blue — flag names */
+    flag: (s: string) => (isColorEnabled ? `\x1b[38;2;147;197;253m${s}\x1b[39m` : s),
+
+    /** Green — success / ok */
+    success: (s: string) => esc("32", s, "39"),
+
+    /** Red — error / failure */
+    error: (s: string) => esc("31", s, "39"),
+
+    /** Amber/yellow — warning / moderate usage */
+    warning: (s: string) => esc("33", s, "39"),
+
+    /** Bold */
+    bold: (s: string) => esc("1", s, "22"),
+
+    /** Dim gray — secondary info */
+    dim: (s: string) => esc("2", s, "22"),
+
+    /** Reset all attributes */
+    reset: isColorEnabled ? "\x1b[0m" : "",
+};
+
+/**
+ * Return a colored usage bar + percentage string.
+ *
+ * @param utilization  0–100 (percentage used)
+ * @param width        bar width in characters (default 10)
+ */
+export function usageBar(utilization: number, width = 10): string {
+    const pct = Math.min(100, Math.max(0, utilization));
+    const filled = Math.round((pct / 100) * width);
+    const empty = width - filled;
+    const bar = "█".repeat(filled) + "░".repeat(empty);
+    const pctStr = `${pct.toFixed(1)}%`;
+
+    if (!isColorEnabled) return `[${bar}] ${pctStr}`;
+
+    let colored: string;
+    if (pct < 50) {
+        colored = `\x1b[32m${bar}\x1b[39m`;
+    } else if (pct < 80) {
+        colored = `\x1b[33m${bar}\x1b[39m`;
+    } else {
+        colored = `\x1b[31m${bar}\x1b[39m`;
+    }
+
+    let pctColored: string;
+    if (pct < 50) {
+        pctColored = `\x1b[32m${pctStr}\x1b[39m`;
+    } else if (pct < 80) {
+        pctColored = `\x1b[33m${pctStr}\x1b[39m`;
+    } else {
+        pctColored = `\x1b[31m${pctStr}\x1b[39m`;
+    }
+
+    return `[${colored}] ${pctColored}`;
+}
+
+/**
+ * Return a colored percentage string without a bar.
+ * Green <50%, amber 50-80%, red ≥80%.
+ */
+export function colorPct(pct: number): string {
+    const s = `${pct.toFixed(1)}%`;
+    if (!isColorEnabled) return s;
+    if (pct < 50) return `\x1b[32m${s}\x1b[39m`;
+    if (pct < 80) return `\x1b[33m${s}\x1b[39m`;
+    return `\x1b[31m${s}\x1b[39m`;
+}

--- a/packages/cli/src/cli-colors.ts
+++ b/packages/cli/src/cli-colors.ts
@@ -8,7 +8,7 @@
 
 const isColorEnabled =
     process.stdout.isTTY === true &&
-    !process.env["NO_COLOR"] &&
+    !("NO_COLOR" in process.env) &&
     process.env["TERM"] !== "dumb";
 
 const esc = (code: string, s: string, reset: string) =>
@@ -67,7 +67,7 @@ export function usageBar(utilization: number, width = 10): string {
     let colored: string;
     if (pct < 50) {
         colored = `\x1b[32m${bar}\x1b[39m`;
-    } else if (pct < 80) {
+    } else if (pct <= 80) {
         colored = `\x1b[33m${bar}\x1b[39m`;
     } else {
         colored = `\x1b[31m${bar}\x1b[39m`;
@@ -76,7 +76,7 @@ export function usageBar(utilization: number, width = 10): string {
     let pctColored: string;
     if (pct < 50) {
         pctColored = `\x1b[32m${pctStr}\x1b[39m`;
-    } else if (pct < 80) {
+    } else if (pct <= 80) {
         pctColored = `\x1b[33m${pctStr}\x1b[39m`;
     } else {
         pctColored = `\x1b[31m${pctStr}\x1b[39m`;
@@ -93,6 +93,6 @@ export function colorPct(pct: number): string {
     const s = `${pct.toFixed(1)}%`;
     if (!isColorEnabled) return s;
     if (pct < 50) return `\x1b[32m${s}\x1b[39m`;
-    if (pct < 80) return `\x1b[33m${s}\x1b[39m`;
+    if (pct <= 80) return `\x1b[33m${s}\x1b[39m`;
     return `\x1b[31m${s}\x1b[39m`;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -269,8 +269,8 @@ async function main() {
                                 ? (1 - bucket.remainingFraction) * 100
                                 : null;
                             const bar = usedPct !== null ? usageBar(usedPct) : "";
-                            const remainingStr = usedPct !== null
-                                ? ` ${colorPct(usedPct)} used`
+                            const remainingStr = bucket.remainingFraction != null
+                                ? ` ${colorRemaining(bucket.remainingFraction * 100)} remaining`
                                 : "";
                             const amt = bucket.remainingAmount != null ? c.dim(` (${bucket.remainingAmount} left)`) : "";
                             const reset = bucket.resetTime ? c.dim(`  resets ${new Date(bucket.resetTime).toLocaleString()}`) : "";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -269,8 +269,8 @@ async function main() {
                                 ? (1 - bucket.remainingFraction) * 100
                                 : null;
                             const bar = usedPct !== null ? usageBar(usedPct) : "";
-                            const remainingStr = bucket.remainingFraction != null
-                                ? ` ${colorRemaining(bucket.remainingFraction * 100)} remaining`
+                            const remainingStr = usedPct !== null
+                                ? ` ${colorPct(usedPct)} used`
                                 : "";
                             const amt = bucket.remainingAmount != null ? c.dim(` (${bucket.remainingAmount} left)`) : "";
                             const reset = bucket.resetTime ? c.dim(`  resets ${new Date(bucket.resetTime).toLocaleString()}`) : "";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -270,7 +270,7 @@ async function main() {
                                 : null;
                             const bar = usedPct !== null ? usageBar(usedPct) : "";
                             const remainingStr = bucket.remainingFraction != null
-                                ? ` ${colorPct(bucket.remainingFraction * 100)} remaining`
+                                ? ` ${colorPct((1 - bucket.remainingFraction) * 100)} remaining`
                                 : "";
                             const amt = bucket.remainingAmount != null ? c.dim(` (${bucket.remainingAmount} left)`) : "";
                             const reset = bucket.resetTime ? c.dim(`  resets ${new Date(bucket.resetTime).toLocaleString()}`) : "";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,7 @@ import { existsSync } from "fs";
 import { readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
-import { c, usageBar, colorPct } from "./cli-colors.js";
+import { c, usageBar, colorPct, colorRemaining } from "./cli-colors.js";
 import { buildInteractiveSkillPaths } from "./skills.js";
 import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
 import { runSetup } from "./setup.js";
@@ -270,7 +270,7 @@ async function main() {
                                 : null;
                             const bar = usedPct !== null ? usageBar(usedPct) : "";
                             const remainingStr = bucket.remainingFraction != null
-                                ? ` ${colorPct((1 - bucket.remainingFraction) * 100)} remaining`
+                                ? ` ${colorRemaining(bucket.remainingFraction * 100)} remaining`
                                 : "";
                             const amt = bucket.remainingAmount != null ? c.dim(` (${bucket.remainingAmount} left)`) : "";
                             const reset = bucket.resetTime ? c.dim(`  resets ${new Date(bucket.resetTime).toLocaleString()}`) : "";

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,6 +10,7 @@ import { existsSync } from "fs";
 import { readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
+import { c, usageBar, colorPct } from "./cli-colors.js";
 import { buildInteractiveSkillPaths } from "./skills.js";
 import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
 import { runSetup } from "./setup.js";
@@ -149,13 +150,14 @@ async function main() {
                 } else {
                     const formatWindow = (label: string, w: UsageWindow) => {
                         if (!w) return;
-                        const pct = `${w.utilization.toFixed(1)}%`;
+                        const bar = usageBar(w.utilization);
                         const reset = new Date(w.resets_at).toLocaleString();
-                        console.log(`  ${label.padEnd(22)} ${pct.padStart(6)}  (resets ${reset})`);
+                        console.log(`  ${label.padEnd(22)} ${bar}  ${c.dim(`resets ${reset}`)}`);
                     };
 
-                    console.log("\nClaude usage (OAuth subscription)");
-                    console.log("─".repeat(58));
+                    console.log();
+                    console.log(c.label("Claude usage") + c.dim(" (OAuth subscription)"));
+                    console.log(c.dim("─".repeat(58)));
                     formatWindow("5-hour window", usage.five_hour);
                     formatWindow("7-day window", usage.seven_day);
                     formatWindow("7-day (OAuth apps)", usage.seven_day_oauth_apps);
@@ -165,10 +167,11 @@ async function main() {
 
                     const ex = usage.extra_usage;
                     if (ex?.is_enabled) {
-                        console.log(`\n  Extra usage enabled`);
-                        if (ex.monthly_limit != null) console.log(`    Monthly limit:   $${ex.monthly_limit}`);
-                        if (ex.used_credits != null) console.log(`    Credits used:    $${ex.used_credits}`);
-                        if (ex.utilization != null) console.log(`    Utilization:     ${ex.utilization.toFixed(1)}%`);
+                        console.log();
+                        console.log(`  ${c.accent("Extra usage enabled")}`);
+                        if (ex.monthly_limit != null) console.log(`    Monthly limit:   ${c.bold(`$${ex.monthly_limit}`)}`);
+                        if (ex.used_credits != null) console.log(`    Credits used:    ${c.bold(`$${ex.used_credits}`)}`);
+                        if (ex.utilization != null) console.log(`    Utilization:     ${colorPct(ex.utilization)}`);
                     }
                     printedAny = true;
                 }
@@ -250,9 +253,10 @@ async function main() {
                     console.log(JSON.stringify({ provider: "gemini", project: projectId, usage: quotaData }, null, 2));
                     printedAny = true;
                 } else {
-                    console.log("\nGemini usage (Google Cloud Code Assist, OAuth)");
-                    console.log(`  Project: ${projectId}`);
-                    console.log("─".repeat(58));
+                    console.log();
+                    console.log(c.label("Gemini usage") + c.dim(" (Google Cloud Code Assist, OAuth)"));
+                    console.log(`  ${c.dim("Project:")} ${projectId}`);
+                    console.log(c.dim("─".repeat(58)));
 
                     const buckets = quotaData.buckets ?? [];
                     if (buckets.length === 0) {
@@ -260,12 +264,17 @@ async function main() {
                     } else {
                         for (const bucket of buckets) {
                             const label = [bucket.tokenType, bucket.modelId].filter(Boolean).join(" / ") || "bucket";
-                            const pct = bucket.remainingFraction != null
-                                ? `${(bucket.remainingFraction * 100).toFixed(1)}% remaining`
+                            // remainingFraction is 0–1 (remaining), so used = 1 - remaining
+                            const usedPct = bucket.remainingFraction != null
+                                ? (1 - bucket.remainingFraction) * 100
+                                : null;
+                            const bar = usedPct !== null ? usageBar(usedPct) : "";
+                            const remainingStr = bucket.remainingFraction != null
+                                ? ` ${colorPct(bucket.remainingFraction * 100)} remaining`
                                 : "";
-                            const amt = bucket.remainingAmount != null ? ` (${bucket.remainingAmount} left)` : "";
-                            const reset = bucket.resetTime ? `  resets ${new Date(bucket.resetTime).toLocaleString()}` : "";
-                            console.log(`  ${label.padEnd(28)} ${pct}${amt}${reset}`);
+                            const amt = bucket.remainingAmount != null ? c.dim(` (${bucket.remainingAmount} left)`) : "";
+                            const reset = bucket.resetTime ? c.dim(`  resets ${new Date(bucket.resetTime).toLocaleString()}`) : "";
+                            console.log(`  ${label.padEnd(28)} ${bar}${remainingStr}${amt}${reset}`);
                         }
                     }
                     printedAny = true;
@@ -317,18 +326,28 @@ async function main() {
             return;
         }
 
-        const providerWidth = Math.max(...configuredModels.map((m) => m.provider.length), "provider".length);
+        // Group by provider for colored output
+        const byProvider = new Map<string, typeof configuredModels>();
+        for (const model of configuredModels) {
+            const group = byProvider.get(model.provider) ?? [];
+            group.push(model);
+            byProvider.set(model.provider, group);
+        }
+
         const modelWidth = Math.max(...configuredModels.map((m) => m.id.length), "model".length);
 
-        console.log(`${"provider".padEnd(providerWidth)}  ${"model".padEnd(modelWidth)}  notes`);
-        console.log(`${"-".repeat(providerWidth)}  ${"-".repeat(modelWidth)}  -----`);
-        for (const model of configuredModels) {
-            const notes = [
-                model.reasoning ? "reasoning" : undefined,
-                model.contextWindow ? `${model.contextWindow.toLocaleString()} ctx` : undefined,
-                model.name && model.name !== model.id ? model.name : undefined,
-            ].filter(Boolean).join(" • ");
-            console.log(`${model.provider.padEnd(providerWidth)}  ${model.id.padEnd(modelWidth)}  ${notes}`);
+        console.log();
+        for (const [provider, models] of byProvider) {
+            console.log(c.label(provider));
+            for (const model of models) {
+                const noteParts: string[] = [];
+                if (model.reasoning) noteParts.push(c.accent("reasoning"));
+                if (model.contextWindow) noteParts.push(c.dim(`${model.contextWindow.toLocaleString()} ctx`));
+                if (model.name && model.name !== model.id) noteParts.push(c.dim(model.name));
+                const notes = noteParts.join(c.dim(" • "));
+                console.log(`  ${c.cmd(model.id.padEnd(modelWidth))}  ${notes}`);
+            }
+            console.log();
         }
         return;
     }
@@ -341,32 +360,33 @@ async function main() {
 
     if (args[0] === "--help" || args[0] === "-h" || args[0] === "help") {
         const { default: pkg } = await import("../package.json");
-        console.log(`
-pizzapi v${pkg.version} — PizzaPi coding agent
-
-Usage:
-  pizza                       Start an interactive agent session
-  pizza web [flags]           Manage the PizzaPi web hub (Docker)
-  pizza runner [args]         Manage the background runner daemon
-  pizza runner stop           Stop the runner daemon
-  pizza setup                 Run first-time setup
-  pizza usage [provider]      Show API usage stats
-  pizza models                List available models
-  pizza plugins [cmd]         Manage Claude Code plugins (list/trust/untrust)
-
-Flags:
-  --cwd <path>    Set working directory
-  --sandbox <mode>  Set sandbox mode: enforce, audit, or off
-  --safe-mode     Skip MCP, plugins, hooks, and relay (fast startup)
-  --no-mcp        Skip MCP server connections
-  --no-plugins    Skip Claude Code plugin loading
-  --no-hooks      Skip hook execution
-  --no-relay      Skip relay server connection
-  -v, --version   Show version
-  -h, --help      Show this help
-
-Run \`pizza <command> --help\` for command-specific help.
-`.trim());
+        const ver = c.dim(`v${pkg.version}`);
+        console.log();
+        console.log(`${c.brand("🍕 PizzaPi")} ${ver}`);
+        console.log();
+        console.log(c.label("Commands"));
+        console.log(`  ${c.cmd("pizza")}                       Start an interactive agent session`);
+        console.log(`  ${c.cmd("pizza web")} ${c.dim("[flags]")}           Manage the PizzaPi web hub (Docker)`);
+        console.log(`  ${c.cmd("pizza runner")} ${c.dim("[args]")}         Manage the background runner daemon`);
+        console.log(`  ${c.cmd("pizza runner stop")}           Stop the runner daemon`);
+        console.log(`  ${c.cmd("pizza setup")}                 Run first-time setup`);
+        console.log(`  ${c.cmd("pizza usage")} ${c.dim("[provider]")}      Show API usage stats`);
+        console.log(`  ${c.cmd("pizza models")}                List available models`);
+        console.log(`  ${c.cmd("pizza plugins")} ${c.dim("[cmd]")}         Manage Claude Code plugins`);
+        console.log();
+        console.log(c.label("Flags"));
+        console.log(`  ${c.flag("--cwd")} ${c.dim("<path>")}         Set working directory`);
+        console.log(`  ${c.flag("--sandbox")} ${c.dim("<mode>")}      Set sandbox mode: ${c.dim("enforce, audit, or off")}`);
+        console.log(`  ${c.flag("--safe-mode")}            Skip MCP, plugins, hooks, and relay`);
+        console.log(`  ${c.flag("--no-mcp")}               Skip MCP server connections`);
+        console.log(`  ${c.flag("--no-plugins")}           Skip Claude Code plugin loading`);
+        console.log(`  ${c.flag("--no-hooks")}             Skip hook execution`);
+        console.log(`  ${c.flag("--no-relay")}             Skip relay server connection`);
+        console.log(`  ${c.flag("-v, --version")}          Show version`);
+        console.log(`  ${c.flag("-h, --help")}             Show this help`);
+        console.log();
+        console.log(c.dim(`Run pizza <command> --help for command-specific help.`));
+        console.log();
         return;
     }
 

--- a/packages/cli/src/plugins-cli.ts
+++ b/packages/cli/src/plugins-cli.ts
@@ -25,6 +25,7 @@ import {
     trustPlugin,
     untrustPlugin,
 } from "./config.js";
+import { c } from "./cli-colors.js";
 
 // ── Formatting helpers ────────────────────────────────────────────────────────
 
@@ -184,27 +185,27 @@ function showTrusted(): void {
 }
 
 function showHelp(): void {
-    console.log(`
-pizza plugins — Manage Claude Code plugins
-
-Usage:
-  pizza plugins                List all discovered plugins (global + local)
-  pizza plugins list           Same as above
-  pizza plugins trust [path]   Trust project-local plugin(s)
-                               No path → trust all untrusted local plugins
-                               With path → trust plugin at that path
-  pizza plugins untrust [path] Remove plugin(s) from the trust list
-                               No path → clear the entire trust list
-                               With path → remove that specific plugin
-  pizza plugins trusted        Show the current trust list
-
-Trusted plugins auto-load without prompting. Global plugins
-(~/.pizzapi/plugins/, ~/.agents/plugins/, ~/.claude/plugins/) are
-always auto-trusted. Project-local plugins require explicit trust
-via this command or interactive confirmation at session start.
-
-Trust state is stored in ~/.pizzapi/config.json (trustedPlugins).
-`.trim());
+    console.log();
+    console.log(`${c.brand("pizza plugins")} ${c.dim("— Manage Claude Code plugins")}`);
+    console.log();
+    console.log(c.label("Commands"));
+    console.log(`  ${c.cmd("pizza plugins")}                List all discovered plugins (global + local)`);
+    console.log(`  ${c.cmd("pizza plugins list")}           Same as above`);
+    console.log(`  ${c.cmd("pizza plugins trust")} ${c.dim("[path]")}   Trust project-local plugin(s)`);
+    console.log(`                               ${c.dim("No path → trust all untrusted local plugins")}`);
+    console.log(`                               ${c.dim("With path → trust plugin at that path")}`);
+    console.log(`  ${c.cmd("pizza plugins untrust")} ${c.dim("[path]")} Remove plugin(s) from the trust list`);
+    console.log(`                               ${c.dim("No path → clear the entire trust list")}`);
+    console.log(`                               ${c.dim("With path → remove that specific plugin")}`);
+    console.log(`  ${c.cmd("pizza plugins trusted")}        Show the current trust list`);
+    console.log();
+    console.log(c.dim("Trusted plugins auto-load without prompting. Global plugins"));
+    console.log(c.dim("(~/.pizzapi/plugins/, ~/.agents/plugins/, ~/.claude/plugins/) are"));
+    console.log(c.dim("always auto-trusted. Project-local plugins require explicit trust"));
+    console.log(c.dim("via this command or interactive confirmation at session start."));
+    console.log();
+    console.log(c.dim("Trust state is stored in ~/.pizzapi/config.json (trustedPlugins)."));
+    console.log();
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -9,6 +9,7 @@ import { ServiceRegistry } from "./service-handler.js";
 import { TerminalService } from "./services/terminal-service.js";
 import { FileExplorerService } from "./services/file-explorer-service.js";
 import { GitService } from "./services/git-service.js";
+import { TunnelService } from "./services/tunnel-service.js";
 import { io, type Socket } from "socket.io-client";
 import type { RunnerClientToServerEvents, RunnerServerToClientEvents } from "@pizzapi/protocol";
 import { loadGlobalConfig } from "../config.js";
@@ -219,6 +220,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         registry.register(new TerminalService());
         registry.register(new FileExplorerService());
         registry.register(new GitService());
+        registry.register(new TunnelService());
 
         const socket: Socket<RunnerServerToClientEvents, RunnerClientToServerEvents> = io(
             sioUrl + "/runner",

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1,20 +1,14 @@
-import { exec, execFile } from "node:child_process";
+import { exec } from "node:child_process";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
-const execFileAsync = promisify(execFile);
-import { readdir, stat } from "node:fs/promises";
 import { existsSync, mkdirSync, renameSync, cpSync, rmSync } from "node:fs";
 import { hostname, homedir } from "node:os";
-import {
-    spawnTerminal,
-    writeTerminalInput,
-    resizeTerminal,
-    killTerminal,
-    listTerminals,
-    killAllTerminals,
-} from "./terminal.js";
-import { join, basename } from "node:path";
+import { join } from "node:path";
+import { ServiceRegistry } from "./service-handler.js";
+import { TerminalService } from "./services/terminal-service.js";
+import { FileExplorerService } from "./services/file-explorer-service.js";
+import { GitService } from "./services/git-service.js";
 import { io, type Socket } from "socket.io-client";
 import type { RunnerClientToServerEvents, RunnerServerToClientEvents } from "@pizzapi/protocol";
 import { loadGlobalConfig } from "../config.js";
@@ -27,7 +21,6 @@ import { getWorkspaceRoots, isCwdAllowed } from "./workspace.js";
 import { type RunnerSession, spawnSession } from "./session-spawner.js";
 
 import {
-    type SkillMeta,
     scanGlobalSkills,
     readSkillContent,
     writeSkill,
@@ -35,7 +28,6 @@ import {
 } from "../skills.js";
 
 import {
-    type AgentMeta,
     scanGlobalAgents,
     readAgentContent,
     writeAgent,
@@ -222,6 +214,12 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         let runnerId: string | null = null;
         let isFirstConnect = true;
 
+        // ── Service registry ──────────────────────────────────────────────
+        const registry = new ServiceRegistry();
+        registry.register(new TerminalService());
+        registry.register(new FileExplorerService());
+        registry.register(new GitService());
+
         const socket: Socket<RunnerServerToClientEvents, RunnerClientToServerEvents> = io(
             sioUrl + "/runner",
             {
@@ -237,6 +235,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             },
         );
 
+        // Initialize all services — registers socket event handlers
+        registry.initAll(socket, { isShuttingDown: () => isShuttingDown });
+
         logInfo(`connecting to relay at ${sioUrl}/runner…`);
 
         // Start periodic usage scan (every 5 minutes)
@@ -249,7 +250,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             isShuttingDown = true;
             clearInterval(endedSessionSweep);
             clearInterval(usageScanInterval);
-            killAllTerminals();
+            registry.disposeAll();
             stopUsageRefreshLoop();
             closeUsage();
             releaseStateLock(statePath);
@@ -516,99 +517,6 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             (socket as any).emit("pong", { now: Date.now() });
         });
 
-        // ── Terminal PTY management ───────────────────────────────────────
-
-        socket.on("new_terminal", (data: any) => {
-            if (isShuttingDown) return;
-            const { terminalId, cwd: requestedCwd, cols, rows, shell } = data;
-            logInfo(
-                `[terminal] new_terminal received: terminalId=${terminalId} cwd=${requestedCwd ?? "(default)"} cols=${cols ?? 80} rows=${rows ?? 24} shell=${shell ?? "(default)"}`,
-            );
-            if (!terminalId) {
-                logWarn("[terminal] new_terminal: missing terminalId — rejecting");
-                socket.emit("terminal_error", { terminalId: "", message: "Missing terminalId" });
-                return;
-            }
-            if (requestedCwd && !isCwdAllowed(requestedCwd)) {
-                logWarn(
-                    `[terminal] new_terminal: cwd="${requestedCwd}" outside allowed roots — rejecting terminalId=${terminalId}`,
-                );
-                socket.emit("terminal_error", {
-                    terminalId,
-                    message: `cwd outside allowed roots: ${requestedCwd}`,
-                });
-                return;
-            }
-            // The terminal module calls termSend with { type: "terminal_*", ... } payloads.
-            // Extract the type field and emit it as a socket.io event.
-            const termSend = (payload: Record<string, unknown>) => {
-                try {
-                    const { type, runnerId: _drop, ...rest } = payload;
-                    if (typeof type === "string") {
-                        (socket as any).emit(type, rest);
-                    }
-                } catch (err) {
-                    logError(
-                        `[terminal] termSend: failed to send ${payload.type} for terminalId=${terminalId}: ${err}`,
-                    );
-                }
-            };
-            spawnTerminal(terminalId, termSend, {
-                cwd: requestedCwd,
-                cols,
-                rows,
-                shell,
-            });
-        });
-
-        socket.on("terminal_input", (data: any) => {
-            if (isShuttingDown) return;
-            const { terminalId, data: inputData } = data;
-            if (!terminalId || !inputData) {
-                logWarn(
-                    `[terminal] terminal_input: missing terminalId or data (terminalId=${terminalId} dataLen=${inputData?.length ?? 0})`,
-                );
-                return;
-            }
-            writeTerminalInput(terminalId, inputData);
-        });
-
-        socket.on("terminal_resize", (data: any) => {
-            if (isShuttingDown) return;
-            const { terminalId, cols, rows } = data;
-            if (!terminalId) {
-                logWarn("[terminal] terminal_resize: missing terminalId");
-                return;
-            }
-            logInfo(`[terminal] terminal_resize: terminalId=${terminalId} ${cols}x${rows}`);
-            resizeTerminal(terminalId, cols, rows);
-        });
-
-        socket.on("kill_terminal", (data: any) => {
-            if (isShuttingDown) return;
-            const { terminalId } = data;
-            if (!terminalId) {
-                logWarn("[terminal] kill_terminal: missing terminalId");
-                return;
-            }
-            logInfo(`[terminal] kill_terminal: terminalId=${terminalId}`);
-            const killed = killTerminal(terminalId);
-            logInfo(`[terminal] kill_terminal: result=${killed} terminalId=${terminalId}`);
-            if (killed) {
-                socket.emit("terminal_exit", { terminalId, exitCode: -1 });
-            } else {
-                socket.emit("terminal_error", { terminalId, message: "Terminal not found" });
-            }
-        });
-
-        socket.on("list_terminals", () => {
-            if (isShuttingDown) return;
-            const list = listTerminals();
-            logInfo(`[terminal] list_terminals: ${list.length} active (${list.join(", ") || "none"})`);
-            // terminals_list is not in the typed protocol yet — emit untyped
-            (socket as any).emit("terminals_list", { terminals: list });
-        });
-
         // ── Skills management ─────────────────────────────────────────────
 
         socket.on("list_skills", (data: any) => {
@@ -849,275 +757,6 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             const plugins = scanAllPluginInfo(scanCwd, { includeProjectLocal: includeLocal });
             // Echo scoped flag so the server can skip cache updates for per-session scans
             socket.emit("plugins_list", { plugins, requestId, ...(rawCwd ? { scoped: true } : {}) });
-        });
-
-        // ── File Explorer ─────────────────────────────────────────────────
-
-        socket.on("list_files", async (data: any) => {
-            if (isShuttingDown) return;
-            const requestId = data.requestId;
-            const dirPath = data.path ?? "";
-            if (!dirPath) {
-                socket.emit("file_result", { requestId, ok: false, message: "Missing path" });
-                return;
-            }
-            if (!isCwdAllowed(dirPath)) {
-                socket.emit("file_result", { requestId, ok: false, message: "Path outside allowed roots" });
-                return;
-            }
-            try {
-                const entries = await readdir(dirPath, { withFileTypes: true });
-                const items = await Promise.all(
-                    entries
-                        .filter((e) => {
-                            // Show all dotfiles/dotfolders except .git (too noisy)
-                            if (e.name === ".git") return false;
-                            return true;
-                        })
-                        .map(async (e) => {
-                            const fullPath = join(dirPath, e.name);
-                            let size: number | undefined;
-                            try {
-                                const s = await stat(fullPath);
-                                size = s.size;
-                            } catch {}
-                            return {
-                                name: e.name,
-                                path: fullPath,
-                                isDirectory: e.isDirectory(),
-                                isSymlink: e.isSymbolicLink(),
-                                size,
-                            };
-                        }),
-                );
-                // Directories first, then files, alphabetically
-                items.sort((a, b) => {
-                    if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
-                    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
-                });
-                socket.emit("file_result", { requestId, ok: true, files: items });
-            } catch (err) {
-                socket.emit("file_result", {
-                    requestId,
-                    ok: false,
-                    message: err instanceof Error ? err.message : String(err),
-                });
-            }
-        });
-
-        socket.on("search_files", async (data: any) => {
-            if (isShuttingDown) return;
-            const requestId = data.requestId;
-            const cwd = (data as any).cwd ?? "";
-            const query = (data as any).query ?? "";
-            const limit = typeof (data as any).limit === "number" ? (data as any).limit : 100;
-
-            if (!cwd) {
-                socket.emit("file_result", { requestId, ok: false, message: "Missing cwd" });
-                return;
-            }
-            if (!isCwdAllowed(cwd)) {
-                socket.emit("file_result", { requestId, ok: false, message: "Path outside allowed roots" });
-                return;
-            }
-            if (!query) {
-                socket.emit("file_result", { requestId, ok: true, files: [] });
-                return;
-            }
-            try {
-                // Use git ls-files to get tracked + untracked-not-ignored files.
-                // Use async exec to avoid blocking the event loop (which would
-                // prevent Socket.IO pings from being answered).
-                const { stdout } = await execFileAsync(
-                    "git",
-                    ["ls-files", "--cached", "--others", "--exclude-standard"],
-                    { cwd, timeout: 10000, maxBuffer: 10 * 1024 * 1024 },
-                );
-                const lowerQuery = query.toLowerCase();
-                const files = stdout
-                    .split("\n")
-                    .filter((line) => {
-                        if (!line) return false;
-                        return line.toLowerCase().includes(lowerQuery);
-                    })
-                    .slice(0, limit)
-                    .map((relativePath) => ({
-                        name: relativePath.split("/").pop() ?? relativePath,
-                        path: join(cwd, relativePath),
-                        relativePath,
-                        isDirectory: false,
-                        isSymlink: false,
-                    }));
-                socket.emit("file_result", { requestId, ok: true, files });
-            } catch (err) {
-                // If git fails (not a git repo, etc.), return empty list
-                const isGitError = err instanceof Error && (err as any).code !== undefined;
-                if (isGitError) {
-                    socket.emit("file_result", { requestId, ok: true, files: [] });
-                    return;
-                }
-                socket.emit("file_result", {
-                    requestId,
-                    ok: false,
-                    message: err instanceof Error ? err.message : String(err),
-                });
-            }
-        });
-
-        socket.on("read_file", async (data: any) => {
-            if (isShuttingDown) return;
-            const requestId = data.requestId;
-            const filePath = data.path ?? "";
-            const encoding = (data as any).encoding ?? "utf8";
-            const maxBytes = typeof (data as any).maxBytes === "number"
-                ? (data as any).maxBytes
-                : encoding === "base64"
-                    ? 10 * 1024 * 1024
-                    : 256 * 1024; // 10MB for base64, 256KB for text
-
-            if (!filePath) {
-                socket.emit("file_result", { requestId, ok: false, message: "Missing path" });
-                return;
-            }
-            if (!isCwdAllowed(filePath)) {
-                socket.emit("file_result", { requestId, ok: false, message: "Path outside allowed roots" });
-                return;
-            }
-            try {
-                const s = await stat(filePath);
-                const truncated = s.size > maxBytes;
-                if (encoding === "base64") {
-                    const buf = await Bun.file(filePath).slice(0, maxBytes).arrayBuffer();
-                    const b64 = Buffer.from(buf).toString("base64");
-                    socket.emit("file_result", {
-                        requestId,
-                        ok: true,
-                        content: b64,
-                        encoding: "base64",
-                        size: s.size,
-                        truncated,
-                    });
-                } else {
-                    const fd = await Bun.file(filePath).slice(0, maxBytes).text();
-                    socket.emit("file_result", {
-                        requestId,
-                        ok: true,
-                        content: fd,
-                        size: s.size,
-                        truncated,
-                    });
-                }
-            } catch (err) {
-                socket.emit("file_result", {
-                    requestId,
-                    ok: false,
-                    message: err instanceof Error ? err.message : String(err),
-                });
-            }
-        });
-
-        // ── Git operations ────────────────────────────────────────────────
-
-        socket.on("git_status", async (data: any) => {
-            if (isShuttingDown) return;
-            const requestId = data.requestId;
-            const cwd = data.cwd ?? "";
-            if (!cwd) {
-                socket.emit("file_result", { requestId, ok: false, message: "Missing cwd" });
-                return;
-            }
-            if (!isCwdAllowed(cwd)) {
-                socket.emit("file_result", { requestId, ok: false, message: "Path outside allowed roots" });
-                return;
-            }
-            try {
-                // Run all git commands asynchronously to avoid blocking the
-                // event loop (which would prevent Socket.IO pings from being
-                // answered, causing spurious disconnects).
-                const [branchResult, statusResult, diffStagedResult, abResult] = await Promise.allSettled([
-                    execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 }),
-                    execFileAsync("git", ["status", "--porcelain=v1", "-uall"], { cwd, timeout: 10000 }),
-                    execFileAsync("git", ["diff", "--cached", "--stat"], { cwd, timeout: 10000 }),
-                    execFileAsync("git", ["rev-list", "--left-right", "--count", "HEAD...@{u}"], { cwd, timeout: 5000 }),
-                ]);
-
-                const branch = branchResult.status === "fulfilled" ? branchResult.value.stdout.trim() : "";
-                const statusOutput = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
-                const diffStaged = diffStagedResult.status === "fulfilled" ? diffStagedResult.value.stdout : "";
-
-                // Parse porcelain output
-                const changes: Array<{ status: string; path: string; originalPath?: string }> = [];
-                for (const line of statusOutput.split("\n")) {
-                    if (!line.trim()) continue;
-                    const xy = line.substring(0, 2);
-                    const rest = line.substring(3);
-                    // Handle renames: "R  old -> new"
-                    const arrowIdx = rest.indexOf(" -> ");
-                    if (arrowIdx >= 0) {
-                        changes.push({
-                            status: xy.trim(),
-                            path: rest.substring(arrowIdx + 4),
-                            originalPath: rest.substring(0, arrowIdx),
-                        });
-                    } else {
-                        changes.push({ status: xy.trim(), path: rest });
-                    }
-                }
-
-                // Get ahead/behind counts
-                let ahead = 0;
-                let behind = 0;
-                if (abResult.status === "fulfilled") {
-                    const abOutput = abResult.value.stdout.trim();
-                    const [a, b] = abOutput.split(/\s+/);
-                    ahead = parseInt(a, 10) || 0;
-                    behind = parseInt(b, 10) || 0;
-                }
-
-                socket.emit("file_result", {
-                    requestId,
-                    ok: true,
-                    branch,
-                    changes,
-                    ahead,
-                    behind,
-                    diffStaged,
-                });
-            } catch (err) {
-                socket.emit("file_result", {
-                    requestId,
-                    ok: false,
-                    message: err instanceof Error ? err.message : String(err),
-                });
-            }
-        });
-
-        socket.on("git_diff", async (data: any) => {
-            if (isShuttingDown) return;
-            const requestId = data.requestId;
-            const cwd = data.cwd ?? "";
-            const filePath = (data as any).path ?? "";
-            const staged = (data as any).staged === true;
-
-            if (!cwd || !filePath) {
-                socket.emit("file_result", { requestId, ok: false, message: "Missing cwd or path" });
-                return;
-            }
-            if (!isCwdAllowed(cwd)) {
-                socket.emit("file_result", { requestId, ok: false, message: "Path outside allowed roots" });
-                return;
-            }
-            try {
-                const args = staged ? ["diff", "--cached", "--", filePath] : ["diff", "--", filePath];
-                const { stdout: diff } = await execFileAsync("git", args, { cwd, timeout: 10000 });
-                socket.emit("file_result", { requestId, ok: true, diff });
-            } catch (err) {
-                socket.emit("file_result", {
-                    requestId,
-                    ok: false,
-                    message: err instanceof Error ? err.message : String(err),
-                });
-            }
         });
 
         // ── Sandbox ────────────────────────────────────────────────────────

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -238,6 +238,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         // Initialize all services — registers socket event handlers
         registry.initAll(socket, { isShuttingDown: () => isShuttingDown });
 
+        // Announce available services to viewers
+        (socket as any).emit("service_announce", {
+            serviceIds: registry.getAll().map((s) => s.id),
+        });
+
         logInfo(`connecting to relay at ${sioUrl}/runner…`);
 
         // Start periodic usage scan (every 5 minutes)

--- a/packages/cli/src/runner/service-handler.ts
+++ b/packages/cli/src/runner/service-handler.ts
@@ -1,0 +1,82 @@
+import type { Socket } from "socket.io-client";
+
+/**
+ * Interface for runner-side service handlers.
+ * Each service registers its socket event handlers in init() and cleans up in dispose().
+ */
+export interface ServiceHandler {
+    /** Unique service identifier (e.g., "terminal", "file-explorer", "git") */
+    readonly id: string;
+
+    /**
+     * Initialize the service — register socket event listeners and perform setup.
+     * Called once per socket connection.
+     */
+    init(socket: Socket, options: ServiceInitOptions): void;
+
+    /**
+     * Clean up the service — kill processes, clear state, remove listeners.
+     * Called on socket disconnect or daemon shutdown.
+     */
+    dispose(): void;
+}
+
+export interface ServiceInitOptions {
+    isShuttingDown: () => boolean;
+}
+
+/**
+ * Generic relay protocol envelope.
+ * All service messages conceptually flow through this shape, even though
+ * the actual socket events don't change in Phase 1 (relay unchanged).
+ */
+export interface ServiceEnvelope {
+    serviceId: string;
+    type: string;
+    requestId?: string;
+    payload: unknown;
+}
+
+/**
+ * Registry of service handlers. The daemon uses this to register and dispose services.
+ */
+export class ServiceRegistry {
+    private readonly handlers = new Map<string, ServiceHandler>();
+
+    register(handler: ServiceHandler): void {
+        if (this.handlers.has(handler.id)) {
+            throw new Error(`ServiceRegistry: duplicate service id "${handler.id}"`);
+        }
+        this.handlers.set(handler.id, handler);
+    }
+
+    get(id: string): ServiceHandler | undefined {
+        return this.handlers.get(id);
+    }
+
+    getAll(): ServiceHandler[] {
+        return Array.from(this.handlers.values());
+    }
+
+    /**
+     * Initialize all registered services against the given socket.
+     */
+    initAll(socket: Socket, options: ServiceInitOptions): void {
+        for (const handler of this.handlers.values()) {
+            handler.init(socket, options);
+        }
+    }
+
+    /**
+     * Dispose all registered services (e.g., on disconnect or shutdown).
+     */
+    disposeAll(): void {
+        for (const handler of this.handlers.values()) {
+            try {
+                handler.dispose();
+            } catch (err) {
+                console.error(`[ServiceRegistry] dispose error for service "${handler.id}":`, err);
+            }
+        }
+    }
+}

--- a/packages/cli/src/runner/services/file-explorer-service.ts
+++ b/packages/cli/src/runner/services/file-explorer-service.ts
@@ -1,0 +1,182 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { readdir, stat } from "node:fs/promises";
+import { join } from "node:path";
+import type { Socket } from "socket.io-client";
+import type { ServiceHandler, ServiceInitOptions } from "../service-handler.js";
+import { isCwdAllowed } from "../workspace.js";
+
+const execFileAsync = promisify(execFile);
+
+export class FileExplorerService implements ServiceHandler {
+    readonly id = "file-explorer";
+
+    init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
+        socket.on("list_files", async (data: any) => {
+            if (isShuttingDown()) return;
+            const requestId = data.requestId;
+            const dirPath = data.path ?? "";
+            if (!dirPath) {
+                socket.emit("file_result", { requestId, ok: false, message: "Missing path" });
+                return;
+            }
+            if (!isCwdAllowed(dirPath)) {
+                socket.emit("file_result", { requestId, ok: false, message: "Path outside allowed roots" });
+                return;
+            }
+            try {
+                const entries = await readdir(dirPath, { withFileTypes: true });
+                const items = await Promise.all(
+                    entries
+                        .filter((e) => {
+                            // Show all dotfiles/dotfolders except .git (too noisy)
+                            if (e.name === ".git") return false;
+                            return true;
+                        })
+                        .map(async (e) => {
+                            const fullPath = join(dirPath, e.name);
+                            let size: number | undefined;
+                            try {
+                                const s = await stat(fullPath);
+                                size = s.size;
+                            } catch {}
+                            return {
+                                name: e.name,
+                                path: fullPath,
+                                isDirectory: e.isDirectory(),
+                                isSymlink: e.isSymbolicLink(),
+                                size,
+                            };
+                        }),
+                );
+                // Directories first, then files, alphabetically
+                items.sort((a, b) => {
+                    if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
+                    return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
+                });
+                socket.emit("file_result", { requestId, ok: true, files: items });
+            } catch (err) {
+                socket.emit("file_result", {
+                    requestId,
+                    ok: false,
+                    message: err instanceof Error ? err.message : String(err),
+                });
+            }
+        });
+
+        socket.on("search_files", async (data: any) => {
+            if (isShuttingDown()) return;
+            const requestId = data.requestId;
+            const cwd = (data as any).cwd ?? "";
+            const query = (data as any).query ?? "";
+            const limit = typeof (data as any).limit === "number" ? (data as any).limit : 100;
+
+            if (!cwd) {
+                socket.emit("file_result", { requestId, ok: false, message: "Missing cwd" });
+                return;
+            }
+            if (!isCwdAllowed(cwd)) {
+                socket.emit("file_result", { requestId, ok: false, message: "Path outside allowed roots" });
+                return;
+            }
+            if (!query) {
+                socket.emit("file_result", { requestId, ok: true, files: [] });
+                return;
+            }
+            try {
+                // Use git ls-files to get tracked + untracked-not-ignored files.
+                // Use async exec to avoid blocking the event loop (which would
+                // prevent Socket.IO pings from being answered).
+                const { stdout } = await execFileAsync(
+                    "git",
+                    ["ls-files", "--cached", "--others", "--exclude-standard"],
+                    { cwd, timeout: 10000, maxBuffer: 10 * 1024 * 1024 },
+                );
+                const lowerQuery = query.toLowerCase();
+                const files = stdout
+                    .split("\n")
+                    .filter((line) => {
+                        if (!line) return false;
+                        return line.toLowerCase().includes(lowerQuery);
+                    })
+                    .slice(0, limit)
+                    .map((relativePath) => ({
+                        name: relativePath.split("/").pop() ?? relativePath,
+                        path: join(cwd, relativePath),
+                        relativePath,
+                        isDirectory: false,
+                        isSymlink: false,
+                    }));
+                socket.emit("file_result", { requestId, ok: true, files });
+            } catch (err) {
+                // If git fails (not a git repo, etc.), return empty list
+                const isGitError = err instanceof Error && (err as any).code !== undefined;
+                if (isGitError) {
+                    socket.emit("file_result", { requestId, ok: true, files: [] });
+                    return;
+                }
+                socket.emit("file_result", {
+                    requestId,
+                    ok: false,
+                    message: err instanceof Error ? err.message : String(err),
+                });
+            }
+        });
+
+        socket.on("read_file", async (data: any) => {
+            if (isShuttingDown()) return;
+            const requestId = data.requestId;
+            const filePath = data.path ?? "";
+            const encoding = (data as any).encoding ?? "utf8";
+            const maxBytes = typeof (data as any).maxBytes === "number"
+                ? (data as any).maxBytes
+                : encoding === "base64"
+                    ? 10 * 1024 * 1024
+                    : 256 * 1024; // 10MB for base64, 256KB for text
+
+            if (!filePath) {
+                socket.emit("file_result", { requestId, ok: false, message: "Missing path" });
+                return;
+            }
+            if (!isCwdAllowed(filePath)) {
+                socket.emit("file_result", { requestId, ok: false, message: "Path outside allowed roots" });
+                return;
+            }
+            try {
+                const s = await stat(filePath);
+                const truncated = s.size > maxBytes;
+                if (encoding === "base64") {
+                    const buf = await Bun.file(filePath).slice(0, maxBytes).arrayBuffer();
+                    const b64 = Buffer.from(buf).toString("base64");
+                    socket.emit("file_result", {
+                        requestId,
+                        ok: true,
+                        content: b64,
+                        encoding: "base64",
+                        size: s.size,
+                        truncated,
+                    });
+                } else {
+                    const fd = await Bun.file(filePath).slice(0, maxBytes).text();
+                    socket.emit("file_result", {
+                        requestId,
+                        ok: true,
+                        content: fd,
+                        size: s.size,
+                        truncated,
+                    });
+                }
+            } catch (err) {
+                socket.emit("file_result", {
+                    requestId,
+                    ok: false,
+                    message: err instanceof Error ? err.message : String(err),
+                });
+            }
+        });
+    }
+
+    dispose(): void {
+        // No persistent resources to clean up
+    }
+}

--- a/packages/cli/src/runner/services/file-explorer-service.ts
+++ b/packages/cli/src/runner/services/file-explorer-service.ts
@@ -54,7 +54,14 @@ export class FileExplorerService implements ServiceHandler {
                     if (a.isDirectory !== b.isDirectory) return a.isDirectory ? -1 : 1;
                     return a.name.localeCompare(b.name, undefined, { sensitivity: "base" });
                 });
-                socket.emit("file_result", { requestId, ok: true, files: items });
+                const listPayload = { requestId, ok: true, files: items };
+                socket.emit("file_result", listPayload);
+                // Dual-emit via service envelope for Phase 3 UI hooks
+                (socket as any).emit("service_message", {
+                    serviceId: "file-explorer",
+                    type: "file_result",
+                    payload: listPayload,
+                });
             } catch (err) {
                 socket.emit("file_result", {
                     requestId,
@@ -107,7 +114,14 @@ export class FileExplorerService implements ServiceHandler {
                         isDirectory: false,
                         isSymlink: false,
                     }));
-                socket.emit("file_result", { requestId, ok: true, files });
+                const searchPayload = { requestId, ok: true, files };
+                socket.emit("file_result", searchPayload);
+                // Dual-emit via service envelope for Phase 3 UI hooks
+                (socket as any).emit("service_message", {
+                    serviceId: "file-explorer",
+                    type: "file_result",
+                    payload: searchPayload,
+                });
             } catch (err) {
                 // If git fails (not a git repo, etc.), return empty list
                 const isGitError = err instanceof Error && (err as any).code !== undefined;
@@ -148,22 +162,36 @@ export class FileExplorerService implements ServiceHandler {
                 if (encoding === "base64") {
                     const buf = await Bun.file(filePath).slice(0, maxBytes).arrayBuffer();
                     const b64 = Buffer.from(buf).toString("base64");
-                    socket.emit("file_result", {
+                    const readB64Payload = {
                         requestId,
                         ok: true,
                         content: b64,
                         encoding: "base64",
                         size: s.size,
                         truncated,
+                    };
+                    socket.emit("file_result", readB64Payload);
+                    // Dual-emit via service envelope for Phase 3 UI hooks
+                    (socket as any).emit("service_message", {
+                        serviceId: "file-explorer",
+                        type: "file_result",
+                        payload: readB64Payload,
                     });
                 } else {
                     const fd = await Bun.file(filePath).slice(0, maxBytes).text();
-                    socket.emit("file_result", {
+                    const readTextPayload = {
                         requestId,
                         ok: true,
                         content: fd,
                         size: s.size,
                         truncated,
+                    };
+                    socket.emit("file_result", readTextPayload);
+                    // Dual-emit via service envelope for Phase 3 UI hooks
+                    (socket as any).emit("service_message", {
+                        serviceId: "file-explorer",
+                        type: "file_result",
+                        payload: readTextPayload,
                     });
                 }
             } catch (err) {

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -66,7 +66,7 @@ export class GitService implements ServiceHandler {
                     behind = parseInt(b, 10) || 0;
                 }
 
-                socket.emit("file_result", {
+                const statusPayload = {
                     requestId,
                     ok: true,
                     branch,
@@ -74,6 +74,13 @@ export class GitService implements ServiceHandler {
                     ahead,
                     behind,
                     diffStaged,
+                };
+                socket.emit("file_result", statusPayload);
+                // Dual-emit via service envelope for Phase 3 UI hooks
+                (socket as any).emit("service_message", {
+                    serviceId: "git",
+                    type: "git_status",
+                    payload: statusPayload,
                 });
             } catch (err) {
                 socket.emit("file_result", {
@@ -102,7 +109,14 @@ export class GitService implements ServiceHandler {
             try {
                 const args = staged ? ["diff", "--cached", "--", filePath] : ["diff", "--", filePath];
                 const { stdout: diff } = await execFileAsync("git", args, { cwd, timeout: 10000 });
-                socket.emit("file_result", { requestId, ok: true, diff });
+                const diffPayload = { requestId, ok: true, diff };
+                socket.emit("file_result", diffPayload);
+                // Dual-emit via service envelope for Phase 3 UI hooks
+                (socket as any).emit("service_message", {
+                    serviceId: "git",
+                    type: "git_diff",
+                    payload: diffPayload,
+                });
             } catch (err) {
                 socket.emit("file_result", {
                     requestId,

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -1,0 +1,119 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { Socket } from "socket.io-client";
+import type { ServiceHandler, ServiceInitOptions } from "../service-handler.js";
+import { isCwdAllowed } from "../workspace.js";
+
+const execFileAsync = promisify(execFile);
+
+export class GitService implements ServiceHandler {
+    readonly id = "git";
+
+    init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
+        socket.on("git_status", async (data: any) => {
+            if (isShuttingDown()) return;
+            const requestId = data.requestId;
+            const cwd = data.cwd ?? "";
+            if (!cwd) {
+                socket.emit("file_result", { requestId, ok: false, message: "Missing cwd" });
+                return;
+            }
+            if (!isCwdAllowed(cwd)) {
+                socket.emit("file_result", { requestId, ok: false, message: "Path outside allowed roots" });
+                return;
+            }
+            try {
+                // Run all git commands asynchronously to avoid blocking the
+                // event loop (which would prevent Socket.IO pings from being
+                // answered, causing spurious disconnects).
+                const [branchResult, statusResult, diffStagedResult, abResult] = await Promise.allSettled([
+                    execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 }),
+                    execFileAsync("git", ["status", "--porcelain=v1", "-uall"], { cwd, timeout: 10000 }),
+                    execFileAsync("git", ["diff", "--cached", "--stat"], { cwd, timeout: 10000 }),
+                    execFileAsync("git", ["rev-list", "--left-right", "--count", "HEAD...@{u}"], { cwd, timeout: 5000 }),
+                ]);
+
+                const branch = branchResult.status === "fulfilled" ? branchResult.value.stdout.trim() : "";
+                const statusOutput = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
+                const diffStaged = diffStagedResult.status === "fulfilled" ? diffStagedResult.value.stdout : "";
+
+                // Parse porcelain output
+                const changes: Array<{ status: string; path: string; originalPath?: string }> = [];
+                for (const line of statusOutput.split("\n")) {
+                    if (!line.trim()) continue;
+                    const xy = line.substring(0, 2);
+                    const rest = line.substring(3);
+                    // Handle renames: "R  old -> new"
+                    const arrowIdx = rest.indexOf(" -> ");
+                    if (arrowIdx >= 0) {
+                        changes.push({
+                            status: xy.trim(),
+                            path: rest.substring(arrowIdx + 4),
+                            originalPath: rest.substring(0, arrowIdx),
+                        });
+                    } else {
+                        changes.push({ status: xy.trim(), path: rest });
+                    }
+                }
+
+                // Get ahead/behind counts
+                let ahead = 0;
+                let behind = 0;
+                if (abResult.status === "fulfilled") {
+                    const abOutput = abResult.value.stdout.trim();
+                    const [a, b] = abOutput.split(/\s+/);
+                    ahead = parseInt(a, 10) || 0;
+                    behind = parseInt(b, 10) || 0;
+                }
+
+                socket.emit("file_result", {
+                    requestId,
+                    ok: true,
+                    branch,
+                    changes,
+                    ahead,
+                    behind,
+                    diffStaged,
+                });
+            } catch (err) {
+                socket.emit("file_result", {
+                    requestId,
+                    ok: false,
+                    message: err instanceof Error ? err.message : String(err),
+                });
+            }
+        });
+
+        socket.on("git_diff", async (data: any) => {
+            if (isShuttingDown()) return;
+            const requestId = data.requestId;
+            const cwd = data.cwd ?? "";
+            const filePath = (data as any).path ?? "";
+            const staged = (data as any).staged === true;
+
+            if (!cwd || !filePath) {
+                socket.emit("file_result", { requestId, ok: false, message: "Missing cwd or path" });
+                return;
+            }
+            if (!isCwdAllowed(cwd)) {
+                socket.emit("file_result", { requestId, ok: false, message: "Path outside allowed roots" });
+                return;
+            }
+            try {
+                const args = staged ? ["diff", "--cached", "--", filePath] : ["diff", "--", filePath];
+                const { stdout: diff } = await execFileAsync("git", args, { cwd, timeout: 10000 });
+                socket.emit("file_result", { requestId, ok: true, diff });
+            } catch (err) {
+                socket.emit("file_result", {
+                    requestId,
+                    ok: false,
+                    message: err instanceof Error ? err.message : String(err),
+                });
+            }
+        });
+    }
+
+    dispose(): void {
+        // No persistent resources to clean up
+    }
+}

--- a/packages/cli/src/runner/services/terminal-service.ts
+++ b/packages/cli/src/runner/services/terminal-service.ts
@@ -38,11 +38,19 @@ export class TerminalService implements ServiceHandler {
             }
             // The terminal module calls termSend with { type: "terminal_*", ... } payloads.
             // Extract the type field and emit it as a socket.io event.
+            // Also dual-emit via service_message envelope for Phase 3 UI hooks.
             const termSend = (payload: Record<string, unknown>) => {
                 try {
                     const { type, runnerId: _drop, ...rest } = payload;
                     if (typeof type === "string") {
+                        // Existing named event — keeps backward compatibility
                         (socket as any).emit(type, rest);
+                        // Also emit via service envelope for useServiceChannel hooks
+                        (socket as any).emit("service_message", {
+                            serviceId: "terminal",
+                            type,
+                            payload: rest,
+                        });
                     }
                 } catch (err) {
                     logError(

--- a/packages/cli/src/runner/services/terminal-service.ts
+++ b/packages/cli/src/runner/services/terminal-service.ts
@@ -1,0 +1,113 @@
+import type { Socket } from "socket.io-client";
+import type { ServiceHandler, ServiceInitOptions } from "../service-handler.js";
+import {
+    spawnTerminal,
+    writeTerminalInput,
+    resizeTerminal,
+    killTerminal,
+    killAllTerminals,
+    listTerminals,
+} from "../terminal.js";
+import { isCwdAllowed } from "../workspace.js";
+import { logInfo, logWarn, logError } from "../logger.js";
+
+export class TerminalService implements ServiceHandler {
+    readonly id = "terminal";
+
+    init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
+        socket.on("new_terminal", (data: any) => {
+            if (isShuttingDown()) return;
+            const { terminalId, cwd: requestedCwd, cols, rows, shell } = data;
+            logInfo(
+                `[terminal] new_terminal received: terminalId=${terminalId} cwd=${requestedCwd ?? "(default)"} cols=${cols ?? 80} rows=${rows ?? 24} shell=${shell ?? "(default)"}`,
+            );
+            if (!terminalId) {
+                logWarn("[terminal] new_terminal: missing terminalId — rejecting");
+                socket.emit("terminal_error", { terminalId: "", message: "Missing terminalId" });
+                return;
+            }
+            if (requestedCwd && !isCwdAllowed(requestedCwd)) {
+                logWarn(
+                    `[terminal] new_terminal: cwd="${requestedCwd}" outside allowed roots — rejecting terminalId=${terminalId}`,
+                );
+                socket.emit("terminal_error", {
+                    terminalId,
+                    message: `cwd outside allowed roots: ${requestedCwd}`,
+                });
+                return;
+            }
+            // The terminal module calls termSend with { type: "terminal_*", ... } payloads.
+            // Extract the type field and emit it as a socket.io event.
+            const termSend = (payload: Record<string, unknown>) => {
+                try {
+                    const { type, runnerId: _drop, ...rest } = payload;
+                    if (typeof type === "string") {
+                        (socket as any).emit(type, rest);
+                    }
+                } catch (err) {
+                    logError(
+                        `[terminal] termSend: failed to send ${payload.type} for terminalId=${terminalId}: ${err}`,
+                    );
+                }
+            };
+            spawnTerminal(terminalId, termSend, {
+                cwd: requestedCwd,
+                cols,
+                rows,
+                shell,
+            });
+        });
+
+        socket.on("terminal_input", (data: any) => {
+            if (isShuttingDown()) return;
+            const { terminalId, data: inputData } = data;
+            if (!terminalId || !inputData) {
+                logWarn(
+                    `[terminal] terminal_input: missing terminalId or data (terminalId=${terminalId} dataLen=${inputData?.length ?? 0})`,
+                );
+                return;
+            }
+            writeTerminalInput(terminalId, inputData);
+        });
+
+        socket.on("terminal_resize", (data: any) => {
+            if (isShuttingDown()) return;
+            const { terminalId, cols, rows } = data;
+            if (!terminalId) {
+                logWarn("[terminal] terminal_resize: missing terminalId");
+                return;
+            }
+            logInfo(`[terminal] terminal_resize: terminalId=${terminalId} ${cols}x${rows}`);
+            resizeTerminal(terminalId, cols, rows);
+        });
+
+        socket.on("kill_terminal", (data: any) => {
+            if (isShuttingDown()) return;
+            const { terminalId } = data;
+            if (!terminalId) {
+                logWarn("[terminal] kill_terminal: missing terminalId");
+                return;
+            }
+            logInfo(`[terminal] kill_terminal: terminalId=${terminalId}`);
+            const killed = killTerminal(terminalId);
+            logInfo(`[terminal] kill_terminal: result=${killed} terminalId=${terminalId}`);
+            if (killed) {
+                socket.emit("terminal_exit", { terminalId, exitCode: -1 });
+            } else {
+                socket.emit("terminal_error", { terminalId, message: "Terminal not found" });
+            }
+        });
+
+        socket.on("list_terminals", () => {
+            if (isShuttingDown()) return;
+            const list = listTerminals();
+            logInfo(`[terminal] list_terminals: ${list.length} active (${list.join(", ") || "none"})`);
+            // terminals_list is not in the typed protocol yet — emit untyped
+            (socket as any).emit("terminals_list", { terminals: list });
+        });
+    }
+
+    dispose(): void {
+        killAllTerminals();
+    }
+}

--- a/packages/cli/src/runner/services/tunnel-service.ts
+++ b/packages/cli/src/runner/services/tunnel-service.ts
@@ -1,0 +1,221 @@
+/**
+ * TunnelService — expose local ports to authenticated remote viewers via the PizzaPi relay.
+ *
+ * Option C constraints (HTTP-only, no WebSocket upgrade, no streaming, max 10 MB body):
+ *   - No WebSocket upgrade (no HMR, no Socket.IO through tunnel)
+ *   - No streaming responses (body fully buffered before forwarding)
+ *   - No SSE support
+ *   - No CORS handling beyond header passthrough
+ *   - Not suitable for large file downloads (>10 MB)
+ */
+
+import type { Socket } from "socket.io-client";
+import type { ServiceHandler, ServiceInitOptions, ServiceEnvelope } from "../service-handler.js";
+import { logInfo, logError } from "../logger.js";
+
+// Local type definitions — mirrors packages/protocol/src/shared.ts.
+// Using inline aliases avoids the cross-worktree symlink issue where
+// node_modules/@pizzapi/protocol resolves to the main branch's dist.
+
+interface TunnelInfo {
+    port: number;
+    name?: string;
+    /** Relay tunnel URL fragment — actual URL is /api/tunnel/{sessionId}/{port}/ */
+    url: string;
+}
+
+interface TunnelRequestData {
+    requestId: string;
+    port: number;
+    method: string;
+    path: string;
+    headers: Record<string, string>;
+    /** Request body, base64-encoded. Absent for bodyless methods. */
+    body?: string;
+}
+
+interface TunnelResponseData {
+    requestId: string;
+    status: number;
+    headers: Record<string, string>;
+    /** Response body, base64-encoded. */
+    body: string;
+    /** Set when the proxy itself failed. */
+    error?: string;
+}
+
+/** Maximum response body size that will be relayed (10 MB). */
+const MAX_RESPONSE_BYTES = 10 * 1024 * 1024;
+
+/** Hop-by-hop headers that must not be forwarded in either direction. */
+const HOP_BY_HOP = new Set([
+    "connection",
+    "keep-alive",
+    "transfer-encoding",
+    "te",
+    "trailer",
+    "upgrade",
+    "proxy-authorization",
+    "proxy-authenticate",
+]);
+
+export class TunnelService implements ServiceHandler {
+    readonly id = "tunnel";
+
+    private tunnels = new Map<number, TunnelInfo>();
+    private socket: Socket | null = null;
+
+    init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
+        this.socket = socket;
+
+        // ── Viewer → Runner: service_message commands ─────────────────────────
+        (socket as any).on("service_message", (envelope: ServiceEnvelope) => {
+            if (isShuttingDown()) return;
+            if (envelope.serviceId !== "tunnel") return;
+
+            switch (envelope.type) {
+                case "tunnel_list":
+                    this.handleList(envelope.requestId);
+                    break;
+                case "tunnel_expose":
+                    this.handleExpose(envelope.requestId, envelope.payload as { port: number; name?: string });
+                    break;
+                case "tunnel_unexpose":
+                    this.handleUnexpose(envelope.payload as { port: number });
+                    break;
+            }
+        });
+
+        // ── Server → Runner: tunnel_request (HTTP proxy) ───────────────────────
+        (socket as any).on("tunnel_request", async (data: TunnelRequestData) => {
+            if (isShuttingDown()) return;
+            await this.handleHttpRequest(data);
+        });
+    }
+
+    dispose(): void {
+        this.tunnels.clear();
+        this.socket = null;
+    }
+
+    // ── Command handlers ──────────────────────────────────────────────────────
+
+    private handleList(requestId?: string): void {
+        if (!this.socket) return;
+        const tunnels = Array.from(this.tunnels.values());
+        (this.socket as any).emit("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_list_result",
+            requestId,
+            payload: { tunnels },
+        } satisfies ServiceEnvelope);
+    }
+
+    private handleExpose(requestId: string | undefined, payload: { port: number; name?: string }): void {
+        if (!this.socket) return;
+        const { port, name } = payload;
+
+        if (!port || port < 1 || port > 65535) {
+            (this.socket as any).emit("service_message", {
+                serviceId: "tunnel",
+                type: "tunnel_error",
+                requestId,
+                payload: { error: `Invalid port: ${port}` },
+            } satisfies ServiceEnvelope);
+            return;
+        }
+
+        // URL placeholder — the actual URL is constructed client-side using
+        // the viewer's known server URL: /api/tunnel/{sessionId}/{port}/
+        const url = `/tunnel/${port}`;
+        const info: TunnelInfo = { port, ...(name ? { name } : {}), url };
+        this.tunnels.set(port, info);
+        logInfo(`[tunnel] exposed port ${port}${name ? ` (${name})` : ""}`);
+
+        (this.socket as any).emit("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_registered",
+            requestId,
+            payload: info,
+        } satisfies ServiceEnvelope);
+    }
+
+    private handleUnexpose(payload: { port: number }): void {
+        if (!this.socket) return;
+        const { port } = payload;
+
+        if (this.tunnels.delete(port)) {
+            logInfo(`[tunnel] unexposed port ${port}`);
+            (this.socket as any).emit("service_message", {
+                serviceId: "tunnel",
+                type: "tunnel_removed",
+                payload: { port },
+            } satisfies ServiceEnvelope);
+        }
+    }
+
+    // ── HTTP proxy ────────────────────────────────────────────────────────────
+
+    private async handleHttpRequest(data: TunnelRequestData): Promise<void> {
+        if (!this.socket) return;
+        const { requestId, port, method, path, headers, body } = data;
+
+        const response: TunnelResponseData = {
+            requestId,
+            status: 500,
+            headers: {},
+            body: "",
+        };
+
+        // Reject requests for unexposed ports
+        if (!this.tunnels.has(port)) {
+            response.status = 404;
+            response.error = `Port ${port} is not exposed`;
+            response.body = Buffer.from(response.error).toString("base64");
+            (this.socket as any).emit("tunnel_response", response);
+            return;
+        }
+
+        try {
+            const url = `http://127.0.0.1:${port}${path}`;
+            const bodyBytes = body ? Buffer.from(body, "base64") : undefined;
+
+            // Strip hop-by-hop headers before forwarding
+            const forwardHeaders: Record<string, string> = {};
+            for (const [k, v] of Object.entries(headers)) {
+                if (!HOP_BY_HOP.has(k.toLowerCase())) forwardHeaders[k] = v;
+            }
+
+            const fetchResponse = await fetch(url, {
+                method,
+                headers: forwardHeaders,
+                // body must be undefined for bodyless methods to avoid fetch errors
+                body: bodyBytes && bodyBytes.byteLength > 0 ? bodyBytes : undefined,
+                signal: AbortSignal.timeout(10_000),
+            });
+
+            const responseBuffer = await fetchResponse.arrayBuffer();
+
+            if (responseBuffer.byteLength > MAX_RESPONSE_BYTES) {
+                response.status = 413;
+                response.error = `Response body exceeds ${MAX_RESPONSE_BYTES / 1024 / 1024} MB limit`;
+                response.body = Buffer.from(response.error).toString("base64");
+            } else {
+                response.status = fetchResponse.status;
+                response.body = Buffer.from(responseBuffer).toString("base64");
+                // Copy response headers (strip hop-by-hop)
+                fetchResponse.headers.forEach((v, k) => {
+                    if (!HOP_BY_HOP.has(k.toLowerCase())) response.headers[k] = v;
+                });
+            }
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            logError(`[tunnel] HTTP proxy error for port ${port}: ${msg}`);
+            response.status = 502;
+            response.error = msg;
+            response.body = Buffer.from(msg).toString("base64");
+        }
+
+        (this.socket as any).emit("tunnel_response", response);
+    }
+}

--- a/packages/cli/src/runner/services/tunnel-service.ts
+++ b/packages/cli/src/runner/services/tunnel-service.ts
@@ -57,7 +57,16 @@ const HOP_BY_HOP = new Set([
     "upgrade",
     "proxy-authorization",
     "proxy-authenticate",
+    // Rewritten to 127.0.0.1:{port} by the runner — strip the viewer's value.
+    "host",
 ]);
+
+/**
+ * Auth headers that must never leak from the viewer session to the tunneled
+ * localhost service.  Stripping these prevents credential forwarding (SSRF
+ * auth-leakage vector).
+ */
+const STRIP_AUTH_HEADERS = new Set(["cookie", "authorization"]);
 
 export class TunnelService implements ServiceHandler {
     readonly id = "tunnel";
@@ -177,24 +186,53 @@ export class TunnelService implements ServiceHandler {
         }
 
         try {
-            const url = `http://127.0.0.1:${port}${path}`;
-            const bodyBytes = body ? Buffer.from(body, "base64") : undefined;
+            const rawUrl = `http://127.0.0.1:${port}${path}`;
 
-            // Strip hop-by-hop headers before forwarding
-            const forwardHeaders: Record<string, string> = {};
-            for (const [k, v] of Object.entries(headers)) {
-                if (!HOP_BY_HOP.has(k.toLowerCase())) forwardHeaders[k] = v;
+            // ── Bug 2: SSRF via path injection ────────────────────────────────
+            // A path containing `@` can cause URL parsers to treat
+            // `127.0.0.1:${port}` as credentials (e.g. http://127.0.0.1:3000@evil/).
+            // Parse and assert the final hostname before fetching.
+            const parsedUrl = new URL(rawUrl);
+            if (parsedUrl.hostname !== "127.0.0.1") {
+                response.status = 400;
+                response.error = `SSRF guard: unexpected hostname '${parsedUrl.hostname}'`;
+                response.body = Buffer.from(response.error).toString("base64");
+                (this.socket as any).emit("tunnel_response", response);
+                return;
             }
 
-            const fetchResponse = await fetch(url, {
+            const bodyBytes = body ? Buffer.from(body, "base64") : undefined;
+
+            // Strip hop-by-hop and auth headers before forwarding.
+            // Auth headers (cookie, authorization) must not leak from the
+            // viewer's authenticated session to the tunneled localhost service.
+            const forwardHeaders: Record<string, string> = {};
+            for (const [k, v] of Object.entries(headers)) {
+                const lk = k.toLowerCase();
+                if (!HOP_BY_HOP.has(lk) && !STRIP_AUTH_HEADERS.has(lk)) forwardHeaders[k] = v;
+            }
+
+            // ── Bug 1: SSRF via redirect-following ────────────────────────────
+            // Default fetch follows 301/302 — a localhost service could redirect
+            // to an internal network address (169.254.169.254, 10.x.x.x, etc.).
+            // Use `redirect: "manual"` and pass 3xx responses back as-is.
+            const fetchResponse = await fetch(parsedUrl.toString(), {
                 method,
                 headers: forwardHeaders,
                 // body must be undefined for bodyless methods to avoid fetch errors
                 body: bodyBytes && bodyBytes.byteLength > 0 ? bodyBytes : undefined,
                 signal: AbortSignal.timeout(10_000),
+                redirect: "manual",
             });
 
+            // ── P2: Race guard — dispose() may have nulled the socket ─────────
+            // We awaited above; re-check before touching this.socket.
+            if (!this.socket) return;
+
             const responseBuffer = await fetchResponse.arrayBuffer();
+
+            // Re-check after second await.
+            if (!this.socket) return;
 
             if (responseBuffer.byteLength > MAX_RESPONSE_BYTES) {
                 response.status = 413;
@@ -216,6 +254,9 @@ export class TunnelService implements ServiceHandler {
             response.body = Buffer.from(msg).toString("base64");
         }
 
+        // Final null-guard: socket may have been cleared by dispose() during
+        // one of the awaits above.
+        if (!this.socket) return;
         (this.socket as any).emit("tunnel_response", response);
     }
 }

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -3,6 +3,7 @@ import { homedir } from "os";
 import { join } from "path";
 import { saveGlobalConfig } from "./config.js";
 import { validatePassword, PASSWORD_REQUIREMENTS } from "@pizzapi/protocol";
+import { c } from "./cli-colors.js";
 
 const RELAY_DEFAULT = "http://localhost:7492";
 
@@ -82,11 +83,15 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
     try {
         const configPath = join(homedir(), ".pizzapi", "config.json");
 
-        console.log("\n┌─────────────────────────────────────────┐");
-        console.log("│        PizzaPi — first-run setup        │");
-        console.log("└─────────────────────────────────────────┘\n");
+        const frame = c.label("─".repeat(43));
+        console.log();
+        console.log(c.label("┌") + frame + c.label("┐"));
+        console.log(c.label("│") + `     ${c.brand("🍕 PizzaPi")} ${c.dim("— first-run setup")}     ` + c.label("│"));
+        console.log(c.label("└") + frame + c.label("┘"));
+        console.log();
         console.log("Connect this node to a PizzaPi relay server so your sessions");
-        console.log("can be monitored from the web UI.\n");
+        console.log("can be monitored from the web UI.");
+        console.log();
 
         if (!opts.force) {
             const skip = await ask(iface, "Skip setup and continue without relay? [y/N] ");
@@ -107,7 +112,7 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
         const name = (await ask(iface, "Your name (leave blank if account already exists): ")).trim();
         const email = (await ask(iface, "Email: ")).trim();
         if (!email) {
-            console.log("\n✗ Email is required. Aborting setup.\n");
+            console.log(`\n${c.error("✗")} Email is required. Aborting setup.\n`);
             return false;
         }
 
@@ -116,7 +121,7 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
 
         const password = await askPassword("Password: ");
         if (!password) {
-            console.log("\n✗ Password is required. Aborting setup.\n");
+            console.log(`\n${c.error("✗")} Password is required. Aborting setup.\n`);
             return false;
         }
 
@@ -124,26 +129,27 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
         if (name) {
             const check = validatePassword(password);
             if (!check.valid) {
-                console.log("\n✗ Password does not meet the requirements:");
-                for (const c of check.checks) {
-                    console.log(`  ${c.met ? "✓" : "✗"} ${c.label}`);
+                console.log(`\n${c.error("✗")} Password does not meet the requirements:`);
+                for (const chk of check.checks) {
+                    const icon = chk.met ? c.success("✓") : c.error("✗");
+                    console.log(`  ${icon} ${chk.label}`);
                 }
                 console.log();
                 return false;
             }
         }
 
-        process.stdout.write("\nConnecting to relay server… ");
+        process.stdout.write(`\n${c.dim("Connecting to relay server…")} `);
         const result = await registerCli(relayUrl, name, email, password);
         if (!result.ok || !result.key) {
-            console.log("✗\n");
+            console.log(c.error("✗") + "\n");
             console.error(
                 `Could not register with the relay server: ${result.error ?? "unknown error"}\n` +
                 "Check that the server is running, your credentials are correct, and try again.\n",
             );
             return false;
         }
-        console.log("✓\n");
+        console.log(c.success("✓") + "\n");
 
         // Derive ws:// URL for the relay config
         const wsRelayUrl = relayUrl.replace(/^http/, "ws");
@@ -153,8 +159,8 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
         process.env.PIZZAPI_API_KEY = result.key;
         process.env.PIZZAPI_RELAY_URL = wsRelayUrl;
 
-        console.log(`✓ API key saved to ${configPath}`);
-        console.log(`✓ Relay: ${wsRelayUrl}\n`);
+        console.log(`${c.success("✓")} API key saved to ${c.dim(configPath)}`);
+        console.log(`${c.success("✓")} Relay: ${c.accent(wsRelayUrl)}\n`);
         return true;
     } finally {
         try { iface.close(); } catch {}

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -17,6 +17,7 @@ import { createECDH, createHash, randomBytes } from "crypto";
 import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
+import { c } from "./cli-colors.js";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -837,34 +838,34 @@ export function parseArgs(args: string[]): ParsedArgs {
 // ─── Help text ────────────────────────────────────────────────────────────────
 
 function printWebHelp(): void {
-    console.log(`
-pizza web — Manage the PizzaPi web hub (server + UI via Docker Compose)
-
-Usage:
-  pizza web [flags]               Start the web hub
-  pizza web stop                  Stop the web hub
-  pizza web logs                  Tail container logs
-  pizza web status                Show container status
-  pizza web config                Show current configuration
-  pizza web config set <k> <v>    Update a config value
-
-Flags:
-  --port <port>       Set the host port (persisted to config.json)
-  --origins <list>    Set extra allowed CORS origins (comma-separated, persisted)
-  -f, --foreground    Run in the foreground (don't detach)
-  -h, --help          Show this help
-
-Configuration (${CONFIG_PATH}):
-  port            Host port (default: 7492)
-  vapidSubject    VAPID subject for push notifications (default: mailto:admin@pizzapi.local)
-  extraOrigins    Extra CORS origins, comma-separated
-
-Examples:
-  pizza web                           Start on default port 7492
-  pizza web --port 8080               Start on port 8080 (remembered for next time)
-  pizza web config set port 9000      Change port without starting
-  pizza web config set extraOrigins "https://example.com"
-`.trim());
+    console.log();
+    console.log(`${c.brand("pizza web")} ${c.dim("— Manage the PizzaPi web hub (server + UI via Docker Compose)")}`);
+    console.log();
+    console.log(c.label("Commands"));
+    console.log(`  ${c.cmd("pizza web")} ${c.dim("[flags]")}               Start the web hub`);
+    console.log(`  ${c.cmd("pizza web stop")}                  Stop the web hub`);
+    console.log(`  ${c.cmd("pizza web logs")}                  Tail container logs`);
+    console.log(`  ${c.cmd("pizza web status")}                Show container status`);
+    console.log(`  ${c.cmd("pizza web config")}                Show current configuration`);
+    console.log(`  ${c.cmd("pizza web config set")} ${c.dim("<k> <v>")}    Update a config value`);
+    console.log();
+    console.log(c.label("Flags"));
+    console.log(`  ${c.flag("--port")} ${c.dim("<port>")}       Set the host port ${c.dim("(persisted to config.json)")}`);
+    console.log(`  ${c.flag("--origins")} ${c.dim("<list>")}    Set extra allowed CORS origins ${c.dim("(comma-separated, persisted)")}`);
+    console.log(`  ${c.flag("-f, --foreground")}    Run in the foreground ${c.dim("(don't detach)")}`);
+    console.log(`  ${c.flag("-h, --help")}          Show this help`);
+    console.log();
+    console.log(`${c.label("Configuration")} ${c.dim(`(${CONFIG_PATH})`)}`);
+    console.log(`  ${c.accent("port")}            Host port ${c.dim("(default: 7492)")}`);
+    console.log(`  ${c.accent("vapidSubject")}    VAPID subject for push notifications`);
+    console.log(`  ${c.accent("extraOrigins")}    Extra CORS origins, comma-separated`);
+    console.log();
+    console.log(c.label("Examples"));
+    console.log(`  ${c.dim("pizza web")}                           Start on default port 7492`);
+    console.log(`  ${c.dim("pizza web --port 8080")}               Start on port 8080 (remembered for next time)`);
+    console.log(`  ${c.dim("pizza web config set port 9000")}      Change port without starting`);
+    console.log(`  ${c.dim('pizza web config set extraOrigins "https://example.com"')}`);
+    console.log();
 }
 
 // ─── Config subcommand ────────────────────────────────────────────────────────

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -15,6 +15,9 @@ export type {
   RunnerHook,
   Attachment,
   ServiceEnvelope,
+  TunnelInfo,
+  TunnelRequestData,
+  TunnelResponseData,
 } from "./shared.js";
 
 // Password validation (shared across server, UI, CLI)

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -14,6 +14,7 @@ export type {
   RunnerPlugin,
   RunnerHook,
   Attachment,
+  ServiceEnvelope,
 } from "./shared.js";
 
 // Password validation (shared across server, UI, CLI)

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -2,7 +2,7 @@
 // /runner namespace — Runner daemon ↔ Server
 // ============================================================================
 
-import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook } from "./shared.js";
+import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook, ServiceEnvelope } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Client → Server (Runner daemon sends to server)
@@ -113,6 +113,14 @@ export interface RunnerClientToServerEvents {
   disconnect_session: (data: {
     sessionId: string;
   }) => void;
+
+  /** Generic service message from runner → relay → viewer.
+   *  The relay forwards this verbatim; it does not inspect serviceId. */
+  service_message: (envelope: ServiceEnvelope) => void;
+
+  /** Announce which services this runner supports.
+   *  Forwarded to all viewers watching sessions on this runner. */
+  service_announce: (data: { serviceIds: string[] }) => void;
 
   /** Terminal is ready for interaction */
   terminal_ready: (data: {
@@ -346,6 +354,10 @@ export interface RunnerServerToClientEvents {
     requestId?: string;
     range?: "7d" | "30d" | "90d" | "all";
   }) => void;
+
+  /** Generic service message from viewer → relay → runner.
+   *  The relay forwards this verbatim; it does not inspect serviceId. */
+  service_message: (envelope: ServiceEnvelope) => void;
 
   /** Generic error */
   error: (data: {

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -2,7 +2,7 @@
 // /runner namespace — Runner daemon ↔ Server
 // ============================================================================
 
-import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook, ServiceEnvelope } from "./shared.js";
+import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook, ServiceEnvelope, TunnelRequestData, TunnelResponseData } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Client → Server (Runner daemon sends to server)
@@ -117,6 +117,10 @@ export interface RunnerClientToServerEvents {
   /** Generic service message from runner → relay → viewer.
    *  The relay forwards this verbatim; it does not inspect serviceId. */
   service_message: (envelope: ServiceEnvelope) => void;
+
+  /** Runner responds to an HTTP proxy request from the server.
+   *  NOT forwarded to viewers — resolved directly by the pending request map. */
+  tunnel_response: (data: TunnelResponseData) => void;
 
   /** Announce which services this runner supports.
    *  Forwarded to all viewers watching sessions on this runner. */
@@ -358,6 +362,10 @@ export interface RunnerServerToClientEvents {
   /** Generic service message from viewer → relay → runner.
    *  The relay forwards this verbatim; it does not inspect serviceId. */
   service_message: (envelope: ServiceEnvelope) => void;
+
+  /** Server-initiated HTTP proxy request sent directly to the runner.
+   *  Bypasses the viewer broadcast path — used exclusively by the tunnel route. */
+  tunnel_request: (data: TunnelRequestData) => void;
 
   /** Generic error */
   error: (data: {

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -101,3 +101,35 @@ export interface ServiceEnvelope {
   requestId?: string;
   payload: unknown;
 }
+
+// ── Tunnel service types ──────────────────────────────────────────────────────
+
+/** Information about an exposed tunnel port. */
+export interface TunnelInfo {
+  port: number;
+  name?: string;
+  /** Relay tunnel URL fragment — actual URL is /api/tunnel/{sessionId}/{port}/ */
+  url: string;
+}
+
+/** Server → Runner: HTTP proxy request forwarded from an authenticated viewer. */
+export interface TunnelRequestData {
+  requestId: string;
+  port: number;
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  /** Request body, base64-encoded. Absent for bodyless methods (GET, HEAD, DELETE). */
+  body?: string;
+}
+
+/** Runner → Server: HTTP proxy response from the local service. */
+export interface TunnelResponseData {
+  requestId: string;
+  status: number;
+  headers: Record<string, string>;
+  /** Response body, base64-encoded. */
+  body: string;
+  /** Set when the proxy itself failed (connection refused, timeout, etc.). */
+  error?: string;
+}

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -91,3 +91,13 @@ export interface Attachment {
   filename?: string;
   url?: string;
 }
+
+/** Generic relay protocol envelope for service messages.
+ *  Enables runner services to communicate with viewers without
+ *  the relay needing to understand service-specific semantics. */
+export interface ServiceEnvelope {
+  serviceId: string;
+  type: string;
+  requestId?: string;
+  payload: unknown;
+}

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -2,7 +2,7 @@
 // /viewer namespace — Browser viewer ↔ Server
 // ============================================================================
 
-import type { Attachment } from "./shared.js";
+import type { Attachment, ServiceEnvelope } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Server → Client (Server sends to browser viewer)
@@ -39,6 +39,13 @@ export interface ViewerServerToClientEvents {
     result?: unknown;
     error?: string;
   }) => void;
+
+  /** Generic service message from runner → relay → viewer.
+   *  serviceId identifies which runner service sent the message. */
+  service_message: (envelope: ServiceEnvelope) => void;
+
+  /** Announces which services the connected runner supports. */
+  service_announce: (data: { serviceIds: string[] }) => void;
 
   /** Generic error */
   error: (data: {
@@ -85,6 +92,9 @@ export interface ViewerClientToServerEvents {
     command: string;
     [key: string]: unknown;
   }) => void;
+
+  /** Generic service message from viewer → relay → runner. */
+  service_message: (envelope: ServiceEnvelope) => void;
 
   /** Human viewer responds to a pending trigger from a child session.
    *  Supports Socket.IO ack — server calls the ack callback only on

--- a/packages/server/src/handler.test.ts
+++ b/packages/server/src/handler.test.ts
@@ -388,6 +388,24 @@ describe("withSecurityHeaders", () => {
         expect(res.statusText).toBe("Not Found");
     });
 
+    test("tunnel responses get SAMEORIGIN and no CSP", () => {
+        const tunnelRes = new Response("tunneled html", {
+            status: 200,
+            headers: { "x-pizzapi-tunnel": "1", "content-type": "text/html" },
+        });
+        const res = withSecurityHeaders(tunnelRes);
+        expect(res.headers.get("X-Frame-Options")).toBe("SAMEORIGIN");
+        expect(res.headers.get("Content-Security-Policy")).toBeNull();
+        // Internal marker must be stripped
+        expect(res.headers.has("x-pizzapi-tunnel")).toBe(false);
+    });
+
+    test("non-tunnel responses still get DENY and CSP", () => {
+        const res = withSecurityHeaders(new Response("ok", { status: 200 }));
+        expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+        expect(res.headers.get("Content-Security-Policy")).not.toBeNull();
+    });
+
     test("no duplicate security headers when response is collected via sendFetchResponse-style merging", () => {
         // Regression test for the P0 bug where sendFetchResponse had its own hardcoded
         // security headers AND withSecurityHeaders also set them, producing header arrays.

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -150,19 +150,39 @@ export async function enforceBodySizeLimit(req: Request, url: URL): Promise<Resp
 /**
  * Clone a Response and inject the standard security headers.
  * Called on every response returned by handleFetch.
+ *
+ * Tunnel proxy responses (marked with x-pizzapi-tunnel) get a relaxed policy:
+ * the tunneled app's content needs its own CSP/framing rules, not PizzaPi's
+ * restrictive defaults.
+ *
  * Exported for testing.
  */
 export function withSecurityHeaders(res: Response): Response {
     const headers = new Headers(res.headers);
+    const isTunnel = headers.has("x-pizzapi-tunnel");
+    // Strip internal marker before sending to client
+    headers.delete("x-pizzapi-tunnel");
+
     headers.set("X-Content-Type-Options", "nosniff");
-    headers.set("X-Frame-Options", "DENY");
     headers.set("X-XSS-Protection", "0");
     headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
     headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()");
-    headers.set(
-        "Content-Security-Policy",
-        "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
-    );
+
+    if (isTunnel) {
+        // Tunnel responses: allow same-origin framing (for the TunnelPanel iframe)
+        // and use a permissive CSP so the tunneled app's scripts/styles/resources load.
+        headers.set("X-Frame-Options", "SAMEORIGIN");
+        // Intentionally omit Content-Security-Policy — the tunneled app may need
+        // inline scripts, external CDN resources, etc. that PizzaPi's strict CSP
+        // would block. The iframe sandbox attribute provides defence-in-depth.
+    } else {
+        headers.set("X-Frame-Options", "DENY");
+        headers.set(
+            "Content-Security-Policy",
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
+        );
+    }
+
     return new Response(res.body, { status: res.status, statusText: res.statusText, headers });
 }
 

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -10,6 +10,9 @@ export const MAX_BODY_SIZE = 1 * 1024 * 1024;
 /** Body size limit for attachment upload routes (50 MB). */
 export const MAX_ATTACHMENT_BODY_SIZE = 50 * 1024 * 1024;
 
+/** Body size limit for tunnel proxy routes (10 MB — Option C). */
+export const MAX_TUNNEL_BODY_SIZE = 10 * 1024 * 1024;
+
 /**
  * Returns true if the URL path is an attachment upload route.
  * Pattern: POST /api/sessions/:id/attachments
@@ -19,6 +22,14 @@ function isAttachmentUploadPath(pathname: string, method: string): boolean {
         method === "POST" &&
         /^\/api\/sessions\/[^/]+\/attachments$/.test(pathname)
     );
+}
+
+/**
+ * Returns true if the URL path is a tunnel proxy route.
+ * Pattern: /api/tunnel/:sessionId/:port/*
+ */
+function isTunnelPath(pathname: string): boolean {
+    return /^\/api\/tunnel\/[^/]+\/\d+(\/.*)?$/.test(pathname);
 }
 
 /**
@@ -42,7 +53,9 @@ export async function enforceBodySizeLimit(req: Request, url: URL): Promise<Resp
 
     const limit = isAttachmentUploadPath(url.pathname, method)
         ? MAX_ATTACHMENT_BODY_SIZE
-        : MAX_BODY_SIZE;
+        : isTunnelPath(url.pathname)
+            ? MAX_TUNNEL_BODY_SIZE
+            : MAX_BODY_SIZE;
 
     const contentLengthHeader = req.headers.get("content-length");
 

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -17,12 +17,14 @@ import { handleChatRoute } from "./chat.js";
 import { handlePushRoute } from "./push.js";
 import { handleSettingsRoute } from "./settings.js";
 import { handleMcpOAuthRoute } from "./mcp-oauth.js";
+import { handleTunnelRoute } from "./tunnel.js";
 import type { RouteHandler } from "./types.js";
 
 /** All domain routers, tried in order. */
 const routers: RouteHandler[] = [
     handleMcpOAuthRoute,   // Before auth — OAuth callback must be unauthenticated
     handleAuthRoute,
+    handleTunnelRoute,     // Before runners — /api/tunnel/* is session-scoped, not runner-scoped
     handleRunnersRoute,
     handleSessionsRoute,
     handleAttachmentsRoute,

--- a/packages/server/src/routes/tunnel.test.ts
+++ b/packages/server/src/routes/tunnel.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { getTunnelBasePath, rewriteTunnelHtml, rewriteTunnelUrl, shouldRewriteTunnelHtml } from "./tunnel";
+
+describe("tunnel route URL rewriting", () => {
+    test("getTunnelBasePath builds the session-scoped proxy prefix", () => {
+        expect(getTunnelBasePath("session-123", 60434)).toBe("/api/tunnel/session-123/60434");
+    });
+
+    test("rewriteTunnelUrl prefixes root-relative paths", () => {
+        expect(rewriteTunnelUrl("/assets/app.js", "session-123", 60434)).toBe(
+            "/api/tunnel/session-123/60434/assets/app.js",
+        );
+    });
+
+    test("rewriteTunnelUrl rewrites localhost absolute URLs", () => {
+        expect(rewriteTunnelUrl("http://127.0.0.1:60434/login?x=1#hash", "session-123", 60434)).toBe(
+            "/api/tunnel/session-123/60434/login?x=1#hash",
+        );
+        expect(rewriteTunnelUrl("https://localhost:60434/app", "session-123", 60434)).toBe(
+            "/api/tunnel/session-123/60434/app",
+        );
+    });
+
+    test("rewriteTunnelUrl leaves non-local absolute URLs and relative URLs alone", () => {
+        expect(rewriteTunnelUrl("https://example.com/app", "session-123", 60434)).toBe("https://example.com/app");
+        expect(rewriteTunnelUrl("assets/app.js", "session-123", 60434)).toBe("assets/app.js");
+        expect(rewriteTunnelUrl("//cdn.example.com/app.js", "session-123", 60434)).toBe("//cdn.example.com/app.js");
+    });
+});
+
+describe("tunnel route HTML rewriting", () => {
+    test("shouldRewriteTunnelHtml matches HTML content types", () => {
+        expect(shouldRewriteTunnelHtml("text/html; charset=utf-8")).toBe(true);
+        expect(shouldRewriteTunnelHtml("application/xhtml+xml")).toBe(true);
+        expect(shouldRewriteTunnelHtml("text/css")).toBe(false);
+        expect(shouldRewriteTunnelHtml(null)).toBe(false);
+    });
+
+    test("rewriteTunnelHtml rewrites common root-relative HTML references and injects a base tag", () => {
+        const html = `<!doctype html>
+<html>
+  <head>
+    <link rel="stylesheet" href="/assets/app.css">
+    <meta http-equiv="refresh" content="0;url=/login">
+  </head>
+  <body style="background-image:url('/bg.png')">
+    <a href="/dashboard">Dashboard</a>
+    <form action="/submit"></form>
+    <script src="/assets/app.js"></script>
+    <img src="/logo.png">
+  </body>
+</html>`;
+
+        const rewritten = rewriteTunnelHtml(html, "session-123", 60434);
+        expect(rewritten).toContain('<base href="/api/tunnel/session-123/60434/">');
+        expect(rewritten).toContain('href="/api/tunnel/session-123/60434/assets/app.css"');
+        expect(rewritten).toContain('content="0;url=/api/tunnel/session-123/60434/login"');
+        expect(rewritten).toContain('href="/api/tunnel/session-123/60434/dashboard"');
+        expect(rewritten).toContain('action="/api/tunnel/session-123/60434/submit"');
+        expect(rewritten).toContain('src="/api/tunnel/session-123/60434/assets/app.js"');
+        expect(rewritten).toContain('src="/api/tunnel/session-123/60434/logo.png"');
+        expect(rewritten).toContain("url('/api/tunnel/session-123/60434/bg.png')");
+    });
+
+    test("rewriteTunnelHtml injects fetch/XHR interceptor script", () => {
+        const html = `<!doctype html><html><head></head><body>hello</body></html>`;
+        const rewritten = rewriteTunnelHtml(html, "s-1", 3000);
+        expect(rewritten).toContain('data-pizzapi-tunnel-intercept');
+        expect(rewritten).toContain('/api/tunnel/s-1/3000');
+        // Interceptor must appear before any app scripts
+        const interceptIdx = rewritten.indexOf('data-pizzapi-tunnel-intercept');
+        const bodyIdx = rewritten.indexOf('<body>');
+        expect(interceptIdx).toBeLessThan(bodyIdx);
+    });
+});

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -70,8 +70,9 @@ export const handleTunnelRoute: RouteHandler = async (req, url) => {
         return Response.json({ error: "Session not found" }, { status: 404 });
     }
 
-    // Only the session owner may access the tunnel — it exposes localhost
-    if (sessionData.userId && sessionData.userId !== identity.userId) {
+    // Only the session owner may access the tunnel — it exposes localhost.
+    // Fail-closed: reject if userId is missing (no confirmed owner) OR mismatched.
+    if (!sessionData.userId || sessionData.userId !== identity.userId) {
         return Response.json({ error: "Forbidden" }, { status: 403 });
     }
 

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -1,0 +1,157 @@
+/**
+ * Tunnel HTTP proxy route — /api/tunnel/:sessionId/:port/*
+ *
+ * Translates an authenticated viewer's HTTP request into a tunnel_request
+ * Socket.IO event sent to the runner daemon, then writes the tunnel_response
+ * back as an HTTP response.
+ *
+ * Option C limitations (documented intentionally):
+ *   - No WebSocket upgrade (no HMR, no Socket.IO through tunnel)
+ *   - No streaming responses (body fully buffered, max 10 MB)
+ *   - No SSE support
+ *   - No CORS handling beyond header passthrough
+ *   - Not suitable for large file downloads (>10 MB)
+ */
+
+import { requireSession } from "../middleware.js";
+import { getSession } from "../ws/sio-state.js";
+import { sendTunnelRequest } from "../ws/namespaces/runner.js";
+import type { RouteHandler } from "./types.js";
+
+/** Maximum request body size for tunnel proxying (10 MB). */
+const MAX_TUNNEL_BODY_SIZE = 10 * 1024 * 1024;
+
+/** Pattern: /api/tunnel/:sessionId/:port/<rest> */
+const TUNNEL_PATH_RE = /^\/api\/tunnel\/([^/]+)\/(\d+)(\/.*)?$/;
+
+/**
+ * Tunnel route handler.
+ *
+ * Auth: the caller must be authenticated (session cookie or API key) AND must
+ * either own the session or the session must be accessible (viewable) by them.
+ * For now we require session ownership (userId match) since tunnels expose the
+ * runner's localhost — they should not be openly accessible to all viewers.
+ */
+export const handleTunnelRoute: RouteHandler = async (req, url) => {
+    const match = url.pathname.match(TUNNEL_PATH_RE);
+    if (!match) return undefined;
+
+    const method = req.method.toUpperCase();
+    if (!["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].includes(method)) {
+        return new Response("Method not allowed", {
+            status: 405,
+            headers: { Allow: "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS" },
+        });
+    }
+
+    // ── Authenticate caller ──────────────────────────────────────────────────
+    const identity = await requireSession(req);
+    if (identity instanceof Response) return identity;
+
+    // ── Parse path segments ──────────────────────────────────────────────────
+    const sessionId = decodeURIComponent(match[1]);
+    const port = parseInt(match[2], 10);
+    const proxyPath = match[3] ?? "/";
+
+    if (!sessionId) {
+        return Response.json({ error: "Missing session ID" }, { status: 400 });
+    }
+
+    if (!Number.isFinite(port) || port < 1 || port > 65535) {
+        return Response.json({ error: "Invalid port" }, { status: 400 });
+    }
+
+    // Reconstruct proxy path with query string
+    const pathWithQuery = url.search ? `${proxyPath}${url.search}` : proxyPath;
+
+    // ── Look up session and verify ownership ─────────────────────────────────
+    const sessionData = await getSession(sessionId);
+    if (!sessionData) {
+        return Response.json({ error: "Session not found" }, { status: 404 });
+    }
+
+    // Only the session owner may access the tunnel — it exposes localhost
+    if (sessionData.userId && sessionData.userId !== identity.userId) {
+        return Response.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const runnerId = sessionData.runnerId;
+    if (!runnerId) {
+        return Response.json({ error: "Session has no runner" }, { status: 503 });
+    }
+
+    // ── Read and enforce body size limit ─────────────────────────────────────
+    let bodyBase64: string | undefined;
+    if (req.body && method !== "GET" && method !== "HEAD") {
+        const bodyBuffer = await req.arrayBuffer();
+        if (bodyBuffer.byteLength > MAX_TUNNEL_BODY_SIZE) {
+            return Response.json(
+                { error: `Request body exceeds ${MAX_TUNNEL_BODY_SIZE / 1024 / 1024} MB limit` },
+                { status: 413 },
+            );
+        }
+        if (bodyBuffer.byteLength > 0) {
+            bodyBase64 = Buffer.from(bodyBuffer).toString("base64");
+        }
+    }
+
+    // ── Forward headers (strip hop-by-hop and host) ───────────────────────────
+    const HOP_BY_HOP = new Set([
+        "connection",
+        "keep-alive",
+        "transfer-encoding",
+        "te",
+        "trailer",
+        "upgrade",
+        "proxy-authorization",
+        "proxy-authenticate",
+        // Rewrite host to 127.0.0.1:{port} in the runner
+        "host",
+    ]);
+
+    const forwardHeaders: Record<string, string> = {};
+    req.headers.forEach((v, k) => {
+        if (!HOP_BY_HOP.has(k.toLowerCase())) forwardHeaders[k] = v;
+    });
+
+    // ── Build requestId and emit tunnel_request ───────────────────────────────
+    const requestId = `${sessionId}-${port}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    let tunnelResponse;
+    try {
+        tunnelResponse = await sendTunnelRequest(runnerId, {
+            requestId,
+            port,
+            method,
+            path: pathWithQuery,
+            headers: forwardHeaders,
+            body: bodyBase64,
+        });
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("not connected") || msg.includes("disconnected")) {
+            return Response.json({ error: "Runner not available" }, { status: 503 });
+        }
+        if (msg.includes("timed out")) {
+            return Response.json({ error: "Tunnel request timed out" }, { status: 504 });
+        }
+        return Response.json({ error: `Tunnel error: ${msg}` }, { status: 502 });
+    }
+
+    // ── Write response back to viewer ─────────────────────────────────────────
+    const responseBody = Buffer.from(tunnelResponse.body, "base64");
+
+    const responseHeaders = new Headers();
+    for (const [k, v] of Object.entries(tunnelResponse.headers)) {
+        try {
+            responseHeaders.set(k, v);
+        } catch {
+            // Skip headers that are invalid in the Headers API
+        }
+    }
+
+    return new Response(responseBody, {
+        status: tunnelResponse.status,
+        headers: responseHeaders,
+    });
+};

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -24,6 +24,99 @@ const MAX_TUNNEL_BODY_SIZE = 10 * 1024 * 1024;
 /** Pattern: /api/tunnel/:sessionId/:port/<rest> */
 const TUNNEL_PATH_RE = /^\/api\/tunnel\/([^/]+)\/(\d+)(\/.*)?$/;
 
+function getTunnelBasePath(sessionId: string, port: number): string {
+    return `/api/tunnel/${encodeURIComponent(sessionId)}/${port}`;
+}
+
+function rewriteTunnelUrl(value: string, sessionId: string, port: number): string {
+    if (!value) return value;
+    if (value.startsWith("//")) return value;
+    if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value)) {
+        try {
+            const parsed = new URL(value);
+            if ((parsed.protocol === "http:" || parsed.protocol === "https:") && (parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost")) {
+                return `${getTunnelBasePath(sessionId, port)}${parsed.pathname}${parsed.search}${parsed.hash}`;
+            }
+        } catch {
+            return value;
+        }
+        return value;
+    }
+    if (!value.startsWith("/")) return value;
+    return `${getTunnelBasePath(sessionId, port)}${value}`;
+}
+
+/**
+ * Build an inline <script> that monkey-patches fetch and XMLHttpRequest
+ * so absolute root-path requests (e.g. `/api/auth`, `/socket.io/`) are
+ * rewritten through the tunnel proxy prefix. Without this, the tunneled
+ * app's runtime JS calls bypass the `<base>` tag (which only affects
+ * relative URLs in HTML attributes) and hit the host origin directly.
+ */
+function buildTunnelInterceptScript(basePath: string): string {
+    // The script is injected synchronously before any app code runs.
+    // It must be self-contained — no external imports.
+    return `<script data-pizzapi-tunnel-intercept>
+(function(){
+  var B="${basePath}";
+  function rw(u){
+    if(typeof u!=="string")return u;
+    if(u.startsWith(B))return u;
+    if(u.startsWith("/"))return B+u;
+    return u;
+  }
+  function rwInput(input,init){
+    if(typeof input==="string") return [rw(input),init];
+    if(input instanceof Request){
+      var nu=rw(input.url);
+      if(nu!==input.url) return [new Request(nu,input),init];
+    }
+    return [input,init];
+  }
+  // Patch fetch
+  var _f=window.fetch;
+  window.fetch=function(input,init){
+    var a=rwInput(input,init);
+    return _f.call(this,a[0],a[1]);
+  };
+  // Patch XMLHttpRequest.open
+  var _o=XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open=function(method,url){
+    arguments[1]=rw(url);
+    return _o.apply(this,arguments);
+  };
+  // Patch EventSource
+  if(window.EventSource){
+    var _E=window.EventSource;
+    window.EventSource=function(url,cfg){return new _E(rw(url),cfg)};
+    window.EventSource.prototype=_E.prototype;
+  }
+})();
+</script>`;
+}
+
+function rewriteTunnelHtml(html: string, sessionId: string, port: number): string {
+    const basePath = getTunnelBasePath(sessionId, port);
+    const rewritten = html
+        .replace(/(<(?:img|script|iframe|audio|video|source|track|embed|input)\b[^>]*\bsrc=["'])(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteTunnelUrl(path, sessionId, port)}${end}`)
+        .replace(/(<(?:a|link|area)\b[^>]*\bhref=["'])(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteTunnelUrl(path, sessionId, port)}${end}`)
+        .replace(/(<(?:form)\b[^>]*\baction=["'])(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteTunnelUrl(path, sessionId, port)}${end}`)
+        .replace(/(<meta\b[^>]*\bcontent=["'][^"']*?url=)(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteTunnelUrl(path, sessionId, port)}${end}`)
+        .replace(/(\burl\(["']?)(\/[^)"']*)(["']?\))/gi, (_m, start, path, end) => `${start}${rewriteTunnelUrl(path, sessionId, port)}${end}`);
+
+    const injection = `<base href="${basePath}/">${buildTunnelInterceptScript(basePath)}`;
+
+    if (/<head\b[^>]*>/i.test(rewritten)) {
+        return rewritten.replace(/<head\b[^>]*>/i, (match) => `${match}${injection}`);
+    }
+
+    return `${injection}${rewritten}`;
+}
+
+function shouldRewriteTunnelHtml(contentType: string | null): boolean {
+    return !!contentType && /text\/html|application\/xhtml\+xml/i.test(contentType);
+}
+
 /**
  * Tunnel route handler.
  *
@@ -140,7 +233,7 @@ export const handleTunnelRoute: RouteHandler = async (req, url) => {
     }
 
     // ── Write response back to viewer ─────────────────────────────────────────
-    const responseBody = Buffer.from(tunnelResponse.body, "base64");
+    let responseBody = Buffer.from(tunnelResponse.body, "base64");
 
     const responseHeaders = new Headers();
     for (const [k, v] of Object.entries(tunnelResponse.headers)) {
@@ -151,8 +244,25 @@ export const handleTunnelRoute: RouteHandler = async (req, url) => {
         }
     }
 
+    const location = responseHeaders.get("location");
+    if (location) {
+        responseHeaders.set("location", rewriteTunnelUrl(location, sessionId, port));
+    }
+
+    if (shouldRewriteTunnelHtml(responseHeaders.get("content-type"))) {
+        const html = responseBody.toString("utf8");
+        responseBody = Buffer.from(rewriteTunnelHtml(html, sessionId, port), "utf8");
+        responseHeaders.delete("content-length");
+        responseHeaders.delete("content-encoding");
+    }
+
+    // Mark as tunnel response so withSecurityHeaders applies relaxed policy.
+    responseHeaders.set("x-pizzapi-tunnel", "1");
+
     return new Response(responseBody, {
         status: tunnelResponse.status,
         headers: responseHeaders,
     });
 };
+
+export { getTunnelBasePath, rewriteTunnelUrl, rewriteTunnelHtml, shouldRewriteTunnelHtml };

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -20,11 +20,13 @@ import type {
     RunnerAgent,
 } from "@pizzapi/protocol";
 
-// Inline definition mirrors packages/protocol/src/shared.ts ServiceEnvelope.
-// Using a local alias avoids a cross-worktree symlink resolution issue where
+// Inline definitions mirror packages/protocol/src/shared.ts.
+// Using local aliases avoids a cross-worktree symlink resolution issue where
 // node_modules/@pizzapi/protocol points to the main branch's dist, not this
 // worktree's updated dist.
 type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
+type TunnelRequestData = { requestId: string; port: number; method: string; path: string; headers: Record<string, string>; body?: string };
+type TunnelResponseData = { requestId: string; status: number; headers: Record<string, string>; body: string; error?: string };
 import { apiKeyAuthMiddleware } from "./auth.js";
 import {
     registerRunner,
@@ -200,6 +202,64 @@ export async function sendRunnerCommand(
         } catch (err) {
             clearTimeout(timer);
             pendingRunnerCommands.delete(requestId);
+            reject(err);
+        }
+    });
+}
+
+// ── Tunnel HTTP proxy request/response registry ───────────────────────────────
+// Maps requestId → resolve callback. Correlates server-initiated tunnel_request
+// events with tunnel_response events from the runner.
+//
+// This map is module-level (not per-socket) because the HTTP route handler
+// that calls sendTunnelRequest() lives outside the socket connection handler.
+// Cleanup on disconnect rejects all pending requests for that runner so HTTP
+// callers don't hang until their timeout fires.
+
+interface PendingTunnelRequest {
+    resolve: (response: TunnelResponseData) => void;
+    reject: (err: Error) => void;
+    timer: ReturnType<typeof setTimeout>;
+    runnerId: string;
+}
+
+const pendingTunnelRequests = new Map<string, PendingTunnelRequest>();
+
+/**
+ * Send an HTTP proxy request to a runner and await its response.
+ *
+ * The runner receives a `tunnel_request` event and must respond with
+ * `tunnel_response` carrying the same `requestId`.  The response is NOT
+ * broadcast to viewers — it is resolved here and returned to the HTTP caller.
+ *
+ * Throws if the runner is not connected or the request times out.
+ */
+export async function sendTunnelRequest(
+    runnerId: string,
+    request: TunnelRequestData,
+    timeoutMs = 10_000,
+): Promise<TunnelResponseData> {
+    const socket = getLocalRunnerSocket(runnerId);
+    if (!socket) throw new Error(`Runner ${runnerId} not connected`);
+
+    return new Promise<TunnelResponseData>((resolve, reject) => {
+        const timer = setTimeout(() => {
+            pendingTunnelRequests.delete(request.requestId);
+            reject(new Error("Tunnel request timed out"));
+        }, timeoutMs);
+
+        pendingTunnelRequests.set(request.requestId, {
+            resolve,
+            reject,
+            timer,
+            runnerId,
+        });
+
+        try {
+            (socket as Socket).emit("tunnel_request" as any, request);
+        } catch (err) {
+            clearTimeout(timer);
+            pendingTunnelRequests.delete(request.requestId);
             reject(err);
         }
     });
@@ -556,6 +616,19 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             }
         });
 
+        // ── tunnel_response — runner responds to an HTTP proxy request ────────
+        // Resolve the pending request (initiated by sendTunnelRequest) so the
+        // HTTP route handler can write the response back to the viewer.
+        // This event must NOT be forwarded to viewers.
+        socket.on("tunnel_response" as any, (data: TunnelResponseData) => {
+            const pending = pendingTunnelRequests.get(data.requestId);
+            if (pending) {
+                clearTimeout(pending.timer);
+                pendingTunnelRequests.delete(data.requestId);
+                pending.resolve(data);
+            }
+        });
+
         // ── Generic service message relay: runner → viewers ──────────────────
         // Forward service envelopes verbatim to all viewers watching sessions
         // on this runner. The relay does not inspect serviceId — it just routes.
@@ -591,6 +664,15 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             }
             const runnerId = socket.data.runnerId;
             if (runnerId) {
+                // Reject any pending tunnel requests for this runner so HTTP
+                // callers don't hang until their timeout fires.
+                for (const [requestId, pending] of pendingTunnelRequests) {
+                    if (pending.runnerId === runnerId) {
+                        clearTimeout(pending.timer);
+                        pendingTunnelRequests.delete(requestId);
+                        pending.reject(new Error("Runner disconnected"));
+                    }
+                }
                 // Clean up local session tracking
                 runnerSessionIds.delete(runnerId);
                 // Clean up any terminals owned by this runner

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -19,6 +19,12 @@ import type {
     RunnerSkill,
     RunnerAgent,
 } from "@pizzapi/protocol";
+
+// Inline definition mirrors packages/protocol/src/shared.ts ServiceEnvelope.
+// Using a local alias avoids a cross-worktree symlink resolution issue where
+// node_modules/@pizzapi/protocol points to the main branch's dist, not this
+// worktree's updated dist.
+type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
 import { apiKeyAuthMiddleware } from "./auth.js";
 import {
     registerRunner,
@@ -38,6 +44,7 @@ import {
     getTerminalEntry,
     getConnectedSessionsForRunner,
     touchRunner,
+    broadcastToSessionViewers,
 } from "../sio-registry.js";
 import { resolveSpawnReady, resolveSpawnError } from "../runner-control.js";
 
@@ -210,6 +217,14 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
 
     // Auth: validate API key from handshake
     runner.use(apiKeyAuthMiddleware() as Parameters<typeof runner.use>[0]);
+
+    // ── Per-runner session tracking (in-memory) ──────────────────────────────
+    // Maps runnerId → Set<sessionId>. Used to broadcast service_message and
+    // service_announce to all viewers watching sessions on this runner.
+    // This mirrors the session_ready / session_killed lifecycle already tracked
+    // in Redis, but is kept in-memory here to avoid async Redis reads on every
+    // service_message event (which may be high-frequency terminal output).
+    const runnerSessionIds = new Map<string, Set<string>>();
 
     runner.on("connection", (socket) => {
         console.log(`[sio/runner] connected: ${socket.id}`);
@@ -439,6 +454,11 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 await recordRunnerSession(runnerId, data.sessionId);
                 await linkSessionToRunner(runnerId, data.sessionId);
                 resolveSpawnReady(data.sessionId);
+                // Track this session for service_message broadcasting
+                if (!runnerSessionIds.has(runnerId)) {
+                    runnerSessionIds.set(runnerId, new Set());
+                }
+                runnerSessionIds.get(runnerId)!.add(data.sessionId);
             }
         });
 
@@ -454,6 +474,8 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             const runnerId = socket.data.runnerId;
             if (runnerId && data.sessionId) {
                 await removeRunnerSession(runnerId, data.sessionId);
+                // Remove from local tracking
+                runnerSessionIds.get(runnerId)?.delete(data.sessionId);
             }
         });
 
@@ -534,6 +556,32 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             }
         });
 
+        // ── Generic service message relay: runner → viewers ──────────────────
+        // Forward service envelopes verbatim to all viewers watching sessions
+        // on this runner. The relay does not inspect serviceId — it just routes.
+        socket.on("service_message", (envelope: ServiceEnvelope) => {
+            const runnerId = socket.data.runnerId;
+            if (!runnerId) return;
+            const sessionIds = runnerSessionIds.get(runnerId);
+            if (!sessionIds || sessionIds.size === 0) return;
+            for (const sessionId of sessionIds) {
+                broadcastToSessionViewers(sessionId, "service_message", envelope);
+            }
+        });
+
+        // ── service_announce — runner announces available services ────────────
+        // Forward to all viewers watching sessions on this runner so they know
+        // which services are available.
+        socket.on("service_announce", (data: { serviceIds: string[] }) => {
+            const runnerId = socket.data.runnerId;
+            if (!runnerId) return;
+            const sessionIds = runnerSessionIds.get(runnerId);
+            if (!sessionIds || sessionIds.size === 0) return;
+            for (const sessionId of sessionIds) {
+                broadcastToSessionViewers(sessionId, "service_announce", data);
+            }
+        });
+
         // ── disconnect — clean up runner resources ───────────────────────────
         socket.on("disconnect", async (reason) => {
             console.log(`[sio/runner] disconnected: ${socket.id} (${reason})`);
@@ -543,6 +591,8 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             }
             const runnerId = socket.data.runnerId;
             if (runnerId) {
+                // Clean up local session tracking
+                runnerSessionIds.delete(runnerId);
                 // Clean up any terminals owned by this runner
                 const terminalIds = await getTerminalIdsForRunner(runnerId);
                 for (const tid of terminalIds) {

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -29,6 +29,7 @@ import {
     getLocalTuiSocket,
     emitToRelaySession,
     emitToRelaySessionVerified,
+    emitToRunner,
 } from "../sio-registry.js";
 import { getPendingChunkedSnapshot } from "./relay/index.js";
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
@@ -446,12 +447,17 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // Viewers send service_message to interact with runner services
         // (e.g. request file listings, git status, etc.) without the relay
         // needing to understand service-specific semantics.
+        // IMPORTANT: service handlers are registered on the /runner namespace
+        // socket, NOT on the /relay TUI socket. emitToRelaySession would target
+        // the TUI worker (/relay namespace) which does NOT handle service_message
+        // events — all viewer-initiated service requests would be silently dropped.
+        // We must route to the runner via emitToRunner(runnerId, ...) instead.
         socket.on("service_message", async (envelope: ServiceEnvelope) => {
-            // Use the same pattern as exec/input: require collab mode and
-            // forward via relay session room for cluster-wide reach.
             const currentSession = await getSharedSession(sessionId);
             if (!currentSession?.collabMode) return;
-            emitToRelaySession(sessionId, "service_message" as string, envelope);
+            const runnerId = currentSession.runnerId;
+            if (!runnerId) return;
+            emitToRunner(runnerId, "service_message", envelope);
         });
 
         // ── disconnect ───────────────────────────────────────────────────────

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -13,6 +13,12 @@ import type {
     ViewerInterServerEvents,
     ViewerSocketData,
 } from "@pizzapi/protocol";
+
+// Inline definition mirrors packages/protocol/src/shared.ts ServiceEnvelope.
+// Using a local alias avoids a cross-worktree symlink resolution issue where
+// node_modules/@pizzapi/protocol points to the main branch's dist, not this
+// worktree's updated dist.
+type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
 import { sessionCookieAuthMiddleware } from "./auth.js";
 import {
     getSharedSession,
@@ -434,6 +440,18 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             } else {
                 socket.emit("trigger_error", { message: `Failed to deliver trigger response to session ${sessionId}`, triggerId });
             }
+        });
+
+        // ── service_message — viewer → runner: forward service envelope ──────
+        // Viewers send service_message to interact with runner services
+        // (e.g. request file listings, git status, etc.) without the relay
+        // needing to understand service-specific semantics.
+        socket.on("service_message", async (envelope: ServiceEnvelope) => {
+            // Use the same pattern as exec/input: require collab mode and
+            // forward via relay session room for cluster-wide reach.
+            const currentSession = await getSharedSession(sessionId);
+            if (!currentSession?.collabMode) return;
+            emitToRelaySession(sessionId, "service_message" as string, envelope);
         });
 
         // ── disconnect ───────────────────────────────────────────────────────

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -241,6 +241,21 @@ export async function emitToRelaySessionAwaitingAck(
     }
 }
 
+/**
+ * Broadcast an event to all viewers of a specific session.
+ * Used to forward runner service messages to session watchers.
+ */
+export function broadcastToSessionViewers(sessionId: string, eventName: string, data: unknown): void {
+    if (!io) return;
+    try {
+        io.of("/viewer")
+            .to(viewerSessionRoom(sessionId))
+            .emit(eventName, data);
+    } catch (err) {
+        console.warn("[sio-registry] broadcastToSessionViewers failed:", (err as Error)?.message);
+    }
+}
+
 /** Extract a ModelInfo from a raw heartbeat payload (or return null). */
 export function modelFromHeartbeat(rawHeartbeat: unknown): ModelInfo | null {
     const hb = rawHeartbeat && typeof rawHeartbeat === "object"

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -5,7 +5,7 @@
 // existing callers continue importing from `../sio-registry.js` unchanged.
 // ============================================================================
 
-export { initSioRegistry, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionAwaitingAck, runnersUserRoom } from "./context.js";
+export { initSioRegistry, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionAwaitingAck, runnersUserRoom, broadcastToSessionViewers } from "./context.js";
 export { broadcastToHub, addHubClient, removeHubClient } from "./hub.js";
 export type { RegisterTuiSessionOpts } from "./sessions.js";
 export {


### PR DESCRIPTION
Exposes agent-spawned local HTTP services to authenticated remote viewers through the PizzaPi relay.

## Runner (TunnelService)
- Implements `ServiceHandler` interface (dish 001)
- Viewer commands via `service_message`: `tunnel_expose`, `tunnel_unexpose`, `tunnel_list`
- HTTP proxy requests via dedicated `tunnel_request`/`tunnel_response` events (not broadcast to viewers)
- Local type aliases avoid cross-worktree symlink issues with `@pizzapi/protocol`

## Relay (server runner namespace)
- Handles `tunnel_response` from runner, resolves pending HTTP requests
- `sendTunnelRequest()` export for the HTTP route handler
- Cleans up pending requests on runner disconnect (rejects, not leaks)
- Module-level pending map survives multiple HTTP requests

## Protocol
- `TunnelInfo`, `TunnelRequestData`, `TunnelResponseData` added to `shared.ts`
- `tunnel_request` (server→runner) and `tunnel_response` (runner→server) events in `runner.ts`
- All new types exported from `index.ts`

## Server (HTTP route)
- `/api/tunnel/:sessionId/:port/*` — authenticated, session-owner-only
- Translates HTTP → `tunnel_request` → HTTP response
- 10MB body limit in handler.ts (separate from 1MB default and 50MB attachments)

## Option C limitations (documented in code)
- HTTP-only: no WebSocket upgrade, no HMR, no Socket.IO through tunnel
- No streaming responses (body fully buffered before forwarding)
- No SSE support
- No CORS handling beyond header passthrough
- Not suitable for large file downloads (>10 MB)

Pair with Dish 003 (UI TunnelPanel) for the complete feature.