### PR TITLE
feat: make all panels fully independent

### DIFF
--- a/packages/cli/src/runner/services/tunnel-service.ts
+++ b/packages/cli/src/runner/services/tunnel-service.ts
@@ -22,6 +22,8 @@ interface TunnelInfo {
     name?: string;
     /** Relay tunnel URL fragment — actual URL is /api/tunnel/{sessionId}/{port}/ */
     url: string;
+    /** Auto-registered by the daemon (e.g. service panel port) — hidden from session TunnelPanel. */
+    pinned?: boolean;
 }
 
 interface TunnelRequestData {
@@ -116,7 +118,7 @@ export class TunnelService implements ServiceHandler {
     registerPort(port: number, name?: string): void {
         if (this.tunnels.has(port)) return;
         const url = `/tunnel/${port}`;
-        const info: TunnelInfo = { port, ...(name ? { name } : {}), url };
+        const info: TunnelInfo = { port, ...(name ? { name } : {}), url, pinned: true };
         this.tunnels.set(port, info);
         logInfo(`[tunnel] auto-registered panel port ${port}${name ? ` (${name})` : ""}`);
 

--- a/packages/cli/src/web.test.ts
+++ b/packages/cli/src/web.test.ts
@@ -7,6 +7,7 @@ import {
     extractVapidFromCompose,
     extractSettingsFromCompose,
     findRepoRoot,
+    parseArgs,
     resolveBetterAuthSecret,
     resolveMissingProxySettings,
     shouldInstallDependencies,
@@ -504,5 +505,35 @@ describe("resolveMissingProxySettings", () => {
             proxyDepth: 2,
             source: "compose",
         });
+    });
+});
+
+describe("parseArgs", () => {
+    test("defaults: detach true, noCache false, help false", () => {
+        const r = parseArgs([]);
+        expect(r.detach).toBe(true);
+        expect(r.noCache).toBe(false);
+        expect(r.help).toBe(false);
+    });
+
+    test("--no-cache sets noCache", () => {
+        const r = parseArgs(["--no-cache"]);
+        expect(r.noCache).toBe(true);
+    });
+
+    test("--foreground disables detach", () => {
+        expect(parseArgs(["--foreground"]).detach).toBe(false);
+        expect(parseArgs(["-f"]).detach).toBe(false);
+    });
+
+    test("--port parses port number", () => {
+        expect(parseArgs(["--port", "8080"]).port).toBe(8080);
+    });
+
+    test("combines multiple flags", () => {
+        const r = parseArgs(["--no-cache", "-f", "--port", "9000"]);
+        expect(r.noCache).toBe(true);
+        expect(r.detach).toBe(false);
+        expect(r.port).toBe(9000);
     });
 });

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -827,11 +827,12 @@ interface ParsedArgs {
     port?: number;
     origins?: string;
     detach: boolean;
+    noCache: boolean;
     help: boolean;
 }
 
 export function parseArgs(args: string[]): ParsedArgs {
-    const result: ParsedArgs = { detach: true, help: false };
+    const result: ParsedArgs = { detach: true, noCache: false, help: false };
 
     for (let i = 0; i < args.length; i++) {
         const arg = args[i];
@@ -857,6 +858,8 @@ export function parseArgs(args: string[]): ParsedArgs {
             i++;
         } else if (arg === "--foreground" || arg === "-f") {
             result.detach = false;
+        } else if (arg === "--no-cache") {
+            result.noCache = true;
         } else if (arg === "--help" || arg === "-h") {
             result.help = true;
         }
@@ -883,6 +886,7 @@ function printWebHelp(): void {
     console.log(`  ${c.flag("--port")} ${c.dim("<port>")}       Set the host port ${c.dim("(persisted to config.json)")}`);
     console.log(`  ${c.flag("--origins")} ${c.dim("<list>")}    Set extra allowed CORS origins ${c.dim("(comma-separated, persisted)")}`);
     console.log(`  ${c.flag("-f, --foreground")}    Run in the foreground ${c.dim("(don't detach)")}`);
+    console.log(`  ${c.flag("--no-cache")}          Rebuild Docker image without layer cache`);
     console.log(`  ${c.flag("-h, --help")}          Show this help`);
     console.log();
     console.log(`${c.label("Configuration")} ${c.dim(`(${CONFIG_PATH})`)}`);
@@ -1087,7 +1091,14 @@ export async function runWeb(args: string[]): Promise<void> {
     // When the host prebuild actually rebuilt, force-recreate containers so
     // Docker picks up the new image even if BuildKit's layer cache didn't
     // detect the change (common on macOS Docker Desktop with virtiofs).
-    const forceRecreate = prebuildResult.rebuilt;
+    const forceRecreate = prebuildResult.rebuilt || parsed.noCache;
+
+    // --no-cache: run a separate `docker compose build --no-cache` first,
+    // because `docker compose up` doesn't support --no-cache directly.
+    if (parsed.noCache) {
+        console.log("Building without cache...");
+        await composeExecAsync(composePath, ["build", "--no-cache"]);
+    }
 
     if (parsed.detach) {
         const upArgs = ["up", "-d", "--build"];

--- a/packages/docs/src/content/docs/running/cli-reference.mdx
+++ b/packages/docs/src/content/docs/running/cli-reference.mdx
@@ -146,6 +146,7 @@ Flags:
   --port <port>       Set the host port (persisted to config.json)
   --origins <list>    Set extra allowed CORS origins (comma-separated, persisted)
   -f, --foreground    Run in the foreground (don't detach)
+  --no-cache          Rebuild Docker image without layer cache
   -h, --help          Show this help
 
 Host build:

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -133,6 +133,12 @@ export interface TunnelInfo {
   name?: string;
   /** Relay tunnel URL fragment — actual URL is /api/tunnel/{sessionId}/{port}/ */
   url: string;
+  /**
+   * When true, this tunnel was auto-registered by the runner daemon (e.g. a
+   * service panel port) and is not user-managed. The UI should hide it from
+   * the TunnelPanel tunnel list.
+   */
+  pinned?: boolean;
 }
 
 /** Server → Runner: HTTP proxy request forwarded from an authenticated viewer. */

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -54,12 +54,12 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Sun, Moon, LogOut, KeyRound, X, User, ChevronsUpDown, PanelLeftOpen, HardDrive, Bell, BellOff, Check, Plus, TerminalIcon, FolderTree, Keyboard, EyeOff, Lock } from "lucide-react";
+import { Sun, Moon, LogOut, KeyRound, X, User, ChevronsUpDown, PanelLeftOpen, HardDrive, Bell, BellOff, Check, Plus, TerminalIcon, FolderTree, GitBranch, Keyboard, EyeOff, Lock } from "lucide-react";
 import { NotificationToggle, MobileNotificationMenuItem } from "@/components/NotificationToggle";
 import { HapticsToggle, MobileHapticsMenuItem } from "@/components/HapticsToggle";
 import { UsageIndicator, type ProviderUsageMap } from "@/components/UsageIndicator";
 import { TerminalManager } from "@/components/TerminalManager";
-import { FileExplorer } from "@/components/FileExplorer";
+import { FileExplorer, GitChangesView } from "@/components/FileExplorer";
 import { CombinedPanel, type CombinedPanelTab } from "@/components/CombinedPanel";
 import { DockedPanelGroup } from "@/components/DockedPanelGroup";
 import { ViewerSocketContext } from "@/lib/viewer-socket-context";
@@ -177,6 +177,8 @@ export function App() {
     showFileExplorer, setShowFileExplorer,
     filesPosition, filesContainerRef,
     handleFilesPositionChange,
+    showGit, setShowGit,
+    gitPosition, handleGitPositionChange,
   } = panelLayout;
 
   const [newSessionOpen, setNewSessionOpen] = React.useState(false);
@@ -3303,25 +3305,16 @@ export function App() {
 
   // Runner service panels — dynamically discovered
   const { services: availableServices, panels: dynamicPanels } = useRunnerServices(viewerSocket);
-  const { activePanelId: activeServicePanel, togglePanel: toggleServicePanel, closePanel: closeServicePanel } = useServicePanelState();
-  const [servicePanelPosition, setServicePanelPosition] = React.useState<import("@/hooks/usePanelLayout").PanelPosition>(() => {
-    try { return (localStorage.getItem("pp-service-panel-position") as import("@/hooks/usePanelLayout").PanelPosition) ?? "right"; } catch { return "right"; }
-  });
-  const handleServicePanelPositionChange = React.useCallback((pos: import("@/hooks/usePanelLayout").PanelPosition) => {
-    setServicePanelPosition(pos);
-    try { localStorage.setItem("pp-service-panel-position", pos); } catch {}
-  }, []);
+  const { activePanelIds: activeServicePanels, togglePanel: toggleServicePanel, closePanelById: closeServicePanelById, closeAllPanels: closeAllServicePanels, getPanelPosition: getServicePanelPosition, setPanelPosition: setServicePanelPosition } = useServicePanelState();
 
   const handleToggleServicePanel = React.useCallback((serviceId: string) => {
-    if (activeServicePanel === serviceId) {
-      closeServicePanel();
-      if (showTerminal) handleCombinedTabChange("terminal");
-      else if (showFileExplorer) handleCombinedTabChange("files");
+    if (activeServicePanels.has(serviceId)) {
+      closeServicePanelById(serviceId);
     } else {
       toggleServicePanel(serviceId);
       handleCombinedTabChange(serviceId);
     }
-  }, [activeServicePanel, closeServicePanel, toggleServicePanel, handleCombinedTabChange, showTerminal, showFileExplorer]);
+  }, [activeServicePanels, closeServicePanelById, toggleServicePanel, handleCombinedTabChange]);
 
   const terminalPanelTab = React.useMemo<CombinedPanelTab | null>(() => showTerminal ? {
     id: "terminal",
@@ -3367,57 +3360,73 @@ export function App() {
     ),
   } : null, [showFileExplorer, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, startPanelDragWith, handleFilesPositionChange]);
 
+  const gitPanelTab = React.useMemo<CombinedPanelTab | null>(() => (showGit && activeSessionInfo?.runnerId && activeSessionInfo?.cwd) ? {
+    id: "git",
+    label: "Git",
+    icon: <GitBranch className="size-3.5" />,
+    onClose: () => setShowGit(false),
+    onDragStart: (e) => startPanelDragWith(e, handleGitPositionChange),
+    content: (
+      <GitChangesView
+        runnerId={activeSessionInfo.runnerId}
+        cwd={activeSessionInfo.cwd}
+      />
+    ),
+  } : null, [showGit, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, startPanelDragWith, handleGitPositionChange]);
+
   const servicePanelTabs = React.useMemo<CombinedPanelTab[]>(() => {
-    if (!activeServicePanel || !activeSessionId) return [];
+    if (activeServicePanels.size === 0 || !activeSessionId) return [];
 
-    // Try static registry first
-    const staticDef = SERVICE_PANELS.find(p => p.serviceId === activeServicePanel);
-    // Then dynamic panels
-    const dynamicDef = !staticDef ? dynamicPanels.find(p => p.serviceId === activeServicePanel) : null;
+    const tabs: CombinedPanelTab[] = [];
+    for (const serviceId of activeServicePanels) {
+      // Try static registry first, then dynamic panels
+      const staticDef = SERVICE_PANELS.find(p => p.serviceId === serviceId);
+      const dynamicDef = !staticDef ? dynamicPanels.find(p => p.serviceId === serviceId) : null;
+      if (!staticDef && !dynamicDef) continue;
 
-    if (!staticDef && !dynamicDef) return [];
+      const label = staticDef?.label ?? dynamicDef!.label;
+      const icon = staticDef?.icon ?? <DynamicLucideIcon name={dynamicDef!.icon} />;
+      const content = staticDef
+        ? <staticDef.component sessionId={activeSessionId} />
+        : <IframeServicePanel sessionId={activeSessionId} port={dynamicDef!.port} />;
 
-    const label = staticDef?.label ?? dynamicDef!.label;
-    const icon = staticDef?.icon ?? <DynamicLucideIcon name={dynamicDef!.icon} />;
-    const content = staticDef
-      ? <staticDef.component sessionId={activeSessionId} />
-      : <IframeServicePanel sessionId={activeSessionId} port={dynamicDef!.port} />;
-
-    return [{
-      id: staticDef?.serviceId ?? dynamicDef!.serviceId,
-      label,
-      icon,
-      onDragStart: (e) => startPanelDragWith(e, handleServicePanelPositionChange),
-      onClose: () => {
-        closeServicePanel();
-        if (showTerminal) handleCombinedTabChange("terminal");
-        else if (showFileExplorer) handleCombinedTabChange("files");
-      },
-      content,
-    }];
-  }, [activeServicePanel, activeSessionId, dynamicPanels, startPanelDragWith, handleServicePanelPositionChange, closeServicePanel, showTerminal, showFileExplorer, handleCombinedTabChange]);
+      tabs.push({
+        id: serviceId,
+        label,
+        icon,
+        onDragStart: (e) => startPanelDragWith(e, (pos) => setServicePanelPosition(serviceId, pos)),
+        onClose: () => closeServicePanelById(serviceId),
+        content,
+      });
+    }
+    return tabs;
+  }, [activeServicePanels, activeSessionId, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById]);
 
   const panelGroups = React.useMemo(() => {
     const groups: Record<"left" | "right" | "bottom", CombinedPanelTab[]> = { left: [], right: [], bottom: [] };
     if (terminalPanelTab) groups[terminalPosition].push(terminalPanelTab);
     if (filesPanelTab) groups[filesPosition].push(filesPanelTab);
-    if (servicePanelTabs[0]) groups[servicePanelPosition].push(servicePanelTabs[0]);
+    if (gitPanelTab) groups[gitPosition].push(gitPanelTab);
+    for (const tab of servicePanelTabs) groups[getServicePanelPosition(tab.id)].push(tab);
     return groups;
-  }, [terminalPanelTab, terminalPosition, filesPanelTab, filesPosition, servicePanelTabs, servicePanelPosition]);
+  }, [terminalPanelTab, terminalPosition, filesPanelTab, filesPosition, gitPanelTab, gitPosition, servicePanelTabs, getServicePanelPosition]);
 
   const handleGroupPositionChange = React.useCallback((tabIds: string[], pos: import("@/hooks/usePanelLayout").PanelPosition) => {
     if (tabIds.includes("terminal")) handleTerminalPositionChange(pos);
     if (tabIds.includes("files")) handleFilesPositionChange(pos);
-    if (activeServicePanel && tabIds.includes(activeServicePanel)) handleServicePanelPositionChange(pos);
-  }, [handleTerminalPositionChange, handleFilesPositionChange, activeServicePanel, handleServicePanelPositionChange]);
+    if (tabIds.includes("git")) handleGitPositionChange(pos);
+    for (const id of activeServicePanels) {
+      if (tabIds.includes(id)) setServicePanelPosition(id, pos);
+    }
+  }, [handleTerminalPositionChange, handleFilesPositionChange, handleGitPositionChange, activeServicePanels, setServicePanelPosition]);
 
   const handleGroupDragStart = React.useCallback((tabIds: string[]) => (e: React.PointerEvent) => {
     startPanelDragWith(e, (pos) => handleGroupPositionChange(tabIds, pos));
   }, [startPanelDragWith, handleGroupPositionChange]);
 
   const mobilePanelTabs = React.useMemo(() => {
-    return [terminalPanelTab, filesPanelTab, ...servicePanelTabs].filter(Boolean) as CombinedPanelTab[];
-  }, [terminalPanelTab, filesPanelTab, servicePanelTabs]);
+    return [terminalPanelTab, filesPanelTab, gitPanelTab, ...servicePanelTabs].filter(Boolean) as CombinedPanelTab[];
+  }, [terminalPanelTab, filesPanelTab, gitPanelTab, servicePanelTabs]);
 
   const resolveActiveTabId = React.useCallback((tabs: CombinedPanelTab[]) => {
     if (tabs.length === 0) return combinedActiveTab;
@@ -3970,11 +3979,13 @@ export function App() {
                       showTerminalButton
                       onToggleFileExplorer={() => setShowFileExplorer((v) => !v)}
                       showFileExplorerButton={!!activeSessionInfo?.runnerId && !!activeSessionInfo?.cwd}
+                      onToggleGit={() => setShowGit((v) => !v)}
+                      showGitButton={!!activeSessionInfo?.runnerId && !!activeSessionInfo?.cwd}
                       extraHeaderButtons={
                         <ServicePanelButtons
                           availableServices={availableServices}
                           dynamicPanels={dynamicPanels}
-                          activePanelId={activeServicePanel}
+                          activePanelIds={activeServicePanels}
                           onTogglePanel={handleToggleServicePanel}
                         />
                       }

--- a/packages/ui/src/components/FileExplorer.tsx
+++ b/packages/ui/src/components/FileExplorer.tsx
@@ -608,7 +608,7 @@ function FileViewer({
 
 // ── Git Changes View ──────────────────────────────────────────────────────────
 
-function GitChangesView({
+export function GitChangesView({
   runnerId,
   cwd,
   outerRef,
@@ -1050,7 +1050,6 @@ function PositionPicker({
 // ── Main File Explorer Component ──────────────────────────────────────────────
 
 export function FileExplorer({ runnerId, cwd, className, onClose, position = "left", onPositionChange, onDragStart }: FileExplorerProps) {
-  const [tab, setTab] = React.useState<"files" | "git">("files");
   const [files, setFiles] = React.useState<FileEntry[] | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
@@ -1149,156 +1148,58 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
 
   return (
     <div ref={outerRef} className={cn("flex flex-col bg-background text-foreground", className)}>
-      {/* Header with tabs */}
-      <div className="flex items-center border-b border-border bg-muted/50">
-        {/* Mobile back button */}
-        {onClose && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="gap-1.5 text-sm text-muted-foreground hover:text-foreground h-9 px-2 md:hidden"
-            onClick={onClose}
-          >
-            <ChevronLeft className="size-4" />
-            Back
-          </Button>
-        )}
-
-        {/* Tab buttons */}
-        <div className="flex items-center flex-1">
-          <button
-            type="button"
-            onClick={() => setTab("files")}
-            className={cn(
-              "flex items-center gap-1.5 px-3 py-2 text-sm font-medium transition-colors border-b-2",
-              tab === "files"
-                ? "border-primary text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <FolderTree className="size-3.5" />
-            Files
-          </button>
-          <button
-            type="button"
-            onClick={() => setTab("git")}
-            className={cn(
-              "flex items-center gap-1.5 px-3 py-2 text-sm font-medium transition-colors border-b-2",
-              tab === "git"
-                ? "border-primary text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
-            )}
-          >
-            <GitBranch className="size-3.5" />
-            Git
-          </button>
-        </div>
-
-        {/* Refresh button for files tab */}
-        {tab === "files" && (
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <button
-                  type="button"
-                  onClick={fetchFiles}
-                  className="text-muted-foreground hover:text-foreground transition-colors px-2 py-1"
-                  aria-label="Refresh file list"
-                >
-                  <RefreshCw className="size-3.5" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent>Refresh file list</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        )}
-
-        {/* Desktop: grip + position buttons + close */}
-        <div className="hidden md:flex items-center gap-px pr-1 shrink-0">
-          {onDragStart && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div
-                    className="flex items-center justify-center size-7 rounded cursor-grab active:cursor-grabbing text-muted-foreground/60 hover:text-muted-foreground hover:bg-accent transition-colors touch-none select-none"
-                    onPointerDown={onDragStart}
-                    aria-label="Drag to reposition panel"
-                  >
-                    <GripHorizontal size={13} />
-                  </div>
-                </TooltipTrigger>
-                <TooltipContent>Drag to reposition panel</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
-          {onPositionChange && (
-            <>
-              <div className="w-px h-4 bg-border mx-1 shrink-0" />
-              <PositionPicker position={position} onPositionChange={onPositionChange} />
-              <div className="w-px h-4 bg-border mx-1 shrink-0" />
-            </>
-          )}
-          {onClose && (
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <button
-                    type="button"
-                    onClick={onClose}
-                    className="flex items-center justify-center size-7 rounded text-muted-foreground/60 hover:text-foreground hover:bg-accent transition-colors"
-                    aria-label="Close file explorer"
-                  >
-                    <X className="size-3.5" />
-                  </button>
-                </TooltipTrigger>
-                <TooltipContent>Close file explorer</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          )}
-        </div>
-
-        {/* Mobile close (back button already handles this, but keep X for symmetry) */}
-      </div>
-
       {/* Path breadcrumb */}
-      <div className="px-3 py-1.5 text-[0.65rem] text-muted-foreground font-mono truncate border-b border-border/50" title={cwd}>
-        {cwd}
+      <div className="flex items-center border-b border-border/50 bg-muted/50">
+        <div className="flex-1 px-3 py-1.5 text-[0.65rem] text-muted-foreground font-mono truncate" title={cwd}>
+          {cwd}
+        </div>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={fetchFiles}
+                className="text-muted-foreground hover:text-foreground transition-colors px-2 py-1"
+                aria-label="Refresh file list"
+              >
+                <RefreshCw className="size-3.5" />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Refresh file list</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
 
       {/* Content */}
       <div className="flex-1 min-h-0 overflow-auto">
-        {tab === "files" ? (
-          loading ? (
-            <div className="flex items-center justify-center p-8">
-              <Spinner className="size-5" />
-            </div>
-          ) : error ? (
-            <div className="p-4">
-              <p className="text-sm text-red-400 mb-3">{error}</p>
-              <Button variant="outline" size="sm" onClick={fetchFiles}>
-                <RefreshCw className="size-3 mr-1.5" /> Retry
-              </Button>
-            </div>
-          ) : files && files.length === 0 ? (
-            <div className="flex flex-col items-center justify-center py-8 text-muted-foreground gap-2">
-              <Folder className="size-8 opacity-30" />
-              <p className="text-sm">Empty directory</p>
-            </div>
-          ) : (
-            <div className="py-1">
-              {files?.map((entry) => (
-                <FileTreeNode
-                  key={entry.path}
-                  entry={entry}
-                  depth={0}
-                  runnerId={runnerId}
-                  onSelectFile={setViewingFile}
-                />
-              ))}
-            </div>
-          )
+        {loading ? (
+          <div className="flex items-center justify-center p-8">
+            <Spinner className="size-5" />
+          </div>
+        ) : error ? (
+          <div className="p-4">
+            <p className="text-sm text-red-400 mb-3">{error}</p>
+            <Button variant="outline" size="sm" onClick={fetchFiles}>
+              <RefreshCw className="size-3 mr-1.5" /> Retry
+            </Button>
+          </div>
+        ) : files && files.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-8 text-muted-foreground gap-2">
+            <Folder className="size-8 opacity-30" />
+            <p className="text-sm">Empty directory</p>
+          </div>
         ) : (
-          <GitChangesView runnerId={runnerId} cwd={cwd} outerRef={outerRef} />
+          <div className="py-1">
+            {files?.map((entry) => (
+              <FileTreeNode
+                key={entry.path}
+                entry={entry}
+                depth={0}
+                runnerId={runnerId}
+                onSelectFile={setViewingFile}
+              />
+            ))}
+          </div>
         )}
       </div>
     </div>

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -74,7 +74,7 @@ import { MultipleChoiceQuestions } from "@/components/ai-elements/multiple-choic
 import { PlanModePanel, type PlanModeAnswer } from "@/components/ai-elements/plan-mode";
 import { formatAnswersForAgent, type QuestionDisplayMode } from "@/lib/ask-user-questions";
 import { dismissNotificationsForSession } from "@/lib/push";
-import { AlertTriangleIcon, BookOpen, Bot, CheckCircle2, ChevronsUpDown, Circle, CircleDashed, Copy, Loader2, MessageSquare, OctagonX, PaperclipIcon, Pencil, Plus, Puzzle, ShieldAlert, Zap, Clock, X, Trash2, TerminalIcon, XCircle, FolderTree } from "lucide-react";
+import { AlertTriangleIcon, BookOpen, Bot, CheckCircle2, ChevronsUpDown, Circle, CircleDashed, Copy, Loader2, MessageSquare, OctagonX, PaperclipIcon, Pencil, Plus, Puzzle, ShieldAlert, Zap, Clock, X, Trash2, TerminalIcon, XCircle, FolderTree, GitBranch } from "lucide-react";
 import { AtMentionPopover } from "@/components/AtMentionPopover";
 import type { Entry as AtMentionEntry } from "@/hooks/useAtMentionFiles";
 import { McpToggleContext, type McpToggleHandler } from "@/components/session-viewer/McpToggleContext";
@@ -138,6 +138,10 @@ export interface SessionViewerProps {
   onToggleFileExplorer?: () => void;
   /** Whether to show the file explorer button */
   showFileExplorerButton?: boolean;
+  /** Toggle the git panel */
+  onToggleGit?: () => void;
+  /** Whether to show the git button */
+  showGitButton?: boolean;
   /** Extra buttons to render in the header bar (e.g. service panel toggles) */
   extraHeaderButtons?: React.ReactNode;
   /** Current agent todo list */
@@ -555,7 +559,7 @@ function SessionSkeleton() {
   );
 }
 
-export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onEditQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse, onQuestionDismiss, onPlanDismiss, onDuplicateSession, runnerInfo, extraHeaderButtons, mcpOAuthPastes, onMcpOAuthPaste, onMcpOAuthPasteDismiss, onMcpServerDisable }: SessionViewerProps) {
+export function SessionViewer({ sessionId, sessionName, messages, activeModel, activeToolCalls, pendingQuestion, pendingPlan, pluginTrustPrompt, onPluginTrustResponse, availableCommands, resumeSessions, resumeSessionsLoading, onRequestResumeSessions, onSendInput, onExec, onShowModelSelector, agentActive, isCompacting, effortLevel, tokenUsage, lastHeartbeatAt, viewerStatus, retryState, messageQueue, onRemoveQueuedMessage, onEditQueuedMessage, onClearMessageQueue, onToggleTerminal, showTerminalButton, onToggleFileExplorer, showFileExplorerButton, onToggleGit, showGitButton, todoList = [], planModeEnabled, runnerId, sessionCwd, onAppendSystemMessage, onSpawnAgentSession, onTriggerResponse, onQuestionDismiss, onPlanDismiss, onDuplicateSession, runnerInfo, extraHeaderButtons, mcpOAuthPastes, onMcpOAuthPaste, onMcpOAuthPasteDismiss, onMcpServerDisable }: SessionViewerProps) {
   const [input, setInput] = React.useState("");
   // Per-session draft storage so switching sessions preserves unsent text
   const draftsRef = React.useRef<Map<string, string>>(new Map());
@@ -1605,6 +1609,23 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>Files</TooltipContent>
+              </Tooltip>
+            )}
+            {showGitButton && onToggleGit && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    className="h-7 w-7"
+                    onClick={onToggleGit}
+                    size="icon"
+                    type="button"
+                    variant="outline"
+                    aria-label="Toggle git panel"
+                  >
+                    <GitBranch className="size-3.5" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Git</TooltipContent>
               </Tooltip>
             )}
             {extraHeaderButtons}

--- a/packages/ui/src/components/TunnelPanel.tsx
+++ b/packages/ui/src/components/TunnelPanel.tsx
@@ -6,6 +6,7 @@ interface TunnelInfo {
     port: number;
     name?: string;
     url: string;
+    pinned?: boolean;
 }
 
 interface TunnelPanelProps {
@@ -27,12 +28,14 @@ export function TunnelPanel({ sessionId }: TunnelPanelProps) {
         onMessage: (type, payload) => {
             const p = payload as Record<string, unknown>;
             if (type === "tunnel_list_result") {
-                setTunnels((p.tunnels as TunnelInfo[]) ?? []);
+                setTunnels(((p.tunnels as TunnelInfo[]) ?? []).filter((t: TunnelInfo) => !t.pinned));
             } else if (type === "tunnel_registered") {
                 const info = p as unknown as TunnelInfo;
+                if (info.pinned) return;
                 setTunnels((prev: TunnelInfo[]) => [...prev.filter((t: TunnelInfo) => t.port !== info.port), info]);
             } else if (type === "tunnel_removed") {
                 const port = p.port as number;
+                // pinned tunnels are never in state, so this is a no-op for them — safe to run regardless
                 setTunnels((prev: TunnelInfo[]) => prev.filter((t: TunnelInfo) => t.port !== port));
                 // If the removed tunnel was being previewed, clear it
                 if (previewPort === port) setPreviewPort(null);

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -12,6 +12,7 @@ import { SERVICE_PANELS, type ServicePanelDef } from "./registry";
 import { DynamicLucideIcon } from "./lucide-icon";
 import { IframeServicePanel } from "./IframeServicePanel";
 import type { ServicePanelInfo } from "@pizzapi/protocol";
+import type { PanelPosition } from "@/hooks/usePanelLayout";
 
 // ── Buttons for the header bar ────────────────────────────────────────────────
 
@@ -19,14 +20,14 @@ interface ServicePanelButtonsProps {
     availableServices: Set<string>;
     /** Dynamic panels announced by runner services at runtime. */
     dynamicPanels?: ServicePanelInfo[];
-    activePanelId: string | null;
+    activePanelIds: Set<string>;
     onTogglePanel: (serviceId: string) => void;
 }
 
 export function ServicePanelButtons({
     availableServices,
     dynamicPanels = [],
-    activePanelId,
+    activePanelIds,
     onTogglePanel,
 }: ServicePanelButtonsProps) {
     // Static panels from the compiled registry
@@ -44,7 +45,7 @@ export function ServicePanelButtons({
                     <TooltipTrigger asChild>
                         <Button
                             className={`h-7 w-7 ${
-                                activePanelId === panel.serviceId ? "bg-accent text-accent-foreground" : ""
+                                activePanelIds.has(panel.serviceId) ? "bg-accent text-accent-foreground" : ""
                             }`}
                             onClick={() => onTogglePanel(panel.serviceId)}
                             size="icon"
@@ -63,7 +64,7 @@ export function ServicePanelButtons({
                     <TooltipTrigger asChild>
                         <Button
                             className={`h-7 w-7 ${
-                                activePanelId === panel.serviceId ? "bg-accent text-accent-foreground" : ""
+                                activePanelIds.has(panel.serviceId) ? "bg-accent text-accent-foreground" : ""
                             }`}
                             onClick={() => onTogglePanel(panel.serviceId)}
                             size="icon"
@@ -150,16 +151,60 @@ export function ServicePanelContainer({
 
 // ── Hook for managing service panel state ─────────────────────────────────────
 
+const SERVICE_PANEL_POSITIONS_KEY = "pp-service-panel-positions";
+
+function loadPanelPositions(): Map<string, PanelPosition> {
+    try {
+        const raw = localStorage.getItem(SERVICE_PANEL_POSITIONS_KEY);
+        if (raw) return new Map(JSON.parse(raw) as [string, PanelPosition][]);
+    } catch { /* ignore */ }
+    return new Map();
+}
+
+function savePanelPositions(positions: Map<string, PanelPosition>) {
+    try { localStorage.setItem(SERVICE_PANEL_POSITIONS_KEY, JSON.stringify([...positions])); } catch { /* ignore */ }
+}
+
 export function useServicePanelState() {
-    const [activePanelId, setActivePanelId] = useState<string | null>(null);
+    const [activePanelIds, setActivePanelIds] = useState<Set<string>>(new Set());
+    const [panelPositions, setPanelPositions] = useState<Map<string, PanelPosition>>(loadPanelPositions);
 
     const togglePanel = useCallback((serviceId: string) => {
-        setActivePanelId(prev => prev === serviceId ? null : serviceId);
+        setActivePanelIds(prev => {
+            const next = new Set(prev);
+            if (next.has(serviceId)) {
+                next.delete(serviceId);
+            } else {
+                next.add(serviceId);
+            }
+            return next;
+        });
     }, []);
 
-    const closePanel = useCallback(() => {
-        setActivePanelId(null);
+    const closePanelById = useCallback((serviceId: string) => {
+        setActivePanelIds(prev => {
+            const next = new Set(prev);
+            next.delete(serviceId);
+            return next;
+        });
     }, []);
 
-    return { activePanelId, togglePanel, closePanel };
+    const closeAllPanels = useCallback(() => {
+        setActivePanelIds(new Set());
+    }, []);
+
+    const getPanelPosition = useCallback((serviceId: string): PanelPosition => {
+        return panelPositions.get(serviceId) ?? "right";
+    }, [panelPositions]);
+
+    const setPanelPosition = useCallback((serviceId: string, pos: PanelPosition) => {
+        setPanelPositions(prev => {
+            const next = new Map(prev);
+            next.set(serviceId, pos);
+            savePanelPositions(next);
+            return next;
+        });
+    }, []);
+
+    return { activePanelIds, togglePanel, closePanelById, closeAllPanels, getPanelPosition, setPanelPosition };
 }

--- a/packages/ui/src/hooks/usePanelLayout.ts
+++ b/packages/ui/src/hooks/usePanelLayout.ts
@@ -58,6 +58,12 @@ export interface PanelLayoutState {
   // ── File explorer outer pointer handlers (resize + drag combined) ───────
   handleFilesOuterPointerMove: (e: React.PointerEvent) => void;
   handleFilesOuterPointerUp: () => void;
+
+  // ── Git panel ───────────────────────────────────────────────────────────
+  showGit: boolean;
+  setShowGit: React.Dispatch<React.SetStateAction<boolean>>;
+  gitPosition: PanelPosition;
+  handleGitPositionChange: (pos: PanelPosition) => void;
 }
 
 /**
@@ -374,6 +380,16 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     handleFilesDragEnd();
   }, [handleFilesResizeEnd, handleFilesDragEnd]);
 
+  // ── Git panel state ───────────────────────────────────────────────────
+  const [showGit, setShowGit] = React.useState(false);
+  const [gitPosition, setGitPosition] = React.useState<PanelPosition>(() => {
+    try { return (localStorage.getItem("pp-git-position") as PanelPosition) ?? "left"; } catch { return "left"; }
+  });
+  const handleGitPositionChange = React.useCallback((pos: PanelPosition) => {
+    setGitPosition(pos);
+    try { localStorage.setItem("pp-git-position", pos); } catch {}
+  }, []);
+
   return {
     showTerminal,
     setShowTerminal,
@@ -414,5 +430,9 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     handleFilesDragStart,
     handleFilesOuterPointerMove,
     handleFilesOuterPointerUp,
+    showGit,
+    setShowGit,
+    gitPosition,
+    handleGitPositionChange,
   };
 }


### PR DESCRIPTION
## Summary

All panels (terminal, files, git, tunnel, custom service panels) are now fully independent — each has its own toggle, position (left/right/bottom), and lifecycle.

### Changes

**Service panels** — Each service panel now tracks its own position via a per-panel `Map<string, PanelPosition>` persisted to localStorage. The tunnel panel is no longer mutually exclusive with user-provided iframe panels — multiple can be open simultaneously.

**Git panel** — Extracted from FileExplorer's internal Files/Git tab switcher into a standalone panel. Gets its own header button (GitBranch icon), own position state, and independent open/close. FileExplorer is now files-only.

**Panel grouping** — Panels that happen to share the same position become tabs in the same CombinedPanel. Panels at different positions render as separate panels. Dragging an individual tab moves only that panel.

### Files changed
- `packages/ui/src/components/service-panels/ServicePanels.tsx` — `useServicePanelState` now uses `Set<string>` for active panels + `Map<string, PanelPosition>` for per-panel positions
- `packages/ui/src/components/FileExplorer.tsx` — Removed internal tab strip, exported `GitChangesView`
- `packages/ui/src/hooks/usePanelLayout.ts` — Added `showGit`, `gitPosition`, `handleGitPositionChange`
- `packages/ui/src/components/SessionViewer.tsx` — Added Git toggle button in header
- `packages/ui/src/App.tsx` — Wired independent git panel tab, per-panel service positions