### PR TITLE
feat(ui): service panel extension platform — Runner Service System Phase 5

### DIFF
--- a/demos/service-panels/README.md
+++ b/demos/service-panels/README.md
@@ -1,0 +1,39 @@
+# Service Panel Demos
+
+Example UI panel components for PizzaPi runner services.
+
+## SystemMonitorPanel
+
+A React component that displays CPU, memory, and disk usage from the `system-monitor` runner service plugin.
+
+### Prerequisites
+
+The `system-monitor` service must be installed on the runner:
+
+```bash
+# Copy the service plugin to the runner's services directory
+cp ~/.pizzapi/services/system-monitor.js ~/.pizzapi/services/
+```
+
+### Usage
+
+To use this panel in your PizzaPi UI, add it to `packages/ui/src/components/service-panels/registry.tsx`:
+
+```tsx
+import { Activity } from "lucide-react";
+import { SystemMonitorPanel } from "./SystemMonitorPanel";
+
+// Add to SERVICE_PANELS array:
+{
+    serviceId: "system-monitor",
+    label: "System",
+    icon: <Activity className="size-3.5" />,
+    component: SystemMonitorPanel as React.ComponentType<{ sessionId: string }>,
+}
+```
+
+### How it works
+
+- Uses `useServiceChannel("system-monitor")` to subscribe to stats updates
+- The runner service pushes CPU load, memory, and disk stats at a configurable interval
+- Renders gauge bars with color-coded thresholds (green → amber → red)

--- a/demos/service-panels/SystemMonitorPanel.tsx
+++ b/demos/service-panels/SystemMonitorPanel.tsx
@@ -1,0 +1,164 @@
+import { useState, useEffect } from "react";
+import { useServiceChannel } from "@/hooks/useServiceChannel";
+import { Cpu, MemoryStick, HardDrive } from "lucide-react";
+
+interface CpuStats {
+    loadAvg1: number;
+    loadAvg5: number;
+    loadAvg15: number;
+    cores: number;
+}
+
+interface MemStats {
+    totalMb: number;
+    usedMb: number;
+    freeMb: number;
+    usedPct: number;
+}
+
+interface DiskStats {
+    path: string;
+    totalGb: number;
+    usedGb: number;
+    availableGb: number;
+    usedPct: number;
+}
+
+interface SystemStats {
+    timestamp: number;
+    cpu: CpuStats;
+    mem: MemStats;
+    disk: DiskStats | null;
+}
+
+// ── Mini gauge bar ────────────────────────────────────────────────────────────
+
+function GaugeBar({ pct, warn = 70, crit = 90 }: { pct: number; warn?: number; crit?: number }) {
+    const color =
+        pct >= crit ? "bg-red-400" :
+        pct >= warn ? "bg-amber-400" :
+        "bg-[#6ee7b7]";
+    return (
+        <div className="h-1.5 w-full rounded-full bg-white/10 overflow-hidden">
+            <div
+                className={`h-full rounded-full transition-all duration-500 ${color}`}
+                style={{ width: `${Math.min(100, pct)}%` }}
+            />
+        </div>
+    );
+}
+
+// ── Stat row ──────────────────────────────────────────────────────────────────
+
+function StatRow({ label, value, sub }: { label: string; value: string; sub?: string }) {
+    return (
+        <div className="flex items-baseline justify-between gap-2">
+            <span className="text-xs text-muted-foreground">{label}</span>
+            <span className="text-xs font-mono tabular-nums text-foreground">
+                {value}
+                {sub && <span className="text-muted-foreground ml-1">{sub}</span>}
+            </span>
+        </div>
+    );
+}
+
+// ── Section card ──────────────────────────────────────────────────────────────
+
+function Section({ icon, title, children }: { icon: React.ReactNode; title: string; children: React.ReactNode }) {
+    return (
+        <div className="rounded-md border border-white/10 bg-white/5 p-3 space-y-2">
+            <div className="flex items-center gap-1.5 text-xs font-medium text-[#e8b4f8]">
+                {icon}
+                {title}
+            </div>
+            {children}
+        </div>
+    );
+}
+
+// ── Main panel ────────────────────────────────────────────────────────────────
+
+export function SystemMonitorPanel() {
+    const [stats, setStats] = useState<SystemStats | null>(null);
+    const [age, setAge] = useState(0);
+
+    const { send, available } = useServiceChannel<unknown, SystemStats>("system-monitor", {
+        onMessage: (type, payload) => {
+            if (type === "stats") {
+                setStats(payload);
+                setAge(0);
+            }
+        },
+    });
+
+    // Subscribe on mount
+    useEffect(() => {
+        if (!available) return;
+        send("subscribe", { interval: 3000 });
+        return () => send("unsubscribe", {});
+    }, [available, send]);
+
+    // Age counter
+    useEffect(() => {
+        if (!stats) return;
+        const id = setInterval(() => setAge(a => a + 1), 1000);
+        return () => clearInterval(id);
+    }, [stats]);
+
+    if (!available) {
+        return (
+            <div className="flex items-center justify-center h-full text-xs text-muted-foreground p-4 text-center">
+                System monitor not available
+                <br />
+                <span className="opacity-60">Add system-monitor.js to ~/.pizzapi/services/</span>
+            </div>
+        );
+    }
+
+    if (!stats) {
+        return (
+            <div className="flex items-center justify-center h-full text-xs text-muted-foreground">
+                Loading…
+            </div>
+        );
+    }
+
+    const { cpu, mem, disk } = stats;
+    const cpuPct = Math.round(cpu.loadAvg1 * 100);
+
+    return (
+        <div className="p-3 space-y-2 overflow-y-auto h-full">
+
+            {/* CPU */}
+            <Section icon={<Cpu size={12} />} title="CPU">
+                <GaugeBar pct={cpuPct} />
+                <StatRow label="Load (1m)" value={`${cpu.loadAvg1.toFixed(2)}`} sub={`/ ${cpu.cores} cores`} />
+                <StatRow label="Load (5m)"  value={`${cpu.loadAvg5.toFixed(2)}`} />
+                <StatRow label="Load (15m)" value={`${cpu.loadAvg15.toFixed(2)}`} />
+            </Section>
+
+            {/* Memory */}
+            <Section icon={<MemoryStick size={12} />} title="Memory">
+                <GaugeBar pct={mem.usedPct} />
+                <StatRow label="Used"  value={`${mem.usedMb.toLocaleString()} MB`} sub={`${mem.usedPct}%`} />
+                <StatRow label="Free"  value={`${mem.freeMb.toLocaleString()} MB`} />
+                <StatRow label="Total" value={`${mem.totalMb.toLocaleString()} MB`} />
+            </Section>
+
+            {/* Disk */}
+            {disk && (
+                <Section icon={<HardDrive size={12} />} title={`Disk (${disk.path})`}>
+                    <GaugeBar pct={disk.usedPct} warn={80} crit={95} />
+                    <StatRow label="Used"  value={`${disk.usedGb} GB`} sub={`${disk.usedPct}%`} />
+                    <StatRow label="Free"  value={`${disk.availableGb} GB`} />
+                    <StatRow label="Total" value={`${disk.totalGb} GB`} />
+                </Section>
+            )}
+
+            {/* Footer */}
+            <div className="text-[10px] text-muted-foreground text-right opacity-50">
+                {age === 0 ? "just updated" : `${age}s ago`} · 3s interval
+            </div>
+        </div>
+    );
+}

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -17,12 +17,14 @@ import { handleChatRoute } from "./chat.js";
 import { handlePushRoute } from "./push.js";
 import { handleSettingsRoute } from "./settings.js";
 import { handleMcpOAuthRoute } from "./mcp-oauth.js";
+import { handleTunnelRoute } from "./tunnel.js";
 import type { RouteHandler } from "./types.js";
 
 /** All domain routers, tried in order. */
 const routers: RouteHandler[] = [
     handleMcpOAuthRoute,   // Before auth — OAuth callback must be unauthenticated
     handleAuthRoute,
+    handleTunnelRoute,     // Before runners — /api/tunnel/* is session-scoped, not runner-scoped
     handleRunnersRoute,
     handleSessionsRoute,
     handleAttachmentsRoute,

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -13,7 +13,14 @@ import type {
     ViewerInterServerEvents,
     ViewerSocketData,
 } from "@pizzapi/protocol";
+
+// Inline definition mirrors packages/protocol/src/shared.ts ServiceEnvelope.
+// Using a local alias avoids a cross-worktree symlink resolution issue where
+// node_modules/@pizzapi/protocol points to the main branch's dist, not this
+// worktree's updated dist.
+type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
 import { sessionCookieAuthMiddleware } from "./auth.js";
+import { getRunnerServiceIds } from "./runner.js";
 import {
     getSharedSession,
     addViewer,
@@ -23,6 +30,7 @@ import {
     getLocalTuiSocket,
     emitToRelaySession,
     emitToRelaySessionVerified,
+    emitToRunner,
 } from "../sio-registry.js";
 import { getPendingChunkedSnapshot } from "./relay/index.js";
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
@@ -472,6 +480,24 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             }
         });
 
+        // ── service_message — viewer → runner: forward service envelope ──────
+        // Viewers send service_message to interact with runner services
+        // (e.g. request file listings, git status, etc.) without the relay
+        // needing to understand service-specific semantics.
+        // IMPORTANT: service handlers are registered on the /runner namespace
+        // socket, NOT on the /relay TUI socket. emitToRelaySession would target
+        // the TUI worker (/relay namespace) which does NOT handle service_message
+        // events — all viewer-initiated service requests would be silently dropped.
+        // We must route to the runner via emitToRunner(runnerId, ...) instead.
+        socket.on("service_message", async (envelope: ServiceEnvelope) => {
+            const currentSession = await getSharedSession(sessionId);
+            if (!currentSession?.collabMode) return;
+            const runnerId = currentSession.runnerId;
+            if (!runnerId) return;
+            // Attach sessionId so the runner service knows which session to respond to
+            emitToRunner(runnerId, "service_message", { ...envelope, sessionId });
+        });
+
         // ── disconnect ───────────────────────────────────────────────────────
         socket.on("disconnect", async (reason) => {
             console.log(`[sio/viewer] disconnected: ${socket.id} sessionId=${sessionId} (${reason})`);
@@ -522,6 +548,17 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             lastHeartbeatAt: freshSession.lastHeartbeatAt,
             sessionName: freshSession.sessionName,
         });
+
+        // Send cached service_announce so the viewer knows which runner
+        // services are available without waiting for a fresh announce.
+        console.log(`[sio/viewer] service_announce check: runnerId=${freshSession.runnerId ?? "null"}`);
+        if (freshSession.runnerId) {
+            const serviceIds = getRunnerServiceIds(freshSession.runnerId);
+            console.log(`[sio/viewer] service_announce: runnerId=${freshSession.runnerId}, cached serviceIds=[${serviceIds.join(",")}]`);
+            if (serviceIds.length > 0) {
+                socket.emit("service_announce", { serviceIds });
+            }
+        }
 
         // Emit an immediate heartbeat snapshot while the runner pushes a fresh
         // session_active in response to "connected".

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -97,6 +97,8 @@ export interface MockRunnerOptions {
     mockFiles?: Map<string, MockFileEntry[]>;
     /** Initial mock git status */
     mockGitStatus?: MockGitStatus;
+    /** Service IDs this runner announces (e.g. ["terminal", "system-monitor"]) */
+    serviceIds?: string[];
 }
 
 export interface MockRunner {
@@ -124,6 +126,9 @@ export interface MockRunner {
     // Request handler registration (backward compat)
     onSkillRequest(handler: (data: unknown) => unknown): void;
     onFileRequest(handler: (data: unknown) => unknown): void;
+
+    // Services
+    announceServices(serviceIds: string[]): void;
 
     // Utilities
     waitForEvent(eventName: string, timeout?: number): Promise<unknown>;
@@ -365,6 +370,10 @@ export async function createMockRunner(
                             });
                         }
                     }
+                }
+                // Announce services after registration (like real daemon)
+                if (opts?.serviceIds && opts.serviceIds.length > 0) {
+                    (socket as any).emit("service_announce", { serviceIds: opts.serviceIds });
                 }
                 resolve();
             });
