### PR TITLE
fix(cli): prevent zombie session re-spawn on kill + exit(43) race

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -194,6 +194,12 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         // relay (triggered when the new worker's registerTuiSession tears down the old
         // connection) must be ignored — the new worker is already live.
         const restartingSessions = new Set<string>();
+        // Sessions that have been explicitly killed via kill_session.
+        // Prevents a race where the worker calls process.exit(43) (restart-in-place)
+        // before SIGTERM is delivered — without this guard, exit code 43 in the child's
+        // exit handler would trigger doSpawn() even for an explicitly killed session,
+        // creating a zombie re-spawn.
+        const killedSessions = new Set<string>();
         // Sessions we've already handled session_ended for.  Prevents log
         // spam when the relay fires duplicate session_ended events (e.g. the
         // orphan sweeper runs after the relay already sent session_ended on
@@ -483,7 +489,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         ? { prompt: requestedPrompt, model: requestedModel, hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId }
                         : { hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId }; // Always pass agent + hidden models + parent on restart
                     isFirstSpawn = false;
-                    spawnSession(sessionId, apiKey!, relayRaw, requestedCwd, runningSessions, restartingSessions, doSpawn, spawnOpts);
+                    spawnSession(sessionId, apiKey!, relayRaw, requestedCwd, runningSessions, restartingSessions, killedSessions, doSpawn, spawnOpts);
                     socket.emit("session_ready", { sessionId });
                     // Re-emit service_announce so viewers that connect for this
                     // session receive the service list.  The relay only forwards
