### PR TITLE
feat: reuse viewer socket across session switches

### DIFF
--- a/packages/protocol/src/viewer.test.ts
+++ b/packages/protocol/src/viewer.test.ts
@@ -21,6 +21,7 @@ describe("viewer — ViewerServerToClientEvents payloads", () => {
     expect(minimal.lastSeq).toBeUndefined();
     expect(minimal.replayOnly).toBeUndefined();
     expect(minimal.isActive).toBeUndefined();
+    expect(minimal.generation).toBeUndefined();
 
     const full: Payload = {
       sessionId: "sess-2",
@@ -29,10 +30,12 @@ describe("viewer — ViewerServerToClientEvents payloads", () => {
       isActive: false,
       lastHeartbeatAt: null,
       sessionName: "My Session",
+      generation: 7,
     };
     expect(full.lastSeq).toBe(42);
     expect(full.replayOnly).toBe(true);
     expect(full.sessionName).toBe("My Session");
+    expect(full.generation).toBe(7);
   });
 
   test("event payload carries event with optional seq and replay", () => {
@@ -42,14 +45,17 @@ describe("viewer — ViewerServerToClientEvents payloads", () => {
     expect(minimal.event).toBeDefined();
     expect(minimal.seq).toBeUndefined();
     expect(minimal.replay).toBeUndefined();
+    expect(minimal.generation).toBeUndefined();
 
     const full: Payload = {
       event: { type: "message_update", content: "Hello" },
       seq: 100,
       replay: true,
+      generation: 7,
     };
     expect(full.seq).toBe(100);
     expect(full.replay).toBe(true);
+    expect(full.generation).toBe(7);
   });
 
   test("disconnected carries reason string with optional structured code", () => {
@@ -57,9 +63,11 @@ describe("viewer — ViewerServerToClientEvents payloads", () => {
     const p: Payload = { reason: "TUI disconnected" };
     expect(typeof p.reason).toBe("string");
     expect(p.code).toBeUndefined();
+    expect(p.generation).toBeUndefined();
 
-    const structured: Payload = { reason: "Session is no longer live (snapshot replay).", code: "snapshot_replay" };
+    const structured: Payload = { reason: "Session is no longer live (snapshot replay).", code: "snapshot_replay", generation: 8 };
     expect(structured.code).toBe("snapshot_replay");
+    expect(structured.generation).toBe(8);
   });
 
   test("exec_result carries id, ok, and command", () => {
@@ -89,8 +97,9 @@ describe("viewer — ViewerServerToClientEvents payloads", () => {
 
   test("error carries message string", () => {
     type Payload = Parameters<ViewerServerToClientEvents["error"]>[0];
-    const p: Payload = { message: "Unauthorized" };
+    const p: Payload = { message: "Unauthorized", generation: 9 };
     expect(typeof p.message).toBe("string");
+    expect(p.generation).toBe(9);
   });
 
   test("trigger_error carries message and triggerId", () => {
@@ -109,6 +118,17 @@ describe("viewer — ViewerClientToServerEvents payloads", () => {
     type Payload = Parameters<ViewerClientToServerEvents["connected"]>[0];
     const p: Payload = {};
     expect(Object.keys(p)).toHaveLength(0);
+  });
+
+  test("switch_session carries target session with optional generation", () => {
+    type Payload = Parameters<ViewerClientToServerEvents["switch_session"]>[0];
+    const minimal: Payload = { sessionId: "sess-1" };
+    expect(minimal.sessionId).toBe("sess-1");
+    expect(minimal.generation).toBeUndefined();
+
+    const full: Payload = { sessionId: "sess-2", generation: 10 };
+    expect(full.sessionId).toBe("sess-2");
+    expect(full.generation).toBe(10);
   });
 
   test("resync sends empty record", () => {
@@ -219,9 +239,11 @@ describe("viewer — ViewerSocketData", () => {
       sessionId: "sess-1",
       userId: "u-42",
       userName: "alice",
+      generation: 11,
     };
     expect(data.sessionId).toBe("sess-1");
     expect(data.userId).toBe("u-42");
     expect(data.userName).toBe("alice");
+    expect(data.generation).toBe(11);
   });
 });

--- a/packages/protocol/src/viewer.ts
+++ b/packages/protocol/src/viewer.ts
@@ -19,6 +19,8 @@ export interface ViewerServerToClientEvents {
     isActive?: boolean;
     lastHeartbeatAt?: string | null;
     sessionName?: string | null;
+    /** Optional switch generation echoed back during logical session switches. */
+    generation?: number;
   }) => void;
 
   /** Forwards an agent event to the viewer */
@@ -26,12 +28,16 @@ export interface ViewerServerToClientEvents {
     event: unknown;
     seq?: number;
     replay?: boolean;
+    /** Optional switch generation echoed back during logical session switches. */
+    generation?: number;
   }) => void;
 
   /** Notifies the viewer that the TUI disconnected */
   disconnected: (data: {
     reason: string;
     code?: ViewerDisconnectCode;
+    /** Optional switch generation echoed back during logical session switches. */
+    generation?: number;
   }) => void;
 
   /** Forwards an exec result back to the viewer */
@@ -48,11 +54,16 @@ export interface ViewerServerToClientEvents {
   service_message: (envelope: ServiceEnvelope) => void;
 
   /** Announces which services the connected runner supports. */
-  service_announce: (data: ServiceAnnounceData) => void;
+  service_announce: (data: ServiceAnnounceData & {
+    /** Optional switch generation echoed back during logical session switches. */
+    generation?: number;
+  }) => void;
 
   /** Generic error */
   error: (data: {
     message: string;
+    /** Optional switch generation echoed back during logical session switches. */
+    generation?: number;
   }) => void;
 
   /** Error delivering a trigger_response to a child session or relay target.
@@ -71,6 +82,12 @@ export interface ViewerServerToClientEvents {
 export interface ViewerClientToServerEvents {
   /** Viewer greeting — triggers TUI capabilities push */
   connected: (data: Record<string, never>) => void;
+
+  /** Logically switch the existing viewer socket to a different session. */
+  switch_session: (data: {
+    sessionId: string;
+    generation?: number;
+  }) => void;
 
   /** Request a fresh snapshot resync */
   resync: (data: Record<string, never>) => void;
@@ -111,8 +128,7 @@ export interface ViewerClientToServerEvents {
 
   /** Submit a pasted OAuth callback URL code for an MCP server.
    *  Used when the MCP server requires a localhost redirect URI that is
-   *  unreachable from the remote web UI (e.g. Figma via Tailscale). */
-  /** Submit a pasted OAuth callback URL code for an MCP server.
+   *  unreachable from the remote web UI (e.g. Figma via Tailscale).
    *  Supports Socket.IO ack — server calls the ack callback only on
    *  successful delivery to the runner, so the client can detect failures. */
   mcp_oauth_paste: (data: {
@@ -138,4 +154,6 @@ export interface ViewerSocketData {
   sessionId?: string;
   userId?: string;
   userName?: string;
+  /** Latest requested logical session-switch generation for this viewer socket. */
+  generation?: number;
 }

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -229,6 +229,36 @@ export function getRunnerServiceAnnounce(runnerId: string): ServiceAnnounceData 
     return runnerServiceAnnounce.get(runnerId) ?? null;
 }
 
+/** @internal — exported for unit tests only */
+export function isSameServiceAnnounce(
+    a: ServiceAnnounceData | null | undefined,
+    b: ServiceAnnounceData | null | undefined,
+): boolean {
+    if (!a || !b) return false;
+    if (a.serviceIds.length !== b.serviceIds.length) return false;
+    for (let i = 0; i < a.serviceIds.length; i++) {
+        if (a.serviceIds[i] !== b.serviceIds[i]) return false;
+    }
+
+    const aPanels = a.panels ?? [];
+    const bPanels = b.panels ?? [];
+    if (aPanels.length !== bPanels.length) return false;
+    for (let i = 0; i < aPanels.length; i++) {
+        const left = aPanels[i];
+        const right = bPanels[i];
+        if (
+            left.serviceId !== right.serviceId ||
+            left.port !== right.port ||
+            left.label !== right.label ||
+            left.icon !== right.icon
+        ) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
 /**
  * Load service announce data from Redis into the in-memory cache.
  * Called after runner registration to seed the cache from persisted data
@@ -671,6 +701,12 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
         socket.on("service_announce", (data: ServiceAnnounceData) => {
             const runnerId = socket.data.runnerId;
             if (!runnerId) return;
+
+            const previous = runnerServiceAnnounce.get(runnerId);
+            // Skip no-op announces to avoid redundant Redis writes and fan-out
+            // to every viewer on this runner when nothing actually changed.
+            if (isSameServiceAnnounce(previous, data)) return;
+
             // Cache in memory for fast lookups
             runnerServiceAnnounce.set(runnerId, data);
             // Persist to Redis so the data survives server restarts

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -13,6 +13,7 @@ import {
     findLatestSnapshotEvent,
     onViewerConnectedSignal,
     onViewerReadyForRunnerSignal,
+    isViewerSwitchCurrent,
 } from "./viewer.js";
 
 // ── isAgentEndEvent ──────────────────────────────────────────────────────────
@@ -130,6 +131,22 @@ describe("findLatestSnapshotEvent", () => {
     test("handles a single snapshot event", () => {
         const sa = { type: "session_active", state: {} };
         expect(findLatestSnapshotEvent([sa])).toBe(sa);
+    });
+});
+
+// ── viewer switch generation guards ────────────────────────────────────────
+
+describe("isViewerSwitchCurrent", () => {
+    test("accepts payloads with no generation", () => {
+        expect(isViewerSwitchCurrent(4, undefined)).toBe(true);
+    });
+
+    test("accepts matching generations", () => {
+        expect(isViewerSwitchCurrent(4, 4)).toBe(true);
+    });
+
+    test("rejects stale generations", () => {
+        expect(isViewerSwitchCurrent(4, 3)).toBe(false);
     });
 });
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -20,7 +20,7 @@ import type {
 // worktree's updated dist.
 type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
 import { sessionCookieAuthMiddleware } from "./auth.js";
-import { getRunnerServiceAnnounce, getRunnerServiceIds } from "./runner.js";
+import { getRunnerServiceAnnounce } from "./runner.js";
 import {
     getSharedSession,
     addViewer,
@@ -103,7 +103,7 @@ export function onViewerConnectedSignal(
     pendingConnectedSignal: boolean,
 ): { pendingConnectedSignal: boolean; forwardNow: boolean } {
     if (viewerReadyForRunnerSignal) {
-        return { pendingConnectedSignal, forwardNow: true };
+        return { pendingConnectedSignal: false, forwardNow: true };
     }
     return { pendingConnectedSignal: true, forwardNow: false };
 }
@@ -118,6 +118,11 @@ export function onViewerReadyForRunnerSignal(
     return { pendingConnectedSignal: false, forwardNow: true };
 }
 
+/** @internal — exported for unit tests only */
+export function isViewerSwitchCurrent(currentGeneration: number | undefined, requestedGeneration?: number): boolean {
+    return requestedGeneration === undefined || currentGeneration === requestedGeneration;
+}
+
 /**
  * Try to send the latest snapshot event from the Redis event cache.
  * Returns true if a snapshot was sent, false otherwise.
@@ -125,6 +130,7 @@ export function onViewerReadyForRunnerSignal(
 async function sendLatestSnapshotFromCache(
     socket: ViewerSocket,
     sessionId: string,
+    generation?: number,
 ): Promise<boolean> {
     const cachedEvents = await getCachedRelayEvents(sessionId);
     if (cachedEvents.length === 0) return false;
@@ -132,7 +138,7 @@ async function sendLatestSnapshotFromCache(
     const snapshotEvent = findLatestSnapshotEvent(cachedEvents);
     if (!snapshotEvent) return false;
 
-    socket.emit("event", { event: snapshotEvent, replay: true });
+    socket.emit("event", { event: snapshotEvent, replay: true, generation });
     return true;
 }
 
@@ -144,6 +150,7 @@ async function replayPersistedSnapshot(
     socket: ViewerSocket,
     sessionId: string,
     userId: string,
+    generation?: number,
 ): Promise<void> {
     try {
         const snapshot = await getPersistedRelaySessionSnapshot(sessionId, userId);
@@ -153,11 +160,11 @@ async function replayPersistedSnapshot(
             return;
         }
 
-        socket.emit("connected", { sessionId, replayOnly: true });
+        socket.emit("connected", { sessionId, replayOnly: true, generation });
 
         // Fast path: send only the latest snapshot from Redis cache
         // (ownership already validated by persisted snapshot lookup above)
-        const sentFromCache = await sendLatestSnapshotFromCache(socket, sessionId);
+        const sentFromCache = await sendLatestSnapshotFromCache(socket, sessionId, generation);
 
         if (!sentFromCache) {
             // Cache miss — fall back to persisted state from SQLite.
@@ -170,12 +177,14 @@ async function replayPersistedSnapshot(
             }
             socket.emit("event", {
                 event: { type: "session_active", state: snapshot.state },
+                generation,
             });
         }
 
         socket.emit("disconnected", {
             reason: "Session is no longer live (snapshot replay).",
             code: "snapshot_replay",
+            generation,
         });
         // Use disconnect() without `true` so the client can still auto-reconnect
         // when the session comes back online. disconnect(true) sets reason to
@@ -203,8 +212,10 @@ export function registerViewerNamespace(io: SocketIOServer): void {
     viewer.use(sessionCookieAuthMiddleware() as Parameters<typeof viewer.use>[0]);
 
     viewer.on("connection", async (socket) => {
-        // Extract sessionId from handshake auth or query
-        const sessionId =
+        // Optional initial session ID from the handshake. Newer clients keep one
+        // viewer socket alive and switch sessions logically via switch_session,
+        // but we preserve handshake-based bootstrap for backward compatibility.
+        const initialSessionId =
             (typeof socket.handshake.auth?.sessionId === "string"
                 ? socket.handshake.auth.sessionId
                 : undefined) ??
@@ -213,12 +224,6 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 : undefined) ??
             "";
 
-        if (!sessionId) {
-            socket.emit("error", { message: "Missing session ID" });
-            socket.disconnect(true);
-            return;
-        }
-
         const viewerUserId = socket.data.userId;
         if (!viewerUserId) {
             socket.emit("error", { message: "Unauthorized" });
@@ -226,23 +231,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             return;
         }
 
-        socket.data.sessionId = sessionId;
-
-        log.info(`connected: ${socket.id} sessionId=${sessionId} userId=${viewerUserId}`);
-
-        // Look up the live session
-        const session = await getSharedSession(sessionId);
-        if (!session) {
-            // Session not live — try to replay a persisted snapshot
-            await replayPersistedSnapshot(socket, sessionId, viewerUserId);
-            return;
-        }
-
-        if (!session.userId || session.userId !== viewerUserId) {
-            socket.emit("error", { message: "Session not found" });
-            socket.disconnect(true);
-            return;
-        }
+        log.info(`connected: ${socket.id} userId=${viewerUserId}`);
 
         // ── Register ALL event handlers FIRST ────────────────────────────────
         // Handlers must be registered synchronously before any async work
@@ -259,19 +248,162 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         let viewerReadyForRunnerSignal = false;
         let pendingConnectedSignal = false;
 
+        const getCurrentSessionId = (): string | null => socket.data.sessionId ?? null;
+        const getCurrentGeneration = (): number | undefined =>
+            typeof socket.data.generation === "number" ? socket.data.generation : undefined;
+
+        const activateSession = async (nextSessionId: string, generation?: number): Promise<void> => {
+            if (!nextSessionId) {
+                socket.data.sessionId = undefined;
+                return;
+            }
+
+            socket.data.generation = generation;
+            const previousSessionId = getCurrentSessionId();
+            if (previousSessionId && previousSessionId !== nextSessionId) {
+                await removeViewer(previousSessionId, socket);
+                if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) return;
+            }
+
+            const session = await getSharedSession(nextSessionId);
+            if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) return;
+
+            if (!session) {
+                socket.data.sessionId = undefined;
+                socket.emit("disconnected", { reason: "Session ended", code: "session_ended", generation });
+                return;
+            }
+
+            if (!session.userId || session.userId !== viewerUserId) {
+                socket.data.sessionId = undefined;
+                socket.emit("error", { message: "Session not found", generation });
+                return;
+            }
+
+            // Join the room first, then allow the viewer's "connected" signal to
+            // reach the runner. This avoids losing the first live snapshot/chunks
+            // and reduces startup resync churn.
+            const ok = await addViewer(nextSessionId, socket);
+            if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) {
+                if (ok) {
+                    await removeViewer(nextSessionId, socket);
+                }
+                return;
+            }
+            if (!ok) {
+                socket.data.sessionId = undefined;
+                socket.emit("disconnected", { reason: "Session ended", code: "session_ended", generation });
+                return;
+            }
+
+            socket.data.sessionId = nextSessionId;
+            viewerReadyForRunnerSignal = true;
+            const flush = onViewerReadyForRunnerSignal(pendingConnectedSignal);
+            pendingConnectedSignal = flush.pendingConnectedSignal;
+            if (flush.forwardNow) {
+                emitToRelaySession(nextSessionId, "connected" as string, {});
+            }
+
+            // Re-fetch session state and seq AFTER addViewer() to avoid emitting
+            // stale data. Between the initial fetch and here, the runner may have
+            // published a newer session_active (especially for chunked delivery).
+            // Using the old lastState + old lastSeq would overwrite the fresh
+            // snapshot and rewind lastSeqRef on the client, triggering a bogus
+            // resync on actively changing sessions.
+            const [freshSession, freshSeq] = await Promise.all([
+                getSharedSession(nextSessionId),
+                getSessionSeq(nextSessionId),
+            ]);
+
+            if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) {
+                await removeViewer(nextSessionId, socket);
+                return;
+            }
+
+            if (!freshSession) {
+                socket.data.sessionId = undefined;
+                socket.emit("disconnected", { reason: "Session ended", code: "session_ended", generation });
+                return;
+            }
+
+            socket.emit("connected", {
+                sessionId: nextSessionId,
+                lastSeq: freshSeq,
+                isActive: freshSession.isActive,
+                lastHeartbeatAt: freshSession.lastHeartbeatAt,
+                sessionName: freshSession.sessionName,
+                generation,
+            });
+
+            // Send cached service_announce so the viewer knows which runner
+            // services are available without waiting for a fresh announce.
+            log.info(`service_announce check: runnerId=${freshSession.runnerId ?? "null"}`);
+            if (freshSession.runnerId) {
+                const announce = getRunnerServiceAnnounce(freshSession.runnerId);
+                const serviceIds = announce?.serviceIds ?? [];
+                log.info(`service_announce: runnerId=${freshSession.runnerId}, cached serviceIds=[${serviceIds.join(",")}]`);
+                if (serviceIds.length > 0) {
+                    socket.emit("service_announce", { ...announce!, generation });
+                }
+            }
+
+            // Emit an immediate heartbeat snapshot while the runner pushes a fresh
+            // session_active in response to "connected".
+            if (freshSession.lastHeartbeat) {
+                try {
+                    socket.emit("event", { event: JSON.parse(freshSession.lastHeartbeat), seq: freshSeq, generation });
+                } catch {}
+            }
+
+            // If a chunked delivery is in-flight, lastState is stale (chunked
+            // session_active intentionally skips updating it). Emitting the old
+            // non-chunked snapshot here would overwrite the chunked header the
+            // viewer already received via the room broadcast, clear chunk-tracking
+            // in App.tsx, and cause remaining chunks to be dropped. Skip it and
+            // let the runner's fresh chunked delivery hydrate the viewer instead.
+            const chunkedPending = getPendingChunkedSnapshot(nextSessionId);
+            if (freshSession.lastState && !chunkedPending) {
+                try {
+                    socket.emit("event", {
+                        event: { type: "session_active", state: JSON.parse(freshSession.lastState) },
+                        seq: freshSeq,
+                        generation,
+                    });
+                } catch {}
+            } else if (!chunkedPending) {
+                // No in-memory state — fall back to event cache.
+                // Don't send partial chunked snapshots here — they'd arrive as
+                // non-chunked SA events, set lastCompletedSnapshotRef, and cause
+                // the UI to reject subsequent chunks from the active stream.
+                // The runner re-emits a fresh snapshot on the "connected" event
+                // below, which will properly restart chunked delivery.
+                await sendLatestSnapshotFromCache(socket, nextSessionId, generation);
+            }
+        };
+
+        // ── switch_session — reuse the viewer socket across session changes ─
+        socket.on("switch_session", async (data) => {
+            if (!data || typeof data.sessionId !== "string" || !data.sessionId) return;
+            await activateSession(data.sessionId, typeof data.generation === "number" ? data.generation : undefined);
+        });
+
         // ── connected — viewer greeting, notify TUI ─────────────────────────
         // Use emitToRelaySession for cluster-wide reach — the runner may
         // be on a different server node in multi-node deployments.
         socket.on("connected", () => {
+            const currentSessionId = getCurrentSessionId();
+            if (!currentSessionId) return;
             const next = onViewerConnectedSignal(viewerReadyForRunnerSignal, pendingConnectedSignal);
             pendingConnectedSignal = next.pendingConnectedSignal;
             if (next.forwardNow) {
-                emitToRelaySession(sessionId, "connected" as string, {});
+                emitToRelaySession(currentSessionId, "connected" as string, {});
             }
         });
 
         // ── resync — send fresh snapshot ─────────────────────────────────────
         socket.on("resync", async () => {
+            const currentSessionId = getCurrentSessionId();
+            if (!currentSessionId) return;
             // If a chunked delivery is in-flight on this node, skip
             // sendSnapshotToViewer() entirely — that helper unconditionally
             // emits lastState (the previous completed non-chunked snapshot),
@@ -286,7 +418,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             // sendSnapshotToViewer(), which is the same behaviour as before this
             // guard was added — a degraded-but-safe fallback for a deployment
             // topology PizzaPi doesn't formally support.
-            const resyncChunkedPending = getPendingChunkedSnapshot(sessionId);
+            const resyncChunkedPending = getPendingChunkedSnapshot(currentSessionId);
             if (resyncChunkedPending) {
                 // A chunked delivery is in-flight on this node.  DON'T request
                 // a room-wide re-emit via emitToRelaySession("connected") —
@@ -305,7 +437,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 // finishes) will bring them fully up to date.
             }
 
-            await sendSnapshotToViewer(sessionId, socket);
+            await sendSnapshotToViewer(currentSessionId, socket);
 
             // If no lastState was available (e.g. mid-chunked-delivery),
             // ask the runner to re-emit a fresh snapshot rather than sending
@@ -314,18 +446,20 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             // still-active stream).
             // Use emitToRelaySession for cluster-wide reach — the runner may
             // be on a different server node in multi-node deployments.
-            const session = await getSharedSession(sessionId);
+            const session = await getSharedSession(currentSessionId);
             if (!session?.lastState) {
-                emitToRelaySession(sessionId, "connected" as string, {});
+                emitToRelaySession(currentSessionId, "connected" as string, {});
             }
         });
 
         // ── input — collab mode: forward user input to TUI ──────────────────
         socket.on("input", async (data) => {
-            const currentSession = await getSharedSession(sessionId);
+            const currentSessionId = getCurrentSessionId();
+            if (!currentSessionId) return;
+            const currentSession = await getSharedSession(currentSessionId);
             if (!currentSession?.collabMode) return;
 
-            const tuiSocket = getLocalTuiSocket(sessionId);
+            const tuiSocket = getLocalTuiSocket(currentSessionId);
             if (!tuiSocket) return;
 
             // Parse and validate attachments
@@ -363,10 +497,12 @@ export function registerViewerNamespace(io: SocketIOServer): void {
 
         // ── model_set — collab mode: forward model switch to TUI ─────────────
         socket.on("model_set", async (data) => {
-            const currentSession = await getSharedSession(sessionId);
+            const currentSessionId = getCurrentSessionId();
+            if (!currentSessionId) return;
+            const currentSession = await getSharedSession(currentSessionId);
             if (!currentSession?.collabMode) return;
 
-            const tuiSocket = getLocalTuiSocket(sessionId);
+            const tuiSocket = getLocalTuiSocket(currentSessionId);
             if (!tuiSocket) return;
 
             tuiSocket.emit("model_set" as string, {
@@ -377,10 +513,12 @@ export function registerViewerNamespace(io: SocketIOServer): void {
 
         // ── exec — collab mode: forward remote command to TUI ────────────────
         socket.on("exec", async (data) => {
-            const currentSession = await getSharedSession(sessionId);
+            const currentSessionId = getCurrentSessionId();
+            if (!currentSessionId) return;
+            const currentSession = await getSharedSession(currentSessionId);
             if (!currentSession?.collabMode) return;
 
-            const tuiSocket = getLocalTuiSocket(sessionId);
+            const tuiSocket = getLocalTuiSocket(currentSessionId);
             if (!tuiSocket) return;
 
             tuiSocket.emit("exec" as string, data);
@@ -392,7 +530,12 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // Uses verified delivery (like trigger_response): acks on success
         // so the UI can distinguish delivered pastes from dropped ones.
         socket.on("mcp_oauth_paste", async (data: any, ack?: (...args: any[]) => void) => {
-            const currentSession = await getSharedSession(sessionId);
+            const currentSessionId = getCurrentSessionId();
+            if (!currentSessionId) {
+                if (typeof ack === "function") ack({ ok: false, error: "No active session" });
+                return;
+            }
+            const currentSession = await getSharedSession(currentSessionId);
             if (!currentSession?.collabMode) {
                 if (typeof ack === "function") ack({ ok: false, error: "Session not in collab mode" });
                 return;
@@ -411,11 +554,11 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             };
 
             // Try local TUI socket first, fall back to relay room.
-            const tuiSocket = getLocalTuiSocket(sessionId);
+            const tuiSocket = getLocalTuiSocket(currentSessionId);
             if (tuiSocket) {
                 tuiSocket.emit("mcp_oauth_paste" as string, payload);
                 if (typeof ack === "function") ack({ ok: true });
-            } else if (await emitToRelaySessionVerified(sessionId, "mcp_oauth_paste", payload)) {
+            } else if (await emitToRelaySessionVerified(currentSessionId, "mcp_oauth_paste", payload)) {
                 if (typeof ack === "function") ack({ ok: true });
             } else {
                 if (typeof ack === "function") ack({ ok: false, error: "Runner session unavailable" });
@@ -430,8 +573,11 @@ export function registerViewerNamespace(io: SocketIOServer): void {
             const { triggerId, response, action, targetSessionId } = data ?? {};
             if (!triggerId || response == null) return;
 
+            const currentSessionId = getCurrentSessionId();
+            if (!currentSessionId) return;
+
             // Require collab mode — same gate as input/exec/model_set
-            const currentSession = await getSharedSession(sessionId);
+            const currentSession = await getSharedSession(currentSessionId);
             if (!currentSession?.collabMode) return;
 
             // If targetSessionId is explicitly provided, route to that child.
@@ -451,7 +597,7 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 }
                 // Security: verify the target is a child of the current session to prevent
                 // cross-session trigger injection between unrelated sessions of the same user.
-                const childVerified = await isChildOfParent(sessionId, targetSessionId);
+                const childVerified = await isChildOfParent(currentSessionId, targetSessionId);
                 if (!childVerified) {
                     socket.emit("trigger_error", { message: `Target session ${targetSessionId} is not a child of this session`, triggerId });
                     return;
@@ -483,14 +629,14 @@ export function registerViewerNamespace(io: SocketIOServer): void {
                 ...(action ? { action } : {}),
                 targetSessionId,
             };
-            const tuiSocket = getLocalTuiSocket(sessionId);
+            const tuiSocket = getLocalTuiSocket(currentSessionId);
             if (tuiSocket) {
                 tuiSocket.emit("trigger_response" as string, triggerPayloadForParent);
                 if (typeof ack === "function") ack();
-            } else if (await emitToRelaySessionVerified(sessionId, "trigger_response", triggerPayloadForParent)) {
+            } else if (await emitToRelaySessionVerified(currentSessionId, "trigger_response", triggerPayloadForParent)) {
                 if (typeof ack === "function") ack();
             } else {
-                socket.emit("trigger_error", { message: `Failed to deliver trigger response to session ${sessionId}`, triggerId });
+                socket.emit("trigger_error", { message: `Failed to deliver trigger response to session ${currentSessionId}`, triggerId });
             }
         });
 
@@ -504,114 +650,42 @@ export function registerViewerNamespace(io: SocketIOServer): void {
         // events — all viewer-initiated service requests would be silently dropped.
         // We must route to the runner via emitToRunner(runnerId, ...) instead.
         socket.on("service_message", async (envelope: ServiceEnvelope) => {
-            const currentSession = await getSharedSession(sessionId);
+            const currentSessionId = getCurrentSessionId();
+            if (!currentSessionId) return;
+            const currentSession = await getSharedSession(currentSessionId);
             if (!currentSession?.collabMode) return;
             const runnerId = currentSession.runnerId;
             if (!runnerId) return;
             // Attach sessionId so the runner service knows which session to respond to
-            emitToRunner(runnerId, "service_message", { ...envelope, sessionId });
+            emitToRunner(runnerId, "service_message", { ...envelope, sessionId: currentSessionId });
         });
 
         // ── disconnect ───────────────────────────────────────────────────────
         socket.on("disconnect", async (reason) => {
-            log.info(`disconnected: ${socket.id} sessionId=${sessionId} (${reason})`);
-            await removeViewer(sessionId, socket);
-        });
-
-        // ── Now do async snapshot/room work ──────────────────────────────────
-        // Join the room first, then allow the viewer's "connected" signal to
-        // reach the runner. This avoids losing the first live snapshot/chunks
-        // and reduces startup resync churn.
-        const ok = await addViewer(sessionId, socket);
-        if (!ok) {
-            socket.emit("disconnected", { reason: "Session ended", code: "session_ended" });
-            // Use disconnect() (not true) so the client can still auto-reconnect;
-            // the session may have just cycled and will come back shortly.
-            socket.disconnect();
-            return;
-        }
-
-        viewerReadyForRunnerSignal = true;
-        const flush = onViewerReadyForRunnerSignal(pendingConnectedSignal);
-        pendingConnectedSignal = flush.pendingConnectedSignal;
-        if (flush.forwardNow) {
-            emitToRelaySession(sessionId, "connected" as string, {});
-        }
-
-        // Re-fetch session state and seq AFTER addViewer() to avoid emitting
-        // stale data. Between the initial fetch and here, the runner may have
-        // published a newer session_active (especially for chunked delivery).
-        // Using the old lastState + old lastSeq would overwrite the fresh
-        // snapshot and rewind lastSeqRef on the client, triggering a bogus
-        // resync on actively changing sessions.
-        const [freshSession, freshSeq] = await Promise.all([
-            getSharedSession(sessionId),
-            getSessionSeq(sessionId),
-        ]);
-
-        if (!freshSession) {
-            socket.emit("disconnected", { reason: "Session ended", code: "session_ended" });
-            socket.disconnect();
-            return;
-        }
-
-        socket.emit("connected", {
-            sessionId,
-            lastSeq: freshSeq,
-            isActive: freshSession.isActive,
-            lastHeartbeatAt: freshSession.lastHeartbeatAt,
-            sessionName: freshSession.sessionName,
-        });
-
-        // Send cached service_announce so the viewer knows which runner
-        // services are available without waiting for a fresh announce.
-        log.info(`service_announce check: runnerId=${freshSession.runnerId ?? "null"}`);
-        if (freshSession.runnerId) {
-            const announce = getRunnerServiceAnnounce(freshSession.runnerId);
-            const serviceIds = announce?.serviceIds ?? [];
-            log.info(`service_announce: runnerId=${freshSession.runnerId}, cached serviceIds=[${serviceIds.join(",")}]`);
-            if (serviceIds.length > 0) {
-                socket.emit("service_announce", announce!);
+            const currentSessionId = getCurrentSessionId();
+            log.info(`disconnected: ${socket.id} sessionId=${currentSessionId ?? "none"} (${reason})`);
+            if (currentSessionId) {
+                await removeViewer(currentSessionId, socket);
             }
-        }
+        });
 
-        // Emit an immediate heartbeat snapshot while the runner pushes a fresh
-        // session_active in response to "connected".
-        if (freshSession.lastHeartbeat) {
-            try {
-                socket.emit("event", { event: JSON.parse(freshSession.lastHeartbeat), seq: freshSeq });
-            } catch {}
-        }
+        // ── Optional initial session bootstrap (backward compatibility) ─────
+        if (initialSessionId) {
+            const initialSession = await getSharedSession(initialSessionId);
+            if (!initialSession) {
+                // Session not live — try to replay a persisted snapshot for older
+                // clients that still bind the session in the handshake.
+                await replayPersistedSnapshot(socket, initialSessionId, viewerUserId);
+                return;
+            }
 
-        // If a chunked delivery is in-flight, lastState is stale (chunked
-        // session_active intentionally skips updating it).  Emitting the old
-        // non-chunked snapshot here would overwrite the chunked header the
-        // viewer already received via the room broadcast, clear chunk-tracking
-        // in App.tsx, and cause remaining chunks to be dropped.  Skip it and
-        // let the runner's fresh chunked delivery (triggered by the "connected"
-        // notification below) hydrate the viewer instead.
-        const chunkedPending = getPendingChunkedSnapshot(sessionId);
-        if (freshSession?.lastState && !chunkedPending) {
-            try {
-                socket.emit("event", { event: { type: "session_active", state: JSON.parse(freshSession.lastState) }, seq: freshSeq });
-            } catch {}
-        } else if (!chunkedPending) {
-            // No in-memory state — fall back to event cache.
-            // Don't send partial chunked snapshots here — they'd arrive as
-            // non-chunked SA events, set lastCompletedSnapshotRef, and cause
-            // the UI to reject subsequent chunks from the active stream.
-            // The runner re-emits a fresh snapshot on the "connected" event
-            // below, which will properly restart chunked delivery.
-            await sendLatestSnapshotFromCache(socket, sessionId);
+            if (!initialSession.userId || initialSession.userId !== viewerUserId) {
+                socket.emit("error", { message: "Session not found" });
+                socket.disconnect(true);
+                return;
+            }
+
+            await activateSession(initialSessionId, 0);
         }
-        // Note: when chunkedPending is true we intentionally do NOT re-trigger
-        // emitToRelaySession("connected") here.  That would cause emitSessionActive()
-        // on the runner to broadcast a fresh session_active (with messages: []) to
-        // the entire room, clearing all existing viewers' transcripts.  The
-        // sequence-gap detection on the client handles the race: if the new viewer
-        // missed the initial chunked snapshot (because it arrived before addViewer
-        // ran), the next event with a higher seq will trigger a resync request,
-        // which the resync handler routes through the runner's fresh chunked
-        // delivery path (see socket.on("resync") above).
     });
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2332,6 +2332,9 @@ export function App() {
   }, [hubSocket, liveSessions, activeSessionId, metaInventoryVersion]);
 
   const openSession = React.useCallback((relaySessionId: string) => {
+    // Already viewing this session — nothing to do.
+    if (relaySessionId === activeSessionRef.current) return;
+
     // Flush/cancel any pending RAF queues (streaming deltas & tool-stream
     // partials) from the previous session so they can't leak into the new one.
     cancelPendingDeltas();

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -63,7 +63,7 @@ import { ViewerSocketContext } from "@/lib/viewer-socket-context";
 import { HubSocketContext } from "@/lib/hub-socket-context";
 import { shouldStopViewerReconnect } from "@/lib/viewer-connection";
 import { getConfirmedMetaSubscriptionTargets } from "@/lib/meta-subscriptions";
-import { useRunnerServices, attachServiceAnnounceListener, seedServiceCache } from "@/hooks/useRunnerServices";
+import { useRunnerServices, attachServiceAnnounceListener, seedServiceCache, setViewerSwitchGeneration } from "@/hooks/useRunnerServices";
 import { ServicePanelButtons, useServicePanelState } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
@@ -109,6 +109,7 @@ import {
 import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
 import { analyzeIncomingSeq, mergeConnectedSeq, shouldDeferEventForHydration } from "@/lib/session-seq";
 import { createLogger } from "@pizzapi/tools";
+import { isActiveViewerSessionPayload, matchesViewerGeneration } from "@/lib/viewer-switch";
 
 const log = createLogger("relay");
 
@@ -431,6 +432,7 @@ export function App() {
   // Tracked as state so HubSocketContext consumers re-render when the socket changes.
   const [hubSocket, setHubSocket] = React.useState<Socket<HubServerToClientEvents, HubClientToServerEvents> | null>(null);
   const activeSessionRef = React.useRef<string | null>(null);
+  const viewerSwitchGenerationRef = React.useRef(0);
 
   // Cache last-known UI state per relay session so switching sessions feels instant.
   const sessionUiCacheRef = React.useRef<Map<string, SessionUiCacheEntry>>(new Map());
@@ -2349,20 +2351,8 @@ export function App() {
       : null;
     const nextRunnerId = sessions.find((s) => s.sessionId === relaySessionId)?.runnerId ?? null;
     const sameRunner = !!(prevRunnerId && nextRunnerId && prevRunnerId === nextRunnerId);
-
-    // Save a ref to the old viewer socket before tearing it down — on same-runner
-    // switches we'll seed the new socket's eager service cache from it.
     const prevViewerSocket = viewerWsRef.current;
-
-    viewerWsRef.current?.disconnect();
-    viewerWsRef.current = null;
-    setViewerSocket(null);
-
-    // Clear any existing stale-connection timer from a previous session.
-    if (staleCheckTimerRef.current !== null) {
-      clearInterval(staleCheckTimerRef.current);
-      staleCheckTimerRef.current = null;
-    }
+    const nextGeneration = ++viewerSwitchGenerationRef.current;
 
     localStorage.setItem("pp.lastSessionId", relaySessionId);
     activeSessionRef.current = relaySessionId;
@@ -2386,7 +2376,6 @@ export function App() {
     setResumeSessionsLoading(false);
 
     const cached = sessionUiCacheRef.current.get(relaySessionId);
-    // Update lastAccessed so this entry is not evicted while actively being viewed.
     touchSessionCache(sessionUiCacheRef.current, relaySessionId);
 
     // ── Session-scoped state: always reset from cache or defaults ────────
@@ -2402,9 +2391,6 @@ export function App() {
     setTodoList(cached?.todoList ?? []);
 
     // ── Runner-scoped state: preserve on same-runner switch ─────────────
-    // These values are identical across sessions on the same runner. Resetting
-    // them causes a flash-to-empty in the header / model selector, followed by
-    // the exact same values arriving again from the capabilities event.
     if (!sameRunner) {
       setAvailableModels(cached?.availableModels ?? []);
       setAvailableCommands(cached?.availableCommands ?? []);
@@ -2419,196 +2405,198 @@ export function App() {
     setPendingQuestion(null);
     setPendingPlan(null);
 
-    const socket: Socket<ViewerServerToClientEvents, ViewerClientToServerEvents> = io("/viewer", {
-      auth: { sessionId: relaySessionId },
-      withCredentials: true,
-    });
-    viewerWsRef.current = socket;
-    // Attach service_announce listener BEFORE setViewerSocket triggers a render,
-    // so the announce event (sent by the server during connection) is captured
-    // eagerly and available when useRunnerServices reads it.
-    attachServiceAnnounceListener(socket);
-
-    // For same-runner switches, seed the new socket's eager service cache from
-    // the previous socket so useRunnerServices doesn't flash to empty while
-    // waiting for the new socket's service_announce event.
-    if (sameRunner) {
-      seedServiceCache(socket, prevViewerSocket);
-    }
-    setViewerSocket(socket);
-
-    // Stale-connection watchdog: if the socket thinks it's connected but
-    // no event has arrived for STALE_THRESHOLD_MS, force a reconnect.
-    // This catches NAT timeouts, middlebox drops, and backgrounded-tab
-    // scenarios where socket.io's own ping/pong doesn't fire in time.
-    staleCheckTimerRef.current = setInterval(() => {
-      if (activeSessionRef.current !== relaySessionId) return;
-      if (!socket.connected) return;
-      const elapsed = Date.now() - lastViewerEventAtRef.current;
-      if (elapsed > STALE_THRESHOLD_MS) {
-        log.warn(`Stale connection detected (${Math.round(elapsed / 1000)}s since last event). Reconnecting…`);
-        socket.disconnect();
-        socket.connect();
+    let socket = viewerWsRef.current;
+    if (!socket) {
+      socket = io("/viewer", {
+        withCredentials: true,
+        autoConnect: false,
+      });
+      viewerWsRef.current = socket;
+      attachServiceAnnounceListener(socket);
+      if (sameRunner) {
+        seedServiceCache(socket, prevViewerSocket);
       }
-    }, STALE_CHECK_INTERVAL_MS);
+      setViewerSocket(socket);
+      const nextSocket = socket;
 
-    socket.on("connected", (data) => {
-      if (activeSessionRef.current !== relaySessionId) return;
-      lastViewerEventAtRef.current = Date.now();
+      // Stale-connection watchdog: if the socket thinks it's connected but
+      // no event has arrived for STALE_THRESHOLD_MS, force a reconnect.
+      staleCheckTimerRef.current = setInterval(() => {
+        if (!activeSessionRef.current) return;
+        if (!nextSocket.connected) return;
+        const elapsed = Date.now() - lastViewerEventAtRef.current;
+        if (elapsed > STALE_THRESHOLD_MS) {
+          log.warn(`Stale connection detected (${Math.round(elapsed / 1000)}s since last event). Reconnecting…`);
+          nextSocket.disconnect();
+          nextSocket.connect();
+        }
+      }, STALE_CHECK_INTERVAL_MS);
 
-      const replayOnly = data.replayOnly === true;
-      setViewerStatus(replayOnly ? "Snapshot replay" : "Connected");
+      nextSocket.on("connect", () => {
+        const currentSessionId = activeSessionRef.current;
+        if (!currentSessionId) return;
+        setViewerStatus("Connecting…");
+        setViewerSwitchGeneration(nextSocket, viewerSwitchGenerationRef.current);
+        nextSocket.emit("switch_session", {
+          sessionId: currentSessionId,
+          generation: viewerSwitchGenerationRef.current,
+        });
+      });
 
-      // Seed sequence for gap detection, but never move backward if live
-      // events already advanced the cursor before "connected" arrives.
-      if (typeof data.lastSeq === "number") {
-        lastSeqRef.current = mergeConnectedSeq(lastSeqRef.current, data.lastSeq);
-      }
-
-      // Reflect initial active status from connected message.
-      if (typeof data.isActive === "boolean") {
-        setAgentActive(data.isActive);
-        patchSessionCache({ agentActive: data.isActive });
-      }
-
-      if (Object.prototype.hasOwnProperty.call(data, "sessionName")) {
-        const nextName = normalizeSessionName(data.sessionName);
-        setSessionName(nextName);
-        patchSessionCache({ sessionName: nextName });
-      }
-
-      // Tell the runner we connected so it can push capabilities (models/commands/etc.)
-      socket.emit("connected", {});
-    });
-
-    socket.on("event", (data) => {
-      if (activeSessionRef.current !== relaySessionId) return;
-      lastViewerEventAtRef.current = Date.now();
-
-      const rawEvent = data.event;
-      const eventType =
-        rawEvent && typeof rawEvent === "object" && typeof (rawEvent as Record<string, unknown>).type === "string"
-          ? (rawEvent as Record<string, unknown>).type as string
-          : "";
-
-      // Ignore pre-snapshot/chunk-hydration events BEFORE sequence analysis,
-      // otherwise dropped events can still advance lastSeq and block hydration.
-      if (shouldDeferEventForHydration(
-        eventType,
-        awaitingSnapshotRef.current,
-        !!chunkedDeliveryRef.current,
-      )) {
-        return;
-      }
-
-      // Detect sequence gaps and reject out-of-order stale events.
-      // This is safe during chunked delivery because the server's resync
-      // handler now falls back to getPendingChunkedSnapshot() when lastState
-      // hasn't been assembled yet, and the resync response is a non-chunked
-      // session_active that sets lastCompletedSnapshotRef, rejecting any
-      // subsequently arriving stale chunks.
-      const seq = typeof data.seq === "number" ? data.seq : null;
-      if (seq !== null) {
-        const decision = analyzeIncomingSeq(lastSeqRef.current, seq);
-        if (!decision.accept) {
+      nextSocket.on("connected", (data) => {
+        if (!isActiveViewerSessionPayload(
+          activeSessionRef.current,
+          data.sessionId,
+          viewerSwitchGenerationRef.current,
+          data.generation,
+        )) {
           return;
         }
-        if (decision.gap && decision.expected !== null) {
-          // Gap detected — request a resync snapshot from the server.
-          log.warn(`Sequence gap: expected ${decision.expected}, got ${seq}. Requesting resync.`);
-          socket.emit("resync", {});
+        lastViewerEventAtRef.current = Date.now();
+
+        const replayOnly = data.replayOnly === true;
+        setViewerStatus(replayOnly ? "Snapshot replay" : "Connected");
+
+        if (typeof data.lastSeq === "number") {
+          lastSeqRef.current = mergeConnectedSeq(lastSeqRef.current, data.lastSeq);
         }
-        lastSeqRef.current = decision.nextSeq;
-      }
 
-      handleRelayEvent(data.event, seq ?? undefined);
-    });
+        if (typeof data.isActive === "boolean") {
+          setAgentActive(data.isActive);
+          patchSessionCache({ agentActive: data.isActive });
+        }
 
-    socket.on("exec_result", (data) => {
-      if (activeSessionRef.current !== relaySessionId) return;
-      lastViewerEventAtRef.current = Date.now();
-      handleRelayEvent({ type: "exec_result", ...data });
-    });
+        if (Object.prototype.hasOwnProperty.call(data, "sessionName")) {
+          const nextName = normalizeSessionName(data.sessionName);
+          setSessionName(nextName);
+          patchSessionCache({ sessionName: nextName });
+        }
 
-    socket.on("disconnected", (data) => {
-      if (activeSessionRef.current !== relaySessionId) return;
-      // Server is actively talking to us — reset stale clock.
-      lastViewerEventAtRef.current = Date.now();
-      // "Session reconnected" means a new worker registered with the same session ID
-      // (e.g. the user ran /restart in the CLI terminal rather than via the web UI
-      // command bar).  Treat it identically to a UI-initiated restart so the
-      // existing auto-reconnect logic fires when the session comes back live.
-      if (data.reason === "Session reconnected" && restartPendingSessionIdRef.current !== relaySessionId) {
-        restartPendingSessionIdRef.current = relaySessionId;
-        if (restartPendingTimerRef.current) clearTimeout(restartPendingTimerRef.current);
-        restartPendingTimerRef.current = setTimeout(() => {
-          restartPendingSessionIdRef.current = null;
-          restartPendingTimerRef.current = null;
-        }, 60_000);
-      }
-      const isRestarting = restartPendingSessionIdRef.current === relaySessionId;
-      if (!isRestarting) {
-        setViewerStatus(data.reason || "Disconnected");
-      } else {
-        setViewerStatus("Restarting CLI\u2026");
-      }
-      setPendingQuestion(null);
-      setPendingPlan(null);
-      setIsChangingModel(false);
+        nextSocket.emit("connected", {});
+      });
 
-      // Snapshot replay means the session is no longer live. If we leave the
-      // namespace socket active, socket.io-client keeps retrying forever,
-      // creating repeated /viewer reconnect churn for a dead session.
-      if (shouldStopViewerReconnect(data)) {
-        socket.disconnect();
-      }
-    });
+      nextSocket.on("event", (data) => {
+        if (!matchesViewerGeneration(viewerSwitchGenerationRef.current, data.generation)) {
+          return;
+        }
+        if (!activeSessionRef.current) return;
+        lastViewerEventAtRef.current = Date.now();
 
-    socket.on("error", (data) => {
-      if (activeSessionRef.current !== relaySessionId) return;
-      // Server is actively talking to us — reset stale clock.
-      lastViewerEventAtRef.current = Date.now();
-      setViewerStatus(data.message || "Failed to load session");
-    });
+        const rawEvent = data.event;
+        const eventType =
+          rawEvent && typeof rawEvent === "object" && typeof (rawEvent as Record<string, unknown>).type === "string"
+            ? (rawEvent as Record<string, unknown>).type as string
+            : "";
 
-    socket.on("connect_error", () => {
-      if (activeSessionRef.current === relaySessionId) {
-        setViewerStatus("Connection error");
-      }
-    });
+        if (shouldDeferEventForHydration(
+          eventType,
+          awaitingSnapshotRef.current,
+          !!chunkedDeliveryRef.current,
+        )) {
+          return;
+        }
 
-    socket.on("disconnect", (reason) => {
-      if (activeSessionRef.current === relaySessionId) {
-        const isRestarting = restartPendingSessionIdRef.current === relaySessionId;
-        setViewerStatus((prev) =>
-          isRestarting
-            ? "Restarting CLI…"
-            : prev === "Connected" || prev === "Connecting…"
-              ? "Disconnected"
-              : prev,
-        );
+        const seq = typeof data.seq === "number" ? data.seq : null;
+        if (seq !== null) {
+          const decision = analyzeIncomingSeq(lastSeqRef.current, seq);
+          if (!decision.accept) {
+            return;
+          }
+          if (decision.gap && decision.expected !== null) {
+            log.warn(`Sequence gap: expected ${decision.expected}, got ${seq}. Requesting resync.`);
+            nextSocket.emit("resync", {});
+          }
+          lastSeqRef.current = decision.nextSeq;
+        }
+
+        handleRelayEvent(data.event, seq ?? undefined);
+      });
+
+      nextSocket.on("exec_result", (data) => {
+        if (!activeSessionRef.current) return;
+        lastViewerEventAtRef.current = Date.now();
+        handleRelayEvent({ type: "exec_result", ...data });
+      });
+
+      nextSocket.on("disconnected", (data) => {
+        if (!matchesViewerGeneration(viewerSwitchGenerationRef.current, data.generation)) {
+          return;
+        }
+        const currentSessionId = activeSessionRef.current;
+        if (!currentSessionId) return;
+        lastViewerEventAtRef.current = Date.now();
+        if (data.reason === "Session reconnected" && restartPendingSessionIdRef.current !== currentSessionId) {
+          restartPendingSessionIdRef.current = currentSessionId;
+          if (restartPendingTimerRef.current) clearTimeout(restartPendingTimerRef.current);
+          restartPendingTimerRef.current = setTimeout(() => {
+            restartPendingSessionIdRef.current = null;
+            restartPendingTimerRef.current = null;
+          }, 60_000);
+        }
+        const isRestarting = restartPendingSessionIdRef.current === currentSessionId;
+        if (!isRestarting) {
+          setViewerStatus(data.reason || "Disconnected");
+        } else {
+          setViewerStatus("Restarting CLI…");
+        }
         setPendingQuestion(null);
         setPendingPlan(null);
         setIsChangingModel(false);
-        // Reset the stale clock so we don't fire immediately on reconnect.
-        lastViewerEventAtRef.current = Date.now();
 
-        // When the server explicitly disconnects us (reason "io server disconnect"),
-        // socket.io permanently disables auto-reconnect on the client. This happens
-        // when the session isn't live yet — e.g. the server just restarted and the
-        // CLI hasn't re-registered. Schedule a manual reconnect so we pick up the
-        // session once it's available again.
-        // The activeSessionRef guard ensures this is a no-op if the user
-        // switches to a different session before the timer fires.
-        if (reason === "io server disconnect") {
-          setTimeout(() => {
-            if (activeSessionRef.current === relaySessionId && !socket.connected) {
-              socket.connect();
-            }
-          }, 2000);
+        if (shouldStopViewerReconnect(data)) {
+          nextSocket.disconnect();
         }
-      }
-    });
+      });
+
+      nextSocket.on("error", (data) => {
+        if (!matchesViewerGeneration(viewerSwitchGenerationRef.current, data.generation)) {
+          return;
+        }
+        if (!activeSessionRef.current) return;
+        lastViewerEventAtRef.current = Date.now();
+        setViewerStatus(data.message || "Failed to load session");
+      });
+
+      nextSocket.on("connect_error", () => {
+        if (activeSessionRef.current) {
+          setViewerStatus("Connection error");
+        }
+      });
+
+      nextSocket.on("disconnect", (reason) => {
+        if (activeSessionRef.current) {
+          const isRestarting = restartPendingSessionIdRef.current === activeSessionRef.current;
+          setViewerStatus((prev) =>
+            isRestarting
+              ? "Restarting CLI…"
+              : prev === "Connected" || prev === "Connecting…"
+                ? "Disconnected"
+                : prev,
+          );
+          setPendingQuestion(null);
+          setPendingPlan(null);
+          setIsChangingModel(false);
+          lastViewerEventAtRef.current = Date.now();
+
+          if (reason === "io server disconnect") {
+            setTimeout(() => {
+              if (activeSessionRef.current && !nextSocket.connected) {
+                nextSocket.connect();
+              }
+            }, 2000);
+          }
+        }
+      });
+    }
+
+    if (!socket) return;
+
+    setViewerSwitchGeneration(socket, nextGeneration);
+    if (socket.connected) {
+      socket.emit("switch_session", { sessionId: relaySessionId, generation: nextGeneration });
+    } else {
+      socket.connect();
+    }
   }, [handleRelayEvent, patchSessionCache, cancelPendingDeltas]);
 
   // Auto-reopen the last viewed session once live sessions arrive.

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -137,6 +137,11 @@ function formatTime(isoString: string): string {
 
 export type DotState = "connecting" | "connected" | "disconnected";
 
+// Wait briefly for the canonical /hub "sessions" snapshot before falling back
+// to REST. This avoids an immediate duplicate /api/sessions fetch on healthy
+// connections while preserving a safety net if the snapshot is missed.
+const HUB_SESSIONS_REST_FALLBACK_DELAY_MS = 1200;
+
 function LiveDot({ state }: { state: DotState }) {
     return (
         <span
@@ -633,10 +638,27 @@ export const SessionSidebar = React.memo(function SessionSidebar({
             }
         };
 
+        let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+        const clearFallbackTimer = () => {
+            if (fallbackTimer) {
+                clearTimeout(fallbackTimer);
+                fallbackTimer = null;
+            }
+        };
+        const scheduleResyncFallback = (epoch: number) => {
+            clearFallbackTimer();
+            fallbackTimer = setTimeout(() => {
+                fallbackTimer = null;
+                if (disposed) return;
+                if (latestHubSnapshotEpoch >= epoch) return;
+                void resyncLiveSessionsFromApi(epoch);
+            }, HUB_SESSIONS_REST_FALLBACK_DELAY_MS);
+        };
+
         const handleConnect = () => {
             setDotState("connected");
             const epoch = ++connectEpoch;
-            void resyncLiveSessionsFromApi(epoch);
+            scheduleResyncFallback(epoch);
         };
 
         const handleDisconnect = () => {
@@ -649,6 +671,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
 
         const handleSessions = (data: unknown) => {
             latestHubSnapshotEpoch = connectEpoch;
+            clearFallbackTimer();
             applyLiveSessionsSnapshot(parseHubSessionsPayload(data));
         };
 
@@ -735,16 +758,18 @@ export const SessionSidebar = React.memo(function SessionSidebar({
         hubSocket.on("session_status", handleSessionStatus);
 
         // If the shared socket is already connected by the time this effect runs,
-        // sync the session list immediately via REST — we will have missed the
-        // server's initial "sessions" emit that fires on namespace join.
+        // we may have missed the server's initial "sessions" emit that fires on
+        // namespace join. Schedule the same delayed REST fallback used for normal
+        // connect events.
         if (hubSocket.connected) {
             setDotState("connected");
             const epoch = ++connectEpoch;
-            void resyncLiveSessionsFromApi(epoch);
+            scheduleResyncFallback(epoch);
         }
 
         return () => {
             disposed = true;
+            clearFallbackTimer();
             // Only remove our event handlers — App.tsx owns the socket lifecycle.
             hubSocket.off("connect", handleConnect);
             hubSocket.off("disconnect", handleDisconnect);

--- a/packages/ui/src/components/ui/error-boundary.render.test.tsx
+++ b/packages/ui/src/components/ui/error-boundary.render.test.tsx
@@ -22,6 +22,15 @@ mock.module("@/lib/utils", () => ({
 		classes.filter(Boolean).join(" "),
 }));
 
+mock.module("@pizzapi/tools", () => ({
+	createLogger: () => ({
+		error: () => {},
+		warn: () => {},
+		info: () => {},
+		debug: () => {},
+	}),
+}));
+
 // Restore all module mocks after this file so they don't bleed into other
 // test files running in the same Bun worker process.
 afterAll(() => mock.restore());

--- a/packages/ui/src/hooks/useRunnerServices.ts
+++ b/packages/ui/src/hooks/useRunnerServices.ts
@@ -17,9 +17,11 @@
 import { useState, useEffect, useRef } from "react";
 import type { Socket } from "socket.io-client";
 import type { ServiceAnnounceData, ServicePanelInfo } from "@pizzapi/protocol";
+import { matchesViewerGeneration } from "@/lib/viewer-switch";
 
 const SERVICE_IDS_KEY = "__serviceIds" as const;
 const PANELS_KEY = "__panels" as const;
+const VIEWER_SWITCH_GENERATION_KEY = "__viewerSwitchGeneration" as const;
 
 /**
  * Call this synchronously right after creating the viewer socket.
@@ -27,7 +29,11 @@ const PANELS_KEY = "__panels" as const;
  * so they're available before any React hooks mount.
  */
 export function attachServiceAnnounceListener(socket: Socket): void {
-    socket.on("service_announce", (data: ServiceAnnounceData) => {
+    socket.on("service_announce", (data: ServiceAnnounceData & { generation?: number }) => {
+        const currentGeneration = (socket as any)[VIEWER_SWITCH_GENERATION_KEY] as number | undefined;
+        if (!matchesViewerGeneration(currentGeneration, data.generation)) {
+            return;
+        }
         (socket as any)[SERVICE_IDS_KEY] = data.serviceIds;
         (socket as any)[PANELS_KEY] = data.panels;
     });
@@ -48,6 +54,10 @@ export function seedServiceCache(newSocket: Socket, prevSocket: Socket | null): 
     const panels = (prevSocket as any)[PANELS_KEY] as ServicePanelInfo[] | undefined;
     if (ids) (newSocket as any)[SERVICE_IDS_KEY] = ids;
     if (panels) (newSocket as any)[PANELS_KEY] = panels;
+}
+
+export function setViewerSwitchGeneration(socket: Socket, generation: number): void {
+    (socket as any)[VIEWER_SWITCH_GENERATION_KEY] = generation;
 }
 
 /** Read any already-captured service IDs from the socket. */
@@ -71,14 +81,8 @@ export function useRunnerServices(socket: Socket | null): RunnerServicesState {
     const [panels, setPanels] = useState<ServicePanelInfo[]>(() => getEagerPanels(socket));
     const prevSocketRef = useRef(socket);
 
-    // When the socket changes, eagerly read any cached announce
     if (socket !== prevSocketRef.current) {
         prevSocketRef.current = socket;
-        const eager = getEagerServiceIds(socket);
-        if (eager.size > 0 || services.size > 0) {
-            // Can't call setState during render in strict mode without this pattern
-            // but since we're comparing refs it's fine — this is a derived-state reset
-        }
     }
 
     useEffect(() => {
@@ -99,7 +103,11 @@ export function useRunnerServices(socket: Socket | null): RunnerServicesState {
             setPanels(cachedPanels);
         }
 
-        const handleAnnounce = (data: ServiceAnnounceData) => {
+        const handleAnnounce = (data: ServiceAnnounceData & { generation?: number }) => {
+            const currentGeneration = (socket as any)[VIEWER_SWITCH_GENERATION_KEY] as number | undefined;
+            if (!matchesViewerGeneration(currentGeneration, data.generation)) {
+                return;
+            }
             setServices(new Set(data.serviceIds));
             setPanels(data.panels ?? []);
         };

--- a/packages/ui/src/lib/viewer-switch.test.ts
+++ b/packages/ui/src/lib/viewer-switch.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test";
+import { isActiveViewerSessionPayload, matchesViewerGeneration } from "./viewer-switch";
+
+describe("matchesViewerGeneration", () => {
+  test("accepts payloads without a generation", () => {
+    expect(matchesViewerGeneration(3, undefined)).toBe(true);
+  });
+
+  test("accepts matching generations", () => {
+    expect(matchesViewerGeneration(3, 3)).toBe(true);
+  });
+
+  test("rejects stale generations", () => {
+    expect(matchesViewerGeneration(3, 2)).toBe(false);
+  });
+
+  test("rejects generated payloads when no current generation is set", () => {
+    expect(matchesViewerGeneration(undefined, 1)).toBe(false);
+  });
+});
+
+describe("isActiveViewerSessionPayload", () => {
+  test("accepts payloads for the active session with matching generation", () => {
+    expect(isActiveViewerSessionPayload("sess-a", "sess-a", 4, 4)).toBe(true);
+  });
+
+  test("rejects payloads for a different session", () => {
+    expect(isActiveViewerSessionPayload("sess-a", "sess-b", 4, 4)).toBe(false);
+  });
+
+  test("rejects stale generation payloads even if the session matches", () => {
+    expect(isActiveViewerSessionPayload("sess-a", "sess-a", 4, 3)).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/viewer-switch.ts
+++ b/packages/ui/src/lib/viewer-switch.ts
@@ -1,0 +1,15 @@
+export function matchesViewerGeneration(
+  currentGeneration: number | undefined,
+  payloadGeneration?: number,
+): boolean {
+  return payloadGeneration === undefined || currentGeneration === payloadGeneration;
+}
+
+export function isActiveViewerSessionPayload(
+  activeSessionId: string | null,
+  payloadSessionId: string,
+  currentGeneration: number | undefined,
+  payloadGeneration?: number,
+): boolean {
+  return activeSessionId === payloadSessionId && matchesViewerGeneration(currentGeneration, payloadGeneration);
+}


### PR DESCRIPTION
## Summary
- reuse a single `/viewer` socket and switch sessions logically instead of reconnecting per click
- add generation-based stale-event filtering so rapid session switches ignore superseded payloads
- reduce extra session churn by deduplicating identical runner `service_announce` broadcasts and delaying the sidebar REST fallback after hub connect

## Testing
- bun run typecheck
- bun test packages/protocol/src/viewer.test.ts packages/server/src/ws/namespaces/viewer.test.ts packages/server/src/ws/sio-registry/runners.broadcast.test.ts packages/ui/src/lib/viewer-switch.test.ts packages/ui/src/components/ui/error-boundary.render.test.tsx
- bun test packages/ui
- bun run build
