### PR TITLE
feat: consistent error messaging across UI

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -62,6 +62,7 @@ import { DockedPanelGroup } from "@/components/DockedPanelGroup";
 import { ViewerSocketContext } from "@/lib/viewer-socket-context";
 import { HubSocketContext } from "@/lib/hub-socket-context";
 import { shouldStopViewerReconnect } from "@/lib/viewer-connection";
+import { mapUserError } from "@/lib/user-error-message";
 import { getConfirmedMetaSubscriptionTargets } from "@/lib/meta-subscriptions";
 import { useRunnerServices, attachServiceAnnounceListener, seedServiceCache, setViewerSwitchGeneration } from "@/hooks/useRunnerServices";
 import { ServicePanelButtons, useServicePanelState } from "@/components/service-panels/ServicePanels";
@@ -2557,12 +2558,23 @@ export function App() {
         }
         if (!activeSessionRef.current) return;
         lastViewerEventAtRef.current = Date.now();
-        setViewerStatus(data.message || "Failed to load session");
+        const mapped = mapUserError({
+          error: data.message,
+          context: "viewer_connection",
+          fallbackMessage: "Failed to load session.",
+        });
+        console.error("Viewer socket error:", mapped.technicalMessage, data);
+        setViewerStatus(mapped.userMessage);
       });
 
-      nextSocket.on("connect_error", () => {
+      nextSocket.on("connect_error", (err) => {
         if (activeSessionRef.current) {
-          setViewerStatus("Connection error");
+          const mapped = mapUserError({
+            error: err,
+            context: "viewer_connection",
+          });
+          console.error("Viewer socket connect_error:", err);
+          setViewerStatus(mapped.userMessage);
         }
       });
 
@@ -3163,16 +3175,26 @@ export function App() {
         body: JSON.stringify(payload),
       });
 
-      const body = await res.json().catch(() => null) as any;
+      const body = await res.json().catch(() => null) as { error?: string; sessionId?: string } | null;
       if (!res.ok) {
-        const msg = body && typeof body.error === "string" ? body.error : `Spawn failed (HTTP ${res.status})`;
-        setViewerStatus(msg);
+        const mapped = mapUserError({
+          error: body?.error,
+          statusCode: res.status,
+          context: "session_spawn",
+        });
+        console.error("Failed to spawn session:", mapped.technicalMessage, body);
+        setViewerStatus(mapped.userMessage);
         return;
       }
 
       sessionId = typeof body?.sessionId === "string" ? body.sessionId : null;
       if (!sessionId) {
-        setViewerStatus("Spawn failed: missing sessionId");
+        const mapped = mapUserError({
+          error: "Spawn failed: missing sessionId",
+          context: "session_spawn",
+        });
+        console.error("Failed to spawn session:", mapped.technicalMessage, body);
+        setViewerStatus(mapped.userMessage);
         return;
       }
 
@@ -3189,8 +3211,12 @@ export function App() {
       handleOpenSession(sessionId);
       setViewerStatus("Connecting…");
     } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      setViewerStatus(`Spawn failed: ${detail}`);
+      const mapped = mapUserError({
+        error: err,
+        context: "session_spawn",
+      });
+      console.error("Failed to spawn session:", err);
+      setViewerStatus(mapped.userMessage);
     } finally {
       setSpawningSession(false);
     }
@@ -3208,14 +3234,26 @@ export function App() {
       body: JSON.stringify(payload),
     });
 
-    const body = await res.json().catch(() => null) as any;
+    const body = await res.json().catch(() => null) as { error?: string; sessionId?: string } | null;
     if (!res.ok) {
-      const msg = body && typeof body.error === "string" ? body.error : `Spawn failed (HTTP ${res.status})`;
-      throw new Error(msg);
+      const mapped = mapUserError({
+        error: body?.error,
+        statusCode: res.status,
+        context: "session_spawn",
+      });
+      console.error("Failed to spawn session from wizard:", mapped.technicalMessage, body);
+      throw new Error(mapped.userMessage);
     }
 
     const sessionId = typeof body?.sessionId === "string" ? body.sessionId : null;
