### PR TITLE
feat: plugin service panels — folder-based services with iframe UI panels

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ Library/Caches/
 # Tool artifacts
 .playwright-cli/
 .python-version
+01-landing.png
+.playwright-cli/

--- a/.pizzapi/skills/testing-sandbox-ui/SKILL.md
+++ b/.pizzapi/skills/testing-sandbox-ui/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: testing-sandbox-ui
+description: Use when testing UI features, service panels, or visual behavior in the PizzaPi sandbox using a headless browser. Use when verifying new UI components work end-to-end before merging.
+---
+
+# Testing Sandbox UI with Playwright
+
+## Overview
+
+The PizzaPi sandbox (`packages/server/tests/harness/sandbox.ts`) spins up a full server with mock sessions, runners, and services. Combined with `playwright-cli`, you can drive a real browser against it to verify UI features work end-to-end — login, navigation, service panels, iframes, etc.
+
+## When to Use
+
+- Verifying new UI components render correctly in the full app
+- Testing service panel iframe loading through the tunnel proxy
+- Checking auth flows (login, session management)
+- Visual regression checks before merging UI branches
+- Any time you need to confirm "does this actually work in a browser?"
+
+## Quick Reference
+
+| Step | Command |
+|------|---------|
+| Start sandbox | `screen -dmS sandbox bash -c 'cd packages/server && exec bun tests/harness/sandbox.ts --headless --redis=memory > /tmp/sandbox-out.log 2>&1'` |
+| Wait for ready | `grep "Sandbox ready" /tmp/sandbox-out.log` |
+| Extract UI URL | `grep "UI (HMR)" /tmp/sandbox-out.log` |
+| Open browser | `playwright-cli open <URL>` |
+| Get element refs | `playwright-cli snapshot` then read the `.yml` file |
+| Interact | `playwright-cli fill <ref> "text"` / `playwright-cli click <ref>` |
+| Screenshot | `playwright-cli screenshot` then read the `.png` file |
+| Clean up | `playwright-cli close && screen -S sandbox -X quit` |
+
+## Starting the Sandbox
+
+**Critical: Use `screen` on macOS.** Background processes started with `nohup &` get killed when the parent bash command times out. `screen` detaches the process from the shell entirely.
+
+```bash
+# Start in a detached screen session
+screen -dmS sandbox bash -c \
+  'cd packages/server && exec bun tests/harness/sandbox.ts --headless --redis=memory > /tmp/sandbox-out.log 2>&1'
+
+# Wait for startup (typically 4-6 seconds)
+sleep 6
+
+# Verify it's running
+pgrep -f "sandbox.ts" && echo "alive" || echo "dead"
+
+# Extract URLs from the log
+grep "UI (HMR)" /tmp/sandbox-out.log   # → http://127.0.0.1:<port>
+grep "Server:"  /tmp/sandbox-out.log   # → http://127.0.0.1:<port>
+grep "API:"     /tmp/sandbox-out.log   # → http://127.0.0.1:<port>
+```
+
+The sandbox starts three things on random ports:
+- **Vite dev server** (UI with HMR) — this is where you point the browser
+- **API server** (WebSocket + REST) — the Vite proxy forwards to this
+- **Sandbox API** (HTTP control surface) — for programmatic session control
+
+## Logging In
+
+The sandbox creates a test user automatically:
+
+| Field | Value |
+|-------|-------|
+| Email | `testuser@pizzapi-harness.test` |
+| Password | `HarnessPass123` |
+
+```bash
+playwright-cli open http://127.0.0.1:<vite-port>
+playwright-cli snapshot                              # find email/password input refs
+playwright-cli fill <email-ref> "testuser@pizzapi-harness.test"
+playwright-cli fill <password-ref> "HarnessPass123"
+playwright-cli snapshot                              # find sign-in button ref (not disabled)
+playwright-cli click <button-ref>
+playwright-cli screenshot                            # verify logged in
+```
+
+## Testing Service Panels
+
+After logging in, select a session from the sidebar. Service panel buttons appear in the session toolbar header. Look for buttons like "Toggle System Monitor" in the snapshot.
+
+```bash
+playwright-cli snapshot
+# grep for "monitor\|panel\|service\|tunnel" in the .yml file
+playwright-cli click <panel-button-ref>
+sleep 2                                              # wait for iframe to load
+playwright-cli screenshot                            # verify panel renders
+```
+
+The panel loads via iframe → tunnel proxy → mock HTTP server. The sandbox starts a mock system monitor server on a random port and announces it through the mock runner's `service_announce` event.
+
+## Cleanup
+
+**Always clean up both browser and sandbox:**
+
+```bash
+playwright-cli close                    # close browser
+screen -S sandbox -X quit              # kill sandbox screen session
+pkill -f "sandbox.ts" 2>/dev/null      # belt-and-suspenders
+```
+
+## Common Problems
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| "Invalid origin" on login | Vite dev server port not in `trustedOrigins` | Fixed in `49116fc8` — `addTrustedOrigin()` called after Vite starts |
+| Sandbox dies immediately | Shell timeout kills background process | Use `screen -dmS` instead of `nohup &` |
+| "net::ERR_CONNECTION_REFUSED" | Sandbox process died or hasn't started yet | Check `pgrep -f sandbox.ts` and `/tmp/sandbox-out.log` |
+| Stale element refs | DOM changed since last snapshot | Re-run `playwright-cli snapshot` to get fresh refs |
+| Panel iframe blank | Tunnel proxy can't reach mock server | Check sandbox log for "Mock system monitor panel on port X" |
+| "Server running in degraded mode" banner | Redis in-memory mode (expected) | Harmless — real-time updates work, it's just a warning |
+
+## Mock Runner Capabilities
+
+The sandbox mock runner (`mock-runner.ts`) supports:
+
+- **`panels` option** — `ServicePanelInfo[]` included in `service_announce`
+- **`tunnel_request` handling** — proxies HTTP to registered panel ports
+- **`announceServices(serviceIds, panels?)`** — re-announce at runtime
+
+To add a new mock service panel, start a `Bun.serve({ port: 0 })` before creating the runner and pass the port in the `panels` array.
+
+## Sandbox Credentials & URLs
+
+All ports are ephemeral (random). Always extract from `/tmp/sandbox-out.log`:
+
+```bash
+# One-liner to extract all three URLs
+grep -E "(UI|Server|API):" /tmp/sandbox-out.log
+```
+
+API key is also in the log if you need direct API access.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "dev": "bun src/index.ts",
     "dev:runner": "bun src/index.ts runner",
-    "build": "tsc --build --force && rm -rf dist/templates && cp -r src/templates dist/templates",
+    "build": "tsc --build --force && rm -rf dist/templates && cp -r src/templates dist/templates && rm -rf dist/skills && cp -r src/skills dist/skills",
     "start": "bun dist/index.js",
     "build:binary": "bun build-binaries.ts --target",
     "build:binary:linux-x64": "bun build-binaries.ts --target linux-x64",

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -223,7 +223,23 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         registry.register(new TerminalService());
         registry.register(new FileExplorerService());
         registry.register(new GitService());
-        registry.register(new TunnelService());
+        const tunnelService = new TunnelService();
+        registry.register(tunnelService);
+
+        // Panel tracking — manifests from folder-based services, ports from announcePanel()
+        type PanelEntry = { serviceId: string; label: string; icon: string; port?: number };
+        const panelEntries = new Map<string, PanelEntry>();
+
+        /** Emit service_announce with current service IDs and panel metadata. */
+        const emitServiceAnnounce = () => {
+            const allServiceIds = registry.getAll().map((s) => s.id);
+            const panels = Array.from(panelEntries.values())
+                .filter((p): p is PanelEntry & { port: number } => p.port != null);
+            (socket as any).emit("service_announce", {
+                serviceIds: allServiceIds,
+                ...(panels.length > 0 ? { panels } : {}),
+            });
+        };
 
         // Discover and register plugin-provided services.
         // pluginServicesReady resolves once discovery + registration is complete.
