### PR TITLE
feat: batch successive trigger messages into a single send

### DIFF
--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -20,7 +20,7 @@ import { cancelPendingAskUserQuestion, consumePendingAskUserQuestionFromWeb } fr
 import { cancelPendingPlanMode, consumePendingPlanModeFromWeb } from "../remote-plan-mode.js";
 import { normalizeRemoteInputAttachments, buildUserMessageFromRemoteInput } from "../remote-input.js";
 import { handleExecFromWeb } from "../remote-exec-handler.js";
-import { renderTrigger } from "../triggers/registry.js";
+import { renderTrigger, renderTriggerBatch } from "../triggers/registry.js";
 import { trackReceivedTrigger, receivedTriggers } from "../triggers/extension.js";
 import type { ConversationTrigger } from "../triggers/types.js";
 import type { RelayContext } from "../remote-types.js";
@@ -196,6 +196,27 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
     );
     rctx.sioSocket = sock;
     resetRelayRegistrationGate();
+
+    // ── Trigger batch queue ───────────────────────────────────────────────
+    // When multiple linked child sessions finish (or send other triggers) at
+    // nearly the same time they each emit a session_trigger event. Without
+    // batching those events are delivered to the agent one at a time, causing
+    // N separate conversation turns. We collect triggers that arrive within a
+    // short window and flush them together as a single message.
+    const TRIGGER_BATCH_DEBOUNCE_MS = 80;
+    type BatchedTrigger = { trigger: ConversationTrigger; rendered: string; deliverAs: "followUp" | "steer" };
+    let pendingTriggerBatch: BatchedTrigger[] = [];
+    let triggerBatchTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const flushTriggerBatch = () => {
+        triggerBatchTimer = null;
+        if (pendingTriggerBatch.length === 0) return;
+        const batch = pendingTriggerBatch.splice(0);
+        // Prefer "followUp" delivery if any trigger requested it; otherwise "steer".
+        const deliverAs = batch.some((b) => b.deliverAs === "followUp") ? "followUp" as const : "steer" as const;
+        const rendered = renderTriggerBatch(batch.map((b) => b.trigger));
+        handlers.sendUserMessage(rendered, { deliverAs });
+    };
 
     // ── Backoff / reconnection logging (Manager-level events) ─────────────
     //
@@ -414,7 +435,12 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         trackReceivedTrigger(trigger.triggerId, trigger.sourceSessionId, trigger.type);
         const rendered = renderTrigger(trigger);
         const deliverAs = trigger.deliverAs === "followUp" ? "followUp" as const : "steer" as const;
