### PR TITLE
test(tools): slim integration tests to unit coverage with mocked subprocess/fs layers

### DIFF
--- a/packages/tools/src/bash.test.ts
+++ b/packages/tools/src/bash.test.ts
@@ -10,7 +10,7 @@
  *    Bun.spawnSync to verify actual shell execution works end-to-end.
  */
 
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach } from "bun:test";
 import { promisify } from "util";
 import { createBashTool, bashTool } from "./bash.js";
 
@@ -127,6 +127,10 @@ async function execBash(command: string, timeout?: number) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("bashTool", () => {
+    // Reset all mock state before each test so stale state from a mid-test
+    // throw can't bleed into subsequent tests.
+    beforeEach(() => resetMockState());
+
     // ── Integration smoke test ─────────────────────────────────────────────
 
     describe("integration smoke test", () => {

--- a/packages/tools/src/bash.test.ts
+++ b/packages/tools/src/bash.test.ts
@@ -1,16 +1,18 @@
 /**
- * bash.test.ts — unit coverage for bashTool with mocked child_process.
+ * bash.test.ts — unit coverage for bashTool with injected dependencies.
  *
  * Strategy:
- *  - mock.module("child_process", ...) is hoisted by Bun before static imports,
- *    so we cannot rely on `import { exec as realExec }` being the real exec.
- *  - We attach util.promisify.custom to the mock exec so promisify(exec) returns
- *    { stdout, stderr } exactly as the real child_process.exec does.
- *  - Integration smoke test uses Bun.spawnSync (bypasses child_process entirely).
+ *  - Uses createBashTool(deps) DI factory instead of mock.module(), so no
+ *    module-level mocks leak into other test files.
+ *  - exec is replaced via the execFn dep; sandbox via isSandboxActiveFn,
+ *    getSandboxEnvFn, and wrapCommandFn.
+ *  - Integration smoke test calls the real bashTool (no DI overrides) via
+ *    Bun.spawnSync to verify actual shell execution works end-to-end.
  */
 
-import { describe, test, expect, afterAll, mock } from "bun:test";
+import { describe, test, expect } from "bun:test";
 import { promisify } from "util";
+import { createBashTool, bashTool } from "./bash.js";
 
 // ── Mock State ────────────────────────────────────────────────────────────────
 
@@ -48,10 +50,15 @@ function setError(err: MockError) {
     mockError = err;
     mockSuccess = null;
 }
-/** Passthrough mode: integration smoke test uses Bun.spawnSync directly. */
-function passthrough() {
+/** Passthrough mode: integration smoke test uses the real bashTool. */
+function resetMockState() {
     mockSuccess = null;
     mockError = null;
+    capturedCmd = "";
+    capturedOpts = {};
+    sandboxActive = false;
+    sandboxEnvVars = {};
+    wrapCommandThrows = false;
 }
 
 // ── Build the mock exec function ──────────────────────────────────────────────
@@ -60,6 +67,8 @@ function passthrough() {
 // We must replicate this or `const { stdout, stderr } = await execAsync(...)` in
 // bash.ts will destructure undefined from a plain string.
 
+import { exec } from "child_process";
+
 function mockExecCallback(
     cmd: string,
     opts: any,
@@ -67,15 +76,6 @@ function mockExecCallback(
 ): void {
     capturedCmd = cmd;
     capturedOpts = { timeout: opts?.timeout, env: opts?.env };
-
-    if (mockSuccess === null && mockError === null) {
-        // Passthrough: run the real shell via Bun.spawnSync (no child_process).
-        const proc = Bun.spawnSync(["bash", "-c", cmd], { env: opts?.env ?? process.env });
-        const stdout = proc.stdout.toString();
-        const stderr = proc.stderr.toString();
-        callback(null, stdout, stderr);
-        return;
-    }
 
     if (mockError) {
         const err = Object.assign(new Error(mockError.message), {
@@ -106,47 +106,33 @@ function mockExecCallback(
         });
     });
 
-// ── Module Mocks (declared before dynamic imports of bash.ts) ─────────────────
+// ── DI-based tool instance ────────────────────────────────────────────────────
 
-mock.module("child_process", () => ({
-    exec: mockExecCallback,
-}));
-
-mock.module("./sandbox.js", () => ({
-    isSandboxActive: () => sandboxActive,
-    getSandboxEnv: () => ({ ...sandboxEnvVars }),
-    wrapCommand: async (cmd: string) => {
+const testTool = createBashTool({
+    execFn: mockExecCallback as typeof exec,
+    isSandboxActiveFn: () => sandboxActive,
+    getSandboxEnvFn: () => ({ ...sandboxEnvVars }),
+    wrapCommandFn: async (cmd: string) => {
         if (wrapCommandThrows) throw new Error("sandbox denied: path not allowed");
         return cmd;
     },
-    initSandbox: async () => {},
-    cleanupSandbox: async () => {},
-    _resetState: () => {},
-}));
-
-// ── Load bash.ts after mocks are registered ───────────────────────────────────
-
-const { bashTool } = await import("./bash.js");
+});
 
 // ── Helper ────────────────────────────────────────────────────────────────────
 
 async function execBash(command: string, timeout?: number) {
-    return bashTool.execute("test-call", { command, timeout });
+    return testTool.execute("test-call", { command, timeout });
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("bashTool", () => {
-    afterAll(() => {
-        mock.restore();
-    });
-
     // ── Integration smoke test ─────────────────────────────────────────────
 
     describe("integration smoke test", () => {
         test("runs real `echo hello` through the actual shell", async () => {
-            passthrough();
-            const result = await execBash("echo hello");
+            // Use the real bashTool (no DI), which runs through the real shell
+            const result = await bashTool.execute("test-call", { command: "echo hello" });
             expect(result.content[0].text).toContain("hello");
             expect(result.details.stdout).toContain("hello");
         });
@@ -208,7 +194,6 @@ describe("bashTool", () => {
         test("returns sandboxBlocked=true when wrapCommand throws", async () => {
             sandboxActive = true;
             wrapCommandThrows = true;
-            // exec should never be reached — mock result doesn't matter
             const result = await execBash("echo ok");
             expect(result.details.sandboxBlocked).toBe(true);
             expect(result.content[0].text).toContain("Sandbox blocked");

--- a/packages/tools/src/bash.test.ts
+++ b/packages/tools/src/bash.test.ts
@@ -1,29 +1,134 @@
-import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { bashTool } from "./bash.js";
-import {
-    initSandbox,
-    cleanupSandbox,
-    _resetState,
-    type ResolvedSandboxConfig,
-} from "./sandbox.js";
+/**
+ * bash.test.ts — unit coverage for bashTool with mocked child_process.
+ *
+ * Strategy:
+ *  - mock.module("child_process", ...) is hoisted by Bun before static imports,
+ *    so we cannot rely on `import { exec as realExec }` being the real exec.
+ *  - We attach util.promisify.custom to the mock exec so promisify(exec) returns
+ *    { stdout, stderr } exactly as the real child_process.exec does.
+ *  - Integration smoke test uses Bun.spawnSync (bypasses child_process entirely).
+ */
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
+import { describe, test, expect, afterAll, mock } from "bun:test";
+import { promisify } from "util";
 
-function makeConfig(mode: ResolvedSandboxConfig["mode"] = "none"): ResolvedSandboxConfig {
-    if (mode === "none") {
-        return { mode: "none", srtConfig: null };
-    }
-    return {
-        mode,
-        srtConfig: {
-            filesystem: {
-                denyRead: [],
-                allowWrite: ["/tmp"],
-                denyWrite: [],
-            },
-        },
-    };
+// ── Mock State ────────────────────────────────────────────────────────────────
+
+interface MockSuccess {
+    stdout: string;
+    stderr: string;
 }
+
+interface MockError {
+    message: string;
+    stdout?: string;
+    stderr?: string;
+    code?: number | string;
+    killed?: boolean;
+    signal?: string;
+}
+
+let mockSuccess: MockSuccess | null = null;
+let mockError: MockError | null = null;
+/** Captured from the most recent exec() call inside bashTool.execute() */
+let capturedCmd = "";
+let capturedOpts: { timeout?: number; env?: NodeJS.ProcessEnv } = {};
+
+/** Sandbox state controlled per-test */
+let sandboxActive = false;
+let sandboxEnvVars: Record<string, string> = {};
+let wrapCommandThrows = false;
+
+// Helpers to set mock state
+function setSuccess(stdout: string, stderr = "") {
+    mockSuccess = { stdout, stderr };
+    mockError = null;
+}
+function setError(err: MockError) {
+    mockError = err;
+    mockSuccess = null;
+}
+/** Passthrough mode: integration smoke test uses Bun.spawnSync directly. */
+function passthrough() {
+    mockSuccess = null;
+    mockError = null;
+}
+
+// ── Build the mock exec function ──────────────────────────────────────────────
+// The real child_process.exec has util.promisify.custom so that promisify(exec)
+// returns { stdout, stderr } instead of just the first callback value.
+// We must replicate this or `const { stdout, stderr } = await execAsync(...)` in
+// bash.ts will destructure undefined from a plain string.
+
+function mockExecCallback(
+    cmd: string,
+    opts: any,
+    callback: (err: any, stdout: string, stderr: string) => void
+): void {
+    capturedCmd = cmd;
+    capturedOpts = { timeout: opts?.timeout, env: opts?.env };
+
+    if (mockSuccess === null && mockError === null) {
+        // Passthrough: run the real shell via Bun.spawnSync (no child_process).
+        const proc = Bun.spawnSync(["bash", "-c", cmd], { env: opts?.env ?? process.env });
+        const stdout = proc.stdout.toString();
+        const stderr = proc.stderr.toString();
+        callback(null, stdout, stderr);
+        return;
+    }
+
+    if (mockError) {
+        const err = Object.assign(new Error(mockError.message), {
+            stdout: mockError.stdout ?? "",
+            stderr: mockError.stderr ?? "",
+            code: mockError.code,
+            killed: mockError.killed ?? false,
+            signal: mockError.signal,
+        });
+        callback(err, mockError.stdout ?? "", mockError.stderr ?? "");
+    } else if (mockSuccess) {
+        callback(null, mockSuccess.stdout, mockSuccess.stderr);
+    }
+}
+
+// Attach util.promisify.custom so promisify(mockExecCallback) behaves like
+// promisify(exec): resolves with { stdout, stderr } on success, rejects with
+// an error that has stdout/stderr attached on failure.
+(mockExecCallback as any)[promisify.custom] = (cmd: string, opts: any) =>
+    new Promise<{ stdout: string; stderr: string }>((resolve, reject) => {
+        mockExecCallback(cmd, opts, (err, stdout, stderr) => {
+            if (err) {
+                Object.assign(err, { stdout, stderr });
+                reject(err);
+            } else {
+                resolve({ stdout, stderr });
+            }
+        });
+    });
+
+// ── Module Mocks (declared before dynamic imports of bash.ts) ─────────────────
+
+mock.module("child_process", () => ({
+    exec: mockExecCallback,
+}));
+
+mock.module("./sandbox.js", () => ({
+    isSandboxActive: () => sandboxActive,
+    getSandboxEnv: () => ({ ...sandboxEnvVars }),
+    wrapCommand: async (cmd: string) => {
+        if (wrapCommandThrows) throw new Error("sandbox denied: path not allowed");
+        return cmd;
+    },
+    initSandbox: async () => {},
+    cleanupSandbox: async () => {},
+    _resetState: () => {},
+}));
+
+// ── Load bash.ts after mocks are registered ───────────────────────────────────
+
+const { bashTool } = await import("./bash.js");
+
+// ── Helper ────────────────────────────────────────────────────────────────────
 
 async function execBash(command: string, timeout?: number) {
     return bashTool.execute("test-call", { command, timeout });
@@ -32,115 +137,208 @@ async function execBash(command: string, timeout?: number) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe("bashTool", () => {
-    beforeEach(() => {
-        _resetState();
+    afterAll(() => {
+        mock.restore();
     });
 
-    afterEach(async () => {
-        await cleanupSandbox();
-    });
+    // ── Integration smoke test ─────────────────────────────────────────────
 
-    describe("basic execution (no sandbox)", () => {
-        test("executes a simple command", async () => {
+    describe("integration smoke test", () => {
+        test("runs real `echo hello` through the actual shell", async () => {
+            passthrough();
             const result = await execBash("echo hello");
             expect(result.content[0].text).toContain("hello");
             expect(result.details.stdout).toContain("hello");
         });
+    });
 
-        test("captures stderr", async () => {
-            const result = await execBash("echo err >&2");
-            expect(result.content[0].text).toContain("stderr: err");
-            expect(result.details.stderr).toContain("err");
+    // ── Timeout selection ──────────────────────────────────────────────────
+
+    describe("timeout selection", () => {
+        test("uses default 30 000 ms when no timeout param is given", async () => {
+            setSuccess("ok");
+            await execBash("echo ok");
+            expect(capturedOpts.timeout).toBe(30_000);
         });
 
-        test("returns both stdout and stderr", async () => {
-            const result = await execBash("echo out && echo err >&2");
-            expect(result.content[0].text).toContain("out");
-            expect(result.content[0].text).toContain("stderr: err");
+        test("forwards an explicit timeout to exec", async () => {
+            setSuccess("ok");
+            await execBash("echo ok", 5_000);
+            expect(capturedOpts.timeout).toBe(5_000);
         });
 
-        test("uses default 30s timeout", async () => {
-            const result = await execBash("echo fast");
-            expect(result.content[0].text).toContain("fast");
-        });
-
-        test("respects custom timeout", async () => {
-            const result = await execBash("echo quick", 5000);
-            expect(result.content[0].text).toContain("quick");
+        test("accepts large timeout values", async () => {
+            setSuccess("ok");
+            await execBash("echo ok", 120_000);
+            expect(capturedOpts.timeout).toBe(120_000);
         });
     });
 
-    describe("sandbox mode: none", () => {
-        test("executes normally when mode is none", async () => {
-            await initSandbox(makeConfig("none"));
-            const result = await execBash("echo no-sandbox");
-            expect(result.content[0].text).toContain("no-sandbox");
+    // ── Sandbox env injection ──────────────────────────────────────────────
+
+    describe("sandbox env injection", () => {
+        test("passes process.env directly when sandbox is inactive", async () => {
+            sandboxActive = false;
+            setSuccess("ok");
+            await execBash("echo ok");
+            // Same object reference — no copy is made in the no-sandbox path
+            expect(capturedOpts.env).toBe(process.env);
         });
 
-        test("no sandbox env vars when mode is none", async () => {
-            await initSandbox(makeConfig("none"));
-            const result = await execBash("echo ${HTTP_PROXY:-none}");
-            expect(result.content[0].text).toContain("none");
+        test("merges sandbox env vars with process.env when sandbox is active", async () => {
+            sandboxActive = true;
+            sandboxEnvVars = {
+                HTTP_PROXY: "http://sandbox:8080",
+                HTTPS_PROXY: "http://sandbox:8080",
+                NO_PROXY: "localhost",
+            };
+            setSuccess("ok");
+            await execBash("echo ok");
+            expect(capturedOpts.env).toMatchObject({
+                HTTP_PROXY: "http://sandbox:8080",
+                HTTPS_PROXY: "http://sandbox:8080",
+                NO_PROXY: "localhost",
+            });
+            // Original env vars are preserved in the merged copy
+            expect(capturedOpts.env?.PATH).toBeDefined();
+            sandboxActive = false;
+            sandboxEnvVars = {};
+        });
+
+        test("returns sandboxBlocked=true when wrapCommand throws", async () => {
+            sandboxActive = true;
+            wrapCommandThrows = true;
+            // exec should never be reached — mock result doesn't matter
+            const result = await execBash("echo ok");
+            expect(result.details.sandboxBlocked).toBe(true);
+            expect(result.content[0].text).toContain("Sandbox blocked");
+            sandboxActive = false;
+            wrapCommandThrows = false;
         });
     });
 
-    describe("sandbox mode: basic / full (graceful degradation)", () => {
-        // Note: actual OS-level sandboxing requires macOS/Linux with the sandbox
-        // runtime. On CI or unsupported platforms, initSandbox degrades gracefully
-        // and isSandboxActive() returns false. These tests verify the integration
-        // plumbing works without relying on OS-level enforcement.
+    // ── Stdout/stderr formatting ───────────────────────────────────────────
 
-        test("still executes commands after sandbox init in basic mode", async () => {
-            await initSandbox(makeConfig("basic"));
-            const result = await execBash("echo sandboxed");
-            expect(result.content[0].text).toContain("sandboxed");
+    describe("stdout/stderr formatting", () => {
+        test("returns raw stdout when stderr is empty", async () => {
+            setSuccess("hello world\n", "");
+            const result = await execBash("echo hello");
+            expect(result.content[0].text).toBe("hello world\n");
+            expect(result.details.stdout).toBe("hello world\n");
+            expect(result.details.stderr).toBe("");
         });
 
-        test("still executes commands after sandbox init in full mode", async () => {
-            await initSandbox(makeConfig("full"));
-            const result = await execBash("echo full-mode");
-            expect(result.content[0].text).toContain("full-mode");
+        test("appends stderr with 'stderr:' label when non-empty", async () => {
+            setSuccess("stdout line\n", "err line\n");
+            const result = await execBash("echo test");
+            expect(result.content[0].text).toBe("stdout line\n\nstderr: err line\n");
+            expect(result.details.stderr).toBe("err line\n");
         });
 
-        test("details always contain original command", async () => {
-            await initSandbox(makeConfig("basic"));
-            const result = await execBash("echo original");
-            expect(result.details.command).toBe("echo original");
+        test("does not add stderr label when stderr is empty string", async () => {
+            setSuccess("output only\n", "");
+            const result = await execBash("echo output");
+            expect(result.content[0].text).toBe("output only\n");
+            expect(result.content[0].text).not.toContain("stderr:");
+        });
+
+        test("preserves original command in details regardless of sandbox wrapping", async () => {
+            setSuccess("wrapped output");
+            const result = await execBash("echo original-cmd");
+            expect(result.details.command).toBe("echo original-cmd");
+        });
+
+        test("passes large output through without truncation", async () => {
+            const largeOutput = "x".repeat(100_000) + "\n";
+            setSuccess(largeOutput, "");
+            const result = await execBash("big-cmd");
+            expect(result.details.stdout).toBe(largeOutput);
+            expect(result.details.stdout.length).toBe(100_001);
         });
     });
 
-    describe("error handling", () => {
-        test("returns stderr on non-zero exit", async () => {
+    // ── Error normalization ────────────────────────────────────────────────
+
+    describe("error normalization", () => {
+        test("captures stdout and stderr on non-zero exit, records exitCode", async () => {
+            setError({
+                message: "Command failed: exit 1",
+                stdout: "partial stdout\n",
+                stderr: "error output\n",
+                code: 1,
+            });
             const result = await execBash("exit 1");
+            expect(result.content[0].text).toContain("partial stdout");
+            expect(result.content[0].text).toContain("error output");
+            expect(result.details.stderr).toBe("error output\n");
+            expect(result.details.exitCode).toBe(1);
+        });
+
+        test("handles killed/timeout process gracefully (no exitCode)", async () => {
+            setError({
+                message: "Command timed out",
+                stdout: "",
+                stderr: "",
+                killed: true,
+                signal: "SIGTERM",
+            });
+            const result = await execBash("sleep 999", 100);
+            expect(result).toBeDefined();
+            expect(result.content[0].text).toBeDefined();
+            // error.code is undefined for signal kills
+            expect(result.details.exitCode).toBeUndefined();
+        });
+
+        test("preserves partial stdout captured before failure", async () => {
+            setError({
+                message: "Command failed",
+                stdout: "partial output\n",
+                stderr: "then it failed\n",
+                code: 2,
+            });
+            const result = await execBash("some-cmd");
+            expect(result.details.stdout).toBe("partial output\n");
+            expect(result.content[0].text).toContain("partial output");
+        });
+
+        test("falls back to error.message when both stdout and stderr are empty", async () => {
+            setError({
+                message: "spawn error ENOENT",
+                stdout: "",
+                stderr: "",
+                code: "ENOENT",
+            });
+            const result = await execBash("nonexistent_cmd");
+            // bash.ts: `stderr = error.stderr || error.message`
+            // error.stderr="" is falsy → falls through to error.message
+            expect(result.details.stderr).toBe("spawn error ENOENT");
+        });
+
+        test("always returns a defined result even on unexpected errors", async () => {
+            setError({ message: "some unexpected error", code: 127 });
+            const result = await execBash("bad-command");
+            expect(result).toBeDefined();
+            expect(result.content).toBeDefined();
             expect(result.content[0].text).toBeDefined();
         });
-
-        test("returns error output for command-not-found", async () => {
-            const result = await execBash("nonexistent_command_xyz_123");
-            // Either captures stderr or returns an error message
-            expect(result.content[0].text).toBeTruthy();
-        });
-
-        test("returns error output for failing commands", async () => {
-            const result = await execBash("ls /nonexistent_xyz_abc");
-            expect(result.content[0].text).toContain("No such file or directory");
-        });
     });
 
+    // ── Tool metadata ──────────────────────────────────────────────────────
+
     describe("tool metadata", () => {
-        test("has correct name", () => {
+        test("name is 'bash'", () => {
             expect(bashTool.name).toBe("bash");
         });
 
-        test("has correct label", () => {
+        test("label is 'Bash'", () => {
             expect(bashTool.label).toBe("Bash");
         });
 
-        test("has description", () => {
+        test("description is non-empty", () => {
             expect(bashTool.description).toBeTruthy();
         });
 
-        test("has command parameter", () => {
+        test("parameters schema is defined", () => {
             expect(bashTool.parameters).toBeDefined();
         });
     });

--- a/packages/tools/src/bash.ts
+++ b/packages/tools/src/bash.ts
@@ -4,52 +4,73 @@ import { exec } from "child_process";
 import { promisify } from "util";
 import { wrapCommand, getSandboxEnv, isSandboxActive } from "./sandbox.js";
 
-const execAsync = promisify(exec);
+// ── Internal types for dependency injection (used in tests) ───────────────────
 
-export const bashTool: AgentTool = {
-    name: "bash",
-    label: "Bash",
-    description: "Execute a bash command and return its output",
-    parameters: Type.Object({
-        command: Type.String({ description: "The command to execute" }),
-        timeout: Type.Optional(Type.Number({ description: "Timeout in milliseconds" })),
-    }),
-    async execute(_toolCallId, params: any) {
-        const timeout = params.timeout ?? 30_000;
+export interface BashDeps {
+    execFn: typeof exec;
+    isSandboxActiveFn: () => boolean;
+    getSandboxEnvFn: () => Record<string, string>;
+    wrapCommandFn: (cmd: string) => Promise<string>;
+}
 
-        let command: string = params.command;
-        let env: NodeJS.ProcessEnv = process.env;
+// ── Factory (accepts injected deps; defaults to real implementations) ─────────
 
-        // Sandbox integration: wrap command and inject proxy env vars
-        if (isSandboxActive()) {
+export function createBashTool(deps?: Partial<BashDeps>): AgentTool {
+    const execFn = deps?.execFn ?? exec;
+    const isSandboxActiveFn = deps?.isSandboxActiveFn ?? isSandboxActive;
+    const getSandboxEnvFn = deps?.getSandboxEnvFn ?? getSandboxEnv;
+    const wrapCommandFn = deps?.wrapCommandFn ?? wrapCommand;
+
+    return {
+        name: "bash",
+        label: "Bash",
+        description: "Execute a bash command and return its output",
+        parameters: Type.Object({
+            command: Type.String({ description: "The command to execute" }),
+            timeout: Type.Optional(Type.Number({ description: "Timeout in milliseconds" })),
+        }),
+        async execute(_toolCallId, params: any) {
+            const execAsync = promisify(execFn);
+            const timeout = params.timeout ?? 30_000;
+
+            let command: string = params.command;
+            let env: NodeJS.ProcessEnv = process.env;
+
+            // Sandbox integration: wrap command and inject proxy env vars
+            if (isSandboxActiveFn()) {
+                try {
+                    command = await wrapCommandFn(params.command);
+                    env = { ...process.env, ...getSandboxEnvFn() };
+                } catch (err) {
+                    const reason = err instanceof Error ? err.message : String(err);
+                    const text = `❌ Sandbox blocked: ${reason}. To allow, update sandbox config.`;
+                    return {
+                        content: [{ type: "text" as const, text }],
+                        details: { command: params.command, stdout: "", stderr: text, sandboxBlocked: true },
+                    };
+                }
+            }
+
             try {
-                command = await wrapCommand(params.command);
-                env = { ...process.env, ...getSandboxEnv() };
-            } catch (err) {
-                const reason = err instanceof Error ? err.message : String(err);
-                const text = `❌ Sandbox blocked: ${reason}. To allow, update sandbox config.`;
+                const { stdout, stderr } = await execAsync(command, { timeout, env });
                 return {
-                    content: [{ type: "text" as const, text }],
-                    details: { command: params.command, stdout: "", stderr: text, sandboxBlocked: true },
+                    content: [{ type: "text" as const, text: stdout + (stderr ? `\nstderr: ${stderr}` : "") }],
+                    details: { command: params.command, stdout, stderr },
+                };
+            } catch (error: any) {
+                // execAsync throws on non-zero exit code.
+                // Return stdout/stderr rather than crashing the tool call.
+                const stdout = error.stdout || "";
+                const stderr = error.stderr || error.message || String(error);
+                return {
+                    content: [{ type: "text" as const, text: stdout + (stderr ? `\nstderr: ${stderr}` : "") }],
+                    details: { command: params.command, stdout, stderr, exitCode: error.code },
                 };
             }
-        }
+        },
+    };
+}
 
-        try {
-            const { stdout, stderr } = await execAsync(command, { timeout, env });
-            return {
-                content: [{ type: "text" as const, text: stdout + (stderr ? `\nstderr: ${stderr}` : "") }],
-                details: { command: params.command, stdout, stderr },
-            };
-        } catch (error: any) {
-            // execAsync throws on non-zero exit code.
-            // Return stdout/stderr rather than crashing the tool call.
-            const stdout = error.stdout || "";
-            const stderr = error.stderr || error.message || String(error);
-            return {
-                content: [{ type: "text" as const, text: stdout + (stderr ? `\nstderr: ${stderr}` : "") }],
-                details: { command: params.command, stdout, stderr, exitCode: error.code },
-            };
-        }
-    },
-};
+// ── Default export — uses real implementations ────────────────────────────────
+
+export const bashTool = createBashTool();

--- a/packages/tools/src/read-file.test.ts
+++ b/packages/tools/src/read-file.test.ts
@@ -1,8 +1,7 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { readFileTool } from "./read-file.js";
 import {
     initSandbox,
     cleanupSandbox,
@@ -11,20 +10,44 @@ import {
     type ResolvedSandboxConfig,
 } from "./sandbox.js";
 
-function makeConfig(overrides?: {
-    denyRead?: string[];
-    allowWrite?: string[];
-}): ResolvedSandboxConfig {
+// ── fs/promises mock ──────────────────────────────────────────────────────────
+// node:fs/promises and fs/promises resolve to the same Bun module registry
+// entry, so we cannot use the named import as the default impl (infinite loop).
+// Instead we default to Bun.file().text() which is a completely separate API.
+//
+// Include writeFile/mkdir stubs so this mock doesn't break write-file.test.ts
+// when both files share a Bun process and this mock.module() call runs first.
+const mockReadFile = mock(async (path: string, _enc?: unknown): Promise<string> =>
+    Bun.file(String(path)).text()
+);
+const _writeFileStub = mock(async (): Promise<void> => {});
+const _mkdirStub = mock(async (): Promise<string | undefined> => undefined);
+mock.module("fs/promises", () => ({
+    readFile: mockReadFile,
+    writeFile: _writeFileStub,
+    mkdir: _mkdirStub,
+}));
+
+// ── SUT — dynamically imported so it binds the mocked fs/promises ─────────────
+const { readFileTool } = await import("./read-file.js");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeConfig(overrides?: { denyRead?: string[] }): ResolvedSandboxConfig {
     return {
         mode: "basic",
         srtConfig: {
             filesystem: {
-                denyRead: overrides?.denyRead ?? ["/etc/secrets", "/home/user/.ssh"],
-                allowWrite: overrides?.allowWrite ?? ["/tmp"],
+                denyRead: overrides?.denyRead ?? ["/etc/secrets"],
+                allowWrite: ["/tmp"],
                 denyWrite: [],
             },
         },
     };
+}
+
+function makeErrno(code: string, message = code): NodeJS.ErrnoException {
+    return Object.assign(new Error(message), { code });
 }
 
 async function execRead(path: string) {
@@ -32,85 +55,106 @@ async function execRead(path: string) {
 }
 
 describe("readFileTool", () => {
-    let tmpDir: string;
-    let testFile: string;
-
     beforeEach(() => {
         _resetState();
-        tmpDir = mkdtempSync(join(tmpdir(), "read-test-"));
-        testFile = join(tmpDir, "test.txt");
-        writeFileSync(testFile, "hello world");
+        mockReadFile.mockClear();
+        // Restore to the Bun.file() pass-through between tests
+        mockReadFile.mockImplementation(async (path: string, _enc?: unknown): Promise<string> =>
+            Bun.file(String(path)).text()
+        );
     });
 
     afterEach(async () => {
         await cleanupSandbox();
     });
 
-    test("reads file content", async () => {
-        const result = await execRead(testFile);
+    // ── Smoke: verifies the real I/O path end-to-end ──────────────────────────
+    test("smoke: reads an actual file from disk", async () => {
+        const dir = mkdtempSync(join(tmpdir(), "read-smoke-"));
+        const file = join(dir, "smoke.txt");
+        writeFileSync(file, "hello world");
+        const result = await execRead(file);
         expect(result.content[0].text).toBe("hello world");
         expect(result.details.size).toBe(11);
     });
 
-    test("works normally when mode is none", async () => {
-        await initSandbox({ mode: "none", srtConfig: null });
-        const result = await execRead(testFile);
-        expect(result.content[0].text).toBe("hello world");
+    // ── Unit: errno → message mapping (no real I/O) ───────────────────────────
+    describe("errno → message mapping", () => {
+        test("ENOENT → 'File not found'", async () => {
+            mockReadFile.mockRejectedValue(makeErrno("ENOENT"));
+            const result = await execRead("/nonexistent/file.txt");
+            expect(result.content[0].text).toContain("❌");
+            expect(result.content[0].text).toContain("File not found");
+            expect(result.details.error).toBe("ENOENT");
+            expect(result.details.size).toBe(0);
+        });
+
+        test("EACCES → 'Permission denied'", async () => {
+            mockReadFile.mockRejectedValue(makeErrno("EACCES"));
+            const result = await execRead("/root/private.txt");
+            expect(result.content[0].text).toContain("Permission denied");
+            expect(result.details.error).toBe("EACCES");
+            expect(result.details.size).toBe(0);
+        });
+
+        test("EISDIR → 'Path is a directory, not a file'", async () => {
+            mockReadFile.mockRejectedValue(makeErrno("EISDIR"));
+            const result = await execRead("/some/dir");
+            expect(result.content[0].text).toContain("Path is a directory");
+            expect(result.details.error).toBe("EISDIR");
+        });
+
+        test("unknown code → generic message with original error text", async () => {
+            mockReadFile.mockRejectedValue(makeErrno("EMFILE", "too many open files"));
+            const result = await execRead("/some/file.txt");
+            expect(result.content[0].text).toContain("❌");
+            expect(result.content[0].text).toContain("too many open files");
+            expect(result.details.error).toBe("EMFILE");
+        });
     });
 
-    describe("sandbox active", () => {
-        test("blocks reads to denied paths", async () => {
-            await initSandbox(makeConfig());
+    // ── Unit: sandbox path validation (no I/O needed) ─────────────────────────
+    describe("sandbox", () => {
+        test("blocks reads to denied paths — no I/O performed", async () => {
+            await initSandbox(makeConfig({ denyRead: ["/etc/secrets"] }));
             const result = await execRead("/etc/secrets/key.pem");
             expect(result.content[0].text).toContain("❌ Sandbox blocked read");
             expect(result.details.sandboxBlocked).toBe(true);
+            expect(mockReadFile.mock.calls.length).toBe(0); // sandbox short-circuits before I/O
         });
 
-        test("blocks reads to children of denied paths", async () => {
-            await initSandbox(makeConfig());
+        test("blocks children of denied paths — no I/O performed", async () => {
+            await initSandbox(makeConfig({ denyRead: ["/home/user/.ssh"] }));
             const result = await execRead("/home/user/.ssh/id_rsa");
             expect(result.content[0].text).toContain("❌ Sandbox blocked read");
+            expect(mockReadFile.mock.calls.length).toBe(0);
+        });
+
+        test("records violation when path is denied", async () => {
+            await initSandbox(makeConfig({ denyRead: ["/secret"] }));
+            await execRead("/secret/token");
+            const violations = getViolations();
+            expect(violations.length).toBe(1);
+            expect(violations[0].operation).toBe("read");
         });
 
         test("allows reads to non-denied paths", async () => {
             await initSandbox(makeConfig());
-            const result = await execRead(testFile);
-            expect(result.content[0].text).toBe("hello world");
+            mockReadFile.mockResolvedValue("safe content");
+            const result = await execRead("/tmp/safe.txt");
+            expect(result.content[0].text).toBe("safe content");
         });
 
-        test("records violation when path is denied", async () => {
-            // Create a file in a path we will deny
-            const deniedDir = mkdtempSync(join(tmpdir(), "denied-"));
-            const deniedFile = join(deniedDir, "secret.txt");
-            writeFileSync(deniedFile, "secret");
-
-            await initSandbox(makeConfig({ denyRead: [deniedDir] }));
-            const result = await execRead(deniedFile);
-            expect(result.content[0].text).toContain("❌ Sandbox blocked read");
-            expect(getViolations().length).toBe(1);
-            expect(getViolations()[0].operation).toBe("read");
+        test("mode=none: no sandbox restrictions apply", async () => {
+            await initSandbox({ mode: "none", srtConfig: null });
+            mockReadFile.mockResolvedValue("unrestricted");
+            const result = await execRead("/etc/secrets/key.pem");
+            expect(result.content[0].text).toBe("unrestricted");
         });
     });
 
-    describe("fs error handling", () => {
-        test("returns graceful error for nonexistent file", async () => {
-            const result = await execRead(join(tmpDir, "does-not-exist.txt"));
-            expect(result.content[0].text).toContain("❌");
-            expect(result.content[0].text).toContain("File not found");
-            expect(result.details.size).toBe(0);
-            expect(result.details.error).toBe("ENOENT");
-        });
-
-        test("returns graceful error when reading a directory as a file", async () => {
-            const result = await execRead(tmpDir);
-            expect(result.content[0].text).toContain("❌");
-            // EISDIR on most platforms, or a generic fs error — either is acceptable
-            expect(result.details.size).toBe(0);
-            expect(result.details.error).toBeTruthy();
-        });
-    });
-
-    test("has correct tool metadata", () => {
+    // ── Metadata ──────────────────────────────────────────────────────────────
+    test("tool metadata", () => {
         expect(readFileTool.name).toBe("read_file");
         expect(readFileTool.label).toBe("Read File");
     });

--- a/packages/tools/src/read-file.test.ts
+++ b/packages/tools/src/read-file.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -159,7 +159,4 @@ describe("readFileTool", () => {
         expect(readFileTool.label).toBe("Read File");
     });
 
-    afterAll(() => {
-        mock.restore();
-    });
 });

--- a/packages/tools/src/read-file.test.ts
+++ b/packages/tools/src/read-file.test.ts
@@ -15,17 +15,16 @@ import {
 // entry, so we cannot use the named import as the default impl (infinite loop).
 // Instead we default to Bun.file().text() which is a completely separate API.
 //
-// Include writeFile/mkdir stubs so this mock doesn't break write-file.test.ts
-// when both files share a Bun process and this mock.module() call runs first.
+// IMPORTANT: We must spread ALL original exports so other test files that share
+// this Bun process (e.g. event-pipeline.test.ts importing `rm`, `stat`) still
+// get the real implementations. Only override the functions we actually mock.
+const _originalFsPromises = await import("node:fs/promises");
 const mockReadFile = mock(async (path: string, _enc?: unknown): Promise<string> =>
     Bun.file(String(path)).text()
 );
-const _writeFileStub = mock(async (): Promise<void> => {});
-const _mkdirStub = mock(async (): Promise<string | undefined> => undefined);
 mock.module("fs/promises", () => ({
+    ..._originalFsPromises,
     readFile: mockReadFile,
-    writeFile: _writeFileStub,
-    mkdir: _mkdirStub,
 }));
 
 // ── SUT — dynamically imported so it binds the mocked fs/promises ─────────────

--- a/packages/tools/src/read-file.test.ts
+++ b/packages/tools/src/read-file.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from "bun:test";
 import { mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -157,5 +157,9 @@ describe("readFileTool", () => {
     test("tool metadata", () => {
         expect(readFileTool.name).toBe("read_file");
         expect(readFileTool.label).toBe("Read File");
+    });
+
+    afterAll(() => {
+        mock.restore();
     });
 });

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -205,6 +205,53 @@ describe("searchTool smoke tests", () => {
         expect(result.content[0].text).toContain("hello");
         expect(result.details.type).toBe("content");
     });
+
+    test("files search caps at exactly 50 lines on large result sets", async () => {
+        // Create 5000 files — well beyond the 50-line cap — to stress the
+        // streaming kill logic and verify no off-by-one from post-kill data events.
+        const dir = mkdtempSync(join(tmpdir(), "search-stream-"));
+        for (let i = 0; i < 5000; i++) {
+            writeFileSync(join(dir, `item-${String(i).padStart(5, "0")}.txt`), `data ${i}\n`);
+        }
+
+        const result = await searchTool.execute("smoke-stream", {
+            pattern: "*.txt",
+            path: dir,
+            type: "files",
+        });
+
+        const text = result.content[0].text;
+        const lines = text.split("\n").filter(Boolean);
+
+        // Must return exactly 50 lines (the cap), never 51+
+        expect(lines.length).toBe(50);
+        for (const line of lines) {
+            expect(line).toContain("item-");
+        }
+    });
+
+    test("content search caps at exactly 100 lines on large result sets (skipped if rg not installed)", async () => {
+        if (!hasRg) {
+            console.log("rg not available — skipping content cap test");
+            return;
+        }
+        // Create a file with 5000 matching lines — well beyond the 100-line cap.
+        const dir = mkdtempSync(join(tmpdir(), "search-rg-cap-"));
+        const fileLines: string[] = [];
+        for (let i = 0; i < 5000; i++) {
+            fileLines.push(`match-line-${i}`);
+        }
+        writeFileSync(join(dir, "big.txt"), fileLines.join("\n") + "\n");
+
+        const result = await searchTool.execute("smoke-rg-cap", {
+            pattern: "match-line",
+            path: dir,
+            type: "content",
+        });
+
+        const resultLines = result.content[0].text.split("\n").filter(Boolean);
+        expect(resultLines.length).toBe(100);
+    });
 });
 
 // ---------------------------------------------------------------------------
@@ -257,6 +304,54 @@ describe("searchTool input sanitization", () => {
         } finally {
             process.env.HOME = origHome;
         }
+    });
+
+    test("does not allow shell injection via pattern", async () => {
+        const dir = makeTempDir();
+        // A malicious pattern that would execute a command if passed to a shell.
+        // With execFile/spawn (no shell), this is safely treated as a literal argument.
+        const result = await searchTool.execute("san-inject-pattern", {
+            pattern: '"; echo INJECTED; "',
+            path: dir,
+            type: "files",
+        });
+        const text = result.content[0].text;
+        // The injection payload must NOT appear in output
+        expect(text).not.toContain("INJECTED");
+    });
+
+    test("does not allow shell injection via path", async () => {
+        const dir = makeTempDir();
+        // A malicious path that would execute a command if passed to a shell.
+        // With spawn (no shell), `; echo INJECTED` is part of the literal path,
+        // so find treats it as a (nonexistent) directory — no command execution.
+        const result = await searchTool.execute("san-inject-path", {
+            pattern: "*.txt",
+            path: `${dir}; echo INJECTED`,
+            type: "files",
+        });
+        const text = result.content[0].text;
+        // The output should be an error or no matches — NOT output from echo INJECTED.
+        expect(text.startsWith("Search failed:") || text === "No matches found").toBe(true);
+        // Crucially, no files should be returned (injection didn't work)
+        expect(text).not.toContain("hello.txt");
+    });
+
+    test("does not allow option injection via pattern starting with -", async () => {
+        if (!hasRg) {
+            console.log("rg not available — skipping option injection via pattern test");
+            return;
+        }
+        // A pattern starting with -- that would be parsed as an rg flag
+        // if not protected by -e / --
+        const result = await searchTool.execute("san-opt-inject-pattern", {
+            pattern: "--help",
+            path: makeTempDir(),
+            type: "content",
+        });
+        const text = result.content[0].text;
+        // rg --help output contains "USAGE" — that should NOT appear
+        expect(text).not.toContain("USAGE");
     });
 
     test("path starting with '-' is made safe with ./ prefix", async () => {

--- a/packages/tools/src/search.test.ts
+++ b/packages/tools/src/search.test.ts
@@ -1,13 +1,27 @@
+/**
+ * search.test.ts — Unit + smoke tests for the search tool.
+ *
+ * Structure:
+ *   1. Pure unit tests (no subprocess): escapeRgGlob, escapeFindPath, isFailure
+ *   2. searchTool metadata (pure)
+ *   3. Smoke tests — 3 real subprocess calls covering the happy path
+ *   4. Input-sanitization tests — lightweight subprocess calls that verify
+ *      path normalization / null-byte stripping (find exits fast on bad paths)
+ */
 import { describe, test, expect } from "bun:test";
-import { searchTool, escapeRgGlob, escapeFindPath } from "./search";
-import { execFile } from "child_process";
-import { promisify } from "util";
+import { searchTool, escapeRgGlob, escapeFindPath, isFailure } from "./search";
+import type { SpawnResult } from "./search";
 import { mkdtempSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { spawnSync } from "child_process";
 
-const execFileAsync = promisify(execFile);
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Whether rg (ripgrep) is available on this machine. */
+const hasRg = spawnSync("rg", ["--version"]).status === 0;
 
 function makeTempDir(): string {
     const dir = mkdtempSync(join(tmpdir(), "search-test-"));
@@ -17,6 +31,20 @@ function makeTempDir(): string {
     writeFileSync(join(dir, "sub", "nested.txt"), "nested content\nhello again\n");
     return dir;
 }
+
+function makeSpawnResult(overrides: Partial<SpawnResult> = {}): SpawnResult {
+    return {
+        lines: [],
+        exitCode: 0,
+        signal: null,
+        truncated: false,
+        ...overrides,
+    };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Pure unit tests — escapeRgGlob
+// ---------------------------------------------------------------------------
 
 describe("escapeRgGlob", () => {
     test("passes through plain paths unchanged", () => {
@@ -44,6 +72,10 @@ describe("escapeRgGlob", () => {
     });
 });
 
+// ---------------------------------------------------------------------------
+// 2. Pure unit tests — escapeFindPath
+// ---------------------------------------------------------------------------
+
 describe("escapeFindPath", () => {
     test("passes through plain paths unchanged", () => {
         expect(escapeFindPath("/tmp/foo/bar")).toBe("/tmp/foo/bar");
@@ -66,15 +98,78 @@ describe("escapeFindPath", () => {
     });
 });
 
-describe("searchTool", () => {
-    test("has correct metadata", () => {
-        expect(searchTool.name).toBe("search");
-        expect(searchTool.description).toBeTruthy();
+// ---------------------------------------------------------------------------
+// 3. Pure unit tests — isFailure
+//    Covers rg vs find exit-code semantics and truncation handling.
+// ---------------------------------------------------------------------------
+
+describe("isFailure", () => {
+    // --- content (rg) ---
+    test("rg exit 0 is not a failure (matches found)", () => {
+        expect(isFailure(makeSpawnResult({ exitCode: 0 }), "content")).toBe(false);
     });
 
+    test("rg exit 1 is not a failure (no matches — normal rg behavior)", () => {
+        expect(isFailure(makeSpawnResult({ exitCode: 1 }), "content")).toBe(false);
+    });
+
+    test("rg exit 2 is a failure (parse/IO error)", () => {
+        expect(isFailure(makeSpawnResult({ exitCode: 2 }), "content")).toBe(true);
+    });
+
+    test("rg exit 3+ is a failure", () => {
+        expect(isFailure(makeSpawnResult({ exitCode: 3 }), "content")).toBe(true);
+        expect(isFailure(makeSpawnResult({ exitCode: 127 }), "content")).toBe(true);
+    });
+
+    // --- files (find) ---
+    test("find exit 0 is not a failure", () => {
+        expect(isFailure(makeSpawnResult({ exitCode: 0 }), "files")).toBe(false);
+    });
+
+    test("find exit 1 is a failure", () => {
+        expect(isFailure(makeSpawnResult({ exitCode: 1 }), "files")).toBe(true);
+    });
+
+    test("find exit 2+ is a failure", () => {
+        expect(isFailure(makeSpawnResult({ exitCode: 2 }), "files")).toBe(true);
+    });
+
+    // --- truncation ---
+    test("truncated result is never a failure (intentional subprocess kill)", () => {
+        expect(isFailure(makeSpawnResult({ exitCode: null, truncated: true }), "content")).toBe(false);
+        expect(isFailure(makeSpawnResult({ exitCode: null, truncated: true }), "files")).toBe(false);
+        // Even if exit code would normally signal failure, truncation wins
+        expect(isFailure(makeSpawnResult({ exitCode: 2, truncated: true }), "content")).toBe(false);
+    });
+
+    // --- null exitCode ---
+    test("null exitCode without truncation is a failure (timeout / ENOENT)", () => {
+        expect(isFailure(makeSpawnResult({ exitCode: null, truncated: false }), "content")).toBe(true);
+        expect(isFailure(makeSpawnResult({ exitCode: null, truncated: false }), "files")).toBe(true);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Metadata — pure, no subprocess
+// ---------------------------------------------------------------------------
+
+describe("searchTool metadata", () => {
+    test("has correct name and description", () => {
+        expect(searchTool.name).toBe("search");
+        expect(searchTool.description).toBeTruthy();
+        expect(typeof searchTool.execute).toBe("function");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// 5. Smoke tests — 3 real subprocess calls covering the happy path
+// ---------------------------------------------------------------------------
+
+describe("searchTool smoke tests", () => {
     test("files search finds matching files", async () => {
         const dir = makeTempDir();
-        const result = await searchTool.execute("test-1", {
+        const result = await searchTool.execute("smoke-1", {
             pattern: "*.txt",
             path: dir,
             type: "files",
@@ -83,11 +178,12 @@ describe("searchTool", () => {
         expect(text).toContain("hello.txt");
         expect(text).toContain("nested.txt");
         expect(text).not.toContain("data.json");
+        expect(result.details.type).toBe("files");
     });
 
     test("files search returns 'No matches found' for no results", async () => {
         const dir = makeTempDir();
-        const result = await searchTool.execute("test-2", {
+        const result = await searchTool.execute("smoke-2", {
             pattern: "*.xyz",
             path: dir,
             type: "files",
@@ -95,375 +191,108 @@ describe("searchTool", () => {
         expect(result.content[0].text).toBe("No matches found");
     });
 
-    test("content search finds matching lines", async () => {
-        const dir = makeTempDir();
-        // Check if rg is available
-        try {
-            await execFileAsync("rg", ["--version"]);
-        } catch {
-            console.log("rg not available, skipping content search test");
+    test("content search finds matching lines (skipped if rg not installed)", async () => {
+        if (!hasRg) {
+            console.log("rg not available — skipping content smoke test");
             return;
         }
-        const result = await searchTool.execute("test-3", {
+        const dir = makeTempDir();
+        const result = await searchTool.execute("smoke-3", {
             pattern: "hello",
             path: dir,
             type: "content",
         });
-        const text = result.content[0].text;
-        expect(text).toContain("hello");
+        expect(result.content[0].text).toContain("hello");
+        expect(result.details.type).toBe("content");
     });
+});
 
-    test("defaults to content search when type is omitted", async () => {
+// ---------------------------------------------------------------------------
+// 6. Input-sanitization tests — verify tool-level logic, not subprocess behavior.
+//    These use real subprocess calls but they resolve fast (bad paths / no rg).
+// ---------------------------------------------------------------------------
+
+describe("searchTool input sanitization", () => {
+    test("defaults type to 'content' when omitted", async () => {
         const dir = makeTempDir();
-        const result = await searchTool.execute("test-4", {
-            pattern: "nonexistent_string_xyz",
+        const result = await searchTool.execute("san-default-type", {
+            pattern: "nonexistent_xyz",
             path: dir,
+            // no type — should default to content
         });
-        // Should not throw — type defaults to "content"
         expect(result.details.type).toBe("content");
     });
 
-    test("does not allow shell injection via pattern", async () => {
+    test("handles null bytes in pattern and path without throwing", async () => {
         const dir = makeTempDir();
-        // A malicious pattern that would execute a command if passed to a shell
-        // With execFile this is safely treated as a literal find -name argument
-        const result = await searchTool.execute("test-inject-1", {
-            pattern: '"; echo INJECTED; "',
+        // spawn() throws synchronously on \0 — tool must strip them
+        const r1 = await searchTool.execute("san-null-pattern", {
+            pattern: "*.txt\0injected",
             path: dir,
             type: "files",
         });
-        const text = result.content[0].text;
-        // The injection payload must NOT appear in output
-        expect(text).not.toContain("INJECTED");
-    });
+        expect(typeof r1.content[0].text).toBe("string");
 
-    test("does not allow shell injection via path", async () => {
-        const dir = makeTempDir();
-        // A malicious path that would execute a command if passed to a shell.
-        // With spawn (no shell), `; echo INJECTED` is part of the literal path,
-        // so find treats it as a (nonexistent) directory — no command execution.
-        const result = await searchTool.execute("test-inject-2", {
-            pattern: "*.txt",
-            path: `${dir}; echo INJECTED`,
-            type: "files",
+        const r2 = await searchTool.execute("san-null-path", {
+            pattern: "hello",
+            path: `${dir}\0/etc/passwd`,
+            type: "content",
         });
-        const text = result.content[0].text;
-        // The output should be an error (nonexistent path) or no matches —
-        // NOT actual output from `echo INJECTED` as a separate command.
-        // The error message may echo the path name, so we check it's a
-        // Search failed message (find error) rather than bare "INJECTED" output.
-        expect(text.startsWith("Search failed:") || text === "No matches found").toBe(true);
-        // Crucially, no files should be returned (injection didn't work)
-        expect(text).not.toContain("hello.txt");
+        expect(typeof r2.content[0].text).toBe("string");
     });
 
-    test("truncates output to max lines", async () => {
-        // Create a directory with many files
-        const dir = mkdtempSync(join(tmpdir(), "search-trunc-"));
-        for (let i = 0; i < 60; i++) {
-            writeFileSync(join(dir, `file-${String(i).padStart(3, "0")}.txt`), `content ${i}\n`);
-        }
-        const result = await searchTool.execute("test-trunc", {
-            pattern: "*.txt",
-            path: dir,
-            type: "files",
-        });
-        const lines = result.content[0].text.split("\n").filter(Boolean);
-        expect(lines.length).toBeLessThanOrEqual(50);
-    });
-
-    test("files search caps at exactly 50 lines on large result sets", async () => {
-        // Create 5000 files — well beyond the 50-line cap — to stress the
-        // streaming kill logic and verify no off-by-one from post-kill data events.
-        const dir = mkdtempSync(join(tmpdir(), "search-stream-"));
-        for (let i = 0; i < 5000; i++) {
-            writeFileSync(join(dir, `item-${String(i).padStart(5, "0")}.txt`), `data ${i}\n`);
-        }
-
-        const result = await searchTool.execute("test-stream", {
-            pattern: "*.txt",
-            path: dir,
-            type: "files",
-        });
-
-        const text = result.content[0].text;
-        const lines = text.split("\n").filter(Boolean);
-
-        // Must return exactly 50 lines (the cap), never 51+
-        expect(lines.length).toBe(50);
-        for (const line of lines) {
-            expect(line).toContain("item-");
-        }
-    });
-
-    test("content search caps at exactly 100 lines on large result sets", async () => {
+    test("expands ~ to home directory in path", async () => {
+        const origHome = process.env.HOME;
+        const fakeHome = mkdtempSync(join(tmpdir(), "search-tilde-"));
+        mkdirSync(join(fakeHome, "proj"));
+        writeFileSync(join(fakeHome, "proj", "tilde-marker.txt"), "tilde-test\n");
+        process.env.HOME = fakeHome;
         try {
-            const r = spawnSync("rg", ["--version"]);
-            if (r.status !== 0) throw new Error();
-        } catch {
-            console.log("rg not available, skipping content cap test");
-            return;
+            const result = await searchTool.execute("san-tilde", {
+                pattern: "*.txt",
+                path: "~/proj",
+                type: "files",
+            });
+            expect(result.content[0].text).toContain("tilde-marker.txt");
+        } finally {
+            process.env.HOME = origHome;
         }
-        // Create a file with 5000 matching lines
-        const dir = mkdtempSync(join(tmpdir(), "search-rg-cap-"));
-        const fileLines: string[] = [];
-        for (let i = 0; i < 5000; i++) {
-            fileLines.push(`match-line-${i}`);
-        }
-        writeFileSync(join(dir, "big.txt"), fileLines.join("\n") + "\n");
-
-        const result = await searchTool.execute("test-rg-cap", {
-            pattern: "match-line",
-            path: dir,
-            type: "content",
-        });
-
-        const resultLines = result.content[0].text.split("\n").filter(Boolean);
-        expect(resultLines.length).toBe(100);
     });
 
-    test("does not allow option injection via pattern starting with -", async () => {
-        const dir = makeTempDir();
-        // A pattern starting with -- that would be parsed as an rg flag
-        // if not protected by -e / --
-        const result = await searchTool.execute("test-opt-inject-1", {
-            pattern: "--help",
-            path: dir,
-            type: "content",
-        });
-        const text = result.content[0].text;
-        // rg --help output contains "USAGE" — that should NOT appear
-        expect(text).not.toContain("USAGE");
-    });
-
-    test("does not allow option injection via path starting with -", async () => {
-        // A path like "--help" would trigger GNU find's help output if passed raw.
-        // The safePath normalization should turn it into "./--help", which is
-        // treated as a literal (non-existent) directory on both BSD and GNU find.
-        const result = await searchTool.execute("test-opt-inject-2", {
+    test("path starting with '-' is made safe with ./ prefix", async () => {
+        // Without safePath normalization, --help would be parsed as a flag
+        const result = await searchTool.execute("san-dash-path", {
             pattern: "*.txt",
             path: "--help",
             type: "files",
         });
         const text = result.content[0].text;
-        // Should be either "No matches found" or "Search failed: ..." (path doesn't exist)
+        // Should error out cleanly (path doesn't exist), not show find/rg help text
         expect(text === "No matches found" || text.startsWith("Search failed:")).toBe(true);
     });
 
-    test("surfaces find errors for nonexistent paths instead of 'No matches'", async () => {
-        const result = await searchTool.execute("test-find-err", {
+    test("nonexistent path surfaces error instead of 'No matches found'", async () => {
+        const result = await searchTool.execute("san-no-path", {
             pattern: "*.txt",
-            path: "/nonexistent/path/that/does/not/exist",
+            path: "/nonexistent/path/xyz-does-not-exist",
             type: "files",
         });
         const text = result.content[0].text;
-        // find exits non-zero for bad paths — must surface as error, not "No matches found"
         expect(text).toStartWith("Search failed:");
         expect(text).not.toBe("No matches found");
     });
 
-    test("surfaces rg errors for invalid regex", async () => {
-        try {
-            const r = spawnSync("rg", ["--version"]);
-            if (r.status !== 0) throw new Error();
-        } catch {
-            console.log("rg not available, skipping rg error test");
+    test("rg exit 1 (no matches) returns 'No matches found', not error (skipped if rg missing)", async () => {
+        if (!hasRg) {
+            console.log("rg not available — skipping rg exit-1 test");
             return;
         }
         const dir = makeTempDir();
-        // Invalid regex — rg exits with code 2
-        const result = await searchTool.execute("test-rg-err", {
-            pattern: "[invalid",
-            path: dir,
-            type: "content",
-        });
-        const text = result.content[0].text;
-        expect(text).toStartWith("Search failed:");
-    });
-
-    test("rg exit 1 (no matches) returns 'No matches found', not an error", async () => {
-        try {
-            const r = spawnSync("rg", ["--version"]);
-            if (r.status !== 0) throw new Error();
-        } catch {
-            console.log("rg not available, skipping rg no-match test");
-            return;
-        }
-        const dir = makeTempDir();
-        const result = await searchTool.execute("test-rg-nomatch", {
+        const result = await searchTool.execute("san-rg-nomatch", {
             pattern: "zzz_definitely_not_present_zzz",
             path: dir,
             type: "content",
         });
         expect(result.content[0].text).toBe("No matches found");
-    });
-
-    test("surfaces partial errors when find has results but also errors", async () => {
-        // Create a directory with an unreadable subdirectory
-        const dir = mkdtempSync(join(tmpdir(), "search-partial-"));
-        writeFileSync(join(dir, "visible.txt"), "data\n");
-        const badDir = join(dir, "noperm");
-        mkdirSync(badDir, { mode: 0o000 });
-
-        try {
-            const result = await searchTool.execute("test-partial-err", {
-                pattern: "*.txt",
-                path: dir,
-                type: "files",
-            });
-            const text = result.content[0].text;
-
-            // Should still return the visible file
-            expect(text).toContain("visible.txt");
-
-            // On systems where permission is actually denied (not running as root),
-            // should include a warning about missing results
-            if (process.getuid?.() !== 0) {
-                expect(text).toContain("[warning:");
-            }
-        } finally {
-            // Restore permissions so temp cleanup works
-            const { chmodSync } = require("fs");
-            chmodSync(badDir, 0o755);
-        }
-    });
-
-    test("handles content search on file with no trailing newline", async () => {
-        try {
-            const r = spawnSync("rg", ["--version"]);
-            if (r.status !== 0) throw new Error();
-        } catch {
-            console.log("rg not available, skipping no-trailing-newline test");
-            return;
-        }
-        const dir = mkdtempSync(join(tmpdir(), "search-nonl-"));
-        // File with no trailing newline
-        writeFileSync(join(dir, "noterminal.txt"), "last-line-no-newline");
-
-        const result = await searchTool.execute("test-nonl", {
-            pattern: "last-line",
-            path: dir,
-            type: "content",
-        });
-        expect(result.content[0].text).toContain("last-line-no-newline");
-    });
-
-    test("handles null bytes in pattern and path without throwing", async () => {
-        const dir = makeTempDir();
-        // Null bytes in args would cause spawn() to throw — must be handled gracefully
-        const result1 = await searchTool.execute("test-null-pattern", {
-            pattern: "*.txt\0injected",
-            path: dir,
-            type: "files",
-        });
-        expect(typeof result1.content[0].text).toBe("string");
-
-        const result2 = await searchTool.execute("test-null-path", {
-            pattern: "hello",
-            path: `${dir}\0/etc/passwd`,
-            type: "content",
-        });
-        expect(typeof result2.content[0].text).toBe("string");
-    });
-
-    test("expands ~ to home directory in path", async () => {
-        // Temporarily override HOME to a controlled temp directory so the test
-        // doesn't depend on the real home dir (which may not be writable in CI).
-        const origHome = process.env.HOME;
-        const fakeHome = mkdtempSync(join(tmpdir(), "search-tilde-home-"));
-        const subdir = "project";
-        mkdirSync(join(fakeHome, subdir));
-        writeFileSync(join(fakeHome, subdir, "tilde-marker.txt"), "tilde-test\n");
-
-        process.env.HOME = fakeHome;
-        try {
-            // Search with ~/subdir path — should expand to fakeHome/subdir
-            const result = await searchTool.execute("test-tilde", {
-                pattern: "*.txt",
-                path: `~/${subdir}`,
-                type: "files",
-            });
-            expect(result.content[0].text).toContain("tilde-marker.txt");
-
-            // Bare ~ should expand to fakeHome
-            const result2 = await searchTool.execute("test-tilde-bare", {
-                pattern: "*.txt",
-                path: "~",
-                type: "files",
-            });
-            expect(result2.content[0].text).toContain("tilde-marker.txt");
-        } finally {
-            process.env.HOME = origHome;
-            const { rmSync } = require("fs");
-            try { rmSync(fakeHome, { recursive: true }); } catch {}
-        }
-    });
-
-    test("does not prepend ./ to Windows-style absolute paths", async () => {
-        // Windows paths like C:\Users or C:/Users should not become ./C:\Users
-        // We can't run find on fake Windows paths, but we can verify the path
-        // in the details is preserved and the tool doesn't crash.
-        const result = await searchTool.execute("test-win-path", {
-            pattern: "*.txt",
-            path: "C:\\Users\\test",
-            type: "files",
-        });
-        // Should fail gracefully (path doesn't exist), not crash
-        const text = result.content[0].text;
-        expect(text).not.toContain("./C:");
-        expect(text === "No matches found" || text.startsWith("Search failed:")).toBe(true);
-
-        // Also test forward-slash variant
-        const result2 = await searchTool.execute("test-win-path-2", {
-            pattern: "*.txt",
-            path: "D:/Projects",
-            type: "files",
-        });
-        expect(result2.content[0].text).not.toContain("./D:");
-    });
-
-    test("preserves Unicode filenames in file search results", async () => {
-        const dir = mkdtempSync(join(tmpdir(), "search-unicode-"));
-        // Create files with multi-byte UTF-8 names: accented, CJK, emoji
-        const names = ["café.txt", "日本語.txt", "🎉party.txt"];
-        for (const name of names) {
-            writeFileSync(join(dir, name), "data\n");
-        }
-
-        const result = await searchTool.execute("test-unicode-files", {
-            pattern: "*.txt",
-            path: dir,
-            type: "files",
-        });
-        const text = result.content[0].text;
-        for (const name of names) {
-            expect(text).toContain(name);
-        }
-        // Must not contain replacement character (U+FFFD) from broken decoding
-        expect(text).not.toContain("\uFFFD");
-    });
-
-    test("preserves Unicode content in content search results", async () => {
-        try {
-            const r = spawnSync("rg", ["--version"]);
-            if (r.status !== 0) throw new Error();
-        } catch {
-            console.log("rg not available, skipping unicode content test");
-            return;
-        }
-        const dir = mkdtempSync(join(tmpdir(), "search-unicode-content-"));
-        const content = "résultat: données CJK 漢字 emoji 🚀✨\n";
-        writeFileSync(join(dir, "unicode.txt"), content);
-
-        const result = await searchTool.execute("test-unicode-content", {
-            pattern: "résultat",
-            path: dir,
-            type: "content",
-        });
-        const text = result.content[0].text;
-        expect(text).toContain("résultat");
-        expect(text).toContain("漢字");
-        expect(text).toContain("🚀");
-        expect(text).not.toContain("\uFFFD");
     });
 });

--- a/packages/tools/src/search.ts
+++ b/packages/tools/src/search.ts
@@ -34,7 +34,7 @@ const MAX_STDERR_CHARS = 512;
  */
 const MAX_PARTIAL_CHARS = 256 * 1024; // 256 KB
 
-interface SpawnResult {
+export interface SpawnResult {
     lines: string[];
     exitCode: number | null;
     signal: string | null;
@@ -154,8 +154,10 @@ function spawnHeadLines(
  * - `rg` exit 1 = no matches (normal), exit 2+ = error.
  * - `find` exit 0 = success (possibly no matches), exit 1+ = error.
  * - exitCode null with no truncation = timeout or command not found.
+ *
+ * Exported for unit testing.
  */
-function isFailure(result: SpawnResult, type: string): boolean {
+export function isFailure(result: SpawnResult, type: string): boolean {
     // Truncated kill is intentional, not a failure
     if (result.truncated) return false;
     // exitCode null means process didn't exit normally (timeout, ENOENT, etc.)

--- a/packages/tools/src/write-file.test.ts
+++ b/packages/tools/src/write-file.test.ts
@@ -1,31 +1,59 @@
-import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { mkdtempSync, existsSync, readFileSync } from "fs";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, existsSync, readFileSync, mkdirSync, writeFileSync as writeFileSyncFs } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { writeFileTool } from "./write-file.js";
 import {
     initSandbox,
     cleanupSandbox,
-    getViolations,
     _resetState,
     type ResolvedSandboxConfig,
 } from "./sandbox.js";
 
+// ── fs/promises mock ──────────────────────────────────────────────────────────
+// node:fs/promises and fs/promises are the same Bun module registry entry, so
+// using the named import as the default impl creates infinite recursion.
+// Instead we use sync fs variants (from the "fs" module, which is not mocked)
+// as the real-I/O implementation for smoke / permitted-path tests.
+//
+// Include readFile stub so this mock doesn't break read-file.test.ts when both
+// files share a Bun process and this mock.module() call runs first.
+const mockMkdir = mock(async (path: string, opts?: unknown): Promise<string | undefined> => {
+    mkdirSync(String(path), opts as Parameters<typeof mkdirSync>[1]);
+    return undefined;
+});
+const mockWriteFile = mock(async (path: string, data: string, enc?: unknown): Promise<void> => {
+    writeFileSyncFs(String(path), data, (enc as BufferEncoding) ?? "utf-8");
+});
+const _readFileStub = mock(async (_path: string, _enc?: unknown): Promise<string> => "");
+mock.module("fs/promises", () => ({
+    readFile: _readFileStub,
+    writeFile: mockWriteFile,
+    mkdir: mockMkdir,
+}));
+
+// ── SUT — dynamically imported so it binds the mocked fs/promises ─────────────
+const { writeFileTool } = await import("./write-file.js");
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
 function makeConfig(overrides?: {
     allowWrite?: string[];
     denyWrite?: string[];
-    denyRead?: string[];
 }): ResolvedSandboxConfig {
     return {
         mode: "basic",
         srtConfig: {
             filesystem: {
-                denyRead: overrides?.denyRead ?? [],
+                denyRead: [],
                 allowWrite: overrides?.allowWrite ?? ["/tmp"],
-                denyWrite: overrides?.denyWrite ?? ["/tmp/.env"],
+                denyWrite: overrides?.denyWrite ?? [],
             },
         },
     };
+}
+
+function makeErrno(code: string, message = code): NodeJS.ErrnoException {
+    return Object.assign(new Error(message), { code });
 }
 
 async function execWrite(path: string, content: string) {
@@ -37,6 +65,16 @@ describe("writeFileTool", () => {
 
     beforeEach(() => {
         _resetState();
+        mockWriteFile.mockClear();
+        mockMkdir.mockClear();
+        // Restore to sync-fs pass-throughs between tests (avoids circular mock via node:fs/promises)
+        mockMkdir.mockImplementation(async (path: string, opts?: unknown): Promise<string | undefined> => {
+            mkdirSync(String(path), opts as Parameters<typeof mkdirSync>[1]);
+            return undefined;
+        });
+        mockWriteFile.mockImplementation(async (path: string, data: string, enc?: unknown): Promise<void> => {
+            writeFileSyncFs(String(path), data, (enc as BufferEncoding) ?? "utf-8");
+        });
         tmpDir = mkdtempSync(join(tmpdir(), "write-test-"));
     });
 
@@ -44,42 +82,77 @@ describe("writeFileTool", () => {
         await cleanupSandbox();
     });
 
-    test("writes file content", async () => {
-        const filePath = join(tmpDir, "out.txt");
-        const result = await execWrite(filePath, "hello");
-        expect(result.content[0].text).toContain("Wrote 5 bytes");
-        expect(readFileSync(filePath, "utf-8")).toBe("hello");
-    });
-
-    test("creates directories as needed", async () => {
+    // ── Smoke: verifies the real I/O path end-to-end (mkdir + writeFile) ──────
+    test("smoke: writes file and creates parent directories", async () => {
         const filePath = join(tmpDir, "sub", "dir", "out.txt");
-        await execWrite(filePath, "nested");
-        expect(readFileSync(filePath, "utf-8")).toBe("nested");
+        const result = await execWrite(filePath, "nested content");
+        expect(result.content[0].text).toContain("Wrote 14 bytes");
+        expect(readFileSync(filePath, "utf-8")).toBe("nested content");
     });
 
-    test("works normally when mode is none", async () => {
-        await initSandbox({ mode: "none", srtConfig: null });
-        const filePath = join(tmpDir, "off.txt");
-        await execWrite(filePath, "off mode");
-        expect(readFileSync(filePath, "utf-8")).toBe("off mode");
+    // ── Unit: errno → message mapping (no real I/O) ───────────────────────────
+    describe("errno → message mapping", () => {
+        test("EACCES → 'Permission denied'", async () => {
+            mockMkdir.mockResolvedValue(undefined);
+            mockWriteFile.mockRejectedValue(makeErrno("EACCES"));
+            const result = await execWrite("/etc/shadow", "x");
+            expect(result.content[0].text).toContain("Permission denied");
+            expect(result.details.error).toBe("EACCES");
+            expect(result.details.size).toBe(0);
+        });
+
+        test("ENOSPC → 'No space left on device'", async () => {
+            mockMkdir.mockResolvedValue(undefined);
+            mockWriteFile.mockRejectedValue(makeErrno("ENOSPC"));
+            const result = await execWrite("/tmp/full.txt", "x");
+            expect(result.content[0].text).toContain("No space left on device");
+            expect(result.details.error).toBe("ENOSPC");
+        });
+
+        test("EISDIR → 'Path is a directory, not a file'", async () => {
+            mockMkdir.mockResolvedValue(undefined);
+            mockWriteFile.mockRejectedValue(makeErrno("EISDIR"));
+            const result = await execWrite("/some/dir", "x");
+            expect(result.content[0].text).toContain("Path is a directory");
+            expect(result.details.error).toBe("EISDIR");
+        });
+
+        test("ENOENT from mkdir → 'Parent directory could not be created'", async () => {
+            mockMkdir.mockRejectedValue(makeErrno("ENOENT"));
+            const result = await execWrite("/deep/missing/path.txt", "x");
+            expect(result.content[0].text).toContain("Parent directory could not be created");
+            expect(result.details.error).toBe("ENOENT");
+        });
+
+        test("unknown code → generic message with original error text", async () => {
+            mockMkdir.mockResolvedValue(undefined);
+            mockWriteFile.mockRejectedValue(makeErrno("EDQUOT", "disk quota exceeded"));
+            const result = await execWrite("/tmp/out.txt", "x");
+            expect(result.content[0].text).toContain("❌");
+            expect(result.content[0].text).toContain("disk quota exceeded");
+            expect(result.details.error).toBe("EDQUOT");
+        });
     });
 
-    describe("sandbox active (basic/full mode)", () => {
-        test("blocks writes outside allowWrite paths", async () => {
+    // ── Unit: sandbox path validation (no I/O needed) ─────────────────────────
+    describe("sandbox", () => {
+        test("blocks writes outside allowWrite — no I/O performed", async () => {
             await initSandbox(makeConfig({ allowWrite: ["/tmp/allowed-only"] }));
             const filePath = join(tmpDir, "blocked.txt");
             const result = await execWrite(filePath, "should fail");
             expect(result.content[0].text).toContain("❌ Sandbox blocked write");
             expect(result.content[0].text).toContain("allowWrite");
             expect(result.details.sandboxBlocked).toBe(true);
+            expect(mockWriteFile.mock.calls.length).toBe(0); // sandbox short-circuits before I/O
             expect(existsSync(filePath)).toBe(false);
         });
 
-        test("blocks writes to denyWrite paths", async () => {
-            await initSandbox(makeConfig());
+        test("blocks writes to denyWrite paths — no I/O performed", async () => {
+            await initSandbox(makeConfig({ allowWrite: ["/tmp"], denyWrite: ["/tmp/.env"] }));
             const result = await execWrite("/tmp/.env", "secret=123");
             expect(result.content[0].text).toContain("❌ Sandbox blocked write");
             expect(result.details.sandboxBlocked).toBe(true);
+            expect(mockWriteFile.mock.calls.length).toBe(0);
         });
 
         test("allows writes to permitted paths", async () => {
@@ -89,28 +162,18 @@ describe("writeFileTool", () => {
             expect(result.content[0].text).toContain("Wrote 7 bytes");
             expect(readFileSync(filePath, "utf-8")).toBe("allowed");
         });
-    });
 
-    describe("fs error handling", () => {
-        test("returns graceful error when writing to a path whose parent cannot be created (root-owned)", async () => {
-            // /proc is always present and non-writable on Linux; use a clearly inaccessible path on macOS too
-            const unwritablePath = "/root/pizzapi-test-canary/out.txt";
-            const result = await execWrite(unwritablePath, "content");
-            expect(result.content[0].text).toContain("❌");
-            expect(result.details.size).toBe(0);
-            expect(result.details.error).toBeTruthy();
-        });
-
-        test("returns graceful error when writing to a directory path", async () => {
-            // Attempt to write to a path that already exists as a directory
-            const result = await execWrite(tmpDir, "content");
-            expect(result.content[0].text).toContain("❌");
-            expect(result.details.size).toBe(0);
-            expect(result.details.error).toBeTruthy();
+        test("mode=none: no sandbox restrictions apply", async () => {
+            await initSandbox({ mode: "none", srtConfig: null });
+            const filePath = join(tmpDir, "off.txt");
+            const result = await execWrite(filePath, "off mode");
+            expect(result.content[0].text).toContain("Wrote 8 bytes");
+            expect(readFileSync(filePath, "utf-8")).toBe("off mode");
         });
     });
 
-    test("has correct tool metadata", () => {
+    // ── Metadata ──────────────────────────────────────────────────────────────
+    test("tool metadata", () => {
         expect(writeFileTool.name).toBe("write_file");
         expect(writeFileTool.label).toBe("Write File");
     });

--- a/packages/tools/src/write-file.test.ts
+++ b/packages/tools/src/write-file.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from "bun:test";
 import { mkdtempSync, existsSync, readFileSync, mkdirSync, writeFileSync as writeFileSyncFs } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -176,5 +176,9 @@ describe("writeFileTool", () => {
     test("tool metadata", () => {
         expect(writeFileTool.name).toBe("write_file");
         expect(writeFileTool.label).toBe("Write File");
+    });
+
+    afterAll(() => {
+        mock.restore();
     });
 });

--- a/packages/tools/src/write-file.test.ts
+++ b/packages/tools/src/write-file.test.ts
@@ -15,8 +15,10 @@ import {
 // Instead we use sync fs variants (from the "fs" module, which is not mocked)
 // as the real-I/O implementation for smoke / permitted-path tests.
 //
-// Include readFile stub so this mock doesn't break read-file.test.ts when both
-// files share a Bun process and this mock.module() call runs first.
+// IMPORTANT: We must spread ALL original exports so other test files that share
+// this Bun process (e.g. event-pipeline.test.ts importing `rm`, `stat`) still
+// get the real implementations. Only override the functions we actually mock.
+const _originalFsPromises = await import("node:fs/promises");
 const mockMkdir = mock(async (path: string, opts?: unknown): Promise<string | undefined> => {
     mkdirSync(String(path), opts as Parameters<typeof mkdirSync>[1]);
     return undefined;
@@ -24,9 +26,8 @@ const mockMkdir = mock(async (path: string, opts?: unknown): Promise<string | un
 const mockWriteFile = mock(async (path: string, data: string, enc?: unknown): Promise<void> => {
     writeFileSyncFs(String(path), data, (enc as BufferEncoding) ?? "utf-8");
 });
-const _readFileStub = mock(async (_path: string, _enc?: unknown): Promise<string> => "");
 mock.module("fs/promises", () => ({
-    readFile: _readFileStub,
+    ..._originalFsPromises,
     writeFile: mockWriteFile,
     mkdir: mockMkdir,
 }));

--- a/packages/tools/src/write-file.test.ts
+++ b/packages/tools/src/write-file.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach, afterAll, mock } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { mkdtempSync, existsSync, readFileSync, mkdirSync, writeFileSync as writeFileSyncFs } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
@@ -178,7 +178,4 @@ describe("writeFileTool", () => {
         expect(writeFileTool.label).toBe("Write File");
     });
 
-    afterAll(() => {
-        mock.restore();
-    });
 });


### PR DESCRIPTION
Night Shift pairing: test-slimming-tools

Dishes:
- **007**: Slim bash tool tests — DI factory (createBashTool) eliminates mock.module cross-file contamination
- **008**: Slim search tool tests — pure unit tests for escape/isFailure + 3 smoke tests  
- **009**: Slim read/write file tests — mocked fs/promises for errno/sandbox coverage

Key fix: bash.ts uses DI injection instead of mock.module() to prevent Bun shared-worker contamination.