### PR TITLE
fix: preserve Redis state during graceful server shutdown

### DIFF
--- a/packages/server/src/health.test.ts
+++ b/packages/server/src/health.test.ts
@@ -1,0 +1,30 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import {
+    isServerShuttingDown,
+    setServerShuttingDown,
+    resetServerShuttingDown,
+} from "./health.js";
+
+describe("server health — shutdown flag", () => {
+    // Always reset after this suite so the module-level flag doesn't leak
+    // into other test files sharing the same Bun process.
+    afterAll(() => {
+        resetServerShuttingDown();
+    });
+
+    test("isServerShuttingDown is false by default", () => {
+        expect(isServerShuttingDown).toBe(false);
+    });
+
+    test("setServerShuttingDown sets the flag to true", () => {
+        setServerShuttingDown();
+        expect(isServerShuttingDown).toBe(true);
+    });
+
+    test("resetServerShuttingDown resets the flag to false", () => {
+        // Flag is still true from previous test
+        expect(isServerShuttingDown).toBe(true);
+        resetServerShuttingDown();
+        expect(isServerShuttingDown).toBe(false);
+    });
+});

--- a/packages/server/src/health.ts
+++ b/packages/server/src/health.ts
@@ -6,3 +6,28 @@
  * imported directly from index.ts.
  */
 export const serverHealth = { redis: false, socketio: false, startedAt: Date.now() };
