### PR TITLE
feat: add create_tunnel, list_tunnels, close_tunnel agent tools

### DIFF
--- a/packages/cli/build-binaries.ts
+++ b/packages/cli/build-binaries.ts
@@ -263,6 +263,12 @@ if (targets.length === 0) {
 const piPkgDir = resolvePiPackageDir();
 console.log(`Resolved pi-coding-agent at: ${piPkgDir}`);
 
+// Read CLI version to embed in the compiled binary via --define
+const cliPkgPath = join(import.meta.dirname, "package.json");
+const cliPkgJson = JSON.parse(readFileSync(cliPkgPath, "utf-8"));
+const cliVersion = cliPkgJson.version ?? "0.0.0";
+console.log(`CLI version: ${cliVersion}`);
+
 const entrypoint = join(import.meta.dirname, "src", "index.ts");
 const distBinaries = join(import.meta.dirname, "dist", "binaries");
 
@@ -276,7 +282,7 @@ for (const target of targets) {
 
     console.log(`\n▶ Building ${target.id} → ${outFile}`);
 
-    const result = await $`bun build --compile --target=${target.bunTarget} ${entrypoint} --outfile ${outFile}`.nothrow();
+    const result = await $`bun build --compile --target=${target.bunTarget} --define __PIZZAPI_VERSION__='"${cliVersion}"' ${entrypoint} --outfile ${outFile}`.nothrow();
 
     if (result.exitCode !== 0) {
         console.error(`  ✗ Build failed for ${target.id}`);

--- a/packages/cli/src/config/system-prompt.ts
+++ b/packages/cli/src/config/system-prompt.ts
@@ -55,6 +55,12 @@ export const BUILTIN_SYSTEM_PROMPT = [
     "so you do NOT need to call `toggle_plan_mode` after approval — just proceed with execution.",
     "Do not exit plan mode without first submitting a plan via `plan_mode` unless the task is trivial.\n",
     ...ASK_USER_QUESTION_PROMPT_FRAGMENT,
+    "## Tunnels\n",
+    "Use `create_tunnel`, `list_tunnels`, and `close_tunnel` to expose local ports through the PizzaPi relay.",
+    "After starting a dev server (e.g. on port 3000), call `create_tunnel` with that port to get a public URL.",
+    "The tunnel proxies HTTP and WebSocket traffic through the relay so the web UI can preview it.",
+    "Tunnels only work when connected to a relay — they are unavailable in offline/local-only sessions.\n",
+
     "## Sandbox\n",
     "This session may run with OS-level sandbox restrictions that control which files you can read/write",
     "and which network domains are accessible. If a tool call is blocked by the sandbox,",

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -14,6 +14,7 @@ import { setSessionNameExtension } from "./set-session-name.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
 import { subagentExtension } from "./subagent.js";
+import { tunnelToolsExtension } from "./tunnel-tools.js";
 import { planModeToggleExtension } from "./plan-mode-toggle.js";
 import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
@@ -24,6 +25,7 @@ import { pizzapiHeaderExtension } from "./pizzapi-header.js";
 const CORE_EXTENSIONS: ExtensionFactory[] = [
     triggersExtension,  // Must be before remoteExtension (shutdown ordering)
     remoteExtension,
+    tunnelToolsExtension,
     mcpExtension,
     restartExtension,
     setSessionNameExtension,
@@ -105,9 +107,10 @@ describe("buildPizzaPiExtensionFactories — safe mode", () => {
         expect(factories).toContain(restartExtension);
     });
 
-    test("skipRelay excludes remote extension", () => {
+    test("skipRelay excludes remote extension and tunnel tools", () => {
         const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test", skipRelay: true });
         expect(factories).not.toContain(remoteExtension);
+        expect(factories).not.toContain(tunnelToolsExtension);
         expect(factories).toContain(mcpExtension);
     });
 

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -12,6 +12,7 @@ import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
 import { createClaudePluginExtension } from "./claude-plugins.js";
 import { subagentExtension } from "./subagent.js";
+import { tunnelToolsExtension } from "./tunnel-tools.js";
 import { planModeToggleExtension } from "./plan-mode-toggle.js";
 import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
@@ -50,6 +51,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
 
     if (!options.skipRelay) {
         factories.push(named(remoteExtension, "relay"));
+        factories.push(named(tunnelToolsExtension, "tunnel-tools"));
     }
 
     if (!options.skipMcp) {

--- a/packages/cli/src/extensions/pizzapi-header.ts
+++ b/packages/cli/src/extensions/pizzapi-header.ts
@@ -17,7 +17,18 @@ import { dirname, join } from "node:path";
 
 // ── Version ──────────────────────────────────────────────────────────────────
 
+// In compiled binaries, __PIZZAPI_VERSION__ is replaced at build time by
+// `--define __PIZZAPI_VERSION__='"X.Y.Z"'` in build-binaries.ts.
+// In dev mode (running from source), the identifier is undeclared and the
+// `typeof` check safely returns "undefined", falling through to the
+// filesystem-based resolution.
+declare const __PIZZAPI_VERSION__: string;
+
 function getPizzaPiVersion(): string {
+    // Compiled binary: version is inlined at build time via --define
+    if (typeof __PIZZAPI_VERSION__ === "string") return __PIZZAPI_VERSION__;
+
+    // Dev mode: read from package.json relative to source file
     try {
         const require = createRequire(import.meta.url);
         const __filename = fileURLToPath(import.meta.url);

--- a/packages/cli/src/extensions/tunnel-tools.test.ts
+++ b/packages/cli/src/extensions/tunnel-tools.test.ts
@@ -1,0 +1,328 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+// Mock the remote module exports before importing tunnel-tools
+const mockGetRelaySocket = mock(() => null as any);
+const mockGetRelaySessionId = mock(() => null as string | null);
+
+mock.module("./remote.js", () => ({
+    getRelaySocket: mockGetRelaySocket,
+    getRelaySessionId: mockGetRelaySessionId,
+    remoteExtension: () => {},
+}));
+
+mock.module("../config.js", () => ({
+    loadConfig: () => ({ relayUrl: "ws://localhost:7492" }),
+    expandHome: (p: string) => p,
+    defaultAgentDir: () => "/tmp/test-agent",
+    BUILTIN_SYSTEM_PROMPT: "",
+}));
+
+// Import after mocks are set up
+import { tunnelToolsExtension } from "./tunnel-tools.js";
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+interface RegisteredTool {
+    name: string;
+    execute: (...args: any[]) => Promise<any>;
+}
+
+function createMockPi() {
+    const tools = new Map<string, RegisteredTool>();
+    return {
+        tools,
+        registerTool(tool: any) {
+            tools.set(tool.name, tool);
+        },
+        on: () => {},
+        registerCommand: () => {},
+    };
+}
+
+function mockSocket() {
+    const listeners = new Map<string, Set<Function>>();
+    return {
+        on: (event: string, handler: Function) => {
+            if (!listeners.has(event)) listeners.set(event, new Set());
+            listeners.get(event)!.add(handler);
+        },
+        off: (event: string, handler: Function) => {
+            listeners.get(event)?.delete(handler);
+        },
+        emit: (_event: string, _data: unknown) => {},
+        connected: true,
+        _listeners: listeners,
+        // Simulate receiving a message from the relay
+        simulateMessage(envelope: any) {
+            for (const handler of listeners.get("service_message") ?? []) {
+                handler(envelope);
+            }
+        },
+    };
+}
+
+function extractText(result: any): string {
+    return result?.content?.[0]?.text ?? "";
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("tunnelToolsExtension", () => {
+    let pi: ReturnType<typeof createMockPi>;
+    let tools: Map<string, RegisteredTool>;
+
+    beforeEach(() => {
+        pi = createMockPi();
+        tunnelToolsExtension(pi as any);
+        tools = pi.tools;
+        mockGetRelaySocket.mockReset();
+        mockGetRelaySessionId.mockReset();
+    });
+
+    test("registers create_tunnel, list_tunnels, and close_tunnel tools", () => {
+        expect(tools.has("create_tunnel")).toBe(true);
+        expect(tools.has("list_tunnels")).toBe(true);
+        expect(tools.has("close_tunnel")).toBe(true);
+    });
+
+    describe("create_tunnel", () => {
+        test("returns error when not connected to relay", async () => {
+            mockGetRelaySocket.mockReturnValue(null);
+            const tool = tools.get("create_tunnel")!;
+            const result = await tool.execute("call-1", { port: 3000 });
+            expect(extractText(result)).toContain("Not connected to relay");
+        });
+
+        test("returns error for invalid port", async () => {
+            mockGetRelaySocket.mockReturnValue({ socket: mockSocket(), token: "t" });
+            const tool = tools.get("create_tunnel")!;
+
+            const r1 = await tool.execute("call-1", { port: 0 });
+            expect(extractText(r1)).toContain("port must be a number");
+
+            const r2 = await tool.execute("call-2", { port: 70000 });
+            expect(extractText(r2)).toContain("port must be a number");
+
+            const r3 = await tool.execute("call-3", { port: -1 });
+            expect(extractText(r3)).toContain("port must be a number");
+        });
+
+        test("sends tunnel_expose and returns tunnel info on success", async () => {
+            const sock = mockSocket();
+            let emittedEnvelope: any = null;
+
+            sock.emit = (_event: string, data: unknown) => {
+                emittedEnvelope = data;
+                // Simulate the daemon responding
+                setTimeout(() => {
+                    sock.simulateMessage({
+                        serviceId: "tunnel",
+                        type: "tunnel_registered",
+                        requestId: (data as any).requestId,
+                        payload: { port: 3000, name: "dev", url: "/tunnel/3000" },
+                    });
+                }, 10);
+            };
+
+            mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+            mockGetRelaySessionId.mockReturnValue("sess-123");
+
+            const tool = tools.get("create_tunnel")!;
+            const result = await tool.execute("call-1", { port: 3000, name: "dev" });
+
+            expect(emittedEnvelope).toBeTruthy();
+            expect(emittedEnvelope.serviceId).toBe("tunnel");
+            expect(emittedEnvelope.type).toBe("tunnel_expose");
+            expect(emittedEnvelope.payload).toEqual({ port: 3000, name: "dev" });
+
+            const text = extractText(result);
+            expect(text).toContain("Tunnel created successfully");
+            expect(text).toContain("3000");
+            expect(result.details.port).toBe(3000);
+            expect(result.details.name).toBe("dev");
+            expect(result.details.publicUrl).toContain("/api/tunnel/sess-123/3000/");
+        });
+
+        test("returns error on tunnel_error response", async () => {
+            const sock = mockSocket();
+            sock.emit = (_event: string, data: unknown) => {
+                setTimeout(() => {
+                    sock.simulateMessage({
+                        serviceId: "tunnel",
+                        type: "tunnel_error",
+                        requestId: (data as any).requestId,
+                        payload: { error: "Invalid port: 0" },
+                    });
+                }, 10);
+            };
+
+            mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+            const tool = tools.get("create_tunnel")!;
+            const result = await tool.execute("call-1", { port: 3000 });
+            expect(extractText(result)).toContain("Invalid port: 0");
+        });
+    });
+
+    describe("list_tunnels", () => {
+        test("returns error when not connected to relay", async () => {
+            mockGetRelaySocket.mockReturnValue(null);
+            const tool = tools.get("list_tunnels")!;
+            const result = await tool.execute("call-1", {});
+            expect(extractText(result)).toContain("Not connected to relay");
+        });
+
+        test("returns tunnel list", async () => {
+            const sock = mockSocket();
+            sock.emit = (_event: string, data: unknown) => {
+                setTimeout(() => {
+                    sock.simulateMessage({
+                        serviceId: "tunnel",
+                        type: "tunnel_list_result",
+                        requestId: (data as any).requestId,
+                        payload: {
+                            tunnels: [
+                                { port: 3000, name: "dev", url: "/tunnel/3000" },
+                                { port: 8080, url: "/tunnel/8080" },
+                            ],
+                        },
+                    });
+                }, 10);
+            };
+
+            mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+            mockGetRelaySessionId.mockReturnValue("sess-123");
+
+            const tool = tools.get("list_tunnels")!;
+            const result = await tool.execute("call-1", {});
+
+            expect(extractText(result)).toContain("2 active tunnel(s)");
+            expect(result.details.tunnels).toHaveLength(2);
+            expect(result.details.tunnels[0].port).toBe(3000);
+            expect(result.details.tunnels[1].port).toBe(8080);
+        });
+
+        test("returns empty list message", async () => {
+            const sock = mockSocket();
+            sock.emit = (_event: string, data: unknown) => {
+                setTimeout(() => {
+                    sock.simulateMessage({
+                        serviceId: "tunnel",
+                        type: "tunnel_list_result",
+                        requestId: (data as any).requestId,
+                        payload: { tunnels: [] },
+                    });
+                }, 10);
+            };
+
+            mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+            const tool = tools.get("list_tunnels")!;
+            const result = await tool.execute("call-1", {});
+            expect(extractText(result)).toContain("No active tunnels");
+        });
+    });
+
+    describe("close_tunnel", () => {
+        test("returns error when not connected to relay", async () => {
+            mockGetRelaySocket.mockReturnValue(null);
+            const tool = tools.get("close_tunnel")!;
+            const result = await tool.execute("call-1", { port: 3000 });
+            expect(extractText(result)).toContain("Not connected to relay");
+        });
+
+        test("returns error for invalid port", async () => {
+            mockGetRelaySocket.mockReturnValue({ socket: mockSocket(), token: "t" });
+            const tool = tools.get("close_tunnel")!;
+            const result = await tool.execute("call-1", { port: 0 });
+            expect(extractText(result)).toContain("port must be a number");
+        });
+
+        test("closes tunnel on tunnel_removed response", async () => {
+            const sock = mockSocket();
+            sock.emit = (_event: string, data: unknown) => {
+                setTimeout(() => {
+                    sock.simulateMessage({
+                        serviceId: "tunnel",
+                        type: "tunnel_removed",
+                        payload: { port: 3000 },
+                    });
+                }, 10);
+            };
+
+            mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+
+            const tool = tools.get("close_tunnel")!;
+            const result = await tool.execute("call-1", { port: 3000 });
+
+            expect(extractText(result)).toContain("closed");
+            expect(result.details.closed).toBe(true);
+            expect(result.details.port).toBe(3000);
+        });
+    });
+});
+
+describe("buildPublicTunnelUrl", () => {
+    const savedRelayUrl = process.env.PIZZAPI_RELAY_URL;
+
+    beforeEach(() => {
+        process.env.PIZZAPI_RELAY_URL = "ws://localhost:7492";
+    });
+
+    // Restore env after the suite
+    test("generates correct URL with session ID and port", async () => {
+        const sock = mockSocket();
+        sock.emit = (_event: string, data: unknown) => {
+            setTimeout(() => {
+                sock.simulateMessage({
+                    serviceId: "tunnel",
+                    type: "tunnel_registered",
+                    requestId: (data as any).requestId,
+                    payload: { port: 8080, url: "/tunnel/8080" },
+                });
+            }, 10);
+        };
+
+        mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+        mockGetRelaySessionId.mockReturnValue("abc-def-123");
+
+        const pi = createMockPi();
+        tunnelToolsExtension(pi as any);
+
+        const tool = pi.tools.get("create_tunnel")!;
+        const result = await tool.execute("call-1", { port: 8080 });
+
+        expect(result.details.publicUrl).toBe("http://localhost:7492/api/tunnel/abc-def-123/8080/");
+
+        // Restore
+        if (savedRelayUrl !== undefined) process.env.PIZZAPI_RELAY_URL = savedRelayUrl;
+        else delete process.env.PIZZAPI_RELAY_URL;
+    });
+
+    test("returns null publicUrl when session ID is missing", async () => {
+        const sock = mockSocket();
+        sock.emit = (_event: string, data: unknown) => {
+            setTimeout(() => {
+                sock.simulateMessage({
+                    serviceId: "tunnel",
+                    type: "tunnel_registered",
+                    requestId: (data as any).requestId,
+                    payload: { port: 8080, url: "/tunnel/8080" },
+                });
+            }, 10);
+        };
+
+        mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+        mockGetRelaySessionId.mockReturnValue(null);
+
+        const pi = createMockPi();
+        tunnelToolsExtension(pi as any);
+
+        const tool = pi.tools.get("create_tunnel")!;
+        const result = await tool.execute("call-1", { port: 8080 });
+
+        expect(result.details.publicUrl).toBeNull();
+
+        // Restore
+        if (savedRelayUrl !== undefined) process.env.PIZZAPI_RELAY_URL = savedRelayUrl;
+        else delete process.env.PIZZAPI_RELAY_URL;
+    });
+});

--- a/packages/cli/src/extensions/tunnel-tools.ts
+++ b/packages/cli/src/extensions/tunnel-tools.ts
@@ -1,0 +1,399 @@
+/**
+ * Tunnel tools extension — provides agent-facing tools to manage HTTP tunnels
+ * through the PizzaPi relay server.
+ *
+ * Tools:
+ *   create_tunnel — Expose a local port through the relay tunnel
+ *   list_tunnels  — List currently active tunnels
+ *   close_tunnel  — Close an active tunnel
+ *
+ * Communication: These tools send `service_message` envelopes on the agent's
+ * relay Socket.IO connection. The relay namespace forwards them to the runner
+ * daemon's TunnelService, which handles the actual port exposure. Responses
+ * come back via `service_message` events with matching `requestId`.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { getRelaySocket, getRelaySessionId } from "./remote.js";
+import { loadConfig } from "../config.js";
+
+/** Timeout for service_message request/response round-trips. */
+const SERVICE_TIMEOUT_MS = 10_000;
+
+interface TunnelInfo {
+    port: number;
+    name?: string;
+    url: string;
+    pinned?: boolean;
+}
+
+/** Minimal Component that renders nothing — keeps the tool call invisible in the TUI. */
+const silent = { render: (_width: number): string[] => [], invalidate: () => {} };
+
+/**
+ * Send a service_message to the daemon's TunnelService via the relay socket
+ * and wait for a response with matching requestId.
+ */
+function sendTunnelServiceMessage(
+    type: string,
+    payload: unknown,
+): Promise<{ type: string; payload: unknown }> {
+    return new Promise((resolve, reject) => {
+        const conn = getRelaySocket();
+        if (!conn) {
+            reject(new Error("Not connected to relay. Cannot manage tunnels without a relay connection."));
+            return;
+        }
+
+        const requestId = randomUUID();
+        const { socket } = conn;
+        let settled = false;
+
+        const timer = setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            socket.off("service_message" as any, handler);
+            reject(new Error("Tunnel service request timed out (10s). Is the runner daemon running?"));
+        }, SERVICE_TIMEOUT_MS);
+
+        const handler = (envelope: { serviceId: string; type: string; requestId?: string; payload: unknown }) => {
+            if (envelope.serviceId !== "tunnel") return;
+            if (envelope.requestId !== requestId) return;
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            socket.off("service_message" as any, handler);
+            resolve({ type: envelope.type, payload: envelope.payload });
+        };
+
+        socket.on("service_message" as any, handler);
+        socket.emit("service_message" as any, {
+            serviceId: "tunnel",
+            type,
+            requestId,
+            payload,
+        });
+    });
+}
+
+function getRelayHttpBaseUrl(): string | null {
+    const configured =
+        process.env.PIZZAPI_RELAY_URL ??
+        loadConfig(process.cwd()).relayUrl ??
+        "ws://localhost:7492";
+
+    if (configured.toLowerCase() === "off") return null;
+
+    const trimmed = configured.trim().replace(/\/$/, "").replace(/\/ws\/sessions$/, "");
+    if (trimmed.startsWith("ws://")) return `http://${trimmed.slice("ws://".length)}`;
+    if (trimmed.startsWith("wss://")) return `https://${trimmed.slice("wss://".length)}`;
+    if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return trimmed;
+    return `https://${trimmed}`;
+}
+
+function buildPublicTunnelUrl(port: number): string | null {
+    const base = getRelayHttpBaseUrl();
+    const sessionId = getRelaySessionId();
+    if (!base || !sessionId) return null;
+    return `${base}/api/tunnel/${encodeURIComponent(sessionId)}/${port}/`;
+}
+
+function ok(text: string, details?: Record<string, unknown>) {
+    return {
+        content: [{ type: "text" as const, text }],
+        details: details as any,
+    };
+}
+
+export const tunnelToolsExtension: ExtensionFactory = (pi) => {
+    // ── create_tunnel ────────────────────────────────────────────────────────
+    pi.registerTool({
+        name: "create_tunnel",
+        label: "Create Tunnel",
+        description:
+            "Expose a local port through the PizzaPi relay server so it's accessible " +
+            "from the web UI. Use this after starting a local dev server to make it " +
+            "accessible remotely. Returns the public URL for the tunnel.",
+        parameters: {
+            type: "object",
+            properties: {
+                port: {
+                    type: "number",
+                    description: "Local port to expose (1–65535).",
+                },
+                name: {
+                    type: "string",
+                    description: "Optional human-readable name for the tunnel (e.g. 'dev-server', 'storybook').",
+                },
+            },
+            required: ["port"],
+        } as any,
+
+        async execute(_toolCallId, rawParams) {
+            const params = (rawParams ?? {}) as { port: number; name?: string };
+            const port = params.port;
+
+            if (!port || !Number.isFinite(port) || port < 1 || port > 65535) {
+                return ok("Error: port must be a number between 1 and 65535.", { error: "Invalid port" });
+            }
+
+            try {
+                const response = await sendTunnelServiceMessage("tunnel_expose", {
+                    port,
+                    name: params.name ?? undefined,
+                });
+
+                if (response.type === "tunnel_error") {
+                    const error = (response.payload as { error?: string })?.error ?? "Unknown tunnel error";
+                    return ok(`Error creating tunnel: ${error}`, { error });
+                }
+
+                if (response.type === "tunnel_registered") {
+                    const info = response.payload as TunnelInfo;
+                    const publicUrl = buildPublicTunnelUrl(info.port);
+
+                    const lines = [
+                        `Tunnel created successfully.`,
+                        `  Port: ${info.port}`,
+                        info.name ? `  Name: ${info.name}` : null,
+                        publicUrl ? `  Public URL: ${publicUrl}` : `  URL: ${info.url}`,
+                    ].filter(Boolean).join("\n");
+
+                    return ok(lines, {
+                        port: info.port,
+                        name: info.name ?? null,
+                        url: info.url,
+                        publicUrl: publicUrl ?? null,
+                    });
+                }
+
+                return ok(`Unexpected response from tunnel service: ${response.type}`, {
+                    error: `Unexpected type: ${response.type}`,
+                });
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                return ok(`Error: ${message}`, { error: message });
+            }
+        },
+
+        renderCall: (args: any, theme: any) => {
+            const port = args.port ?? "?";
+            const name = args.name ? ` (${args.name})` : "";
+            return new Text(
+                theme.fg("accent", "⇡") + " " +
+                theme.fg("muted", "creating tunnel") +
+                theme.fg("dim", ` :${port}${name}`),
+                0, 0,
+            );
+        },
+        renderResult: (result: any, _opts: any, theme: any) => {
+            const details = result?.details as Record<string, unknown> | undefined;
+            const text: string = result?.content?.[0]?.text ?? "";
+
+            if (details?.error || text.startsWith("Error")) {
+                const msg = typeof details?.error === "string" ? details.error : text;
+                return new Text(theme.fg("error", "✗ " + (msg.length > 80 ? msg.slice(0, 77) + "..." : msg)), 0, 0);
+            }
+
+            const port = details?.port ?? "?";
+            const url = typeof details?.publicUrl === "string" ? ` ${details.publicUrl}` : "";
+            return new Text(
+                theme.fg("success", "✓") + " " +
+                theme.fg("muted", "tunnel :") +
+                theme.fg("accent", String(port)) +
+                theme.fg("dim", url),
+                0, 0,
+            );
+        },
+    });
+
+    // ── list_tunnels ─────────────────────────────────────────────────────────
+    pi.registerTool({
+        name: "list_tunnels",
+        label: "List Tunnels",
+        description:
+            "List all currently active tunnels for this session. Returns each tunnel's " +
+            "port, name, and public URL.",
+        parameters: {
+            type: "object",
+            properties: {},
+        } as any,
+
+        async execute() {
+            try {
+                const response = await sendTunnelServiceMessage("tunnel_list", {});
+
+                if (response.type === "tunnel_list_result") {
+                    const tunnels = ((response.payload as { tunnels?: TunnelInfo[] })?.tunnels ?? [])
+                        .map((t) => ({
+                            port: t.port,
+                            name: t.name ?? null,
+                            url: t.url,
+                            publicUrl: buildPublicTunnelUrl(t.port) ?? null,
+                            pinned: t.pinned ?? false,
+                        }));
+
+                    if (tunnels.length === 0) {
+                        return ok("No active tunnels.", { tunnels: [] });
+                    }
+
+                    const lines = [
+                        `${tunnels.length} active tunnel(s):`,
+                        ...tunnels.map((t) => {
+                            const name = t.name ? ` (${t.name})` : "";
+                            const pinned = t.pinned ? " [pinned]" : "";
+                            const url = t.publicUrl ?? t.url;
+                            return `  :${t.port}${name}${pinned} → ${url}`;
+                        }),
+                    ];
+
+                    return ok(lines.join("\n"), { tunnels });
+                }
+
+                return ok(`Unexpected response: ${response.type}`, { error: `Unexpected type: ${response.type}` });
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                return ok(`Error: ${message}`, { error: message });
+            }
+        },
+
+        renderCall: (_args: any, theme: any) => {
+            return new Text(
+                theme.fg("accent", "⇡") + " " +
+                theme.fg("muted", "listing tunnels"),
+                0, 0,
+            );
+        },
+        renderResult: (result: any, _opts: any, theme: any) => {
+            const details = result?.details as Record<string, unknown> | undefined;
+            const text: string = result?.content?.[0]?.text ?? "";
+
+            if (details?.error || text.startsWith("Error")) {
+                const msg = typeof details?.error === "string" ? details.error : text;
+                return new Text(theme.fg("error", "✗ " + msg), 0, 0);
+            }
+
+            const tunnels = (details?.tunnels as any[]) ?? [];
+            return new Text(
+                theme.fg("success", "✓") + " " +
+                theme.fg("muted", `${tunnels.length} tunnel(s)`),
+                0, 0,
+            );
+        },
+    });
+
+    // ── close_tunnel ─────────────────────────────────────────────────────────
+    pi.registerTool({
+        name: "close_tunnel",
+        label: "Close Tunnel",
+        description:
+            "Close an active tunnel by port number. Stops proxying traffic to the " +
+            "specified local port.",
+        parameters: {
+            type: "object",
+            properties: {
+                port: {
+                    type: "number",
+                    description: "Port of the tunnel to close.",
+                },
+            },
+            required: ["port"],
+        } as any,
+
+        async execute(_toolCallId, rawParams) {
+            const params = (rawParams ?? {}) as { port: number };
+            const port = params.port;
+
+            if (!port || !Number.isFinite(port) || port < 1 || port > 65535) {
+                return ok("Error: port must be a number between 1 and 65535.", { error: "Invalid port" });
+            }
+
+            try {
+                // The tunnel service emits tunnel_removed on success (fire-and-forget).
+                // We listen for it briefly, but also accept that the operation may
+                // succeed silently if the port wasn't tracked.
+                const conn = getRelaySocket();
+                if (!conn) {
+                    return ok("Error: Not connected to relay.", { error: "Not connected" });
+                }
+
+                const requestId = randomUUID();
+                const { socket } = conn;
+
+                // Set up a brief listener for the tunnel_removed response
+                const result = await new Promise<{ closed: boolean }>((resolve) => {
+                    let settled = false;
+
+                    const timer = setTimeout(() => {
+                        if (settled) return;
+                        settled = true;
+                        socket.off("service_message" as any, handler);
+                        // If we time out, the unexpose likely succeeded anyway
+                        // (it's fire-and-forget on the daemon side for unknown ports).
+                        resolve({ closed: true });
+                    }, SERVICE_TIMEOUT_MS);
+
+                    const handler = (envelope: { serviceId: string; type: string; requestId?: string; payload: unknown }) => {
+                        if (envelope.serviceId !== "tunnel") return;
+                        // tunnel_removed doesn't echo requestId, match by port
+                        if (envelope.type === "tunnel_removed") {
+                            const removedPort = (envelope.payload as { port?: number })?.port;
+                            if (removedPort === port) {
+                                if (settled) return;
+                                settled = true;
+                                clearTimeout(timer);
+                                socket.off("service_message" as any, handler);
+                                resolve({ closed: true });
+                            }
+                        }
+                    };
+
+                    socket.on("service_message" as any, handler);
+                    socket.emit("service_message" as any, {
+                        serviceId: "tunnel",
+                        type: "tunnel_unexpose",
+                        requestId,
+                        payload: { port },
+                    });
+                });
+
+                return ok(
+                    result.closed ? `Tunnel on port ${port} closed.` : `Port ${port} was not tunneled.`,
+                    { closed: result.closed, port },
+                );
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                return ok(`Error: ${message}`, { error: message });
+            }
+        },
+
+        renderCall: (args: any, theme: any) => {
+            const port = args.port ?? "?";
+            return new Text(
+                theme.fg("accent", "⇣") + " " +
+                theme.fg("muted", "closing tunnel") +
+                theme.fg("dim", ` :${port}`),
+                0, 0,
+            );
+        },
+        renderResult: (result: any, _opts: any, theme: any) => {
+            const details = result?.details as Record<string, unknown> | undefined;
+            const text: string = result?.content?.[0]?.text ?? "";
+
+            if (details?.error || text.startsWith("Error")) {
+                const msg = typeof details?.error === "string" ? details.error : text;
+                return new Text(theme.fg("error", "✗ " + msg), 0, 0);
+            }
+
+            const port = details?.port ?? "?";
+            return new Text(
+                theme.fg("success", "✓") + " " +
+                theme.fg("muted", "closed :") +
+                theme.fg("accent", String(port)),
+                0, 0,
+            );
+        },
+    });
+};

--- a/packages/server/src/ws/namespaces/relay/index.ts
+++ b/packages/server/src/ws/namespaces/relay/index.ts
@@ -20,6 +20,7 @@ import { registerEventHandler } from "./event-pipeline.js";
 import { registerSessionLifecycleHandlers } from "./session-lifecycle.js";
 import { registerMessagingHandlers } from "./messaging.js";
 import { registerChildLifecycleHandlers } from "./child-lifecycle.js";
+import { registerServiceMessageHandler } from "./service-message.js";
 import { createLogger } from "@pizzapi/tools";
 
 // Re-export for viewer.ts compatibility
@@ -45,5 +46,6 @@ export function registerRelayNamespace(io: SocketIOServer): void {
         registerEventHandler(socket);
         registerMessagingHandlers(socket);
         registerChildLifecycleHandlers(socket, io);
+        registerServiceMessageHandler(socket);
     });
 }

--- a/packages/server/src/ws/namespaces/relay/service-message.test.ts
+++ b/packages/server/src/ws/namespaces/relay/service-message.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetSharedSession = mock(async (_id: string) => null as any);
+const mockEmitToRunner = mock((..._args: any[]) => {});
+
+mock.module("../../sio-registry/sessions.js", () => ({
+    getSharedSession: mockGetSharedSession,
+}));
+
+mock.module("../../sio-registry/context.js", () => ({
+    emitToRunner: mockEmitToRunner,
+}));
+
+mock.module("@pizzapi/tools", () => ({
+    createLogger: () => ({
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+    }),
+}));
+
+import { registerServiceMessageHandler } from "./service-message.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createMockSocket(sessionId?: string) {
+    const handlers = new Map<string, Function>();
+    return {
+        data: {
+            sessionId: sessionId ?? null,
+            token: "test-token",
+        },
+        on: (event: string, handler: Function) => {
+            handlers.set(event, handler);
+        },
+        _handlers: handlers,
+        fireEvent(event: string, data: unknown) {
+            handlers.get(event)?.(data);
+        },
+    };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("registerServiceMessageHandler", () => {
+    beforeEach(() => {
+        mockGetSharedSession.mockReset();
+        mockEmitToRunner.mockReset();
+    });
+
+    test("registers a service_message handler on the socket", () => {
+        const socket = createMockSocket("sess-1");
+        registerServiceMessageHandler(socket as any);
+        expect(socket._handlers.has("service_message")).toBe(true);
+    });
+
+    test("does nothing when sessionId is not set", async () => {
+        const socket = createMockSocket(undefined);
+        (socket.data as any).sessionId = undefined;
+        registerServiceMessageHandler(socket as any);
+
+        socket.fireEvent("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            payload: {},
+        });
+
+        // Give async handlers time to settle
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockEmitToRunner).not.toHaveBeenCalled();
+    });
+
+    test("does nothing when session has no collabMode", async () => {
+        const socket = createMockSocket("sess-1");
+        mockGetSharedSession.mockResolvedValue({ collabMode: false, runnerId: "runner-1" });
+        registerServiceMessageHandler(socket as any);
+
+        socket.fireEvent("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            payload: {},
+        });
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockEmitToRunner).not.toHaveBeenCalled();
+    });
+
+    test("does nothing when session has no runnerId", async () => {
+        const socket = createMockSocket("sess-1");
+        mockGetSharedSession.mockResolvedValue({ collabMode: true, runnerId: null });
+        registerServiceMessageHandler(socket as any);
+
+        socket.fireEvent("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            payload: {},
+        });
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockEmitToRunner).not.toHaveBeenCalled();
+    });
+
+    test("forwards service_message to runner with sessionId attached", async () => {
+        const socket = createMockSocket("sess-1");
+        mockGetSharedSession.mockResolvedValue({ collabMode: true, runnerId: "runner-1" });
+        registerServiceMessageHandler(socket as any);
+
+        const envelope = {
+            serviceId: "tunnel",
+            type: "tunnel_expose",
+            requestId: "req-123",
+            payload: { port: 3000, name: "dev" },
+        };
+
+        socket.fireEvent("service_message", envelope);
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockEmitToRunner).toHaveBeenCalledTimes(1);
+        expect(mockEmitToRunner).toHaveBeenCalledWith("runner-1", "service_message", {
+            ...envelope,
+            sessionId: "sess-1",
+        });
+    });
+
+    test("does not forward when session is null", async () => {
+        const socket = createMockSocket("sess-1");
+        mockGetSharedSession.mockResolvedValue(null);
+        registerServiceMessageHandler(socket as any);
+
+        socket.fireEvent("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            payload: {},
+        });
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockEmitToRunner).not.toHaveBeenCalled();
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/service-message.ts
+++ b/packages/server/src/ws/namespaces/relay/service-message.ts
@@ -1,0 +1,31 @@
+// ── Service message relay — TUI session → runner daemon ──────────────────────
+//
+// Allows agent sessions (connected via the /relay namespace) to send
+// service_message envelopes to the runner daemon's ServiceHandler system.
+// This mirrors the viewer → runner path but originates from the TUI worker
+// instead of a browser viewer.
+
+import type { ServiceEnvelope } from "@pizzapi/protocol";
+import { getSharedSession } from "../../sio-registry/sessions.js";
+import { emitToRunner } from "../../sio-registry/context.js";
+import type { RelaySocket } from "./types.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/relay");
+
+export function registerServiceMessageHandler(socket: RelaySocket): void {
+    socket.on("service_message" as any, async (envelope: ServiceEnvelope) => {
+        const sessionId = socket.data.sessionId;
+        if (!sessionId) return;
+
+        const session = await getSharedSession(sessionId);
+        if (!session?.collabMode) return;
+
+        const runnerId = session.runnerId;
+        if (!runnerId) return;
+
+        // Attach sessionId so the runner service knows which session to
+        // respond to (same pattern as the viewer namespace).
+        emitToRunner(runnerId, "service_message", { ...envelope, sessionId });
+    });
+}

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -46,6 +46,7 @@ import {
     getConnectedSessionsForRunner,
     touchRunner,
     broadcastToSessionViewers,
+    emitToRelaySession,
 } from "../sio-registry.js";
 import { resolveSpawnReady, resolveSpawnError } from "../runner-control.js";
 import { createLogger } from "@pizzapi/tools";
@@ -632,11 +633,15 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                     return;
                 }
                 broadcastToSessionViewers(targetSessionId, "service_message", envelope);
