### PR TITLE
feat(ui): show +/- diff stats for multi-edit tool calls

### DIFF
--- a/packages/ui/src/components/ai-elements/diff-view.tsx
+++ b/packages/ui/src/components/ai-elements/diff-view.tsx
@@ -163,7 +163,7 @@ function DiffContent({
 
   return (
     <div className="overflow-x-auto min-h-full bg-background">
-      <pre className="m-0 p-0 text-xs font-mono leading-5 min-h-full">
+      <pre className="m-0 p-0 text-xs font-mono leading-5 min-h-full min-w-fit">
         <code>
           {rows.map((row, i) => (
             <span

--- a/packages/ui/src/components/ai-elements/diff-view.tsx
+++ b/packages/ui/src/components/ai-elements/diff-view.tsx
@@ -237,3 +237,53 @@ export function DiffView({
     </EditFileCard>
   );
 }
+
+export interface EditPair {
+  oldText: string;
+  newText: string;
+}
+
+/**
+ * Renders multiple disjoint edits (from the `edits[]` tool input mode) as
+ * consecutive diff hunks within a single EditFileCard, with a visual separator
+ * between each hunk.
+ */
+export function MultiDiffView({
+  path,
+  edits,
+}: {
+  path: string;
+  edits: EditPair[];
+}) {
+  const { additions, deletions } = React.useMemo(() => {
+    let add = 0;
+    let del = 0;
+    for (const edit of edits) {
+      const stats = countDiffStats(edit.oldText, edit.newText);
+      add += stats.additions;
+      del += stats.deletions;
+    }
+    return { additions: add, deletions: del };
+  }, [edits]);
+
+  return (
+    <EditFileCard path={path} additions={additions} deletions={deletions}>
+      <div className="overflow-x-auto min-h-full bg-background">
+        {edits.map((edit, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && (
+              <div className="flex items-center gap-2 px-2 py-1 border-y border-border/40">
+                <span className="flex-1 border-t border-dashed border-muted-foreground/20" />
+                <span className="text-[10px] text-muted-foreground/50 select-none">
+                  hunk {i + 1} of {edits.length}
+                </span>
+                <span className="flex-1 border-t border-dashed border-muted-foreground/20" />
+              </div>
+            )}
+            <DiffContent path={path} oldText={edit.oldText} newText={edit.newText} />
+          </React.Fragment>
+        ))}
+      </div>
+    </EditFileCard>
+  );
+}

--- a/packages/ui/src/components/session-viewer/tool-rendering.tsx
+++ b/packages/ui/src/components/session-viewer/tool-rendering.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import type { BundledLanguage } from "shiki";
 
-import { DiffView } from "@/components/ai-elements/diff-view";
+import { DiffView, MultiDiffView } from "@/components/ai-elements/diff-view";
+import type { EditPair } from "@/components/ai-elements/diff-view";
 import {
   StatusBadge,
   type ToolPart,
@@ -566,8 +567,31 @@ export function renderGroupedToolExecution(
             ? contentObj.newText
             : null;
 
+    // Extract edits[] array for multi-edit mode
+    const editsArray: EditPair[] | null = (() => {
+      const raw = inputArgs.edits;
+      if (!Array.isArray(raw) || raw.length === 0) return null;
+      const pairs: EditPair[] = [];
+      for (const entry of raw) {
+        if (!entry || typeof entry !== "object") continue;
+        const e = entry as Record<string, unknown>;
+        const eOld =
+          typeof e.old_string === "string" ? e.old_string :
+          typeof e.oldText === "string" ? e.oldText : null;
+        const eNew =
+          typeof e.new_string === "string" ? e.new_string :
+          typeof e.newText === "string" ? e.newText : null;
+        if (eOld !== null && eNew !== null) {
+          pairs.push({ oldText: eOld, newText: eNew });
+        }
+      }
+      return pairs.length > 0 ? pairs : null;
+    })();
+
     if (editPath && oldText !== null && newText !== null) {
       card = <DiffView path={editPath} oldText={oldText} newText={newText} />;
+    } else if (editPath && editsArray) {
+      card = <MultiDiffView path={editPath} edits={editsArray} />;
     } else {
       const pendingPath = editPath ?? "file";
       const pendingName = pendingPath.split(/[\\/]/).filter(Boolean).pop() ?? "file";


### PR DESCRIPTION
## Problem

The edit tool has two modes, but the UI only rendered diffs for one:

1. **Single mode** (`{ path, oldText, newText }`) — ✅ `DiffView` rendered with +/- counts
2. **Multi-edit mode** (`{ path, edits: [{ oldText, newText }, ...] }`) — ❌ Fell through to a plain `EditFileCard` with no diff and `additions=0, deletions=0`

Since the system prompt encourages agents to use `edits[]` for multiple disjoint changes, **most edit calls were missing the diff view entirely** — you'd just see "Successfully replaced N block(s)" with no +/- stats.

## Fix

### `diff-view.tsx`
- New `MultiDiffView` component that accepts an `edits[]` array
- Aggregates +/- counts across all hunks
- Renders each hunk with syntax-highlighted diffs and visual "hunk N of M" separators

### `tool-rendering.tsx`
- Extracts `inputArgs.edits` array when top-level `oldText`/`newText` is absent
- Routes to `MultiDiffView` for multi-edit calls
- Supports both `oldText`/`newText` and `old_string`/`new_string` field names

## Verification

- `bunx tsc --noEmit` — clean
- `bun run build` — passes
- `bun test packages/ui` — 741 tests pass, 0 failures