### PR TITLE
fix(ui): replace (session as any).user casts with typed better-auth session accessor

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@ import { RunnerTokenManager } from "@/components/RunnerTokenManager";
 import { RunnerManager } from "@/components/RunnerManager";
 import { NewSessionWizardDialog } from "@/components/NewSessionWizardDialog";
 import { PizzaLogo } from "@/components/PizzaLogo";
-import { authClient, useSession, signOut } from "@/lib/auth-client";
+import { authClient, useSession, signOut, type BetterAuthSession } from "@/lib/auth-client";
 import { useRunnersFeed } from "@/lib/useRunnersFeed";
 import { io, type Socket } from "socket.io-client";
 import type {
@@ -133,7 +133,7 @@ export function App() {
   }>>([]);
   // User-scoped cache key for sidebar runners (prevents cross-account data leakage)
   const sidebarCacheKey = React.useMemo(() => {
-    const userId = session && typeof session === "object" ? (session as any).user?.id : null;
+    const userId = (session as BetterAuthSession | null)?.user?.id ?? null;
     return userId ? `pp-sidebar-runners:${userId}` : null;
   }, [session]);
   // Hydrate from cache once we know the user
@@ -3168,7 +3168,7 @@ export function App() {
     return <AuthPage onAuthenticated={() => authClient.$store.notify("$sessionSignal")} />
   }
 
-  const rawUser = session && typeof session === "object" ? (session as any).user : undefined;
+  const rawUser = (session as BetterAuthSession | null)?.user;
   const userName = rawUser && typeof rawUser.name === "string" ? (rawUser.name as string) : "";
   const userEmail = rawUser && typeof rawUser.email === "string" ? (rawUser.email as string) : "";
   const userLabel = userName || userEmail || "Account";

--- a/packages/ui/src/lib/auth-client.ts
+++ b/packages/ui/src/lib/auth-client.ts
@@ -7,3 +7,6 @@ export const authClient = createAuthClient({
 });
 
 export const { signIn, signUp, signOut, useSession } = authClient;
+
+/** Typed shape of the session data returned by useSession().data */
+export type BetterAuthSession = typeof authClient.$Infer.Session;


### PR DESCRIPTION
## Problem

Two locations in App.tsx access the `user` property on the better-auth session via unsafe `(session as any)` casts, because `useSession()`'s return type doesn't include the user shape.

## Fix

Replaced both `(session as any).user` accesses with a properly typed approach using `typeof authClient.$Infer.Session` — better-auth's built-in session type inference utility.

**`packages/ui/src/lib/auth-client.ts`:** Exported a named type alias:
```ts
export type BetterAuthSession = typeof authClient.$Infer.Session;
```

**`packages/ui/src/App.tsx`:** Replaced both casts:
- Line ~136: `(session as BetterAuthSession | null)?.user?.id ?? null`
- Line ~3171: `(session as BetterAuthSession | null)?.user`

## Locations
- App.tsx line ~136: sidebar cache key generation (user ID)
- App.tsx line ~3171: user display name/email extraction

## Verification
- `bun run typecheck` exits with code 0 (zero errors)
- 611 UI tests pass

Fixes Godmother idea: IBj63TgN