-    if (!sessionId) throw new Error("Spawn failed: missing sessionId");
+    if (!sessionId) {
+      const mapped = mapUserError({
+        error: "Spawn failed: missing sessionId",
+        context: "session_spawn",
+      });
+      console.error("Spawn response missing sessionId:", mapped.technicalMessage, body);
+      throw new Error(mapped.userMessage);
+    }
 
     setNewSessionOpen(false);
 
@@ -3321,16 +3359,26 @@ export function App() {
         }),
       });
 
-      const body = await res.json().catch(() => null) as any;
+      const body = await res.json().catch(() => null) as { error?: string; sessionId?: string } | null;
       if (!res.ok) {
-        const msg = body && typeof body.error === "string" ? body.error : `Spawn failed (HTTP ${res.status})`;
-        setViewerStatus(msg);
+        const mapped = mapUserError({
+          error: body?.error,
+          statusCode: res.status,
+          context: "session_spawn",
+        });
+        console.error("Failed to spawn agent session:", mapped.technicalMessage, body);
+        setViewerStatus(mapped.userMessage);
         return;
       }
 
       const sessionId = typeof body?.sessionId === "string" ? body.sessionId : null;
       if (!sessionId) {
-        setViewerStatus("Spawn failed: missing sessionId");
+        const mapped = mapUserError({
+          error: "Spawn failed: missing sessionId",
+          context: "session_spawn",
+        });
+        console.error("Agent spawn response missing sessionId:", mapped.technicalMessage, body);
+        setViewerStatus(mapped.userMessage);
         return;
       }
 
@@ -3344,8 +3392,12 @@ export function App() {
       handleOpenSession(sessionId);
       setViewerStatus("Connecting…");
     } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      setViewerStatus(`Agent spawn failed: ${detail}`);
+      const mapped = mapUserError({
+        error: err,
+        context: "session_spawn",
+      });
+      console.error("Failed to spawn agent session:", err);
+      setViewerStatus(mapped.userMessage);
     }
   }, [activeSessionId, liveSessions, handleOpenSession, waitForSessionToGoLive]);
 