@@ -509,6 +515,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             if (entry) {
                 if (entry.child) {
                     try {
+                        // Mark as killed BEFORE sending SIGTERM so the child's
+                        // exit handler sees it even if exit code 43 (restart-in-place)
+                        // arrives before SIGTERM is delivered.
+                        killedSessions.add(sessionId);
                         entry.child.kill("SIGTERM");
                     } catch {}
                 } else if (entry.adopted) {
@@ -561,6 +571,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     return;
                 }
                 runningSessions.delete(sessionId);
+                killedSessions.delete(sessionId);
                 endedSessionIds.set(sessionId, Date.now());
                 logInfo(`session ${sessionId} ended on relay${entry.adopted ? " (adopted)" : ""}${reason ? ` (${reason})` : ""}`);
             } else if (!endedSessionIds.has(sessionId)) {

--- a/packages/cli/src/runner/session-spawner.test.ts
+++ b/packages/cli/src/runner/session-spawner.test.ts
@@ -5,10 +5,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 describe("session-spawner", () => {
-    test("spawns workers with the expected env and handles restart/cleanup paths", () => {
-        const repoRoot = join(import.meta.dir, "../../../..");
+    test("spawns workers with the expected env, handles restart/cleanup, and guards killed sessions from re-spawn", () => {
         const tmpHome = mkdtempSync(join(tmpdir(), "session-spawner-test-"));
         const childTestPath = join(import.meta.dir, `.session-spawner-child-${Date.now()}-${Math.random().toString(16).slice(2)}.test.ts`);
+
+        // Use the packages/cli directory as the cwd so bun picks up its local
+        // bunfig.toml (root="./src", no preload) instead of the root bunfig.toml
+        // which has a redis preload that fails in isolated test runs.
+        const cliDir = join(import.meta.dir, "../../..");
 
         try {
             writeFileSync(
@@ -80,6 +84,7 @@ describe("session-spawner child", () => {
         try {
             const runningSessions = new Map();
             const restartingSessions = new Set<string>();
+            const killedSessions = new Set<string>();
 
             spawnSession(
                 "sess-main",
@@ -88,6 +93,7 @@ describe("session-spawner child", () => {
                 tempCwd,
                 runningSessions,
                 restartingSessions,
+                killedSessions,
                 undefined,
                 {
                     prompt: "hello",
@@ -134,6 +140,7 @@ describe("session-spawner child", () => {
 
             const restartRunningSessions = new Map();
             const restartRestartingSessions = new Set<string>();
+            const restartKilledSessions = new Set<string>();
             const onRestartRequested = mock(() => {});
             spawnSession(
                 "sess-restart",
@@ -142,6 +149,7 @@ describe("session-spawner child", () => {
                 tempCwd,
                 restartRunningSessions,
                 restartRestartingSessions,
+                restartKilledSessions,
                 onRestartRequested,
             );
             latestChild!.exitCode = 43;
@@ -155,7 +163,8 @@ describe("session-spawner child", () => {
 
             const normalRunningSessions = new Map();
             const normalRestartingSessions = new Set<string>();
-            spawnSession("sess-exit", "api-key", "https://relay.example", tempCwd, normalRunningSessions, normalRestartingSessions);
+            const normalKilledSessions = new Set<string>();
+            spawnSession("sess-exit", "api-key", "https://relay.example", tempCwd, normalRunningSessions, normalRestartingSessions, normalKilledSessions);
             latestChild!.exitCode = 0;
             latestChild!.emit("exit", 0, null);
             await Promise.resolve();
@@ -164,8 +173,86 @@ describe("session-spawner child", () => {
 
             allowCwd = false;
             expect(() =>
-                spawnSession("sess-bad", "api-key", "https://relay.example", tempCwd, new Map(), new Set()),
+                spawnSession("sess-bad", "api-key", "https://relay.example", tempCwd, new Map(), new Set(), new Set()),
             ).toThrow("Requested cwd is outside allowed workspace root(s): " + tempCwd);
+        } finally {
+            rmSync(tempCwd, { recursive: true, force: true });
+        }
+    });
+
+    test("killed session with exit code 43 does not re-spawn (race condition guard)", async () => {
+        const cleanupSessionAttachments = mock(async (_sessionId: string) => {});
+        const logInfo = mock((_message: string) => {});
+        const trackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
+        const untrackSessionCwd = mock((_sessionId: string, _cwd: string) => {});
+        const runnerUsageCacheFilePath = mock(() => "/tmp/test-usage-cache.json");
+        const isCwdAllowed = mock((_cwd: string | undefined) => true);
+
+        let latestChild: FakeChild | null = null;
+
+        const spawnMock = mock((_execPath: string, _args: string[], _options: { stdio: string[]; env: Record<string, string> }) => {
+            latestChild = new FakeChild();
+            return latestChild;
+        });
+
+        mock.module("node:child_process", () => ({
+            spawn: spawnMock,
+        }));
+
+        mock.module("../extensions/session-attachments.js", () => ({
+            cleanupSessionAttachments,
+        }));
+
+        mock.module("./logger.js", () => ({
+            logInfo,
+        }));
+
+        mock.module("./runner-usage-cache.js", () => ({
+            runnerUsageCacheFilePath,
+            trackSessionCwd,
+            untrackSessionCwd,
+        }));
+
+        mock.module("./workspace.js", () => ({
+            isCwdAllowed,
+        }));
+
+        const { spawnSession } = await import("./session-spawner.js");
+        const tempCwd = mkdtempSync(join(tmpdir(), "session-spawner-killed-race-"));
+
+        try {
+            const runningSessions = new Map();
+            const restartingSessions = new Set<string>();
+            const killedSessions = new Set<string>();
+            const onRestartRequested = mock(() => {});
+
+            spawnSession(
+                "sess-killed-race",
+                "api-key",
+                "https://relay.example",
+                tempCwd,
+                runningSessions,
+                restartingSessions,
+                killedSessions,
+                onRestartRequested,
+            );
+
+            // Simulate kill_session: daemon marks session as killed before SIGTERM
+            killedSessions.add("sess-killed-race");
+
+            // Race: worker exits with code 43 (restart-in-place) before SIGTERM arrives
+            latestChild!.exitCode = 43;
+            latestChild!.emit("exit", 43, null);
+            await Promise.resolve();
+
+            // Guard must prevent re-spawning for an explicitly killed session
+            expect(onRestartRequested).not.toHaveBeenCalled();
+            // Should clean up attachments (treated as true termination, not restart)
+            expect(cleanupSessionAttachments).toHaveBeenCalledWith("sess-killed-race");
+            // killedSessions entry must be removed to prevent set growth
+            expect(killedSessions.has("sess-killed-race")).toBe(false);
+            // Session must be removed from runningSessions
+            expect(runningSessions.has("sess-killed-race")).toBe(false);
         } finally {
             rmSync(tempCwd, { recursive: true, force: true });
         }
@@ -175,7 +262,7 @@ describe("session-spawner child", () => {
             );
 
             execFileSync(process.execPath, ["test", childTestPath], {
-                cwd: repoRoot,
+                cwd: cliDir,
                 encoding: "utf-8",
                 env: {
                     ...process.env,

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -57,6 +57,7 @@ export function spawnSession(
     requestedCwd: string | undefined,
     runningSessions: Map<string, RunnerSession>,
     restartingSessions: Set<string>,
+    killedSessions: Set<string>,
     onRestartRequested?: () => void,
     options?: {
         prompt?: string;
@@ -152,7 +153,7 @@ export function spawnSession(
         runningSessions.delete(sessionId);
         untrackSessionCwd(sessionId, effectiveCwd);
         logInfo(`session ${sessionId} exited (code=${code}, signal=${signal})`);
-        if (code === 43 && onRestartRequested) {
+        if (code === 43 && onRestartRequested && !killedSessions.has(sessionId)) {
             // Restart-in-place: re-spawn immediately without touching attachments.
             // The session continues under the same ID — files saved to
             // ~/.pizzapi/session-attachments/{sessionId} must survive the restart.
@@ -166,6 +167,8 @@ export function spawnSession(
             // True termination — clean up persisted attachments now.
             // session_ended will also arrive later but runningSessions will be empty
             // by then, so this is the reliable cleanup point for spawned sessions.
+            // Also remove from killedSessions if this was an explicit kill to prevent leaks.
+            killedSessions.delete(sessionId);
             void cleanupSessionAttachments(sessionId).catch(() => {});
         }
     });


### PR DESCRIPTION
Night Shift dish 005 — adds killedSessions Set in daemon.ts to guard against race where a worker calls exit(43) (restart-in-place) before SIGTERM is delivered, which caused doSpawn() to re-create an explicitly killed session.

Godmother: CVM8j9cS