### PR TITLE
feat(ui): yellow chase indicator in sidebar when session is compacting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,12 +51,20 @@ RUN node_modules/typescript/bin/tsc --build packages/server/tsconfig.json
 # When PREBUILT_UI=true (default), `pizza web` builds the UI on the host first
 # (native speed, ~15s) and the Dockerfile just copies the dist from context.
 # Set PREBUILT_UI=false to build inside Docker (slow on Docker Desktop VMs).
+#
+# UI_DIST_HASH is a cache-buster: `pizza web` sets it to a content hash of the
+# pre-built dist/ so BuildKit invalidates the COPY layer when the dist changes.
+# Without this, BuildKit can serve a stale build-ui stage from its layer cache
+# even though the host dist/ has new content.
 ARG PREBUILT_UI=false
+ARG UI_DIST_HASH=none
 FROM builder AS build-ui
 ARG PREBUILT_UI
+ARG UI_DIST_HASH
 COPY packages/tools/ packages/tools/
 COPY packages/ui/ packages/ui/
-RUN if [ "$PREBUILT_UI" = "true" ] && [ -d packages/ui/dist ]; then \
+RUN echo "ui-dist-hash: $UI_DIST_HASH" \
+    && if [ "$PREBUILT_UI" = "true" ] && [ -d packages/ui/dist ]; then \
         echo "Using pre-built UI dist from host"; \
     else \
         node_modules/typescript/bin/tsc --build packages/protocol/tsconfig.json \

--- a/packages/cli/src/templates/compose.yml.template
+++ b/packages/cli/src/templates/compose.yml.template
@@ -12,6 +12,7 @@ services:
       dockerfile: Dockerfile
       args:
         PREBUILT_UI: "{{PREBUILT_UI}}"
+        UI_DIST_HASH: "{{UI_DIST_HASH}}"
     ports:
       - "{{PORT}}:7492"
     environment:

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -35,6 +35,7 @@ services:
       dockerfile: Dockerfile
       args:
         PREBUILT_UI: "{{PREBUILT_UI}}"
+        UI_DIST_HASH: "{{UI_DIST_HASH}}"
     ports:
       - "{{PORT}}:7492"
     environment:
