### PR TITLE
perf(server): reduce session switch lag in viewer path

### DIFF
--- a/packages/server/src/sessions/redis.snapshot.test.ts
+++ b/packages/server/src/sessions/redis.snapshot.test.ts
@@ -1,0 +1,123 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const rowsByKey = new Map<string, string[]>();
+const lRangeCalls: Array<{ key: string; start: number; end: number }> = [];
+
+const mockConnect = mock(() => Promise.resolve());
+const mockOn = mock(() => {});
+const mockDisconnect = mock(() => Promise.resolve());
+const mockQuit = mock(() => Promise.resolve());
+const mockDel = mock((_keys: string | string[]) => Promise.resolve(1));
+const mockLlen = mock((key: string) => Promise.resolve((rowsByKey.get(key) ?? []).length));
+const mockLrange = mock((key: string, start: number, end: number) => {
+    lRangeCalls.push({ key, start, end });
+    const rows = rowsByKey.get(key) ?? [];
+    return Promise.resolve(rows.slice(start, end + 1));
+});
+const mockMulti = mock(() => ({
+    rPush: mock(() => {}),
+    lTrim: mock(() => {}),
+    pExpire: mock(() => {}),
+    exec: mock(() => Promise.resolve()),
+}));
+
+mock.module("redis", () => ({
+    createClient: () => ({
+        connect: mockConnect,
+        on: mockOn,
+        disconnect: mockDisconnect,
+        quit: mockQuit,
+        del: mockDel,
+        lLen: mockLlen,
+        lRange: mockLrange,
+        multi: mockMulti,
+        isOpen: true,
+    }),
+}));
+
+import {
+    _resetRelayRedisCacheForTesting,
+    getLatestCachedSnapshotEvent,
+    initializeRelayRedisCache,
+} from "./redis";
+
+afterAll(() => {
+    mock.restore();
+});
+
+function keyForSession(sessionId: string): string {
+    return `pizzapi:relay:session:${sessionId}:events`;
+}
+
+function rowForEvent(event: unknown): string {
+    return JSON.stringify({ ts: Date.now(), event });
+}
+
+function noiseEvent(index: number): Record<string, unknown> {
+    return { type: "tool_use", id: `tc-${index}` };
+}
+
+describe("getLatestCachedSnapshotEvent", () => {
+    beforeEach(async () => {
+        rowsByKey.clear();
+        lRangeCalls.length = 0;
+        mockConnect.mockClear();
+        mockOn.mockClear();
+        mockLlen.mockClear();
+        mockLrange.mockClear();
+        _resetRelayRedisCacheForTesting();
+        process.env.PIZZAPI_RELAY_SNAPSHOT_SCAN_CHUNK_SIZE = "4";
+        await initializeRelayRedisCache();
+    });
+
+    test("returns latest snapshot and only scans the newest chunk when snapshot is near tail", async () => {
+        const sessionId = "s-tail";
+        const key = keyForSession(sessionId);
+        const rows = Array.from({ length: 10 }, (_, i) => rowForEvent(noiseEvent(i)));
+        rows.push(rowForEvent({ type: "session_active", state: { messages: [] } }));
+        rowsByKey.set(key, rows);
+
+        const snapshot = await getLatestCachedSnapshotEvent(sessionId);
+
+        expect(snapshot).not.toBeNull();
+        expect(snapshot?.type).toBe("session_active");
+        expect(lRangeCalls).toHaveLength(1);
+        expect(lRangeCalls[0]).toEqual({ key, start: 7, end: 10 });
+    });
+
+    test("scans older chunks when needed and returns oldest snapshot", async () => {
+        const sessionId = "s-head";
+        const key = keyForSession(sessionId);
+        const rows = [
+            rowForEvent({ type: "agent_end", messages: [{ role: "assistant", content: "done" }] }),
+            ...Array.from({ length: 9 }, (_, i) => rowForEvent(noiseEvent(i))),
+        ];
+        rowsByKey.set(key, rows);
+
+        const snapshot = await getLatestCachedSnapshotEvent(sessionId);
+
+        expect(snapshot).not.toBeNull();
+        expect(snapshot?.type).toBe("agent_end");
+        // length=10, chunk=4 => ranges [6..9], [2..5], [0..1]
+        expect(lRangeCalls).toEqual([
+            { key, start: 6, end: 9 },
+            { key, start: 2, end: 5 },
+            { key, start: 0, end: 1 },
+        ]);
+    });
+
+    test("ignores malformed rows and returns null when no snapshot exists", async () => {
+        const sessionId = "s-none";
+        const key = keyForSession(sessionId);
+        rowsByKey.set(key, [
+            "not-json",
+            rowForEvent(noiseEvent(1)),
+            rowForEvent({ type: "agent_end", messages: "not-array" }),
+        ]);
+
+        const snapshot = await getLatestCachedSnapshotEvent(sessionId);
+
+        expect(snapshot).toBeNull();
+        expect(lRangeCalls.length).toBeGreaterThan(0);
+    });
+});

