### PR TITLE
fix(ui): mobile polish — safe area, iOS zoom, keyboard viewport, swipe resilience

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3651,7 +3651,7 @@ export function App() {
                 </button>
               )}
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="center" className="w-72 max-h-[70vh] overflow-y-auto">
+            <DropdownMenuContent align="center" className="w-72 max-h-[70dvh] overflow-y-auto">
               <DropdownMenuLabel className="flex items-center justify-between">
                 <span>Sessions</span>
                 <span className={`inline-block h-1.5 w-1.5 rounded-full ${relayStatus === "connected" ? "bg-green-500 shadow-[0_0_4px_#22c55e80]" : relayStatus === "connecting" ? "bg-slate-400" : "bg-red-500"}`} />
@@ -3899,6 +3899,7 @@ export function App() {
             "pp-sidebar-overlay absolute inset-0 z-30 bg-black/50 md:hidden transition-opacity duration-300",
             sidebarOpen ? "opacity-100 pointer-events-auto" : "opacity-0 pointer-events-none",
           )}
+          style={{ touchAction: 'none' }}
           onPointerDown={sidebarOpen ? handleSidebarPointerDown : undefined}
           onPointerMove={sidebarOpen ? handleSidebarPointerMove : undefined}
           onPointerUp={sidebarOpen ? handleSidebarPointerUp : undefined}
