### PR TITLE
fix: embed CLI version in compiled binary via --define

### DIFF
--- a/packages/cli/build-binaries.ts
+++ b/packages/cli/build-binaries.ts
@@ -263,6 +263,12 @@ if (targets.length === 0) {
 const piPkgDir = resolvePiPackageDir();
 console.log(`Resolved pi-coding-agent at: ${piPkgDir}`);
 
+// Read CLI version to embed in the compiled binary via --define
+const cliPkgPath = join(import.meta.dirname, "package.json");
+const cliPkgJson = JSON.parse(readFileSync(cliPkgPath, "utf-8"));
+const cliVersion = cliPkgJson.version ?? "0.0.0";
+console.log(`CLI version: ${cliVersion}`);
+
 const entrypoint = join(import.meta.dirname, "src", "index.ts");
 const distBinaries = join(import.meta.dirname, "dist", "binaries");
 
@@ -276,7 +282,7 @@ for (const target of targets) {
 
     console.log(`\n▶ Building ${target.id} → ${outFile}`);
 
-    const result = await $`bun build --compile --target=${target.bunTarget} ${entrypoint} --outfile ${outFile}`.nothrow();
+    const result = await $`bun build --compile --target=${target.bunTarget} --define __PIZZAPI_VERSION__='"${cliVersion}"' ${entrypoint} --outfile ${outFile}`.nothrow();
 
     if (result.exitCode !== 0) {
         console.error(`  ✗ Build failed for ${target.id}`);

--- a/packages/cli/src/extensions/pizzapi-header.ts
+++ b/packages/cli/src/extensions/pizzapi-header.ts
@@ -17,7 +17,18 @@ import { dirname, join } from "node:path";
 
 // ── Version ──────────────────────────────────────────────────────────────────
 
+// In compiled binaries, __PIZZAPI_VERSION__ is replaced at build time by
+// `--define __PIZZAPI_VERSION__='"X.Y.Z"'` in build-binaries.ts.
+// In dev mode (running from source), the identifier is undeclared and the
+// `typeof` check safely returns "undefined", falling through to the
+// filesystem-based resolution.
+declare const __PIZZAPI_VERSION__: string;
+
 function getPizzaPiVersion(): string {
+    // Compiled binary: version is inlined at build time via --define
+    if (typeof __PIZZAPI_VERSION__ === "string") return __PIZZAPI_VERSION__;
+
+    // Dev mode: read from package.json relative to source file
     try {
         const require = createRequire(import.meta.url);
         const __filename = fileURLToPath(import.meta.url);


### PR DESCRIPTION
## Problem

The TUI header displayed `PizzaPi v0.0.0` in compiled binaries because `getPizzaPiVersion()` resolved `package.json` relative to `import.meta.url`, which doesn't point to a real filesystem path inside a Bun compiled binary.

## Fix

- **`build-binaries.ts`**: Read CLI version from `package.json` and pass `--define __PIZZAPI_VERSION__='"X.Y.Z"'` to `bun build --compile`
- **`pizzapi-header.ts`**: Check for the compile-time constant first (`typeof __PIZZAPI_VERSION__ === "string"`); fall back to filesystem resolution in dev mode

All existing tests pass, typecheck clean.