### PR TITLE
fix(runner): reconnection resilience — listener cleanup + panel port restoration

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -445,7 +445,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 // sessions that ended while the daemon was down or crashed.
                 void sweepOrphanedAttachments(new Set(runningSessions.keys())).catch(() => {});
             } catch (err) {
-                logError("[daemon] runner_registered handler failed:", err);
+                logError(`[daemon] runner_registered handler failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
             }
         });
 

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -366,67 +366,87 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         // ── Registration confirmation ─────────────────────────────────────
 
         socket.on("runner_registered", async (data: any) => {
-            runnerId = data.runnerId;
-            if (runnerId !== identity.runnerId) {
-                logWarn(`server assigned unexpected ID ${runnerId} (expected ${identity.runnerId})`);
-            }
-            logInfo(`registered as ${runnerId}`);
+            // Fix 3 (P2): wrap the entire handler in try/catch so that any
+            // service init() error doesn't silently swallow and leave the
+            // daemon in a half-initialized state.
+            try {
+                runnerId = data.runnerId;
+                if (runnerId !== identity.runnerId) {
+                    logWarn(`server assigned unexpected ID ${runnerId} (expected ${identity.runnerId})`);
+                }
+                logInfo(`registered as ${runnerId}`);
 
-            // Wait for plugin service discovery to finish, then init ALL services
-            // (built-in + plugins) and announce the full list.
-            // On reconnect, dispose first to clear stale listeners from the old socket.
-            await pluginServicesReady;
-            if (servicesInitialized) {
-                registry.disposeAll();
-            }
-            servicesInitialized = true;
-            // Build announcePanel callback — when a service calls it, we register
-            // the port with the tunnel service and re-announce to viewers.
-            const announcePanel = (serviceId: string) => (port: number) => {
-                const entry = panelEntries.get(serviceId);
-                if (!entry) return;
-                entry.port = port;
-                tunnelService.registerPort(port, entry.label);
-                logInfo(`[services] panel announced for "${serviceId}" on port ${port}`);
-                // Re-announce so viewers pick up the panel
+                // Wait for plugin service discovery to finish, then init ALL services
+                // (built-in + plugins) and announce the full list.
+                // On reconnect, dispose first to clear stale listeners from the old socket.
+                await pluginServicesReady;
+                if (servicesInitialized) {
+                    registry.disposeAll();
+                }
+                servicesInitialized = true;
+                // Build announcePanel callback — when a service calls it, we register
+                // the port with the tunnel service and re-announce to viewers.
+                const announcePanel = (serviceId: string) => (port: number) => {
+                    const entry = panelEntries.get(serviceId);
+                    if (!entry) return;
+                    entry.port = port;
+                    tunnelService.registerPort(port, entry.label);
+                    logInfo(`[services] panel announced for "${serviceId}" on port ${port}`);
+                    // Re-announce so viewers pick up the panel
+                    emitServiceAnnounce();
+                };
+
+                // Init all services — pass announcePanel to those with panel manifests
+                for (const handler of registry.getAll()) {
+                    const opts: any = { isShuttingDown: () => isShuttingDown };
+                    if (panelEntries.has(handler.id)) {
+                        opts.announcePanel = announcePanel(handler.id);
+                    }
+                    handler.init(socket, opts);
+                }
+                const allServiceIds = registry.getAll().map((s) => s.id);
+                logInfo(`[services] initialized ${allServiceIds.length} services: ${allServiceIds.join(", ")}`);
+
+                // Fix 2 (P1): Re-register already-known panel ports after reconnect.
+                // Folder-based services don't re-call announcePanel() on reconnect
+                // because their HTTP servers are already running. TunnelService.dispose()
+                // clears this.tunnels, so all ports must be re-registered explicitly or
+                // tunnel_requests return 404 for the rest of the connection.
+                for (const [, entry] of panelEntries) {
+                    if (entry.port) {
+                        tunnelService.registerPort(entry.port, entry.label);
+                        logInfo(`[services] re-registered panel port ${entry.port} for "${entry.serviceId}" after reconnect`);
+                    }
+                }
+
                 emitServiceAnnounce();
-            };
 
-            // Init all services — pass announcePanel to those with panel manifests
-            for (const handler of registry.getAll()) {
-                const opts: any = { isShuttingDown: () => isShuttingDown };
-                if (panelEntries.has(handler.id)) {
-                    opts.announcePanel = announcePanel(handler.id);
+                // Re-adopt orphaned sessions that survived a daemon restart.
+                // Their worker processes are still running and connected to the relay.
+                const existingSessions = data.existingSessions ?? [];
+                if (existingSessions.length > 0) {
+                    let adopted = 0;
+                    for (const { sessionId, cwd } of existingSessions) {
+                        if (runningSessions.has(sessionId)) continue; // already tracked
+                        runningSessions.set(sessionId, {
+                            sessionId,
+                            child: null,
+                            startedAt: Date.now(),
+                            adopted: true,
+                        });
+                        adopted++;
+                    }
+                    if (adopted > 0) {
+                        logInfo(`re-adopted ${adopted} orphaned session(s): ${existingSessions.map((s: any) => s.sessionId.slice(0, 8)).join(", ")}`);
+                    }
                 }
-                handler.init(socket, opts);
+
+                // Sweep orphaned session attachment directories — removes dirs for
+                // sessions that ended while the daemon was down or crashed.
+                void sweepOrphanedAttachments(new Set(runningSessions.keys())).catch(() => {});
+            } catch (err) {
+                logError("[daemon] runner_registered handler failed:", err);
             }
-            const allServiceIds = registry.getAll().map((s) => s.id);
-            logInfo(`[services] initialized ${allServiceIds.length} services: ${allServiceIds.join(", ")}`);
-            emitServiceAnnounce();
-
-            // Re-adopt orphaned sessions that survived a daemon restart.
-            // Their worker processes are still running and connected to the relay.
-            const existingSessions = data.existingSessions ?? [];
-            if (existingSessions.length > 0) {
-                let adopted = 0;
-                for (const { sessionId, cwd } of existingSessions) {
-                    if (runningSessions.has(sessionId)) continue; // already tracked
-                    runningSessions.set(sessionId, {
-                        sessionId,
-                        child: null,
-                        startedAt: Date.now(),
-                        adopted: true,
-                    });
-                    adopted++;
-                }
-                if (adopted > 0) {
-                    logInfo(`re-adopted ${adopted} orphaned session(s): ${existingSessions.map((s: any) => s.sessionId.slice(0, 8)).join(", ")}`);
-                }
-            }
-
-            // Sweep orphaned session attachment directories — removes dirs for
-            // sessions that ended while the daemon was down or crashed.
-            void sweepOrphanedAttachments(new Set(runningSessions.keys())).catch(() => {});
         });
 
         // ── Session management ────────────────────────────────────────────

--- a/packages/cli/src/runner/services/file-explorer-service.ts
+++ b/packages/cli/src/runner/services/file-explorer-service.ts
@@ -11,7 +11,18 @@ const execFileAsync = promisify(execFile);
 export class FileExplorerService implements ServiceHandler {
     readonly id = "file-explorer";
 
+    // Socket reference and named handler refs — kept so dispose() can call
+    // socket.off() with the exact same function object that was passed to
+    // socket.on().  Without this, each reconnect would add a new listener
+    // while the old one stayed registered (listener leak).
+    private _socket: Socket | null = null;
+    private _onListFiles: ((data: any) => void) | null = null;
+    private _onSearchFiles: ((data: any) => void) | null = null;
+    private _onReadFile: ((data: any) => void) | null = null;
+
     init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
+        this._socket = socket;
+
         // Helper: emit file_result on both channels (direct + service envelope).
         // ALL file_result emissions in this service go through this helper so
         // error paths and success paths are both covered.
@@ -24,7 +35,7 @@ export class FileExplorerService implements ServiceHandler {
             });
         };
 
-        socket.on("list_files", async (data: any) => {
+        this._onListFiles = async (data: any) => {
             if (isShuttingDown()) return;
             const requestId = data.requestId;
             const dirPath = data.path ?? "";
@@ -74,9 +85,10 @@ export class FileExplorerService implements ServiceHandler {
                     message: err instanceof Error ? err.message : String(err),
                 });
             }
-        });
+        };
+        socket.on("list_files", this._onListFiles);
 
-        socket.on("search_files", async (data: any) => {
+        this._onSearchFiles = async (data: any) => {
             if (isShuttingDown()) return;
             const requestId = data.requestId;
             const cwd = (data as any).cwd ?? "";
@@ -133,9 +145,10 @@ export class FileExplorerService implements ServiceHandler {
                     message: err instanceof Error ? err.message : String(err),
                 });
             }
-        });
+        };
+        socket.on("search_files", this._onSearchFiles);
 
-        socket.on("read_file", async (data: any) => {
+        this._onReadFile = async (data: any) => {
             if (isShuttingDown()) return;
             const requestId = data.requestId;
             const filePath = data.path ?? "";
@@ -185,10 +198,21 @@ export class FileExplorerService implements ServiceHandler {
                     message: err instanceof Error ? err.message : String(err),
                 });
             }
-        });
+        };
+        socket.on("read_file", this._onReadFile);
     }
 
     dispose(): void {
-        // No persistent resources to clean up
+        // Remove all socket listeners registered by init() so that reconnects
+        // don't accumulate N+1 handlers per event.
+        if (this._socket) {
+            if (this._onListFiles) (this._socket as any).off("list_files", this._onListFiles);
+            if (this._onSearchFiles) (this._socket as any).off("search_files", this._onSearchFiles);
+            if (this._onReadFile) (this._socket as any).off("read_file", this._onReadFile);
+            this._socket = null;
+        }
+        this._onListFiles = null;
+        this._onSearchFiles = null;
+        this._onReadFile = null;
     }
 }

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -9,7 +9,17 @@ const execFileAsync = promisify(execFile);
 export class GitService implements ServiceHandler {
     readonly id = "git";
 
+    // Socket reference and named handler refs — kept so dispose() can call
+    // socket.off() with the exact same function object that was passed to
+    // socket.on().  Without this, each reconnect would add a new listener
+    // while the old one stayed registered (listener leak).
+    private _socket: Socket | null = null;
+    private _onGitStatus: ((data: any) => void) | null = null;
+    private _onGitDiff: ((data: any) => void) | null = null;
+
     init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
+        this._socket = socket;
+
         // Helper: emit file_result on both channels (direct + service envelope).
         // ALL file_result emissions in this service go through this helper so
         // error paths and success paths are both covered.
@@ -22,7 +32,7 @@ export class GitService implements ServiceHandler {
             });
         };
 
-        socket.on("git_status", async (data: any) => {
+        this._onGitStatus = async (data: any) => {
             if (isShuttingDown()) return;
             const requestId = data.requestId;
             const cwd = data.cwd ?? "";
@@ -94,9 +104,10 @@ export class GitService implements ServiceHandler {
                     message: err instanceof Error ? err.message : String(err),
                 });
             }
-        });
+        };
+        socket.on("git_status", this._onGitStatus);
 
-        socket.on("git_diff", async (data: any) => {
+        this._onGitDiff = async (data: any) => {
             if (isShuttingDown()) return;
             const requestId = data.requestId;
             const cwd = data.cwd ?? "";
@@ -122,10 +133,19 @@ export class GitService implements ServiceHandler {
                     message: err instanceof Error ? err.message : String(err),
                 });
             }
-        });
+        };
+        socket.on("git_diff", this._onGitDiff);
     }
 
     dispose(): void {
-        // No persistent resources to clean up
+        // Remove all socket listeners registered by init() so that reconnects
+        // don't accumulate N+1 handlers per event.
+        if (this._socket) {
+            if (this._onGitStatus) (this._socket as any).off("git_status", this._onGitStatus);
+            if (this._onGitDiff) (this._socket as any).off("git_diff", this._onGitDiff);
+            this._socket = null;
+        }
+        this._onGitStatus = null;
+        this._onGitDiff = null;
     }
 }

--- a/packages/cli/src/runner/services/terminal-service.ts
+++ b/packages/cli/src/runner/services/terminal-service.ts
@@ -14,8 +14,21 @@ import { logInfo, logWarn, logError } from "../logger.js";
 export class TerminalService implements ServiceHandler {
     readonly id = "terminal";
 
+    // Socket reference and named handler refs — kept so dispose() can call
+    // socket.off() with the exact same function object that was passed to
+    // socket.on().  Without this, each reconnect would add a new listener
+    // while the old one stayed registered (listener leak).
+    private _socket: Socket | null = null;
+    private _onNewTerminal: ((data: any) => void) | null = null;
+    private _onTerminalInput: ((data: any) => void) | null = null;
+    private _onTerminalResize: ((data: any) => void) | null = null;
+    private _onKillTerminal: ((data: any) => void) | null = null;
+    private _onListTerminals: (() => void) | null = null;
+
     init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
-        socket.on("new_terminal", (data: any) => {
+        this._socket = socket;
+
+        this._onNewTerminal = (data: any) => {
             if (isShuttingDown()) return;
             const { terminalId, cwd: requestedCwd, cols, rows, shell } = data;
             logInfo(
@@ -74,9 +87,10 @@ export class TerminalService implements ServiceHandler {
                 rows,
                 shell,
             });
-        });
+        };
+        socket.on("new_terminal", this._onNewTerminal);
 
-        socket.on("terminal_input", (data: any) => {
+        this._onTerminalInput = (data: any) => {
             if (isShuttingDown()) return;
             const { terminalId, data: inputData } = data;
             if (!terminalId || !inputData) {
@@ -86,9 +100,10 @@ export class TerminalService implements ServiceHandler {
                 return;
             }
             writeTerminalInput(terminalId, inputData);
-        });
+        };
+        socket.on("terminal_input", this._onTerminalInput);
 
-        socket.on("terminal_resize", (data: any) => {
+        this._onTerminalResize = (data: any) => {
             if (isShuttingDown()) return;
             const { terminalId, cols, rows } = data;
             if (!terminalId) {
@@ -97,9 +112,10 @@ export class TerminalService implements ServiceHandler {
             }
             logInfo(`[terminal] terminal_resize: terminalId=${terminalId} ${cols}x${rows}`);
             resizeTerminal(terminalId, cols, rows);
-        });
+        };
+        socket.on("terminal_resize", this._onTerminalResize);
 
-        socket.on("kill_terminal", (data: any) => {
+        this._onKillTerminal = (data: any) => {
             if (isShuttingDown()) return;
             const { terminalId } = data;
             if (!terminalId) {
@@ -126,9 +142,10 @@ export class TerminalService implements ServiceHandler {
                     payload: { terminalId, message: "Terminal not found" },
                 });
             }
-        });
+        };
+        socket.on("kill_terminal", this._onKillTerminal);
 
-        socket.on("list_terminals", () => {
+        this._onListTerminals = () => {
             if (isShuttingDown()) return;
             const list = listTerminals();
             logInfo(`[terminal] list_terminals: ${list.length} active (${list.join(", ") || "none"})`);
@@ -140,10 +157,26 @@ export class TerminalService implements ServiceHandler {
                 type: "terminals_list",
                 payload: { terminals: list },
             });
-        });
+        };
+        socket.on("list_terminals", this._onListTerminals);
     }
 
     dispose(): void {
+        // Remove all socket listeners registered by init() so that reconnects
+        // don't accumulate N+1 handlers per event.
+        if (this._socket) {
+            if (this._onNewTerminal) (this._socket as any).off("new_terminal", this._onNewTerminal);
+            if (this._onTerminalInput) (this._socket as any).off("terminal_input", this._onTerminalInput);
+            if (this._onTerminalResize) (this._socket as any).off("terminal_resize", this._onTerminalResize);
+            if (this._onKillTerminal) (this._socket as any).off("kill_terminal", this._onKillTerminal);
+            if (this._onListTerminals) (this._socket as any).off("list_terminals", this._onListTerminals);
+            this._socket = null;
+        }
+        this._onNewTerminal = null;
+        this._onTerminalInput = null;
+        this._onTerminalResize = null;
+        this._onKillTerminal = null;
+        this._onListTerminals = null;
         killAllTerminals();
     }
 }

--- a/packages/cli/src/runner/services/tunnel-service.ts
+++ b/packages/cli/src/runner/services/tunnel-service.ts
@@ -273,11 +273,21 @@ export class TunnelService implements ServiceHandler {
         }
     }
 
+    // Named handler refs — kept so dispose() can call socket.off() with the
+    // exact same function object that was passed to socket.on().  Without this,
+    // each reconnect adds a new listener while the old one stays registered
+    // (listener leak).
+    private _onServiceMessage: ((envelope: ServiceEnvelope) => void) | null = null;
+    private _onTunnelRequest: ((data: TunnelRequestData) => void) | null = null;
+    private _onTunnelWsOpen: ((data: TunnelWsOpenData) => void) | null = null;
+    private _onTunnelWsData: ((data: TunnelWsDataPayload) => void) | null = null;
+    private _onTunnelWsClose: ((data: TunnelWsCloseData) => void) | null = null;
+
     init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
         this.socket = socket;
 
         // ── Viewer → Runner: service_message commands ─────────────────────────
-        (socket as any).on("service_message", (envelope: ServiceEnvelope) => {
+        this._onServiceMessage = (envelope: ServiceEnvelope) => {
             if (isShuttingDown()) return;
             if (envelope.serviceId !== "tunnel") return;
 
@@ -292,34 +302,54 @@ export class TunnelService implements ServiceHandler {
                     this.handleUnexpose(envelope.payload as { port: number });
                     break;
             }
-        });
+        };
+        (socket as any).on("service_message", this._onServiceMessage);
 
         // ── Server → Runner: tunnel_request (HTTP proxy) ───────────────────────
-        (socket as any).on("tunnel_request", async (data: TunnelRequestData) => {
+        this._onTunnelRequest = async (data: TunnelRequestData) => {
             if (isShuttingDown()) return;
             await this.handleHttpRequest(data);
-        });
+        };
+        (socket as any).on("tunnel_request", this._onTunnelRequest);
 
         // ── Server → Runner: tunnel_ws_open (WebSocket proxy) ─────────────────
-        (socket as any).on("tunnel_ws_open", (data: TunnelWsOpenData) => {
+        this._onTunnelWsOpen = (data: TunnelWsOpenData) => {
             if (isShuttingDown()) return;
             this.handleWsOpen(data);
-        });
+        };
+        (socket as any).on("tunnel_ws_open", this._onTunnelWsOpen);
 
         // ── Server → Runner: tunnel_ws_data (WebSocket frame from viewer) ─────
-        (socket as any).on("tunnel_ws_data", (data: TunnelWsDataPayload) => {
+        this._onTunnelWsData = (data: TunnelWsDataPayload) => {
             if (isShuttingDown()) return;
             this.handleWsData(data);
-        });
+        };
+        (socket as any).on("tunnel_ws_data", this._onTunnelWsData);
 
         // ── Server → Runner: tunnel_ws_close (viewer WS closed) ──────────────
-        (socket as any).on("tunnel_ws_close", (data: TunnelWsCloseData) => {
+        this._onTunnelWsClose = (data: TunnelWsCloseData) => {
             if (isShuttingDown()) return;
             this.handleWsClose(data);
-        });
+        };
+        (socket as any).on("tunnel_ws_close", this._onTunnelWsClose);
     }
 
     dispose(): void {
+        // Remove all socket listeners registered by init() so that reconnects
+        // don't accumulate N+1 handlers per event.
+        if (this.socket) {
+            if (this._onServiceMessage) (this.socket as any).off("service_message", this._onServiceMessage);
+            if (this._onTunnelRequest) (this.socket as any).off("tunnel_request", this._onTunnelRequest);
+            if (this._onTunnelWsOpen) (this.socket as any).off("tunnel_ws_open", this._onTunnelWsOpen);
+            if (this._onTunnelWsData) (this.socket as any).off("tunnel_ws_data", this._onTunnelWsData);
+            if (this._onTunnelWsClose) (this.socket as any).off("tunnel_ws_close", this._onTunnelWsClose);
+            this.socket = null;
+        }
+        this._onServiceMessage = null;
+        this._onTunnelRequest = null;
+        this._onTunnelWsOpen = null;
+        this._onTunnelWsData = null;
+        this._onTunnelWsClose = null;
         // Close all active WebSocket tunnel connections
         for (const [, ws] of this.wsConnections) {
             try { ws.close(1001, "tunnel service disposed"); } catch { /* ignore */ }
@@ -328,7 +358,6 @@ export class TunnelService implements ServiceHandler {
         this.wsPortMap.clear();
         this.tunnels.clear();
         this.responseCache.clear();
-        this.socket = null;
     }
 
     // ── Internal API (called by daemon, not via socket) ───────────────────


### PR DESCRIPTION
## Reconnection Resilience Fixes

Addresses three systemic bugs that cause degraded behavior after a runner reconnects to the relay server.

---

### Fix 1 (P1): Socket listener leak — N+1 handlers per event after N reconnects

**Files:** `terminal-service.ts`, `file-explorer-service.ts`, `git-service.ts`, `tunnel-service.ts`

`runner_registered` fires on every reconnect and calls `handler.init(socket, opts)` which registers new `socket.on()` listeners. Previously `dispose()` never called `socket.off()`, so after N reconnects each socket event had N+1 listeners registered — causing duplicate terminal output, duplicate git responses, etc.

**Fix:** Each service now stores named handler references as class fields (`_onNewTerminal`, `_onGitStatus`, `_onServiceMessage`, etc.) and calls `socket.off(event, this._handlerRef)` in `dispose()` with the exact same function object that was passed to `socket.on()`. The socket reference itself is also stored so `dispose()` has access to it.

---

### Fix 2 (P1): Panel tunnel ports cleared on reconnect — 404 after reconnect

**File:** `daemon.ts`

`TunnelService.dispose()` clears `this.tunnels`. On reconnect, folder-based services (which have HTTP servers already running) don't re-call `announcePanel()` — their HTTP server lifecycle predates the reconnect. So `this.tunnels` stays empty and all `tunnel_request`s return 404 until the user manually re-exposes ports.

**Fix:** After all services are init'd in the `runner_registered` handler, iterate `panelEntries` and call `tunnelService.registerPort(entry.port, entry.label)` for any entry with a port already set. `registerPort()` is idempotent (guards with `this.tunnels.has(port)`) so first-connect is unaffected.

---

### Fix 3 (P2): runner_registered async handler — no try/catch

**File:** `daemon.ts`

The entire `runner_registered` async handler body had no try/catch. Any service `init()` throwing would silently reject the promise, leaving the daemon half-initialized with no log output.

**Fix:** Wrapped the entire handler body in `try { ... } catch (err) { logError(..., err) }`.

---

### Verification

- All 5 modified files typecheck cleanly in isolation (errors in worktree are pre-existing, unrelated to this branch)
- Test suite outcome unchanged vs. baseline (116 pre-existing failures in worktree, 0 new failures introduced)