### PR TITLE
feat: add timestamped logger for app logs

### DIFF
--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -9,6 +9,9 @@ import {
     isPlainObject,
 } from "./types.js";
 import { mergeSandboxConfig } from "./sandbox.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("hooks");
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
@@ -116,8 +119,8 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     const projectHooksTrusted = isProjectHooksTrusted(global);
     const projectHooks = projectHooksTrusted ? project.hooks : undefined;
     if (project.hooks && !projectHooksTrusted) {
-        console.warn(
-            "[hooks] Project hooks found in .pizzapi/config.json but not trusted. " +
+        log.warn(
+            "Project hooks found in .pizzapi/config.json but not trusted. " +
                 'Set "allowProjectHooks": true in ~/.pizzapi/config.json or ' +
                 "PIZZAPI_ALLOW_PROJECT_HOOKS=1 to enable.",
         );

--- a/packages/cli/src/extensions/claude-plugins.ts
+++ b/packages/cli/src/extensions/claude-plugins.ts
@@ -25,6 +25,9 @@ import { isPluginTrusted, trustPlugin } from "../config.js";
 import { execFile } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import { join } from "node:path";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("claude-plugins");
 
 // ── Hook executor ─────────────────────────────────────────────────────────────
 
@@ -65,8 +68,7 @@ async function execHookCommand(
                         (error as any).code === "ERR_CHILD_PROCESS_STDIO_MAXBUFFER" ||
                         (error.message ?? "").includes("maxBuffer");
                     if (isMaxBuffer) {
-                        console.warn(
-                            `[claude-plugins] Hook stdout was truncated (maxBuffer exceeded) for command: ${command}. ` +
+                        log.warn(`Hook stdout was truncated (maxBuffer exceeded) for command: ${command}. ` +
                             `A {"decision":"block"} at the end of large output may have been silently lost.`,
                         );
                     }

--- a/packages/cli/src/extensions/hooks/events.ts
+++ b/packages/cli/src/extensions/hooks/events.ts
@@ -2,6 +2,9 @@ import type { HookEntry, HookMatcher } from "../../config.js";
 import type { HookOutput } from "./types.js";
 import { matchesTool } from "./matcher.js";
 import { runHook, parseHookOutput } from "./runner.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("hooks");
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -91,7 +94,7 @@ export async function runFireAndForgetHooks(
             await runHook(hook, payload, cwd);
         } catch (err) {
             const msg = err instanceof Error ? err.message : String(err);
-            console.error(`[hooks] ${eventName} handler error: ${msg}`);
+            log.error(`${eventName} handler error: ${msg}`);
         }
     }
 }

--- a/packages/cli/src/extensions/hooks/extension.ts
+++ b/packages/cli/src/extensions/hooks/extension.ts
@@ -3,6 +3,9 @@ import type { HooksConfig } from "../../config.js";
 import { normalizeToolInput } from "./matcher.js";
 import { runHook, parseHookOutput } from "./runner.js";
 import { getMatchingHooks, runEventHooks, runFireAndForgetHooks } from "./events.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("hooks");
 
 // ---------------------------------------------------------------------------
 // Extension factory
@@ -113,7 +116,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                 } catch (err) {
                     // Defensive: never let hook errors crash the tool pipeline
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] PreToolUse handler error: ${msg}`);
+                    log.error(`PreToolUse handler error: ${msg}`);
                 }
             });
         }
@@ -179,7 +182,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                 } catch (err) {
                     // Defensive: never let hook errors crash the tool pipeline
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] PostToolUse handler error: ${msg}`);
+                    log.error(`PostToolUse handler error: ${msg}`);
                 }
             });
         }
@@ -206,7 +209,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
 
                     // Block → mark as handled so the agent doesn't see it
                     if (blocked) {
-                        console.error(`[hooks] Input blocked: ${reason}`);
+                        log.error(`Input blocked: ${reason}`);
                         return { action: "handled" as const };
                     }
 
@@ -226,7 +229,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                     return { action: "continue" as const };
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] Input handler error: ${msg}`);
+                    log.error(`Input handler error: ${msg}`);
                     return { action: "continue" as const };
                 }
             });
@@ -254,7 +257,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
 
                     // BeforeAgentStart doesn't support blocking — just log
                     if (blocked) {
-                        console.error("[hooks] BeforeAgentStart hook failed (non-fatal)");
+                        log.error("BeforeAgentStart hook failed (non-fatal)");
                     }
 
                     // Collect context and system prompt overrides
@@ -287,7 +290,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                     if (Object.keys(result).length > 0) return result;
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] BeforeAgentStart handler error: ${msg}`);
+                    log.error(`BeforeAgentStart handler error: ${msg}`);
                 }
             });
         }
@@ -328,7 +331,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                     }
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] UserBash handler error: ${msg}`);
+                    log.error(`UserBash handler error: ${msg}`);
                 }
             });
         }
@@ -354,12 +357,12 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                     );
 
                     if (blocked) {
-                        console.error(`[hooks] Session switch cancelled: ${reason}`);
+                        log.error(`Session switch cancelled: ${reason}`);
                         return { cancel: true };
                     }
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] SessionBeforeSwitch handler error: ${msg}`);
+                    log.error(`SessionBeforeSwitch handler error: ${msg}`);
                 }
             });
         }
@@ -380,12 +383,12 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                     );
 
                     if (blocked) {
-                        console.error(`[hooks] Session fork cancelled: ${reason}`);
+                        log.error(`Session fork cancelled: ${reason}`);
                         return { cancel: true };
                     }
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] SessionBeforeFork handler error: ${msg}`);
+                    log.error(`SessionBeforeFork handler error: ${msg}`);
                 }
             });
         }
@@ -402,7 +405,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                     );
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] SessionShutdown handler error: ${msg}`);
+                    log.error(`SessionShutdown handler error: ${msg}`);
                 }
             });
         }
@@ -427,12 +430,12 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                     );
 
                     if (blocked) {
-                        console.error(`[hooks] Session compaction cancelled: ${reason}`);
+                        log.error(`Session compaction cancelled: ${reason}`);
                         return { cancel: true };
                     }
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] SessionBeforeCompact handler error: ${msg}`);
+                    log.error(`SessionBeforeCompact handler error: ${msg}`);
                 }
             });
         }
@@ -455,12 +458,12 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                     );
 
                     if (blocked) {
-                        console.error(`[hooks] Session tree navigation cancelled: ${reason}`);
+                        log.error(`Session tree navigation cancelled: ${reason}`);
                         return { cancel: true };
                     }
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] SessionBeforeTree handler error: ${msg}`);
+                    log.error(`SessionBeforeTree handler error: ${msg}`);
                 }
             });
         }
@@ -493,7 +496,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                     );
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
-                    console.error(`[hooks] ModelSelect handler error: ${msg}`);
+                    log.error(`ModelSelect handler error: ${msg}`);
                 }
             });
         }

--- a/packages/cli/src/extensions/initial-prompt.ts
+++ b/packages/cli/src/extensions/initial-prompt.ts
@@ -1,5 +1,8 @@
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { createLogger } from "@pizzapi/tools";
 import { waitForRelayRegistration } from "./remote.js";
+
+const log = createLogger("worker");
 
 /**
  * InitialPrompt extension — handles one-time model selection, initial prompt
@@ -51,19 +54,19 @@ export const initialPromptExtension: ExtensionFactory = (pi) => {
                 try {
                     const ok = await pi.setModel(model);
                     if (ok) {
-                        console.log(`pizzapi worker: initial model set to ${initialModelProvider}/${initialModelId}`);
+                        log.info(`pizzapi worker: initial model set to ${initialModelProvider}/${initialModelId}`);
                     } else {
-                        console.warn(
+                        log.warn(
                             `pizzapi worker: model ${initialModelProvider}/${initialModelId} selected but no valid credentials found — using default`,
                         );
                     }
                 } catch (err) {
-                    console.warn(
+                    log.warn(
                         `pizzapi worker: failed to set initial model ${initialModelProvider}/${initialModelId}: ${err instanceof Error ? err.message : String(err)}`,
                     );
                 }
             } else {
-                console.warn(
+                log.warn(
                     `pizzapi worker: requested model ${initialModelProvider}/${initialModelId} not found in registry`,
                 );
             }
@@ -73,9 +76,9 @@ export const initialPromptExtension: ExtensionFactory = (pi) => {
         if (agentName) {
             try {
                 pi.setSessionName(`🤖 ${agentName}`);
-                console.log(`pizzapi worker: session name set to agent "${agentName}"`);
+                log.info(`pizzapi worker: session name set to agent "${agentName}"`);
             } catch (err) {
-                console.warn(
+                log.warn(
                     `pizzapi worker: failed to set agent session name: ${err instanceof Error ? err.message : String(err)}`,
                 );
             }
@@ -122,13 +125,13 @@ export const initialPromptExtension: ExtensionFactory = (pi) => {
                 // no tools resolved — an empty set is safer than full access.
                 pi.setActiveTools(uniqueAllowed);
                 if (uniqueAllowed.length > 0) {
-                    console.log(`pizzapi worker: agent tool allowlist applied: ${uniqueAllowed.join(", ")}`);
+                    log.info(`pizzapi worker: agent tool allowlist applied: ${uniqueAllowed.join(", ")}`);
                 } else {
-                    console.warn(`pizzapi worker: agent tool allowlist matched no known tools (requested: ${requested.join(", ")}). All tools disabled for safety.`);
+                    log.warn(`pizzapi worker: agent tool allowlist matched no known tools (requested: ${requested.join(", ")}). All tools disabled for safety.`);
                 }
             } catch (err) {
-                console.warn(
-                    `pizzapi worker: failed to apply agent tool allowlist: ${err instanceof Error ? err.message : String(err)}`,
+                log.warn(
+                    `failed to apply agent tool allowlist: ${err instanceof Error ? err.message : String(err)}`,
                 );
             }
         }
@@ -151,10 +154,10 @@ export const initialPromptExtension: ExtensionFactory = (pi) => {
                 const filtered = current.filter(t => !denied.has(t.toLowerCase()));
                 if (filtered.length < current.length) {
                     pi.setActiveTools(filtered);
-                    console.log(`pizzapi worker: agent tool denylist applied, removed: ${[...denied].join(", ")}`);
+                    log.info(`pizzapi worker: agent tool denylist applied, removed: ${[...denied].join(", ")}`);
                 }
             } catch (err) {
-                console.warn(
+                log.warn(
                     `pizzapi worker: failed to apply agent tool denylist: ${err instanceof Error ? err.message : String(err)}`,
                 );
             }
@@ -166,7 +169,7 @@ export const initialPromptExtension: ExtensionFactory = (pi) => {
         // to the parent. Falls back after 10s if relay never connects.
         if (initialPrompt) {
             waitForRelayRegistration(10_000).then(() => {
-                console.log(`pizzapi worker: sending initial prompt (${initialPrompt.length} chars)`);
+                log.info(`pizzapi worker: sending initial prompt (${initialPrompt.length} chars)`);
                 pi.sendUserMessage(initialPrompt);
             });
         }

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -14,6 +14,9 @@ import {
 import { setMcpBridge } from "./mcp-bridge.js";
 import type { RelayContext } from "./mcp-oauth.js";
 import { waitForRelayRegistration } from "./remote.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("mcp");
 
 type McpServerConfigEntry = {
   name: string;
@@ -588,7 +591,7 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
       // Ignore expected aborts when session lifecycle changes.
       const msg = err instanceof Error ? err.message : String(err);
       if (!/aborted/i.test(msg)) {
-        console.warn(`pizzapi: MCP eager init failed, will retry in session_start: ${msg}`);
+        log.warn(`pizzapi: MCP eager init failed, will retry in session_start: ${msg}`);
       }
       return null;
     });

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -11,11 +11,14 @@
 
 import { type PizzaPiConfig } from "../../config.js";
 import { PizzaPiOAuthProvider, type RelayContext } from "../mcp-oauth.js";
-import { isSandboxActive, getResolvedConfig } from "@pizzapi/tools";
+import { createLogger, isSandboxActive, getResolvedConfig } from "@pizzapi/tools";
 import { createStdioMcpClient } from "./transport-stdio.js";
 import { createHttpMcpClient, createStreamableMcpClient } from "./transport-http.js";
 import { allocateProviderSafeToolName } from "./tool-naming.js";
 import { type McpClient, type McpTool } from "./types.js";
+
+const log = createLogger("MCP");
+const sandboxLog = createLogger("sandbox/mcp");
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Config types
@@ -109,8 +112,7 @@ function isMcpDomainAllowed(url: string, serverName: string): boolean {
   const allowedDomains = sandboxCfg.srtConfig.network.allowedDomains;
   // Empty allowedDomains in full mode means deny-all network
   if (allowedDomains.length === 0) {
-    console.warn(
-      `[sandbox/mcp] Blocked MCP server "${serverName}": no domains in allowedDomains (full mode). ` +
+    sandboxLog.warn(`Blocked MCP server "${serverName}": no domains in allowedDomains (full mode). ` +
       `Add the domain to sandbox.network.allowedDomains in config.`,
     );
     return false;
@@ -123,8 +125,7 @@ function isMcpDomainAllowed(url: string, serverName: string): boolean {
     // Normalize to lowercase for case-insensitive DNS matching
     const deniedDomains = (sandboxCfg.srtConfig.network.deniedDomains ?? []).map(d => d.toLowerCase());
     if (deniedDomains.some(d => hostname === d || hostname.endsWith(`.${d.replace(/^\*\./, "")}`))) {
-      console.warn(
-        `[sandbox/mcp] Blocked MCP server "${serverName}": domain "${hostname}" ` +
+      sandboxLog.warn(`Blocked MCP server "${serverName}": domain "${hostname}" ` +
         `is in deniedDomains [${deniedDomains.join(", ")}]`,
       );
       return false;
@@ -134,13 +135,12 @@ function isMcpDomainAllowed(url: string, serverName: string): boolean {
     if (normalizedAllowed.some(d => hostname === d || hostname.endsWith(`.${d.replace(/^\*\./, "")}`))) {
       return true;
     }
-    console.warn(
-      `[sandbox/mcp] Blocked MCP server "${serverName}": domain "${hostname}" ` +
+    sandboxLog.warn(`Blocked MCP server "${serverName}": domain "${hostname}" ` +
       `not in allowedDomains [${allowedDomains.join(", ")}]`,
     );
     return false;
   } catch {
-    console.warn(`[sandbox/mcp] Blocked MCP server "${serverName}": invalid URL "${url}"`);
+    sandboxLog.warn(`Blocked MCP server "${serverName}": invalid URL "${url}"`);
     return false;
   }
 }
@@ -178,7 +178,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
           }),
         );
       } catch (err) {
-        console.error(`[MCP] Failed to create stdio client for "${s.name}": ${err}`);
+        log.error(`Failed to create stdio client for "${s.name}": ${err}`);
       }
     } else if (s.transport === "http") {
       if (!isMcpDomainAllowed(s.url, s.name)) continue;
@@ -228,7 +228,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
           }),
         );
       } catch (err) {
-        console.error(`[MCP] Failed to create stdio client for "${name}": ${err}`);
+        log.error(`Failed to create stdio client for "${name}": ${err}`);
       }
       continue;
     }
@@ -649,7 +649,7 @@ export async function registerMcpTools(
           const errStr = String(result.error);
           const isAuthError = /oauth|authentication|auth callback/i.test(errStr);
           if (!isAuthError) {
-            console.warn(`pizzapi: MCP server "${result.name}" failed in background: ${result.error}`);
+            log.warn(`pizzapi: MCP server "${result.name}" failed in background: ${result.error}`);
           }
         }
       }

--- a/packages/cli/src/extensions/remote-input.ts
+++ b/packages/cli/src/extensions/remote-input.ts
@@ -7,6 +7,9 @@
 
 import type { RemoteInputAttachment } from "./remote-types.js";
 import { saveSessionAttachment } from "./session-attachments.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("remote-input");
 
 /** MIME types and file extensions recognized as text-based (safe to decode as UTF-8). */
 const TEXT_MIME_PREFIXES = ["text/"];
@@ -99,13 +102,13 @@ export async function loadAttachmentFromRelay(
             headers: { "x-api-key": apiKey },
         });
     } catch (err) {
-        console.error(`pizzapi: attachment fetch failed (network error): ${url} — ${err instanceof Error ? err.message : String(err)}`);
+        log.error(`attachment fetch failed (network error): ${url} — ${err instanceof Error ? err.message : String(err)}`);
         return null;
     }
 
     if (!response.ok) {
         const body = await response.text().catch(() => "");
-        console.error(`pizzapi: attachment fetch failed: ${response.status} ${response.statusText} — ${url}${body ? ` — ${body}` : ""}`);
+        log.error(`pizzapi: attachment fetch failed: ${response.status} ${response.statusText} — ${url}${body ? ` — ${body}` : ""}`);
         return null;
     }
 
@@ -175,7 +178,7 @@ export async function buildUserMessageFromRemoteInput(
                 const saved = await saveSessionAttachment(sessionId, attachFilename, mediaType, buf);
                 savedPath = saved.filePath;
             } catch (err) {
-                console.error(`pizzapi: failed to persist attachment: ${err instanceof Error ? err.message : String(err)}`);
+                log.error(`pizzapi: failed to persist attachment: ${err instanceof Error ? err.message : String(err)}`);
             }
         }
 

--- a/packages/cli/src/extensions/remote/chunked-delivery.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.ts
@@ -16,8 +16,11 @@
 
 import { randomUUID } from "node:crypto";
 import { buildSessionContext } from "@mariozechner/pi-coding-agent";
+import { createLogger } from "@pizzapi/tools";
 import { getCurrentTodoList } from "../update-todo.js";
 import type { RelayContext } from "../remote-types.js";
+
+const log = createLogger("remote");
 
 /** Estimated payload size (bytes) above which we chunk messages. */
 const CHUNK_THRESHOLD = 5 * 1024 * 1024; // 5 MB — safely below 10 MB server limit
@@ -114,7 +117,7 @@ export function capOversizedMessages(messages: unknown[]): unknown[] {
             }
 
             result[i] = capped;
-            console.warn(
+            log.warn(
                 `pizzapi: message ${i} truncated (~${(size / 1024 / 1024).toFixed(0)} MB exceeds ${(MAX_MESSAGE_SIZE / 1024 / 1024).toFixed(0)} MB cap).`,
             );
         }
@@ -173,7 +176,7 @@ function sendChunkedMessages(rctx: RelayContext, rawMessages: unknown[], snapsho
     const chunks = computeChunkBoundaries(messages);
     const totalChunks = chunks.length;
 
-    console.log(
+    log.info(
         `pizzapi: session is large (${messages.length} messages, ~${(estimateMessagesSize(messages) / 1024 / 1024).toFixed(0)} MB). ` +
         `Sending in ${totalChunks} chunks (snapshot=${snapshotId.slice(0, 8)}).`,
     );

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -7,6 +7,7 @@
 
 import { io, type Socket } from "socket.io-client";
 import type { RelayClientToServerEvents, RelayServerToClientEvents } from "@pizzapi/protocol";
+import { createLogger } from "@pizzapi/tools";
 import { loadConfig } from "../../config.js";
 import { RELAY_BACKOFF_DEFAULTS, computeBackoffDelay } from "../../backoff.js";
 import { getMcpBridge } from "../mcp-bridge.js";
@@ -34,6 +35,7 @@ let connectFailureNotified = false;
 
 /** Pending OAuth callback resolvers, keyed by nonce. */
 const oauthPendingCallbacks = new Map<string, (result: { code: string; state?: string }) => void>();
+const log = createLogger("relay");
 
 // ── Dependency injection for factory-closure callbacks ────────────────────────
 
@@ -175,7 +177,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
     }
 
     const sioUrl = socketIoUrl(rctx);
-    console.log(`pizzapi: connecting to relay at ${sioUrl}/relay…`);
+    log.info(`pizzapi: connecting to relay at ${sioUrl}/relay…`);
 
     const sock: Socket<RelayServerToClientEvents, RelayClientToServerEvents> = io(
         sioUrl + "/relay",
@@ -206,17 +208,17 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         const approxDelayMs = computeBackoffDelay(attempt - 1);
         const delaySec = (approxDelayMs / 1000).toFixed(1);
         rctx.setRelayStatus(`Reconnecting to relay… (attempt ${attempt})`);
-        console.log(`pizzapi: relay reconnect attempt ${attempt} — retrying in ~${delaySec}s`);
+        log.info(`pizzapi: relay reconnect attempt ${attempt} — retrying in ~${delaySec}s`);
     });
 
     sock.io.on("reconnect", (attempt: number) => {
-        console.log(
+        log.info(
             `pizzapi: relay reconnected after ${attempt} attempt${attempt === 1 ? "" : "s"}`,
         );
     });
 
     sock.io.on("reconnect_error", (err: Error) => {
-        console.log(`pizzapi: relay reconnect error — ${err?.message ?? String(err)}`);
+        log.info(`pizzapi: relay reconnect error — ${err?.message ?? String(err)}`);
     });
 
     // ── Connection lifecycle ──────────────────────────────────────────────
@@ -246,7 +248,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         };
         connectFailureNotified = false;
         rctx.setRelayStatus("Connected to Relay");
-        console.log(
+        log.info(
             wasReconnect
                 ? `pizzapi: relay reconnected — session ${data.sessionId} (${data.shareUrl})`
                 : `pizzapi: relay connected — session ${data.sessionId} (${data.shareUrl})`,
@@ -279,12 +281,12 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
             case "link":
                 rctx.parentSessionId = parentStateDecision.parentSessionId;
                 rctx.isChildSession = true;
-                console.log(`pizzapi: linked as child of parent session ${parentStateDecision.parentSessionId}`);
+                log.info(`pizzapi: linked as child of parent session ${parentStateDecision.parentSessionId}`);
                 break;
             case "ignore_stale_server_link":
                 // The child ran /new while disconnected — don't restore the
                 // stale parent link from Redis.
-                console.log("pizzapi: ignoring stale parentSessionId from server (pendingDelinkOwnParent)");
+                log.info("pizzapi: ignoring stale parentSessionId from server (pendingDelinkOwnParent)");
                 rctx.parentSessionId = null;
                 rctx.isChildSession = false;
                 break;
@@ -333,7 +335,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         // the old parent can still inject tell_child / follow-up input.
         // Drop agent-originated input until the server-side link is severed.
         if (handlers.isPendingDelinkOwnParent() && (data as any).client === "agent") {
-            console.log("pizzapi: dropping stale parent tell_child/follow-up input — delink_own_parent pending");
+            log.info("pizzapi: dropping stale parent tell_child/follow-up input — delink_own_parent pending");
             return;
         }
 
@@ -357,7 +359,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                 const message = await buildUserMessageFromRemoteInput(inputText, attachments, httpBase, key ?? "", relaySessionId);
                 handlers.sendUserMessage(message, deliverAs ? { deliverAs } : undefined);
             } catch (err) {
-                console.error(`pizzapi: failed to deliver remote input: ${err instanceof Error ? err.message : String(err)}`);
+                log.error(`pizzapi: failed to deliver remote input: ${err instanceof Error ? err.message : String(err)}`);
             }
         })();
     });
