### PR TITLE
fix: build multi-arch UI Docker image (amd64 + arm64)

### DIFF
--- a/.github/workflows/ui-docker.yml
+++ b/.github/workflows/ui-docker.yml
@@ -34,6 +34,9 @@ jobs:
           VERSION="$(python3 -c "import json, pathlib; version=(json.loads(pathlib.Path('packages/ui/package.json').read_text()).get('version') or '').strip(); assert version, 'packages/ui/package.json is missing a semantic version'; print(version)")"
           echo "value=$VERSION" >> "$GITHUB_OUTPUT"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -49,6 +52,7 @@ jobs:
         with:
           context: .
           file: packages/ui/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: |
             ghcr.io/pizzaface/pizzapi-ui:latest


### PR DESCRIPTION
## Summary
- Add QEMU setup step and `platforms: linux/amd64,linux/arm64` to the UI Docker workflow
- Fixes `no matching manifest for linux/arm64/v8` on Apple Silicon / ARM64 hosts

## Test plan
- [ ] Workflow dispatch builds successfully for both platforms
- [ ] `docker pull` works on ARM64

🤖 Generated with [Claude Code](https://claude.com/claude-code)