+
+/**
+ * Set to `true` when the server receives SIGTERM/SIGINT (graceful shutdown).
+ *
+ * When true, Socket.IO disconnect handlers MUST skip destructive cleanup
+ * (deleting sessions from Redis, removing runner registrations, etc.).
+ * The runners and TUI workers are still alive — they will reconnect to the
+ * new server instance after the restart.  Destroying their state forces them
+ * to fully re-register from scratch and creates a window where sessions
+ * appear orphaned / de-registered from their runner.
+ */
+export let isServerShuttingDown = false;
+
+/** Mark the server as shutting down. Called from SIGTERM/SIGINT handlers. */
+export function setServerShuttingDown(): void {
+    isServerShuttingDown = true;
+}
+
+/**
+ * Reset the shutdown flag. **Test-only** — allows test suites to restore
+ * the default state after exercising shutdown behavior.
+ */
+export function resetServerShuttingDown(): void {
+    isServerShuttingDown = false;
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,43 +9,7 @@ import { sweepExpiredSessions } from "./ws/sio-registry.js";
 import { sweepExpiredAttachments, rehydrateExtractedAttachments } from "./attachments/store.js";
 import { runAllMigrations } from "./migrations.js";
 
-// ── Graceful shutdown ────────────────────────────────────────────────────────
-// On SIGTERM/SIGINT (e.g. Docker stop, pizza web restart), set a flag so
-// Socket.IO disconnect handlers skip destructive state cleanup.  The runners
-// and TUI workers will reconnect to the new server — their Redis state must
-// survive the restart.
 import { setServerShuttingDown } from "./health.js";
-
-function onShutdownSignal(signal: string): void {
-    console.log(`[shutdown] Received ${signal} — marking server as shutting down`);
-    setServerShuttingDown();
-
-    // Close the Socket.IO server so disconnect handlers fire with the
-    // shuttingDown flag already set, then close the HTTP server.
-    if (io) {
-        io.close(() => {
-            console.log("[shutdown] Socket.IO closed");
-            httpServer.close(() => {
-                console.log("[shutdown] HTTP server closed");
-                process.exit(0);
-            });
-        });
-    } else {
-        httpServer.close(() => {
-            console.log("[shutdown] HTTP server closed");
-            process.exit(0);
-        });
-    }
-
-    // Force exit after 10s if graceful shutdown stalls
-    setTimeout(() => {
-        console.warn("[shutdown] Graceful shutdown timed out — forcing exit");
-        process.exit(1);
-    }, 10_000).unref();
-}
-
-process.on("SIGTERM", () => onShutdownSignal("SIGTERM"));
-process.on("SIGINT", () => onShutdownSignal("SIGINT"));
 
 // ── Process-level safety net ─────────────────────────────────────────────────
 // The Socket.IO Redis adapter can throw EPIPE synchronously when the Redis
@@ -342,3 +306,38 @@ setInterval(() => {
 }, sweepMs);
 
 console.log(`Relay session maintenance enabled (every ${Math.round(sweepMs / 1000)}s).`);
+
+// ── Graceful shutdown ────────────────────────────────────────────────────────
+// Registered after httpServer and io are initialized so there's no TDZ risk
+// if SIGTERM arrives during startup.  Sets isServerShuttingDown before closing
+// Socket.IO so disconnect handlers can skip destructive Redis cleanup.
+function onShutdownSignal(signal: string): void {
+    console.log(`[shutdown] Received ${signal} — marking server as shutting down`);
+    setServerShuttingDown();
+
+    // Close the Socket.IO server so disconnect handlers fire with the
+    // shuttingDown flag already set, then close the HTTP server.
+    if (io) {
+        io.close(() => {
+            console.log("[shutdown] Socket.IO closed");
+            httpServer.close(() => {
+                console.log("[shutdown] HTTP server closed");
+                process.exit(0);
+            });
+        });
+    } else {
+        httpServer.close(() => {
+            console.log("[shutdown] HTTP server closed");
+            process.exit(0);
+        });
+    }
+
+    // Force exit after 10s if graceful shutdown stalls
+    setTimeout(() => {
+        console.warn("[shutdown] Graceful shutdown timed out — forcing exit");
+        process.exit(1);
+    }, 10_000).unref();
+}
+
+process.on("SIGTERM", () => onShutdownSignal("SIGTERM"));
+process.on("SIGINT", () => onShutdownSignal("SIGINT"));

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -5,7 +5,7 @@ import {
     pruneExpiredRelaySessions,
 } from "./sessions/store.js";
 import { deleteRelayEventCaches, initializeRelayRedisCache } from "./sessions/redis.js";
-import { sweepExpiredSessions } from "./ws/sio-registry.js";
+import { sweepExpiredSessions, sweepOrphanedRunners } from "./ws/sio-registry.js";
 import { sweepExpiredAttachments, rehydrateExtractedAttachments } from "./attachments/store.js";
 import { runAllMigrations } from "./migrations.js";
 
@@ -306,6 +306,19 @@ setInterval(() => {
 }, sweepMs);
 
 console.log(`Relay session maintenance enabled (every ${Math.round(sweepMs / 1000)}s).`);
+
+// ── Post-startup orphaned runner sweep ───────────────────────────────────────
+// After a graceful shutdown, runner Redis entries are intentionally preserved
+// so reconnecting runners find their state intact.  But if the previous
+// server was stopped permanently (not restarted), or a runner died, those
+// entries become ghosts.  Give runners a 90-second grace period to reconnect,
+// then prune any that didn't.
+const RUNNER_RECONNECT_GRACE_MS = 90_000;
+setTimeout(() => {
+    void sweepOrphanedRunners().catch((err) => {
+        console.error("[startup] Failed to sweep orphaned runners:", err);
+    });
+}, RUNNER_RECONNECT_GRACE_MS);
 
 // ── Graceful shutdown ────────────────────────────────────────────────────────
 // Registered after httpServer and io are initialized so there's no TDZ risk

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -9,6 +9,44 @@ import { sweepExpiredSessions } from "./ws/sio-registry.js";
 import { sweepExpiredAttachments, rehydrateExtractedAttachments } from "./attachments/store.js";
 import { runAllMigrations } from "./migrations.js";
 
+// ── Graceful shutdown ────────────────────────────────────────────────────────
+// On SIGTERM/SIGINT (e.g. Docker stop, pizza web restart), set a flag so
+// Socket.IO disconnect handlers skip destructive state cleanup.  The runners
+// and TUI workers will reconnect to the new server — their Redis state must
+// survive the restart.
+import { setServerShuttingDown } from "./health.js";
+
+function onShutdownSignal(signal: string): void {
+    console.log(`[shutdown] Received ${signal} — marking server as shutting down`);
+    setServerShuttingDown();
+
+    // Close the Socket.IO server so disconnect handlers fire with the
+    // shuttingDown flag already set, then close the HTTP server.
+    if (io) {
+        io.close(() => {
+            console.log("[shutdown] Socket.IO closed");
+            httpServer.close(() => {
+                console.log("[shutdown] HTTP server closed");
+                process.exit(0);
+            });
+        });
+    } else {
+        httpServer.close(() => {
+            console.log("[shutdown] HTTP server closed");
+            process.exit(0);
+        });
+    }
+
+    // Force exit after 10s if graceful shutdown stalls
+    setTimeout(() => {
+        console.warn("[shutdown] Graceful shutdown timed out — forcing exit");
+        process.exit(1);
+    }, 10_000).unref();
+}
+
+process.on("SIGTERM", () => onShutdownSignal("SIGTERM"));
+process.on("SIGINT", () => onShutdownSignal("SIGINT"));
+
 // ── Process-level safety net ─────────────────────────────────────────────────
 // The Socket.IO Redis adapter can throw EPIPE synchronously when the Redis
 // connection drops mid-broadcast. We catch any that slip through call-site

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -105,12 +105,11 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
                 return;
             }
 