@@ -986,6 +995,10 @@ export async function createMockRunner(
 
         wasShutdownRequested(): boolean {
             return shutdownRequested;
+        },
+
+        announceServices(serviceIds: string[]): void {
+            (socket as any).emit("service_announce", { serviceIds });
         },
 
         onSkillRequest(handler: (data: unknown) => unknown): void {

--- a/packages/server/tests/harness/sandbox.ts
+++ b/packages/server/tests/harness/sandbox.ts
@@ -34,7 +34,7 @@ const _origLog = console.log;
 const SUPPRESSED = [
     "[sio/relay]",
     "[sio/hub]",
-    "[sio/viewer]",
+    // "[sio/viewer]",  // temporarily unsuppressed for service_announce debugging
     "[sio/runners]",
     "[sio/runner]",
     "[sio-state]",
@@ -483,6 +483,25 @@ async function main() {
 
     console.log("Populating mock sessions...\n");
 
+    // Create a default mock runner so sessions have a runner association
+    // and service_announce reaches viewers.
+    const defaultRunner = await createMockRunner(server, {
+        name: "sandbox-runner",
+        roots: ["/Users/jordan/Documents/Projects/PizzaPi"],
+        platform: "darwin",
+        serviceIds: ["terminal", "file-explorer", "git", "tunnel", "system-monitor"],
+        skills: [
+            { name: "code-review", description: "Code review", filePath: "/skills/code-review/SKILL.md" },
+            { name: "brainstorming", description: "Explore ideas", filePath: "/skills/brainstorming/SKILL.md" },
+        ],
+        agents: [
+            { name: "task", description: "General-purpose task agent", filePath: "/agents/task.md" },
+        ],
+    });
+    runners.push(defaultRunner);
+    runnerCounter++;
+    console.log(`  🖥️  Default runner: sandbox-runner (darwin) [${defaultRunner.runnerId.slice(0, 8)}...]`);
+
     // Session 1: active with a conversation
     const s1 = await scenario.addSession({
         cwd: "/Users/jordan/Documents/Projects/PizzaPi",
@@ -508,6 +527,8 @@ async function main() {
         s1.relay.emitEvent(s1.sessionId, s1.token, convo[i], i + 1);
         await sleep(80);
     }
+    // Link to runner so service_announce reaches viewers
+    defaultRunner.emitSessionReady(s1.sessionId);
     console.log(`  🟢 Session 1: refactor-auth-module (Sonnet 4.6) — ${convo.length} events`);
 
     // Session 2: active, different model
@@ -528,6 +549,7 @@ async function main() {
         tokenUsage: { input: 95_400, output: 8_100, cacheRead: 0, cacheWrite: 0, cost: 0.312, contextTokens: 95_400 },
         providerUsage: {},
     });
+    defaultRunner.emitSessionReady(s2.sessionId);
     console.log("  🟢 Session 2: fix-dark-mode-css (GPT-5.4)");
 
     // Session 3: child of session 1
@@ -543,6 +565,7 @@ async function main() {
         model: MODELS[2], // Haiku 4.5
         cwd: "/Users/jordan/Documents/Projects/PizzaPi",
     }), 0);
+    defaultRunner.emitSessionReady(s3.sessionId);
     console.log(`  🔗 Session 3: code-review-subagent (Haiku 4.5) → child of S1`);
 
     // ── Start Vite dev server for HMR ──────────────────────────────────
@@ -706,6 +729,7 @@ async function main() {
                             model,
                             cwd,
                         }), 0);
+                        defaultRunner.emitSessionReady(sess.sessionId);
                         const idx = scenario.sessions.length;
                         console.log(`  🟢 Session ${idx}: ${name} (${model.name}) [${sess.sessionId.slice(0, 8)}...]`);
                         break;
@@ -753,6 +777,7 @@ async function main() {
                             sessionName: `subagent-${sessionCounter}`,
                             model,
                         }), 0);
+                        defaultRunner.emitSessionReady(child.sessionId);
                         const childIdx = scenario.sessions.length;
                         console.log(`  🔗 Session ${childIdx}: subagent-${sessionCounter} (${model.name}) → child of S${parentIdx}`);
                         break;
@@ -801,6 +826,7 @@ async function main() {
                                 model,
                                 cwd,
                             }), 0);
+                            defaultRunner.emitSessionReady(sess.sessionId);
                             await sleep(50);
                         }
                         console.log(`  ✅ Created ${count} sessions (total: ${scenario.sessions.length})`);
@@ -870,6 +896,7 @@ async function main() {
                                 { name: "task", description: "General-purpose task agent", filePath: "/agents/task.md" },
                                 { name: "reviewer", description: "Code reviewer", filePath: "/agents/reviewer.md" },
                             ],
+                            serviceIds: ["terminal", "file-explorer", "git", "tunnel", "system-monitor"],
                         });
                         runnerCounter++;
                         runners.push(runner);
@@ -889,6 +916,15 @@ async function main() {
                                 console.log(`    ${i + 1}. ${connected} ${r.runnerId.slice(0, 8)}...`);
                             }
                         }
+                        break;
+                    }
+
+                    case "services": {
+                        const serviceIds = args.length > 0
+                            ? args
+                            : ["terminal", "file-explorer", "git", "tunnel", "system-monitor"];
+                        defaultRunner.announceServices(serviceIds);
+                        console.log(`  📡 Announced services: ${serviceIds.join(", ")}`);
                         break;
                     }
 