+                // Also route to the session's relay socket (TUI worker) so
+                // agent-initiated service_message requests get their responses.
+                emitToRelaySession(targetSessionId, "service_message", envelope);
             } else {
                 const sessionIds = runnerSessionIds.get(runnerId);
                 if (!sessionIds || sessionIds.size === 0) return;
                 for (const sid of sessionIds) {
                     broadcastToSessionViewers(sid, "service_message", envelope);
+                    emitToRelaySession(sid, "service_message", envelope);
                 }
             }
         });


### PR DESCRIPTION
## Summary

Agent sessions can now manage HTTP tunnels through the PizzaPi relay with three new tools:

| Tool | Description |
|------|-------------|
| **`create_tunnel`** | Expose a local port and get a public URL through the relay |
| **`list_tunnels`** | List all active tunnels for the current session |
| **`close_tunnel`** | Stop proxying traffic to a specific port |

### How it works

Tools emit `service_message` envelopes on the agent's relay Socket.IO connection. A new handler in the `/relay` namespace routes these to the runner daemon's `TunnelService` (the same path the UI's TunnelPanel uses, just initiated from the worker instead of a browser viewer). Responses are routed back to the relay socket via `requestId` matching.

```
Agent tool → relay socket (service_message)
  → /relay namespace handler → emitToRunner
  → daemon TunnelService → response service_message
  → runner namespace → broadcastToSessionViewers + emitToRelaySession
  → agent tool receives response
```

### Changes

**Server (2 new, 2 modified):**
- `relay/service-message.ts` — New `/relay` namespace handler to route `service_message` to the runner daemon
- `relay/index.ts` — Wire in the new handler
- `runner.ts` — Also `emitToRelaySession` for responses (previously only forwarded to viewers)

**CLI (2 new, 3 modified):**
- `tunnel-tools.ts` — Three tool implementations with TUI rendering
- `factories.ts` — Wire extension (relay-dependent, excluded by `--no-relay`)
- `system-prompt.ts` — Agent guidance for tunnel tools

### Tests

- **30 new tests** across 3 files — all passing
- Typecheck: clean
- Build: clean
- No regressions in existing test suite