-            // During graceful shutdown (SIGTERM/SIGINT), skip destructive
-            // Redis cleanup.  The TUI worker is still alive and will
-            // reconnect to the new server instance.  Deleting the session
-            // from Redis would force it to re-register from scratch and
-            // lose its runner association.
-            if (isServerShuttingDown) {
+            // During graceful shutdown (io.close()), Socket.IO disconnects
+            // all sockets with reason "server shutting down".  Skip
+            // destructive Redis cleanup for those — the TUI worker is
+            // still alive and will reconnect to the new server instance.
+            if (isServerShuttingDown && reason === "server shutting down") {
                 console.log(`[sio/relay] server shutting down — preserving Redis state for session ${sessionId}`);
                 socketAckedSeqs.delete(socket.id);
                 return;

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -2,6 +2,7 @@
 // Handles register, session_end, exec_result, and disconnect events.
 
 import type { RelaySocketData } from "@pizzapi/protocol";
+import { isServerShuttingDown } from "../../../health.js";
 import {
     registerTuiSession,
     getLocalTuiSocket,
@@ -100,6 +101,17 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             const currentSocket = getLocalTuiSocket(sessionId);
             if (currentSocket && currentSocket !== socket) {
                 console.log(`[sio/relay] disconnect for ${socket.id} — session ${sessionId} already owned by ${currentSocket.id}, skipping teardown`);
+                socketAckedSeqs.delete(socket.id);
+                return;
+            }
+
+            // During graceful shutdown (SIGTERM/SIGINT), skip destructive
+            // Redis cleanup.  The TUI worker is still alive and will
+            // reconnect to the new server instance.  Deleting the session
+            // from Redis would force it to re-register from scratch and
+            // lose its runner association.
+            if (isServerShuttingDown) {
+                console.log(`[sio/relay] server shutting down — preserving Redis state for session ${sessionId}`);
                 socketAckedSeqs.delete(socket.id);
                 return;
             }

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -19,6 +19,7 @@ import type {
     RunnerSkill,
     RunnerAgent,
 } from "@pizzapi/protocol";
+import { isServerShuttingDown } from "../../health.js";
 import { apiKeyAuthMiddleware } from "./auth.js";
 import {
     registerRunner,
@@ -543,6 +544,15 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             }
             const runnerId = socket.data.runnerId;
             if (runnerId) {
+                // During graceful shutdown (SIGTERM/SIGINT), skip destructive
+                // Redis cleanup.  The runner is still alive and will reconnect
+                // to the new server instance.  Deleting its Redis state would
+                // force a full re-registration and orphan all its sessions.
+                if (isServerShuttingDown) {
+                    console.log(`[sio/runner] server shutting down — preserving Redis state for runner ${runnerId}`);
+                    return;
+                }
+
                 // Clean up any terminals owned by this runner
                 const terminalIds = await getTerminalIdsForRunner(runnerId);
                 for (const tid of terminalIds) {

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -544,11 +544,14 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             }
             const runnerId = socket.data.runnerId;
             if (runnerId) {
-                // During graceful shutdown (SIGTERM/SIGINT), skip destructive
-                // Redis cleanup.  The runner is still alive and will reconnect
-                // to the new server instance.  Deleting its Redis state would
-                // force a full re-registration and orphan all its sessions.
-                if (isServerShuttingDown) {
+                // During graceful shutdown (io.close()), Socket.IO disconnects
+                // all sockets with reason "server shutting down".  Skip
+                // destructive Redis cleanup for those — the runner is still
+                // alive and will reconnect to the new server instance.
+                // We check BOTH the flag and the reason to avoid preserving
+                // state for runners that genuinely crashed during the brief
+                // shutdown window.
+                if (isServerShuttingDown && reason === "server shutting down") {
                     console.log(`[sio/runner] server shutting down — preserving Redis state for runner ${runnerId}`);
                     return;
                 }

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -46,6 +46,7 @@ export {
     getLocalRunnerSocket,
     removeRunner,
     touchRunner,
+    sweepOrphanedRunners,
 } from "./runners.js";
 export type { TerminalSpawnOpts } from "./terminals.js";
 export {

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -402,3 +402,33 @@ export async function removeRunner(runnerId: string): Promise<void> {
 export async function touchRunner(runnerId: string): Promise<void> {
     await refreshRunnerTTL(runnerId);
 }
+
+/**
+ * Sweep runners in Redis that have no live Socket.IO connection on this
+ * server node.  This catches "ghost" runners preserved during a graceful
+ * shutdown when the runner never reconnected — e.g. the runner process
+ * was also stopped, or the server was shut down permanently rather than
+ * restarted.
+ *
+ * Called once after a startup grace period to give runners time to
+ * reconnect before being pruned.
+ */
+export async function sweepOrphanedRunners(): Promise<void> {
+    const allRunners = await getAllRunners();
+    let pruned = 0;
+    for (const runner of allRunners) {
+        if (!localRunnerSockets.has(runner.runnerId)) {
+            console.log(`[sio-registry] Pruning orphaned runner ${runner.runnerId} (${runner.name ?? "unnamed"}) — not reconnected after restart`);
+            await deleteRunnerState(runner.runnerId);
+            void broadcastToRunnersNs(
+                "runner_removed",
+                { runnerId: runner.runnerId },
+                runner.userId ?? undefined,
+            );
+            pruned++;
+        }
+    }
+    if (pruned > 0) {
+        console.log(`[sio-registry] Pruned ${pruned} orphaned runner(s)`);
+    }
+}

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -34,6 +34,7 @@ import {
     runnerRoom,
     safeJsonParse,
     modelFromHeartbeat,
+    getIo,
 } from "./context.js";
 import { broadcastToHub } from "./hub.js";
 import { broadcastToRunnersNs } from "./runners-broadcast.js";
@@ -404,29 +405,44 @@ export async function touchRunner(runnerId: string): Promise<void> {
 }
 
 /**
- * Sweep runners in Redis that have no live Socket.IO connection on this
+ * Sweep runners in Redis that have no live Socket.IO connection on ANY
  * server node.  This catches "ghost" runners preserved during a graceful
  * shutdown when the runner never reconnected — e.g. the runner process
  * was also stopped, or the server was shut down permanently rather than
  * restarted.
+ *
+ * Uses the Socket.IO Redis adapter's cluster-wide room query so that
+ * in multi-node deployments a runner connected to a different relay
+ * node is NOT pruned.
  *
  * Called once after a startup grace period to give runners time to
  * reconnect before being pruned.
  */
 export async function sweepOrphanedRunners(): Promise<void> {
     const allRunners = await getAllRunners();
+    const io = getIo();
+    const runnerNs = io.of("/runner");
     let pruned = 0;
     for (const runner of allRunners) {
-        if (!localRunnerSockets.has(runner.runnerId)) {
-            console.log(`[sio-registry] Pruning orphaned runner ${runner.runnerId} (${runner.name ?? "unnamed"}) — not reconnected after restart`);
-            await deleteRunnerState(runner.runnerId);
-            void broadcastToRunnersNs(
-                "runner_removed",
-                { runnerId: runner.runnerId },
-                runner.userId ?? undefined,
-            );
-            pruned++;
+        // Check cluster-wide: is any socket in this runner's room?
+        // adapter.fetchSockets queries all nodes via the Redis adapter.
+        try {
+            const sockets = await runnerNs.in(runnerRoom(runner.runnerId)).fetchSockets();
+            if (sockets.length > 0) continue; // runner is alive on some node
+        } catch {
+            // If the adapter query fails (e.g. Redis issue), skip this
+            // runner rather than risk pruning a live one.
+            continue;
         }
+
+        console.log(`[sio-registry] Pruning orphaned runner ${runner.runnerId} (${runner.name ?? "unnamed"}) — not reconnected after restart`);
+        await deleteRunnerState(runner.runnerId);
+        void broadcastToRunnersNs(
+            "runner_removed",
+            { runnerId: runner.runnerId },
+            runner.userId ?? undefined,
+        );
+        pruned++;
     }
     if (pruned > 0) {
         console.log(`[sio-registry] Pruned ${pruned} orphaned runner(s)`);


### PR DESCRIPTION
## Problem

When `pizza web` restarts the Docker container, the server receives SIGTERM and Socket.IO connections close. The disconnect handlers were **actively destroying Redis state** that the new server instance needs:

1. **Runner disconnect** → `removeRunner()` deleted the runner hash from Redis and broadcast `runner_removed`
2. **Relay disconnect** → `endSharedSession()` deleted all session hashes from Redis and notified runners of `session_ended`
3. New server starts with empty Redis → runners and workers must fully re-register → sessions appear orphaned/de-registered from their runner

## Fix

Add a `isServerShuttingDown` flag that's set on SIGTERM/SIGINT **before** Socket.IO is closed. Disconnect handlers check this flag and skip destructive Redis cleanup during graceful shutdown. Redis state survives the restart; runners and workers reconnect and find their existing state intact.

| File | Change |
|------|--------|
| `health.ts` | `isServerShuttingDown` flag + setter/reset |
| `index.ts` | SIGTERM/SIGINT handlers: set flag → close Socket.IO → close HTTP → exit (10s force-exit timeout) |
| `runner.ts` | Skip `removeRunner()` during shutdown |
| `session-lifecycle.ts` | Skip `endSharedSession()` during shutdown |
| `health.test.ts` | Tests for shutdown flag lifecycle |

## Testing

- All 574 server tests pass
- Full typecheck clean
- New test file for shutdown flag behavior