### PR TITLE
feat: client-side tool search extension for dynamic MCP tool discovery

### DIFF
--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -253,6 +253,36 @@ export interface ProviderSettings {
     };
 }
 
+/**
+ * Tool search configuration — enables dynamic tool discovery to reduce
+ * context window bloat when many MCP tools are registered.
+ *
+ * When enabled, MCP tools that exceed the token threshold are deactivated
+ * from the context window. A `search_tools` tool is registered that the
+ * LLM can call to discover and load deferred tools on-demand.
+ */
+export interface ToolSearchConfig {
+    /** Enable tool search. Default: false. */
+    enabled?: boolean;
+    /**
+     * Character threshold for MCP tool descriptions. If the total character
+     * count of all MCP tool definitions (name + description + schema) exceeds
+     * this, tools are deferred. Default: 10000.
+     *
+     * Roughly 4 characters ≈ 1 token, so 10000 chars ≈ 2500 tokens.
+     */
+    tokenThreshold?: number;
+    /** Maximum number of tools to return per search. Default: 5. */
+    maxResults?: number;
+    /**
+     * Keep tools loaded after they are discovered via search.
+     * When true, discovered tools remain active for the rest of the session.
+     * When false, tools are deactivated after each turn.
+     * Default: true.
+     */
+    keepLoadedTools?: boolean;
+}
+
 export interface PizzaPiConfig {
     /** Override the default system prompt */
     systemPrompt?: string;
@@ -370,4 +400,14 @@ export interface PizzaPiConfig {
      * ```
      */
     providerSettings?: ProviderSettings;
+
+    /**
+     * Tool search configuration — dynamic MCP tool discovery.
+     *
+     * When enabled, defers MCP tools that exceed a token threshold
+     * and provides a `search_tools` tool for on-demand discovery.
+     *
+     * Also supports per-server `deferLoading: true` in mcpServers entries.
+     */
+    toolSearch?: ToolSearchConfig;
 }

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -21,12 +21,14 @@ import { sandboxEventsExtension } from "./sandbox-events.js";
 import { pizzapiTitleExtension } from "./pizzapi-title.js";
 import { initialPromptExtension } from "./initial-prompt.js";
 import { pizzapiHeaderExtension } from "./pizzapi-header.js";
+import { toolSearchExtension } from "./tool-search.js";
 
 const CORE_EXTENSIONS: ExtensionFactory[] = [
     triggersExtension,  // Must be before remoteExtension (shutdown ordering)
     remoteExtension,
     tunnelToolsExtension,
     mcpExtension,
+    toolSearchExtension,  // Must be after MCP to see registered MCP tools
     restartExtension,
     setSessionNameExtension,
     updateTodoExtension,

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -18,6 +18,7 @@ import { triggersExtension } from "./triggers/extension.js";
 import { sandboxEventsExtension } from "./sandbox-events.js";
 import { pizzapiTitleExtension } from "./pizzapi-title.js";
 import { pizzapiHeaderExtension } from "./pizzapi-header.js";
+import { toolSearchExtension } from "./tool-search.js";
 
 export interface BuildExtensionFactoriesOptions {
     cwd: string;
@@ -56,6 +57,8 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
 
     if (!options.skipMcp) {
         factories.push(named(mcpExtension, "mcp"));
+        // Tool search must come after MCP so it can see registered MCP tools
+        factories.push(named(toolSearchExtension, "tool-search"));
     }
 
     factories.push(

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -558,6 +558,14 @@ export async function registerMcpTools(
               },
             });
           }
+
+          // Notify extensions that the registry snapshot changed so they can
+          // resync against late or background MCP completion.
+          pi.events?.emit?.("mcp:registry_updated", {
+            server: client.name,
+            toolCount: serverToolList.length,
+            totalToolCount: toolCount,
+          });
         }
 
         return { name: client.name, tools, durationMs, timedOut };

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -28,9 +28,9 @@ export type McpConfig = {
   // Preferred format
   mcp?: {
     servers?: Array<
-      | { name: string; transport: "stdio"; command: string; args?: string[]; env?: Record<string, string>; cwd?: string }
-      | { name: string; transport: "http"; url: string; headers?: Record<string, string>; oauthClientName?: string }
-      | { name: string; transport: "streamable"; url: string; headers?: Record<string, string>; oauthClientName?: string }
+      | { name: string; transport: "stdio"; command: string; args?: string[]; env?: Record<string, string>; cwd?: string; deferLoading?: boolean }
+      | { name: string; transport: "http"; url: string; headers?: Record<string, string>; oauthClientName?: string; deferLoading?: boolean }
+      | { name: string; transport: "streamable"; url: string; headers?: Record<string, string>; oauthClientName?: string; deferLoading?: boolean }
     >;
   };
 
@@ -50,8 +50,8 @@ export type McpConfig = {
   // Note: in the standard MCP ecosystem, type "http" means Streamable HTTP.
   mcpServers?: Record<
     string,
-    | { command: string; args?: string[]; env?: Record<string, string>; cwd?: string }
-    | { url: string; transport?: "http" | "streamable"; type?: "http" | "sse"; headers?: Record<string, string>; oauthClientName?: string }
+    | { command: string; args?: string[]; env?: Record<string, string>; cwd?: string; deferLoading?: boolean }
+    | { url: string; transport?: "http" | "streamable"; type?: "http" | "sse"; headers?: Record<string, string>; oauthClientName?: string; deferLoading?: boolean }
   >;
 };
 

--- a/packages/cli/src/extensions/tool-search.lifecycle.test.ts
+++ b/packages/cli/src/extensions/tool-search.lifecycle.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+type EventHandler = (event?: unknown, ctx?: unknown) => unknown;
+
+describe("toolSearchExtension lifecycle sync", () => {
+  let snapshot: { serverTools?: Record<string, string[]> };
+  let config: Record<string, unknown>;
+
+  beforeEach(() => {
+    snapshot = { serverTools: {} };
+    config = {
+      toolSearch: {
+        enabled: true,
+        tokenThreshold: 0,
+        maxResults: 5,
+        keepLoadedTools: true,
+      },
+      mcpServers: {},
+    };
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  function createHarness() {
+    const handlers = new Map<string, EventHandler[]>();
+    const activeTools = new Set<string>(["mcp_github_create_issue", "search_tools"]);
+    const registeredTools = new Map<string, any>();
+    const registeredCommands = new Map<string, any>();
+
+    const pi = {
+      on: mock((event: string, handler: EventHandler) => {
+        const list = handlers.get(event) ?? [];
+        list.push(handler);
+        handlers.set(event, list);
+      }),
+      events: {
+        on: mock((event: string, handler: EventHandler) => {
+          const list = handlers.get(event) ?? [];
+          list.push(handler);
+          handlers.set(event, list);
+        }),
+        emit: mock((event: string, payload?: unknown) => {
+          for (const handler of handlers.get(event) ?? []) {
+            handler(payload, undefined);
+          }
+        }),
+      },
+      registerTool: mock((tool: any) => {
+        registeredTools.set(tool.name, tool);
+      }),
+      registerCommand: mock((name: string, command: any) => {
+        registeredCommands.set(name, command);
+      }),
+      getAllTools: mock(() => ([
+        {
+          name: "mcp_github_create_issue",
+          description: "Create an issue in GitHub",
+          parameters: { type: "object", properties: { owner: { type: "string" }, repo: { type: "string" } } },
+          sourceInfo: undefined,
+        },
+      ])),
+      getActiveTools: mock(() => [...activeTools]),
+      setActiveTools: mock((tools: string[]) => {
+        activeTools.clear();
+        for (const tool of tools) activeTools.add(tool);
+      }),
+    };
+
+    return { pi, handlers, registeredTools, registeredCommands, activeTools };
+  }
+
+  async function loadExtension() {
+    mock.module("../config.js", () => ({
+      loadConfig: mock(() => config),
+    }));
+    mock.module("./mcp-bridge.js", () => ({
+      getMcpBridge: mock(() => ({ status: () => snapshot })),
+    }));
+
+    return await import("./tool-search.js");
+  }
+
+  test("re-evaluates when MCP tools appear after startup", async () => {
+    snapshot = { serverTools: {} };
+    const { toolSearchExtension } = await loadExtension();
+    const { pi, registeredTools, registeredCommands, activeTools } = createHarness();
+
+    toolSearchExtension(pi as any);
+
+    const sessionStart = pi.on.mock.calls.find(([event]) => event === "session_start")?.[1] as EventHandler | undefined;
+    expect(sessionStart).toBeDefined();
+    await sessionStart!(undefined, undefined);
+
+    const statusCommand = registeredCommands.get("tool-search");
+    expect(statusCommand).toBeDefined();
+
+    const initialNotes: string[] = [];
+    statusCommand.handler("status", { ui: { notify: (msg: string) => initialNotes.push(msg) } });
+    expect(initialNotes.at(-1)).toContain("Tool search: inactive");
+    expect(initialNotes.at(-1)).toContain("Deferred tools: 0");
+
+    snapshot = { serverTools: { github: ["mcp_github_create_issue"] } };
+    pi.events.emit("mcp:registry_updated", { server: "github" });
+
+    const refreshedNotes: string[] = [];
+    statusCommand.handler("status", { ui: { notify: (msg: string) => refreshedNotes.push(msg) } });
+    expect(refreshedNotes.at(-1)).toContain("Tool search: active");
+    expect(refreshedNotes.at(-1)).toContain("Deferred tools: 1");
+    expect(activeTools.has("search_tools")).toBe(true);
+    expect(activeTools.has("mcp_github_create_issue")).toBe(false);
+
+    const searchTool = registeredTools.get("search_tools");
+    const result = await searchTool.execute("tool-call-1", { query: "github issue" }, undefined);
+    const text = result.content?.[0]?.text ?? "";
+    expect(text).toContain("mcp_github_create_issue");
+  });
+
+  test("clears stale state when the MCP snapshot disappears", async () => {
+    snapshot = { serverTools: { github: ["mcp_github_create_issue"] } };
+    const { toolSearchExtension } = await loadExtension();
+    const { pi, registeredCommands } = createHarness();
+
+    toolSearchExtension(pi as any);
+
+    const sessionStart = pi.on.mock.calls.find(([event]) => event === "session_start")?.[1] as EventHandler | undefined;
+    expect(sessionStart).toBeDefined();
+    await sessionStart!(undefined, undefined);
+
+    const statusCommand = registeredCommands.get("tool-search");
+    expect(statusCommand).toBeDefined();
+
+    const activeNotes: string[] = [];
+    statusCommand.handler("status", { ui: { notify: (msg: string) => activeNotes.push(msg) } });
+    expect(activeNotes.at(-1)).toContain("Tool search: active");
+    expect(activeNotes.at(-1)).toContain("Deferred tools: 1");
+
+    snapshot = { serverTools: {} };
+    pi.events.emit("mcp:startup_report", { toolCount: 0 });
+
+    const clearedNotes: string[] = [];
+    statusCommand.handler("status", { ui: { notify: (msg: string) => clearedNotes.push(msg) } });
+    expect(clearedNotes.at(-1)).toContain("Tool search: inactive");
+    expect(clearedNotes.at(-1)).toContain("Deferred tools: 0");
+    expect(clearedNotes.at(-1)).toContain("Loaded on-demand: 0");
+  });
+});

--- a/packages/cli/src/extensions/tool-search.test.ts
+++ b/packages/cli/src/extensions/tool-search.test.ts
@@ -1,0 +1,262 @@
+import { describe, test, expect } from "bun:test";
+import {
+  scoreToolMatch,
+  searchDeferredTools,
+  estimateToolChars,
+  extractParamNames,
+} from "./tool-search.js";
+
+// ── Test fixtures ─────────────────────────────────────────────────────────
+
+const makeToolInfo = (
+  name: string,
+  description: string,
+  parameterNames: string[] = [],
+  serverName?: string,
+) => ({
+  name,
+  description,
+  parameterNames,
+  charCount: name.length + description.length,
+  serverName,
+});
+
+const sampleTools = new Map([
+  ["mcp_github_create_issue", makeToolInfo(
+    "mcp_github_create_issue",
+    "Create a new issue in a GitHub repository",
+    ["owner", "repo", "title", "body", "labels"],
+    "github",
+  )],
+  ["mcp_github_list_prs", makeToolInfo(
+    "mcp_github_list_prs",
+    "List pull requests for a GitHub repository",
+    ["owner", "repo", "state"],
+    "github",
+  )],
+  ["mcp_slack_send_message", makeToolInfo(
+    "mcp_slack_send_message",
+    "Send a message to a Slack channel",
+    ["channel", "text", "thread_ts"],
+    "slack",
+  )],
+  ["mcp_slack_list_channels", makeToolInfo(
+    "mcp_slack_list_channels",
+    "List Slack channels in a workspace",
+    ["cursor", "limit"],
+    "slack",
+  )],
+  ["mcp_sentry_get_issues", makeToolInfo(
+    "mcp_sentry_get_issues",
+    "Get issues from Sentry error tracking",
+    ["project", "query"],
+    "sentry",
+  )],
+  ["mcp_grafana_query", makeToolInfo(
+    "mcp_grafana_query",
+    "Query metrics from Grafana dashboards",
+    ["dashboard", "panel", "timeRange"],
+    "grafana",
+  )],
+]);
+
+// ── scoreToolMatch ────────────────────────────────────────────────────────
+
+describe("scoreToolMatch", () => {
+  test("exact name match scores highest", () => {
+    const tool = makeToolInfo("weather", "Get weather information");
+    const score = scoreToolMatch(tool, "weather");
+    expect(score).toBeGreaterThan(0);
+    // Should score higher than partial match
+    const partialScore = scoreToolMatch(tool, "weath");
+    expect(score).toBeGreaterThan(partialScore);
+  });
+
+  test("name contains keyword scores well", () => {
+    const tool = makeToolInfo("mcp_github_create_issue", "Create a new issue");
+    const score = scoreToolMatch(tool, "github");
+    expect(score).toBeGreaterThan(0);
+  });
+
+  test("description match scores", () => {
+    const tool = makeToolInfo("create_issue", "Create a new issue in a GitHub repository");
+    const score = scoreToolMatch(tool, "repository");
+    expect(score).toBeGreaterThan(0);
+  });
+
+  test("parameter name match scores lowest", () => {
+    const tool = makeToolInfo("create_issue", "Create an issue", ["owner", "repo", "title"]);
+    const nameScore = scoreToolMatch(tool, "create");
+    const paramScore = scoreToolMatch(tool, "owner");
+    expect(nameScore).toBeGreaterThan(paramScore);
+  });
+
+  test("no match returns zero", () => {
+    const tool = makeToolInfo("weather", "Get weather information");
+    expect(scoreToolMatch(tool, "database")).toBe(0);
+  });
+
+  test("case insensitive matching", () => {
+    const tool = makeToolInfo("GitHub_Tool", "A GitHub tool");
+    expect(scoreToolMatch(tool, "github")).toBeGreaterThan(0);
+    expect(scoreToolMatch(tool, "GITHUB")).toBeGreaterThan(0);
+  });
+
+  test("multi-keyword query scores cumulatively", () => {
+    const tool = makeToolInfo("mcp_github_create_issue", "Create a new issue in a GitHub repository");
+    const singleScore = scoreToolMatch(tool, "github");
+    const multiScore = scoreToolMatch(tool, "github create issue");
+    // More keywords that match should produce a higher score
+    expect(multiScore).toBeGreaterThan(singleScore);
+  });
+
+  test("single-char keywords are ignored", () => {
+    const tool = makeToolInfo("weather", "Get weather");
+    expect(scoreToolMatch(tool, "a")).toBe(0);
+  });
+
+  test("empty query returns zero", () => {
+    const tool = makeToolInfo("weather", "Get weather");
+    expect(scoreToolMatch(tool, "")).toBe(0);
+  });
+
+  test("full query as substring in name gives bonus", () => {
+    const tool = makeToolInfo("create_issue", "Create a new issue");
+    const exactSubScore = scoreToolMatch(tool, "create_issue");
+    const partialScore = scoreToolMatch(tool, "create");
+    expect(exactSubScore).toBeGreaterThan(partialScore);
+  });
+});
+
+// ── searchDeferredTools ───────────────────────────────────────────────────
+
+describe("searchDeferredTools", () => {
+  test("finds tools by keyword", () => {
+    const results = searchDeferredTools(sampleTools, "github", 5);
+    expect(results.length).toBe(2);
+    expect(results.every((t) => t.name.includes("github"))).toBe(true);
+  });
+
+  test("respects maxResults", () => {
+    const results = searchDeferredTools(sampleTools, "mcp", 2);
+    expect(results.length).toBe(2);
+  });
+
+  test("returns empty for no matches", () => {
+    const results = searchDeferredTools(sampleTools, "kubernetes", 5);
+    expect(results.length).toBe(0);
+  });
+
+  test("ranks by relevance — name match beats description", () => {
+    const results = searchDeferredTools(sampleTools, "slack", 5);
+    expect(results.length).toBe(2);
+    // Both slack tools should match
+    expect(results.every((t) => t.name.includes("slack"))).toBe(true);
+  });
+
+  test("finds by description keyword", () => {
+    const results = searchDeferredTools(sampleTools, "error tracking", 5);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].name).toBe("mcp_sentry_get_issues");
+  });
+
+  test("finds by parameter name", () => {
+    const results = searchDeferredTools(sampleTools, "dashboard", 5);
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].name).toBe("mcp_grafana_query");
+  });
+
+  test("multi-word query narrows results", () => {
+    const broadResults = searchDeferredTools(sampleTools, "list", 10);
+    const narrowResults = searchDeferredTools(sampleTools, "list channels", 10);
+    // Narrow should rank slack_list_channels higher
+    if (narrowResults.length > 0) {
+      expect(narrowResults[0].name).toBe("mcp_slack_list_channels");
+    }
+  });
+});
+
+// ── estimateToolChars ─────────────────────────────────────────────────────
+
+describe("estimateToolChars", () => {
+  test("sums name + description + schema", () => {
+    const result = estimateToolChars({
+      name: "test_tool",
+      description: "A test tool",
+      parameters: { type: "object", properties: { foo: { type: "string" } } },
+    });
+    expect(result).toBeGreaterThan(0);
+    // Should be roughly: "test_tool".length + "A test tool".length + JSON.stringify(schema).length
+    expect(result).toBe(
+      "test_tool".length +
+      "A test tool".length +
+      JSON.stringify({ type: "object", properties: { foo: { type: "string" } } }).length,
+    );
+  });
+
+  test("handles null/undefined parameters", () => {
+    const result = estimateToolChars({
+      name: "test",
+      description: "desc",
+      parameters: null,
+    });
+    expect(result).toBeGreaterThan(0);
+  });
+
+  test("handles empty description", () => {
+    const result = estimateToolChars({
+      name: "test",
+      description: "",
+      parameters: {},
+    });
+    expect(result).toBe("test".length + JSON.stringify({}).length);
+  });
+});
+
+// ── extractParamNames ─────────────────────────────────────────────────────
+
+describe("extractParamNames", () => {
+  test("extracts property names from JSON Schema", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+        age: { type: "number" },
+        active: { type: "boolean" },
+      },
+    };
+    expect(extractParamNames(schema)).toEqual(["name", "age", "active"]);
+  });
+
+  test("returns empty for null/undefined", () => {
+    expect(extractParamNames(null)).toEqual([]);
+    expect(extractParamNames(undefined)).toEqual([]);
+  });
+
+  test("returns empty for non-object", () => {
+    expect(extractParamNames("string")).toEqual([]);
+    expect(extractParamNames(42)).toEqual([]);
+  });
+
+  test("returns empty for schema without properties", () => {
+    expect(extractParamNames({ type: "object" })).toEqual([]);
+    expect(extractParamNames({ type: "object", properties: null })).toEqual([]);
+  });
+
+  test("handles nested schema", () => {
+    const schema = {
+      type: "object",
+      properties: {
+        query: { type: "string" },
+        filters: {
+          type: "object",
+          properties: {
+            status: { type: "string" },
+          },
+        },
+      },
+    };
+    // Only extracts top-level
+    expect(extractParamNames(schema)).toEqual(["query", "filters"]);
+  });
+});

--- a/packages/cli/src/extensions/tool-search.ts
+++ b/packages/cli/src/extensions/tool-search.ts
@@ -162,6 +162,12 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
     active: false,
   };
 
+  function clearState(): void {
+    state.deferredTools.clear();
+    state.loadedTools.clear();
+    state.active = false;
+  }
+
   /**
    * Evaluate whether tool search should activate, and if so, which tools to defer.
    * Called after MCP tools are loaded (on session_start, after MCP extension runs).
@@ -171,7 +177,7 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
     const tsConfig = config.toolSearch;
 
     if (!tsConfig?.enabled) {
-      state.active = false;
+      clearState();
       return;
     }
 
@@ -188,7 +194,7 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
 
     if (!snapshot?.serverTools) {
       log.info("No MCP tools found, tool search not needed");
-      state.active = false;
+      clearState();
       return;
     }
 
@@ -242,14 +248,14 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
 
     if (toolsToDefer.length === 0) {
       log.info(`Tool search: no tools to defer (${totalMcpChars} chars, threshold ${threshold})`);
-      state.active = false;
+      clearState();
       return;
     }
 
+    const previousLoadedTools = new Set(state.loadedTools);
+
     // Build deferred tool info map
     state.deferredTools.clear();
-    state.loadedTools.clear();
-
     for (const toolName of toolsToDefer) {
       const tool = allTools.find((t) => t.name === toolName);
       if (!tool) continue;
@@ -263,8 +269,16 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
       });
     }
 
-    // Deactivate deferred tools
+    // Preserve any tools that were previously loaded on-demand and are still active.
     const currentActive = new Set(pi.getActiveTools() as string[]);
+    state.loadedTools.clear();
+    for (const name of previousLoadedTools) {
+      if (currentActive.has(name)) {
+        state.loadedTools.add(name);
+      }
+    }
+
+    // Deactivate deferred tools
     for (const name of toolsToDefer) {
       currentActive.delete(name);
     }
@@ -437,6 +451,11 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
   });
 
   // ── Session lifecycle ───────────────────────────────────────────────────
+
+  // Keep tool search synchronized with MCP registry changes, including
+  // background completion of slow servers and /mcp reload.
+  pi.events?.on?.("mcp:startup_report", evaluateAndDefer);
+  pi.events?.on?.("mcp:registry_updated", evaluateAndDefer);
 
   // Use a small delay after session_start to let MCP extension finish loading.
   // The MCP extension also runs on session_start, and extension factories are

--- a/packages/cli/src/extensions/tool-search.ts
+++ b/packages/cli/src/extensions/tool-search.ts
@@ -1,0 +1,469 @@
+/**
+ * Tool Search Extension
+ *
+ * Reduces context window bloat by deferring MCP tools and providing a
+ * `search_tools` custom tool that the LLM can call to discover and load
+ * them on-demand. Provider-agnostic — works with any model.
+ *
+ * Decision logic:
+ * 1. Tools from MCP servers with `deferLoading: true` in config are always deferred.
+ * 2. If total MCP tool char count exceeds `toolSearch.tokenThreshold`, ALL MCP tools
+ *    are deferred (except those from servers explicitly marked `deferLoading: false`).
+ * 3. Built-in tools (read, bash, edit, write, etc.) are never deferred.
+ * 4. The `search_tools` tool itself is always active.
+ */
+import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
+import { loadConfig, type PizzaPiConfig } from "../config.js";
+import { getMcpBridge } from "./mcp-bridge.js";
+import type { McpConfig } from "./mcp/registry.js";
+import { createLogger } from "@pizzapi/tools";
+
+const log = createLogger("tool-search");
+
+// ── Defaults ────────────────────────────────────────────────────────────────
+
+const DEFAULT_TOKEN_THRESHOLD = 10_000; // chars (≈ 2500 tokens)
+const DEFAULT_MAX_RESULTS = 5;
+const DEFAULT_KEEP_LOADED = true;
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+interface ToolInfo {
+  name: string;
+  description: string;
+  parameterNames: string[];
+  /** Serialized char count for token estimation. */
+  charCount: number;
+  /** Which MCP server this tool belongs to (if any). */
+  serverName?: string;
+}
+
+type ToolSearchState = {
+  /** Tools that have been deferred (removed from active set). */
+  deferredTools: Map<string, ToolInfo>;
+  /** Tools that have been loaded on-demand via search. */
+  loadedTools: Set<string>;
+  /** Whether tool search is actively managing tools this session. */
+  active: boolean;
+};
+
+// ── Scoring ─────────────────────────────────────────────────────────────────
+
+/**
+ * Score a tool against a search query using keyword matching.
+ * Higher score = better match.
+ */
+export function scoreToolMatch(tool: ToolInfo, query: string): number {
+  const queryLower = query.toLowerCase();
+  const keywords = queryLower
+    .split(/[\s_\-:.,;/\\|]+/)
+    .filter((k) => k.length > 1);
+
+  if (keywords.length === 0) return 0;
+
+  let score = 0;
+  const nameLower = tool.name.toLowerCase();
+  const descLower = tool.description.toLowerCase();
+  const paramText = tool.parameterNames.join(" ").toLowerCase();
+
+  for (const keyword of keywords) {
+    // Exact name match is highest signal
+    if (nameLower === keyword) score += 10;
+    // Name contains keyword
+    else if (nameLower.includes(keyword)) score += 5;
+    // Description contains keyword
+    if (descLower.includes(keyword)) score += 3;
+    // Parameter names contain keyword
+    if (paramText.includes(keyword)) score += 1;
+  }
+
+  // Bonus for full query appearing as substring
+  if (nameLower.includes(queryLower)) score += 8;
+  if (descLower.includes(queryLower)) score += 4;
+
+  return score;
+}
+
+/**
+ * Search deferred tools and return the top matches.
+ */
+export function searchDeferredTools(
+  deferred: Map<string, ToolInfo>,
+  query: string,
+  maxResults: number,
+): ToolInfo[] {
+  const scored: Array<{ tool: ToolInfo; score: number }> = [];
+
+  for (const tool of deferred.values()) {
+    const score = scoreToolMatch(tool, query);
+    if (score > 0) {
+      scored.push({ tool, score });
+    }
+  }
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, maxResults).map((s) => s.tool);
+}
+
+/**
+ * Estimate the character count of a tool definition for token threshold checks.
+ */
+export function estimateToolChars(tool: { name: string; description: string; parameters: unknown }): number {
+  const schemaStr = typeof tool.parameters === "string"
+    ? tool.parameters
+    : JSON.stringify(tool.parameters ?? {});
+  return tool.name.length + (tool.description?.length ?? 0) + schemaStr.length;
+}
+
+/**
+ * Extract parameter names from a JSON Schema object.
+ */
+export function extractParamNames(schema: unknown): string[] {
+  if (!schema || typeof schema !== "object") return [];
+  const obj = schema as Record<string, unknown>;
+  if (!obj.properties || typeof obj.properties !== "object") return [];
+  return Object.keys(obj.properties as Record<string, unknown>);
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Determine which MCP servers have `deferLoading` set.
+ * Returns a map of server name → deferLoading value (true/false/undefined).
+ */
+function getServerDeferConfig(config: PizzaPiConfig & McpConfig): Map<string, boolean | undefined> {
+  const result = new Map<string, boolean | undefined>();
+
+  // mcp.servers format
+  if (config.mcp?.servers) {
+    for (const server of config.mcp.servers) {
+      result.set(server.name, (server as any).deferLoading);
+    }
+  }
+
+  // mcpServers compatibility format
+  if (config.mcpServers) {
+    for (const [name, serverCfg] of Object.entries(config.mcpServers)) {
+      if (serverCfg && typeof serverCfg === "object") {
+        result.set(name, (serverCfg as any).deferLoading);
+      }
+    }
+  }
+
+  return result;
+}
+
+// ── Extension ───────────────────────────────────────────────────────────────
+
+export const toolSearchExtension: ExtensionFactory = (pi: any) => {
+  const state: ToolSearchState = {
+    deferredTools: new Map(),
+    loadedTools: new Set(),
+    active: false,
+  };
+
+  /**
+   * Evaluate whether tool search should activate, and if so, which tools to defer.
+   * Called after MCP tools are loaded (on session_start, after MCP extension runs).
+   */
+  function evaluateAndDefer(): void {
+    const config = loadConfig(process.cwd());
+    const tsConfig = config.toolSearch;
+
+    if (!tsConfig?.enabled) {
+      state.active = false;
+      return;
+    }
+
+    const threshold = tsConfig.tokenThreshold ?? DEFAULT_TOKEN_THRESHOLD;
+    const mcpConfig = config as PizzaPiConfig & McpConfig;
+    const serverDeferConfig = getServerDeferConfig(mcpConfig);
+
+    // Get MCP bridge status to know which tools belong to which servers
+    const bridge = getMcpBridge();
+    const snapshot = bridge?.status() as {
+      serverTools?: Record<string, string[]>;
+      toolNames?: string[];
+    } | null;
+
+    if (!snapshot?.serverTools) {
+      log.info("No MCP tools found, tool search not needed");
+      state.active = false;
+      return;
+    }
+
+    // Build reverse map: tool name → server name
+    const toolToServer = new Map<string, string>();
+    for (const [serverName, toolNames] of Object.entries(snapshot.serverTools)) {
+      for (const toolName of toolNames) {
+        toolToServer.set(toolName, serverName);
+      }
+    }
+
+    // Get all registered tools
+    const allTools: Array<{ name: string; description: string; parameters: unknown; sourceInfo: unknown }> = pi.getAllTools();
+
+    // Identify MCP tools and calculate their total char count
+    const mcpTools: Array<typeof allTools[number] & { serverName: string }> = [];
+    let totalMcpChars = 0;
+
+    for (const tool of allTools) {
+      const serverName = toolToServer.get(tool.name);
+      if (serverName) {
+        const chars = estimateToolChars(tool);
+        totalMcpChars += chars;
+        mcpTools.push({ ...tool, serverName });
+      }
+    }
+
+    // Determine which tools to defer
+    const thresholdExceeded = totalMcpChars > threshold;
+    const toolsToDefer: string[] = [];
+
+    for (const tool of mcpTools) {
+      const serverDefer = serverDeferConfig.get(tool.serverName);
+
+      // Explicitly marked for deferral → always defer
+      if (serverDefer === true) {
+        toolsToDefer.push(tool.name);
+        continue;
+      }
+
+      // Explicitly marked to NOT defer → never defer
+      if (serverDefer === false) {
+        continue;
+      }
+
+      // No explicit config → defer if threshold exceeded
+      if (thresholdExceeded) {
+        toolsToDefer.push(tool.name);
+      }
+    }
+
+    if (toolsToDefer.length === 0) {
+      log.info(`Tool search: no tools to defer (${totalMcpChars} chars, threshold ${threshold})`);
+      state.active = false;
+      return;
+    }
+
+    // Build deferred tool info map
+    state.deferredTools.clear();
+    state.loadedTools.clear();
+
+    for (const toolName of toolsToDefer) {
+      const tool = allTools.find((t) => t.name === toolName);
+      if (!tool) continue;
+
+      state.deferredTools.set(toolName, {
+        name: tool.name,
+        description: tool.description ?? "",
+        parameterNames: extractParamNames(tool.parameters),
+        charCount: estimateToolChars(tool),
+        serverName: toolToServer.get(tool.name),
+      });
+    }
+
+    // Deactivate deferred tools
+    const currentActive = new Set(pi.getActiveTools() as string[]);
+    for (const name of toolsToDefer) {
+      currentActive.delete(name);
+    }
+    // Ensure search_tools stays active
+    currentActive.add("search_tools");
+    pi.setActiveTools([...currentActive]);
+
+    state.active = true;
+    log.info(
+      `Tool search active: deferred ${state.deferredTools.size} tools ` +
+      `(${totalMcpChars} chars, threshold ${threshold})`
+    );
+  }
+
+  // ── Register the search_tools tool ──────────────────────────────────────
+
+  pi.registerTool({
+    name: "search_tools",
+    label: "Search Tools",
+    description:
+      "Search for available tools by keyword query. " +
+      "Some tools are deferred to save context space — use this to discover and load them. " +
+      "Returns matching tool names and descriptions. Matched tools are automatically loaded " +
+      "and become available for use in subsequent tool calls.",
+    promptSnippet:
+      "Search for and load deferred MCP tools by keyword. " +
+      "Use when you need a tool that isn't currently available.",
+    promptGuidelines: [
+      "Use search_tools when you need to call a tool that isn't in your current tool list.",
+      "Search with descriptive keywords about what you want to do (e.g., 'create github issue', 'send slack message').",
+      "After search_tools returns results, the matched tools are loaded and ready to use.",
+    ],
+    parameters: {
+      type: "object",
+      properties: {
+        query: {
+          type: "string",
+          description: "Search query — keywords describing the tool you need",
+        },
+      },
+      required: ["query"],
+    },
+    async execute(_toolCallId: string, params: { query: string }, _signal: AbortSignal | undefined) {
+      if (!state.active || state.deferredTools.size === 0) {
+        return {
+          content: [{
+            type: "text" as const,
+            text: "Tool search is not active — all tools are already loaded in context.",
+          }],
+          details: { active: false },
+        };
+      }
+
+      const config = loadConfig(process.cwd());
+      const maxResults = config.toolSearch?.maxResults ?? DEFAULT_MAX_RESULTS;
+      const keepLoaded = config.toolSearch?.keepLoadedTools ?? DEFAULT_KEEP_LOADED;
+
+      const matches = searchDeferredTools(state.deferredTools, params.query, maxResults);
+
+      if (matches.length === 0) {
+        // Show all available deferred tools as fallback
+        const available = [...state.deferredTools.values()]
+          .map((t) => `- ${t.name}: ${t.description.slice(0, 100)}`)
+          .join("\n");
+
+        return {
+          content: [{
+            type: "text" as const,
+            text: `No tools matched "${params.query}". Available deferred tools:\n${available}`,
+          }],
+          details: { query: params.query, matches: 0 },
+        };
+      }
+
+      // Activate the matched tools
+      const currentActive = new Set(pi.getActiveTools() as string[]);
+      const newlyLoaded: string[] = [];
+
+      for (const match of matches) {
+        if (!currentActive.has(match.name)) {
+          currentActive.add(match.name);
+          newlyLoaded.push(match.name);
+          if (keepLoaded) {
+            state.loadedTools.add(match.name);
+          }
+          // Remove from deferred since they're now loaded
+          if (keepLoaded) {
+            state.deferredTools.delete(match.name);
+          }
+        }
+      }
+
+      if (newlyLoaded.length > 0) {
+        pi.setActiveTools([...currentActive]);
+      }
+
+      const resultLines = matches.map((t) => {
+        const params = t.parameterNames.length > 0
+          ? ` (params: ${t.parameterNames.join(", ")})`
+          : "";
+        return `- **${t.name}**${params}: ${t.description}`;
+      });
+
+      const loadedMsg = newlyLoaded.length > 0
+        ? `\n\n✅ Loaded ${newlyLoaded.length} tool(s): ${newlyLoaded.join(", ")}. They are now available for use.`
+        : "\n\nAll matched tools were already loaded.";
+
+      const remainingDeferred = state.deferredTools.size;
+      const deferredMsg = remainingDeferred > 0
+        ? `\n\n${remainingDeferred} more deferred tool(s) available — search again if needed.`
+        : "";
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: `Found ${matches.length} tool(s) matching "${params.query}":\n\n${resultLines.join("\n")}${loadedMsg}${deferredMsg}`,
+        }],
+        details: {
+          query: params.query,
+          matches: matches.length,
+          loaded: newlyLoaded,
+          remainingDeferred,
+        },
+      };
+    },
+  });
+
+  // ── Register /tool-search command ───────────────────────────────────────
+
+  pi.registerCommand?.("tool-search", {
+    description: "Tool search status: /tool-search [status|reset]",
+    getArgumentCompletions: (prefix: string) => {
+      const cmds = ["status", "reset"];
+      const matches = cmds.filter((c) => c.startsWith(prefix.trim().toLowerCase()));
+      return matches.length > 0 ? matches.map((c) => ({ value: c, label: c })) : null;
+    },
+    handler: async (args: string, ctx: any) => {
+      const arg = (args ?? "").trim().toLowerCase();
+
+      if (arg === "reset") {
+        evaluateAndDefer();
+        ctx?.ui?.notify?.(`Tool search reset. ${state.deferredTools.size} tools deferred.`);
+        return;
+      }
+
+      // Default: status
+      const lines: string[] = [];
+      lines.push(`Tool search: ${state.active ? "active" : "inactive"}`);
+      lines.push(`Deferred tools: ${state.deferredTools.size}`);
+      lines.push(`Loaded on-demand: ${state.loadedTools.size}`);
+
+      if (state.deferredTools.size > 0) {
+        lines.push("");
+        lines.push("Deferred:");
+        for (const tool of state.deferredTools.values()) {
+          lines.push(`  - ${tool.name} [${tool.serverName ?? "unknown"}]: ${tool.description.slice(0, 80)}`);
+        }
+      }
+
+      if (state.loadedTools.size > 0) {
+        lines.push("");
+        lines.push("Loaded on-demand:");
+        for (const name of state.loadedTools) {
+          lines.push(`  - ${name}`);
+        }
+      }
+
+      ctx?.ui?.notify?.(lines.join("\n"));
+    },
+  });
+
+  // ── Session lifecycle ───────────────────────────────────────────────────
+
+  // Use a small delay after session_start to let MCP extension finish loading.
+  // The MCP extension also runs on session_start, and extension factories are
+  // loaded in order (MCP is registered before tool-search in factories.ts).
+  // Since session_start handlers fire in registration order, MCP tools should
+  // already be available when our handler runs.
+  pi.on?.("session_start", async (_event: any, _ctx: any) => {
+    // Small delay to ensure MCP tools are fully registered
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    evaluateAndDefer();
+  });
+
+  // If keepLoadedTools is false, deactivate on-demand tools after each turn
+  pi.on?.("turn_end", async (_event: any, _ctx: any) => {
+    if (!state.active) return;
+
+    const config = loadConfig(process.cwd());
+    const keepLoaded = config.toolSearch?.keepLoadedTools ?? DEFAULT_KEEP_LOADED;
+
+    if (keepLoaded) return;
+
+    // Re-defer tools that were loaded on-demand
+    const currentActive = new Set(pi.getActiveTools() as string[]);
+    for (const name of state.loadedTools) {
+      currentActive.delete(name);
+    }
+    pi.setActiveTools([...currentActive]);
+    state.loadedTools.clear();
+  });
+};


### PR DESCRIPTION
## Summary

Reduces context window bloat by deferring MCP tools and providing a `search_tools` tool the LLM can call to discover and load them on-demand. Provider-agnostic — works with Anthropic, OpenAI, Google, etc.

Inspired by [Anthropic's server-side tool_search_tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/tool-search-tool), but implemented client-side as a pi extension so it works across all providers.

## How It Works

1. **On session start**, scans all MCP tool definitions and estimates total char count
2. If above threshold (default 10K chars ≈ 2.5K tokens), defers MCP tools from the active context
3. Registers a `search_tools` tool with keyword search over deferred tools
4. When the LLM calls `search_tools`, matched tools are activated on-demand via `pi.setActiveTools()`
5. Discovered tools remain available for the rest of the session (configurable)

## Configuration

In `~/.pizzapi/config.json`:

```json
{
  "toolSearch": {
    "enabled": true,
    "tokenThreshold": 10000,
    "maxResults": 5,
    "keepLoadedTools": true
  }
}
```

Per-server deferral on individual MCP server entries:

```json
{
  "mcpServers": {
    "github": { "command": "...", "deferLoading": true },
    "godmother": { "command": "..." }
  }
}
```

### Decision Logic

| Condition | Result |
|-----------|--------|
| Server has `deferLoading: true` | Always deferred |
| Server has `deferLoading: false` | Never deferred |
| No explicit config + threshold exceeded | Deferred |
| No explicit config + under threshold | Not deferred |

Built-in tools (read, bash, edit, write, etc.) are never deferred.

## Commands

- `/tool-search` or `/tool-search status` — show deferred/loaded tool counts
- `/tool-search reset` — re-evaluate and re-defer tools

## Files Changed

| File | Change |
|------|--------|
| `packages/cli/src/extensions/tool-search.ts` | New extension |
| `packages/cli/src/extensions/tool-search.test.ts` | 25 unit tests |
| `packages/cli/src/config/types.ts` | `ToolSearchConfig` type + `toolSearch` on `PizzaPiConfig` |
| `packages/cli/src/extensions/mcp/registry.ts` | `deferLoading?: boolean` on MCP server configs |
| `packages/cli/src/extensions/factories.ts` | Register extension after MCP |
| `packages/cli/src/extensions/factories.test.ts` | Updated core extensions list |

## Test Results

- 25 new unit tests (scoring, search, char estimation, param extraction)
- All 945 existing tests pass
- Typecheck clean
- Build clean