### PR TITLE
chore: update pi packages 0.58.3 → 0.63.1 and rebase patches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,7 +349,7 @@ jobs:
               echo "✅ CLI help & config tests passed"
 
               echo "[1/6] Starting pizza web"
-              $CLI_CMD web --port 7492 2>&1 | tee /tmp/pizza-web.log
+              $CLI_CMD web --build --port 7492 2>&1 | tee /tmp/pizza-web.log
 
               echo "[2/6] Waiting for web"
               for i in $(seq 1 60); do

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,13 +352,20 @@ jobs:
               $CLI_CMD web --build --port 7492 2>&1 | tee /tmp/pizza-web.log
 
               echo "[2/6] Waiting for web"
+              # Probe the explicit health endpoint instead of `/`.
+              # The API routes are the actual readiness contract for this test,
+              # while the root HTML route can vary across packaging modes.
               for i in $(seq 1 60); do
-                if curl -fsS "http://localhost:7492/" >/dev/null; then
+                HTTP_CODE=$(curl -sS -o /tmp/web-status.json -w "%{http_code}" "http://localhost:7492/api/status" || true)
+                if [ "$HTTP_CODE" = "200" ] && jq -e '.status == "ok" or .status == "degraded"' /tmp/web-status.json >/dev/null 2>&1; then
                   break
                 fi
                 if [ "$i" -eq 60 ]; then
-                  echo "Server did not become ready" >&2
-                  docker compose -p pizzapi-web logs || true
+                  echo "Server did not become ready (HTTP $HTTP_CODE)" >&2
+                  cat /tmp/web-status.json >&2 || true
+                  echo "--- GET / (debug) ---" >&2
+                  curl -i "http://localhost:7492/" >&2 || true
+                  docker compose -p pizzapi-web logs >&2 || true
                   exit 1
                 fi
                 sleep 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -357,7 +357,7 @@ jobs:
               # while the root HTML route can vary across packaging modes.
               for i in $(seq 1 60); do
                 HTTP_CODE=$(curl -sS -o /tmp/web-status.json -w "%{http_code}" "http://localhost:7492/api/status" || true)
-                if [ "$HTTP_CODE" = "200" ] && jq -e '.status == "ok" or .status == "degraded"' /tmp/web-status.json >/dev/null 2>&1; then
+                if [ "$HTTP_CODE" = "200" ] && jq -e ".status == \"ok\" or .status == \"degraded\"" /tmp/web-status.json >/dev/null 2>&1; then
                   break
                 fi
                 if [ "$i" -eq 60 ]; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,34 +105,6 @@ bun run clean
 
 ---
 
-## Worktrees & Branching
-
-**Always create worktree branches from `origin/main`, not local `main`.** Local `main` may have commits from other branches that haven't been merged yet (e.g., from a rebase or local-only work). If you create a worktree from local `main`, your feature branch silently inherits those unmerged commits, and your PR will include them.
-
-```bash
-# WRONG — local main may be ahead of origin/main
-git worktree add .worktrees/my-feature -b feat/my-feature
-
-# RIGHT — always base on origin/main
-git fetch origin main
-git worktree add .worktrees/my-feature -b feat/my-feature origin/main
-```
-
-**After creating a worktree, verify your branch only has your commits:**
-
-```bash
-git log --oneline origin/main..HEAD
-# Should show ONLY your new commits, nothing else
-```
-
-If you see unexpected commits, rebase onto `origin/main`:
-
-```bash
-git rebase --onto origin/main HEAD~<N>  # where N = number of YOUR commits
-```
-
----
-
 ## Upstream Patches
 
 PizzaPi patches two upstream pi packages via `patchedDependencies` in the root `package.json`. Patches live in `patches/` and are auto-applied on `bun install`. See `patches/README.md` for full details.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -105,6 +105,34 @@ bun run clean
 
 ---
 
+## Worktrees & Branching
+
+**Always create worktree branches from `origin/main`, not local `main`.** Local `main` may have commits from other branches that haven't been merged yet (e.g., from a rebase or local-only work). If you create a worktree from local `main`, your feature branch silently inherits those unmerged commits, and your PR will include them.
+
+```bash
+# WRONG — local main may be ahead of origin/main
+git worktree add .worktrees/my-feature -b feat/my-feature
+
+# RIGHT — always base on origin/main
+git fetch origin main
+git worktree add .worktrees/my-feature -b feat/my-feature origin/main
+```
+
+**After creating a worktree, verify your branch only has your commits:**
+
+```bash
+git log --oneline origin/main..HEAD
+# Should show ONLY your new commits, nothing else
+```
+
+If you see unexpected commits, rebase onto `origin/main`:
+
+```bash
+git rebase --onto origin/main HEAD~<N>  # where N = number of YOUR commits
+```
+
+---
+
 ## Upstream Patches
 
 PizzaPi patches two upstream pi packages via `patchedDependencies` in the root `package.json`. Patches live in `patches/` and are auto-applied on `bun install`. See `patches/README.md` for full details.

--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "pizzapi",
       "dependencies": {
-        "@mariozechner/pi-agent-core": "^0.58.3",
-        "@mariozechner/pi-ai": "^0.58.3",
-        "@mariozechner/pi-tui": "^0.58.3",
+        "@mariozechner/pi-agent-core": "^0.63.1",
+        "@mariozechner/pi-ai": "^0.63.1",
+        "@mariozechner/pi-tui": "^0.63.1",
         "motion": "^12.34.2",
         "pizzapi": ".",
       },
