### PR TITLE
fix(ci): add Docker Hub credentials to redis service container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
     services:
       redis:
         image: redis:7-alpine
+        credentials:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-


### PR DESCRIPTION
## Problem

All recent CI runs are failing at the `Initialize containers` phase when pulling `redis:7-alpine` for the service container. Two distinct errors observed across 4 consecutive failures:

- **`unauthorized: incorrect username or password`** — GH runner's embedded Docker Hub token is being rejected
- **`toomanyrequests` + Cloudflare JS challenge** — Docker Hub rate-limiting the shared GH runner IP and serving a Cloudflare challenge the Docker daemon can't solve

Since `services:` blocks pull images **before** any workflow steps run, `docker/login-action` cannot help here.

## Fix

Add `credentials:` to the redis service definition in the `test` job so GHA authenticates with our own Docker Hub account during the service container pull phase.

## Required Setup

Before merging, add these **repo secrets** (Settings → Secrets → Actions):

- `DOCKERHUB_USERNAME` — Docker Hub username
- `DOCKERHUB_TOKEN` — Docker Hub [personal access token](https://hub.docker.com/settings/security) (not password)

⚠️ **This PR will not fix CI until the secrets are configured.** Without them, the credentials fields are empty strings and the pull falls back to unauthenticated (same as before).