### PR TITLE
fix: stop infinite trigger cancellation retry on permanent errors

### DIFF
--- a/packages/cli/src/extensions/remote/trigger-cancellation.test.ts
+++ b/packages/cli/src/extensions/remote/trigger-cancellation.test.ts
@@ -1,0 +1,188 @@
+import { describe, test, expect, beforeEach } from "bun:test";
+import { createCancellationManager, type CancellationState } from "./trigger-cancellation.js";
+import type { RelayContext } from "../remote-types.js";
+
+/** Minimal mock for the RelayContext / socket needed by the cancellation manager. */
+function createMockContext(emitHandler?: (event: string, data: any, ack: Function) => void) {
+    const emitted: Array<{ event: string; data: any }> = [];
+    const sioSocket = {
+        connected: true,
+        emit(event: string, data: any, ack?: Function) {
+            emitted.push({ event, data });
+            if (emitHandler) emitHandler(event, data, ack!);
+        },
+    };
+    const rctx = {
+        relay: { token: "test-token" },
+        sioSocket,
+    } as unknown as RelayContext;
+
+    return { rctx, sioSocket, emitted };
+}
+
+function createState(cancellations: CancellationState["pendingCancellations"] = []): CancellationState {
+    return {
+        pendingCancellations: cancellations,
+        pendingCancellationRetryTimer: null,
+        pendingCancellationRetryInFlight: false,
+    };
+}
+
+describe("trigger-cancellation", () => {
+    describe("permanent error handling", () => {
+        test("drops cancellation on 'Target session belongs to a different user' error", () => {
+            const { rctx } = createMockContext((_event, _data, ack) => {
+                ack({ ok: false, error: "Target session belongs to a different user" });
+            });
+
+            const state = createState([
+                { triggerId: "t1", childSessionId: "child1" },
+            ]);
+            const mgr = createCancellationManager(rctx, state);
+
+            mgr.retryPendingTriggerCancellations("test");
+
+            // The permanent error should have removed the cancellation
+            expect(state.pendingCancellations).toHaveLength(0);
+        });
+
+        test("drops cancellation on 'Sender is not the parent of the target session' error", () => {
+            const { rctx } = createMockContext((_event, _data, ack) => {
+                ack({ ok: false, error: "Sender is not the parent of the target session" });
+            });
+
+            const state = createState([
+                { triggerId: "t1", childSessionId: "child1" },
+            ]);
+            const mgr = createCancellationManager(rctx, state);
+
+            mgr.retryPendingTriggerCancellations("test");
+
+            expect(state.pendingCancellations).toHaveLength(0);
+        });
+
+        test("keeps cancellation on transient errors and increments retryCount", () => {
+            const { rctx } = createMockContext((_event, _data, ack) => {
+                ack({ ok: false, error: "Network timeout" });
+            });
+
+            const state = createState([
+                { triggerId: "t1", childSessionId: "child1" },
+            ]);
+            const mgr = createCancellationManager(rctx, state);
+
+            mgr.retryPendingTriggerCancellations("test");
+
+            expect(state.pendingCancellations).toHaveLength(1);
+            expect(state.pendingCancellations[0].retryCount).toBe(1);
+        });
+    });
+
+    describe("max retries", () => {
+        test("drops cancellation after 10 retries even for transient errors", () => {
+            const { rctx } = createMockContext((_event, _data, ack) => {
+                ack({ ok: false, error: "Some transient error" });
+            });
+
+            const state = createState([
+                { triggerId: "t1", childSessionId: "child1", retryCount: 9 },
+            ]);
+            const mgr = createCancellationManager(rctx, state);
+
+            mgr.retryPendingTriggerCancellations("test");
+
+            // retryCount was 9, now 10 — should be dropped
+            expect(state.pendingCancellations).toHaveLength(0);
+        });
+
+        test("keeps cancellation at retryCount 8 (below max)", () => {
+            const { rctx } = createMockContext((_event, _data, ack) => {
+                ack({ ok: false, error: "Some transient error" });
+            });
+
+            const state = createState([
+                { triggerId: "t1", childSessionId: "child1", retryCount: 8 },
+            ]);
+            const mgr = createCancellationManager(rctx, state);
+
+            mgr.retryPendingTriggerCancellations("test");
+
+            expect(state.pendingCancellations).toHaveLength(1);
+            expect(state.pendingCancellations[0].retryCount).toBe(9);
+        });
+    });
+
+    describe("successful cancellations", () => {
+        test("removes cancellation on ok:true response", () => {
+            const { rctx } = createMockContext((_event, _data, ack) => {
+                ack({ ok: true });
+            });
+
+            const state = createState([
+                { triggerId: "t1", childSessionId: "child1" },
+            ]);
+            const mgr = createCancellationManager(rctx, state);
+
+            mgr.retryPendingTriggerCancellations("test");
+
+            expect(state.pendingCancellations).toHaveLength(0);
+        });
+
+        test("handles mixed results in a batch", () => {
+            let callCount = 0;
+            const { rctx } = createMockContext((_event, data, ack) => {
+                callCount++;
+                if (data.triggerId === "t1") {
+                    ack({ ok: true }); // success
+                } else if (data.triggerId === "t2") {
+                    ack({ ok: false, error: "Target session belongs to a different user" }); // permanent
+                } else {
+                    ack({ ok: false, error: "Temporary" }); // transient
+                }
+            });
+
+            const state = createState([
+                { triggerId: "t1", childSessionId: "child1" },
+                { triggerId: "t2", childSessionId: "child2" },
+                { triggerId: "t3", childSessionId: "child3" },
+            ]);
+            const mgr = createCancellationManager(rctx, state);
+
+            mgr.retryPendingTriggerCancellations("test");
+
+            expect(callCount).toBe(3);
+            // t1 succeeded, t2 permanent-dropped, t3 still pending
+            expect(state.pendingCancellations).toHaveLength(1);
+            expect(state.pendingCancellations[0].triggerId).toBe("t3");
+        });
+    });
+
+    describe("no-op when empty", () => {
+        test("does nothing when no pending cancellations", () => {
+            const { rctx, emitted } = createMockContext();
+            const state = createState([]);
+            const mgr = createCancellationManager(rctx, state);
+
+            mgr.retryPendingTriggerCancellations("test");
+
+            expect(emitted).toHaveLength(0);
+        });
+    });
+
+    describe("skips when not connected", () => {
+        test("does nothing when socket is not connected", () => {
+            const { rctx, sioSocket, emitted } = createMockContext();
+            sioSocket.connected = false;
+            const state = createState([
+                { triggerId: "t1", childSessionId: "child1" },
+            ]);
+            const mgr = createCancellationManager(rctx, state);
+
+            mgr.retryPendingTriggerCancellations("test");
+
+            expect(emitted).toHaveLength(0);
+            // Should still be pending
+            expect(state.pendingCancellations).toHaveLength(1);
+        });
+    });
+});