--- a/packages/ui/src/components/RunnerManager.tsx
+++ b/packages/ui/src/components/RunnerManager.tsx
@@ -15,9 +15,7 @@ import {
 import { ErrorAlert } from "@/components/ui/error-alert";
 import type { HubSession } from "@/components/SessionSidebar";
 import type { RunnerInfo } from "@pizzapi/protocol";
-import { createLogger } from "@pizzapi/tools";
-
-const log = createLogger("runner-ui");
+import { mapUserError } from "@/lib/user-error-message";
 
 export interface RunnerManagerProps {
     /** Runner list from the /runners WS feed — passed from App.tsx (single hook instance) */
@@ -107,11 +105,22 @@ export function RunnerManager({
                 credentials: "include",
             });
             if (!res.ok) {
-                const data = await res.json();
-                setError(`Failed to restart runner: ${data.error || "Unknown error"}`);
+                const data = await res.json().catch(() => null) as { error?: string } | null;
+                const mapped = mapUserError({
+                    error: data?.error,
+                    statusCode: res.status,
+                    context: "runner_restart",
+                });
+                console.error("Failed to restart runner:", mapped.technicalMessage, data);
+                setError(mapped.userMessage);
             }
         } catch (err) {
-            log.error("Failed to restart runner:", err);
+            const mapped = mapUserError({
+                error: err,
+                context: "runner_restart",
+            });
+            console.error("Failed to restart runner:", err);
+            setError(mapped.userMessage);
         } finally {
             setTimeout(() => {
                 setRestarting((prev) => {
@@ -141,11 +150,22 @@ export function RunnerManager({
                 credentials: "include",
             });
             if (!res.ok) {
-                const data = await res.json();
-                setError(`Failed to stop runner: ${data.error || "Unknown error"}`);
+                const data = await res.json().catch(() => null) as { error?: string } | null;
+                const mapped = mapUserError({
+                    error: data?.error,
+                    statusCode: res.status,
+                    context: "runner_stop",
+                });
+                console.error("Failed to stop runner:", mapped.technicalMessage, data);
+                setError(mapped.userMessage);
             }
         } catch (err) {
-            log.error("Failed to stop runner:", err);
+            const mapped = mapUserError({
+                error: err,
+                context: "runner_stop",
+            });
+            console.error("Failed to stop runner:", err);
+            setError(mapped.userMessage);
         } finally {
             setTimeout(() => {
                 setStopping((prev) => {
@@ -168,12 +188,25 @@ export function RunnerManager({
             headers: { "content-type": "application/json" },
             body: JSON.stringify({ runnerId, ...(cwd ? { cwd } : {}) }),
         });
-        const body = await res.json().catch(() => null) as any;
+        const body = await res.json().catch(() => null) as { error?: string; sessionId?: string } | null;
         if (!res.ok) {
-            throw new Error(body?.error || `Spawn failed (HTTP ${res.status})`);
+            const mapped = mapUserError({
+                error: body?.error,
+                statusCode: res.status,
+                context: "session_spawn",
+            });
+            console.error("Failed to spawn session:", mapped.technicalMessage, body);
+            throw new Error(mapped.userMessage);
         }
         const sessionId = body?.sessionId;
-        if (!sessionId) throw new Error("Spawn failed: missing sessionId in response");
+        if (!sessionId) {
+            const mapped = mapUserError({
+                error: "Spawn failed: missing sessionId in response",
+                context: "session_spawn",
+            });
+            console.error("Failed to spawn session:", mapped.technicalMessage, body);
+            throw new Error(mapped.userMessage);
+        }
 
         setSpawnRunnerId(null);
         setPendingSessionId(sessionId);

--- a/packages/ui/src/lib/user-error-message.test.ts
+++ b/packages/ui/src/lib/user-error-message.test.ts
@@ -98,4 +98,65 @@ describe("mapUserError", () => {
         expect(result.userMessage).toContain("Couldn't reach the selected runner");
         expect(result.technicalMessage).toBe("HTTP 502");
     });
+
+    // Regression: Socket.IO auth failures during viewer connect_error
+    //
+    // When the server rejects the connection with HTTP 401/403, Socket.IO
+    // reports err.message = "xhr poll error" (the transport error) but places
+    // the actual HTTP status in err.description.status.  Without inspecting
+    // that field, mapUserError would misclassify these as network errors and
+    // tell the user to "check your network" instead of "sign in again".
+
+    test("Socket.IO connect_error 401 via err.description.status → sign-in guidance (not network error)", () => {
+        const err = new Error("xhr poll error");
+        (err as unknown as Record<string, unknown>).description = { status: 401 };
+
+        const result = mapUserError({
+            error: err,
+            context: "viewer_connection",
+        });
+
+        expect(result.userMessage).toContain("Sign in");
+        expect(result.userMessage).not.toContain("Lost connection");
+        expect(result.technicalMessage).toBe("xhr poll error");
+    });
+
+    test("Socket.IO connect_error 403 via err.description.status → access guidance (not network error)", () => {
+        const err = new Error("xhr poll error");
+        (err as unknown as Record<string, unknown>).description = { status: 403 };
+
+        const result = mapUserError({
+            error: err,
+            context: "viewer_connection",
+        });
+
+        expect(result.userMessage).toContain("access");
+        expect(result.userMessage).not.toContain("Lost connection");
+    });
+
+    test("Socket.IO connect_error 401 via err.context.status → sign-in guidance", () => {
+        const err = new Error("xhr poll error");
+        (err as unknown as Record<string, unknown>).context = { status: 401 };
+
+        const result = mapUserError({
+            error: err,
+            context: "viewer_connection",
+        });
+
+        expect(result.userMessage).toContain("Sign in");
+        expect(result.userMessage).not.toContain("Lost connection");
+    });
+
+    test("Socket.IO connect_error without status stays as network error", () => {
+        // Plain "xhr poll error" with no description/context status should still
+        // be treated as a network/transport error.
+        const err = new Error("xhr poll error");
+
+        const result = mapUserError({
+            error: err,
+            context: "viewer_connection",
+        });
+
+        expect(result.userMessage).toContain("Lost connection");
+    });
 });

--- a/packages/ui/src/lib/user-error-message.test.ts
+++ b/packages/ui/src/lib/user-error-message.test.ts
@@ -79,6 +79,67 @@ describe("mapUserError", () => {
         expect(result.userMessage).toContain("couldn't be loaded");
     });
 
+    // session_spawn HTTP 400 — distinct server error messages should be preserved
+
+    test("maps cwd-inaccessible 400 to folder-path hint", () => {
+        const result = mapUserError({
+            error: "Runner cannot access cwd: /home/user/secret",
+            statusCode: 400,
+            context: "session_spawn",
+        });
+
+        expect(result.userMessage).toContain("can't access that folder");
+        expect(result.userMessage).toContain("folder path");
+        expect(result.technicalMessage).toBe("Runner cannot access cwd: /home/user/secret");
+    });
+
+    test("maps invalid-agent-name 400 to agent guidance (not folder hint)", () => {
+        const result = mapUserError({
+            error: "Invalid agent name",
+            statusCode: 400,
+            context: "session_spawn",
+        });
+
+        expect(result.userMessage).toContain("agent name is invalid");
+        expect(result.userMessage).not.toContain("folder path");
+        expect(result.technicalMessage).toBe("Invalid agent name");
+    });
+
+    test("maps requested-model-unavailable 400 to model guidance", () => {
+        const result = mapUserError({
+            error: "Requested model is not available",
+            statusCode: 400,
+            context: "session_spawn",
+        });
+
+        expect(result.userMessage).toContain("model is not available");
+        expect(result.userMessage).not.toContain("folder path");
+        expect(result.technicalMessage).toBe("Requested model is not available");
+    });
+
+    test("passes through runner ack error message for 400 (not folder hint)", () => {
+        const result = mapUserError({
+            error: "Runner rejected spawn: unsupported prompt format",
+            statusCode: 400,
+            context: "session_spawn",
+        });
+
+        // Server message surfaced directly rather than replaced with folder hint
+        expect(result.userMessage).toContain("unsupported prompt format");
+        expect(result.userMessage).not.toContain("folder path");
+        expect(result.technicalMessage).toBe("Runner rejected spawn: unsupported prompt format");
+    });
+
+    test("uses generic 400 message when no body text available", () => {
+        const result = mapUserError({
+            statusCode: 400,
+            context: "session_spawn",
+        });
+
+        expect(result.userMessage).toContain("Couldn't start that session");
+        expect(result.userMessage).not.toContain("folder path");
+    });
+
     test("uses context fallback for unknown errors", () => {
         const result = mapUserError({
             error: "Unexpected explosion",

--- a/packages/ui/src/lib/user-error-message.test.ts
+++ b/packages/ui/src/lib/user-error-message.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { mapUserError } from "./user-error-message.js";
+
+describe("mapUserError", () => {
+    test("maps runner-not-found errors to a user-friendly message", () => {
+        const result = mapUserError({
+            error: "Runner not found",
+            context: "session_spawn",
+        });
+
+        expect(result.userMessage).toContain("runner is no longer available");
+        expect(result.technicalMessage).toBe("Runner not found");
+    });
+
+    test("maps spawn delivery failures to runner guidance", () => {
+        const result = mapUserError({
+            error: "Failed to send spawn request to runner",
+            context: "session_spawn",
+        });
+
+        expect(result.userMessage).toContain("Couldn't reach the selected runner");
+    });
+
+    test("maps missing session id to recovery guidance", () => {
+        const result = mapUserError({
+            error: "Spawn failed: missing sessionId",
+            context: "session_spawn",
+        });
+
+        expect(result.userMessage).toContain("didn't return full session details");
+    });
+
+    test("maps viewer connection network failures", () => {
+        const result = mapUserError({
+            error: "connect_error: xhr poll error",
+            context: "viewer_connection",
+        });
+
+        expect(result.userMessage).toContain("Lost connection to PizzaPi");
+    });
+
+    test("uses context fallback for unknown errors", () => {
+        const result = mapUserError({
+            error: "Unexpected explosion",
+            context: "runner_restart",
+        });
+
+        expect(result.userMessage).toBe("Couldn't restart the runner. Please try again.");
+    });
+
+    test("maps HTTP 502 via status code", () => {
+        const result = mapUserError({
+            statusCode: 502,
+            context: "session_spawn",
+            fallbackMessage: "fallback",
+        });
+
+        expect(result.userMessage).toContain("Couldn't reach the selected runner");
+        expect(result.technicalMessage).toBe("HTTP 502");
+    });
+});

--- a/packages/ui/src/lib/user-error-message.test.ts
+++ b/packages/ui/src/lib/user-error-message.test.ts
@@ -30,13 +30,53 @@ describe("mapUserError", () => {
         expect(result.userMessage).toContain("didn't return full session details");
     });
 
-    test("maps viewer connection network failures", () => {
+    test("maps viewer connection xhr poll error (real socket.io format)", () => {
+        // Real socket.io connect_error delivers an Error object with .message = "xhr poll error" (no prefix)
         const result = mapUserError({
-            error: "connect_error: xhr poll error",
+            error: new Error("xhr poll error"),
             context: "viewer_connection",
         });
 
         expect(result.userMessage).toContain("Lost connection to PizzaPi");
+    });
+
+    test("maps viewer connection transport error (real socket.io format)", () => {
+        const result = mapUserError({
+            error: new Error("transport error"),
+            context: "viewer_connection",
+        });
+
+        expect(result.userMessage).toContain("Lost connection to PizzaPi");
+    });
+
+    test("maps 'Session not found' server message to permanent-removal message", () => {
+        const result = mapUserError({
+            error: "Session not found",
+            context: "viewer_connection",
+            fallbackMessage: "Failed to load session.",
+        });
+
+        expect(result.userMessage).toContain("no longer exists");
+        expect(result.userMessage).not.toContain("Failed to load session");
+        expect(result.technicalMessage).toBe("Session not found");
+    });
+
+    test("maps 'Session snapshot not available' to refresh guidance", () => {
+        const result = mapUserError({
+            error: "Session snapshot not available",
+            context: "viewer_connection",
+        });
+
+        expect(result.userMessage).toContain("couldn't be loaded");
+    });
+
+    test("maps 'Failed to load session snapshot' to refresh guidance", () => {
+        const result = mapUserError({
+            error: "Failed to load session snapshot",
+            context: "viewer_connection",
+        });
+
+        expect(result.userMessage).toContain("couldn't be loaded");
     });
 
     test("uses context fallback for unknown errors", () => {

--- a/packages/ui/src/lib/user-error-message.ts
+++ b/packages/ui/src/lib/user-error-message.ts
@@ -145,8 +145,35 @@ export function mapUserError(input: UserErrorInput): UserErrorResult {
     }
 
     if (context === "session_spawn" && statusCode === 400) {
+        // Only show the folder-path hint when the error is actually about cwd access
+        if (normalized.includes("runner cannot access cwd") || normalized.includes("cannot access cwd")) {
+            return {
+                userMessage: "Couldn't start that session — the runner can't access that folder. Check the folder path and try again.",
+                technicalMessage,
+            };
+        }
+        if (normalized.includes("invalid agent name")) {
+            return {
+                userMessage: "The agent name is invalid. Check the agent configuration and try again.",
+                technicalMessage,
+            };
+        }
+        if (normalized.includes("requested model is not available")) {
+            return {
+                userMessage: "The requested model is not available. Select a different model and try again.",
+                technicalMessage,
+            };
+        }
+        // For other 400s (including runner ack errors), surface the server's message directly
+        // rather than replacing it with a misleading folder-path hint.
+        if (technicalMessage && technicalMessage !== `HTTP ${statusCode}`) {
+            return {
+                userMessage: technicalMessage,
+                technicalMessage,
+            };
+        }
         return {
-            userMessage: "Couldn't start that session with the selected options. Check the folder path and try again.",
+            userMessage: "Couldn't start that session. Check the options and try again.",
             technicalMessage,
         };
     }

--- a/packages/ui/src/lib/user-error-message.ts
+++ b/packages/ui/src/lib/user-error-message.ts
@@ -1,0 +1,137 @@
+export type UserErrorContext =
+    | "session_spawn"
+    | "runner_restart"
+    | "runner_stop"
+    | "viewer_connection"
+    | "generic";
+
+export interface UserErrorInput {
+    error?: unknown;
+    statusCode?: number;
+    context?: UserErrorContext;
+    fallbackMessage?: string;
+}
+
+export interface UserErrorResult {
+    userMessage: string;
+    technicalMessage: string;
+}
+
+function coerceErrorMessage(error: unknown): string {
+    if (typeof error === "string") return error.trim();
+    if (error instanceof Error) return error.message.trim();
+    if (error && typeof error === "object") {
+        const maybeMessage = (error as { message?: unknown }).message;
+        if (typeof maybeMessage === "string") return maybeMessage.trim();
+    }
+    return "";
+}
+
+function extractStatusCode(message: string): number | null {
+    const match = message.match(/\bHTTP\s*([1-5]\d{2})\b/i);
+    if (!match) return null;
+    const parsed = Number(match[1]);
+    return Number.isInteger(parsed) ? parsed : null;
+}
+
+function defaultFallbackForContext(context: UserErrorContext): string {
+    switch (context) {
+        case "session_spawn":
+            return "Couldn't start a new session. Please try again.";
+        case "runner_restart":
+            return "Couldn't restart the runner. Please try again.";
+        case "runner_stop":
+            return "Couldn't stop the runner. Please try again.";
+        case "viewer_connection":
+            return "Couldn't connect to the session. Check your connection and try again.";
+        default:
+            return "Something went wrong. Please try again.";
+    }
+}
+
+export function mapUserError(input: UserErrorInput): UserErrorResult {
+    const context = input.context ?? "generic";
+    const technicalFromError = coerceErrorMessage(input.error);
+    const statusCode = input.statusCode ?? extractStatusCode(technicalFromError) ?? undefined;
+    const technicalMessage = technicalFromError || (statusCode ? `HTTP ${statusCode}` : "Unknown error");
+
+    const normalized = technicalMessage.toLowerCase();
+
+    const fallback = input.fallbackMessage ?? defaultFallbackForContext(context);
+
+    if (normalized.includes("runner not found")) {
+        return {
+            userMessage: "That runner is no longer available. Refresh the runner list and try again.",
+            technicalMessage,
+        };
+    }
+
+    if (
+        normalized.includes("failed to send spawn request to runner") ||
+        normalized.includes("runner is not connected to this server") ||
+        (context === "session_spawn" && statusCode !== undefined && [502, 503, 504].includes(statusCode))
+    ) {
+        return {
+            userMessage: "Couldn't reach the selected runner. Make sure `pizzapi runner` is online, then try again.",
+            technicalMessage,
+        };
+    }
+
+    if (normalized.includes("missing sessionid")) {
+        return {
+            userMessage: "The runner started but didn't return full session details. Try again, or restart the runner if this keeps happening.",
+            technicalMessage,
+        };
+    }
+
+    if (normalized.includes("forbidden") || normalized.includes("unauthorized") || statusCode === 401 || statusCode === 403) {
+        return {
+            userMessage: "You don't have access to do that right now. Sign in again and retry.",
+            technicalMessage,
+        };
+    }
+
+    if (
+        context === "viewer_connection" && (
+            normalized.includes("connect error") ||
+            normalized.includes("connect_error") ||
+            normalized.includes("failed to fetch") ||
+            normalized.includes("network error") ||
+            normalized.includes("websocket") ||
+            statusCode === 502 ||
+            statusCode === 503 ||
+            statusCode === 504
+        )
+    ) {
+        return {
+            userMessage: "Lost connection to PizzaPi. Check your network, then reconnect.",
+            technicalMessage,
+        };
+    }
+
+    if (context === "session_spawn" && statusCode === 400) {
+        return {
+            userMessage: "Couldn't start that session with the selected options. Check the folder path and try again.",
+            technicalMessage,
+        };
+    }
+
+    if (statusCode === 404) {
+        return {
+            userMessage: "The requested item could not be found. Refresh and try again.",
+            technicalMessage,
+        };
+    }
+
+    if (statusCode !== undefined && statusCode >= 500) {
+        return {
+            userMessage: "PizzaPi hit a temporary server problem. Please retry in a moment.",
+            technicalMessage,
+        };
+    }
+
+    return {
+        userMessage: fallback,
+        technicalMessage,
+    };
+}

--- a/packages/ui/src/lib/user-error-message.ts
+++ b/packages/ui/src/lib/user-error-message.ts
@@ -34,6 +34,35 @@ function extractStatusCode(message: string): number | null {
     return Number.isInteger(parsed) ? parsed : null;
 }
 
+/**
+ * Extracts an HTTP status code from non-message fields of a Socket.IO error.
+ *
+ * When Socket.IO's XHR transport gets a 401/403 response, it reports:
+ *   err.message      = "xhr poll error"   (transport-level description)
+ *   err.description  = { status: 401 }    (the actual HTTP response object)
+ *   err.context      = { status: 401 }    (alternative field in some versions)
+ *
+ * Without this check those auth failures are misclassified as network errors
+ * because "xhr poll error" is matched by the network-error branch first.
+ */
+function extractSocketIOStatusCode(error: unknown): number | null {
+    if (!error || typeof error !== "object") return null;
+
+    // Socket.IO v4: err.description may be an XHR object or a plain object with .status
+    const errObj = error as Record<string, unknown>;
+
+    for (const field of ["description", "context"]) {
+        const candidate = errObj[field];
+        if (!candidate || typeof candidate !== "object") continue;
+        const status = (candidate as Record<string, unknown>).status;
+        if (typeof status === "number" && status >= 100 && status <= 599) {
+            return status;
+        }
+    }
+
+    return null;
+}
+
 function defaultFallbackForContext(context: UserErrorContext): string {
     switch (context) {
         case "session_spawn":
@@ -52,7 +81,11 @@ function defaultFallbackForContext(context: UserErrorContext): string {
 export function mapUserError(input: UserErrorInput): UserErrorResult {
     const context = input.context ?? "generic";
     const technicalFromError = coerceErrorMessage(input.error);
-    const statusCode = input.statusCode ?? extractStatusCode(technicalFromError) ?? undefined;
+    const statusCode =
+        input.statusCode ??
+        extractStatusCode(technicalFromError) ??
+        extractSocketIOStatusCode(input.error) ??
+        undefined;
     const technicalMessage = technicalFromError || (statusCode ? `HTTP ${statusCode}` : "Unknown error");
 
     const normalized = technicalMessage.toLowerCase();

--- a/packages/ui/src/lib/user-error-message.ts
+++ b/packages/ui/src/lib/user-error-message.ts
@@ -98,6 +98,8 @@ export function mapUserError(input: UserErrorInput): UserErrorResult {
             normalized.includes("failed to fetch") ||
             normalized.includes("network error") ||
             normalized.includes("websocket") ||
+            normalized.includes("xhr poll error") ||
+            normalized.includes("transport error") ||
             statusCode === 502 ||
             statusCode === 503 ||
             statusCode === 504
@@ -126,6 +128,20 @@ export function mapUserError(input: UserErrorInput): UserErrorResult {
     if (statusCode !== undefined && statusCode >= 500) {
         return {
             userMessage: "PizzaPi hit a temporary server problem. Please retry in a moment.",
+            technicalMessage,
+        };
+    }
+
+    if (normalized.includes("session not found")) {
+        return {
+            userMessage: "This session no longer exists. It may have ended or been removed.",
+            technicalMessage,
+        };
+    }
+
+    if (normalized.includes("snapshot not available") || normalized.includes("load session snapshot")) {
+        return {
+            userMessage: "Session history couldn't be loaded. Try refreshing.",
             technicalMessage,
         };
     }


### PR DESCRIPTION
## Problem

Technical error messages were surfaced raw across the UI with no actionable guidance. Users could see strings like `"xhr poll error"`, raw HTTP status codes, or server-internal strings like `"Session not found"` with no context — and errors like "Failed to load session." could silently hide a session that had already been permanently removed.

## What Changed

### New: `packages/ui/src/lib/user-error-message.ts`

Central `mapUserError()` function that translates raw errors into user-friendly messages with actionable guidance. It accepts a structured input (error object/string, optional HTTP status code, context) and returns a `{ userMessage, technicalMessage }` pair.

**Covered contexts and mappings:**

| Scenario | User sees |
|---|---|
| Socket disconnect / `xhr poll error` / `transport error` | "Lost connection to PizzaPi. Check your network, then reconnect." |
| 401 / 403 / Unauthorized / Forbidden | "You don't have access to do that right now. Sign in again and retry." |
| Session not found (server string) | "This session no longer exists. It may have ended or been removed." |
| Runner not reachable (502/503/504 on spawn) | "Couldn't reach the selected runner. Make sure `pizzapi runner` is online, then try again." |
| Runner not found | "That runner is no longer available. Refresh the runner list and try again." |
| Spawn missing sessionId | "The runner started but didn't return full session details." |
| 5xx server errors | "PizzaPi hit a temporary server problem. Please retry in a moment." |
| Context-specific fallback | Actionable fallback per context (spawn, restart, stop, viewer) |

### Applied across the UI

- **`App.tsx`** — viewer socket `connect_error` and `error` events, session spawn failures
- **`RunnerManager.tsx`** — runner stop and restart errors

### Tests: `packages/ui/src/lib/user-error-message.test.ts`

101-line test suite covering all mapped cases, including correct socket.io `Error` object format.

---

## Bug Fixes (commit `349a1748` — Health Inspection follow-up)

- **"Session not found" swallowed by fallback** — Previously, passing a server `"Session not found"` string together with a `fallbackMessage` would return the fallback ("Failed to load session.") because the specific-string check was ordered after the `statusCode >= 500` block. Moved the string checks before the generic status-code catches so `"Session not found"` now correctly surfaces as "This session no longer exists.".

- **`connect_error` test used fabricated string format** — Real socket.io `connect_error` events deliver a plain `Error` object whose `.message` is just `"xhr poll error"` or `"transport error"` — no `"connect_error:"` prefix. Updated the keyword list and tests to match real socket.io behavior.

---

## How to Verify

1. **Lost connection** — Disconnect from the server (kill the server process or toggle network) while viewing an active session. You should see **"Lost connection to PizzaPi. Check your network, then reconnect."** instead of a raw socket error string.

2. **Deleted session** — Navigate to a session URL that no longer exists (or delete an active session from another tab). You should see **"This session no longer exists. It may have ended or been removed."** instead of **"Failed to load session."**

3. **Runner offline** — Spawn a session with the runner process stopped. You should see **"Couldn't reach the selected runner. Make sure `pizzapi runner` is online, then try again."**

---

<!-- godmother: v5v2saRu -->