--- a/packages/server/src/sessions/redis.ts
+++ b/packages/server/src/sessions/redis.ts
@@ -7,10 +7,23 @@ const log = createLogger("redis");
 const DEFAULT_REDIS_URL = "redis://127.0.0.1:6379";
 const DEFAULT_EVENT_BUFFER_SIZE = 1000;
 const DEFAULT_EVENT_TTL_MS = 24 * 60 * 60 * 1000;
+const DEFAULT_SNAPSHOT_SCAN_CHUNK_SIZE = 64;
 
 interface CachedRelayEventEnvelope {
     ts: number;
     event: unknown;
+}
+
+function isSnapshotEvent(event: unknown): event is Record<string, unknown> {
+    if (!event || typeof event !== "object") return false;
+    const evt = event as Record<string, unknown>;
+    if (evt.type === "agent_end") {
+        return Array.isArray(evt.messages);
+    }
+    if (evt.type === "session_active") {
+        return Object.prototype.hasOwnProperty.call(evt, "state") && evt.state !== undefined;
+    }
+    return false;
 }
 
 function parsePositiveInt(value: string | undefined, fallback: number): number {
@@ -39,6 +52,10 @@ function nonEphemeralEventTtlMs(): number {
 
 function ttlMsForSession(isEphemeral: boolean | undefined): number {
     return isEphemeral === false ? nonEphemeralEventTtlMs() : getEphemeralTtlMs();
+}
+
+function snapshotScanChunkSize(): number {
+    return parsePositiveInt(process.env.PIZZAPI_RELAY_SNAPSHOT_SCAN_CHUNK_SIZE, DEFAULT_SNAPSHOT_SCAN_CHUNK_SIZE);
 }
 
 function eventsKey(sessionId: string): string {
@@ -164,6 +181,51 @@ export async function getCachedRelayEvents(sessionId: string): Promise<unknown[]
     } catch (error) {
         logUnavailableOnce("Failed to read relay event cache from Redis", error);
         return [];
+    }
+}
+
+/**
+ * Read only the newest portion(s) of the relay cache and return the latest
+ * full snapshot event (session_active/agent_end), if present.
+ *
+ * This avoids parsing the entire event list on each viewer switch when the
+ * newest snapshot is near the tail (common case).
+ */
+export async function getLatestCachedSnapshotEvent(sessionId: string): Promise<Record<string, unknown> | null> {
+    if (isRedisDisabled()) return null;
+    if (!initPromise) {
+        void initializeRelayRedisCache();
+    }
+
+    const redis = activeClient();
+    if (!redis) return null;
+
+    try {
+        const key = eventsKey(sessionId);
+        const length = await redis.lLen(key);
+        if (!Number.isFinite(length) || length <= 0) return null;
+
+        const chunkSize = snapshotScanChunkSize();
+        for (let end = length - 1; end >= 0; end -= chunkSize) {
+            const start = Math.max(0, end - chunkSize + 1);
+            const rows = await redis.lRange(key, start, end);
+            for (let i = rows.length - 1; i >= 0; i--) {
+                const row = rows[i];
+                try {
+                    const parsed = JSON.parse(row) as CachedRelayEventEnvelope;
+                    if (isSnapshotEvent(parsed?.event)) {
+                        return parsed.event;
+                    }
+                } catch {
+                    // Ignore malformed cache entries.
+                }
+            }
+        }
+
+        return null;
+    } catch (error) {
+        logUnavailableOnce("Failed to read latest snapshot from Redis cache", error);
+        return null;
     }
 }
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -23,6 +23,7 @@ import { sessionCookieAuthMiddleware } from "./auth.js";
 import { getRunnerServiceAnnounce } from "./runner.js";
 import {
     getSharedSession,
+    getSharedSessionSummary,
     addViewer,
     removeViewer,
     getSessionSeq,
@@ -268,16 +269,16 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) return;
             }
 
