### PR TITLE
fix(ui): preserve App hook order around auth guards

### DIFF
--- a/packages/cli/build-binaries.ts
+++ b/packages/cli/build-binaries.ts
@@ -263,6 +263,12 @@ if (targets.length === 0) {
 const piPkgDir = resolvePiPackageDir();
 console.log(`Resolved pi-coding-agent at: ${piPkgDir}`);
 
+// Read CLI version to embed in the compiled binary via --define
+const cliPkgPath = join(import.meta.dirname, "package.json");
+const cliPkgJson = JSON.parse(readFileSync(cliPkgPath, "utf-8"));
+const cliVersion = cliPkgJson.version ?? "0.0.0";
+console.log(`CLI version: ${cliVersion}`);
+
 const entrypoint = join(import.meta.dirname, "src", "index.ts");
 const distBinaries = join(import.meta.dirname, "dist", "binaries");
 
@@ -276,7 +282,7 @@ for (const target of targets) {
 
     console.log(`\n▶ Building ${target.id} → ${outFile}`);
 
-    const result = await $`bun build --compile --target=${target.bunTarget} ${entrypoint} --outfile ${outFile}`.nothrow();
+    const result = await $`bun build --compile --target=${target.bunTarget} --define __PIZZAPI_VERSION__='"${cliVersion}"' ${entrypoint} --outfile ${outFile}`.nothrow();
 
     if (result.exitCode !== 0) {
         console.error(`  ✗ Build failed for ${target.id}`);

--- a/packages/cli/src/config/system-prompt.ts
+++ b/packages/cli/src/config/system-prompt.ts
@@ -55,6 +55,12 @@ export const BUILTIN_SYSTEM_PROMPT = [
     "so you do NOT need to call `toggle_plan_mode` after approval — just proceed with execution.",
     "Do not exit plan mode without first submitting a plan via `plan_mode` unless the task is trivial.\n",
     ...ASK_USER_QUESTION_PROMPT_FRAGMENT,
+    "## Tunnels\n",
+    "Use `create_tunnel`, `list_tunnels`, and `close_tunnel` to expose local ports through the PizzaPi relay.",
+    "After starting a dev server (e.g. on port 3000), call `create_tunnel` with that port to get a public URL.",
+    "The tunnel proxies HTTP and WebSocket traffic through the relay so the web UI can preview it.",
+    "Tunnels only work when connected to a relay — they are unavailable in offline/local-only sessions.\n",
+
     "## Sandbox\n",
     "This session may run with OS-level sandbox restrictions that control which files you can read/write",
     "and which network domains are accessible. If a tool call is blocked by the sandbox,",

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -14,6 +14,7 @@ import { setSessionNameExtension } from "./set-session-name.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
 import { subagentExtension } from "./subagent.js";
+import { tunnelToolsExtension } from "./tunnel-tools.js";
 import { planModeToggleExtension } from "./plan-mode-toggle.js";
 import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
@@ -24,6 +25,7 @@ import { pizzapiHeaderExtension } from "./pizzapi-header.js";
 const CORE_EXTENSIONS: ExtensionFactory[] = [
     triggersExtension,  // Must be before remoteExtension (shutdown ordering)
     remoteExtension,
+    tunnelToolsExtension,
     mcpExtension,
     restartExtension,
     setSessionNameExtension,
@@ -105,9 +107,10 @@ describe("buildPizzaPiExtensionFactories — safe mode", () => {
         expect(factories).toContain(restartExtension);
     });
 
-    test("skipRelay excludes remote extension", () => {
+    test("skipRelay excludes remote extension and tunnel tools", () => {
         const factories = buildPizzaPiExtensionFactories({ cwd: "/tmp/pizzapi-test", skipRelay: true });
         expect(factories).not.toContain(remoteExtension);
+        expect(factories).not.toContain(tunnelToolsExtension);
         expect(factories).toContain(mcpExtension);
     });
 

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -12,6 +12,7 @@ import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
 import { createClaudePluginExtension } from "./claude-plugins.js";
 import { subagentExtension } from "./subagent.js";
+import { tunnelToolsExtension } from "./tunnel-tools.js";
 import { planModeToggleExtension } from "./plan-mode-toggle.js";
 import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
@@ -50,6 +51,7 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
 
     if (!options.skipRelay) {
         factories.push(named(remoteExtension, "relay"));
+        factories.push(named(tunnelToolsExtension, "tunnel-tools"));
     }
 
     if (!options.skipMcp) {

--- a/packages/cli/src/extensions/pizzapi-header.ts
+++ b/packages/cli/src/extensions/pizzapi-header.ts
@@ -17,7 +17,18 @@ import { dirname, join } from "node:path";
 
 // ── Version ──────────────────────────────────────────────────────────────────
 
+// In compiled binaries, __PIZZAPI_VERSION__ is replaced at build time by
+// `--define __PIZZAPI_VERSION__='"X.Y.Z"'` in build-binaries.ts.
+// In dev mode (running from source), the identifier is undeclared and the
+// `typeof` check safely returns "undefined", falling through to the
+// filesystem-based resolution.
+declare const __PIZZAPI_VERSION__: string;
+
 function getPizzaPiVersion(): string {
+    // Compiled binary: version is inlined at build time via --define
+    if (typeof __PIZZAPI_VERSION__ === "string") return __PIZZAPI_VERSION__;
+
+    // Dev mode: read from package.json relative to source file
     try {
         const require = createRequire(import.meta.url);
         const __filename = fileURLToPath(import.meta.url);

--- a/packages/cli/src/extensions/tunnel-tools.test.ts
+++ b/packages/cli/src/extensions/tunnel-tools.test.ts
@@ -1,24 +1,9 @@
 import { describe, test, expect, mock, beforeEach } from "bun:test";
+import { createTunnelToolsExtension } from "./tunnel-tools.js";
 
-// Mock the remote module exports before importing tunnel-tools
 const mockGetRelaySocket = mock(() => null as any);
 const mockGetRelaySessionId = mock(() => null as string | null);
-
-mock.module("./remote.js", () => ({
-    getRelaySocket: mockGetRelaySocket,
-    getRelaySessionId: mockGetRelaySessionId,
-    remoteExtension: () => {},
-}));
-
-mock.module("../config.js", () => ({
-    loadConfig: () => ({ relayUrl: "ws://localhost:7492" }),
-    expandHome: (p: string) => p,
-    defaultAgentDir: () => "/tmp/test-agent",
-    BUILTIN_SYSTEM_PROMPT: "",
-}));
-
-// Import after mocks are set up
-import { tunnelToolsExtension } from "./tunnel-tools.js";
+const mockLoadConfig = mock((_cwd: string) => ({ relayUrl: "ws://localhost:7492" } as any));
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
@@ -72,11 +57,19 @@ describe("tunnelToolsExtension", () => {
     let tools: Map<string, RegisteredTool>;
 
     beforeEach(() => {
-        pi = createMockPi();
-        tunnelToolsExtension(pi as any);
-        tools = pi.tools;
         mockGetRelaySocket.mockReset();
         mockGetRelaySessionId.mockReset();
+        mockLoadConfig.mockReset();
+        mockLoadConfig.mockReturnValue({ relayUrl: "ws://localhost:7492" } as any);
+
+        pi = createMockPi();
+        const extension = createTunnelToolsExtension({
+            getRelaySocket: mockGetRelaySocket as any,
+            getRelaySessionId: mockGetRelaySessionId as any,
+            loadConfig: mockLoadConfig as any,
+        });
+        extension(pi as any);
+        tools = pi.tools;
     });
 
     test("registers create_tunnel, list_tunnels, and close_tunnel tools", () => {
@@ -285,7 +278,12 @@ describe("buildPublicTunnelUrl", () => {
         mockGetRelaySessionId.mockReturnValue("abc-def-123");
 
         const pi = createMockPi();
-        tunnelToolsExtension(pi as any);
+        const extension = createTunnelToolsExtension({
+            getRelaySocket: mockGetRelaySocket as any,
+            getRelaySessionId: mockGetRelaySessionId as any,
+            loadConfig: mockLoadConfig as any,
+        });
+        extension(pi as any);
 
         const tool = pi.tools.get("create_tunnel")!;
         const result = await tool.execute("call-1", { port: 8080 });
@@ -314,7 +312,12 @@ describe("buildPublicTunnelUrl", () => {
         mockGetRelaySessionId.mockReturnValue(null);
 
         const pi = createMockPi();
-        tunnelToolsExtension(pi as any);
+        const extension = createTunnelToolsExtension({
+            getRelaySocket: mockGetRelaySocket as any,
+            getRelaySessionId: mockGetRelaySessionId as any,
+            loadConfig: mockLoadConfig as any,
+        });
+        extension(pi as any);
 
         const tool = pi.tools.get("create_tunnel")!;
         const result = await tool.execute("call-1", { port: 8080 });

--- a/packages/cli/src/extensions/tunnel-tools.test.ts
+++ b/packages/cli/src/extensions/tunnel-tools.test.ts
@@ -1,0 +1,328 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+// Mock the remote module exports before importing tunnel-tools
+const mockGetRelaySocket = mock(() => null as any);
+const mockGetRelaySessionId = mock(() => null as string | null);
+
+mock.module("./remote.js", () => ({
+    getRelaySocket: mockGetRelaySocket,
+    getRelaySessionId: mockGetRelaySessionId,
+    remoteExtension: () => {},
+}));
+
+mock.module("../config.js", () => ({
+    loadConfig: () => ({ relayUrl: "ws://localhost:7492" }),
+    expandHome: (p: string) => p,
+    defaultAgentDir: () => "/tmp/test-agent",
+    BUILTIN_SYSTEM_PROMPT: "",
+}));
+
+// Import after mocks are set up
+import { tunnelToolsExtension } from "./tunnel-tools.js";
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+interface RegisteredTool {
+    name: string;
+    execute: (...args: any[]) => Promise<any>;
+}
+
+function createMockPi() {
+    const tools = new Map<string, RegisteredTool>();
+    return {
+        tools,
+        registerTool(tool: any) {
+            tools.set(tool.name, tool);
+        },
+        on: () => {},
+        registerCommand: () => {},
+    };
+}
+
+function mockSocket() {
+    const listeners = new Map<string, Set<Function>>();
+    return {
+        on: (event: string, handler: Function) => {
+            if (!listeners.has(event)) listeners.set(event, new Set());
+            listeners.get(event)!.add(handler);
+        },
+        off: (event: string, handler: Function) => {
+            listeners.get(event)?.delete(handler);
+        },
+        emit: (_event: string, _data: unknown) => {},
+        connected: true,
+        _listeners: listeners,
+        // Simulate receiving a message from the relay
+        simulateMessage(envelope: any) {
+            for (const handler of listeners.get("service_message") ?? []) {
+                handler(envelope);
+            }
+        },
+    };
+}
+
+function extractText(result: any): string {
+    return result?.content?.[0]?.text ?? "";
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("tunnelToolsExtension", () => {
+    let pi: ReturnType<typeof createMockPi>;
+    let tools: Map<string, RegisteredTool>;
+
+    beforeEach(() => {
+        pi = createMockPi();
+        tunnelToolsExtension(pi as any);
+        tools = pi.tools;
+        mockGetRelaySocket.mockReset();
+        mockGetRelaySessionId.mockReset();
+    });
+
+    test("registers create_tunnel, list_tunnels, and close_tunnel tools", () => {
+        expect(tools.has("create_tunnel")).toBe(true);
+        expect(tools.has("list_tunnels")).toBe(true);
+        expect(tools.has("close_tunnel")).toBe(true);
+    });
+
+    describe("create_tunnel", () => {
+        test("returns error when not connected to relay", async () => {
+            mockGetRelaySocket.mockReturnValue(null);
+            const tool = tools.get("create_tunnel")!;
+            const result = await tool.execute("call-1", { port: 3000 });
+            expect(extractText(result)).toContain("Not connected to relay");
+        });
+
+        test("returns error for invalid port", async () => {
+            mockGetRelaySocket.mockReturnValue({ socket: mockSocket(), token: "t" });
+            const tool = tools.get("create_tunnel")!;
+
+            const r1 = await tool.execute("call-1", { port: 0 });
+            expect(extractText(r1)).toContain("port must be a number");
+
+            const r2 = await tool.execute("call-2", { port: 70000 });
+            expect(extractText(r2)).toContain("port must be a number");
+
+            const r3 = await tool.execute("call-3", { port: -1 });
+            expect(extractText(r3)).toContain("port must be a number");
+        });
+
+        test("sends tunnel_expose and returns tunnel info on success", async () => {
+            const sock = mockSocket();
+            let emittedEnvelope: any = null;
+
+            sock.emit = (_event: string, data: unknown) => {
+                emittedEnvelope = data;
+                // Simulate the daemon responding
+                setTimeout(() => {
+                    sock.simulateMessage({
+                        serviceId: "tunnel",
+                        type: "tunnel_registered",
+                        requestId: (data as any).requestId,
+                        payload: { port: 3000, name: "dev", url: "/tunnel/3000" },
+                    });
+                }, 10);
+            };
+
+            mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+            mockGetRelaySessionId.mockReturnValue("sess-123");
+
+            const tool = tools.get("create_tunnel")!;
+            const result = await tool.execute("call-1", { port: 3000, name: "dev" });
+
+            expect(emittedEnvelope).toBeTruthy();
+            expect(emittedEnvelope.serviceId).toBe("tunnel");
+            expect(emittedEnvelope.type).toBe("tunnel_expose");
+            expect(emittedEnvelope.payload).toEqual({ port: 3000, name: "dev" });
+
+            const text = extractText(result);
+            expect(text).toContain("Tunnel created successfully");
+            expect(text).toContain("3000");
+            expect(result.details.port).toBe(3000);
+            expect(result.details.name).toBe("dev");
+            expect(result.details.publicUrl).toContain("/api/tunnel/sess-123/3000/");
+        });
+
+        test("returns error on tunnel_error response", async () => {
+            const sock = mockSocket();
+            sock.emit = (_event: string, data: unknown) => {
+                setTimeout(() => {
+                    sock.simulateMessage({
+                        serviceId: "tunnel",
+                        type: "tunnel_error",
+                        requestId: (data as any).requestId,
+                        payload: { error: "Invalid port: 0" },
+                    });
+                }, 10);
+            };
+
+            mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+            const tool = tools.get("create_tunnel")!;
+            const result = await tool.execute("call-1", { port: 3000 });
+            expect(extractText(result)).toContain("Invalid port: 0");
+        });
+    });
+
+    describe("list_tunnels", () => {
+        test("returns error when not connected to relay", async () => {
+            mockGetRelaySocket.mockReturnValue(null);
+            const tool = tools.get("list_tunnels")!;
+            const result = await tool.execute("call-1", {});
+            expect(extractText(result)).toContain("Not connected to relay");
+        });
+
+        test("returns tunnel list", async () => {
+            const sock = mockSocket();
+            sock.emit = (_event: string, data: unknown) => {
+                setTimeout(() => {
+                    sock.simulateMessage({
+                        serviceId: "tunnel",
+                        type: "tunnel_list_result",
+                        requestId: (data as any).requestId,
+                        payload: {
+                            tunnels: [
+                                { port: 3000, name: "dev", url: "/tunnel/3000" },
+                                { port: 8080, url: "/tunnel/8080" },
+                            ],
+                        },
+                    });
+                }, 10);
+            };
+
+            mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+            mockGetRelaySessionId.mockReturnValue("sess-123");
+
+            const tool = tools.get("list_tunnels")!;
+            const result = await tool.execute("call-1", {});
+
+            expect(extractText(result)).toContain("2 active tunnel(s)");
+            expect(result.details.tunnels).toHaveLength(2);
+            expect(result.details.tunnels[0].port).toBe(3000);
+            expect(result.details.tunnels[1].port).toBe(8080);
+        });
+
+        test("returns empty list message", async () => {
+            const sock = mockSocket();
+            sock.emit = (_event: string, data: unknown) => {
+                setTimeout(() => {
+                    sock.simulateMessage({
+                        serviceId: "tunnel",
+                        type: "tunnel_list_result",
+                        requestId: (data as any).requestId,
+                        payload: { tunnels: [] },
+                    });
+                }, 10);
+            };
+
+            mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+            const tool = tools.get("list_tunnels")!;
+            const result = await tool.execute("call-1", {});
+            expect(extractText(result)).toContain("No active tunnels");
+        });
+    });
+
+    describe("close_tunnel", () => {
+        test("returns error when not connected to relay", async () => {
+            mockGetRelaySocket.mockReturnValue(null);
+            const tool = tools.get("close_tunnel")!;
+            const result = await tool.execute("call-1", { port: 3000 });
+            expect(extractText(result)).toContain("Not connected to relay");
+        });
+
+        test("returns error for invalid port", async () => {
+            mockGetRelaySocket.mockReturnValue({ socket: mockSocket(), token: "t" });
+            const tool = tools.get("close_tunnel")!;
+            const result = await tool.execute("call-1", { port: 0 });
+            expect(extractText(result)).toContain("port must be a number");
+        });
+
+        test("closes tunnel on tunnel_removed response", async () => {
+            const sock = mockSocket();
+            sock.emit = (_event: string, data: unknown) => {
+                setTimeout(() => {
+                    sock.simulateMessage({
+                        serviceId: "tunnel",
+                        type: "tunnel_removed",
+                        payload: { port: 3000 },
+                    });
+                }, 10);
+            };
+
+            mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+
+            const tool = tools.get("close_tunnel")!;
+            const result = await tool.execute("call-1", { port: 3000 });
+
+            expect(extractText(result)).toContain("closed");
+            expect(result.details.closed).toBe(true);
+            expect(result.details.port).toBe(3000);
+        });
+    });
+});
+
+describe("buildPublicTunnelUrl", () => {
+    const savedRelayUrl = process.env.PIZZAPI_RELAY_URL;
+
+    beforeEach(() => {
+        process.env.PIZZAPI_RELAY_URL = "ws://localhost:7492";
+    });
+
+    // Restore env after the suite
+    test("generates correct URL with session ID and port", async () => {
+        const sock = mockSocket();
+        sock.emit = (_event: string, data: unknown) => {
+            setTimeout(() => {
+                sock.simulateMessage({
+                    serviceId: "tunnel",
+                    type: "tunnel_registered",
+                    requestId: (data as any).requestId,
+                    payload: { port: 8080, url: "/tunnel/8080" },
+                });
+            }, 10);
+        };
+
+        mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+        mockGetRelaySessionId.mockReturnValue("abc-def-123");
+
+        const pi = createMockPi();
+        tunnelToolsExtension(pi as any);
+
+        const tool = pi.tools.get("create_tunnel")!;
+        const result = await tool.execute("call-1", { port: 8080 });
+
+        expect(result.details.publicUrl).toBe("http://localhost:7492/api/tunnel/abc-def-123/8080/");
+
+        // Restore
+        if (savedRelayUrl !== undefined) process.env.PIZZAPI_RELAY_URL = savedRelayUrl;
+        else delete process.env.PIZZAPI_RELAY_URL;
+    });
+
+    test("returns null publicUrl when session ID is missing", async () => {
+        const sock = mockSocket();
+        sock.emit = (_event: string, data: unknown) => {
+            setTimeout(() => {
+                sock.simulateMessage({
+                    serviceId: "tunnel",
+                    type: "tunnel_registered",
+                    requestId: (data as any).requestId,
+                    payload: { port: 8080, url: "/tunnel/8080" },
+                });
+            }, 10);
+        };
+
+        mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+        mockGetRelaySessionId.mockReturnValue(null);
+
+        const pi = createMockPi();
+        tunnelToolsExtension(pi as any);
+
+        const tool = pi.tools.get("create_tunnel")!;
+        const result = await tool.execute("call-1", { port: 8080 });
+
+        expect(result.details.publicUrl).toBeNull();
+
+        // Restore
+        if (savedRelayUrl !== undefined) process.env.PIZZAPI_RELAY_URL = savedRelayUrl;
+        else delete process.env.PIZZAPI_RELAY_URL;
+    });
+});

--- a/packages/cli/src/extensions/tunnel-tools.ts
+++ b/packages/cli/src/extensions/tunnel-tools.ts
@@ -16,8 +16,8 @@
 import { randomUUID } from "node:crypto";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
-import { getRelaySocket, getRelaySessionId } from "./remote.js";
-import { loadConfig } from "../config.js";
+import { getRelaySocket as getRelaySocketDefault, getRelaySessionId as getRelaySessionIdDefault } from "./remote.js";
+import { loadConfig as loadConfigDefault } from "../config.js";
 
 /** Timeout for service_message request/response round-trips. */
 const SERVICE_TIMEOUT_MS = 10_000;
@@ -29,6 +29,18 @@ interface TunnelInfo {
     pinned?: boolean;
 }
 
+interface TunnelToolsDeps {
+    getRelaySocket: typeof getRelaySocketDefault;
+    getRelaySessionId: typeof getRelaySessionIdDefault;
+    loadConfig: typeof loadConfigDefault;
+}
+
+const defaultDeps: TunnelToolsDeps = {
+    getRelaySocket: getRelaySocketDefault,
+    getRelaySessionId: getRelaySessionIdDefault,
+    loadConfig: loadConfigDefault,
+};
+
 /** Minimal Component that renders nothing — keeps the tool call invisible in the TUI. */
 const silent = { render: (_width: number): string[] => [], invalidate: () => {} };
 
@@ -37,11 +49,12 @@ const silent = { render: (_width: number): string[] => [], invalidate: () => {} 
  * and wait for a response with matching requestId.
  */
 function sendTunnelServiceMessage(
+    deps: TunnelToolsDeps,
     type: string,
     payload: unknown,
 ): Promise<{ type: string; payload: unknown }> {
     return new Promise((resolve, reject) => {
-        const conn = getRelaySocket();
+        const conn = deps.getRelaySocket();
         if (!conn) {
             reject(new Error("Not connected to relay. Cannot manage tunnels without a relay connection."));
             return;
@@ -78,10 +91,10 @@ function sendTunnelServiceMessage(
     });
 }
 
-function getRelayHttpBaseUrl(): string | null {
+function getRelayHttpBaseUrl(deps: TunnelToolsDeps): string | null {
     const configured =
         process.env.PIZZAPI_RELAY_URL ??
-        loadConfig(process.cwd()).relayUrl ??
+        deps.loadConfig(process.cwd()).relayUrl ??
         "ws://localhost:7492";
 
     if (configured.toLowerCase() === "off") return null;
@@ -93,9 +106,9 @@ function getRelayHttpBaseUrl(): string | null {
     return `https://${trimmed}`;
 }
 
-function buildPublicTunnelUrl(port: number): string | null {
-    const base = getRelayHttpBaseUrl();
-    const sessionId = getRelaySessionId();
+function buildPublicTunnelUrl(deps: TunnelToolsDeps, port: number): string | null {
+    const base = getRelayHttpBaseUrl(deps);
+    const sessionId = deps.getRelaySessionId();
     if (!base || !sessionId) return null;
     return `${base}/api/tunnel/${encodeURIComponent(sessionId)}/${port}/`;
 }
@@ -107,7 +120,8 @@ function ok(text: string, details?: Record<string, unknown>) {
     };
 }
 
-export const tunnelToolsExtension: ExtensionFactory = (pi) => {
+export function createTunnelToolsExtension(deps: TunnelToolsDeps = defaultDeps): ExtensionFactory {
+    return (pi) => {
     // ── create_tunnel ────────────────────────────────────────────────────────
     pi.registerTool({
         name: "create_tunnel",
@@ -140,7 +154,7 @@ export const tunnelToolsExtension: ExtensionFactory = (pi) => {
             }
 
             try {
-                const response = await sendTunnelServiceMessage("tunnel_expose", {
+                const response = await sendTunnelServiceMessage(deps, "tunnel_expose", {
                     port,
                     name: params.name ?? undefined,
                 });
@@ -152,7 +166,7 @@ export const tunnelToolsExtension: ExtensionFactory = (pi) => {
 
                 if (response.type === "tunnel_registered") {
                     const info = response.payload as TunnelInfo;
-                    const publicUrl = buildPublicTunnelUrl(info.port);
+                    const publicUrl = buildPublicTunnelUrl(deps, info.port);
 
                     const lines = [
                         `Tunnel created successfully.`,
@@ -223,7 +237,7 @@ export const tunnelToolsExtension: ExtensionFactory = (pi) => {
 
         async execute() {
             try {
-                const response = await sendTunnelServiceMessage("tunnel_list", {});
+                const response = await sendTunnelServiceMessage(deps, "tunnel_list", {});
 
                 if (response.type === "tunnel_list_result") {
                     const tunnels = ((response.payload as { tunnels?: TunnelInfo[] })?.tunnels ?? [])
@@ -231,7 +245,7 @@ export const tunnelToolsExtension: ExtensionFactory = (pi) => {
                             port: t.port,
                             name: t.name ?? null,
                             url: t.url,
-                            publicUrl: buildPublicTunnelUrl(t.port) ?? null,
+                            publicUrl: buildPublicTunnelUrl(deps, t.port) ?? null,
                             pinned: t.pinned ?? false,
                         }));
 
@@ -314,7 +328,7 @@ export const tunnelToolsExtension: ExtensionFactory = (pi) => {
                 // The tunnel service emits tunnel_removed on success (fire-and-forget).
                 // We listen for it briefly, but also accept that the operation may
                 // succeed silently if the port wasn't tracked.
-                const conn = getRelaySocket();
+                const conn = deps.getRelaySocket();
                 if (!conn) {
                     return ok("Error: Not connected to relay.", { error: "Not connected" });
                 }
@@ -396,4 +410,7 @@ export const tunnelToolsExtension: ExtensionFactory = (pi) => {
             );
         },
     });
-};
+    };
+}
+
+export const tunnelToolsExtension: ExtensionFactory = createTunnelToolsExtension();

--- a/packages/cli/src/extensions/tunnel-tools.ts
+++ b/packages/cli/src/extensions/tunnel-tools.ts
@@ -1,0 +1,399 @@
+/**
+ * Tunnel tools extension — provides agent-facing tools to manage HTTP tunnels
+ * through the PizzaPi relay server.
+ *
+ * Tools:
+ *   create_tunnel — Expose a local port through the relay tunnel
+ *   list_tunnels  — List currently active tunnels
+ *   close_tunnel  — Close an active tunnel
+ *
+ * Communication: These tools send `service_message` envelopes on the agent's
+ * relay Socket.IO connection. The relay namespace forwards them to the runner
+ * daemon's TunnelService, which handles the actual port exposure. Responses
+ * come back via `service_message` events with matching `requestId`.
+ */
+
+import { randomUUID } from "node:crypto";
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { Text } from "@mariozechner/pi-tui";
+import { getRelaySocket, getRelaySessionId } from "./remote.js";
+import { loadConfig } from "../config.js";
+
+/** Timeout for service_message request/response round-trips. */
+const SERVICE_TIMEOUT_MS = 10_000;
+
+interface TunnelInfo {
+    port: number;
+    name?: string;
+    url: string;
+    pinned?: boolean;
+}
+
+/** Minimal Component that renders nothing — keeps the tool call invisible in the TUI. */
+const silent = { render: (_width: number): string[] => [], invalidate: () => {} };
+
+/**
+ * Send a service_message to the daemon's TunnelService via the relay socket
+ * and wait for a response with matching requestId.
+ */
+function sendTunnelServiceMessage(
+    type: string,
+    payload: unknown,
+): Promise<{ type: string; payload: unknown }> {
+    return new Promise((resolve, reject) => {
+        const conn = getRelaySocket();
+        if (!conn) {
+            reject(new Error("Not connected to relay. Cannot manage tunnels without a relay connection."));
+            return;
+        }
+
+        const requestId = randomUUID();
+        const { socket } = conn;
+        let settled = false;
+
+        const timer = setTimeout(() => {
+            if (settled) return;
+            settled = true;
+            socket.off("service_message" as any, handler);
+            reject(new Error("Tunnel service request timed out (10s). Is the runner daemon running?"));
+        }, SERVICE_TIMEOUT_MS);
+
+        const handler = (envelope: { serviceId: string; type: string; requestId?: string; payload: unknown }) => {
+            if (envelope.serviceId !== "tunnel") return;
+            if (envelope.requestId !== requestId) return;
+            if (settled) return;
+            settled = true;
+            clearTimeout(timer);
+            socket.off("service_message" as any, handler);
+            resolve({ type: envelope.type, payload: envelope.payload });
+        };
+
+        socket.on("service_message" as any, handler);
+        socket.emit("service_message" as any, {
+            serviceId: "tunnel",
+            type,
+            requestId,
+            payload,
+        });
+    });
+}
+
+function getRelayHttpBaseUrl(): string | null {
+    const configured =
+        process.env.PIZZAPI_RELAY_URL ??
+        loadConfig(process.cwd()).relayUrl ??
+        "ws://localhost:7492";
+
+    if (configured.toLowerCase() === "off") return null;
+
+    const trimmed = configured.trim().replace(/\/$/, "").replace(/\/ws\/sessions$/, "");
+    if (trimmed.startsWith("ws://")) return `http://${trimmed.slice("ws://".length)}`;
+    if (trimmed.startsWith("wss://")) return `https://${trimmed.slice("wss://".length)}`;
+    if (trimmed.startsWith("http://") || trimmed.startsWith("https://")) return trimmed;
+    return `https://${trimmed}`;
+}
+
+function buildPublicTunnelUrl(port: number): string | null {
+    const base = getRelayHttpBaseUrl();
+    const sessionId = getRelaySessionId();
+    if (!base || !sessionId) return null;
+    return `${base}/api/tunnel/${encodeURIComponent(sessionId)}/${port}/`;
+}
+
+function ok(text: string, details?: Record<string, unknown>) {
+    return {
+        content: [{ type: "text" as const, text }],
+        details: details as any,
+    };
+}
+
+export const tunnelToolsExtension: ExtensionFactory = (pi) => {
+    // ── create_tunnel ────────────────────────────────────────────────────────
+    pi.registerTool({
+        name: "create_tunnel",
+        label: "Create Tunnel",
+        description:
+            "Expose a local port through the PizzaPi relay server so it's accessible " +
+            "from the web UI. Use this after starting a local dev server to make it " +
+            "accessible remotely. Returns the public URL for the tunnel.",
+        parameters: {
+            type: "object",
+            properties: {
+                port: {
+                    type: "number",
+                    description: "Local port to expose (1–65535).",
+                },
+                name: {
+                    type: "string",
+                    description: "Optional human-readable name for the tunnel (e.g. 'dev-server', 'storybook').",
+                },
+            },
+            required: ["port"],
+        } as any,
+
+        async execute(_toolCallId, rawParams) {
+            const params = (rawParams ?? {}) as { port: number; name?: string };
+            const port = params.port;
+
+            if (!port || !Number.isFinite(port) || port < 1 || port > 65535) {
+                return ok("Error: port must be a number between 1 and 65535.", { error: "Invalid port" });
+            }
+
+            try {
+                const response = await sendTunnelServiceMessage("tunnel_expose", {
+                    port,
+                    name: params.name ?? undefined,
+                });
+
+                if (response.type === "tunnel_error") {
+                    const error = (response.payload as { error?: string })?.error ?? "Unknown tunnel error";
+                    return ok(`Error creating tunnel: ${error}`, { error });
+                }
+
+                if (response.type === "tunnel_registered") {
+                    const info = response.payload as TunnelInfo;
+                    const publicUrl = buildPublicTunnelUrl(info.port);
+
+                    const lines = [
+                        `Tunnel created successfully.`,
+                        `  Port: ${info.port}`,
+                        info.name ? `  Name: ${info.name}` : null,
+                        publicUrl ? `  Public URL: ${publicUrl}` : `  URL: ${info.url}`,
+                    ].filter(Boolean).join("\n");
+
+                    return ok(lines, {
+                        port: info.port,
+                        name: info.name ?? null,
+                        url: info.url,
+                        publicUrl: publicUrl ?? null,
+                    });
+                }
+
+                return ok(`Unexpected response from tunnel service: ${response.type}`, {
+                    error: `Unexpected type: ${response.type}`,
+                });
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                return ok(`Error: ${message}`, { error: message });
+            }
+        },
+
+        renderCall: (args: any, theme: any) => {
+            const port = args.port ?? "?";
+            const name = args.name ? ` (${args.name})` : "";
+            return new Text(
+                theme.fg("accent", "⇡") + " " +
+                theme.fg("muted", "creating tunnel") +
+                theme.fg("dim", ` :${port}${name}`),
+                0, 0,
+            );
+        },
+        renderResult: (result: any, _opts: any, theme: any) => {
+            const details = result?.details as Record<string, unknown> | undefined;
+            const text: string = result?.content?.[0]?.text ?? "";
+
+            if (details?.error || text.startsWith("Error")) {
+                const msg = typeof details?.error === "string" ? details.error : text;
+                return new Text(theme.fg("error", "✗ " + (msg.length > 80 ? msg.slice(0, 77) + "..." : msg)), 0, 0);
+            }
+
+            const port = details?.port ?? "?";
+            const url = typeof details?.publicUrl === "string" ? ` ${details.publicUrl}` : "";
+            return new Text(
+                theme.fg("success", "✓") + " " +
+                theme.fg("muted", "tunnel :") +
+                theme.fg("accent", String(port)) +
+                theme.fg("dim", url),
+                0, 0,
+            );
+        },
+    });
+
+    // ── list_tunnels ─────────────────────────────────────────────────────────
+    pi.registerTool({
+        name: "list_tunnels",
+        label: "List Tunnels",
+        description:
+            "List all currently active tunnels for this session. Returns each tunnel's " +
+            "port, name, and public URL.",
+        parameters: {
+            type: "object",
+            properties: {},
+        } as any,
+
+        async execute() {
+            try {
+                const response = await sendTunnelServiceMessage("tunnel_list", {});
+
+                if (response.type === "tunnel_list_result") {
+                    const tunnels = ((response.payload as { tunnels?: TunnelInfo[] })?.tunnels ?? [])
+                        .map((t) => ({
+                            port: t.port,
+                            name: t.name ?? null,
+                            url: t.url,
+                            publicUrl: buildPublicTunnelUrl(t.port) ?? null,
+                            pinned: t.pinned ?? false,
+                        }));
+
+                    if (tunnels.length === 0) {
+                        return ok("No active tunnels.", { tunnels: [] });
+                    }
+
+                    const lines = [
+                        `${tunnels.length} active tunnel(s):`,
+                        ...tunnels.map((t) => {
+                            const name = t.name ? ` (${t.name})` : "";
+                            const pinned = t.pinned ? " [pinned]" : "";
+                            const url = t.publicUrl ?? t.url;
+                            return `  :${t.port}${name}${pinned} → ${url}`;
+                        }),
+                    ];
+
+                    return ok(lines.join("\n"), { tunnels });
+                }
+
+                return ok(`Unexpected response: ${response.type}`, { error: `Unexpected type: ${response.type}` });
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                return ok(`Error: ${message}`, { error: message });
+            }
+        },
+
+        renderCall: (_args: any, theme: any) => {
+            return new Text(
+                theme.fg("accent", "⇡") + " " +
+                theme.fg("muted", "listing tunnels"),
+                0, 0,
+            );
+        },
+        renderResult: (result: any, _opts: any, theme: any) => {
+            const details = result?.details as Record<string, unknown> | undefined;
+            const text: string = result?.content?.[0]?.text ?? "";
+
+            if (details?.error || text.startsWith("Error")) {
+                const msg = typeof details?.error === "string" ? details.error : text;
+                return new Text(theme.fg("error", "✗ " + msg), 0, 0);
+            }
+
+            const tunnels = (details?.tunnels as any[]) ?? [];
+            return new Text(
+                theme.fg("success", "✓") + " " +
+                theme.fg("muted", `${tunnels.length} tunnel(s)`),
+                0, 0,
+            );
+        },
+    });
+
+    // ── close_tunnel ─────────────────────────────────────────────────────────
+    pi.registerTool({
+        name: "close_tunnel",
+        label: "Close Tunnel",
+        description:
+            "Close an active tunnel by port number. Stops proxying traffic to the " +
+            "specified local port.",
+        parameters: {
+            type: "object",
+            properties: {
+                port: {
+                    type: "number",
+                    description: "Port of the tunnel to close.",
+                },
+            },
+            required: ["port"],
+        } as any,
+
+        async execute(_toolCallId, rawParams) {
+            const params = (rawParams ?? {}) as { port: number };
+            const port = params.port;
+
+            if (!port || !Number.isFinite(port) || port < 1 || port > 65535) {
+                return ok("Error: port must be a number between 1 and 65535.", { error: "Invalid port" });
+            }
+
+            try {
+                // The tunnel service emits tunnel_removed on success (fire-and-forget).
+                // We listen for it briefly, but also accept that the operation may
+                // succeed silently if the port wasn't tracked.
+                const conn = getRelaySocket();
+                if (!conn) {
+                    return ok("Error: Not connected to relay.", { error: "Not connected" });
+                }
+
+                const requestId = randomUUID();
+                const { socket } = conn;
+
+                // Set up a brief listener for the tunnel_removed response
+                const result = await new Promise<{ closed: boolean }>((resolve) => {
+                    let settled = false;
+
+                    const timer = setTimeout(() => {
+                        if (settled) return;
+                        settled = true;
+                        socket.off("service_message" as any, handler);
+                        // If we time out, the unexpose likely succeeded anyway
+                        // (it's fire-and-forget on the daemon side for unknown ports).
+                        resolve({ closed: true });
+                    }, SERVICE_TIMEOUT_MS);
+
+                    const handler = (envelope: { serviceId: string; type: string; requestId?: string; payload: unknown }) => {
+                        if (envelope.serviceId !== "tunnel") return;
+                        // tunnel_removed doesn't echo requestId, match by port
+                        if (envelope.type === "tunnel_removed") {
+                            const removedPort = (envelope.payload as { port?: number })?.port;
+                            if (removedPort === port) {
+                                if (settled) return;
+                                settled = true;
+                                clearTimeout(timer);
+                                socket.off("service_message" as any, handler);
+                                resolve({ closed: true });
+                            }
+                        }
+                    };
+
+                    socket.on("service_message" as any, handler);
+                    socket.emit("service_message" as any, {
+                        serviceId: "tunnel",
+                        type: "tunnel_unexpose",
+                        requestId,
+                        payload: { port },
+                    });
+                });
+
+                return ok(
+                    result.closed ? `Tunnel on port ${port} closed.` : `Port ${port} was not tunneled.`,
+                    { closed: result.closed, port },
+                );
+            } catch (err) {
+                const message = err instanceof Error ? err.message : String(err);
+                return ok(`Error: ${message}`, { error: message });
+            }
+        },
+
+        renderCall: (args: any, theme: any) => {
+            const port = args.port ?? "?";
+            return new Text(
+                theme.fg("accent", "⇣") + " " +
+                theme.fg("muted", "closing tunnel") +
+                theme.fg("dim", ` :${port}`),
+                0, 0,
+            );
+        },
+        renderResult: (result: any, _opts: any, theme: any) => {
+            const details = result?.details as Record<string, unknown> | undefined;
+            const text: string = result?.content?.[0]?.text ?? "";
+
+            if (details?.error || text.startsWith("Error")) {
+                const msg = typeof details?.error === "string" ? details.error : text;
+                return new Text(theme.fg("error", "✗ " + msg), 0, 0);
+            }
+
+            const port = details?.port ?? "?";
+            return new Text(
+                theme.fg("success", "✓") + " " +
+                theme.fg("muted", "closed :") +
+                theme.fg("accent", String(port)),
+                0, 0,
+            );
+        },
+    });
+};

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -331,6 +331,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             tunnelClient.on("registered", () => {
                 logInfo(`[tunnel] registered at ${tunnelRelayUrl}`);
                 tunnelService.setTunnelClient(tunnelClient);
+                // Clear any previous tunnel warning now that we're connected
+                socket.emit("runner_warning_clear", {} as Record<string, never>);
             });
             tunnelClient.on("disconnect", () => {
                 if (!isShuttingDown) {
@@ -343,6 +345,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             tunnelClient.on("disabled", (data: { reason: string; failures: number; relayUrl: string }) => {
                 logWarn(`[tunnel] disabled after ${data.failures} failed connection attempts to ${data.relayUrl}`);
                 logWarn("[tunnel] The relay server may not support the /_tunnel endpoint. Upgrade the server with 'pizza web'.");
+                // Surface as a visible warning in the web UI
+                socket.emit("runner_warning", {
+                    message: "Tunnel unavailable — the relay server does not support the tunnel endpoint. Upgrade with 'pizza web' to enable tunnels and service panels.",
+                });
             });
         } else {
             logWarn("[tunnel] disabled: runner is missing an API key for tunnel authentication");

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -340,6 +340,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             tunnelClient.on("error", (error) => {
                 logError(`[tunnel] ${error instanceof Error ? error.message : String(error)}`);
             });
+            tunnelClient.on("disabled", (data: { reason: string; failures: number; relayUrl: string }) => {
+                logWarn(`[tunnel] disabled after ${data.failures} failed connection attempts to ${data.relayUrl}`);
+                logWarn("[tunnel] The relay server may not support the /_tunnel endpoint. Upgrade the server with 'pizza web'.");
+            });
         } else {
             logWarn("[tunnel] disabled: runner is missing an API key for tunnel authentication");
         }

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -122,6 +122,13 @@ export interface RunnerClientToServerEvents {
    *  Forwarded to all viewers watching sessions on this runner. */
   service_announce: (data: ServiceAnnounceData) => void;
 
+  /** Report a warning (e.g. tunnel connection failure).
+   *  Server stores the warning and broadcasts runner_updated to viewers. */
+  runner_warning: (data: { message: string }) => void;
+
+  /** Clear all warnings for this runner. */
+  runner_warning_clear: (data?: Record<string, never>) => void;
+
   /** Terminal is ready for interaction */
   terminal_ready: (data: {
     terminalId: string;

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -55,6 +55,8 @@ export interface RunnerInfo {
   serviceIds?: string[];
   /** Panel metadata for services that expose a UI panel. */
   panels?: ServicePanelInfo[];
+  /** Active warnings from the runner daemon (e.g. tunnel connection failures). */
+  warnings?: string[];
 }
 
 /** A discovered Claude Code plugin on a runner */

--- a/packages/server/src/ws/namespaces/relay/index.ts
+++ b/packages/server/src/ws/namespaces/relay/index.ts
@@ -20,6 +20,7 @@ import { registerEventHandler } from "./event-pipeline.js";
 import { registerSessionLifecycleHandlers } from "./session-lifecycle.js";
 import { registerMessagingHandlers } from "./messaging.js";
 import { registerChildLifecycleHandlers } from "./child-lifecycle.js";
+import { registerServiceMessageHandler } from "./service-message.js";
 import { createLogger } from "@pizzapi/tools";
 
 // Re-export for viewer.ts compatibility
@@ -45,5 +46,6 @@ export function registerRelayNamespace(io: SocketIOServer): void {
         registerEventHandler(socket);
         registerMessagingHandlers(socket);
         registerChildLifecycleHandlers(socket, io);
+        registerServiceMessageHandler(socket);
     });
 }

--- a/packages/server/src/ws/namespaces/relay/service-message.test.ts
+++ b/packages/server/src/ws/namespaces/relay/service-message.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, mock, beforeEach } from "bun:test";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockGetSharedSession = mock(async (_id: string) => null as any);
+const mockEmitToRunner = mock((..._args: any[]) => {});
+
+mock.module("../../sio-registry/sessions.js", () => ({
+    getSharedSession: mockGetSharedSession,
+}));
+
+mock.module("../../sio-registry/context.js", () => ({
+    emitToRunner: mockEmitToRunner,
+}));
+
+mock.module("@pizzapi/tools", () => ({
+    createLogger: () => ({
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+    }),
+}));
+
+import { registerServiceMessageHandler } from "./service-message.js";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createMockSocket(sessionId?: string) {
+    const handlers = new Map<string, Function>();
+    return {
+        data: {
+            sessionId: sessionId ?? null,
+            token: "test-token",
+        },
+        on: (event: string, handler: Function) => {
+            handlers.set(event, handler);
+        },
+        _handlers: handlers,
+        fireEvent(event: string, data: unknown) {
+            handlers.get(event)?.(data);
+        },
+    };
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("registerServiceMessageHandler", () => {
+    beforeEach(() => {
+        mockGetSharedSession.mockReset();
+        mockEmitToRunner.mockReset();
+    });
+
+    test("registers a service_message handler on the socket", () => {
+        const socket = createMockSocket("sess-1");
+        registerServiceMessageHandler(socket as any);
+        expect(socket._handlers.has("service_message")).toBe(true);
+    });
+
+    test("does nothing when sessionId is not set", async () => {
+        const socket = createMockSocket(undefined);
+        (socket.data as any).sessionId = undefined;
+        registerServiceMessageHandler(socket as any);
+
+        socket.fireEvent("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            payload: {},
+        });
+
+        // Give async handlers time to settle
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockEmitToRunner).not.toHaveBeenCalled();
+    });
+
+    test("does nothing when session has no collabMode", async () => {
+        const socket = createMockSocket("sess-1");
+        mockGetSharedSession.mockResolvedValue({ collabMode: false, runnerId: "runner-1" });
+        registerServiceMessageHandler(socket as any);
+
+        socket.fireEvent("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            payload: {},
+        });
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockEmitToRunner).not.toHaveBeenCalled();
+    });
+
+    test("does nothing when session has no runnerId", async () => {
+        const socket = createMockSocket("sess-1");
+        mockGetSharedSession.mockResolvedValue({ collabMode: true, runnerId: null });
+        registerServiceMessageHandler(socket as any);
+
+        socket.fireEvent("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            payload: {},
+        });
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockEmitToRunner).not.toHaveBeenCalled();
+    });
+
+    test("forwards service_message to runner with sessionId attached", async () => {
+        const socket = createMockSocket("sess-1");
+        mockGetSharedSession.mockResolvedValue({ collabMode: true, runnerId: "runner-1" });
+        registerServiceMessageHandler(socket as any);
+
+        const envelope = {
+            serviceId: "tunnel",
+            type: "tunnel_expose",
+            requestId: "req-123",
+            payload: { port: 3000, name: "dev" },
+        };
+
+        socket.fireEvent("service_message", envelope);
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockEmitToRunner).toHaveBeenCalledTimes(1);
+        expect(mockEmitToRunner).toHaveBeenCalledWith("runner-1", "service_message", {
+            ...envelope,
+            sessionId: "sess-1",
+        });
+    });
+
+    test("does not forward when session is null", async () => {
+        const socket = createMockSocket("sess-1");
+        mockGetSharedSession.mockResolvedValue(null);
+        registerServiceMessageHandler(socket as any);
+
+        socket.fireEvent("service_message", {
+            serviceId: "tunnel",
+            type: "tunnel_list",
+            payload: {},
+        });
+
+        await new Promise((r) => setTimeout(r, 50));
+        expect(mockEmitToRunner).not.toHaveBeenCalled();
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/service-message.ts
+++ b/packages/server/src/ws/namespaces/relay/service-message.ts
@@ -1,0 +1,31 @@
+// ── Service message relay — TUI session → runner daemon ──────────────────────
+//
+// Allows agent sessions (connected via the /relay namespace) to send
+// service_message envelopes to the runner daemon's ServiceHandler system.
+// This mirrors the viewer → runner path but originates from the TUI worker
+// instead of a browser viewer.
+
+import type { ServiceEnvelope } from "@pizzapi/protocol";
+import { getSharedSession } from "../../sio-registry/sessions.js";
+import { emitToRunner } from "../../sio-registry/context.js";
+import type { RelaySocket } from "./types.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("sio/relay");
+
+export function registerServiceMessageHandler(socket: RelaySocket): void {
+    socket.on("service_message" as any, async (envelope: ServiceEnvelope) => {
+        const sessionId = socket.data.sessionId;
+        if (!sessionId) return;
+
+        const session = await getSharedSession(sessionId);
+        if (!session?.collabMode) return;
+
+        const runnerId = session.runnerId;
+        if (!runnerId) return;
+
+        // Attach sessionId so the runner service knows which session to
+        // respond to (same pattern as the viewer namespace).
+        emitToRunner(runnerId, "service_message", { ...envelope, sessionId });
+    });
+}

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -46,6 +46,7 @@ import {
     getConnectedSessionsForRunner,
     touchRunner,
     broadcastToSessionViewers,
+    emitToRelaySession,
 } from "../sio-registry.js";
 import { resolveSpawnReady, resolveSpawnError } from "../runner-control.js";
 import { createLogger } from "@pizzapi/tools";
@@ -632,11 +633,15 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                     return;
                 }
                 broadcastToSessionViewers(targetSessionId, "service_message", envelope);
+                // Also route to the session's relay socket (TUI worker) so
+                // agent-initiated service_message requests get their responses.
+                emitToRelaySession(targetSessionId, "service_message", envelope);
             } else {
                 const sessionIds = runnerSessionIds.get(runnerId);
                 if (!sessionIds || sessionIds.size === 0) return;
                 for (const sid of sessionIds) {
                     broadcastToSessionViewers(sid, "service_message", envelope);
+                    emitToRelaySession(sid, "service_message", envelope);
                 }
             }
         });

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -215,7 +215,7 @@ export async function sendRunnerCommand(
 // via updateRunnerServices() so late-joining viewers (or viewers after a server
 // restart) can receive the data without waiting for a fresh announce.
 import type { ServiceAnnounceData } from "@pizzapi/protocol";
-import { updateRunnerServices, getRunnerServices } from "../sio-registry/index.js";
+import { updateRunnerServices, getRunnerServices, addRunnerWarning, clearRunnerWarnings } from "../sio-registry/index.js";
 
 const runnerServiceAnnounce = new Map<string, ServiceAnnounceData>();
 
@@ -644,6 +644,25 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                     emitToRelaySession(sid, "service_message", envelope);
                 }
             }
+        });
+
+        // ── runner_warning — runner reports a warning (e.g. tunnel failure) ───
+        socket.on("runner_warning", (data: { message: string }) => {
+            const runnerId = socket.data.runnerId;
+            if (!runnerId || !data?.message) return;
+            log.warn(`runner_warning from ${runnerId}: ${data.message}`);
+            void addRunnerWarning(runnerId, data.message).catch((err) => {
+                log.error(`failed to persist runner_warning for ${runnerId}:`, err);
+            });
+        });
+
+        // ── runner_warning_clear — runner clears all warnings ────────────────
+        socket.on("runner_warning_clear", () => {
+            const runnerId = socket.data.runnerId;
+            if (!runnerId) return;
+            void clearRunnerWarnings(runnerId).catch((err) => {
+                log.error(`failed to clear warnings for ${runnerId}:`, err);
+            });
         });
 
         // ── service_announce — runner announces available services ────────────

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -39,6 +39,8 @@ export {
     updateRunnerPlugins,
     updateRunnerServices,
     getRunnerServices,
+    addRunnerWarning,
+    clearRunnerWarnings,
     recordRunnerSession,
     linkSessionToRunner,
     removeRunnerSession,

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -242,6 +242,29 @@ export async function updateRunnerPlugins(runnerId: string, plugins: unknown[]):
     }
 }
 
+/** Add a warning to the runner's warnings list. Deduplicates by message. */
+export async function addRunnerWarning(runnerId: string, message: string): Promise<void> {
+    const existing = await getRunnerState(runnerId);
+    if (!existing) return;
+    const current: string[] = existing.warnings ? safeJsonParse(existing.warnings) ?? [] : [];
+    if (current.includes(message)) return; // already present
+    current.push(message);
+    await updateRunnerFields(runnerId, { warnings: JSON.stringify(current) });
+    const fresh = await getRunnerState(runnerId);
+    if (fresh) {
+        void broadcastToRunnersNs("runner_updated", runnerDataToInfo(fresh), fresh.userId ?? undefined);
+    }
+}
+
+/** Clear all warnings for a runner. */
+export async function clearRunnerWarnings(runnerId: string): Promise<void> {
+    await updateRunnerFields(runnerId, { warnings: "[]" });
+    const fresh = await getRunnerState(runnerId);
+    if (fresh) {
+        void broadcastToRunnersNs("runner_updated", runnerDataToInfo(fresh), fresh.userId ?? undefined);
+    }
+}
+
 /**
  * Persist service announce data (service IDs + panels) to Redis.
  * Called when a runner emits service_announce so the data survives
@@ -371,6 +394,7 @@ export async function getConnectedSessionsForRunner(runnerId: string): Promise<A
 function runnerDataToInfo(r: RedisRunnerData): RunnerInfo {
     const serviceIds: string[] | undefined = r.serviceIds ? safeJsonParse(r.serviceIds) ?? undefined : undefined;
     const panels = r.panels ? safeJsonParse(r.panels) ?? undefined : undefined;
+    const warnings: string[] | undefined = r.warnings ? safeJsonParse(r.warnings) ?? undefined : undefined;
     return {
         runnerId: r.runnerId,
         name: r.name,
@@ -384,6 +408,7 @@ function runnerDataToInfo(r: RedisRunnerData): RunnerInfo {
         platform: r.platform ?? null,
         ...(serviceIds ? { serviceIds } : {}),
         ...(panels ? { panels } : {}),
+        ...(warnings && warnings.length > 0 ? { warnings } : {}),
     };
 }
 

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -199,6 +199,8 @@ export interface RedisRunnerData {
     serviceIds?: string;
     /** JSON-stringified ServicePanelInfo[] — panel metadata from last service_announce */
     panels?: string;
+    /** JSON-stringified string[] — active warnings from the runner daemon */
+    warnings?: string;
 }
 
 export interface RedisTerminalData {

--- a/packages/tunnel/src/client.test.ts
+++ b/packages/tunnel/src/client.test.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import { createServer, type Server } from "node:http";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, jest } from "bun:test";
 import { TunnelClient } from "./client.js";
 
 function attachMockRelay(client: TunnelClient) {
@@ -339,5 +339,152 @@ describe("TunnelClient", () => {
 
     expect(Buffer.isBuffer(sentFrames[0])).toBe(true);
     expect((sentFrames[0] as Buffer).toString("utf-8")).toBe("hello");
+  });
+});
+
+describe("TunnelClient backoff and failure handling", () => {
+  test("currentReconnectDelay uses exponential backoff", () => {
+    const client = new TunnelClient({
+      runnerId: "r1",
+      apiKey: "key1",
+      relayUrl: "ws://localhost:9999/_tunnel",
+      reconnectDelayMs: 1000,
+      maxReconnectDelayMs: 16000,
+    });
+
+    // 0 failures → base delay
+    expect((client as any).currentReconnectDelay).toBe(1000);
+
+    // Simulate consecutive failures
+    (client as any).consecutiveFailures = 1;
+    expect((client as any).currentReconnectDelay).toBe(1000); // 1000 * 2^0
+
+    (client as any).consecutiveFailures = 2;
+    expect((client as any).currentReconnectDelay).toBe(2000); // 1000 * 2^1
+
+    (client as any).consecutiveFailures = 3;
+    expect((client as any).currentReconnectDelay).toBe(4000); // 1000 * 2^2
+
+    (client as any).consecutiveFailures = 4;
+    expect((client as any).currentReconnectDelay).toBe(8000); // 1000 * 2^3
+
+    (client as any).consecutiveFailures = 5;
+    expect((client as any).currentReconnectDelay).toBe(16000); // 1000 * 2^4 = cap
+
+    // Should cap at maxReconnectDelayMs
+    (client as any).consecutiveFailures = 10;
+    expect((client as any).currentReconnectDelay).toBe(16000);
+  });
+
+  test("consecutiveFailures resets on successful registration", () => {
+    const client = new TunnelClient({
+      runnerId: "r1",
+      apiKey: "key1",
+      relayUrl: "ws://localhost:9999/_tunnel",
+      autoReconnect: false,
+    });
+    attachMockRelay(client);
+
+    // Simulate some failures
+    (client as any).consecutiveFailures = 5;
+
+    // Simulate receiving a "registered" message
+    (client as any).handleMessage(JSON.stringify({ type: "registered", runnerId: "r1" }));
+
+    expect((client as any).consecutiveFailures).toBe(0);
+    expect((client as any).registeredThisConnection).toBe(true);
+  });
+
+  test("consecutiveFailures increments on disconnect without registration", () => {
+    const client = new TunnelClient({
+      runnerId: "r1",
+      apiKey: "key1",
+      relayUrl: "ws://localhost:9999/_tunnel",
+      autoReconnect: false, // Don't actually reconnect in test
+    });
+
+    expect((client as any).consecutiveFailures).toBe(0);
+
+    // Simulate a connection that closes without ever registering
+    (client as any).registeredThisConnection = false;
+    // Manually trigger the close logic
+    (client as any).ws = null;
+    if (!(client as any).registeredThisConnection) {
+      (client as any).consecutiveFailures++;
+    }
+
+    expect((client as any).consecutiveFailures).toBe(1);
+  });
+
+  test("emits 'disabled' event after maxConsecutiveFailures", () => {
+    const client = new TunnelClient({
+      runnerId: "r1",
+      apiKey: "key1",
+      relayUrl: "ws://localhost:9999/_tunnel",
+      autoReconnect: true,
+      maxConsecutiveFailures: 3,
+    });
+
+    const disabledEvents: any[] = [];
+    client.on("disabled", (data) => disabledEvents.push(data));
+
+    // Simulate reaching max failures
+    (client as any).consecutiveFailures = 2; // Will become 3 on next disconnect
+    (client as any).registeredThisConnection = false;
+
+    // Simulate the close handler logic
+    (client as any).consecutiveFailures++;
+    // Check the give-up condition
+    if ((client as any).consecutiveFailures >= (client as any).maxConsecutiveFailures) {
+      client.emit("disabled", {
+        reason: "max-failures",
+        failures: (client as any).consecutiveFailures,
+        relayUrl: (client as any).relayUrl,
+      });
+    }
+
+    expect(disabledEvents).toHaveLength(1);
+    expect(disabledEvents[0]).toMatchObject({
+      reason: "max-failures",
+      failures: 3,
+      relayUrl: "ws://localhost:9999/_tunnel",
+    });
+  });
+
+  test("consecutiveFailures does NOT increment on disconnect after successful registration", () => {
+    const client = new TunnelClient({
+      runnerId: "r1",
+      apiKey: "key1",
+      relayUrl: "ws://localhost:9999/_tunnel",
+      autoReconnect: false,
+    });
+
+    (client as any).consecutiveFailures = 0;
+    (client as any).registeredThisConnection = true; // Was registered
+
+    // Simulate close — should NOT increment
+    if (!(client as any).registeredThisConnection) {
+      (client as any).consecutiveFailures++;
+    }
+
+    expect((client as any).consecutiveFailures).toBe(0);
+  });
+
+  test("default maxConsecutiveFailures is 10", () => {
+    const client = new TunnelClient({
+      runnerId: "r1",
+      apiKey: "key1",
+      relayUrl: "ws://localhost:9999/_tunnel",
+    });
+    expect((client as any).maxConsecutiveFailures).toBe(10);
+  });
+
+  test("default maxReconnectDelayMs is 60000", () => {
+    const client = new TunnelClient({
+      runnerId: "r1",
+      apiKey: "key1",
+      relayUrl: "ws://localhost:9999/_tunnel",
+    });
+    expect((client as any).maxReconnectDelayMs).toBe(60000);
   });
 });

--- a/packages/tunnel/src/client.ts
+++ b/packages/tunnel/src/client.ts
@@ -22,8 +22,12 @@ export interface TunnelClientOptions {
   log?: TunnelClientLogger;
   /** Auto-reconnect on disconnect. Default true. */
   autoReconnect?: boolean;
-  /** Reconnect delay in ms. Default 3000. */
+  /** Initial reconnect delay in ms. Default 3000. */
   reconnectDelayMs?: number;
+  /** Maximum reconnect delay in ms (exponential backoff cap). Default 60000. */
+  maxReconnectDelayMs?: number;
+  /** Stop reconnecting after this many consecutive failures. Default 10. */
+  maxConsecutiveFailures?: number;
 }
 
 export interface TunnelClientLogger {
@@ -76,10 +80,17 @@ export class TunnelClient extends EventEmitter {
   private log: TunnelClientLogger;
   private autoReconnect: boolean;
   private reconnectDelayMs: number;
+  private maxReconnectDelayMs: number;
+  private maxConsecutiveFailures: number;
 
   private ws: WebSocket | null = null;
   private exposedPorts = new Set<number>();
   private disposed = false;
+
+  /** Tracks consecutive connection failures (never received "registered"). */
+  private consecutiveFailures = 0;
+  /** Whether a "registered" message was received for the current connection. */
+  private registeredThisConnection = false;
 
   /** Active HTTP requests: requestId → { controller, req } */
   private activeRequests = new Map<string, { controller: AbortController; req: http.ClientRequest }>();
@@ -94,6 +105,15 @@ export class TunnelClient extends EventEmitter {
     this.log = options.log ?? noopLog;
     this.autoReconnect = options.autoReconnect ?? true;
     this.reconnectDelayMs = options.reconnectDelayMs ?? 3000;
+    this.maxReconnectDelayMs = options.maxReconnectDelayMs ?? 60_000;
+    this.maxConsecutiveFailures = options.maxConsecutiveFailures ?? 10;
+  }
+
+  /** Current reconnect delay (increases with consecutive failures). */
+  private get currentReconnectDelay(): number {
+    if (this.consecutiveFailures === 0) return this.reconnectDelayMs;
+    const delay = this.reconnectDelayMs * Math.pow(2, this.consecutiveFailures - 1);
+    return Math.min(delay, this.maxReconnectDelayMs);
   }
 
   connect(): void {
@@ -102,6 +122,7 @@ export class TunnelClient extends EventEmitter {
       return;
     }
 
+    this.registeredThisConnection = false;
     this.log.info("[tunnel-client] Connecting to", this.relayUrl);
     this.ws = new WebSocket(this.relayUrl);
 
@@ -118,14 +139,43 @@ export class TunnelClient extends EventEmitter {
       this.log.info("[tunnel-client] Disconnected");
       this.cleanup();
       this.ws = null;
+
+      if (!this.registeredThisConnection) {
+        this.consecutiveFailures++;
+      }
+
       this.emit("disconnect");
+
       if (this.autoReconnect && !this.disposed) {
-        setTimeout(() => this.connect(), this.reconnectDelayMs);
+        if (this.consecutiveFailures >= this.maxConsecutiveFailures) {
+          this.log.warn(
+            `[tunnel-client] Giving up after ${this.consecutiveFailures} consecutive failed connections.`,
+            "The relay server may not support the /_tunnel endpoint — upgrade the server or run 'pizza web'.",
+          );
+          this.emit("disabled", {
+            reason: "max-failures",
+            failures: this.consecutiveFailures,
+            relayUrl: this.relayUrl,
+          });
+          return;
+        }
+        const delay = this.currentReconnectDelay;
+        if (this.consecutiveFailures > 0) {
+          this.log.info(`[tunnel-client] Reconnecting in ${Math.round(delay / 1000)}s (attempt ${this.consecutiveFailures + 1}/${this.maxConsecutiveFailures})`);
+        }
+        setTimeout(() => this.connect(), delay);
       }
     });
 
-    this.ws.addEventListener("error", (error) => {
-      this.log.error("[tunnel-client] WebSocket error:", error);
+    this.ws.addEventListener("error", (event) => {
+      // ErrorEvent.toString() produces "[object ErrorEvent]" which is useless.
+      // Extract the actual error message if available.
+      const msg = (event as any)?.message
+        ?? (event as any)?.error?.message
+        ?? (event as any)?.error
+        ?? (event as any)?.type
+        ?? "unknown error";
+      this.log.error("[tunnel-client] WebSocket error:", msg);
     });
   }
 
@@ -171,6 +221,8 @@ export class TunnelClient extends EventEmitter {
 
     switch (msg.type) {
       case "registered":
+        this.registeredThisConnection = true;
+        this.consecutiveFailures = 0;
         this.log.info("[tunnel-client] Registered as", msg.runnerId);
         this.emit("registered", msg.runnerId);
         break;

--- a/packages/ui/src/App.hook-order.test.ts
+++ b/packages/ui/src/App.hook-order.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+
+const CALLBACK_NAMES = [
+  "handleToggleDark",
+  "handleShowApiKeys",
+  "handleShowRunners",
+  "handleShowShortcuts",
+  "handleShowHiddenModels",
+  "handleChangePassword",
+  "handleToggleSidebar",
+  "handleMobileShowApiKeys",
+  "handleMobileShowRunners",
+  "handleMobileShowHiddenModels",
+  "handleMobileChangePassword",
+  "handleSessionSwitcherOpenChange",
+] as const;
+
+describe("App auth guard hook ordering", () => {
+  test("declares stable header callbacks before auth early returns", () => {
+    const path = new URL("./App.tsx", import.meta.url);
+    const sourceText = readFileSync(path, "utf8");
+    const sourceFile = ts.createSourceFile(
+      path.pathname,
+      sourceText,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.TSX,
+    );
+
+    const appDecl = sourceFile.statements.find(
+      (stmt): stmt is ts.FunctionDeclaration =>
+        ts.isFunctionDeclaration(stmt) && stmt.name?.text === "App",
+    );
+
+    expect(appDecl).toBeDefined();
+    expect(appDecl?.body).toBeDefined();
+
+    const statements = appDecl!.body!.statements;
+    const statementText = (index: number) => statements[index]!.getText(sourceFile);
+
+    const pendingGuardIndex = statements.findIndex((stmt) =>
+      ts.isIfStatement(stmt) && stmt.getText(sourceFile).startsWith("if (isPending)"),
+    );
+    const sessionGuardIndex = statements.findIndex((stmt) =>
+      ts.isIfStatement(stmt) && stmt.getText(sourceFile).startsWith("if (!session)"),
+    );
+
+    expect(pendingGuardIndex).toBeGreaterThanOrEqual(0);
+    expect(sessionGuardIndex).toBeGreaterThanOrEqual(0);
+
+    for (const name of CALLBACK_NAMES) {
+      const idx = statements.findIndex((stmt) =>
+        ts.isVariableStatement(stmt) &&
+        stmt.declarationList.declarations.some(
+          (decl) => ts.isIdentifier(decl.name) && decl.name.text === name,
+        ),
+      );
+
+      expect(idx, `${name} should be declared in App()`).toBeGreaterThanOrEqual(0);
+      expect(
+        idx,
+        `${name} must stay above the isPending early return to preserve hook order.\nStatement was: ${idx >= 0 ? statementText(idx) : "<missing>"}`,
+      ).toBeLessThan(pendingGuardIndex);
+      expect(
+        idx,
+        `${name} must stay above the !session early return to preserve hook order.\nStatement was: ${idx >= 0 ? statementText(idx) : "<missing>"}`,
+      ).toBeLessThan(sessionGuardIndex);
+    }
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -83,6 +83,7 @@ import {
 import { HiddenModelsManager, loadHiddenModels, fetchHiddenModels, modelKey } from "@/components/HiddenModelsManager";
 import { ChangePasswordDialog } from "@/components/ChangePasswordDialog";
 import { DegradedBanner } from "@/components/DegradedBanner";
+import { RunnerWarningBanner } from "@/components/RunnerWarningBanner";
 import { ShortcutsDialog } from "@/components/ShortcutsDialog";
 import {
   beginInputAttempt,
@@ -3585,6 +3586,7 @@ export function App() {
         Skip to content
       </a>
       <DegradedBanner relayStatus={relayStatus} />
+      <RunnerWarningBanner runners={feedRunners} />
       {/* ── Desktop header (memoized — skips re-render on same-runner session switch) ── */}
       <DesktopHeader
         relayStatus={relayStatus}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3530,6 +3530,29 @@ export function App() {
     return tabs.some((tab) => tab.id === combinedActiveTab) ? combinedActiveTab : tabs[0]!.id;
   }, [combinedActiveTab]);
 
+  // Stable callbacks for memoized header components.
+  //
+  // Important: these hooks must stay ABOVE the auth/loading early returns
+  // below. Moving them under `if (isPending)` / `if (!session)` changes the
+  // number of hooks executed between renders and triggers React error #310
+  // (“Rendered more hooks than during the previous render”).
+  //
+  // Keeping them here also preserves referential stability so React.memo can
+  // skip re-rendering when only session-scoped state changes.
+  const handleToggleDark = React.useCallback(() => setIsDark((d) => !d), []);
+  const handleShowApiKeys = React.useCallback(() => { setShowApiKeys(true); setShowRunners(false); }, []);
+  const handleShowRunners = React.useCallback(() => { setShowRunners(true); setShowApiKeys(false); setActiveSessionId(null); }, []);
+  const handleShowShortcuts = React.useCallback(() => setShowShortcutsHelp(true), []);
+  const handleShowHiddenModels = React.useCallback(() => setHiddenModelsOpen(true), []);
+  const handleChangePassword = React.useCallback(() => setChangePasswordOpen(true), []);
+  const handleToggleSidebar = React.useCallback(() => setSidebarOpen((prev) => !prev), []);
+  // Mobile-specific variants that also close the sidebar
+  const handleMobileShowApiKeys = React.useCallback(() => { setShowApiKeys(true); setShowRunners(false); setSidebarOpen(false); }, []);
+  const handleMobileShowRunners = React.useCallback(() => { setShowRunners(true); setShowApiKeys(false); setActiveSessionId(null); setSidebarOpen(false); }, []);
+  const handleMobileShowHiddenModels = React.useCallback(() => { setHiddenModelsOpen(true); setSidebarOpen(false); }, []);
+  const handleMobileChangePassword = React.useCallback(() => { setChangePasswordOpen(true); setSidebarOpen(false); }, []);
+  const handleSessionSwitcherOpenChange = React.useCallback((open: boolean) => setSessionSwitcherOpen(open), []);
+
   if (isPending) {
     return (
       <div className="flex h-[100dvh] w-full flex-col items-center justify-center bg-background gap-2 animate-in fade-in duration-300">
@@ -3546,23 +3569,6 @@ export function App() {
   const userName = rawUser && typeof rawUser.name === "string" ? (rawUser.name as string) : "";
   const userEmail = rawUser && typeof rawUser.email === "string" ? (rawUser.email as string) : "";
   const userLabel = userName || userEmail || "Account";
-
-  // Stable callbacks for memoized header components — these must not change
-  // between renders so React.memo can skip re-rendering when only session-
-  // scoped state changes.
-  const handleToggleDark = React.useCallback(() => setIsDark((d) => !d), []);
-  const handleShowApiKeys = React.useCallback(() => { setShowApiKeys(true); setShowRunners(false); }, []);
-  const handleShowRunners = React.useCallback(() => { setShowRunners(true); setShowApiKeys(false); setActiveSessionId(null); }, []);
-  const handleShowShortcuts = React.useCallback(() => setShowShortcutsHelp(true), []);
-  const handleShowHiddenModels = React.useCallback(() => setHiddenModelsOpen(true), []);
-  const handleChangePassword = React.useCallback(() => setChangePasswordOpen(true), []);
-  const handleToggleSidebar = React.useCallback(() => setSidebarOpen((prev) => !prev), []);
-  // Mobile-specific variants that also close the sidebar
-  const handleMobileShowApiKeys = React.useCallback(() => { setShowApiKeys(true); setShowRunners(false); setSidebarOpen(false); }, []);
-  const handleMobileShowRunners = React.useCallback(() => { setShowRunners(true); setShowApiKeys(false); setActiveSessionId(null); setSidebarOpen(false); }, []);
-  const handleMobileShowHiddenModels = React.useCallback(() => { setHiddenModelsOpen(true); setSidebarOpen(false); }, []);
-  const handleMobileChangePassword = React.useCallback(() => { setChangePasswordOpen(true); setSidebarOpen(false); }, []);
-  const handleSessionSwitcherOpenChange = React.useCallback((open: boolean) => setSessionSwitcherOpen(open), []);
 
   const activeModelKey = activeModel ? `${activeModel.provider}/${activeModel.id}` : "";
   const visibleModels = availableModels.filter(

--- a/packages/ui/src/components/RunnerWarningBanner.tsx
+++ b/packages/ui/src/components/RunnerWarningBanner.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+import { X } from "lucide-react";
+import type { RunnerInfo } from "@pizzapi/protocol";
+
+/**
+ * Dismissable amber banner shown when any connected runner has active warnings
+ * (e.g. tunnel connection failures, version mismatches).
+ *
+ * Automatically clears when the runner removes the warning. Dismissible per-session
+ * — dismissing hides the banner until a new (different) warning arrives.
+ */
+export function RunnerWarningBanner({ runners }: { runners: RunnerInfo[] }) {
+    // Collect all warnings across all runners, tagged with runner name
+    const allWarnings = React.useMemo(() => {
+        const result: Array<{ runner: string; message: string; key: string }> = [];
+        for (const r of runners) {
+            if (!r.warnings?.length) continue;
+            const name = r.name ?? r.runnerId.slice(0, 8);
+            for (const msg of r.warnings) {
+                result.push({ runner: name, message: msg, key: `${r.runnerId}:${msg}` });
+            }
+        }
+        return result;
+    }, [runners]);
+
+    // Track which warning keys have been dismissed
+    const [dismissed, setDismissed] = React.useState<Set<string>>(new Set());
+
+    // When warnings change, un-dismiss any that are no longer present (so if
+    // the same warning comes back later, it shows again)
+    const prevKeysRef = React.useRef<Set<string>>(new Set());
+    React.useEffect(() => {
+        const currentKeys = new Set(allWarnings.map((w) => w.key));
+        const removed = [...prevKeysRef.current].filter((k) => !currentKeys.has(k));
+        if (removed.length > 0) {
+            setDismissed((prev) => {
+                const next = new Set(prev);
+                for (const k of removed) next.delete(k);
+                return next.size !== prev.size ? next : prev;
+            });
+        }
+        prevKeysRef.current = currentKeys;
+    }, [allWarnings]);
+
+    const visible = allWarnings.filter((w) => !dismissed.has(w.key));
+    if (visible.length === 0) return null;
+
+    return (
+        <>
+            {visible.map((w) => (
+                <div
+                    key={w.key}
+                    role="alert"
+                    className="flex items-center justify-between gap-3 px-4 py-2 text-sm bg-amber-500/10 text-amber-600 dark:text-amber-400 border-b border-amber-500/20"
+                >
+                    <span>
+                        <span aria-hidden="true">⚠️</span>{" "}
+                        <span className="font-medium">{w.runner}:</span>{" "}
+                        {w.message}
+                    </span>
+                    <button
+                        type="button"
+                        aria-label="Dismiss warning"
+                        onClick={() =>
+                            setDismissed((prev) => new Set(prev).add(w.key))
+                        }
+                        className="shrink-0 rounded p-0.5 hover:bg-amber-500/20 transition-colors"
+                    >
+                        <X className="size-4" />
+                    </button>
+                </div>
+            ))}
+        </>
+    );
+}


### PR DESCRIPTION
## Problem

Production crash: React error #310 — **"Rendered more hooks than during the previous render."**

The `App` component had 12 `React.useCallback` hooks declared **after** the `if (isPending)` / `if (!session)` early returns. When auth state transitioned (e.g. initial load, session refresh flicker during heavy WebSocket activity), React saw a different hook count between renders and threw.

## Root Cause

Introduced in #355 (`3e58f14f`) — the session-scoping refactor moved stable header callbacks below the auth guards, making them conditional.

## Fix

Moved the 12 stable `useCallback` hooks above the auth early returns so hook count is invariant across all render paths. Added an inline comment explaining the constraint.

## Regression Test

`packages/ui/src/App.hook-order.test.ts` — parses `App.tsx` with the TypeScript compiler API and asserts every stable header callback is declared before both auth guards. Fails immediately if someone moves them back below.

## Verification

- `bun test packages/ui/src` ✅ (677 pass, 0 fail)
- `bun run typecheck` ✅
- `bun run build:ui` ✅