--- a/packages/cli/src/extensions/remote/trigger-cancellation.ts
+++ b/packages/cli/src/extensions/remote/trigger-cancellation.ts
@@ -13,10 +13,21 @@ import { createLogger } from "@pizzapi/tools";
 import type { RelayContext } from "../remote-types.js";
 
 const TRIGGER_CANCELLATION_RETRY_INTERVAL_MS = 3_000;
+/** Max attempts before dropping a cancellation as permanently failed. */
+const MAX_CANCELLATION_RETRIES = 10;
+/**
+ * Error messages that indicate the cancellation will never succeed,
+ * regardless of how many times we retry (e.g. the target session no
+ * longer exists under this user, or the parent relationship is broken).
+ */
+const PERMANENT_ERRORS = [
+    "Target session belongs to a different user",
+    "Sender is not the parent of the target session",
+];
 const log = createLogger("remote");
 
 export interface CancellationState {
-    pendingCancellations: Array<{ triggerId: string; childSessionId: string }>;
+    pendingCancellations: Array<{ triggerId: string; childSessionId: string; retryCount?: number }>;
     pendingCancellationRetryTimer: ReturnType<typeof setInterval> | null;
     pendingCancellationRetryInFlight: boolean;
 }
@@ -102,10 +113,35 @@ export function createCancellationManager(rctx: RelayContext, state: Cancellatio
                         state.pendingCancellations.splice(index, 1);
                     }
                 } else {
-                    failedCancellations++;
-                    log.info(
-                        `pizzapi: trigger cancellation failed for ${triggerId}: ${result?.error ?? "unknown"} — will retry`,
+                    const errorMsg = result?.error ?? "unknown";
+                    const isPermanent = PERMANENT_ERRORS.some((pe) => errorMsg.includes(pe));
+                    const entry = state.pendingCancellations.find(
+                        (c) => c.triggerId === triggerId && c.childSessionId === childSessionId,
                     );
+                    if (entry) {
+                        entry.retryCount = (entry.retryCount ?? 0) + 1;
+                    }
+                    const retries = entry?.retryCount ?? 1;
+
+                    if (isPermanent || retries >= MAX_CANCELLATION_RETRIES) {
+                        // Permanent error or exceeded max retries — drop it
+                        const reason = isPermanent ? "permanent error" : `exceeded ${MAX_CANCELLATION_RETRIES} retries`;
+                        log.info(
+                            `pizzapi: trigger cancellation for ${triggerId} dropped (${reason}: ${errorMsg})`,
+                        );
+                        const index = state.pendingCancellations.findIndex(
+                            (c) => c.triggerId === triggerId && c.childSessionId === childSessionId,
+                        );
+                        if (index >= 0) {
+                            state.pendingCancellations.splice(index, 1);
+                        }
+                        successfulCancellations++; // Count as resolved for batch logging
+                    } else {
+                        failedCancellations++;
+                        log.info(
+                            `pizzapi: trigger cancellation failed for ${triggerId}: ${errorMsg} — will retry (${retries}/${MAX_CANCELLATION_RETRIES})`,
+                        );
+                    }
                 }
 
                 if (completedResponses === cancellationsToRetry.length) {

--- a/packages/server/src/ws/namespaces/relay/messaging.ts
+++ b/packages/server/src/ws/namespaces/relay/messaging.ts
@@ -265,7 +265,20 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
         // Validate that the target session belongs to the same user
         const senderSession = await getSharedSession(socket.data.sessionId);
         const targetSession = await getSharedSession(targetSessionId);
-        if (!senderSession?.userId || !targetSession?.userId || senderSession.userId !== targetSession.userId) {
+
+        // If the target session no longer exists (e.g. runner/server restarted
+        // and the old child session was already cleaned up), treat the
+        // trigger_response as a no-op success.  The trigger is implicitly
+        // cancelled when its session is gone — retrying forever would just
+        // spam the logs.  We specifically check for a missing target session
+        // (as opposed to a userId mismatch) to keep the security guard for
+        // cross-user access intact.
+        if (!targetSession) {
+            if (typeof ack === "function") ack({ ok: true });
+            return;
+        }
+
+        if (!senderSession?.userId || !targetSession.userId || senderSession.userId !== targetSession.userId) {
             socket.emit("error", { message: "Target session belongs to a different user" });
             if (typeof ack === "function") ack({ ok: false, error: "Target session belongs to a different user" });
             return;


### PR DESCRIPTION
## Problem

When a runner/server restarts, the trigger cancellation retry loop would attempt to cancel triggers for sessions that no longer exist. The server returned `Target session belongs to a different user` (because the session was gone from Redis and had no userId), and the client retried every 3 seconds **indefinitely**, spamming the runner log forever:

```
pizzapi: trigger cancellation failed for ext_a89ea5f9f5364525: Target session belongs to a different user — will retry
pizzapi: trigger cancellation retry complete: 0 succeeded, 1 failed
```

This repeated hundreds of times until the next restart.

## Root Cause

Two issues combined:

1. **Server**: `trigger_response` handler checked `targetSession.userId` but didn't distinguish between a *missing* session (gone after restart) and a *different-user* session. Both hit the same error path.

2. **Client**: The cancellation retry loop treated ALL errors as transient — it would retry forever with no max attempts and no permanent-error detection.

## Fix

### Server (`messaging.ts`)
- When the target session doesn't exist in Redis, return `ok: true` (idempotent no-op). The trigger is implicitly cancelled when its session is gone.
- The cross-user security check remains for sessions that *do* exist.

### Client (`trigger-cancellation.ts`)
- Detect permanent errors (`Target session belongs to a different user`, `Sender is not the parent of the target session`) and drop the cancellation immediately.
- Add `MAX_CANCELLATION_RETRIES = 10` as a safety net — even transient errors stop after 10 attempts.
- Track `retryCount` per cancellation entry for accurate logging.

## Tests

Added 9 unit tests for the cancellation manager covering:
- Permanent error detection (both error types)
- Max retry enforcement
- Successful cancellations
- Mixed batch results
- No-op and disconnected edge cases