@@ -231,10 +247,18 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         let resolvePluginServices: () => void;
         const pluginServicesReady = new Promise<void>(r => { resolvePluginServices = r; });
         discoverServices({ pluginDirs: globalPluginDirs() }).then(({ services, errors }) => {
-            for (const { handler, source } of services) {
+            for (const { handler, source, manifest } of services) {
                 try {
                     registry.register(handler);
                     logInfo(`[services] loaded plugin service "${handler.id}" from ${source.pluginName ?? source.path}`);
+                    // Track panel metadata from folder-based services
+                    if (manifest?.panel) {
+                        panelEntries.set(handler.id, {
+                            serviceId: handler.id,
+                            label: manifest.label,
+                            icon: manifest.icon,
+                        });
+                    }
                 } catch (err) {
                     logWarn(`[services] failed to register plugin service "${handler.id}": ${err}`);
                 }
@@ -350,10 +374,29 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 registry.disposeAll();
             }
             servicesInitialized = true;
-            registry.initAll(socket, { isShuttingDown: () => isShuttingDown });
+            // Build announcePanel callback — when a service calls it, we register
+            // the port with the tunnel service and re-announce to viewers.
+            const announcePanel = (serviceId: string) => (port: number) => {
+                const entry = panelEntries.get(serviceId);
+                if (!entry) return;
+                entry.port = port;
+                tunnelService.registerPort(port, entry.label);
+                logInfo(`[services] panel announced for "${serviceId}" on port ${port}`);
+                // Re-announce so viewers pick up the panel
+                emitServiceAnnounce();
+            };
+
+            // Init all services — pass announcePanel to those with panel manifests
+            for (const handler of registry.getAll()) {
+                const opts: any = { isShuttingDown: () => isShuttingDown };
+                if (panelEntries.has(handler.id)) {
+                    opts.announcePanel = announcePanel(handler.id);
+                }
+                handler.init(socket, opts);
+            }
             const allServiceIds = registry.getAll().map((s) => s.id);
             logInfo(`[services] initialized ${allServiceIds.length} services: ${allServiceIds.join(", ")}`);
-            (socket as any).emit("service_announce", { serviceIds: allServiceIds });
+            emitServiceAnnounce();
 
             // Re-adopt orphaned sessions that survived a daemon restart.
             // Their worker processes are still running and connected to the relay.
@@ -448,9 +491,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     // map — by the time session_ready fires the session is
                     // registered there, so this announce is guaranteed to reach
                     // any already-connected viewer for this session.
-                    (socket as any).emit("service_announce", {
-                        serviceIds: registry.getAll().map((s) => s.id),
-                    });
+                    emitServiceAnnounce();
                 } catch (err) {
                     socket.emit("session_error", {
                         sessionId,

--- a/packages/cli/src/runner/service-handler.ts
+++ b/packages/cli/src/runner/service-handler.ts
@@ -23,6 +23,8 @@ export interface ServiceHandler {
 
 export interface ServiceInitOptions {
     isShuttingDown: () => boolean;
+    /** Call to announce a panel HTTP server port. Only provided to services with a panel manifest. */
+    announcePanel?: (port: number) => void;
 }
 
 /**

--- a/packages/cli/src/runner/service-loader.test.ts
+++ b/packages/cli/src/runner/service-loader.test.ts
@@ -6,6 +6,7 @@ import {
     discoverServices,
     globalServicesDir,
     projectServicesDir,
+    type ServiceManifest,
 } from "./service-loader.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -406,5 +407,148 @@ describe("discoverServices — plugin manifest discovery", () => {
         } finally {
             process.env.HOME = origHome;
         }
+    });
+});
+
+// ── Folder-based service discovery ────────────────────────────────────────────
+
+describe("discoverServices — folder-based services", () => {
+    let tmpDir: string;
+    let servicesDir: string;
+    let origHome: string;
+
+    beforeEach(() => {
+        tmpDir = makeTmpDir();
+        servicesDir = join(tmpDir, ".pizzapi", "services");
+        mkdirSync(servicesDir, { recursive: true });
+        origHome = process.env.HOME!;
+        process.env.HOME = tmpDir;
+    });
+
+    afterEach(() => {
+        process.env.HOME = origHome;
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function writeFolderService(name: string, manifest: Record<string, unknown>, handlerId?: string): string {
+        const dir = join(servicesDir, name);
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify(manifest));
+        const id = handlerId ?? (manifest.id as string) ?? name;
+        writeFileSync(
+            join(dir, "index.ts"),
+            `export default class {
+  get id() { return "${id}"; }
+  init() {}
+  dispose() {}
+}
+`,
+        );
+        return dir;
+    }
+
+    test("loads a folder-based service with manifest.json", async () => {
+        writeFolderService("my-panel", {
+            id: "my-panel",
+            label: "My Panel",
+            icon: "activity",
+            panel: { dir: "./panel" },
+        });
+
+        const result = await discoverServices();
+        expect(result.errors).toHaveLength(0);
+        expect(result.services).toHaveLength(1);
+        expect(result.services[0].handler.id).toBe("my-panel");
+        expect(result.services[0].manifest).toBeDefined();
+        expect(result.services[0].manifest!.label).toBe("My Panel");
+        expect(result.services[0].manifest!.icon).toBe("activity");
+        expect(result.services[0].manifest!.panel).toEqual({ dir: "./panel" });
+    });
+
+    test("uses default icon when not specified in manifest", async () => {
+        writeFolderService("no-icon", {
+            id: "no-icon",
+            label: "No Icon Service",
+        });
+
+        const result = await discoverServices();
+        expect(result.services).toHaveLength(1);
+        expect(result.services[0].manifest!.icon).toBe("square");
+    });
+
+    test("errors when manifest is missing required fields", async () => {
+        const dir = join(servicesDir, "bad-manifest");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({ icon: "cpu" }));
+        writeFileSync(join(dir, "index.ts"), `export default { id: "bad", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.services).toHaveLength(0);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].error).toContain("missing required");
+    });
+
+    test("errors when entry point does not exist", async () => {
+        const dir = join(servicesDir, "no-entry");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "no-entry",
+            label: "No Entry",
+            entry: "./missing.ts",
+        }));
+
+        const result = await discoverServices();
+        expect(result.services).toHaveLength(0);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0].error).toContain("does not exist");
+    });
+
+    test("skips directories without manifest.json", async () => {
+        const dir = join(servicesDir, "no-manifest");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "index.ts"), `export default { id: "nm", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.services).toHaveLength(0);
+        expect(result.errors).toHaveLength(0);
+    });
+
+    test("coexists with file-based services", async () => {
+        writeFolderService("folder-svc", {
+            id: "folder-svc",
+            label: "Folder Service",
+            icon: "box",
+            panel: {},
+        });
+        writeHandler(servicesDir, "file-svc.ts", "file-svc");
+
+        const result = await discoverServices();
+        expect(result.errors).toHaveLength(0);
+        expect(result.services).toHaveLength(2);
+        const ids = result.services.map(s => s.handler.id).sort();
+        expect(ids).toEqual(["file-svc", "folder-svc"]);
+        const folderResult = result.services.find(s => s.handler.id === "folder-svc");
+        const fileResult = result.services.find(s => s.handler.id === "file-svc");
+        expect(folderResult!.manifest).toBeDefined();
+        expect(fileResult!.manifest).toBeUndefined();
+    });
+
+    test("respects custom entry path in manifest", async () => {
+        const dir = join(servicesDir, "custom-entry");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "custom-entry",
+            label: "Custom Entry",
+            entry: "./service.ts",
+        }));
+        writeFileSync(
+            join(dir, "service.ts"),
+            `export default { id: "custom-entry", init() {}, dispose() {} };`,
+        );
+
+        const result = await discoverServices();
+        expect(result.errors).toHaveLength(0);
+        expect(result.services).toHaveLength(1);
+        expect(result.services[0].handler.id).toBe("custom-entry");
     });
 });

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -20,9 +20,22 @@ import type { ServiceHandler } from "./service-handler.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+/** Manifest for folder-based service plugins. */
+export interface ServiceManifest {
+    id: string;
+    label: string;
+    icon: string;
+    entry?: string;
+    panel?: {
+        dir?: string;
+    };
+}
+
 export interface ServicePluginResult {
     handler: ServiceHandler;
     source: ServicePluginSource;
+    /** Present for folder-based services with a manifest.json. */
+    manifest?: ServiceManifest;
 }
 
 export interface ServicePluginSource {
@@ -87,38 +100,85 @@ async function loadServicesFromDir(
     }
 
     for (const entry of entries) {
-        // Skip dotfiles, test files, type declarations
+        // Skip dotfiles and underscore-prefixed entries
         if (entry.startsWith(".") || entry.startsWith("_")) continue;
+
+        const entryPath = join(dir, entry);
+        let stats;
+        try {
+            stats = statSync(entryPath);
+        } catch {
+            continue;
+        }
+
+        // ── Directory: folder-based service with manifest.json ────────────
+        if (stats.isDirectory()) {
+            const manifestPath = join(entryPath, "manifest.json");
+            if (!existsSync(manifestPath)) continue;
+
+            try {
+                const manifest = parseServiceManifest(manifestPath);
+                const moduleEntry = manifest.entry ?? findDefaultEntry(entryPath);
+                if (!moduleEntry) {
+                    errors.push({
+                        path: entryPath,
+                        error: "No entry point found (no 'entry' in manifest and no index.ts/index.js)",
+                    });
+                    continue;
+                }
+                const modulePath = resolve(entryPath, moduleEntry);
+                if (!existsSync(modulePath)) {
+                    errors.push({
+                        path: modulePath,
+                        error: `Service entry "${moduleEntry}" declared in manifest does not exist`,
+                    });
+                    continue;
+                }
+
+                const handler = await loadServiceModule(modulePath);
+                if (handler) {
+                    services.push({
+                        handler,
+                        source: { origin, path: entryPath },
+                        manifest,
+                    });
+                } else {
+                    errors.push({
+                        path: modulePath,
+                        error: "Module does not export a valid ServiceHandler (needs default export with id, init, dispose)",
+                    });
+                }
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                errors.push({ path: entryPath, error: msg });
+            }
+            continue;
+        }
+
+        // ── File: simple file-based service ───────────────────────────────
+        if (!stats.isFile()) continue;
         if (entry.includes(".test.") || entry.includes(".spec.")) continue;
         if (entry.endsWith(".d.ts") || entry.endsWith(".d.mts")) continue;
 
         const ext = extname(entry);
         if (!SERVICE_EXTENSIONS.has(ext)) continue;
 
-        const filePath = join(dir, entry);
         try {
-            const stats = statSync(filePath);
-            if (!stats.isFile()) continue;
-        } catch {
-            continue;
-        }
-
-        try {
-            const handler = await loadServiceModule(filePath);
+            const handler = await loadServiceModule(entryPath);
             if (handler) {
                 services.push({
                     handler,
-                    source: { origin, path: filePath },
+                    source: { origin, path: entryPath },
                 });
             } else {
                 errors.push({
-                    path: filePath,
+                    path: entryPath,
                     error: "Module does not export a valid ServiceHandler (needs default export with id, init, dispose)",
                 });
             }
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            errors.push({ path: filePath, error: msg });
+            errors.push({ path: entryPath, error: msg });
         }
     }
 
@@ -271,6 +331,39 @@ function readServiceDeclarations(pluginDir: string, pluginName: string): Service
         }
     }
 
+    return null;
+}
+
+// ── Service manifest parsing ──────────────────────────────────────────────────
+
+function parseServiceManifest(manifestPath: string): ServiceManifest {
+    const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
+    if (!raw || typeof raw !== "object") {
+        throw new Error("manifest.json is not a JSON object");
+    }
+    if (typeof raw.id !== "string" || !raw.id) {
+        throw new Error('manifest.json missing required "id" field');
+    }
+    if (typeof raw.label !== "string" || !raw.label) {
+        throw new Error('manifest.json missing required "label" field');
+    }
+    return {
+        id: raw.id,
+        label: raw.label,
+        icon: typeof raw.icon === "string" ? raw.icon : "square",
+        entry: typeof raw.entry === "string" ? raw.entry : undefined,
+        panel: raw.panel && typeof raw.panel === "object"
+            ? { dir: typeof raw.panel.dir === "string" ? raw.panel.dir : undefined }
+            : undefined,
+    };
+}
+
+const DEFAULT_ENTRIES = ["index.ts", "index.js", "index.mts", "index.mjs"];
+
+function findDefaultEntry(dir: string): string | null {
+    for (const name of DEFAULT_ENTRIES) {
+        if (existsSync(join(dir, name))) return `./${name}`;
+    }
     return null;
 }
 

--- a/packages/cli/src/runner/services/tunnel-service.ts
+++ b/packages/cli/src/runner/services/tunnel-service.ts
@@ -107,6 +107,29 @@ export class TunnelService implements ServiceHandler {
         this.socket = null;
     }
 
+    // ── Internal API (called by daemon, not via socket) ───────────────────
+
+    /**
+     * Register a port for HTTP proxying without a viewer-initiated tunnel_expose.
+     * Used by the daemon to auto-expose panel ports from folder-based services.
+     */
+    registerPort(port: number, name?: string): void {
+        if (this.tunnels.has(port)) return;
+        const url = `/tunnel/${port}`;
+        const info: TunnelInfo = { port, ...(name ? { name } : {}), url };
+        this.tunnels.set(port, info);
+        logInfo(`[tunnel] auto-registered panel port ${port}${name ? ` (${name})` : ""}`);
+
+        // Announce to server so it knows the port is proxiable
+        if (this.socket) {
+            (this.socket as any).emit("service_message", {
+                serviceId: "tunnel",
+                type: "tunnel_registered",
+                payload: info,
+            } satisfies ServiceEnvelope);
+        }
+    }
+
     // ── Command handlers ──────────────────────────────────────────────────────
 
     private handleList(requestId?: string): void {

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -9,6 +9,7 @@ import {
     readSkillContent,
     writeSkill,
     deleteSkill,
+    builtinSkillsDir,
     buildInteractiveSkillPaths,
     buildWorkerSkillPaths,
 } from "./skills.js";
@@ -434,19 +435,19 @@ describe("buildInteractiveSkillPaths", () => {
 
     test("filters out empty and whitespace-only config entries", () => {
         const paths = buildInteractiveSkillPaths("/tmp", ["", "  ", "/valid"]);
-        // Should have 2 default paths + 1 valid config path
-        expect(paths).toHaveLength(3);
-        expect(paths[2]).toBe("/valid");
+        // Should have 3 default paths (builtin + global + project) + 1 valid config path
+        expect(paths).toHaveLength(4);
+        expect(paths[3]).toBe("/valid");
     });
 
     test("handles undefined configSkills", () => {
         const paths = buildInteractiveSkillPaths("/tmp");
-        expect(paths).toHaveLength(2);
+        expect(paths).toHaveLength(3);
     });
 
     test("handles empty configSkills array", () => {
         const paths = buildInteractiveSkillPaths("/tmp", []);
-        expect(paths).toHaveLength(2);
+        expect(paths).toHaveLength(3);
     });
 });
 
@@ -482,7 +483,7 @@ describe("buildWorkerSkillPaths", () => {
 
     test("handles undefined configSkills", () => {
         const paths = buildWorkerSkillPaths("/tmp");
-        expect(paths).toHaveLength(5); // 5 default paths
+        expect(paths).toHaveLength(6); // 6 default paths (builtin + 5 existing)
     });
 });
 

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -7,8 +7,16 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { expandHome } from "./config.js";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/** Built-in skills shipped with the CLI package. */
+export function builtinSkillsDir(): string {
+    return join(__dirname, "skills");
+}
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -189,6 +197,7 @@ export function deleteSkill(name: string, dir?: string): boolean {
  */
 export function buildInteractiveSkillPaths(cwd: string, configSkills?: string[]): string[] {
     const paths: string[] = [
+        builtinSkillsDir(),
         join(homedir(), ".pizzapi", "skills"),
         join(cwd, ".pizzapi", "skills"),
     ];
@@ -211,6 +220,7 @@ export function buildInteractiveSkillPaths(cwd: string, configSkills?: string[])
  */
 export function buildWorkerSkillPaths(cwd: string, configSkills?: string[]): string[] {
     const paths: string[] = [
+        builtinSkillsDir(),
         join(cwd, ".pizzapi", "skills"),
         join(homedir(), ".pizzapi", "agents"),
         join(cwd, ".pizzapi", "agents"),

--- a/packages/cli/src/skills/creating-service-panels/SKILL.md
+++ b/packages/cli/src/skills/creating-service-panels/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: creating-service-panels
+description: Use when building a new runner service that needs a UI panel in the PizzaPi web interface, or when packaging a service as a folder-based plugin with an iframe dashboard
+---
+
+# Creating Service Panels
+
+Build runner services that ship their own UI panel, rendered as an iframe in the PizzaPi web interface. No React compilation needed — the panel is a self-contained HTML page served by the service's own HTTP server and proxied through the tunnel system.
+
+## Folder Structure
+
+```
+~/.pizzapi/services/<service-name>/
+  manifest.json       # Required — declares metadata and panel config
+  index.ts            # ServiceHandler module (default export)
+  panel/
+    index.html        # Self-contained UI (HTML/CSS/JS)
+    ...               # Any additional static assets
+```
+
+## manifest.json
+
+```json
+{
+  "id": "my-service",
+  "label": "My Service",
+  "icon": "activity",
+  "entry": "./index.ts",
+  "panel": {
+    "dir": "./panel"
+  }
+}
+```
+
+| Field       | Required | Default        | Description |
+|-------------|----------|----------------|-------------|
+| `id`        | Yes      |                | Unique service ID (must match `ServiceHandler.id`) |
+| `label`     | Yes      |                | Button label shown in the PizzaPi header bar |
+| `icon`      | No       | `"square"`     | [Lucide](https://lucide.dev/icons) icon name (kebab-case) |
+| `entry`     | No       | `./index.ts`   | Service module path relative to folder |
+| `panel.dir` | No       | `./panel`      | Panel static files directory |
+
+## ServiceHandler Template
+
+```typescript
+import { existsSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Server } from "bun";
+
+class MyService {
+    get id() { return "my-service"; }
+
+    #server: Server | null = null;
+
+    init(socket: any, { isShuttingDown, announcePanel }: any) {
+        // Resolve panel directory relative to this file
+        const panelDir = join(dirname(fileURLToPath(import.meta.url)), "panel");
+        const indexHtml = readFileSync(join(panelDir, "index.html"), "utf-8");
+
+        // Start HTTP server on a random available port
+        this.#server = Bun.serve({
+            port: 0,
+            fetch: async (req) => {
+                const url = new URL(req.url);
+
+                // API endpoints
+                if (url.pathname.endsWith("/api/data")) {
+                    const data = { /* your data */ };
+                    return new Response(JSON.stringify(data), {
+                        headers: {
+                            "Content-Type": "application/json",
+                            "Access-Control-Allow-Origin": "*",
+                        },
+                    });
+                }
+
+                // Serve panel HTML for everything else
+                return new Response(indexHtml, {
+                    headers: { "Content-Type": "text/html; charset=utf-8" },
+                });
+            },
+        });
+
+        // Announce panel port — triggers tunnel auto-registration
+        if (announcePanel) {
+            announcePanel(this.#server.port);
+        }
+
+        // Socket-based events (optional, for non-panel consumers)
+        socket.on("service_message", async (envelope: any) => {
+            if (envelope?.serviceId !== "my-service") return;
+            // Handle socket messages...
+        });
+    }
+
+    dispose() {
+        if (this.#server) {
+            this.#server.stop(true);
+            this.#server = null;
+        }
+    }
+}
+
+export default MyService;
+```
+
+## Panel HTML Guidelines
+
+The panel renders inside a 280px-tall iframe. Key constraints:
+
+- **Self-contained** — all CSS and JS inline (no build step)
+- **Dark theme** — match PizzaPi's dark UI:
+  ```css
+  body { background: #0a0a0b; color: #e4e4e7; font-size: 11px; }
+  ```
+- **Relative API URLs** — use `./api/data` (the tunnel proxy preserves the path)
+- **Polling** — use `setInterval` + `fetch` for live data (typically 3–5s)
+- **No external dependencies** — the iframe is sandboxed; CDN scripts may be blocked
+
+## How It Works
+
+```
+1. Daemon discovers folder in ~/.pizzapi/services/
+2. Reads manifest.json → extracts panel metadata (label, icon)
+3. Loads service module → calls init(socket, { announcePanel })
+4. Service starts Bun.serve() on port 0 → calls announcePanel(port)
+5. Daemon auto-registers port with TunnelService
+6. Daemon emits service_announce with panels array
+7. UI renders iframe at /api/tunnel/{sessionId}/{port}/
+```
+
+## Quick Reference
+
+| Task | How |
+|------|-----|
+| Serve static files | `Bun.serve()` with `readFileSync` for index.html |
+| Expose an API | Add route checks in the `fetch` handler |
+| Get a random port | `Bun.serve({ port: 0 })` then read `.port` |
+| Announce the panel | Call `announcePanel(server.port)` in `init()` |
+| Match PizzaPi theme | Use `#0a0a0b` bg, `#e4e4e7` text, `#27272a` borders |
+| Choose an icon | Browse [lucide.dev/icons](https://lucide.dev/icons), use kebab-case name |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Forgetting `announcePanel()` | Panel won't appear in UI — always call it after server starts |
+| Using absolute API URLs | Tunnel proxy rewrites paths; use relative URLs (`./api/...`) |
+| Not cleaning up server in `dispose()` | Call `server.stop(true)` to avoid port leaks |
+| Large panel height assumptions | Panel container is 280px tall — design accordingly |
+| Missing `Access-Control-Allow-Origin` | Iframe requests need CORS headers on API responses |

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -15,6 +15,8 @@ export type {
   RunnerHook,
   Attachment,
   ServiceEnvelope,
+  ServicePanelInfo,
+  ServiceAnnounceData,
   TunnelInfo,
   TunnelRequestData,
   TunnelResponseData,

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -2,7 +2,7 @@
 // /runner namespace — Runner daemon ↔ Server
 // ============================================================================
 
-import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook, ServiceEnvelope, TunnelRequestData, TunnelResponseData } from "./shared.js";
+import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook, ServiceAnnounceData, ServiceEnvelope, TunnelRequestData, TunnelResponseData } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Client → Server (Runner daemon sends to server)
@@ -124,7 +124,7 @@ export interface RunnerClientToServerEvents {
 
   /** Announce which services this runner supports.
    *  Forwarded to all viewers watching sessions on this runner. */
-  service_announce: (data: { serviceIds: string[] }) => void;
+  service_announce: (data: ServiceAnnounceData) => void;
 
   /** Terminal is ready for interaction */
   terminal_ready: (data: {

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -104,6 +104,27 @@ export interface ServiceEnvelope {
   payload: unknown;
 }
 
+// ── Service panel types ───────────────────────────────────────────────────────
+
+/** Metadata for a service panel announced by the runner. */
+export interface ServicePanelInfo {
+  /** Must match the runner service's `id`. */
+  serviceId: string;
+  /** Local port the service's HTTP server is listening on (proxied via tunnel). */
+  port: number;
+  /** Human-readable label for the panel button. */
+  label: string;
+  /** Lucide icon name (e.g. "activity", "cpu"). */
+  icon: string;
+}
+
+/** Payload for the service_announce event. */
+export interface ServiceAnnounceData {
+  serviceIds: string[];
+  /** Panels exposed by plugin services (present when ≥1 service has a panel). */
+  panels?: ServicePanelInfo[];
+}
+
 // ── Tunnel service types ──────────────────────────────────────────────────────
 
 /** Information about an exposed tunnel port. */

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -2,7 +2,7 @@
 // /viewer namespace — Browser viewer ↔ Server
 // ============================================================================
 
-import type { Attachment, ServiceEnvelope } from "./shared.js";
+import type { Attachment, ServiceAnnounceData, ServiceEnvelope } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Server → Client (Server sends to browser viewer)
@@ -45,7 +45,7 @@ export interface ViewerServerToClientEvents {
   service_message: (envelope: ServiceEnvelope) => void;
 
   /** Announces which services the connected runner supports. */
-  service_announce: (data: { serviceIds: string[] }) => void;
+  service_announce: (data: ServiceAnnounceData) => void;
 
   /** Generic error */
   error: (data: {

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -345,6 +345,14 @@ export function getTrustedOrigins(): string[] {
     return _trustedOrigins!;
 }
 
+/** Add an origin to the trusted origins list at runtime (e.g. Vite dev port in sandbox). */
+export function addTrustedOrigin(origin: string): void {
+    ensureInitialized();
+    if (!_trustedOrigins!.includes(origin)) {
+        _trustedOrigins!.push(origin);
+    }
+}
+
 /** Get API key rate limit configuration. */
 export function getApiKeyRateLimitConfig() {
     ensureInitialized();

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -226,14 +226,21 @@ interface PendingTunnelRequest {
 
 const pendingTunnelRequests = new Map<string, PendingTunnelRequest>();
 
-// ── Runner service ID cache ──────────────────────────────────────────────────
+// ── Runner service announce cache ─────────────────────────────────────────────
 // Stores the last service_announce payload per runnerId so newly-joining
 // viewers can receive it immediately without waiting for a fresh announce.
-const runnerServiceIds = new Map<string, string[]>();
+import type { ServiceAnnounceData } from "@pizzapi/protocol";
+
+const runnerServiceAnnounce = new Map<string, ServiceAnnounceData>();
 
 /** Get cached service IDs for a runner (empty array if none). */
 export function getRunnerServiceIds(runnerId: string): string[] {
-    return runnerServiceIds.get(runnerId) ?? [];
+    return runnerServiceAnnounce.get(runnerId)?.serviceIds ?? [];
+}
+
+/** Get the full cached service announce data for a runner. */
+export function getRunnerServiceAnnounce(runnerId: string): ServiceAnnounceData | null {
+    return runnerServiceAnnounce.get(runnerId) ?? null;
 }
 
 /**
@@ -677,11 +684,11 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
         // ── service_announce — runner announces available services ────────────
         // Forward to all viewers watching sessions on this runner so they know
         // which services are available.
-        socket.on("service_announce", (data: { serviceIds: string[] }) => {
+        socket.on("service_announce", (data: ServiceAnnounceData) => {
             const runnerId = socket.data.runnerId;
             if (!runnerId) return;
             // Cache for late-joining viewers
-            runnerServiceIds.set(runnerId, data.serviceIds);
+            runnerServiceAnnounce.set(runnerId, data);
             const sessionIds = runnerSessionIds.get(runnerId);
             if (!sessionIds || sessionIds.size === 0) return;
             for (const sessionId of sessionIds) {
@@ -721,7 +728,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 }
                 // Clean up local session tracking
                 runnerSessionIds.delete(runnerId);
-                runnerServiceIds.delete(runnerId);
+                runnerServiceAnnounce.delete(runnerId);
                 // Clean up any terminals owned by this runner
                 const terminalIds = await getTerminalIdsForRunner(runnerId);
                 for (const tid of terminalIds) {

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -20,7 +20,7 @@ import type {
 // worktree's updated dist.
 type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
 import { sessionCookieAuthMiddleware } from "./auth.js";
-import { getRunnerServiceIds } from "./runner.js";
+import { getRunnerServiceAnnounce, getRunnerServiceIds } from "./runner.js";
 import {
     getSharedSession,
     addViewer,
@@ -553,10 +553,11 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // services are available without waiting for a fresh announce.
         console.log(`[sio/viewer] service_announce check: runnerId=${freshSession.runnerId ?? "null"}`);
         if (freshSession.runnerId) {
-            const serviceIds = getRunnerServiceIds(freshSession.runnerId);
+            const announce = getRunnerServiceAnnounce(freshSession.runnerId);
+            const serviceIds = announce?.serviceIds ?? [];
             console.log(`[sio/viewer] service_announce: runnerId=${freshSession.runnerId}, cached serviceIds=[${serviceIds.join(",")}]`);
             if (serviceIds.length > 0) {
-                socket.emit("service_announce", { serviceIds });
+                socket.emit("service_announce", announce!);
             }
         }
 

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -16,6 +16,7 @@ import type {
     RunnerAgent,
     RunnerPlugin,
     RunnerHook,
+    ServicePanelInfo,
 } from "@pizzapi/protocol";
 
 import type { TestServer } from "./types.js";
@@ -99,6 +100,8 @@ export interface MockRunnerOptions {
     mockGitStatus?: MockGitStatus;
     /** Service IDs this runner announces (e.g. ["terminal", "system-monitor"]) */
     serviceIds?: string[];
+    /** Service panels to announce (dynamic iframe panels). */
+    panels?: ServicePanelInfo[];
 }
 
 export interface MockRunner {
@@ -128,7 +131,7 @@ export interface MockRunner {
     onFileRequest(handler: (data: unknown) => unknown): void;
 
     // Services
-    announceServices(serviceIds: string[]): void;
+    announceServices(serviceIds: string[], panels?: ServicePanelInfo[]): void;
 
     // Utilities
     waitForEvent(eventName: string, timeout?: number): Promise<unknown>;
@@ -373,7 +376,10 @@ export async function createMockRunner(
                 }
                 // Announce services after registration (like real daemon)
                 if (opts?.serviceIds && opts.serviceIds.length > 0) {
-                    (socket as any).emit("service_announce", { serviceIds: opts.serviceIds });
+                    (socket as any).emit("service_announce", {
+                        serviceIds: opts.serviceIds,
+                        ...(opts.panels && opts.panels.length > 0 ? { panels: opts.panels } : {}),
+                    });
                 }
                 resolve();
             });
@@ -928,6 +934,72 @@ export async function createMockRunner(
         });
     });
 
+    // --- Tunnel proxy (for service panel iframes) ---
+
+    // Track registered tunnel ports (from service_announce panels)
+    const tunnelPorts = new Set<number>();
+    if (opts?.panels) {
+        for (const p of opts.panels) tunnelPorts.add(p.port);
+    }
+
+    socket.on("tunnel_request", async (data: any) => {
+        if (isShuttingDown) return;
+        const { requestId, port, method, path, headers, body } = data;
+
+        if (!tunnelPorts.has(port)) {
+            (socket as any).emit("tunnel_response", {
+                requestId,
+                status: 404,
+                headers: {},
+                body: Buffer.from(`Port ${port} is not exposed`).toString("base64"),
+                error: `Port ${port} is not exposed`,
+            });
+            return;
+        }
+
+        try {
+            const url = `http://127.0.0.1:${port}${path}`;
+            const bodyBytes = body ? Buffer.from(body, "base64") : undefined;
+            const forwardHeaders: Record<string, string> = {};
+            if (headers) {
+                for (const [k, v] of Object.entries(headers)) {
+                    const lk = k.toLowerCase();
+                    if (!["connection", "keep-alive", "transfer-encoding", "cookie", "authorization"].includes(lk)) {
+                        forwardHeaders[k] = v as string;
+                    }
+                }
+            }
+
+            const resp = await fetch(url, {
+                method,
+                headers: forwardHeaders,
+                body: bodyBytes && bodyBytes.byteLength > 0 ? bodyBytes : undefined,
+                signal: AbortSignal.timeout(10_000),
+                redirect: "manual",
+            });
+
+            const respBuffer = await resp.arrayBuffer();
+            const respHeaders: Record<string, string> = {};
+            resp.headers.forEach((v, k) => { respHeaders[k] = v; });
+
+            (socket as any).emit("tunnel_response", {
+                requestId,
+                status: resp.status,
+                headers: respHeaders,
+                body: Buffer.from(respBuffer).toString("base64"),
+            });
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            (socket as any).emit("tunnel_response", {
+                requestId,
+                status: 502,
+                headers: {},
+                body: Buffer.from(msg).toString("base64"),
+                error: msg,
+            });
+        }
+    });
+
     // --- Usage ---
 
     socket.on("get_usage", (data: any) => {
@@ -997,8 +1069,11 @@ export async function createMockRunner(
             return shutdownRequested;
         },
 
-        announceServices(serviceIds: string[]): void {
-            (socket as any).emit("service_announce", { serviceIds });
+        announceServices(serviceIds: string[], panels?: ServicePanelInfo[]): void {
+            (socket as any).emit("service_announce", {
+                serviceIds,
+                ...(panels && panels.length > 0 ? { panels } : {}),
+            });
         },
 
         onSkillRequest(handler: (data: unknown) => unknown): void {

--- a/packages/server/tests/harness/sandbox.ts
+++ b/packages/server/tests/harness/sandbox.ts
@@ -448,6 +448,130 @@ async function getFreePort(): Promise<number> {
     return port;
 }
 
+// ── Mock system monitor panel server ─────────────────────────────────────────
+
+import { cpus, freemem, totalmem, loadavg } from "node:os";
+
+function startMockSystemMonitor(): { port: number; stop: () => void } {
+    // Generate synthetic but realistic-looking stats
+    function mockStats() {
+        const cores = cpus();
+        const numCpus = cores.length;
+        const load = loadavg();
+        const total = totalmem();
+        const free = freemem();
+        const used = total - free;
+
+        return {
+            timestamp: Date.now(),
+            cpu: {
+                loadAvg1: Math.round((load[0] / numCpus) * 100) / 100,
+                loadAvg5: Math.round((load[1] / numCpus) * 100) / 100,
+                loadAvg15: Math.round((load[2] / numCpus) * 100) / 100,
+                cores: numCpus,
+                overallPct: Math.round(20 + Math.random() * 40),
+                perCore: Array.from({ length: numCpus }, () => Math.round(5 + Math.random() * 60)),
+            },
+            mem: {
+                totalMb: Math.round(total / 1024 / 1024),
+                usedMb: Math.round(used / 1024 / 1024),
+                freeMb: Math.round(free / 1024 / 1024),
+                usedPct: Math.round((used / total) * 100),
+            },
+            disk: {
+                path: "/",
+                totalGb: 494.4,
+                usedGb: Math.round((280 + Math.random() * 20) * 10) / 10,
+                availableGb: Math.round((200 - Math.random() * 20) * 10) / 10,
+                usedPct: Math.round(56 + Math.random() * 5),
+            },
+            net: { interfaces: ["en0", "en1"] },
+            processes: [
+                { pid: 1234, cpu: +(12 + Math.random() * 8).toFixed(1), mem: 4.2, command: "/usr/bin/node" },
+                { pid: 5678, cpu: +(8 + Math.random() * 5).toFixed(1), mem: 3.1, command: "/opt/homebrew/bin/bun" },
+                { pid: 9012, cpu: +(3 + Math.random() * 4).toFixed(1), mem: 2.8, command: "/Applications/Safari.app/Contents/MacOS/Safari" },
+                { pid: 3456, cpu: +(2 + Math.random() * 3).toFixed(1), mem: 1.9, command: "/usr/sbin/WindowServer" },
+                { pid: 7890, cpu: +(1 + Math.random() * 2).toFixed(1), mem: 1.2, command: "/usr/libexec/rapportd" },
+            ],
+        };
+    }
+
+    const PANEL_HTML = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>System Monitor</title><style>
+:root{--bg:#0a0a0b;--bg-card:#131316;--border:#27272a;--text:#e4e4e7;--text-muted:#71717a;--green:#22c55e;--yellow:#eab308;--red:#ef4444}
+*{margin:0;padding:0;box-sizing:border-box}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',system-ui,sans-serif;background:var(--bg);color:var(--text);font-size:11px;overflow-y:auto;height:100vh}
+.grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:8px;padding:8px}
+.card{background:var(--bg-card);border:1px solid var(--border);border-radius:6px;padding:8px 10px}
+.card-title{font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-muted);margin-bottom:6px}
+.metric{display:flex;justify-content:space-between;align-items:center;margin-bottom:3px}
+.metric-label{color:var(--text-muted)}.metric-value{font-weight:600;font-variant-numeric:tabular-nums}
+.bar-track{width:100%;height:6px;background:var(--border);border-radius:3px;overflow:hidden;margin-top:3px}
+.bar-fill{height:100%;border-radius:3px;transition:width .5s ease}
+.bar-fill.green{background:var(--green)}.bar-fill.yellow{background:var(--yellow)}.bar-fill.red{background:var(--red)}
+.core-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(28px,1fr));gap:3px;margin-top:4px}
+.core-bar{height:24px;background:var(--border);border-radius:3px;position:relative;overflow:hidden}
+.core-bar-fill{position:absolute;bottom:0;width:100%;border-radius:3px;transition:height .5s ease}
+.core-bar-label{position:absolute;top:1px;left:0;right:0;text-align:center;font-size:8px;color:var(--text-muted);z-index:1}
+.proc-table{width:100%;border-collapse:collapse}
+.proc-table th{text-align:left;font-size:9px;font-weight:600;color:var(--text-muted);padding:2px 4px;border-bottom:1px solid var(--border)}
+.proc-table td{padding:2px 4px;font-size:10px;font-variant-numeric:tabular-nums;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;max-width:120px}
+.status{font-size:9px;color:var(--text-muted);padding:4px 8px;text-align:right}
+.loading{display:flex;align-items:center;justify-content:center;height:100vh;color:var(--text-muted)}
+</style></head><body>
+<div id="app" class="loading">Connecting…</div>
+<script>
+(function(){
+  function bc(p){return p>90?'red':p>70?'yellow':'green'}
+  function fm(m){return m>=1024?(m/1024).toFixed(1)+' GB':m+' MB'}
+  function render(d){
+    var c=d.cpu,m=d.mem,dk=d.disk,pr=d.processes,a=document.getElementById('app');
+    a.className='';var h='<div class="grid">';
+    h+='<div class="card"><div class="card-title">CPU</div>';
+    h+='<div class="metric"><span class="metric-label">Usage</span><span class="metric-value">'+c.overallPct+'%</span></div>';
+    h+='<div class="bar-track"><div class="bar-fill '+bc(c.overallPct)+'" style="width:'+c.overallPct+'%"></div></div>';
+    h+='<div class="metric" style="margin-top:4px"><span class="metric-label">Load</span><span class="metric-value">'+c.loadAvg1+' / '+c.loadAvg5+' / '+c.loadAvg15+'</span></div>';
+    if(c.perCore&&c.perCore.length>0){h+='<div class="core-grid">';c.perCore.forEach(function(p,i){h+='<div class="core-bar"><div class="core-bar-label">'+i+'</div><div class="core-bar-fill '+bc(p)+'" style="height:'+Math.max(p,2)+'%"></div></div>'});h+='</div>'}
+    h+='</div>';
+    h+='<div class="card"><div class="card-title">Memory</div>';
+    h+='<div class="metric"><span class="metric-label">Used</span><span class="metric-value">'+fm(m.usedMb)+' / '+fm(m.totalMb)+'</span></div>';
+    h+='<div class="bar-track"><div class="bar-fill '+bc(m.usedPct)+'" style="width:'+m.usedPct+'%"></div></div>';
+    h+='<div class="metric" style="margin-top:4px"><span class="metric-label">Free</span><span class="metric-value">'+fm(m.freeMb)+'</span></div></div>';
+    if(dk){h+='<div class="card"><div class="card-title">Disk /</div>';
+    h+='<div class="metric"><span class="metric-label">Used</span><span class="metric-value">'+dk.usedGb+' / '+dk.totalGb+' GB</span></div>';
+    h+='<div class="bar-track"><div class="bar-fill '+bc(dk.usedPct)+'" style="width:'+dk.usedPct+'%"></div></div>';
+    h+='<div class="metric" style="margin-top:4px"><span class="metric-label">Available</span><span class="metric-value">'+dk.availableGb+' GB</span></div></div>'}
+    h+='</div>';
+    if(pr&&pr.length>0){h+='<div style="padding:0 8px 8px"><div class="card"><div class="card-title">Top Processes</div><table class="proc-table"><thead><tr><th>PID</th><th>CPU%</th><th>MEM%</th><th>Command</th></tr></thead><tbody>';
+    pr.slice(0,8).forEach(function(p){var cmd=p.command.split('/').pop()||p.command;h+='<tr><td>'+p.pid+'</td><td>'+p.cpu+'</td><td>'+p.mem+'</td><td title="'+p.command+'">'+cmd+'</td></tr>'});
+    h+='</tbody></table></div></div>'}
+    h+='<div class="status">Updated '+new Date(d.timestamp).toLocaleTimeString()+'</div>';
+    a.innerHTML=h;
+  }
+  async function poll(){try{var r=await fetch('./api/stats');if(r.ok)render(await r.json())}catch(e){}}
+  poll();setInterval(poll,3000);
+})();
+</script></body></html>`;
+
+    const server = Bun.serve({
+        port: 0,
+        fetch(req) {
+            const url = new URL(req.url);
+            if (url.pathname === "/api/stats" || url.pathname.endsWith("/api/stats")) {
+                return new Response(JSON.stringify(mockStats()), {
+                    headers: { "Content-Type": "application/json", "Access-Control-Allow-Origin": "*" },
+                });
+            }
+            return new Response(PANEL_HTML, {
+                headers: { "Content-Type": "text/html; charset=utf-8" },
+            });
+        },
+    });
+
+    return { port: server.port!, stop: () => server.stop(true) };
+}
+
 async function main() {
     const opts = parseCliOptions(process.argv.slice(2));
 
@@ -483,6 +607,11 @@ async function main() {
 
     console.log("Populating mock sessions...\n");
 
+    // Start mock system monitor HTTP server for the service panel demo.
+    const monitorServer = startMockSystemMonitor();
+    const monitorPort = monitorServer.port;
+    console.log(`  📊 Mock system monitor panel on port ${monitorPort}`);
+
     // Create a default mock runner so sessions have a runner association
     // and service_announce reaches viewers.
     const defaultRunner = await createMockRunner(server, {
@@ -490,6 +619,9 @@ async function main() {
         roots: ["/Users/jordan/Documents/Projects/PizzaPi"],
         platform: "darwin",
         serviceIds: ["terminal", "file-explorer", "git", "tunnel", "system-monitor"],
+        panels: [
+            { serviceId: "system-monitor", port: monitorPort, label: "System Monitor", icon: "activity" },
+        ],
         skills: [
             { name: "code-review", description: "Code review", filePath: "/skills/code-review/SKILL.md" },
             { name: "brainstorming", description: "Explore ideas", filePath: "/skills/brainstorming/SKILL.md" },
@@ -979,6 +1111,7 @@ async function main() {
             process.env.PIZZAPI_BASE_URL = savedBaseUrl;
         }
         sandboxApi.stop();
+        monitorServer.stop();
         await scenario.teardown();
         viteProc.kill();
         await stopRedis();

--- a/packages/server/tests/harness/sandbox.ts
+++ b/packages/server/tests/harness/sandbox.ts
@@ -25,6 +25,7 @@ import {
     type ConversationTurn,
 } from "./builders.js";
 import { startSandboxApi, type SandboxApi } from "./sandbox-api.js";
+import { addTrustedOrigin } from "../../src/auth.js";
 import { RedisMemoryServer } from "redis-memory-server";
 
 // ── Suppress noisy server logs so the REPL stays clean ───────────────────────
@@ -724,6 +725,9 @@ async function main() {
             if (resp.ok) break;
         } catch { /* not ready */ }
     }
+
+    // Add the Vite dev URL as a trusted origin so auth works from the HMR UI.
+    addTrustedOrigin(`http://127.0.0.1:${vitePort}`);
 
     // ── Start HTTP control API ────────────────────────────────────────
     const sandboxApi = await startSandboxApi({

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -66,6 +66,8 @@ import { ViewerSocketContext } from "@/lib/viewer-socket-context";
 import { useRunnerServices, attachServiceAnnounceListener } from "@/hooks/useRunnerServices";
 import { ServicePanelButtons, useServicePanelState } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
+import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
+import { IframeServicePanel } from "@/components/service-panels/IframeServicePanel";
 import {
   ModelSelector,
   ModelSelectorContent,
@@ -3300,7 +3302,7 @@ export function App() {
   );
 
   // Runner service panels — dynamically discovered
-  const availableServices = useRunnerServices(viewerSocket);
+  const { services: availableServices, panels: dynamicPanels } = useRunnerServices(viewerSocket);
   const { activePanelId: activeServicePanel, togglePanel: toggleServicePanel, closePanel: closeServicePanel } = useServicePanelState();
   const [servicePanelPosition, setServicePanelPosition] = React.useState<import("@/hooks/usePanelLayout").PanelPosition>(() => {
     try { return (localStorage.getItem("pp-service-panel-position") as import("@/hooks/usePanelLayout").PanelPosition) ?? "right"; } catch { return "right"; }
@@ -3367,22 +3369,33 @@ export function App() {
 
   const servicePanelTabs = React.useMemo<CombinedPanelTab[]>(() => {
     if (!activeServicePanel || !activeSessionId) return [];
-    const panelDef = SERVICE_PANELS.find(p => p.serviceId === activeServicePanel);
-    if (!panelDef) return [];
-    const PanelComponent = panelDef.component;
+
+    // Try static registry first
+    const staticDef = SERVICE_PANELS.find(p => p.serviceId === activeServicePanel);
+    // Then dynamic panels
+    const dynamicDef = !staticDef ? dynamicPanels.find(p => p.serviceId === activeServicePanel) : null;
+
+    if (!staticDef && !dynamicDef) return [];
+
+    const label = staticDef?.label ?? dynamicDef!.label;
+    const icon = staticDef?.icon ?? <DynamicLucideIcon name={dynamicDef!.icon} />;
+    const content = staticDef
+      ? <staticDef.component sessionId={activeSessionId} />
+      : <IframeServicePanel sessionId={activeSessionId} port={dynamicDef!.port} />;
+
     return [{
-      id: panelDef.serviceId,
-      label: panelDef.label,
-      icon: panelDef.icon,
+      id: staticDef?.serviceId ?? dynamicDef!.serviceId,
+      label,
+      icon,
       onDragStart: (e) => startPanelDragWith(e, handleServicePanelPositionChange),
       onClose: () => {
         closeServicePanel();
         if (showTerminal) handleCombinedTabChange("terminal");
         else if (showFileExplorer) handleCombinedTabChange("files");
       },
-      content: <PanelComponent sessionId={activeSessionId} />,
+      content,
     }];
-  }, [activeServicePanel, activeSessionId, startPanelDragWith, handleServicePanelPositionChange, closeServicePanel, showTerminal, showFileExplorer, handleCombinedTabChange]);
+  }, [activeServicePanel, activeSessionId, dynamicPanels, startPanelDragWith, handleServicePanelPositionChange, closeServicePanel, showTerminal, showFileExplorer, handleCombinedTabChange]);
 
   const panelGroups = React.useMemo(() => {
     const groups: Record<"left" | "right" | "bottom", CombinedPanelTab[]> = { left: [], right: [], bottom: [] };
@@ -3960,6 +3973,7 @@ export function App() {
                       extraHeaderButtons={
                         <ServicePanelButtons
                           availableServices={availableServices}
+                          dynamicPanels={dynamicPanels}
                           activePanelId={activeServicePanel}
                           onTogglePanel={handleToggleServicePanel}
                         />

--- a/packages/ui/src/components/service-panels/IframeServicePanel.tsx
+++ b/packages/ui/src/components/service-panels/IframeServicePanel.tsx
@@ -1,0 +1,22 @@
+/**
+ * Generic iframe panel for dynamic service panels.
+ *
+ * Renders the service's self-hosted UI inside an iframe,
+ * proxied through the tunnel system at /api/tunnel/{sessionId}/{port}/.
+ */
+
+interface IframeServicePanelProps {
+    sessionId: string;
+    port: number;
+}
+
+export function IframeServicePanel({ sessionId, port }: IframeServicePanelProps) {
+    return (
+        <iframe
+            src={`/api/tunnel/${sessionId}/${port}/`}
+            className="w-full h-full border-0"
+            title={`Service panel — port ${port}`}
+            sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
+        />
+    );
+}

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -9,27 +9,37 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { X } from "lucide-react";
 import { SERVICE_PANELS, type ServicePanelDef } from "./registry";
+import { DynamicLucideIcon } from "./lucide-icon";
+import { IframeServicePanel } from "./IframeServicePanel";
+import type { ServicePanelInfo } from "@pizzapi/protocol";
 
 // ── Buttons for the header bar ────────────────────────────────────────────────
 
 interface ServicePanelButtonsProps {
     availableServices: Set<string>;
+    /** Dynamic panels announced by runner services at runtime. */
+    dynamicPanels?: ServicePanelInfo[];
     activePanelId: string | null;
     onTogglePanel: (serviceId: string) => void;
 }
 
 export function ServicePanelButtons({
     availableServices,
+    dynamicPanels = [],
     activePanelId,
     onTogglePanel,
 }: ServicePanelButtonsProps) {
-    const visiblePanels = SERVICE_PANELS.filter(p => availableServices.has(p.serviceId));
+    // Static panels from the compiled registry
+    const visibleStaticPanels = SERVICE_PANELS.filter(p => availableServices.has(p.serviceId));
+    // Dynamic panels — exclude any that have a static panel (static wins)
+    const staticIds = new Set(SERVICE_PANELS.map(p => p.serviceId));
+    const visibleDynamicPanels = dynamicPanels.filter(p => !staticIds.has(p.serviceId));
 
-    if (visiblePanels.length === 0) return null;
+    if (visibleStaticPanels.length === 0 && visibleDynamicPanels.length === 0) return null;
 
     return (
         <>
-            {visiblePanels.map(panel => (
+            {visibleStaticPanels.map(panel => (
                 <Tooltip key={panel.serviceId}>
                     <TooltipTrigger asChild>
                         <Button
@@ -48,6 +58,25 @@ export function ServicePanelButtons({
                     <TooltipContent>{panel.label}</TooltipContent>
                 </Tooltip>
             ))}
+            {visibleDynamicPanels.map(panel => (
+                <Tooltip key={panel.serviceId}>
+                    <TooltipTrigger asChild>
+                        <Button
+                            className={`h-7 w-7 ${
+                                activePanelId === panel.serviceId ? "bg-accent text-accent-foreground" : ""
+                            }`}
+                            onClick={() => onTogglePanel(panel.serviceId)}
+                            size="icon"
+                            type="button"
+                            variant="outline"
+                            aria-label={`Toggle ${panel.label}`}
+                        >
+                            <DynamicLucideIcon name={panel.icon} />
+                        </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>{panel.label}</TooltipContent>
+                </Tooltip>
+            ))}
         </>
     );
 }
@@ -57,6 +86,8 @@ export function ServicePanelButtons({
 interface ServicePanelContainerProps {
     activePanelId: string | null;
     sessionId: string;
+    /** Dynamic panels from service_announce. */
+    dynamicPanels?: ServicePanelInfo[];
     onClose: () => void;
     position?: "bottom" | "right";
 }
@@ -64,15 +95,20 @@ interface ServicePanelContainerProps {
 export function ServicePanelContainer({
     activePanelId,
     sessionId,
+    dynamicPanels = [],
     onClose,
     position = "bottom",
 }: ServicePanelContainerProps) {
     if (!activePanelId) return null;
 
-    const panelDef = SERVICE_PANELS.find(p => p.serviceId === activePanelId);
-    if (!panelDef) return null;
+    // Try static registry first, then dynamic panels
+    const staticDef = SERVICE_PANELS.find(p => p.serviceId === activePanelId);
+    const dynamicDef = !staticDef ? dynamicPanels.find(p => p.serviceId === activePanelId) : null;
 
-    const PanelComponent = panelDef.component;
+    if (!staticDef && !dynamicDef) return null;
+
+    const label = staticDef?.label ?? dynamicDef!.label;
+    const icon = staticDef?.icon ?? <DynamicLucideIcon name={dynamicDef!.icon} />;
 
     return (
         <div
@@ -86,15 +122,15 @@ export function ServicePanelContainer({
             {/* Panel header */}
             <div className="flex items-center justify-between px-3 py-1.5 border-b border-border bg-muted/30 shrink-0">
                 <div className="flex items-center gap-1.5 text-xs font-medium">
-                    {panelDef.icon}
-                    {panelDef.label}
+                    {icon}
+                    {label}
                 </div>
                 <Button
                     variant="ghost"
                     size="icon"
                     className="h-5 w-5"
                     onClick={onClose}
-                    aria-label={`Close ${panelDef.label}`}
+                    aria-label={`Close ${label}`}
                 >
                     <X className="size-3" />
                 </Button>
@@ -102,7 +138,11 @@ export function ServicePanelContainer({
 
             {/* Panel content */}
             <div className="flex-1 overflow-hidden">
-                <PanelComponent sessionId={sessionId} />
+                {staticDef ? (
+                    <staticDef.component sessionId={sessionId} />
+                ) : (
+                    <IframeServicePanel sessionId={sessionId} port={dynamicDef!.port} />
+                )}
             </div>
         </div>
     );

--- a/packages/ui/src/components/service-panels/lucide-icon.tsx
+++ b/packages/ui/src/components/service-panels/lucide-icon.tsx
@@ -1,0 +1,42 @@
+/**
+ * Resolve a Lucide icon name string to a React component.
+ *
+ * Dynamic panels declare their icon as a string (e.g. "activity", "cpu").
+ * This utility maps those strings to the corresponding lucide-react component.
+ *
+ * Uses a lazy lookup into the lucide-react exports. Unknown names fall back
+ * to the Square icon.
+ */
+import React from "react";
+import * as LucideIcons from "lucide-react";
+
+/**
+ * Convert a kebab-case icon name to PascalCase component name.
+ * e.g. "arrow-right" → "ArrowRight", "cpu" → "Cpu", "activity" → "Activity"
+ */
+function toPascalCase(name: string): string {
+    return name
+        .split("-")
+        .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+        .join("");
+}
+
+/**
+ * Get a Lucide icon component by name. Returns Square if not found.
+ */
+export function getLucideIcon(name: string): LucideIcons.LucideIcon {
+    const pascalName = toPascalCase(name);
+    const icon = (LucideIcons as Record<string, unknown>)[pascalName];
+    if (icon && typeof icon === "function") {
+        return icon as LucideIcons.LucideIcon;
+    }
+    return LucideIcons.Square;
+}
+
+/**
+ * Render a Lucide icon by name string with standard panel icon sizing.
+ */
+export function DynamicLucideIcon({ name, className = "size-3.5" }: { name: string; className?: string }) {
+    const Icon = getLucideIcon(name);
+    return <Icon className={className} />;
+}

--- a/packages/ui/src/components/service-panels/registry.tsx
+++ b/packages/ui/src/components/service-panels/registry.tsx
@@ -2,12 +2,23 @@
  * Service Panel Registry
  *
  * Maps runner service IDs to their UI panel components, labels, and icons.
- * When the runner announces a service and this registry has a panel for it,
- * the UI renders a toggleable panel button in the session header.
+ * Two sources of panels:
  *
- * To add a new service panel:
+ * 1. **Static panels** — hardcoded in SERVICE_PANELS below (e.g. Tunnel).
+ *    These have custom React components compiled into the bundle.
+ *
+ * 2. **Dynamic panels** — announced by runner services at runtime via
+ *    service_announce.panels[]. These render in a generic iframe that
+ *    proxies to the service's HTTP server via the tunnel system.
+ *
+ * To add a new static panel:
  * 1. Create a React component (e.g. MyServicePanel.tsx)
  * 2. Add an entry to SERVICE_PANELS below
+ *
+ * To add a dynamic panel:
+ * 1. Create a folder-based service in ~/.pizzapi/services/<name>/
+ * 2. Include a manifest.json with label, icon, and panel config
+ * 3. Start an HTTP server in init() and call announcePanel(port)
  */
 import React from "react";
 import { Network } from "lucide-react";
@@ -25,7 +36,7 @@ export interface ServicePanelDef {
 }
 
 /**
- * All known service panels. Order determines button order in the header.
+ * Static service panels. Order determines button order in the header.
  * A panel only appears if the runner announces its serviceId.
  */
 export const SERVICE_PANELS: ServicePanelDef[] = [

--- a/packages/ui/src/hooks/useRunnerServices.ts
+++ b/packages/ui/src/hooks/useRunnerServices.ts
@@ -16,8 +16,10 @@
  */
 import { useState, useEffect, useRef } from "react";
 import type { Socket } from "socket.io-client";
+import type { ServiceAnnounceData, ServicePanelInfo } from "@pizzapi/protocol";
 
 const SERVICE_IDS_KEY = "__serviceIds" as const;
+const PANELS_KEY = "__panels" as const;
 
 /**
  * Call this synchronously right after creating the viewer socket.
@@ -25,11 +27,13 @@ const SERVICE_IDS_KEY = "__serviceIds" as const;
  * so they're available before any React hooks mount.
  */
 export function attachServiceAnnounceListener(socket: Socket): void {
-    socket.on("service_announce", (data: { serviceIds: string[] }) => {
+    socket.on("service_announce", (data: ServiceAnnounceData) => {
         (socket as any)[SERVICE_IDS_KEY] = data.serviceIds;
+        (socket as any)[PANELS_KEY] = data.panels;
     });
     socket.on("disconnect", () => {
         (socket as any)[SERVICE_IDS_KEY] = undefined;
+        (socket as any)[PANELS_KEY] = undefined;
     });
 }
 
@@ -39,8 +43,19 @@ function getEagerServiceIds(socket: Socket | null): Set<string> {
     return ids ? new Set(ids) : new Set();
 }
 
-export function useRunnerServices(socket: Socket | null): Set<string> {
+/** Read any already-captured panels from the socket. */
+function getEagerPanels(socket: Socket | null): ServicePanelInfo[] {
+    return (socket ? (socket as any)[PANELS_KEY] as ServicePanelInfo[] | undefined : undefined) ?? [];
+}
+
+export interface RunnerServicesState {
+    services: Set<string>;
+    panels: ServicePanelInfo[];
+}
+
+export function useRunnerServices(socket: Socket | null): RunnerServicesState {
     const [services, setServices] = useState<Set<string>>(() => getEagerServiceIds(socket));
+    const [panels, setPanels] = useState<ServicePanelInfo[]>(() => getEagerPanels(socket));
     const prevSocketRef = useRef(socket);
 
     // When the socket changes, eagerly read any cached announce
@@ -56,6 +71,7 @@ export function useRunnerServices(socket: Socket | null): Set<string> {
     useEffect(() => {
         if (!socket) {
             setServices(new Set());
+            setPanels([]);
             return;
         }
 
@@ -64,11 +80,19 @@ export function useRunnerServices(socket: Socket | null): Set<string> {
         if (cached.size > 0) {
             setServices(cached);
         }
+        const cachedPanels = getEagerPanels(socket);
+        if (cachedPanels.length > 0) {
+            setPanels(cachedPanels);
+        }
 
-        const handleAnnounce = (data: { serviceIds: string[] }) => {
+        const handleAnnounce = (data: ServiceAnnounceData) => {
             setServices(new Set(data.serviceIds));
+            setPanels(data.panels ?? []);
         };
-        const handleDisconnect = () => setServices(new Set());
+        const handleDisconnect = () => {
+            setServices(new Set());
+            setPanels([]);
+        };
 
         socket.on("service_announce", handleAnnounce);
         socket.on("disconnect", handleDisconnect);
@@ -79,5 +103,5 @@ export function useRunnerServices(socket: Socket | null): Set<string> {
         };
     }, [socket]);
 
-    return services;
+    return { services, panels };
 }

--- a/packages/ui/src/hooks/useServiceChannel.ts
+++ b/packages/ui/src/hooks/useServiceChannel.ts
@@ -1,6 +1,6 @@
 import { useEffect, useCallback, useRef, useState } from "react";
 import { useViewerSocket } from "@/lib/viewer-socket-context";
-import type { ServiceEnvelope } from "@pizzapi/protocol";
+import type { ServiceAnnounceData, ServiceEnvelope } from "@pizzapi/protocol";
 
 const SERVICE_IDS_KEY = "__serviceIds" as const;
 
@@ -42,7 +42,7 @@ export function useServiceChannel<TSend = unknown, TPayload = unknown>(
             onMessageRef.current?.(envelope.type, envelope.payload as TPayload, envelope.requestId);
         };
 
-        const handleAnnounce = (data: { serviceIds: string[] }) => {
+        const handleAnnounce = (data: ServiceAnnounceData) => {
             setAvailable(data.serviceIds.includes(serviceId));
         };
 


### PR DESCRIPTION
## Summary

Adds a plugin service panel system that lets runner services ship their own UI dashboards, rendered via iframe in the PizzaPi web interface. The System Monitor is the first proof-of-concept.

## How it works

1. **Folder-based services** in `~/.pizzapi/services/<name>/` with `manifest.json` + `index.ts` + `panel/`
2. Each service **owns its own HTTP server** (started in `init()`, `Bun.serve({ port: 0 })`)
3. Panel traffic is **proxied through the existing tunnel system** — zero new infrastructure
4. The manifest declares metadata (label, icon) used by the UI to render panel buttons

## Changes by layer

### Protocol (`packages/protocol`)
- New `ServicePanelInfo` and `ServiceAnnounceData` types in `shared.ts`
- Updated `runner.ts` and `viewer.ts` event types to carry panel metadata

### Server (`packages/server`)
- Runner namespace caches full `ServiceAnnounceData` (not just string IDs)
- Viewer namespace sends panel metadata to late-joining viewers
- `addTrustedOrigin()` in `auth.ts` for runtime origin additions (sandbox fix)

### CLI / Runner (`packages/cli`)
- **Service loader**: folder discovery with `manifest.json` parsing, `ServiceManifest` type
- **TunnelService**: `registerPort(port, name?)` internal API for auto-registering panel ports
- **Daemon**: `announcePanel` callback passed to each handler; `emitServiceAnnounce()` hoisted to outer scope for re-announce on reconnect
- **Built-in skill**: `creating-service-panels/SKILL.md` ships in `packages/cli/src/skills/`, copied to `dist/skills/` at build time

### UI (`packages/ui`)
- `IframeServicePanel.tsx` — renders panel in sandboxed iframe via tunnel URL
- `DynamicLucideIcon` + `getLucideIcon` — maps manifest icon names to Lucide components
- `ServicePanels.tsx` — buttons + container handle both static (registry) and dynamic (announced) panels
- `useRunnerServices.ts` — returns `{ services, panels }` from `service_announce` events

### Sandbox / Testing
- Mock runner supports `panels` option and handles `tunnel_request` for panel ports
- Sandbox starts a mock System Monitor HTTP server with live CPU/memory/disk stats
- 7 new service-loader tests, updated skill tests
- Project-local `testing-sandbox-ui` skill documenting the Playwright + sandbox workflow

## System Monitor (proof of concept)

Lives at `~/.pizzapi/services/system-monitor/` (not in repo):
- `manifest.json` — label, icon, description
- `index.ts` — `Bun.serve` on random port, `/api/stats` endpoint
- `panel/index.html` — dark-themed dashboard polling every 3s

## Screenshots

Tested end-to-end with Playwright: login → select session → click System Monitor button → iframe panel loads in right sidebar showing live CPU, memory, disk, and process stats.

## Future work

- Approach C (shared `httpProxy()` engine) tracked in Godmother for future refactoring
