### PR TITLE
fix(ui): React state hygiene + hub socket dedup

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -63,6 +63,7 @@ import { FileExplorer, GitChangesView } from "@/components/FileExplorer";
 import { CombinedPanel, type CombinedPanelTab } from "@/components/CombinedPanel";
 import { DockedPanelGroup } from "@/components/DockedPanelGroup";
 import { ViewerSocketContext } from "@/lib/viewer-socket-context";
+import { HubSocketContext } from "@/lib/hub-socket-context";
 import { useRunnerServices, attachServiceAnnounceListener } from "@/hooks/useRunnerServices";
 import { ServicePanelButtons, useServicePanelState } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
@@ -413,6 +414,8 @@ export function App() {
   // Tracked as state so ViewerSocketContext consumers re-render when the socket changes.
   const [viewerSocket, setViewerSocket] = React.useState<Socket<ViewerServerToClientEvents, ViewerClientToServerEvents> | null>(null);
   const hubSocketRef = React.useRef<Socket<HubServerToClientEvents, HubClientToServerEvents> | null>(null);
+  // Tracked as state so HubSocketContext consumers re-render when the socket changes.
+  const [hubSocket, setHubSocket] = React.useState<Socket<HubServerToClientEvents, HubClientToServerEvents> | null>(null);
   const activeSessionRef = React.useRef<string | null>(null);
 
   // Cache last-known UI state per relay session so switching sessions feels instant.
@@ -2115,6 +2118,7 @@ export function App() {
   React.useEffect(() => {
     const socket = io("/hub", { withCredentials: true });
     hubSocketRef.current = socket;
+    setHubSocket(socket);
 
     const handleStateSnapshot = ({ sessionId, state }: { sessionId: string; state: SessionMetaState }) => {
       const currentSessionId = activeSessionRef.current;
@@ -2234,6 +2238,7 @@ export function App() {
       socket.off("connect", handleReconnect);
       socket.disconnect();
       hubSocketRef.current = null;
+      setHubSocket(null);
     };
   }, [applyMetaStateSnapshot, applyMetaPatch, applyMcpReport]);
 
@@ -3475,6 +3480,7 @@ export function App() {
   }
 
   return (
+    <HubSocketContext.Provider value={hubSocket}>
     <ViewerSocketContext.Provider value={viewerSocket}>
     <TooltipProvider delayDuration={0}>
     <div className="flex h-[100dvh] w-full flex-col overflow-hidden bg-background pp-safe-left pp-safe-right">
@@ -4158,5 +4164,6 @@ export function App() {
     </div>
     </TooltipProvider>
     </ViewerSocketContext.Provider>
+    </HubSocketContext.Provider>
   );
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -124,6 +124,12 @@ export function App() {
   });
   const [activeSessionId, setActiveSessionId] = React.useState<string | null>(null);
   const [messages, setMessages] = React.useState<RelayMessage[]>([]);
+  // Ref kept in sync with `messages` via useLayoutEffect so we can read the
+  // latest committed value in event handlers without needing functional updaters.
+  // This lets us move patchSessionCache side effects OUT of setMessages updaters,
+  // which would otherwise be called speculatively in React concurrent mode.
+  const messagesRef = React.useRef<RelayMessage[]>(messages);
+  React.useLayoutEffect(() => { messagesRef.current = messages; }, [messages]);
   const [viewerStatus, setViewerStatus] = React.useState("Idle");
   const [retryState, setRetryState] = React.useState<{ errorMessage: string; detectedAt: number } | null>(null);
   const [relayStatus, setRelayStatus] = React.useState<DotState>("connecting");
@@ -753,11 +759,9 @@ export function App() {
       content: typeof content === "string" ? content.trim() : content,
     };
 
-    setMessages((prev) => {
-      const next = [...prev, message];
-      patchSessionCache({ messages: next });
-      return next;
-    });
+    const next = [...messagesRef.current, message];
+    setMessages(next);
+    patchSessionCache({ messages: next });
   }, [patchSessionCache]);
 
 
@@ -801,12 +805,11 @@ export function App() {
       content: parts.join("\n"),
       isError: hasErrors,
     };
-    setMessages((prev) => {
-      if (prev.some((m) => m.key?.startsWith(`mcp_startup:${reportTs}`))) return prev;
-      const next = [...prev, message];
+    if (!messagesRef.current.some((m) => m.key?.startsWith(`mcp_startup:${reportTs}`))) {
+      const next = [...messagesRef.current, message];
+      setMessages(next);
       patchSessionCache({ messages: next });
-      return next;
-    });
+    }
   }, [patchSessionCache]);
 
   const applyMetaStateSnapshot = React.useCallback((state: SessionMetaState) => {
@@ -1418,12 +1421,10 @@ export function App() {
         // cross-chunk duplicates (e.g., partial messages from one chunk and
         // their final timestamped versions from another). This prevents
         // duplicate assistant/tool content from appearing in large-session reloads.
-        setMessages((current) => {
-          const deduped = deduplicateMessages(current);
-          setActiveToolCalls(detectInFlightTools(deduped));
-          patchSessionCache({ messages: deduped });
-          return deduped;
-        });
+        const deduped = deduplicateMessages(messagesRef.current);
+        setActiveToolCalls(detectInFlightTools(deduped));
+        setMessages(deduped);
+        patchSessionCache({ messages: deduped });
       }
       return;
     }
@@ -1755,11 +1756,9 @@ export function App() {
           setMessages((prev) => prev.map((m) => m.key === stableKey ? message : m));
         } else {
           injectedMessagesRef.current = [...injectedMessagesRef.current, message];
-          setMessages((prev) => {
-            const next = [...prev, message];
-            patchSessionCache({ messages: next });
-            return next;
-          });
+          const next = [...messagesRef.current, message];
+          setMessages(next);
+          patchSessionCache({ messages: next });
         }
       }
       return;
