### PR TITLE
fix: suppress noisy MCP auth log messages in TUI

### DIFF
--- a/packages/cli/src/extensions/mcp-oauth.ts
+++ b/packages/cli/src/extensions/mcp-oauth.ts
@@ -580,9 +580,7 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
           nonce: this._currentNonce,
           ts: Date.now(),
         });
-        process.stderr.write(
-          `🔐 ${this._serverName} requires authentication (paste mode) — check web UI\n`,
-        );
+        // Web UI receives the event above — no need to duplicate to stderr.
       } else {
         // Relay mode: emit event for web UI to show clickable link
         this.relayContext!.emitEvent("mcp:auth_required", {
@@ -591,8 +589,7 @@ export class PizzaPiOAuthProvider implements OAuthClientProvider {
           authUrl: url,
           ts: Date.now(),
         });
-        // Inform the user in case no web viewer is currently attached.
-        process.stderr.write(`🔐 ${this._serverName} requires authentication — check web UI\n`);
+        // Web UI receives the event above — no need to duplicate to stderr.
       }
     } else {
       // Local mode: open browser directly

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -643,8 +643,14 @@ export async function registerMcpTools(
           if (client && !liveClients.includes(client)) {
             try { client.close(); } catch {}
           }
-          // Log the background failure so it's visible in runner logs.
-          console.warn(`pizzapi: MCP server "${result.name}" failed in background: ${result.error}`);
+          // Log non-auth background failures. OAuth/auth errors are already surfaced
+          // to the user via web UI events (mcp:auth_required / mcp:auth_paste_required),
+          // so there's no need to repeat them as noisy console output.
+          const errStr = String(result.error);
+          const isAuthError = /oauth|authentication|auth callback/i.test(errStr);
+          if (!isAuthError) {
+            console.warn(`pizzapi: MCP server "${result.name}" failed in background: ${result.error}`);
+          }
         }
       }
     }).catch(() => {

--- a/packages/cli/src/extensions/mcp/transport-http.ts
+++ b/packages/cli/src/extensions/mcp/transport-http.ts
@@ -375,9 +375,7 @@ export function createStreamableMcpClient(opts: {
           // Retry with localhost-only registration: register with a localhost
           // placeholder, but keep using the relay URL for the actual redirect.
           if (oauthProvider.relayContext && !oauthProvider.clientInformation()) {
-            process.stderr.write(
-              `⚠ ${opts.name}: registration failed with relay redirect — retrying with localhost registration\n`,
-            );
+            // Silent fallback — no need to surface this implementation detail to the user.
             oauthProvider.enableLocalhostRegistration();
             result1 = await auth(oauthProvider, {
               serverUrl: opts.url,


### PR DESCRIPTION
## Problem

When an OAuth MCP server (e.g. Figma) is configured but unauthenticated, the TUI gets flooded with ugly messages in the status bar:

- `⚠ figma: registration failed with relay redirect — retrying with localhost registration:5173/session/...`
- `🔐 figma requires authentication (paste mode) — check web UI`  
- `pizzapi: MCP server "figma" failed in background: OAuth authentication failed for "figma": OAuth callback timed out`

## Fix

**transport-http.ts** — Remove `stderr.write` for the relay registration retry. This is a silent internal fallback; the user never needs to know it happened.

**mcp-oauth.ts** — Remove both `stderr.write` calls for the 🔐 auth prompts in relay and paste mode. The web UI already receives `mcp:auth_required` / `mcp:auth_paste_required` events and shows a proper notification panel — duplicating to stderr is redundant noise.

**registry.ts** — Suppress the `console.warn` for `failed in background` when the error is OAuth/auth-related. Already surfaced via web UI events. Genuine connection failures (non-auth) are still logged.