-        handlers.sendUserMessage(rendered, { deliverAs });
+
+        // Enqueue and debounce: triggers that arrive within the batch window are
+        // flushed together as a single agent message (see flushTriggerBatch above).
+        pendingTriggerBatch.push({ trigger, rendered, deliverAs });
+        if (triggerBatchTimer !== null) clearTimeout(triggerBatchTimer);
+        triggerBatchTimer = setTimeout(flushTriggerBatch, TRIGGER_BATCH_DEBOUNCE_MS);
     });
 
     sock.on("trigger_response" as any, (data: { triggerId: string; response: string; action?: string; targetSessionId?: string }) => {
@@ -501,6 +527,9 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
     });
 
     sock.on("disconnect", (_reason) => {
+        // Discard any pending batched triggers — don't deliver them after disconnect.
+        if (triggerBatchTimer !== null) { clearTimeout(triggerBatchTimer); triggerBatchTimer = null; }
+        pendingTriggerBatch = [];
         handlers.onDelinkDisconnect();
         rctx.relay = null;
         cancelPendingAskUserQuestion(rctx);

--- a/packages/cli/src/extensions/triggers/integration.test.ts
+++ b/packages/cli/src/extensions/triggers/integration.test.ts
@@ -6,7 +6,7 @@
 // ============================================================================
 
 import { describe, it, expect, beforeEach } from "bun:test";
-import { renderTrigger, parseTriggerResponse, TRIGGER_RENDERERS } from "./registry.js";
+import { renderTrigger, renderTriggerBatch, parseTriggerResponse, TRIGGER_RENDERERS } from "./registry.js";
 import { trackReceivedTrigger, receivedTriggers } from "./extension.js";
 import type { ConversationTrigger } from "./types.js";
 
@@ -158,6 +158,49 @@ describe("trigger routing flow", () => {
 
         it("responding to non-existent trigger returns empty lookup", () => {
             expect(receivedTriggers.has("nonexistent")).toBe(false);
+        });
+    });
+
+    describe("renderTriggerBatch", () => {
+        it("single trigger: output identical to renderTrigger", () => {
+            const trigger = makeTrigger();
+            expect(renderTriggerBatch([trigger])).toBe(renderTrigger(trigger));
+        });
+
+        it("multiple triggers: contains all trigger IDs", () => {
+            const t1 = makeTrigger({ triggerId: "tid-1", sourceSessionId: "child-1", sourceSessionName: "worker-1", type: "session_complete", payload: { summary: "Done A" } });
+            const t2 = makeTrigger({ triggerId: "tid-2", sourceSessionId: "child-2", sourceSessionName: "worker-2", type: "session_complete", payload: { summary: "Done B" } });
+            const rendered = renderTriggerBatch([t1, t2]);
+            expect(rendered).toContain("tid-1");
+            expect(rendered).toContain("tid-2");
+            expect(rendered).toContain("Done A");
+            expect(rendered).toContain("Done B");
+        });
+
+        it("multiple triggers: includes batch header", () => {
+            const triggers = [
+                makeTrigger({ triggerId: "tid-1", type: "session_complete", payload: { summary: "A" } }),
+                makeTrigger({ triggerId: "tid-2", type: "session_complete", payload: { summary: "B" } }),
+                makeTrigger({ triggerId: "tid-3", type: "session_complete", payload: { summary: "C" } }),
+            ];
+            const rendered = renderTriggerBatch(triggers);
+            expect(rendered).toContain("3 child triggers");
+        });
+
+        it("multiple triggers: separated by ---", () => {
+            const t1 = makeTrigger({ triggerId: "tid-1", type: "session_complete", payload: { summary: "A" } });
+            const t2 = makeTrigger({ triggerId: "tid-2", type: "session_complete", payload: { summary: "B" } });
+            const rendered = renderTriggerBatch([t1, t2]);
+            expect(rendered).toContain("---");
+        });
+
+        it("each batched trigger still has its metadata comment for respond_to_trigger", () => {
+            const t1 = makeTrigger({ triggerId: "trigger-alpha", sourceSessionId: "child-alpha", type: "session_complete", payload: { summary: "Done" } });
+            const t2 = makeTrigger({ triggerId: "trigger-beta", sourceSessionId: "child-beta", type: "session_complete", payload: { summary: "Done" } });
+            const rendered = renderTriggerBatch([t1, t2]);
+            // Each individual trigger must have its trigger comment so respond_to_trigger IDs are present
+            expect(rendered).toContain("<!-- trigger:trigger-alpha");
+            expect(rendered).toContain("<!-- trigger:trigger-beta");
         });
     });
 });

--- a/packages/cli/src/extensions/triggers/registry.ts
+++ b/packages/cli/src/extensions/triggers/registry.ts
@@ -185,6 +185,18 @@ export const TRIGGER_RENDERERS: ReadonlyMap<string, TriggerRenderer> = new Map([
     ["escalate", escalateRenderer],
 ]);
 
+/**
+ * Render multiple triggers that arrived in the same batch window into a single
+ * message. When only one trigger is in the batch the output is identical to
+ * `renderTrigger`. For multiple triggers each is rendered individually and the
+ * results are joined with a separator so the parent agent sees them all at once.
+ */
+export function renderTriggerBatch(triggers: ConversationTrigger[]): string {
+    if (triggers.length === 1) return renderTrigger(triggers[0]);
+    const parts = triggers.map((t) => renderTrigger(t));
+    return `🔗 ${triggers.length} child triggers arrived simultaneously:\n\n` + parts.join("\n\n---\n\n");
+}
+
 /** Render a trigger to text, with trigger ID metadata prefix. */
 export function renderTrigger(trigger: ConversationTrigger): string {
     const renderer = TRIGGER_RENDERERS.get(trigger.type);


### PR DESCRIPTION
## Summary

Consecutive finishes of linked child sessions previously caused N separate conversation turns in the parent — one `session_trigger` delivery per child. This PR groups triggers that arrive within an 80ms window into a single agent message.

## Changes

- **`registry.ts`**: Add `renderTriggerBatch(triggers[])` — single trigger renders identically to `renderTrigger()`; multiple triggers get a header + `---`-separated individual renders. All `<!-- trigger:ID -->` metadata comments are preserved so `respond_to_trigger` still works per-trigger.

- **`connection.ts`**: `session_trigger` handler now enqueues into a local batch and debounces 80ms. On flush, `renderTriggerBatch` renders all queued triggers and they're delivered as one `sendUserMessage` call. Batch is cleared on `disconnect`.

- **`integration.test.ts`**: 5 new tests covering single-trigger passthrough, multi-trigger ID presence, batch header count, separator, and per-trigger metadata comment preservation.

## Review

LGTM from gpt-5.1-codex-mini (0 P0–P2 findings).

Closes: b2qp9YfJ