@@ -26,7 +26,7 @@
         "pizzapi": "src/index.ts",
       },
       "dependencies": {
-        "@mariozechner/pi-coding-agent": "^0.58.3",
+        "@mariozechner/pi-coding-agent": "^0.63.1",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
@@ -60,8 +60,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@mariozechner/pi-agent-core": "^0.58.3",
-        "@mariozechner/pi-ai": "^0.58.3",
+        "@mariozechner/pi-agent-core": "^0.63.1",
+        "@mariozechner/pi-ai": "^0.63.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",
@@ -89,8 +89,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@mariozechner/pi-agent-core": "^0.58.3",
-        "@mariozechner/pi-ai": "^0.58.3",
+        "@mariozechner/pi-agent-core": "^0.63.1",
+        "@mariozechner/pi-ai": "^0.63.1",
       },
       "devDependencies": {
         "typescript": "^5.7.0",
@@ -169,8 +169,8 @@
     },
   },
   "patchedDependencies": {
-    "@mariozechner/pi-coding-agent@0.58.3": "patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch",
-    "@mariozechner/pi-ai@0.58.3": "patches/@mariozechner%2Fpi-ai@0.58.3.patch",
+    "@mariozechner/pi-ai@0.63.1": "patches/@mariozechner%2Fpi-ai@0.63.1.patch",
+    "@mariozechner/pi-coding-agent@0.63.1": "patches/@mariozechner%2Fpi-coding-agent@0.63.1.patch",
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
@@ -711,13 +711,13 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.58.3", "", { "dependencies": { "@mariozechner/pi-ai": "^0.58.3" } }, "sha512-WGej7amRgHNxc3EcM4ATt/UEWpis8BttmzEt7zyadE2ZmuZAqI888pol3+sODnn+Lol704lNEJPlore9B9VMww=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.63.1", "", { "dependencies": { "@mariozechner/pi-ai": "^0.63.1" } }, "sha512-h0B20xfs/iEVR2EC4gwiE8hKI1TPeB8REdRJMgV+uXKH7gpeIZ9+s8Dp9nX35ZR0QUjkNey2+ULk2DxQtdg14Q=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.58.3", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-jdj6+Us94Ayrf4/rdSs7b7yCon8qMHAgU1qVQT/IIGHPgAktilD2Fkb4dv2LtgGr0Z5YKY2CAj9hyESKA6VbHw=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.63.1", "", { "dependencies": { "@anthropic-ai/sdk": "^0.73.0", "@aws-sdk/client-bedrock-runtime": "^3.983.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-wjgwY+yfrFO6a9QdAfjWpH7iSrDean6GsKDDMohNcLCy6PreMxHOZvNM0NwJARL1tZoZovr7ikAQfLGFZbnjsw=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.58.3", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.58.3", "@mariozechner/pi-ai": "^0.58.3", "@mariozechner/pi-tui": "^0.58.3", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-nYZnefl8YPpbzxuIF8I6SkorodCmUtt/4Nti++DvKzQwBMOpavyzb1InCwO57hJiPSfDXkXtQSrscoWEH1W4kg=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.63.1", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.63.1", "@mariozechner/pi-ai": "^0.63.1", "@mariozechner/pi-tui": "^0.63.1", "@silvia-odwyer/photon-node": "^0.3.4", "ajv": "^8.17.1", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-XSoMyLtuMA7ePK1UBWqSJ/BBdtBdJUHY9nbtnNyG6GeW7Gbgd+iqljIuwmAUf8wlYL981UIfYM/WIPQ6t/dIxw=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.58.3", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-eofZKuDFTrClu0fuZAInlG3w+2nAyJ25qz5bOAJylMzoTqlzsOSzqAeL0y2ZN/Nuy9ahwOzKQIXUwbrTXEVybw=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.63.1", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-G5p+eh1EPkFCNaaggX6vRrqttnDscK6npgmEOknoCQXZtch8XNgh9Lf3VJ0A2lZXSgR7IntG5dfXHPH/Ki64wA=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 

--- a/docker/e2e-tools.Dockerfile
+++ b/docker/e2e-tools.Dockerfile
@@ -12,7 +12,12 @@ RUN apt-get update \
         jq \
         nodejs \
         npm \
+        unzip \
     && rm -rf /var/lib/apt/lists/*
+
+# Install Bun — needed by `pizza web` to prebuild the UI on the host
+RUN curl -fsSL https://bun.sh/install | bash
+ENV PATH="/root/.bun/bin:$PATH"
 
 # Normalize command availability across distros/images
 RUN if ! docker compose version >/dev/null 2>&1; then \

--- a/package.json
+++ b/package.json
@@ -1,57 +1,57 @@
 {
-    "name": "pizzapi",
-    "private": true,
-    "workspaces": [
-        "packages/protocol",
-        "packages/tunnel",
-        "packages/tools",
-        "packages/server",
-        "packages/ui",
-        "packages/cli",
-        "packages/docs"
-    ],
-    "scripts": {
-        "build": "bun run build:protocol && bun run build:tunnel && bun run build:tools && bun run build:server && bun run build:ui && bun run build:cli",
-        "build:docs": "cd packages/docs && bun run build",
-        "dev:docs": "cd packages/docs && bun run dev",
-        "build:protocol": "cd packages/protocol && bun run build",
-        "build:tunnel": "cd packages/tunnel && bun run build",
-        "build:tools": "cd packages/tools && bun run build",
-        "build:server": "cd packages/server && bun run build",
-        "build:ui": "cd packages/ui && bun run build",
-        "build:cli": "cd packages/cli && bun run build",
-        "build:binaries": "cd packages/cli && bun run build:binaries",
-        "build:npm": "bun packages/npm/build-npm.ts",
-        "build:npm:skip-compile": "bun packages/npm/build-npm.ts --skip-compile",
-        "publish:npm": "bun packages/npm/publish-npm.ts",
-        "publish:npm:dry": "bun packages/npm/publish-npm.ts --dry-run",
-        "dev": "concurrently \"bun run dev:server\" \"bun run dev:ui --host\" --kill-others-on-exit",
-        "dev:server": "cd packages/server && bun run dev",
-        "dev:ui": "cd packages/ui && bun run dev",
-        "dev:cli": "bun packages/cli/src/index.ts",
-        "dev:runner": "bun packages/cli/src/index.ts runner",
-        "test": "bun test packages/protocol/src packages/tunnel/src packages/server/src packages/server/tests packages/tools/src && cd packages/cli && bun test src && cd ../ui && bun test src",
-        "typecheck": "tsc --build && bun run --cwd packages/protocol typecheck:tests && bun run --cwd packages/server typecheck:tests",
-        "migrate": "cd packages/server && bun run migrate",
-        "clean": "bun -e \"['protocol','tunnel','tools','server','ui','cli','docs'].forEach(p=>{require('fs').rmSync('packages/'+p+'/dist',{recursive:true,force:true});require('fs').rmSync('packages/'+p+'/tsconfig.tsbuildinfo',{force:true})})\"",
-        "postinstall": "bun scripts/link-workspaces.ts"
-    },
-    "dependencies": {
-        "@mariozechner/pi-agent-core": "^0.58.3",
-        "@mariozechner/pi-ai": "^0.58.3",
-        "@mariozechner/pi-tui": "^0.58.3",
-        "motion": "^12.34.2",
-        "pizzapi": "."
-    },
-    "devDependencies": {
-        "@playwright/test": "^1.58.2",
-        "concurrently": "^9.2.1",
-        "lefthook": "^2.1.1",
-        "typescript": "^5.7.0"
-    },
-    "patchedDependencies": {
-        "@mariozechner/pi-coding-agent@0.58.3": "patches/@mariozechner%2Fpi-coding-agent@0.58.3.patch",
-        "@mariozechner/pi-ai@0.58.3": "patches/@mariozechner%2Fpi-ai@0.58.3.patch"
-    },
-    "version": ""
+  "name": "pizzapi",
+  "private": true,
+  "workspaces": [
+    "packages/protocol",
+    "packages/tunnel",
+    "packages/tools",
+    "packages/server",
+    "packages/ui",
+    "packages/cli",
+    "packages/docs"
+  ],
+  "scripts": {
+    "build": "bun run build:protocol && bun run build:tunnel && bun run build:tools && bun run build:server && bun run build:ui && bun run build:cli",
+    "build:docs": "cd packages/docs && bun run build",
+    "dev:docs": "cd packages/docs && bun run dev",
+    "build:protocol": "cd packages/protocol && bun run build",
+    "build:tunnel": "cd packages/tunnel && bun run build",
+    "build:tools": "cd packages/tools && bun run build",
+    "build:server": "cd packages/server && bun run build",
+    "build:ui": "cd packages/ui && bun run build",
+    "build:cli": "cd packages/cli && bun run build",
+    "build:binaries": "cd packages/cli && bun run build:binaries",
+    "build:npm": "bun packages/npm/build-npm.ts",
+    "build:npm:skip-compile": "bun packages/npm/build-npm.ts --skip-compile",
+    "publish:npm": "bun packages/npm/publish-npm.ts",
+    "publish:npm:dry": "bun packages/npm/publish-npm.ts --dry-run",
+    "dev": "concurrently \"bun run dev:server\" \"bun run dev:ui --host\" --kill-others-on-exit",
+    "dev:server": "cd packages/server && bun run dev",
+    "dev:ui": "cd packages/ui && bun run dev",
+    "dev:cli": "bun packages/cli/src/index.ts",
+    "dev:runner": "bun packages/cli/src/index.ts runner",
+    "test": "bun test packages/protocol/src packages/tunnel/src packages/server/src packages/server/tests packages/tools/src && cd packages/cli && bun test src && cd ../ui && bun test src",
+    "typecheck": "tsc --build && bun run --cwd packages/protocol typecheck:tests && bun run --cwd packages/server typecheck:tests",
+    "migrate": "cd packages/server && bun run migrate",
+    "clean": "bun -e \"['protocol','tunnel','tools','server','ui','cli','docs'].forEach(p=>{require('fs').rmSync('packages/'+p+'/dist',{recursive:true,force:true});require('fs').rmSync('packages/'+p+'/tsconfig.tsbuildinfo',{force:true})})\"",
+    "postinstall": "bun scripts/link-workspaces.ts"
+  },
+  "dependencies": {
+    "@mariozechner/pi-agent-core": "^0.63.1",
+    "@mariozechner/pi-ai": "^0.63.1",
+    "@mariozechner/pi-tui": "^0.63.1",
+    "motion": "^12.34.2",
+    "pizzapi": "."
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.58.2",
+    "concurrently": "^9.2.1",
+    "lefthook": "^2.1.1",
+    "typescript": "^5.7.0"
+  },
+  "version": "",
+  "patchedDependencies": {
+    "@mariozechner/pi-coding-agent@0.63.1": "patches/@mariozechner%2Fpi-coding-agent@0.63.1.patch",
+    "@mariozechner/pi-ai@0.63.1": "patches/@mariozechner%2Fpi-ai@0.63.1.patch"
+  }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable PizzaPi changes are documented here. Version numbers track the
+underlying `@mariozechner/pi-coding-agent` release that each PizzaPi update
+ships with — this is how the TUI detects "what's new" on startup.
+
+## [Unreleased]
+
+## [0.63.1] - 2026-03-27
+
+### Upstream (pi 0.58.3 → 0.63.1)
+
+- **Multi-edit support** — the `edit` tool can now update multiple disjoint regions in one call
+- **JSONL session export/import** — `/export path.jsonl` and `/import path.jsonl`
+- **Fork sessions** — `--fork <path|id>` copies a session into a new one
+- **Resizable sidebar** in HTML share/export views
+- **Namespaced keybindings** — unified keybinding manager with configurable `keybindings.json`
+- **Built-in tools as extensible ToolDefinitions** — override rendering of read/write/edit/bash tools
+- **Typed `tool_call` handler return values** via `ToolCallEventResult`
+- Fixed repeated compaction dropping earlier kept messages
+- Fixed concurrent `edit`/`write` mutations targeting the same file
+- Fixed auto-compaction overflow recovery for Ollama models
+- Fixed `@` autocomplete debouncing and stale suggestion cleanup
+- Many provider fixes (Bedrock, Google Vertex, OpenRouter, Copilot, MiniMax)
+
+### PizzaPi
+
+- **PizzaPi changelog** — version bumps now show "What's New" in the TUI on first launch, and `/changelog` shows full history
+- Ported all patches forward to 0.63.1 (session control, configDir override, version check removal, auth path fix, retryable JSON errors, web search)
+
+## [0.58.3] - 2026-02-25
+
+_Initial changelog tracking. Prior changes are not recorded here._

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,7 +28,7 @@
     "build:binaries": "bun build-binaries.ts"
   },
   "dependencies": {
-    "@mariozechner/pi-coding-agent": "^0.58.3",
+    "@mariozechner/pi-coding-agent": "^0.63.1",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@pizzapi/protocol": "workspace:*",
     "@pizzapi/tools": "workspace:*",

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -198,7 +198,7 @@ export function expandHome(path: string): string {
 }
 
 export function defaultAgentDir(): string {
-    return join(homedir(), ".pizzapi", "agent");
+    return join(homedir(), ".pizzapi");
 }
 
 // ── Changelog path ────────────────────────────────────────────────────────────

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -198,7 +198,7 @@ export function expandHome(path: string): string {
 }
 
 export function defaultAgentDir(): string {
-    return join(homedir(), ".pizzapi");
+    return join(homedir(), ".pizzapi", "agent");
 }
 
 // ── Changelog path ────────────────────────────────────────────────────────────

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -1,6 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
-import { join } from "path";
+import { dirname, join, resolve } from "path";
+import { fileURLToPath } from "url";
 
 import {
     type PizzaPiConfig,
@@ -198,6 +199,25 @@ export function expandHome(path: string): string {
 
 export function defaultAgentDir(): string {
     return join(homedir(), ".pizzapi");
+}
+
+// ── Changelog path ────────────────────────────────────────────────────────────
+
+/**
+ * Resolve the PizzaPi CHANGELOG.md path and export it as an env var so the
+ * patched upstream `getChangelogPath()` picks it up. This file lives in the
+ * CLI package root (next to package.json), not in the pi-coding-agent package.
+ */
+function resolveChangelogPath(): string {
+    const __filename = fileURLToPath(import.meta.url);
+    const __dirname = dirname(__filename);
+    // From dist/config/io.js → ../../CHANGELOG.md  (or src/config/io.ts → same)
+    return resolve(__dirname, "..", "..", "CHANGELOG.md");
+}
+
+const changelogPath = resolveChangelogPath();
+if (existsSync(changelogPath)) {
+    process.env.PIZZAPI_CHANGELOG_PATH = changelogPath;
 }
 
 // ── Plugin trust helpers ──────────────────────────────────────────────────────

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -13,6 +13,7 @@ import { BUILTIN_SYSTEM_PROMPT, defaultAgentDir, expandHome, loadConfig, resolve
 import { c, usageBar, colorPct, colorRemaining } from "./cli-colors.js";
 import { buildInteractiveSkillPaths } from "./skills.js";
 import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
+import { migrateAgentDir } from "./migrations.js";
 import { runSetup } from "./setup.js";
 import { createLogger, initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 
@@ -427,6 +428,9 @@ async function main() {
         const idx = args.indexOf(flag);
         if (idx !== -1) args.splice(idx, 1);
     }
+
+    // Migrate legacy agent data into flat ~/.pizzapi/ before anything reads from it
+    migrateAgentDir();
 
     const config = loadConfig(cwd);
     const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();

--- a/packages/cli/src/migrations.ts
+++ b/packages/cli/src/migrations.ts
@@ -1,0 +1,85 @@
+/**
+ * PizzaPi startup migrations — consolidate agent data into flat ~/.pizzapi/.
+ *
+ * Called from both the daemon and interactive TUI on startup.
+ * Idempotent — safe to call repeatedly.
+ */
+import { existsSync, mkdirSync, readdirSync, renameSync, statSync, cpSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("migrations");
+
+/**
+ * Migrate session & agent data into the flat ~/.pizzapi/ directory.
+ *
+ * Phase 1: ~/.pi/agent → ~/.pizzapi/  (legacy pi installs)
+ * Phase 2: ~/.pizzapi/agent/ → ~/.pizzapi/  (pre-fix PizzaPi installs that
+ *          had upstream's getAgentDir() returning ~/.pizzapi/agent/)
+ *
+ * A `.migrated` marker file is written to ~/.pizzapi/agent/ after phase 2
+ * so we don't re-scan on every boot.
+ */
+export function migrateAgentDir(): void {
+    const pizzapiDir = join(homedir(), ".pizzapi");
+    const agentSubdir = join(pizzapiDir, "agent");
+    const markerFile = join(agentSubdir, ".migrated");
+
+    // ── Phase 1: ~/.pi/agent → ~/.pizzapi/ ─────────────────────────────────
+    const piAgentDir = join(homedir(), ".pi", "agent");
+    if (existsSync(piAgentDir)) {
+        // Only migrate if we haven't already (sessions dir doesn't exist at root)
+        if (!existsSync(join(pizzapiDir, "sessions"))) {
+            try {
+                mergeDir(piAgentDir, pizzapiDir);
+                log.info("Migrated session data from ~/.pi/agent into ~/.pizzapi");
+            } catch (e: any) {
+                log.warn(`Failed to migrate ~/.pi/agent: ${e.message}`);
+            }
+        }
+    }
+
+    // ── Phase 2: ~/.pizzapi/agent/ → ~/.pizzapi/ ───────────────────────────
+    // Earlier PizzaPi versions (and the upstream lib) stored sessions, auth,
+    // bin, and usage.db under ~/.pizzapi/agent/. Now that getAgentDir() returns
+    // ~/.pizzapi/ directly, consolidate everything into the flat structure.
+    if (existsSync(agentSubdir) && !existsSync(markerFile)) {
+        try {
+            mergeDir(agentSubdir, pizzapiDir);
+            // Write marker so we don't re-scan
+            mkdirSync(agentSubdir, { recursive: true });
+            Bun.write(markerFile, new Date().toISOString());
+            log.info("Consolidated ~/.pizzapi/agent/ into ~/.pizzapi/");
+        } catch (e: any) {
+            log.warn(`Failed to consolidate ~/.pizzapi/agent/: ${e.message}`);
+        }
+    }
+}
+
+/**
+ * Recursively merge `src` into `dst`, skipping files that already exist in dst.
+ * Does not delete src — caller decides cleanup.
+ */
+export function mergeDir(src: string, dst: string): void {
+    mkdirSync(dst, { recursive: true });
+    for (const entry of readdirSync(src)) {
+        // Skip the .migrated marker and .DS_Store
+        if (entry === ".migrated" || entry === ".DS_Store") continue;
+        const srcPath = join(src, entry);
+        const dstPath = join(dst, entry);
+        const stat = statSync(srcPath);
+        if (stat.isDirectory()) {
+            // Recursively merge subdirectories (e.g. sessions/*)
+            mergeDir(srcPath, dstPath);
+        } else if (!existsSync(dstPath)) {
+            // Move file — try rename first, fall back to copy
+            try {
+                renameSync(srcPath, dstPath);
+            } catch {
+                cpSync(srcPath, dstPath);
+            }
+        }
+        // If dst already has the file, skip (don't overwrite)
+    }
+}

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -118,6 +118,17 @@ describe("pi-coding-agent patch application", () => {
         expect(source).not.toContain('CONFIG_DIR_NAME = pkg.piConfig');
         expect(source).toContain("PATCH(pizzapi)");
     });
+
+    test("config.js: getAgentDir() returns ~/.pizzapi/ (flat, no /agent/ segment)", async () => {
+        const source = await Bun.file(
+            piCodingAgentPath("dist/config.js"),
+        ).text();
+
+        // Must NOT append "agent" to the path
+        expect(source).toContain('return join(homedir(), CONFIG_DIR_NAME)');
+        expect(source).not.toContain('return join(homedir(), CONFIG_DIR_NAME, "agent")');
+        expect(source).toContain("PATCH(pizzapi): drop the /agent/ segment");
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -192,13 +203,23 @@ describe("pi-coding-agent patched runtime behavior", () => {
         expect(CONFIG_DIR_NAME).toBe(".pizzapi");
     });
 
-    test("getSessionsDir uses .pizzapi path", async () => {
+    test("getAgentDir returns flat ~/.pizzapi/ path (no /agent/ segment)", async () => {
+        const { getAgentDir } = await import(
+            piCodingAgentPath("dist/config.js")
+        );
+        const dir = getAgentDir();
+        expect(dir).toContain(".pizzapi");
+        expect(dir).not.toContain(".pizzapi/agent");
+        expect(dir).not.toMatch(/\/\.pi\//);
+    });
+
+    test("getSessionsDir uses flat ~/.pizzapi/sessions path", async () => {
         const { getSessionsDir } = await import(
             piCodingAgentPath("dist/config.js")
         );
         const dir = getSessionsDir();
-        expect(dir).toContain(".pizzapi");
-        expect(dir).not.toMatch(/\/\.pi\//);
+        expect(dir).toContain(".pizzapi/sessions");
+        expect(dir).not.toContain(".pizzapi/agent/sessions");
     });
 
     test("runtime.newSession/switchSession are assignable (runner can bind them)", async () => {

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -2,7 +2,7 @@ import { exec } from "node:child_process";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
-import { existsSync, mkdirSync, renameSync, cpSync, rmSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, renameSync, statSync, cpSync, rmSync } from "node:fs";
 import { hostname, homedir } from "node:os";
 import { join } from "node:path";
 import { ServiceRegistry } from "./service-handler.js";
@@ -55,47 +55,76 @@ import {
 import type { UsageRange } from "../usage/types.js";
 
 /**
- * Migrate session storage from ~/.pi/agent to ~/.pizzapi/agent.
+ * Migrate session & agent data into the flat ~/.pizzapi/ directory.
+ *
+ * Phase 1: ~/.pi/agent → ~/.pizzapi/  (legacy pi installs)
+ * Phase 2: ~/.pizzapi/agent/ → ~/.pizzapi/  (pre-fix PizzaPi installs that
+ *          had upstream's getAgentDir() returning ~/.pizzapi/agent/)
+ *
  * Runs on daemon startup and is idempotent (safe to call repeatedly).
+ * A `.migrated` marker file is written to ~/.pizzapi/agent/ after phase 2
+ * so we don't re-scan on every boot.
  */
 function migrateSessionStorage(): void {
-    const oldDir = join(homedir(), ".pi", "agent");
-    const newDir = join(homedir(), ".pizzapi", "agent");
-    const newSessions = join(newDir, "sessions");
+    const pizzapiDir = join(homedir(), ".pizzapi");
+    const agentSubdir = join(pizzapiDir, "agent");
+    const markerFile = join(agentSubdir, ".migrated");
 
-    // Skip if old dir doesn't exist or new sessions dir already exists
-    if (!existsSync(oldDir) || existsSync(newSessions)) return;
-
-    // Ensure the parent directory exists but do NOT pre-create newDir itself —
-    // renameSync requires the target to not exist, or on some platforms it will
-    // fail with EEXIST/ENOTEMPTY when renaming onto an existing directory.
-    mkdirSync(join(newDir, ".."), { recursive: true });
-
-    if (existsSync(newDir)) {
-        // newDir already exists (e.g. a fresh install created it) but newSessions
-        // does not — merge any files from oldDir into newDir and remove oldDir.
-        try {
-            cpSync(oldDir, newDir, { recursive: true });
-            rmSync(oldDir, { recursive: true, force: true });
-            logInfo(`Merged session data from ~/.pi/agent into ~/.pizzapi/agent`);
-        } catch (e: any) {
-            logWarn(`Failed to merge session storage: ${e.message}`);
+    // ── Phase 1: ~/.pi/agent → ~/.pizzapi/ ─────────────────────────────────
+    const piAgentDir = join(homedir(), ".pi", "agent");
+    if (existsSync(piAgentDir)) {
+        // Only migrate if we haven't already (sessions dir doesn't exist at root)
+        if (!existsSync(join(pizzapiDir, "sessions"))) {
+            try {
+                _mergeDir(piAgentDir, pizzapiDir);
+                logInfo("Migrated session data from ~/.pi/agent into ~/.pizzapi");
+            } catch (e: any) {
+                logWarn(`Failed to migrate ~/.pi/agent: ${e.message}`);
+            }
         }
-        return;
     }
 
-    try {
-        renameSync(oldDir, newDir);
-        logInfo(`Migrated session data from ~/.pi/agent to ~/.pizzapi/agent`);
-    } catch (e: any) {
-        if (e.code === "EXDEV") {
-            // Cross-device move failed — fall back to copy
-            cpSync(oldDir, newDir, { recursive: true });
-            rmSync(oldDir, { recursive: true, force: true });
-            logInfo(`Migrated session data from ~/.pi/agent to ~/.pizzapi/agent (cross-device copy)`);
-        } else {
-            logWarn(`Failed to migrate session storage: ${e.message}`);
+    // ── Phase 2: ~/.pizzapi/agent/ → ~/.pizzapi/ ───────────────────────────
+    // Earlier PizzaPi versions (and the upstream lib) stored sessions, auth,
+    // bin, and usage.db under ~/.pizzapi/agent/. Now that getAgentDir() returns
+    // ~/.pizzapi/ directly, consolidate everything into the flat structure.
+    if (existsSync(agentSubdir) && !existsSync(markerFile)) {
+        try {
+            _mergeDir(agentSubdir, pizzapiDir);
+            // Write marker so we don't re-scan
+            mkdirSync(agentSubdir, { recursive: true });
+            Bun.write(markerFile, new Date().toISOString());
+            logInfo("Consolidated ~/.pizzapi/agent/ into ~/.pizzapi/");
+        } catch (e: any) {
+            logWarn(`Failed to consolidate ~/.pizzapi/agent/: ${e.message}`);
         }
+    }
+}
+
+/**
+ * Recursively merge `src` into `dst`, skipping files that already exist in dst.
+ * Does not delete src — caller decides cleanup.
+ */
+function _mergeDir(src: string, dst: string): void {
+    mkdirSync(dst, { recursive: true });
+    for (const entry of readdirSync(src)) {
+        // Skip the .migrated marker and .DS_Store
+        if (entry === ".migrated" || entry === ".DS_Store") continue;
+        const srcPath = join(src, entry);
+        const dstPath = join(dst, entry);
+        const stat = statSync(srcPath);
+        if (stat.isDirectory()) {
+            // Recursively merge subdirectories (e.g. sessions/*)
+            _mergeDir(srcPath, dstPath);
+        } else if (!existsSync(dstPath)) {
+            // Move file — try rename first, fall back to copy
+            try {
+                renameSync(srcPath, dstPath);
+            } catch {
+                cpSync(srcPath, dstPath);
+            }
+        }
+        // If dst already has the file, skip (don't overwrite)
     }
 }
 

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -2,7 +2,6 @@ import { exec } from "node:child_process";
 import { promisify } from "node:util";
 
 const execAsync = promisify(exec);
-import { existsSync, mkdirSync, readdirSync, renameSync, statSync, cpSync, rmSync } from "node:fs";
 import { hostname, homedir } from "node:os";
 import { join } from "node:path";
 import { ServiceRegistry } from "./service-handler.js";
@@ -54,79 +53,8 @@ import {
 } from "../usage/index.js";
 import type { UsageRange } from "../usage/types.js";
 
-/**
- * Migrate session & agent data into the flat ~/.pizzapi/ directory.
- *
- * Phase 1: ~/.pi/agent → ~/.pizzapi/  (legacy pi installs)
- * Phase 2: ~/.pizzapi/agent/ → ~/.pizzapi/  (pre-fix PizzaPi installs that
- *          had upstream's getAgentDir() returning ~/.pizzapi/agent/)
- *
- * Runs on daemon startup and is idempotent (safe to call repeatedly).
- * A `.migrated` marker file is written to ~/.pizzapi/agent/ after phase 2
- * so we don't re-scan on every boot.
- */
-function migrateSessionStorage(): void {
-    const pizzapiDir = join(homedir(), ".pizzapi");
-    const agentSubdir = join(pizzapiDir, "agent");
-    const markerFile = join(agentSubdir, ".migrated");
-
-    // ── Phase 1: ~/.pi/agent → ~/.pizzapi/ ─────────────────────────────────
-    const piAgentDir = join(homedir(), ".pi", "agent");
-    if (existsSync(piAgentDir)) {
-        // Only migrate if we haven't already (sessions dir doesn't exist at root)
-        if (!existsSync(join(pizzapiDir, "sessions"))) {
-            try {
-                _mergeDir(piAgentDir, pizzapiDir);
-                logInfo("Migrated session data from ~/.pi/agent into ~/.pizzapi");
-            } catch (e: any) {
-                logWarn(`Failed to migrate ~/.pi/agent: ${e.message}`);
-            }
-        }
-    }
-
-    // ── Phase 2: ~/.pizzapi/agent/ → ~/.pizzapi/ ───────────────────────────
-    // Earlier PizzaPi versions (and the upstream lib) stored sessions, auth,
-    // bin, and usage.db under ~/.pizzapi/agent/. Now that getAgentDir() returns
-    // ~/.pizzapi/ directly, consolidate everything into the flat structure.
-    if (existsSync(agentSubdir) && !existsSync(markerFile)) {
-        try {
-            _mergeDir(agentSubdir, pizzapiDir);
-            // Write marker so we don't re-scan
-            mkdirSync(agentSubdir, { recursive: true });
-            Bun.write(markerFile, new Date().toISOString());
-            logInfo("Consolidated ~/.pizzapi/agent/ into ~/.pizzapi/");
-        } catch (e: any) {
-            logWarn(`Failed to consolidate ~/.pizzapi/agent/: ${e.message}`);
-        }
-    }
-}
-
-/**
- * Recursively merge `src` into `dst`, skipping files that already exist in dst.
- * Does not delete src — caller decides cleanup.
- */
-function _mergeDir(src: string, dst: string): void {
-    mkdirSync(dst, { recursive: true });
-    for (const entry of readdirSync(src)) {
-        // Skip the .migrated marker and .DS_Store
-        if (entry === ".migrated" || entry === ".DS_Store") continue;
-        const srcPath = join(src, entry);
-        const dstPath = join(dst, entry);
-        const stat = statSync(srcPath);
-        if (stat.isDirectory()) {
-            // Recursively merge subdirectories (e.g. sessions/*)
-            _mergeDir(srcPath, dstPath);
-        } else if (!existsSync(dstPath)) {
-            // Move file — try rename first, fall back to copy
-            try {
-                renameSync(srcPath, dstPath);
-            } catch {
-                cpSync(srcPath, dstPath);
-            }
-        }
-        // If dst already has the file, skip (don't overwrite)
-    }
-}
+// Re-export migration from shared module — used on daemon startup
+import { migrateAgentDir } from "../migrations.js";
 
 /**
  * Read the `relayUrl` from ~/.pizzapi/config.json, returning undefined
@@ -159,8 +87,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
     const statePath = defaultStatePath();
     const identity = acquireStateAndIdentity(statePath);
 
-    // Migrate session storage from ~/.pi to ~/.pizzapi on startup
-    migrateSessionStorage();
+    // Migrate session storage from legacy locations into flat ~/.pizzapi/
+    migrateAgentDir();
 
     // Initialize usage tracking
     initUsage();

--- a/packages/cli/src/usage/scanner.ts
+++ b/packages/cli/src/usage/scanner.ts
@@ -341,14 +341,20 @@ export function processFile(
  */
 export async function scanSessions(db: Database): Promise<void> {
   const primaryDir = getSessionsDir();
-  const piDir = join(homedir(), ".pi", "agent", "sessions");
+  // Legacy fallback directories for unmigrated installs
+  const legacyDirs = [
+    join(homedir(), ".pizzapi", "agent", "sessions"),
+    join(homedir(), ".pi", "agent", "sessions"),
+  ];
 
   const dirsToScan = [];
   if (existsSync(primaryDir)) {
     dirsToScan.push(primaryDir);
   }
-  if (existsSync(piDir) && piDir !== primaryDir) {
-    dirsToScan.push(piDir);
+  for (const legacyDir of legacyDirs) {
+    if (existsSync(legacyDir) && legacyDir !== primaryDir && !dirsToScan.includes(legacyDir)) {
+      dirsToScan.push(legacyDir);
+    }
   }
 
   for (const sessionsDir of dirsToScan) {

--- a/packages/cli/src/usage/schema.ts
+++ b/packages/cli/src/usage/schema.ts
@@ -6,12 +6,12 @@ import { mkdirSync } from "node:fs";
 const SCHEMA_VERSION = 1;
 
 export function getUsageDbPath(): string {
-  return join(homedir(), ".pizzapi", "agent", "usage.db");
+  return join(homedir(), ".pizzapi", "usage.db");
 }
 
 export function getSessionsDir(): string {
-  // Primary directory — scanner also checks piDir as fallback
-  return join(homedir(), ".pizzapi", "agent", "sessions");
+  // Primary directory — scanner also checks legacy dirs as fallback
+  return join(homedir(), ".pizzapi", "sessions");
 }
 
 export function openUsageDb(): Database {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,8 +14,8 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@mariozechner/pi-agent-core": "^0.58.3",
-        "@mariozechner/pi-ai": "^0.58.3",
+        "@mariozechner/pi-agent-core": "^0.63.1",
+        "@mariozechner/pi-ai": "^0.63.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,8 +10,8 @@
     },
     "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@mariozechner/pi-agent-core": "^0.58.3",
-        "@mariozechner/pi-ai": "^0.58.3"
+        "@mariozechner/pi-agent-core": "^0.63.1",
+        "@mariozechner/pi-ai": "^0.63.1"
     },
     "devDependencies": {
         "typescript": "^5.7.0"

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3866,14 +3866,14 @@ export function App() {
   // skip re-rendering when only session-scoped state changes.
   const handleToggleDark = React.useCallback(() => setIsDark((d) => !d), []);
   const handleShowApiKeys = React.useCallback(() => { setShowApiKeys(true); setShowRunners(false); }, []);
-  const handleShowRunners = React.useCallback(() => { setShowRunners(true); setShowApiKeys(false); setActiveSessionId(null); }, []);
+  const handleShowRunners = React.useCallback(() => { setShowRunners(true); setShowApiKeys(false); activeSessionRef.current = null; setActiveSessionId(null); }, []);
   const handleShowShortcuts = React.useCallback(() => setShowShortcutsHelp(true), []);
   const handleShowHiddenModels = React.useCallback(() => setHiddenModelsOpen(true), []);
   const handleChangePassword = React.useCallback(() => setChangePasswordOpen(true), []);
   const handleToggleSidebar = React.useCallback(() => setSidebarOpen((prev) => !prev), []);
   // Mobile-specific variants that also close the sidebar
   const handleMobileShowApiKeys = React.useCallback(() => { setShowApiKeys(true); setShowRunners(false); setSidebarOpen(false); }, []);
-  const handleMobileShowRunners = React.useCallback(() => { setShowRunners(true); setShowApiKeys(false); setActiveSessionId(null); setSidebarOpen(false); }, []);
+  const handleMobileShowRunners = React.useCallback(() => { setShowRunners(true); setShowApiKeys(false); activeSessionRef.current = null; setActiveSessionId(null); setSidebarOpen(false); }, []);
   const handleMobileShowHiddenModels = React.useCallback(() => { setHiddenModelsOpen(true); setSidebarOpen(false); }, []);
   const handleMobileChangePassword = React.useCallback(() => { setChangePasswordOpen(true); setSidebarOpen(false); }, []);
   const handleSessionSwitcherOpenChange = React.useCallback((open: boolean) => setSessionSwitcherOpen(open), []);
@@ -4079,7 +4079,7 @@ export function App() {
               onOpenSession={handleOpenSession}
               onNewSession={handleNewSession}
               onClearSelection={handleClearSelection}
-              onShowRunners={() => { setShowRunners(true); setShowApiKeys(false); setActiveSessionId(null); }}
+              onShowRunners={() => { setShowRunners(true); setShowApiKeys(false); activeSessionRef.current = null; setActiveSessionId(null); }}
               activeSessionId={activeSessionId}
               showRunners={showRunners}
               activeModel={activeModel}

--- a/patches/@mariozechner%2Fpi-ai@0.63.1.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.63.1.patch
@@ -1,0 +1,128 @@
+diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
+index d4fc29b8c97264ae51b212bdf69b29f7e8001ad1..b24a943c5bb06f521c629bbe93c8ea2eb295b7c5 100644
+--- a/dist/providers/anthropic.js
++++ b/dist/providers/anthropic.js
+@@ -220,6 +220,37 @@ export const streamAnthropic = (model, context, options) => {
+                         output.content.push(block);
+                         stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+                     }
++                    // PATCH(pizzapi): handle server_tool_use (web search query)
++                    // Input arrives empty ({}) at start; actual input streams via
++                    // input_json_delta events, so we accumulate partialJson just
++                    // like regular toolCall blocks. Text is left empty — the UI
++                    // renderer decides how to display web-search blocks using the
++                    // structured _serverToolUse metadata.
++                    else if (event.content_block.type === "server_tool_use") {
++                        const block = {
++                            type: "text",
++                            text: "",
++                            partialJson: "",
++                            _serverToolUse: { id: event.content_block.id, name: event.content_block.name, input: event.content_block.input },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
++                    // PATCH(pizzapi): handle web_search_tool_result
++                    // content is a union: Array<WebSearchResultBlock> | WebSearchToolResultError
++                    // — must check Array.isArray before iterating to avoid "{} is not iterable".
++                    // Text is left empty; the UI renderer uses _webSearchResult metadata.
++                    else if (event.content_block.type === "web_search_tool_result") {
++                        const block = {
++                            type: "text",
++                            text: "",
++                            _webSearchResult: { tool_use_id: event.content_block.tool_use_id, content: event.content_block.content },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
+                 }
+                 else if (event.type === "content_block_delta") {
+                     if (event.delta.type === "text_delta") {
+@@ -261,6 +292,10 @@ export const streamAnthropic = (model, context, options) => {
+                                 partial: output,
+                             });
+                         }
++                        // PATCH(pizzapi): accumulate input_json_delta for server_tool_use blocks
++                        else if (block && block._serverToolUse && block.partialJson !== undefined) {
++                            block.partialJson += event.delta.partial_json;
++                        }
+                     }
+                     else if (event.delta.type === "signature_delta") {
+                         const index = blocks.findIndex((b) => b.index === event.index);
+@@ -277,6 +312,15 @@ export const streamAnthropic = (model, context, options) => {
+                     if (block) {
+                         delete block.index;
+                         if (block.type === "text") {
++                            // PATCH(pizzapi): finalize server_tool_use input from accumulated JSON
++                            if (block._serverToolUse && block.partialJson) {
++                                try {
++                                    block._serverToolUse.input = JSON.parse(block.partialJson);
++                                } catch (e) {
++                                    block._serverToolUse.input = parseStreamingJson(block.partialJson);
++                                }
++                            }
++                            delete block.partialJson;
+                             stream.push({
+                                 type: "text_end",
+                                 contentIndex: index,
+@@ -507,6 +551,20 @@ function buildParams(model, context, isOAuthToken, options) {
+     if (context.tools) {
+         params.tools = convertTools(context.tools, isOAuthToken);
+     }
++    // PATCH(pizzapi): inject Anthropic web search tool when PIZZAPI_WEB_SEARCH is set
++    if (typeof process !== "undefined" && process.env.PIZZAPI_WEB_SEARCH && !["0", "false", "no", "off"].includes(process.env.PIZZAPI_WEB_SEARCH.toLowerCase())) {
++        if (!params.tools) params.tools = [];
++        const webSearchTool = { type: "web_search_20250305", name: "web_search" };
++        const maxUses = parseInt(process.env.PIZZAPI_WEB_SEARCH_MAX_USES || "5", 10);
++        if (maxUses > 0) webSearchTool.max_uses = maxUses;
++        if (process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS) {
++            webSearchTool.allowed_domains = process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS.split(",").map(d => d.trim());
++        }
++        if (process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS) {
++            webSearchTool.blocked_domains = process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS.split(",").map(d => d.trim());
++        }
++        params.tools.push(webSearchTool);
++    }
+     // Configure thinking mode: adaptive (Opus 4.6 and Sonnet 4.6),
+     // budget-based (older models), or explicitly disabled.
+     if (model.reasoning) {
+@@ -602,7 +660,25 @@ function convertMessages(messages, model, isOAuthToken, cacheControl) {
+         else if (msg.role === "assistant") {
+             const blocks = [];
+             for (const block of msg.content) {
+-                if (block.type === "text") {
++                // PATCH(pizzapi): round-trip server tool use and web search results
++                // These must be checked BEFORE the generic text handler since they
++                // use type:"text" with metadata that needs to be restored.
++                if (block.type === "text" && block._serverToolUse) {
++                    blocks.push({
++                        type: "server_tool_use",
++                        id: block._serverToolUse.id,
++                        name: block._serverToolUse.name,
++                        input: block._serverToolUse.input,
++                    });
++                }
++                else if (block.type === "text" && block._webSearchResult) {
++                    blocks.push({
++                        type: "web_search_tool_result",
++                        tool_use_id: block._webSearchResult.tool_use_id,
++                        content: block._webSearchResult.content,
++                    });
++                }
++                else if (block.type === "text") {
+                     if (block.text.trim().length === 0)
+                         continue;
+                     blocks.push({
+@@ -713,6 +789,10 @@ function convertTools(tools, isOAuthToken) {
+     if (!tools)
+         return [];
+     return tools.map((tool) => {
++        // PATCH(pizzapi): pass through server-side tools (e.g., web_search) as-is
++        if (tool.type && typeof tool.type === "string") {
++            return tool;
++        }
+         const jsonSchema = tool.parameters; // TypeBox already generates JSON Schema
+         return {
+             name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,

--- a/patches/@mariozechner%2Fpi-coding-agent@0.63.1.patch
+++ b/patches/@mariozechner%2Fpi-coding-agent@0.63.1.patch
@@ -4,11 +4,25 @@ index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2
 diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-3bb5b1e4e0f13aee b/.bun-tag-3bb5b1e4e0f13aee
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-b7972330f11a52eb b/.bun-tag-b7972330f11a52eb
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/config.js b/dist/config.js
-index 51cdae907f8cda750b66dd361b3acc7143ae22a2..f9e667986119c512aa1d222f2a171c08d9570323 100644
+index 51cdae907f8cda750b66dd361b3acc7143ae22a2..3fc188e21b73621fde5848af772d873098d3d068 100644
 --- a/dist/config.js
 +++ b/dist/config.js
-@@ -138,7 +138,9 @@ export function getChangelogPath() {
+@@ -131,6 +131,10 @@ export function getExamplesPath() {
+ }
+ /** Get path to CHANGELOG.md */
+ export function getChangelogPath() {
++    // PATCH(pizzapi): allow PizzaPi to redirect to its own changelog
++    if (process.env.PIZZAPI_CHANGELOG_PATH) {
++        return resolve(process.env.PIZZAPI_CHANGELOG_PATH);
++    }
+     return resolve(join(getPackageDir(), "CHANGELOG.md"));
+ }
+ // =============================================================================
+@@ -138,7 +142,9 @@ export function getChangelogPath() {
  // =============================================================================
  const pkg = JSON.parse(readFileSync(getPackageJsonPath(), "utf-8"));
  export const APP_NAME = pkg.piConfig?.name || "pi";

--- a/patches/@mariozechner%2Fpi-coding-agent@0.63.1.patch
+++ b/patches/@mariozechner%2Fpi-coding-agent@0.63.1.patch
@@ -1,0 +1,264 @@
+diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-1b35b7c8e69bb102 b/.bun-tag-1b35b7c8e69bb102
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-3bb5b1e4e0f13aee b/.bun-tag-3bb5b1e4e0f13aee
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/config.js b/dist/config.js
+index 51cdae907f8cda750b66dd361b3acc7143ae22a2..f9e667986119c512aa1d222f2a171c08d9570323 100644
+--- a/dist/config.js
++++ b/dist/config.js
+@@ -138,7 +138,9 @@ export function getChangelogPath() {
+ // =============================================================================
+ const pkg = JSON.parse(readFileSync(getPackageJsonPath(), "utf-8"));
+ export const APP_NAME = pkg.piConfig?.name || "pi";
+-export const CONFIG_DIR_NAME = pkg.piConfig?.configDir || ".pi";
++// PATCH(pizzapi): override configDir — upstream reads its own package.json
++// which has ".pi", but PizzaPi stores everything under ~/.pizzapi/.
++export const CONFIG_DIR_NAME = ".pizzapi";
+ export const VERSION = pkg.version;
+ // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
+ export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+index 209ee2939d441e0523fbe155c039fdd81fafba9b..569a70fa71e4c2a2c221a5d8d69a188d110ea7fd 100644
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -1948,7 +1948,9 @@ export class AgentSession {
+             return false;
+         const err = message.errorMessage;
+         // Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors, fetch failed, terminated, retry delay exceeded
+-        return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay/i.test(err);
++        // PATCH(pizzapi): add JSON parse errors to retryable patterns — these occur
++        // when the Anthropic SSE stream is truncated mid-event (transient network issue).
++        return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|timed? out|timeout|terminated|retry delay|json.?parse.?error|unexpected.?end.?of.?json/i.test(err);
+     }
+     /**
+      * Handle retryable errors with exponential backoff.
+diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
+index efcb7da874223a2537e324494bee307bf59d24e7..46cd68f6ccb48998a2f647315413b56db41ef9b0 100644
+--- a/dist/core/extensions/loader.js
++++ b/dist/core/extensions/loader.js
+@@ -119,6 +119,9 @@ export function createExtensionRuntime() {
+         unregisterProvider: (name) => {
+             runtime.pendingProviderRegistrations = runtime.pendingProviderRegistrations.filter((r) => r.name !== name);
+         },
++        // PATCH(pizzapi): session control for extensions
++        newSession: () => Promise.reject(new Error("Extension runtime not initialized")),
++        switchSession: () => Promise.reject(new Error("Extension runtime not initialized")),
+     };
+     return runtime;
+ }
+@@ -216,6 +219,13 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
+         unregisterProvider(name) {
+             runtime.unregisterProvider(name, extension.path);
+         },
++        // PATCH(pizzapi): session control for extensions
++        newSession(options) {
++            return runtime.newSession(options);
++        },
++        switchSession(sessionPath) {
++            return runtime.switchSession(sessionPath);
++        },
+         events: eventBus,
+     };
+     return api;
+diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
+index d0c7fa328255651cb0a7d01715ac4555e247386b..245a602578139e300e780325e4c428503db4d572 100644
+--- a/dist/core/extensions/runner.js
++++ b/dist/core/extensions/runner.js
+@@ -182,6 +182,9 @@ export class ExtensionRunner {
+             this.navigateTreeHandler = actions.navigateTree;
+             this.switchSessionHandler = actions.switchSession;
+             this.reloadHandler = actions.reload;
++            // PATCH(pizzapi): expose session control on runtime for extension access
++            this.runtime.newSession = (options) => this.newSessionHandler(options);
++            this.runtime.switchSession = (sessionPath) => this.switchSessionHandler(sessionPath);
+             return;
+         }
+         this.waitForIdleFn = async () => { };
+@@ -190,6 +193,9 @@ export class ExtensionRunner {
+         this.navigateTreeHandler = async () => ({ cancelled: false });
+         this.switchSessionHandler = async () => ({ cancelled: false });
+         this.reloadHandler = async () => { };
++        // PATCH(pizzapi): expose session control on runtime for extension access
++        this.runtime.newSession = (options) => this.newSessionHandler(options);
++        this.runtime.switchSession = (sessionPath) => this.switchSessionHandler(sessionPath);
+     }
+     setUIContext(uiContext) {
+         this.uiContext = uiContext ?? noOpUIContext;
+diff --git a/dist/core/resource-loader.js b/dist/core/resource-loader.js
+index b0a40cc1682fa07421aabe7f44029e25cecc6de0..501ec0257fbd70c0006138452466c8b3d96605a7 100644
+--- a/dist/core/resource-loader.js
++++ b/dist/core/resource-loader.js
+@@ -568,7 +568,10 @@ export class DefaultResourceLoader {
+         const extensions = [];
+         const errors = [];
+         for (const [index, factory] of this.extensionFactories.entries()) {
+-            const extensionPath = `<inline:${index + 1}>`;
++            // PATCH(pizzapi): use factory displayName/name instead of <inline:N>
++            // Wrap in <inline:...> so createExtension() treats it as non-local (no stat/dirname).
++            const label = factory.displayName || factory.name || String(index + 1);
++            const extensionPath = `<inline:${label}>`;
+             try {
+                 const extension = await loadExtensionFromFactory(factory, this.cwd, this.eventBus, runtime, extensionPath);
+                 extensions.push(extension);
+diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
+index c72674771999e87b9969c9a8b1f56ba77281cd75..48eb45e13397d3efd8d195cb7b58f7a7f593e549 100644
+--- a/dist/modes/interactive/interactive-mode.js
++++ b/dist/modes/interactive/interactive-mode.js
+@@ -403,12 +403,6 @@ export class InteractiveMode {
+      */
+     async run() {
+         await this.init();
+-        // Start version check asynchronously
+-        this.checkForNewVersion().then((newVersion) => {
+-            if (newVersion) {
+-                this.showNewVersionNotification(newVersion);
+-            }
+-        });
+         // Start package update check asynchronously
+         this.checkForPackageUpdates().then((updates) => {
+             if (updates.length > 0) {
+@@ -466,29 +460,6 @@ export class InteractiveMode {
+             }
+         }
+     }
+-    /**
+-     * Check npm registry for a newer version.
+-     */
+-    async checkForNewVersion() {
+-        if (process.env.PI_SKIP_VERSION_CHECK || process.env.PI_OFFLINE)
+-            return undefined;
+-        try {
+-            const response = await fetch("https://registry.npmjs.org/@mariozechner/pi-coding-agent/latest", {
+-                signal: AbortSignal.timeout(10000),
+-            });
+-            if (!response.ok)
+-                return undefined;
+-            const data = (await response.json());
+-            const latestVersion = data.version;
+-            if (latestVersion && latestVersion !== this.version) {
+-                return latestVersion;
+-            }
+-            return undefined;
+-        }
+-        catch {
+-            return undefined;
+-        }
+-    }
+     async checkForPackageUpdates() {
+         if (process.env.PI_OFFLINE) {
+             return [];
+@@ -750,7 +721,12 @@ export class InteractiveMode {
+         if (!showListing && !showDiagnostics) {
+             return;
+         }
+-        const sectionHeader = (name, color = "mdHeading") => theme.fg(color, `[${name}]`);
++        // PATCH(pizzapi): themed section headers with box-drawing
++        const sectionHeader = (name, color = "accent") => {
++            const label = ` ${name} `;
++            const line = "─".repeat(Math.max(0, 40 - label.length));
++            return theme.fg(color, `├${label}`) + theme.fg("dim", line);
++        };
+         const skillsResult = this.session.resourceLoader.getSkills();
+         const promptsResult = this.session.resourceLoader.getPrompts();
+         const themesResult = this.session.resourceLoader.getThemes();
+@@ -817,13 +793,32 @@ export class InteractiveMode {
+                 this.chatContainer.addChild(new Text(`${sectionHeader("Prompts")}\n${templateList}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
++            // PATCH(pizzapi): display extensions as a compact table
+             if (extensions.length > 0) {
+-                const groups = this.buildScopeGroups(extensions);
+-                const extList = this.formatScopeGroups(groups, {
+-                    formatPath: (item) => this.formatDisplayPath(item.path),
+-                    formatPackagePath: (item) => this.getShortPath(item.path, item.sourceInfo),
+-                });
+-                this.chatContainer.addChild(new Text(`${sectionHeader("Extensions", "mdHeading")}\n${extList}`, 0, 0));
++                const builtIn = extensions.filter(e => !e.path.startsWith("/") && !e.path.startsWith("~") && !e.path.startsWith("."));
++                const fileBased = extensions.filter(e => e.path.startsWith("/") || e.path.startsWith("~") || e.path.startsWith("."));
++                const lines = [];
++                if (builtIn.length > 0) {
++                    // Render as a multi-column table
++                    const cols = 4;
++                    const colW = 16;
++                    const pad = (s, w) => { const stripped = s.replace(/\x1b\[[0-9;]*m/g, ""); return s + " ".repeat(Math.max(0, w - stripped.length)); };
++                    for (let i = 0; i < builtIn.length; i += cols) {
++                        const row = builtIn.slice(i, i + cols).map(e => {
++                            const name = e.path.startsWith("<inline:") ? e.path.slice(8, -1) : e.path;
++                            return pad(theme.fg("dim", name), colW);
++                        }).join("");
++                        lines.push("  " + row);
++                    }
++                }
++                if (fileBased.length > 0) {
++                    const groups = this.buildScopeGroups(fileBased);
++                    lines.push(this.formatScopeGroups(groups, {
++                        formatPath: (item) => this.formatDisplayPath(item.path),
++                        formatPackagePath: (item) => this.getShortPath(item.path, item.sourceInfo),
++                    }));
++                }
++                this.chatContainer.addChild(new Text(`${sectionHeader("Extensions")}\n${lines.join("\n")}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
+             // Show loaded themes (excluding built-in)
+@@ -846,13 +841,13 @@ export class InteractiveMode {
+             const skillDiagnostics = skillsResult.diagnostics;
+             if (skillDiagnostics.length > 0) {
+                 const warningLines = this.formatDiagnostics(skillDiagnostics, sourceInfos);
+-                this.chatContainer.addChild(new Text(`${theme.fg("warning", "[Skill conflicts]")}\n${warningLines}`, 0, 0));
++                this.chatContainer.addChild(new Text(`${sectionHeader("Skill Issues", "warning")}\n${warningLines}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
+             const promptDiagnostics = promptsResult.diagnostics;
+             if (promptDiagnostics.length > 0) {
+                 const warningLines = this.formatDiagnostics(promptDiagnostics, sourceInfos);
+-                this.chatContainer.addChild(new Text(`${theme.fg("warning", "[Prompt conflicts]")}\n${warningLines}`, 0, 0));
++                this.chatContainer.addChild(new Text(`${sectionHeader("Prompt Issues", "warning")}\n${warningLines}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
+             const extensionDiagnostics = [];
+@@ -869,13 +864,13 @@ export class InteractiveMode {
+             extensionDiagnostics.push(...shortcutDiagnostics);
+             if (extensionDiagnostics.length > 0) {
+                 const warningLines = this.formatDiagnostics(extensionDiagnostics, sourceInfos);
+-                this.chatContainer.addChild(new Text(`${theme.fg("warning", "[Extension issues]")}\n${warningLines}`, 0, 0));
++                this.chatContainer.addChild(new Text(`${sectionHeader("Extension Issues", "warning")}\n${warningLines}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
+             const themeDiagnostics = themesResult.diagnostics;
+             if (themeDiagnostics.length > 0) {
+                 const warningLines = this.formatDiagnostics(themeDiagnostics, sourceInfos);
+-                this.chatContainer.addChild(new Text(`${theme.fg("warning", "[Theme conflicts]")}\n${warningLines}`, 0, 0));
++                this.chatContainer.addChild(new Text(`${sectionHeader("Theme Issues", "warning")}\n${warningLines}`, 0, 0));
+                 this.chatContainer.addChild(new Spacer(1));
+             }
+         }
+@@ -2485,17 +2480,6 @@ export class InteractiveMode {
+         this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
+         this.ui.requestRender();
+     }
+-    showNewVersionNotification(newVersion) {
+-        const action = theme.fg("accent", getUpdateInstruction("@mariozechner/pi-coding-agent"));
+-        const updateInstruction = theme.fg("muted", `New version ${newVersion} is available. `) + action;
+-        const changelogUrl = theme.fg("accent", "https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md");
+-        const changelogLine = theme.fg("muted", "Changelog: ") + changelogUrl;
+-        this.chatContainer.addChild(new Spacer(1));
+-        this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+-        this.chatContainer.addChild(new Text(`${theme.bold(theme.fg("warning", "Update Available"))}\n${updateInstruction}\n${changelogLine}`, 1, 0));
+-        this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+-        this.ui.requestRender();
+-    }
+     showPackageUpdateNotification(packages) {
+         const action = theme.fg("accent", `${APP_NAME} update`);
+         const updateInstruction = theme.fg("muted", "Package updates are available. Run ") + action;
+@@ -3272,7 +3256,8 @@ export class InteractiveMode {
+             restoreEditor();
+             this.session.modelRegistry.refresh();
+             await this.updateAvailableProviderCount();
+-            this.showStatus(`Logged in to ${providerName}. Credentials saved to ${getAuthPath()}`);
++            const actualAuthPath = this.session.modelRegistry.authStorage.storage?.authPath ?? getAuthPath();
++            this.showStatus(`Logged in to ${providerName}. Credentials saved to ${actualAuthPath}`);
+         }
+         catch (error) {
+             restoreEditor();

--- a/patches/@mariozechner%2Fpi-coding-agent@0.63.1.patch
+++ b/patches/@mariozechner%2Fpi-coding-agent@0.63.1.patch
@@ -8,7 +8,7 @@ diff --git a/node_modules/@mariozechner/pi-coding-agent/.bun-tag-b7972330f11a52e
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/config.js b/dist/config.js
-index 51cdae907f8cda750b66dd361b3acc7143ae22a2..3fc188e21b73621fde5848af772d873098d3d068 100644
+index 51cdae907f8cda750b66dd361b3acc7143ae22a2..66cb107d9d1d965eb835bf591c93e920813488bf 100644
 --- a/dist/config.js
 +++ b/dist/config.js
 @@ -131,6 +131,10 @@ export function getExamplesPath() {
@@ -33,6 +33,30 @@ index 51cdae907f8cda750b66dd361b3acc7143ae22a2..3fc188e21b73621fde5848af772d8730
  export const VERSION = pkg.version;
  // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
  export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
+@@ -149,9 +155,12 @@ export function getShareViewerUrl(gistId) {
+     return `${baseUrl}#${gistId}`;
+ }
+ // =============================================================================
+-// User Config Paths (~/.pi/agent/*)
++// User Config Paths (~/.pizzapi/*)
+ // =============================================================================
+-/** Get the agent config directory (e.g., ~/.pi/agent/) */
++// PATCH(pizzapi): drop the /agent/ segment — PizzaPi uses a flat directory
++// structure where sessions, auth, models, bin, etc. all live directly under
++// ~/.pizzapi/ instead of ~/.pizzapi/agent/.
++/** Get the agent config directory (e.g., ~/.pizzapi/) */
+ export function getAgentDir() {
+     const envDir = process.env[ENV_AGENT_DIR];
+     if (envDir) {
+@@ -162,7 +171,7 @@ export function getAgentDir() {
+             return homedir() + envDir.slice(1);
+         return envDir;
+     }
+-    return join(homedir(), CONFIG_DIR_NAME, "agent");
++    return join(homedir(), CONFIG_DIR_NAME);
+ }
+ /** Get path to user's custom themes directory */
+ export function getCustomThemesDir() {
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
 index 209ee2939d441e0523fbe155c039fdd81fafba9b..569a70fa71e4c2a2c221a5d8d69a188d110ea7fd 100644
 --- a/dist/core/agent-session.js

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,6 +4,42 @@ Patches in this directory are applied automatically by Bun via the
 `patchedDependencies` field in the root `package.json`. They are reapplied on
 every `bun install` — no postinstall script is needed.
 
+## @mariozechner/pi-coding-agent@0.63.1
+
+Same five changes as 0.58.3 (see below), ported forward. The upstream
+retryable error regex gained several new patterns in this release
+(`provider.?returned.?error`, `network.?error`, `socket hang up`,
+`timed? out`, `timeout`); our `json.?parse.?error` addition is appended
+on top.
+
+**What it changes:**
+
+| File | Change |
+|------|--------|
+| `dist/config.js` — `CONFIG_DIR_NAME` | Hardcodes `".pizzapi"` |
+| `dist/core/agent-session.js` — `_isRetryableError()` | Adds `json.?parse.?error\|unexpected.?end.?of.?json` |
+| `dist/core/extensions/loader.js` — `createExtensionRuntime()` | Adds `newSession`/`switchSession` stubs |
+| `dist/core/extensions/loader.js` — `createExtensionAPI()` | Adds `newSession`/`switchSession` wrappers |
+| `dist/core/extensions/runner.js` — `bindCommandContext()` | Copies real handlers onto the runtime |
+| `dist/core/resource-loader.js` | Uses factory `displayName`/`name` for inline extension paths |
+| `dist/modes/interactive/interactive-mode.js` — `run()` | Removes `checkForNewVersion()` call |
+| `dist/modes/interactive/interactive-mode.js` | Removes `checkForNewVersion()` and `showNewVersionNotification()` methods |
+| `dist/modes/interactive/interactive-mode.js` — login flow | Uses `authStorage.storage?.authPath` instead of `getAuthPath()` |
+
+## @mariozechner/pi-ai@0.63.1
+
+Same web search changes as 0.58.3 (see below), ported forward. No upstream
+changes affected our patch points in this release.
+
+**What it changes:**
+
+| File | Change |
+|------|--------|
+| `dist/providers/anthropic.js` — `convertTools()` | Pass through server-side tools as-is |
+| `dist/providers/anthropic.js` — `buildParams()` | Inject `web_search_20250305` tool when `PIZZAPI_WEB_SEARCH` env var is set |
+| `dist/providers/anthropic.js` — stream handler | Handle `server_tool_use` and `web_search_tool_result` blocks |
+| `dist/providers/anthropic.js` — `convertMessages()` | Round-trip `_serverToolUse` and `_webSearchResult` blocks |
+
 ## @mariozechner/pi-coding-agent@0.58.3
 
 **Purpose:** Five changes:
@@ -151,7 +187,15 @@ this patch can be deleted.
 
 ## Previously patched (no longer needed)
 
+### @mariozechner/pi-coding-agent@0.58.3 (replaced by 0.63.1 patch)
+
+Same purpose as the current patch, just targeting an older version.
+
 ### @mariozechner/pi-coding-agent@0.55.4 (replaced by 0.58.3 patch)
+
+Same purpose as the current patch, just targeting an older version.
+
+### @mariozechner/pi-ai@0.58.3 (replaced by 0.63.1 patch)
 
 Same purpose as the current patch, just targeting an older version.
 

--- a/patches/README.md
+++ b/patches/README.md
@@ -6,8 +6,14 @@ every `bun install` — no postinstall script is needed.
 
 ## @mariozechner/pi-coding-agent@0.63.1
 
-Same five changes as 0.58.3 (see below), ported forward. The upstream
-retryable error regex gained several new patterns in this release
+Same changes as 0.58.3 (see below), ported forward, plus one new patch:
+
+- **Flat agent directory:** `getAgentDir()` now returns `~/.pizzapi/` instead of
+  `~/.pizzapi/agent/`. PizzaPi uses a flat directory structure where sessions,
+  auth, models, bin, etc. all live directly under `~/.pizzapi/`. A startup
+  migration in the daemon consolidates any data from `~/.pizzapi/agent/`.
+
+The upstream retryable error regex gained several new patterns in this release
 (`provider.?returned.?error`, `network.?error`, `socket hang up`,
 `timed? out`, `timeout`); our `json.?parse.?error` addition is appended
 on top.
@@ -17,6 +23,7 @@ on top.
 | File | Change |
 |------|--------|
 | `dist/config.js` — `CONFIG_DIR_NAME` | Hardcodes `".pizzapi"` |
+| `dist/config.js` — `getAgentDir()` | Returns `~/.pizzapi/` instead of `~/.pizzapi/agent/` — PizzaPi uses a flat directory structure |
 | `dist/core/agent-session.js` — `_isRetryableError()` | Adds `json.?parse.?error\|unexpected.?end.?of.?json` |
 | `dist/core/extensions/loader.js` — `createExtensionRuntime()` | Adds `newSession`/`switchSession` stubs |
 | `dist/core/extensions/loader.js` — `createExtensionAPI()` | Adds `newSession`/`switchSession` wrappers |

--- a/patches/README.md
+++ b/patches/README.md
@@ -25,6 +25,7 @@ on top.
 | `dist/modes/interactive/interactive-mode.js` — `run()` | Removes `checkForNewVersion()` call |
 | `dist/modes/interactive/interactive-mode.js` | Removes `checkForNewVersion()` and `showNewVersionNotification()` methods |
 | `dist/modes/interactive/interactive-mode.js` — login flow | Uses `authStorage.storage?.authPath` instead of `getAuthPath()` |
+| `dist/config.js` — `getChangelogPath()` | Checks `PIZZAPI_CHANGELOG_PATH` env var first, allowing PizzaPi to redirect to its own changelog |
 
 ## @mariozechner/pi-ai@0.63.1
 


### PR DESCRIPTION
## Summary

Bumps all `@mariozechner/pi-*` packages from 0.58.3 to 0.63.1 and ports both patch files forward.

## Changes

### Version bumps
- `@mariozechner/pi-coding-agent` 0.58.3 → 0.63.1
- `@mariozechner/pi-ai` 0.58.3 → 0.63.1
- `@mariozechner/pi-tui` 0.58.3 → 0.63.1
- `@mariozechner/pi-agent-core` 0.58.3 → 0.63.1

### pi-coding-agent patch (ported)
- `CONFIG_DIR_NAME` override to `.pizzapi`
- `newSession`/`switchSession` on extension runtime + API + runner
- Version check removal (`checkForNewVersion`, `showNewVersionNotification`)
- Auth path fix (`authStorage.storage?.authPath`)
- JSON parse errors in retryable regex (appended to upstream's now-longer pattern list)
- Factory `displayName`/`name` for inline extension paths
- Themed `sectionHeader` with box-drawing characters
- Compact multi-column extensions table (adapted for 0.63.1's `{path, sourceInfo}` objects)
- Diagnostics labels using `sectionHeader` instead of raw brackets

### pi-ai patch (ported)
- `convertTools` server-side tool pass-through
- `buildParams` web search tool injection (`PIZZAPI_WEB_SEARCH`)
- Stream handler for `server_tool_use` and `web_search_tool_result` blocks
- `convertMessages` round-trip for `_serverToolUse`/`_webSearchResult` metadata

### Notes
- Upstream 0.63.1 retryable error regex gained `provider.?returned.?error`, `network.?error`, `socket hang up`, `timed? out`, `timeout` — our JSON parse addition appended on top
- No upstream changes conflicted with the pi-ai patch points

## Verification
- 25/25 `patches.test.ts` assertions pass
- Typecheck clean
- Full build clean