### PR TITLE
fix(git): stale state guard, repo-root paths, explicit isRemote checkout

### DIFF
--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -136,36 +136,40 @@ export class GitService implements ServiceHandler {
         if (!cwd) return;
 
         try {
-            const [branchResult, statusResult, diffStagedResult, abResult] = await Promise.allSettled([
+            const [branchResult, toplevelResult, statusResult, diffStagedResult, abResult] = await Promise.allSettled([
                 execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 }),
-                execFileAsync("git", ["status", "--porcelain=v1", "-uall"], { cwd, timeout: 10000 }),
+                execFileAsync("git", ["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 }),
+                // Use -z for NUL-delimited output — avoids C-quoting of filenames
+                // with spaces/special chars and makes parsing unambiguous.
+                execFileAsync("git", ["status", "--porcelain=v1", "-uall", "-z"], { cwd, timeout: 10000 }),
                 execFileAsync("git", ["diff", "--cached", "--stat"], { cwd, timeout: 10000 }),
                 execFileAsync("git", ["rev-list", "--left-right", "--count", "HEAD...@{u}"], { cwd, timeout: 5000 }),
             ]);
 
             const branch = branchResult.status === "fulfilled" ? branchResult.value.stdout.trim() : "";
+            const repoRoot = toplevelResult.status === "fulfilled" ? toplevelResult.value.stdout.trim() : cwd;
             const statusOutput = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
             const diffStaged = diffStagedResult.status === "fulfilled" ? diffStagedResult.value.stdout : "";
 
-            // Parse porcelain v1 output.
+            // Parse porcelain v1 -z output (NUL-delimited).
+            // Format: XY PATH\0 (for renames: XY ORIG\0NEW\0)
             // IMPORTANT: preserve the raw 2-char XY status (e.g. " M", "M ", "MM", "??").
-            // The UI's partition logic depends on checking X (index) and Y (worktree)
-            // positions separately. Trimming collapses " M" and "M " into "M", breaking
-            // the staged/unstaged categorization.
             const changes: Array<{ status: string; path: string; originalPath?: string }> = [];
-            for (const line of statusOutput.split("\n")) {
-                if (!line.trim()) continue;
-                const xy = line.substring(0, 2);
-                const rest = line.substring(3);
-                const arrowIdx = rest.indexOf(" -> ");
-                if (arrowIdx >= 0) {
-                    changes.push({
-                        status: xy,
-                        path: rest.substring(arrowIdx + 4),
-                        originalPath: rest.substring(0, arrowIdx),
-                    });
+            const entries = statusOutput.split("\0");
+            let i = 0;
+            while (i < entries.length) {
+                const entry = entries[i];
+                if (!entry || entry.length < 3) { i++; continue; }
+                const xy = entry.substring(0, 2);
+                const path = entry.substring(3);
+                // Renames (R/C) have a second NUL-delimited field for the new path
+                if (xy[0] === "R" || xy[0] === "C") {
+                    const newPath = entries[i + 1] ?? path;
+                    changes.push({ status: xy, path: newPath, originalPath: path });
+                    i += 2;
                 } else {
-                    changes.push({ status: xy, path: rest });
+                    changes.push({ status: xy, path });
+                    i++;
                 }
             }
 
@@ -182,6 +186,7 @@ export class GitService implements ServiceHandler {
             this.emit("git_status_result", {
                 ok: true,
                 branch,
+                repoRoot,
                 changes,
                 ahead,
                 behind,
@@ -212,10 +217,17 @@ export class GitService implements ServiceHandler {
         }
 
         try {
+            // Resolve repo root — paths from git status are repo-root-relative,
+            // so diff must run from repo root for paths to resolve correctly.
+            const { stdout: toplevel } = await execFileAsync(
+                "git", ["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
+            );
+            const repoRoot = toplevel.trim() || cwd;
+
             const args = staged
                 ? ["diff", "--cached", "--", filePath]
                 : ["diff", "--", filePath];
-            const { stdout: diff } = await execFileAsync("git", args, { cwd, timeout: 10000 });
+            const { stdout: diff } = await execFileAsync("git", args, { cwd: repoRoot, timeout: 10000 });
             this.emit("git_diff_result", { ok: true, diff }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_diff_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
@@ -323,26 +335,21 @@ export class GitService implements ServiceHandler {
             return;
         }
 
+        // The UI passes isRemote explicitly based on which section the user
+        // clicked (local vs remote). This avoids name heuristics that misclassify
+        // local branches like "feature/foo" when a remote named "feature" exists.
+        const isRemote = payload.isRemote === true;
+
         try {
-            // Detect remote tracking branches (e.g. "origin/foo", "upstream/bar").
-            // Extract local branch name and use `git switch --track` for safe checkout.
-            const remoteMatch = branch.match(/^([^/]+)\/(.+)$/);
             let targetBranch = branch;
-
-            // Check if this looks like a remote branch by verifying the remote exists
-            let isRemoteRef = false;
-            if (remoteMatch) {
-                try {
-                    await execFileAsync("git", ["remote", "get-url", remoteMatch[1]], { cwd, timeout: 5000 });
-                    isRemoteRef = true;
-                } catch {
-                    // Not a known remote — treat as a local branch name containing "/"
-                }
-            }
-
             const args: string[] = [];
-            if (isRemoteRef && remoteMatch) {
-                targetBranch = remoteMatch[2];
+
+            if (isRemote) {
+                // Remote branch: extract local name from "remote/branch" and create tracking branch
+                const slashIdx = branch.indexOf("/");
+                if (slashIdx > 0) {
+                    targetBranch = branch.substring(slashIdx + 1);
+                }
                 // Check if a local branch with this name already exists
                 try {
                     await execFileAsync("git", ["rev-parse", "--verify", `refs/heads/${targetBranch}`], { cwd, timeout: 5000 });
@@ -353,6 +360,7 @@ export class GitService implements ServiceHandler {
                     args.push("checkout", "-b", targetBranch, branch);
                 }
             } else {
+                // Local branch — check out directly
                 args.push("checkout", targetBranch);
             }
 
@@ -396,8 +404,15 @@ export class GitService implements ServiceHandler {
         }
 
         try {
+            // Resolve repo root — paths from git status are repo-root-relative,
+            // so operations must run from repo root for paths to resolve correctly.
+            const { stdout: toplevel } = await execFileAsync(
+                "git", ["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
+            );
+            const repoRoot = toplevel.trim() || cwd;
+
             const args = all ? ["add", "--all"] : ["add", "--", ...paths];
-            await execFileAsync("git", args, { cwd, timeout: 15000 });
+            await execFileAsync("git", args, { cwd: repoRoot, timeout: 15000 });
             this.emit("git_stage_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_stage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
@@ -432,10 +447,18 @@ export class GitService implements ServiceHandler {
         }
 
         try {
+            // Resolve repo root — run from there so repo-root-relative paths work.
+            // For unstage-all, use ":/" pathspec (magic "repo root") instead of "."
+            // which would only cover the cwd subtree.
+            const { stdout: toplevel } = await execFileAsync(
+                "git", ["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
+            );
+            const repoRoot = toplevel.trim() || cwd;
+
             const args = all
-                ? ["restore", "--staged", "."]
+                ? ["restore", "--staged", ":/"]
                 : ["restore", "--staged", "--", ...paths];
-            await execFileAsync("git", args, { cwd, timeout: 15000 });
+            await execFileAsync("git", args, { cwd: repoRoot, timeout: 15000 });
             this.emit("git_unstage_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_unstage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);

--- a/packages/ui/src/components/git/GitBranchSelector.tsx
+++ b/packages/ui/src/components/git/GitBranchSelector.tsx
@@ -6,7 +6,7 @@ import type { GitBranch } from "@/hooks/useGitService";
 interface GitBranchSelectorProps {
     currentBranch: string;
     branches: GitBranch[];
-    onCheckout: (branch: string) => void;
+    onCheckout: (branch: string, isRemote: boolean) => void;
     onOpen: () => void;
     disabled?: boolean;
     isCheckingOut?: boolean;
@@ -71,7 +71,7 @@ export function GitBranchSelector({
             setSearch("");
             return;
         }
-        onCheckout(branch.name);
+        onCheckout(branch.name, branch.isRemote);
         setOpen(false);
         setSearch("");
     };

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -60,7 +60,7 @@ export interface UseGitServiceReturn {
     fetchStatus: () => void;
     fetchDiff: (path: string, staged?: boolean) => Promise<string>;
     fetchBranches: () => void;
-    checkout: (branch: string) => void;
+    checkout: (branch: string, isRemote?: boolean) => void;
     stage: (paths: string[]) => void;
     stageAll: () => void;
     unstage: (paths: string[]) => void;
@@ -82,6 +82,12 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     // Track pending diff requests: requestId → resolve callback
     const pendingDiffsRef = useRef(new Map<string, (diff: string) => void>());
 
+    // Generation counter — incremented on cwd change. Responses from stale
+    // generations are discarded so a slow response from the old cwd doesn't
+    // overwrite the new session's state.
+    const generationRef = useRef(0);
+    const statusGenRef = useRef(0); // generation when last status request was sent
+
     // Generate unique request IDs
     const nextId = useRef(0);
     const makeRequestId = useCallback(() => `git-${Date.now()}-${nextId.current++}`, []);
@@ -100,6 +106,8 @@ export function useGitService(cwd: string): UseGitServiceReturn {
 
             switch (type) {
                 case "git_status_result": {
+                    // Ignore stale responses from a previous cwd
+                    if (statusGenRef.current !== generationRef.current) break;
                     setLoading(false);
                     if (payload.ok) {
                         setStatus({
@@ -168,6 +176,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
 
     const fetchStatus = useCallback(() => {
         if (!available) return;
+        statusGenRef.current = generationRef.current;
         setLoading(true);
         setError(null);
         send("git_status", { cwd }, makeRequestId());
@@ -198,11 +207,11 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         send("git_branches", { cwd }, makeRequestId());
     }, [available, send, cwd, makeRequestId]);
 
-    const checkout = useCallback((branch: string) => {
+    const checkout = useCallback((branch: string, isRemote = false) => {
         if (!available) return;
         setOperationInProgress("checkout");
         setLastOperationResult(null);
-        send("git_checkout", { cwd, branch }, makeRequestId());
+        send("git_checkout", { cwd, branch, isRemote }, makeRequestId());
     }, [available, send, cwd, makeRequestId]);
 
     const stage = useCallback((paths: string[]) => {
@@ -251,11 +260,22 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         setLastOperationResult(null);
     }, []);
 
-    // Auto-fetch status when service becomes available or cwd changes
+    // Clear stale state and re-fetch when cwd changes or service becomes available.
+    // Bump generation so in-flight responses from the old cwd are discarded.
     useEffect(() => {
+        generationRef.current++;
+        // Clear state immediately so old data doesn't flash
+        setStatus(null);
+        setBranches([]);
+        setCurrentBranch("");
+        setError(null);
+        setOperationInProgress(null);
+        setLastOperationResult(null);
+        pendingDiffsRef.current.clear();
+
         if (available && cwd) {
+            statusGenRef.current = generationRef.current;
             setLoading(true);
-            setError(null);
             send("git_status", { cwd }, makeRequestId());
         }
     }, [available, cwd]); // eslint-disable-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fast-follow fixes from code review of #382.

## Fixes

### P1: Stale git state on cwd switch
Added generation counter to `useGitService`. In-flight responses from a previous cwd are discarded. State (status, branches, operations) is cleared immediately on cwd change to prevent flash of stale data.

### P1: Path handling for subdirectory sessions and special characters
- Use `-z` (NUL-delimited) output for `git status` to avoid C-quoting of filenames with spaces/special chars
- Resolve repo root via `--show-toplevel` and run diff/stage/unstage from repo root so repo-root-relative paths resolve correctly
- Unstage-all uses `:/` pathspec (repo root scope) instead of `.` which only covers the cwd subtree

### P2: Branch checkout misclassification
Checkout now accepts explicit `isRemote` flag from the UI instead of using name heuristics. Prevents local branches like `feature/foo` from being misclassified as remote when a remote named `feature` exists.

## Stats
3 files changed, +88 / -45