### PR TITLE
fix: UI stability — relay timeout leak, panel focus, graceful shutdown

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -28,21 +28,6 @@ import {
 // Truly fatal errors trigger a graceful shutdown with a 10 s drain window
 // rather than an immediate process.exit so in-flight requests can complete.
 
-// Only classify errors that are genuinely scoped to a single request and
-// cannot indicate broader server-state corruption.  Per-socket network
-// errors (ECONNRESET, ENOTCONN, ERR_STREAM_DESTROYED) are handled
-// separately in the uncaughtException handler because they deserve their
-// own log level and comment — they are transient but still unusual at the
-// uncaughtException level (they should be caught at the call site).
-function isRecoverableError(err: Error): boolean {
-    // JSON.parse failures from malformed request bodies — fully scoped to
-    // one request; the server's state is untouched.
-    if (err instanceof SyntaxError && err.message.toLowerCase().includes("json")) {
-        return true;
-    }
-    return false;
-}
-
 process.on("uncaughtException", (err: Error) => {
     const code = (err as NodeJS.ErrnoException).code;
 
@@ -63,11 +48,13 @@ process.on("uncaughtException", (err: Error) => {
         return;
     }
 
-    // Single-request failures (e.g. malformed JSON body) — no state damage.
-    if (isRecoverableError(err)) {
-        processLog.warn("Caught recoverable per-request error — logging and continuing:", err);
-        return;
-    }
+    // NOTE: SyntaxError / JSON parse failures are intentionally NOT handled
+    // here.  At the uncaughtException level there is no reliable way to
+    // determine whether a SyntaxError originated from a single malformed
+    // request body (safe to swallow) or from startup / config / background
+    // code (potentially corrupted state).  Malformed request bodies must be
+    // caught at the request boundary (e.g. in handler.ts), not reclassified
+    // as recoverable at process scope.
 
     // Fatal: initiate graceful shutdown instead of an immediate process.exit(1).
     // onShutdownSignal is a hoisted function declaration and is callable here

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -22,14 +22,48 @@ import {
 // The Socket.IO Redis adapter can throw EPIPE synchronously when the Redis
 // connection drops mid-broadcast. We catch any that slip through call-site
 // try/catches so the server never exits on a transient Redis disconnect.
+//
+// Known recoverable errors (per-request / transient network) are logged and
+// swallowed so a single bad request cannot bring down the whole server.
+// Truly fatal errors trigger a graceful shutdown with a 10 s drain window
+// rather than an immediate process.exit so in-flight requests can complete.
+
+function isRecoverableError(err: Error): boolean {
+    const code = (err as NodeJS.ErrnoException).code;
+    // Transient network conditions — only affect the current socket/stream,
+    // not the server's ability to serve future requests.
+    if (code === "ECONNRESET" || code === "ERR_STREAM_DESTROYED" || code === "ENOTCONN") {
+        return true;
+    }
+    // JSON.parse failures from malformed request bodies — scoped to one request.
+    if (err instanceof SyntaxError && err.message.toLowerCase().includes("json")) {
+        return true;
+    }
+    return false;
+}
+
 process.on("uncaughtException", (err: Error) => {
     if ((err as NodeJS.ErrnoException).code === "EPIPE") {
         processLog.warn("Caught EPIPE (Redis connection dropped) — ignoring:", err.message);
         return;
     }
-    // Re-throw anything that isn't an EPIPE so genuine bugs still surface.
-    processLog.error("Uncaught exception:", err);
-    process.exit(1);
+    if (isRecoverableError(err)) {
+        processLog.warn("Caught recoverable error — logging and continuing:", err);
+        return;
+    }
+    // Fatal: initiate graceful shutdown instead of an immediate process.exit(1).
+    // onShutdownSignal is a hoisted function declaration and is callable here
+    // even though it is defined later in the file.  We wrap in try/catch as a
+    // safety net for the narrow window during startup before httpServer exists.
+    processLog.error("Uncaught fatal exception — initiating graceful shutdown:", err);
+    try {
+        onShutdownSignal("uncaughtException", 1);
+    } catch (shutdownErr) {
+        // Server not yet fully initialized (e.g. exception during migrations).
+        // Fall back to immediate exit — there is nothing to drain.
+        processLog.error("Graceful shutdown unavailable (server not ready) — exiting immediately:", shutdownErr);
+        process.exit(1);
+    }
 });
 
 // Socket.IO imports
@@ -362,25 +396,26 @@ setTimeout(() => {
 // Registered after httpServer and io are initialized so there's no TDZ risk
 // if SIGTERM arrives during startup.  Sets isServerShuttingDown before closing
 // Socket.IO so disconnect handlers can skip destructive Redis cleanup.
-function onShutdownSignal(signal: string): void {
+function onShutdownSignal(signal: string, exitCode = 0): void {
     shutdownLog.info(`Received ${signal} — marking server as shutting down`);
     setServerShuttingDown();
     disposeTunnelRelay();
 
     // Close the Socket.IO server so disconnect handlers fire with the
-    // shuttingDown flag already set, then close the HTTP server.
+    // shuttingDown flag already set, then close the HTTP server so
+    // in-flight requests have a chance to complete before exit.
     if (io) {
         io.close(() => {
             shutdownLog.info("Socket.IO closed");
             httpServer.close(() => {
                 shutdownLog.info("HTTP server closed");
-                process.exit(0);
+                process.exit(exitCode);
             });
         });
     } else {
         httpServer.close(() => {
             shutdownLog.info("HTTP server closed");
-            process.exit(0);
+            process.exit(exitCode);
         });
     }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -28,14 +28,15 @@ import {
 // Truly fatal errors trigger a graceful shutdown with a 10 s drain window
 // rather than an immediate process.exit so in-flight requests can complete.
 
+// Only classify errors that are genuinely scoped to a single request and
+// cannot indicate broader server-state corruption.  Per-socket network
+// errors (ECONNRESET, ENOTCONN, ERR_STREAM_DESTROYED) are handled
+// separately in the uncaughtException handler because they deserve their
+// own log level and comment — they are transient but still unusual at the
+// uncaughtException level (they should be caught at the call site).
 function isRecoverableError(err: Error): boolean {
-    const code = (err as NodeJS.ErrnoException).code;
-    // Transient network conditions — only affect the current socket/stream,
-    // not the server's ability to serve future requests.
-    if (code === "ECONNRESET" || code === "ERR_STREAM_DESTROYED" || code === "ENOTCONN") {
-        return true;
-    }
-    // JSON.parse failures from malformed request bodies — scoped to one request.
+    // JSON.parse failures from malformed request bodies — fully scoped to
+    // one request; the server's state is untouched.
     if (err instanceof SyntaxError && err.message.toLowerCase().includes("json")) {
         return true;
     }
@@ -43,14 +44,31 @@ function isRecoverableError(err: Error): boolean {
 }
 
 process.on("uncaughtException", (err: Error) => {
-    if ((err as NodeJS.ErrnoException).code === "EPIPE") {
+    const code = (err as NodeJS.ErrnoException).code;
+
+    // EPIPE — Redis/socket write to a closed pipe.  Always per-connection;
+    // never indicates server-state damage.  Log and continue.
+    if (code === "EPIPE") {
         processLog.warn("Caught EPIPE (Redis connection dropped) — ignoring:", err.message);
         return;
     }
-    if (isRecoverableError(err)) {
-        processLog.warn("Caught recoverable error — logging and continuing:", err);
+
+    // Transient per-socket / per-stream network errors.  These should
+    // normally be caught at the call site; reaching uncaughtException means
+    // an error boundary was missed somewhere.  They are still connection-
+    // scoped and do NOT corrupt shared server state, so we log at warn
+    // level and continue rather than triggering a full shutdown.
+    if (code === "ECONNRESET" || code === "ERR_STREAM_DESTROYED" || code === "ENOTCONN") {
+        processLog.warn(`Caught transient network error (${code}) — logging and continuing:`, err.message);
         return;
     }
+
+    // Single-request failures (e.g. malformed JSON body) — no state damage.
+    if (isRecoverableError(err)) {
+        processLog.warn("Caught recoverable per-request error — logging and continuing:", err);
+        return;
+    }
+
     // Fatal: initiate graceful shutdown instead of an immediate process.exit(1).
     // onShutdownSignal is a hoisted function declaration and is callable here
     // even though it is defined later in the file.  We wrap in try/catch as a
@@ -396,10 +414,34 @@ setTimeout(() => {
 // Registered after httpServer and io are initialized so there's no TDZ risk
 // if SIGTERM arrives during startup.  Sets isServerShuttingDown before closing
 // Socket.IO so disconnect handlers can skip destructive Redis cleanup.
+
+// Guards against re-entrant shutdown (e.g. SIGTERM followed by SIGINT, or
+// SIGTERM followed by an uncaughtException during the drain window).
+let shuttingDown = false;
+
 function onShutdownSignal(signal: string, exitCode = 0): void {
+    if (shuttingDown) {
+        shutdownLog.warn(`Received ${signal} during shutdown — ignoring duplicate signal`);
+        return;
+    }
+    shuttingDown = true;
+
     shutdownLog.info(`Received ${signal} — marking server as shutting down`);
     setServerShuttingDown();
     disposeTunnelRelay();
+
+    // Helper: close the HTTP server and wait for in-flight requests to drain.
+    // `httpServer.close()` stops accepting new connections but keeps existing
+    // ones alive until they finish.  `closeIdleConnections()` immediately
+    // releases keep-alive connections that are not currently serving a
+    // request, so the close callback fires as soon as the last in-flight
+    // request completes rather than waiting for clients to time out.
+    function closeHttp(cb: () => void): void {
+        httpServer.close(cb);
+        // closeIdleConnections was added in Node 18.2 / Bun equivalent.
+        // Optional chaining ensures forward-compat without a runtime check.
+        (httpServer as any).closeIdleConnections?.();
+    }
 
     // Close the Socket.IO server so disconnect handlers fire with the
     // shuttingDown flag already set, then close the HTTP server so
@@ -407,14 +449,14 @@ function onShutdownSignal(signal: string, exitCode = 0): void {
     if (io) {
         io.close(() => {
             shutdownLog.info("Socket.IO closed");
-            httpServer.close(() => {
-                shutdownLog.info("HTTP server closed");
+            closeHttp(() => {
+                shutdownLog.info("HTTP server closed — all connections drained");
                 process.exit(exitCode);
             });
         });
     } else {
-        httpServer.close(() => {
-            shutdownLog.info("HTTP server closed");
+        closeHttp(() => {
+            shutdownLog.info("HTTP server closed — all connections drained");
             process.exit(exitCode);
         });
     }

--- a/packages/tunnel/src/server.ts
+++ b/packages/tunnel/src/server.ts
@@ -136,6 +136,7 @@ export class TunnelRelay {
     }
 
     const timer = setTimeout(() => {
+      this.send(runner.ws, { type: "request-end", id: request.id });
       this.pendingRequests.delete(request.id);
       callbacks.onError("Tunnel request timed out");
     }, timeoutMs);
@@ -211,6 +212,7 @@ export class TunnelRelay {
     }
 
     const timer = setTimeout(() => {
+      this.send(runner.ws, { type: "ws-close", id: request.id, code: 1001, reason: "open timeout" });
       this.pendingWs.delete(request.id);
       callbacks.onError("WebSocket open timed out");
     }, timeoutMs);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3644,10 +3644,17 @@ export function App() {
     if (activeServicePanels.has(serviceId)) {
       closeServicePanelById(serviceId);
     } else {
+      // If the currently-active tab is a service panel, place the new panel in
+      // the same position group so both appear together rather than in separate
+      // groups (which would leave the Tunnels panel highlighted in its group
+      // while the new panel appeared elsewhere).
+      if (activeServicePanels.has(combinedActiveTab)) {
+        setServicePanelPosition(serviceId, getServicePanelPosition(combinedActiveTab));
+      }
       toggleServicePanel(serviceId);
       handleCombinedTabChange(serviceId);
     }
-  }, [activeServicePanels, closeServicePanelById, toggleServicePanel, handleCombinedTabChange]);
+  }, [activeServicePanels, closeServicePanelById, toggleServicePanel, handleCombinedTabChange, combinedActiveTab, setServicePanelPosition, getServicePanelPosition]);
 
   const terminalPanelTab = React.useMemo<CombinedPanelTab | null>(() => showTerminal ? {
     id: "terminal",
@@ -3732,13 +3739,18 @@ export function App() {
         id: serviceId,
         label,
         icon,
-        onDragStart: (e) => startPanelDragWith(e, (pos) => setServicePanelPosition(serviceId, pos)),
+        onDragStart: (e) => startPanelDragWith(e, (pos) => {
+          setServicePanelPosition(serviceId, pos);
+          // Re-assert focus on the moved panel so the destination group
+          // highlights it rather than falling back to tabs[0] (Tunnels).
+          handleCombinedTabChange(serviceId);
+        }),
         onClose: () => closeServicePanelById(serviceId),
         content,
       });
     }
     return tabs;
-  }, [activeServicePanels, tunnelSessionId, activeSessionId, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById]);
+  }, [activeServicePanels, tunnelSessionId, activeSessionId, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById, handleCombinedTabChange]);
 
   const panelGroups = React.useMemo(() => {
     const groups: Record<"left" | "right" | "bottom", CombinedPanelTab[]> = { left: [], right: [], bottom: [] };

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3645,7 +3645,7 @@ export function App() {
 
   // Runner service panels — dynamically discovered
   const { services: availableServices, panels: dynamicPanels } = useRunnerServices(viewerSocket);
-  const { activePanelIds: activeServicePanels, togglePanel: toggleServicePanel, closePanelById: closeServicePanelById, closeAllPanels: closeAllServicePanels, getPanelPosition: getServicePanelPosition, setPanelPosition: setServicePanelPosition } = useServicePanelState();
+  const { activePanelIds: activeServicePanels, togglePanel: toggleServicePanel, closePanelById: closeServicePanelById, closeAllPanels: closeAllServicePanels, getPanelPosition: getServicePanelPosition, setPanelPosition: setServicePanelPosition, setEphemeralPanelPosition: setEphemeralServicePanelPosition } = useServicePanelState();
 
   const handleToggleServicePanel = React.useCallback((serviceId: string) => {
     if (activeServicePanels.has(serviceId)) {
@@ -3661,11 +3661,20 @@ export function App() {
         activeServicePanels,
         getServicePanelPosition,
       );
-      setServicePanelPosition(serviceId, newPosition);
+      if (activeServicePanels.has(combinedActiveTab)) {
+        // Auto-placement: the position was derived from another panel, not from
+        // this panel's own saved preference.  Store it as an ephemeral override
+        // so it is used for rendering this session but does NOT overwrite the
+        // panel's persisted dock preference in localStorage.
+        setEphemeralServicePanelPosition(serviceId, newPosition);
+      }
+      // When the active tab is NOT a service panel, newPosition equals the
+      // panel's own stored/default preference — no action needed, getPanelPosition
+      // will already return the correct value.
       toggleServicePanel(serviceId);
       handleCombinedTabChange(serviceId);
     }
-  }, [activeServicePanels, closeServicePanelById, toggleServicePanel, handleCombinedTabChange, combinedActiveTab, setServicePanelPosition, getServicePanelPosition]);
+  }, [activeServicePanels, closeServicePanelById, toggleServicePanel, handleCombinedTabChange, combinedActiveTab, setEphemeralServicePanelPosition, getServicePanelPosition]);
 
   const terminalPanelTab = React.useMemo<CombinedPanelTab | null>(() => showTerminal ? {
     id: "terminal",

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -96,7 +96,7 @@ import {
   shouldDeduplicateInput,
   type InputDedupeState,
 } from "@/lib/input-dedupe";
-import { parsePendingQuestionDisplayMode, parsePendingQuestions, type QuestionDisplayMode } from "@/lib/ask-user-questions";
+import { parsePendingQuestionDisplayMode, parsePendingQuestions, type QuestionDisplayMode, type QuestionType } from "@/lib/ask-user-questions";
 import type { TodoItem, TokenUsage, ConfiguredModelInfo, ResumeSessionOption, QueuedMessage, SessionUiCacheEntry } from "@/lib/types";
 import { metaEventToStatePatch, type MetaStatePatch } from "@/lib/meta-state-apply";
 import { usePanelLayout } from "@/hooks/usePanelLayout";
@@ -131,6 +131,71 @@ const BUILD_TIMESTAMP =
     ? __PIZZAPI_BUILD_TIMESTAMP__.trim()
     : null;
 
+// ─── Session-scoped state ─────────────────────────────────────────────────────
+// All fields below are reset atomically by clearSelection(). Adding new
+// session-scoped state here ensures it is automatically included in the reset
+// — nothing can be accidentally left stale when switching sessions.
+interface SessionState {
+  viewerSocket: Socket<ViewerServerToClientEvents, ViewerClientToServerEvents> | null;
+  activeSessionId: string | null;
+  messages: RelayMessage[];
+  viewerStatus: string;
+  retryState: { errorMessage: string; detectedAt: number } | null;
+  pendingQuestion: { toolCallId: string; questions: Array<{ question: string; options: string[]; type?: QuestionType }>; display: QuestionDisplayMode } | null;
+  pendingPlan: { toolCallId: string; title: string; description: string | null; steps: Array<{ title: string; description?: string }> } | null;
+  pluginTrustPrompt: { promptId: string; pluginNames: string[]; pluginSummaries: string[] } | null;
+  activeToolCalls: Map<string, string>;
+  mcpOAuthPastes: Array<{ serverName: string; authUrl: string; nonce: string; ts: number }>;
+  messageQueue: QueuedMessage[];
+  activeModel: ConfiguredModelInfo | null;
+  sessionName: string | null;
+  availableModels: ConfiguredModelInfo[];
+  modelSelectorOpen: boolean;
+  isChangingModel: boolean;
+  agentActive: boolean;
+  effortLevel: string | null;
+  authSource: string | null;
+  tokenUsage: TokenUsage | null;
+  providerUsage: ProviderUsageMap | null;
+  usageRefreshing: boolean;
+  lastHeartbeatAt: number | null;
+  availableCommands: Array<{ name: string; description?: string; source?: string }>;
+  resumeSessions: ResumeSessionOption[];
+  resumeSessionsLoading: boolean;
+}
+
+function createInitialSessionState(): SessionState {
+  return {
+    viewerSocket: null,
+    activeSessionId: null,
+    messages: [],
+    viewerStatus: "Idle",
+    retryState: null,
+    pendingQuestion: null,
+    pendingPlan: null,
+    pluginTrustPrompt: null,
+    activeToolCalls: new Map(),
+    mcpOAuthPastes: [],
+    messageQueue: [],
+    activeModel: null,
+    sessionName: null,
+    availableModels: [],
+    modelSelectorOpen: false,
+    isChangingModel: false,
+    agentActive: false,
+    effortLevel: null,
+    authSource: null,
+    tokenUsage: null,
+    providerUsage: null,
+    usageRefreshing: false,
+    lastHeartbeatAt: null,
+    availableCommands: [],
+    resumeSessions: [],
+    resumeSessionsLoading: false,
+  };
+}
+// ─────────────────────────────────────────────────────────────────────────────
+
 export function App() {
   const { data: session, isPending } = useSession();
   const { runners: feedRunners, status: runnersStatus } = useRunnersFeed({
@@ -142,16 +207,158 @@ export function App() {
     const saved = localStorage.getItem("theme");
     return saved === "dark" || (!saved && window.matchMedia("(prefers-color-scheme: dark)").matches);
   });
-  const [activeSessionId, setActiveSessionId] = React.useState<string | null>(null);
-  const [messages, setMessages] = React.useState<RelayMessage[]>([]);
+  // ─── Consolidated session state ─────────────────────────────────────────────
+  // clearSelection() resets this entire object in a single atomic call.
+  const [sessionState, setSessionState] = React.useState<SessionState>(createInitialSessionState);
+  const {
+    viewerSocket, activeSessionId, messages, viewerStatus, retryState,
+    pendingQuestion, pendingPlan, pluginTrustPrompt, activeToolCalls,
+    mcpOAuthPastes, messageQueue, activeModel, sessionName, availableModels,
+    modelSelectorOpen, isChangingModel, agentActive, effortLevel, authSource,
+    tokenUsage, providerUsage, usageRefreshing, lastHeartbeatAt,
+    availableCommands, resumeSessions, resumeSessionsLoading,
+  } = sessionState;
+
+  // Thin setter wrappers — identical signatures to the original useState setters
+  // so all existing call-sites compile unchanged. Each supports both direct
+  // values and functional updates (React.SetStateAction<T>).
+  const setViewerSocket = React.useCallback(
+    (v: React.SetStateAction<SessionState["viewerSocket"]>) =>
+      setSessionState((p: SessionState) => ({ ...p, viewerSocket: typeof v === "function" ? v(p.viewerSocket) : v })),
+    []
+  );
+  const setActiveSessionId = React.useCallback(
+    (v: React.SetStateAction<string | null>) =>
+      setSessionState((p: SessionState) => ({ ...p, activeSessionId: typeof v === "function" ? v(p.activeSessionId) : v })),
+    []
+  );
+  const setMessages = React.useCallback(
+    (v: React.SetStateAction<RelayMessage[]>) =>
+      setSessionState((p: SessionState) => ({ ...p, messages: typeof v === "function" ? v(p.messages) : v })),
+    []
+  );
+  const setViewerStatus = React.useCallback(
+    (v: React.SetStateAction<string>) =>
+      setSessionState((p: SessionState) => ({ ...p, viewerStatus: typeof v === "function" ? v(p.viewerStatus) : v })),
+    []
+  );
+  const setRetryState = React.useCallback(
+    (v: React.SetStateAction<SessionState["retryState"]>) =>
+      setSessionState((p: SessionState) => ({ ...p, retryState: typeof v === "function" ? v(p.retryState) : v })),
+    []
+  );
+  const setPendingQuestion = React.useCallback(
+    (v: React.SetStateAction<SessionState["pendingQuestion"]>) =>
+      setSessionState((p: SessionState) => ({ ...p, pendingQuestion: typeof v === "function" ? v(p.pendingQuestion) : v })),
+    []
+  );
+  const setPendingPlan = React.useCallback(
+    (v: React.SetStateAction<SessionState["pendingPlan"]>) =>
+      setSessionState((p: SessionState) => ({ ...p, pendingPlan: typeof v === "function" ? v(p.pendingPlan) : v })),
+    []
+  );
+  const setPluginTrustPrompt = React.useCallback(
+    (v: React.SetStateAction<SessionState["pluginTrustPrompt"]>) =>
+      setSessionState((p: SessionState) => ({ ...p, pluginTrustPrompt: typeof v === "function" ? v(p.pluginTrustPrompt) : v })),
+    []
+  );
+  const setActiveToolCalls = React.useCallback(
+    (v: React.SetStateAction<Map<string, string>>) =>
+      setSessionState((p: SessionState) => ({ ...p, activeToolCalls: typeof v === "function" ? v(p.activeToolCalls) : v })),
+    []
+  );
+  const setMcpOAuthPastes = React.useCallback(
+    (v: React.SetStateAction<SessionState["mcpOAuthPastes"]>) =>
+      setSessionState((p: SessionState) => ({ ...p, mcpOAuthPastes: typeof v === "function" ? v(p.mcpOAuthPastes) : v })),
+    []
+  );
+  const setMessageQueue = React.useCallback(
+    (v: React.SetStateAction<QueuedMessage[]>) =>
+      setSessionState((p: SessionState) => ({ ...p, messageQueue: typeof v === "function" ? v(p.messageQueue) : v })),
+    []
+  );
+  const setActiveModel = React.useCallback(
+    (v: React.SetStateAction<ConfiguredModelInfo | null>) =>
+      setSessionState((p: SessionState) => ({ ...p, activeModel: typeof v === "function" ? v(p.activeModel) : v })),
+    []
+  );
+  const setSessionName = React.useCallback(
+    (v: React.SetStateAction<string | null>) =>
+      setSessionState((p: SessionState) => ({ ...p, sessionName: typeof v === "function" ? v(p.sessionName) : v })),
+    []
+  );
+  const setAvailableModels = React.useCallback(
+    (v: React.SetStateAction<ConfiguredModelInfo[]>) =>
+      setSessionState((p: SessionState) => ({ ...p, availableModels: typeof v === "function" ? v(p.availableModels) : v })),
+    []
+  );
+  const setModelSelectorOpen = React.useCallback(
+    (v: React.SetStateAction<boolean>) =>
+      setSessionState((p: SessionState) => ({ ...p, modelSelectorOpen: typeof v === "function" ? v(p.modelSelectorOpen) : v })),
+    []
+  );
+  const setIsChangingModel = React.useCallback(
+    (v: React.SetStateAction<boolean>) =>
+      setSessionState((p: SessionState) => ({ ...p, isChangingModel: typeof v === "function" ? v(p.isChangingModel) : v })),
+    []
+  );
+  const setAgentActive = React.useCallback(
+    (v: React.SetStateAction<boolean>) =>
+      setSessionState((p: SessionState) => ({ ...p, agentActive: typeof v === "function" ? v(p.agentActive) : v })),
+    []
+  );
+  const setEffortLevel = React.useCallback(
+    (v: React.SetStateAction<string | null>) =>
+      setSessionState((p: SessionState) => ({ ...p, effortLevel: typeof v === "function" ? v(p.effortLevel) : v })),
+    []
+  );
+  const setAuthSource = React.useCallback(
+    (v: React.SetStateAction<string | null>) =>
+      setSessionState((p: SessionState) => ({ ...p, authSource: typeof v === "function" ? v(p.authSource) : v })),
+    []
+  );
+  const setTokenUsage = React.useCallback(
+    (v: React.SetStateAction<TokenUsage | null>) =>
+      setSessionState((p: SessionState) => ({ ...p, tokenUsage: typeof v === "function" ? v(p.tokenUsage) : v })),
+    []
+  );
+  const setProviderUsage = React.useCallback(
+    (v: React.SetStateAction<ProviderUsageMap | null>) =>
+      setSessionState((p: SessionState) => ({ ...p, providerUsage: typeof v === "function" ? v(p.providerUsage) : v })),
+    []
+  );
+  const setUsageRefreshing = React.useCallback(
+    (v: React.SetStateAction<boolean>) =>
+      setSessionState((p: SessionState) => ({ ...p, usageRefreshing: typeof v === "function" ? v(p.usageRefreshing) : v })),
+    []
+  );
+  const setLastHeartbeatAt = React.useCallback(
+    (v: React.SetStateAction<number | null>) =>
+      setSessionState((p: SessionState) => ({ ...p, lastHeartbeatAt: typeof v === "function" ? v(p.lastHeartbeatAt) : v })),
+    []
+  );
+  const setAvailableCommands = React.useCallback(
+    (v: React.SetStateAction<Array<{ name: string; description?: string; source?: string }>>) =>
+      setSessionState((p: SessionState) => ({ ...p, availableCommands: typeof v === "function" ? v(p.availableCommands) : v })),
+    []
+  );
+  const setResumeSessions = React.useCallback(
+    (v: React.SetStateAction<ResumeSessionOption[]>) =>
+      setSessionState((p: SessionState) => ({ ...p, resumeSessions: typeof v === "function" ? v(p.resumeSessions) : v })),
+    []
+  );
+  const setResumeSessionsLoading = React.useCallback(
+    (v: React.SetStateAction<boolean>) =>
+      setSessionState((p: SessionState) => ({ ...p, resumeSessionsLoading: typeof v === "function" ? v(p.resumeSessionsLoading) : v })),
+    []
+  );
+  // ────────────────────────────────────────────────────────────────────────────
   // Ref kept in sync with `messages` via useLayoutEffect so we can read the
   // latest committed value in event handlers without needing functional updaters.
   // This lets us move patchSessionCache side effects OUT of setMessages updaters,
   // which would otherwise be called speculatively in React concurrent mode.
   const messagesRef = React.useRef<RelayMessage[]>(messages);
   React.useLayoutEffect(() => { messagesRef.current = messages; }, [messages]);
-  const [viewerStatus, setViewerStatus] = React.useState("Idle");
-  const [retryState, setRetryState] = React.useState<{ errorMessage: string; detectedAt: number } | null>(null);
   const [relayStatus, setRelayStatus] = React.useState<DotState>("connecting");
   const [versionBanner, setVersionBanner] = React.useState<{ message: string | null; protocolCompatible: boolean }>({
     message: null,
@@ -219,28 +426,12 @@ export function App() {
   const [recentFolders, setRecentFolders] = React.useState<string[]>([]);
   const [recentFoldersLoading, setRecentFoldersLoading] = React.useState(false);
 
-  const [pendingQuestion, setPendingQuestion] = React.useState<{ toolCallId: string; questions: Array<{ question: string; options: string[]; type?: import("@/lib/ask-user-questions").QuestionType }>; display: QuestionDisplayMode } | null>(null);
-
   /** Set of session IDs that currently have a pending AskUserQuestion. */
   const [sessionsAwaitingInput, setSessionsAwaitingInput] = React.useState<Set<string>>(new Set());
 
   /** Set of session IDs that are actively compacting their context window. */
   const [sessionsCompacting, setSessionsCompacting] = React.useState<Set<string>>(new Set());
 
-  /** Pending plan mode prompt from the worker — shown as a plan review panel in the viewer. */
-  const [pendingPlan, setPendingPlan] = React.useState<{
-    toolCallId: string;
-    title: string;
-    description: string | null;
-    steps: Array<{ title: string; description?: string }>;
-  } | null>(null);
-
-  /** Pending plugin trust prompt from the worker — shown as a confirmation dialog in the viewer. */
-  const [pluginTrustPrompt, setPluginTrustPrompt] = React.useState<{
-    promptId: string;
-    pluginNames: string[];
-    pluginSummaries: string[];
-  } | null>(null);
   // Cached fallback promptKey for when toolCallId is absent (legacy/compat).
   // Only changes when the question content changes, preventing heartbeat
   // re-applications from resetting the MC component's selection state.
@@ -258,35 +449,15 @@ export function App() {
     }
     return pendingQuestionFallbackRef.current.key;
   }, []);
-  const [activeToolCalls, setActiveToolCalls] = React.useState<Map<string, string>>(new Map());
-
-  // Message queue: messages sent while the agent is active
-  const [messageQueue, setMessageQueue] = React.useState<QueuedMessage[]>([]);
-  const [activeModel, setActiveModel] = React.useState<ConfiguredModelInfo | null>(null);
-  const [sessionName, setSessionName] = React.useState<string | null>(null);
-  const [availableModels, setAvailableModels] = React.useState<ConfiguredModelInfo[]>([]);
-  const [modelSelectorOpen, setModelSelectorOpen] = React.useState(false);
-  const [isChangingModel, setIsChangingModel] = React.useState(false);
   const [hiddenModels, setHiddenModels] = React.useState<Set<string>>(() => loadHiddenModels());
   const [hiddenModelsOpen, setHiddenModelsOpen] = React.useState(false);
   const [changePasswordOpen, setChangePasswordOpen] = React.useState(false);
 
-  // Live session status from heartbeats
-  const [agentActive, setAgentActive] = React.useState(false);
+  // Live session status from heartbeats (isCompacting and planModeEnabled are intentionally
+  // NOT part of SessionState because they are not reset by clearSelection)
   const [isCompacting, setIsCompacting] = React.useState(false);
-  const [effortLevel, setEffortLevel] = React.useState<string | null>(null);
   const [planModeEnabled, setPlanModeEnabled] = React.useState(false);
-  const [tokenUsage, setTokenUsage] = React.useState<TokenUsage | null>(null);
-  const [lastHeartbeatAt, setLastHeartbeatAt] = React.useState<number | null>(null);
-  const [providerUsage, setProviderUsage] = React.useState<ProviderUsageMap | null>(null);
-  const [usageRefreshing, setUsageRefreshing] = React.useState(false);
   const [todoList, setTodoList] = React.useState<TodoItem[]>([]);
-  const [authSource, setAuthSource] = React.useState<string | null>(null);
-
-  /** Pending MCP OAuth paste prompts: server requires localhost redirect, user must paste callback URL. */
-  const [mcpOAuthPastes, setMcpOAuthPastes] = React.useState<
-    Array<{ serverName: string; authUrl: string; nonce: string; ts: number }>
-  >([]);
 
   // Keyboard shortcuts
   const isMac = React.useMemo(() => {
@@ -355,13 +526,6 @@ export function App() {
   // Track the last completed snapshot ID so we can reject stale chunks that
   // arrive after the ref has been cleared (e.g. from a superseded sender).
   const lastCompletedSnapshotRef = React.useRef<string | null>(null);
-
-  // Capabilities advertised by the runner (commands, models, etc.)
-  const [availableCommands, setAvailableCommands] = React.useState<Array<{ name: string; description?: string; source?: string }>>([]);
-
-  // /resume picker state (fetched from runner session files)
-  const [resumeSessions, setResumeSessions] = React.useState<ResumeSessionOption[]>([]);
-  const [resumeSessionsLoading, setResumeSessionsLoading] = React.useState(false);
 
   // Mobile layout
   const {
@@ -445,8 +609,7 @@ export function App() {
   }, [newSessionOpen, spawnRunnerId]);
 
   const viewerWsRef = React.useRef<Socket<ViewerServerToClientEvents, ViewerClientToServerEvents> | null>(null);
-  // Tracked as state so ViewerSocketContext consumers re-render when the socket changes.
-  const [viewerSocket, setViewerSocket] = React.useState<Socket<ViewerServerToClientEvents, ViewerClientToServerEvents> | null>(null);
+  // viewerSocket is part of SessionState — tracked so ViewerSocketContext consumers re-render.
   const hubSocketRef = React.useRef<Socket<HubServerToClientEvents, HubClientToServerEvents> | null>(null);
   // Tracked as state so HubSocketContext consumers re-render when the socket changes.
   const [hubSocket, setHubSocket] = React.useState<Socket<HubServerToClientEvents, HubClientToServerEvents> | null>(null);
@@ -582,37 +745,15 @@ export function App() {
     }
     viewerWsRef.current?.disconnect();
     viewerWsRef.current = null;
-    setViewerSocket(null);
     activeSessionRef.current = null;
     lastSeqRef.current = null;
     awaitingSnapshotRef.current = false;
     renderedMcpReportTsRef.current = null;
     injectedMessagesRef.current = [];
-    setActiveSessionId(null);
-    setMessages([]);
-    setViewerStatus("Idle");
-    setPendingQuestion(null);
-    setPendingPlan(null);
-    setPluginTrustPrompt(null);
-    setRetryState(null);
-    setActiveToolCalls(new Map());
-    setMcpOAuthPastes([]);
-    setMessageQueue([]);
-    setActiveModel(null);
-    setSessionName(null);
-    setAvailableModels([]);
-    setAvailableCommands([]);
-    setResumeSessions([]);
-    setResumeSessionsLoading(false);
-    setModelSelectorOpen(false);
-    setIsChangingModel(false);
-    setAgentActive(false);
-    setEffortLevel(null);
-    setAuthSource(null);
-    setTokenUsage(null);
-    setProviderUsage(null);
-    setUsageRefreshing(false);
-    setLastHeartbeatAt(null);
+    // Single atomic reset — all session-scoped fields defined in SessionState
+    // are cleared together. New fields added to SessionState are automatically
+    // included; nothing can be accidentally left stale between sessions.
+    setSessionState(createInitialSessionState());
   }, []);
 
   // Full reset: cancel the RAF and wipe all pending streaming state. Use before

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -70,6 +70,7 @@ import { useRunnerServices, attachServiceAnnounceListener, seedServiceCache, set
 import { ServicePanelButtons, useServicePanelState } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
+import { resolveNewPanelPosition, resolveActiveTabIdFromIds } from "@/utils/servicePanelUtils";
 import { IframeServicePanel } from "@/components/service-panels/IframeServicePanel";
 import {
   ModelSelector,
@@ -754,6 +755,12 @@ export function App() {
     // are cleared together. New fields added to SessionState are automatically
     // included; nothing can be accidentally left stale between sessions.
     setSessionState(createInitialSessionState());
+    // Reset live-status fields that are intentionally outside SessionState
+    // (they are driven by heartbeats, not snapshots) but must still be cleared
+    // when switching sessions so stale "compacting" / "plan mode" indicators
+    // are not carried over until the next heartbeat arrives.
+    setIsCompacting(false);
+    setPlanModeEnabled(false);
   }, []);
 
   // Full reset: cancel the RAF and wipe all pending streaming state. Use before
@@ -3644,13 +3651,17 @@ export function App() {
     if (activeServicePanels.has(serviceId)) {
       closeServicePanelById(serviceId);
     } else {
-      // If the currently-active tab is a service panel, place the new panel in
-      // the same position group so both appear together rather than in separate
-      // groups (which would leave the Tunnels panel highlighted in its group
-      // while the new panel appeared elsewhere).
-      if (activeServicePanels.has(combinedActiveTab)) {
-        setServicePanelPosition(serviceId, getServicePanelPosition(combinedActiveTab));
-      }
+      // Resolve the correct position for the new panel using the shared pure
+      // helper (also tested in ServicePanels.test.ts).  When the currently-
+      // active tab is a service panel, the new panel inherits that panel's
+      // position so both appear together rather than in separate dock groups.
+      const newPosition = resolveNewPanelPosition(
+        serviceId,
+        combinedActiveTab,
+        activeServicePanels,
+        getServicePanelPosition,
+      );
+      setServicePanelPosition(serviceId, newPosition);
       toggleServicePanel(serviceId);
       handleCombinedTabChange(serviceId);
     }
@@ -3779,8 +3790,7 @@ export function App() {
   }, [terminalPanelTab, filesPanelTab, gitPanelTab, servicePanelTabs]);
 
   const resolveActiveTabId = React.useCallback((tabs: CombinedPanelTab[]) => {
-    if (tabs.length === 0) return combinedActiveTab;
-    return tabs.some((tab) => tab.id === combinedActiveTab) ? combinedActiveTab : tabs[0]!.id;
+    return resolveActiveTabIdFromIds(tabs.map((t) => t.id), combinedActiveTab);
   }, [combinedActiveTab]);
 
   // Stable callbacks for memoized header components.

--- a/packages/ui/src/components/service-panels/ServicePanels.test.ts
+++ b/packages/ui/src/components/service-panels/ServicePanels.test.ts
@@ -121,6 +121,81 @@ describe("resolveNewPanelPosition — adding bug", () => {
     });
 });
 
+// ── Persistence bug: auto-placement must NOT overwrite saved dock position ────
+
+describe("resolveNewPanelPosition — persistence safety", () => {
+    test("auto-placed position differs from the panel's own stored preference — persisting would corrupt it", () => {
+        // Repro: godmother saved at "right". Tunnel is active at "bottom".
+        // Auto-placement returns "bottom" (inherits from tunnel).
+        // This confirms the computed position diverges from the stored preference,
+        // so calling setServicePanelPosition with it would corrupt the saved value.
+        // The fix: use setEphemeralPanelPosition (non-persisted) in this case.
+        const activeServicePanels = new Set(["tunnel"]);
+        const positions = new Map([
+            ["tunnel", "bottom"],
+            ["godmother", "right"], // godmother's OWN saved preference
+        ] as const);
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
+
+        const autoPlacedPosition = resolveNewPanelPosition(
+            "godmother",
+            "tunnel",           // active service panel → auto-placement triggered
+            activeServicePanels,
+            getPanelPosition,
+        );
+
+        // Auto-placement correctly returns "bottom" (same group as tunnel)…
+        expect(autoPlacedPosition).toBe("bottom");
+        // …but this DIFFERS from godmother's own stored preference ("right"),
+        // so persisting it would permanently corrupt the saved dock position.
+        expect(autoPlacedPosition).not.toBe(getPanelPosition("godmother"));
+    });
+
+    test("non-auto-placement returns panel's own stored position — identical, safe to skip persistence", () => {
+        // When the active tab is NOT a service panel, resolveNewPanelPosition
+        // returns the panel's own stored preference, making any persist call a no-op.
+        // The fix: skip the setServicePanelPosition call entirely in this path.
+        const activeServicePanels = new Set<string>();
+        const positions = new Map([["godmother", "left"]] as const);
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
+
+        const position = resolveNewPanelPosition(
+            "godmother",
+            "terminal",         // NOT a service panel → no auto-placement
+            activeServicePanels,
+            getPanelPosition,
+        );
+
+        expect(position).toBe("left");
+        // Position equals the panel's own stored preference — no corruption possible.
+        expect(position).toBe(getPanelPosition("godmother"));
+    });
+
+    test("reopening after auto-placement should still use stored position (ephemeral cleared on close)", () => {
+        // Verifies the conceptual contract: after a panel is closed, its next
+        // open (without auto-placement context) should use the stored preference,
+        // not the stale transient position from the previous open.
+        // The ephemeral override must be cleared on panel close.
+        //
+        // Scenario: godmother stored at "right". Opened next to tunnel ("bottom")
+        // → auto-placed ephemeral="bottom". Closed. Opened again standalone.
+        // Expected: uses stored "right", NOT the stale "bottom".
+        const positions = new Map([["godmother", "right"]] as const);
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
+
+        // Second open: active tab is NOT a service panel (tunnel closed)
+        const activeServicePanels = new Set<string>();
+        const position = resolveNewPanelPosition(
+            "godmother",
+            "terminal",
+            activeServicePanels,
+            getPanelPosition,
+        );
+        // Returns stored preference, not any stale ephemeral value
+        expect(position).toBe("right");
+    });
+});
+
 // ── Moving bug: resolveActiveTabIdFromIds should use combinedActiveTab when present ──
 
 describe("resolveActiveTabIdFromIds — moving bug", () => {

--- a/packages/ui/src/components/service-panels/ServicePanels.test.ts
+++ b/packages/ui/src/components/service-panels/ServicePanels.test.ts
@@ -1,0 +1,206 @@
+/**
+ * Tests for service panel focus behaviour.
+ *
+ * The two bugs addressed by this test suite:
+ *
+ * 1. **Adding bug** — when a new service panel is opened while a different
+ *    service panel is already the active (combinedActiveTab) tab, the new
+ *    panel should be placed into the *same position group* as the currently-
+ *    active panel.  Previously the new panel used its stored/default position,
+ *    which could be a different group — leaving the Tunnels panel highlighted
+ *    in the old group while the new panel appeared elsewhere.
+ *
+ * 2. **Moving bug** — when a service panel tab is dragged to a new dock
+ *    position, handleCombinedTabChange(serviceId) is now called so the moved
+ *    panel stays as the globally-active tab.  Without this, the source group
+ *    fell back to tabs[0] (Tunnels) and the user perceived Tunnels as having
+ *    stolen focus.
+ *
+ * Because the fix lives in App.tsx (a large React component that requires a
+ * real DOM renderer), the tests here verify the *pure decision logic*
+ * extracted from that component — the same way usePanelLayout.test.ts tests
+ * pure helpers rather than the full hook.
+ */
+
+import { describe, expect, test } from "bun:test";
+import type { PanelPosition } from "@/hooks/usePanelLayout";
+
+// ── Pure helpers mirroring App.tsx logic ──────────────────────────────────────
+
+/**
+ * Mirrors the position-override logic added to handleToggleServicePanel:
+ *
+ * When the currently-active tab IS a service panel (i.e. it's in
+ * activeServicePanels), the new panel should inherit that panel's position so
+ * both appear in the same group.  Otherwise the stored/default position is
+ * used unchanged.
+ */
+function resolveNewPanelPosition(
+    newServiceId: string,
+    combinedActiveTab: string,
+    activeServicePanels: Set<string>,
+    getPanelPosition: (id: string) => PanelPosition,
+): PanelPosition {
+    if (activeServicePanels.has(combinedActiveTab)) {
+        return getPanelPosition(combinedActiveTab);
+    }
+    return getPanelPosition(newServiceId);
+}
+
+/**
+ * Mirrors resolveActiveTabId in App.tsx:
+ * returns combinedActiveTab if it is in the group, otherwise tabs[0].
+ */
+function resolveActiveTabId(tabs: string[], combinedActiveTab: string): string {
+    if (tabs.length === 0) return combinedActiveTab;
+    return tabs.includes(combinedActiveTab) ? combinedActiveTab : tabs[0]!;
+}
+
+// ── Adding bug: new panel should join the current active group ────────────────
+
+describe("resolveNewPanelPosition — adding bug", () => {
+    test("new panel inherits position of the currently-active service panel", () => {
+        // Tunnel is open and at "bottom".  User opens godmother.
+        // Before fix: godmother used its own stored position ("right"), causing
+        // the two panels to land in different groups.
+        // After fix: godmother is placed at "bottom" (same as tunnel).
+        const activeServicePanels = new Set(["tunnel"]);
+        const positions = new Map<string, PanelPosition>([
+            ["tunnel", "bottom"],
+            // godmother has a *different* stored position
+            ["godmother", "right"],
+        ]);
+        const getPanelPosition = (id: string): PanelPosition =>
+            positions.get(id) ?? "right";
+
+        const result = resolveNewPanelPosition(
+            "godmother",
+            "tunnel",           // combinedActiveTab = tunnel (active service panel)
+            activeServicePanels,
+            getPanelPosition,
+        );
+
+        expect(result).toBe("bottom"); // same group as the active panel (tunnel)
+    });
+
+    test("uses stored position when no service panel is currently active", () => {
+        // No service panels open yet.  combinedActiveTab = "terminal".
+        // The new panel should use its stored/default position.
+        const activeServicePanels = new Set<string>(); // empty
+        const positions = new Map<string, PanelPosition>([["godmother", "left"]]);
+        const getPanelPosition = (id: string): PanelPosition =>
+            positions.get(id) ?? "right";
+
+        const result = resolveNewPanelPosition(
+            "godmother",
+            "terminal",         // combinedActiveTab is NOT a service panel
+            activeServicePanels,
+            getPanelPosition,
+        );
+
+        expect(result).toBe("left"); // godmother's own stored position
+    });
+
+    test("uses default 'right' position when no service panel is active and no stored position", () => {
+        const activeServicePanels = new Set<string>();
+        const getPanelPosition = (_id: string): PanelPosition => "right"; // default
+
+        const result = resolveNewPanelPosition(
+            "godmother",
+            "terminal",
+            activeServicePanels,
+            getPanelPosition,
+        );
+
+        expect(result).toBe("right");
+    });
+
+    test("opening a second panel while the first is active puts it in the same group", () => {
+        // Tunnel is active at "right", godmother has a stale "bottom" in localStorage.
+        // User clicks godmother button → should appear at "right" (same group as tunnel).
+        const activeServicePanels = new Set(["tunnel"]);
+        const positions = new Map<string, PanelPosition>([
+            ["tunnel", "right"],
+            ["godmother", "bottom"], // stale stored position
+        ]);
+        const getPanelPosition = (id: string): PanelPosition =>
+            positions.get(id) ?? "right";
+
+        const result = resolveNewPanelPosition(
+            "godmother",
+            "tunnel",
+            activeServicePanels,
+            getPanelPosition,
+        );
+
+        expect(result).toBe("right"); // follows tunnel, not the stale stored position
+    });
+
+    test("does not change position when new panel is already in the same group", () => {
+        // Both panels default to "right" — the fix is a no-op in this case.
+        const activeServicePanels = new Set(["tunnel"]);
+        const positions = new Map<string, PanelPosition>([
+            ["tunnel", "right"],
+            ["godmother", "right"],
+        ]);
+        const getPanelPosition = (id: string): PanelPosition =>
+            positions.get(id) ?? "right";
+
+        const result = resolveNewPanelPosition(
+            "godmother",
+            "tunnel",
+            activeServicePanels,
+            getPanelPosition,
+        );
+
+        expect(result).toBe("right"); // no change needed
+    });
+});
+
+// ── Moving bug: resolveActiveTabId should use combinedActiveTab when present ──
+
+describe("resolveActiveTabId — moving bug", () => {
+    test("returns combinedActiveTab when it is in the group", () => {
+        // Both tunnel and godmother are in the right group; godmother is active.
+        expect(
+            resolveActiveTabId(["tunnel", "godmother"], "godmother"),
+        ).toBe("godmother");
+    });
+
+    test("falls back to tabs[0] when combinedActiveTab is not in the group", () => {
+        // Godmother moved to bottom; right group only has tunnel.
+        // The correct fallback is tabs[0] = tunnel.
+        expect(
+            resolveActiveTabId(["tunnel"], "godmother"),
+        ).toBe("tunnel");
+    });
+
+    test("after adding fix: both panels are in the same group so resolveActiveTabId returns the new panel", () => {
+        // With the adding fix, godmother is placed in the same group as tunnel.
+        // combinedActiveTab = "godmother" (set by handleCombinedTabChange).
+        // Both panels are in the right group.
+        const rightGroupTabs = ["tunnel", "godmother"];
+        expect(resolveActiveTabId(rightGroupTabs, "godmother")).toBe("godmother");
+    });
+
+    test("single-tab group always returns its only tab", () => {
+        // If godmother is the only tab in its group and is combinedActiveTab:
+        expect(resolveActiveTabId(["godmother"], "godmother")).toBe("godmother");
+        // If godmother is elsewhere and tunnel is the only tab:
+        expect(resolveActiveTabId(["tunnel"], "godmother")).toBe("tunnel");
+    });
+
+    test("returns combinedActiveTab unchanged for empty tab list", () => {
+        // No tabs → return combinedActiveTab (caller must not render a panel)
+        expect(resolveActiveTabId([], "godmother")).toBe("godmother");
+    });
+
+    test("moving panel: combinedActiveTab re-asserted via handleCombinedTabChange keeps focus", () => {
+        // After moving godmother from right to bottom, handleCombinedTabChange
+        // is called with "godmother".  The bottom group correctly highlights it.
+        const bottomGroupAfterMove = ["godmother"];
+        expect(
+            resolveActiveTabId(bottomGroupAfterMove, "godmother"),
+        ).toBe("godmother");
+    });
+});

--- a/packages/ui/src/components/service-panels/ServicePanels.test.ts
+++ b/packages/ui/src/components/service-panels/ServicePanels.test.ts
@@ -16,45 +16,13 @@
  *    fell back to tabs[0] (Tunnels) and the user perceived Tunnels as having
  *    stolen focus.
  *
- * Because the fix lives in App.tsx (a large React component that requires a
- * real DOM renderer), the tests here verify the *pure decision logic*
- * extracted from that component — the same way usePanelLayout.test.ts tests
- * pure helpers rather than the full hook.
+ * The helpers under test (`resolveNewPanelPosition`, `resolveActiveTabIdFromIds`)
+ * are extracted from App.tsx into `@/utils/servicePanelUtils` so that these
+ * tests exercise the real production code rather than mirror copies.
  */
 
 import { describe, expect, test } from "bun:test";
-import type { PanelPosition } from "@/hooks/usePanelLayout";
-
-// ── Pure helpers mirroring App.tsx logic ──────────────────────────────────────
-
-/**
- * Mirrors the position-override logic added to handleToggleServicePanel:
- *
- * When the currently-active tab IS a service panel (i.e. it's in
- * activeServicePanels), the new panel should inherit that panel's position so
- * both appear in the same group.  Otherwise the stored/default position is
- * used unchanged.
- */
-function resolveNewPanelPosition(
-    newServiceId: string,
-    combinedActiveTab: string,
-    activeServicePanels: Set<string>,
-    getPanelPosition: (id: string) => PanelPosition,
-): PanelPosition {
-    if (activeServicePanels.has(combinedActiveTab)) {
-        return getPanelPosition(combinedActiveTab);
-    }
-    return getPanelPosition(newServiceId);
-}
-
-/**
- * Mirrors resolveActiveTabId in App.tsx:
- * returns combinedActiveTab if it is in the group, otherwise tabs[0].
- */
-function resolveActiveTabId(tabs: string[], combinedActiveTab: string): string {
-    if (tabs.length === 0) return combinedActiveTab;
-    return tabs.includes(combinedActiveTab) ? combinedActiveTab : tabs[0]!;
-}
+import { resolveNewPanelPosition, resolveActiveTabIdFromIds } from "../../utils/servicePanelUtils";
 
 // ── Adding bug: new panel should join the current active group ────────────────
 
@@ -65,13 +33,12 @@ describe("resolveNewPanelPosition — adding bug", () => {
         // the two panels to land in different groups.
         // After fix: godmother is placed at "bottom" (same as tunnel).
         const activeServicePanels = new Set(["tunnel"]);
-        const positions = new Map<string, PanelPosition>([
+        const positions = new Map([
             ["tunnel", "bottom"],
             // godmother has a *different* stored position
             ["godmother", "right"],
-        ]);
-        const getPanelPosition = (id: string): PanelPosition =>
-            positions.get(id) ?? "right";
+        ] as const);
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
 
         const result = resolveNewPanelPosition(
             "godmother",
@@ -87,9 +54,8 @@ describe("resolveNewPanelPosition — adding bug", () => {
         // No service panels open yet.  combinedActiveTab = "terminal".
         // The new panel should use its stored/default position.
         const activeServicePanels = new Set<string>(); // empty
-        const positions = new Map<string, PanelPosition>([["godmother", "left"]]);
-        const getPanelPosition = (id: string): PanelPosition =>
-            positions.get(id) ?? "right";
+        const positions = new Map([["godmother", "left"]] as const);
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
 
         const result = resolveNewPanelPosition(
             "godmother",
@@ -103,7 +69,7 @@ describe("resolveNewPanelPosition — adding bug", () => {
 
     test("uses default 'right' position when no service panel is active and no stored position", () => {
         const activeServicePanels = new Set<string>();
-        const getPanelPosition = (_id: string): PanelPosition => "right"; // default
+        const getPanelPosition = (_id: string) => "right" as const; // default
 
         const result = resolveNewPanelPosition(
             "godmother",
@@ -119,12 +85,11 @@ describe("resolveNewPanelPosition — adding bug", () => {
         // Tunnel is active at "right", godmother has a stale "bottom" in localStorage.
         // User clicks godmother button → should appear at "right" (same group as tunnel).
         const activeServicePanels = new Set(["tunnel"]);
-        const positions = new Map<string, PanelPosition>([
+        const positions = new Map([
             ["tunnel", "right"],
             ["godmother", "bottom"], // stale stored position
-        ]);
-        const getPanelPosition = (id: string): PanelPosition =>
-            positions.get(id) ?? "right";
+        ] as const);
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
 
         const result = resolveNewPanelPosition(
             "godmother",
@@ -139,12 +104,11 @@ describe("resolveNewPanelPosition — adding bug", () => {
     test("does not change position when new panel is already in the same group", () => {
         // Both panels default to "right" — the fix is a no-op in this case.
         const activeServicePanels = new Set(["tunnel"]);
-        const positions = new Map<string, PanelPosition>([
+        const positions = new Map([
             ["tunnel", "right"],
             ["godmother", "right"],
-        ]);
-        const getPanelPosition = (id: string): PanelPosition =>
-            positions.get(id) ?? "right";
+        ] as const);
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
 
         const result = resolveNewPanelPosition(
             "godmother",
@@ -157,13 +121,13 @@ describe("resolveNewPanelPosition — adding bug", () => {
     });
 });
 
-// ── Moving bug: resolveActiveTabId should use combinedActiveTab when present ──
+// ── Moving bug: resolveActiveTabIdFromIds should use combinedActiveTab when present ──
 
-describe("resolveActiveTabId — moving bug", () => {
+describe("resolveActiveTabIdFromIds — moving bug", () => {
     test("returns combinedActiveTab when it is in the group", () => {
         // Both tunnel and godmother are in the right group; godmother is active.
         expect(
-            resolveActiveTabId(["tunnel", "godmother"], "godmother"),
+            resolveActiveTabIdFromIds(["tunnel", "godmother"], "godmother"),
         ).toBe("godmother");
     });
 
@@ -171,28 +135,28 @@ describe("resolveActiveTabId — moving bug", () => {
         // Godmother moved to bottom; right group only has tunnel.
         // The correct fallback is tabs[0] = tunnel.
         expect(
-            resolveActiveTabId(["tunnel"], "godmother"),
+            resolveActiveTabIdFromIds(["tunnel"], "godmother"),
         ).toBe("tunnel");
     });
 
-    test("after adding fix: both panels are in the same group so resolveActiveTabId returns the new panel", () => {
+    test("after adding fix: both panels are in the same group so resolveActiveTabIdFromIds returns the new panel", () => {
         // With the adding fix, godmother is placed in the same group as tunnel.
         // combinedActiveTab = "godmother" (set by handleCombinedTabChange).
         // Both panels are in the right group.
         const rightGroupTabs = ["tunnel", "godmother"];
-        expect(resolveActiveTabId(rightGroupTabs, "godmother")).toBe("godmother");
+        expect(resolveActiveTabIdFromIds(rightGroupTabs, "godmother")).toBe("godmother");
     });
 
     test("single-tab group always returns its only tab", () => {
         // If godmother is the only tab in its group and is combinedActiveTab:
-        expect(resolveActiveTabId(["godmother"], "godmother")).toBe("godmother");
+        expect(resolveActiveTabIdFromIds(["godmother"], "godmother")).toBe("godmother");
         // If godmother is elsewhere and tunnel is the only tab:
-        expect(resolveActiveTabId(["tunnel"], "godmother")).toBe("tunnel");
+        expect(resolveActiveTabIdFromIds(["tunnel"], "godmother")).toBe("tunnel");
     });
 
     test("returns combinedActiveTab unchanged for empty tab list", () => {
         // No tabs → return combinedActiveTab (caller must not render a panel)
-        expect(resolveActiveTabId([], "godmother")).toBe("godmother");
+        expect(resolveActiveTabIdFromIds([], "godmother")).toBe("godmother");
     });
 
     test("moving panel: combinedActiveTab re-asserted via handleCombinedTabChange keeps focus", () => {
@@ -200,7 +164,7 @@ describe("resolveActiveTabId — moving bug", () => {
         // is called with "godmother".  The bottom group correctly highlights it.
         const bottomGroupAfterMove = ["godmother"];
         expect(
-            resolveActiveTabId(bottomGroupAfterMove, "godmother"),
+            resolveActiveTabIdFromIds(bottomGroupAfterMove, "godmother"),
         ).toBe("godmother");
     });
 });

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -168,6 +168,11 @@ function savePanelPositions(positions: Map<string, PanelPosition>) {
 export function useServicePanelState() {
     const [activePanelIds, setActivePanelIds] = useState<Set<string>>(new Set());
     const [panelPositions, setPanelPositions] = useState<Map<string, PanelPosition>>(loadPanelPositions);
+    // Ephemeral (non-persisted) position overrides used for auto-placement.
+    // When a panel is opened next to an active panel, its position for this
+    // session is stored here rather than in panelPositions / localStorage.
+    // The override is cleared when the panel is closed.
+    const [ephemeralPositions, setEphemeralPositions] = useState<Map<string, PanelPosition>>(new Map());
 
     const togglePanel = useCallback((serviceId: string) => {
         setActivePanelIds(prev => {
@@ -179,6 +184,14 @@ export function useServicePanelState() {
             }
             return next;
         });
+        // Clear ephemeral override when closing so that the next open uses the
+        // stored preference (or a fresh auto-placement), not a stale transient.
+        setEphemeralPositions(prev => {
+            if (!prev.has(serviceId)) return prev;
+            const next = new Map(prev);
+            next.delete(serviceId);
+            return next;
+        });
     }, []);
 
     const closePanelById = useCallback((serviceId: string) => {
@@ -187,15 +200,25 @@ export function useServicePanelState() {
             next.delete(serviceId);
             return next;
         });
+        // Clear ephemeral override on explicit close as well.
+        setEphemeralPositions(prev => {
+            if (!prev.has(serviceId)) return prev;
+            const next = new Map(prev);
+            next.delete(serviceId);
+            return next;
+        });
     }, []);
 
     const closeAllPanels = useCallback(() => {
         setActivePanelIds(new Set());
+        setEphemeralPositions(new Map());
     }, []);
 
     const getPanelPosition = useCallback((serviceId: string): PanelPosition => {
-        return panelPositions.get(serviceId) ?? "right";
-    }, [panelPositions]);
+        // Ephemeral overrides take precedence over persisted positions so that
+        // auto-placed panels render in the correct dock group for this session.
+        return ephemeralPositions.get(serviceId) ?? panelPositions.get(serviceId) ?? "right";
+    }, [ephemeralPositions, panelPositions]);
 
     const setPanelPosition = useCallback((serviceId: string, pos: PanelPosition) => {
         setPanelPositions(prev => {
@@ -204,7 +227,24 @@ export function useServicePanelState() {
             savePanelPositions(next);
             return next;
         });
+        // A deliberate user action (drag/dock) clears any ephemeral override so
+        // the newly-saved preference is used from this point forward.
+        setEphemeralPositions(prev => {
+            if (!prev.has(serviceId)) return prev;
+            const next = new Map(prev);
+            next.delete(serviceId);
+            return next;
+        });
     }, []);
 
-    return { activePanelIds, togglePanel, closePanelById, closeAllPanels, getPanelPosition, setPanelPosition };
+    /** Set a transient position for this session only — does NOT persist to localStorage. */
+    const setEphemeralPanelPosition = useCallback((serviceId: string, pos: PanelPosition) => {
+        setEphemeralPositions(prev => {
+            const next = new Map(prev);
+            next.set(serviceId, pos);
+            return next;
+        });
+    }, []);
+
+    return { activePanelIds, togglePanel, closePanelById, closeAllPanels, getPanelPosition, setPanelPosition, setEphemeralPanelPosition };
 }

--- a/packages/ui/src/utils/servicePanelUtils.ts
+++ b/packages/ui/src/utils/servicePanelUtils.ts
@@ -1,0 +1,42 @@
+/**
+ * Pure helpers for service panel layout decisions.
+ *
+ * Extracted from App.tsx so they can be imported by both the component and
+ * tests.  Keeping the logic here means the tests exercise the real production
+ * code rather than mirroring it, turning them into genuine regression guards.
+ */
+
+import type { PanelPosition } from "@/hooks/usePanelLayout";
+
+/**
+ * Decide which position a newly-opened service panel should occupy.
+ *
+ * When the currently-active tab is already a service panel, the new panel
+ * inherits that panel's position so both appear in the same dock group.
+ * Otherwise the new panel's own stored/default position is used.
+ */
+export function resolveNewPanelPosition(
+    newServiceId: string,
+    combinedActiveTab: string,
+    activeServicePanels: Set<string>,
+    getPanelPosition: (id: string) => PanelPosition,
+): PanelPosition {
+    if (activeServicePanels.has(combinedActiveTab)) {
+        return getPanelPosition(combinedActiveTab);
+    }
+    return getPanelPosition(newServiceId);
+}
+
+/**
+ * Given an ordered list of tab IDs in a dock group and the globally-active
+ * tab ID, return which tab should be highlighted in that group.
+ *
+ * - If the active tab is present in the group → return it.
+ * - Otherwise fall back to the first tab in the group.
+ * - If the group is empty → return the active tab unchanged (caller must not
+ *   render a panel for an empty group).
+ */
+export function resolveActiveTabIdFromIds(tabIds: string[], combinedActiveTab: string): string {
+    if (tabIds.length === 0) return combinedActiveTab;
+    return tabIds.includes(combinedActiveTab) ? combinedActiveTab : tabIds[0]!;
+}


### PR DESCRIPTION
Night Shift pairing: `ui-stability-core`

Three independent fixes landed together as a stability pairing.

---

## Fix 1 — Tunnel relay timeout resource leak

**Godmother:** `1f5l22Vq`

**Problem:** When a relay-side HTTP or WebSocket request timed out, the timeout handler cleaned up the relay side but sent no signal to the runner. The runner kept the in-flight `http.ClientRequest` or local WebSocket alive indefinitely, silently leaking connections over time.

**Fix:** On HTTP timeout, send `request-end` to the runner before deleting the pending entry. On WS open-timeout, send `ws-close` (code `1001`). Both messages are safe no-ops if the runner has already disconnected.

---

## Fix 2 — Service panel auto-focus bug

**Godmother:** `JX5XfOLM`

**Problem:** Adding or moving a service panel auto-focused the Tunnels Panel instead of the newly added/moved panel.

**Fix:** When adding a panel while another service panel is the active tab, first move the new panel to the same position group, then toggle it open and set focus — all in one React batch so no stale render can redirect focus to the wrong panel.

---

## Fix 3 — Server graceful shutdown

**Godmother:** `VxkPFouT`

**Problem:** Uncaught exceptions called `process.exit(1)` immediately, killing in-flight HTTP requests and WebSocket connections without any cleanup.

**Fix:** Non-recoverable exceptions now trigger a graceful drain (close idle connections, finish in-flight requests, then exit). Recoverable errors (`EPIPE`, `ECONNRESET`, malformed JSON) are logged at `warn` level and don't crash the server.

---

## How to verify

- **Relay timeout leak:** Tunnel a service and let a request time out — the runner should not accumulate orphaned connections.
- **Panel focus:** Add a second service panel — it should receive focus, not the Tunnels Panel.
- **Graceful shutdown:** Send a bad request that would previously crash the server — it should log a warning and keep running.