### PR TITLE
fix: runner-scoped tunnel URLs + auto-open Tunnel panel

### DIFF
--- a/packages/cli/src/extensions/tunnel-tools.test.ts
+++ b/packages/cli/src/extensions/tunnel-tools.test.ts
@@ -4,6 +4,7 @@ import { createTunnelToolsExtension } from "./tunnel-tools.js";
 const mockGetRelaySocket = mock(() => null as any);
 const mockGetRelaySessionId = mock(() => null as string | null);
 const mockLoadConfig = mock((_cwd: string) => ({ relayUrl: "ws://localhost:7492" } as any));
+const mockGetRunnerId = mock(() => null as string | null);
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
@@ -60,6 +61,7 @@ describe("tunnelToolsExtension", () => {
         mockGetRelaySocket.mockReset();
         mockGetRelaySessionId.mockReset();
         mockLoadConfig.mockReset();
+        mockGetRunnerId.mockReset();
         mockLoadConfig.mockReturnValue({ relayUrl: "ws://localhost:7492" } as any);
 
         pi = createMockPi();
@@ -67,6 +69,7 @@ describe("tunnelToolsExtension", () => {
             getRelaySocket: mockGetRelaySocket as any,
             getRelaySessionId: mockGetRelaySessionId as any,
             loadConfig: mockLoadConfig as any,
+            getRunnerId: mockGetRunnerId as any,
         });
         extension(pi as any);
         tools = pi.tools;
@@ -133,6 +136,7 @@ describe("tunnelToolsExtension", () => {
             expect(text).toContain("3000");
             expect(result.details.port).toBe(3000);
             expect(result.details.name).toBe("dev");
+            // With no runner ID, falls back to session-based URL
             expect(result.details.publicUrl).toContain("/api/tunnel/sess-123/3000/");
         });
 
@@ -258,10 +262,49 @@ describe("buildPublicTunnelUrl", () => {
 
     beforeEach(() => {
         process.env.PIZZAPI_RELAY_URL = "ws://localhost:7492";
+        mockGetRelaySocket.mockReset();
+        mockGetRelaySessionId.mockReset();
+        mockGetRunnerId.mockReset();
+        mockLoadConfig.mockReset();
+        mockLoadConfig.mockReturnValue({ relayUrl: "ws://localhost:7492" } as any);
     });
 
-    // Restore env after the suite
-    test("generates correct URL with session ID and port", async () => {
+    test("prefers runner-based URL when runner ID is available", async () => {
+        const sock = mockSocket();
+        sock.emit = (_event: string, data: unknown) => {
+            setTimeout(() => {
+                sock.simulateMessage({
+                    serviceId: "tunnel",
+                    type: "tunnel_registered",
+                    requestId: (data as any).requestId,
+                    payload: { port: 8080, url: "/tunnel/8080" },
+                });
+            }, 10);
+        };
+
+        mockGetRelaySocket.mockReturnValue({ socket: sock, token: "t" });
+        mockGetRelaySessionId.mockReturnValue("sess-123");
+        mockGetRunnerId.mockReturnValue("runner-abc");
+
+        const pi = createMockPi();
+        const extension = createTunnelToolsExtension({
+            getRelaySocket: mockGetRelaySocket as any,
+            getRelaySessionId: mockGetRelaySessionId as any,
+            loadConfig: mockLoadConfig as any,
+            getRunnerId: mockGetRunnerId as any,
+        });
+        extension(pi as any);
+
+        const tool = pi.tools.get("create_tunnel")!;
+        const result = await tool.execute("call-1", { port: 8080 });
+
+        expect(result.details.publicUrl).toBe("http://localhost:7492/api/tunnel/runner/runner-abc/8080/");
+
+        if (savedRelayUrl !== undefined) process.env.PIZZAPI_RELAY_URL = savedRelayUrl;
+        else delete process.env.PIZZAPI_RELAY_URL;
+    });
+
+    test("falls back to session-based URL when runner ID is unavailable", async () => {
         const sock = mockSocket();
         sock.emit = (_event: string, data: unknown) => {
             setTimeout(() => {
@@ -282,12 +325,14 @@ describe("buildPublicTunnelUrl", () => {
             getRelaySocket: mockGetRelaySocket as any,
             getRelaySessionId: mockGetRelaySessionId as any,
             loadConfig: mockLoadConfig as any,
+            getRunnerId: mockGetRunnerId as any,
         });
         extension(pi as any);
 
         const tool = pi.tools.get("create_tunnel")!;
         const result = await tool.execute("call-1", { port: 8080 });
 
+        // No runner ID mocked, falls back to session-based URL
         expect(result.details.publicUrl).toBe("http://localhost:7492/api/tunnel/abc-def-123/8080/");
 
         // Restore
@@ -295,7 +340,7 @@ describe("buildPublicTunnelUrl", () => {
         else delete process.env.PIZZAPI_RELAY_URL;
     });
 
-    test("returns null publicUrl when session ID is missing", async () => {
+    test("returns null publicUrl when both runner ID and session ID are missing", async () => {
         const sock = mockSocket();
         sock.emit = (_event: string, data: unknown) => {
             setTimeout(() => {
@@ -316,6 +361,7 @@ describe("buildPublicTunnelUrl", () => {
             getRelaySocket: mockGetRelaySocket as any,
             getRelaySessionId: mockGetRelaySessionId as any,
             loadConfig: mockLoadConfig as any,
+            getRunnerId: mockGetRunnerId as any,
         });
         extension(pi as any);
 

--- a/packages/cli/src/extensions/tunnel-tools.ts
+++ b/packages/cli/src/extensions/tunnel-tools.ts
@@ -14,6 +14,9 @@
  */
 
 import { randomUUID } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
 import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import { Text } from "@mariozechner/pi-tui";
 import { getRelaySocket as getRelaySocketDefault, getRelaySessionId as getRelaySessionIdDefault } from "./remote.js";
@@ -33,12 +36,25 @@ interface TunnelToolsDeps {
     getRelaySocket: typeof getRelaySocketDefault;
     getRelaySessionId: typeof getRelaySessionIdDefault;
     loadConfig: typeof loadConfigDefault;
+    getRunnerId: () => string | null;
+}
+
+function getRunnerIdDefault(): string | null {
+    const statePath = process.env.PIZZAPI_RUNNER_STATE_PATH ?? join(homedir(), ".pizzapi", "runner.json");
+    try {
+        if (!existsSync(statePath)) return null;
+        const state = JSON.parse(readFileSync(statePath, "utf-8"));
+        return typeof state.runnerId === "string" ? state.runnerId : null;
+    } catch {
+        return null;
+    }
 }
 
 const defaultDeps: TunnelToolsDeps = {
     getRelaySocket: getRelaySocketDefault,
     getRelaySessionId: getRelaySessionIdDefault,
     loadConfig: loadConfigDefault,
+    getRunnerId: getRunnerIdDefault,
 };
 
 /** Minimal Component that renders nothing — keeps the tool call invisible in the TUI. */
@@ -106,10 +122,23 @@ function getRelayHttpBaseUrl(deps: TunnelToolsDeps): string | null {
     return `https://${trimmed}`;
 }
 
+/**
+ * Build the public tunnel URL. Prefers runner-based URLs (stable across session
+ * switches) and falls back to session-based URLs if runner ID is unavailable.
+ */
 function buildPublicTunnelUrl(deps: TunnelToolsDeps, port: number): string | null {
     const base = getRelayHttpBaseUrl(deps);
+    if (!base) return null;
+
+    // Prefer runner-based URL — stable across session switches.
+    const runnerId = deps.getRunnerId();
+    if (runnerId) {
+        return `${base}/api/tunnel/runner/${encodeURIComponent(runnerId)}/${port}/`;
+    }
+
+    // Fall back to session-based URL.
     const sessionId = deps.getRelaySessionId();
-    if (!base || !sessionId) return null;
+    if (!sessionId) return null;
     return `${base}/api/tunnel/${encodeURIComponent(sessionId)}/${port}/`;
 }
 

--- a/packages/server/src/routes/tunnel-ws.ts
+++ b/packages/server/src/routes/tunnel-ws.ts
@@ -4,9 +4,13 @@ import { WebSocketServer, WebSocket as NodeWebSocket } from "ws";
 import { getAuth } from "../auth.js";
 import { getTunnelRelay } from "../tunnel-relay.js";
 import { getSession } from "../ws/sio-state.js";
+import { getRunnerData } from "../ws/sio-registry.js";
 import { createLogger } from "@pizzapi/tools";
 
 const log = createLogger("tunnel-ws");
+
+/** Pattern: /api/tunnel/runner/:runnerId/:port/<rest> — checked first (more specific). */
+const RUNNER_TUNNEL_PATH_RE = /^\/api\/tunnel\/runner\/([^/]+)\/(\d+)(\/.*)?$/;
 
 /** Pattern: /api/tunnel/:sessionId/:port/<rest> */
 const TUNNEL_PATH_RE = /^\/api\/tunnel\/([^/]+)\/(\d+)(\/.*)?$/;
@@ -38,6 +42,17 @@ export function handleTunnelWsUpgrade(
 ): boolean {
     const url = req.url ?? "/";
     const pathname = url.split("?")[0];
+
+    // Try runner-based path first (more specific).
+    const runnerMatch = pathname.match(RUNNER_TUNNEL_PATH_RE);
+    if (runnerMatch) {
+        handleRunnerUpgradeAsync(req, socket, head, runnerMatch, url).catch((err) => {
+            log.error("Unexpected error in runner upgrade handler:", err);
+            if (!socket.destroyed) rejectUpgrade(socket, 500, "Internal Server Error");
+        });
+        return true;
+    }
+
     const match = pathname.match(TUNNEL_PATH_RE);
     if (!match) return false;
 
@@ -227,6 +242,141 @@ async function handleUpgradeAsync(
             proxy.cancel();
         }
     });
+}
+
+/** Runner-based WebSocket tunnel upgrade — resolves runnerId directly. */
+async function handleRunnerUpgradeAsync(
+    req: IncomingMessage,
+    rawSocket: Duplex,
+    head: Buffer,
+    match: RegExpMatchArray,
+    fullUrl: string,
+): Promise<void> {
+    let runnerId: string;
+    try {
+        runnerId = decodeURIComponent(match[1]);
+    } catch {
+        rejectUpgrade(rawSocket, 400, "Bad Request");
+        return;
+    }
+
+    const port = parseInt(match[2], 10);
+    const proxyPath = match[3] ?? "/";
+
+    let pathWithQuery: string;
+    const qIdx = fullUrl.indexOf("?");
+    if (qIdx >= 0) {
+        const qs = new URLSearchParams(fullUrl.slice(qIdx + 1));
+        qs.delete("apiKey");
+        const qsStr = qs.toString();
+        pathWithQuery = qsStr ? `${proxyPath}?${qsStr}` : proxyPath;
+    } else {
+        pathWithQuery = proxyPath;
+    }
+
+    if (!runnerId || !Number.isFinite(port) || port < 1 || port > 65535) {
+        rejectUpgrade(rawSocket, 400, "Bad Request");
+        return;
+    }
+
+    const identity = await authenticateUpgrade(req);
+    if (!identity) {
+        rejectUpgrade(rawSocket, 401, "Unauthorized");
+        return;
+    }
+
+    const runnerData = await getRunnerData(runnerId);
+    if (!runnerData) {
+        rejectUpgrade(rawSocket, 404, "Runner not found");
+        return;
+    }
+
+    if (!runnerData.userId || runnerData.userId !== identity.userId) {
+        rejectUpgrade(rawSocket, 403, "Forbidden");
+        return;
+    }
+
+    const relay = getTunnelRelay();
+    if (!relay?.hasRunner(runnerId)) {
+        rejectUpgrade(rawSocket, 503, "Runner not available");
+        return;
+    }
+
+    // Reuse the common WebSocket proxy setup from handleUpgradeAsync.
+    // We inline the proxy creation here to keep the code self-contained.
+    const protocols = req.headers["sec-websocket-protocol"]
+        ? req.headers["sec-websocket-protocol"].split(",").map((s) => s.trim()).filter(Boolean)
+        : undefined;
+
+    const forwardHeaders: Record<string, string> = {};
+    for (const [key, value] of Object.entries(req.headers)) {
+        if (value === undefined) continue;
+        const lowerKey = key.toLowerCase();
+        if (HOP_BY_HOP.has(lowerKey)) continue;
+        if (lowerKey === "cookie" || lowerKey === "authorization" || lowerKey === "x-api-key") continue;
+        forwardHeaders[key] = Array.isArray(value) ? value.join(", ") : value;
+    }
+
+    const tunnelWsId = `tws-runner-${runnerId}-${port}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    let viewerWs: NodeWebSocket | null = null;
+    let closingFromRelay = false;
+    let handshakeComplete = false;
+
+    const finalizeUpgrade = (protocol?: string): void => {
+        if (handshakeComplete || rawSocket.destroyed) {
+            if (rawSocket.destroyed) relay.sendWsClose(runnerId, tunnelWsId, 1001, "viewer disconnected");
+            return;
+        }
+        if (protocol) req.headers["sec-websocket-protocol"] = protocol;
+        handshakeComplete = true;
+        tunnelProxyWss.handleUpgrade(req, rawSocket, head, (ws) => {
+            viewerWs = ws;
+            ws.on("message", (data, isBinary) => {
+                relay.sendWsData(runnerId, tunnelWsId, isBinary ? Buffer.from(data as Buffer).toString("base64") : data.toString(), isBinary || undefined);
+            });
+            ws.on("close", (code, reason) => {
+                if (!closingFromRelay) relay.sendWsClose(runnerId, tunnelWsId, code, reason.toString());
+            });
+            ws.on("error", () => {
+                if (!closingFromRelay) relay.sendWsClose(runnerId, tunnelWsId, 1011, "viewer websocket error");
+            });
+        });
+    };
+
+    const closePendingSocket = (status: number, message: string): void => {
+        if (handshakeComplete || rawSocket.destroyed) return;
+        rejectUpgrade(rawSocket, status, message);
+    };
+
+    const proxy = relay.proxyWsOpen(
+        runnerId,
+        { id: tunnelWsId, port, path: pathWithQuery, protocols, headers: forwardHeaders },
+        {
+            onOpened: (protocol) => finalizeUpgrade(protocol),
+            onData: (data, binary) => {
+                if (!viewerWs || viewerWs.readyState !== NodeWebSocket.OPEN) return;
+                viewerWs.send(binary ? Buffer.from(data, "base64") : data);
+            },
+            onClose: (code, reason) => {
+                if (!handshakeComplete) { closePendingSocket(502, reason || "Tunnel WebSocket closed"); return; }
+                if (!viewerWs || viewerWs.readyState >= NodeWebSocket.CLOSING) return;
+                closingFromRelay = true;
+                viewerWs.close(code ?? 1000, reason ?? "");
+            },
+            onError: (message) => {
+                if (!handshakeComplete) {
+                    closePendingSocket(message.includes("not connected") || message.includes("disconnected") ? 503 : 502, message);
+                    return;
+                }
+                if (!viewerWs || viewerWs.readyState >= NodeWebSocket.CLOSING) return;
+                closingFromRelay = true;
+                viewerWs.close(1011, message);
+            },
+        },
+    );
+
+    rawSocket.once("close", () => { if (!handshakeComplete) proxy.cancel(); });
+    rawSocket.once("error", () => { if (!handshakeComplete) proxy.cancel(); });
 }
 
 async function authenticateUpgrade(req: IncomingMessage): Promise<{ userId: string } | null> {

--- a/packages/server/src/routes/tunnel.test.ts
+++ b/packages/server/src/routes/tunnel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
     getTunnelBasePath,
+    getRunnerTunnelBasePath,
     rewriteTunnelHtml,
     rewriteInlineModuleScripts,
     rewriteTunnelUrl,
@@ -14,6 +15,10 @@ import {
 describe("tunnel route URL rewriting", () => {
     test("getTunnelBasePath builds the session-scoped proxy prefix", () => {
         expect(getTunnelBasePath("session-123", 60434)).toBe("/api/tunnel/session-123/60434");
+    });
+
+    test("getRunnerTunnelBasePath builds the runner-scoped proxy prefix", () => {
+        expect(getRunnerTunnelBasePath("runner-abc", 3000)).toBe("/api/tunnel/runner/runner-abc/3000");
     });
 
     test("rewriteTunnelUrl prefixes root-relative paths", () => {

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -1,16 +1,24 @@
 /**
- * Tunnel HTTP proxy route — /api/tunnel/:sessionId/:port/*
+ * Tunnel HTTP proxy route — /api/tunnel/:sessionId/:port/* and /api/tunnel/runner/:runnerId/:port/*
  *
  * Translates an authenticated viewer's HTTP request into a streamed relay
  * request sent to the runner daemon, then writes the streamed response back as
  * an HTTP response. WebSocket upgrades on this path are handled by tunnel-ws.ts.
+ *
+ * Two URL schemes:
+ *   - Session-based: /api/tunnel/:sessionId/:port/* (legacy, resolves sessionId → runnerId)
+ *   - Runner-based:  /api/tunnel/runner/:runnerId/:port/* (preferred, stable across session switches)
  */
 
 import type { TunnelRelay } from "@pizzapi/tunnel";
 import { requireSession } from "../middleware.js";
 import { getTunnelRelay } from "../tunnel-relay.js";
 import { getSession } from "../ws/sio-state.js";
+import { getRunnerData } from "../ws/sio-registry.js";
 import type { RouteHandler } from "./types.js";
+
+/** Pattern: /api/tunnel/runner/:runnerId/:port/<rest> — must be checked first (more specific). */
+const RUNNER_TUNNEL_PATH_RE = /^\/api\/tunnel\/runner\/([^/]+)\/(\d+)(\/.*)?$/;
 
 /** Pattern: /api/tunnel/:sessionId/:port/<rest> */
 const TUNNEL_PATH_RE = /^\/api\/tunnel\/([^/]+)\/(\d+)(\/.*)?$/;
@@ -19,14 +27,19 @@ function getTunnelBasePath(sessionId: string, port: number): string {
     return `/api/tunnel/${encodeURIComponent(sessionId)}/${port}`;
 }
 
-function rewriteTunnelUrl(value: string, sessionId: string, port: number): string {
+function getRunnerTunnelBasePath(runnerId: string, port: number): string {
+    return `/api/tunnel/runner/${encodeURIComponent(runnerId)}/${port}`;
+}
+
+/** Core URL rewriter — all variants delegate here. */
+function rewriteUrlByBasePath(value: string, basePath: string): string {
     if (!value) return value;
     if (value.startsWith("//")) return value;
     if (/^[a-zA-Z][a-zA-Z\d+.-]*:/.test(value)) {
         try {
             const parsed = new URL(value);
             if ((parsed.protocol === "http:" || parsed.protocol === "https:") && (parsed.hostname === "127.0.0.1" || parsed.hostname === "localhost")) {
-                return `${getTunnelBasePath(sessionId, port)}${parsed.pathname}${parsed.search}${parsed.hash}`;
+                return `${basePath}${parsed.pathname}${parsed.search}${parsed.hash}`;
             }
         } catch {
             return value;
@@ -34,7 +47,11 @@ function rewriteTunnelUrl(value: string, sessionId: string, port: number): strin
         return value;
     }
     if (!value.startsWith("/")) return value;
-    return `${getTunnelBasePath(sessionId, port)}${value}`;
+    return `${basePath}${value}`;
+}
+
+function rewriteTunnelUrl(value: string, sessionId: string, port: number): string {
+    return rewriteUrlByBasePath(value, getTunnelBasePath(sessionId, port));
 }
 
 /**
@@ -182,17 +199,18 @@ function buildTunnelInterceptScript(basePath: string): string {
 </script>`;
 }
 
-function rewriteInlineModuleScripts(html: string, sessionId: string, port: number): string {
+function rewriteInlineModuleScriptsByBasePath(html: string, basePath: string): string {
     return html.replace(/<script\b([^>]*)type=["']module["']([^>]*)>([\s\S]*?)<\/script>/gi, (match, before, after, scriptBody) => {
-        // Skip external module scripts; their src attribute is already rewritten separately.
         if (/\bsrc\s*=/i.test(before) || /\bsrc\s*=/i.test(after)) return match;
-        return `<script${before}type="module"${after}>${rewriteTunnelJsModule(scriptBody, sessionId, port)}</script>`;
+        return `<script${before}type="module"${after}>${rewriteJsModuleByBasePath(scriptBody, basePath)}</script>`;
     });
 }
 
-function rewriteTunnelHtml(html: string, sessionId: string, port: number, proxyPath?: string): string {
-    const basePath = getTunnelBasePath(sessionId, port);
+function rewriteInlineModuleScripts(html: string, sessionId: string, port: number): string {
+    return rewriteInlineModuleScriptsByBasePath(html, getTunnelBasePath(sessionId, port));
+}
 
+function rewriteHtmlByBasePath(html: string, basePath: string, proxyPath?: string): string {
     // Compute the base href from the actual document path so relative URLs
     // in apps served from sub-paths (e.g. Jellyfin at /web/) resolve correctly.
     // The interceptor script still uses the tunnel root for root-relative rewrites.
@@ -207,15 +225,14 @@ function rewriteTunnelHtml(html: string, sessionId: string, port: number, proxyP
     // must be the only <base> so it takes effect per the HTML spec (first wins).
     const cleaned = html.replace(/<base\b[^>]*>/gi, "");
 
-    const rewritten = rewriteInlineModuleScripts(
+    const rewritten = rewriteInlineModuleScriptsByBasePath(
         cleaned
-            .replace(/(<(?:img|script|iframe|audio|video|source|track|embed|input)\b[^>]*\bsrc=["'])(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteTunnelUrl(path, sessionId, port)}${end}`)
-            .replace(/(<(?:a|link|area)\b[^>]*\bhref=["'])(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteTunnelUrl(path, sessionId, port)}${end}`)
-            .replace(/(<(?:form)\b[^>]*\baction=["'])(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteTunnelUrl(path, sessionId, port)}${end}`)
-            .replace(/(<meta\b[^>]*\bcontent=["'][^"']*?url=)(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteTunnelUrl(path, sessionId, port)}${end}`)
-            .replace(/(\burl\(["']?)(\/[^)"']*)(["']?\))/gi, (_m, start, path, end) => `${start}${rewriteTunnelUrl(path, sessionId, port)}${end}`),
-        sessionId,
-        port,
+            .replace(/(<(?:img|script|iframe|audio|video|source|track|embed|input)\b[^>]*\bsrc=["'])(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteUrlByBasePath(path, basePath)}${end}`)
+            .replace(/(<(?:a|link|area)\b[^>]*\bhref=["'])(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteUrlByBasePath(path, basePath)}${end}`)
+            .replace(/(<(?:form)\b[^>]*\baction=["'])(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteUrlByBasePath(path, basePath)}${end}`)
+            .replace(/(<meta\b[^>]*\bcontent=["'][^"']*?url=)(\/[^"']*)(["'])/gi, (_m, start, path, end) => `${start}${rewriteUrlByBasePath(path, basePath)}${end}`)
+            .replace(/(\burl\(["']?)(\/[^)"']*)(["']?\))/gi, (_m, start, path, end) => `${start}${rewriteUrlByBasePath(path, basePath)}${end}`),
+        basePath,
     );
 
     const injection = `<base href="${baseHref}">${buildTunnelInterceptScript(basePath)}`;
@@ -225,6 +242,10 @@ function rewriteTunnelHtml(html: string, sessionId: string, port: number, proxyP
     }
 
     return `${injection}${rewritten}`;
+}
+
+function rewriteTunnelHtml(html: string, sessionId: string, port: number, proxyPath?: string): string {
+    return rewriteHtmlByBasePath(html, getTunnelBasePath(sessionId, port), proxyPath);
 }
 
 function shouldRewriteTunnelHtml(contentType: string | null): boolean {
@@ -261,9 +282,7 @@ function shouldRewriteTunnelCss(contentType: string | null): boolean {
  * Only rewrites root-relative paths (`/...`). Leaves relative paths, bare
  * specifiers, and full URLs (http://, //) untouched.
  */
-function rewriteTunnelJsModule(js: string, sessionId: string, port: number): string {
-    const basePath = getTunnelBasePath(sessionId, port);
-
+function rewriteJsModuleByBasePath(js: string, basePath: string): string {
     // Already-rewritten paths start with basePath — skip them.
     // The regex matches: (from/import)( whitespace "or' )( /path )( "or' )
     // We capture the absolute path and prefix it.
@@ -286,12 +305,14 @@ function rewriteTunnelJsModule(js: string, sessionId: string, port: number): str
         });
 }
 
+function rewriteTunnelJsModule(js: string, sessionId: string, port: number): string {
+    return rewriteJsModuleByBasePath(js, getTunnelBasePath(sessionId, port));
+}
+
 /**
  * Rewrite absolute paths in CSS — @import and url() references.
  */
-function rewriteTunnelCss(css: string, sessionId: string, port: number): string {
-    const basePath = getTunnelBasePath(sessionId, port);
-
+function rewriteCssByBasePath(css: string, basePath: string): string {
     return css
         // @import "/path" or @import '/path' or @import url("/path")
         .replace(/(@import\s+)(["'])(\/(?!\/)[^"']*)(["'])/g, (match, prefix, q1, path, q2) => {
@@ -305,49 +326,48 @@ function rewriteTunnelCss(css: string, sessionId: string, port: number): string 
         });
 }
 
+function rewriteTunnelCss(css: string, sessionId: string, port: number): string {
+    return rewriteCssByBasePath(css, getTunnelBasePath(sessionId, port));
+}
+
 function shouldBufferTunnelResponse(contentType: string | null): boolean {
     return shouldRewriteTunnelHtml(contentType)
         || shouldRewriteTunnelJs(contentType)
         || shouldRewriteTunnelCss(contentType);
 }
 
-function applyTunnelResponseHeaders(responseHeaders: Headers, sessionId: string, port: number): void {
+function applyResponseHeadersByBasePath(responseHeaders: Headers, basePath: string): void {
     const location = responseHeaders.get("location");
     if (location) {
-        responseHeaders.set("location", rewriteTunnelUrl(location, sessionId, port));
+        responseHeaders.set("location", rewriteUrlByBasePath(location, basePath));
     }
-
     responseHeaders.set("x-pizzapi-tunnel", "1");
 }
 
-function rewriteBufferedTunnelResponse(
+function rewriteBufferedResponseByBasePath(
     responseBody: Buffer,
     responseHeaders: Headers,
-    sessionId: string,
-    port: number,
+    basePath: string,
     proxyPath: string,
 ): Buffer {
     const contentType = responseHeaders.get("content-type");
 
     if (shouldRewriteTunnelHtml(contentType)) {
-        const html = responseBody.toString("utf8");
         responseHeaders.delete("content-length");
         responseHeaders.delete("content-encoding");
-        return Buffer.from(rewriteTunnelHtml(html, sessionId, port, proxyPath), "utf8");
+        return Buffer.from(rewriteHtmlByBasePath(responseBody.toString("utf8"), basePath, proxyPath), "utf8");
     }
 
     if (shouldRewriteTunnelJs(contentType)) {
-        const js = responseBody.toString("utf8");
         responseHeaders.delete("content-length");
         responseHeaders.delete("content-encoding");
-        return Buffer.from(rewriteTunnelJsModule(js, sessionId, port), "utf8");
+        return Buffer.from(rewriteJsModuleByBasePath(responseBody.toString("utf8"), basePath), "utf8");
     }
 
     if (shouldRewriteTunnelCss(contentType)) {
-        const css = responseBody.toString("utf8");
         responseHeaders.delete("content-length");
         responseHeaders.delete("content-encoding");
-        return Buffer.from(rewriteTunnelCss(css, sessionId, port), "utf8");
+        return Buffer.from(rewriteCssByBasePath(responseBody.toString("utf8"), basePath), "utf8");
     }
 
     return responseBody;
@@ -400,7 +420,7 @@ function proxyTunnelRequestViaRelay(
     relay: TunnelRelay,
     runnerId: string,
     requestId: string,
-    sessionId: string,
+    basePath: string,
     port: number,
     proxyPath: string,
     pathWithQuery: string,
@@ -446,7 +466,7 @@ function proxyTunnelRequestViaRelay(
                     shouldBuffer = shouldBufferTunnelResponse(responseHeaders.get("content-type"));
                     if (shouldBuffer) return;
 
-                    applyTunnelResponseHeaders(responseHeaders, sessionId, port);
+                    applyResponseHeadersByBasePath(responseHeaders, basePath);
                     const stream = new ReadableStream<Uint8Array>({
                         start(controller) {
                             streamController = controller;
@@ -478,14 +498,13 @@ function proxyTunnelRequestViaRelay(
                             return;
                         }
 
-                        const responseBody = rewriteBufferedTunnelResponse(
+                        const responseBody = rewriteBufferedResponseByBasePath(
                             Buffer.concat(bodyChunks),
                             responseHeaders,
-                            sessionId,
-                            port,
+                            basePath,
                             proxyPath,
                         );
-                        applyTunnelResponseHeaders(responseHeaders, sessionId, port);
+                        applyResponseHeadersByBasePath(responseHeaders, basePath);
                         resolveOnce(new Response(bufferToBodyInit(responseBody), {
                             status: statusCode,
                             headers: responseHeaders,
@@ -534,6 +553,10 @@ function proxyTunnelRequestViaRelay(
  * runner's localhost — they should not be openly accessible to all viewers.
  */
 export const handleTunnelRoute: RouteHandler = async (req, url) => {
+    // Try runner-based path first (more specific prefix avoids false matches).
+    const runnerMatch = url.pathname.match(RUNNER_TUNNEL_PATH_RE);
+    if (runnerMatch) return handleRunnerTunnel(req, url, runnerMatch);
+
     const match = url.pathname.match(TUNNEL_PATH_RE);
     if (!match) return undefined;
 
@@ -634,7 +657,7 @@ export const handleTunnelRoute: RouteHandler = async (req, url) => {
         relay,
         runnerId,
         requestId,
-        sessionId,
+        getTunnelBasePath(sessionId, port),
         port,
         proxyPath,
         pathWithQuery,
@@ -642,8 +665,97 @@ export const handleTunnelRoute: RouteHandler = async (req, url) => {
     );
 };
 
+// ── Hop-by-hop and auth header sets (shared between session and runner handlers) ──
+const HOP_BY_HOP_HEADERS = new Set([
+    "connection", "keep-alive", "transfer-encoding", "te", "trailer",
+    "upgrade", "proxy-authorization", "proxy-authenticate",
+    "host",        // Rewrite host to 127.0.0.1:{port} in the runner
+    "accept-encoding",  // Strip so local service returns uncompressed
+]);
+
+const STRIP_AUTH_HEADERS = new Set(["cookie", "authorization", "x-api-key"]);
+
+function buildForwardHeaders(req: Request): Record<string, string> {
+    const forwardHeaders: Record<string, string> = {};
+    req.headers.forEach((v, k) => {
+        const lk = k.toLowerCase();
+        if (!HOP_BY_HOP_HEADERS.has(lk) && !STRIP_AUTH_HEADERS.has(lk)) forwardHeaders[k] = v;
+    });
+    return forwardHeaders;
+}
+
+function buildPathWithQuery(url: URL, proxyPath: string): string {
+    if (url.search) {
+        const qs = new URLSearchParams(url.search.slice(1));
+        qs.delete("apiKey");
+        const qsStr = qs.toString();
+        return qsStr ? `${proxyPath}?${qsStr}` : proxyPath;
+    }
+    return proxyPath;
+}
+
+/**
+ * Runner-based tunnel route handler.
+ *
+ * URL: /api/tunnel/runner/:runnerId/:port/*
+ *
+ * Resolves the runner directly (no session lookup needed). This makes tunnel
+ * URLs stable across session switches — the URL survives session restarts as
+ * long as the runner daemon is alive.
+ */
+async function handleRunnerTunnel(req: Request, url: URL, match: RegExpMatchArray): Promise<Response> {
+    const method = req.method.toUpperCase();
+    if (!["GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"].includes(method)) {
+        return new Response("Method not allowed", {
+            status: 405,
+            headers: { Allow: "GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS" },
+        });
+    }
+
+    const identity = await requireSession(req);
+    if (identity instanceof Response) return identity;
+
+    const runnerId = decodeURIComponent(match[1]);
+    const port = parseInt(match[2], 10);
+    const proxyPath = match[3] ?? "/";
+
+    if (!runnerId) return Response.json({ error: "Missing runner ID" }, { status: 400 });
+    if (!Number.isFinite(port) || port < 1 || port > 65535) {
+        return Response.json({ error: "Invalid port" }, { status: 400 });
+    }
+
+    const pathWithQuery = buildPathWithQuery(url, proxyPath);
+
+    // Verify runner ownership — tunnels expose localhost.
+    const runnerData = await getRunnerData(runnerId);
+    if (!runnerData) return Response.json({ error: "Runner not found" }, { status: 404 });
+    if (!runnerData.userId || runnerData.userId !== identity.userId) {
+        return Response.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    const relay = getTunnelRelay();
+    if (!relay?.hasRunner(runnerId)) {
+        return tunnelErrorResponse(`Runner ${runnerId} not connected`);
+    }
+
+    const requestId = `runner-${runnerId}-${port}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    return proxyTunnelRequestViaRelay(
+        req,
+        relay,
+        runnerId,
+        requestId,
+        getRunnerTunnelBasePath(runnerId, port),
+        port,
+        proxyPath,
+        pathWithQuery,
+        buildForwardHeaders(req),
+    );
+}
+
 export {
     getTunnelBasePath,
+    getRunnerTunnelBasePath,
     rewriteTunnelUrl,
     rewriteTunnelHtml,
     rewriteInlineModuleScripts,

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3700,6 +3700,22 @@ export function App() {
   const { services: availableServices, panels: dynamicPanels } = useRunnerServices(viewerSocket);
   const { activePanelIds: activeServicePanels, togglePanel: toggleServicePanel, closePanelById: closeServicePanelById, closeAllPanels: closeAllServicePanels, getPanelPosition: getServicePanelPosition, setPanelPosition: setServicePanelPosition, setEphemeralPanelPosition: setEphemeralServicePanelPosition } = useServicePanelState();
 
+  // Auto-open Tunnel panel when a non-pinned tunnel is registered.
+  React.useEffect(() => {
+    if (!viewerSocket) return;
+    const handler = (envelope: { serviceId: string; type: string; payload: unknown }) => {
+      if (envelope.serviceId !== "tunnel" || envelope.type !== "tunnel_registered") return;
+      const info = envelope.payload as { pinned?: boolean } | undefined;
+      if (info?.pinned) return; // Don't auto-open for daemon-pinned panel ports
+      // Open the Tunnel panel if not already open
+      if (!activeServicePanels.has("tunnel")) {
+        toggleServicePanel("tunnel");
+      }
+    };
+    viewerSocket.on("service_message", handler);
+    return () => { viewerSocket.off("service_message", handler); };
+  }, [viewerSocket, activeServicePanels, toggleServicePanel]);
+
   const handleToggleServicePanel = React.useCallback((serviceId: string) => {
     if (activeServicePanels.has(serviceId)) {
       closeServicePanelById(serviceId);
@@ -3805,7 +3821,7 @@ export function App() {
       const label = staticDef?.label ?? dynamicDef!.label;
       const icon = staticDef?.icon ?? <DynamicLucideIcon name={dynamicDef!.icon} />;
       const content = staticDef
-        ? <staticDef.component sessionId={effectiveSessionId} />
+        ? <staticDef.component sessionId={effectiveSessionId} runnerId={activeSessionInfo?.runnerId ?? undefined} />
         : <IframeServicePanel sessionId={effectiveSessionId} port={dynamicDef!.port} />;
 
       tabs.push({

--- a/packages/ui/src/components/TunnelPanel.tsx
+++ b/packages/ui/src/components/TunnelPanel.tsx
@@ -11,9 +11,10 @@ interface TunnelInfo {
 
 interface TunnelPanelProps {
     sessionId: string;
+    runnerId?: string;
 }
 
-export function TunnelPanel({ sessionId }: TunnelPanelProps) {
+export function TunnelPanel({ sessionId, runnerId }: TunnelPanelProps) {
     const [tunnels, setTunnels] = useState<TunnelInfo[]>([]);
     const [portInput, setPortInput] = useState("");
     const [nameInput, setNameInput] = useState("");
@@ -78,7 +79,10 @@ export function TunnelPanel({ sessionId }: TunnelPanelProps) {
 
     if (!available) return null;
 
-    const tunnelUrl = (port: number) => `/api/tunnel/${sessionId}/${port}/`;
+    const tunnelUrl = (port: number) =>
+        runnerId
+            ? `/api/tunnel/runner/${encodeURIComponent(runnerId)}/${port}/`
+            : `/api/tunnel/${sessionId}/${port}/`;
 
     return (
         <div className="flex flex-col h-full">

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -87,6 +87,7 @@ export function ServicePanelButtons({
 interface ServicePanelContainerProps {
     activePanelId: string | null;
     sessionId: string;
+    runnerId?: string;
     /** Dynamic panels from service_announce. */
     dynamicPanels?: ServicePanelInfo[];
     onClose: () => void;
@@ -96,6 +97,7 @@ interface ServicePanelContainerProps {
 export function ServicePanelContainer({
     activePanelId,
     sessionId,
+    runnerId,
     dynamicPanels = [],
     onClose,
     position = "bottom",
@@ -140,7 +142,7 @@ export function ServicePanelContainer({
             {/* Panel content */}
             <div className="flex-1 overflow-hidden">
                 {staticDef ? (
-                    <staticDef.component sessionId={sessionId} />
+                    <staticDef.component sessionId={sessionId} runnerId={runnerId} />
                 ) : (
                     <IframeServicePanel sessionId={sessionId} port={dynamicDef!.port} />
                 )}

--- a/packages/ui/src/components/service-panels/registry.tsx
+++ b/packages/ui/src/components/service-panels/registry.tsx
@@ -31,8 +31,8 @@ export interface ServicePanelDef {
     label: string;
     /** Icon component (lucide) */
     icon: React.ReactNode;
-    /** The panel component to render. Receives sessionId as a prop. */
-    component: React.ComponentType<{ sessionId: string }>;
+    /** The panel component to render. Receives sessionId and optional runnerId as props. */
+    component: React.ComponentType<{ sessionId: string; runnerId?: string }>;
 }
 
 /**


### PR DESCRIPTION
## What was fixed

### Bug 1: Wrong URLs returned to the agent
Tunnels are **runner-scoped** (they live on the runner daemon and survive session switches), but the URLs returned by `create_tunnel` used **session IDs** — which break when the session ends even though the tunnel is still alive.

**Fix:** Added a new runner-based tunnel route `/api/tunnel/runner/:runnerId/:port/*` to both HTTP and WebSocket handlers on the server. The agent tool now reads the runner ID from `~/.pizzapi/runner.json` and returns runner-based URLs by default, falling back to session-based URLs only if the runner ID isn't available.

### Bug 2: Tunnel Panel doesn't auto-open
When the agent called `create_tunnel`, the `tunnel_registered` event updated the TunnelPanel's internal state, but the panel stayed hidden unless the user manually clicked the Tunnels button.

**Fix:** Added a `useEffect` in `App.tsx` that listens for `tunnel_registered` service messages and automatically opens the Tunnel panel when a non-pinned tunnel is created.

## Files changed (9 files, +416/-52)

| File | Change |
|------|--------|
| `packages/server/src/routes/tunnel.ts` | Refactored rewrite functions to use `basePath` internally; added runner-based route handler + `getRunnerTunnelBasePath` |
| `packages/server/src/routes/tunnel-ws.ts` | Added runner-based WebSocket upgrade handler |
| `packages/cli/src/extensions/tunnel-tools.ts` | `buildPublicTunnelUrl` now prefers runner-based URLs |
| `packages/ui/src/App.tsx` | Auto-open Tunnel panel on `tunnel_registered`; pass `runnerId` to static service panels |
| `packages/ui/src/components/TunnelPanel.tsx` | Uses runner-based URLs for iframe previews and "open in new tab" links |
| `packages/ui/src/components/service-panels/registry.tsx` | Extended component type to accept `runnerId` prop |
| `packages/ui/src/components/service-panels/ServicePanels.tsx` | Pass `runnerId` through to static panel components |
| `packages/server/src/routes/tunnel.test.ts` | Added `getRunnerTunnelBasePath` test |
| `packages/cli/src/extensions/tunnel-tools.test.ts` | Added runner-based URL test + fallback test |

## Testing
- ✅ All 50 tunnel tests pass (tunnel-tools + server tunnel route)
- ✅ All 741 UI tests pass
- ✅ Typecheck clean
- ✅ Full build succeeds
- Session-based route preserved for backward compatibility