@@ -969,6 +1005,7 @@ function printHelp() {
     console.log("  oauth <n> [server]   — Simulate MCP OAuth paste prompt (e.g. figma)");
     console.log("  runner [name]        — Add a faux runner (with skills/agents)");
     console.log("  runners              — List all runners");
+    console.log("  services [ids...]    — Re-announce services (default: all 5)");
     console.log("  status               — Show all sessions");
     console.log("  help                 — Show this help");
     console.log("  quit                 — Shut down and exit");

--- a/packages/ui/dev-dist/sw.js
+++ b/packages/ui/dev-dist/sw.js
@@ -80,7 +80,7 @@ define(['./workbox-e44ca4aa'], (function (workbox) { 'use strict';
    */
   workbox.precacheAndRoute([{
     "url": "/index.html",
-    "revision": "0.j2uultm1tlc"
+    "revision": "0.lpasq5j3cf"
   }], {});
   workbox.cleanupOutdatedCaches();
   workbox.registerRoute(new workbox.NavigationRoute(workbox.createHandlerBoundToURL("/index.html"), {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@ import { RunnerTokenManager } from "@/components/RunnerTokenManager";
 import { RunnerManager } from "@/components/RunnerManager";
 import { NewSessionWizardDialog } from "@/components/NewSessionWizardDialog";
 import { PizzaLogo } from "@/components/PizzaLogo";
-import { authClient, useSession, signOut } from "@/lib/auth-client";
+import { authClient, useSession, signOut, type BetterAuthSession } from "@/lib/auth-client";
 import { useRunnersFeed } from "@/lib/useRunnersFeed";
 import { io, type Socket } from "socket.io-client";
 import type {
@@ -60,7 +60,12 @@ import { HapticsToggle, MobileHapticsMenuItem } from "@/components/HapticsToggle
 import { UsageIndicator, type ProviderUsageMap } from "@/components/UsageIndicator";
 import { TerminalManager } from "@/components/TerminalManager";
 import { FileExplorer } from "@/components/FileExplorer";
-import { CombinedPanel } from "@/components/CombinedPanel";
+import { CombinedPanel, type CombinedPanelTab } from "@/components/CombinedPanel";
+import { DockedPanelGroup } from "@/components/DockedPanelGroup";
+import { ViewerSocketContext } from "@/lib/viewer-socket-context";
+import { useRunnerServices, attachServiceAnnounceListener } from "@/hooks/useRunnerServices";
+import { ServicePanelButtons, useServicePanelState } from "@/components/service-panels/ServicePanels";
+import { SERVICE_PANELS } from "@/components/service-panels/registry";
 import {
   ModelSelector,
   ModelSelectorContent,
@@ -133,7 +138,7 @@ export function App() {
   }>>([]);
   // User-scoped cache key for sidebar runners (prevents cross-account data leakage)
   const sidebarCacheKey = React.useMemo(() => {
-    const userId = session && typeof session === "object" ? (session as any).user?.id : null;
+    const userId = (session as BetterAuthSession | null)?.user?.id ?? null;
     return userId ? `pp-sidebar-runners:${userId}` : null;
   }, [session]);
   // Hydrate from cache once we know the user
@@ -160,19 +165,16 @@ export function App() {
   const {
     showTerminal, setShowTerminal,
     terminalPosition, terminalHeight, terminalWidth, terminalColumnRef,
-    handleTerminalResizeStart, handleTerminalPositionChange,
+    handleTerminalPositionChange, startPanelResizeForPosition,
     panelDragActive, panelDragZone,
-    handlePanelDragStart, handleTerminalTabDragStart,
+    startPanelDragWith,
     handleOuterPointerMove, handleOuterPointerUp,
-    combinedActiveTab, handleCombinedTabChange, handleCombinedPositionChange,
+    combinedActiveTab, handleCombinedTabChange,
     terminalTabs, activeTerminalId, setActiveTerminalId,
     handleTerminalTabAdd, handleTerminalTabClose,
     showFileExplorer, setShowFileExplorer,
-    filesPosition, filesWidth, filesHeight, filesContainerRef,
-    handleFilesWidthLeftResizeStart, handleFilesWidthRightResizeStart, handleFilesHeightResizeStart,
+    filesPosition, filesContainerRef,
     handleFilesPositionChange,
-    filesDragActive, filesDragZone, handleFilesDragStart,
-    handleFilesOuterPointerMove, handleFilesOuterPointerUp,
   } = panelLayout;
 
   const [newSessionOpen, setNewSessionOpen] = React.useState(false);
@@ -395,6 +397,8 @@ export function App() {
   }, [newSessionOpen, spawnRunnerId]);
 
   const viewerWsRef = React.useRef<Socket<ViewerServerToClientEvents, ViewerClientToServerEvents> | null>(null);
+  // Tracked as state so ViewerSocketContext consumers re-render when the socket changes.
+  const [viewerSocket, setViewerSocket] = React.useState<Socket<ViewerServerToClientEvents, ViewerClientToServerEvents> | null>(null);
   const hubSocketRef = React.useRef<Socket<HubServerToClientEvents, HubClientToServerEvents> | null>(null);
   const activeSessionRef = React.useRef<string | null>(null);
 
@@ -492,6 +496,7 @@ export function App() {
       }
       viewerWsRef.current?.disconnect();
       viewerWsRef.current = null;
+      setViewerSocket(null);
     };
   }, []);
 
@@ -502,6 +507,7 @@ export function App() {
     }
     viewerWsRef.current?.disconnect();
     viewerWsRef.current = null;
+    setViewerSocket(null);
     activeSessionRef.current = null;
     lastSeqRef.current = null;
     awaitingSnapshotRef.current = false;
@@ -2252,6 +2258,7 @@ export function App() {
 
     viewerWsRef.current?.disconnect();
     viewerWsRef.current = null;
+    setViewerSocket(null);
 
     // Clear any existing stale-connection timer from a previous session.
     if (staleCheckTimerRef.current !== null) {
@@ -2309,6 +2316,11 @@ export function App() {
       withCredentials: true,
     });
     viewerWsRef.current = socket;
+    // Attach service_announce listener BEFORE setViewerSocket triggers a render,
+    // so the announce event (sent by the server during connection) is captured
+    // eagerly and available when useRunnerServices reads it.
+    attachServiceAnnounceListener(socket);
+    setViewerSocket(socket);
 
     // Stale-connection watchdog: if the socket thinks it's connected but
     // no event has arrived for STALE_THRESHOLD_MS, force a reconnect.
@@ -2917,7 +2929,6 @@ export function App() {
         !e.metaKey &&
         !e.ctrlKey &&
         !e.altKey &&
-        !e.shiftKey &&
         !document.querySelector('[role="dialog"]')
       ) {
         setShowShortcutsHelp(true);
@@ -3241,9 +3252,117 @@ export function App() {
     [feedRunners, activeSessionInfo?.runnerId],
   );
 
-  // When both panels are at the same position, combine them into a single tabbed panel
-  const areCombined = showTerminal && showFileExplorer && terminalPosition === filesPosition
-    && !!activeSessionInfo?.runnerId && !!activeSessionInfo?.cwd;
+  // Runner service panels — dynamically discovered
+  const availableServices = useRunnerServices(viewerSocket);
+  const { activePanelId: activeServicePanel, togglePanel: toggleServicePanel, closePanel: closeServicePanel } = useServicePanelState();
+  const [servicePanelPosition, setServicePanelPosition] = React.useState<import("@/hooks/usePanelLayout").PanelPosition>(() => {
+    try { return (localStorage.getItem("pp-service-panel-position") as import("@/hooks/usePanelLayout").PanelPosition) ?? "right"; } catch { return "right"; }
+  });
+  const handleServicePanelPositionChange = React.useCallback((pos: import("@/hooks/usePanelLayout").PanelPosition) => {
+    setServicePanelPosition(pos);
+    try { localStorage.setItem("pp-service-panel-position", pos); } catch {}
+  }, []);
+
+  const handleToggleServicePanel = React.useCallback((serviceId: string) => {
+    if (activeServicePanel === serviceId) {
+      closeServicePanel();
+      if (showTerminal) handleCombinedTabChange("terminal");
+      else if (showFileExplorer) handleCombinedTabChange("files");
+    } else {
+      toggleServicePanel(serviceId);
+      handleCombinedTabChange(serviceId);
+    }
+  }, [activeServicePanel, closeServicePanel, toggleServicePanel, handleCombinedTabChange, showTerminal, showFileExplorer]);
+
+  const terminalPanelTab = React.useMemo<CombinedPanelTab | null>(() => showTerminal ? {
+    id: "terminal",
+    label: "Terminal",
+    icon: <TerminalIcon className="size-3.5" />,
+    onClose: () => setShowTerminal(false),
+    onDragStart: (e) => startPanelDragWith(e, handleTerminalPositionChange),
+    content: (
+      <TerminalManager
+        className="h-full"
+        embedded
+        sessionId={activeSessionId}
+        runnerId={activeSessionInfo?.runnerId ?? undefined}
+        defaultCwd={activeSessionInfo?.cwd || undefined}
+        runners={feedRunners.map(r => ({
+          runnerId: r.runnerId,
+          name: r.name,
+          roots: r.roots,
+          sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
+        }))}
+        runnersLoading={runnersStatus === "connecting"}
+        tabs={terminalTabs}
+        activeTabId={activeTerminalId}
+        onActiveTabChange={setActiveTerminalId}
+        onTabAdd={handleTerminalTabAdd}
+        onTabClose={handleTerminalTabClose}
+      />
+    ),
+  } : null, [showTerminal, activeSessionId, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, feedRunners, liveSessions, runnersStatus, terminalTabs, activeTerminalId, setActiveTerminalId, handleTerminalTabAdd, handleTerminalTabClose, startPanelDragWith, handleTerminalPositionChange]);
+
+  const filesPanelTab = React.useMemo<CombinedPanelTab | null>(() => (showFileExplorer && activeSessionInfo?.runnerId && activeSessionInfo?.cwd) ? {
+    id: "files",
+    label: "Files",
+    icon: <FolderTree className="size-3.5" />,
+    onClose: () => setShowFileExplorer(false),
+    onDragStart: (e) => startPanelDragWith(e, handleFilesPositionChange),
+    content: (
+      <FileExplorer
+        runnerId={activeSessionInfo.runnerId}
+        cwd={activeSessionInfo.cwd}
+        className="h-full"
+      />
+    ),
+  } : null, [showFileExplorer, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, startPanelDragWith, handleFilesPositionChange]);
+
+  const servicePanelTabs = React.useMemo<CombinedPanelTab[]>(() => {
+    if (!activeServicePanel || !activeSessionId) return [];
+    const panelDef = SERVICE_PANELS.find(p => p.serviceId === activeServicePanel);
+    if (!panelDef) return [];
+    const PanelComponent = panelDef.component;
+    return [{
+      id: panelDef.serviceId,
+      label: panelDef.label,
+      icon: panelDef.icon,
+      onDragStart: (e) => startPanelDragWith(e, handleServicePanelPositionChange),
+      onClose: () => {
+        closeServicePanel();
+        if (showTerminal) handleCombinedTabChange("terminal");
+        else if (showFileExplorer) handleCombinedTabChange("files");
+      },
+      content: <PanelComponent sessionId={activeSessionId} />,
+    }];
+  }, [activeServicePanel, activeSessionId, startPanelDragWith, handleServicePanelPositionChange, closeServicePanel, showTerminal, showFileExplorer, handleCombinedTabChange]);
+
+  const panelGroups = React.useMemo(() => {
+    const groups: Record<"left" | "right" | "bottom", CombinedPanelTab[]> = { left: [], right: [], bottom: [] };
+    if (terminalPanelTab) groups[terminalPosition].push(terminalPanelTab);
+    if (filesPanelTab) groups[filesPosition].push(filesPanelTab);
+    if (servicePanelTabs[0]) groups[servicePanelPosition].push(servicePanelTabs[0]);
+    return groups;
+  }, [terminalPanelTab, terminalPosition, filesPanelTab, filesPosition, servicePanelTabs, servicePanelPosition]);
+
+  const handleGroupPositionChange = React.useCallback((tabIds: string[], pos: import("@/hooks/usePanelLayout").PanelPosition) => {
+    if (tabIds.includes("terminal")) handleTerminalPositionChange(pos);
+    if (tabIds.includes("files")) handleFilesPositionChange(pos);
+    if (activeServicePanel && tabIds.includes(activeServicePanel)) handleServicePanelPositionChange(pos);
+  }, [handleTerminalPositionChange, handleFilesPositionChange, activeServicePanel, handleServicePanelPositionChange]);
+
+  const handleGroupDragStart = React.useCallback((tabIds: string[]) => (e: React.PointerEvent) => {
+    startPanelDragWith(e, (pos) => handleGroupPositionChange(tabIds, pos));
+  }, [startPanelDragWith, handleGroupPositionChange]);
+
+  const mobilePanelTabs = React.useMemo(() => {
+    return [terminalPanelTab, filesPanelTab, ...servicePanelTabs].filter(Boolean) as CombinedPanelTab[];
+  }, [terminalPanelTab, filesPanelTab, servicePanelTabs]);
+
+  const resolveActiveTabId = React.useCallback((tabs: CombinedPanelTab[]) => {
+    if (tabs.length === 0) return combinedActiveTab;
+    return tabs.some((tab) => tab.id === combinedActiveTab) ? combinedActiveTab : tabs[0]!.id;
+  }, [combinedActiveTab]);
 
   if (isPending) {
     return (
@@ -3257,7 +3376,7 @@ export function App() {
     return <AuthPage onAuthenticated={() => authClient.$store.notify("$sessionSignal")} />
   }
 
-  const rawUser = session && typeof session === "object" ? (session as any).user : undefined;
+  const rawUser = (session as BetterAuthSession | null)?.user;
   const userName = rawUser && typeof rawUser.name === "string" ? (rawUser.name as string) : "";
   const userEmail = rawUser && typeof rawUser.email === "string" ? (rawUser.email as string) : "";
   const userLabel = userName || userEmail || "Account";
@@ -3292,6 +3411,7 @@ export function App() {
   }
 
   return (
+    <ViewerSocketContext.Provider value={viewerSocket}>
     <TooltipProvider delayDuration={0}>
     <div className="flex h-[100dvh] w-full flex-col overflow-hidden bg-background pp-safe-left pp-safe-right">
       <a
@@ -3722,156 +3842,32 @@ export function App() {
 
         <div
           ref={filesContainerRef}
-          className={cn(
-            "relative flex flex-1 min-w-0 h-full overflow-hidden",
-            showFileExplorer && filesPosition === "bottom" ? "flex-col" : "flex-row",
-          )}
-          onPointerMove={showFileExplorer ? handleFilesOuterPointerMove : undefined}
-          onPointerUp={showFileExplorer ? handleFilesOuterPointerUp : undefined}
-          onPointerCancel={showFileExplorer ? handleFilesOuterPointerUp : undefined}
+          className="relative flex flex-1 min-w-0 h-full overflow-hidden"
         >
-          {/* Drop-zone overlay while dragging the file explorer header */}
-          {filesDragActive && (
-            <div className="absolute inset-0 z-50 pointer-events-none hidden md:block">
-              <div className={cn(
-                "absolute top-0 left-0 w-[35%] h-[55%] flex flex-col items-center justify-center gap-2 border-r-2 transition-colors duration-100",
-                filesDragZone === "left" ? "bg-blue-500/20 border-blue-500" : "bg-zinc-900/60 border-zinc-700/60",
-              )}>
-                <svg className={cn("size-6 transition-colors", filesDragZone === "left" ? "text-blue-400" : "text-zinc-500")} viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="1" width="6" height="14" rx="1.5"/><rect x="9" y="1" width="6" height="14" rx="1.5" opacity=".3"/></svg>
-                <span className={cn("text-xs font-medium transition-colors", filesDragZone === "left" ? "text-blue-300" : "text-zinc-500")}>Left</span>
-              </div>
-              <div className={cn(
-                "absolute top-0 right-0 w-[35%] h-[55%] flex flex-col items-center justify-center gap-2 border-l-2 transition-colors duration-100",
-                filesDragZone === "right" ? "bg-blue-500/20 border-blue-500" : "bg-zinc-900/60 border-zinc-700/60",
-              )}>
-                <svg className={cn("size-6 transition-colors", filesDragZone === "right" ? "text-blue-400" : "text-zinc-500")} viewBox="0 0 16 16" fill="currentColor"><rect x="9" y="1" width="6" height="14" rx="1.5"/><rect x="1" y="1" width="6" height="14" rx="1.5" opacity=".3"/></svg>
-                <span className={cn("text-xs font-medium transition-colors", filesDragZone === "right" ? "text-blue-300" : "text-zinc-500")}>Right</span>
-              </div>
-              <div className={cn(
-                "absolute bottom-0 left-0 right-0 h-[40%] flex flex-col items-center justify-center gap-2 border-t-2 transition-colors duration-100",
-                filesDragZone === "bottom" ? "bg-blue-500/20 border-blue-500" : "bg-zinc-900/60 border-zinc-700/60",
-              )}>
-                <svg className={cn("size-6 transition-colors", filesDragZone === "bottom" ? "text-blue-400" : "text-zinc-500")} viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="9" width="14" height="6" rx="1.5"/><rect x="1" y="1" width="14" height="6" rx="1.5" opacity=".3"/></svg>
-                <span className={cn("text-xs font-medium transition-colors", filesDragZone === "bottom" ? "text-blue-300" : "text-zinc-500")}>Bottom</span>
-              </div>
-            </div>
-          )}
-
-          {/* ── File Explorer panels ── */}
-          {/* Mobile overlay — always rendered when file explorer is open */}
-          {showFileExplorer && activeSessionInfo?.runnerId && activeSessionInfo?.cwd && (
-            <div
-              className="md:hidden fixed inset-0 z-[60] flex flex-col bg-zinc-950 pp-safe-left pp-safe-right"
-              style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
-            >
-              <FileExplorer
-                runnerId={activeSessionInfo.runnerId}
-                cwd={activeSessionInfo.cwd}
-                className="h-full"
-                onClose={() => setShowFileExplorer(false)}
-                position={filesPosition}
-                onPositionChange={handleFilesPositionChange}
-                onDragStart={handleFilesDragStart}
-              />
-            </div>
-          )}
-
-          {/* Desktop file explorer — only when NOT combined with terminal */}
-          {showFileExplorer && !areCombined && activeSessionInfo?.runnerId && activeSessionInfo?.cwd && (
-            <>
-              {/* Desktop: left panel */}
-              {filesPosition === "left" && (
-                <>
-                  <div className="hidden md:flex flex-col shrink-0" style={{ width: filesWidth }}>
-                    <FileExplorer
-                      runnerId={activeSessionInfo.runnerId}
-                      cwd={activeSessionInfo.cwd}
-                      className="h-full"
-                      onClose={() => setShowFileExplorer(false)}
-                      position={filesPosition}
-                      onPositionChange={handleFilesPositionChange}
-                      onDragStart={handleFilesDragStart}
-                    />
-                  </div>
-                  <div
-                    className="hidden md:flex w-[5px] cursor-col-resize shrink-0 items-center justify-center group"
-                    onPointerDown={handleFilesWidthLeftResizeStart}
-                  >
-                    <div className="h-full w-px bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors" />
-                  </div>
-                </>
-              )}
-
-              {/* Desktop: right panel — order-last so it appears after the terminal column */}
-              {filesPosition === "right" && (
-                <>
-                  <div
-                    className="hidden md:flex w-[5px] cursor-col-resize shrink-0 items-center justify-center group order-last"
-                    onPointerDown={handleFilesWidthRightResizeStart}
-                  >
-                    <div className="h-full w-px bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors" />
-                  </div>
-                  <div className="hidden md:flex flex-col shrink-0 order-last" style={{ width: filesWidth }}>
-                    <FileExplorer
-                      runnerId={activeSessionInfo.runnerId}
-                      cwd={activeSessionInfo.cwd}
-                      className="h-full"
-                      onClose={() => setShowFileExplorer(false)}
-                      position={filesPosition}
-                      onPositionChange={handleFilesPositionChange}
-                      onDragStart={handleFilesDragStart}
-                    />
-                  </div>
-                </>
-              )}
-
-              {/* Desktop: bottom panel — order-last so it appears below the terminal column */}
-              {filesPosition === "bottom" && (
-                <>
-                  <div
-                    className="hidden md:flex h-[5px] cursor-row-resize shrink-0 items-center justify-center group order-last"
-                    onPointerDown={handleFilesHeightResizeStart}
-                  >
-                    <div className="w-full h-px bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors" />
-                  </div>
-                  <div className="hidden md:flex flex-col shrink-0 order-last" style={{ height: filesHeight }}>
-                    <FileExplorer
-                      runnerId={activeSessionInfo.runnerId}
-                      cwd={activeSessionInfo.cwd}
-                      className="h-full"
-                      onClose={() => setShowFileExplorer(false)}
-                      position={filesPosition}
-                      onPositionChange={handleFilesPositionChange}
-                      onDragStart={handleFilesDragStart}
-                    />
-                  </div>
-                </>
-              )}
-            </>
-          )}
-
           <div
             ref={terminalColumnRef}
-            className={cn(
-              "relative flex flex-1 min-w-0",
-              showFileExplorer && filesPosition === "bottom" ? "min-h-0" : "h-full",
-              showTerminal && terminalPosition !== "bottom" ? "flex-row" : "flex-col",
-            )}
-            onPointerMove={showTerminal ? handleOuterPointerMove : undefined}
-            onPointerUp={showTerminal ? handleOuterPointerUp : undefined}
-            onPointerCancel={showTerminal ? handleOuterPointerUp : undefined}
+            className="relative flex flex-1 min-w-0 h-full flex-col"
+            onPointerMove={mobilePanelTabs.length > 0 ? handleOuterPointerMove : undefined}
+            onPointerUp={mobilePanelTabs.length > 0 ? handleOuterPointerUp : undefined}
+            onPointerCancel={mobilePanelTabs.length > 0 ? handleOuterPointerUp : undefined}
           >
-            <div
-              id="main-content"
-              tabIndex={-1}
-              className={cn(
-              "flex flex-col flex-1 min-h-0",
-              showTerminal && "overflow-hidden",
-              showTerminal && terminalPosition !== "bottom" && "min-w-0",
-              showTerminal && terminalPosition === "left" && "order-last",
-            )}>
-              {showRunners ? (
-                <RunnerManager
+            <div className="flex flex-1 min-w-0 min-h-0">
+              {panelGroups.left.length > 0 && (
+                <DockedPanelGroup
+                  position="left"
+                  size={terminalWidth}
+                  tabs={panelGroups.left}
+                  activeTabId={resolveActiveTabId(panelGroups.left)}
+                  onActiveTabChange={handleCombinedTabChange}
+                  onPositionChange={(pos) => handleGroupPositionChange(panelGroups.left.map(tab => tab.id), pos)}
+                  onDragStart={handleGroupDragStart(panelGroups.left.map(tab => tab.id))}
+                  onResizeStart={(e) => startPanelResizeForPosition("left", e)}
+                />
+              )}
+
+              <div id="main-content" tabIndex={-1} className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
+                {showRunners ? (
+                  <RunnerManager
                     runners={feedRunners}
                     runnersStatus={runnersStatus}
                     sessions={liveSessions}
@@ -3879,284 +3875,151 @@ export function App() {
                     selectedRunnerId={selectedRunnerId}
                     onSelectRunner={setSelectedRunnerId}
                   />
-              ) : (
-                <ErrorBoundary level="section" resetKeys={[activeSessionId]}>
-                  <SessionViewer
-                    sessionId={activeSessionId}
-                    sessionName={sessionName}
-                    messages={messages}
-                    activeModel={activeModel}
-                    activeToolCalls={activeToolCalls}
-                    pendingQuestion={pendingQuestion}
-                    pendingPlan={pendingPlan}
-                    pluginTrustPrompt={pluginTrustPrompt}
-                    onPluginTrustResponse={respondPluginTrust}
-                    availableCommands={availableCommands}
-                    resumeSessions={resumeSessions}
-                    resumeSessionsLoading={resumeSessionsLoading}
-                    onRequestResumeSessions={requestResumeSessions}
-                    onSendInput={sendSessionInput}
-                    onExec={sendRemoteExec}
-                    onShowModelSelector={() => setModelSelectorOpen(true)}
-                    agentActive={agentActive}
-                    isCompacting={isCompacting}
-                    effortLevel={effortLevel}
-                    tokenUsage={tokenUsage}
-                    lastHeartbeatAt={lastHeartbeatAt}
-                    viewerStatus={viewerStatus}
-                    retryState={retryState}
-                    messageQueue={messageQueue}
-                    onRemoveQueuedMessage={removeQueuedMessage}
-                    onEditQueuedMessage={editQueuedMessage}
-                    onClearMessageQueue={clearMessageQueue}
-                    onToggleTerminal={() => setShowTerminal((v) => !v)}
-                    showTerminalButton
-                    onToggleFileExplorer={() => setShowFileExplorer((v) => !v)}
-                    showFileExplorerButton={!!activeSessionInfo?.runnerId && !!activeSessionInfo?.cwd}
-                    todoList={todoList}
-                    planModeEnabled={planModeEnabled}
-                    runnerId={activeSessionInfo?.runnerId ?? undefined}
-                    sessionCwd={activeSessionInfo?.cwd || undefined}
-                    onAppendSystemMessage={appendLocalSystemMessage}
-                    onSpawnAgentSession={handleSpawnAgentSession}
-                    onTriggerResponse={handleTriggerResponse}
-                    onQuestionDismiss={() => setPendingQuestion(null)}
-                    onPlanDismiss={() => setPendingPlan(null)}
-                    onDuplicateSession={activeSessionInfo?.runnerId ? () => handleDuplicateSession(activeSessionInfo.runnerId!, activeSessionInfo.cwd || "") : undefined}
-                    runnerInfo={activeRunnerInfo}
-                    mcpOAuthPastes={mcpOAuthPastes}
-                    onMcpOAuthPaste={(nonce, code, state) => {
-                      const socket = viewerWsRef.current;
-                      if (!socket?.connected) return Promise.resolve({ ok: false, error: "Not connected" });
-                      return new Promise<{ ok: boolean; error?: string }>((resolve) => {
-                        const timeout = setTimeout(() => resolve({ ok: false, error: "Delivery timed out" }), 5000);
-                        socket.emit("mcp_oauth_paste", { nonce, code, state }, (result: any) => {
-                          clearTimeout(timeout);
-                          resolve(result && typeof result === "object" ? result : { ok: false, error: "Invalid response" });
-                        });
-                      });
-                    }}
-                    onMcpOAuthPasteDismiss={(serverName) => {
-                      setMcpOAuthPastes((prev) => prev.filter((p) => p.serverName !== serverName));
-                      // Also remove the injected auth banner so the user isn't left
-                      // with a "use the prompt below" message pointing at nothing.
-                      const stableKey = `mcp_auth:${serverName}`;
-                      injectedMessagesRef.current = injectedMessagesRef.current.filter(
-                        (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
-                      );
-                      setMessages((prev) => {
-                        const next = prev.filter((m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`));
-                        return next.length !== prev.length ? next : prev;
-                      });
-                    }}
-                    onMcpServerDisable={(serverName) => {
-                      // Remove the paste prompt immediately
-                      setMcpOAuthPastes((prev) => prev.filter((p) => p.serverName !== serverName));
-                      // Remove the auth system message
-                      const stableKey = `mcp_auth:${serverName}`;
-                      injectedMessagesRef.current = injectedMessagesRef.current.filter(
-                        (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
-                      );
-                      setMessages((prev) => {
-                        const next = prev.filter((m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`));
-                        if (next.length !== prev.length) patchSessionCache({ messages: next });
-                        return next.length !== prev.length ? next : prev;
-                      });
-                      // Send exec command to disable the server on the runner
-                      const socket = viewerWsRef.current;
-                      if (socket?.connected) {
-                        socket.emit("exec", {
-                          id: `disable-mcp-${serverName}-${Date.now()}`,
-                          command: "mcp_toggle_server",
-                          serverName,
-                          disabled: true,
-                        });
+                ) : (
+                  <ErrorBoundary level="section" resetKeys={[activeSessionId]}>
+                    <SessionViewer
+                      sessionId={activeSessionId}
+                      sessionName={sessionName}
+                      messages={messages}
+                      activeModel={activeModel}
+                      activeToolCalls={activeToolCalls}
+                      pendingQuestion={pendingQuestion}
+                      pendingPlan={pendingPlan}
+                      pluginTrustPrompt={pluginTrustPrompt}
+                      onPluginTrustResponse={respondPluginTrust}
+                      availableCommands={availableCommands}
+                      resumeSessions={resumeSessions}
+                      resumeSessionsLoading={resumeSessionsLoading}
+                      onRequestResumeSessions={requestResumeSessions}
+                      onSendInput={sendSessionInput}
+                      onExec={sendRemoteExec}
+                      onShowModelSelector={() => setModelSelectorOpen(true)}
+                      agentActive={agentActive}
+                      isCompacting={isCompacting}
+                      effortLevel={effortLevel}
+                      tokenUsage={tokenUsage}
+                      lastHeartbeatAt={lastHeartbeatAt}
+                      viewerStatus={viewerStatus}
+                      retryState={retryState}
+                      messageQueue={messageQueue}
+                      onRemoveQueuedMessage={removeQueuedMessage}
+                      onEditQueuedMessage={editQueuedMessage}
+                      onClearMessageQueue={clearMessageQueue}
+                      onToggleTerminal={() => setShowTerminal((v) => !v)}
+                      showTerminalButton
+                      onToggleFileExplorer={() => setShowFileExplorer((v) => !v)}
+                      showFileExplorerButton={!!activeSessionInfo?.runnerId && !!activeSessionInfo?.cwd}
+                      extraHeaderButtons={
+                        <ServicePanelButtons
+                          availableServices={availableServices}
+                          activePanelId={activeServicePanel}
+                          onTogglePanel={handleToggleServicePanel}
+                        />
                       }
-                    }}
-                  />
-                </ErrorBoundary>
+                      todoList={todoList}
+                      planModeEnabled={planModeEnabled}
+                      runnerId={activeSessionInfo?.runnerId ?? undefined}
+                      sessionCwd={activeSessionInfo?.cwd || undefined}
+                      onAppendSystemMessage={appendLocalSystemMessage}
+                      onSpawnAgentSession={handleSpawnAgentSession}
+                      onTriggerResponse={handleTriggerResponse}
+                      onQuestionDismiss={() => setPendingQuestion(null)}
+                      onPlanDismiss={() => setPendingPlan(null)}
+                      onDuplicateSession={activeSessionInfo?.runnerId ? () => handleDuplicateSession(activeSessionInfo.runnerId!, activeSessionInfo.cwd || "") : undefined}
+                      runnerInfo={activeRunnerInfo}
+                      mcpOAuthPastes={mcpOAuthPastes}
+                      onMcpOAuthPaste={(nonce, code, state) => {
+                        const socket = viewerWsRef.current;
+                        if (!socket?.connected) return Promise.resolve({ ok: false, error: "Not connected" });
+                        return new Promise<{ ok: boolean; error?: string }>((resolve) => {
+                          const timeout = setTimeout(() => resolve({ ok: false, error: "Delivery timed out" }), 5000);
+                          socket.emit("mcp_oauth_paste", { nonce, code, state }, (result: any) => {
+                            clearTimeout(timeout);
+                            resolve(result && typeof result === "object" ? result : { ok: false, error: "Invalid response" });
+                          });
+                        });
+                      }}
+                      onMcpOAuthPasteDismiss={(serverName) => {
+                        setMcpOAuthPastes((prev) => prev.filter((p) => p.serverName !== serverName));
+                        const stableKey = `mcp_auth:${serverName}`;
+                        injectedMessagesRef.current = injectedMessagesRef.current.filter(
+                          (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
+                        );
+                        setMessages((prev) => {
+                          const next = prev.filter((m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`));
+                          return next.length !== prev.length ? next : prev;
+                        });
+                      }}
+                      onMcpServerDisable={(serverName) => {
+                        setMcpOAuthPastes((prev) => prev.filter((p) => p.serverName !== serverName));
+                        const stableKey = `mcp_auth:${serverName}`;
+                        injectedMessagesRef.current = injectedMessagesRef.current.filter(
+                          (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
+                        );
+                        setMessages((prev) => {
+                          const next = prev.filter((m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`));
+                          if (next.length !== prev.length) patchSessionCache({ messages: next });
+                          return next.length !== prev.length ? next : prev;
+                        });
+                        const socket = viewerWsRef.current;
+                        if (socket?.connected) {
+                          socket.emit("exec", {
+                            id: `disable-mcp-${serverName}-${Date.now()}`,
+                            command: "mcp_toggle_server",
+                            serverName,
+                            disabled: true,
+                          });
+                        }
+                      }}
+                    />
+                  </ErrorBoundary>
+                )}
+              </div>
+
+              {panelGroups.right.length > 0 && (
+                <DockedPanelGroup
+                  position="right"
+                  size={terminalWidth}
+                  tabs={panelGroups.right}
+                  activeTabId={resolveActiveTabId(panelGroups.right)}
+                  onActiveTabChange={handleCombinedTabChange}
+                  onPositionChange={(pos) => handleGroupPositionChange(panelGroups.right.map(tab => tab.id), pos)}
+                  onDragStart={handleGroupDragStart(panelGroups.right.map(tab => tab.id))}
+                  onResizeStart={(e) => startPanelResizeForPosition("right", e)}
+                />
               )}
             </div>
-            {/* Mobile: terminal overlay (always separate from combined) */}
-            {showTerminal && (
+
+            {panelGroups.bottom.length > 0 && (
+              <DockedPanelGroup
+                position="bottom"
+                size={terminalHeight}
+                tabs={panelGroups.bottom}
+                activeTabId={resolveActiveTabId(panelGroups.bottom)}
+                onActiveTabChange={handleCombinedTabChange}
+                onPositionChange={(pos) => handleGroupPositionChange(panelGroups.bottom.map(tab => tab.id), pos)}
+                onDragStart={handleGroupDragStart(panelGroups.bottom.map(tab => tab.id))}
+                onResizeStart={(e) => startPanelResizeForPosition("bottom", e)}
+              />
+            )}
+
+            {mobilePanelTabs.length > 0 && (
               <div
-                className="md:hidden fixed inset-0 z-[60] flex flex-col bg-zinc-950 pp-safe-left pp-safe-right"
-                style={{ paddingBottom: "env(safe-area-inset-bottom)" }}
+                className="md:hidden fixed inset-0 z-[60] flex flex-col bg-background pp-safe-left pp-safe-right"
+                style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
               >
-                <TerminalManager
+                <CombinedPanel
+                  activeTabId={resolveActiveTabId(mobilePanelTabs)}
+                  onActiveTabChange={handleCombinedTabChange}
+                  position="bottom"
                   className="h-full"
-                  onClose={() => setShowTerminal(false)}
-                  position={terminalPosition}
-                  onPositionChange={handleTerminalPositionChange}
-                  onDragStart={handlePanelDragStart}
-                  sessionId={activeSessionId}
-                  runnerId={activeSessionInfo?.runnerId ?? undefined}
-                  defaultCwd={activeSessionInfo?.cwd || undefined}
-                  runners={feedRunners.map(r => ({
-                    runnerId: r.runnerId,
-                    name: r.name,
-                    roots: r.roots,
-                    sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
-                  }))}
-                  runnersLoading={runnersStatus === "connecting"}
-                  tabs={terminalTabs}
-                  activeTabId={activeTerminalId}
-                  onActiveTabChange={setActiveTerminalId}
-                  onTabAdd={handleTerminalTabAdd}
-                  onTabClose={handleTerminalTabClose}
+                  tabs={mobilePanelTabs}
                 />
               </div>
             )}
 
-            {/* Desktop: Combined panel (terminal + file explorer at same position) */}
-            {areCombined && (
-              <>
-                <div
-                  className={cn(
-                    "hidden md:flex shrink-0 items-center justify-center group",
-                    terminalPosition === "bottom"
-                      ? "h-[5px] cursor-row-resize"
-                      : "w-[5px] cursor-col-resize",
-                  )}
-                  style={{ order: terminalPosition === "left" ? 1 : 9998 }}
-                  onPointerDown={handleTerminalResizeStart}
-                >
-                  <div className={cn(
-                    "bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors",
-                    terminalPosition === "bottom" ? "w-full h-px" : "h-full w-px",
-                  )} />
-                </div>
-                <div
-                  className="hidden md:flex flex-col shrink-0"
-                  style={{
-                    order: terminalPosition === "left" ? 0 : 9999,
-                    ...(terminalPosition === "bottom"
-                      ? { height: terminalHeight }
-                      : { width: terminalWidth }),
-                  }}
-                >
-                  <CombinedPanel
-                    activeTabId={combinedActiveTab}
-                    onActiveTabChange={handleCombinedTabChange}
-                    position={terminalPosition}
-                    onPositionChange={handleCombinedPositionChange}
-                    onDragStart={handlePanelDragStart}
-                    className="h-full"
-                    tabs={[
-                      {
-                        id: "terminal",
-                        label: "Terminal",
-                        icon: <TerminalIcon className="size-3.5" />,
-                        onClose: () => { setShowTerminal(false); handleCombinedTabChange("files"); },
-                        // Dragging the Terminal tab detaches it (moves only the terminal panel)
-                        onDragStart: handleTerminalTabDragStart,
-                        content: (
-                          <TerminalManager
-                            className="h-full"
-                            embedded
-                            sessionId={activeSessionId}
-                            runnerId={activeSessionInfo?.runnerId ?? undefined}
-                            defaultCwd={activeSessionInfo?.cwd || undefined}
-                            runners={feedRunners.map(r => ({
-                              runnerId: r.runnerId,
-                              name: r.name,
-                              roots: r.roots,
-                              sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
-                            }))}
-                            runnersLoading={runnersStatus === "connecting"}
-                            tabs={terminalTabs}
-                            activeTabId={activeTerminalId}
-                            onActiveTabChange={setActiveTerminalId}
-                            onTabAdd={handleTerminalTabAdd}
-                            onTabClose={handleTerminalTabClose}
-                          />
-                        ),
-                      },
-                      {
-                        id: "files",
-                        label: "Files",
-                        icon: <FolderTree className="size-3.5" />,
-                        onClose: () => { setShowFileExplorer(false); handleCombinedTabChange("terminal"); },
-                        // Dragging the Files tab detaches it (moves only the files panel)
-                        onDragStart: handleFilesDragStart,
-                        content: (
-                          <FileExplorer
-                            runnerId={activeSessionInfo!.runnerId!}
-                            cwd={activeSessionInfo!.cwd}
-                            className="h-full"
-                          />
-                        ),
-                      },
-                    ]}
-                  />
-                </div>
-              </>
-            )}
-
-            {/* Desktop: standalone terminal (when not combined) */}
-            {showTerminal && !areCombined && (
-              <>
-                {/*
-                  Single always-mounted instance so xterm state survives position changes.
-                  CSS `order` repositions the handle and panel without unmounting:
-                    left   → panel(0)  handle(1)  session(9999 via order-last)
-                    right  → session(0) handle(9998) panel(9999)
-                    bottom → session(0) handle(9998) panel(9999)  [outer is flex-col]
-                */}
-                <div
-                  className={cn(
-                    "hidden md:flex shrink-0 items-center justify-center group",
-                    terminalPosition === "bottom"
-                      ? "h-[5px] cursor-row-resize"
-                      : "w-[5px] cursor-col-resize",
-                  )}
-                  style={{ order: terminalPosition === "left" ? 1 : 9998 }}
-                  onPointerDown={handleTerminalResizeStart}
-                >
-                  <div className={cn(
-                    "bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors",
-                    terminalPosition === "bottom" ? "w-full h-px" : "h-full w-px",
-                  )} />
-                </div>
-                <div
-                  className="hidden md:flex flex-col shrink-0"
-                  style={{
-                    order: terminalPosition === "left" ? 0 : 9999,
-                    ...(terminalPosition === "bottom"
-                      ? { height: terminalHeight }
-                      : { width: terminalWidth }),
-                  }}
-                >
-                  <TerminalManager
-                    className="h-full"
-                    onClose={() => setShowTerminal(false)}
-                    position={terminalPosition}
-                    onPositionChange={handleTerminalPositionChange}
-                    onDragStart={handlePanelDragStart}
-                    sessionId={activeSessionId}
-                    runnerId={activeSessionInfo?.runnerId ?? undefined}
-                    defaultCwd={activeSessionInfo?.cwd || undefined}
-                    runners={feedRunners.map(r => ({
-                      runnerId: r.runnerId,
-                      name: r.name,
-                      roots: r.roots,
-                      sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
-                    }))}
-                    runnersLoading={runnersStatus === "connecting"}
-                    tabs={terminalTabs}
-                    activeTabId={activeTerminalId}
-                    onActiveTabChange={setActiveTerminalId}
-                    onTabAdd={handleTerminalTabAdd}
-                    onTabClose={handleTerminalTabClose}
-                  />
-                </div>
-              </>
-            )}
-
-            {/* Drop-zone overlay shown while dragging the panel header */}
             {panelDragActive && (
               <div className="absolute inset-0 z-50 pointer-events-none hidden md:block">
-                {/* Bottom zone */}
                 <div className={cn(
                   "absolute bottom-0 left-0 right-0 h-[40%] flex flex-col items-center justify-center gap-2 border-t-2 transition-colors duration-100",
                   panelDragZone === "bottom" ? "bg-blue-500/20 border-blue-500" : "bg-zinc-900/60 border-zinc-700/60",
@@ -4164,7 +4027,6 @@ export function App() {
                   <svg className={cn("size-6 transition-colors", panelDragZone === "bottom" ? "text-blue-400" : "text-zinc-500")} viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="9" width="14" height="6" rx="1.5"/><rect x="1" y="1" width="14" height="6" rx="1.5" opacity=".3"/></svg>
                   <span className={cn("text-xs font-medium transition-colors", panelDragZone === "bottom" ? "text-blue-300" : "text-zinc-500")}>Bottom</span>
                 </div>
-                {/* Right zone */}
                 <div className={cn(
                   "absolute top-0 right-0 w-[35%] h-[55%] flex flex-col items-center justify-center gap-2 border-l-2 transition-colors duration-100",
                   panelDragZone === "right" ? "bg-blue-500/20 border-blue-500" : "bg-zinc-900/60 border-zinc-700/60",
@@ -4172,7 +4034,6 @@ export function App() {
                   <svg className={cn("size-6 transition-colors", panelDragZone === "right" ? "text-blue-400" : "text-zinc-500")} viewBox="0 0 16 16" fill="currentColor"><rect x="9" y="1" width="6" height="14" rx="1.5"/><rect x="1" y="1" width="6" height="14" rx="1.5" opacity=".3"/></svg>
                   <span className={cn("text-xs font-medium transition-colors", panelDragZone === "right" ? "text-blue-300" : "text-zinc-500")}>Right</span>
                 </div>
-                {/* Left zone */}
                 <div className={cn(
                   "absolute top-0 left-0 w-[35%] h-[55%] flex flex-col items-center justify-center gap-2 border-r-2 transition-colors duration-100",
                   panelDragZone === "left" ? "bg-blue-500/20 border-blue-500" : "bg-zinc-900/60 border-zinc-700/60",
@@ -4184,7 +4045,6 @@ export function App() {
             )}
           </div>
         </div>
-
         <NewSessionWizardDialog
           open={newSessionOpen}
           onOpenChange={(open) => { if (!spawningSession) setNewSessionOpen(open); }}
@@ -4227,5 +4087,6 @@ export function App() {
       </div>
     </div>
     </TooltipProvider>
+    </ViewerSocketContext.Provider>
   );
 }

--- a/packages/ui/src/components/CombinedPanel.test.tsx
+++ b/packages/ui/src/components/CombinedPanel.test.tsx
@@ -1,0 +1,61 @@
+import { beforeAll, afterEach, describe, test, expect } from "bun:test";
+import { Window } from "happy-dom";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+
+const { CombinedPanel } = await import("./CombinedPanel");
+
+beforeAll(() => {
+  const win = new Window({ url: "http://localhost/" });
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (globalThis as any).window = win;
+  (globalThis as any).document = win.document;
+  (globalThis as any).navigator = win.navigator;
+  (globalThis as any).HTMLElement = win.HTMLElement;
+  (globalThis as any).Element = win.Element;
+  (globalThis as any).Node = win.Node;
+  (globalThis as any).SVGElement = win.SVGElement;
+  (globalThis as any).MutationObserver = win.MutationObserver;
+  (globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
+
+describe("CombinedPanel", () => {
+  test("close button works for draggable tabs", () => {
+    let closed = 0;
+    const { container } = render(
+      <CombinedPanel
+        tabs={[
+          {
+            id: "tunnels",
+            label: "Tunnels",
+            icon: <span>T</span>,
+            onDragStart: () => {},
+            onClose: () => {
+              closed += 1;
+            },
+            content: <div>Tunnel content</div>,
+          },
+        ]}
+        activeTabId="tunnels"
+        onActiveTabChange={() => {}}
+        position="right"
+      />,
+    );
+
+    const elements = Array.from(container.getElementsByTagName("*"));
+    const closeButton = elements.find((el) => el.getAttribute("aria-label") === "Close Tunnels") as HTMLElement | undefined;
+    expect(closeButton).toBeTruthy();
+
+    fireEvent.pointerDown(closeButton!);
+    fireEvent.pointerUp(closeButton!);
+    fireEvent.click(closeButton!);
+
+    expect(closed).toBe(1);
+  });
+});

--- a/packages/ui/src/components/CombinedPanel.tsx
+++ b/packages/ui/src/components/CombinedPanel.tsx
@@ -272,7 +272,16 @@ export function CombinedPanel({
                 {tab.onClose && (
                   <button
                     type="button"
-                    onClick={(e) => { e.stopPropagation(); tab.onClose!(); }}
+                    onPointerDown={(e) => {
+                      e.stopPropagation();
+                    }}
+                    onPointerUp={(e) => {
+                      e.stopPropagation();
+                    }}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      tab.onClose!();
+                    }}
                     className={cn(
                       "rounded p-0.5 transition-colors ml-0.5",
                       isActive

--- a/packages/ui/src/components/DockedPanelGroup.test.tsx
+++ b/packages/ui/src/components/DockedPanelGroup.test.tsx
@@ -1,0 +1,79 @@
+import { beforeAll, afterEach, describe, test, expect, mock } from "bun:test";
+import { Window } from "happy-dom";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+
+mock.module("@/lib/utils", () => ({
+  cn: (...classes: (string | undefined | null | false)[]) => classes.filter(Boolean).join(" "),
+}));
+mock.module("@/components/CombinedPanel", async () => await import("./CombinedPanel"));
+
+const { DockedPanelGroup } = await import("./DockedPanelGroup");
+
+beforeAll(() => {
+  const win = new Window({ url: "http://localhost/" });
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (globalThis as any).window = win;
+  (globalThis as any).document = win.document;
+  (globalThis as any).navigator = win.navigator;
+  (globalThis as any).HTMLElement = win.HTMLElement;
+  (globalThis as any).Element = win.Element;
+  (globalThis as any).Node = win.Node;
+  (globalThis as any).SVGElement = win.SVGElement;
+  (globalThis as any).MutationObserver = win.MutationObserver;
+  (globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+});
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
+
+describe("DockedPanelGroup", () => {
+  test("renders tabs and forwards resize + drag handlers", () => {
+    let resized = 0;
+    let dragged = 0;
+
+    const { container } = render(
+      <DockedPanelGroup
+        position="right"
+        size={320}
+        activeTabId="terminal"
+        onActiveTabChange={() => {}}
+        onPositionChange={() => {}}
+        onDragStart={() => { dragged += 1; }}
+        onResizeStart={() => { resized += 1; }}
+        tabs={[
+          {
+            id: "terminal",
+            label: "Terminal",
+            icon: <span>T</span>,
+            content: <div>Terminal content</div>,
+          },
+          {
+            id: "files",
+            label: "Files",
+            icon: <span>F</span>,
+            content: <div>Files content</div>,
+          },
+        ]}
+      />,
+    );
+
+    expect(container.textContent).toContain("Terminal");
+    expect(container.textContent).toContain("Files");
+    expect(container.textContent).toContain("Terminal content");
+
+    const elements = Array.from(container.getElementsByTagName("*"));
+    const dragHandle = elements.find((el) => el.getAttribute("aria-label") === "Drag to reposition panel") as HTMLElement | undefined;
+    expect(dragHandle).toBeTruthy();
+    fireEvent.pointerDown(dragHandle!);
+    expect(dragged).toBe(1);
+
+    const resizeHandle = elements.find((el) => (el as HTMLElement).className?.includes?.("cursor-col-resize")) as HTMLElement | undefined;
+    expect(resizeHandle).toBeTruthy();
+    fireEvent.pointerDown(resizeHandle!);
+    expect(resized).toBe(1);
+  });
+});

--- a/packages/ui/src/components/DockedPanelGroup.tsx
+++ b/packages/ui/src/components/DockedPanelGroup.tsx
@@ -1,0 +1,83 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import { CombinedPanel, type CombinedPanelTab } from "@/components/CombinedPanel";
+
+export type DockPosition = "left" | "right" | "bottom";
+
+export interface DockedPanelGroupProps {
+  position: DockPosition;
+  size: number;
+  tabs: CombinedPanelTab[];
+  activeTabId: string;
+  onActiveTabChange: (id: string) => void;
+  onPositionChange: (pos: DockPosition) => void;
+  onDragStart: (e: React.PointerEvent) => void;
+  onResizeStart: (e: React.PointerEvent) => void;
+  className?: string;
+}
+
+export function DockedPanelGroup({
+  position,
+  size,
+  tabs,
+  activeTabId,
+  onActiveTabChange,
+  onPositionChange,
+  onDragStart,
+  onResizeStart,
+  className,
+}: DockedPanelGroupProps) {
+  const isBottom = position === "bottom";
+  const isLeft = position === "left";
+
+  const panel = (
+    <div
+      className={cn("hidden md:flex flex-col shrink-0", className, !isLeft && !isBottom && "order-last")}
+      style={isBottom ? { height: size } : { width: size }}
+    >
+      <CombinedPanel
+        activeTabId={activeTabId}
+        onActiveTabChange={onActiveTabChange}
+        position={position}
+        onPositionChange={onPositionChange}
+        onDragStart={onDragStart}
+        className="h-full"
+        tabs={tabs}
+      />
+    </div>
+  );
+
+  const handle = (
+    <div
+      className={cn(
+        "hidden md:flex shrink-0 items-center justify-center group",
+        isBottom ? "h-[5px] cursor-row-resize" : "w-[5px] cursor-col-resize",
+        !isLeft && !isBottom && "order-last",
+      )}
+      onPointerDown={onResizeStart}
+    >
+      <div
+        className={cn(
+          "bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors",
+          isBottom ? "w-full h-px" : "h-full w-px",
+        )}
+      />
+    </div>
+  );
+
+  if (isLeft) {
+    return (
+      <>
+        {panel}
+        {handle}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {handle}
+      {panel}
+    </>
+  );
+}

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -79,6 +79,7 @@ import { AtMentionPopover } from "@/components/AtMentionPopover";
 import type { Entry as AtMentionEntry } from "@/hooks/useAtMentionFiles";
 import { McpToggleContext, type McpToggleHandler } from "@/components/session-viewer/McpToggleContext";
 import { isTriggerMessage, renderTriggerCard } from "@/components/session-viewer/cards/InterAgentCards";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 
 
 export type { RelayMessage } from "@/components/session-viewer/types";
@@ -137,6 +138,8 @@ export interface SessionViewerProps {
   onToggleFileExplorer?: () => void;
   /** Whether to show the file explorer button */
   showFileExplorerButton?: boolean;
+  /** Extra buttons to render in the header bar (e.g. service panel toggles) */
+  extraHeaderButtons?: React.ReactNode;
   /** Current agent todo list */
   todoList?: TodoItem[];
   /** Whether plan mode (read-only exploration) is currently active */
@@ -552,7 +555,7 @@ function SessionSkeleton() {
   );
 }
 
-export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onEditQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse, onQuestionDismiss, onPlanDismiss, onDuplicateSession, runnerInfo, mcpOAuthPastes, onMcpOAuthPaste, onMcpOAuthPasteDismiss, onMcpServerDisable }: SessionViewerProps) {
+export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onEditQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse, onQuestionDismiss, onPlanDismiss, onDuplicateSession, runnerInfo, extraHeaderButtons, mcpOAuthPastes, onMcpOAuthPaste, onMcpOAuthPasteDismiss, onMcpServerDisable }: SessionViewerProps) {
   const [input, setInput] = React.useState("");
   // Per-session draft storage so switching sessions preserves unsent text
   const draftsRef = React.useRef<Map<string, string>>(new Map());
@@ -1571,94 +1574,115 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
               </span>
             )}
             {showTerminalButton && onToggleTerminal && (
-              <Button
-                className="h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem]"
-                onClick={onToggleTerminal}
-                size="icon"
-                type="button"
-                variant="outline"
-                title="Toggle terminal"
-                aria-label="Toggle terminal"
-              >
-                <TerminalIcon className="size-3.5" />
-                <span className="hidden sm:inline ml-1">Terminal</span>
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    className="h-7 w-7"
+                    onClick={onToggleTerminal}
+                    size="icon"
+                    type="button"
+                    variant="outline"
+                    aria-label="Toggle terminal"
+                  >
+                    <TerminalIcon className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Terminal</TooltipContent>
+              </Tooltip>
             )}
             {showFileExplorerButton && onToggleFileExplorer && (
-              <Button
-                className="h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem]"
-                onClick={onToggleFileExplorer}
-                size="icon"
-                type="button"
-                variant="outline"
-                title="Toggle file explorer"
-                aria-label="Toggle file explorer"
-              >
-                <FolderTree className="size-3.5" />
-                <span className="hidden sm:inline ml-1">Files</span>
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    className="h-7 w-7"
+                    onClick={onToggleFileExplorer}
+                    size="icon"
+                    type="button"
+                    variant="outline"
+                    aria-label="Toggle file explorer"
+                  >
+                    <FolderTree className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Files</TooltipContent>
+              </Tooltip>
             )}
-            <ConversationExport
-              messages={sortedMessages}
-              filename={`session-${sessionId || "export"}.md`}
-              className="static top-auto right-auto h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem] border-border bg-background hover:bg-accent hover:text-accent-foreground rounded-md"
-              variant="outline"
-              size="icon"
-            />
+            {extraHeaderButtons}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <ConversationExport
+                  messages={sortedMessages}
+                  filename={`session-${sessionId || "export"}.md`}
+                  className="static top-auto right-auto h-7 w-7 border-border bg-background hover:bg-accent hover:text-accent-foreground rounded-md"
+                  variant="outline"
+                  size="icon"
+                />
+              </TooltipTrigger>
+              <TooltipContent>Export</TooltipContent>
+            </Tooltip>
             {onDuplicateSession && (
-              <Button
-                className="h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem]"
-                onClick={onDuplicateSession}
-                size="icon"
-                type="button"
-                variant="outline"
-                title="Duplicate session (same runner & directory)"
-                aria-label="Duplicate session"
-              >
-                <Copy className="size-3.5" />
-                <span className="hidden sm:inline ml-1">Duplicate</span>
-              </Button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    className="h-7 w-7"
+                    onClick={onDuplicateSession}
+                    size="icon"
+                    type="button"
+                    variant="outline"
+                    aria-label="Duplicate session"
+                  >
+                    <Copy className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Duplicate</TooltipContent>
+              </Tooltip>
             )}
-            <Button
-              className="h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem]"
-              disabled={!onExec}
-              onClick={() => {
-                if (!onExec || !sessionId) return;
-                if (window.innerWidth < 640) {
-                  setShowEndSessionDialog(true);
-                } else {
-                  onExec({ type: "exec", id: `${Date.now()}-${Math.random().toString(16).slice(2)}`, command: "end_session" });
-                }
-              }}
-              size="icon"
-              type="button"
-              variant="destructive"
-              title="End Session"
-              aria-label="End session"
-            >
-              <OctagonX className="size-3.5" />
-              <span className="hidden sm:inline ml-1">End</span>
-            </Button>
-            <Button
-              className="h-7 w-7 sm:h-7 sm:w-auto sm:px-2.5 sm:text-[0.7rem]"
-              disabled={!onExec}
-              onClick={() => {
-                if (!onExec) return;
-                if (window.innerWidth < 640) {
-                  setShowClearDialog(true);
-                } else {
-                  onExec({ type: "exec", id: `${Date.now()}-${Math.random().toString(16).slice(2)}`, command: "new_session" });
-                }
-              }}
-              size="icon"
-              type="button"
-              variant="outline"
-              title="New conversation (/new)"
-              aria-label="Clear conversation"
-            >
-              <Plus className="size-3.5" />
-              <span className="hidden sm:inline ml-1">Clear</span>
-            </Button>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  className="h-7 w-7"
+                  disabled={!onExec}
+                  onClick={() => {
+                    if (!onExec || !sessionId) return;
+                    if (window.innerWidth < 640) {
+                      setShowEndSessionDialog(true);
+                    } else {
+                      onExec({ type: "exec", id: `${Date.now()}-${Math.random().toString(16).slice(2)}`, command: "end_session" });
+                    }
+                  }}
+                  size="icon"
+                  type="button"
+                  variant="destructive"
+                  aria-label="End session"
+                >
+                  <OctagonX className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>End Session</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  className="h-7 w-7"
+                  disabled={!onExec}
+                  onClick={() => {
+                    if (!onExec) return;
+                    if (window.innerWidth < 640) {
+                      setShowClearDialog(true);
+                    } else {
+                      onExec({ type: "exec", id: `${Date.now()}-${Math.random().toString(16).slice(2)}`, command: "new_session" });
+                    }
+                  }}
+                  size="icon"
+                  type="button"
+                  variant="outline"
+                  aria-label="New conversation"
+                >
+                  <Plus className="size-3.5" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>New Conversation</TooltipContent>
+            </Tooltip>
           </div>
         </div>
       )}

--- a/packages/ui/src/components/ai-elements/conversation.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.tsx
@@ -260,7 +260,6 @@ export const ConversationExport = ({
           ) : (
             <ShareIcon className="size-3.5" />
           )}
-          <span className="hidden sm:inline ml-1">Export</span>
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -1,0 +1,125 @@
+/**
+ * Dynamic service panel buttons and panel rendering.
+ *
+ * ServicePanelButtons — renders a button for each available service panel in the header.
+ * ServicePanelContainer — renders the active service panel below the session viewer.
+ */
+import React, { useState, useCallback } from "react";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
+import { X } from "lucide-react";
+import { SERVICE_PANELS, type ServicePanelDef } from "./registry";
+
+// ── Buttons for the header bar ────────────────────────────────────────────────
+
+interface ServicePanelButtonsProps {
+    availableServices: Set<string>;
+    activePanelId: string | null;
+    onTogglePanel: (serviceId: string) => void;
+}
+
+export function ServicePanelButtons({
+    availableServices,
+    activePanelId,
+    onTogglePanel,
+}: ServicePanelButtonsProps) {
+    const visiblePanels = SERVICE_PANELS.filter(p => availableServices.has(p.serviceId));
+
+    if (visiblePanels.length === 0) return null;
+
+    return (
+        <>
+            {visiblePanels.map(panel => (
+                <Tooltip key={panel.serviceId}>
+                    <TooltipTrigger asChild>
+                        <Button
+                            className={`h-7 w-7 ${
+                                activePanelId === panel.serviceId ? "bg-accent text-accent-foreground" : ""
+                            }`}
+                            onClick={() => onTogglePanel(panel.serviceId)}
+                            size="icon"
+                            type="button"
+                            variant="outline"
+                            aria-label={`Toggle ${panel.label}`}
+                        >
+                            {panel.icon}
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{panel.label}</TooltipContent>
+                </Tooltip>
+            ))}
+        </>
+    );
+}
+
+// ── Panel container (renders the active panel) ───────────────────────────────
+
+interface ServicePanelContainerProps {
+    activePanelId: string | null;
+    sessionId: string;
+    onClose: () => void;
+    position?: "bottom" | "right";
+}
+
+export function ServicePanelContainer({
+    activePanelId,
+    sessionId,
+    onClose,
+    position = "bottom",
+}: ServicePanelContainerProps) {
+    if (!activePanelId) return null;
+
+    const panelDef = SERVICE_PANELS.find(p => p.serviceId === activePanelId);
+    if (!panelDef) return null;
+
+    const PanelComponent = panelDef.component;
+
+    return (
+        <div
+            className={`border-border bg-background flex flex-col ${
+                position === "bottom"
+                    ? "border-t w-full"
+                    : "border-l h-full"
+            }`}
+            style={position === "bottom" ? { height: "280px" } : { width: "320px" }}
+        >
+            {/* Panel header */}
+            <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-muted/30 shrink-0">
+                <div className="flex items-center gap-1.5 text-xs font-medium">
+                    {panelDef.icon}
+                    {panelDef.label}
+                </div>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-5 w-5"
+                    onClick={onClose}
+                    aria-label={`Close ${panelDef.label}`}
+                >
+                    <X className="size-3" />
+                </Button>
+            </div>
+
+            {/* Panel content */}
+            <div className="flex-1 overflow-hidden">
+                <PanelComponent sessionId={sessionId} />
+            </div>
+        </div>
+    );
+}
+
+// ── Hook for managing service panel state ─────────────────────────────────────
+
+export function useServicePanelState() {
+    const [activePanelId, setActivePanelId] = useState<string | null>(null);
+
+    const togglePanel = useCallback((serviceId: string) => {
+        setActivePanelId(prev => prev === serviceId ? null : serviceId);
+    }, []);
+
+    const closePanel = useCallback(() => {
+        setActivePanelId(null);
+    }, []);
+
+    return { activePanelId, togglePanel, closePanel };
+}

--- a/packages/ui/src/components/service-panels/registry.tsx
+++ b/packages/ui/src/components/service-panels/registry.tsx
@@ -1,0 +1,38 @@
+/**
+ * Service Panel Registry
+ *
+ * Maps runner service IDs to their UI panel components, labels, and icons.
+ * When the runner announces a service and this registry has a panel for it,
+ * the UI renders a toggleable panel button in the session header.
+ *
+ * To add a new service panel:
+ * 1. Create a React component (e.g. MyServicePanel.tsx)
+ * 2. Add an entry to SERVICE_PANELS below
+ */
+import React from "react";
+import { Network } from "lucide-react";
+import { TunnelPanel } from "@/components/TunnelPanel";
+
+export interface ServicePanelDef {
+    /** Must match the runner service's `id` */
+    serviceId: string;
+    /** Button label in the header bar */
+    label: string;
+    /** Icon component (lucide) */
+    icon: React.ReactNode;
+    /** The panel component to render. Receives sessionId as a prop. */
+    component: React.ComponentType<{ sessionId: string }>;
+}
+
+/**
+ * All known service panels. Order determines button order in the header.
+ * A panel only appears if the runner announces its serviceId.
+ */
+export const SERVICE_PANELS: ServicePanelDef[] = [
+    {
+        serviceId: "tunnel",
+        label: "Tunnels",
+        icon: <Network className="size-3.5" />,
+        component: TunnelPanel,
+    },
+];

--- a/packages/ui/src/hooks/usePanelLayout.ts
+++ b/packages/ui/src/hooks/usePanelLayout.ts
@@ -4,7 +4,7 @@ import type { TerminalTab } from "@/components/TerminalManager";
 export type PanelPosition = "bottom" | "right" | "left";
 
 export interface PanelLayoutState {
-  // ── Terminal panel ──────────────────────────────────────────────────────
+  // ── Shared docked panel state ────────────────────────────────────────────
   showTerminal: boolean;
   setShowTerminal: React.Dispatch<React.SetStateAction<boolean>>;
   terminalPosition: PanelPosition;
@@ -13,19 +13,21 @@ export interface PanelLayoutState {
   terminalColumnRef: React.RefObject<HTMLDivElement | null>;
   handleTerminalResizeStart: (e: React.PointerEvent) => void;
   handleTerminalPositionChange: (pos: PanelPosition) => void;
+  startPanelResizeForPosition: (position: PanelPosition, e: React.PointerEvent) => void;
 
-  // ── Terminal drag-to-reposition ─────────────────────────────────────────
+  // ── Shared drag-to-reposition ───────────────────────────────────────────
   panelDragActive: boolean;
   panelDragZone: PanelPosition | null;
   handlePanelDragStart: (e: React.PointerEvent) => void;
   handleTerminalTabDragStart: (e: React.PointerEvent) => void;
+  startPanelDragWith: (e: React.PointerEvent, applyPosition: (pos: PanelPosition) => void) => void;
 
-  // ── Terminal outer pointer handlers (resize + drag combined) ────────────
+  // ── Shared outer pointer handlers (resize + drag combined) ──────────────
   handleOuterPointerMove: (e: React.PointerEvent) => void;
   handleOuterPointerUp: () => void;
 
-  // ── Combined panel (terminal + file explorer at same position) ──────────
-  combinedActiveTab: "terminal" | "files";
+  // ── Combined panel (terminal + file explorer + service panels) ───────────
+  combinedActiveTab: string;
   handleCombinedTabChange: (tab: string) => void;
   handleCombinedPositionChange: (pos: PanelPosition) => void;
 
@@ -87,14 +89,18 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
   // "height" = bottom panel vertical drag, "width-right" = right panel, "width-left" = left panel
   const resizeDir = React.useRef<"height" | "width-right" | "width-left" | null>(null);
 
-  // Single handler — direction is derived from current terminalPosition at drag start
-  const handleTerminalResizeStart = React.useCallback((e: React.PointerEvent) => {
+  const startPanelResizeForPosition = React.useCallback((position: PanelPosition, e: React.PointerEvent) => {
     e.preventDefault();
-    resizeDir.current = terminalPosition === "bottom" ? "height"
-      : terminalPosition === "right" ? "width-right"
+    resizeDir.current = position === "bottom" ? "height"
+      : position === "right" ? "width-right"
       : "width-left";
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, [terminalPosition]);
+  }, []);
+
+  // Single handler — direction is derived from current terminalPosition at drag start
+  const handleTerminalResizeStart = React.useCallback((e: React.PointerEvent) => {
+    startPanelResizeForPosition(terminalPosition, e);
+  }, [terminalPosition, startPanelResizeForPosition]);
 
   const handleTerminalResizeMove = React.useCallback((e: React.PointerEvent) => {
     const dir = resizeDir.current;
@@ -131,14 +137,21 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     try { localStorage.setItem("pp-terminal-position", pos); } catch {}
   }, []);
 
-  const handlePanelDragStart = React.useCallback((e: React.PointerEvent) => {
+  const dragApplyRef = React.useRef<((zone: PanelPosition) => void) | null>(null);
+
+  const startPanelDragWith = React.useCallback((e: React.PointerEvent, applyPosition: (pos: PanelPosition) => void) => {
     e.preventDefault();
+    dragApplyRef.current = applyPosition;
     isPanelDragging.current = true;
     panelDragZoneRef.current = null;
     setPanelDragActive(true);
     setPanelDragZone(null);
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
   }, []);
+
+  const handlePanelDragStart = React.useCallback((e: React.PointerEvent) => {
+    startPanelDragWith(e, handleTerminalPositionChange);
+  }, [startPanelDragWith, handleTerminalPositionChange]);
 
   const handlePanelDragMove = React.useCallback((e: React.PointerEvent) => {
     if (!isPanelDragging.current || !terminalColumnRef.current) return;
@@ -153,17 +166,11 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     setPanelDragZone(zone);
   }, []);
 
-  // Ref to sync file explorer position when panels are combined (avoids forward-reference issues)
-  const combinedDragSyncRef = React.useRef<((zone: PanelPosition) => void) | null>(null);
-
   // Drag start handler for the Terminal tab inside the combined panel.
-  // Unlike the grip handle (which moves both panels together), this only moves
-  // the terminal panel so it can be detached from the files panel.
+  // Unlike the grip handle, this only moves the terminal panel.
   const handleTerminalTabDragStart = React.useCallback((e: React.PointerEvent) => {
-    // Clear the sync ref so handlePanelDragEnd doesn't also reposition the files panel
-    combinedDragSyncRef.current = null;
-    handlePanelDragStart(e);
-  }, [handlePanelDragStart]);
+    startPanelDragWith(e, handleTerminalPositionChange);
+  }, [startPanelDragWith, handleTerminalPositionChange]);
 
   const handlePanelDragEnd = React.useCallback(() => {
     if (!isPanelDragging.current) return;
@@ -173,11 +180,10 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     setPanelDragActive(false);
     setPanelDragZone(null);
     if (zone) {
-      handleTerminalPositionChange(zone);
-      // When panels are combined (same position), also move file explorer
-      combinedDragSyncRef.current?.(zone);
+      dragApplyRef.current?.(zone);
     }
-  }, [handleTerminalPositionChange]);
+    dragApplyRef.current = null;
+  }, []);
 
   const handleOuterPointerMove = React.useCallback((e: React.PointerEvent) => {
     handleTerminalResizeMove(e);
@@ -190,13 +196,12 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
   }, [handleTerminalResizeEnd, handlePanelDragEnd]);
 
   // ── Combined panel tab state ──────────────────────────────────────────
-  const [combinedActiveTab, setCombinedActiveTab] = React.useState<"terminal" | "files">(() => {
-    try { return (localStorage.getItem("pp-combined-tab") as "terminal" | "files") ?? "terminal"; } catch { return "terminal"; }
+  const [combinedActiveTab, setCombinedActiveTab] = React.useState<string>(() => {
+    try { return localStorage.getItem("pp-combined-tab") ?? "terminal"; } catch { return "terminal"; }
   });
   const handleCombinedTabChange = React.useCallback((tab: string) => {
-    const t = tab as "terminal" | "files";
-    setCombinedActiveTab(t);
-    try { localStorage.setItem("pp-combined-tab", t); } catch {}
+    setCombinedActiveTab(tab);
+    try { localStorage.setItem("pp-combined-tab", tab); } catch {}
   }, []);
 
   // ── Lifted terminal tab state ─────────────────────────────────────────
@@ -325,15 +330,6 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     handleFilesPositionChange(pos);
   }, [handleTerminalPositionChange, handleFilesPositionChange]);
 
-  // Keep the drag sync ref up-to-date so handlePanelDragEnd can sync file explorer
-  React.useEffect(() => {
-    if (showTerminal && showFileExplorer && terminalPosition === filesPosition) {
-      combinedDragSyncRef.current = handleFilesPositionChange;
-    } else {
-      combinedDragSyncRef.current = null;
-    }
-  }, [showTerminal, showFileExplorer, terminalPosition, filesPosition, handleFilesPositionChange]);
-
   // ── File explorer drag-to-reposition ──────────────────────────────────
   const isFilesDragging = React.useRef(false);
   const filesDragZoneRef = React.useRef<PanelPosition | null>(null);
@@ -387,10 +383,12 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     terminalColumnRef,
     handleTerminalResizeStart,
     handleTerminalPositionChange,
+    startPanelResizeForPosition,
     panelDragActive,
     panelDragZone,
     handlePanelDragStart,
     handleTerminalTabDragStart,
+    startPanelDragWith,
     handleOuterPointerMove,
     handleOuterPointerUp,
     combinedActiveTab,

--- a/packages/ui/src/hooks/useRunnerServices.ts
+++ b/packages/ui/src/hooks/useRunnerServices.ts
@@ -1,0 +1,83 @@
+/**
+ * Track which runner services are available via service_announce events.
+ * Returns a Set<string> of service IDs that updates reactively.
+ *
+ * ## Race condition note
+ *
+ * The server sends `service_announce` immediately after the viewer socket
+ * connects (during the `connected` event handler). A naive useEffect-based
+ * listener would miss this because React effects run AFTER the first render,
+ * by which time the event has already fired.
+ *
+ * Solution: `attachServiceAnnounceListener()` must be called synchronously
+ * when the socket is created (before any render). It stores the latest
+ * announce in `socket.__serviceIds`. The hook reads this eagerly as the
+ * initial state and also listens for subsequent announces.
+ */
+import { useState, useEffect, useRef } from "react";
+import type { Socket } from "socket.io-client";
+
+const SERVICE_IDS_KEY = "__serviceIds" as const;
+
+/**
+ * Call this synchronously right after creating the viewer socket.
+ * Attaches a persistent listener that captures service_announce events
+ * so they're available before any React hooks mount.
+ */
+export function attachServiceAnnounceListener(socket: Socket): void {
+    socket.on("service_announce", (data: { serviceIds: string[] }) => {
+        (socket as any)[SERVICE_IDS_KEY] = data.serviceIds;
+    });
+    socket.on("disconnect", () => {
+        (socket as any)[SERVICE_IDS_KEY] = undefined;
+    });
+}
+
+/** Read any already-captured service IDs from the socket. */
+function getEagerServiceIds(socket: Socket | null): Set<string> {
+    const ids = socket ? (socket as any)[SERVICE_IDS_KEY] as string[] | undefined : undefined;
+    return ids ? new Set(ids) : new Set();
+}
+
+export function useRunnerServices(socket: Socket | null): Set<string> {
+    const [services, setServices] = useState<Set<string>>(() => getEagerServiceIds(socket));
+    const prevSocketRef = useRef(socket);
+
+    // When the socket changes, eagerly read any cached announce
+    if (socket !== prevSocketRef.current) {
+        prevSocketRef.current = socket;
+        const eager = getEagerServiceIds(socket);
+        if (eager.size > 0 || services.size > 0) {
+            // Can't call setState during render in strict mode without this pattern
+            // but since we're comparing refs it's fine — this is a derived-state reset
+        }
+    }
+
+    useEffect(() => {
+        if (!socket) {
+            setServices(new Set());
+            return;
+        }
+
+        // Read eagerly in case announce arrived before this effect ran
+        const cached = getEagerServiceIds(socket);
+        if (cached.size > 0) {
+            setServices(cached);
+        }
+
+        const handleAnnounce = (data: { serviceIds: string[] }) => {
+            setServices(new Set(data.serviceIds));
+        };
+        const handleDisconnect = () => setServices(new Set());
+
+        socket.on("service_announce", handleAnnounce);
+        socket.on("disconnect", handleDisconnect);
+
+        return () => {
+            socket.off("service_announce", handleAnnounce);
+            socket.off("disconnect", handleDisconnect);
+        };
+    }, [socket]);
+
+    return services;
+}

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -82,6 +82,16 @@ export default defineConfig({
                 navigateFallbackDenylist: [/^\/api\//],
                 runtimeCaching: [
                     {
+                        // API calls (including tunnel proxy) always go to the network — never cache.
+                        // MUST be first: tunnel sub-resources like /api/tunnel/.../app.js
+                        // would otherwise match the .js$ StaleWhileRevalidate rule below
+                        // and get served from the PizzaPi JS cache instead of the tunneled app.
+                        // NOTE: Workbox RegExpRoute tests against url.href (full URL), not pathname,
+                        // so we match `/api/` anywhere in the URL string.
+                        urlPattern: /\/api\//,
+                        handler: "NetworkOnly",
+                    },
+                    {
                         // Cache JS chunks (including lazy shiki/mermaid language chunks)
                         // after first load, so they're available instantly on revisits.
                         urlPattern: /\.js$/,
@@ -90,11 +100,6 @@ export default defineConfig({
                             cacheName: "js-chunks",
                             expiration: { maxEntries: 200, maxAgeSeconds: 7 * 24 * 60 * 60 },
                         },
-                    },
-                    {
-                        // API calls always go to the network — never cache
-                        urlPattern: /^\/api\//,
-                        handler: "NetworkOnly",
                     },
                     {
                         // WebSocket upgrade requests — ignored by workbox automatically,

--- a/patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch
+++ b/patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch
@@ -1,7 +1,13 @@
 diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-337ecc0e082ff23b b/.bun-tag-337ecc0e082ff23b
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-6d703b66423bf786 b/.bun-tag-6d703b66423bf786
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-8164784f1eb34c4d b/.bun-tag-8164784f1eb34c4d
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-e7a6243888af15fb b/.bun-tag-e7a6243888af15fb
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/config.js b/dist/config.js
@@ -86,8 +92,22 @@ index 8ef7aa25255056266cf9103bbd6f14685a09937c..79394dadbd85abef0c8847754289f2ea
      }
      setUIContext(uiContext) {
          this.uiContext = uiContext ?? noOpUIContext;
+diff --git a/dist/core/resource-loader.js b/dist/core/resource-loader.js
+index d47894a1441798e3b93ab28c1c90faf4f12e0b38..6662fa276771364d5bf6446531852ad4112f03e0 100644
+--- a/dist/core/resource-loader.js
++++ b/dist/core/resource-loader.js
+@@ -493,7 +493,8 @@ export class DefaultResourceLoader {
+         const extensions = [];
+         const errors = [];
+         for (const [index, factory] of this.extensionFactories.entries()) {
+-            const extensionPath = `<inline:${index + 1}>`;
++            // PATCH(pizzapi): use factory displayName/name instead of <inline:N>
++            const extensionPath = factory.displayName || factory.name || `<inline:${index + 1}>`;
+             try {
+                 const extension = await loadExtensionFromFactory(factory, this.cwd, this.eventBus, runtime, extensionPath);
+                 extensions.push(extension);
 diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
-index 038e6600ead762073fda085c806f8aa1eafef9a1..11a82c0fc46f22a71a85654f847543ee5f430cbe 100644
+index 038e6600ead762073fda085c806f8aa1eafef9a1..c1c351b89efcee9fba084e68265e405f553fd641 100644
 --- a/dist/modes/interactive/interactive-mode.js
 +++ b/dist/modes/interactive/interactive-mode.js
 @@ -354,12 +354,6 @@ export class InteractiveMode {
@@ -130,7 +150,90 @@ index 038e6600ead762073fda085c806f8aa1eafef9a1..11a82c0fc46f22a71a85654f847543ee
      async checkTmuxKeyboardSetup() {
          if (!process.env.TMUX)
              return undefined;
-@@ -2386,17 +2360,6 @@ export class InteractiveMode {
+@@ -692,7 +666,12 @@ export class InteractiveMode {
+             return;
+         }
+         const metadata = this.session.resourceLoader.getPathMetadata();
+-        const sectionHeader = (name, color = "mdHeading") => theme.fg(color, `[${name}]`);
++        // PATCH(pizzapi): themed section headers with box-drawing
++        const sectionHeader = (name, color = "accent") => {
++            const label = ` ${name} `;
++            const line = "─".repeat(Math.max(0, 40 - label.length));
++            return theme.fg(color, `├${label}`) + theme.fg("dim", line);
++        };
+         const skillsResult = this.session.resourceLoader.getSkills();
+         const promptsResult = this.session.resourceLoader.getPrompts();
+         const themesResult = this.session.resourceLoader.getThemes();
+@@ -735,14 +714,30 @@ export class InteractiveMode {
+                 this.chatContainer.addChild(new Text(`${sectionHeader("Prompts")}\n${templateList}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
++            // PATCH(pizzapi): display extensions as a compact table
+             const extensionPaths = options?.extensionPaths ?? [];
+             if (extensionPaths.length > 0) {
+-                const groups = this.buildScopeGroups(extensionPaths, metadata);
+-                const extList = this.formatScopeGroups(groups, {
+-                    formatPath: (p) => this.formatDisplayPath(p),
+-                    formatPackagePath: (p, source) => this.getShortPath(p, source),
+-                });
+-                this.chatContainer.addChild(new Text(`${sectionHeader("Extensions", "mdHeading")}\n${extList}`, 0, 0));
++                const builtIn = extensionPaths.filter(p => !p.startsWith("/") && !p.startsWith("~") && !p.startsWith("."));
++                const fileBased = extensionPaths.filter(p => p.startsWith("/") || p.startsWith("~") || p.startsWith("."));
++                const lines = [];
++                if (builtIn.length > 0) {
++                    // Render as a multi-column table
++                    const cols = 4;
++                    const colW = 16;
++                    const pad = (s, w) => { const stripped = s.replace(/\x1b\[[0-9;]*m/g, ""); return s + " ".repeat(Math.max(0, w - stripped.length)); };
++                    for (let i = 0; i < builtIn.length; i += cols) {
++                        const row = builtIn.slice(i, i + cols).map(n => pad(theme.fg("dim", n), colW)).join("");
++                        lines.push("  " + row);
++                    }
++                }
++                if (fileBased.length > 0) {
++                    const groups = this.buildScopeGroups(fileBased, metadata);
++                    lines.push(this.formatScopeGroups(groups, {
++                        formatPath: (p) => this.formatDisplayPath(p),
++                        formatPackagePath: (p, source) => this.getShortPath(p, source),
++                    }));
++                }
++                this.chatContainer.addChild(new Text(`${sectionHeader("Extensions")}\n${lines.join("\n")}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
+             // Show loaded themes (excluding built-in)
+@@ -763,13 +758,13 @@ export class InteractiveMode {
+             const skillDiagnostics = skillsResult.diagnostics;
+             if (skillDiagnostics.length > 0) {
+                 const warningLines = this.formatDiagnostics(skillDiagnostics, metadata);
+-                this.chatContainer.addChild(new Text(`${theme.fg("warning", "[Skill conflicts]")}\n${warningLines}`, 0, 0));
++                this.chatContainer.addChild(new Text(`${sectionHeader("Skill Issues", "warning")}\n${warningLines}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
+             const promptDiagnostics = promptsResult.diagnostics;
+             if (promptDiagnostics.length > 0) {
+                 const warningLines = this.formatDiagnostics(promptDiagnostics, metadata);
+-                this.chatContainer.addChild(new Text(`${theme.fg("warning", "[Prompt conflicts]")}\n${warningLines}`, 0, 0));
++                this.chatContainer.addChild(new Text(`${sectionHeader("Prompt Issues", "warning")}\n${warningLines}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
+             const extensionDiagnostics = [];
+@@ -785,13 +780,13 @@ export class InteractiveMode {
+             extensionDiagnostics.push(...shortcutDiagnostics);
+             if (extensionDiagnostics.length > 0) {
+                 const warningLines = this.formatDiagnostics(extensionDiagnostics, metadata);
+-                this.chatContainer.addChild(new Text(`${theme.fg("warning", "[Extension issues]")}\n${warningLines}`, 0, 0));
++                this.chatContainer.addChild(new Text(`${sectionHeader("Extension Issues", "warning")}\n${warningLines}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
+             const themeDiagnostics = themesResult.diagnostics;
+             if (themeDiagnostics.length > 0) {
+                 const warningLines = this.formatDiagnostics(themeDiagnostics, metadata);
+-                this.chatContainer.addChild(new Text(`${theme.fg("warning", "[Theme conflicts]")}\n${warningLines}`, 0, 0));
++                this.chatContainer.addChild(new Text(`${sectionHeader("Theme Issues", "warning")}\n${warningLines}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
+         }
+@@ -2386,17 +2381,6 @@ export class InteractiveMode {
          this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
          this.ui.requestRender();
      }
@@ -148,7 +251,7 @@ index 038e6600ead762073fda085c806f8aa1eafef9a1..11a82c0fc46f22a71a85654f847543ee
      /**
       * Get all queued messages (read-only).
       * Combines session queue and compaction queue.
-@@ -3163,7 +3126,8 @@ export class InteractiveMode {
+@@ -3163,7 +3147,8 @@ export class InteractiveMode {
              restoreEditor();
              this.session.modelRegistry.refresh();
              await this.updateAvailableProviderCount();


### PR DESCRIPTION
## Summary

Runner Service System Phase 5: Extension Platform UI. This PR adds the UI layer for dynamic service panels — the visual counterpart to the runner service handler pattern introduced in Phases 1–4.

### What's included

**New components:**
- `ServicePanels` — dynamic panel registration from runner service announcements
- `DockedPanelGroup` — unified docked panel management (combined + service panels)
- `useRunnerServices` hook — service_announce lifecycle management
- `registry.tsx` — service panel component registry

**Refactors:**
- `App.tsx` — integrates service panels as first-class draggable/resizable/dockable citizens
- `CombinedPanel` — tab support + header button tooltips
- `usePanelLayout` — extended for service panel positions and drag/resize
- `SessionViewer` — service panel integration

**Server:**
- `viewer.ts` — service_message routing from viewer → runner via emitToRunner
- `routes/index.ts` — tunnel route registration
- Test harness updates with service_announce mock support

**Demo:**
- `demos/service-panels/` — system-monitor reference implementation

### Dependencies
Depends on the Runner Service System chain:
- #315 (Phase 1: runner service refactor)
- #317 (Phase 2: relay service envelope)
- #318 (Phase 4: tunnel service)
- #319 (Phase 3: UI service channel)

Should be merged LAST in the service system chain.

### Testing
- CombinedPanel tests
- DockedPanelGroup tests
- useServiceChannel tests (in #319)