@@ -1790,11 +1789,9 @@ export function App() {
           setMessages((prev) => prev.map((m) => m.key === stableKey ? message : m));
         } else {
           injectedMessagesRef.current = [...injectedMessagesRef.current, message];
-          setMessages((prev) => {
-            const next = [...prev, message];
-            patchSessionCache({ messages: next });
-            return next;
-          });
+          const next = [...messagesRef.current, message];
+          setMessages(next);
+          patchSessionCache({ messages: next });
         }
         // Add/update pending paste prompt (always update nonce/authUrl)
         setMcpOAuthPastes((prev) => [
@@ -1813,13 +1810,13 @@ export function App() {
         (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
       );
       // Also remove from rendered messages
-      setMessages((prev) => {
-        const next = prev.filter((m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`));
-        if (next.length !== prev.length) {
-          patchSessionCache({ messages: next });
-        }
-        return next.length !== prev.length ? next : prev;
-      });
+      const filteredNext = messagesRef.current.filter(
+        (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
+      );
+      if (filteredNext.length !== messagesRef.current.length) {
+        setMessages(filteredNext);
+        patchSessionCache({ messages: filteredNext });
+      }
       // Remove from pending paste prompts
       setMcpOAuthPastes((prev) => prev.filter((p) => p.serverName !== serverName));
       return;
@@ -1837,11 +1834,9 @@ export function App() {
         content: `⚠ ${label}: ${message}`,
         isError: true,
       };
-      setMessages((prev) => {
-        const next = [...prev, errMessage];
-        patchSessionCache({ messages: next });
-        return next;
-      });
+      const next = [...messagesRef.current, errMessage];
+      setMessages(next);
+      patchSessionCache({ messages: next });
       return;
     }
 
@@ -4029,11 +4024,13 @@ export function App() {
                         injectedMessagesRef.current = injectedMessagesRef.current.filter(
                           (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
                         );
-                        setMessages((prev) => {
-                          const next = prev.filter((m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`));
-                          if (next.length !== prev.length) patchSessionCache({ messages: next });
-                          return next.length !== prev.length ? next : prev;
-                        });
+                        const disableNext = messagesRef.current.filter(
+                          (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
+                        );
+                        if (disableNext.length !== messagesRef.current.length) {
+                          setMessages(disableNext);
+                          patchSessionCache({ messages: disableNext });
+                        }
                         const socket = viewerWsRef.current;
                         if (socket?.connected) {
                           socket.emit("exec", {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -808,10 +808,20 @@ export function App() {
       content: parts.join("\n"),
       isError: hasErrors,
     };
-    if (!messagesRef.current.some((m) => m.key?.startsWith(`mcp_startup:${reportTs}`))) {
-      const next = [...messagesRef.current, message];
-      setMessages(next);
-      patchSessionCache({ messages: next });
+    // Use a functional updater so this chains correctly with any preceding
+    // setMessages(prev => ...) call in the same React batch (e.g. the final
+    // snapshot chunk updater).  Reading messagesRef.current here would be
+    // stale because the ref is only synced after the React commit.
+    let mcpNext: RelayMessage[] | null = null;
+    setMessages((prev) => {
+      if (prev.some((m) => m.key?.startsWith(`mcp_startup:${reportTs}`))) {
+        return prev; // already appended — no change
+      }
+      mcpNext = [...prev, message];
+      return mcpNext;
+    });
+    if (mcpNext !== null) {
+      patchSessionCache({ messages: mcpNext });
     }
   }, [patchSessionCache]);
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1398,7 +1398,17 @@ export function App() {
         .map((m, i) => toRelayMessage(m, `snapshot-${keyOffset + i}`))
         .filter((m): m is RelayMessage => m !== null);
 
-      setMessages((prev) => [...prev, ...convertedChunk]);
+      // For the final chunk, append + dedupe in a single updater pass so the
+      // dedup operates on the complete message array (including this chunk).
+      // For non-final chunks, just append.
+      let dedupedForSideEffects: RelayMessage[] | null = null;
+      setMessages((prev) => {
+        const appended = [...prev, ...convertedChunk];
+        if (!isFinal) return appended;
+        const deduped = deduplicateMessages(appended);
+        dedupedForSideEffects = deduped;
+        return deduped;
+      });
 
       // Update chunked delivery tracking
       if (chunkedDeliveryRef.current) {
@@ -1420,14 +1430,12 @@ export function App() {
         }
         setViewerStatus("Connected");
 
-        // Now that all messages are assembled, run global dedupe to remove
-        // cross-chunk duplicates (e.g., partial messages from one chunk and
-        // their final timestamped versions from another). This prevents
-        // duplicate assistant/tool content from appearing in large-session reloads.
-        const deduped = deduplicateMessages(messagesRef.current);
-        setActiveToolCalls(detectInFlightTools(deduped));
-        setMessages(deduped);
-        patchSessionCache({ messages: deduped });
+        // Side effects from the deduped result — the updater above assigned
+        // dedupedForSideEffects synchronously before returning.
+        if (dedupedForSideEffects) {
+          setActiveToolCalls(detectInFlightTools(dedupedForSideEffects));
+          patchSessionCache({ messages: dedupedForSideEffects });
+        }
       }
       return;
     }

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -687,7 +687,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
             sessionId: string;
             isActive: boolean;
             lastHeartbeatAt: string | null;
-            model?: string | null;
+            model?: { provider: string; id: string; name?: string } | null;
             sessionName?: string | null;
             runnerId?: string | null;
             runnerName?: string | null;

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -10,8 +10,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
-import { io } from "socket.io-client";
-import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/protocol";
+import { useHubSocket } from "@/lib/hub-socket-context";
 import { extractWorktreeName, formatPathTail, worktreeRoots } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { PanelLeftClose, PanelLeftOpen, Plus, X, HardDrive, FolderOpen, CheckSquare, Square, CheckCheck, Trash2, Pin, PinOff, ChevronDown, ChevronRight, MessageSquare, Copy } from "lucide-react";
@@ -434,6 +433,10 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     const [dotState, setDotState] = React.useState<DotState>("connecting");
     const [hasLoaded, setHasLoaded] = React.useState(false);
 
+    // Use the shared hub socket provided by App.tsx via context — avoids a
+    // second /hub WebSocket connection per browser tab.
+    const hubSocket = useHubSocket();
+
     // ── Pinned sessions ──────────────────────────────────────────────────
     const [pinnedSessions, setPinnedSessions] = React.useState<PinnedSession[]>([]);
     const [pinnedSessionIds, setPinnedSessionIds] = React.useState<Set<string>>(new Set());
@@ -603,7 +606,8 @@ export const SessionSidebar = React.memo(function SessionSidebar({
     }, [activeSessionId]);
 
     React.useEffect(() => {
-        const socket = io("/hub", { withCredentials: true });
+        if (!hubSocket) return;
+
         let disposed = false;
         let connectEpoch = 0;
         let latestHubSnapshotEpoch = 0;
@@ -629,26 +633,26 @@ export const SessionSidebar = React.memo(function SessionSidebar({
             }
         };
 
-        socket.on("connect", () => {
+        const handleConnect = () => {
             setDotState("connected");
             const epoch = ++connectEpoch;
             void resyncLiveSessionsFromApi(epoch);
-        });
+        };
 
-        socket.on("disconnect", () => {
+        const handleDisconnect = () => {
             setDotState("disconnected");
-        });
+        };
 
-        socket.on("connect_error", () => {
+        const handleConnectError = () => {
             setDotState("disconnected");
-        });
+        };
 
-        socket.on("sessions", (data) => {
+        const handleSessions = (data: unknown) => {
             latestHubSnapshotEpoch = connectEpoch;
             applyLiveSessionsSnapshot(parseHubSessionsPayload(data));
-        });
+        };
 
-        socket.on("session_added", (data) => {
+        const handleSessionAdded = (data: unknown) => {
             const s = data as unknown as HubSession;
             setLiveSessions((prev) => {
                 if (prev.some((p) => p.sessionId === s.sessionId)) return prev;
@@ -673,13 +677,21 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                     },
                 ];
             });
-        });
+        };
 
-        socket.on("session_removed", (data) => {
+        const handleSessionRemoved = (data: { sessionId: string }) => {
             setLiveSessions((prev) => prev.filter((s) => s.sessionId !== data.sessionId));
-        });
+        };
 
-        socket.on("session_status", (data) => {
+        const handleSessionStatus = (data: {
+            sessionId: string;
+            isActive: boolean;
+            lastHeartbeatAt: string | null;
+            model?: string | null;
+            sessionName?: string | null;
+            runnerId?: string | null;
+            runnerName?: string | null;
+        }) => {
             const { sessionId, isActive, lastHeartbeatAt, model, sessionName, runnerId, runnerName } = data;
             setLiveSessions((prev) =>
                 prev.map((s) =>
@@ -712,13 +724,37 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                     ),
                 );
             }
-        });
+        };
+
+        hubSocket.on("connect", handleConnect);
+        hubSocket.on("disconnect", handleDisconnect);
+        hubSocket.on("connect_error", handleConnectError);
+        hubSocket.on("sessions", handleSessions);
+        hubSocket.on("session_added", handleSessionAdded);
+        hubSocket.on("session_removed", handleSessionRemoved);
+        hubSocket.on("session_status", handleSessionStatus);
+
+        // If the shared socket is already connected by the time this effect runs,
+        // sync the session list immediately via REST — we will have missed the
+        // server's initial "sessions" emit that fires on namespace join.
+        if (hubSocket.connected) {
+            setDotState("connected");
+            const epoch = ++connectEpoch;
+            void resyncLiveSessionsFromApi(epoch);
+        }
 
         return () => {
             disposed = true;
-            socket.disconnect();
+            // Only remove our event handlers — App.tsx owns the socket lifecycle.
+            hubSocket.off("connect", handleConnect);
+            hubSocket.off("disconnect", handleDisconnect);
+            hubSocket.off("connect_error", handleConnectError);
+            hubSocket.off("sessions", handleSessions);
+            hubSocket.off("session_added", handleSessionAdded);
+            hubSocket.off("session_removed", handleSessionRemoved);
+            hubSocket.off("session_status", handleSessionStatus);
         };
-    }, []);
+    }, [hubSocket]);
 
     interface ProjectGroup {
         cwd: string;

--- a/packages/ui/src/lib/hub-socket-context.ts
+++ b/packages/ui/src/lib/hub-socket-context.ts
@@ -1,0 +1,11 @@
+import { createContext, useContext } from "react";
+import type { Socket } from "socket.io-client";
+import type { HubServerToClientEvents, HubClientToServerEvents } from "@pizzapi/protocol";
+
+export type HubSocket = Socket<HubServerToClientEvents, HubClientToServerEvents>;
+
+export const HubSocketContext = createContext<HubSocket | null>(null);
+
+export function useHubSocket(): HubSocket | null {
+    return useContext(HubSocketContext);
+}


### PR DESCRIPTION
## Night Shift Deferred Pairing: react-state-hub-socket

### Dish 001 — React State Hygiene (P1)
Lifted `patchSessionCache` side effects out of `setMessages` functional updaters in 7 locations. Uses `messagesRef` (synced via useLayoutEffect) so cache writes happen outside the updater. Fixes concurrent mode violation where React could double-fire side effects.

### Dish 002 — Hub Socket Dedup (P1)
Replaced SessionSidebar's independent `io('/hub')` socket with a shared `HubSocketContext` from App.tsx. One socket per tab instead of two. Named handler functions with surgical `socket.off()` cleanup.

### Godmother
Closes: MyhlJhuS, wexNsZ1X