@@ -378,13 +380,13 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
     sock.on("session_message", (data) => {
         // Drop session_messages only from senders we know are pre-/new children.
         if (handlers.isStaleChild(data.fromSessionId)) {
-            console.log(`pizzapi: dropping stale session_message from ${data.fromSessionId} — sender is a pre-/new child`);
+            log.info(`pizzapi: dropping stale session_message from ${data.fromSessionId} — sender is a pre-/new child`);
             return;
         }
         // Drop stale send_message traffic from old parent during pending delink.
         const stalePrimary = handlers.getStalePrimaryParentId();
         if (handlers.isPendingDelinkOwnParent() && stalePrimary && data.fromSessionId === stalePrimary) {
-            console.log(`pizzapi: dropping stale session_message from old parent ${data.fromSessionId} — delink_own_parent pending`);
+            log.info(`pizzapi: dropping stale session_message from old parent ${data.fromSessionId} — delink_own_parent pending`);
             return;
         }
         messageBus.receive({
@@ -399,7 +401,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         if (!trigger) return;
         // Drop triggers from known pre-/new children.
         if (handlers.isStaleChild(trigger.sourceSessionId)) {
-            console.log(`pizzapi: dropping stale session_trigger (${trigger.type}) from ${trigger.sourceSessionId} — sender is a pre-/new child`);
+            log.info(`dropping stale session_trigger (${trigger.type}) from ${trigger.sourceSessionId} — sender is a pre-/new child`);
             return;
         }
 
@@ -482,7 +484,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         const url = socketIoUrl(rctx);
         const reason = err?.message ?? String(err);
         rctx.setRelayStatus(`Relay connection failed (${url})`);
-        console.log(`pizzapi: relay connection error — ${reason}`);
+        log.info(`pizzapi: relay connection error — ${reason}`);
 
         if (!connectFailureNotified && rctx.latestCtx) {
             connectFailureNotified = true;

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -32,6 +32,7 @@ import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { buildSessionContext, type ExtensionContext, type ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { createLogger } from "@pizzapi/tools";
 import { loadConfig } from "../../config.js";
 import { setTodoUpdateCallback, setTodoMetaEmitter, type TodoItem } from "../update-todo.js";
 import { getCurrentTodoList } from "../update-todo.js";
@@ -76,6 +77,7 @@ export { estimateMessagesSize, needsChunkedDelivery, capOversizedMessages, compu
 const RELAY_DEFAULT = "ws://localhost:7492";
 const RELAY_STATUS_KEY = "relay";
 const TRIGGER_CANCELLATION_RETRY_INTERVAL_MS = 3_000;
+const log = createLogger("remote");
 
 // ── Module-level state for external consumers ─────────────────────────────────
 let _ctx: RelayContext | null = null;
@@ -165,20 +167,20 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             });
 
             if (plan.ignoreAck) {
-                console.log("pizzapi: ignoring stale delink_children ack (superseded by a later /new)");
+                log.info("pizzapi: ignoring stale delink_children ack (superseded by a later /new)");
                 if (plan.clearRetryTimer) clearPendingDelinkRetryTimer(rawEpoch);
                 return;
             }
 
             if (plan.scheduleRetry) {
-                console.log(`pizzapi: delink_children server error: ${result?.error ?? "unknown"} — scheduling retry in ${DELINK_RETRY_DELAY_MS}ms`);
+                log.info(`pizzapi: delink_children server error: ${result?.error ?? "unknown"} — scheduling retry in ${DELINK_RETRY_DELAY_MS}ms`);
                 if (plan.clearRetryTimer) clearPendingDelinkRetryTimer(rawEpoch);
                 pendingDelinkRetryEpoch = rawEpoch;
                 pendingDelinkRetryTimer = setTimeout(() => {
                     pendingDelinkRetryTimer = null;
                     pendingDelinkRetryEpoch = null;
                     if (pendingDelinkEpoch === rawEpoch && rctx.sioSocket?.connected) {
-                        console.log("pizzapi: retrying delink_children after server error");
+                        log.info("pizzapi: retrying delink_children after server error");
                         emitDelinkChildren(rawEpoch);
                     }
                 }, DELINK_RETRY_DELAY_MS);
@@ -215,17 +217,17 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                     clearPendingDelinkOwnParentRetryTimer();
                     pendingDelinkOwnParent = false;
                     stalePrimaryParentId = null;
-                    console.log("pizzapi: delink_own_parent confirmed by server");
+                    log.info("pizzapi: delink_own_parent confirmed by server");
                     return;
                 }
 
                 if (!plan.scheduleRetry) return;
-                console.log(`pizzapi: delink_own_parent server error: ${result?.error ?? "unknown"} — scheduling retry in ${DELINK_RETRY_DELAY_MS}ms`);
+                log.info(`pizzapi: delink_own_parent server error: ${result?.error ?? "unknown"} — scheduling retry in ${DELINK_RETRY_DELAY_MS}ms`);
                 clearPendingDelinkOwnParentRetryTimer();
                 pendingDelinkOwnParentRetryTimer = setTimeout(() => {
                     pendingDelinkOwnParentRetryTimer = null;
                     if (pendingDelinkOwnParent && rctx.sioSocket?.connected) {
-                        console.log("pizzapi: retrying delink_own_parent after server error");
+                        log.info("pizzapi: retrying delink_own_parent after server error");
                         emitDelinkOwnParent();
                     }
                 }, DELINK_RETRY_DELAY_MS);
@@ -279,11 +281,11 @@ export const remoteExtension: ExtensionFactory = (pi) => {
             if (finished) return;
             const missing = cancellationsToRetry.length - completedResponses;
             failedCancellations += missing;
-            console.log(`pizzapi: trigger cancellation retry timed out (${missing} ack callback(s) missing) — will retry`);
+            log.info(`pizzapi: trigger cancellation retry timed out (${missing} ack callback(s) missing) — will retry`);
             finishBatch();
         }, 10_000);
 
-        console.log(`pizzapi: retrying ${cancellationsToRetry.length} deferred trigger cancellation(s) (${reason})`);
+        log.info(`pizzapi: retrying ${cancellationsToRetry.length} deferred trigger cancellation(s) (${reason})`);
 
         for (const { triggerId, childSessionId } of cancellationsToRetry) {
             rctx.sioSocket.emit("trigger_response" as any, {
@@ -306,12 +308,12 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                     }
                 } else {
                     failedCancellations++;
-                    console.log(`pizzapi: trigger cancellation failed for ${triggerId}: ${result?.error ?? "unknown"} — will retry`);
+                    log.info(`pizzapi: trigger cancellation failed for ${triggerId}: ${result?.error ?? "unknown"} — will retry`);
                 }
 
                 if (completedResponses === cancellationsToRetry.length) {
                     clearTimeout(timeout);
-                    console.log(`pizzapi: trigger cancellation retry complete: ${successfulCancellations} succeeded, ${failedCancellations} failed`);
+                    log.info(`pizzapi: trigger cancellation retry complete: ${successfulCancellations} succeeded, ${failedCancellations} failed`);
                     finishBatch();
                 }
             });
@@ -645,7 +647,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         if (followUpGraceShutdown) {
             const shutdown = followUpGraceShutdown;
             clearFollowUpGrace();
-            console.log("pizzapi: parent delinked while follow-up grace active — shutting down immediately");
+            log.info("parent delinked while follow-up grace active — shutting down immediately");
             shutdown();
         }
     }
@@ -653,11 +655,11 @@ export const remoteExtension: ExtensionFactory = (pi) => {
     function startFollowUpGrace(ctx: { shutdown: () => void }) {
         clearFollowUpGrace();
         followUpGraceShutdown = ctx.shutdown;
-        console.log(`pizzapi: waiting ${FOLLOWUP_GRACE_MS / 1000}s for parent follow-up before shutting down`);
+        log.info(`pizzapi: waiting ${FOLLOWUP_GRACE_MS / 1000}s for parent follow-up before shutting down`);
         followUpGraceTimer = setTimeout(() => {
             followUpGraceTimer = null;
             followUpGraceShutdown = null;
-            console.log("pizzapi: follow-up grace period expired — shutting down");
+            log.info("pizzapi: follow-up grace period expired — shutting down");
             ctx.shutdown();
         }, FOLLOWUP_GRACE_MS);
         if (followUpGraceTimer && typeof followUpGraceTimer === "object" && "unref" in followUpGraceTimer) {
@@ -707,22 +709,22 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         onParentExplicitlyDelinked: () => {
             const cancelledWaits = triggerWaits.cancelAll("Parent started a new session — trigger cancelled.");
             if (cancelledWaits > 0) {
-                console.log(`pizzapi: parent explicitly delinked (wasDelinked) — cancelled ${cancelledWaits} pending trigger wait(s)`);
+                log.info(`pizzapi: parent explicitly delinked (wasDelinked) — cancelled ${cancelledWaits} pending trigger wait(s)`);
             }
             shutdownFollowUpGraceImmediately();
-            console.log(`pizzapi: parent explicitly delinked — clearing parent link permanently`);
+            log.info(`pizzapi: parent explicitly delinked — clearing parent link permanently`);
             rctx.parentSessionId = null;
             rctx.isChildSession = false;
         },
 
         onParentTransientlyOffline: () => {
-            console.log(`pizzapi: parent temporarily offline (${rctx.parentSessionId}) — preserving parent link and child mode for reconnect`);
+            log.info(`pizzapi: parent temporarily offline (${rctx.parentSessionId}) — preserving parent link and child mode for reconnect`);
         },
 
         onParentDelinked: (ack?: (result: { ok: boolean }) => void) => {
             if (rctx.isChildSession) {
                 const cancelled = triggerWaits.cancelAll("Parent started a new session — trigger cancelled.");
-                console.log(`pizzapi: parent delinked — this session is no longer a child${cancelled > 0 ? ` — cancelled ${cancelled} pending trigger wait(s)` : ""}`);
+                log.info(`pizzapi: parent delinked — this session is no longer a child${cancelled > 0 ? ` — cancelled ${cancelled} pending trigger wait(s)` : ""}`);
                 rctx.parentSessionId = null;
                 rctx.isChildSession = false;
                 shutdownFollowUpGraceImmediately();
@@ -733,11 +735,11 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         flushDeferredDelinks: () => {
             if (pendingDelink && pendingDelinkEpoch !== null && rctx.sioSocket?.connected) {
                 emitDelinkChildren(pendingDelinkEpoch);
-                console.log("pizzapi: flushed deferred delink_children after reconnect");
+                log.info("pizzapi: flushed deferred delink_children after reconnect");
             }
             if (pendingDelinkOwnParent && rctx.sioSocket?.connected) {
                 emitDelinkOwnParent();
-                console.log("pizzapi: flushed deferred delink_own_parent after reconnect");
+                log.info("pizzapi: flushed deferred delink_own_parent after reconnect");
             }
             if (pendingCancellations.length > 0 && rctx.sioSocket?.connected) {
                 startPendingCancellationRetryLoop();
@@ -811,7 +813,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                     );
                     if (idx >= 0) {
                         pendingCancellations.splice(idx, 1);
-                        console.log(`pizzapi: trigger cancellation confirmed for ${confirmedTriggerId} — removed from retry queue`);
+                        log.info(`pizzapi: trigger cancellation confirmed for ${confirmedTriggerId} — removed from retry queue`);
                         if (pendingCancellations.length === 0) {
                             stopPendingCancellationRetryLoop();
                         }
@@ -819,7 +821,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
                 },
             );
             if (cancelled > 0) {
-                console.log(`pizzapi: cancelled ${cancelled} pending trigger(s) on session switch (${sent.length} sent-pending-ack, ${failed.length} deferred)`);
+                log.info(`pizzapi: cancelled ${cancelled} pending trigger(s) on session switch (${sent.length} sent-pending-ack, ${failed.length} deferred)`);
             }
 
             const allNeedingConfirmation = [...sent, ...failed];
@@ -843,7 +845,7 @@ export const remoteExtension: ExtensionFactory = (pi) => {
 
             if (rctx.isChildSession) {
                 const cancelledChild = triggerWaits.cancelAll("Session switched — parent link cleared.");
-                console.log(`pizzapi: clearing own parent link on /new${cancelledChild > 0 ? ` — cancelled ${cancelledChild} pending trigger wait(s)` : ""}`);
+                log.info(`pizzapi: clearing own parent link on /new${cancelledChild > 0 ? ` — cancelled ${cancelledChild} pending trigger wait(s)` : ""}`);
                 pendingDelinkOwnParent = true;
                 clearPendingDelinkOwnParentRetryTimer();
                 stalePrimaryParentId = rctx.parentSessionId;

--- a/packages/cli/src/extensions/session-attachments.ts
+++ b/packages/cli/src/extensions/session-attachments.ts
@@ -13,6 +13,9 @@
 import { mkdir, rm, readdir, readFile, writeFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("attachments");
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -239,7 +242,7 @@ export async function sweepOrphanedAttachments(activeSessionIds: Set<string>): P
     }
 
     if (removed > 0) {
-        console.log(`pizzapi: swept ${removed} orphaned session attachment director${removed === 1 ? "y" : "ies"}`);
+        log.info(`swept ${removed} orphaned session attachment director${removed === 1 ? "y" : "ies"}`);
     }
     return removed;
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -14,7 +14,9 @@ import { c, usageBar, colorPct, colorRemaining } from "./cli-colors.js";
 import { buildInteractiveSkillPaths } from "./skills.js";
 import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
 import { runSetup } from "./setup.js";
-import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
+import { createLogger, initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
+
+const log = createLogger("cli");
 
 async function main() {
     const args = process.argv.slice(2);
@@ -94,7 +96,7 @@ async function main() {
             const accessToken = await authStorage.getApiKey("anthropic");
             if (!accessToken) {
                 if (providerArg === "anthropic") {
-                    console.error("No Anthropic credentials found. Log in with /login inside pizzapi.");
+                    log.error("No Anthropic credentials found. Log in with /login inside pizzapi.");
                     process.exit(1);
                 }
                 // silently skip when showing all providers
@@ -111,15 +113,15 @@ async function main() {
                 } catch (err) {
                     const cause = err instanceof Error && (err as any).cause instanceof Error ? (err as any).cause.message : null;
                     const detail = cause ?? (err instanceof Error ? err.message : String(err));
-                    console.error(`Failed to fetch Anthropic usage: network error (${detail})`);
+                    log.error(`Failed to fetch Anthropic usage: network error (${detail})`);
                     process.exit(1);
                 }
 
                 if (!res.ok) {
-                    console.error(`Failed to fetch Anthropic usage: HTTP ${res.status} ${res.statusText}`);
+                    log.error(`Failed to fetch Anthropic usage: HTTP ${res.status} ${res.statusText}`);
                     try {
                         const body = await res.text();
-                        if (body) console.error(body);
+                        if (body) log.error(body);
                     } catch { /* ignore */ }
                     process.exit(1);
                 }
@@ -140,24 +142,24 @@ async function main() {
                 try {
                     usage = (await res.json()) as AnthropicUsageResponse;
                 } catch (err) {
-                    console.error(`Failed to parse Anthropic usage response: ${err instanceof Error ? err.message : String(err)}`);
+                    log.error(`Failed to parse Anthropic usage response: ${err instanceof Error ? err.message : String(err)}`);
                     process.exit(1);
                 }
 
                 if (showJson) {
-                    console.log(JSON.stringify({ provider: "anthropic", usage }, null, 2));
+                    log.info(JSON.stringify({ provider: "anthropic", usage }, null, 2));
                     printedAny = true;
                 } else {
                     const formatWindow = (label: string, w: UsageWindow) => {
                         if (!w) return;
                         const bar = usageBar(w.utilization);
                         const reset = new Date(w.resets_at).toLocaleString();
-                        console.log(`  ${label.padEnd(22)} ${bar}  ${c.dim(`resets ${reset}`)}`);
+                        log.info(`  ${label.padEnd(22)} ${bar}  ${c.dim(`resets ${reset}`)}`);
                     };
 
-                    console.log();
-                    console.log(c.label("Claude usage") + c.dim(" (OAuth subscription)"));
-                    console.log(c.dim("─".repeat(58)));
+                    log.info("");
+                    log.info(c.label("Claude usage") + c.dim(" (OAuth subscription)"));
+                    log.info(c.dim("─".repeat(58)));
                     formatWindow("5-hour window", usage.five_hour);
                     formatWindow("7-day window", usage.seven_day);
                     formatWindow("7-day (OAuth apps)", usage.seven_day_oauth_apps);
@@ -167,11 +169,11 @@ async function main() {
 
                     const ex = usage.extra_usage;
                     if (ex?.is_enabled) {
-                        console.log();
-                        console.log(`  ${c.accent("Extra usage enabled")}`);
-                        if (ex.monthly_limit != null) console.log(`    Monthly limit:   ${c.bold(`$${ex.monthly_limit}`)}`);
-                        if (ex.used_credits != null) console.log(`    Credits used:    ${c.bold(`$${ex.used_credits}`)}`);
-                        if (ex.utilization != null) console.log(`    Utilization:     ${colorPct(ex.utilization)}`);
+                        log.info("");
+                        log.info(`  ${c.accent("Extra usage enabled")}`);
+                        if (ex.monthly_limit != null) log.info(`    Monthly limit:   ${c.bold(`$${ex.monthly_limit}`)}`);
+                        if (ex.used_credits != null) log.info(`    Credits used:    ${c.bold(`$${ex.used_credits}`)}`);
+                        if (ex.utilization != null) log.info(`    Utilization:     ${colorPct(ex.utilization)}`);
                     }
                     printedAny = true;
                 }
@@ -183,7 +185,7 @@ async function main() {
             const rawCred = await authStorage.getApiKey("google-gemini-cli");
             if (!rawCred) {
                 if (providerArg === "gemini") {
-                    console.error("No Gemini credentials found. Log in with /login inside pizzapi.");
+                    log.error("No Gemini credentials found. Log in with /login inside pizzapi.");
                     process.exit(1);
                 }
                 // silently skip when showing all providers
@@ -197,7 +199,7 @@ async function main() {
                     token = parsed.token;
                     projectId = parsed.projectId;
                 } catch {
-                    console.error("Gemini credentials are malformed. Use /login inside pizzapi to re-authenticate.");
+                    log.error("Gemini credentials are malformed. Use /login inside pizzapi to re-authenticate.");
                     process.exit(1);
                 }
 
@@ -219,15 +221,15 @@ async function main() {
                 } catch (err) {
                     const cause = err instanceof Error && (err as any).cause instanceof Error ? (err as any).cause.message : null;
                     const detail = cause ?? (err instanceof Error ? err.message : String(err));
-                    console.error(`Failed to fetch Gemini usage: network error (${detail})`);
+                    log.error(`Failed to fetch Gemini usage: network error (${detail})`);
                     process.exit(1);
                 }
 
                 if (!quotaRes.ok) {
-                    console.error(`Failed to fetch Gemini usage: HTTP ${quotaRes.status} ${quotaRes.statusText}`);
+                    log.error(`Failed to fetch Gemini usage: HTTP ${quotaRes.status} ${quotaRes.statusText}`);
                     try {
                         const body = await quotaRes.text();
-                        if (body) console.error(body);
+                        if (body) log.error(body);
                     } catch { /* ignore */ }
                     process.exit(1);
                 }
@@ -245,22 +247,22 @@ async function main() {
                 try {
                     quotaData = (await quotaRes.json()) as GeminiQuotaResponse;
                 } catch (err) {
-                    console.error(`Failed to parse Gemini usage response: ${err instanceof Error ? err.message : String(err)}`);
+                    log.error(`Failed to parse Gemini usage response: ${err instanceof Error ? err.message : String(err)}`);
                     process.exit(1);
                 }
 
                 if (showJson) {
-                    console.log(JSON.stringify({ provider: "gemini", project: projectId, usage: quotaData }, null, 2));
+                    log.info(JSON.stringify({ provider: "gemini", project: projectId, usage: quotaData }, null, 2));
                     printedAny = true;
                 } else {
-                    console.log();
-                    console.log(c.label("Gemini usage") + c.dim(" (Google Cloud Code Assist, OAuth)"));
-                    console.log(`  ${c.dim("Project:")} ${projectId}`);
-                    console.log(c.dim("─".repeat(58)));
+                    log.info("");
+                    log.info(c.label("Gemini usage") + c.dim(" (Google Cloud Code Assist, OAuth)"));
+                    log.info(`  ${c.dim("Project:")} ${projectId}`);
+                    log.info(c.dim("─".repeat(58)));
 
                     const buckets = quotaData.buckets ?? [];
                     if (buckets.length === 0) {
-                        console.log("  No quota buckets returned.");
+                        log.info("  No quota buckets returned.");
                     } else {
                         for (const bucket of buckets) {
                             const label = [bucket.tokenType, bucket.modelId].filter(Boolean).join(" / ") || "bucket";
@@ -274,7 +276,7 @@ async function main() {
                                 : "";
                             const amt = bucket.remainingAmount != null ? c.dim(` (${bucket.remainingAmount} left)`) : "";
                             const reset = bucket.resetTime ? c.dim(`  resets ${new Date(bucket.resetTime).toLocaleString()}`) : "";
-                            console.log(`  ${label.padEnd(28)} ${bar}${remainingStr}${amt}${reset}`);
+                            log.info(`  ${label.padEnd(28)} ${bar}${remainingStr}${amt}${reset}`);
                         }
                     }
                     printedAny = true;
@@ -283,9 +285,9 @@ async function main() {
         }
 
         if (!printedAny && !showJson) {
-            console.log("\nNo usage data found. Log in with /login inside pizzapi to authenticate.");
+            log.info("\nNo usage data found. Log in with /login inside pizzapi to authenticate.");
         }
-        console.log();
+        log.info("");
         return;
     }
 
@@ -316,13 +318,13 @@ async function main() {
             });
 
         if (args.includes("--json")) {
-            console.log(JSON.stringify({ models: configuredModels }, null, 2));
+            log.info(JSON.stringify({ models: configuredModels }, null, 2));
             return;
         }
 
         if (configuredModels.length === 0) {
-            console.log("No configured models found.");
-            console.log(`Checked credentials in ${join(agentDir, "auth.json")}`);
+            log.info("No configured models found.");
+            log.info(`Checked credentials in ${join(agentDir, "auth.json")}`);
             return;
         }
 
@@ -336,57 +338,57 @@ async function main() {
 
         const modelWidth = Math.max(...configuredModels.map((m) => m.id.length), "model".length);
 
-        console.log();
+        log.info("");
         for (const [provider, models] of byProvider) {
-            console.log(c.label(provider));
+            log.info(c.label(provider));
             for (const model of models) {
                 const noteParts: string[] = [];
                 if (model.reasoning) noteParts.push(c.accent("reasoning"));
                 if (model.contextWindow) noteParts.push(c.dim(`${model.contextWindow.toLocaleString()} ctx`));
                 if (model.name && model.name !== model.id) noteParts.push(c.dim(model.name));
                 const notes = noteParts.join(c.dim(" • "));
-                console.log(`  ${c.cmd(model.id.padEnd(modelWidth))}  ${notes}`);
+                log.info(`  ${c.cmd(model.id.padEnd(modelWidth))}  ${notes}`);
             }
-            console.log();
+            log.info("");
         }
         return;
     }
 
     if (args.includes("--version") || args.includes("-v")) {
         const { default: pkg } = await import("../package.json");
-        console.log(`pizzapi v${pkg.version}`);
+        log.info(`pizzapi v${pkg.version}`);
         return;
     }
 
     if (args[0] === "--help" || args[0] === "-h" || args[0] === "help") {
         const { default: pkg } = await import("../package.json");
         const ver = c.dim(`v${pkg.version}`);
-        console.log();
-        console.log(`${c.brand("🍕 PizzaPi")} ${ver}`);
-        console.log();
-        console.log(c.label("Commands"));
-        console.log(`  ${c.cmd("pizza")}                       Start an interactive agent session`);
-        console.log(`  ${c.cmd("pizza web")} ${c.dim("[flags]")}           Manage the PizzaPi web hub (Docker)`);
-        console.log(`  ${c.cmd("pizza runner")} ${c.dim("[args]")}         Manage the background runner daemon`);
-        console.log(`  ${c.cmd("pizza runner stop")}           Stop the runner daemon`);
-        console.log(`  ${c.cmd("pizza setup")}                 Run first-time setup`);
-        console.log(`  ${c.cmd("pizza usage")} ${c.dim("[provider]")}      Show API usage stats`);
-        console.log(`  ${c.cmd("pizza models")}                List available models`);
-        console.log(`  ${c.cmd("pizza plugins")} ${c.dim("[cmd]")}         Manage Claude Code plugins`);
-        console.log();
-        console.log(c.label("Flags"));
-        console.log(`  ${c.flag("--cwd")} ${c.dim("<path>")}         Set working directory`);
-        console.log(`  ${c.flag("--sandbox")} ${c.dim("<mode>")}      Set sandbox mode: ${c.dim("enforce, audit, or off")}`);
-        console.log(`  ${c.flag("--safe-mode")}            Skip MCP, plugins, hooks, and relay`);
-        console.log(`  ${c.flag("--no-mcp")}               Skip MCP server connections`);
-        console.log(`  ${c.flag("--no-plugins")}           Skip Claude Code plugin loading`);
-        console.log(`  ${c.flag("--no-hooks")}             Skip hook execution`);
-        console.log(`  ${c.flag("--no-relay")}             Skip relay server connection`);
-        console.log(`  ${c.flag("-v, --version")}          Show version`);
-        console.log(`  ${c.flag("-h, --help")}             Show this help`);
-        console.log();
-        console.log(c.dim(`Run pizza <command> --help for command-specific help.`));
-        console.log();
+        log.info("");
+        log.info(`${c.brand("🍕 PizzaPi")} ${ver}`);
+        log.info("");
+        log.info(c.label("Commands"));
+        log.info(`  ${c.cmd("pizza")}                       Start an interactive agent session`);
+        log.info(`  ${c.cmd("pizza web")} ${c.dim("[flags]")}           Manage the PizzaPi web hub (Docker)`);
+        log.info(`  ${c.cmd("pizza runner")} ${c.dim("[args]")}         Manage the background runner daemon`);
+        log.info(`  ${c.cmd("pizza runner stop")}           Stop the runner daemon`);
+        log.info(`  ${c.cmd("pizza setup")}                 Run first-time setup`);
+        log.info(`  ${c.cmd("pizza usage")} ${c.dim("[provider]")}      Show API usage stats`);
+        log.info(`  ${c.cmd("pizza models")}                List available models`);
+        log.info(`  ${c.cmd("pizza plugins")} ${c.dim("[cmd]")}         Manage Claude Code plugins`);
+        log.info("");
+        log.info(c.label("Flags"));
+        log.info(`  ${c.flag("--cwd")} ${c.dim("<path>")}         Set working directory`);
+        log.info(`  ${c.flag("--sandbox")} ${c.dim("<mode>")}      Set sandbox mode: ${c.dim("enforce, audit, or off")}`);
+        log.info(`  ${c.flag("--safe-mode")}            Skip MCP, plugins, hooks, and relay`);
+        log.info(`  ${c.flag("--no-mcp")}               Skip MCP server connections`);
+        log.info(`  ${c.flag("--no-plugins")}           Skip Claude Code plugin loading`);
+        log.info(`  ${c.flag("--no-hooks")}             Skip hook execution`);
+        log.info(`  ${c.flag("--no-relay")}             Skip relay server connection`);
+        log.info(`  ${c.flag("-v, --version")}          Show version`);
+        log.info(`  ${c.flag("-h, --help")}             Show this help`);
+        log.info("");
+        log.info(c.dim(`Run pizza <command> --help for command-specific help.`));
+        log.info("");
         return;
     }
 
@@ -441,7 +443,7 @@ async function main() {
 
     if (safeMode) {
         if (process.stdout.isTTY) {
-            console.log(
+            log.info(
                 "\n\x1b[33m⚡ Safe mode\x1b[0m\x1b[2m — \x1b[0m" +
                 "\x1b[31mMCP servers\x1b[0m\x1b[2m, \x1b[0m" +
                 "\x1b[31mplugins\x1b[0m\x1b[2m, \x1b[0m" +
@@ -449,7 +451,7 @@ async function main() {
                 "\x1b[31mrelay\x1b[0m\x1b[2m are disabled.\x1b[0m\n",
             );
         } else {
-            console.log("\n⚡ Safe mode — MCP servers, plugins, hooks, and relay are disabled.\n");
+            log.info("\n⚡ Safe mode — MCP servers, plugins, hooks, and relay are disabled.\n");
         }
     }
 
@@ -473,7 +475,7 @@ async function main() {
     try {
         await initSandbox(sandboxConfig);
     } catch (err) {
-        console.warn(
+        log.warn(
             `pizzapi: sandbox init failed, continuing unsandboxed: ${err instanceof Error ? err.message : String(err)}`,
         );
     }
@@ -481,7 +483,7 @@ async function main() {
         process.env.PIZZAPI_SANDBOX_ACTIVE = "1";
         process.env.PIZZAPI_SANDBOX_MODE = sandboxConfig.mode;
     } else if (sandboxConfig.mode !== "none") {
-        console.warn("pizzapi: sandbox was requested but is not active (platform unsupported or init failed)");
+        log.warn("pizzapi: sandbox was requested but is not active (platform unsupported or init failed)");
     }
 
     // Load AGENTS.md from cwd (if present)
@@ -492,7 +494,7 @@ async function main() {
             const content = await readFile(agentsMdPath, "utf-8");
             agentFiles.push({ path: agentsMdPath, content });
         } catch (err) {
-            console.warn(`Warning: skipping unreadable ${agentsMdPath}: ${err instanceof Error ? err.message : String(err)}`);
+            log.warn(`Warning: skipping unreadable ${agentsMdPath}: ${err instanceof Error ? err.message : String(err)}`);
         }
     }
 
@@ -508,7 +510,7 @@ async function main() {
                     const content = await readFile(filePath, "utf-8");
                     return { path: filePath, content };
                 } catch (err) {
-                    console.warn(`Warning: skipping unreadable agent file ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
+                    log.warn(`Warning: skipping unreadable agent file ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
                     return null;
                 }
             })
@@ -566,6 +568,6 @@ async function main() {
 }
 
 main().catch((err) => {
-    console.error(err instanceof Error ? err.message : String(err));
+    log.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
 });

--- a/packages/cli/src/plugins-cli.ts
+++ b/packages/cli/src/plugins-cli.ts
@@ -26,6 +26,9 @@ import {
     untrustPlugin,
 } from "./config.js";
 import { c } from "./cli-colors.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("plugins");
 
 // ── Formatting helpers ────────────────────────────────────────────────────────
 
@@ -64,38 +67,38 @@ function listPlugins(cwd: string): void {
     const localOnly = localPlugins.filter((p) => !globalNames.has(p.name));
 
     if (globalPlugins.length === 0 && localOnly.length === 0) {
-        console.log("No Claude Code plugins found.");
-        console.log("\nSearch directories (global):");
+        log.info("No Claude Code plugins found.");
+        log.info("\nSearch directories (global):");
         for (const dir of globalPluginDirs()) {
-            console.log(`  ${dir}`);
+            log.info(`  ${dir}`);
         }
         if (localDirs.length > 0) {
-            console.log("\nSearch directories (project-local):");
+            log.info("\nSearch directories (project-local):");
             for (const dir of localDirs) {
-                console.log(`  ${dir}`);
+                log.info(`  ${dir}`);
             }
         }
         return;
     }
 
     if (globalPlugins.length > 0) {
-        console.log(`Global plugins (auto-trusted): ${globalPlugins.length}`);
+        log.info(`Global plugins (auto-trusted): ${globalPlugins.length}`);
         for (const p of globalPlugins) {
-            console.log(pluginLine(p));
+            log.info(pluginLine(p));
         }
     }
 
     if (localOnly.length > 0) {
-        if (globalPlugins.length > 0) console.log();
-        console.log(`Project-local plugins: ${localOnly.length}`);
+        if (globalPlugins.length > 0) log.info("");
+        log.info(`Project-local plugins: ${localOnly.length}`);
         for (const p of localOnly) {
-            console.log(pluginLine(p, isPluginTrusted(p.rootPath)));
+            log.info(pluginLine(p, isPluginTrusted(p.rootPath)));
         }
     }
 
     const untrustedLocal = localOnly.filter((p) => !isPluginTrusted(p.rootPath));
     if (untrustedLocal.length > 0) {
-        console.log(
+        log.info(
             `\n💡 ${untrustedLocal.length} untrusted local plugin${untrustedLocal.length > 1 ? "s" : ""}. ` +
             `Run \`pizza plugins trust <path>\` to pre-approve.`
         );
@@ -113,17 +116,17 @@ function trustCommand(args: string[], cwd: string): void {
         const untrusted = localPlugins.filter((p) => !isPluginTrusted(p.rootPath));
 
         if (untrusted.length === 0) {
-            console.log("No untrusted project-local plugins found.");
+            log.info("No untrusted project-local plugins found.");
             return;
         }
 
         // Trust all untrusted local plugins
-        console.log(`Trusting ${untrusted.length} local plugin${untrusted.length > 1 ? "s" : ""}:`);
+        log.info(`Trusting ${untrusted.length} local plugin${untrusted.length > 1 ? "s" : ""}:`);
         for (const p of untrusted) {
             const added = trustPlugin(p.rootPath);
-            console.log(`  ${added ? "✓" : "⋅"} ${p.name} → ${p.rootPath}`);
+            log.info(`  ${added ? "✓" : "⋅"} ${p.name} → ${p.rootPath}`);
         }
-        console.log("\nPlugins will auto-load on next session start.");
+        log.info("\nPlugins will auto-load on next session start.");
         return;
     }
 
@@ -134,15 +137,15 @@ function trustCommand(args: string[], cwd: string): void {
         // Path is a plugins directory — trust all plugins in it
         for (const p of plugins) {
             const added = trustPlugin(p.rootPath);
-            console.log(`${added ? "✓ Trusted" : "⋅ Already trusted"}: ${p.name} (${p.rootPath})`);
+            log.info(`${added ? "✓ Trusted" : "⋅ Already trusted"}: ${p.name} (${p.rootPath})`);
         }
     } else {
         // Path might be a single plugin directory
         const added = trustPlugin(target);
         if (added) {
-            console.log(`✓ Trusted: ${target}`);
+            log.info(`✓ Trusted: ${target}`);
         } else {
-            console.log(`⋅ Already trusted: ${target}`);
+            log.info(`⋅ Already trusted: ${target}`);
         }
     }
 }
@@ -151,61 +154,61 @@ function untrustCommand(args: string[], cwd: string): void {
     if (args.length === 0) {
         const list = getTrustedPlugins();
         if (list.length === 0) {
-            console.log("No plugins in the trust list.");
+            log.info("No plugins in the trust list.");
             return;
         }
         // Remove all
         for (const p of [...list]) {
             untrustPlugin(p);
         }
-        console.log(`Removed ${list.length} plugin${list.length > 1 ? "s" : ""} from the trust list.`);
+        log.info(`Removed ${list.length} plugin${list.length > 1 ? "s" : ""} from the trust list.`);
         return;
     }
 
     const target = resolve(cwd, args[0]);
     const removed = untrustPlugin(target);
     if (removed) {
-        console.log(`✓ Removed from trust list: ${target}`);
+        log.info(`✓ Removed from trust list: ${target}`);
     } else {
-        console.log(`⋅ Not in trust list: ${target}`);
+        log.info(`⋅ Not in trust list: ${target}`);
     }
 }
 
 function showTrusted(): void {
     const list = getTrustedPlugins();
     if (list.length === 0) {
-        console.log("No plugins in the trust list.");
-        console.log('Use `pizza plugins trust <path>` to add plugins.');
+        log.info("No plugins in the trust list.");
+        log.info('Use `pizza plugins trust <path>` to add plugins.');
         return;
     }
-    console.log(`Trusted plugins (${list.length}):`);
+    log.info(`Trusted plugins (${list.length}):`);
     for (const p of list) {
-        console.log(`  ${p}`);
+        log.info(`  ${p}`);
     }
 }
 
 function showHelp(): void {
-    console.log();
-    console.log(`${c.brand("pizza plugins")} ${c.dim("— Manage Claude Code plugins")}`);
-    console.log();
-    console.log(c.label("Commands"));
-    console.log(`  ${c.cmd("pizza plugins")}                List all discovered plugins (global + local)`);
-    console.log(`  ${c.cmd("pizza plugins list")}           Same as above`);
-    console.log(`  ${c.cmd("pizza plugins trust")} ${c.dim("[path]")}   Trust project-local plugin(s)`);
-    console.log(`                               ${c.dim("No path → trust all untrusted local plugins")}`);
-    console.log(`                               ${c.dim("With path → trust plugin at that path")}`);
-    console.log(`  ${c.cmd("pizza plugins untrust")} ${c.dim("[path]")} Remove plugin(s) from the trust list`);
-    console.log(`                               ${c.dim("No path → clear the entire trust list")}`);
-    console.log(`                               ${c.dim("With path → remove that specific plugin")}`);
-    console.log(`  ${c.cmd("pizza plugins trusted")}        Show the current trust list`);
-    console.log();
-    console.log(c.dim("Trusted plugins auto-load without prompting. Global plugins"));
-    console.log(c.dim("(~/.pizzapi/plugins/, ~/.agents/plugins/, ~/.claude/plugins/) are"));
-    console.log(c.dim("always auto-trusted. Project-local plugins require explicit trust"));
-    console.log(c.dim("via this command or interactive confirmation at session start."));
-    console.log();
-    console.log(c.dim("Trust state is stored in ~/.pizzapi/config.json (trustedPlugins)."));
-    console.log();
+    log.info("");
+    log.info(`${c.brand("pizza plugins")} ${c.dim("— Manage Claude Code plugins")}`);
+    log.info("");
+    log.info(c.label("Commands"));
+    log.info(`  ${c.cmd("pizza plugins")}                List all discovered plugins (global + local)`);
+    log.info(`  ${c.cmd("pizza plugins list")}           Same as above`);
+    log.info(`  ${c.cmd("pizza plugins trust")} ${c.dim("[path]")}   Trust project-local plugin(s)`);
+    log.info(`                               ${c.dim("No path → trust all untrusted local plugins")}`);
+    log.info(`                               ${c.dim("With path → trust plugin at that path")}`);
+    log.info(`  ${c.cmd("pizza plugins untrust")} ${c.dim("[path]")} Remove plugin(s) from the trust list`);
+    log.info(`                               ${c.dim("No path → clear the entire trust list")}`);
+    log.info(`                               ${c.dim("With path → remove that specific plugin")}`);
+    log.info(`  ${c.cmd("pizza plugins trusted")}        Show the current trust list`);
+    log.info("");
+    log.info(c.dim("Trusted plugins auto-load without prompting. Global plugins"));
+    log.info(c.dim("(~/.pizzapi/plugins/, ~/.agents/plugins/, ~/.claude/plugins/) are"));
+    log.info(c.dim("always auto-trusted. Project-local plugins require explicit trust"));
+    log.info(c.dim("via this command or interactive confirmation at session start."));
+    log.info("");
+    log.info(c.dim("Trust state is stored in ~/.pizzapi/config.json (trustedPlugins)."));
+    log.info("");
 }
 
 // ── Entry point ───────────────────────────────────────────────────────────────

--- a/packages/cli/src/runner/boot-timing.test.ts
+++ b/packages/cli/src/runner/boot-timing.test.ts
@@ -3,37 +3,39 @@ import { createBootTimer } from "./boot-timing.js";
 
 describe("createBootTimer", () => {
     test("logs elapsed time to stdout format", () => {
-        const logs: string[] = [];
-        const originalLog = console.log;
-        console.log = (...args: unknown[]) => {
-            logs.push(args.map(String).join(" "));
-        };
+        const writes: string[] = [];
+        const originalWrite = process.stdout.write.bind(process.stdout);
+        process.stdout.write = ((chunk: string | Uint8Array) => {
+            writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+            return true;
+        }) as typeof process.stdout.write;
 
         try {
             const timer = createBootTimer();
             timer.start("[boot] config");
             timer.end("[boot] config");
 
-            expect(logs).toHaveLength(1);
-            expect(logs[0]).toMatch(/^\[boot\] config: \d+\.\d{3}ms$/);
+            expect(writes).toHaveLength(1);
+            expect(writes[0]).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z \[unknown\] \[boot\] config: \d+\.\d{3}ms\n$/);
         } finally {
-            console.log = originalLog;
+            process.stdout.write = originalWrite;
         }
     });
 
     test("missing timer end is a no-op", () => {
-        const logs: string[] = [];
-        const originalLog = console.log;
-        console.log = (...args: unknown[]) => {
-            logs.push(args.map(String).join(" "));
-        };
+        const writes: string[] = [];
+        const originalWrite = process.stdout.write.bind(process.stdout);
+        process.stdout.write = ((chunk: string | Uint8Array) => {
+            writes.push(typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8"));
+            return true;
+        }) as typeof process.stdout.write;
 
         try {
             const timer = createBootTimer();
             timer.end("[boot] never-started");
-            expect(logs).toHaveLength(0);
+            expect(writes).toHaveLength(0);
         } finally {
-            console.log = originalLog;
+            process.stdout.write = originalWrite;
         }
     });
 });

--- a/packages/cli/src/runner/boot-timing.ts
+++ b/packages/cli/src/runner/boot-timing.ts
@@ -1,10 +1,12 @@
+import { logInfo } from "./logger.js";
+
 type TimerEntry = {
     label: string;
     startedAtMs: number;
 };
 
 /**
- * Lightweight boot timer that logs to stdout via console.log.
+ * Lightweight boot timer that logs to stdout via the runner logger.
  *
  * Node/Bun's console.timeEnd() writes to stderr, which causes normal
  * boot instrumentation to appear as error logs when workers are spawned
@@ -25,7 +27,7 @@ export function createBootTimer(): {
             if (!timer) return;
             timers.delete(name);
             const elapsedMs = performance.now() - timer.startedAtMs;
-            console.log(`${timer.label}: ${elapsedMs.toFixed(3)}ms`);
+            logInfo(`${timer.label}: ${elapsedMs.toFixed(3)}ms`);
         },
     };
 }

--- a/packages/cli/src/runner/service-handler.ts
+++ b/packages/cli/src/runner/service-handler.ts
@@ -1,4 +1,5 @@
 import type { Socket } from "socket.io-client";
+import { logError } from "./logger.js";
 
 /**
  * Interface for runner-side service handlers.
@@ -77,7 +78,7 @@ export class ServiceRegistry {
             try {
                 handler.dispose();
             } catch (err) {
-                console.error(`[ServiceRegistry] dispose error for service "${handler.id}":`, err);
+                logError(`[ServiceRegistry] dispose error for service "${handler.id}": ${err instanceof Error ? err.stack ?? err.message : String(err)}`);
             }
         }
     }

--- a/packages/cli/src/runner/stop.ts
+++ b/packages/cli/src/runner/stop.ts
@@ -10,13 +10,15 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
+import { logError, logInfo, logWarn, setLogComponent } from "./logger.js";
 import { defaultStatePath, isPidRunning } from "./runner-state.js";
 
 export async function runStop(): Promise<number> {
+    setLogComponent("supervisor");
     const statePath = defaultStatePath();
 
     if (!existsSync(statePath)) {
-        console.error("No runner state file found. Is a runner running?");
+        logError("No runner state file found. Is a runner running?");
         return 1;
     }
 
@@ -28,7 +30,7 @@ export async function runStop(): Promise<number> {
     try {
         state = JSON.parse(readFileSync(statePath, "utf-8"));
     } catch {
-        console.error(`Failed to read runner state from ${statePath}`);
+        logError(`Failed to read runner state from ${statePath}`);
         return 1;
     }
 
@@ -44,21 +46,21 @@ export async function runStop(): Promise<number> {
             : 0;
 
     if (targetPid === 0) {
-        console.log("No running runner process found.");
+        logInfo("No running runner process found.");
         return 0;
     }
 
     const label = targetPid === supervisorPid ? "supervisor" : "daemon";
-    console.log(`Stopping runner ${label} (pid ${targetPid})…`);
+    logInfo(`Stopping runner ${label} (pid ${targetPid})…`);
 
     try {
         process.kill(targetPid, "SIGTERM");
     } catch (err: any) {
         if (err?.code === "ESRCH") {
-            console.log("Process already exited.");
+            logInfo("Process already exited.");
             return 0;
         }
-        console.error(`Failed to send SIGTERM: ${err?.message ?? String(err)}`);
+        logError(`Failed to send SIGTERM: ${err?.message ?? String(err)}`);
         return 1;
     }
 
@@ -66,7 +68,7 @@ export async function runStop(): Promise<number> {
     const deadline = Date.now() + 10_000;
     while (Date.now() < deadline) {
         if (!isPidRunning(targetPid)) {
-            console.log("Runner stopped.");
+            logInfo("Runner stopped.");
             return 0;
         }
         await new Promise((r) => setTimeout(r, 250));
@@ -76,7 +78,7 @@ export async function runStop(): Promise<number> {
     // On Windows, SIGKILL is not supported; use SIGTERM which unconditionally
     // terminates the process on Windows (equivalent to SIGKILL on Unix).
     const forceSignal = process.platform === "win32" ? "SIGTERM" : "SIGKILL";
-    console.warn(`Runner did not exit in time. Force-killing…`);
+    logWarn("Runner did not exit in time. Force-killing…");
     try {
         process.kill(targetPid, forceSignal);
     } catch { /* ignore */ }
@@ -88,6 +90,6 @@ export async function runStop(): Promise<number> {
         } catch { /* ignore */ }
     }
 
-    console.log("Runner force-stopped.");
+    logInfo("Runner force-stopped.");
     return 0;
 }

--- a/packages/cli/src/runner/terminal-worker.ts
+++ b/packages/cli/src/runner/terminal-worker.ts
@@ -31,6 +31,7 @@
 
 import { spawn as spawnPty } from "@zenyr/bun-pty";
 import { homedir } from "node:os";
+import { logError } from "./logger.js";
 import { getShellArgs, resolveDefaultShell } from "./terminal-utils.js";
 
 const terminalId = process.env.TERMINAL_WORKER_ID ?? "unknown";
@@ -118,7 +119,7 @@ process.on("message", (msg: unknown) => {
                 // PTY fd may already be closed (shell exited). Ignore.
                 const errMsg = err instanceof Error ? err.message : String(err);
                 if (!errMsg.includes("EBADF")) {
-                    console.error(`[terminal ${terminalId}] resize error: ${errMsg}`);
+                    logError(`[terminal ${terminalId}] resize error: ${errMsg}`);
                 }
             }
             break;

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -44,7 +44,7 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
                     if (Object.keys(data).length > 0) {
                         // File has data but AuthStorage didn't load it — lock contention.
                         // Wait and retry.
-                        console.warn(
+                        logWarn(
                             `pizzapi worker: auth.json has ${Object.keys(data).length} provider(s) but AuthStorage loaded 0 (attempt ${attempt}/${maxAttempts}, likely lock contention)`,
                         );
                         lastError = new Error("Lock contention: auth.json has data but AuthStorage loaded empty");
@@ -83,7 +83,7 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
     // at least stale-but-valid credentials rather than none.
     // Retry the lockless read a few times with short delays because a
     // concurrent writeFileSync can produce empty/partial JSON momentarily.
-    console.warn(
+    logWarn(
         `pizzapi worker: AuthStorage lock retries exhausted (${maxAttempts} attempts), falling back to lockless read`,
     );
     const locklessRetries = 3;
@@ -106,7 +106,7 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
                 try {
                     const fileStorage = AuthStorage.create(authPath);
                     if (fileStorage.list().length > 0) {
-                        console.log(
+                        logInfo(
                             `pizzapi worker: lock released — file-backed AuthStorage loaded ${fileStorage.list().length} provider(s) on final retry`,
                         );
                         return fileStorage;
@@ -118,7 +118,7 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
                 // refreshes won't be persisted and credential updates won't
                 // be visible, but at least the worker can start).
                 const storage = AuthStorage.inMemory(data);
-                console.warn(
+                logWarn(
                     `pizzapi worker: lockless fallback loaded ${Object.keys(data).length} provider(s) from ${authPath} (in-memory snapshot — token refreshes will not persist)`,
                 );
                 return storage;
@@ -128,20 +128,20 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
         } catch (err) {
             // Partial JSON (concurrent write) — retry
             if (lr < locklessRetries) {
-                console.warn(
+                logWarn(
                     `pizzapi worker: lockless read attempt ${lr}/${locklessRetries} got bad JSON, retrying...`,
                 );
                 await Bun.sleep(50 * lr);
                 continue;
             }
-            console.warn(
+            logWarn(
                 `pizzapi worker: lockless fallback read failed after ${locklessRetries} attempts: ${err instanceof Error ? err.message : String(err)}`,
             );
         }
     }
 
     // Truly nothing worked — return default (will fail at model selection time)
-    console.error(
+    logError(
         `pizzapi worker: failed to load auth credentials after ${maxAttempts} attempts: ${lastError instanceof Error ? lastError.message : String(lastError)}`,
     );
     return AuthStorage.create(authPath);

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -4,8 +4,10 @@ import { join, dirname } from "path";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 import { saveGlobalConfig } from "./config.js";
 import { validatePassword, PASSWORD_REQUIREMENTS } from "@pizzapi/protocol";
+import { createLogger } from "@pizzapi/tools";
 import { c } from "./cli-colors.js";
 
+const log = createLogger("setup");
 const RELAY_DEFAULT = "http://localhost:7492";
 
 function rl() {
@@ -85,19 +87,19 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
         const configPath = join(homedir(), ".pizzapi", "config.json");
 
         const frame = c.label("─".repeat(43));
-        console.log();
-        console.log(c.label("┌") + frame + c.label("┐"));
-        console.log(c.label("│") + `     ${c.brand("🍕 PizzaPi")} ${c.dim("— first-run setup")}     ` + c.label("│"));
-        console.log(c.label("└") + frame + c.label("┘"));
-        console.log();
-        console.log("Connect this node to a PizzaPi relay server so your sessions");
-        console.log("can be monitored from the web UI.");
-        console.log();
+        log.info("");
+        log.info(c.label("┌") + frame + c.label("┐"));
+        log.info(c.label("│") + `     ${c.brand("🍕 PizzaPi")} ${c.dim("— first-run setup")}     ` + c.label("│"));
+        log.info(c.label("└") + frame + c.label("┘"));
+        log.info("");
+        log.info("Connect this node to a PizzaPi relay server so your sessions");
+        log.info("can be monitored from the web UI.");
+        log.info("");
 
         if (!opts.force) {
             const skip = await ask(iface, "Skip setup and continue without relay? [y/N] ");
             if (skip.trim().toLowerCase() === "y") {
-                console.log("\nSkipping relay setup. Run `pizzapi setup` at any time to configure.\n");
+                log.info("\nSkipping relay setup. Run `pizzapi setup` at any time to configure.\n");
                 return false;
             }
         }
@@ -113,7 +115,7 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
         const name = (await ask(iface, "Your name (leave blank if account already exists): ")).trim();
         const email = (await ask(iface, "Email: ")).trim();
         if (!email) {
-            console.log(`\n${c.error("✗")} Email is required. Aborting setup.\n`);
+            log.info(`\n${c.error("✗")} Email is required. Aborting setup.\n`);
             return false;
         }
 
@@ -122,7 +124,7 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
 
         const password = await askPassword("Password: ");
         if (!password) {
-            console.log(`\n${c.error("✗")} Password is required. Aborting setup.\n`);
+            log.info(`\n${c.error("✗")} Password is required. Aborting setup.\n`);
             return false;
         }
 
@@ -130,12 +132,12 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
         if (name) {
             const check = validatePassword(password);
             if (!check.valid) {
-                console.log(`\n${c.error("✗")} Password does not meet the requirements:`);
+                log.info(`\n${c.error("✗")} Password does not meet the requirements:`);
                 for (const chk of check.checks) {
                     const icon = chk.met ? c.success("✓") : c.error("✗");
-                    console.log(`  ${icon} ${chk.label}`);
+                    log.info(`  ${icon} ${chk.label}`);
                 }
-                console.log();
+                log.info("");
                 return false;
             }
         }
@@ -143,14 +145,14 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
         process.stdout.write(`\n${c.dim("Connecting to relay server…")} `);
         const result = await registerCli(relayUrl, name, email, password);
         if (!result.ok || !result.key) {
-            console.log(c.error("✗") + "\n");
-            console.error(
+            log.info(c.error("✗") + "\n");
+            log.error(
                 `Could not register with the relay server: ${result.error ?? "unknown error"}\n` +
                 "Check that the server is running, your credentials are correct, and try again.\n",
             );
             return false;
         }
-        console.log(c.success("✓") + "\n");
+        log.info(c.success("✓") + "\n");
 
         // Derive ws:// URL for the relay config
         const wsRelayUrl = relayUrl.replace(/^http/, "ws");
@@ -160,8 +162,8 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
         process.env.PIZZAPI_API_KEY = result.key;
         process.env.PIZZAPI_RELAY_URL = wsRelayUrl;
 
-        console.log(`${c.success("✓")} API key saved to ${c.dim(configPath)}`);
-        console.log(`${c.success("✓")} Relay: ${c.accent(wsRelayUrl)}\n`);
+        log.info(`${c.success("✓")} API key saved to ${c.dim(configPath)}`);
+        log.info(`${c.success("✓")} Relay: ${c.accent(wsRelayUrl)}\n`);
 
         // Auto-select the PizzaPi dark theme for new installations
         try {
@@ -175,10 +177,10 @@ export async function runSetup(opts: { force?: boolean } = {}): Promise<boolean>
                 piSettings.theme = "pizzapi-dark";
                 mkdirSync(dirname(piSettingsPath), { recursive: true });
                 writeFileSync(piSettingsPath, JSON.stringify(piSettings, null, 2) + "\n", "utf-8");
-                console.log("✓ Theme set to pizzapi-dark\n");
+                log.info("✓ Theme set to pizzapi-dark\n");
             }
         } catch (err) {
-            console.warn("Note: Could not set default theme:", err instanceof Error ? err.message : String(err));
+            log.warn("Note: Could not set default theme:", err instanceof Error ? err.message : String(err));
         }
 
         return true;

--- a/packages/cli/src/usage/index.ts
+++ b/packages/cli/src/usage/index.ts
@@ -3,7 +3,9 @@ import { scanSessions } from "./scanner.js";
 import { getUsageData } from "./aggregator.js";
 import type { UsageData, UsageRange } from "./types.js";
 import type { Database } from "bun:sqlite";
+import { createLogger } from "@pizzapi/tools";
 
+const log = createLogger("usage");
 let db: Database | null = null;
 let lastScanAt = 0;
 let scanning = false;
@@ -12,7 +14,7 @@ export function initUsage(): void {
   db = openUsageDb();
   // Initial scan in background
   triggerScan().catch((err) => {
-    console.error("[usage] initial scan failed:", err);
+    log.error("initial scan failed:", err);
   });
 }
 
@@ -32,7 +34,7 @@ export function getData(range: UsageRange = "90d"): UsageData | null {
   // Trigger scan if stale (> 1 min)
   if (Date.now() - lastScanAt > 60_000) {
     triggerScan().catch((err) => {
-      console.error("[usage] background scan failed:", err);
+      log.error("background scan failed:", err);
     }); // fire and forget — return current data
   }
   return getUsageData(db, range);

--- a/packages/cli/src/usage/scanner.ts
+++ b/packages/cli/src/usage/scanner.ts
@@ -3,8 +3,11 @@ import { readFileSync, statSync, existsSync } from "node:fs";
 import { readdir } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
+import { createLogger } from "@pizzapi/tools";
 import type { SessionHeader, UsageMessage } from "./types.js";
 import { getSessionsDir } from "./schema.js";
+
+const log = createLogger("usage");
 
 export interface ParsedSessionHeader extends SessionHeader {}
 
@@ -409,7 +412,7 @@ export async function scanSessions(db: Database): Promise<void> {
         try {
           processFile(db, filePath, relativePath, sessionHeader, content, state?.last_offset);
         } catch (e) {
-          console.error(`Error processing ${filePath}:`, e);
+          log.error(`Error processing ${filePath}:`, e);
         }
       }
     }

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -18,6 +18,7 @@ import { existsSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { c } from "./cli-colors.js";
+import { createLogger } from "@pizzapi/tools";
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -44,6 +45,7 @@ const WEB_DIR = join(homedir(), ".pizzapi", "web");
 const CONFIG_PATH = join(WEB_DIR, "config.json");
 const HOST_BUILD_STATE_PATH = join(WEB_DIR, "host-build.json");
 const REPO_URL = "https://github.com/Pizzaface/PizzaPi.git";
+const log = createLogger("web");
 
 interface HostBuildState {
     lastLockHash?: string | null;
@@ -401,7 +403,7 @@ function migrateLegacySettings(): Partial<WebConfig> {
     }
 
     if (sources.length > 0) {
-        console.log(`Migrated settings from ${sources.join(", ")} → config.json`);
+        log.info(`Migrated settings from ${sources.join(", ")} → config.json`);
     }
 
     return migrated;
@@ -459,7 +461,7 @@ export function loadWebConfig(): WebConfig {
 
             return config;
         } catch {
-            console.warn("Warning: config.json is corrupted, using defaults.");
+            log.warn("Warning: config.json is corrupted, using defaults.");
         }
     }
 
@@ -471,7 +473,7 @@ export function loadWebConfig(): WebConfig {
         config.vapid = legacy.vapid;
     } else {
         config.vapid = generateVapidKeys();
-        console.log("Generated new VAPID keys for push notifications.");
+        log.info("Generated new VAPID keys for push notifications.");
     }
     if (legacy.vapidSubject) config.vapidSubject = legacy.vapidSubject;
     if (legacy.extraOrigins) config.extraOrigins = legacy.extraOrigins;
@@ -483,7 +485,7 @@ export function loadWebConfig(): WebConfig {
         config.betterAuthSecret = legacy.betterAuthSecret;
     } else {
         config.betterAuthSecret = generateBetterAuthSecret();
-        console.log("Generated BETTER_AUTH_SECRET for authentication.");
+        log.info("Generated BETTER_AUTH_SECRET for authentication.");
     }
 
     saveWebConfig(config);
@@ -503,7 +505,7 @@ function ensureDocker(): void {
         execFileSync("docker", ["--version"], { stdio: "ignore" });
         execFileSync("docker", ["compose", "version"], { stdio: "ignore" });
     } catch {
-        console.error(
+        log.error(
             "Error: Docker with Compose is required for `pizza web`.\n" +
             "Install Docker Desktop: https://docs.docker.com/get-docker/\n"
         );
@@ -541,21 +543,21 @@ function getRepoPath(): string {
 
     const clonedRepo = join(WEB_DIR, "repo");
     if (existsSync(join(clonedRepo, "Dockerfile"))) {
-        console.log("Updating PizzaPi repository...");
+        log.info("Updating PizzaPi repository...");
         try {
             execFileSync("git", ["pull", "--rebase"], { cwd: clonedRepo, stdio: "inherit" });
         } catch {
-            console.warn("Warning: Could not update repo, using existing version.");
+            log.warn("Warning: Could not update repo, using existing version.");
         }
         return clonedRepo;
     }
 
-    console.log("Cloning PizzaPi repository...");
+    log.info("Cloning PizzaPi repository...");
     mkdirSync(WEB_DIR, { recursive: true });
     try {
         execFileSync("git", ["clone", "--depth", "1", REPO_URL, clonedRepo], { stdio: "inherit" });
     } catch {
-        console.error(
+        log.error(
             "Error: Failed to clone the PizzaPi repository.\n\n" +
             "You can clone it manually:\n" +
             `  git clone ${REPO_URL} ${clonedRepo}\n\n` +
@@ -632,11 +634,11 @@ function prebuildUI(repoPath: string): PrebuildResult {
     try {
         execFileSync("bun", ["--version"], { stdio: "ignore" });
     } catch {
-        console.log("bun not found on host — UI will be built inside Docker (slower).");
+        log.info("bun not found on host — UI will be built inside Docker (slower).");
         return { prebuilt: false, rebuilt: false };
     }
 
-    console.log("Pre-building UI on host for faster Docker build...");
+    log.info("Pre-building UI on host for faster Docker build...");
 
     const state = loadHostBuildState();
     let stateDirty = false;
@@ -650,7 +652,7 @@ function prebuildUI(repoPath: string): PrebuildResult {
 
     try {
         if (needsInstall) {
-            console.log("  Installing dependencies (bun install)...");
+            log.info("  Installing dependencies (bun install)...");
             execFileSync("bun", ["install"], { cwd: repoPath, stdio: "inherit" });
             state.lastLockHash = lockHash ?? null;
             stateDirty = true;
@@ -665,7 +667,7 @@ function prebuildUI(repoPath: string): PrebuildResult {
         });
 
         if (!needsUiBuild && distReady) {
-            console.log("  Host UI build is up to date (reusing dist/).");
+            log.info("  Host UI build is up to date (reusing dist/).");
             if (stateDirty) saveHostBuildState(state);
             return { prebuilt: true, rebuilt: false, distHash: computeDistHash(uiDist) };
         }
@@ -675,14 +677,14 @@ function prebuildUI(repoPath: string): PrebuildResult {
         // the filesystem bridge (virtiofs/gRPC-FUSE) can miss subtle changes.
         // Belt-and-suspenders: nuke it ourselves.
         if (existsSync(uiDist)) {
-            console.log("  Cleaning old dist/...");
+            log.info("  Cleaning old dist/...");
             rmSync(uiDist, { recursive: true, force: true });
         }
 
-        console.log("  Building protocol...");
+        log.info("  Building protocol...");
         execFileSync("bun", ["run", "build:protocol"], { cwd: repoPath, stdio: "inherit" });
 
-        console.log("  Building UI...");
+        log.info("  Building UI...");
         execFileSync("bun", ["run", "build:ui"], { cwd: repoPath, stdio: "inherit" });
 
         if (existsSync(uiDistIndex)) {
@@ -690,7 +692,7 @@ function prebuildUI(repoPath: string): PrebuildResult {
             // detects the rebuild, even if Vite produced byte-identical output.
             writeBuildStamp(uiDist);
 
-            console.log("  ✓ UI pre-built successfully.");
+            log.info("  ✓ UI pre-built successfully.");
             if (uiSignature) {
                 state.lastUiSignature = uiSignature;
                 stateDirty = true;
@@ -699,8 +701,8 @@ function prebuildUI(repoPath: string): PrebuildResult {
             return { prebuilt: true, rebuilt: true, distHash: computeDistHash(uiDist) };
         }
     } catch (err) {
-        console.warn("Warning: Host UI build failed, falling back to Docker build.");
-        if (err instanceof Error) console.warn(`  ${err.message}`);
+        log.warn("Warning: Host UI build failed, falling back to Docker build.");
+        if (err instanceof Error) log.warn(`  ${err.message}`);
         if (stateDirty) saveHostBuildState(state);
         return { prebuilt: false, rebuilt: false };
     }
@@ -793,10 +795,10 @@ function generateComposeFile(repoPath: string, config: WebConfig, prebuiltUi: bo
     // Only write if changed
     const existing = existsSync(composePath) ? readFileSync(composePath, "utf-8") : null;
     if (existing === compose) {
-        console.log(`Config unchanged: ${composePath}`);
+        log.info(`Config unchanged: ${composePath}`);
     } else {
         writeFileSync(composePath, compose);
-        console.log(existing ? `Updated ${composePath}` : `Created ${composePath}`);
+        log.info(existing ? `Updated ${composePath}` : `Created ${composePath}`);
     }
 
     return composePath;
@@ -838,12 +840,12 @@ export function parseArgs(args: string[]): ParsedArgs {
         const arg = args[i];
         if (arg === "--port" && args[i + 1]) {
             if (!/^\d+$/.test(args[i + 1])) {
-                console.error("Invalid port number");
+                log.error("Invalid port number");
                 process.exit(1);
             }
             const p = parseInt(args[i + 1], 10);
             if (p < 1 || p > 65535) {
-                console.error("Invalid port number");
+                log.error("Invalid port number");
                 process.exit(1);
             }
             result.port = p;
@@ -851,7 +853,7 @@ export function parseArgs(args: string[]): ParsedArgs {
         } else if (arg === "--origins") {
             const next = args[i + 1];
             if (!next || next.startsWith("-")) {
-                console.error("--origins requires a value (comma-separated origin URLs)");
+                log.error("--origins requires a value (comma-separated origin URLs)");
                 process.exit(1);
             }
             result.origins = next;
@@ -871,35 +873,35 @@ export function parseArgs(args: string[]): ParsedArgs {
 // ─── Help text ────────────────────────────────────────────────────────────────
 
 function printWebHelp(): void {
-    console.log();
-    console.log(`${c.brand("pizza web")} ${c.dim("— Manage the PizzaPi web hub (server + UI via Docker Compose)")}`);
-    console.log();
-    console.log(c.label("Commands"));
-    console.log(`  ${c.cmd("pizza web")} ${c.dim("[flags]")}               Start the web hub`);
-    console.log(`  ${c.cmd("pizza web stop")}                  Stop the web hub`);
-    console.log(`  ${c.cmd("pizza web logs")}                  Tail container logs`);
-    console.log(`  ${c.cmd("pizza web status")}                Show container status`);
-    console.log(`  ${c.cmd("pizza web config")}                Show current configuration`);
-    console.log(`  ${c.cmd("pizza web config set")} ${c.dim("<k> <v>")}    Update a config value`);
-    console.log();
-    console.log(c.label("Flags"));
-    console.log(`  ${c.flag("--port")} ${c.dim("<port>")}       Set the host port ${c.dim("(persisted to config.json)")}`);
-    console.log(`  ${c.flag("--origins")} ${c.dim("<list>")}    Set extra allowed CORS origins ${c.dim("(comma-separated, persisted)")}`);
-    console.log(`  ${c.flag("-f, --foreground")}    Run in the foreground ${c.dim("(don't detach)")}`);
-    console.log(`  ${c.flag("--no-cache")}          Rebuild Docker image without layer cache`);
-    console.log(`  ${c.flag("-h, --help")}          Show this help`);
-    console.log();
-    console.log(`${c.label("Configuration")} ${c.dim(`(${CONFIG_PATH})`)}`);
-    console.log(`  ${c.accent("port")}            Host port ${c.dim("(default: 7492)")}`);
-    console.log(`  ${c.accent("vapidSubject")}    VAPID subject for push notifications`);
-    console.log(`  ${c.accent("extraOrigins")}    Extra CORS origins, comma-separated`);
-    console.log();
-    console.log(c.label("Examples"));
-    console.log(`  ${c.dim("pizza web")}                           Start on default port 7492`);
-    console.log(`  ${c.dim("pizza web --port 8080")}               Start on port 8080 (remembered for next time)`);
-    console.log(`  ${c.dim("pizza web config set port 9000")}      Change port without starting`);
-    console.log(`  ${c.dim('pizza web config set extraOrigins "https://example.com"')}`);
-    console.log();
+    log.info("");
+    log.info(`${c.brand("pizza web")} ${c.dim("— Manage the PizzaPi web hub (server + UI via Docker Compose)")}`);
+    log.info("");
+    log.info(c.label("Commands"));
+    log.info(`  ${c.cmd("pizza web")} ${c.dim("[flags]")}               Start the web hub`);
+    log.info(`  ${c.cmd("pizza web stop")}                  Stop the web hub`);
+    log.info(`  ${c.cmd("pizza web logs")}                  Tail container logs`);
+    log.info(`  ${c.cmd("pizza web status")}                Show container status`);
+    log.info(`  ${c.cmd("pizza web config")}                Show current configuration`);
+    log.info(`  ${c.cmd("pizza web config set")} ${c.dim("<k> <v>")}    Update a config value`);
+    log.info("");
+    log.info(c.label("Flags"));
+    log.info(`  ${c.flag("--port")} ${c.dim("<port>")}       Set the host port ${c.dim("(persisted to config.json)")}`);
+    log.info(`  ${c.flag("--origins")} ${c.dim("<list>")}    Set extra allowed CORS origins ${c.dim("(comma-separated, persisted)")}`);
+    log.info(`  ${c.flag("-f, --foreground")}    Run in the foreground ${c.dim("(don't detach)")}`);
+    log.info(`  ${c.flag("--no-cache")}          Rebuild Docker image without layer cache`);
+    log.info(`  ${c.flag("-h, --help")}          Show this help`);
+    log.info("");
+    log.info(`${c.label("Configuration")} ${c.dim(`(${CONFIG_PATH})`)}`);
+    log.info(`  ${c.accent("port")}            Host port ${c.dim("(default: 7492)")}`);
+    log.info(`  ${c.accent("vapidSubject")}    VAPID subject for push notifications`);
+    log.info(`  ${c.accent("extraOrigins")}    Extra CORS origins, comma-separated`);
+    log.info("");
+    log.info(c.label("Examples"));
+    log.info(`  ${c.dim("pizza web")}                           Start on default port 7492`);
+    log.info(`  ${c.dim("pizza web --port 8080")}               Start on port 8080 (remembered for next time)`);
+    log.info(`  ${c.dim("pizza web config set port 9000")}      Change port without starting`);
+    log.info(`  ${c.dim('pizza web config set extraOrigins "https://example.com"')}`);
+    log.info("");
 }
 
 // ─── Config subcommand ────────────────────────────────────────────────────────
@@ -910,7 +912,7 @@ type SettableKey = typeof SETTABLE_KEYS[number];
 function runConfigSubcommand(args: string[]): void {
     // Handle help before loading config (no side effects)
     if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
-        console.log(`
+        log.info(`
 pizza web config — View or update web hub configuration
 
 Usage:
@@ -929,13 +931,13 @@ Settable keys:
 
     // pizza web config (show)
     if (args.length === 0) {
-        console.log(`PizzaPi Web Config (${CONFIG_PATH}):\n`);
-        console.log(`  port:          ${config.port}`);
-        console.log(`  vapidSubject:  ${config.vapidSubject}`);
-        console.log(`  extraOrigins:  ${config.extraOrigins || "(none)"}`);
-        console.log(`  authSecret:    ${config.betterAuthSecret ? "*".repeat(20) + "..." : "(missing)"}`);
-        console.log(`  vapid.public:  ${config.vapid.publicKey.slice(0, 20)}...`);
-        console.log(`  vapid.private: ${"*".repeat(20)}...`);
+        log.info(`PizzaPi Web Config (${CONFIG_PATH}):\n`);
+        log.info(`  port:          ${config.port}`);
+        log.info(`  vapidSubject:  ${config.vapidSubject}`);
+        log.info(`  extraOrigins:  ${config.extraOrigins || "(none)"}`);
+        log.info(`  authSecret:    ${config.betterAuthSecret ? "*".repeat(20) + "..." : "(missing)"}`);
+        log.info(`  vapid.public:  ${config.vapid.publicKey.slice(0, 20)}...`);
+        log.info(`  vapid.private: ${"*".repeat(20)}...`);
         return;
     }
 
@@ -944,14 +946,14 @@ Settable keys:
         const key = args[1] as SettableKey;
 
         if (!key || args.length < 3) {
-            console.error("Usage: pizza web config set <key> <value>");
-            console.error(`Settable keys: ${SETTABLE_KEYS.join(", ")}`);
+            log.error("Usage: pizza web config set <key> <value>");
+            log.error(`Settable keys: ${SETTABLE_KEYS.join(", ")}`);
             process.exit(1);
         }
 
         if (!SETTABLE_KEYS.includes(key)) {
-            console.error(`Unknown config key: ${key}`);
-            console.error(`Settable keys: ${SETTABLE_KEYS.join(", ")}`);
+            log.error(`Unknown config key: ${key}`);
+            log.error(`Settable keys: ${SETTABLE_KEYS.join(", ")}`);
             process.exit(1);
         }
 
@@ -959,18 +961,18 @@ Settable keys:
 
         if (key === "port") {
             if (!/^\d+$/.test(value)) {
-                console.error("Invalid port number");
+                log.error("Invalid port number");
                 process.exit(1);
             }
             const p = parseInt(value, 10);
             if (p < 1 || p > 65535) {
-                console.error("Invalid port number");
+                log.error("Invalid port number");
                 process.exit(1);
             }
             config.port = p;
         } else if (key === "vapidSubject") {
             if (!value) {
-                console.error("vapidSubject cannot be empty (required for push notifications)");
+                log.error("vapidSubject cannot be empty (required for push notifications)");
                 process.exit(1);
             }
             config.vapidSubject = value;
@@ -980,13 +982,13 @@ Settable keys:
         }
 
         saveWebConfig(config);
-        console.log(`Set ${key} = ${value}`);
-        console.log("Run `pizza web` to apply changes.");
+        log.info(`Set ${key} = ${value}`);
+        log.info("Run `pizza web` to apply changes.");
         return;
     }
 
-    console.error(`Unknown config subcommand: ${args[0]}`);
-    console.error("Run `pizza web config --help` for usage.");
+    log.error(`Unknown config subcommand: ${args[0]}`);
+    log.error("Run `pizza web config --help` for usage.");
     process.exit(1);
 }
 
@@ -1006,10 +1008,10 @@ export async function runWeb(args: string[]): Promise<void> {
         ensureDocker();
         const composePath = join(WEB_DIR, "compose.yml");
         if (!existsSync(composePath)) {
-            console.log("PizzaPi web is not running.");
+            log.info("PizzaPi web is not running.");
             return;
         }
-        console.log("Stopping PizzaPi web...");
+        log.info("Stopping PizzaPi web...");
         await composeExecAsync(composePath, ["down"]);
         return;
     }
@@ -1019,7 +1021,7 @@ export async function runWeb(args: string[]): Promise<void> {
         ensureDocker();
         const composePath = join(WEB_DIR, "compose.yml");
         if (!existsSync(composePath)) {
-            console.log("PizzaPi web is not running.");
+            log.info("PizzaPi web is not running.");
             return;
         }
         await composeExecAsync(composePath, ["logs", "-f", "--tail", "100"]);
@@ -1031,7 +1033,7 @@ export async function runWeb(args: string[]): Promise<void> {
         ensureDocker();
         const composePath = join(WEB_DIR, "compose.yml");
         if (!existsSync(composePath)) {
-            console.log("PizzaPi web is not set up. Run `pizza web` to start.");
+            log.info("PizzaPi web is not set up. Run `pizza web` to start.");
             return;
         }
         await composeExecAsync(composePath, ["ps"]);
@@ -1074,7 +1076,7 @@ export async function runWeb(args: string[]): Promise<void> {
 
     const useHostPrebuild = readBooleanEnv(process.env.PIZZAPI_PREBUILD_UI, true);
     if (!useHostPrebuild) {
-        console.log("Skipping host UI pre-build (PIZZAPI_PREBUILD_UI=false).");
+        log.info("Skipping host UI pre-build (PIZZAPI_PREBUILD_UI=false).");
     }
 
     // Pre-build UI on the host for much faster Docker builds when enabled.
@@ -1083,10 +1085,10 @@ export async function runWeb(args: string[]): Promise<void> {
         : { prebuilt: false, rebuilt: false };
     const composePath = generateComposeFile(repoPath, config, prebuildResult.prebuilt, prebuildResult.distHash);
 
-    console.log(`Starting PizzaPi web on port ${config.port}...`);
-    console.log(`  Repo:    ${repoPath}`);
-    console.log(`  Config:  ${CONFIG_PATH}`);
-    console.log();
+    log.info(`Starting PizzaPi web on port ${config.port}...`);
+    log.info(`  Repo:    ${repoPath}`);
+    log.info(`  Config:  ${CONFIG_PATH}`);
+    log.info("");
 
     // When the host prebuild actually rebuilt, force-recreate containers so
     // Docker picks up the new image even if BuildKit's layer cache didn't
@@ -1096,7 +1098,7 @@ export async function runWeb(args: string[]): Promise<void> {
     // --no-cache: run a separate `docker compose build --no-cache` first,
     // because `docker compose up` doesn't support --no-cache directly.
     if (parsed.noCache) {
-        console.log("Building without cache...");
+        log.info("Building without cache...");
         await composeExecAsync(composePath, ["build", "--no-cache"]);
     }
 
@@ -1104,13 +1106,13 @@ export async function runWeb(args: string[]): Promise<void> {
         const upArgs = ["up", "-d", "--build"];
         if (forceRecreate) upArgs.push("--force-recreate");
         await composeExecAsync(composePath, upArgs);
-        console.log();
-        console.log(`✅ PizzaPi web is running at http://localhost:${config.port}`);
-        console.log();
-        console.log("  pizza web logs      View logs");
-        console.log("  pizza web status    Check status");
-        console.log("  pizza web stop      Stop the hub");
-        console.log("  pizza web config    View configuration");
+        log.info("");
+        log.info(`✅ PizzaPi web is running at http://localhost:${config.port}`);
+        log.info("");
+        log.info("  pizza web logs      View logs");
+        log.info("  pizza web status    Check status");
+        log.info("  pizza web stop      Stop the hub");
+        log.info("  pizza web config    View configuration");
     } else {
         const upArgs = ["up", "--build"];
         if (forceRecreate) upArgs.push("--force-recreate");

--- a/packages/server/src/attachments/store.ts
+++ b/packages/server/src/attachments/store.ts
@@ -1,6 +1,9 @@
 import { mkdir, rm, access } from "node:fs/promises";
 import path from "node:path";
 import { getKysely } from "../auth.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("attachments");
 
 export interface StoredAttachment {
     attachmentId: string;
@@ -168,7 +171,7 @@ export async function storeExtractedImage(input: {
         // delete an image that's still used by a durable session.
         addSessionRef(attachmentId, sessionId);
         await persistExtractedAttachment(existing).catch((err) => {
-            console.error("[attachments] Failed to persist refreshed expiry:", err);
+            log.error("Failed to persist refreshed expiry:", err);
         });
         await persistSessionRef(attachmentId, sessionId).catch(() => {});
         return existing;
@@ -211,7 +214,7 @@ export async function storeExtractedImage(input: {
     // this, a crash between the file-write and the SQLite commit leaves dangling
     // /api/attachments/:id URLs in snapshots that can never be rehydrated.
     await persistExtractedAttachment(record).catch((err) => {
-        console.error("[attachments] Failed to persist extracted attachment:", err);
+        log.error("Failed to persist extracted attachment:", err);
     });
     await persistSessionRef(attachmentId, sessionId).catch(() => {});
     return record;

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -3,6 +3,9 @@ import { apiKey } from "better-auth/plugins";
 import { BunSqliteDialect } from "kysely-bun-sqlite";
 import { Kysely } from "kysely";
 import { Database } from "bun:sqlite";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("auth");
 
 // ── DB schema types ───────────────────────────────────────────────────────────
 
@@ -255,12 +258,12 @@ export function initAuth(config: AuthConfig = {}): void {
             throw new Error(`[auth] ${msg}`);
         } else {
             const fallback = crypto.randomUUID().replace(/-/g, "") + crypto.randomUUID().replace(/-/g, "");
-            console.warn(`[auth] WARNING: ${msg}\n  Using a random ephemeral secret for this development session.`);
+            log.warn(`WARNING: ${msg}\n  Using a random ephemeral secret for this development session.`);
             secret = fallback;
         }
     } else if (secret.length < 32) {
-        console.warn(
-            `[auth] WARNING: BETTER_AUTH_SECRET is shorter than 32 characters (got ${secret.length}). ` +
+        log.warn(
+            `WARNING: BETTER_AUTH_SECRET is shorter than 32 characters (got ${secret.length}). ` +
             "A longer secret is strongly recommended for security.",
         );
     }
@@ -287,7 +290,7 @@ export function initAuth(config: AuthConfig = {}): void {
             : []);
     const isProduction = process.env.NODE_ENV === "production";
     if (isProduction && !process.env.PIZZAPI_BASE_URL) {
-        console.warn("WARNING: PIZZAPI_BASE_URL is not set in production. This may cause CORS or WebSocket connection issues.");
+        log.warn("WARNING: PIZZAPI_BASE_URL is not set in production. This may cause CORS or WebSocket connection issues.");
     }
     const baseOrigins: string[] = [];
     if (process.env.PIZZAPI_BASE_URL) {

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -3,6 +3,10 @@ import { isValidPassword, PASSWORD_REQUIREMENTS_SUMMARY } from "@pizzapi/protoco
 import { handleApi } from "./routes/index.js";
 import { serveStaticFile } from "./static.js";
 import { getClientIp } from "./security.js";
+import { createLogger } from "@pizzapi/tools";
+
+const authLog = createLogger("auth");
+const apiLog = createLogger("api");
 
 /** Default body size limit for API routes (1 MB). */
 export const MAX_BODY_SIZE = 1 * 1024 * 1024;
@@ -248,7 +252,7 @@ async function _handleFetch(req: Request): Promise<Response> {
             const authReq = new Request(req, { headers: authHeaders });
             return await getAuth().handler(authReq);
         } catch (e) {
-            console.error("[auth] handler threw:", e);
+            authLog.error("handler threw:", e);
             return Response.json({ error: "Auth error" }, { status: 500 });
         }
     }
@@ -258,7 +262,7 @@ async function _handleFetch(req: Request): Promise<Response> {
         const res = await handleApi(req, url);
         if (res !== undefined) return res;
     } catch (e) {
-        console.error("[api] handleApi threw:", e);
+        apiLog.error("handleApi threw:", e);
         return Response.json({ error: "Internal server error" }, { status: 500 });
     }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -11,6 +11,7 @@ import { runAllMigrations } from "./migrations.js";
 
 import { setServerShuttingDown } from "./health.js";
 import { handleTunnelWsUpgrade } from "./routes/tunnel-ws.js";
+import { createLogger } from "@pizzapi/tools";
 
 // ── Process-level safety net ─────────────────────────────────────────────────
 // The Socket.IO Redis adapter can throw EPIPE synchronously when the Redis
@@ -18,11 +19,11 @@ import { handleTunnelWsUpgrade } from "./routes/tunnel-ws.js";
 // try/catches so the server never exits on a transient Redis disconnect.
 process.on("uncaughtException", (err: Error) => {
     if ((err as NodeJS.ErrnoException).code === "EPIPE") {
-        console.warn("[process] Caught EPIPE (Redis connection dropped) — ignoring:", err.message);
+        processLog.warn("Caught EPIPE (Redis connection dropped) — ignoring:", err.message);
         return;
     }
     // Re-throw anything that isn't an EPIPE so genuine bugs still surface.
-    console.error("[process] Uncaught exception:", err);
+    processLog.error("Uncaught exception:", err);
     process.exit(1);
 });
 
@@ -45,6 +46,14 @@ const PORT = parseInt(process.env.PORT ?? "7492");
 export { serverHealth } from "./health.js";
 import { serverHealth } from "./health.js";
 
+const log = createLogger("index");
+const processLog = createLogger("process");
+const startupLog = createLogger("startup");
+const httpLog = createLogger("http");
+const healthLog = createLogger("health");
+const socketIoLog = createLogger("Socket.IO");
+const shutdownLog = createLogger("shutdown");
+
 await runAllMigrations();
 void initializeRelayRedisCache();
 
@@ -52,9 +61,9 @@ void initializeRelayRedisCache();
 // session state survive server restarts.
 try {
     const count = await rehydrateExtractedAttachments();
-    if (count > 0) console.log(`[startup] Rehydrated ${count} extracted image attachment(s) from database.`);
+    if (count > 0) startupLog.info(`Rehydrated ${count} extracted image attachment(s) from database.`);
 } catch (err) {
-    console.error("[startup] Failed to rehydrate extracted attachments:", err);
+    startupLog.error("Failed to rehydrate extracted attachments:", err);
 }
 
 // ── Helpers: convert node:http request/response ↔ fetch API ──────────────
@@ -143,7 +152,7 @@ const httpServer = createServer(async (req, res) => {
         const fetchRes = await handleFetch(fetchReq);
         await sendFetchResponse(res, fetchRes);
     } catch (e) {
-        console.error("[http] Unhandled error:", e);
+        httpLog.error("Unhandled error:", e);
         if (!res.headersSent) {
             res.writeHead(500, {
                 "content-type": "application/json",
@@ -195,7 +204,7 @@ try {
     pubClient.on("ready", () => {
         pubReady = true;
         syncRedisHealth();
-        console.log("[health] Redis pub connected — health flags updated");
+        healthLog.info("Redis pub connected — health flags updated");
     });
 
     pubClient.on("error", (err: Error) => {
@@ -203,20 +212,20 @@ try {
         pubReady = false;
         syncRedisHealth();
         if (wasHealthy) {
-            console.warn("[health] Redis pub connection error — health flags set to degraded:", err.message);
+            healthLog.warn("Redis pub connection error — health flags set to degraded:", err.message);
         }
     });
 
     pubClient.on("reconnecting", () => {
         pubReady = false;
         syncRedisHealth();
-        console.warn("[health] Redis pub reconnecting — health flags set to degraded");
+        healthLog.warn("Redis pub reconnecting — health flags set to degraded");
     });
 
     subClient.on("ready", () => {
         subReady = true;
         syncRedisHealth();
-        console.log("[health] Redis sub connected — health flags updated");
+        healthLog.info("Redis sub connected — health flags updated");
     });
 
     subClient.on("error", (err: Error) => {
@@ -224,14 +233,14 @@ try {
         subReady = false;
         syncRedisHealth();
         if (wasHealthy) {
-            console.warn("[health] Redis sub connection error — health flags set to degraded:", err.message);
+            healthLog.warn("Redis sub connection error — health flags set to degraded:", err.message);
         }
     });
 
     subClient.on("reconnecting", () => {
         subReady = false;
         syncRedisHealth();
-        console.warn("[health] Redis sub reconnecting — health flags set to degraded");
+        healthLog.warn("Redis sub reconnecting — health flags set to degraded");
     });
 
     await Promise.all([pubClient.connect(), subClient.connect()]);
@@ -297,16 +306,16 @@ try {
         sioInitialized = true;
         serverHealth.socketio = true;
     } catch (sioErr) {
-        console.error("[Socket.IO] Failed to initialize Socket.IO layer:", sioErr);
-        console.error("[Socket.IO] The server will continue without real-time Socket.IO support.");
+        socketIoLog.error("Failed to initialize Socket.IO layer:", sioErr);
+        socketIoLog.error("The server will continue without real-time Socket.IO support.");
     }
 } catch (err) {
-    console.error("[Socket.IO] Failed to connect to Redis:", err);
-    console.error("[Socket.IO] The server will continue without Redis and Socket.IO support.");
+    socketIoLog.error("Failed to connect to Redis:", err);
+    socketIoLog.error("The server will continue without Redis and Socket.IO support.");
 }
 
 httpServer.listen(PORT, () => {
-    console.log(`PizzaPi server running on http://localhost:${PORT}`);
+    log.info(`PizzaPi server running on http://localhost:${PORT}`);
 });
 
 // ── Periodic maintenance ──────────────────────────────────────────────────
@@ -321,11 +330,11 @@ setInterval(() => {
             return deleteRelayEventCaches(expiredIds);
         })
         .catch((error) => {
-            console.error("Failed to prune expired relay sessions", error);
+            log.error("Failed to prune expired relay sessions", error);
         });
 }, sweepMs);
 
-console.log(`Relay session maintenance enabled (every ${Math.round(sweepMs / 1000)}s).`);
+log.info(`Relay session maintenance enabled (every ${Math.round(sweepMs / 1000)}s).`);
 
 // ── Post-startup orphaned runner sweep ───────────────────────────────────────
 // After a graceful shutdown, runner Redis entries are intentionally preserved
@@ -336,7 +345,7 @@ console.log(`Relay session maintenance enabled (every ${Math.round(sweepMs / 100
 const RUNNER_RECONNECT_GRACE_MS = 90_000;
 setTimeout(() => {
     void sweepOrphanedRunners().catch((err) => {
-        console.error("[startup] Failed to sweep orphaned runners:", err);
+        startupLog.error("Failed to sweep orphaned runners:", err);
     });
 }, RUNNER_RECONNECT_GRACE_MS);
 
@@ -345,29 +354,29 @@ setTimeout(() => {
 // if SIGTERM arrives during startup.  Sets isServerShuttingDown before closing
 // Socket.IO so disconnect handlers can skip destructive Redis cleanup.
 function onShutdownSignal(signal: string): void {
-    console.log(`[shutdown] Received ${signal} — marking server as shutting down`);
+    shutdownLog.info(`Received ${signal} — marking server as shutting down`);
     setServerShuttingDown();
 
     // Close the Socket.IO server so disconnect handlers fire with the
     // shuttingDown flag already set, then close the HTTP server.
     if (io) {
         io.close(() => {
-            console.log("[shutdown] Socket.IO closed");
+            shutdownLog.info("Socket.IO closed");
             httpServer.close(() => {
-                console.log("[shutdown] HTTP server closed");
+                shutdownLog.info("HTTP server closed");
                 process.exit(0);
             });
         });
     } else {
         httpServer.close(() => {
-            console.log("[shutdown] HTTP server closed");
+            shutdownLog.info("HTTP server closed");
             process.exit(0);
         });
     }
 
     // Force exit after 10s if graceful shutdown stalls
     setTimeout(() => {
-        console.warn("[shutdown] Graceful shutdown timed out — forcing exit");
+        shutdownLog.warn("Graceful shutdown timed out — forcing exit");
         process.exit(1);
     }, 10_000).unref();
 }

--- a/packages/server/src/migrations.ts
+++ b/packages/server/src/migrations.ts
@@ -5,6 +5,9 @@ import { ensurePushSubscriptionTable } from "./push.js";
 import { ensureRunnerRecentFoldersTable } from "./runner-recent-folders.js";
 import { ensureUserHiddenModelTable } from "./user-hidden-models.js";
 import { ensureExtractedAttachmentTable } from "./attachments/store.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("startup");
 
 /**
  * Run all database migrations (better-auth + custom tables).
@@ -19,9 +22,9 @@ export async function runAllMigrations(): Promise<void> {
         await ensureUserHiddenModelTable();
         await ensureRunnerRecentFoldersTable();
         await ensureExtractedAttachmentTable();
-        console.log("[startup] All database migrations complete.");
+        log.info("All database migrations complete.");
     } catch (e) {
-        console.error("[startup] Migration failed:", e);
+        log.error("Migration failed:", e);
         process.exit(1);
     }
 }

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -1,5 +1,8 @@
 import webpush from "web-push";
 import { getKysely } from "./auth.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("push");
 
 // ── VAPID configuration ─────────────────────────────────────────────────────
 //
@@ -33,18 +36,18 @@ function areVapidKeysValid(publicKey: string, privateKey: string): boolean {
 if (!areVapidKeysValid(vapidPublicKey, vapidPrivateKey)) {
     if (vapidPublicKey || vapidPrivateKey) {
         // Keys were provided but are malformed — warn loudly so the user can fix them.
-        console.warn("[push] ⚠️  VAPID keys are set but invalid (private key must be 32 bytes, public key 65 bytes when base64url-decoded).");
-        console.warn("[push]    Falling back to ephemeral keys.");
+        log.warn("⚠️  VAPID keys are set but invalid (private key must be 32 bytes, public key 65 bytes when base64url-decoded).");
+        log.warn("   Falling back to ephemeral keys.");
     }
     const generated = webpush.generateVAPIDKeys();
     vapidPublicKey = generated.publicKey;
     vapidPrivateKey = generated.privateKey;
-    console.warn("[push] ⚠️  No valid VAPID keys configured — using ephemeral keys.");
-    console.warn("[push]    Push subscriptions will break on every server restart.");
-    console.warn("[push]    To fix, add these to your environment:");
-    console.warn(`[push]    VAPID_PUBLIC_KEY=${vapidPublicKey}`);
-    console.warn(`[push]    VAPID_PRIVATE_KEY=${vapidPrivateKey}`);
-    console.warn(`[push]    VAPID_SUBJECT=mailto:your@email.com`);
+    log.warn("⚠️  No valid VAPID keys configured — using ephemeral keys.");
+    log.warn("   Push subscriptions will break on every server restart.");
+    log.warn("   To fix, add these to your environment:");
+    log.warn(`   VAPID_PUBLIC_KEY=${vapidPublicKey}`);
+    log.warn(`   VAPID_PRIVATE_KEY=${vapidPrivateKey}`);
+    log.warn(`   VAPID_SUBJECT=mailto:your@email.com`);
 }
 
 const vapidSubject = process.env.VAPID_SUBJECT ?? "mailto:admin@pizzapi.local";
@@ -277,7 +280,7 @@ export async function sendPushToUser(userId: string, payload: PushPayload, isChi
                     // Subscription expired or unregistered — clean up
                     staleIds.push(sub.id);
                 } else {
-                    console.error(`[push] Failed to send to ${sub.endpoint.slice(0, 60)}…:`, err?.statusCode ?? err?.message);
+                    log.error(`Failed to send to ${sub.endpoint.slice(0, 60)}…:`, err?.statusCode ?? err?.message);
                 }
             }
         }),
@@ -303,7 +306,7 @@ export function notifyAgentFinished(userId: string, sessionId: string, sessionNa
         body: `Your agent in "${label}" has finished its task.`,
         sessionId,
     }, isChildSession).catch((err) => {
-        console.error("[push] notifyAgentFinished failed:", err);
+        log.error("notifyAgentFinished failed:", err);
     });
 }
 
@@ -362,7 +365,7 @@ export function notifyAgentNeedsInput(
             ...(toolCallId ? { toolCallId } : {}),
         },
     }, isChildSession).catch((err) => {
-        console.error("[push] notifyAgentNeedsInput failed:", err);
+        log.error("notifyAgentNeedsInput failed:", err);
     });
 }
 
@@ -380,6 +383,6 @@ export function notifyAgentError(userId: string, sessionId: string, errorMessage
         body,
         sessionId,
     }, isChildSession).catch((err) => {
-        console.error("[push] notifyAgentError failed:", err);
+        log.error("notifyAgentError failed:", err);
     });
 }

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -24,6 +24,12 @@ import { isValidSkillName } from "../validation.js";
 import { parseJsonArray } from "./utils.js";
 import { isHiddenModel } from "./model-guard.js";
 import type { RouteHandler } from "./types.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("runners");
+const skillsLog = createLogger("skills");
+const agentsLog = createLogger("agents");
+const pluginsLog = createLogger("plugins");
 
 export const handleRunnersRoute: RouteHandler = async (req, url) => {
     // ── List runners ───────────────────────────────────────────────────
@@ -116,7 +122,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         try {
             hiddenModels = await getHiddenModels(identity.userId);
         } catch (err) {
-            console.error("Failed to fetch hidden models for user", identity.userId, err);
+            log.error("Failed to fetch hidden models for user", identity.userId, err);
             return Response.json({ error: "Unable to validate model availability" }, { status: 500 });
         }
 
@@ -316,7 +322,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 if (!result.ok) return Response.json({ error: result.message ?? "Skill scan failed" }, { status: 500 });
                 return Response.json({ ok: true, skills: result.skills ?? [] });
             } catch (err) {
-                console.error(`[skills] refresh failed:`, err);
+                skillsLog.error("refresh failed:", err);
                 return Response.json({ error: "Failed to refresh skills" }, { status: 502 });
             }
         }
@@ -334,7 +340,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 if (!result.ok) return Response.json({ error: result.message ?? "Skill not found" }, { status: 404 });
                 return Response.json({ name: result.name, content: result.content });
             } catch (err) {
-                console.error(`[skills] GET ${skillName} failed:`, err);
+                skillsLog.error(`GET ${skillName} failed:`, err);
                 return Response.json({ error: "Failed to retrieve skill" }, { status: 502 });
             }
         }
@@ -354,7 +360,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 if (!result.ok) return Response.json({ error: result.message ?? "Failed to create skill" }, { status: 400 });
                 return Response.json({ ok: true, skills: result.skills ?? [] });
             } catch (err) {
-                console.error(`[skills] POST ${name} failed:`, err);
+                skillsLog.error(`POST ${name} failed:`, err);
                 return Response.json({ error: "Failed to create skill" }, { status: 502 });
             }
         }
@@ -370,7 +376,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 if (!result.ok) return Response.json({ error: result.message ?? "Failed to update skill" }, { status: 400 });
                 return Response.json({ ok: true, skills: result.skills ?? [] });
             } catch (err) {
-                console.error(`[skills] PUT ${skillName} failed:`, err);
+                skillsLog.error(`PUT ${skillName} failed:`, err);
                 return Response.json({ error: "Failed to update skill" }, { status: 502 });
             }
         }
@@ -383,7 +389,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 if (!result.ok) return Response.json({ error: result.message ?? "Skill not found" }, { status: 404 });
                 return Response.json({ ok: true, skills: result.skills ?? [] });
             } catch (err) {
-                console.error(`[skills] DELETE ${skillName} failed:`, err);
+                skillsLog.error(`DELETE ${skillName} failed:`, err);
                 return Response.json({ error: "Failed to delete skill" }, { status: 502 });
             }
         }
@@ -411,7 +417,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 if (!result.ok) return Response.json({ error: result.message ?? "Agent scan failed" }, { status: 500 });
                 return Response.json({ ok: true, agents: result.agents ?? [] });
             } catch (err) {
-                console.error(`[agents] refresh failed:`, err);
+                agentsLog.error("refresh failed:", err);
                 return Response.json({ error: "Failed to refresh agents" }, { status: 502 });
             }
         }
@@ -429,7 +435,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 if (!result.ok) return Response.json({ error: result.message ?? "Agent not found" }, { status: 404 });
                 return Response.json({ name: result.name, content: result.content });
             } catch (err) {
-                console.error(`[agents] GET ${agentName} failed:`, err);
+                agentsLog.error(`GET ${agentName} failed:`, err);
                 return Response.json({ error: "Failed to retrieve agent" }, { status: 502 });
             }
         }
@@ -449,7 +455,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 if (!result.ok) return Response.json({ error: result.message ?? "Failed to create agent" }, { status: 400 });
                 return Response.json({ ok: true, agents: result.agents ?? [] });
             } catch (err) {
-                console.error(`[agents] POST ${name} failed:`, err);
+                agentsLog.error(`POST ${name} failed:`, err);
                 return Response.json({ error: "Failed to create agent" }, { status: 502 });
             }
         }
@@ -465,7 +471,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 if (!result.ok) return Response.json({ error: result.message ?? "Failed to update agent" }, { status: 400 });
                 return Response.json({ ok: true, agents: result.agents ?? [] });
             } catch (err) {
-                console.error(`[agents] PUT ${agentName} failed:`, err);
+                agentsLog.error(`PUT ${agentName} failed:`, err);
                 return Response.json({ error: "Failed to update agent" }, { status: 502 });
             }
         }
@@ -478,7 +484,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 if (!result.ok) return Response.json({ error: result.message ?? "Agent not found" }, { status: 404 });
                 return Response.json({ ok: true, agents: result.agents ?? [] });
             } catch (err) {
-                console.error(`[agents] DELETE ${agentName} failed:`, err);
+                agentsLog.error(`DELETE ${agentName} failed:`, err);
                 return Response.json({ error: "Failed to delete agent" }, { status: 502 });
             }
         }
@@ -519,7 +525,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 }
                 return Response.json({ plugins: result?.plugins ?? [] });
             } catch (err) {
-                console.error(`[plugins] cwd-scoped scan failed:`, err);
+                pluginsLog.error("cwd-scoped scan failed:", err);
                 return Response.json({ error: "Failed to scan plugins" }, { status: 502 });
             }
         }
@@ -546,7 +552,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
             }
             return Response.json({ ok: true, plugins: result?.plugins ?? [] });
         } catch (err) {
-            console.error(`[plugins] refresh failed:`, err);
+            pluginsLog.error("refresh failed:", err);
             return Response.json({ error: "Failed to refresh plugins" }, { status: 502 });
         }
     }

--- a/packages/server/src/routes/tunnel-ws.ts
+++ b/packages/server/src/routes/tunnel-ws.ts
@@ -20,6 +20,9 @@ import { getAuth } from "../auth.js";
 import { getSession } from "../ws/sio-state.js";
 import { getLocalRunnerSocket } from "../ws/sio-registry.js";
 import type { Socket } from "socket.io";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("tunnel-ws");
 
 /** Pattern: /api/tunnel/:sessionId/:port/<rest> */
 const TUNNEL_PATH_RE = /^\/api\/tunnel\/([^/]+)\/(\d+)(\/.*)?$/;
@@ -80,7 +83,7 @@ export function handleTunnelWsUpgrade(
     // The catch handles any unexpected errors (e.g. auth library throws synchronously
     // after an await point) so the rejected promise never becomes unhandled.
     handleUpgradeAsync(req, socket, head, match, url).catch((err) => {
-        console.error("[tunnel-ws] Unexpected error in upgrade handler:", err);
+        log.error("Unexpected error in upgrade handler:", err);
         if (!socket.destroyed) {
             rejectUpgrade(socket, 500, "Internal Server Error");
         }

--- a/packages/server/src/sessions/redis.ts
+++ b/packages/server/src/sessions/redis.ts
@@ -1,5 +1,8 @@
 import { createClient } from "redis";
 import { getEphemeralTtlMs } from "./store.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("redis");
 
 const DEFAULT_REDIS_URL = "redis://127.0.0.1:6379";
 const DEFAULT_EVENT_BUFFER_SIZE = 1000;
@@ -52,9 +55,9 @@ function logUnavailableOnce(message: string, error?: unknown) {
     if (unavailableLogged) return;
     unavailableLogged = true;
     if (error) {
-        console.warn(`${message}:`, error);
+        log.warn(`${message}:`, error);
     } else {
-        console.warn(message);
+        log.warn(message);
     }
 }
 
@@ -65,7 +68,7 @@ function activeClient(): RelayRedisClient | null {
 
 export async function initializeRelayRedisCache(): Promise<void> {
     if (isRedisDisabled()) {
-        console.log("Relay Redis cache disabled (PIZZAPI_REDIS_URL=off).");
+        log.info("Relay Redis cache disabled (PIZZAPI_REDIS_URL=off).");
         return;
     }
 
@@ -91,7 +94,7 @@ export async function initializeRelayRedisCache(): Promise<void> {
             await next.connect();
             client = next;
             unavailableLogged = false;
-            console.log(`Relay Redis cache connected at ${url}.`);
+            log.info(`Relay Redis cache connected at ${url}.`);
         } catch (error) {
             logUnavailableOnce("Relay Redis cache unavailable; continuing without event replay", error);
             try {

--- a/packages/server/src/sessions/redis_perf.test.ts
+++ b/packages/server/src/sessions/redis_perf.test.ts
@@ -68,9 +68,11 @@ describe("deleteRelayEventCaches Performance", () => {
         const sessionIds = ["s1"];
         await deleteRelayEventCaches(sessionIds);
 
-        // Should verify that it caught the error and logged it
+        // Should verify that it caught the error and logged it.
+        // The logger outputs: timestamp, "[tag]", message, ...args
         expect(consoleSpy).toHaveBeenCalled();
-        expect(consoleSpy.mock.calls[0][0]).toContain("Failed to delete relay event caches from Redis");
+        const allArgs = consoleSpy.mock.calls[0].join(" ");
+        expect(allArgs).toContain("Failed to delete relay event caches from Redis");
 
         consoleSpy.mockRestore();
     });

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -1,4 +1,7 @@
 import { getKysely } from "../auth.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sessions/store");
 
 const DEFAULT_EPHEMERAL_TTL_MS = 10 * 60 * 1000;
 const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000;
@@ -93,7 +96,7 @@ export async function ensureRelaySessionTables(): Promise<void> {
             .execute();
     } catch (error) {
         if (!isDuplicateColumnError(error, "isPinned")) {
-            console.error("[sessions/store] Failed to migrate relay_session.isPinned:", error);
+            log.error("Failed to migrate relay_session.isPinned:", error);
             throw error;
         }
     }
@@ -106,7 +109,7 @@ export async function ensureRelaySessionTables(): Promise<void> {
             .execute();
     } catch (error) {
         if (!isDuplicateColumnError(error, "runnerId")) {
-            console.error("[sessions/store] Failed to migrate relay_session.runnerId:", error);
+            log.error("Failed to migrate relay_session.runnerId:", error);
             throw error;
         }
     }
@@ -119,7 +122,7 @@ export async function ensureRelaySessionTables(): Promise<void> {
             .execute();
     } catch (error) {
         if (!isDuplicateColumnError(error, "runnerName")) {
-            console.error("[sessions/store] Failed to migrate relay_session.runnerName:", error);
+            log.error("Failed to migrate relay_session.runnerName:", error);
             throw error;
         }
     }
@@ -246,8 +249,8 @@ export async function updateRelaySessionRunner(
         }
     }
 
-    console.warn(
-        `[sessions/store] updateRelaySessionRunner: gave up linking runner ${runnerId} to session ${sessionId} after ${MAX_ATTEMPTS} attempts`,
+    log.warn(
+        `updateRelaySessionRunner: gave up linking runner ${runnerId} to session ${sessionId} after ${MAX_ATTEMPTS} attempts`,
     );
     return false;
 }

--- a/packages/server/src/static.ts
+++ b/packages/server/src/static.ts
@@ -6,6 +6,9 @@
 import { existsSync } from "fs";
 import { stat } from "node:fs/promises";
 import { join, extname, resolve, sep } from "path";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("static");
 
 // Resolve UI dist directory. Check in order:
 // 1. PIZZAPI_UI_DIR env var
@@ -37,9 +40,9 @@ export function setUiDir(dir: string | null) {
 }
 
 if (UI_DIR) {
-    console.log(`[static] Serving UI from ${UI_DIR}`);
+    log.info(`Serving UI from ${UI_DIR}`);
 } else {
-    console.log("[static] No UI dist found — static file serving disabled");
+    log.info("No UI dist found — static file serving disabled");
 }
 
 const MIME_TYPES: Record<string, string> = {

--- a/packages/server/src/ws/namespaces/hub.ts
+++ b/packages/server/src/ws/namespaces/hub.ts
@@ -21,6 +21,9 @@ import {
 } from "../sio-registry.js";
 import { getSession } from "../sio-state.js";
 import { getSessionMetaState, sessionMetaRoom } from "../sio-registry/meta.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/hub");
 
 export function registerHubNamespace(io: SocketIOServer): void {
     const hub: Namespace<
@@ -36,7 +39,7 @@ export function registerHubNamespace(io: SocketIOServer): void {
     hub.on("connection", async (socket) => {
         const userId = socket.data.userId ?? "";
 
-        console.log(`[sio/hub] connected: ${socket.id} userId=${userId}`);
+        log.info(`connected: ${socket.id} userId=${userId}`);
 
         // Join hub room (filtered by user)
         await addHubClient(socket, userId);
@@ -47,7 +50,7 @@ export function registerHubNamespace(io: SocketIOServer): void {
 
         // ── disconnect ───────────────────────────────────────────────────────
         socket.on("disconnect", async (reason) => {
-            console.log(`[sio/hub] disconnected: ${socket.id} (${reason})`);
+            log.info(`disconnected: ${socket.id} (${reason})`);
             await removeHubClient(socket, userId);
         });
 
@@ -59,7 +62,7 @@ export function registerHubNamespace(io: SocketIOServer): void {
           // Validate ownership — only the session owner may subscribe
           const session = await getSession(sessionId);
           if (!session || session.userId !== userId) {
-            console.warn(`[sio/hub] subscribe_session_meta: unauthorized userId=${userId} sessionId=${sessionId}`);
+            log.warn(`subscribe_session_meta: unauthorized userId=${userId} sessionId=${sessionId}`);
             return;
           }
 
@@ -81,14 +84,14 @@ export function registerHubNamespace(io: SocketIOServer): void {
           const state = await getSessionMetaState(sessionId) ?? stateBeforeJoin;
           socket.emit("state_snapshot", { sessionId, state });
 
-          console.log(`[sio/hub] meta subscribe: ${socket.id} → session ${sessionId}`);
+          log.info(`meta subscribe: ${socket.id} → session ${sessionId}`);
         });
 
         socket.on("unsubscribe_session_meta", async (data: unknown) => {
           if (!data || typeof (data as Record<string, unknown>).sessionId !== "string") return;
           const sessionId = (data as { sessionId: string }).sessionId;
           socket.leave(sessionMetaRoom(sessionId));
-          console.log(`[sio/hub] meta unsubscribe: ${socket.id} ← session ${sessionId}`);
+          log.info(`meta unsubscribe: ${socket.id} ← session ${sessionId}`);
         });
     });
 }

--- a/packages/server/src/ws/namespaces/relay/ack-tracker.ts
+++ b/packages/server/src/ws/namespaces/relay/ack-tracker.ts
@@ -3,6 +3,9 @@
 // Stored outside socket.data because RelaySocketData doesn't include it.
 
 import type { RelaySocket } from "./types.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/relay");
 
 export const socketAckedSeqs = new Map<string, number>();
 
@@ -20,7 +23,7 @@ export function sendCumulativeEventAck(socket: RelaySocket, seq: number): void {
             // Redis adapter can throw EPIPE when the Redis connection is temporarily
             // closed. Log and swallow — the ack is best-effort and the TUI will
             // resend any un-acked events on reconnect.
-            console.warn("[sio/relay] sendCumulativeEventAck emit failed (Redis EPIPE?):", (err as Error)?.message);
+            log.warn("sendCumulativeEventAck emit failed (Redis EPIPE?):", (err as Error)?.message);
         }
     }
 }

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
@@ -23,6 +23,9 @@ import {
     clearParentSessionId,
 } from "../../sio-state.js";
 import type { RelaySocket } from "./types.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/relay");
 
 export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIOServer): void {
     // ── cleanup_child_session — parent requests child teardown on ack ────
@@ -67,7 +70,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             return;
         }
 
-        console.log(`[sio/relay] cleanup_child_session: parent=${sessionId} child=${childSessionId}`);
+        log.info(`cleanup_child_session: parent=${sessionId} child=${childSessionId}`);
 
         try {
             // Terminate the child process via two complementary paths:
@@ -118,7 +121,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
 
             if (typeof ack === "function") ack({ ok: true });
         } catch (err: any) {
-            console.error(`[sio/relay] cleanup_child_session failed: parent=${sessionId} child=${childSessionId}`, err);
+            log.error(`cleanup_child_session failed: parent=${sessionId} child=${childSessionId}`, err);
             if (typeof ack === "function") ack({ ok: false, error: err?.message ?? "Internal error" });
         }
     });
@@ -140,7 +143,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
         const epoch: number | undefined =
             typeof data.epoch === "number" && data.epoch > 0 ? data.epoch : undefined;
 
-        console.log(`[sio/relay] delink_children: parent=${sessionId}${epoch ? ` epoch=${new Date(epoch).toISOString()}` : ""}`);
+        log.info(`delink_children: parent=${sessionId}${epoch ? ` epoch=${new Date(epoch).toISOString()}` : ""}`);
 
         try {
             // Snapshot current children plus any children whose
@@ -178,9 +181,9 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
                         const hasDelinkMarker = await isChildDelinked(childId);
                         if (hasDelinkMarker) {
                             filtered.push(childId);
-                            console.log(`[sio/relay] delink_children: including child ${childId} (startedAt > epoch but has delink marker)`);
+                            log.info(`delink_children: including child ${childId} (startedAt > epoch but has delink marker)`);
                         } else {
-                            console.log(`[sio/relay] delink_children: skipping child ${childId} (startedAt=${childSession.startedAt} > epoch)`);
+                            log.info(`delink_children: skipping child ${childId} (startedAt=${childSession.startedAt} > epoch)`);
                         }
                     }
                 }
@@ -242,7 +245,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             // new conversation.
             if (typeof ack === "function") ack({ ok: true });
         } catch (err) {
-            console.error(`[sio/relay] delink_children failed for parent=${sessionId}:`, err);
+            log.error(`delink_children failed for parent=${sessionId}:`, err);
             // Always nack so the client can clear its pendingDelink guard
             // and retry on reconnect rather than latching permanently.
             if (typeof ack === "function") ack({ ok: false, error: String(err) });
@@ -274,13 +277,13 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             // left behind to avoid a /new race window.
             const oldParentId = typeof data?.oldParentId === "string" ? data.oldParentId : null;
             if (oldParentId) {
-                console.log(
-                    `[sio/relay] delink_own_parent: child=${sessionId} parentSessionId already cleared — removing stale child entry from parent=${oldParentId}`,
+                log.info(
+                    `delink_own_parent: child=${sessionId} parentSessionId already cleared — removing stale child entry from parent=${oldParentId}`,
                 );
                 try {
                     await removeChildSession(oldParentId, sessionId);
                 } catch (err) {
-                    console.error("[sio/relay] delink_own_parent: failed to remove stale child entry:", err);
+                    log.error("delink_own_parent: failed to remove stale child entry:", err);
                     if (typeof ack === "function") ack({ ok: false, error: err instanceof Error ? err.message : String(err) });
                     return;
                 }
@@ -292,7 +295,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             try {
                 await clearParentSessionId(sessionId);
             } catch (err) {
-                console.error("[sio/relay] delink_own_parent: failed to clear linkedParentId:", err);
+                log.error("delink_own_parent: failed to clear linkedParentId:", err);
                 // Non-fatal: suppression will self-correct once the membership set expires.
             }
             // Already delinked or never linked — confirm success so the
@@ -301,7 +304,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             return;
         }
 
-        console.log(`[sio/relay] delink_own_parent: child=${sessionId} parent=${parentId}`);
+        log.info(`delink_own_parent: child=${sessionId} parent=${parentId}`);
 
         // Clear our own parentSessionId FIRST — this closes the race
         // window where a stale ack/followUp/cleanup_child_session from
@@ -314,7 +317,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             await clearParentSessionId(sessionId);
             await removeChildSession(parentId, sessionId);
         } catch (err) {
-            console.error("[sio/relay] delink_own_parent: Redis write failed:", err);
+            log.error("delink_own_parent: Redis write failed:", err);
             if (typeof ack === "function") ack({ ok: false, error: err instanceof Error ? err.message : String(err) });
             return;
         }

--- a/packages/server/src/ws/namespaces/relay/index.ts
+++ b/packages/server/src/ws/namespaces/relay/index.ts
@@ -20,9 +20,12 @@ import { registerEventHandler } from "./event-pipeline.js";
 import { registerSessionLifecycleHandlers } from "./session-lifecycle.js";
 import { registerMessagingHandlers } from "./messaging.js";
 import { registerChildLifecycleHandlers } from "./child-lifecycle.js";
+import { createLogger } from "@pizzapi/tools";
 
 // Re-export for viewer.ts compatibility
 export { getPendingChunkedSnapshot } from "./event-pipeline.js";
+
+const log = createLogger("sio/relay");
 
 export function registerRelayNamespace(io: SocketIOServer): void {
     const relay: Namespace<
@@ -36,7 +39,7 @@ export function registerRelayNamespace(io: SocketIOServer): void {
     relay.use(apiKeyAuthMiddleware() as Parameters<typeof relay.use>[0]);
 
     relay.on("connection", (socket) => {
-        console.log(`[sio/relay] connected: ${socket.id}`);
+        log.info(`connected: ${socket.id}`);
 
         registerSessionLifecycleHandlers(socket);
         registerEventHandler(socket);

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -17,6 +17,9 @@ import { socketAckedSeqs } from "./ack-tracker.js";
 import { clearThinkingMaps } from "./thinking-tracker.js";
 import { pendingChunkedStates, enqueueSessionEvent } from "./event-pipeline.js";
 import type { RelaySocket } from "./types.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/relay");
 
 export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
     // ── register ─────────────────────────────────────────────────────────
@@ -91,7 +94,7 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
 
     // ── disconnect ───────────────────────────────────────────────────────
     socket.on("disconnect", async (reason) => {
-        console.log(`[sio/relay] disconnected: ${socket.id} (${reason})`);
+        log.info(`disconnected: ${socket.id} (${reason})`);
         const sessionId = socket.data.sessionId;
         if (sessionId) {
             // If a newer socket already re-registered this session (reconnect),
@@ -100,7 +103,7 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             // for any remaining race windows.
             const currentSocket = getLocalTuiSocket(sessionId);
             if (currentSocket && currentSocket !== socket) {
-                console.log(`[sio/relay] disconnect for ${socket.id} — session ${sessionId} already owned by ${currentSocket.id}, skipping teardown`);
+                log.info(`disconnect for ${socket.id} — session ${sessionId} already owned by ${currentSocket.id}, skipping teardown`);
                 socketAckedSeqs.delete(socket.id);
                 return;
             }
@@ -110,7 +113,7 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             // destructive Redis cleanup for those — the TUI worker is
             // still alive and will reconnect to the new server instance.
             if (shouldPreserveOnSocketDisconnect(reason)) {
-                console.log(`[sio/relay] server shutting down — preserving Redis state for session ${sessionId}`);
+                log.info(`server shutting down — preserving Redis state for session ${sessionId}`);
                 socketAckedSeqs.delete(socket.id);
                 return;
             }

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -62,6 +62,9 @@ import {
     broadcastToSessionViewers,
 } from "../sio-registry.js";
 import { resolveSpawnReady, resolveSpawnError } from "../runner-control.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/runner");
 
 // ── Skill request/response registry ──────────────────────────────────────────
 // Maps requestId → { resolve, timer }. Used to correlate skill command
@@ -335,7 +338,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
     const runnerSessionIds = new Map<string, Set<string>>();
 
     runner.on("connection", (socket) => {
-        console.log(`[sio/runner] connected: ${socket.id}`);
+        log.info(`connected: ${socket.id}`);
 
         // ── Periodic Redis TTL refresh ───────────────────────────────────────
         // The runner's Redis key has a 2-hour TTL. Without periodic refresh,
@@ -634,8 +637,8 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
         socket.on("terminal_ready", (data) => {
             const terminalId = data.terminalId;
             if (!terminalId) return;
-            console.log(
-                `[sio/runner] terminal_ready terminalId=${terminalId} runnerId=${socket.data.runnerId}`,
+            log.info(
+                `terminal_ready terminalId=${terminalId} runnerId=${socket.data.runnerId}`,
             );
             sendToTerminalViewer(terminalId, {
                 type: "terminal_ready",
@@ -656,8 +659,8 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
         socket.on("terminal_exit", async (data) => {
             const terminalId = data.terminalId;
             if (!terminalId) return;
-            console.log(
-                `[sio/runner] terminal_exit terminalId=${terminalId} exitCode=${data.exitCode} runnerId=${socket.data.runnerId}`,
+            log.info(
+                `terminal_exit terminalId=${terminalId} exitCode=${data.exitCode} runnerId=${socket.data.runnerId}`,
             );
             sendToTerminalViewer(terminalId, {
                 type: "terminal_exit",
@@ -670,8 +673,8 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
         socket.on("terminal_error", async (data) => {
             const terminalId = data.terminalId;
             if (!terminalId) return;
-            console.warn(
-                `[sio/runner] terminal_error terminalId=${terminalId} message="${data.message}" runnerId=${socket.data.runnerId}`,
+            log.warn(
+                `terminal_error terminalId=${terminalId} message="${data.message}" runnerId=${socket.data.runnerId}`,
             );
             const entry = await getTerminalEntry(terminalId);
             sendToTerminalViewer(terminalId, {
@@ -732,7 +735,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 // Security: verify the target session belongs to this runner to prevent
                 // cross-session injection by a compromised or malicious runner.
                 if (!runnerSessionIds.get(runnerId)?.has(targetSessionId)) {
-                    console.warn(`[sio/runner] service_message rejected: session ${targetSessionId} not owned by runner ${runnerId}`);
+                    log.warn(`service_message rejected: session ${targetSessionId} not owned by runner ${runnerId}`);
                     return;
                 }
                 broadcastToSessionViewers(targetSessionId, "service_message", envelope);
@@ -755,7 +758,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             runnerServiceAnnounce.set(runnerId, data);
             // Persist to Redis so the data survives server restarts
             void updateRunnerServices(runnerId, data.serviceIds, data.panels).catch((err) => {
-                console.error(`[sio/runner] failed to persist service_announce to Redis for ${runnerId}:`, err);
+                log.error(`failed to persist service_announce to Redis for ${runnerId}:`, err);
             });
             const sessionIds = runnerSessionIds.get(runnerId);
             if (!sessionIds || sessionIds.size === 0) return;
@@ -766,7 +769,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
 
         // ── disconnect — clean up runner resources ───────────────────────────
         socket.on("disconnect", async (reason) => {
-            console.log(`[sio/runner] disconnected: ${socket.id} (${reason})`);
+            log.info(`disconnected: ${socket.id} (${reason})`);
             if (runnerTtlTimer) {
                 clearInterval(runnerTtlTimer);
                 runnerTtlTimer = null;
@@ -781,7 +784,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 // state for runners that genuinely crashed during the brief
                 // shutdown window.
                 if (shouldPreserveOnSocketDisconnect(reason)) {
-                    console.log(`[sio/runner] server shutting down — preserving Redis state for runner ${runnerId}`);
+                    log.info(`server shutting down — preserving Redis state for runner ${runnerId}`);
                     return;
                 }
 

--- a/packages/server/src/ws/namespaces/runners.ts
+++ b/packages/server/src/ws/namespaces/runners.ts
@@ -15,6 +15,9 @@ import type {
 } from "@pizzapi/protocol";
 import { sessionCookieAuthMiddleware } from "./auth.js";
 import { getRunners, runnersUserRoom } from "../sio-registry.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/runners");
 
 export function registerRunnersNamespace(io: SocketIOServer): void {
     const runners: Namespace<
@@ -30,7 +33,7 @@ export function registerRunnersNamespace(io: SocketIOServer): void {
     runners.on("connection", async (socket) => {
         const userId = socket.data.userId ?? "";
 
-        console.log(`[sio/runners] connected: ${socket.id} userId=${userId}`);
+        log.info(`connected: ${socket.id} userId=${userId}`);
 
         // Join per-user room so broadcasts are user-scoped
         await socket.join(runnersUserRoom(userId));
@@ -41,7 +44,7 @@ export function registerRunnersNamespace(io: SocketIOServer): void {
 
         // ── disconnect ───────────────────────────────────────────────────────
         socket.on("disconnect", (reason) => {
-            console.log(`[sio/runners] disconnected: ${socket.id} (${reason})`);
+            log.info(`disconnected: ${socket.id} (${reason})`);
             // Socket.IO automatically removes sockets from rooms on disconnect
         });
     });

--- a/packages/server/src/ws/namespaces/terminal.ts
+++ b/packages/server/src/ws/namespaces/terminal.ts
@@ -21,6 +21,9 @@ import {
     removeTerminalViewer,
     getLocalRunnerSocket,
 } from "../sio-registry.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/terminal");
 
 export function registerTerminalNamespace(io: SocketIOServer): void {
     const terminal: Namespace<
@@ -52,15 +55,15 @@ export function registerTerminalNamespace(io: SocketIOServer): void {
 
         socket.data.terminalId = terminalId;
 
-        console.log(
-            `[sio/terminal] viewer connected: terminalId=${terminalId} userId=${socket.data.userId}`,
+        log.info(
+            `viewer connected: terminalId=${terminalId} userId=${socket.data.userId}`,
         );
 
         // Validate terminal exists
         const entry = await getTerminalEntry(terminalId);
         if (!entry) {
-            console.warn(
-                `[sio/terminal] viewer connected but no terminal entry found: terminalId=${terminalId}`,
+            log.warn(
+                `viewer connected but no terminal entry found: terminalId=${terminalId}`,
             );
             socket.emit("terminal_error", { terminalId, message: "Terminal not found" });
             socket.disconnect(true);
@@ -69,8 +72,8 @@ export function registerTerminalNamespace(io: SocketIOServer): void {
 
         // Validate user owns the terminal
         if (entry.userId !== socket.data.userId) {
-            console.warn(
-                `[sio/terminal] viewer forbidden: terminalId=${terminalId} ` +
+            log.warn(
+                `viewer forbidden: terminalId=${terminalId} ` +
                     `entry.userId=${entry.userId} viewer.userId=${socket.data.userId}`,
             );
             socket.emit("terminal_error", { terminalId, message: "Forbidden" });
@@ -86,8 +89,8 @@ export function registerTerminalNamespace(io: SocketIOServer): void {
             return;
         }
 
-        console.log(
-            `[sio/terminal] viewer attached to runnerId=${entry.runnerId}: terminalId=${terminalId}`,
+        log.info(
+            `viewer attached to runnerId=${entry.runnerId}: terminalId=${terminalId}`,
         );
         socket.emit("terminal_connected", { terminalId });
 
@@ -101,8 +104,8 @@ export function registerTerminalNamespace(io: SocketIOServer): void {
 
             const runnerSocket = getLocalRunnerSocket(te.runnerId);
             if (!runnerSocket) {
-                console.warn(
-                    `[sio/terminal] runner not found runnerId=${te.runnerId} for terminalId=${tid} — input dropped`,
+                log.warn(
+                    `runner not found runnerId=${te.runnerId} for terminalId=${tid} — input dropped`,
                 );
                 return;
             }
@@ -123,8 +126,8 @@ export function registerTerminalNamespace(io: SocketIOServer): void {
 
             const runnerSocket = getLocalRunnerSocket(te.runnerId);
             if (!runnerSocket) {
-                console.warn(
-                    `[sio/terminal] runner not found runnerId=${te.runnerId} for terminalId=${tid} — resize dropped`,
+                log.warn(
+                    `runner not found runnerId=${te.runnerId} for terminalId=${tid} — resize dropped`,
                 );
                 return;
             }
@@ -147,8 +150,8 @@ export function registerTerminalNamespace(io: SocketIOServer): void {
                         ? data.rows
                         : (spawnOpts.rows ?? 24);
 
-                console.log(
-                    `[sio/terminal] deferred spawn: viewer sent resize → spawning PTY ` +
+                log.info(
+                    `deferred spawn: viewer sent resize → spawning PTY ` +
                         `terminalId=${tid} ${cols}x${rows} cwd=${spawnOpts.cwd ?? "(default)"}`,
                 );
 
@@ -163,8 +166,8 @@ export function registerTerminalNamespace(io: SocketIOServer): void {
                         rows,
                     });
                 } catch (err) {
-                    console.error(
-                        `[sio/terminal] deferred spawn: failed to send new_terminal to runner ` +
+                    log.error(
+                        `deferred spawn: failed to send new_terminal to runner ` +
                             `runnerId=${te.runnerId} terminalId=${tid}:`,
                         err,
                     );
@@ -177,8 +180,8 @@ export function registerTerminalNamespace(io: SocketIOServer): void {
             }
 
             // Normal resize: forward to runner
-            console.log(
-                `[sio/terminal] viewer→runner: terminalId=${tid} terminal_resize cols=${data.cols} rows=${data.rows}`,
+            log.info(
+                `viewer→runner: terminalId=${tid} terminal_resize cols=${data.cols} rows=${data.rows}`,
             );
             runnerSocket.emit("terminal_resize" as string, {
                 terminalId: tid,
@@ -204,8 +207,8 @@ export function registerTerminalNamespace(io: SocketIOServer): void {
         // ── disconnect ───────────────────────────────────────────────────────
         socket.on("disconnect", async (reason) => {
             const tid = socket.data.terminalId;
-            console.log(
-                `[sio/terminal] viewer disconnected: terminalId=${tid} userId=${socket.data.userId} (${reason})`,
+            log.info(
+                `viewer disconnected: terminalId=${tid} userId=${socket.data.userId} (${reason})`,
             );
             if (tid) {
                 await removeTerminalViewer(tid, socket);

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -36,8 +36,11 @@ import { isChildOfParent } from "../sio-state.js";
 import { getPendingChunkedSnapshot } from "./relay/index.js";
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
 import { getCachedRelayEvents } from "../../sessions/redis.js";
+import { createLogger } from "@pizzapi/tools";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
+
+const log = createLogger("sio/viewer");
 
 type ViewerSocket = Socket<
     ViewerClientToServerEvents,
@@ -179,7 +182,7 @@ async function replayPersistedSnapshot(
     } catch (error) {
         socket.emit("error", { message: "Failed to load session snapshot" });
         socket.disconnect();
-        console.error("[sio/viewer] Failed to replay persisted snapshot:", error);
+        log.error("Failed to replay persisted snapshot:", error);
     }
 }
 
@@ -222,7 +225,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
 
         socket.data.sessionId = sessionId;
 
-        console.log(`[sio/viewer] connected: ${socket.id} sessionId=${sessionId} userId=${viewerUserId}`);
+        log.info(`connected: ${socket.id} sessionId=${sessionId} userId=${viewerUserId}`);
 
         // Look up the live session
         const session = await getSharedSession(sessionId);
@@ -508,7 +511,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
 
         // ── disconnect ───────────────────────────────────────────────────────
         socket.on("disconnect", async (reason) => {
-            console.log(`[sio/viewer] disconnected: ${socket.id} sessionId=${sessionId} (${reason})`);
+            log.info(`disconnected: ${socket.id} sessionId=${sessionId} (${reason})`);
             await removeViewer(sessionId, socket);
         });
 
@@ -559,11 +562,11 @@ export function registerViewerNamespace(io: SocketIOServer): void {
 
         // Send cached service_announce so the viewer knows which runner
         // services are available without waiting for a fresh announce.
-        console.log(`[sio/viewer] service_announce check: runnerId=${freshSession.runnerId ?? "null"}`);
+        log.info(`service_announce check: runnerId=${freshSession.runnerId ?? "null"}`);
         if (freshSession.runnerId) {
             const announce = getRunnerServiceAnnounce(freshSession.runnerId);
             const serviceIds = announce?.serviceIds ?? [];
-            console.log(`[sio/viewer] service_announce: runnerId=${freshSession.runnerId}, cached serviceIds=[${serviceIds.join(",")}]`);
+            log.info(`service_announce: runnerId=${freshSession.runnerId}, cached serviceIds=[${serviceIds.join(",")}]`);
             if (serviceIds.length > 0) {
                 socket.emit("service_announce", announce!);
             }

--- a/packages/server/src/ws/sio-registry/context.ts
+++ b/packages/server/src/ws/sio-registry/context.ts
@@ -13,6 +13,9 @@
 import type { Server as SocketIOServer, Socket } from "socket.io";
 import type { ModelInfo } from "@pizzapi/protocol";
 import { getEphemeralTtlMs } from "../../sessions/store.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio-registry");
 
 // ── Socket.IO server reference ──────────────────────────────────────────────
 
@@ -115,7 +118,7 @@ export function emitToRunner(runnerId: string, eventName: string, data: unknown)
             .to(runnerRoom(runnerId))
             .emit(eventName, data);
     } catch (err) {
-        console.warn("[sio-registry] emitToRunner room emit failed:", (err as Error)?.message);
+        log.warn("emitToRunner room emit failed:", (err as Error)?.message);
     }
     // Compatibility fallback: direct local socket emit.
     // Handles runners on this node that haven't joined the room yet
@@ -146,7 +149,7 @@ export function emitToRelaySession(sessionId: string, eventName: string, data: u
         // only if the session's TUI socket is actually on this server —
         // otherwise the local room is empty and returning true would mislead
         // callers (e.g. MCP OAuth would consume the nonce for a dropped callback).
-        console.warn("[sio-registry] emitToRelaySession failed, falling back to local:", (err as Error)?.message);
+        log.warn("emitToRelaySession failed, falling back to local:", (err as Error)?.message);
         if (!localTuiSockets.has(sessionId)) return false;
         try {
             io.of("/relay")
@@ -179,7 +182,7 @@ export async function emitToRelaySessionVerified(sessionId: string, eventName: s
         io.of("/relay").to(room).emit(eventName, data);
         return true;
     } catch (err) {
-        console.warn("[sio-registry] emitToRelaySessionVerified failed:", (err as Error)?.message);
+        log.warn("emitToRelaySessionVerified failed:", (err as Error)?.message);
         return false;
     }
 }
@@ -236,7 +239,7 @@ export async function emitToRelaySessionAwaitingAck(
 
         return { hadListeners: true, acked: responses.length > 0 };
     } catch (err) {
-        console.warn("[sio-registry] emitToRelaySessionAwaitingAck failed:", (err as Error)?.message);
+        log.warn("emitToRelaySessionAwaitingAck failed:", (err as Error)?.message);
         return { hadListeners: true, acked: false };
     }
 }
@@ -252,7 +255,7 @@ export function broadcastToSessionViewers(sessionId: string, eventName: string, 
             .to(viewerSessionRoom(sessionId))
             .emit(eventName, data);
     } catch (err) {
-        console.warn("[sio-registry] broadcastToSessionViewers failed:", (err as Error)?.message);
+        log.warn("broadcastToSessionViewers failed:", (err as Error)?.message);
     }
 }
 

--- a/packages/server/src/ws/sio-registry/hub.ts
+++ b/packages/server/src/ws/sio-registry/hub.ts
@@ -7,8 +7,11 @@
 
 import type { Socket } from "socket.io";
 import { getIo, HUB_ROOM, hubUserRoom } from "./context.js";
+import { createLogger } from "@pizzapi/tools";
 
 // ── Hub broadcasting ────────────────────────────────────────────────────────
+
+const log = createLogger("sio-registry");
 
 /**
  * Broadcast a message to all hub clients, optionally filtered by user.
@@ -31,7 +34,7 @@ export async function broadcastToHub(
         // Redis adapter publishes before local fan-out, so EPIPE drops the
         // event for local sockets too. Fall back to local-only delivery so
         // browsers on this server still get session_added/session_removed.
-        console.warn("[sio-registry] broadcastToHub failed, falling back to local:", (err as Error)?.message);
+        log.warn("broadcastToHub failed, falling back to local:", (err as Error)?.message);
         try {
             const hubNs = io.of("/hub");
             if (targetUserId) {

--- a/packages/server/src/ws/sio-registry/meta.ts
+++ b/packages/server/src/ws/sio-registry/meta.ts
@@ -8,8 +8,11 @@
 import { defaultMetaState, type SessionMetaState, type MetaRelayEvent } from "@pizzapi/protocol";
 import { getSession, updateSessionFields } from "../sio-state.js";
 import { getIo } from "./context.js";
+import { createLogger } from "@pizzapi/tools";
 
 // ── Hub broadcasting ─────────────────────────────────────────────────────────
+
+const log = createLogger("meta");
 
 export function sessionMetaRoom(sessionId: string): string {
   return `session:${sessionId}:meta`;
@@ -28,7 +31,7 @@ export async function broadcastToSessionMeta(
     const room = sessionMetaRoom(sessionId);
     io.of("/hub").to(room).emit("meta_event", { sessionId, version, ...event });
   } catch (err) {
-    console.warn("[meta] broadcastToSessionMeta failed:", (err as Error)?.message);
+    log.warn("broadcastToSessionMeta failed:", (err as Error)?.message);
   }
 }
 

--- a/packages/server/src/ws/sio-registry/runners-broadcast.ts
+++ b/packages/server/src/ws/sio-registry/runners-broadcast.ts
@@ -1,6 +1,9 @@
 // runners-broadcast.ts — Helpers for broadcasting runner events to /runners namespace
 // Room helper lives in context.ts (alongside hubUserRoom) to avoid circular deps.
 import { getIo, runnersUserRoom } from "./context.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio-registry");
 
 /**
  * Broadcast a runner lifecycle event to all connected /runners clients.
@@ -21,7 +24,7 @@ export async function broadcastToRunnersNs(
             runnersNs.emit(eventName, data);
         }
     } catch (err) {
-        console.warn("[sio-registry] broadcastToRunnersNs failed, falling back to local:", (err as Error)?.message);
+        log.warn("broadcastToRunnersNs failed, falling back to local:", (err as Error)?.message);
         try {
             const runnersNs = io.of("/runners");
             if (userId) {

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -38,6 +38,9 @@ import {
 } from "./context.js";
 import { broadcastToHub } from "./hub.js";
 import { broadcastToRunnersNs } from "./runners-broadcast.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio-registry");
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
@@ -314,7 +317,7 @@ export async function linkSessionToRunner(runnerId: string, sessionId: string): 
     // Also persist the runner link in SQLite so historical/pinned sessions
     // retain their runner provenance after the Redis session hash is deleted.
     void updateRelaySessionRunner(sessionId, runnerId, runner.name).catch((error) => {
-        console.error("[sio-registry] Failed to persist runner link to SQLite:", error);
+        log.error("Failed to persist runner link to SQLite:", error);
     });
 
     const heartbeat = session.lastHeartbeat ? safeJsonParse(session.lastHeartbeat) : null;
@@ -464,7 +467,7 @@ export async function touchRunner(runnerId: string): Promise<void> {
 export async function sweepOrphanedRunners(): Promise<void> {
     const io = getIo();
     if (!io) {
-        console.warn("[sweepOrphanedRunners] Socket.IO not initialized — skipping sweep");
+        log.warn("Socket.IO not initialized — skipping sweep");
         return;
     }
     const allRunners = await getAllRunners();
@@ -482,7 +485,7 @@ export async function sweepOrphanedRunners(): Promise<void> {
             continue;
         }
 
-        console.log(`[sio-registry] Pruning orphaned runner ${runner.runnerId} (${runner.name ?? "unnamed"}) — not reconnected after restart`);
+        log.info(`Pruning orphaned runner ${runner.runnerId} (${runner.name ?? "unnamed"}) — not reconnected after restart`);
         await deleteRunnerState(runner.runnerId);
         void broadcastToRunnersNs(
             "runner_removed",
@@ -492,6 +495,6 @@ export async function sweepOrphanedRunners(): Promise<void> {
         pruned++;
     }
     if (pruned > 0) {
-        console.log(`[sio-registry] Pruned ${pruned} orphaned runner(s)`);
+        log.info(`Pruned ${pruned} orphaned runner(s)`);
     }
 }

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -59,6 +59,9 @@ import {
     emitToRunner,
 } from "./context.js";
 import { broadcastToHub } from "./hub.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio-registry");
 
 // ── Internal helpers ─────────────────────────────────────────────────────────
 
@@ -303,7 +306,7 @@ export async function registerTuiSession(
         runnerId,
         runnerName,
     }).catch((error) => {
-        console.error("[sio-registry] Failed to persist relay session start:", error);
+        log.error("Failed to persist relay session start:", error);
     });
 
     // Broadcast to hub
@@ -394,7 +397,7 @@ export async function updateSessionState(sessionId: string, state: unknown): Pro
     try {
         strippedState = await storeAndReplaceImages(state, sessionId, userId);
     } catch (err) {
-        console.error("[sio-registry] Image extraction failed, using original state:", err);
+        log.error("Image extraction failed, using original state:", err);
         strippedState = state;
     }
 
@@ -430,7 +433,7 @@ export async function updateSessionState(sessionId: string, state: unknown): Pro
     }
 
     void recordRelaySessionState(sessionId, strippedState).catch((error) => {
-        console.error("[sio-registry] Failed to persist relay session state:", error);
+        log.error("Failed to persist relay session state:", error);
     });
 }
 
@@ -466,7 +469,7 @@ export async function touchSessionActivity(sessionId: string): Promise<void> {
     }
 
     void touchRelaySession(sessionId).catch((error) => {
-        console.error("[sio-registry] Failed to touch relay session:", error);
+        log.error("Failed to touch relay session:", error);
     });
 }
 
@@ -483,7 +486,7 @@ export async function broadcastSessionEventToViewers(sessionId: string, event: u
             .to(viewerSessionRoom(sessionId))
             .emit("event", { event, seq });
     } catch (err) {
-        console.warn("[sio-registry] broadcastSessionEventToViewers failed:", (err as Error)?.message);
+        log.warn("broadcastSessionEventToViewers failed:", (err as Error)?.message);
         try {
             io.of("/viewer")
                 .local
@@ -519,7 +522,7 @@ export async function publishSessionEvent(sessionId: string, event: unknown): Pr
     try {
         strippedEvent = await storeAndReplaceImagesInEvent(event, sessionId, userId);
     } catch (err) {
-        console.error("[sio-registry] Image extraction from event failed, using original event:", err);
+        log.error("Image extraction from event failed, using original event:", err);
         strippedEvent = event;
     }
 
@@ -540,7 +543,7 @@ export async function publishSessionEvent(sessionId: string, event: unknown): Pr
         // Fall back to local-only delivery so viewers on this server still receive
         // the event and its seq — without seeing the new seq they'd never trigger
         // a resync and would permanently miss this event even though it was cached.
-        console.warn("[sio-registry] publishSessionEvent broadcast failed, falling back to local:", (err as Error)?.message);
+        log.warn("publishSessionEvent broadcast failed, falling back to local:", (err as Error)?.message);
         try {
             io.of("/viewer")
                 .local
@@ -670,7 +673,7 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
             .to(viewerSessionRoom(sessionId))
             .emit("disconnected", { reason });
     } catch (err) {
-        console.warn("[sio-registry] endSharedSession viewer notify failed, falling back to local:", (err as Error)?.message);
+        log.warn("endSharedSession viewer notify failed, falling back to local:", (err as Error)?.message);
         try {
             io.of("/viewer")
                 .local
@@ -704,7 +707,7 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
 
     // Persist end in SQLite
     void recordRelaySessionEnd(sessionId).catch((error) => {
-        console.error("[sio-registry] Failed to persist relay session end:", error);
+        log.error("Failed to persist relay session end:", error);
     });
 
     // Broadcast removal to hub
@@ -790,8 +793,8 @@ export async function sweepOrphanedSessions(nowMs: number): Promise<void> {
         // Verify locally right before teardown to catch fresh reconnections
         if (localTuiSockets.has(candidate.sessionId)) continue;
 
-        console.log(
-            `[sio-registry] Sweeping orphaned session ${candidate.sessionId} ` +
+        log.info(
+            `Sweeping orphaned session ${candidate.sessionId} ` +
             `(last activity: ${new Date(candidate.lastActivity).toISOString()})`,
         );
         await endSharedSession(candidate.sessionId, "Session orphaned (no active relay connection)");
@@ -833,7 +836,7 @@ export function broadcastToViewers(sessionId: string, eventName: string, data: u
         // cached in Redis, so viewers can't recover them via replay. Fall back
         // to local-only delivery so at least viewers connected to this server
         // instance still receive the event.
-        console.warn("[sio-registry] broadcastToViewers Redis broadcast failed, falling back to local:", (err as Error)?.message);
+        log.warn("broadcastToViewers Redis broadcast failed, falling back to local:", (err as Error)?.message);
         try {
             io.of("/viewer")
                 .local

--- a/packages/server/src/ws/sio-registry/terminals.ts
+++ b/packages/server/src/ws/sio-registry/terminals.ts
@@ -23,8 +23,11 @@ import {
     localTerminalGcTimers,
     terminalRoom,
 } from "./context.js";
+import { createLogger } from "@pizzapi/tools";
 
 // ── Terminal Management ─────────────────────────────────────────────────────
+
+const log = createLogger("sio-terminal");
 
 export interface TerminalSpawnOpts {
     cwd?: string;
@@ -64,7 +67,7 @@ export async function registerTerminal(
     const timer = setTimeout(async () => {
         const t = await getTerminalState(terminalId);
         if (t && !t.spawned) {
-            console.log(`[sio-terminal] GC: removing unspawned terminal ${terminalId} (no viewer within ${TERMINAL_PENDING_TIMEOUT_MS}ms)`);
+            log.info(`GC: removing unspawned terminal ${terminalId} (no viewer within ${TERMINAL_PENDING_TIMEOUT_MS}ms)`);
             await cleanupTerminal(terminalId);
         }
     }, TERMINAL_PENDING_TIMEOUT_MS);
@@ -95,7 +98,7 @@ export async function setTerminalViewer(terminalId: string, socket: Socket): Pro
     // Replay buffered messages
     const buffer = localTerminalBuffers.get(terminalId) ?? [];
     if (buffer.length > 0) {
-        console.log(`[sio-terminal] replaying ${buffer.length} buffered messages for terminal ${terminalId}`);
+        log.info(`replaying ${buffer.length} buffered messages for terminal ${terminalId}`);
         for (const msg of buffer) {
             const msgObj = msg as Record<string, unknown>;
             const eventName = (msgObj.type as string) ?? "terminal_data";
@@ -176,7 +179,7 @@ export async function removeTerminal(terminalId: string): Promise<void> {
     if (existingTimer) clearTimeout(existingTimer);
 
     const timer = setTimeout(async () => {
-        console.log(`[sio-terminal] GC: removing terminal ${terminalId} (no viewer within ${TERMINAL_GC_DELAY_MS}ms)`);
+        log.info(`GC: removing terminal ${terminalId} (no viewer within ${TERMINAL_GC_DELAY_MS}ms)`);
         await cleanupTerminal(terminalId);
     }, TERMINAL_GC_DELAY_MS);
     localTerminalGcTimers.set(terminalId, timer);
@@ -192,7 +195,7 @@ export function sendToTerminalViewer(terminalId: string, msg: unknown): void {
             buffer.push(msg);
         } else {
             const type = msg && typeof msg === "object" ? (msg as Record<string, unknown>).type : "?";
-            console.warn(`[sio-terminal] sendToTerminalViewer: no entry for ${terminalId} (msg.type=${type}) — dropped`);
+            log.warn(`sendToTerminalViewer: no entry for ${terminalId} (msg.type=${type}) — dropped`);
         }
         return;
     }

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -16,6 +16,9 @@
 // ============================================================================
 
 import { createClient, type RedisClientType } from "redis";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio-state");
 
 // ── Redis connection ────────────────────────────────────────────────────────
 
@@ -42,11 +45,11 @@ export async function initStateRedis(createClientOverride?: typeof createClient)
     }) as RedisClientType;
 
     redis.on("error", (err) => {
-        console.error("[sio-state] Redis error:", err);
+        log.error("Redis error:", err);
     });
 
     await redis.connect();
-    console.log(`[sio-state] Redis connected at ${getRedisUrl()}`);
+    log.info(`Redis connected at ${getRedisUrl()}`);
 }
 
 /** Return the state Redis client (or null if not initialized). */

--- a/packages/server/src/ws/strip-images.ts
+++ b/packages/server/src/ws/strip-images.ts
@@ -12,6 +12,9 @@
 
 import { createHash } from "node:crypto";
 import { storeExtractedImage, getExtractedImageUrl } from "../attachments/store.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("strip-images");
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -208,8 +211,8 @@ export async function storeAndReplaceImages(
         ),
     );
 
-    console.log(
-        `[strip-images] Extracted ${result.extracted.length} image(s) from session ${sessionId}, ` +
+    log.info(
+        `Extracted ${result.extracted.length} image(s) from session ${sessionId}, ` +
         `saved ~${(result.savedBytes / 1024 / 1024).toFixed(1)} MB from state payload`,
     );
 
@@ -245,8 +248,8 @@ export async function storeAndReplaceImagesInEvent(
         ),
     );
 
-    console.log(
-        `[strip-images] Extracted ${result.extracted.length} image(s) from agent_end for session ${sessionId}, ` +
+    log.info(
+        `Extracted ${result.extracted.length} image(s) from agent_end for session ${sessionId}, ` +
         `saved ~${(result.savedBytes / 1024 / 1024).toFixed(1)} MB`,
     );
 

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -1,3 +1,5 @@
+export { createLogger } from "./log.js";
+export type { Logger } from "./log.js";
 export { bashTool } from "./bash.js";
 export { readFileTool } from "./read-file.js";
 export { writeFileTool } from "./write-file.js";

--- a/packages/tools/src/log.test.ts
+++ b/packages/tools/src/log.test.ts
@@ -1,0 +1,80 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
+import { createLogger } from "./log.js";
+
+describe("createLogger", () => {
+    let logSpy: ReturnType<typeof spyOn>;
+    let warnSpy: ReturnType<typeof spyOn>;
+    let errorSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+        logSpy = spyOn(console, "log").mockImplementation(() => {});
+        warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+        errorSpy = spyOn(console, "error").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        logSpy.mockRestore();
+        warnSpy.mockRestore();
+        errorSpy.mockRestore();
+    });
+
+    test("info() writes to console.log with timestamp and tag", () => {
+        const log = createLogger("health");
+        log.info("Redis connected");
+
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        const [ts, tag, msg] = logSpy.mock.calls[0];
+        expect(tag).toBe("[health]");
+        expect(msg).toBe("Redis connected");
+        // Timestamp should be ISO 8601
+        expect(() => new Date(ts as string).toISOString()).not.toThrow();
+    });
+
+    test("warn() writes to console.warn with timestamp and tag", () => {
+        const log = createLogger("sio/relay");
+        log.warn("Degraded:", "ECONNRESET");
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const [ts, tag, msg, extra] = warnSpy.mock.calls[0];
+        expect(tag).toBe("[sio/relay]");
+        expect(msg).toBe("Degraded:");
+        expect(extra).toBe("ECONNRESET");
+        expect(() => new Date(ts as string).toISOString()).not.toThrow();
+    });
+
+    test("error() writes to console.error with timestamp and tag", () => {
+        const log = createLogger("startup");
+        const err = new Error("boom");
+        log.error("Failed:", err);
+
+        expect(errorSpy).toHaveBeenCalledTimes(1);
+        const [ts, tag, msg, errArg] = errorSpy.mock.calls[0];
+        expect(tag).toBe("[startup]");
+        expect(msg).toBe("Failed:");
+        expect(errArg).toBe(err);
+        expect(() => new Date(ts as string).toISOString()).not.toThrow();
+    });
+
+    test("passes through extra variadic args", () => {
+        const log = createLogger("test");
+        log.info("multi", 1, true, { key: "val" });
+
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        const args = logSpy.mock.calls[0];
+        // [timestamp, "[test]", "multi", 1, true, { key: "val" }]
+        expect(args.length).toBe(6);
+        expect(args[3]).toBe(1);
+        expect(args[4]).toBe(true);
+        expect(args[5]).toEqual({ key: "val" });
+    });
+
+    test("different loggers have independent tags", () => {
+        const a = createLogger("alpha");
+        const b = createLogger("beta");
+        a.info("hello");
+        b.info("world");
+
+        expect(logSpy.mock.calls[0][1]).toBe("[alpha]");
+        expect(logSpy.mock.calls[1][1]).toBe("[beta]");
+    });
+});

--- a/packages/tools/src/log.ts
+++ b/packages/tools/src/log.ts
@@ -1,0 +1,40 @@
+/**
+ * Lightweight timestamped logger.
+ *
+ * Every message is prefixed with an ISO-8601 timestamp and a bracketed tag
+ * so log files are correlatable and grep-friendly:
+ *
+ *   2026-03-26T10:30:00.123Z [health] Redis pub connected
+ *   2026-03-26T10:30:00.456Z [sio/relay] session started sid=abc123
+ *
+ * Usage:
+ *   import { createLogger } from "@pizzapi/tools";
+ *   const log = createLogger("health");
+ *   log.info("Redis connected");
+ *   log.warn("Degraded:", err.message);
+ *   log.error("Failed:", err);
+ */
+
+export interface Logger {
+    /** Log at info level (→ stdout / console.log). */
+    info(msg: string, ...args: unknown[]): void;
+    /** Log at warn level (→ stderr / console.warn). */
+    warn(msg: string, ...args: unknown[]): void;
+    /** Log at error level (→ stderr / console.error). */
+    error(msg: string, ...args: unknown[]): void;
+}
+
+/**
+ * Create a tagged logger that prepends an ISO timestamp and `[tag]` to
+ * every message.
+ *
+ * @param tag  Short component/subsystem name (e.g. "health", "sio/relay").
+ */
+export function createLogger(tag: string): Logger {
+    const prefix = `[${tag}]`;
+    return {
+        info:  (msg, ...args) => console.log(new Date().toISOString(), prefix, msg, ...args),
+        warn:  (msg, ...args) => console.warn(new Date().toISOString(), prefix, msg, ...args),
+        error: (msg, ...args) => console.error(new Date().toISOString(), prefix, msg, ...args),
+    };
+}

--- a/packages/tools/src/sandbox.ts
+++ b/packages/tools/src/sandbox.ts
@@ -15,9 +15,11 @@ import {
     type SandboxRuntimeConfig,
     getDefaultWritePaths,
 } from "@anthropic-ai/sandbox-runtime";
+import { createLogger } from "./log.js";
 
 /** Whether the current platform is case-insensitive (macOS, Windows). */
 const _caseInsensitiveFS = platform() === "darwin" || platform() === "win32";
+const log = createLogger("sandbox");
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -114,14 +116,12 @@ export async function initSandbox(config: ResolvedSandboxConfig): Promise<void> 
     // Detect SSH agent socket for allowlisting
     _sshAuthSock = process.env.SSH_AUTH_SOCK ?? null;
     if (_sshAuthSock) {
-        console.log(`[sandbox] SSH agent detected: ${_sshAuthSock}`);
+        log.info(`SSH agent detected: ${_sshAuthSock}`);
     }
 
     // Check platform support
     if (!SandboxManager.isSupportedPlatform()) {
-        console.warn(
-            "[sandbox] Platform not supported for sandboxing. Running unsandboxed.",
-        );
+        log.warn("Platform not supported for sandboxing. Running unsandboxed.");
         _initialized = true;
         _initFailed = true;
         return;
@@ -134,10 +134,7 @@ export async function initSandbox(config: ResolvedSandboxConfig): Promise<void> 
         await SandboxManager.initialize(runtimeConfig);
         _initialized = true;
     } catch (err) {
-        console.error(
-            "[sandbox] Failed to initialize sandbox. Continuing unsandboxed:",
-            err instanceof Error ? err.message : String(err),
-        );
+        log.error(`Failed to initialize sandbox. Continuing unsandboxed: ${err instanceof Error ? err.message : String(err)}`);
         _initialized = true;
         _initFailed = true;
     }
@@ -165,7 +162,7 @@ export async function wrapCommand(cmd: string): Promise<string> {
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         // Fail closed: block the command rather than run it unsandboxed.
-        console.error(`[sandbox] Failed to wrap command, blocking: ${msg}`);
+        log.error(`Failed to wrap command, blocking: ${msg}`);
         throw new Error(`Sandbox enforcement failed: ${msg}`);
     }
 }
@@ -301,10 +298,7 @@ export async function cleanupSandbox(): Promise<void> {
         try {
             await SandboxManager.reset();
         } catch (err) {
-            console.error(
-                "[sandbox] Error during cleanup:",
-                err instanceof Error ? err.message : String(err),
-            );
+            log.error(`Error during cleanup: ${err instanceof Error ? err.message : String(err)}`);
         }
     }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -108,6 +108,9 @@ import {
 } from "@/lib/message-helpers";
 import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
 import { analyzeIncomingSeq, mergeConnectedSeq, shouldDeferEventForHydration } from "@/lib/session-seq";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("relay");
 
 // Sync all CSS animations (pulse, chase-spin, etc.) to the same phase globally.
 initAnimationSync();
@@ -2400,7 +2403,7 @@ export function App() {
       if (!socket.connected) return;
       const elapsed = Date.now() - lastViewerEventAtRef.current;
       if (elapsed > STALE_THRESHOLD_MS) {
-        console.warn(`[relay] Stale connection detected (${Math.round(elapsed / 1000)}s since last event). Reconnecting…`);
+        log.warn(`Stale connection detected (${Math.round(elapsed / 1000)}s since last event). Reconnecting…`);
         socket.disconnect();
         socket.connect();
       }
@@ -2469,7 +2472,7 @@ export function App() {
         }
         if (decision.gap && decision.expected !== null) {
           // Gap detected — request a resync snapshot from the server.
-          console.warn(`[relay] Sequence gap: expected ${decision.expected}, got ${seq}. Requesting resync.`);
+          log.warn(`Sequence gap: expected ${decision.expected}, got ${seq}. Requesting resync.`);
           socket.emit("resync", {});
         }
         lastSeqRef.current = decision.nextSeq;

--- a/packages/ui/src/components/AgentsManager.tsx
+++ b/packages/ui/src/components/AgentsManager.tsx
@@ -24,6 +24,9 @@ import {
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("agents-ui");
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -436,7 +439,7 @@ export function AgentsManager({ runnerId, agents: initialAgents, onAgentsChange,
                 handleAgentsChange(data.agents);
             }
         } catch (err) {
-            console.error("Failed to refresh agents:", err);
+            log.error("Failed to refresh agents:", err);
         } finally {
             setRefreshing(false);
         }

--- a/packages/ui/src/components/NotificationToggle.tsx
+++ b/packages/ui/src/components/NotificationToggle.tsx
@@ -25,6 +25,9 @@ import {
     getSuppressChildNotifications,
     setSuppressChildNotifications,
 } from "@/lib/push";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("push");
 
 function usePushState() {
     const [subscribed, setSubscribed] = React.useState(false);
@@ -71,7 +74,7 @@ function usePushState() {
                 }
             }
         } catch (err) {
-            console.error("[push] toggle failed:", err);
+            log.error("toggle failed:", err);
         } finally {
             setLoading(false);
         }
@@ -85,7 +88,7 @@ function usePushState() {
             const ok = await setSuppressChildNotifications(next);
             if (ok) setSuppressChild(next);
         } catch (err) {
-            console.error("[push] suppressChild toggle failed:", err);
+            log.error("suppressChild toggle failed:", err);
         } finally {
             setSuppressChildLoading(false);
         }

--- a/packages/ui/src/components/PluginsManager.tsx
+++ b/packages/ui/src/components/PluginsManager.tsx
@@ -23,6 +23,9 @@ import {
 } from "lucide-react";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("plugins-ui");
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -370,7 +373,7 @@ export function PluginsManager({ runnerId, plugins: initialPlugins, onPluginsCha
                 }
             }
         } catch (err) {
-            console.error("Failed to refresh plugins:", err);
+            log.error("Failed to refresh plugins:", err);
         } finally {
             setRefreshing(false);
         }

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -15,6 +15,9 @@ import {
 import { ErrorAlert } from "@/components/ui/error-alert";
 import type { HubSession } from "@/components/SessionSidebar";
 import type { RunnerInfo } from "@pizzapi/protocol";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("runner-ui");
 
 export interface RunnerManagerProps {
     /** Runner list from the /runners WS feed — passed from App.tsx (single hook instance) */
@@ -108,7 +111,7 @@ export function RunnerManager({
                 setError(`Failed to restart runner: ${data.error || "Unknown error"}`);
             }
         } catch (err) {
-            console.error("Failed to restart runner:", err);
+            log.error("Failed to restart runner:", err);
         } finally {
             setTimeout(() => {
                 setRestarting((prev) => {
@@ -142,7 +145,7 @@ export function RunnerManager({
                 setError(`Failed to stop runner: ${data.error || "Unknown error"}`);
             }
         } catch (err) {
-            console.error("Failed to stop runner:", err);
+            log.error("Failed to stop runner:", err);
         } finally {
             setTimeout(() => {
                 setStopping((prev) => {

--- a/packages/ui/src/components/SkillsManager.tsx
+++ b/packages/ui/src/components/SkillsManager.tsx
@@ -24,6 +24,9 @@ import {
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("skills-ui");
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -428,7 +431,7 @@ export function SkillsManager({ runnerId, skills: initialSkills, onSkillsChange,
                 handleSkillsChange(data.skills);
             }
         } catch (err) {
-            console.error("Failed to refresh skills:", err);
+            log.error("Failed to refresh skills:", err);
         } finally {
             setRefreshing(false);
         }

--- a/packages/ui/src/components/ai-elements/code-block.tsx
+++ b/packages/ui/src/components/ai-elements/code-block.tsx
@@ -131,6 +131,9 @@ import {
   MAX_HIGHLIGHTER_CACHE_SIZE,
   MAX_TOKENS_CACHE_SIZE,
 } from "./code-block-cache";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("code-block");
 
 // Highlighter cache (singleton per language)
 const highlighterCache = new Map<
@@ -237,7 +240,7 @@ export const highlightCode = (
     })
     // oxlint-disable-next-line eslint-plugin-promise(prefer-await-to-then), eslint-plugin-promise(prefer-await-to-callbacks)
     .catch((error) => {
-      console.error("Failed to highlight code:", error);
+      log.error("Failed to highlight code:", error);
       subscribers.delete(tokensCacheKey);
     });
 

--- a/packages/ui/src/components/ai-elements/conversation.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.tsx
@@ -15,6 +15,9 @@ import { cn } from "@/lib/utils";
 import { ArrowDownIcon, CheckIcon, ClipboardIcon, DownloadIcon, ShareIcon } from "lucide-react";
 import { useCallback, useEffect, useState, useRef } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("conversation");
 
 /**
  * Default distance-from-bottom (in px) within which auto-follow remains
@@ -223,7 +226,7 @@ export const ConversationExport = ({
       clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => setCopied(false), feedbackMs);
     } catch {
-      console.warn("Clipboard write failed");
+      log.warn("Clipboard write failed");
     }
   }, [messages, feedbackMs]);
 
@@ -305,7 +308,7 @@ export const MessageCopyButton = ({
       clearTimeout(timerRef.current);
       timerRef.current = setTimeout(() => setCopied(false), feedbackMs);
     } catch {
-      console.warn("Clipboard write failed");
+      log.warn("Clipboard write failed");
     }
   }, [text, feedbackMs]);
 

--- a/packages/ui/src/components/ui/error-boundary.tsx
+++ b/packages/ui/src/components/ui/error-boundary.tsx
@@ -1,6 +1,9 @@
 import * as React from "react";
 import { AlertCircle, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("error-boundary");
 
 export type ErrorBoundaryLevel = "root" | "section" | "widget";
 
@@ -42,7 +45,7 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
   }
 
   componentDidCatch(error: Error, info: React.ErrorInfo): void {
-    console.error("[ErrorBoundary] Caught render error:", error, info.componentStack);
+    log.error("Caught render error:", error, info.componentStack);
   }
 
   componentDidUpdate(prevProps: ErrorBoundaryProps): void {

--- a/packages/ui/src/lib/push.ts
+++ b/packages/ui/src/lib/push.ts
@@ -1,3 +1,5 @@
+import { createLogger } from "@pizzapi/tools";
+
 /**
  * WebPush notification subscription management for the browser.
  *
@@ -5,6 +7,8 @@
  * to push notifications via the Web Push API. It communicates with the
  * PizzaPi server to register the PushSubscription with VAPID credentials.
  */
+
+const log = createLogger("push");
 
 let cachedVapidKey: string | null = null;
 
@@ -71,14 +75,14 @@ export async function getExistingSubscription(): Promise<PushSubscription | null
  */
 export async function subscribeToPush(): Promise<PushSubscription | null> {
     if (!isPushSupported()) {
-        console.warn("[push] Push notifications are not supported in this browser.");
+        log.warn("Push notifications are not supported in this browser.");
         return null;
     }
 
     // Request permission
     const permission = await Notification.requestPermission();
     if (permission !== "granted") {
-        console.warn("[push] Notification permission denied.");
+        log.warn("Notification permission denied.");
         return null;
     }
 
@@ -107,7 +111,7 @@ export async function subscribeToPush(): Promise<PushSubscription | null> {
     });
 
     if (!res.ok) {
-        console.error("[push] Failed to register subscription with server:", res.status);
+        log.error("Failed to register subscription with server:", res.status);
         // Unsubscribe since server registration failed
         await subscription.unsubscribe();
         return null;
@@ -132,7 +136,7 @@ export async function unsubscribeFromPush(): Promise<boolean> {
             body: JSON.stringify({ endpoint: subscription.endpoint }),
         });
     } catch (err) {
-        console.error("[push] Failed to unregister subscription from server:", err);
+        log.error("Failed to unregister subscription from server:", err);
     }
 
     // Unsubscribe locally


### PR DESCRIPTION
## Summary
- add a shared `createLogger(tag)` utility in `@pizzapi/tools` that prepends ISO-8601 timestamps and bracketed tags
- replace raw `console.log/warn/error` usage across server, CLI, tools, and UI code with tagged logger calls
- keep the existing runner structured logger in place and migrate stray runner `console.*` calls to it

## Test Plan
- [x] `bun test packages/tools/src/log.test.ts`
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun test packages/server/src/sessions/redis_perf.test.ts`
- [x] `bun run test` *(27 existing failures also reproduce on `main`; branch does not add new suite failures)*