-            const session = await getSharedSession(nextSessionId);
+            const sessionSummary = await getSharedSessionSummary(nextSessionId);
             if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) return;
 
-            if (!session) {
+            if (!sessionSummary) {
                 socket.data.sessionId = undefined;
                 socket.emit("disconnected", { reason: "Session ended", code: "session_ended", generation });
                 return;
             }
 
-            if (!session.userId || session.userId !== viewerUserId) {
+            if (!sessionSummary.userId || sessionSummary.userId !== viewerUserId) {
                 socket.data.sessionId = undefined;
                 socket.emit("error", { message: "Session not found", generation });
                 return;
@@ -287,7 +288,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             // reach the runner. This avoids losing the first live snapshot/chunks
             // and reduces startup resync churn.
             const ok = await addViewer(nextSessionId, socket, {
-                sessionHint: session,
+                sessionSummaryHint: sessionSummary,
                 touchAsync: true,
             });
             if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) {

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -35,7 +35,7 @@ import {
 import { isChildOfParent } from "../sio-state.js";
 import { getPendingChunkedSnapshot } from "./relay/index.js";
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
-import { getCachedRelayEvents } from "../../sessions/redis.js";
+import { getLatestCachedSnapshotEvent } from "../../sessions/redis.js";
 import { createLogger } from "@pizzapi/tools";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -132,10 +132,7 @@ async function sendLatestSnapshotFromCache(
     sessionId: string,
     generation?: number,
 ): Promise<boolean> {
-    const cachedEvents = await getCachedRelayEvents(sessionId);
-    if (cachedEvents.length === 0) return false;
-
-    const snapshotEvent = findLatestSnapshotEvent(cachedEvents);
+    const snapshotEvent = await getLatestCachedSnapshotEvent(sessionId);
     if (!snapshotEvent) return false;
 
     socket.emit("event", { event: snapshotEvent, replay: true, generation });
@@ -289,7 +286,10 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             // Join the room first, then allow the viewer's "connected" signal to
             // reach the runner. This avoids losing the first live snapshot/chunks
             // and reduces startup resync churn.
-            const ok = await addViewer(nextSessionId, socket);
+            const ok = await addViewer(nextSessionId, socket, {
+                sessionHint: session,
+                touchAsync: true,
+            });
             if (!isViewerSwitchCurrent(getCurrentGeneration(), generation)) {
                 if (ok) {
                     await removeViewer(nextSessionId, socket);

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -14,6 +14,7 @@ export {
     removeLocalTuiSocket,
     getSessions,
     getSharedSession,
+    getSharedSessionSummary,
     updateSessionState,
     getSessionState,
     touchSessionActivity,

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -11,8 +11,10 @@ import type { Socket } from "socket.io";
 import { randomBytes, randomUUID } from "crypto";
 import {
     type RedisSessionData,
+    type RedisSessionSummaryData,
     setSession,
     getSession,
+    getSessionSummary,
     updateSessionFields,
     deleteSession,
     getAllSessionSummaries,
@@ -397,6 +399,11 @@ export async function getSharedSession(sessionId: string): Promise<RedisSessionD
     return getSession(sessionId);
 }
 
+/** Get a lightweight session summary (without lastState). */
+export async function getSharedSessionSummary(sessionId: string): Promise<RedisSessionSummaryData | null> {
+    return getSessionSummary(sessionId);
+}
+
 /** Update session state (lastState + sessionName detection). */
 export async function updateSessionState(sessionId: string, state: unknown): Promise<void> {
     const session = await getSession(sessionId);
@@ -459,7 +466,15 @@ export async function getSessionState(sessionId: string): Promise<unknown | unde
 }
 
 /** Refresh ephemeral session expiry and SQLite touch. */
-export async function touchSessionActivity(sessionId: string, sessionHint?: RedisSessionData | null): Promise<void> {
+interface SessionActivityHint {
+    isEphemeral: boolean;
+    runnerId: string | null;
+}
+
+export async function touchSessionActivity(
+    sessionId: string,
+    sessionHint?: SessionActivityHint | null,
+): Promise<void> {
     const now = Date.now();
     const lastTouch = lastTouchTimes.get(sessionId) || 0;
 
@@ -835,9 +850,13 @@ export async function sweepOrphanedSessions(nowMs: number): Promise<void> {
  */
 export interface AddViewerOptions {
     /**
-     * Optional already-fetched session data to avoid a redundant Redis read.
+     * Optional already-fetched full session data to avoid a redundant Redis read.
      */
     sessionHint?: RedisSessionData | null;
+    /**
+     * Optional lightweight summary hint for paths that only fetched summary fields.
+     */
+    sessionSummaryHint?: RedisSessionSummaryData | null;
     /**
      * When true, viewer join acks are not blocked on activity bookkeeping.
      */
@@ -849,7 +868,7 @@ export async function addViewer(
     socket: Socket,
     options: AddViewerOptions = {},
 ): Promise<boolean> {
-    const session = options.sessionHint ?? await getSession(sessionId);
+    const session = options.sessionHint ?? options.sessionSummaryHint ?? await getSession(sessionId);
     if (!session) return false;
 
     await socket.join(viewerSessionRoom(sessionId));

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -459,7 +459,7 @@ export async function getSessionState(sessionId: string): Promise<unknown | unde
 }
 
 /** Refresh ephemeral session expiry and SQLite touch. */
-export async function touchSessionActivity(sessionId: string): Promise<void> {
+export async function touchSessionActivity(sessionId: string, sessionHint?: RedisSessionData | null): Promise<void> {
     const now = Date.now();
     const lastTouch = lastTouchTimes.get(sessionId) || 0;
 
@@ -468,7 +468,7 @@ export async function touchSessionActivity(sessionId: string): Promise<void> {
     }
     lastTouchTimes.set(sessionId, now);
 
-    const session = await getSession(sessionId);
+    const session = sessionHint ?? await getSession(sessionId);
     if (!session) return;
 
     if (session.isEphemeral) {
@@ -833,12 +833,36 @@ export async function sweepOrphanedSessions(nowMs: number): Promise<void> {
  * Add a viewer to a session (joins the viewer room).
  * Returns false if the session doesn't exist.
  */
-export async function addViewer(sessionId: string, socket: Socket): Promise<boolean> {
-    const session = await getSession(sessionId);
+export interface AddViewerOptions {
+    /**
+     * Optional already-fetched session data to avoid a redundant Redis read.
+     */
+    sessionHint?: RedisSessionData | null;
+    /**
+     * When true, viewer join acks are not blocked on activity bookkeeping.
+     */
+    touchAsync?: boolean;
+}
+
+export async function addViewer(
+    sessionId: string,
+    socket: Socket,
+    options: AddViewerOptions = {},
+): Promise<boolean> {
+    const session = options.sessionHint ?? await getSession(sessionId);
     if (!session) return false;
 
     await socket.join(viewerSessionRoom(sessionId));
-    await touchSessionActivity(sessionId);
+
+    const touchPromise = touchSessionActivity(sessionId, session);
+    if (options.touchAsync) {
+        void touchPromise.catch((error) => {
+            log.error("addViewer async touch failed:", error);
+        });
+    } else {
+        await touchPromise;
+    }
+
     return true;
 }
 

--- a/packages/server/src/ws/sio-state-summary.test.ts
+++ b/packages/server/src/ws/sio-state-summary.test.ts
@@ -1,0 +1,149 @@
+import { afterAll, beforeEach, describe, expect, it, mock } from "bun:test";
+
+const hashStore = new Map<string, Record<string, string>>();
+const setStore = new Map<string, Set<string>>();
+
+const mockMulti = () => {
+    const ops: Array<() => void> = [];
+    const chain = {
+        hSet: mock((key: string, fields: Record<string, string>) => {
+            ops.push(() => {
+                const current = hashStore.get(key) ?? {};
+                hashStore.set(key, { ...current, ...fields });
+            });
+            return chain;
+        }),
+        expire: mock((_key: string, _ttl: number) => {
+            ops.push(() => {});
+            return chain;
+        }),
+        sAdd: mock((key: string, member: string) => {
+            ops.push(() => {
+                const current = setStore.get(key) ?? new Set<string>();
+                current.add(member);
+                setStore.set(key, current);
+            });
+            return chain;
+        }),
+        exec: mock(async () => {
+            for (const op of ops) op();
+            return [];
+        }),
+    };
+    return chain;
+};
+
+const mockRedis = {
+    isOpen: true,
+    on: mock(() => mockRedis),
+    connect: mock(async () => {}),
+    multi: mock(() => mockMulti()),
+    hGetAll: mock(async (key: string) => ({ ...(hashStore.get(key) ?? {}) })),
+    hmGet: mock(async (key: string, fields: readonly string[]) => {
+        const hash = hashStore.get(key) ?? {};
+        return fields.map((f) => hash[f] ?? null);
+    }),
+    exists: mock(async (key: string) => (hashStore.has(key) ? 1 : 0)),
+    get: mock(async () => null),
+    set: mock(async () => "OK"),
+    del: mock(async () => 1),
+    sMembers: mock(async (key: string) => Array.from(setStore.get(key) ?? [])),
+    sRem: mock(async (key: string, ...members: string[]) => {
+        const current = setStore.get(key);
+        if (!current) return;
+        for (const member of members) current.delete(member);
+    }),
+    incr: mock(async () => 1),
+    eval: mock(async () => 0),
+};
+
+mock.module("redis", () => ({
+    createClient: () => mockRedis,
+}));
+
+afterAll(() => {
+    mock.restore();
+});
+
+const { initStateRedis, setSession, getSessionSummary } = await import("./sio-state.js");
+
+describe("getSessionSummary", () => {
+    beforeEach(async () => {
+        hashStore.clear();
+        setStore.clear();
+        mockRedis.hmGet.mockClear();
+        mockRedis.hGetAll.mockClear();
+        await initStateRedis();
+    });
+
+    it("uses hmGet fast path when available", async () => {
+        const sessionId = "session-hmget";
+        await setSession(sessionId, {
+            sessionId,
+            token: "tkn",
+            collabMode: true,
+            shareUrl: "http://localhost/session",
+            cwd: "/tmp/project",
+            startedAt: new Date().toISOString(),
+            userId: "user-1",
+            userName: "Jordan",
+            sessionName: "Test Session",
+            isEphemeral: false,
+            expiresAt: null,
+            isActive: true,
+            lastHeartbeatAt: new Date().toISOString(),
+            lastHeartbeat: JSON.stringify({ model: { provider: "anthropic", id: "haiku" } }),
+            lastState: JSON.stringify({ messages: Array.from({ length: 1000 }, (_, i) => ({ i })) }),
+            runnerId: "runner-1",
+            runnerName: "Runner",
+            seq: 42,
+            parentSessionId: null,
+        });
+
+        const summary = await getSessionSummary(sessionId);
+
+        expect(summary).not.toBeNull();
+        expect(summary?.sessionId).toBe(sessionId);
+        expect(summary?.userId).toBe("user-1");
+        expect(summary?.runnerId).toBe("runner-1");
+        expect(mockRedis.hmGet).toHaveBeenCalledTimes(1);
+        expect(mockRedis.hGetAll).toHaveBeenCalledTimes(0);
+    });
+
+    it("falls back to hGetAll when hmGet is unavailable", async () => {
+        const sessionId = "session-fallback";
+        await setSession(sessionId, {
+            sessionId,
+            token: "tkn",
+            collabMode: true,
+            shareUrl: "http://localhost/session",
+            cwd: "/tmp/project",
+            startedAt: new Date().toISOString(),
+            userId: "user-1",
+            userName: "Jordan",
+            sessionName: "Fallback Session",
+            isEphemeral: false,
+            expiresAt: null,
+            isActive: true,
+            lastHeartbeatAt: new Date().toISOString(),
+            lastHeartbeat: null,
+            lastState: JSON.stringify({ large: "x".repeat(10_000) }),
+            runnerId: "runner-1",
+            runnerName: "Runner",
+            seq: 7,
+            parentSessionId: null,
+        });
+
+        const originalHmGet = (mockRedis as any).hmGet;
+        delete (mockRedis as any).hmGet;
+
+        try {
+            const summary = await getSessionSummary(sessionId);
+            expect(summary).not.toBeNull();
+            expect(summary?.sessionName).toBe("Fallback Session");
+            expect(mockRedis.hGetAll).toHaveBeenCalledTimes(1);
+        } finally {
+            (mockRedis as any).hmGet = originalHmGet;
+        }
+    });
+});

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -414,6 +414,31 @@ export async function getSession(sessionId: string): Promise<RedisSessionData | 
     return parseSessionFromHash(hash);
 }
 
+/**
+ * Fetch only the lightweight session summary fields for a single session.
+ * Avoids pulling large lastState blobs from Redis on hot paths that only
+ * need identity/liveness metadata.
+ */
+export async function getSessionSummary(sessionId: string): Promise<RedisSessionSummaryData | null> {
+    const r = requireRedis();
+    const key = sessionKey(sessionId);
+
+    if (typeof (r as unknown as { hmGet?: unknown }).hmGet === "function") {
+        const row = await (
+            r as unknown as { hmGet: (key: string, fields: readonly string[]) => Promise<unknown> }
+        ).hmGet(key, SESSION_SUMMARY_FIELDS);
+
+        const hash = rowToSummaryHash(row);
+        if (!hash || Object.keys(hash).length === 0) return null;
+        return parseSessionSummaryFromHash(hash);
+    }
+
+    // Fallback for clients/mocks that do not expose hmGet.
+    const hash = await r.hGetAll(key);
+    if (!hash || Object.keys(hash).length === 0) return null;
+    return parseSessionSummaryFromHash(hash);
+}
+
 export async function updateSessionFields(
     sessionId: string,
     fields: Partial<RedisSessionData>,

--- a/packages/ui/src/components/DegradedBanner.tsx
+++ b/packages/ui/src/components/DegradedBanner.tsx
@@ -55,9 +55,9 @@ export function DegradedBanner({ relayStatus }: { relayStatus?: RelayStatus }) {
     return (
         <div
             role="alert"
-            className="flex items-center justify-between gap-3 px-4 py-2 text-sm bg-amber-500/10 text-amber-600 dark:text-amber-400 border-b border-amber-500/20"
+            className="flex flex-wrap items-start sm:items-center justify-between gap-x-3 gap-y-2 px-3 sm:px-4 py-2 text-sm bg-amber-500/10 text-amber-600 dark:text-amber-400 border-b border-amber-500/20"
         >
-            <span>
+            <span className="min-w-0 flex-1 leading-snug">
                 <span aria-hidden="true">⚠️</span>{" "}
                 Server running in degraded mode — real-time updates unavailable
             </span>
@@ -65,7 +65,7 @@ export function DegradedBanner({ relayStatus }: { relayStatus?: RelayStatus }) {
                 type="button"
                 aria-label="Dismiss"
                 onClick={() => setDismissed(true)}
-                className="shrink-0 rounded p-0.5 hover:bg-amber-500/20 transition-colors"
+                className="shrink-0 self-start sm:self-auto rounded p-1 hover:bg-amber-500/20 transition-colors"
             >
                 <X className="size-4" />
             </button>

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -66,8 +66,9 @@ import {
   CommandItem,
   CommandList,
 } from "@/components/ui/command";
-import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
+import { PizzaLogo } from "@/components/PizzaLogo";
+import { getSessionEmptyStateUi } from "@/lib/session-empty-state";
 import { formatPathTail } from "@/lib/path";
 import { ProviderIcon } from "@/components/ProviderIcon";
 import { MultipleChoiceQuestions } from "@/components/ai-elements/multiple-choice";
@@ -552,27 +553,6 @@ function PaginationSentinel({ hasMore, onLoadMore }: { hasMore: boolean; onLoadM
         </div>
       )}
     </>
-  );
-}
-
-function SessionSkeleton() {
-  return (
-    <div className="flex flex-col gap-6 p-4 max-w-3xl mx-auto w-full animate-in fade-in duration-700">
-      <div className="flex flex-col items-end gap-1 opacity-40">
-        <Skeleton className="h-10 w-1/2 rounded-2xl rounded-br-sm" />
-      </div>
-      <div className="flex flex-col items-start gap-1 opacity-40">
-        <div className="flex items-center gap-2 mb-1 px-1">
-             <Skeleton className="h-2.5 w-12 rounded-sm" />
-             <Skeleton className="h-2.5 w-2.5 rounded-full" />
-             <Skeleton className="h-2.5 w-20 rounded-sm" />
-        </div>
-        <Skeleton className="h-24 w-3/4 rounded-2xl rounded-bl-sm" />
-      </div>
-       <div className="flex flex-col items-end gap-1 opacity-30 delay-100">
-        <Skeleton className="h-16 w-1/3 rounded-2xl rounded-br-sm" />
-      </div>
-    </div>
   );
 }
 
@@ -1846,19 +1826,25 @@ export function SessionViewer({ sessionId, sessionName, messages, activeModel, a
             description="Open the sidebar and pick a session to get started."
           />
         ) : visibleMessages.length === 0 ? (
-          viewerStatus === "Connecting…" ? (
-            <SessionSkeleton />
-          ) : (
-            <ConversationEmptyState
-              icon={
-                <span className="inline-flex items-center justify-center h-10 w-10 rounded-full bg-muted/60 border border-border/60">
-                  <span className="inline-block h-2.5 w-2.5 rounded-full bg-slate-400 animate-pulse" />
-                </span>
-              }
-              title="Waiting for session events"
-              description="Messages will appear here in real time."
-            />
-          )
+          (() => {
+            const emptyUi = getSessionEmptyStateUi(viewerStatus);
+            return (
+              <ConversationEmptyState
+                icon={
+                  <span
+                    className={cn(
+                      "inline-flex items-center justify-center h-11 w-11 rounded-full bg-muted/60 border border-border/60",
+                      emptyUi.shouldSpinLogo && "animate-spin motion-reduce:animate-none",
+                    )}
+                  >
+                    <PizzaLogo className="h-7 w-7 sm:h-8 sm:w-8 pointer-events-none cursor-default select-none" />
+                  </span>
+                }
+                title={emptyUi.title}
+                description={emptyUi.description}
+              />
+            );
+          })()
         ) : (
           <Conversation key={sessionId} className="overflow-x-hidden">
             <ConversationContent className="w-full gap-0 p-0 py-2">

--- a/packages/ui/src/lib/session-empty-state.test.ts
+++ b/packages/ui/src/lib/session-empty-state.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { getSessionEmptyStateUi, isSessionHydrating } from "./session-empty-state";
+
+describe("isSessionHydrating", () => {
+  test("returns true for connecting statuses", () => {
+    expect(isSessionHydrating("Connecting…")).toBe(true);
+    expect(isSessionHydrating("connecting...")).toBe(true);
+    expect(isSessionHydrating("  Connecting  ")).toBe(true);
+  });
+
+  test("returns true for chunked loading statuses", () => {
+    expect(isSessionHydrating("Loading session (0 of 120 messages)…")).toBe(true);
+    expect(isSessionHydrating("loading session (12 of 120 messages)...")).toBe(true);
+  });
+
+  test("returns false for idle waiting/connected states", () => {
+    expect(isSessionHydrating("Waiting for session events")).toBe(false);
+    expect(isSessionHydrating("Connected")).toBe(false);
+    expect(isSessionHydrating("")).toBe(false);
+    expect(isSessionHydrating(undefined)).toBe(false);
+  });
+});
+
+describe("getSessionEmptyStateUi", () => {
+  test("returns spinning loading state for hydrating statuses", () => {
+    expect(getSessionEmptyStateUi("Connecting…")).toEqual({
+      title: "Loading session",
+      description: "Fetching conversation data…",
+      shouldSpinLogo: true,
+    });
+  });
+
+  test("returns non-spinning waiting state for idle empty sessions", () => {
+    expect(getSessionEmptyStateUi("Waiting for session events")).toEqual({
+      title: "Waiting for session events",
+      description: "Messages will appear here in real time.",
+      shouldSpinLogo: false,
+    });
+  });
+});

--- a/packages/ui/src/lib/session-empty-state.ts
+++ b/packages/ui/src/lib/session-empty-state.ts
@@ -1,0 +1,34 @@
+export interface SessionEmptyStateUi {
+  title: string;
+  description: string;
+  shouldSpinLogo: boolean;
+}
+
+/**
+ * Returns true when the viewer is actively hydrating/loading a session.
+ */
+export function isSessionHydrating(viewerStatus: string | null | undefined): boolean {
+  if (typeof viewerStatus !== "string") return false;
+  const status = viewerStatus.trim().toLowerCase();
+  if (!status) return false;
+  return status.startsWith("connecting") || status.startsWith("loading session");
+}
+
+/**
+ * Copy + animation state for session-specific empty states.
+ */
+export function getSessionEmptyStateUi(viewerStatus: string | null | undefined): SessionEmptyStateUi {
+  if (isSessionHydrating(viewerStatus)) {
+    return {
+      title: "Loading session",
+      description: "Fetching conversation data…",
+      shouldSpinLogo: true,
+    };
+  }
+
+  return {
+    title: "Waiting for session events",
+    description: "Messages will appear here in real time.",
+    shouldSpinLogo: false,
+  };
+}


### PR DESCRIPTION
## Summary
- optimize Redis snapshot replay lookup by scanning from the tail in bounded chunks instead of parsing the full event cache
- add a session-summary fast path (`hmGet`) so viewer switch auth/existence checks avoid fetching large `lastState` blobs
- reduce switch-session critical path overhead by avoiding redundant session reads and moving viewer touch bookkeeping off the join-ack path
- add regression tests for latest-snapshot cache scanning and single-session summary retrieval fallback behavior
- improve mobile degraded banner layout so alert text wraps cleanly and dismiss control remains reachable on narrow screens
- replace session-specific empty-state pulse placeholder with a Pizza logo treatment that spins only while loading/hydrating and stays static while idle/waiting

## Benchmark Notes
- snapshot cache scan (1000 events): tail-case ~250x faster, mid-case ~2x faster
- live Redis benchmark with ~1MB `lastState`: `getSessionSummary` ~7.66x faster than `getSession` for the switch precheck path

## Test Plan
- [x] `bun run typecheck`
- [x] `bun test packages/server/src/sessions/redis.snapshot.test.ts packages/server/src/ws/sio-state-summary.test.ts packages/server/src/ws/namespaces/viewer.test.ts packages/server/src/ws/sio-registry.delink.test.ts packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts`
- [x] `bun test packages/ui/src/lib/session-empty-state.test.ts packages/ui/src/components/DegradedBanner.test.ts`