@@ -4079,7 +4080,7 @@ export function App() {
             {mobilePanelTabs.length > 0 && (
               <div
                 className="md:hidden fixed inset-0 z-[60] flex flex-col bg-background pp-safe-left pp-safe-right"
-                style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
+                style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}
               >
                 <CombinedPanel
                   activeTabId={resolveActiveTabId(mobilePanelTabs)}

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -1314,6 +1314,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                         onPointerDown={selectMode ? undefined : (e) => handleSessionPointerDown(e, s.sessionId, s.runnerId ? REVEAL_WIDTH : REVEAL_WIDTH_NO_RUNNER)}
                                                         onPointerMove={selectMode ? undefined : handleSessionPointerMove}
                                                         onPointerUp={selectMode ? undefined : handleSessionPointerUp}
+                                                        onPointerCancel={selectMode ? undefined : handleSessionPointerUp}
                                                         onContextMenu={(e) => e.preventDefault()}
                                                         className={cn(
                                                             "relative flex items-center gap-2.5 w-full min-w-0 px-2.5 py-3 md:py-2.5 text-left rounded-md",
@@ -1559,6 +1560,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                                                 onPointerDown={(e) => handleSessionPointerDown(e, p.sessionId)}
                                                 onPointerMove={handleSessionPointerMove}
                                                 onPointerUp={handleSessionPointerUp}
+                                                onPointerCancel={handleSessionPointerUp}
                                                 onContextMenu={(e) => e.preventDefault()}
                                                 title={`View pinned session ${p.sessionId}`}
                                                 className={cn(

--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -73,7 +73,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
+          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-base md:text-sm outline-hidden disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         {...props}

--- a/packages/ui/src/hooks/useMobileSidebar.test.ts
+++ b/packages/ui/src/hooks/useMobileSidebar.test.ts
@@ -30,13 +30,15 @@ function detectAxisDecision(dx: number, dy: number): AxisDecision {
 
 /**
  * Swipe-offset clamping — mirrors the clamped value computation in
- * handleSidebarPointerMove: `Math.min(8, dx)`.
+ * handleSidebarPointerMove: `Math.max(-288, Math.min(8, dx))`.
  *
  * Only leftward drags produce significant negative offsets; rightward motion
  * is limited to a small (8 px) overscroll to give tactile feedback.
+ * Leftward motion is bounded at -288 px (full sidebar width) to prevent
+ * runaway offsets from over-translation.
  */
 function clampSwipeOffset(dx: number): number {
-  return Math.min(8, dx);
+  return Math.max(-288, Math.min(8, dx));
 }
 
 /**
@@ -86,10 +88,18 @@ describe("detectAxisDecision", () => {
 // ── Swipe-offset clamping ────────────────────────────────────────────────────
 
 describe("clampSwipeOffset", () => {
-  test("passes leftward (negative) drag values through unchanged", () => {
+  test("passes leftward (negative) drag values through unchanged when within -288px bound", () => {
     expect(clampSwipeOffset(-10)).toBe(-10);
     expect(clampSwipeOffset(-80)).toBe(-80);
     expect(clampSwipeOffset(-200)).toBe(-200);
+    expect(clampSwipeOffset(-288)).toBe(-288); // boundary — exactly at limit
+  });
+
+  test("clamps leftward drag at -288px (full sidebar width) lower bound", () => {
+    expect(clampSwipeOffset(-289)).toBe(-288);
+    expect(clampSwipeOffset(-300)).toBe(-288);
+    expect(clampSwipeOffset(-500)).toBe(-288);
+    expect(clampSwipeOffset(-1000)).toBe(-288);
   });
 
   test("clamps rightward (positive) drag to 8px maximum", () => {

--- a/packages/ui/src/hooks/useMobileSidebar.ts
+++ b/packages/ui/src/hooks/useMobileSidebar.ts
@@ -64,7 +64,7 @@ export function useMobileSidebar(): MobileSidebarState {
     if (s.isVertical || !s.locked) return;
     s.didSwipe = true;
     // Only allow leftward swipes (negative dx), with a tiny rightward overscroll
-    const clamped = Math.min(8, dx);
+    const clamped = Math.max(-288, Math.min(8, dx));
     sidebarSwipeOffsetRef.current = clamped;
     setSidebarSwipeOffset(clamped);
     e.preventDefault();


### PR DESCRIPTION
## Mobile Polish — 6 Targeted Fixes

This PR resolves six mobile UX issues across the PizzaPi UI identified in the Wave 4 audit.

### Fix 1 — Panel overlay: missing `safe-area-inset-top` (P1)
**File:** `packages/ui/src/App.tsx`
Added `paddingTop: 'env(safe-area-inset-top)'` to the mobile full-screen panel overlay alongside the existing `paddingBottom`. Without this, content rendered under the notch/Dynamic Island on iPhone.

### Fix 2 — CommandInput: iOS auto-zoom prevention (P1)
**File:** `packages/ui/src/components/ui/command.tsx`
Changed `text-sm` → `text-base md:text-sm` on `CommandPrimitive.Input`. iOS auto-zooms any input below 16px font size; `text-sm` is 14px. Matches the pattern already used in `input.tsx` and `textarea.tsx`.

### Fix 3 — Session switcher: keyboard-aware height (P2)
**File:** `packages/ui/src/App.tsx`
Changed `max-h-[70vh]` → `max-h-[70dvh]` on `DropdownMenuContent`. On iOS, `vh` does not shrink when the software keyboard is open, causing the dropdown to be clipped behind it. `dvh` (dynamic viewport height) respects the keyboard.

### Fix 4 — Sidebar overlay: `touchAction: none` (P2)
**File:** `packages/ui/src/App.tsx`
Added `style={{ touchAction: 'none' }}` to the `pp-sidebar-overlay` div. Without this, vertical swipes on the backdrop would trigger browser pull-to-refresh or scroll content underneath.

### Fix 5 — Sidebar swipe: lower bound clamp (P2)
**File:** `packages/ui/src/hooks/useMobileSidebar.ts`
Added a floor to the swipe offset clamp: `Math.max(-288, Math.min(8, dx))`. The sidebar is `w-72` (18rem = 288px). Without the floor, fast leftward swipes could produce offsets of -600px or worse, causing jarring visual artifacts.

### Fix 6 — Session card: `onPointerCancel` handler (P2)
**File:** `packages/ui/src/components/SessionSidebar.tsx`
Added `onPointerCancel={handleSessionPointerUp}` (same handler as `onPointerUp`) to both session card `<button>` elements (pinned and normal). Without this, system interruptions (incoming calls, app switching) during a swipe leave the long-press timer running indefinitely.

## Verification
- ✅ UI build: passes (`vite build` — 8.56s, no new errors)
- ✅ Tests: **646 pass, 0 fail** (`bun test packages/ui`)
- ✅ Typecheck: pre-existing error count unchanged (4054 errors, all in CLI/server, none in changed files)
- ✅ No regressions introduced