### PR TITLE
fix(ui): set up DOM globals before component imports in render tests

### DIFF
--- a/packages/ui/src/components/CombinedPanel.test.tsx
+++ b/packages/ui/src/components/CombinedPanel.test.tsx
@@ -1,24 +1,24 @@
-import { beforeAll, afterEach, describe, test, expect } from "bun:test";
+import { afterEach, describe, test, expect } from "bun:test";
 import { Window } from "happy-dom";
 import { render, fireEvent, cleanup } from "@testing-library/react";
 import React from "react";
 
-const { CombinedPanel } = await import("./CombinedPanel");
+// Set up DOM globals BEFORE importing the component — CombinedPanel's
+// transitive deps (lucide-react, ReactDOM) need a DOM at evaluation time.
+const win = new Window({ url: "http://localhost/" });
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+/* eslint-enable @typescript-eslint/no-explicit-any */
 
-beforeAll(() => {
-  const win = new Window({ url: "http://localhost/" });
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  (globalThis as any).window = win;
-  (globalThis as any).document = win.document;
-  (globalThis as any).navigator = win.navigator;
-  (globalThis as any).HTMLElement = win.HTMLElement;
-  (globalThis as any).Element = win.Element;
-  (globalThis as any).Node = win.Node;
-  (globalThis as any).SVGElement = win.SVGElement;
-  (globalThis as any).MutationObserver = win.MutationObserver;
-  (globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
-  /* eslint-enable @typescript-eslint/no-explicit-any */
-});
+const { CombinedPanel } = await import("./CombinedPanel");
 
 afterEach(() => {
   cleanup();

--- a/packages/ui/src/components/DockedPanelGroup.test.tsx
+++ b/packages/ui/src/components/DockedPanelGroup.test.tsx
@@ -1,29 +1,34 @@
-import { beforeAll, afterEach, describe, test, expect, mock } from "bun:test";
+import { afterEach, describe, test, expect, mock } from "bun:test";
 import { Window } from "happy-dom";
 import { render, fireEvent, cleanup } from "@testing-library/react";
 import React from "react";
 
+// Set up DOM globals BEFORE any component imports — transitive deps
+// (lucide-react, ReactDOM) need a DOM at module-evaluation time.
+const win = new Window({ url: "http://localhost/" });
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
 mock.module("@/lib/utils", () => ({
   cn: (...classes: (string | undefined | null | false)[]) => classes.filter(Boolean).join(" "),
 }));
-mock.module("@/components/CombinedPanel", async () => await import("./CombinedPanel"));
+
+// Eagerly import CombinedPanel (DOM globals are already set above) and
+// register the mock synchronously — async mock factories resolve too late
+// when Bun evaluates modules in parallel across test files.
+const CombinedPanelModule = await import("./CombinedPanel");
+mock.module("@/components/CombinedPanel", () => CombinedPanelModule);
 
 const { DockedPanelGroup } = await import("./DockedPanelGroup");
-
-beforeAll(() => {
-  const win = new Window({ url: "http://localhost/" });
-  /* eslint-disable @typescript-eslint/no-explicit-any */
-  (globalThis as any).window = win;
-  (globalThis as any).document = win.document;
-  (globalThis as any).navigator = win.navigator;
-  (globalThis as any).HTMLElement = win.HTMLElement;
-  (globalThis as any).Element = win.Element;
-  (globalThis as any).Node = win.Node;
-  (globalThis as any).SVGElement = win.SVGElement;
-  (globalThis as any).MutationObserver = win.MutationObserver;
-  (globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
-  /* eslint-enable @typescript-eslint/no-explicit-any */
-});
 
 afterEach(() => {
   cleanup();


### PR DESCRIPTION
## Problem

`CombinedPanel.test.tsx` and `DockedPanelGroup.test.tsx` were setting up happy-dom globals in `beforeAll()`, but component imports (`await import()`) run at module-evaluation time — before `beforeAll` fires. When Bun runs the full test suite, `CombinedPanel.tsx` would fail to evaluate (lucide-react/ReactDOM need DOM globals at load time), and the cached failed module poisoned both test files.

## Fix

- **`CombinedPanel.test.tsx`**: Move DOM global setup from `beforeAll()` to module scope, before the `await import`
- **`DockedPanelGroup.test.tsx`**: Same DOM setup move, plus change the mock factory from async to eagerly resolved to avoid race conditions with Bun's parallel module evaluation

## Result

638 pass, 0 fail ✅