@@ -156,6 +157,7 @@ describe("readBooleanEnv", () => {
         expect(COMPOSE_TEMPLATE).toContain("{{VAPID_SUBJECT}}");
         expect(COMPOSE_TEMPLATE).toContain("{{EXTRA_ORIGINS_LINE}}");
         expect(COMPOSE_TEMPLATE).toContain("{{PREBUILT_UI}}");
+        expect(COMPOSE_TEMPLATE).toContain("{{UI_DIST_HASH}}");
     });
 
     test("template substitution produces valid compose structure", () => {
@@ -170,7 +172,8 @@ describe("readBooleanEnv", () => {
             .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, "      - PIZZAPI_EXTRA_ORIGINS=https://example.com\n")
             .replace(/\{\{TRUST_PROXY_LINE}}/g, "      # - PIZZAPI_TRUST_PROXY=\n")
             .replace(/\{\{PROXY_DEPTH_LINE}}/g, "      # - PIZZAPI_PROXY_DEPTH=\n")
-            .replace(/\{\{PREBUILT_UI}}/g, "true");
+            .replace(/\{\{PREBUILT_UI}}/g, "true")
+            .replace(/\{\{UI_DIST_HASH}}/g, "abc123def456");
 
         // No unsubstituted placeholders remain
         expect(composed).not.toContain("{{");
@@ -203,7 +206,8 @@ describe("readBooleanEnv", () => {
             .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, "      # - PIZZAPI_EXTRA_ORIGINS=\n")
             .replace(/\{\{TRUST_PROXY_LINE}}/g, "      # - PIZZAPI_TRUST_PROXY=\n")
             .replace(/\{\{PROXY_DEPTH_LINE}}/g, "      # - PIZZAPI_PROXY_DEPTH=\n")
-            .replace(/\{\{PREBUILT_UI}}/g, "false");
+            .replace(/\{\{PREBUILT_UI}}/g, "false")
+            .replace(/\{\{UI_DIST_HASH}}/g, "none");
 
         expect(composed).toContain("# - PIZZAPI_EXTRA_ORIGINS=");
         expect(composed).not.toContain("{{");

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -71,6 +71,25 @@ function hashFile(path: string): string | null {
     }
 }
 
+/**
+ * Compute a short content hash of the UI dist/ directory for Docker cache-busting.
+ * Uses the .build-stamp file (written on every prebuild) as a fast proxy —
+ * if it's missing, falls back to hashing the index.html.
+ */
+function computeDistHash(distDir: string): string {
+    const stampPath = join(distDir, ".build-stamp");
+    const indexPath = join(distDir, "index.html");
+    try {
+        const content = existsSync(stampPath)
+            ? readFileSync(stampPath, "utf-8")
+            : readFileSync(indexPath, "utf-8");
+        return createHash("sha256").update(content).digest("hex").slice(0, 12);
+    } catch {
+        // Fallback: unique per invocation so Docker always rebuilds
+        return Date.now().toString(36);
+    }
+}
+
 function computeUiSignature(repoPath: string): string | null {
     try {
         const head = execFileSync("git", ["-C", repoPath, "rev-parse", "HEAD"], { encoding: "utf-8" }).trim();
@@ -566,6 +585,7 @@ services:
       dockerfile: Dockerfile
       args:
         PREBUILT_UI: "{{PREBUILT_UI}}"
+        UI_DIST_HASH: "{{UI_DIST_HASH}}"
     ports:
       - "{{PORT}}:7492"
     environment:
@@ -590,6 +610,8 @@ export interface PrebuildResult {
     prebuilt: boolean;
     /** Whether a build was actually performed (vs. cache hit) */
     rebuilt: boolean;
+    /** Content hash of dist/ for Docker cache-busting (only set when prebuilt=true) */
+    distHash?: string;
 }
 
 /**
@@ -645,7 +667,7 @@ function prebuildUI(repoPath: string): PrebuildResult {
         if (!needsUiBuild && distReady) {
             console.log("  Host UI build is up to date (reusing dist/).");
             if (stateDirty) saveHostBuildState(state);
-            return { prebuilt: true, rebuilt: false };
+            return { prebuilt: true, rebuilt: false, distHash: computeDistHash(uiDist) };
         }
 
         // Explicitly clean dist/ before building to prevent stale artifacts.
@@ -674,7 +696,7 @@ function prebuildUI(repoPath: string): PrebuildResult {
                 stateDirty = true;
             }
             if (stateDirty) saveHostBuildState(state);
-            return { prebuilt: true, rebuilt: true };
+            return { prebuilt: true, rebuilt: true, distHash: computeDistHash(uiDist) };
         }
     } catch (err) {
         console.warn("Warning: Host UI build failed, falling back to Docker build.");
@@ -704,7 +726,7 @@ function writeBuildStamp(distDir: string): void {
     }
 }
 
-function generateComposeFile(repoPath: string, config: WebConfig, prebuiltUi: boolean): string {
+function generateComposeFile(repoPath: string, config: WebConfig, prebuiltUi: boolean, uiDistHash?: string): string {
     const composePath = join(WEB_DIR, "compose.yml");
     mkdirSync(WEB_DIR, { recursive: true });
 
@@ -765,7 +787,8 @@ function generateComposeFile(repoPath: string, config: WebConfig, prebuiltUi: bo
         .replace(/\{\{EXTRA_ORIGINS_LINE}}/g, extraOriginsLine)
         .replace(/\{\{TRUST_PROXY_LINE}}/g, trustProxyLine)
         .replace(/\{\{PROXY_DEPTH_LINE}}/g, proxyDepthLine)
-        .replace(/\{\{PREBUILT_UI}}/g, prebuiltUi ? "true" : "false");
+        .replace(/\{\{PREBUILT_UI}}/g, prebuiltUi ? "true" : "false")
+        .replace(/\{\{UI_DIST_HASH}}/g, uiDistHash ?? "none");
 
     // Only write if changed
     const existing = existsSync(composePath) ? readFileSync(composePath, "utf-8") : null;
@@ -1054,7 +1077,7 @@ export async function runWeb(args: string[]): Promise<void> {
     const prebuildResult: PrebuildResult = useHostPrebuild
         ? prebuildUI(repoPath)
         : { prebuilt: false, rebuilt: false };
-    const composePath = generateComposeFile(repoPath, config, prebuildResult.prebuilt);
+    const composePath = generateComposeFile(repoPath, config, prebuildResult.prebuilt, prebuildResult.distHash);
 
     console.log(`Starting PizzaPi web on port ${config.port}...`);
     console.log(`  Repo:    ${repoPath}`);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -190,6 +190,9 @@ export function App() {
   /** Set of session IDs that currently have a pending AskUserQuestion. */
   const [sessionsAwaitingInput, setSessionsAwaitingInput] = React.useState<Set<string>>(new Set());
 
+  /** Set of session IDs that are actively compacting their context window. */
+  const [sessionsCompacting, setSessionsCompacting] = React.useState<Set<string>>(new Set());
+
   /** Pending plan mode prompt from the worker — shown as a plan review panel in the viewer. */
   const [pendingPlan, setPendingPlan] = React.useState<{
     toolCallId: string;
@@ -867,6 +870,14 @@ export function App() {
       if (state.isCompacting) {
         setViewerStatus("Compacting…");
       }
+      const snapSessionId = activeSessionRef.current;
+      if (snapSessionId) {
+        setSessionsCompacting((prev) => {
+          const next = new Set(prev);
+          if (state.isCompacting) { next.add(snapSessionId); } else { next.delete(snapSessionId); }
+          return next;
+        });
+      }
     }
 
     if (Object.prototype.hasOwnProperty.call(state, "retryState")) {
@@ -991,6 +1002,14 @@ export function App() {
     if (patch.isCompacting !== undefined) {
       setIsCompacting(patch.isCompacting);
       cachePatch.isCompacting = patch.isCompacting;
+      const patchSessionId = activeSessionRef.current;
+      if (patchSessionId) {
+        setSessionsCompacting((prev) => {
+          const next = new Set(prev);
+          if (patch.isCompacting) { next.add(patchSessionId); } else { next.delete(patchSessionId); }
+          return next;
+        });
+      }
       if (patch.viewerStatusOverride) {
         setViewerStatus(patch.viewerStatusOverride);
       } else if (!patch.isCompacting) {
@@ -1113,6 +1132,15 @@ export function App() {
 
       setAgentActive(nextAgentActive);
       setIsCompacting(nextIsCompacting);
+
+      const hbSessionId = activeSessionRef.current;
+      if (hbSessionId) {
+        setSessionsCompacting((prev) => {
+          const next = new Set(prev);
+          if (nextIsCompacting) { next.add(hbSessionId); } else { next.delete(hbSessionId); }
+          return next;
+        });
+      }
 
       if (nextIsCompacting) {
         setViewerStatus("Compacting…");
@@ -1612,6 +1640,10 @@ export function App() {
 
       if (command === "compact") {
         setIsCompacting(false);
+        const compactDoneId = activeSessionRef.current;
+        if (compactDoneId) {
+          setSessionsCompacting((prev) => { const next = new Set(prev); next.delete(compactDoneId); return next; });
+        }
         const tokensBefore = typeof result?.tokensBefore === "number" ? result.tokensBefore : 0;
         const summary = typeof result?.summary === "string"
           ? `Compacted (${tokensBefore > 0 ? `${Math.round(tokensBefore / 1000)}k tokens summarized` : "done"})`
@@ -3818,6 +3850,7 @@ export function App() {
               onSelectRunner={setSelectedRunnerId}
               onShowSessions={() => setShowRunners(false)}
               sessionsAwaitingInput={sessionsAwaitingInput}
+              sessionsCompacting={sessionsCompacting}
             />
           </ErrorBoundary>
         </div>

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2163,6 +2163,21 @@ export function App() {
         });
       }
 
+      // Track compaction state for ANY session's meta event (same pattern as
+      // sessionsAwaitingInput above) so the sidebar shows the yellow chase
+      // indicator even for background sessions.
+      if (payload.type === "compact_started" || payload.type === "compact_ended") {
+        setSessionsCompacting((prev) => {
+          const next = new Set(prev);
+          if (payload.type === "compact_started") {
+            next.add(payload.sessionId);
+          } else {
+            next.delete(payload.sessionId);
+          }
+          return next;
+        });
+      }
+
       const currentSessionId = activeSessionRef.current;
       if (payload.sessionId !== currentSessionId) return;
       const { sessionId, version, ...event } = payload;

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -106,6 +106,8 @@ export interface SessionSidebarProps {
     onSelectRunner?: (runnerId: string) => void;
     /** Set of session IDs that currently have a pending AskUserQuestion or plan_mode review. */
     sessionsAwaitingInput?: Set<string>;
+    /** Set of session IDs that are actively compacting their context window. */
+    sessionsCompacting?: Set<string>;
 }
 
 function formatRelativeDate(isoString: string): string {
@@ -192,6 +194,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     onSelectRunner,
     onShowSessions,
     sessionsAwaitingInput,
+    sessionsCompacting,
 }: SessionSidebarProps) {
     const [collapsed, setCollapsed] = React.useState(false);
 
@@ -1316,9 +1319,11 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                             "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
                                                             !hasOffset && "transition-transform duration-200 ease-out",
                                                             visualState === "selected" && "bg-sidebar-accent text-sidebar-accent-foreground",
-                                                            visualState === "selectedActive" && "bg-sidebar-accent text-sidebar-accent-foreground animate-selected-active-chase",
+                                                            visualState === "selectedActive" && !sessionsCompacting?.has(s.sessionId) && "bg-sidebar-accent text-sidebar-accent-foreground animate-selected-active-chase",
+                                                            visualState === "selectedActive" && sessionsCompacting?.has(s.sessionId) && "bg-sidebar-accent text-sidebar-accent-foreground animate-compacting-chase",
                                                             visualState === "awaiting" && "text-sidebar-foreground animate-awaiting-pulse",
-                                                            visualState === "active" && "text-sidebar-foreground animate-working-chase",
+                                                            visualState === "active" && !sessionsCompacting?.has(s.sessionId) && "text-sidebar-foreground animate-working-chase",
+                                                            visualState === "active" && sessionsCompacting?.has(s.sessionId) && "text-sidebar-foreground animate-compacting-chase",
                                                             visualState === "completedUnread" && "text-sidebar-foreground animate-completed-pulse",
                                                             visualState === "idle" && "bg-sidebar text-sidebar-foreground hover:bg-sidebar-accent/50",
                                                         )}
@@ -1397,8 +1402,10 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         <div
                                                             className={cn(
                                                                 "relative flex-shrink-0 flex items-center justify-center w-7 h-7 rounded-md transition-all duration-300",
-                                                                visualState === "active" && "bg-blue-500/20 shadow-[0_0_8px_#3b82f680] animate-pulse",
-                                                                visualState === "selectedActive" && "bg-blue-500/10 shadow-[0_0_6px_#3b82f640] animate-pulse",
+                                                                visualState === "active" && !sessionsCompacting?.has(s.sessionId) && "bg-blue-500/20 shadow-[0_0_8px_#3b82f680] animate-pulse",
+                                                                visualState === "active" && sessionsCompacting?.has(s.sessionId) && "bg-yellow-500/20 shadow-[0_0_8px_#eab30880] animate-pulse",
+                                                                visualState === "selectedActive" && !sessionsCompacting?.has(s.sessionId) && "bg-blue-500/10 shadow-[0_0_6px_#3b82f640] animate-pulse",
+                                                                visualState === "selectedActive" && sessionsCompacting?.has(s.sessionId) && "bg-yellow-500/10 shadow-[0_0_6px_#eab30840] animate-pulse",
                                                                 visualState === "awaiting" && "bg-amber-500/20 shadow-[0_0_8px_#f59e0b60]",
                                                                 visualState === "completedUnread" && "bg-green-500/20 shadow-[0_0_8px_#22c55e60]",
                                                                 (visualState === "idle" || visualState === "selected") && "bg-sidebar-accent/50",

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1191,6 +1191,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                 isSelected: isActiveSession || (selectMode && isChecked),
                                                 isAwaiting: !!sessionsAwaitingInput?.has(s.sessionId),
                                                 isActive: !!s.isActive,
+                                                isCompacting: !!sessionsCompacting?.has(s.sessionId),
                                                 isCompletedUnread: completedUnreadSessions.has(s.sessionId),
                                             });
                                             const provider = s.model?.provider ??

--- a/packages/ui/src/lib/session-visual-state.test.ts
+++ b/packages/ui/src/lib/session-visual-state.test.ts
@@ -55,4 +55,34 @@ describe("getSessionVisualState", () => {
       isSelected: true,
     })).toBe("selectedActive");
   });
+
+  test("returns 'active' when compacting but not heartbeat-active", () => {
+    expect(getSessionVisualState({
+      isActive: false,
+      isAwaiting: false,
+      isCompletedUnread: false,
+      isSelected: false,
+      isCompacting: true,
+    })).toBe("active");
+  });
+
+  test("returns 'selectedActive' when selected and compacting", () => {
+    expect(getSessionVisualState({
+      isActive: false,
+      isAwaiting: false,
+      isCompletedUnread: false,
+      isSelected: true,
+      isCompacting: true,
+    })).toBe("selectedActive");
+  });
+
+  test("awaiting still wins over compacting", () => {
+    expect(getSessionVisualState({
+      isActive: false,
+      isAwaiting: true,
+      isCompletedUnread: false,
+      isSelected: false,
+      isCompacting: true,
+    })).toBe("awaiting");
+  });
 });

--- a/packages/ui/src/lib/session-visual-state.ts
+++ b/packages/ui/src/lib/session-visual-state.ts
@@ -5,17 +5,23 @@ export interface SessionVisualStateInput {
   isAwaiting: boolean;
   isActive: boolean;
   isCompletedUnread: boolean;
+  /** Session is compacting its context — treated as "active" for visual purposes. */
+  isCompacting?: boolean;
 }
 
 /**
  * Determine the visual state of a sidebar session row.
  * Priority: selected (+ active variant) > awaiting > active > completedUnread > idle.
+ *
+ * Compacting is treated as active: the agent is doing internal work (context
+ * compaction) even though the heartbeat reports `active: false`.
  */
 export function getSessionVisualState(input: SessionVisualStateInput): SessionVisualState {
-  if (input.isSelected && input.isActive) return "selectedActive";
+  const effectivelyActive = input.isActive || !!input.isCompacting;
+  if (input.isSelected && effectivelyActive) return "selectedActive";
   if (input.isSelected) return "selected";
   if (input.isAwaiting) return "awaiting";
-  if (input.isActive) return "active";
+  if (effectivelyActive) return "active";
   if (input.isCompletedUnread) return "completedUnread";
   return "idle";
 }

--- a/packages/ui/src/style.css
+++ b/packages/ui/src/style.css
@@ -137,6 +137,41 @@
   pointer-events: none;
 }
 
+/* Compacting — yellow/amber dot chase */
+.animate-compacting-chase {
+  isolation: isolate;
+}
+
+.animate-compacting-chase::after {
+  content: '';
+  position: absolute;
+  inset: 1.5px;
+  border-radius: 5px;
+  background: var(--sidebar);
+  z-index: -1;
+  pointer-events: none;
+}
+
+.animate-compacting-chase::before {
+  content: '';
+  position: absolute;
+  inset: -1.5px;
+  border-radius: 8px;
+  background: conic-gradient(from var(--chase-angle),
+    transparent                  0deg,
+    transparent                  290deg,
+    oklch(0.65 0.18  80 / 0)     290deg,
+    oklch(0.75 0.20  80 / 0.4)   310deg,
+    oklch(0.88 0.22  85 / 0.85)  330deg,
+    oklch(0.97 0.18  90 / 1)     345deg,
+    oklch(0.88 0.22  85 / 0.5)   355deg,
+    oklch(0.65 0.18  80 / 0)     360deg
+  );
+  animation: chase-spin 2s linear infinite;
+  z-index: -1;
+  pointer-events: none;
+}
+
 /* Awaiting input — soft amber pulse */
 @keyframes awaiting-pulse {
   0%, 100% {


### PR DESCRIPTION
## Summary

Adds a small yellow conic-gradient chase animation to sidebar session rows that are actively compacting their context window.

## Changes

- **`style.css`** — New `.animate-compacting-chase` class: yellow/amber conic-gradient border chase, identical in structure to the existing blue `.animate-working-chase` but using warm yellow oklch hues.
- **`SessionSidebar.tsx`** — New `sessionsCompacting?: Set<string>` prop. When a session is in that set, the button gets the yellow chase instead of the blue active/selectedActive chase, and the provider icon box glows yellow instead of blue.
- **`App.tsx`** — New `sessionsCompacting` React state (`Set<string>`), updated from:
  - `applyMetaStateSnapshot` (on session connect/restore)
  - `applyMetaPatch` (compact_started / compact_ended meta events)
  - Heartbeat handler (`isCompacting` field)
  - `compact` command result handler

## Behavior

The yellow chase replaces the blue active chase for the duration of compaction. It appears on any sidebar row the moment compaction starts — including background sessions — and disappears automatically when compaction ends.