### PR TITLE
fix: stop relay crash and replay viewer reconnect churn

### DIFF
--- a/packages/protocol/src/viewer.test.ts
+++ b/packages/protocol/src/viewer.test.ts
@@ -52,10 +52,14 @@ describe("viewer — ViewerServerToClientEvents payloads", () => {
     expect(full.replay).toBe(true);
   });
 
-  test("disconnected carries reason string", () => {
+  test("disconnected carries reason string with optional structured code", () => {
     type Payload = Parameters<ViewerServerToClientEvents["disconnected"]>[0];
     const p: Payload = { reason: "TUI disconnected" };
     expect(typeof p.reason).toBe("string");
+    expect(p.code).toBeUndefined();
+
+    const structured: Payload = { reason: "Session is no longer live (snapshot replay).", code: "snapshot_replay" };
+    expect(structured.code).toBe("snapshot_replay");
   });
 
   test("exec_result carries id, ok, and command", () => {

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -4,6 +4,8 @@
 
 import type { Attachment, ServiceAnnounceData, ServiceEnvelope } from "./shared.js";
 
+export type ViewerDisconnectCode = "snapshot_replay" | "session_ended" | "session_reconnected";
+
 // ---------------------------------------------------------------------------
 // Server → Client (Server sends to browser viewer)
 // ---------------------------------------------------------------------------
@@ -29,6 +31,7 @@ export interface ViewerServerToClientEvents {
   /** Notifies the viewer that the TUI disconnected */
   disconnected: (data: {
     reason: string;
+    code?: ViewerDisconnectCode;
   }) => void;
 
   /** Forwards an exec result back to the viewer */

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -69,6 +69,11 @@ export interface PersistedRelaySessionSummary {
     runnerName: string | null;
 }
 
+export interface PersistedRelaySessionRunnerInfo {
+    runnerId: string | null;
+    runnerName: string | null;
+}
+
 export async function ensureRelaySessionTables(): Promise<void> {
     await getKysely().schema
         .createTable("relay_session")
@@ -315,6 +320,22 @@ export async function recordRelaySessionEnd(sessionId: string): Promise<void> {
             ]),
         )
         .execute();
+}
+
+export async function getPersistedRelaySessionRunner(
+    sessionId: string,
+): Promise<PersistedRelaySessionRunnerInfo | null> {
+    const row = await getKysely()
+        .selectFrom("relay_session")
+        .select(["runnerId", "runnerName"])
+        .where("id", "=", sessionId)
+        .executeTakeFirst();
+
+    if (!row) return null;
+    return {
+        runnerId: row.runnerId ?? null,
+        runnerName: row.runnerName ?? null,
+    };
 }
 
 export async function getPersistedRelaySessionSnapshot(

--- a/packages/server/src/ws/namespaces/hub.ts
+++ b/packages/server/src/ws/namespaces/hub.ts
@@ -59,9 +59,16 @@ export function registerHubNamespace(io: SocketIOServer): void {
           if (!data || typeof (data as Record<string, unknown>).sessionId !== "string") return;
           const sessionId = (data as { sessionId: string }).sessionId;
 
-          // Validate ownership — only the session owner may subscribe
+          // Validate ownership — only the session owner may subscribe.
+          // Distinguish "session is not live yet / no longer live" from an
+          // actual cross-user subscription attempt so restart-time reconnect
+          // races don't look like auth failures in the logs.
           const session = await getSession(sessionId);
-          if (!session || session.userId !== userId) {
+          if (!session) {
+            log.info(`subscribe_session_meta: session missing userId=${userId} sessionId=${sessionId}`);
+            return;
+          }
+          if (session.userId !== userId) {
             log.warn(`subscribe_session_meta: unauthorized userId=${userId} sessionId=${sessionId}`);
             return;
           }

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import { enqueueSessionEvent, sessionEventQueues } from "./event-pipeline.js";
+
+async function flushQueue(): Promise<void> {
+    for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+    }
+}
+
+describe("enqueueSessionEvent", () => {
+    afterEach(() => {
+        sessionEventQueues.clear();
+    });
+
+    test("logs a failed task and continues processing later tasks", async () => {
+        const errorSpy = spyOn(console, "error").mockImplementation(() => {});
+        let ranSecond = false;
+
+        enqueueSessionEvent("session-1", async () => {
+            throw new Error("boom");
+        });
+        enqueueSessionEvent("session-1", async () => {
+            ranSecond = true;
+        });
+
+        await flushQueue();
+        await sessionEventQueues.get("session-1");
+        await flushQueue();
+
+        expect(ranSecond).toBe(true);
+        expect(errorSpy).toHaveBeenCalled();
+        expect(sessionEventQueues.has("session-1")).toBe(false);
+
+        errorSpy.mockRestore();
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -45,7 +45,11 @@ export const sessionEventQueues = new Map<string, Promise<void>>();
 
 export function enqueueSessionEvent(sessionId: string, fn: () => Promise<void>): void {
     const prev = sessionEventQueues.get(sessionId) ?? Promise.resolve();
-    const next = prev.then(fn, fn); // always chain, even on prior rejection
+    const next = prev
+        .then(fn, fn) // always chain, even on prior rejection
+        .catch((error) => {
+            console.error(`[sio/relay] Session event pipeline failed for ${sessionId}:`, error);
+        });
     sessionEventQueues.set(sessionId, next);
     // Clean up the map entry when the chain settles to avoid unbounded growth.
     // Use .finally() so cleanup runs even if fn rejects (otherwise the map

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -173,7 +173,10 @@ async function replayPersistedSnapshot(
             });
         }
 
-        socket.emit("disconnected", { reason: "Session is no longer live (snapshot replay)." });
+        socket.emit("disconnected", {
+            reason: "Session is no longer live (snapshot replay).",
+            code: "snapshot_replay",
+        });
         // Use disconnect() without `true` so the client can still auto-reconnect
         // when the session comes back online. disconnect(true) sets reason to
         // "io server disconnect" on the client, which permanently disables
@@ -521,7 +524,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // and reduces startup resync churn.
         const ok = await addViewer(sessionId, socket);
         if (!ok) {
-            socket.emit("disconnected", { reason: "Session ended" });
+            socket.emit("disconnected", { reason: "Session ended", code: "session_ended" });
             // Use disconnect() (not true) so the client can still auto-reconnect;
             // the session may have just cycled and will come back shortly.
             socket.disconnect();
@@ -547,7 +550,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         ]);
 
         if (!freshSession) {
-            socket.emit("disconnected", { reason: "Session ended" });
+            socket.emit("disconnected", { reason: "Session ended", code: "session_ended" });
             socket.disconnect();
             return;
         }

--- a/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
@@ -106,8 +106,12 @@ mock.module("redis", () => ({
 // Prevent this unit test from touching the real SQLite-backed session store or
 // the global Socket.IO hub registry. Those are covered by separate integration
 // tests; here we only care about parent link resolution.
+const mockGetPersistedRelaySessionRunner = mock(
+    async (_sessionId: string): Promise<{ runnerId: string | null; runnerName: string | null } | null> => null,
+);
 mock.module("../../sessions/store.js", () => ({
     getEphemeralTtlMs: () => 60_000,
+    getPersistedRelaySessionRunner: mockGetPersistedRelaySessionRunner,
     recordRelaySessionStart: async () => {},
     recordRelaySessionEnd: async () => {},
     recordRelaySessionState: async () => {},
@@ -130,6 +134,8 @@ describe("registerTuiSession parent resolution", () => {
         store.clear();
         setStore.clear();
         ttlStore.clear();
+        mockGetPersistedRelaySessionRunner.mockReset();
+        mockGetPersistedRelaySessionRunner.mockImplementation(async () => null);
         await initStateRedis();
     });
 
@@ -178,5 +184,37 @@ describe("registerTuiSession parent resolution", () => {
         // The delink marker means the parent ran /new — do not re-add the child
         // to the old parent's membership set even if the parent is currently offline.
         expect(setStore.has("pizzapi:sio:children:parent-old")).toBe(false);
+    });
+
+    it("restores runner association from persisted session data when Redis association is missing", async () => {
+        const socket = {
+            join: async () => {},
+            data: {},
+        } as any;
+
+        mockGetPersistedRelaySessionRunner.mockImplementation(async (sessionId: string) => {
+            expect(sessionId).toBe("session-with-persisted-runner");
+            return { runnerId: "runner-persisted", runnerName: "Persisted Runner" };
+        });
+
+        await registerTuiSession(socket, "/repo", {
+            sessionId: "session-with-persisted-runner",
+            userId: "u1",
+            userName: "User",
+            isEphemeral: false,
+        });
+
+        const sessionHash = JSON.parse(
+            store.get("__hash__:pizzapi:sio:session:session-with-persisted-runner") ?? "{}",
+        ) as Record<string, string>;
+        expect(sessionHash.runnerId).toBe("runner-persisted");
+        expect(sessionHash.runnerName).toBe("Persisted Runner");
+
+        const runnerAssoc = store.get("pizzapi:sio:runner-assoc:session-with-persisted-runner");
+        expect(runnerAssoc).toBeDefined();
+        expect(JSON.parse(runnerAssoc ?? "null")).toEqual({
+            runnerId: "runner-persisted",
+            runnerName: "Persisted Runner",
+        });
     });
 });

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -36,6 +36,7 @@ import {
     getRunner as getRunnerState,
 } from "../sio-state.js";
 import {
+    getPersistedRelaySessionRunner,
     recordRelaySessionStart,
     recordRelaySessionEnd,
     recordRelaySessionState,
@@ -159,6 +160,19 @@ export async function registerTuiSession(
         if (assoc) {
             runnerId = assoc.runnerId;
             runnerName = assoc.runnerName;
+        }
+    }
+
+    // Redis-side runner association keys can disappear during a Redis restart
+    // even though SQLite still has durable session provenance. Fall back to the
+    // persisted session row so reconnecting live sessions keep their runner link
+    // (service panels, runner routing, etc.) after the relay re-registers.
+    if (!runnerId) {
+        const persistedRunner = await getPersistedRelaySessionRunner(sessionId);
+        if (persistedRunner?.runnerId) {
+            runnerId = persistedRunner.runnerId;
+            runnerName = persistedRunner.runnerName;
+            await setRunnerAssociation(sessionId, runnerId, runnerName);
         }
     }
 

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -659,6 +659,16 @@ export async function sendSnapshotToViewer(sessionId: string, socket: Socket): P
     }
 }
 
+function viewerDisconnectPayload(reason: string): { reason: string; code?: "session_ended" | "session_reconnected" } {
+    if (reason === "Session reconnected") {
+        return { reason, code: "session_reconnected" };
+    }
+    if (reason === "Session ended") {
+        return { reason, code: "session_ended" };
+    }
+    return { reason };
+}
+
 /** End a shared session: notify viewers, clean up Redis, broadcast to hub. */
 export async function endSharedSession(sessionId: string, reason: string = "Session ended"): Promise<void> {
     const io = getIo();
@@ -667,18 +677,20 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
     const session = await getSession(sessionId);
     if (!session) return;
 
+    const disconnectPayload = viewerDisconnectPayload(reason);
+
     // Notify all viewers in the room and disconnect them
     try {
         io.of("/viewer")
             .to(viewerSessionRoom(sessionId))
-            .emit("disconnected", { reason });
+            .emit("disconnected", disconnectPayload);
     } catch (err) {
         log.warn("endSharedSession viewer notify failed, falling back to local:", (err as Error)?.message);
         try {
             io.of("/viewer")
                 .local
                 .to(viewerSessionRoom(sessionId))
-                .emit("disconnected", { reason });
+                .emit("disconnected", disconnectPayload);
         } catch {
             // Local delivery also failed.
         }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -64,6 +64,7 @@ import { CombinedPanel, type CombinedPanelTab } from "@/components/CombinedPanel
 import { DockedPanelGroup } from "@/components/DockedPanelGroup";
 import { ViewerSocketContext } from "@/lib/viewer-socket-context";
 import { HubSocketContext } from "@/lib/hub-socket-context";
+import { shouldStopViewerReconnect } from "@/lib/viewer-connection";
 import { useRunnerServices, attachServiceAnnounceListener } from "@/hooks/useRunnerServices";
 import { ServicePanelButtons, useServicePanelState } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
@@ -2512,6 +2513,13 @@ export function App() {
       setPendingQuestion(null);
       setPendingPlan(null);
       setIsChangingModel(false);
+
+      // Snapshot replay means the session is no longer live. If we leave the
+      // namespace socket active, socket.io-client keeps retrying forever,
+      // creating repeated /viewer reconnect churn for a dead session.
+      if (shouldStopViewerReconnect(data)) {
+        socket.disconnect();
+      }
     });
 
     socket.on("error", (data) => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -65,6 +65,7 @@ import { DockedPanelGroup } from "@/components/DockedPanelGroup";
 import { ViewerSocketContext } from "@/lib/viewer-socket-context";
 import { HubSocketContext } from "@/lib/hub-socket-context";
 import { shouldStopViewerReconnect } from "@/lib/viewer-connection";
+import { getConfirmedMetaSubscriptionTargets } from "@/lib/meta-subscriptions";
 import { useRunnerServices, attachServiceAnnounceListener } from "@/hooks/useRunnerServices";
 import { ServicePanelButtons, useServicePanelState } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
@@ -317,6 +318,8 @@ export function App() {
 
   // Tracks which session's meta room we've joined so we can unsubscribe when needed.
   const prevMetaSessionRef = React.useRef<string | null>(null);
+  const confirmedMetaLiveSessionIdsRef = React.useRef<Set<string>>(new Set());
+  const [metaInventoryVersion, setMetaInventoryVersion] = React.useState(0);
 
   // Chunked session delivery: when session_active arrives with chunked:true,
   // messages follow as session_messages_chunk events. This ref tracks state.
@@ -349,6 +352,11 @@ export function App() {
     handleSidebarPointerDown, handleSidebarPointerMove, handleSidebarPointerUp,
   } = useMobileSidebar();
   const [liveSessions, setLiveSessions] = React.useState<HubSession[]>([]);
+
+  React.useEffect(() => {
+    confirmedMetaLiveSessionIdsRef.current = new Set(liveSessions.map((s) => s.sessionId));
+    setMetaInventoryVersion((version) => version + 1);
+  }, [liveSessions]);
 
   // Derive sidebar runners from the /runners WS feed
   React.useEffect(() => {
@@ -2232,27 +2240,16 @@ export function App() {
     // version counter to 0 on restart, so any previously-seen version would cause
     // all new events to be silently ignored.
     const handleReconnect = () => {
-      const currentSessionId = activeSessionRef.current;
-      if (currentSessionId) {
-        metaVersionsRef.current.delete(currentSessionId);
-        socket.emit("subscribe_session_meta", { sessionId: currentSessionId });
-      }
-      // Re-subscribe background sessions and clear their version state.
-      for (const id of backgroundMetaIdsRef.current) {
-        metaVersionsRef.current.delete(id);
-        socket.emit("subscribe_session_meta", { sessionId: id });
-      }
+      metaVersionsRef.current.clear();
+      prevMetaSessionRef.current = null;
+      backgroundMetaIdsRef.current.clear();
+      confirmedMetaLiveSessionIdsRef.current = new Set();
+      setMetaInventoryVersion((version) => version + 1);
     };
 
     socket.on("state_snapshot", handleStateSnapshot);
     socket.on("meta_event", handleMetaEvent);
     socket.on("connect", handleReconnect);
-
-    const initialSessionId = activeSessionRef.current;
-    if (initialSessionId) {
-      socket.emit("subscribe_session_meta", { sessionId: initialSessionId });
-      prevMetaSessionRef.current = initialSessionId;
-    }
 
     return () => {
       socket.off("state_snapshot", handleStateSnapshot);
@@ -2268,21 +2265,27 @@ export function App() {
     const hubSock = hubSocketRef.current;
     if (!hubSock) return;
 
+    const { activeSessionId: confirmedActiveSessionId } = getConfirmedMetaSubscriptionTargets({
+      liveSessionIds: liveSessions.map((s) => s.sessionId),
+      confirmedLiveSessionIds: confirmedMetaLiveSessionIdsRef.current,
+      activeSessionId,
+    });
     const prevId = prevMetaSessionRef.current;
-    const nextId = activeSessionId;
 
-    if (prevId && prevId !== nextId) {
+    if (prevId && prevId !== confirmedActiveSessionId) {
       hubSock.emit("unsubscribe_session_meta", { sessionId: prevId });
       metaVersionsRef.current.delete(prevId);
     }
 
-    if (nextId) {
-      hubSock.emit("subscribe_session_meta", { sessionId: nextId });
-      prevMetaSessionRef.current = nextId;
+    if (confirmedActiveSessionId) {
+      if (prevId !== confirmedActiveSessionId) {
+        hubSock.emit("subscribe_session_meta", { sessionId: confirmedActiveSessionId });
+      }
+      prevMetaSessionRef.current = confirmedActiveSessionId;
     } else {
       prevMetaSessionRef.current = null;
     }
-  }, [activeSessionId]);
+  }, [hubSocket, activeSessionId, liveSessions, metaInventoryVersion]);
 
   // Subscribe to meta rooms for ALL live sessions (not just the active one) so
   // that background sessions can update the sidebar pending-question badge.
@@ -2293,9 +2296,12 @@ export function App() {
     const hubSock = hubSocketRef.current;
     if (!hubSock) return;
 
-    const currentIds = new Set(
-      liveSessions.map((s) => s.sessionId).filter((id) => id !== activeSessionId),
-    );
+    const { backgroundSessionIds } = getConfirmedMetaSubscriptionTargets({
+      liveSessionIds: liveSessions.map((s) => s.sessionId),
+      confirmedLiveSessionIds: confirmedMetaLiveSessionIdsRef.current,
+      activeSessionId,
+    });
+    const currentIds = new Set(backgroundSessionIds);
     const prev = backgroundMetaIdsRef.current;
 
     // Unsubscribe from sessions that are no longer in the live list.
@@ -2319,7 +2325,7 @@ export function App() {
         prev.add(id);
       }
     }
-  }, [liveSessions, activeSessionId]);
+  }, [hubSocket, liveSessions, activeSessionId, metaInventoryVersion]);
 
   const openSession = React.useCallback((relaySessionId: string) => {
     // Flush/cancel any pending RAF queues (streaming deltas & tool-stream

--- a/packages/ui/src/lib/meta-subscriptions.test.ts
+++ b/packages/ui/src/lib/meta-subscriptions.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "bun:test";
+import { getConfirmedMetaSubscriptionTargets } from "./meta-subscriptions";
+
+describe("getConfirmedMetaSubscriptionTargets", () => {
+  test("ignores stale cached sessions that are not confirmed by the fresh hub inventory", () => {
+    const result = getConfirmedMetaSubscriptionTargets({
+      liveSessionIds: ["active-stale", "background-stale", "fresh-background"],
+      confirmedLiveSessionIds: new Set(["fresh-background"]),
+      activeSessionId: "active-stale",
+    });
+
+    expect(result).toEqual({
+      activeSessionId: null,
+      backgroundSessionIds: ["fresh-background"],
+    });
+  });
+
+  test("keeps the active session and background sessions once they are confirmed live", () => {
+    const result = getConfirmedMetaSubscriptionTargets({
+      liveSessionIds: ["active-live", "background-a", "background-b"],
+      confirmedLiveSessionIds: new Set(["background-b", "active-live", "background-a"]),
+      activeSessionId: "active-live",
+    });
+
+    expect(result).toEqual({
+      activeSessionId: "active-live",
+      backgroundSessionIds: ["background-a", "background-b"],
+    });
+  });
+});

--- a/packages/ui/src/lib/meta-subscriptions.ts
+++ b/packages/ui/src/lib/meta-subscriptions.ts
@@ -1,0 +1,26 @@
+export interface ConfirmedMetaSubscriptionTargetsInput {
+  liveSessionIds: string[];
+  confirmedLiveSessionIds: ReadonlySet<string>;
+  activeSessionId: string | null;
+}
+
+export interface ConfirmedMetaSubscriptionTargets {
+  activeSessionId: string | null;
+  backgroundSessionIds: string[];
+}
+
+export function getConfirmedMetaSubscriptionTargets(
+  input: ConfirmedMetaSubscriptionTargetsInput,
+): ConfirmedMetaSubscriptionTargets {
+  const activeSessionId =
+    input.activeSessionId && input.confirmedLiveSessionIds.has(input.activeSessionId)
+      ? input.activeSessionId
+      : null;
+
+  const backgroundSessionIds = input.liveSessionIds.filter(
+    (sessionId) =>
+      sessionId !== activeSessionId && input.confirmedLiveSessionIds.has(sessionId),
+  );
+
+  return { activeSessionId, backgroundSessionIds };
+}

--- a/packages/ui/src/lib/viewer-connection.test.ts
+++ b/packages/ui/src/lib/viewer-connection.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { shouldStopViewerReconnect } from "./viewer-connection.js";
+
+describe("shouldStopViewerReconnect", () => {
+    test("stops reconnecting after snapshot replay disconnects", () => {
+        expect(shouldStopViewerReconnect({ code: "snapshot_replay", reason: "Session is no longer live (snapshot replay)." })).toBe(true);
+    });
+
+    test("does not rely on the human-readable reason string", () => {
+        expect(shouldStopViewerReconnect({ code: "snapshot_replay", reason: "Replay copy changed" })).toBe(true);
+    });
+
+    test("keeps reconnect behavior for other disconnect reasons", () => {
+        expect(shouldStopViewerReconnect({ code: "session_reconnected", reason: "Session reconnected" })).toBe(false);
+        expect(shouldStopViewerReconnect({ code: "session_ended", reason: "Session ended" })).toBe(false);
+        expect(shouldStopViewerReconnect({ reason: "Session is no longer live (snapshot replay)." })).toBe(false);
+        expect(shouldStopViewerReconnect({ reason: "" })).toBe(false);
+    });
+});

--- a/packages/ui/src/lib/viewer-connection.ts
+++ b/packages/ui/src/lib/viewer-connection.ts
@@ -1,0 +1,8 @@
+export interface ViewerDisconnectLike {
+    code?: string;
+    reason?: string | null;
+}
+
+export function shouldStopViewerReconnect(data: ViewerDisconnectLike): boolean {
+    return data.code === "snapshot_replay";
+}


### PR DESCRIPTION
## Summary
- catch and log failed relay session-event tasks so Redis disconnect errors do not break the per-session queue and restart the server
- send structured `/viewer` disconnect codes and stop client reconnects for replay-only dead sessions
- add regression coverage for the relay queue hardening and viewer reconnect decision logic

## Test Plan
- [x] bun test packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
- [x] bun test packages/protocol/src/viewer.test.ts
- [x] bun test packages/ui/src/lib/viewer-connection.test.ts
- [x] bun run typecheck
- [x] bun run build:protocol && bun run build:server && bun run build:ui
- [ ] bun run test *(currently fails in existing server test harness with `Another test server is already active`; not introduced by this branch)*