### PR TITLE
feat(git): rewrite git tab as service channel with checkout, stage, commit, push

### DIFF
--- a/packages/cli/src/runner/service-handler.ts
+++ b/packages/cli/src/runner/service-handler.ts
@@ -37,6 +37,8 @@ export interface ServiceEnvelope {
     serviceId: string;
     type: string;
     requestId?: string;
+    /** Attached by the relay when forwarding viewer→runner, so services can route responses back. */
+    sessionId?: string;
     payload: unknown;
 }
 

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -147,7 +147,11 @@ export class GitService implements ServiceHandler {
             const statusOutput = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
             const diffStaged = diffStagedResult.status === "fulfilled" ? diffStagedResult.value.stdout : "";
 
-            // Parse porcelain v1 output
+            // Parse porcelain v1 output.
+            // IMPORTANT: preserve the raw 2-char XY status (e.g. " M", "M ", "MM", "??").
+            // The UI's partition logic depends on checking X (index) and Y (worktree)
+            // positions separately. Trimming collapses " M" and "M " into "M", breaking
+            // the staged/unstaged categorization.
             const changes: Array<{ status: string; path: string; originalPath?: string }> = [];
             for (const line of statusOutput.split("\n")) {
                 if (!line.trim()) continue;
@@ -156,12 +160,12 @@ export class GitService implements ServiceHandler {
                 const arrowIdx = rest.indexOf(" -> ");
                 if (arrowIdx >= 0) {
                     changes.push({
-                        status: xy.trim(),
+                        status: xy,
                         path: rest.substring(arrowIdx + 4),
                         originalPath: rest.substring(0, arrowIdx),
                     });
                 } else {
-                    changes.push({ status: xy.trim(), path: rest });
+                    changes.push({ status: xy, path: rest });
                 }
             }
 
@@ -492,9 +496,32 @@ export class GitService implements ServiceHandler {
             );
             const branch = branchName.trim();
 
-            const args = setUpstream
-                ? ["push", "--set-upstream", "origin", branch]
-                : ["push"];
+            let args: string[];
+            if (setUpstream) {
+                // Resolve the default remote dynamically instead of hardcoding "origin".
+                // Try the configured push remote, then fall back to the first remote.
+                let remote = "origin";
+                try {
+                    const { stdout } = await execFileAsync(
+                        "git", ["config", "--get", `branch.${branch}.remote`],
+                        { cwd, timeout: 5000 },
+                    );
+                    if (stdout.trim()) remote = stdout.trim();
+                } catch {
+                    // No tracked remote — try first remote in list
+                    try {
+                        const { stdout } = await execFileAsync(
+                            "git", ["remote"],
+                            { cwd, timeout: 5000 },
+                        );
+                        const firstRemote = stdout.trim().split("\n")[0]?.trim();
+                        if (firstRemote) remote = firstRemote;
+                    } catch { /* fall through to "origin" */ }
+                }
+                args = ["push", "--set-upstream", remote, branch];
+            } else {
+                args = ["push"];
+            }
 
             // git push writes to stderr (progress), use a larger timeout for network ops
             const result = await execFileAsync("git", args, { cwd, timeout: 60000 });

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -24,9 +24,12 @@ function isValidBranchName(name: string): boolean {
 function isValidPath(p: string): boolean {
     if (!p) return false;
     const norm = normalize(p);
-    // Reject absolute paths and path traversal
+    // Reject absolute paths
     if (norm.startsWith("/") || norm.startsWith("\\")) return false;
-    if (norm.includes("..")) return false;
+    // Reject path traversal by checking segments — allows valid filenames
+    // like "foo..bar.ts" while blocking "../" traversal.
+    const segments = norm.split(/[/\\]/);
+    if (segments.some((s) => s === "..")) return false;
     return true;
 }
 
@@ -164,7 +167,9 @@ export class GitService implements ServiceHandler {
 
             let ahead = 0;
             let behind = 0;
-            if (abResult.status === "fulfilled") {
+            // If rev-list against @{u} failed, the branch has no upstream
+            const hasUpstream = abResult.status === "fulfilled";
+            if (hasUpstream) {
                 const [a, b] = abResult.value.stdout.trim().split(/\s+/);
                 ahead = parseInt(a, 10) || 0;
                 behind = parseInt(b, 10) || 0;
@@ -176,6 +181,7 @@ export class GitService implements ServiceHandler {
                 changes,
                 ahead,
                 behind,
+                hasUpstream,
                 diffStaged,
             }, requestId, sessionId);
         } catch (err) {
@@ -229,12 +235,25 @@ export class GitService implements ServiceHandler {
                 { cwd, timeout: 5000 },
             );
 
-            // List all branches: local and remote, sorted by most recent commit
-            const { stdout: branchOutput } = await execFileAsync(
-                "git",
-                ["branch", "-a", "--sort=-committerdate", "--format=%(refname:short)\t%(objectname:short)\t%(committerdate:relative)\t%(HEAD)"],
-                { cwd, timeout: 10000 },
-            );
+            // Use for-each-ref for reliable branch listing with ref-type awareness.
+            // List local branches from refs/heads and remote branches from refs/remotes,
+            // excluding remote HEAD aliases (e.g. refs/remotes/origin/HEAD).
+            const [localResult, remoteResult] = await Promise.allSettled([
+                execFileAsync(
+                    "git",
+                    ["for-each-ref", "--sort=-committerdate",
+                     "--format=%(refname:short)\t%(objectname:short)\t%(committerdate:relative)\t%(HEAD)",
+                     "refs/heads"],
+                    { cwd, timeout: 10000 },
+                ),
+                execFileAsync(
+                    "git",
+                    ["for-each-ref", "--sort=-committerdate",
+                     "--format=%(refname:short)\t%(objectname:short)\t%(committerdate:relative)",
+                     "refs/remotes", "--exclude=refs/remotes/*/HEAD"],
+                    { cwd, timeout: 10000 },
+                ),
+            ]);
 
             const branches: Array<{
                 name: string;
@@ -244,18 +263,33 @@ export class GitService implements ServiceHandler {
                 isRemote: boolean;
             }> = [];
 
-            for (const line of branchOutput.split("\n")) {
+            // Parse local branches
+            const localOutput = localResult.status === "fulfilled" ? localResult.value.stdout : "";
+            for (const line of localOutput.split("\n")) {
                 if (!line.trim()) continue;
                 const [name, shortHash, lastCommit, head] = line.split("\t");
                 if (!name) continue;
-                // Skip HEAD -> refs (detached state pointers)
-                if (name.includes("HEAD")) continue;
                 branches.push({
                     name: name.trim(),
                     shortHash: shortHash?.trim() ?? "",
                     lastCommit: lastCommit?.trim() ?? "",
                     isCurrent: head?.trim() === "*",
-                    isRemote: name.startsWith("origin/"),
+                    isRemote: false,
+                });
+            }
+
+            // Parse remote branches
+            const remoteOutput = remoteResult.status === "fulfilled" ? remoteResult.value.stdout : "";
+            for (const line of remoteOutput.split("\n")) {
+                if (!line.trim()) continue;
+                const [name, shortHash, lastCommit] = line.split("\t");
+                if (!name) continue;
+                branches.push({
+                    name: name.trim(),
+                    shortHash: shortHash?.trim() ?? "",
+                    lastCommit: lastCommit?.trim() ?? "",
+                    isCurrent: false,
+                    isRemote: true,
                 });
             }
 
@@ -286,23 +320,36 @@ export class GitService implements ServiceHandler {
         }
 
         try {
-            // For remote tracking branches like "origin/foo", create a local tracking branch "foo"
+            // Detect remote tracking branches (e.g. "origin/foo", "upstream/bar").
+            // Extract local branch name and use `git switch --track` for safe checkout.
+            const remoteMatch = branch.match(/^([^/]+)\/(.+)$/);
             let targetBranch = branch;
-            const args = ["checkout"];
 
-            if (branch.startsWith("origin/")) {
-                targetBranch = branch.slice("origin/".length);
+            // Check if this looks like a remote branch by verifying the remote exists
+            let isRemoteRef = false;
+            if (remoteMatch) {
+                try {
+                    await execFileAsync("git", ["remote", "get-url", remoteMatch[1]], { cwd, timeout: 5000 });
+                    isRemoteRef = true;
+                } catch {
+                    // Not a known remote — treat as a local branch name containing "/"
+                }
+            }
+
+            const args: string[] = [];
+            if (isRemoteRef && remoteMatch) {
+                targetBranch = remoteMatch[2];
                 // Check if a local branch with this name already exists
                 try {
-                    await execFileAsync("git", ["rev-parse", "--verify", targetBranch], { cwd, timeout: 5000 });
+                    await execFileAsync("git", ["rev-parse", "--verify", `refs/heads/${targetBranch}`], { cwd, timeout: 5000 });
                     // Local branch exists, just check it out
-                    args.push(targetBranch);
+                    args.push("checkout", targetBranch);
                 } catch {
                     // No local branch — create tracking branch
-                    args.push("-b", targetBranch, branch);
+                    args.push("checkout", "-b", targetBranch, branch);
                 }
             } else {
-                args.push(targetBranch);
+                args.push("checkout", targetBranch);
             }
 
             await execFileAsync("git", args, { cwd, timeout: 15000 });

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -1,151 +1,471 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
+import { resolve, normalize } from "node:path";
 import type { Socket } from "socket.io-client";
-import type { ServiceHandler, ServiceInitOptions } from "../service-handler.js";
+import type { ServiceHandler, ServiceInitOptions, ServiceEnvelope } from "../service-handler.js";
 import { isCwdAllowed } from "../workspace.js";
 
 const execFileAsync = promisify(execFile);
 
+// ── Validation helpers ──────────────────────────────────────────────────────
+
+/** Validate that a branch name doesn't contain shell-dangerous characters. */
+function isValidBranchName(name: string): boolean {
+    if (!name || name.length > 256) return false;
+    // Reject control chars, space-only, "..", "~", "^", ":", "\\", NUL
+    if (/[\x00-\x1f\x7f~^:\\]/.test(name)) return false;
+    if (name.includes("..")) return false;
+    if (name.includes("@{")) return false;
+    if (name.endsWith(".lock") || name.endsWith(".") || name.endsWith("/") || name.startsWith("/")) return false;
+    return true;
+}
+
+/** Validate that file paths don't attempt path traversal. */
+function isValidPath(p: string): boolean {
+    if (!p) return false;
+    const norm = normalize(p);
+    // Reject absolute paths and path traversal
+    if (norm.startsWith("/") || norm.startsWith("\\")) return false;
+    if (norm.includes("..")) return false;
+    return true;
+}
+
+// ── GitService ──────────────────────────────────────────────────────────────
+
 export class GitService implements ServiceHandler {
     readonly id = "git";
 
-    // Socket reference and named handler refs — kept so dispose() can call
-    // socket.off() with the exact same function object that was passed to
-    // socket.on().  Without this, each reconnect would add a new listener
-    // while the old one stayed registered (listener leak).
     private _socket: Socket | null = null;
-    private _onGitStatus: ((data: any) => void) | null = null;
-    private _onGitDiff: ((data: any) => void) | null = null;
+    private _onServiceMessage: ((envelope: ServiceEnvelope) => void) | null = null;
+    private _isShuttingDown: () => boolean = () => false;
 
     init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
         this._socket = socket;
+        this._isShuttingDown = isShuttingDown;
 
-        // Helper: emit file_result on both channels (direct + service envelope).
-        // ALL file_result emissions in this service go through this helper so
-        // error paths and success paths are both covered.
-        const emitFileResult = (payload: Record<string, unknown>) => {
-            socket.emit("file_result" as any, payload);
-            (socket as any).emit("service_message", {
-                serviceId: "git",
-                type: "file_result",
-                payload,
-            });
-        };
-
-        this._onGitStatus = async (data: any) => {
+        this._onServiceMessage = (envelope: ServiceEnvelope) => {
             if (isShuttingDown()) return;
-            const requestId = data.requestId;
-            const cwd = data.cwd ?? "";
-            if (!cwd) {
-                emitFileResult({ requestId, ok: false, message: "Missing cwd" });
-                return;
-            }
-            if (!isCwdAllowed(cwd)) {
-                emitFileResult({ requestId, ok: false, message: "Path outside allowed roots" });
-                return;
-            }
-            try {
-                // Run all git commands asynchronously to avoid blocking the
-                // event loop (which would prevent Socket.IO pings from being
-                // answered, causing spurious disconnects).
-                const [branchResult, statusResult, diffStagedResult, abResult] = await Promise.allSettled([
-                    execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 }),
-                    execFileAsync("git", ["status", "--porcelain=v1", "-uall"], { cwd, timeout: 10000 }),
-                    execFileAsync("git", ["diff", "--cached", "--stat"], { cwd, timeout: 10000 }),
-                    execFileAsync("git", ["rev-list", "--left-right", "--count", "HEAD...@{u}"], { cwd, timeout: 5000 }),
-                ]);
+            if (envelope.serviceId !== "git") return;
 
-                const branch = branchResult.status === "fulfilled" ? branchResult.value.stdout.trim() : "";
-                const statusOutput = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
-                const diffStaged = diffStagedResult.status === "fulfilled" ? diffStagedResult.value.stdout : "";
+            const payload = (envelope.payload ?? {}) as Record<string, unknown>;
+            const requestId = envelope.requestId;
+            const sessionId = envelope.sessionId;
 
-                // Parse porcelain output
-                const changes: Array<{ status: string; path: string; originalPath?: string }> = [];
-                for (const line of statusOutput.split("\n")) {
-                    if (!line.trim()) continue;
-                    const xy = line.substring(0, 2);
-                    const rest = line.substring(3);
-                    // Handle renames: "R  old -> new"
-                    const arrowIdx = rest.indexOf(" -> ");
-                    if (arrowIdx >= 0) {
-                        changes.push({
-                            status: xy.trim(),
-                            path: rest.substring(arrowIdx + 4),
-                            originalPath: rest.substring(0, arrowIdx),
-                        });
-                    } else {
-                        changes.push({ status: xy.trim(), path: rest });
-                    }
-                }
-
-                // Get ahead/behind counts
-                let ahead = 0;
-                let behind = 0;
-                if (abResult.status === "fulfilled") {
-                    const abOutput = abResult.value.stdout.trim();
-                    const [a, b] = abOutput.split(/\s+/);
-                    ahead = parseInt(a, 10) || 0;
-                    behind = parseInt(b, 10) || 0;
-                }
-
-                emitFileResult({
-                    requestId,
-                    ok: true,
-                    branch,
-                    changes,
-                    ahead,
-                    behind,
-                    diffStaged,
-                });
-            } catch (err) {
-                emitFileResult({
-                    requestId,
-                    ok: false,
-                    message: err instanceof Error ? err.message : String(err),
-                });
+            switch (envelope.type) {
+                case "git_status":
+                    void this.handleStatus(payload, requestId, sessionId);
+                    break;
+                case "git_diff":
+                    void this.handleDiff(payload, requestId, sessionId);
+                    break;
+                case "git_branches":
+                    void this.handleBranches(payload, requestId, sessionId);
+                    break;
+                case "git_checkout":
+                    void this.handleCheckout(payload, requestId, sessionId);
+                    break;
+                case "git_stage":
+                    void this.handleStage(payload, requestId, sessionId);
+                    break;
+                case "git_unstage":
+                    void this.handleUnstage(payload, requestId, sessionId);
+                    break;
+                case "git_commit":
+                    void this.handleCommit(payload, requestId, sessionId);
+                    break;
+                case "git_push":
+                    void this.handlePush(payload, requestId, sessionId);
+                    break;
             }
         };
-        socket.on("git_status", this._onGitStatus);
 
-        this._onGitDiff = async (data: any) => {
-            if (isShuttingDown()) return;
-            const requestId = data.requestId;
-            const cwd = data.cwd ?? "";
-            const filePath = (data as any).path ?? "";
-            const staged = (data as any).staged === true;
-
-            if (!cwd || !filePath) {
-                emitFileResult({ requestId, ok: false, message: "Missing cwd or path" });
-                return;
-            }
-            if (!isCwdAllowed(cwd)) {
-                emitFileResult({ requestId, ok: false, message: "Path outside allowed roots" });
-                return;
-            }
-            try {
-                const args = staged ? ["diff", "--cached", "--", filePath] : ["diff", "--", filePath];
-                const { stdout: diff } = await execFileAsync("git", args, { cwd, timeout: 10000 });
-                emitFileResult({ requestId, ok: true, diff });
-            } catch (err) {
-                emitFileResult({
-                    requestId,
-                    ok: false,
-                    message: err instanceof Error ? err.message : String(err),
-                });
-            }
-        };
-        socket.on("git_diff", this._onGitDiff);
+        (socket as any).on("service_message", this._onServiceMessage);
     }
 
     dispose(): void {
-        // Remove all socket listeners registered by init() so that reconnects
-        // don't accumulate N+1 handlers per event.
-        if (this._socket) {
-            if (this._onGitStatus) (this._socket as any).off("git_status", this._onGitStatus);
-            if (this._onGitDiff) (this._socket as any).off("git_diff", this._onGitDiff);
-            this._socket = null;
+        if (this._socket && this._onServiceMessage) {
+            (this._socket as any).off("service_message", this._onServiceMessage);
         }
-        this._onGitStatus = null;
-        this._onGitDiff = null;
+        this._socket = null;
+        this._onServiceMessage = null;
+    }
+
+    // ── Response helper ─────────────────────────────────────────────────
+
+    private emit(type: string, payload: Record<string, unknown>, requestId?: string, sessionId?: string): void {
+        if (!this._socket) return;
+        const envelope: ServiceEnvelope & { sessionId?: string } = {
+            serviceId: "git",
+            type,
+            payload,
+            ...(requestId ? { requestId } : {}),
+            ...(sessionId ? { sessionId } : {}),
+        };
+        (this._socket as any).emit("service_message", envelope);
+    }
+
+    private emitError(type: string, message: string, requestId?: string, sessionId?: string): void {
+        this.emit(type, { ok: false, message }, requestId, sessionId);
+    }
+
+    // ── cwd validation ──────────────────────────────────────────────────
+
+    private validateCwd(cwd: unknown, responseType: string, requestId?: string, sessionId?: string): string | null {
+        if (typeof cwd !== "string" || !cwd) {
+            this.emitError(responseType, "Missing cwd", requestId, sessionId);
+            return null;
+        }
+        if (!isCwdAllowed(cwd)) {
+            this.emitError(responseType, "Path outside allowed roots", requestId, sessionId);
+            return null;
+        }
+        return cwd;
+    }
+
+    // ── git status ──────────────────────────────────────────────────────
+
+    private async handleStatus(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_status_result", requestId, sessionId);
+        if (!cwd) return;
+
+        try {
+            const [branchResult, statusResult, diffStagedResult, abResult] = await Promise.allSettled([
+                execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 }),
+                execFileAsync("git", ["status", "--porcelain=v1", "-uall"], { cwd, timeout: 10000 }),
+                execFileAsync("git", ["diff", "--cached", "--stat"], { cwd, timeout: 10000 }),
+                execFileAsync("git", ["rev-list", "--left-right", "--count", "HEAD...@{u}"], { cwd, timeout: 5000 }),
+            ]);
+
+            const branch = branchResult.status === "fulfilled" ? branchResult.value.stdout.trim() : "";
+            const statusOutput = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
+            const diffStaged = diffStagedResult.status === "fulfilled" ? diffStagedResult.value.stdout : "";
+
+            // Parse porcelain v1 output
+            const changes: Array<{ status: string; path: string; originalPath?: string }> = [];
+            for (const line of statusOutput.split("\n")) {
+                if (!line.trim()) continue;
+                const xy = line.substring(0, 2);
+                const rest = line.substring(3);
+                const arrowIdx = rest.indexOf(" -> ");
+                if (arrowIdx >= 0) {
+                    changes.push({
+                        status: xy.trim(),
+                        path: rest.substring(arrowIdx + 4),
+                        originalPath: rest.substring(0, arrowIdx),
+                    });
+                } else {
+                    changes.push({ status: xy.trim(), path: rest });
+                }
+            }
+
+            let ahead = 0;
+            let behind = 0;
+            if (abResult.status === "fulfilled") {
+                const [a, b] = abResult.value.stdout.trim().split(/\s+/);
+                ahead = parseInt(a, 10) || 0;
+                behind = parseInt(b, 10) || 0;
+            }
+
+            this.emit("git_status_result", {
+                ok: true,
+                branch,
+                changes,
+                ahead,
+                behind,
+                diffStaged,
+            }, requestId, sessionId);
+        } catch (err) {
+            this.emitError("git_status_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        }
+    }
+
+    // ── git diff ────────────────────────────────────────────────────────
+
+    private async handleDiff(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_diff_result", requestId, sessionId);
+        if (!cwd) return;
+
+        const filePath = typeof payload.path === "string" ? payload.path : "";
+        const staged = payload.staged === true;
+
+        if (!filePath) {
+            this.emitError("git_diff_result", "Missing path", requestId, sessionId);
+            return;
+        }
+
+        try {
+            const args = staged
+                ? ["diff", "--cached", "--", filePath]
+                : ["diff", "--", filePath];
+            const { stdout: diff } = await execFileAsync("git", args, { cwd, timeout: 10000 });
+            this.emit("git_diff_result", { ok: true, diff }, requestId, sessionId);
+        } catch (err) {
+            this.emitError("git_diff_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        }
+    }
+
+    // ── git branches ────────────────────────────────────────────────────
+
+    private async handleBranches(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_branches_result", requestId, sessionId);
+        if (!cwd) return;
+
+        try {
+            // Get current branch
+            const { stdout: currentBranch } = await execFileAsync(
+                "git", ["rev-parse", "--abbrev-ref", "HEAD"],
+                { cwd, timeout: 5000 },
+            );
+
+            // List all branches: local and remote, sorted by most recent commit
+            const { stdout: branchOutput } = await execFileAsync(
+                "git",
+                ["branch", "-a", "--sort=-committerdate", "--format=%(refname:short)\t%(objectname:short)\t%(committerdate:relative)\t%(HEAD)"],
+                { cwd, timeout: 10000 },
+            );
+
+            const branches: Array<{
+                name: string;
+                shortHash: string;
+                lastCommit: string;
+                isCurrent: boolean;
+                isRemote: boolean;
+            }> = [];
+
+            for (const line of branchOutput.split("\n")) {
+                if (!line.trim()) continue;
+                const [name, shortHash, lastCommit, head] = line.split("\t");
+                if (!name) continue;
+                // Skip HEAD -> refs (detached state pointers)
+                if (name.includes("HEAD")) continue;
+                branches.push({
+                    name: name.trim(),
+                    shortHash: shortHash?.trim() ?? "",
+                    lastCommit: lastCommit?.trim() ?? "",
+                    isCurrent: head?.trim() === "*",
+                    isRemote: name.startsWith("origin/"),
+                });
+            }
+
+            this.emit("git_branches_result", {
+                ok: true,
+                currentBranch: currentBranch.trim(),
+                branches,
+            }, requestId, sessionId);
+        } catch (err) {
+            this.emitError("git_branches_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        }
+    }
+
+    // ── git checkout ────────────────────────────────────────────────────
+
+    private async handleCheckout(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_checkout_result", requestId, sessionId);
+        if (!cwd) return;
+
+        const branch = typeof payload.branch === "string" ? payload.branch : "";
+        if (!branch || !isValidBranchName(branch)) {
+            this.emitError("git_checkout_result", "Invalid branch name", requestId, sessionId);
+            return;
+        }
+
+        try {
+            // For remote tracking branches like "origin/foo", create a local tracking branch "foo"
+            let targetBranch = branch;
+            const args = ["checkout"];
+
+            if (branch.startsWith("origin/")) {
+                targetBranch = branch.slice("origin/".length);
+                // Check if a local branch with this name already exists
+                try {
+                    await execFileAsync("git", ["rev-parse", "--verify", targetBranch], { cwd, timeout: 5000 });
+                    // Local branch exists, just check it out
+                    args.push(targetBranch);
+                } catch {
+                    // No local branch — create tracking branch
+                    args.push("-b", targetBranch, branch);
+                }
+            } else {
+                args.push(targetBranch);
+            }
+
+            await execFileAsync("git", args, { cwd, timeout: 15000 });
+
+            this.emit("git_checkout_result", {
+                ok: true,
+                branch: targetBranch,
+            }, requestId, sessionId);
+        } catch (err) {
+            this.emitError("git_checkout_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        }
+    }
+
+    // ── git stage ───────────────────────────────────────────────────────
+
+    private async handleStage(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_stage_result", requestId, sessionId);
+        if (!cwd) return;
+
+        const all = payload.all === true;
+        const paths = Array.isArray(payload.paths) ? payload.paths.filter((p): p is string => typeof p === "string") : [];
+
+        if (!all && paths.length === 0) {
+            this.emitError("git_stage_result", "No paths specified and all is false", requestId, sessionId);
+            return;
+        }
+
+        // Validate individual paths
+        if (!all) {
+            for (const p of paths) {
+                if (!isValidPath(p)) {
+                    this.emitError("git_stage_result", `Invalid path: ${p}`, requestId, sessionId);
+                    return;
+                }
+            }
+        }
+
+        try {
+            const args = all ? ["add", "--all"] : ["add", "--", ...paths];
+            await execFileAsync("git", args, { cwd, timeout: 15000 });
+            this.emit("git_stage_result", { ok: true }, requestId, sessionId);
+        } catch (err) {
+            this.emitError("git_stage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        }
+    }
+
+    // ── git unstage ─────────────────────────────────────────────────────
+
+    private async handleUnstage(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_unstage_result", requestId, sessionId);
+        if (!cwd) return;
+
+        const all = payload.all === true;
+        const paths = Array.isArray(payload.paths) ? payload.paths.filter((p): p is string => typeof p === "string") : [];
+
+        if (!all && paths.length === 0) {
+            this.emitError("git_unstage_result", "No paths specified and all is false", requestId, sessionId);
+            return;
+        }
+
+        if (!all) {
+            for (const p of paths) {
+                if (!isValidPath(p)) {
+                    this.emitError("git_unstage_result", `Invalid path: ${p}`, requestId, sessionId);
+                    return;
+                }
+            }
+        }
+
+        try {
+            const args = all
+                ? ["restore", "--staged", "."]
+                : ["restore", "--staged", "--", ...paths];
+            await execFileAsync("git", args, { cwd, timeout: 15000 });
+            this.emit("git_unstage_result", { ok: true }, requestId, sessionId);
+        } catch (err) {
+            this.emitError("git_unstage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        }
+    }
+
+    // ── git commit ──────────────────────────────────────────────────────
+
+    private async handleCommit(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_commit_result", requestId, sessionId);
+        if (!cwd) return;
+
+        const message = typeof payload.message === "string" ? payload.message.trim() : "";
+        if (!message) {
+            this.emitError("git_commit_result", "Empty commit message", requestId, sessionId);
+            return;
+        }
+
+        try {
+            const { stdout } = await execFileAsync(
+                "git", ["commit", "-m", message],
+                { cwd, timeout: 30000 },
+            );
+
+            // Parse the short summary (e.g. "[main abc1234] Fix thing\n 1 file changed...")
+            const firstLine = stdout.split("\n")[0] ?? "";
+
+            this.emit("git_commit_result", {
+                ok: true,
+                summary: firstLine.trim(),
+            }, requestId, sessionId);
+        } catch (err) {
+            this.emitError("git_commit_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        }
+    }
+
+    // ── git push ────────────────────────────────────────────────────────
+
+    private async handlePush(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_push_result", requestId, sessionId);
+        if (!cwd) return;
+
+        const setUpstream = payload.setUpstream === true;
+
+        try {
+            // Determine current branch for --set-upstream
+            const { stdout: branchName } = await execFileAsync(
+                "git", ["rev-parse", "--abbrev-ref", "HEAD"],
+                { cwd, timeout: 5000 },
+            );
+            const branch = branchName.trim();
+
+            const args = setUpstream
+                ? ["push", "--set-upstream", "origin", branch]
+                : ["push"];
+
+            // git push writes to stderr (progress), use a larger timeout for network ops
+            const result = await execFileAsync("git", args, { cwd, timeout: 60000 });
+            const output = (result.stdout + "\n" + result.stderr).trim();
+
+            this.emit("git_push_result", {
+                ok: true,
+                output,
+            }, requestId, sessionId);
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            // Detect "no upstream" and hint the user
+            const noUpstream = message.includes("has no upstream branch") || message.includes("--set-upstream");
+            this.emit("git_push_result", {
+                ok: false,
+                message,
+                noUpstream,
+            }, requestId, sessionId);
+        }
     }
 }

--- a/packages/protocol/src/runner.test.ts
+++ b/packages/protocol/src/runner.test.ts
@@ -382,15 +382,22 @@ describe("runner — RunnerServerToClientEvents payloads", () => {
     expect(typeof p.path).toBe("string");
   });
 
-  test("git_status and git_diff carry cwd", () => {
-    type GitStatusPayload = Parameters<RunnerServerToClientEvents["git_status"]>[0];
-    type GitDiffPayload = Parameters<RunnerServerToClientEvents["git_diff"]>[0];
+  test("git operations use service_message channel (no dedicated events)", () => {
+    // git_status and git_diff were removed from RunnerServerToClientEvents
+    // in favor of the generic service_message channel with serviceId="git".
+    type Events = RunnerServerToClientEvents;
+    type ServiceMsg = Parameters<Events["service_message"]>[0];
 
-    const status: GitStatusPayload = { cwd: "/home/user/project" };
-    const diff: GitDiffPayload = { cwd: "/home/user/project", requestId: "r1" };
+    const envelope: ServiceMsg = {
+      serviceId: "git",
+      type: "git_status",
+      payload: { cwd: "/home/user/project" },
+      requestId: "r1",
+    };
 
-    expect(typeof status.cwd).toBe("string");
-    expect(diff.requestId).toBe("r1");
+    expect(envelope.serviceId).toBe("git");
+    expect(envelope.type).toBe("git_status");
+    expect(envelope.requestId).toBe("r1");
   });
 
   test("sandbox_get_status has optional requestId", () => {

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -333,17 +333,9 @@ export interface RunnerServerToClientEvents {
     path: string;
   }) => void;
 
-  /** Requests git status */
-  git_status: (data: {
-    requestId?: string;
-    cwd: string;
-  }) => void;
-
-  /** Requests git diff */
-  git_diff: (data: {
-    requestId?: string;
-    cwd: string;
-  }) => void;
+  // Git operations (status, diff, branches, checkout, stage, unstage,
+  // commit, push) are handled via the service_message channel with
+  // serviceId="git". No dedicated socket events needed.
 
   /** Requests current sandbox status */
   sandbox_get_status: (data: {

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -1,8 +1,9 @@
 /**
- * Runners router — runner management, session spawn, skills, files, git.
+ * Runners router — runner management, session spawn, skills, files.
  *
+ * Git operations are handled via the service_message channel (see git-service.ts).
  * This is the largest router. If it exceeds 500 lines, split into sub-modules
- * (runners-core.ts, runners-skills.ts, runners-files.ts, runners-git.ts).
+ * (runners-core.ts, runners-skills.ts, runners-files.ts).
  */
 
 import {
@@ -658,69 +659,12 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         }
     }
 
-    // ── Git status ─────────────────────────────────────────────────────
-    const gitStatusMatch = url.pathname.match(/^\/api\/runners\/([^/]+)\/git-status$/);
-    if (gitStatusMatch && req.method === "POST") {
-        const identity = await requireSession(req);
-        if (identity instanceof Response) return identity;
-
-        const runnerId = decodeURIComponent(gitStatusMatch[1]);
-        const runner = await getRunnerData(runnerId);
-        if (!runner) return Response.json({ error: "Runner not found" }, { status: 404 });
-        if (runner.userId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
-
-        let body: any = {};
-        try { body = await req.json(); } catch { body = {}; }
-
-        const cwd = typeof body.cwd === "string" ? body.cwd : "";
-        if (!cwd) return Response.json({ error: "Missing cwd" }, { status: 400 });
-
-        const gitStatusRoots = parseJsonArray(runner.roots);
-        if (gitStatusRoots.length > 0 && !cwdMatchesRoots(gitStatusRoots, cwd)) {
-            return Response.json({ error: `Runner cannot access cwd: ${cwd}` }, { status: 400 });
-        }
-
-        try {
-            const result = await sendRunnerCommand(runnerId, { type: "git_status", cwd });
-            if (!(result as any).ok) return Response.json({ error: (result as any).message ?? "Failed to get git status" }, { status: 500 });
-            return Response.json(result);
-        } catch (err) {
-            return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 502 });
-        }
-    }
-
-    // ── Git diff ───────────────────────────────────────────────────────
-    const gitDiffMatch = url.pathname.match(/^\/api\/runners\/([^/]+)\/git-diff$/);
-    if (gitDiffMatch && req.method === "POST") {
-        const identity = await requireSession(req);
-        if (identity instanceof Response) return identity;
-
-        const runnerId = decodeURIComponent(gitDiffMatch[1]);
-        const runner = await getRunnerData(runnerId);
-        if (!runner) return Response.json({ error: "Runner not found" }, { status: 404 });
-        if (runner.userId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
-
-        let body: any = {};
-        try { body = await req.json(); } catch { body = {}; }
-
-        const cwd = typeof body.cwd === "string" ? body.cwd : "";
-        const path = typeof body.path === "string" ? body.path : "";
-        const staged = body.staged === true;
-        if (!cwd || !path) return Response.json({ error: "Missing cwd or path" }, { status: 400 });
-
-        const gitDiffRoots = parseJsonArray(runner.roots);
-        if (gitDiffRoots.length > 0 && !cwdMatchesRoots(gitDiffRoots, cwd)) {
-            return Response.json({ error: `Runner cannot access cwd: ${cwd}` }, { status: 400 });
-        }
-
-        try {
-            const result = await sendRunnerCommand(runnerId, { type: "git_diff", cwd, path, staged });
-            if (!(result as any).ok) return Response.json({ error: (result as any).message ?? "Failed to get diff" }, { status: 500 });
-            return Response.json(result);
-        } catch (err) {
-            return Response.json({ error: err instanceof Error ? err.message : String(err) }, { status: 502 });
-        }
-    }
+    // ── Git ───────────────────────────────────────────────────────────
+    // Git operations (status, diff, branches, checkout, stage, unstage,
+    // commit, push) are handled entirely through the service_message
+    // channel. The viewer sends service_message envelopes with
+    // serviceId="git" which are relayed to the runner's GitService.
+    // No REST routes needed — see git-service.ts on the runner side.
 
     // ── Sandbox ───────────────────────────────────────────────────────
 

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -177,7 +177,7 @@ const pendingRunnerCommands = new Map<string, PendingRunnerCommand>();
  * Returns the runner's file_result payload or throws on timeout.
  *
  * The command object must include a `type` field that maps to the event name
- * (e.g. "list_files", "read_file", "git_status", "git_diff").
+ * (e.g. "list_files", "read_file", "search_files").
  */
 export async function sendRunnerCommand(
     runnerId: string,
@@ -464,7 +464,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             }
         });
 
-        // ── file_result — runner responds to file/git commands ───────────────
+        // ── file_result — runner responds to file explorer commands ────────────
         socket.on("file_result", (data) => {
             const requestId = data.requestId;
             if (requestId) {

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -838,47 +838,91 @@ export async function createMockRunner(
         });
     });
 
-    // --- Git Operations ---
+    // --- Git Operations (via service_message channel) ---
 
-    socket.on("git_status", (data: any) => {
+    socket.on("service_message", (envelope: any) => {
         if (isShuttingDown) return;
-        const requestId = data?.requestId;
-        const cwd = data?.cwd ?? "";
+        if (envelope?.serviceId !== "git") return;
 
-        if (!cwd) {
-            socket.emit("file_result", { requestId, ok: false, message: "Missing cwd" });
-            return;
+        const payload = (envelope.payload ?? {}) as Record<string, unknown>;
+        const requestId = envelope.requestId;
+        const sessionId = envelope.sessionId;
+
+        const emitGit = (type: string, data: Record<string, unknown>) => {
+            socket.emit("service_message", {
+                serviceId: "git",
+                type,
+                ...(requestId ? { requestId } : {}),
+                ...(sessionId ? { sessionId } : {}),
+                payload: data,
+            });
+        };
+
+        switch (envelope.type) {
+            case "git_status": {
+                const cwd = payload.cwd;
+                if (!cwd) {
+                    emitGit("git_status_result", { ok: false, message: "Missing cwd" });
+                    return;
+                }
+                emitGit("git_status_result", {
+                    ok: true,
+                    branch: gitStatus.branch,
+                    changes: gitStatus.changes,
+                    ahead: gitStatus.ahead,
+                    behind: gitStatus.behind,
+                    diffStaged: gitStatus.diffStaged,
+                });
+                break;
+            }
+            case "git_diff": {
+                const cwd = payload.cwd;
+                const filePath = payload.path;
+                if (!cwd || !filePath) {
+                    emitGit("git_diff_result", { ok: false, message: "Missing cwd or path" });
+                    return;
+                }
+                const change = gitStatus.changes.find((c) => c.path === filePath);
+                const diff = change
+                    ? `diff --git a/${filePath} b/${filePath}\nindex abc1234..def5678 100644\n--- a/${filePath}\n+++ b/${filePath}\n@@ -1,3 +1,3 @@\n-old line\n+new line`
+                    : "";
+                emitGit("git_diff_result", { ok: true, diff });
+                break;
+            }
+            case "git_branches": {
+                emitGit("git_branches_result", {
+                    ok: true,
+                    currentBranch: gitStatus.branch,
+                    branches: [
+                        { name: gitStatus.branch, shortHash: "abc1234", lastCommit: "2 hours ago", isCurrent: true, isRemote: false },
+                        { name: "main", shortHash: "def5678", lastCommit: "1 day ago", isCurrent: false, isRemote: false },
+                    ],
+                });
+                break;
+            }
+            case "git_checkout": {
+                const branch = payload.branch;
+                if (!branch) {
+                    emitGit("git_checkout_result", { ok: false, message: "Invalid branch name" });
+                    return;
+                }
+                gitStatus.branch = branch as string;
+                emitGit("git_checkout_result", { ok: true, branch });
+                break;
+            }
+            case "git_stage":
+                emitGit("git_stage_result", { ok: true });
+                break;
+            case "git_unstage":
+                emitGit("git_unstage_result", { ok: true });
+                break;
+            case "git_commit":
+                emitGit("git_commit_result", { ok: true, summary: "[main abc1234] Mock commit" });
+                break;
+            case "git_push":
+                emitGit("git_push_result", { ok: true, output: "Everything up-to-date" });
+                break;
         }
-
-        socket.emit("file_result", {
-            requestId,
-            ok: true,
-            branch: gitStatus.branch,
-            changes: gitStatus.changes,
-            ahead: gitStatus.ahead,
-            behind: gitStatus.behind,
-            diffStaged: gitStatus.diffStaged,
-        });
-    });
-
-    socket.on("git_diff", (data: any) => {
-        if (isShuttingDown) return;
-        const requestId = data?.requestId;
-        const cwd = data?.cwd ?? "";
-        const filePath = data?.path ?? "";
-
-        if (!cwd || !filePath) {
-            socket.emit("file_result", { requestId, ok: false, message: "Missing cwd or path" });
-            return;
-        }
-
-        // Return a mock diff for any file in the git changes list
-        const change = gitStatus.changes.find((c) => c.path === filePath);
-        const diff = change
-            ? `diff --git a/${filePath} b/${filePath}\nindex abc1234..def5678 100644\n--- a/${filePath}\n+++ b/${filePath}\n@@ -1,3 +1,3 @@\n-old line\n+new line`
-            : "";
-
-        socket.emit("file_result", { requestId, ok: true, diff });
     });
 
     // --- Sandbox ---

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -871,6 +871,7 @@ export async function createMockRunner(
                     changes: gitStatus.changes,
                     ahead: gitStatus.ahead,
                     behind: gitStatus.behind,
+                    hasUpstream: true,
                     diffStaged: gitStatus.diffStaged,
                 });
                 break;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -57,7 +57,8 @@ import {
 import { X, TerminalIcon, FolderTree, GitBranch, EyeOff } from "lucide-react";
 import type { ProviderUsageMap } from "@/components/UsageIndicator";
 import { TerminalManager } from "@/components/TerminalManager";
-import { FileExplorer, GitChangesView } from "@/components/FileExplorer";
+import { FileExplorer } from "@/components/FileExplorer";
+import { GitPanel } from "@/components/git";
 import { CombinedPanel, type CombinedPanelTab } from "@/components/CombinedPanel";
 import { DockedPanelGroup } from "@/components/DockedPanelGroup";
 import { ViewerSocketContext } from "@/lib/viewer-socket-context";
@@ -3780,8 +3781,7 @@ export function App() {
     onClose: () => setShowGit(false),
     onDragStart: (e) => startPanelDragWith(e, handleGitPositionChange),
     content: (
-      <GitChangesView
-        runnerId={activeSessionInfo.runnerId}
+      <GitPanel
         cwd={activeSessionInfo.cwd}
       />
     ),

--- a/packages/ui/src/components/git/GitBranchSelector.tsx
+++ b/packages/ui/src/components/git/GitBranchSelector.tsx
@@ -1,0 +1,195 @@
+import { useState, useMemo, useRef, useEffect } from "react";
+import { cn } from "@/lib/utils";
+import { GitBranch as GitBranchIcon, ChevronDown, Search, Check, Globe, Loader2 } from "lucide-react";
+import type { GitBranch } from "@/hooks/useGitService";
+
+interface GitBranchSelectorProps {
+    currentBranch: string;
+    branches: GitBranch[];
+    onCheckout: (branch: string) => void;
+    onOpen: () => void;
+    disabled?: boolean;
+    isCheckingOut?: boolean;
+}
+
+export function GitBranchSelector({
+    currentBranch,
+    branches,
+    onCheckout,
+    onOpen,
+    disabled,
+    isCheckingOut,
+}: GitBranchSelectorProps) {
+    const [open, setOpen] = useState(false);
+    const [search, setSearch] = useState("");
+    const containerRef = useRef<HTMLDivElement>(null);
+    const searchInputRef = useRef<HTMLInputElement>(null);
+
+    // Close on click outside
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: PointerEvent) => {
+            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+                setOpen(false);
+                setSearch("");
+            }
+        };
+        document.addEventListener("pointerdown", handler, true);
+        return () => document.removeEventListener("pointerdown", handler, true);
+    }, [open]);
+
+    // Close on Escape
+    useEffect(() => {
+        if (!open) return;
+        const handler = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                e.stopPropagation();
+                setOpen(false);
+                setSearch("");
+            }
+        };
+        document.addEventListener("keydown", handler, true);
+        return () => document.removeEventListener("keydown", handler, true);
+    }, [open]);
+
+    // Auto-focus search on open
+    useEffect(() => {
+        if (open) {
+            searchInputRef.current?.focus();
+        }
+    }, [open]);
+
+    const handleOpen = () => {
+        if (disabled || isCheckingOut) return;
+        onOpen(); // Fetch branches
+        setOpen(true);
+    };
+
+    const handleSelect = (branch: GitBranch) => {
+        if (branch.isCurrent) {
+            setOpen(false);
+            setSearch("");
+            return;
+        }
+        onCheckout(branch.name);
+        setOpen(false);
+        setSearch("");
+    };
+
+    const filtered = useMemo(() => {
+        if (!search) return branches;
+        const q = search.toLowerCase();
+        return branches.filter((b) => b.name.toLowerCase().includes(q));
+    }, [branches, search]);
+
+    const localBranches = filtered.filter((b) => !b.isRemote);
+    const remoteBranches = filtered.filter((b) => b.isRemote);
+
+    return (
+        <div ref={containerRef} className="relative">
+            <button
+                type="button"
+                onClick={handleOpen}
+                disabled={disabled || isCheckingOut}
+                className={cn(
+                    "inline-flex items-center gap-1.5 px-2 py-1 rounded text-sm font-medium transition-colors",
+                    "hover:bg-accent/60 text-foreground",
+                    disabled && "opacity-50 cursor-not-allowed",
+                )}
+            >
+                <GitBranchIcon className="size-4 text-green-600 dark:text-green-400" />
+                <span className="truncate max-w-[200px]">{currentBranch || "detached"}</span>
+                {isCheckingOut ? (
+                    <Loader2 className="size-3 animate-spin" />
+                ) : (
+                    <ChevronDown className="size-3 text-muted-foreground" />
+                )}
+            </button>
+
+            {open && (
+                <div className="absolute top-full left-0 mt-1 w-72 max-h-80 bg-popover border border-border rounded-lg shadow-xl z-50 flex flex-col overflow-hidden animate-in fade-in zoom-in-95 duration-100">
+                    {/* Search */}
+                    <div className="flex items-center gap-2 px-3 py-2 border-b border-border/50">
+                        <Search className="size-3.5 text-muted-foreground flex-shrink-0" />
+                        <input
+                            ref={searchInputRef}
+                            type="text"
+                            value={search}
+                            onChange={(e) => setSearch(e.target.value)}
+                            placeholder="Find a branch…"
+                            className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/60"
+                        />
+                    </div>
+
+                    {/* Branch list */}
+                    <div className="flex-1 overflow-auto py-1">
+                        {filtered.length === 0 && (
+                            <div className="px-3 py-4 text-center text-xs text-muted-foreground">
+                                No branches found
+                            </div>
+                        )}
+
+                        {localBranches.length > 0 && (
+                            <div>
+                                <div className="px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                                    Local
+                                </div>
+                                {localBranches.map((branch) => (
+                                    <BranchItem
+                                        key={branch.name}
+                                        branch={branch}
+                                        onSelect={handleSelect}
+                                    />
+                                ))}
+                            </div>
+                        )}
+
+                        {remoteBranches.length > 0 && (
+                            <div className={localBranches.length > 0 ? "mt-1" : ""}>
+                                <div className="px-3 py-1 text-[0.6rem] font-semibold uppercase tracking-wider text-muted-foreground/70">
+                                    Remote
+                                </div>
+                                {remoteBranches.map((branch) => (
+                                    <BranchItem
+                                        key={branch.name}
+                                        branch={branch}
+                                        onSelect={handleSelect}
+                                    />
+                                ))}
+                            </div>
+                        )}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+function BranchItem({ branch, onSelect }: { branch: GitBranch; onSelect: (b: GitBranch) => void }) {
+    return (
+        <button
+            type="button"
+            onClick={() => onSelect(branch)}
+            className={cn(
+                "flex items-center gap-2 w-full px-3 py-1.5 text-sm text-left transition-colors",
+                branch.isCurrent
+                    ? "bg-accent/40 text-foreground"
+                    : "hover:bg-accent/60 text-foreground/80",
+            )}
+        >
+            <span className="flex-shrink-0 w-4">
+                {branch.isCurrent ? (
+                    <Check className="size-3.5 text-green-600 dark:text-green-400" />
+                ) : branch.isRemote ? (
+                    <Globe className="size-3 text-muted-foreground" />
+                ) : (
+                    <GitBranchIcon className="size-3 text-muted-foreground" />
+                )}
+            </span>
+            <span className="truncate flex-1 font-mono text-xs">{branch.name}</span>
+            <span className="text-[0.6rem] text-muted-foreground flex-shrink-0 tabular-nums">
+                {branch.shortHash}
+            </span>
+        </button>
+    );
+}

--- a/packages/ui/src/components/git/GitCommitForm.tsx
+++ b/packages/ui/src/components/git/GitCommitForm.tsx
@@ -1,0 +1,81 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+import { cn } from "@/lib/utils";
+import { Loader2 } from "lucide-react";
+
+interface GitCommitFormProps {
+    hasStagedChanges: boolean;
+    onCommit: (message: string) => void;
+    isCommitting: boolean;
+}
+
+export function GitCommitForm({ hasStagedChanges, onCommit, isCommitting }: GitCommitFormProps) {
+    const [message, setMessage] = useState("");
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    const canCommit = hasStagedChanges && message.trim().length > 0 && !isCommitting;
+
+    const handleCommit = useCallback(() => {
+        if (!canCommit) return;
+        onCommit(message.trim());
+        setMessage("");
+    }, [canCommit, message, onCommit]);
+
+    const handleKeyDown = useCallback(
+        (e: React.KeyboardEvent) => {
+            // Cmd/Ctrl+Enter to commit
+            if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                handleCommit();
+            }
+        },
+        [handleCommit],
+    );
+
+    // Auto-resize textarea
+    useEffect(() => {
+        const el = textareaRef.current;
+        if (!el) return;
+        el.style.height = "auto";
+        el.style.height = `${Math.min(el.scrollHeight, 120)}px`;
+    }, [message]);
+
+    return (
+        <div className="border-t border-border bg-muted/20 px-3 py-2 space-y-2">
+            <textarea
+                ref={textareaRef}
+                value={message}
+                onChange={(e) => setMessage(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder={hasStagedChanges ? "Commit message…" : "Stage changes to commit"}
+                disabled={!hasStagedChanges || isCommitting}
+                rows={1}
+                className={cn(
+                    "w-full resize-none rounded border border-border bg-background px-2 py-1.5",
+                    "text-xs font-mono placeholder:text-muted-foreground/50",
+                    "outline-none focus:ring-1 focus:ring-ring",
+                    "disabled:opacity-50 disabled:cursor-not-allowed",
+                    "min-h-[32px]",
+                )}
+            />
+            <div className="flex items-center justify-between">
+                <span className="text-[0.6rem] text-muted-foreground">
+                    {hasStagedChanges ? "⌘↵ to commit" : ""}
+                </span>
+                <button
+                    type="button"
+                    onClick={handleCommit}
+                    disabled={!canCommit}
+                    className={cn(
+                        "inline-flex items-center gap-1.5 px-3 py-1 rounded text-xs font-medium transition-colors",
+                        canCommit
+                            ? "bg-primary text-primary-foreground hover:bg-primary/90"
+                            : "bg-muted text-muted-foreground cursor-not-allowed",
+                    )}
+                >
+                    {isCommitting && <Loader2 className="size-3 animate-spin" />}
+                    Commit
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/components/git/GitDiffView.tsx
+++ b/packages/ui/src/components/git/GitDiffView.tsx
@@ -1,0 +1,43 @@
+import { cn } from "@/lib/utils";
+import { ChevronLeft } from "lucide-react";
+
+interface GitDiffViewProps {
+    path: string;
+    diff: string;
+    onClose: () => void;
+}
+
+export function GitDiffView({ path, diff, onClose }: GitDiffViewProps) {
+    return (
+        <div className="flex flex-col h-full outline-none">
+            <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/50">
+                <button
+                    type="button"
+                    onClick={onClose}
+                    className="text-muted-foreground hover:text-foreground transition-colors"
+                    title="Back to changes"
+                    aria-label="Back to changes"
+                >
+                    <ChevronLeft className="size-4" />
+                </button>
+                <span className="text-sm font-mono truncate flex-1">{path}</span>
+            </div>
+            <div className="flex-1 overflow-auto">
+                <pre className="p-3 text-xs font-mono leading-relaxed whitespace-pre-wrap break-all">
+                    {diff.split("\n").map((line, i) => {
+                        let color = "text-muted-foreground";
+                        if (line.startsWith("+") && !line.startsWith("+++")) color = "text-green-600 dark:text-green-400";
+                        else if (line.startsWith("-") && !line.startsWith("---")) color = "text-red-600 dark:text-red-400";
+                        else if (line.startsWith("@@")) color = "text-blue-600 dark:text-blue-400";
+                        else if (line.startsWith("diff ") || line.startsWith("index ")) color = "text-muted-foreground/70";
+                        return (
+                            <div key={i} className={cn(color, "min-h-[1.25em]")}>
+                                {line || "\u00A0"}
+                            </div>
+                        );
+                    })}
+                </pre>
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -49,18 +49,24 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
         if (!git.lastOperationResult) return;
         const result = git.lastOperationResult;
         if (result.ok) {
-            const messages: Record<string, string> = {
-                summary: (result.summary as string) ?? "Done",
-                output: (result.output as string) ?? "Done",
-                branch: `Switched to ${result.branch as string}`,
-            };
-            const msg = messages.summary ?? messages.output ?? messages.branch ?? "Done";
+            const msg = (result.summary as string)
+                ?? (result.output as string)
+                ?? (result.branch ? `Switched to ${result.branch as string}` : null)
+                ?? "Done";
             setToast({ type: "success", message: msg });
         } else {
-            setToast({
-                type: "error",
-                message: (result.message as string) ?? "Operation failed",
-            });
+            // If push failed because no upstream, offer to retry with --set-upstream
+            if (result.noUpstream) {
+                setToast({
+                    type: "error",
+                    message: "No upstream branch. Click Publish to push and set upstream.",
+                });
+            } else {
+                setToast({
+                    type: "error",
+                    message: (result.message as string) ?? "Operation failed",
+                });
+            }
         }
 
         const timer = setTimeout(() => setToast(null), 5000);
@@ -162,7 +168,8 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
     const { staged } = partitionChanges(git.status.changes);
     const hasChanges = git.status.changes.length > 0;
     const isPushing = git.operationInProgress === "push";
-    const showPush = git.status.ahead > 0;
+    // Show push when ahead of remote OR on a branch with no upstream yet
+    const showPush = git.status.ahead > 0 || !git.status.hasUpstream;
 
     return (
         <div className={cn("flex flex-col h-full", className)}>
@@ -200,17 +207,17 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                 {showPush && (
                     <button
                         type="button"
-                        onClick={() => git.push()}
+                        onClick={() => git.push(!git.status!.hasUpstream)}
                         disabled={isPushing}
                         className={cn(
                             "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors",
                             "bg-green-600/20 text-green-600 dark:text-green-400 hover:bg-green-600/30",
                             "disabled:opacity-50",
                         )}
-                        title="Push to remote"
+                        title={git.status!.hasUpstream ? "Push to remote" : "Push & set upstream"}
                     >
                         {isPushing ? <Loader2 className="size-3 animate-spin" /> : <Upload className="size-3" />}
-                        Push
+                        {git.status!.hasUpstream ? "Push" : "Publish"}
                     </button>
                 )}
 

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -1,0 +1,290 @@
+/**
+ * GitPanel — interactive git GUI panel.
+ *
+ * Communicates with the runner's GitService entirely through the
+ * service_message channel (no REST routes). Session-scoped via cwd.
+ */
+import { useState, useCallback, useRef, useEffect } from "react";
+import { cn } from "@/lib/utils";
+import {
+    ArrowUp,
+    ArrowDown,
+    RefreshCw,
+    GitCommit,
+    Upload,
+    Loader2,
+    Check,
+    AlertCircle,
+} from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+import { Button } from "@/components/ui/button";
+import { useGitService } from "@/hooks/useGitService";
+import { GitBranchSelector } from "./GitBranchSelector";
+import { GitStagingArea, partitionChanges } from "./GitStagingArea";
+import { GitCommitForm } from "./GitCommitForm";
+import { GitDiffView } from "./GitDiffView";
+
+// ── Props ───────────────────────────────────────────────────────────────────
+
+interface GitPanelProps {
+    cwd: string;
+    className?: string;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export function GitPanel({ cwd, className }: GitPanelProps) {
+    const git = useGitService(cwd);
+
+    // Diff view state
+    const [selectedDiff, setSelectedDiff] = useState<{ path: string; diff: string } | null>(null);
+    const [diffLoading, setDiffLoading] = useState(false);
+    const diffContainerRef = useRef<HTMLDivElement>(null);
+
+    // Toast-style feedback for operations
+    const [toast, setToast] = useState<{ type: "success" | "error"; message: string } | null>(null);
+
+    // Show toast when operation completes
+    useEffect(() => {
+        if (!git.lastOperationResult) return;
+        const result = git.lastOperationResult;
+        if (result.ok) {
+            const messages: Record<string, string> = {
+                summary: (result.summary as string) ?? "Done",
+                output: (result.output as string) ?? "Done",
+                branch: `Switched to ${result.branch as string}`,
+            };
+            const msg = messages.summary ?? messages.output ?? messages.branch ?? "Done";
+            setToast({ type: "success", message: msg });
+        } else {
+            setToast({
+                type: "error",
+                message: (result.message as string) ?? "Operation failed",
+            });
+        }
+
+        const timer = setTimeout(() => setToast(null), 5000);
+        return () => clearTimeout(timer);
+    }, [git.lastOperationResult]);
+
+    // ── Diff viewing ────────────────────────────────────────────────────
+
+    const viewDiff = useCallback(
+        async (path: string, staged = false) => {
+            setDiffLoading(true);
+            try {
+                const diff = await git.fetchDiff(path, staged);
+                setSelectedDiff({ path, diff });
+            } catch {
+                setSelectedDiff({ path, diff: "(failed to load diff)" });
+            } finally {
+                setDiffLoading(false);
+            }
+        },
+        [git],
+    );
+
+    // Intercept Escape in diff view
+    useEffect(() => {
+        if (!selectedDiff) return;
+        diffContainerRef.current?.focus();
+        const handler = (e: KeyboardEvent) => {
+            if (e.key !== "Escape") return;
+            // Only intercept if focus is inside the diff container
+            const active = document.activeElement;
+            if (!active || active === document.body || !diffContainerRef.current?.contains(active)) {
+                // Also intercept if body-focused and diff is visible (click on non-focusable content)
+                if (active === document.body && diffContainerRef.current) {
+                    // ok — intercept
+                } else {
+                    return;
+                }
+            }
+            e.preventDefault();
+            e.stopImmediatePropagation();
+            setSelectedDiff(null);
+        };
+        const restoreFocus = (e: PointerEvent) => {
+            if (!diffContainerRef.current?.contains(e.target as Node)) return;
+            requestAnimationFrame(() => {
+                if (document.activeElement === document.body) {
+                    diffContainerRef.current?.focus();
+                }
+            });
+        };
+        document.addEventListener("keydown", handler, true);
+        document.addEventListener("pointerdown", restoreFocus);
+        return () => {
+            document.removeEventListener("keydown", handler, true);
+            document.removeEventListener("pointerdown", restoreFocus);
+        };
+    }, [selectedDiff]);
+
+    // ── Loading state ───────────────────────────────────────────────────
+
+    if (git.loading && !git.status) {
+        return (
+            <div className={cn("flex items-center justify-center p-8", className)}>
+                <Spinner className="size-5" />
+            </div>
+        );
+    }
+
+    if (git.error && !git.status) {
+        return (
+            <div className={cn("p-4", className)}>
+                <p className="text-sm text-red-400 mb-3">{git.error}</p>
+                <Button variant="outline" size="sm" onClick={git.fetchStatus}>
+                    <RefreshCw className="size-3 mr-1.5" /> Retry
+                </Button>
+            </div>
+        );
+    }
+
+    if (!git.status) return null;
+
+    // ── Diff view ───────────────────────────────────────────────────────
+
+    if (selectedDiff) {
+        return (
+            <div ref={diffContainerRef} tabIndex={-1} className={cn("flex flex-col h-full outline-none", className)}>
+                <GitDiffView
+                    path={selectedDiff.path}
+                    diff={selectedDiff.diff}
+                    onClose={() => setSelectedDiff(null)}
+                />
+            </div>
+        );
+    }
+
+    // ── Main view ───────────────────────────────────────────────────────
+
+    const { staged } = partitionChanges(git.status.changes);
+    const hasChanges = git.status.changes.length > 0;
+    const isPushing = git.operationInProgress === "push";
+    const showPush = git.status.ahead > 0;
+
+    return (
+        <div className={cn("flex flex-col h-full", className)}>
+            {/* Branch header */}
+            <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border bg-muted/50 min-h-[40px]">
+                <GitBranchSelector
+                    currentBranch={git.status.branch}
+                    branches={git.branches}
+                    onCheckout={git.checkout}
+                    onOpen={git.fetchBranches}
+                    isCheckingOut={git.operationInProgress === "checkout"}
+                />
+
+                <div className="flex-1" />
+
+                {/* Ahead/behind badges */}
+                {git.status.ahead > 0 && (
+                    <span
+                        className="inline-flex items-center gap-0.5 text-[0.65rem] text-green-600 dark:text-green-400"
+                        title={`${git.status.ahead} commit(s) ahead`}
+                    >
+                        <ArrowUp className="size-3" /> {git.status.ahead}
+                    </span>
+                )}
+                {git.status.behind > 0 && (
+                    <span
+                        className="inline-flex items-center gap-0.5 text-[0.65rem] text-amber-500 dark:text-amber-400"
+                        title={`${git.status.behind} commit(s) behind`}
+                    >
+                        <ArrowDown className="size-3" /> {git.status.behind}
+                    </span>
+                )}
+
+                {/* Push button */}
+                {showPush && (
+                    <button
+                        type="button"
+                        onClick={() => git.push()}
+                        disabled={isPushing}
+                        className={cn(
+                            "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors",
+                            "bg-green-600/20 text-green-600 dark:text-green-400 hover:bg-green-600/30",
+                            "disabled:opacity-50",
+                        )}
+                        title="Push to remote"
+                    >
+                        {isPushing ? <Loader2 className="size-3 animate-spin" /> : <Upload className="size-3" />}
+                        Push
+                    </button>
+                )}
+
+                {/* Refresh */}
+                <button
+                    type="button"
+                    onClick={git.fetchStatus}
+                    disabled={git.loading}
+                    className="text-muted-foreground hover:text-foreground transition-colors p-1"
+                    title="Refresh git status"
+                    aria-label="Refresh git status"
+                >
+                    <RefreshCw className={cn("size-3.5", git.loading && "animate-spin")} />
+                </button>
+            </div>
+
+            {/* Toast notification */}
+            {toast && (
+                <div
+                    className={cn(
+                        "flex items-center gap-2 px-3 py-1.5 text-xs border-b",
+                        toast.type === "success"
+                            ? "bg-green-600/10 border-green-600/20 text-green-600 dark:text-green-400"
+                            : "bg-red-500/10 border-red-500/20 text-red-500 dark:text-red-400",
+                    )}
+                >
+                    {toast.type === "success" ? <Check className="size-3" /> : <AlertCircle className="size-3" />}
+                    <span className="truncate flex-1">{toast.message}</span>
+                    <button
+                        type="button"
+                        onClick={() => setToast(null)}
+                        className="text-current opacity-60 hover:opacity-100"
+                    >
+                        ×
+                    </button>
+                </div>
+            )}
+
+            {/* Content area */}
+            <div className="flex-1 overflow-auto">
+                {!hasChanges ? (
+                    <div className="flex flex-col items-center justify-center py-8 text-muted-foreground gap-2">
+                        <GitCommit className="size-8 opacity-30" />
+                        <p className="text-sm">Working tree clean</p>
+                    </div>
+                ) : (
+                    <GitStagingArea
+                        changes={git.status.changes}
+                        onViewDiff={viewDiff}
+                        onStage={git.stage}
+                        onStageAll={git.stageAll}
+                        onUnstage={git.unstage}
+                        onUnstageAll={git.unstageAll}
+                        operationInProgress={git.operationInProgress}
+                    />
+                )}
+            </div>
+
+            {/* Commit form — always visible at bottom when there are changes */}
+            {hasChanges && (
+                <GitCommitForm
+                    hasStagedChanges={staged.length > 0}
+                    onCommit={git.commit}
+                    isCommitting={git.operationInProgress === "commit"}
+                />
+            )}
+
+            {/* Diff loading indicator */}
+            {diffLoading && (
+                <div className="flex items-center justify-center py-4 border-t border-border">
+                    <Spinner className="size-4" />
+                    <span className="text-xs text-muted-foreground ml-2">Loading diff…</span>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/components/git/GitStagingArea.tsx
+++ b/packages/ui/src/components/git/GitStagingArea.tsx
@@ -1,0 +1,186 @@
+import { cn } from "@/lib/utils";
+import { Plus, Minus, Edit3, FileQuestion, HelpCircle, File, ChevronUp, ChevronDown } from "lucide-react";
+import type { GitChange } from "@/hooks/useGitService";
+
+// ── Status helpers ──────────────────────────────────────────────────────────
+
+function gitStatusLabel(status: string): { label: string; color: string; icon: React.ReactNode } {
+    switch (status) {
+        case "M":
+            return { label: "Modified", color: "text-amber-500 dark:text-amber-400", icon: <Edit3 className="size-3" /> };
+        case "A":
+            return { label: "Added", color: "text-green-600 dark:text-green-400", icon: <Plus className="size-3" /> };
+        case "D":
+            return { label: "Deleted", color: "text-red-500 dark:text-red-400", icon: <Minus className="size-3" /> };
+        case "R":
+            return { label: "Renamed", color: "text-blue-500 dark:text-blue-400", icon: <Edit3 className="size-3" /> };
+        case "C":
+            return { label: "Copied", color: "text-blue-500 dark:text-blue-400", icon: <Plus className="size-3" /> };
+        case "??":
+            return { label: "Untracked", color: "text-muted-foreground", icon: <FileQuestion className="size-3" /> };
+        case "!!":
+            return { label: "Ignored", color: "text-muted-foreground/60", icon: <HelpCircle className="size-3" /> };
+        case "MM":
+            return { label: "Modified (staged+unstaged)", color: "text-amber-500 dark:text-amber-400", icon: <Edit3 className="size-3" /> };
+        case "AM":
+            return { label: "Added + Modified", color: "text-green-600 dark:text-green-400", icon: <Plus className="size-3" /> };
+        default:
+            return { label: status, color: "text-muted-foreground", icon: <File className="size-3" /> };
+    }
+}
+
+// ── Partition helpers ────────────────────────────────────────────────────────
+
+export function partitionChanges(changes: GitChange[]): {
+    staged: GitChange[];
+    unstaged: GitChange[];
+} {
+    const staged: GitChange[] = [];
+    const unstaged: GitChange[] = [];
+
+    for (const c of changes) {
+        // Porcelain v1: XY where X=index status, Y=worktree status
+        if (c.status.length === 2 && c.status[0] !== "?" && c.status[0] !== " " && c.status[0] !== "!") {
+            staged.push(c);
+        }
+        if (c.status === "??" || (c.status.length === 2 && c.status[1] !== " ")) {
+            unstaged.push(c);
+        }
+    }
+
+    return { staged, unstaged };
+}
+
+// ── Props ───────────────────────────────────────────────────────────────────
+
+interface GitStagingAreaProps {
+    changes: GitChange[];
+    onViewDiff: (path: string, staged?: boolean) => void;
+    onStage: (paths: string[]) => void;
+    onStageAll: () => void;
+    onUnstage: (paths: string[]) => void;
+    onUnstageAll: () => void;
+    operationInProgress: string | null;
+}
+
+// ── Component ───────────────────────────────────────────────────────────────
+
+export function GitStagingArea({
+    changes,
+    onViewDiff,
+    onStage,
+    onStageAll,
+    onUnstage,
+    onUnstageAll,
+    operationInProgress,
+}: GitStagingAreaProps) {
+    const { staged, unstaged } = partitionChanges(changes);
+    const isBusy = operationInProgress === "stage" || operationInProgress === "unstage";
+
+    return (
+        <div className="py-1">
+            {/* Staged changes */}
+            {staged.length > 0 && (
+                <div className="mb-1">
+                    <div className="flex items-center px-3 py-1.5">
+                        <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground flex-1">
+                            Staged Changes ({staged.length})
+                        </span>
+                        <button
+                            type="button"
+                            onClick={onUnstageAll}
+                            disabled={isBusy}
+                            className="text-[0.6rem] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 flex items-center gap-0.5"
+                            title="Unstage all"
+                        >
+                            <ChevronDown className="size-3" /> Unstage All
+                        </button>
+                    </div>
+                    {staged.map((change) => {
+                        const info = gitStatusLabel(change.status[0]);
+                        return (
+                            <div
+                                key={`staged-${change.path}`}
+                                className="flex items-center gap-1 w-full px-3 py-1 text-sm group"
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => onUnstage([change.path])}
+                                    disabled={isBusy}
+                                    className="flex-shrink-0 p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+                                    title={`Unstage ${change.path}`}
+                                >
+                                    <Minus className="size-3" />
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => onViewDiff(change.path, true)}
+                                    className="flex items-center gap-2 flex-1 min-w-0 text-left hover:bg-accent/40 rounded px-1 py-0.5 transition-colors"
+                                >
+                                    <span className={cn("flex-shrink-0", info.color)} title={info.label}>{info.icon}</span>
+                                    <span className="truncate flex-1 font-mono text-xs text-foreground/80">{change.path}</span>
+                                    <span className={cn("text-[0.6rem] flex-shrink-0", info.color)}>{change.status[0]}</span>
+                                </button>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+
+            {/* Unstaged/untracked changes */}
+            {unstaged.length > 0 && (
+                <div>
+                    <div className="flex items-center px-3 py-1.5">
+                        <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground flex-1">
+                            Changes ({unstaged.length})
+                        </span>
+                        <button
+                            type="button"
+                            onClick={onStageAll}
+                            disabled={isBusy}
+                            className="text-[0.6rem] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 flex items-center gap-0.5"
+                            title="Stage all"
+                        >
+                            <ChevronUp className="size-3" /> Stage All
+                        </button>
+                    </div>
+                    {unstaged.map((change) => {
+                        const displayStatus = change.status === "??" ? "??" : change.status.length === 2 ? change.status[1] : change.status;
+                        const info = gitStatusLabel(displayStatus);
+                        const isUntracked = change.status === "??";
+                        return (
+                            <div
+                                key={`unstaged-${change.path}`}
+                                className="flex items-center gap-1 w-full px-3 py-1 text-sm group"
+                            >
+                                <button
+                                    type="button"
+                                    onClick={() => onStage([change.path])}
+                                    disabled={isBusy}
+                                    className="flex-shrink-0 p-0.5 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors disabled:opacity-50"
+                                    title={`Stage ${change.path}`}
+                                >
+                                    <Plus className="size-3" />
+                                </button>
+                                <button
+                                    type="button"
+                                    onClick={() => !isUntracked && onViewDiff(change.path)}
+                                    disabled={isUntracked}
+                                    className={cn(
+                                        "flex items-center gap-2 flex-1 min-w-0 text-left rounded px-1 py-0.5 transition-colors",
+                                        !isUntracked && "hover:bg-accent/40",
+                                        isUntracked && "cursor-default",
+                                    )}
+                                >
+                                    <span className={cn("flex-shrink-0", info.color)} title={info.label}>{info.icon}</span>
+                                    <span className="truncate flex-1 font-mono text-xs text-foreground/80">{change.path}</span>
+                                    <span className={cn("text-[0.6rem] flex-shrink-0", info.color)}>{displayStatus}</span>
+                                </button>
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/ui/src/components/git/index.ts
+++ b/packages/ui/src/components/git/index.ts
@@ -1,0 +1,5 @@
+export { GitPanel } from "./GitPanel";
+export { GitDiffView } from "./GitDiffView";
+export { GitBranchSelector } from "./GitBranchSelector";
+export { GitStagingArea, partitionChanges } from "./GitStagingArea";
+export { GitCommitForm } from "./GitCommitForm";

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -1,0 +1,281 @@
+/**
+ * useGitService — typed wrapper around useServiceChannel("git").
+ *
+ * Provides methods for all git operations (status, diff, branches,
+ * checkout, stage, unstage, commit, push) and reactive state that
+ * updates when responses arrive from the runner's GitService.
+ */
+import { useState, useCallback, useRef, useEffect } from "react";
+import { useServiceChannel } from "./useServiceChannel";
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface GitChange {
+    status: string;
+    path: string;
+    originalPath?: string;
+}
+
+export interface GitStatus {
+    branch: string;
+    changes: GitChange[];
+    ahead: number;
+    behind: number;
+    diffStaged: string;
+}
+
+export interface GitBranch {
+    name: string;
+    shortHash: string;
+    lastCommit: string;
+    isCurrent: boolean;
+    isRemote: boolean;
+}
+
+export interface GitOperationResult {
+    ok: boolean;
+    message?: string;
+    [key: string]: unknown;
+}
+
+// ── Hook ────────────────────────────────────────────────────────────────────
+
+export interface UseGitServiceReturn {
+    available: boolean;
+
+    // State
+    status: GitStatus | null;
+    branches: GitBranch[];
+    currentBranch: string;
+    loading: boolean;
+    error: string | null;
+
+    // Operation feedback
+    operationInProgress: string | null;
+    lastOperationResult: GitOperationResult | null;
+
+    // Actions
+    fetchStatus: () => void;
+    fetchDiff: (path: string, staged?: boolean) => Promise<string>;
+    fetchBranches: () => void;
+    checkout: (branch: string) => void;
+    stage: (paths: string[]) => void;
+    stageAll: () => void;
+    unstage: (paths: string[]) => void;
+    unstageAll: () => void;
+    commit: (message: string) => void;
+    push: (setUpstream?: boolean) => void;
+    clearOperationResult: () => void;
+}
+
+export function useGitService(cwd: string): UseGitServiceReturn {
+    const [status, setStatus] = useState<GitStatus | null>(null);
+    const [branches, setBranches] = useState<GitBranch[]>([]);
+    const [currentBranch, setCurrentBranch] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+    const [operationInProgress, setOperationInProgress] = useState<string | null>(null);
+    const [lastOperationResult, setLastOperationResult] = useState<GitOperationResult | null>(null);
+
+    // Track pending diff requests: requestId → resolve callback
+    const pendingDiffsRef = useRef(new Map<string, (diff: string) => void>());
+
+    // Generate unique request IDs
+    const nextId = useRef(0);
+    const makeRequestId = useCallback(() => `git-${Date.now()}-${nextId.current++}`, []);
+
+    // Stable ref for cwd so the onMessage callback sees the latest value
+    // without needing to re-create the service channel.
+    const cwdRef = useRef(cwd);
+    cwdRef.current = cwd;
+
+    // Ref for sendGit so callbacks can access latest version
+    const sendRef = useRef<(type: string, payload: unknown, requestId?: string) => void>(() => {});
+
+    const { send, available } = useServiceChannel<unknown, unknown>("git", {
+        onMessage: (type, rawPayload, requestId) => {
+            const payload = rawPayload as Record<string, unknown>;
+
+            switch (type) {
+                case "git_status_result": {
+                    setLoading(false);
+                    if (payload.ok) {
+                        setStatus({
+                            branch: (payload.branch as string) ?? "",
+                            changes: (payload.changes as GitChange[]) ?? [],
+                            ahead: (payload.ahead as number) ?? 0,
+                            behind: (payload.behind as number) ?? 0,
+                            diffStaged: (payload.diffStaged as string) ?? "",
+                        });
+                        setError(null);
+                    } else {
+                        setError((payload.message as string) ?? "Failed to get git status");
+                    }
+                    break;
+                }
+                case "git_diff_result": {
+                    if (requestId && pendingDiffsRef.current.has(requestId)) {
+                        const resolve = pendingDiffsRef.current.get(requestId)!;
+                        pendingDiffsRef.current.delete(requestId);
+                        resolve(
+                            payload.ok
+                                ? ((payload.diff as string) ?? "(no diff)")
+                                : ((payload.message as string) ?? "(failed to load diff)"),
+                        );
+                    }
+                    break;
+                }
+                case "git_branches_result": {
+                    if (payload.ok) {
+                        setBranches((payload.branches as GitBranch[]) ?? []);
+                        setCurrentBranch((payload.currentBranch as string) ?? "");
+                    }
+                    break;
+                }
+                case "git_checkout_result":
+                case "git_stage_result":
+                case "git_unstage_result":
+                case "git_commit_result":
+                case "git_push_result": {
+                    setOperationInProgress(null);
+                    setLastOperationResult(payload as GitOperationResult);
+                    // Auto-refresh status after mutating operations
+                    if (payload.ok) {
+                        setTimeout(() => {
+                            sendRef.current("git_status", { cwd: cwdRef.current });
+                        }, 100);
+                    }
+                    break;
+                }
+            }
+        },
+    });
+
+    // Keep send ref current
+    sendRef.current = send;
+
+    // Clean up pending diffs on unmount
+    useEffect(() => {
+        return () => {
+            pendingDiffsRef.current.clear();
+        };
+    }, []);
+
+    // ── Actions ─────────────────────────────────────────────────────────
+
+    const fetchStatus = useCallback(() => {
+        if (!available) return;
+        setLoading(true);
+        setError(null);
+        send("git_status", { cwd }, makeRequestId());
+    }, [available, send, cwd, makeRequestId]);
+
+    const fetchDiff = useCallback((path: string, staged = false): Promise<string> => {
+        return new Promise((resolve) => {
+            if (!available) {
+                resolve("(git service unavailable)");
+                return;
+            }
+            const reqId = makeRequestId();
+            pendingDiffsRef.current.set(reqId, resolve);
+            send("git_diff", { cwd, path, staged }, reqId);
+
+            // Timeout after 15s
+            setTimeout(() => {
+                if (pendingDiffsRef.current.has(reqId)) {
+                    pendingDiffsRef.current.delete(reqId);
+                    resolve("(diff request timed out)");
+                }
+            }, 15000);
+        });
+    }, [available, send, cwd, makeRequestId]);
+
+    const fetchBranches = useCallback(() => {
+        if (!available) return;
+        send("git_branches", { cwd }, makeRequestId());
+    }, [available, send, cwd, makeRequestId]);
+
+    const checkout = useCallback((branch: string) => {
+        if (!available) return;
+        setOperationInProgress("checkout");
+        setLastOperationResult(null);
+        send("git_checkout", { cwd, branch }, makeRequestId());
+    }, [available, send, cwd, makeRequestId]);
+
+    const stage = useCallback((paths: string[]) => {
+        if (!available) return;
+        setOperationInProgress("stage");
+        setLastOperationResult(null);
+        send("git_stage", { cwd, paths }, makeRequestId());
+    }, [available, send, cwd, makeRequestId]);
+
+    const stageAll = useCallback(() => {
+        if (!available) return;
+        setOperationInProgress("stage");
+        setLastOperationResult(null);
+        send("git_stage", { cwd, all: true }, makeRequestId());
+    }, [available, send, cwd, makeRequestId]);
+
+    const unstage = useCallback((paths: string[]) => {
+        if (!available) return;
+        setOperationInProgress("unstage");
+        setLastOperationResult(null);
+        send("git_unstage", { cwd, paths }, makeRequestId());
+    }, [available, send, cwd, makeRequestId]);
+
+    const unstageAll = useCallback(() => {
+        if (!available) return;
+        setOperationInProgress("unstage");
+        setLastOperationResult(null);
+        send("git_unstage", { cwd, all: true }, makeRequestId());
+    }, [available, send, cwd, makeRequestId]);
+
+    const commit = useCallback((message: string) => {
+        if (!available) return;
+        setOperationInProgress("commit");
+        setLastOperationResult(null);
+        send("git_commit", { cwd, message }, makeRequestId());
+    }, [available, send, cwd, makeRequestId]);
+
+    const push = useCallback((setUpstream = false) => {
+        if (!available) return;
+        setOperationInProgress("push");
+        setLastOperationResult(null);
+        send("git_push", { cwd, setUpstream }, makeRequestId());
+    }, [available, send, cwd, makeRequestId]);
+
+    const clearOperationResult = useCallback(() => {
+        setLastOperationResult(null);
+    }, []);
+
+    // Auto-fetch status when service becomes available or cwd changes
+    useEffect(() => {
+        if (available && cwd) {
+            setLoading(true);
+            setError(null);
+            send("git_status", { cwd }, makeRequestId());
+        }
+    }, [available, cwd]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    return {
+        available,
+        status,
+        branches,
+        currentBranch,
+        loading,
+        error,
+        operationInProgress,
+        lastOperationResult,
+        fetchStatus,
+        fetchDiff,
+        fetchBranches,
+        checkout,
+        stage,
+        stageAll,
+        unstage,
+        unstageAll,
+        commit,
+        push,
+        clearOperationResult,
+    };
+}

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -21,6 +21,8 @@ export interface GitStatus {
     changes: GitChange[];
     ahead: number;
     behind: number;
+    /** Whether the current branch has an upstream tracking branch configured. */
+    hasUpstream: boolean;
     diffStaged: string;
 }
 
@@ -105,6 +107,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                             changes: (payload.changes as GitChange[]) ?? [],
                             ahead: (payload.ahead as number) ?? 0,
                             behind: (payload.behind as number) ?? 0,
+                            hasUpstream: (payload.hasUpstream as boolean) ?? false,
                             diffStaged: (payload.diffStaged as string) ?? "",
                         });
                         setError(null);


### PR DESCRIPTION
Transform the Git tab from a read-only status viewer into a full interactive mini-Git GUI. Major architectural change: git operations now flow through the `service_message` channel (like TunnelService) instead of dedicated REST routes.

## Architecture Changes
- **Runner**: Rewrote GitService to use `service_message` handler pattern instead of direct socket events (`git_status`, `git_diff`). All operations dispatch via `envelope.type` switch with session-scoped responses.
- **Server**: Removed REST routes `POST /api/runners/:id/git-status` and `POST /api/runners/:id/git-diff`. Git ops no longer need REST proxying.
- **Protocol**: Removed `git_status`/`git_diff` from `RunnerServerToClientEvents`. All git communication goes through the generic `service_message` channel.
- **UI**: New `useGitService` hook wraps `useServiceChannel('git')` with typed methods. New `GitPanel` component hierarchy replaces `GitChangesView`.

## New Git Operations (all via service_message)
- `git_branches`: List local + remote branches with metadata
- `git_checkout`: Switch branch (handles remote tracking branches)
- `git_stage`: Stage individual files or all (`git add`)
- `git_unstage`: Unstage individual files or all (`git restore --staged`)
- `git_commit`: Commit staged changes with message
- `git_push`: Push to remote (with `--set-upstream` detection)

## New UI Components
- **GitPanel**: Main container with branch header, staging area, commit form
- **GitBranchSelector**: Dropdown with search, local/remote sections
- **GitStagingArea**: Per-file stage/unstage buttons, Stage All/Unstage All
- **GitCommitForm**: Commit message textarea with Cmd+Enter shortcut
- **GitDiffView**: Colorized diff viewer (extracted from old code)

## Security
- All paths validated via `isCwdAllowed()` and `isValidPath()`
- Branch names validated against git ref naming rules
- All git commands use `execFileAsync` (no shell injection)
- Commit messages passed as args to `execFile`, not interpolated

## Stats
14 files changed, +1621 / -238

Closes idea `yjTOqnWz`