### PR TITLE
feat(ui): 9-zone panel grid system — 8 docking positions

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -412,8 +412,9 @@ export function App() {
   const panelLayout = usePanelLayout(activeSessionId);
   const {
     showTerminal, setShowTerminal,
-    terminalPosition, terminalHeight, terminalWidth, terminalColumnRef,
-    handleTerminalPositionChange, startPanelResizeForPosition,
+    terminalPosition,
+    terminalColumnRef,
+    handleTerminalPositionChange,
     panelDragActive, panelDragZone,
     startPanelDragWith,
     handleOuterPointerMove, handleOuterPointerUp,
@@ -421,10 +422,15 @@ export function App() {
     terminalTabs, activeTerminalId, setActiveTerminalId,
     handleTerminalTabAdd, handleTerminalTabClose,
     showFileExplorer, setShowFileExplorer,
-    filesPosition, filesContainerRef,
+    filesPosition,
     handleFilesPositionChange,
     showGit, setShowGit,
     gitPosition, handleGitPositionChange,
+    leftColumnWidth, rightColumnWidth,
+    leftTopHeight, leftBottomHeight,
+    rightTopHeight, rightBottomHeight,
+    centerTopHeight, centerBottomHeight,
+    startColumnWidthResize, startZoneHeightResize,
   } = panelLayout;
 
   const [newSessionOpen, setNewSessionOpen] = React.useState(false);
@@ -3842,13 +3848,47 @@ export function App() {
   }, [activeServicePanels, tunnelSessionId, activeSessionId, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById, handleCombinedTabChange]);
 
   const panelGroups = React.useMemo(() => {
-    const groups: Record<"left" | "right" | "bottom", CombinedPanelTab[]> = { left: [], right: [], bottom: [] };
+    type PG = import("@/hooks/usePanelLayout").PanelPosition;
+    const groups: Record<PG, CombinedPanelTab[]> = {
+      "left-top": [], "left-middle": [], "left-bottom": [],
+      "center-top": [], "center-bottom": [],
+      "right-top": [], "right-middle": [], "right-bottom": [],
+    };
     if (terminalPanelTab) groups[terminalPosition].push(terminalPanelTab);
     if (filesPanelTab) groups[filesPosition].push(filesPanelTab);
     if (gitPanelTab) groups[gitPosition].push(gitPanelTab);
     for (const tab of servicePanelTabs) groups[getServicePanelPosition(tab.id)].push(tab);
     return groups;
   }, [terminalPanelTab, terminalPosition, filesPanelTab, filesPosition, gitPanelTab, gitPosition, servicePanelTabs, getServicePanelPosition]);
+
+  // ── Derived column zone arrays ─────────────────────────────────────────────
+  // Each side column orders its zones top→middle→bottom. Middle zone fills the
+  // remaining vertical space; if absent, the first visible zone fills.
+  const leftColZones = React.useMemo(() => {
+    const candidates = [
+      { pos: "left-top"    as const, tabs: panelGroups["left-top"],    storedHeight: leftTopHeight },
+      { pos: "left-middle" as const, tabs: panelGroups["left-middle"],  storedHeight: 0 },
+      { pos: "left-bottom" as const, tabs: panelGroups["left-bottom"],  storedHeight: leftBottomHeight },
+    ].filter(z => z.tabs.length > 0);
+    const midIdx = candidates.findIndex(z => z.pos === "left-middle");
+    const fillIdx = midIdx >= 0 ? midIdx : 0;
+    return candidates.map((z, i) => ({ ...z, fills: i === fillIdx }));
+  }, [panelGroups, leftTopHeight, leftBottomHeight]);
+
+  const rightColZones = React.useMemo(() => {
+    const candidates = [
+      { pos: "right-top"    as const, tabs: panelGroups["right-top"],    storedHeight: rightTopHeight },
+      { pos: "right-middle" as const, tabs: panelGroups["right-middle"],  storedHeight: 0 },
+      { pos: "right-bottom" as const, tabs: panelGroups["right-bottom"],  storedHeight: rightBottomHeight },
+    ].filter(z => z.tabs.length > 0);
+    const midIdx = candidates.findIndex(z => z.pos === "right-middle");
+    const fillIdx = midIdx >= 0 ? midIdx : 0;
+    return candidates.map((z, i) => ({ ...z, fills: i === fillIdx }));
+  }, [panelGroups, rightTopHeight, rightBottomHeight]);
+
+  const hasPanels = React.useMemo(() =>
+    Object.values(panelGroups).some(g => g.length > 0),
+  [panelGroups]);
 
   const handleGroupPositionChange = React.useCallback((tabIds: string[], pos: import("@/hooks/usePanelLayout").PanelPosition) => {
     if (tabIds.includes("terminal")) handleTerminalPositionChange(pos);
@@ -4134,31 +4174,84 @@ export function App() {
         />
 
         <div
-          ref={filesContainerRef}
+          ref={terminalColumnRef}
           className="relative flex flex-1 min-w-0 h-full overflow-hidden"
+          onPointerMove={hasPanels ? handleOuterPointerMove : undefined}
+          onPointerUp={hasPanels ? handleOuterPointerUp : undefined}
+          onPointerCancel={hasPanels ? handleOuterPointerUp : undefined}
         >
-          <div
-            ref={terminalColumnRef}
-            className="relative flex flex-1 min-w-0 h-full flex-col"
-            onPointerMove={mobilePanelTabs.length > 0 ? handleOuterPointerMove : undefined}
-            onPointerUp={mobilePanelTabs.length > 0 ? handleOuterPointerUp : undefined}
-            onPointerCancel={mobilePanelTabs.length > 0 ? handleOuterPointerUp : undefined}
-          >
-            <div className="flex flex-1 min-w-0 min-h-0">
-              {panelGroups.left.length > 0 && (
-                <DockedPanelGroup
-                  position="left"
-                  size={terminalWidth}
-                  tabs={panelGroups.left}
-                  activeTabId={resolveActiveTabId(panelGroups.left)}
-                  onActiveTabChange={handleCombinedTabChange}
-                  onPositionChange={(pos) => handleGroupPositionChange(panelGroups.left.map(tab => tab.id), pos)}
-                  onDragStart={handleGroupDragStart(panelGroups.left.map(tab => tab.id))}
-                  onResizeStart={(e) => startPanelResizeForPosition("left", e)}
-                />
-              )}
+          {/* ── LEFT COLUMN ─────────────────────────────────────────────── */}
+          {leftColZones.length > 0 && (
+            <>
+              <div className="hidden md:flex flex-col shrink-0 min-h-0" style={{ width: leftColumnWidth }}>
+                {leftColZones.map((zone, i) => {
+                  const nextZone = leftColZones[i + 1];
+                  const handleZonePos = nextZone
+                    ? (zone.fills ? nextZone.pos : zone.pos)
+                    : undefined;
+                  return (
+                    <React.Fragment key={zone.pos}>
+                      <div
+                        className={cn(zone.fills ? "flex-1 min-h-0" : "shrink-0")}
+                        style={!zone.fills ? { height: zone.storedHeight } : undefined}
+                      >
+                        <CombinedPanel
+                          position={zone.pos}
+                          tabs={zone.tabs}
+                          activeTabId={resolveActiveTabId(zone.tabs)}
+                          onActiveTabChange={handleCombinedTabChange}
+                          onPositionChange={(pos) => handleGroupPositionChange(zone.tabs.map(t => t.id), pos)}
+                          onDragStart={handleGroupDragStart(zone.tabs.map(t => t.id))}
+                          className="h-full"
+                        />
+                      </div>
+                      {nextZone && (
+                        <div
+                          className="hidden md:flex h-[5px] cursor-row-resize shrink-0 items-center justify-center group"
+                          onPointerDown={handleZonePos ? (e) => startZoneHeightResize(handleZonePos, e) : undefined}
+                        >
+                          <div className="bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors w-full h-px" />
+                        </div>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
+              </div>
+              <div
+                className="hidden md:flex w-[5px] cursor-col-resize shrink-0 items-center justify-center group"
+                onPointerDown={(e) => startColumnWidthResize("left", e)}
+              >
+                <div className="bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors h-full w-px" />
+              </div>
+            </>
+          )}
 
-              <div id="main-content" tabIndex={-1} className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
+          {/* ── CENTER COLUMN ───────────────────────────────────────────── */}
+          <div className="flex flex-col flex-1 min-w-0 min-h-0">
+            {/* center-top zone */}
+            {panelGroups["center-top"].length > 0 && (
+              <>
+                <div className="hidden md:flex flex-col shrink-0" style={{ height: centerTopHeight }}>
+                  <CombinedPanel
+                    position="center-top"
+                    tabs={panelGroups["center-top"]}
+                    activeTabId={resolveActiveTabId(panelGroups["center-top"])}
+                    onActiveTabChange={handleCombinedTabChange}
+                    onPositionChange={(pos) => handleGroupPositionChange(panelGroups["center-top"].map(t => t.id), pos)}
+                    onDragStart={handleGroupDragStart(panelGroups["center-top"].map(t => t.id))}
+                    className="h-full"
+                  />
+                </div>
+                <div
+                  className="hidden md:flex h-[5px] cursor-row-resize shrink-0 items-center justify-center group"
+                  onPointerDown={(e) => startZoneHeightResize("center-top", e)}
+                >
+                  <div className="bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors w-full h-px" />
+                </div>
+              </>
+            )}
+
+            <div id="main-content" tabIndex={-1} className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
                 {showRunners ? (
                   <RunnerManager
                     runners={feedRunners}
@@ -4277,74 +4370,131 @@ export function App() {
                 )}
               </div>
 
-              {panelGroups.right.length > 0 && (
-                <DockedPanelGroup
-                  position="right"
-                  size={terminalWidth}
-                  tabs={panelGroups.right}
-                  activeTabId={resolveActiveTabId(panelGroups.right)}
-                  onActiveTabChange={handleCombinedTabChange}
-                  onPositionChange={(pos) => handleGroupPositionChange(panelGroups.right.map(tab => tab.id), pos)}
-                  onDragStart={handleGroupDragStart(panelGroups.right.map(tab => tab.id))}
-                  onResizeStart={(e) => startPanelResizeForPosition("right", e)}
-                />
-              )}
-            </div>
-
-            {panelGroups.bottom.length > 0 && (
-              <DockedPanelGroup
-                position="bottom"
-                size={terminalHeight}
-                tabs={panelGroups.bottom}
-                activeTabId={resolveActiveTabId(panelGroups.bottom)}
-                onActiveTabChange={handleCombinedTabChange}
-                onPositionChange={(pos) => handleGroupPositionChange(panelGroups.bottom.map(tab => tab.id), pos)}
-                onDragStart={handleGroupDragStart(panelGroups.bottom.map(tab => tab.id))}
-                onResizeStart={(e) => startPanelResizeForPosition("bottom", e)}
-              />
+            {/* center-bottom zone */}
+            {panelGroups["center-bottom"].length > 0 && (
+              <>
+                <div
+                  className="hidden md:flex h-[5px] cursor-row-resize shrink-0 items-center justify-center group"
+                  onPointerDown={(e) => startZoneHeightResize("center-bottom", e)}
+                >
+                  <div className="bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors w-full h-px" />
+                </div>
+                <div className="hidden md:flex flex-col shrink-0" style={{ height: centerBottomHeight }}>
+                  <CombinedPanel
+                    position="center-bottom"
+                    tabs={panelGroups["center-bottom"]}
+                    activeTabId={resolveActiveTabId(panelGroups["center-bottom"])}
+                    onActiveTabChange={handleCombinedTabChange}
+                    onPositionChange={(pos) => handleGroupPositionChange(panelGroups["center-bottom"].map(t => t.id), pos)}
+                    onDragStart={handleGroupDragStart(panelGroups["center-bottom"].map(t => t.id))}
+                    className="h-full"
+                  />
+                </div>
+              </>
             )}
+          </div>{/* end center column */}
 
-            {mobilePanelTabs.length > 0 && (
+          {/* ── RIGHT COLUMN ────────────────────────────────────────────── */}
+          {rightColZones.length > 0 && (
+            <>
               <div
-                className="md:hidden fixed inset-0 z-[60] flex flex-col bg-background pp-safe-left pp-safe-right"
-                style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}
+                className="hidden md:flex w-[5px] cursor-col-resize shrink-0 items-center justify-center group"
+                onPointerDown={(e) => startColumnWidthResize("right", e)}
               >
-                <CombinedPanel
-                  activeTabId={resolveActiveTabId(mobilePanelTabs)}
-                  onActiveTabChange={handleCombinedTabChange}
-                  position="bottom"
-                  className="h-full"
-                  tabs={mobilePanelTabs}
-                />
+                <div className="bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors h-full w-px" />
               </div>
-            )}
+              <div className="hidden md:flex flex-col shrink-0 min-h-0" style={{ width: rightColumnWidth }}>
+                {rightColZones.map((zone, i) => {
+                  const nextZone = rightColZones[i + 1];
+                  const handleZonePos = nextZone
+                    ? (zone.fills ? nextZone.pos : zone.pos)
+                    : undefined;
+                  return (
+                    <React.Fragment key={zone.pos}>
+                      <div
+                        className={cn(zone.fills ? "flex-1 min-h-0" : "shrink-0")}
+                        style={!zone.fills ? { height: zone.storedHeight } : undefined}
+                      >
+                        <CombinedPanel
+                          position={zone.pos}
+                          tabs={zone.tabs}
+                          activeTabId={resolveActiveTabId(zone.tabs)}
+                          onActiveTabChange={handleCombinedTabChange}
+                          onPositionChange={(pos) => handleGroupPositionChange(zone.tabs.map(t => t.id), pos)}
+                          onDragStart={handleGroupDragStart(zone.tabs.map(t => t.id))}
+                          className="h-full"
+                        />
+                      </div>
+                      {nextZone && (
+                        <div
+                          className="hidden md:flex h-[5px] cursor-row-resize shrink-0 items-center justify-center group"
+                          onPointerDown={handleZonePos ? (e) => startZoneHeightResize(handleZonePos, e) : undefined}
+                        >
+                          <div className="bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors w-full h-px" />
+                        </div>
+                      )}
+                    </React.Fragment>
+                  );
+                })}
+              </div>
+            </>
+          )}
 
-            {panelDragActive && (
-              <div className="absolute inset-0 z-50 pointer-events-none hidden md:block">
-                <div className={cn(
-                  "absolute bottom-0 left-0 right-0 h-[40%] flex flex-col items-center justify-center gap-2 border-t-2 transition-colors duration-100",
-                  panelDragZone === "bottom" ? "bg-blue-500/20 border-blue-500" : "bg-zinc-900/60 border-zinc-700/60",
-                )}>
-                  <svg className={cn("size-6 transition-colors", panelDragZone === "bottom" ? "text-blue-400" : "text-zinc-500")} viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="9" width="14" height="6" rx="1.5"/><rect x="1" y="1" width="14" height="6" rx="1.5" opacity=".3"/></svg>
-                  <span className={cn("text-xs font-medium transition-colors", panelDragZone === "bottom" ? "text-blue-300" : "text-zinc-500")}>Bottom</span>
-                </div>
-                <div className={cn(
-                  "absolute top-0 right-0 w-[35%] h-[55%] flex flex-col items-center justify-center gap-2 border-l-2 transition-colors duration-100",
-                  panelDragZone === "right" ? "bg-blue-500/20 border-blue-500" : "bg-zinc-900/60 border-zinc-700/60",
-                )}>
-                  <svg className={cn("size-6 transition-colors", panelDragZone === "right" ? "text-blue-400" : "text-zinc-500")} viewBox="0 0 16 16" fill="currentColor"><rect x="9" y="1" width="6" height="14" rx="1.5"/><rect x="1" y="1" width="6" height="14" rx="1.5" opacity=".3"/></svg>
-                  <span className={cn("text-xs font-medium transition-colors", panelDragZone === "right" ? "text-blue-300" : "text-zinc-500")}>Right</span>
-                </div>
-                <div className={cn(
-                  "absolute top-0 left-0 w-[35%] h-[55%] flex flex-col items-center justify-center gap-2 border-r-2 transition-colors duration-100",
-                  panelDragZone === "left" ? "bg-blue-500/20 border-blue-500" : "bg-zinc-900/60 border-zinc-700/60",
-                )}>
-                  <svg className={cn("size-6 transition-colors", panelDragZone === "left" ? "text-blue-400" : "text-zinc-500")} viewBox="0 0 16 16" fill="currentColor"><rect x="1" y="1" width="6" height="14" rx="1.5"/><rect x="9" y="1" width="6" height="14" rx="1.5" opacity=".3"/></svg>
-                  <span className={cn("text-xs font-medium transition-colors", panelDragZone === "left" ? "text-blue-300" : "text-zinc-500")}>Left</span>
-                </div>
-              </div>
-            )}
-          </div>
+          {/* ── MOBILE OVERLAY ──────────────────────────────────────────── */}
+          {mobilePanelTabs.length > 0 && (
+            <div
+              className="md:hidden fixed inset-0 z-[60] flex flex-col bg-background pp-safe-left pp-safe-right"
+              style={{ paddingTop: 'env(safe-area-inset-top)', paddingBottom: 'env(safe-area-inset-bottom)' }}
+            >
+              <CombinedPanel
+                activeTabId={resolveActiveTabId(mobilePanelTabs)}
+                onActiveTabChange={handleCombinedTabChange}
+                position="center-bottom"
+                className="h-full"
+                tabs={mobilePanelTabs}
+              />
+            </div>
+          )}
+
+          {/* ── 3×3 DRAG OVERLAY ────────────────────────────────────────── */}
+          {panelDragActive && (
+            <div className="absolute inset-0 z-50 pointer-events-none hidden md:grid grid-cols-3 grid-rows-3">
+              {([
+                { pos: "left-top",      label: "Left\ntop"    },
+                { pos: "center-top",    label: "Top"          },
+                { pos: "right-top",     label: "Right\ntop"   },
+                { pos: "left-middle",   label: "Left"         },
+                { pos: null,            label: ""             },
+                { pos: "right-middle",  label: "Right"        },
+                { pos: "left-bottom",   label: "Left\nbottom" },
+                { pos: "center-bottom", label: "Bottom"       },
+                { pos: "right-bottom",  label: "Right\nbottom"},
+              ] as const).map((zone, idx) => {
+                if (zone.pos === null) {
+                  return <div key={idx} />;
+                }
+                const isActive = panelDragZone === zone.pos;
+                return (
+                  <div
+                    key={zone.pos}
+                    className={cn(
+                      "flex items-center justify-center border transition-colors duration-100",
+                      isActive
+                        ? "bg-blue-500/20 border-blue-500"
+                        : "bg-zinc-900/40 border-zinc-700/30",
+                    )}
+                  >
+                    <span className={cn(
+                      "text-[10px] font-medium text-center transition-colors whitespace-pre-line leading-tight",
+                      isActive ? "text-blue-300" : "text-zinc-600",
+                    )}>
+                      {zone.label}
+                    </span>
+                  </div>
+                );
+              })}
+            </div>
+          )}
         </div>
         <NewSessionWizardDialog
           open={newSessionOpen}

--- a/packages/ui/src/components/CombinedPanel.tsx
+++ b/packages/ui/src/components/CombinedPanel.tsx
@@ -1,22 +1,77 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import { cn } from "@/lib/utils";
-import { GripHorizontal, PanelBottom, PanelLeft, PanelRight, X } from "lucide-react";
+import { GripHorizontal, X } from "lucide-react";
+import type { PanelPosition } from "@/hooks/usePanelLayout";
 
-// ── Position Picker (shared with TerminalManager / FileExplorer) ─────────────
+// ── 9-zone grid definition ───────────────────────────────────────────────────
+// Row 0 = top, Row 1 = middle (center-middle is main content), Row 2 = bottom.
+// Col 0 = left, Col 1 = center, Col 2 = right.
 
-const POSITION_OPTIONS = [
-  { pos: "left" as const, Icon: PanelLeft, label: "Left" },
-  { pos: "bottom" as const, Icon: PanelBottom, label: "Bottom" },
-  { pos: "right" as const, Icon: PanelRight, label: "Right" },
-] as const;
+interface ZoneCell {
+  pos: PanelPosition | null;   // null → center-middle (main content, not selectable)
+  label: string;
+}
+
+const ZONE_GRID: ZoneCell[][] = [
+  [
+    { pos: "left-top",      label: "Left — top"    },
+    { pos: "center-top",    label: "Top"           },
+    { pos: "right-top",     label: "Right — top"   },
+  ],
+  [
+    { pos: "left-middle",   label: "Left"          },
+    { pos: null,            label: "Main"          },
+    { pos: "right-middle",  label: "Right"         },
+  ],
+  [
+    { pos: "left-bottom",   label: "Left — bottom" },
+    { pos: "center-bottom", label: "Bottom"        },
+    { pos: "right-bottom",  label: "Right — bottom"},
+  ],
+];
+
+// ── Inline SVG: mini 3×3 grid icon showing active zone ──────────────────────
+function PositionGridIcon({ position }: { position: PanelPosition }) {
+  const colIdx = position.startsWith("left-") ? 0 : position.startsWith("right-") ? 2 : 1;
+  const rowIdx = position.endsWith("-top")    ? 0 : position.endsWith("-bottom") ? 2 : 1;
+
+  const CELL = 4;
+  const GAP  = 1;
+  const SIZE  = 3 * CELL + 2 * GAP; // 14
+
+  return (
+    <svg viewBox={`0 0 ${SIZE} ${SIZE}`} width="13" height="13" aria-hidden="true">
+      {ZONE_GRID.map((row, r) =>
+        row.map((cell, c) => {
+          const isActive = c === colIdx && r === rowIdx;
+          const isMain   = cell.pos === null;
+          return (
+            <rect
+              key={`${r}-${c}`}
+              x={c * (CELL + GAP)}
+              y={r * (CELL + GAP)}
+              width={CELL}
+              height={CELL}
+              rx={0.75}
+              fill="currentColor"
+              opacity={isActive ? 1 : isMain ? 0.12 : 0.3}
+            />
+          );
+        })
+      )}
+    </svg>
+  );
+}
+
+// ── Position Picker ──────────────────────────────────────────────────────────
 
 const PositionDropdown = React.forwardRef<
   HTMLDivElement,
   {
     containerRef: React.RefObject<HTMLDivElement | null>;
-    position: "left" | "right" | "bottom";
-    onSelect: (pos: "left" | "right" | "bottom") => void;
+    position: PanelPosition;
+    onSelect: (pos: PanelPosition) => void;
   }
 >(function PositionDropdown({ containerRef, position, onSelect }, ref) {
   const [coords, setCoords] = React.useState<{ top: number; left: number } | null>(null);
@@ -24,11 +79,13 @@ const PositionDropdown = React.forwardRef<
   React.useLayoutEffect(() => {
     const el = containerRef.current;
     if (!el) return;
-    const rect = el.getBoundingClientRect();
-    const dropdownWidth = 3 * 28 + 2 * 2 + 8;
+    const rect   = el.getBoundingClientRect();
+    // 3 cols × 26px + 2 gaps × 2px + 8px padding
+    const width  = 3 * 26 + 2 * 2 + 8;
+    const height = 3 * 26 + 2 * 2 + 8;
     setCoords({
-      top: rect.top - 6 - 36,
-      left: rect.left + rect.width / 2 - dropdownWidth / 2,
+      top:  rect.top - 6 - height,
+      left: rect.left + rect.width / 2 - width / 2,
     });
   }, [containerRef]);
 
@@ -37,26 +94,38 @@ const PositionDropdown = React.forwardRef<
   return (
     <div
       ref={ref}
-      className="fixed flex items-center gap-0.5 rounded-lg bg-popover border border-border p-1 shadow-xl z-[9999] animate-in fade-in zoom-in-95 duration-100"
+      className="fixed rounded-lg bg-popover border border-border p-1 shadow-xl z-[9999] animate-in fade-in zoom-in-95 duration-100"
       style={{ top: coords.top, left: coords.left }}
     >
-      {POSITION_OPTIONS.map(({ pos, Icon, label }) => (
-        <button
-          key={pos}
-          type="button"
-          onClick={() => onSelect(pos)}
-          className={cn(
-            "flex items-center justify-center size-7 rounded transition-colors",
-            position === pos
-              ? "bg-accent text-foreground"
-              : "text-muted-foreground hover:text-foreground hover:bg-accent",
-          )}
-          title={label}
-          aria-label={`Move panel to ${label}`}
-        >
-          <Icon size={14} />
-        </button>
-      ))}
+      <div className="grid grid-cols-3 gap-0.5">
+        {ZONE_GRID.map((row, r) =>
+          row.map((cell, c) => {
+            const isActive = cell.pos === position;
+            const isMain   = cell.pos === null;
+            return (
+              <button
+                key={`${r}-${c}`}
+                type="button"
+                disabled={isMain}
+                onClick={isMain ? undefined : () => onSelect(cell.pos!)}
+                className={cn(
+                  "flex items-center justify-center size-[26px] rounded text-[9px] font-medium transition-colors leading-none",
+                  isMain
+                    ? "text-muted-foreground/30 cursor-default"
+                    : isActive
+                      ? "bg-primary text-primary-foreground"
+                      : "text-muted-foreground hover:text-foreground hover:bg-accent",
+                )}
+                title={cell.label}
+                aria-label={isMain ? "Main content (not a dock target)" : `Move panel to ${cell.label}`}
+                aria-pressed={isActive}
+              >
+                {isMain ? "●" : <PositionGridIcon position={cell.pos!} />}
+              </button>
+            );
+          })
+        )}
+      </div>
     </div>
   );
 });
@@ -65,16 +134,14 @@ function PositionPicker({
   position,
   onPositionChange,
 }: {
-  position: "left" | "right" | "bottom";
-  onPositionChange: (pos: "left" | "right" | "bottom") => void;
+  position: PanelPosition;
+  onPositionChange: (pos: PanelPosition) => void;
 }) {
   const [open, setOpen] = React.useState(false);
-  const holdTimer = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const holdTimer    = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const containerRef = React.useRef<HTMLDivElement>(null);
-  const dropdownRef = React.useRef<HTMLDivElement>(null);
-  const wasHeld = React.useRef(false);
-
-  const ActiveIcon = POSITION_OPTIONS.find((o) => o.pos === position)!.Icon;
+  const dropdownRef  = React.useRef<HTMLDivElement>(null);
+  const wasHeld      = React.useRef(false);
 
   React.useEffect(() => {
     if (!open) return;
@@ -93,40 +160,26 @@ function PositionPicker({
 
   React.useEffect(() => {
     if (!open) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
-    };
+    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") setOpen(false); };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, [open]);
 
   const clearHold = () => {
-    if (holdTimer.current) {
-      clearTimeout(holdTimer.current);
-      holdTimer.current = null;
-    }
+    if (holdTimer.current) { clearTimeout(holdTimer.current); holdTimer.current = null; }
   };
 
   const handlePointerDown = () => {
     wasHeld.current = false;
-    holdTimer.current = setTimeout(() => {
-      wasHeld.current = true;
-      setOpen(true);
-    }, 300);
+    holdTimer.current = setTimeout(() => { wasHeld.current = true; setOpen(true); }, 300);
   };
-
   const handlePointerUp = () => {
     clearHold();
-    if (!wasHeld.current) {
-      setOpen((v) => !v);
-    }
+    if (!wasHeld.current) setOpen((v) => !v);
   };
+  const handlePointerLeave = () => clearHold();
 
-  const handlePointerLeave = () => {
-    clearHold();
-  };
-
-  const handleSelect = (pos: "left" | "right" | "bottom") => {
+  const handleSelect = (pos: PanelPosition) => {
     onPositionChange(pos);
     setOpen(false);
   };
@@ -146,8 +199,9 @@ function PositionPicker({
         )}
         title="Panel position"
         aria-label="Panel position"
+        aria-expanded={open}
       >
-        <ActiveIcon size={13} />
+        <PositionGridIcon position={position} />
       </button>
 
       {open && ReactDOM.createPortal(
@@ -179,9 +233,11 @@ export interface CombinedPanelProps {
   tabs: CombinedPanelTab[];
   activeTabId: string;
   onActiveTabChange: (id: string) => void;
-  position: "left" | "right" | "bottom";
-  onPositionChange?: (pos: "left" | "right" | "bottom") => void;
+  position: PanelPosition;
+  onPositionChange?: (pos: PanelPosition) => void;
   onDragStart?: (e: React.PointerEvent) => void;
+  /** Called when a tab is double-clicked — typically used to toggle panel collapse */
+  onCollapseToggle?: () => void;
   className?: string;
 }
 
@@ -192,6 +248,7 @@ export function CombinedPanel({
   position,
   onPositionChange,
   onDragStart,
+  onCollapseToggle,
   className,
 }: CombinedPanelProps) {
   // Track per-tab drag gestures so that dragging a tab detaches it
@@ -204,6 +261,8 @@ export function CombinedPanel({
     activated: boolean;
   } | null>(null);
 
+  const activeTab = tabs.find((t) => t.id === activeTabId);
+
   return (
     <div className={cn("flex flex-col bg-background text-foreground", className)}>
       {/* Tab bar */}
@@ -211,7 +270,7 @@ export function CombinedPanel({
         <div className="flex items-center flex-1 min-w-0 overflow-x-auto gap-0.5 px-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
           {tabs.map((tab) => {
             const isActive = activeTabId === tab.id;
-            const hasDrag = !!tab.onDragStart;
+            const hasDrag  = !!tab.onDragStart;
             return (
               <div
                 key={tab.id}
@@ -223,12 +282,13 @@ export function CombinedPanel({
                   hasDrag ? "cursor-grab active:cursor-grabbing" : "cursor-pointer",
                 )}
                 onClick={() => {
-                  // Suppress click if this pointer-down became a drag
-                  if (tabDragRef.current?.activated) {
-                    tabDragRef.current = null;
-                    return;
-                  }
+                  if (tabDragRef.current?.activated) { tabDragRef.current = null; return; }
                   onActiveTabChange(tab.id);
+                }}
+                onDoubleClick={() => onCollapseToggle?.()}
+                onMouseDown={(e) => {
+                  // Middle-click to close
+                  if (e.button === 1) { e.preventDefault(); tab.onClose?.(); }
                 }}
                 onPointerDown={hasDrag ? (e) => {
                   if (e.button !== 0) return;
@@ -240,7 +300,6 @@ export function CombinedPanel({
                     pointerId: e.pointerId,
                     activated: false,
                   };
-                  // Capture so move/up are reliable even if pointer leaves the tab
                   (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
                 } : undefined}
                 onPointerMove={hasDrag ? (e) => {
@@ -248,51 +307,17 @@ export function CombinedPanel({
                   if (!drag || drag.tabId !== tab.id || drag.pointerId !== e.pointerId || drag.activated) return;
                   const dx = e.clientX - drag.startX;
                   const dy = e.clientY - drag.startY;
-                  // 4 px threshold to distinguish drag from click
-                  if (dx * dx + dy * dy > 16) {
-                    drag.activated = true;
-                    drag.onDragStart(e);
-                  }
+                  if (dx * dx + dy * dy > 16) { drag.activated = true; drag.onDragStart(e); }
                 } : undefined}
                 onPointerUp={hasDrag ? (e) => {
                   const drag = tabDragRef.current;
                   if (!drag || drag.tabId !== tab.id || drag.pointerId !== e.pointerId) return;
-                  if (!drag.activated) {
-                    // Was a click — null the ref so onClick fires normally
-                    tabDragRef.current = null;
-                  }
-                  // If activated, keep ref alive so onClick can detect and suppress it
+                  if (!drag.activated) tabDragRef.current = null;
                 } : undefined}
-                onPointerCancel={hasDrag ? () => {
-                  tabDragRef.current = null;
-                } : undefined}
+                onPointerCancel={hasDrag ? () => { tabDragRef.current = null; } : undefined}
               >
                 {tab.icon}
                 <span>{tab.label}</span>
-                {tab.onClose && (
-                  <button
-                    type="button"
-                    onPointerDown={(e) => {
-                      e.stopPropagation();
-                    }}
-                    onPointerUp={(e) => {
-                      e.stopPropagation();
-                    }}
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      tab.onClose!();
-                    }}
-                    className={cn(
-                      "rounded p-0.5 transition-colors ml-0.5",
-                      isActive
-                        ? "text-muted-foreground hover:text-foreground hover:bg-accent"
-                        : "text-transparent group-hover:text-muted-foreground hover:!text-foreground hover:bg-accent",
-                    )}
-                    aria-label={`Close ${tab.label}`}
-                  >
-                    <X size={10} />
-                  </button>
-                )}
               </div>
             );
           })}
@@ -314,6 +339,21 @@ export function CombinedPanel({
             <>
               <div className="w-px h-4 bg-border mx-1 shrink-0" />
               <PositionPicker position={position} onPositionChange={onPositionChange} />
+            </>
+          )}
+          {/* Close button for the active tab */}
+          {activeTab?.onClose && (
+            <>
+              <div className="w-px h-4 bg-border mx-1 shrink-0" />
+              <button
+                type="button"
+                onClick={() => activeTab.onClose!()}
+                className="flex items-center justify-center size-7 rounded text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+                aria-label={`Close ${activeTab.label}`}
+                title={`Close ${activeTab.label}`}
+              >
+                <X size={13} />
+              </button>
             </>
           )}
         </div>

--- a/packages/ui/src/components/DockedPanelGroup.test.tsx
+++ b/packages/ui/src/components/DockedPanelGroup.test.tsx
@@ -39,34 +39,26 @@ afterEach(() => {
   document.body.innerHTML = "";
 });
 
-describe("DockedPanelGroup", () => {
-  test("renders tabs and forwards resize + drag handlers", () => {
-    let resized = 0;
-    let dragged = 0;
+const TAB_PROPS = {
+  activeTabId: "terminal",
+  onActiveTabChange: () => {},
+  onPositionChange: () => {},
+  tabs: [
+    { id: "terminal", label: "Terminal", icon: <span>T</span>, content: <div>Terminal content</div> },
+    { id: "files",    label: "Files",    icon: <span>F</span>, content: <div>Files content</div>    },
+  ],
+};
 
+describe("DockedPanelGroup", () => {
+  test("renders tabs and forwards drag handler (right-middle zone)", () => {
+    let dragged = 0;
     const { container } = render(
       <DockedPanelGroup
-        position="right"
+        {...TAB_PROPS}
+        position="right-middle"
         size={320}
-        activeTabId="terminal"
-        onActiveTabChange={() => {}}
-        onPositionChange={() => {}}
         onDragStart={() => { dragged += 1; }}
-        onResizeStart={() => { resized += 1; }}
-        tabs={[
-          {
-            id: "terminal",
-            label: "Terminal",
-            icon: <span>T</span>,
-            content: <div>Terminal content</div>,
-          },
-          {
-            id: "files",
-            label: "Files",
-            icon: <span>F</span>,
-            content: <div>Files content</div>,
-          },
-        ]}
+        onResizeStart={() => {}}
       />,
     );
 
@@ -80,7 +72,27 @@ describe("DockedPanelGroup", () => {
     fireEvent.pointerDown(dragHandle!);
     expect(dragged).toBe(1);
 
-    const resizeHandle = elements.find((el) => (el as HTMLElement).className?.includes?.("cursor-col-resize")) as HTMLElement | undefined;
+    // NOTE: column-width resize handles for left-*/right-* zones are managed at
+    // the column level in App.tsx, NOT inside DockedPanelGroup. The component
+    // only renders an inline row-resize handle for center-top / center-bottom.
+    const colResizeHandle = elements.find((el) => (el as HTMLElement).className?.includes?.("cursor-col-resize"));
+    expect(colResizeHandle).toBeUndefined(); // by design — handled in App.tsx
+  });
+
+  test("center-bottom zone renders an inline row-resize handle", () => {
+    let resized = 0;
+    const { container } = render(
+      <DockedPanelGroup
+        {...TAB_PROPS}
+        position="center-bottom"
+        size={280}
+        onDragStart={() => {}}
+        onResizeStart={() => { resized += 1; }}
+      />,
+    );
+
+    const elements = Array.from(container.getElementsByTagName("*"));
+    const resizeHandle = elements.find((el) => (el as HTMLElement).className?.includes?.("cursor-row-resize")) as HTMLElement | undefined;
     expect(resizeHandle).toBeTruthy();
     fireEvent.pointerDown(resizeHandle!);
     expect(resized).toBe(1);

--- a/packages/ui/src/components/DockedPanelGroup.tsx
+++ b/packages/ui/src/components/DockedPanelGroup.tsx
@@ -1,11 +1,16 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 import { CombinedPanel, type CombinedPanelTab } from "@/components/CombinedPanel";
+import type { PanelPosition } from "@/hooks/usePanelLayout";
 
-export type DockPosition = "left" | "right" | "bottom";
+export type DockPosition = PanelPosition;
+
+/** Height in pixels of the tab bar — used as the collapsed size */
+const TAB_BAR_HEIGHT = 32;
 
 export interface DockedPanelGroupProps {
   position: DockPosition;
+  /** Width (for left/right zones) or height (for top/bottom zones) in pixels. */
   size: number;
   tabs: CombinedPanelTab[];
   activeTabId: string;
@@ -27,13 +32,54 @@ export function DockedPanelGroup({
   onResizeStart,
   className,
 }: DockedPanelGroupProps) {
-  const isBottom = position === "bottom";
-  const isLeft = position === "left";
+  // Determine orientation from position string
+  const isHorizontal =
+    position === "center-top" || position === "center-bottom";
+  const isLeft = position.startsWith("left-");
+  const isRight = position.startsWith("right-");
+
+  // Column (left/right) panels use width; horizontal (center-top/bottom) use height.
+  // In the 9-zone layout, left/right column widths are managed at the column level,
+  // so individual zones in those columns are always `flex-1` — `size` is only
+  // meaningful for horizontal zones (center-top / center-bottom) or when this
+  // component is used standalone.
+  const isSized = isHorizontal;
+
+  const [collapsed, setCollapsed] = React.useState(false);
+
+  // When position changes, un-collapse so the panel is usable in the new spot
+  const prevPosition = React.useRef(position);
+  if (prevPosition.current !== position) {
+    prevPosition.current = position;
+    if (collapsed) setCollapsed(false);
+  }
+
+  const handleCollapseToggle = React.useCallback(() => {
+    setCollapsed((c) => !c);
+  }, []);
+
+  const effectiveSize = collapsed ? TAB_BAR_HEIGHT : size;
+
+  // Resize handle orientation:
+  //   - center-top: horizontal handle below (row-resize)
+  //   - center-bottom: horizontal handle above (row-resize)
+  //   - left-*/right-*: vertical handle on edge (col-resize)
+  //     NOTE: in the new column layout, left/right column width handles are
+  //     rendered by the parent (ZoneColumn in App.tsx), so the per-zone resize
+  //     handle here is only for inter-zone height splits within a column.
+  const resizeCursor = (isLeft || isRight) ? "cursor-row-resize" : "cursor-row-resize";
+  // Horizontal handle always uses row-resize cursor
 
   const panel = (
     <div
-      className={cn("hidden md:flex flex-col shrink-0", className, !isLeft && !isBottom && "order-last")}
-      style={isBottom ? { height: size } : { width: size }}
+      className={cn(
+        "flex flex-col shrink-0",
+        // hide on mobile (mobile uses full-screen overlay)
+        "hidden md:flex",
+        className,
+        isSized && { height: effectiveSize },
+      )}
+      style={isSized ? { height: effectiveSize } : undefined}
     >
       <CombinedPanel
         activeTabId={activeTabId}
@@ -41,43 +87,39 @@ export function DockedPanelGroup({
         position={position}
         onPositionChange={onPositionChange}
         onDragStart={onDragStart}
+        onCollapseToggle={handleCollapseToggle}
         className="h-full"
         tabs={tabs}
       />
     </div>
   );
 
-  const handle = (
+  // Resize handle — hidden when collapsed
+  const handle = collapsed ? null : (
     <div
       className={cn(
         "hidden md:flex shrink-0 items-center justify-center group",
-        isBottom ? "h-[5px] cursor-row-resize" : "w-[5px] cursor-col-resize",
-        !isLeft && !isBottom && "order-last",
+        "h-[5px]",
+        resizeCursor,
       )}
       onPointerDown={onResizeStart}
     >
-      <div
-        className={cn(
-          "bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors",
-          isBottom ? "w-full h-px" : "h-full w-px",
-        )}
-      />
+      <div className="bg-zinc-800 group-hover:bg-blue-500/60 group-active:bg-blue-500 transition-colors w-full h-px" />
     </div>
   );
 
-  if (isLeft) {
-    return (
-      <>
-        {panel}
-        {handle}
-      </>
-    );
+  // center-top: panel then handle (handle is below, toward main content)
+  // center-bottom: handle then panel (handle is above, toward main content)
+  if (position === "center-top") {
+    return <>{panel}{handle}</>;
+  }
+  if (position === "center-bottom") {
+    return <>{handle}{panel}</>;
   }
 
-  return (
-    <>
-      {handle}
-      {panel}
-    </>
-  );
+  // left-* zones: handle is below the zone (handle toward next zone down)
+  // right-* zones: same
+  // In the column layout, the parent (App.tsx) decides handle placement,
+  // so we just render the panel itself here.
+  return <>{panel}</>;
 }

--- a/packages/ui/src/components/service-panels/ServicePanels.test.ts
+++ b/packages/ui/src/components/service-panels/ServicePanels.test.ts
@@ -34,11 +34,11 @@ describe("resolveNewPanelPosition — adding bug", () => {
         // After fix: godmother is placed at "bottom" (same as tunnel).
         const activeServicePanels = new Set(["tunnel"]);
         const positions = new Map([
-            ["tunnel", "bottom"],
+            ["tunnel", "center-bottom"],
             // godmother has a *different* stored position
-            ["godmother", "right"],
+            ["godmother", "right-middle"],
         ] as const);
-        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right-middle";
 
         const result = resolveNewPanelPosition(
             "godmother",
@@ -47,15 +47,15 @@ describe("resolveNewPanelPosition — adding bug", () => {
             getPanelPosition,
         );
 
-        expect(result).toBe("bottom"); // same group as the active panel (tunnel)
+        expect(result).toBe("center-bottom"); // same group as the active panel (tunnel)
     });
 
     test("uses stored position when no service panel is currently active", () => {
         // No service panels open yet.  combinedActiveTab = "terminal".
         // The new panel should use its stored/default position.
         const activeServicePanels = new Set<string>(); // empty
-        const positions = new Map([["godmother", "left"]] as const);
-        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
+        const positions = new Map([["godmother", "left-middle"]] as const);
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right-middle";
 
         const result = resolveNewPanelPosition(
             "godmother",
@@ -64,12 +64,12 @@ describe("resolveNewPanelPosition — adding bug", () => {
             getPanelPosition,
         );
 
-        expect(result).toBe("left"); // godmother's own stored position
+        expect(result).toBe("left-middle"); // godmother's own stored position
     });
 
     test("uses default 'right' position when no service panel is active and no stored position", () => {
         const activeServicePanels = new Set<string>();
-        const getPanelPosition = (_id: string) => "right" as const; // default
+        const getPanelPosition = (_id: string) => "right-middle" as const; // default
 
         const result = resolveNewPanelPosition(
             "godmother",
@@ -78,7 +78,7 @@ describe("resolveNewPanelPosition — adding bug", () => {
             getPanelPosition,
         );
 
-        expect(result).toBe("right");
+        expect(result).toBe("right-middle");
     });
 
     test("opening a second panel while the first is active puts it in the same group", () => {
@@ -86,10 +86,10 @@ describe("resolveNewPanelPosition — adding bug", () => {
         // User clicks godmother button → should appear at "right" (same group as tunnel).
         const activeServicePanels = new Set(["tunnel"]);
         const positions = new Map([
-            ["tunnel", "right"],
-            ["godmother", "bottom"], // stale stored position
+            ["tunnel", "right-middle"],
+            ["godmother", "center-bottom"], // stale stored position
         ] as const);
-        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right-middle";
 
         const result = resolveNewPanelPosition(
             "godmother",
@@ -98,17 +98,17 @@ describe("resolveNewPanelPosition — adding bug", () => {
             getPanelPosition,
         );
 
-        expect(result).toBe("right"); // follows tunnel, not the stale stored position
+        expect(result).toBe("right-middle"); // follows tunnel, not the stale stored position
     });
 
     test("does not change position when new panel is already in the same group", () => {
         // Both panels default to "right" — the fix is a no-op in this case.
         const activeServicePanels = new Set(["tunnel"]);
         const positions = new Map([
-            ["tunnel", "right"],
-            ["godmother", "right"],
+            ["tunnel", "right-middle"],
+            ["godmother", "right-middle"],
         ] as const);
-        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right-middle";
 
         const result = resolveNewPanelPosition(
             "godmother",
@@ -117,7 +117,7 @@ describe("resolveNewPanelPosition — adding bug", () => {
             getPanelPosition,
         );
 
-        expect(result).toBe("right"); // no change needed
+        expect(result).toBe("right-middle"); // no change needed
     });
 });
 
@@ -132,10 +132,10 @@ describe("resolveNewPanelPosition — persistence safety", () => {
         // The fix: use setEphemeralPanelPosition (non-persisted) in this case.
         const activeServicePanels = new Set(["tunnel"]);
         const positions = new Map([
-            ["tunnel", "bottom"],
-            ["godmother", "right"], // godmother's OWN saved preference
+            ["tunnel", "center-bottom"],
+            ["godmother", "right-middle"], // godmother's OWN saved preference
         ] as const);
-        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right-middle";
 
         const autoPlacedPosition = resolveNewPanelPosition(
             "godmother",
@@ -144,9 +144,9 @@ describe("resolveNewPanelPosition — persistence safety", () => {
             getPanelPosition,
         );
 
-        // Auto-placement correctly returns "bottom" (same group as tunnel)…
-        expect(autoPlacedPosition).toBe("bottom");
-        // …but this DIFFERS from godmother's own stored preference ("right"),
+        // Auto-placement correctly returns "center-bottom" (same group as tunnel)…
+        expect(autoPlacedPosition).toBe("center-bottom");
+        // …but this DIFFERS from godmother's own stored preference ("right-middle"),
         // so persisting it would permanently corrupt the saved dock position.
         expect(autoPlacedPosition).not.toBe(getPanelPosition("godmother"));
     });
@@ -156,8 +156,8 @@ describe("resolveNewPanelPosition — persistence safety", () => {
         // returns the panel's own stored preference, making any persist call a no-op.
         // The fix: skip the setServicePanelPosition call entirely in this path.
         const activeServicePanels = new Set<string>();
-        const positions = new Map([["godmother", "left"]] as const);
-        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
+        const positions = new Map([["godmother", "left-middle"]] as const);
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right-middle";
 
         const position = resolveNewPanelPosition(
             "godmother",
@@ -166,7 +166,7 @@ describe("resolveNewPanelPosition — persistence safety", () => {
             getPanelPosition,
         );
 
-        expect(position).toBe("left");
+        expect(position).toBe("left-middle");
         // Position equals the panel's own stored preference — no corruption possible.
         expect(position).toBe(getPanelPosition("godmother"));
     });
@@ -180,8 +180,8 @@ describe("resolveNewPanelPosition — persistence safety", () => {
         // Scenario: godmother stored at "right". Opened next to tunnel ("bottom")
         // → auto-placed ephemeral="bottom". Closed. Opened again standalone.
         // Expected: uses stored "right", NOT the stale "bottom".
-        const positions = new Map([["godmother", "right"]] as const);
-        const getPanelPosition = (id: string) => positions.get(id) ?? "right";
+        const positions = new Map([["godmother", "right-middle"]] as const);
+        const getPanelPosition = (id: string) => positions.get(id) ?? "right-middle";
 
         // Second open: active tab is NOT a service panel (tunnel closed)
         const activeServicePanels = new Set<string>();
@@ -192,7 +192,7 @@ describe("resolveNewPanelPosition — persistence safety", () => {
             getPanelPosition,
         );
         // Returns stored preference, not any stale ephemeral value
-        expect(position).toBe("right");
+        expect(position).toBe("right-middle");
     });
 });
 

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -219,7 +219,14 @@ export function useServicePanelState() {
     const getPanelPosition = useCallback((serviceId: string): PanelPosition => {
         // Ephemeral overrides take precedence over persisted positions so that
         // auto-placed panels render in the correct dock group for this session.
-        return ephemeralPositions.get(serviceId) ?? panelPositions.get(serviceId) ?? "right";
+        // Migrate old 3-value positions from localStorage to new 8-value format.
+        // Cast to string for comparison since localStorage may hold pre-migration values.
+        const stored: string | undefined = ephemeralPositions.get(serviceId) ?? panelPositions.get(serviceId);
+        if (!stored) return "right-middle";
+        if (stored === "right")  return "right-middle";
+        if (stored === "left")   return "left-middle";
+        if (stored === "bottom") return "center-bottom";
+        return stored as PanelPosition;
     }, [ephemeralPositions, panelPositions]);
 
     const setPanelPosition = useCallback((serviceId: string, pos: PanelPosition) => {

--- a/packages/ui/src/hooks/usePanelLayout.test.ts
+++ b/packages/ui/src/hooks/usePanelLayout.test.ts
@@ -3,279 +3,249 @@
  *
  * Because the hook requires a React renderer (DOM environment) we test the
  * pure computational pieces extracted from the hook body. This ensures
- * regressions in the drag-zone detection, resize bounds, and localStorage
- * clamping logic are caught without requiring @testing-library/react.
+ * regressions in the drag-zone detection and resize bounds logic are caught
+ * without requiring @testing-library/react.
  */
 
 import { describe, expect, test } from "bun:test";
 import type { PanelPosition } from "./usePanelLayout";
 
-// ── Pure helpers mirroring hook internals ──────────────────────────────────────
+// ── 9-zone drag detection ─────────────────────────────────────────────────────
+// Mirrors the detectDragZone logic in usePanelLayout.ts (handleDragMove).
+// col: left < 0.33, right > 0.67, else center
+// row: top  < 0.33, bottom > 0.67, else middle
+// center-middle returns null (main content area — not a dock target).
 
-/**
- * Drag-zone detection — mirrors handlePanelDragMove / handleFilesDragMove.
- * Given normalised cursor position within the container rectangle, returns
- * the PanelPosition zone the cursor is in, or null if none.
- */
 function detectDragZone(pctX: number, pctY: number): PanelPosition | null {
-  if (pctY > 0.55) return "bottom";
-  if (pctX > 0.65) return "right";
-  if (pctX < 0.35) return "left";
-  return null;
+  const col: "left" | "center" | "right" =
+    pctX < 0.33 ? "left" : pctX > 0.67 ? "right" : "center";
+  const row: "top" | "middle" | "bottom" =
+    pctY < 0.33 ? "top" : pctY > 0.67 ? "bottom" : "middle";
+  if (col === "center" && row === "middle") return null;
+  return `${col}-${row}` as PanelPosition;
 }
 
-/**
- * Terminal height clamp — mirrors handleTerminalResizeMove (height path)
- * and the localStorage initialiser clamping.
- */
-function clampTerminalHeight(raw: number): number {
-  return Math.max(120, Math.min(raw, 900));
-}
+// ── Column width clamp ────────────────────────────────────────────────────────
+function clampColWidth(v: number) { return Math.max(200, Math.min(v, 1400)); }
 
-/**
- * Terminal width clamp — mirrors handleTerminalResizeMove (width path)
- * and the localStorage initialiser clamping.
- */
-function clampTerminalWidth(raw: number): number {
-  return Math.max(200, Math.min(raw, 1400));
-}
+// ── Zone height clamp ─────────────────────────────────────────────────────────
+function clampZoneHeight(v: number) { return Math.max(80, Math.min(v, 900)); }
 
-/**
- * File-explorer width clamp — mirrors handleFilesResizeMove and initialiser.
- */
-function clampFilesWidth(raw: number): number {
-  return Math.max(160, Math.min(raw, 800));
-}
+// ── detectDragZone ────────────────────────────────────────────────────────────
 
-/**
- * File-explorer height clamp — mirrors handleFilesResizeMove and initialiser.
- */
-function clampFilesHeight(raw: number): number {
-  return Math.max(150, Math.min(raw, 800));
-}
-
-/**
- * Parse a persisted terminal height from localStorage — mirrors the hook
- * initialiser.  Returns the default (280) when the saved value is absent or
- * invalid.
- */
-function parsePersistedTerminalHeight(saved: string | null): number {
-  if (saved) {
-    const parsed = parseInt(saved, 10);
-    if (!isNaN(parsed)) return clampTerminalHeight(parsed);
-  }
-  return 280; // default
-}
-
-function parsePersistedTerminalWidth(saved: string | null): number {
-  if (saved) {
-    const parsed = parseInt(saved, 10);
-    if (!isNaN(parsed)) return clampTerminalWidth(parsed);
-  }
-  return 480; // default
-}
-
-function parsePersistedFilesWidth(saved: string | null): number {
-  if (saved) {
-    const parsed = parseInt(saved, 10);
-    if (!isNaN(parsed)) return clampFilesWidth(parsed);
-  }
-  return 280; // default
-}
-
-function parsePersistedFilesHeight(saved: string | null): number {
-  if (saved) {
-    const parsed = parseInt(saved, 10);
-    if (!isNaN(parsed)) return clampFilesHeight(parsed);
-  }
-  return 280; // default
-}
-
-// ── Drag-zone detection ───────────────────────────────────────────────────────
-
-describe("detectDragZone", () => {
-  test("returns 'bottom' when cursor is in the lower portion (pctY > 0.55)", () => {
-    expect(detectDragZone(0.5, 0.6)).toBe("bottom");
-    expect(detectDragZone(0.5, 1.0)).toBe("bottom");
-    // boundary: exactly 0.55 is NOT > 0.55
-    expect(detectDragZone(0.5, 0.55)).toBeNull();
+describe("detectDragZone — 9-zone 3×3 grid", () => {
+  // Corners
+  test("top-left corner → left-top", () => {
+    expect(detectDragZone(0, 0)).toBe("left-top");
+    expect(detectDragZone(0.1, 0.1)).toBe("left-top");
   });
 
-  test("returns 'right' when cursor is in the right zone (pctX > 0.65, not bottom)", () => {
-    expect(detectDragZone(0.7, 0.3)).toBe("right");
-    expect(detectDragZone(1.0, 0.0)).toBe("right");
-    // boundary: exactly 0.65 is NOT > 0.65
-    expect(detectDragZone(0.65, 0.3)).toBeNull();
+  test("top-right corner → right-top", () => {
+    expect(detectDragZone(1.0, 0)).toBe("right-top");
+    expect(detectDragZone(0.9, 0.1)).toBe("right-top");
   });
 
-  test("returns 'left' when cursor is in the left zone (pctX < 0.35, not bottom)", () => {
-    expect(detectDragZone(0.2, 0.3)).toBe("left");
-    expect(detectDragZone(0.0, 0.0)).toBe("left");
-    // boundary: exactly 0.35 is NOT < 0.35
-    expect(detectDragZone(0.35, 0.3)).toBeNull();
+  test("bottom-left corner → left-bottom", () => {
+    expect(detectDragZone(0, 1.0)).toBe("left-bottom");
+    expect(detectDragZone(0.1, 0.9)).toBe("left-bottom");
   });
 
-  test("returns null for cursor in the centre (no zone)", () => {
-    expect(detectDragZone(0.5, 0.3)).toBeNull();
-    expect(detectDragZone(0.5, 0.0)).toBeNull();
+  test("bottom-right corner → right-bottom", () => {
+    expect(detectDragZone(1.0, 1.0)).toBe("right-bottom");
+    expect(detectDragZone(0.9, 0.9)).toBe("right-bottom");
   });
 
-  test("'bottom' takes precedence over left/right zones", () => {
-    // pctY > 0.55 is checked first; even extreme left/right lose to bottom
-    expect(detectDragZone(0.9, 0.6)).toBe("bottom");
-    expect(detectDragZone(0.1, 0.6)).toBe("bottom");
+  // Edges
+  test("top-center → center-top", () => {
+    expect(detectDragZone(0.5, 0)).toBe("center-top");
+    expect(detectDragZone(0.5, 0.1)).toBe("center-top");
+  });
+
+  test("bottom-center → center-bottom", () => {
+    expect(detectDragZone(0.5, 1.0)).toBe("center-bottom");
+    expect(detectDragZone(0.5, 0.9)).toBe("center-bottom");
+  });
+
+  test("middle-left → left-middle", () => {
+    expect(detectDragZone(0, 0.5)).toBe("left-middle");
+    expect(detectDragZone(0.2, 0.5)).toBe("left-middle");
+  });
+
+  test("middle-right → right-middle", () => {
+    expect(detectDragZone(1.0, 0.5)).toBe("right-middle");
+    expect(detectDragZone(0.8, 0.5)).toBe("right-middle");
+  });
+
+  // Center-middle is null (main content, not a dock target)
+  test("center-middle → null", () => {
+    expect(detectDragZone(0.5, 0.5)).toBeNull();
+    expect(detectDragZone(0.4, 0.4)).toBeNull();
+    expect(detectDragZone(0.6, 0.6)).toBeNull();
+  });
+
+  // Boundary: exactly 0.33 is NOT < 0.33 → goes to center col
+  test("pctX exactly 0.33 → center column (not left)", () => {
+    expect(detectDragZone(0.33, 0.5)).toBeNull();  // center-middle
+    expect(detectDragZone(0.33, 0.1)).toBe("center-top");
+  });
+
+  // Boundary: exactly 0.67 is NOT > 0.67 → stays in center col
+  test("pctX exactly 0.67 → center column (not right)", () => {
+    expect(detectDragZone(0.67, 0.5)).toBeNull();
+    expect(detectDragZone(0.67, 0.9)).toBe("center-bottom");
+  });
+
+  // Boundary: exactly 0.33 for Y → center row (not top)
+  test("pctY exactly 0.33 → middle row (not top)", () => {
+    expect(detectDragZone(0.1, 0.33)).toBe("left-middle");
+  });
+
+  // Boundary: exactly 0.67 for Y → middle row (not bottom)
+  test("pctY exactly 0.67 → middle row (not bottom)", () => {
+    expect(detectDragZone(0.1, 0.67)).toBe("left-middle");
+  });
+
+  // All 8 dock zones are reachable
+  test("all 8 dock zones are distinct and reachable", () => {
+    const zones = new Set<PanelPosition | null>([
+      detectDragZone(0.1, 0.1),  // left-top
+      detectDragZone(0.5, 0.1),  // center-top
+      detectDragZone(0.9, 0.1),  // right-top
+      detectDragZone(0.1, 0.5),  // left-middle
+      detectDragZone(0.9, 0.5),  // right-middle
+      detectDragZone(0.1, 0.9),  // left-bottom
+      detectDragZone(0.5, 0.9),  // center-bottom
+      detectDragZone(0.9, 0.9),  // right-bottom
+    ]);
+    expect(zones.size).toBe(8);
+    expect(zones.has("left-top")).toBe(true);
+    expect(zones.has("center-top")).toBe(true);
+    expect(zones.has("right-top")).toBe(true);
+    expect(zones.has("left-middle")).toBe(true);
+    expect(zones.has("right-middle")).toBe(true);
+    expect(zones.has("left-bottom")).toBe(true);
+    expect(zones.has("center-bottom")).toBe(true);
+    expect(zones.has("right-bottom")).toBe(true);
   });
 });
 
-// ── Terminal resize bounds ────────────────────────────────────────────────────
+// ── Column width bounds ───────────────────────────────────────────────────────
 
-describe("clampTerminalHeight", () => {
-  test("enforces minimum height of 120", () => {
-    expect(clampTerminalHeight(0)).toBe(120);
-    expect(clampTerminalHeight(119)).toBe(120);
-    expect(clampTerminalHeight(120)).toBe(120);
+describe("clampColWidth", () => {
+  test("enforces minimum of 200", () => {
+    expect(clampColWidth(0)).toBe(200);
+    expect(clampColWidth(199)).toBe(200);
+    expect(clampColWidth(200)).toBe(200);
   });
 
-  test("enforces maximum height of 900", () => {
-    expect(clampTerminalHeight(901)).toBe(900);
-    expect(clampTerminalHeight(9999)).toBe(900);
-    expect(clampTerminalHeight(900)).toBe(900);
+  test("enforces maximum of 1400", () => {
+    expect(clampColWidth(1401)).toBe(1400);
+    expect(clampColWidth(9999)).toBe(1400);
+    expect(clampColWidth(1400)).toBe(1400);
   });
 
-  test("passes through values in the valid range", () => {
-    expect(clampTerminalHeight(280)).toBe(280);
-    expect(clampTerminalHeight(500)).toBe(500);
-  });
-});
-
-describe("clampTerminalWidth", () => {
-  test("enforces minimum width of 200", () => {
-    expect(clampTerminalWidth(0)).toBe(200);
-    expect(clampTerminalWidth(199)).toBe(200);
-    expect(clampTerminalWidth(200)).toBe(200);
-  });
-
-  test("enforces maximum width of 1400", () => {
-    expect(clampTerminalWidth(1401)).toBe(1400);
-    expect(clampTerminalWidth(9999)).toBe(1400);
-    expect(clampTerminalWidth(1400)).toBe(1400);
-  });
-
-  test("passes through values in the valid range", () => {
-    expect(clampTerminalWidth(480)).toBe(480);
-    expect(clampTerminalWidth(800)).toBe(800);
+  test("passes through values in range", () => {
+    expect(clampColWidth(320)).toBe(320);
+    expect(clampColWidth(800)).toBe(800);
   });
 });
 
-// ── File-explorer resize bounds ───────────────────────────────────────────────
+// ── Zone height bounds ────────────────────────────────────────────────────────
 
-describe("clampFilesWidth", () => {
-  test("enforces minimum width of 160", () => {
-    expect(clampFilesWidth(0)).toBe(160);
-    expect(clampFilesWidth(159)).toBe(160);
-    expect(clampFilesWidth(160)).toBe(160);
+describe("clampZoneHeight", () => {
+  test("enforces minimum of 80", () => {
+    expect(clampZoneHeight(0)).toBe(80);
+    expect(clampZoneHeight(79)).toBe(80);
+    expect(clampZoneHeight(80)).toBe(80);
   });
 
-  test("enforces maximum width of 800", () => {
-    expect(clampFilesWidth(801)).toBe(800);
-    expect(clampFilesWidth(9999)).toBe(800);
-    expect(clampFilesWidth(800)).toBe(800);
+  test("enforces maximum of 900", () => {
+    expect(clampZoneHeight(901)).toBe(900);
+    expect(clampZoneHeight(9999)).toBe(900);
+    expect(clampZoneHeight(900)).toBe(900);
   });
 
-  test("passes through values in the valid range", () => {
-    expect(clampFilesWidth(280)).toBe(280);
-  });
-});
-
-describe("clampFilesHeight", () => {
-  test("enforces minimum height of 150", () => {
-    expect(clampFilesHeight(0)).toBe(150);
-    expect(clampFilesHeight(149)).toBe(150);
-    expect(clampFilesHeight(150)).toBe(150);
-  });
-
-  test("enforces maximum height of 800", () => {
-    expect(clampFilesHeight(801)).toBe(800);
-    expect(clampFilesHeight(9999)).toBe(800);
+  test("passes through values in range", () => {
+    expect(clampZoneHeight(200)).toBe(200);
+    expect(clampZoneHeight(500)).toBe(500);
   });
 });
 
-// ── localStorage persisted value parsing ─────────────────────────────────────
+// ── PanelPosition type guard ──────────────────────────────────────────────────
 
-describe("parsePersistedTerminalHeight", () => {
-  test("returns default 280 when saved value is null", () => {
-    expect(parsePersistedTerminalHeight(null)).toBe(280);
+describe("PanelPosition type", () => {
+  const allPositions: PanelPosition[] = [
+    "left-top",    "left-middle",    "left-bottom",
+    "center-top",  "center-bottom",
+    "right-top",   "right-middle",   "right-bottom",
+  ];
+
+  test("has exactly 8 distinct values (center-middle is main content, not a zone)", () => {
+    expect(new Set(allPositions).size).toBe(8);
   });
 
-  test("returns parsed + clamped value for valid saved string", () => {
-    expect(parsePersistedTerminalHeight("400")).toBe(400);
-    expect(parsePersistedTerminalHeight("120")).toBe(120);
+  test("contains all expected zone names", () => {
+    expect(allPositions).toContain("left-top");
+    expect(allPositions).toContain("left-middle");
+    expect(allPositions).toContain("left-bottom");
+    expect(allPositions).toContain("center-top");
+    expect(allPositions).toContain("center-bottom");
+    expect(allPositions).toContain("right-top");
+    expect(allPositions).toContain("right-middle");
+    expect(allPositions).toContain("right-bottom");
   });
 
-  test("clamps values that are out of range", () => {
-    expect(parsePersistedTerminalHeight("50")).toBe(120); // below min
-    expect(parsePersistedTerminalHeight("1000")).toBe(900); // above max
-  });
-
-  test("returns default 280 for NaN strings", () => {
-    expect(parsePersistedTerminalHeight("not-a-number")).toBe(280);
-    expect(parsePersistedTerminalHeight("")).toBe(280);
-  });
-});
-
-describe("parsePersistedTerminalWidth", () => {
-  test("returns default 480 when saved value is null", () => {
-    expect(parsePersistedTerminalWidth(null)).toBe(480);
-  });
-
-  test("clamps to valid range", () => {
-    expect(parsePersistedTerminalWidth("100")).toBe(200); // below min
-    expect(parsePersistedTerminalWidth("2000")).toBe(1400); // above max
-    expect(parsePersistedTerminalWidth("600")).toBe(600); // valid
+  test("does not include old 3-value positions", () => {
+    // Old values ("left", "right", "bottom") are migrated on load, not valid at runtime
+    const set = new Set(allPositions as string[]);
+    expect(set.has("left")).toBe(false);
+    expect(set.has("right")).toBe(false);
+    expect(set.has("bottom")).toBe(false);
   });
 });
 
-describe("parsePersistedFilesWidth", () => {
-  test("returns default 280 when saved value is null", () => {
-    expect(parsePersistedFilesWidth(null)).toBe(280);
+// ── Migration ─────────────────────────────────────────────────────────────────
+// Mirrors the migratePanelPosition helper in usePanelLayout.ts.
+
+function migratePanelPosition(raw: string | null, fallback: PanelPosition): PanelPosition {
+  if (!raw) return fallback;
+  if (raw === "left") return "left-middle";
+  if (raw === "right") return "right-middle";
+  if (raw === "bottom") return "center-bottom";
+  const valid: readonly string[] = [
+    "left-top", "left-middle", "left-bottom",
+    "center-top", "center-bottom",
+    "right-top", "right-middle", "right-bottom",
+  ];
+  return valid.includes(raw) ? (raw as PanelPosition) : fallback;
+}
+
+describe("migratePanelPosition — old 3-value → new 8-value", () => {
+  test("'left' → 'left-middle'", () => {
+    expect(migratePanelPosition("left", "right-middle")).toBe("left-middle");
   });
 
-  test("clamps to valid range", () => {
-    expect(parsePersistedFilesWidth("50")).toBe(160); // below min
-    expect(parsePersistedFilesWidth("1000")).toBe(800); // above max
-    expect(parsePersistedFilesWidth("350")).toBe(350); // valid
-  });
-});
-
-describe("parsePersistedFilesHeight", () => {
-  test("returns default 280 when saved value is null", () => {
-    expect(parsePersistedFilesHeight(null)).toBe(280);
+  test("'right' → 'right-middle'", () => {
+    expect(migratePanelPosition("right", "left-middle")).toBe("right-middle");
   });
 
-  test("clamps to valid range", () => {
-    expect(parsePersistedFilesHeight("100")).toBe(150); // below min
-    expect(parsePersistedFilesHeight("1000")).toBe(800); // above max
-  });
-});
-
-// ── localStorage key validation ───────────────────────────────────────────────
-// Note: the hook's try/catch approach wraps every localStorage call so storage
-// errors (e.g., private browsing quota exceeded) degrade gracefully to defaults.
-// The persistence logic itself is tested via the parsePersistedX helpers above,
-// which mirror the initialiser clamping. Browser-side integration of localStorage
-// is tested by the Playwright E2E suite.
-
-describe("panel position type guard", () => {
-  const validPositions: PanelPosition[] = ["bottom", "right", "left"];
-
-  test("all three PanelPosition values are distinct", () => {
-    const positions = new Set(validPositions);
-    expect(positions.size).toBe(3);
+  test("'bottom' → 'center-bottom'", () => {
+    expect(migratePanelPosition("bottom", "right-middle")).toBe("center-bottom");
   });
 
-  test("'bottom', 'right', and 'left' are valid panel positions", () => {
-    expect(validPositions).toContain("bottom");
-    expect(validPositions).toContain("right");
-    expect(validPositions).toContain("left");
+  test("null → fallback", () => {
+    expect(migratePanelPosition(null, "left-middle")).toBe("left-middle");
+    expect(migratePanelPosition(null, "right-middle")).toBe("right-middle");
+  });
+
+  test("valid new position → unchanged", () => {
+    expect(migratePanelPosition("left-top",      "right-middle")).toBe("left-top");
+    expect(migratePanelPosition("center-bottom", "right-middle")).toBe("center-bottom");
+    expect(migratePanelPosition("right-bottom",  "left-middle")).toBe("right-bottom");
+  });
+
+  test("unknown string → fallback", () => {
+    expect(migratePanelPosition("unknown-zone", "right-middle")).toBe("right-middle");
+    expect(migratePanelPosition("center-middle", "left-middle")).toBe("left-middle");
   });
 });

--- a/packages/ui/src/hooks/usePanelLayout.ts
+++ b/packages/ui/src/hooks/usePanelLayout.ts
@@ -1,151 +1,267 @@
 import * as React from "react";
 import type { TerminalTab } from "@/components/TerminalManager";
 
-export type PanelPosition = "bottom" | "right" | "left";
+// ── 9-Zone panel position ─────────────────────────────────────────────────────
+// Layout grid (center-middle = main content, not a dock target):
+//   ┌──────────┬──────────────┬──────────┐
+//   │ left-top │  center-top  │right-top │
+//   ├──────────┤              ├──────────┤
+//   │left-mid  │  MAIN CONTENT│right-mid │
+//   ├──────────┤              ├──────────┤
+//   │left-bot  │ center-bot   │right-bot │
+//   └──────────┴──────────────┴──────────┘
+export type PanelPosition =
+  | "left-top"    | "left-middle"    | "left-bottom"
+  | "center-top"  | "center-bottom"
+  | "right-top"   | "right-middle"   | "right-bottom";
 
+/** Migrate old 3-value localStorage position strings → new 8-value format. */
+function migratePanelPosition(raw: string | null, fallback: PanelPosition): PanelPosition {
+  if (!raw) return fallback;
+  if (raw === "left") return "left-middle";
+  if (raw === "right") return "right-middle";
+  if (raw === "bottom") return "center-bottom";
+  const valid: readonly PanelPosition[] = [
+    "left-top", "left-middle", "left-bottom",
+    "center-top", "center-bottom",
+    "right-top", "right-middle", "right-bottom",
+  ];
+  return (valid as readonly string[]).includes(raw) ? (raw as PanelPosition) : fallback;
+}
+
+// ── Resize direction ──────────────────────────────────────────────────────────
+type ResizeDir =
+  | "col-left"           // drag left-column right edge → adjust leftColumnWidth
+  | "col-right"          // drag right-column left edge → adjust rightColumnWidth
+  | "zone-left-top"      // drag handle under left-top → adjust leftTopHeight
+  | "zone-left-bottom"   // drag handle above left-bottom → adjust leftBottomHeight
+  | "zone-right-top"
+  | "zone-right-bottom"
+  | "zone-center-top"
+  | "zone-center-bottom"
+  | null;
+
+// ── Size bounds ───────────────────────────────────────────────────────────────
+const COL_MIN  = 200;
+const COL_MAX  = 1400;
+const ZONE_MIN = 80;
+const ZONE_MAX = 900;
+
+function clampColWidth(v: number)    { return Math.max(COL_MIN, Math.min(v, COL_MAX)); }
+function clampZoneHeight(v: number)  { return Math.max(ZONE_MIN, Math.min(v, ZONE_MAX)); }
+
+function loadColWidth(key: string, def: number): number {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw) return clampColWidth(parseInt(raw, 10));
+  } catch {}
+  return def;
+}
+function loadZoneHeight(key: string, def: number): number {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw) return clampZoneHeight(parseInt(raw, 10));
+  } catch {}
+  return def;
+}
+function saveNum(key: string, value: number) {
+  try { localStorage.setItem(key, String(Math.round(value))); } catch {}
+}
+function loadPos(key: string, fallback: PanelPosition): PanelPosition {
+  try { return migratePanelPosition(localStorage.getItem(key), fallback); } catch { return fallback; }
+}
+function savePos(key: string, pos: PanelPosition) {
+  try { localStorage.setItem(key, pos); } catch {}
+}
+
+// ── Public interface ──────────────────────────────────────────────────────────
 export interface PanelLayoutState {
-  // ── Shared docked panel state ────────────────────────────────────────────
-  showTerminal: boolean;
-  setShowTerminal: React.Dispatch<React.SetStateAction<boolean>>;
-  terminalPosition: PanelPosition;
-  terminalHeight: number;
-  terminalWidth: number;
-  terminalColumnRef: React.RefObject<HTMLDivElement | null>;
-  handleTerminalResizeStart: (e: React.PointerEvent) => void;
-  handleTerminalPositionChange: (pos: PanelPosition) => void;
-  startPanelResizeForPosition: (position: PanelPosition, e: React.PointerEvent) => void;
+  // ── Column widths ──────────────────────────────────────────────────────────
+  leftColumnWidth: number;
+  rightColumnWidth: number;
 
-  // ── Shared drag-to-reposition ───────────────────────────────────────────
+  // ── Zone heights (for the 6 non-fill zones) ────────────────────────────────
+  leftTopHeight: number;
+  leftBottomHeight: number;
+  rightTopHeight: number;
+  rightBottomHeight: number;
+  centerTopHeight: number;
+  centerBottomHeight: number;
+
+  // ── Main layout container ref ──────────────────────────────────────────────
+  // Attach to the outermost layout div; used for all resize + drag calculations.
+  terminalColumnRef: React.RefObject<HTMLDivElement | null>;
+
+  // ── Column + zone resize starters ─────────────────────────────────────────
+  startColumnWidthResize: (side: "left" | "right", e: React.PointerEvent) => void;
+  startZoneHeightResize: (zone: PanelPosition, e: React.PointerEvent) => void;
+
+  // ── Drag-to-reposition ─────────────────────────────────────────────────────
   panelDragActive: boolean;
   panelDragZone: PanelPosition | null;
-  handlePanelDragStart: (e: React.PointerEvent) => void;
-  handleTerminalTabDragStart: (e: React.PointerEvent) => void;
   startPanelDragWith: (e: React.PointerEvent, applyPosition: (pos: PanelPosition) => void) => void;
 
-  // ── Shared outer pointer handlers (resize + drag combined) ──────────────
+  // ── Combined outer pointer handlers (resize + drag) ────────────────────────
   handleOuterPointerMove: (e: React.PointerEvent) => void;
   handleOuterPointerUp: () => void;
 
-  // ── Combined panel (terminal + file explorer + service panels) ───────────
+  // ── Combined panel tab state ───────────────────────────────────────────────
   combinedActiveTab: string;
   handleCombinedTabChange: (tab: string) => void;
   handleCombinedPositionChange: (pos: PanelPosition) => void;
 
-  // ── Lifted terminal tab state ───────────────────────────────────────────
+  // ── Lifted terminal tab state ──────────────────────────────────────────────
   terminalTabs: TerminalTab[];
   activeTerminalId: string | null;
   setActiveTerminalId: React.Dispatch<React.SetStateAction<string | null>>;
   handleTerminalTabAdd: (tab: TerminalTab) => void;
   handleTerminalTabClose: (terminalId: string) => void;
 
-  // ── File explorer panel ─────────────────────────────────────────────────
+  // ── Terminal panel ─────────────────────────────────────────────────────────
+  showTerminal: boolean;
+  setShowTerminal: React.Dispatch<React.SetStateAction<boolean>>;
+  terminalPosition: PanelPosition;
+  handleTerminalPositionChange: (pos: PanelPosition) => void;
+
+  // ── File explorer panel ────────────────────────────────────────────────────
   showFileExplorer: boolean;
   setShowFileExplorer: React.Dispatch<React.SetStateAction<boolean>>;
   filesPosition: PanelPosition;
-  filesWidth: number;
-  filesHeight: number;
-  filesContainerRef: React.RefObject<HTMLDivElement | null>;
-  handleFilesWidthLeftResizeStart: (e: React.PointerEvent) => void;
-  handleFilesWidthRightResizeStart: (e: React.PointerEvent) => void;
-  handleFilesHeightResizeStart: (e: React.PointerEvent) => void;
   handleFilesPositionChange: (pos: PanelPosition) => void;
 
-  // ── File explorer drag-to-reposition ────────────────────────────────────
-  filesDragActive: boolean;
-  filesDragZone: PanelPosition | null;
-  handleFilesDragStart: (e: React.PointerEvent) => void;
-
-  // ── File explorer outer pointer handlers (resize + drag combined) ───────
-  handleFilesOuterPointerMove: (e: React.PointerEvent) => void;
-  handleFilesOuterPointerUp: () => void;
-
-  // ── Git panel ───────────────────────────────────────────────────────────
+  // ── Git panel ─────────────────────────────────────────────────────────────
   showGit: boolean;
   setShowGit: React.Dispatch<React.SetStateAction<boolean>>;
   gitPosition: PanelPosition;
   handleGitPositionChange: (pos: PanelPosition) => void;
+
+  // ── Triggers panel ────────────────────────────────────────────────────────
+  showTriggers: boolean;
+  setShowTriggers: React.Dispatch<React.SetStateAction<boolean>>;
+  triggersPosition: PanelPosition;
+  handleTriggersPositionChange: (pos: PanelPosition) => void;
 }
 
-/**
- * Manages the full panel layout: terminal and file explorer positioning,
- * resizing, drag-to-reposition, combined-panel tab state, and lifted
- * terminal tab state that survives panel remounts.
- */
+// ── Hook ──────────────────────────────────────────────────────────────────────
 export function usePanelLayout(activeSessionId: string | null): PanelLayoutState {
-  // ── Terminal panel state ───────────────────────────────────────────────
-  const [showTerminal, setShowTerminal] = React.useState(false);
-  const [terminalPosition, setTerminalPosition] = React.useState<PanelPosition>(() => {
-    try { return (localStorage.getItem("pp-terminal-position") as PanelPosition) ?? "bottom"; } catch { return "bottom"; }
-  });
-  const [terminalHeight, setTerminalHeight] = React.useState<number>(() => {
-    try {
-      const saved = localStorage.getItem("pp-terminal-height");
-      if (saved) return Math.max(120, Math.min(parseInt(saved, 10), 900));
-    } catch {}
-    return 280;
-  });
-  const [terminalWidth, setTerminalWidth] = React.useState<number>(() => {
-    try {
-      const saved = localStorage.getItem("pp-terminal-width");
-      if (saved) return Math.max(200, Math.min(parseInt(saved, 10), 1400));
-    } catch {}
-    return 480;
-  });
-  const terminalColumnRef = React.useRef<HTMLDivElement>(null);
-  // "height" = bottom panel vertical drag, "width-right" = right panel, "width-left" = left panel
-  const resizeDir = React.useRef<"height" | "width-right" | "width-left" | null>(null);
+  // ── Column widths ───────────────────────────────────────────────────────
+  const [leftColumnWidth, setLeftColumnWidth] = React.useState(() =>
+    // Migrate from legacy pp-terminal-width / pp-files-width if present
+    loadColWidth("pp-left-col-width",
+      loadColWidth("pp-terminal-width",
+        loadColWidth("pp-files-width", 320))),
+  );
+  const [rightColumnWidth, setRightColumnWidth] = React.useState(() =>
+    loadColWidth("pp-right-col-width",
+      loadColWidth("pp-terminal-width", 320)),
+  );
 
-  const startPanelResizeForPosition = React.useCallback((position: PanelPosition, e: React.PointerEvent) => {
+  // ── Zone heights ────────────────────────────────────────────────────────
+  const [leftTopHeight, setLeftTopHeight] = React.useState(() =>
+    loadZoneHeight("pp-zone-left-top-h", 200));
+  const [leftBottomHeight, setLeftBottomHeight] = React.useState(() =>
+    loadZoneHeight("pp-zone-left-bottom-h", 200));
+  const [rightTopHeight, setRightTopHeight] = React.useState(() =>
+    loadZoneHeight("pp-zone-right-top-h", 200));
+  const [rightBottomHeight, setRightBottomHeight] = React.useState(() =>
+    loadZoneHeight("pp-zone-right-bottom-h", 200));
+  const [centerTopHeight, setCenterTopHeight] = React.useState(() =>
+    loadZoneHeight("pp-zone-center-top-h",
+      // migrate from old pp-terminal-height (which was the bottom panel height)
+      loadZoneHeight("pp-terminal-height", 200)));
+  const [centerBottomHeight, setCenterBottomHeight] = React.useState(() =>
+    loadZoneHeight("pp-zone-center-bottom-h",
+      loadZoneHeight("pp-terminal-height", 280)));
+
+  // ── Main layout container ref ───────────────────────────────────────────
+  const terminalColumnRef = React.useRef<HTMLDivElement>(null);
+
+  // ── Resize ──────────────────────────────────────────────────────────────
+  const resizeDir = React.useRef<ResizeDir>(null);
+
+  const startColumnWidthResize = React.useCallback((side: "left" | "right", e: React.PointerEvent) => {
     e.preventDefault();
-    resizeDir.current = position === "bottom" ? "height"
-      : position === "right" ? "width-right"
-      : "width-left";
+    resizeDir.current = side === "left" ? "col-left" : "col-right";
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
   }, []);
 
-  // Single handler — direction is derived from current terminalPosition at drag start
-  const handleTerminalResizeStart = React.useCallback((e: React.PointerEvent) => {
-    startPanelResizeForPosition(terminalPosition, e);
-  }, [terminalPosition, startPanelResizeForPosition]);
+  const startZoneHeightResize = React.useCallback((zone: PanelPosition, e: React.PointerEvent) => {
+    e.preventDefault();
+    const dirMap: Partial<Record<PanelPosition, ResizeDir>> = {
+      "left-top":      "zone-left-top",
+      "left-bottom":   "zone-left-bottom",
+      "right-top":     "zone-right-top",
+      "right-bottom":  "zone-right-bottom",
+      "center-top":    "zone-center-top",
+      "center-bottom": "zone-center-bottom",
+    };
+    resizeDir.current = dirMap[zone] ?? null;
+    if (resizeDir.current) {
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    }
+  }, []);
 
-  const handleTerminalResizeMove = React.useCallback((e: React.PointerEvent) => {
+  const handleResizeMove = React.useCallback((e: React.PointerEvent) => {
     const dir = resizeDir.current;
     if (!dir || !terminalColumnRef.current) return;
     const rect = terminalColumnRef.current.getBoundingClientRect();
-    if (dir === "height") {
-      setTerminalHeight(Math.max(120, Math.min(rect.bottom - e.clientY, rect.height - 80)));
-    } else if (dir === "width-right") {
-      setTerminalWidth(Math.max(200, Math.min(rect.right - e.clientX, rect.width - 200)));
-    } else {
-      setTerminalWidth(Math.max(200, Math.min(e.clientX - rect.left, rect.width - 200)));
+
+    switch (dir) {
+      case "col-left":
+        setLeftColumnWidth(clampColWidth(e.clientX - rect.left));
+        break;
+      case "col-right":
+        setRightColumnWidth(clampColWidth(rect.right - e.clientX));
+        break;
+      case "zone-left-top":
+        setLeftTopHeight(clampZoneHeight(e.clientY - rect.top));
+        break;
+      case "zone-left-bottom":
+        setLeftBottomHeight(clampZoneHeight(rect.bottom - e.clientY));
+        break;
+      case "zone-right-top":
+        setRightTopHeight(clampZoneHeight(e.clientY - rect.top));
+        break;
+      case "zone-right-bottom":
+        setRightBottomHeight(clampZoneHeight(rect.bottom - e.clientY));
+        break;
+      case "zone-center-top":
+        setCenterTopHeight(clampZoneHeight(e.clientY - rect.top));
+        break;
+      case "zone-center-bottom":
+        setCenterBottomHeight(clampZoneHeight(rect.bottom - e.clientY));
+        break;
     }
   }, []);
 
-  const handleTerminalResizeEnd = React.useCallback(() => {
+  const handleResizeEnd = React.useCallback(() => {
     const dir = resizeDir.current;
     if (!dir) return;
     resizeDir.current = null;
-    if (dir === "height") {
-      setTerminalHeight((h) => { try { localStorage.setItem("pp-terminal-height", String(Math.round(h))); } catch {} return h; });
-    } else {
-      setTerminalWidth((w) => { try { localStorage.setItem("pp-terminal-width", String(Math.round(w))); } catch {} return w; });
+    // Persist on pointer-up
+    switch (dir) {
+      case "col-left":      setLeftColumnWidth((v)      => { saveNum("pp-left-col-width",           v); return v; }); break;
+      case "col-right":     setRightColumnWidth((v)     => { saveNum("pp-right-col-width",          v); return v; }); break;
+      case "zone-left-top":    setLeftTopHeight((v)     => { saveNum("pp-zone-left-top-h",          v); return v; }); break;
+      case "zone-left-bottom": setLeftBottomHeight((v)  => { saveNum("pp-zone-left-bottom-h",       v); return v; }); break;
+      case "zone-right-top":   setRightTopHeight((v)    => { saveNum("pp-zone-right-top-h",         v); return v; }); break;
+      case "zone-right-bottom":setRightBottomHeight((v) => { saveNum("pp-zone-right-bottom-h",      v); return v; }); break;
+      case "zone-center-top":  setCenterTopHeight((v)   => { saveNum("pp-zone-center-top-h",        v); return v; }); break;
+      case "zone-center-bottom":setCenterBottomHeight((v)=>{ saveNum("pp-zone-center-bottom-h",     v); return v; }); break;
     }
   }, []);
 
-  // ── Panel drag-to-reposition ──────────────────────────────────────────
+  // ── Drag-to-reposition ──────────────────────────────────────────────────
   const isPanelDragging = React.useRef(false);
   const panelDragZoneRef = React.useRef<PanelPosition | null>(null);
   const [panelDragActive, setPanelDragActive] = React.useState(false);
   const [panelDragZone, setPanelDragZone] = React.useState<PanelPosition | null>(null);
-
-  const handleTerminalPositionChange = React.useCallback((pos: PanelPosition) => {
-    setTerminalPosition(pos);
-    try { localStorage.setItem("pp-terminal-position", pos); } catch {}
-  }, []);
-
   const dragApplyRef = React.useRef<((zone: PanelPosition) => void) | null>(null);
 
-  const startPanelDragWith = React.useCallback((e: React.PointerEvent, applyPosition: (pos: PanelPosition) => void) => {
+  const startPanelDragWith = React.useCallback((
+    e: React.PointerEvent,
+    applyPosition: (pos: PanelPosition) => void,
+  ) => {
     e.preventDefault();
     dragApplyRef.current = applyPosition;
     isPanelDragging.current = true;
@@ -155,53 +271,48 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
   }, []);
 
-  const handlePanelDragStart = React.useCallback((e: React.PointerEvent) => {
-    startPanelDragWith(e, handleTerminalPositionChange);
-  }, [startPanelDragWith, handleTerminalPositionChange]);
-
-  const handlePanelDragMove = React.useCallback((e: React.PointerEvent) => {
+  const handleDragMove = React.useCallback((e: React.PointerEvent) => {
     if (!isPanelDragging.current || !terminalColumnRef.current) return;
     const rect = terminalColumnRef.current.getBoundingClientRect();
     const pctX = (e.clientX - rect.left) / rect.width;
-    const pctY = (e.clientY - rect.top) / rect.height;
-    let zone: PanelPosition | null = null;
-    if (pctY > 0.55) zone = "bottom";
-    else if (pctX > 0.65) zone = "right";
-    else if (pctX < 0.35) zone = "left";
+    const pctY = (e.clientY - rect.top)  / rect.height;
+
+    const col: "left" | "center" | "right" =
+      pctX < 0.33 ? "left" : pctX > 0.67 ? "right" : "center";
+    const row: "top" | "middle" | "bottom" =
+      pctY < 0.33 ? "top" : pctY > 0.67 ? "bottom" : "middle";
+
+    // center-middle is the main content area — not a valid dock target
+    const zone: PanelPosition | null =
+      col === "center" && row === "middle" ? null : `${col}-${row}` as PanelPosition;
+
     panelDragZoneRef.current = zone;
     setPanelDragZone(zone);
   }, []);
 
-  // Drag start handler for the Terminal tab inside the combined panel.
-  // Unlike the grip handle, this only moves the terminal panel.
-  const handleTerminalTabDragStart = React.useCallback((e: React.PointerEvent) => {
-    startPanelDragWith(e, handleTerminalPositionChange);
-  }, [startPanelDragWith, handleTerminalPositionChange]);
-
-  const handlePanelDragEnd = React.useCallback(() => {
+  const handleDragEnd = React.useCallback(() => {
     if (!isPanelDragging.current) return;
     isPanelDragging.current = false;
     const zone = panelDragZoneRef.current;
     panelDragZoneRef.current = null;
     setPanelDragActive(false);
     setPanelDragZone(null);
-    if (zone) {
-      dragApplyRef.current?.(zone);
-    }
+    if (zone) dragApplyRef.current?.(zone);
     dragApplyRef.current = null;
   }, []);
 
+  // ── Combined pointer handlers ───────────────────────────────────────────
   const handleOuterPointerMove = React.useCallback((e: React.PointerEvent) => {
-    handleTerminalResizeMove(e);
-    handlePanelDragMove(e);
-  }, [handleTerminalResizeMove, handlePanelDragMove]);
+    handleResizeMove(e);
+    handleDragMove(e);
+  }, [handleResizeMove, handleDragMove]);
 
   const handleOuterPointerUp = React.useCallback(() => {
-    handleTerminalResizeEnd();
-    handlePanelDragEnd();
-  }, [handleTerminalResizeEnd, handlePanelDragEnd]);
+    handleResizeEnd();
+    handleDragEnd();
+  }, [handleResizeEnd, handleDragEnd]);
 
-  // ── Combined panel tab state ──────────────────────────────────────────
+  // ── Combined panel tab state ────────────────────────────────────────────
   const [combinedActiveTab, setCombinedActiveTab] = React.useState<string>(() => {
     try { return localStorage.getItem("pp-combined-tab") ?? "terminal"; } catch { return "terminal"; }
   });
@@ -210,16 +321,12 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     try { localStorage.setItem("pp-combined-tab", tab); } catch {}
   }, []);
 
-  // ── Lifted terminal tab state ─────────────────────────────────────────
-  // Stored here (not inside TerminalManager) so tabs survive panel remounts
-  // (e.g., when the panel transitions between combined and standalone layouts).
+  // ── Lifted terminal tab state ───────────────────────────────────────────
   const [terminalTabs, setTerminalTabs] = React.useState<TerminalTab[]>([]);
   const [activeTerminalId, setActiveTerminalId] = React.useState<string | null>(null);
 
-  // Per-session last-active terminal: save/restore when switching sessions.
   const sessionActiveTerminalRef = React.useRef<Map<string | null, string | null>>(new Map());
   const prevSessionIdForTerminalRef = React.useRef<string | null>(null);
-  // Stable ref so the effect doesn't need activeTerminalId in its dep array
   const activeTerminalIdRef = React.useRef<string | null>(null);
   activeTerminalIdRef.current = activeTerminalId;
 
@@ -227,17 +334,12 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     const prev = prevSessionIdForTerminalRef.current;
     if (prev === activeSessionId) return;
     prevSessionIdForTerminalRef.current = activeSessionId;
-
-    // Save current active terminal for the outgoing session
     sessionActiveTerminalRef.current.set(prev, activeTerminalIdRef.current);
-
-    // Restore the last-active terminal for the incoming session
     const incoming = activeSessionId;
     const sessionTabs = incoming != null
       ? terminalTabs.filter((t) => t.sessionId === incoming)
       : terminalTabs;
     const savedActive = sessionActiveTerminalRef.current.get(incoming);
-
     if (savedActive && sessionTabs.some((t) => t.terminalId === savedActive)) {
       setActiveTerminalId(savedActive);
     } else if (sessionTabs.length > 0) {
@@ -257,7 +359,6 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
       const next = prev.filter((t) => t.terminalId !== terminalId);
       setActiveTerminalId((current) => {
         if (current !== terminalId) return current;
-        // Find the closest remaining tab in the same session
         const removed = prev.find((t) => t.terminalId === terminalId);
         const sameSess = next.filter((t) => t.sessionId === (removed?.sessionId ?? null));
         return sameSess.length > 0 ? sameSess[sameSess.length - 1].terminalId : null;
@@ -266,144 +367,66 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     });
   }, []);
 
-  // ── File explorer panel state ─────────────────────────────────────────
+  // ── Terminal panel ──────────────────────────────────────────────────────
+  const [showTerminal, setShowTerminal] = React.useState(false);
+  const [terminalPosition, setTerminalPosition] = React.useState<PanelPosition>(() =>
+    loadPos("pp-terminal-position", "center-bottom"),
+  );
+  const handleTerminalPositionChange = React.useCallback((pos: PanelPosition) => {
+    setTerminalPosition(pos);
+    savePos("pp-terminal-position", pos);
+  }, []);
+
+  // ── File explorer panel ─────────────────────────────────────────────────
   const [showFileExplorer, setShowFileExplorer] = React.useState(false);
-  const [filesPosition, setFilesPosition] = React.useState<PanelPosition>(() => {
-    try { return (localStorage.getItem("pp-files-position") as PanelPosition) ?? "left"; } catch { return "left"; }
-  });
-  const [filesWidth, setFilesWidth] = React.useState<number>(() => {
-    try {
-      const saved = localStorage.getItem("pp-files-width");
-      if (saved) return Math.max(160, Math.min(parseInt(saved, 10), 800));
-    } catch {}
-    return 280;
-  });
-  const [filesHeight, setFilesHeight] = React.useState<number>(() => {
-    try {
-      const saved = localStorage.getItem("pp-files-height");
-      if (saved) return Math.max(150, Math.min(parseInt(saved, 10), 800));
-    } catch {}
-    return 280;
-  });
-  const filesContainerRef = React.useRef<HTMLDivElement>(null);
-  const filesResizeDir = React.useRef<"width-right" | "width-left" | "height" | null>(null);
-
-  const handleFilesWidthLeftResizeStart = React.useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    filesResizeDir.current = "width-left";
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-  const handleFilesWidthRightResizeStart = React.useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    filesResizeDir.current = "width-right";
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-  const handleFilesHeightResizeStart = React.useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    filesResizeDir.current = "height";
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-  const handleFilesResizeMove = React.useCallback((e: React.PointerEvent) => {
-    const dir = filesResizeDir.current;
-    if (!dir || !filesContainerRef.current) return;
-    const rect = filesContainerRef.current.getBoundingClientRect();
-    if (dir === "width-right") {
-      setFilesWidth(Math.max(160, Math.min(rect.right - e.clientX, rect.width - 200)));
-    } else if (dir === "width-left") {
-      setFilesWidth(Math.max(160, Math.min(e.clientX - rect.left, rect.width - 200)));
-    } else {
-      setFilesHeight(Math.max(150, Math.min(rect.bottom - e.clientY, rect.height - 100)));
-    }
-  }, []);
-  const handleFilesResizeEnd = React.useCallback(() => {
-    const dir = filesResizeDir.current;
-    if (!dir) return;
-    filesResizeDir.current = null;
-    if (dir === "height") {
-      setFilesHeight((h) => { try { localStorage.setItem("pp-files-height", String(Math.round(h))); } catch {} return h; });
-    } else {
-      setFilesWidth((w) => { try { localStorage.setItem("pp-files-width", String(Math.round(w))); } catch {} return w; });
-    }
-  }, []);
-
+  const [filesPosition, setFilesPosition] = React.useState<PanelPosition>(() =>
+    loadPos("pp-files-position", "left-middle"),
+  );
   const handleFilesPositionChange = React.useCallback((pos: PanelPosition) => {
     setFilesPosition(pos);
-    try { localStorage.setItem("pp-files-position", pos); } catch {}
+    savePos("pp-files-position", pos);
   }, []);
 
+  // ── Git panel ───────────────────────────────────────────────────────────
+  const [showGit, setShowGit] = React.useState(false);
+  const [gitPosition, setGitPosition] = React.useState<PanelPosition>(() =>
+    loadPos("pp-git-position", "left-middle"),
+  );
+  const handleGitPositionChange = React.useCallback((pos: PanelPosition) => {
+    setGitPosition(pos);
+    savePos("pp-git-position", pos);
+  }, []);
+
+  // ── Triggers panel ──────────────────────────────────────────────────────
+  const [showTriggers, setShowTriggers] = React.useState(false);
+  const [triggersPosition, setTriggersPosition] = React.useState<PanelPosition>(() =>
+    loadPos("pp-triggers-position", "right-middle"),
+  );
+  const handleTriggersPositionChange = React.useCallback((pos: PanelPosition) => {
+    setTriggersPosition(pos);
+    savePos("pp-triggers-position", pos);
+  }, []);
+
+  // ── Combined-position change (moves all co-located panels) ─────────────
   const handleCombinedPositionChange = React.useCallback((pos: PanelPosition) => {
     handleTerminalPositionChange(pos);
     handleFilesPositionChange(pos);
   }, [handleTerminalPositionChange, handleFilesPositionChange]);
 
-  // ── File explorer drag-to-reposition ──────────────────────────────────
-  const isFilesDragging = React.useRef(false);
-  const filesDragZoneRef = React.useRef<PanelPosition | null>(null);
-  const [filesDragActive, setFilesDragActive] = React.useState(false);
-  const [filesDragZone, setFilesDragZone] = React.useState<PanelPosition | null>(null);
-
-  const handleFilesDragStart = React.useCallback((e: React.PointerEvent) => {
-    e.preventDefault();
-    isFilesDragging.current = true;
-    filesDragZoneRef.current = null;
-    setFilesDragActive(true);
-    setFilesDragZone(null);
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-  }, []);
-  const handleFilesDragMove = React.useCallback((e: React.PointerEvent) => {
-    if (!isFilesDragging.current || !filesContainerRef.current) return;
-    const rect = filesContainerRef.current.getBoundingClientRect();
-    const pctX = (e.clientX - rect.left) / rect.width;
-    const pctY = (e.clientY - rect.top) / rect.height;
-    let zone: PanelPosition | null = null;
-    if (pctY > 0.55) zone = "bottom";
-    else if (pctX > 0.65) zone = "right";
-    else if (pctX < 0.35) zone = "left";
-    filesDragZoneRef.current = zone;
-    setFilesDragZone(zone);
-  }, []);
-  const handleFilesDragEnd = React.useCallback(() => {
-    if (!isFilesDragging.current) return;
-    isFilesDragging.current = false;
-    const zone = filesDragZoneRef.current;
-    filesDragZoneRef.current = null;
-    setFilesDragActive(false);
-    setFilesDragZone(null);
-    if (zone) handleFilesPositionChange(zone);
-  }, [handleFilesPositionChange]);
-  const handleFilesOuterPointerMove = React.useCallback((e: React.PointerEvent) => {
-    handleFilesResizeMove(e);
-    handleFilesDragMove(e);
-  }, [handleFilesResizeMove, handleFilesDragMove]);
-  const handleFilesOuterPointerUp = React.useCallback(() => {
-    handleFilesResizeEnd();
-    handleFilesDragEnd();
-  }, [handleFilesResizeEnd, handleFilesDragEnd]);
-
-  // ── Git panel state ───────────────────────────────────────────────────
-  const [showGit, setShowGit] = React.useState(false);
-  const [gitPosition, setGitPosition] = React.useState<PanelPosition>(() => {
-    try { return (localStorage.getItem("pp-git-position") as PanelPosition) ?? "left"; } catch { return "left"; }
-  });
-  const handleGitPositionChange = React.useCallback((pos: PanelPosition) => {
-    setGitPosition(pos);
-    try { localStorage.setItem("pp-git-position", pos); } catch {}
-  }, []);
-
   return {
-    showTerminal,
-    setShowTerminal,
-    terminalPosition,
-    terminalHeight,
-    terminalWidth,
+    leftColumnWidth,
+    rightColumnWidth,
+    leftTopHeight,
+    leftBottomHeight,
+    rightTopHeight,
+    rightBottomHeight,
+    centerTopHeight,
+    centerBottomHeight,
     terminalColumnRef,
-    handleTerminalResizeStart,
-    handleTerminalPositionChange,
-    startPanelResizeForPosition,
+    startColumnWidthResize,
+    startZoneHeightResize,
     panelDragActive,
     panelDragZone,
-    handlePanelDragStart,
-    handleTerminalTabDragStart,
     startPanelDragWith,
     handleOuterPointerMove,
     handleOuterPointerUp,
@@ -415,24 +438,21 @@ export function usePanelLayout(activeSessionId: string | null): PanelLayoutState
     setActiveTerminalId,
     handleTerminalTabAdd,
     handleTerminalTabClose,
+    showTerminal,
+    setShowTerminal,
+    terminalPosition,
+    handleTerminalPositionChange,
     showFileExplorer,
     setShowFileExplorer,
     filesPosition,
-    filesWidth,
-    filesHeight,
-    filesContainerRef,
-    handleFilesWidthLeftResizeStart,
-    handleFilesWidthRightResizeStart,
-    handleFilesHeightResizeStart,
     handleFilesPositionChange,
-    filesDragActive,
-    filesDragZone,
-    handleFilesDragStart,
-    handleFilesOuterPointerMove,
-    handleFilesOuterPointerUp,
     showGit,
     setShowGit,
     gitPosition,
     handleGitPositionChange,
+    showTriggers,
+    setShowTriggers,
+    triggersPosition,
+    handleTriggersPositionChange,
   };
 }


### PR DESCRIPTION
## Summary

Evolves `PanelPosition` from 3 values (`left`/`right`/`bottom`) to 8 independent docking zones arranged in a 3×3 grid:

```
┌──────────┬──────────────┬──────────┐
│ left-top │  center-top  │right-top │
├──────────┤              ├──────────┤
│left-mid  │  MAIN CONTENT│right-mid │
├──────────┤              ├──────────┤
│left-bot  │  center-bot  │right-bot │
└──────────┴──────────────┴──────────┘
```

Each panel docks independently into any of the 8 zones. Center-middle is the main content area and is not a dock target.

## Changes

### `usePanelLayout.ts`
- New `PanelPosition` type with 8 values
- Independent `leftColumnWidth` + `rightColumnWidth` (left and right columns can be sized separately)
- Per-zone height state for 6 non-fill zones (left-top, left-bottom, right-top, right-bottom, center-top, center-bottom)
- New `startColumnWidthResize` / `startZoneHeightResize` handlers
- 3×3 drag-zone detection (replaces old 3-zone detection)
- localStorage migration: old `"left"→"left-middle"`, `"right"→"right-middle"`, `"bottom"→"center-bottom"`

### `CombinedPanel.tsx`
- 3×3 grid position picker replaces the 3-button linear picker
- Trigger button shows a mini grid SVG with the active zone highlighted
- Preserves collapse (double-click tab) + middle-click-to-close from in-progress panel-tabs work

### `DockedPanelGroup.tsx`
- `DockPosition` aliased to `PanelPosition`
- Inline resize handle only for `center-top`/`center-bottom`; column-width handles live in App.tsx

### `App.tsx`
- 3-column layout: left column (stacked zones) | center (top + main + bottom) | right column
- Independent column-width resize handles (vertical drag bars between columns)
- Inter-zone height resize handles (horizontal drag bars within columns)
- 3×3 drag overlay replaces old 3-zone overlay

### `ServicePanels.tsx`
- Default position fallback migrated from `"right"` to `"right-middle"`
- In-memory migration for stored old-format values

## Layout rules
- **Middle zone fills** within each side column (flex-1); top/bottom have explicit stored heights
- **Backward compat**: old localStorage values auto-migrate on first load — no user action needed
- **Mobile**: unchanged — still uses full-screen overlay panel

## Tests
- `usePanelLayout.test.ts`: full 3×3 drag detection tests, migration tests, bounds tests (43 tests)
- `DockedPanelGroup.test.tsx`: updated for new architecture
- `ServicePanels.test.ts`: updated position literals
- All 743 UI tests pass, typecheck clean, build succeeds