### PR TITLE
docs: comprehensive documentation coverage — 34 missing/underdocumented features

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -83,11 +83,34 @@ export default defineConfig({
                     ],
                 },
                 {
+                    label: "Web UI",
+                    items: [
+                        { label: "Overview", slug: "web-ui/overview" },
+                        { label: "File Explorer", slug: "web-ui/file-explorer" },
+                        { label: "Git Panel", slug: "web-ui/git-panel" },
+                        { label: "Web Terminal", slug: "web-ui/terminal" },
+                        { label: "Usage Dashboard", slug: "web-ui/usage-dashboard" },
+                        { label: "Push Notifications", slug: "web-ui/push-notifications" },
+                    ],
+                },
+                {
+                    label: "Features",
+                    items: [
+                        { label: "Slash Commands", slug: "features/slash-commands" },
+                        { label: "Plan Mode", slug: "features/plan-mode" },
+                        { label: "Multi-Agent Sessions", slug: "features/multi-agent" },
+                        { label: "Webhooks", slug: "features/webhooks" },
+                        { label: "Tunnel Tools", slug: "features/tunnels" },
+                    ],
+                },
+                {
                     label: "Customization",
                     items: [
                         { label: "Configuration", slug: "customization/configuration" },
                         { label: "MCP Servers", slug: "customization/mcp-servers" },
                         { label: "Hooks", slug: "customization/hooks" },
+                        { label: "Tool Search", slug: "customization/tool-search" },
+                        { label: "Prompt Templates", slug: "customization/prompt-templates" },
                         { label: "Skills", slug: "customization/skills" },
                         { label: "Agent Definitions", slug: "customization/agent-definitions" },
                         { label: "Claude Code Plugins", slug: "customization/claude-plugins" },

--- a/packages/docs/src/content/docs/customization/agent-definitions.mdx
+++ b/packages/docs/src/content/docs/customization/agent-definitions.mdx
@@ -203,3 +203,40 @@ For each issue found, report:
 
 Prioritize security issues and correctness bugs over style nits.
 ```
+
+---
+
+## Managing Agent Definitions via the API
+
+PizzaPi provides a full CRUD API for managing agent definitions on a connected runner. You can create, edit, and delete agents from the web UI without manually editing files on disk.
+
+### API Endpoints
+
+All endpoints require an authenticated session and are scoped to a specific runner.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/runners/{runnerId}/agents` | List all discovered agent definitions (from Redis cache) |
+| `GET` | `/api/runners/{runnerId}/agents/{name}` | Get full content of a specific agent definition |
+| `POST` | `/api/runners/{runnerId}/agents` | Create a new agent (body: `{ name, content }`) |
+| `PUT` | `/api/runners/{runnerId}/agents/{name}` | Update an existing agent (body: `{ content }`) |
+| `DELETE` | `/api/runners/{runnerId}/agents/{name}` | Delete an agent definition |
+| `POST` | `/api/runners/{runnerId}/agents/refresh` | Re-scan the filesystem and refresh the agent list |
+
+### Using the Web UI
+
+In the PizzaPi web interface, navigate to a runner's detail page and open the **Agents** tab. From there you can:
+
+- **Browse** all agent definitions discovered from the runner's agent directories
+- **Create** a new agent definition with the in-browser editor (including frontmatter for `name`, `description`, `tools`, `model`, etc.)
+- **Edit** an existing agent's content and configuration
+- **Delete** agent definitions you no longer need
+- **Refresh** to re-scan the filesystem if you've added definitions outside the UI
+
+### Relationship to File-Based Discovery
+
+The API writes directly to the same directories used by file-based discovery (`~/.pizzapi/agents/`, `~/.claude/agents/`, etc.). An agent created via the API is a regular `.md` file on disk — there's no separate "API-only" storage. Similarly, agents added to the filesystem can be picked up by hitting the **Refresh** button or calling the `/refresh` endpoint.
+
+<Aside type="note">
+  Agent names are validated to prevent path traversal — only alphanumeric characters, hyphens, and underscores are allowed.
+</Aside>

--- a/packages/docs/src/content/docs/customization/claude-plugins.mdx
+++ b/packages/docs/src/content/docs/customization/claude-plugins.mdx
@@ -1,6 +1,6 @@
 ---
 title: Claude Code Plugins
-description: Use Claude Code plugins with PizzaPi — commands, hooks, and skills from the Claude ecosystem.
+description: Use Claude Code plugins with PizzaPi — commands, hooks, rules, and skills from the Claude ecosystem.
 ---
 
 import { Aside, FileTree, Steps } from "@astrojs/starlight/components";
@@ -40,7 +40,7 @@ PizzaPi includes a **Claude Code plugin adapter** that discovers plugins designe
 
 ## Plugin Structure
 
-A Claude Code plugin is a directory with any combination of commands, hooks, skills, and metadata:
+A Claude Code plugin is a directory with any combination of commands, hooks, skills, rules, and metadata:
 
 <FileTree>
 - my-plugin/
@@ -53,6 +53,9 @@ A Claude Code plugin is a directory with any combination of commands, hooks, ski
   - skills/
     - my-skill/
       - SKILL.md
+  - rules/
+    - no-console-log.md
+    - prefer-const.md
   - mcp.json *(not adapted — shown as warning)*
 </FileTree>
 
@@ -216,6 +219,52 @@ Plugin skills follow the [Agent Skills standard](https://agentskills.io/specific
 <Aside type="tip">
   Skills are the most portable part of Claude Code plugins — they work identically in both ecosystems because both implement the Agent Skills open standard.
 </Aside>
+
+---
+
+## Rules
+
+Plugin rules are **static markdown files** that are injected into the system prompt as always-on context. They're the plugin equivalent of project-level `.claude/CLAUDE.md` rules — guidelines, conventions, and constraints that the agent follows for every message.
+
+<FileTree>
+- my-plugin/
+  - rules/
+    - no-console-log.md
+    - prefer-const.md
+    - error-handling.md
+</FileTree>
+
+Every `.md` file in the `rules/` directory is loaded and injected under a `# Plugin Rules (plugin-name)` heading in the system prompt. There's no frontmatter, no registration step — just write markdown.
+
+### Example rule file
+
+```markdown title="rules/no-console-log.md"
+## No console.log in production code
+
+Never use `console.log()` for logging in source files under `src/`.
+Use the structured logger (`import { log } from '@lib/logger'`) instead.
+
+`console.log` is acceptable only in:
+- Test files (`*.test.ts`)
+- Build scripts (`scripts/`)
+```
+
+### Rules vs. skills
+
+Rules and skills serve different purposes:
+
+| | Rules | Skills |
+|---|---|---|
+| **Loaded** | Always — injected into every session automatically | On-demand — agent activates when relevant |
+| **Format** | Plain markdown (no frontmatter needed) | `SKILL.md` with structured frontmatter |
+| **Purpose** | Constraints, conventions, guidelines | Capabilities, how-to knowledge |
+| **Analogy** | `.claude/CLAUDE.md` | Tool documentation |
+
+Use rules for things the agent should **always** know ("never commit to main", "use bun not npm"). Use skills for things the agent should know **when relevant** ("how to deploy to staging").
+
+### Rules in the web UI
+
+The plugin detail view in the web UI shows a **rules badge** with the count of loaded rule files, alongside the existing badges for commands, hooks, and skills.
 
 ---
 

--- a/packages/docs/src/content/docs/customization/prompt-templates.mdx
+++ b/packages/docs/src/content/docs/customization/prompt-templates.mdx
@@ -1,0 +1,254 @@
+---
+title: Prompt Templates
+description: Create reusable prompt templates that appear as slash commands in the web UI.
+---
+
+import { Aside, FileTree, Steps } from "@astrojs/starlight/components";
+
+**Prompt templates** are Markdown files that expand into full prompts when invoked as `/` commands. Instead of retyping the same complex instruction every time, save it as a template and trigger it with a short slash command like `/review` or `/component`.
+
+---
+
+## How It Works
+
+Each `.md` file you place in a recognized directory becomes a slash command. The filename (minus the `.md` extension) is the command name:
+
+- `review.md` → `/review`
+- `refactor.md` → `/refactor`
+- `create-component.md` → `/create-component`
+
+When you type `/` in the web UI input, prompt templates appear in a dedicated **Prompt Templates** group in the slash command picker alongside built-in commands, skills, and extension commands.
+
+---
+
+## Directory Locations
+
+PizzaPi discovers prompt templates from several directories. **All** matching templates are merged — if the same name exists in multiple locations, the first match wins (top of this list = highest precedence):
+
+| Path | Scope |
+|------|-------|
+| `~/.pizzapi/prompts/` | Global — available in all projects |
+| `~/.pizzapi/commands/` | Global — Claude Code naming convention |
+| `<cwd>/.pizzapi/prompts/` | Project-local — scoped to this repo |
+| `<cwd>/.pizzapi/commands/` | Project-local — Claude Code naming convention |
+| `<cwd>/.agents/commands/` | Project-local — Claude Code / agents compatibility |
+
+<Aside type="note">
+  The `~/.pizzapi/prompts/` directory is discovered automatically as part of the PizzaPi agent directory. The other paths (`commands/`, `.agents/commands/`) are added for compatibility with Claude Code conventions.
+</Aside>
+
+<FileTree>
+- ~/.pizzapi/
+  - prompts/
+    - review.md
+    - explain.md
+  - commands/
+    - deploy-checklist.md
+- my-project/
+  - .pizzapi/
+    - prompts/
+      - component.md
+    - commands/
+      - test-plan.md
+  - .agents/
+    - commands/
+      - fix.md
+</FileTree>
+
+---
+
+## File Format
+
+A prompt template is a Markdown file with optional YAML frontmatter:
+
+```markdown
+---
+description: Review staged git changes for bugs and security issues
+---
+Review the staged changes (`git diff --cached`). Focus on:
+
+- Bugs and logic errors
+- Security issues
+- Error handling gaps
+- Performance concerns
+```
+
+### Frontmatter Fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `description` | No | Short description shown in the slash command picker. If omitted, the first non-empty line of the body is used. |
+
+The body of the file is the prompt text that gets expanded when the command is invoked.
+
+---
+
+## Arguments
+
+Templates support positional arguments and argument slicing. When a user types `/component Button "click handler"`, the arguments are substituted into the template body:
+
+| Placeholder | Expands to |
+|-------------|------------|
+| `$1`, `$2`, ... | Individual positional arguments |
+| `$@` or `$ARGUMENTS` | All arguments joined together |
+| `${@:N}` | All arguments from the Nth position onward (1-indexed) |
+| `${@:N:L}` | `L` arguments starting at position N |
+
+### Example Template with Arguments
+
+```markdown
+---
+description: Create a React component
+---
+Create a React component named $1 with the following features: ${@:2}
+
+Requirements:
+- TypeScript with proper prop types
+- Include unit tests
+- Export as named export
+```
+
+**Usage:**
+
+```
+/component Button "onClick handler" "disabled state" "loading spinner"
+```
+
+This expands `$1` to `Button` and `${@:2}` to `"onClick handler" "disabled state" "loading spinner"`.
+
+---
+
+## Creating Your First Template
+
+<Steps>
+
+1. **Create the prompts directory:**
+
+   ```bash
+   mkdir -p ~/.pizzapi/commands
+   ```
+
+2. **Write a template file:**
+
+   ```bash
+   cat > ~/.pizzapi/commands/review.md << 'EOF'
+   ---
+   description: Review staged changes for bugs and security issues
+   ---
+   Review the staged changes (`git diff --cached`). Focus on:
+
+   - Bugs and logic errors
+   - Security issues
+   - Error handling gaps
+
+   Provide specific line references and suggested fixes.
+   EOF
+   ```
+
+3. **Use it in the web UI:**
+
+   Type `/review` in the input field. The command appears in the **Prompt Templates** group of the slash command picker. Select it to expand the template into your prompt.
+
+</Steps>
+
+---
+
+## Web UI Integration
+
+When you type `/` in the session input, the slash command picker groups available commands into sections:
+
+- **Built-in commands** — `/new`, `/resume`, `/compact`, etc.
+- **Extension commands** — commands from plugins and extensions
+- **Prompt Templates** — your custom prompt templates
+- **Skills** — skill invocations like `/skill:name`
+
+Prompt templates show the command name (e.g., `/review`) and the description from frontmatter. You can filter by typing part of the name or description.
+
+<Aside type="tip">
+  When you select a prompt template from the picker, the input field is pre-filled with `/<command-name> ` (with a trailing space) so you can immediately type any arguments the template expects.
+</Aside>
+
+---
+
+## Claude Code Compatibility
+
+PizzaPi supports the Claude Code `commands/` directory convention alongside its own `prompts/` directories. This means:
+
+- Templates in `~/.claude/commands/` work if you symlink or copy them to `~/.pizzapi/commands/`
+- The `.agents/commands/` directory in your project root is discovered automatically
+- The file format (Markdown with optional frontmatter and `$ARGUMENTS` substitution) is the same
+
+If you're migrating from Claude Code, you can symlink your existing commands directory:
+
+```bash
+ln -s ~/.claude/commands ~/.pizzapi/commands
+```
+
+<Aside type="caution">
+  Discovery within prompt template directories is **non-recursive** — only `.md` files directly inside the directory are loaded. Subdirectories are not scanned.
+</Aside>
+
+---
+
+## Examples
+
+### Code Review Template
+
+`~/.pizzapi/commands/review.md`:
+
+```markdown
+---
+description: Thorough code review of staged changes
+---
+Review the staged changes (`git diff --cached`).
+
+Check for:
+1. Logic errors and edge cases
+2. Security vulnerabilities
+3. Error handling completeness
+4. Performance issues
+5. Type safety
+
+For each issue found, provide:
+- The file and line number
+- What's wrong
+- A suggested fix
+```
+
+### Component Generator
+
+`.pizzapi/commands/component.md` (project-local):
+
+```markdown
+---
+description: Generate a React component with tests
+---
+Create a React component named `$1` in the components directory.
+
+Requirements:
+- TypeScript with explicit prop interface
+- Unit tests in a co-located `.test.tsx` file
+- Storybook story if `stories/` directory exists
+- Follow existing component patterns in this project
+
+Additional requirements: ${@:2}
+```
+
+**Usage:** `/component SearchBar "with debounced input" "accessible with ARIA labels"`
+
+### Commit Message Helper
+
+`~/.pizzapi/commands/commit.md`:
+
+```markdown
+---
+description: Generate a conventional commit message
+---
+Look at the staged changes (`git diff --cached`) and generate a commit message following
+the Conventional Commits specification.
+
+Format: `type(scope): description`
+
+Types: feat, fix, docs, style, refactor, perf, test, chore
+Keep the first line under 72 characters. Add a body if the change is complex.
+```

--- a/packages/docs/src/content/docs/customization/runner-services.mdx
+++ b/packages/docs/src/content/docs/customization/runner-services.mdx
@@ -219,6 +219,180 @@ Once triggers are advertised, agents can interact with them using built-in tools
 
 Subscribed triggers arrive as injected messages in the agent's conversation, with the payload and metadata from the broadcast.
 
+### Trigger Subscription Filters
+
+By default, subscribing to a trigger type delivers **every** event of that type. Filters let you narrow delivery to only payloads that match specific criteria — evaluated server-side before the trigger reaches the agent.
+
+#### Filters vs Params
+
+| Concept | Where evaluated | Purpose |
+|---------|----------------|---------|
+| `params` | Passed to the service | Subscription parameters forwarded to the service (e.g. which repo to watch) |
+| `filters` | Server-side, on delivery | Evaluated against the trigger payload — only matching events are delivered |
+
+You can use both on the same subscription. Params tell the service *what to emit*; filters tell the relay *what to deliver*.
+
+#### Filter objects
+
+Each filter is a `{field, value, op}` object:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `field` | Yes | Dot-path into the trigger payload (e.g. `"status"`, `"meta.priority"`) |
+| `value` | Yes | Expected value — string, number, boolean, or array (array = OR within this filter) |
+| `op` | No | `"eq"` (exact match, default) or `"contains"` (substring match on string fields) |
+
+#### Filter mode
+
+When a subscription has multiple filters, `filterMode` controls how they combine:
+
+| Mode | Behavior |
+|------|----------|
+| `"and"` (default) | **All** filters must match for the trigger to be delivered |
+| `"or"` | **Any** filter matching is enough |
+
+#### Example: subscribe to only shipped orders
+
+```
+subscribe_trigger("orders:status_changed", {
+  filters: [
+    { field: "status", value: "shipped", op: "eq" }
+  ],
+  filterMode: "and"
+})
+```
+
+Only `orders:status_changed` events whose payload contains `status === "shipped"` will reach the agent.
+
+#### Updating filters without re-subscribing
+
+Use the `update_trigger_subscription` tool to change filters or filterMode on an existing subscription without unsubscribing and re-subscribing:
+
+```
+update_trigger_subscription("orders:status_changed", {
+  filters: [
+    { field: "status", value: "delivered", op: "eq" }
+  ],
+  filterMode: "or"
+})
+```
+
+This preserves the runner binding and only updates the filter criteria.
+
+---
+
+### Runner Trigger Listeners
+
+Trigger listeners are **persistent configurations** on a runner that automatically spawn a new agent session when a matching trigger fires. Unlike regular subscriptions (which deliver events into an existing session), listeners create a fresh session for each event.
+
+#### Use cases
+
+- **Auto-review:** Spawn a code review session whenever a `git:push` trigger fires
+- **Scheduled runs:** Pair with a cron service to auto-spawn sessions on a schedule
+- **Reactive automation:** Kick off deployment, test, or analysis sessions in response to service events
+
+#### Listeners vs Webhooks
+
+| | Trigger Listeners | Webhooks |
+|--|-------------------|----------|
+| **Input** | Internal PizzaPi triggers | External HTTP POST requests |
+| **Scope** | Bound to a runner | Bound to a user/org |
+| **Action** | Spawns a new agent session on the runner | Fires a trigger into existing subscribed sessions |
+
+#### CRUD API
+
+All endpoints require runner authentication (`x-api-key` header).
+
+**List listeners:**
+```
+GET /api/runners/{runnerId}/trigger-listeners
+```
+
+**Add a listener:**
+```
+POST /api/runners/{runnerId}/trigger-listeners
+Content-Type: application/json
+
+{
+  "triggerType": "my-service:deploy_requested",
+  "prompt": "Run the deploy checklist for the provided payload.",
+  "cwd": "/home/user/project",
+  "model": { "provider": "anthropic", "id": "claude-sonnet-4-20250514" },
+  "params": { "environment": "production" }
+}
+```
+
+**Update a listener:**
+```
+PUT /api/runners/{runnerId}/trigger-listeners/{triggerType}
+```
+
+**Remove a listener:**
+```
+DELETE /api/runners/{runnerId}/trigger-listeners/{triggerType}
+```
+
+#### `RunnerTriggerListener` fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `triggerType` | Yes | The trigger type to listen for (e.g. `"my-service:event_name"`) |
+| `prompt` | No | Initial prompt for the spawned session |
+| `cwd` | No | Working directory for the spawned session |
+| `model` | No | Model override (`{ provider, id }`) |
+| `params` | No | Subscription params — only triggers matching these params will spawn a session |
+| `createdAt` | Auto | ISO timestamp set when the listener is created |
+
+Listeners are stored durably in both SQLite and Redis, so they survive runner restarts.
+
+---
+
+### Trigger History
+
+Every trigger delivered to a session is recorded in a per-session history log. This provides an audit trail of what events reached the agent and how they were handled.
+
+#### Storage details
+
+- Backed by Redis (list per session)
+- Maximum **200 entries** per session (oldest trimmed on insert)
+- **24-hour TTL** — history expires automatically if the session is idle
+
+#### REST API
+
+**Get trigger history:**
+```
+GET /api/sessions/{sessionId}/triggers?limit=50
+```
+
+Returns `{ triggers: TriggerHistoryEntry[] }`, most recent first. The `limit` query parameter defaults to 50 (max 200).
+
+**Clear trigger history:**
+```
+DELETE /api/sessions/{sessionId}/triggers
+```
+
+Removes all history entries for the session.
+
+#### `TriggerHistoryEntry` fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `triggerId` | `string` | Unique ID for this trigger delivery |
+| `type` | `string` | Trigger type (e.g. `"my-service:file_changed"`) |
+| `source` | `string` | Who fired the trigger (service name or `"external:api"`) |
+| `summary` | `string?` | Human-readable one-liner |
+| `payload` | `object` | The full trigger payload |
+| `deliverAs` | `"steer" \| "followUp"` | Delivery mode used |
+| `ts` | `string` | ISO timestamp of delivery |
+| `direction` | `"inbound" \| "outbound"` | Whether the trigger was received or sent by this session |
+| `response` | `object?` | Agent's response — `{ action?, text?, ts }` |
+
+#### Viewing in the UI
+
+The **Triggers panel** in the session viewer shows the live trigger history for the active session. Each entry displays the trigger type, summary, timestamp, and delivery status. Entries update in real time as triggers are delivered.
+
+---
+
 ### Services Without Panels
 
 A service doesn't need a UI panel. Omit `panel` from the manifest and skip `announcePanel()`. The service still runs in the background and can fire triggers:

--- a/packages/docs/src/content/docs/customization/skills.mdx
+++ b/packages/docs/src/content/docs/customization/skills.mdx
@@ -200,6 +200,43 @@ description: Use when implementing any feature or bugfix, before writing impleme
 
 ---
 
+## Managing Skills via the API
+
+PizzaPi exposes a full CRUD API for managing skills on a connected runner. This lets you create, edit, and delete skills from the web UI without touching the filesystem directly.
+
+### API Endpoints
+
+All endpoints are scoped to a specific runner and require an authenticated session.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/api/runners/{runnerId}/skills` | List all discovered skills (from Redis cache) |
+| `GET` | `/api/runners/{runnerId}/skills/{name}` | Get full content of a specific skill |
+| `POST` | `/api/runners/{runnerId}/skills` | Create a new skill (body: `{ name, content }`) |
+| `PUT` | `/api/runners/{runnerId}/skills/{name}` | Update an existing skill (body: `{ content }`) |
+| `DELETE` | `/api/runners/{runnerId}/skills/{name}` | Delete a skill |
+| `POST` | `/api/runners/{runnerId}/skills/refresh` | Re-scan the filesystem and refresh the skill list |
+
+### Using the Web UI
+
+In the PizzaPi web interface, navigate to a runner's detail page and open the **Skills** tab. From there you can:
+
+- **Browse** all skills discovered from the runner's skill directories
+- **Create** a new skill with the in-browser editor
+- **Edit** an existing skill's content (including frontmatter)
+- **Delete** skills you no longer need
+- **Refresh** to re-scan the filesystem if you've added skills outside the UI
+
+### Relationship to File-Based Discovery
+
+The API writes directly to the same directories used by file-based discovery (`~/.pizzapi/skills/`, etc.). A skill created via the API is a regular `SKILL.md` file on disk — there's no separate "API-only" storage. Similarly, skills added to the filesystem can be picked up by hitting the **Refresh** button or calling the `/refresh` endpoint.
+
+<Aside type="note">
+  Skill names are validated to prevent path traversal — only alphanumeric characters, hyphens, and underscores are allowed.
+</Aside>
+
+---
+
 ## Agent Skills Standard
 
 PizzaPi's skill format is compatible with the [Agent Skills](https://agentskills.io) open standard. Skills written for other compatible tools (like Claude Code) work in PizzaPi without modification, and vice versa.

--- a/packages/docs/src/content/docs/customization/tool-search.mdx
+++ b/packages/docs/src/content/docs/customization/tool-search.mdx
@@ -1,0 +1,170 @@
+---
+title: Tool Search
+description: Defer MCP tool loading to reduce context window usage and let agents discover tools on demand.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+When you connect many MCP servers, the agent's context window fills up with tool definitions — names, descriptions, and parameter schemas for every registered tool. With 100+ tools this can consume thousands of tokens before the agent even starts working, leaving less room for conversation history, file contents, and reasoning.
+
+**Tool Search** solves this by *deferring* MCP tools and giving the agent a single `search_tools` tool it can call to discover and load tools on demand.
+
+## How it works
+
+<Steps>
+
+1. **On session start**, PizzaPi measures the total character count of all MCP tool definitions (name + description + JSON schema).
+
+2. **If the total exceeds `tokenThreshold`**, all MCP tools are removed from the agent's active tool set. Built-in tools (`read`, `bash`, `edit`, `write`, etc.) are never deferred.
+
+3. **The agent receives `search_tools`** — a lightweight tool that stays in context. When the agent needs a capability it doesn't have, it calls `search_tools("create github issue")` with a descriptive keyword query.
+
+4. **Matching tools are activated** and become available for the agent to call immediately. By default, they stay loaded for the rest of the session.
+
+</Steps>
+
+<Aside type="tip">
+  Tool Search is provider-agnostic — it works with any model, not just Anthropic.
+</Aside>
+
+## Configuration
+
+Enable Tool Search in `~/.pizzapi/config.json`:
+
+```json title="~/.pizzapi/config.json"
+{
+  "toolSearch": {
+    "enabled": true,
+    "tokenThreshold": 10000,
+    "maxResults": 5,
+    "keepLoadedTools": true
+  }
+}
+```
+
+### Options
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | `boolean` | `false` | Enable tool search and deferred loading. |
+| `tokenThreshold` | `number` | `10000` | Character threshold for MCP tool definitions. If total chars exceed this, tools are deferred. Roughly 4 characters ≈ 1 token, so 10,000 chars ≈ 2,500 tokens. |
+| `maxResults` | `number` | `5` | Maximum number of tools returned per `search_tools` call. |
+| `keepLoadedTools` | `boolean` | `true` | When `true`, discovered tools stay active for the rest of the session. When `false`, tools are deactivated after each agent turn — useful for very large tool sets where you want minimal context at all times. |
+
+## Per-server `deferLoading` override
+
+You can force individual MCP servers to always defer (or never defer) their tools, regardless of whether the global threshold is exceeded:
+
+```json title="~/.pizzapi/config.json"
+{
+  "toolSearch": {
+    "enabled": true,
+    "tokenThreshold": 10000
+  },
+  "mcpServers": {
+    "github": {
+      "command": "gh-mcp-server",
+      "deferLoading": true
+    },
+    "essential-db": {
+      "command": "db-tools-server",
+      "deferLoading": false
+    }
+  }
+}
+```
+
+The decision logic for each tool:
+
+1. **`deferLoading: true`** on the server → tool is always deferred.
+2. **`deferLoading: false`** on the server → tool is never deferred, even if threshold is exceeded.
+3. **No `deferLoading` set** → tool is deferred only if the global threshold is exceeded.
+
+<Aside>
+  `deferLoading` is supported in both the `mcpServers` format and the `mcp.servers[]` array format.
+</Aside>
+
+## The `search_tools` tool
+
+When Tool Search is active, agents see a single `search_tools` tool with this interface:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | `string` | Yes | Keywords describing the tool you need (e.g., `"send slack message"`, `"create jira ticket"`). |
+
+### What it returns
+
+- **Matches found**: a list of matching tool names, descriptions, and parameter names. Matched tools are immediately loaded into the active tool set.
+- **No matches**: a fallback list of all deferred tools so the agent can refine its search.
+- **Not active**: if all tools are already loaded, it reports that tool search is inactive.
+
+### How scoring works
+
+Tools are matched against the query using keyword scoring:
+
+- **Exact name match**: highest score
+- **Name contains keyword**: high score
+- **Description contains keyword**: moderate score
+- **Parameter names contain keyword**: low score
+- **Full query as substring** in name or description: bonus points
+
+The top results (up to `maxResults`) are returned and activated.
+
+## Slash command: `/tool-search`
+
+You can check Tool Search status interactively:
+
+- **`/tool-search status`** — shows how many tools are deferred, which are loaded on-demand, and which servers they belong to.
+- **`/tool-search reset`** — re-evaluates all tools against the threshold and resets the deferred/loaded state.
+
+## Difference from `--no-mcp`
+
+| | Tool Search | `--no-mcp` / `PIZZAPI_NO_MCP=1` |
+|---|---|---|
+| MCP servers connect | ✅ Yes | ❌ No |
+| Tools available | On demand via `search_tools` | Not available at all |
+| Use case | Reduce token usage while keeping tools accessible | Skip MCP entirely for fast startup or debugging |
+
+Tool Search keeps MCP servers connected and tools ready — they're just hidden from the context window until needed. `--no-mcp` skips MCP server connections entirely.
+
+## Full example
+
+A configuration with many MCP servers where only the essentials stay loaded:
+
+```json title="~/.pizzapi/config.json"
+{
+  "toolSearch": {
+    "enabled": true,
+    "tokenThreshold": 8000,
+    "maxResults": 8,
+    "keepLoadedTools": true
+  },
+  "mcpServers": {
+    "filesystem": {
+      "command": "mcp-fs-server",
+      "deferLoading": false
+    },
+    "github": {
+      "command": "gh-mcp-server"
+    },
+    "jira": {
+      "command": "jira-mcp-server",
+      "deferLoading": true
+    },
+    "slack": {
+      "command": "slack-mcp-server",
+      "deferLoading": true
+    },
+    "linear": {
+      "command": "linear-mcp-server"
+    }
+  }
+}
+```
+
+In this setup:
+
+- **filesystem** tools are always in context (`deferLoading: false`).
+- **jira** and **slack** tools are always deferred (`deferLoading: true`), even if the threshold isn't hit.
+- **github** and **linear** tools are deferred only if the combined tool definitions exceed 8,000 characters.
+- The agent calls `search_tools("create issue")` and gets matching tools from github, jira, or linear loaded automatically.

--- a/packages/docs/src/content/docs/features/multi-agent.mdx
+++ b/packages/docs/src/content/docs/features/multi-agent.mdx
@@ -1,0 +1,418 @@
+---
+title: Multi-Agent Sessions
+description: Spawn child sessions, communicate via triggers and messages, and orchestrate multi-agent workflows.
+---
+
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+
+PizzaPi supports multiple agent sessions running in parallel, communicating through two complementary systems: **triggers** (automatic parent↔child events) and **messages** (explicit inter-session messaging). This guide covers all multi-agent communication primitives and when to use each.
+
+---
+
+## Communication model
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Parent Session                                     │
+│                                                     │
+│  spawn_session(prompt, linked: true)                │
+│       │                                             │
+│       │ ◄── ask_user_question trigger ──┐           │
+│       │ ◄── plan_review trigger ────────┤           │
+│       │ ◄── session_error trigger ──────┤           │
+│       │ ◄── session_complete trigger ───┤           │
+│       │                                 │           │
+│  respond_to_trigger(id, response)       │           │
+│  tell_child(sessionId, message)  ──►    │           │
+│  escalate_trigger(id)  ──► human        │           │
+│                                         │           │
+│                              ┌──────────┴─────────┐ │
+│                              │  Child Session     │ │
+│                              │  (linked)          │ │
+│                              └────────────────────┘ │
+└─────────────────────────────────────────────────────┘
+```
+
+**Linked sessions** use triggers — structured events that arrive automatically in the parent's conversation. The parent responds with `respond_to_trigger`, `tell_child`, or `escalate_trigger`.
+
+**Unlinked sessions** use the message bus — explicit `send_message` / `wait_for_message` calls between any two sessions, regardless of parent-child relationship.
+
+---
+
+## `spawn_session`
+
+Spawn a new independent agent session on the runner. The new session runs in parallel and can be monitored through the PizzaPi web UI.
+
+### Parameters
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `prompt` | `string` | ✅ | — | Initial prompt for the new session. Must be self-contained — the child has no context from the parent. |
+| `model` | `{ provider, id }` | | Runner default | Model to use. Call `list_models` to discover available values. |
+| `cwd` | `string` | | Parent's cwd | Working directory for the new session. |
+| `linked` | `boolean` | | `true` | Whether to auto-link as a child session (enables trigger system). |
+| `runnerId` | `string` | | Current runner | Target runner ID. Usually not needed. |
+
+### Return value
+
+On success, returns the session ID, runner ID, working directory, status (`Pending` or `Ready`), and a web UI share URL.
+
+### Linked vs. unlinked
+
+<Tabs>
+  <TabItem label="Linked (default)">
+    ```json
+    {
+      "prompt": "Refactor the auth module to use JWTs",
+      "model": { "provider": "anthropic", "id": "claude-sonnet-4-20250514" }
+    }
+    ```
+
+    - `linked` defaults to `true`
+    - Parent's session ID is sent as `parentSessionId`
+    - Child events (questions, plans, completion, errors) arrive as triggers in the parent's conversation
+    - No manual polling needed — triggers are injected automatically
+  </TabItem>
+  <TabItem label="Unlinked">
+    ```json
+    {
+      "prompt": "Run the test suite and report results",
+      "linked": false
+    }
+    ```
+
+    - No trigger system — use `send_message` / `wait_for_message` for communication
+    - Avoids redundant `session_complete` triggers when you're already consuming output via messages
+    - Useful for peer-to-peer session communication patterns
+  </TabItem>
+</Tabs>
+
+<Aside type="caution">
+  **Don't stall while waiting for children.** Triggers arrive automatically as injected messages — do not use `sleep` loops or idle waits. Simply stop responding and your session will resume when the child's trigger arrives.
+</Aside>
+
+---
+
+## Trigger system
+
+When a linked child session hits certain lifecycle events, it fires a **trigger** to the parent. Triggers arrive in the parent's conversation prefixed with `<!-- trigger:ID -->` metadata.
+
+### Trigger types
+
+#### `ask_user_question`
+
+Fired when a child session calls `AskUserQuestion`. The trigger payload includes the question text, options, and the full structured `questions` array. The parent can answer on behalf of the user with `respond_to_trigger`.
+
+```
+<!-- trigger:abc123 -->
+Child session "auth-refactor" is asking:
+  "Should I use RS256 or HS256 for JWT signing?"
+  Options: RS256, HS256
+
+Use respond_to_trigger(triggerId, response) to answer.
+```
+
+#### `plan_review`
+
+Fired when a child calls `plan_mode` to propose a multi-step plan. The payload includes the plan's `title`, `steps`, and optional `description`.
+
+Respond with an `action`:
+- **`approve`** — Accept the plan. The child proceeds with execution.
+- **`cancel`** — Reject the plan. The child stops.
+- **`edit`** — Provide feedback in `response`. The child revises and resubmits.
+
+#### `session_complete`
+
+Fired when the child session finishes. The payload includes the child's final output and an `exitReason`:
+- `exitReason: "completed"` — Normal completion.
+- `exitReason: "error"` — The child hit a usage limit or provider failure.
+
+Respond with an `action`:
+- **`ack`** — Acknowledge and **terminate the child process**. This sends `SIGTERM` to the child and tears down its relay session. Only use when the child is truly finished.
+- **`followUp`** — Send more work to the child in `response`. The child resumes with a new turn.
+
+<Aside type="danger">
+  **`ack` terminates the child.** It is not a passive acknowledgement — it kills the child process and cleans up relay resources. If the child's output says it's still dispatching workers or waiting for sub-tasks, do **not** call `ack`. Wait for the next `session_complete` trigger.
+</Aside>
+
+#### `session_error`
+
+Fired **before** `session_complete` when a child hits a usage limit or provider error. This gives the parent an early signal to react — retry with a different model, skip the task, or escalate to the user. Check the `exitReason` field on the subsequent `session_complete` to distinguish error exits from successful completions.
+
+### Trigger lifecycle
+
+<Steps>
+1. Child hits a lifecycle event (asks a question, proposes a plan, completes, or errors)
+2. Child emits a `session_trigger` event over the relay WebSocket
+3. Relay routes the trigger to the parent session
+4. Trigger is injected into the parent's conversation with a `<!-- trigger:ID -->` prefix
+5. Parent responds via `respond_to_trigger`, `escalate_trigger`, or `tell_child`
+6. Response is routed back to the child, which unblocks and continues
+</Steps>
+
+Triggers have a **10-minute TTL**. If the parent doesn't respond within that window, the trigger expires and the child times out (5-minute default for `ask_user_question` and `plan_review`).
+
+---
+
+## `respond_to_trigger`
+
+Respond to a pending trigger from a child session.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `triggerId` | `string` | ✅ | The trigger ID from the `<!-- trigger:ID -->` prefix |
+| `response` | `string` | ✅ | Response text sent to the child |
+| `action` | `string` | | Structured intent — see below |
+
+### Actions
+
+| Action | Used with | Effect |
+|--------|-----------|--------|
+| `approve` | `plan_review` | Accept the child's plan; child proceeds with execution |
+| `cancel` | `plan_review` | Reject the plan; child stops |
+| `edit` | `plan_review` | Provide feedback in `response`; child revises the plan |
+| `ack` | `session_complete` | Acknowledge completion and **terminate** the child process |
+| `followUp` | `session_complete` | Send `response` as new input to resume the child |
+
+For `ask_user_question` triggers, `action` is not required — just provide the `response` text.
+
+### Example
+
+```
+// Child asks a question
+respond_to_trigger("abc-123", "Use RS256 — it supports key rotation")
+
+// Child proposes a plan
+respond_to_trigger("def-456", "Approved", "approve")
+
+// Child completes — send follow-up work
+respond_to_trigger("ghi-789", "Now add unit tests for the JWT module", "followUp")
+
+// Child completes — done, clean up
+respond_to_trigger("jkl-012", "Looks good, shutting down", "ack")
+```
+
+---
+
+## `escalate_trigger`
+
+Pass a child's trigger to the human viewer when the parent agent can't or shouldn't handle it.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `triggerId` | `string` | ✅ | The trigger ID to escalate |
+| `context` | `string` | | Additional context for the human |
+
+The trigger is re-emitted as an `escalate` type trigger targeting the parent's own session, where it surfaces in the web UI for the human to respond. The original trigger remains pending — when the human responds (via the web UI), the response routes back through `respond_to_trigger` to the child.
+
+---
+
+## `tell_child`
+
+Proactively send a message to a linked child session. Unlike `respond_to_trigger` (which responds to a child's request), `tell_child` initiates a new turn in the child's conversation — the message is delivered as agent input.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sessionId` | `string` | ✅ | Child session ID |
+| `message` | `string` | ✅ | Message to send |
+
+### Use cases
+
+- Redirect a child mid-task: `tell_child(id, "Stop the refactor — focus on the auth bug instead")`
+- Provide additional context the child didn't ask for
+- Coordinate between multiple children by relaying information
+
+---
+
+## Manual messaging: `send_message`, `wait_for_message`, `check_messages`
+
+For **unlinked sessions** or peer-to-peer communication, use the message bus. These tools work between any two sessions — no parent-child relationship required.
+
+### `send_message`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sessionId` | `string` | ✅ | Target session ID |
+| `message` | `string` | ✅ | Message text |
+
+Sends a message to the target session's message queue. The recipient reads it with `wait_for_message` or `check_messages`.
+
+### `wait_for_message`
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `fromSessionId` | `string` | | Any session | Only accept messages from this sender |
+| `timeout` | `number` | | `120` | Max wait time in seconds |
+
+**Blocking.** Waits until a message arrives or the timeout expires. If a matching message is already queued, it resolves immediately.
+
+### `check_messages`
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `fromSessionId` | `string` | | Only check messages from this sender |
+
+**Non-blocking.** Drains all pending messages from the queue and returns them. Returns an empty list if no messages are waiting. Useful for polling between other work.
+
+### `get_session_id`
+
+Takes no parameters. Returns this session's own session ID — useful when you need to tell another agent your ID so they can send messages to you.
+
+### Example: two-session ping-pong
+
+```
+// Session A (spawner)
+spawn_session({ prompt: "...", linked: false })
+// → gets back sessionId: "child-xyz"
+
+send_message({ sessionId: "child-xyz", message: "Here's the data you need: ..." })
+response = wait_for_message({ fromSessionId: "child-xyz", timeout: 300 })
+```
+
+```
+// Session B (spawned with linked: false)
+myId = get_session_id()
+// wait for parent to send data
+data = wait_for_message({ timeout: 300 })
+// ... do work ...
+send_message({ sessionId: data.fromSessionId, message: "Results: ..." })
+```
+
+---
+
+## `fire_trigger`
+
+Fire a trigger into **any** session — not just children. This enables peer-to-peer trigger communication between sessions that aren't in a parent-child relationship.
+
+### Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `sessionId` | `string` | ✅ | Target session ID |
+| `type` | `string` | ✅ | Trigger type (e.g. `"service"`, `"webhook"`, `"godmother:idea_started"`) |
+| `payload` | `object` | ✅ | Arbitrary payload delivered to the target session |
+| `source` | `string` | | Source identifier shown in trigger history |
+| `deliverAs` | `string` | | `"steer"` (default, interrupts current turn) or `"followUp"` (queued after turn) |
+
+### Delivery modes
+
+- **`steer`** (default) — Interrupts the target session's current turn. The trigger is injected immediately into the conversation.
+- **`followUp`** — Queued and delivered after the target's current turn completes. Use this when the trigger isn't urgent and shouldn't disrupt ongoing work.
+
+`fire_trigger` uses the HTTP Trigger API with API key auth, with a Socket.IO fallback for offline/local mode.
+
+---
+
+## Pattern comparison
+
+| | `subagent` tool | `spawn_session` (linked) | `spawn_session` (unlinked) + messages |
+|---|---|---|---|
+| **Communication** | Tool call → result (synchronous) | Triggers (automatic) | `send_message` / `wait_for_message` (manual) |
+| **Blocking** | Yes — parent waits for result | No — parent continues, triggers arrive async | Depends on `wait_for_message` usage |
+| **Context** | Isolated in-process session | Fully independent session + process | Fully independent session + process |
+| **UI** | Inline card in parent session | Separate session in web UI | Separate session in web UI |
+| **Overhead** | Near-zero (in-process SDK) | Higher (relay round-trip, new PTY) | Higher + manual coordination |
+| **Model selection** | Via agent definition `model` field | Via `model` parameter | Via `model` parameter |
+| **Best for** | Quick tasks: research, review, refactor | Long-running parallel work, background tasks | Peer-to-peer coordination, custom protocols |
+| **Agent definitions** | File-based (`~/.pizzapi/agents/`) | Prompt-based (inline) | Prompt-based (inline) |
+| **Modes** | Single, parallel, chain | One session per call | One session per call |
+
+<Aside type="tip">
+  **Prefer `subagent` for most delegation.** It's simpler, manages context isolation automatically, and returns results inline. Use `spawn_session` only when you need independent lifecycle, background execution, or async trigger-based coordination. See the [Subagents guide](/PizzaPi/customization/subagents/) for full details.
+</Aside>
+
+---
+
+## Real-world patterns
+
+### Orchestrator → workers
+
+A parent spawns multiple linked children to work in parallel, then synthesizes their results:
+
+```
+// 1. Spawn workers
+spawn_session({ prompt: "Review packages/server/ for security issues" })
+// → sessionId: "worker-1"
+
+spawn_session({ prompt: "Review packages/ui/ for accessibility issues" })
+// → sessionId: "worker-2"
+
+// 2. Triggers arrive automatically as children complete:
+//    <!-- trigger:t1 --> session_complete from worker-1
+//    <!-- trigger:t2 --> session_complete from worker-2
+
+// 3. Acknowledge each worker
+respond_to_trigger("t1", "Received security review", "ack")
+respond_to_trigger("t2", "Received a11y review", "ack")
+
+// 4. Synthesize results into a summary
+```
+
+If a worker asks a question mid-task, the parent gets an `ask_user_question` trigger and can answer directly or escalate to the human:
+
+```
+// Worker asks: "The auth module uses both bcrypt and argon2. Which should I focus on?"
+respond_to_trigger("t3", "Focus on argon2 — that's the active path")
+
+// Or if unsure:
+escalate_trigger("t3", "Worker needs domain knowledge about our crypto choices")
+```
+
+### Review ping-pong
+
+A parent spawns a reviewer and iterates on feedback:
+
+```
+// 1. Spawn reviewer
+spawn_session({ prompt: "Review this PR diff for bugs: ..." })
+// → sessionId: "reviewer-1"
+
+// 2. Reviewer proposes a plan (plan_review trigger)
+respond_to_trigger("plan-t1", "Skip the style checks, focus on logic bugs", "edit")
+
+// 3. Reviewer revises plan and resubmits (another plan_review trigger)
+respond_to_trigger("plan-t2", "Looks good", "approve")
+
+// 4. Reviewer completes (session_complete trigger)
+// If findings need action:
+respond_to_trigger("complete-t1", "Fix the null check bug you found in auth.ts", "followUp")
+
+// 5. Reviewer fixes and completes again
+respond_to_trigger("complete-t2", "Done, thanks", "ack")
+```
+
+### Error recovery
+
+When a child hits a usage limit, the parent gets a `session_error` trigger before `session_complete`:
+
+```
+// session_error arrives: "Rate limit exceeded for claude-sonnet-4"
+// Option 1: Retry with a different model
+spawn_session({
+  prompt: "Continue this task: ...",
+  model: { provider: "google", id: "gemini-2.5-pro" }
+})
+
+// Option 2: Escalate to human
+escalate_trigger("err-t1", "Child hit rate limit — need human to decide next steps")
+```
+
+---
+
+## Push notification behavior
+
+Linked child sessions **do not trigger push notifications**. Only top-level sessions — those started by a user or the runner daemon directly — send push notifications. This prevents notification spam when orchestrating multiple child sessions.
+
+---
+
+## Related guides
+
+- [Subagents](/PizzaPi/customization/subagents/) — File-based agent definitions, parallel/chain modes, model routing
+- [Runner Daemon](/PizzaPi/running/runner-daemon/) — How sessions are spawned on runners
+- [CLI Reference](/PizzaPi/running/cli-reference/) — Full tool parameter reference

--- a/packages/docs/src/content/docs/features/plan-mode.mdx
+++ b/packages/docs/src/content/docs/features/plan-mode.mdx
@@ -1,0 +1,223 @@
+---
+title: Plan Mode
+description: Read-only exploration and structured plan review for careful, step-by-step agent workflows.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+Plan mode puts the agent into a **read-only exploration state** where file writes and destructive commands are blocked at the tool level (and at the OS level when [sandbox](/security/sandbox/) is active). The agent can freely read code, search, and analyze — but cannot modify anything until a plan is reviewed and approved.
+
+This is useful when you want the agent to **think before it acts**: explore a complex codebase, identify the right files, and present a structured plan for your approval before any changes are made.
+
+---
+
+## Activating Plan Mode
+
+There are three ways to enter plan mode:
+
+| Method | Who uses it | How |
+|--------|-------------|-----|
+| `/plan` slash command | You (human) | Type `/plan` in the input bar — toggles plan mode on/off |
+| `toggle_plan_mode` tool | The agent | Agent calls `toggle_plan_mode` with `enabled: true` to enter or `enabled: false` to exit |
+| Web UI remote command | You (human) | Send `/plan` from the PizzaPi web interface |
+
+When plan mode activates, you'll see a notification:
+
+> ⏸ Plan mode ON — read-only exploration. Write/edit tools blocked.
+
+When it deactivates:
+
+> ▶ Plan mode OFF — full tool access restored.
+
+---
+
+## What's Blocked in Plan Mode
+
+Plan mode enforces read-only access through two layers:
+
+### Tool-level blocking
+
+The following tools are **completely blocked** while plan mode is active:
+
+- `edit` — file editing
+- `write` — file creation/overwrite
+- `write_file` — custom write tool
+
+The agent can still use `read`, `bash` (with restrictions), `grep`, `find`, `ls`, and any MCP read tools.
+
+### Bash command restrictions
+
+Bash commands go through a destructive-command detector that blocks:
+
+- **File-mutating commands**: `rm`, `mv`, `cp`, `mkdir`, `touch`, `chmod`, `ln`, `tee`, `truncate`, `dd`, `sed -i`, etc.
+- **Process/system control**: `sudo`, `kill`, `pkill`, `reboot`, `systemctl start/stop`, etc.
+- **Package managers**: `npm install`, `bun add`, `pip install`, `brew install`, etc.
+- **Output redirection**: `>` and `>>` (except `2>/dev/null`)
+- **Script interpreters**: `python`, `ruby`, `node` (running scripts, not `--version`/`--help`)
+- **Git mutations**: only read-only git subcommands are allowed (`status`, `log`, `diff`, `show`, `blame`, `grep`, `branch` (listing), `ls-files`, etc.). Mutating operations like `git commit`, `git push`, `git checkout`, `git stash push` are blocked.
+
+<Aside type="tip" title="Sandbox enforcement">
+  When the [sandbox](/security/sandbox/) is active, plan mode activates an **OS-level read-only overlay** via `setReadOnlyOverlay()`. This means the filesystem itself is write-protected — even if a command somehow bypasses the regex checks, the OS blocks the write. Without sandbox, the regex-based command detection is the only line of defense.
+</Aside>
+
+### What the agent _can_ do
+
+- Read any file (`read` tool)
+- Run read-only bash commands (`ls`, `find`, `grep`, `rg`, `cat`, `head`, `wc`, `git log`, `git diff`, etc.)
+- Use MCP tools that only read data
+- Call `toggle_plan_mode` to exit plan mode
+- Call `plan_mode` to submit a structured plan for review
+
+---
+
+## The Plan Review Flow
+
+The core workflow in plan mode follows this pattern:
+
+<Steps>
+1. **You activate plan mode** — via `/plan` or the agent enters it with `toggle_plan_mode`.
+
+2. **The agent explores** — reads files, searches code, runs read-only commands to understand the problem.
+
+3. **The agent submits a plan** — calls the `plan_mode` tool with a title, optional description, and a list of steps.
+
+4. **You review the plan** — a plan review card appears with the plan details and action buttons.
+
+5. **You respond** — approve, suggest edits, or cancel.
+
+6. **The agent executes** — if approved, plan mode exits automatically and the agent proceeds with full tool access.
+</Steps>
+
+### The `plan_mode` tool
+
+The agent submits a plan by calling `plan_mode` with these parameters:
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `title` | `string` | ✅ | Short title summarizing the plan |
+| `description` | `string` | No | Detailed description in markdown |
+| `steps` | `array` | No | Ordered list of steps, each with a `title` (required) and optional `description` |
+
+The tool **blocks** until the user responds — the agent cannot continue until you act.
+
+### Your response options
+
+When a plan is submitted, you see four actions:
+
+| Action | What it does |
+|--------|-------------|
+| **Clear Context & Begin** | Clears the conversation history and starts fresh execution of the plan. The agent gets a clean context with only the approved plan. |
+| **Begin** | Approves the plan and proceeds with the current conversation context intact. |
+| **Suggest Edit** | Opens a text input where you describe changes. The agent receives your feedback and should resubmit an updated plan. |
+| **Cancel** | Rejects the plan entirely. The agent is told not to proceed. |
+
+<Aside type="note">
+  **Clear Context & Begin** is useful for long exploration sessions where the context window has filled up with read-only analysis. It gives the agent a fresh start focused purely on execution.
+</Aside>
+
+---
+
+## Plan Mode in the Web UI
+
+In the PizzaPi web UI, the plan review appears as an interactive **Plan Review panel** that replaces the text input area:
+
+- A blue-accented card shows the plan **title**, **description**, and **numbered steps**
+- Steps auto-collapse when there are more than 5 (click to expand)
+- Four action buttons are displayed in a responsive grid (2×2 on mobile, inline row on desktop)
+- The **Suggest Edit** button reveals an inline text input — type your feedback and press Enter or click Send
+- The panel is capped at 50% viewport height (60% on desktop) and scrolls internally so it never blocks the full screen
+
+In the terminal TUI, the plan renders as an ANSI-styled box with numbered options (1–4). Type a number to choose, or type free text to submit it as an edit suggestion.
+
+---
+
+## Execution Tracking
+
+After a plan is approved, the agent enters **execution mode**. If the plan had steps, PizzaPi tracks progress:
+
+- The agent marks steps complete by including `[DONE:n]` tags in its responses (e.g., `[DONE:1]`)
+- A checklist of plan steps is displayed, updating as steps are completed
+- When all steps are marked done, a **Plan Complete! ✓** message appears with all steps struck through
+
+In the TUI, after the agent finishes exploring (if it hasn't used the `plan_mode` tool), a menu appears:
+- **Execute the plan (track progress)** — exits plan mode and starts execution with step tracking
+- **Stay in plan mode** — keep exploring
+- **Refine the plan** — opens an editor to provide feedback
+
+---
+
+## Multi-Agent Plan Review
+
+In multi-agent setups where a parent agent spawns child sessions, plan review integrates with the [trigger system](/customization/subagents/).
+
+When a **child session** calls `plan_mode`, it fires a `plan_review` trigger to the parent session instead of waiting for a human response. The parent sees:
+
+```
+🔗 Child "my-child" submitted a plan for review:
+## Refactor Authentication Module
+
+1. Extract token validation into shared utility
+2. Update all route handlers to use new utility
+3. Add unit tests for edge cases
+
+Respond with `respond_to_trigger` using trigger ID `abc-123`.
+Use respond_to_trigger with action: "approve" to accept, "cancel" to reject, or "edit" with feedback.
+```
+
+The parent agent can respond with:
+
+- `respond_to_trigger(triggerId, "approve", { action: "approve" })` — child proceeds with execution
+- `respond_to_trigger(triggerId, "cancel", { action: "cancel" })` — child stops
+- `respond_to_trigger(triggerId, "Your step 2 should also handle middleware", { action: "edit" })` — child revises the plan
+- `escalate_trigger(triggerId)` — passes the decision to the human viewer
+
+<Aside type="caution">
+  Plan review triggers have a **5-minute timeout** (`300,000ms`). If the parent doesn't respond in time, the child treats it as a cancellation.
+</Aside>
+
+---
+
+## The `toggle_plan_mode` Tool
+
+Separate from `plan_mode` (which submits a plan for review), the `toggle_plan_mode` tool lets the agent **enter or exit** read-only exploration mode programmatically.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `enabled` | `boolean` | ✅ | `true` to enter plan mode (read-only), `false` to exit (full access) |
+
+**Response examples:**
+
+- `"Plan mode is now ON (read-only)."` — when entering
+- `"Plan mode is now OFF (full access)."` — when exiting
+- `"Plan mode was already ON (read-only). No change."` — if already in the requested state
+
+If the agent exits plan mode without ever submitting a plan via `plan_mode`, it receives a soft nudge:
+
+> Note: you exited plan mode without submitting a plan for user review. Next time, use the plan_mode tool to present your plan before exiting.
+
+---
+
+## Session Behavior
+
+- **State persists across resumes** — if you resume a session that was in plan mode, plan mode is restored along with any in-progress execution steps and the sandbox overlay.
+- **State resets on session switch** — switching to a different session clears plan mode so the new session starts with full access. The sandbox overlay is also cleared.
+- **Context filtering** — when plan mode is off, the `[PLAN MODE ACTIVE]` context messages are automatically stripped from the conversation to keep the context window clean.
+
+---
+
+## Best Practices
+
+**Use plan mode when:**
+- The task is complex and touches many files — you want to verify the approach before changes begin
+- You're working with an unfamiliar codebase and want the agent to explore first
+- The change is risky or hard to reverse (database migrations, config changes, refactors)
+- You're using a multi-agent setup and want parent approval before child agents make changes
+
+**Skip plan mode when:**
+- The task is simple and well-defined (fix a typo, add a log line)
+- You've already described the exact changes you want
+- Speed matters more than review — you can always undo with git
+
+<Aside type="tip">
+  Plan mode works especially well with the **Clear Context & Begin** action. Let the agent spend its context window on thorough analysis, then start execution with a clean slate focused on the approved plan.
+</Aside>

--- a/packages/docs/src/content/docs/features/slash-commands.mdx
+++ b/packages/docs/src/content/docs/features/slash-commands.mdx
@@ -1,0 +1,143 @@
+---
+title: Slash Commands
+description: Complete reference for all / commands available in the PizzaPi web UI chat input.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Slash commands let you control your PizzaPi session directly from the chat input. Type `/` to open the command picker, then select or type a command.
+
+## Using the command picker
+
+### Opening the picker
+
+Type `/` at the beginning of the chat input. A popover appears listing all available commands, grouped into sections:
+
+- **Commands** — built-in session and UI commands
+- **Extensions** — commands registered by Claude Code plugins
+- **Prompts** — prompt template shortcuts
+- **Skills** — skill-based commands from your configuration
+
+The list filters as you type. For example, typing `/mo` narrows the list to `/model`.
+
+### Keyboard navigation
+
+| Key | Action |
+|-----|--------|
+| <kbd>↑</kbd> / <kbd>↓</kbd> | Move highlight through the list |
+| <kbd>Enter</kbd> | Select the highlighted command |
+| <kbd>Escape</kbd> | Close the picker |
+
+On touch devices, tap a command to select it.
+
+### Sub-command mode
+
+Some commands (like `/mcp`) have sub-commands. When you select one of these, the picker stays open and shows the available sub-options. For example, selecting `/mcp` then shows `status`, `reload`, `disable`, and `enable`.
+
+If a sub-command requires an argument (like `/mcp disable`), selecting it fills the input with the command prefix and positions your cursor to type the argument.
+
+---
+
+## Built-in commands
+
+### Session management
+
+| Command | Description |
+|---------|-------------|
+| `/new` | Start a new conversation. If linked child sessions are still active, a confirmation dialog appears first. |
+| `/resume [query]` | Resume a previous session. Opens a session picker showing recent sessions with name, date, and path. Type to fuzzy-search by session name, ID, path, or first message. |
+| `/stop` | Abort the current generation. |
+| `/restart` | Restart the underlying CLI process. |
+
+<Aside type="tip">
+  `/resume` keeps the picker open so you can browse and filter sessions interactively. Select a session with <kbd>Enter</kbd> or click/tap it.
+</Aside>
+
+### Model and reasoning
+
+| Command | Description |
+|---------|-------------|
+| `/model` | Open the model selector dialog. |
+| `/cycle_model` | Same as `/model` — opens the model selector. |
+| `/effort` | Cycle through reasoning effort levels (low → medium → high). |
+| `/cycle_effort` | Same as `/effort`. |
+
+### Context and planning
+
+| Command | Description |
+|---------|-------------|
+| `/compact [instructions]` | Compact the conversation context. Optionally pass custom instructions to guide summarization, e.g. `/compact focus on the auth module`. |
+| `/plan` | Toggle plan mode. In plan mode, the agent explores and plans without making changes (read-only). |
+
+### Session display
+
+| Command | Description |
+|---------|-------------|
+| `/name <name>` | Set a display name for the current session, e.g. `/name auth-refactor`. |
+| `/copy` | Copy the last assistant message to your clipboard. |
+
+### Introspection
+
+| Command | Description |
+|---------|-------------|
+| `/plugins` | List all loaded Claude Code plugins, including their commands, hooks, skills, agents, and MCP servers. |
+| `/skills` | List all available skills from your configuration and plugins. |
+| `/sandbox` | Show the current sandbox status — mode (none/basic/full), platform, and recent violations. |
+
+### MCP server management
+
+The `/mcp` command manages Model Context Protocol servers. Type `/mcp ` (with a space) to see sub-commands:
+
+| Sub-command | Description |
+|-------------|-------------|
+| `/mcp status` | Show the status of all configured MCP servers. |
+| `/mcp reload` | Reload MCP server configurations. |
+| `/mcp disable <name>` | Disable a specific MCP server by name. |
+| `/mcp enable <name>` | Re-enable a previously disabled MCP server. |
+
+<Aside>
+  `/mcp disable` and `/mcp enable` require a server name argument. The picker fills in the command prefix — just type the server name and press <kbd>Enter</kbd>.
+</Aside>
+
+### Agent sessions
+
+| Command | Description |
+|---------|-------------|
+| `/agents [name]` | Start a new session as a named agent. Without an argument, opens a picker showing all available agent definitions. With a name, spawns directly, e.g. `/agents reviewer`. |
+
+The agent picker shows each agent's name and description. Select one to start a new session with that agent's system prompt.
+
+---
+
+## Dynamic commands
+
+In addition to the built-in commands above, three types of commands appear dynamically based on your configuration:
+
+### Skill commands
+
+Skills defined in your `~/.pizzapi/skills/` directory (or registered by plugins) appear in the **Skills** group. They are prefixed with `skill:` internally but shown by their short name in the picker. Running a skill command sends its content to the agent.
+
+### Extension (plugin) commands
+
+Claude Code plugins can register custom commands. These appear in the **Extensions** group. Each shows the command name and description provided by the plugin.
+
+### Prompt template commands
+
+Prompt templates from your configuration appear in the **Prompts** group. Selecting one inserts the template content into the conversation.
+
+---
+
+## Examples
+
+```
+/new                          # Start a fresh session
+/resume auth                  # Find and resume a session matching "auth"
+/compact focus on API routes  # Compact context with custom instructions
+/name deploy-fix              # Name the current session
+/mcp status                   # Check MCP server health
+/mcp disable filesystem       # Disable the "filesystem" MCP server
+/agents reviewer              # Start a session as the "reviewer" agent
+/effort                       # Cycle to the next reasoning effort level
+/plan                         # Toggle read-only plan mode
+/copy                         # Copy last response to clipboard
+```

--- a/packages/docs/src/content/docs/features/tunnels.mdx
+++ b/packages/docs/src/content/docs/features/tunnels.mdx
@@ -1,0 +1,212 @@
+---
+title: Tunnel Tools
+description: Expose local ports through the PizzaPi relay for remote access to dev servers and services.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+Tunnels let the agent **expose a local port on the runner machine** through the PizzaPi relay server, making it accessible as a public URL in the web UI. This is useful when the agent starts a dev server, build preview, or any local service and you want to interact with it from your browser — even if the runner is on a different machine or behind NAT.
+
+---
+
+## How It Works
+
+When the agent creates a tunnel, the following happens:
+
+<Steps>
+1. The agent calls `create_tunnel` with a local port number.
+2. A `service_message` is sent over the relay's Socket.IO connection to the runner daemon's **TunnelService**.
+3. The daemon registers the port and confirms the tunnel.
+4. The relay server begins proxying HTTP requests (and WebSocket upgrades) from the public URL to `127.0.0.1:<port>` on the runner.
+</Steps>
+
+All traffic flows through the relay server — the runner's local port is never directly exposed to the internet. The relay handles:
+
+- **HTTP proxying** — `GET`, `POST`, `PUT`, `DELETE`, `PATCH`, `HEAD`, and `OPTIONS` requests are forwarded to the local service and streamed back.
+- **WebSocket proxying** — upgrade requests are tunneled through a second WebSocket channel, enabling live-reload, HMR, and real-time protocols.
+- **HTML/JS/CSS rewriting** — the proxy rewrites absolute paths in HTML responses, ES module imports, and CSS `url()` references so they route through the tunnel prefix. An injected interceptor script patches `fetch`, `XMLHttpRequest`, `EventSource`, `WebSocket`, `history.pushState`, and dynamic resource loading at runtime.
+
+### URL Schemes
+
+Tunnels support two URL schemes:
+
+| Scheme | URL pattern | Stability |
+|--------|------------|-----------|
+| **Runner-based** (preferred) | `/api/tunnel/runner/<runnerId>/<port>/` | Stable across session switches |
+| **Session-based** (legacy) | `/api/tunnel/<sessionId>/<port>/` | Breaks when session changes |
+
+The agent automatically prefers runner-based URLs when a runner ID is available, falling back to session-based URLs otherwise.
+
+---
+
+## Tools
+
+### `create_tunnel`
+
+Expose a local port through the relay and get a public URL.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `port` | `number` | Yes | Local port to expose (1–65535) |
+| `name` | `string` | No | Human-readable label (e.g. `"dev-server"`, `"storybook"`) |
+
+**Returns:** A text result containing the port, optional name, and the public URL. The structured `details` object includes:
+
+```json
+{
+  "port": 3000,
+  "name": "dev-server",
+  "url": "http://127.0.0.1:3000",
+  "publicUrl": "https://your-relay.example.com/api/tunnel/runner/abc123/3000/"
+}
+```
+
+**Example agent output:**
+
+```
+Tunnel created successfully.
+  Port: 3000
+  Name: dev-server
+  Public URL: https://your-relay.example.com/api/tunnel/runner/abc123/3000/
+```
+
+---
+
+### `list_tunnels`
+
+List all currently active tunnels for this runner.
+
+**Parameters:** None.
+
+**Returns:** A text summary of active tunnels with their ports, names, pinned status, and public URLs. The structured `details` object includes:
+
+```json
+{
+  "tunnels": [
+    {
+      "port": 3000,
+      "name": "dev-server",
+      "url": "http://127.0.0.1:3000",
+      "publicUrl": "https://your-relay.example.com/api/tunnel/runner/abc123/3000/",
+      "pinned": false
+    }
+  ]
+}
+```
+
+**Example agent output:**
+
+```
+1 active tunnel(s):
+  :3000 (dev-server) → https://your-relay.example.com/api/tunnel/runner/abc123/3000/
+```
+
+---
+
+### `close_tunnel`
+
+Close an active tunnel and stop proxying traffic to the local port.
+
+**Parameters:**
+
+| Name | Type | Required | Description |
+|------|------|----------|-------------|
+| `port` | `number` | Yes | Port of the tunnel to close (1–65535) |
+
+**Returns:** Confirmation that the tunnel was closed.
+
+```json
+{
+  "closed": true,
+  "port": 3000
+}
+```
+
+---
+
+## Authentication & Security
+
+<Aside type="caution" title="Tunnels expose localhost">
+  Tunnel URLs expose the runner's `127.0.0.1:<port>` to authenticated users. Only the **session owner** (or runner owner for runner-based URLs) can access a tunnel — other authenticated users receive a `403 Forbidden` response.
+</Aside>
+
+The relay enforces several security measures:
+
+- **Auth-only access** — every tunnel request requires a valid session cookie or API key.
+- **Owner verification** — the caller's user ID must match the session/runner owner.
+- **Header stripping** — `Cookie`, `Authorization`, and `X-API-Key` headers are never forwarded to the local service, preventing auth-leakage to tunneled apps.
+- **Query param sanitization** — `apiKey` query parameters are stripped before forwarding.
+- **Hop-by-hop header removal** — standard proxy headers (`Connection`, `Transfer-Encoding`, etc.) and `Accept-Encoding` are stripped so responses arrive uncompressed for rewriting.
+
+---
+
+## Use Cases
+
+### Dev Server Preview
+
+The most common use case — an agent starts a development server and creates a tunnel so you can preview it in your browser:
+
+```
+Agent: I'll start the Vite dev server and create a tunnel so you can preview it.
+
+> bun run dev
+  → Local: http://localhost:5173/
+
+> create_tunnel(port: 5173, name: "vite-dev")
+  → Public URL: https://relay.example.com/api/tunnel/runner/abc123/5173/
+```
+
+The tunnel's runtime interceptor ensures Vite's HMR WebSocket connection, dynamic chunk loading, and SPA router navigation all work through the tunnel.
+
+### Sharing a Local Service
+
+When the agent sets up a local API server, database UI, or documentation preview, tunnels let you interact with it without SSH or port forwarding:
+
+```
+> create_tunnel(port: 8080, name: "api-server")
+> create_tunnel(port: 6006, name: "storybook")
+```
+
+Use `list_tunnels` to see all active tunnels at a glance.
+
+### SSE and Streaming Endpoints
+
+Tunnels support Server-Sent Events (SSE) and chunked streaming responses. Non-HTML content types are streamed directly without buffering, so real-time data flows through with minimal latency.
+
+---
+
+## Example Workflow
+
+A typical agent interaction using tunnels:
+
+```
+User: Set up the Next.js project and let me preview it.
+
+Agent:
+  1. npm install
+  2. npm run dev          → starts on port 3000
+  3. create_tunnel(3000, "next-dev")
+     → https://relay.example.com/api/tunnel/runner/r1/3000/
+  4. "Here's your preview URL: [link]. The dev server is running
+      with hot reload — changes will appear automatically."
+
+  ... later ...
+
+  5. close_tunnel(3000)   → tunnel closed after work is done
+```
+
+---
+
+## Limitations
+
+<Aside type="note">
+  Tunnels require an active relay connection. They do not work in offline or local-only mode.
+</Aside>
+
+- **Relay required** — the runner must be connected to the relay server. If the relay connection drops, tunnel URLs return `503 Runner not available`.
+- **No offline support** — tunnels are inherently a network feature. Without a relay, use direct `localhost` access on the runner machine.
+- **Request timeout** — service message round-trips time out after **10 seconds**. If the runner daemon is unresponsive, tunnel creation fails with a timeout error.
+- **Single-user access** — only the session/runner owner can access tunnel URLs. There is no sharing with other authenticated users.
+- **Content rewriting limits** — while the proxy rewrites HTML, JS modules, and CSS, some edge cases (e.g. paths constructed entirely at runtime from string concatenation, binary protocol WebSockets) may not be intercepted. Most modern frameworks (Vite, Next.js, webpack) work out of the box.

--- a/packages/docs/src/content/docs/features/webhooks.mdx
+++ b/packages/docs/src/content/docs/features/webhooks.mdx
@@ -1,0 +1,396 @@
+---
+title: Webhooks
+description: Trigger agent sessions from external services via HTTP webhooks with HMAC-SHA256 authentication.
+---
+
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+
+Webhooks let external services — CI/CD pipelines, chatops bots, cron jobs, monitoring alerts — **automatically spawn a fresh agent session** and deliver a JSON payload into it. Each webhook has an HMAC-SHA256 secret so only authorized callers can fire it.
+
+When a webhook fires, PizzaPi:
+
+1. Validates the HMAC signature against the webhook's secret
+2. Spawns a new session on the webhook's assigned runner
+3. Delivers the request body as a trigger into that session
+
+The agent receives the payload and can act on it immediately — run tests, triage an alert, process a deployment notification, or anything else you configure via the webhook's prompt.
+
+---
+
+## When to use webhooks
+
+- **CI/CD integration** — GitHub Actions, GitLab CI, or Jenkins fires a webhook after a failed build; the agent investigates and opens a fix PR.
+- **ChatOps** — A Slack bot forwards a message to PizzaPi; the agent processes it and responds.
+- **Scheduled tasks** — A cron job fires a webhook periodically to run maintenance scripts.
+- **Monitoring** — An alerting system (PagerDuty, Datadog) triggers an agent to diagnose an incident.
+
+---
+
+## Creating a webhook
+
+Webhooks are managed from the **Webhooks** tab in the runner detail view of the web UI.
+
+<Steps>
+
+1. **Open your runner** in the PizzaPi web interface and switch to the **Webhooks** tab.
+
+2. Click **New Webhook** to expand the creation form.
+
+3. Fill in the fields:
+
+   | Field | Required | Description |
+   |-------|----------|-------------|
+   | **Name** | Yes | A human-readable label (e.g. "GitHub Deploy Hook"). |
+   | **Source** | Yes | An identifier for the origin system (e.g. `github`, `slack`, `cron`, `custom`). Defaults to `custom`. |
+   | **Project** | No | Working directory (`cwd`) for spawned sessions. You can pick from recent projects or type a path. |
+   | **Prompt** | No | Initial instructions sent to the spawned session. This is where you tell the agent what to do with the payload. |
+   | **Model** | No | Override the model for spawned sessions (`provider`/`id`). If empty, the runner's default model is used. If available models are detected from the runner, a dropdown is shown. |
+   | **Event Filter** | No | Comma-separated list of event types (e.g. `deploy, build`). When set, the webhook only fires for payloads whose `type` field matches one of these values. Non-matching events return `200 OK` with `"filtered": true` and do not spawn a session. |
+
+4. Click **Create**. PizzaPi generates a unique **webhook ID** and a random **HMAC secret** (64-character hex string, 32 bytes of entropy).
+
+5. **Copy the secret immediately.** It's shown in a banner after creation. You'll need it to sign requests.
+
+</Steps>
+
+<Aside type="caution">
+  The HMAC secret is shown once when the webhook is created and is always visible in the expanded webhook detail. Treat it like a password — anyone with the secret and webhook URL can fire sessions on your runner.
+</Aside>
+
+---
+
+## Webhook fields reference
+
+Each webhook object contains:
+
+```json
+{
+  "id": "uuid",
+  "userId": "owner-user-id",
+  "name": "My Webhook",
+  "secret": "64-char-hex-hmac-secret",
+  "source": "github",
+  "runnerId": "runner-uuid",
+  "cwd": "/path/to/project",
+  "prompt": "Process the incoming webhook event.",
+  "model": { "provider": "anthropic", "id": "claude-sonnet-4-20250514" },
+  "eventFilter": ["push", "pull_request"],
+  "enabled": true,
+  "createdAt": "2025-01-15T10:30:00.000Z",
+  "updatedAt": "2025-01-15T10:30:00.000Z"
+}
+```
+
+- **`enabled`** — Toggle a webhook on/off from the UI without deleting it. Disabled webhooks return `404` on fire attempts.
+- **`eventFilter`** — When non-empty, the `type` field of the incoming JSON body is checked against this list. Unmatched events are silently accepted (HTTP 200) but don't spawn a session.
+- **`model`** — An object with `provider` (e.g. `"anthropic"`) and `id` (e.g. `"claude-sonnet-4-20250514"`). Set to `null` to use the runner default.
+
+---
+
+## Firing a webhook
+
+The fire endpoint does **not** require session cookie authentication — it's validated entirely via HMAC-SHA256.
+
+### Endpoint
+
+```
+POST /api/webhooks/:id/fire
+```
+
+### Headers
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `Content-Type` | Yes | Must be `application/json` |
+| `X-Webhook-Signature` | Yes | HMAC-SHA256 hex digest of the raw request body, using the webhook's secret as the key |
+
+### Request body
+
+Any valid JSON object. If you're using event filters, include a `type` field:
+
+```json
+{
+  "type": "deploy",
+  "repo": "myorg/myapp",
+  "branch": "main",
+  "commit": "abc123",
+  "status": "failure",
+  "url": "https://github.com/myorg/myapp/actions/runs/12345"
+}
+```
+
+### Response
+
+**Success (session spawned and trigger delivered):**
+```json
+{ "ok": true, "triggerId": "wh_a1b2c3d4e5f6g7h8", "sessionId": "uuid" }
+```
+
+**Filtered (event type didn't match the filter — no session spawned):**
+```json
+{ "ok": true, "filtered": true }
+```
+
+**Errors:**
+
+| Status | Meaning |
+|--------|---------|
+| `401` | Missing `X-Webhook-Signature` header, or signature doesn't match |
+| `400` | Invalid JSON body |
+| `404` | Webhook not found or disabled |
+| `500` | Webhook has no runner assigned |
+| `502` | Runner rejected the spawn request or is unreachable |
+| `503` | Runner is not connected to the server |
+| `504` | Session was spawned but didn't connect within the timeout (~15s) |
+
+---
+
+## Computing the HMAC signature
+
+The signature is an HMAC-SHA256 hex digest of the **raw request body** using the webhook secret as the key.
+
+<Tabs>
+  <TabItem label="Bash (curl)">
+    ```bash
+    # Set your variables
+    WEBHOOK_URL="https://pizza.example.com/api/webhooks/YOUR_WEBHOOK_ID/fire"
+    SECRET="your-64-char-hex-secret"
+    BODY='{"type":"deploy","repo":"myorg/myapp","status":"failure"}'
+
+    # Compute HMAC-SHA256 signature
+    # Works with both LibreSSL (macOS default) and OpenSSL 3.x
+    SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.*= //')
+
+    # Fire the webhook
+    curl -X POST "$WEBHOOK_URL" \
+      -H "Content-Type: application/json" \
+      -H "X-Webhook-Signature: $SIG" \
+      -d "$BODY"
+    ```
+  </TabItem>
+  <TabItem label="Node.js">
+    ```javascript
+    import { createHmac } from "crypto";
+
+    const secret = "your-64-char-hex-secret";
+    const body = JSON.stringify({ type: "deploy", repo: "myorg/myapp", status: "failure" });
+    const signature = createHmac("sha256", secret).update(body).digest("hex");
+
+    const res = await fetch("https://pizza.example.com/api/webhooks/YOUR_WEBHOOK_ID/fire", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Webhook-Signature": signature,
+      },
+      body,
+    });
+    console.log(await res.json());
+    ```
+  </TabItem>
+  <TabItem label="Python">
+    ```python
+    import hmac, hashlib, json, requests
+
+    secret = "your-64-char-hex-secret"
+    body = json.dumps({"type": "deploy", "repo": "myorg/myapp", "status": "failure"})
+    signature = hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+
+    res = requests.post(
+        "https://pizza.example.com/api/webhooks/YOUR_WEBHOOK_ID/fire",
+        headers={
+            "Content-Type": "application/json",
+            "X-Webhook-Signature": signature,
+        },
+        data=body,
+    )
+    print(res.json())
+    ```
+  </TabItem>
+</Tabs>
+
+<Aside type="tip">
+  The signature is compared using **timing-safe comparison** on the server, which prevents timing attacks that could leak the secret.
+</Aside>
+
+---
+
+## Example: GitHub Actions → PizzaPi
+
+This workflow fires a PizzaPi webhook when a CI build fails, so the agent can investigate and propose a fix.
+
+```yaml title=".github/workflows/notify-pizzapi.yml"
+name: Notify PizzaPi on failure
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+jobs:
+  notify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fire PizzaPi webhook
+        env:
+          WEBHOOK_URL: ${{ secrets.PIZZAPI_WEBHOOK_URL }}
+          WEBHOOK_SECRET: ${{ secrets.PIZZAPI_WEBHOOK_SECRET }}
+        run: |
+          BODY=$(jq -n \
+            --arg type "ci_failure" \
+            --arg repo "${{ github.repository }}" \
+            --arg branch "${{ github.event.workflow_run.head_branch }}" \
+            --arg commit "${{ github.event.workflow_run.head_sha }}" \
+            --arg run_url "${{ github.event.workflow_run.html_url }}" \
+            '{type: $type, repo: $repo, branch: $branch, commit: $commit, run_url: $run_url}')
+
+          SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/^.*= //')
+
+          curl -sf -X POST "$WEBHOOK_URL" \
+            -H "Content-Type: application/json" \
+            -H "X-Webhook-Signature: $SIG" \
+            -d "$BODY"
+    ```
+
+**Setup steps:**
+
+<Steps>
+
+1. Create a webhook in PizzaPi with:
+   - **Name:** `GitHub CI Failure`
+   - **Source:** `github`
+   - **Project:** path to the repo on your runner
+   - **Prompt:** `A CI build failed. The trigger payload has the repo, branch, commit, and run URL. Clone the repo if needed, check out the failing branch, read the CI logs at the run URL, diagnose the failure, and open a PR with a fix.`
+   - **Event Filter:** `ci_failure`
+
+2. Copy the **fire URL** and **secret** from the expanded webhook in the UI.
+
+3. In your GitHub repo, go to **Settings → Secrets and variables → Actions** and add:
+   - `PIZZAPI_WEBHOOK_URL` — the fire URL
+   - `PIZZAPI_WEBHOOK_SECRET` — the HMAC secret
+
+4. Add the workflow file above to your repo.
+
+</Steps>
+
+---
+
+## Managing webhooks
+
+### Enable / disable
+
+Each webhook has a toggle switch in the UI. Disabled webhooks return `404` on fire attempts — the caller sees no difference from a non-existent webhook, which avoids leaking information about your webhook IDs.
+
+### Editing
+
+Click the expand arrow (chevron) on any webhook row to see its details. Currently, webhooks can be toggled on/off via the UI. To change other fields (name, source, prompt, cwd, model, event filter), use the REST API:
+
+```bash
+curl -X PUT "https://pizza.example.com/api/webhooks/WEBHOOK_ID" \
+  -H "Content-Type: application/json" \
+  -H "Cookie: your-session-cookie" \
+  -d '{"prompt": "Updated instructions for the agent."}'
+```
+
+### Deleting
+
+Click the trash icon on a webhook row. You'll see a **"Sure?"** confirmation button (auto-dismisses after 3 seconds). Deletion is permanent — the webhook ID and secret are gone forever.
+
+---
+
+## REST API reference
+
+All CRUD endpoints require **session cookie authentication** (i.e., you must be logged into the PizzaPi web UI). The fire endpoint uses HMAC authentication instead.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/api/webhooks` | Create a new webhook |
+| `GET` | `/api/webhooks` | List all your webhooks |
+| `GET` | `/api/webhooks/:id` | Get a single webhook |
+| `PUT` | `/api/webhooks/:id` | Update webhook fields |
+| `DELETE` | `/api/webhooks/:id` | Delete a webhook |
+| `POST` | `/api/webhooks/:id/fire` | Fire webhook (HMAC auth) |
+
+### Create webhook
+
+```bash
+curl -X POST "https://pizza.example.com/api/webhooks" \
+  -H "Content-Type: application/json" \
+  -H "Cookie: your-session-cookie" \
+  -d '{
+    "name": "Deploy Hook",
+    "source": "github",
+    "runnerId": "runner-uuid",
+    "cwd": "/Users/me/projects/myapp",
+    "prompt": "Process the deploy event.",
+    "model": { "provider": "anthropic", "id": "claude-sonnet-4-20250514" },
+    "eventFilter": ["deploy"]
+  }'
+```
+
+**Required fields:** `name`, `source`. All other fields are optional.
+
+The response includes the full webhook object with the generated `id` and `secret`.
+
+### Update webhook
+
+Send only the fields you want to change:
+
+```bash
+curl -X PUT "https://pizza.example.com/api/webhooks/WEBHOOK_ID" \
+  -H "Content-Type: application/json" \
+  -H "Cookie: your-session-cookie" \
+  -d '{"enabled": false, "prompt": "New instructions."}'
+```
+
+Set a field to `null` to clear it (e.g., `"model": null` to revert to the runner default).
+
+---
+
+## Security guidance
+
+### Protect your secrets
+
+- **Store webhook secrets in your CI/CD platform's secret manager** (GitHub Actions Secrets, GitLab CI Variables, etc.). Never hardcode them in workflow files or commit them to a repository.
+- **Use HTTPS** for your PizzaPi server. HMAC authenticates the payload but doesn't encrypt it — without TLS, the payload and signature are visible to network observers.
+
+### Secret rotation
+
+PizzaPi doesn't currently have a one-click secret rotation in the UI. To rotate a secret:
+
+<Steps>
+
+1. Create a **new webhook** with the same configuration (name, source, prompt, cwd, model, event filter).
+2. Update your external service (GitHub Actions, etc.) to use the **new webhook URL and secret**.
+3. Verify the new webhook fires successfully.
+4. **Disable** the old webhook (toggle it off), then **delete** it once you're confident the new one works.
+
+</Steps>
+
+<Aside type="tip">
+  Keep the old webhook enabled during the transition so in-flight requests still succeed. Disable it only after all callers have been updated.
+</Aside>
+
+### Signature verification details
+
+- The server uses **timing-safe comparison** (`crypto.timingSafeEqual`) to prevent timing side-channel attacks.
+- The HMAC is computed over the **raw request body bytes**, not a parsed-and-re-serialized version. Your client must sign the exact bytes it sends.
+- Disabled webhooks return `404` (not `403`), so attackers cannot distinguish disabled webhooks from non-existent ones.
+
+### Runner assignment
+
+A webhook **must have a runner assigned** (`runnerId`) to fire successfully. If no runner is assigned, fire attempts return `500`. When creating webhooks from the runner detail view in the UI, the runner is automatically assigned.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|-------------|
+| `401 Invalid signature` | Secret mismatch, or the body was modified between signing and sending (e.g., re-serialized by a proxy). Sign the **exact** bytes you send. |
+| `401 Missing X-Webhook-Signature` | The header name is case-insensitive but must be present. Check for typos. |
+| `404 Webhook not found` | Webhook ID is wrong, webhook was deleted, or webhook is disabled. |
+| `500 Webhook has no runner assigned` | The webhook's `runnerId` is `null`. Update it via the API or recreate from the runner detail view. |
+| `503 Runner is not connected` | The assigned runner is offline. Start the runner daemon or check connectivity. |
+| `504 Session did not connect in time` | The session was spawned on the runner but didn't register with the server within ~15 seconds. Check runner logs for errors. |
+| Session spawns but agent does nothing | The webhook's **prompt** field is empty, so the agent has no instructions. Set a prompt that tells the agent what to do with the payload. |

--- a/packages/docs/src/content/docs/reference/api.mdx
+++ b/packages/docs/src/content/docs/reference/api.mdx
@@ -130,19 +130,70 @@ Spawn a new agent session on a runner.
 
 ### `POST /api/runners/restart`
 
-Restart an agent session.
+Restart an agent session on a runner. Sends a restart signal to the runner daemon.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "runnerId": "runner_a1b2c3"
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true }
+```
 
 ---
 
 ### `POST /api/runners/stop`
 
-Stop a running session.
+Stop (shut down) a runner daemon.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "runnerId": "runner_a1b2c3"
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true }
+```
 
 ---
 
 ### `POST /api/runners/terminal`
 
-Register a terminal (xterm) for a session.
+Register a new terminal (xterm) session on a runner.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "runnerId": "runner_a1b2c3",
+  "cwd": "/path/to/project",   // optional
+  "cols": 80,                   // optional, default 80
+  "rows": 24                    // optional, default 24
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true, "terminalId": "uuid", "runnerId": "runner_a1b2c3" }
+```
 
 ---
 
@@ -150,35 +201,548 @@ Register a terminal (xterm) for a session.
 
 Get recently used working directories for a runner.
 
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{
+  "folders": ["/Users/jordan/Projects/app", "/Users/jordan/Projects/lib"]
+}
+```
+
+---
+
+### `DELETE /api/runners/{runnerId}/recent-folders`
+
+Remove a folder from the recent-folders list.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{ "path": "/Users/jordan/Projects/old-project" }
+```
+
+**Response:**
+
+```json
+{ "ok": true, "deleted": true }
+```
+
+---
+
+### `GET /api/runners/{runnerId}/models`
+
+List available AI models on a runner, excluding user-hidden models.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{
+  "models": [
+    { "provider": "anthropic", "id": "claude-sonnet-4-20250514" },
+    { "provider": "openai", "id": "gpt-4o" }
+  ]
+}
+```
+
+---
+
+### `GET /api/runners/{runnerId}/services`
+
+List registered services and UI panels for a runner.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{
+  "serviceIds": ["git", "godmother"],
+  "panels": [{ "id": "panel-1", "title": "Service Panel" }]
+}
+```
+
 ---
 
 ### `GET /api/runners/{runnerId}/skills`
 
-List available skills on a runner.
+List available skills on a runner (from Redis cache).
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{
+  "skills": ["deploy", "review-pr", "run-tests"]
+}
+```
 
 ---
 
-### `GET /api/runners/{runnerId}/files`
+### `GET /api/runners/{runnerId}/skills/{name}`
 
-List files in a directory on the runner.
+Get the full content of a specific skill.
 
----
+**Auth:** Session cookie.
 
-### `GET /api/runners/{runnerId}/read-file`
+**Response:**
 
-Read the contents of a file on the runner.
-
----
-
-### `GET /api/runners/{runnerId}/git-status`
-
-Get the Git status of the runner's working directory.
+```json
+{ "name": "deploy", "content": "# Deploy Skill\n..." }
+```
 
 ---
 
-### `GET /api/runners/{runnerId}/git-diff`
+### `POST /api/runners/{runnerId}/skills`
 
-Get a Git diff for the runner's working directory.
+Create a new skill on the runner.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{ "name": "my-skill", "content": "# Skill instructions..." }
+```
+
+**Response:**
+
+```json
+{ "ok": true, "skills": ["my-skill", "deploy", "review-pr"] }
+```
+
+---
+
+### `POST /api/runners/{runnerId}/skills/refresh`
+
+Ask the runner to re-scan skills from disk.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "ok": true, "skills": ["deploy", "review-pr"] }
+```
+
+---
+
+### `PUT /api/runners/{runnerId}/skills/{name}`
+
+Update an existing skill.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{ "content": "# Updated skill content..." }
+```
+
+**Response:**
+
+```json
+{ "ok": true, "skills": ["deploy", "review-pr"] }
+```
+
+---
+
+### `DELETE /api/runners/{runnerId}/skills/{name}`
+
+Delete a skill from the runner.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "ok": true, "skills": ["deploy"] }
+```
+
+---
+
+### `POST /api/runners/{runnerId}/files`
+
+List files in a directory on the runner. Path must be within the runner's allowed workspace roots.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{ "path": "/Users/jordan/Projects/app" }
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "files": [
+    { "name": "src", "type": "directory" },
+    { "name": "package.json", "type": "file" }
+  ]
+}
+```
+
+---
+
+### `POST /api/runners/{runnerId}/search-files`
+
+Search for files by name within a directory on the runner.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "cwd": "/Users/jordan/Projects/app",
+  "query": "component",
+  "limit": 100   // optional, default 100
+}
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "files": ["src/components/Button.tsx", "src/components/Modal.tsx"]
+}
+```
+
+---
+
+### `POST /api/runners/{runnerId}/read-file`
+
+Read the contents of a file on the runner. Supports UTF-8 text and base64-encoded binary.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "path": "/Users/jordan/Projects/app/src/index.ts",
+  "encoding": "utf8"   // "utf8" (default, 512KB max) or "base64" (10MB max)
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true, "content": "import express from 'express';\n..." }
+```
+
+---
+
+### Git Operations
+
+Git operations (status, diff, branches, checkout, stage, unstage, commit, push) are handled entirely through the WebSocket `service_message` channel with `serviceId="git"`, not via REST endpoints. See the WebSocket section below.
+
+---
+
+### `GET /api/runners/{runnerId}/sandbox-status`
+
+Get the current sandbox configuration and status for a runner.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "mode": "basic",
+  "filesystem": { "denyRead": [], "allowWrite": ["/tmp"], "denyWrite": [] },
+  "network": { "allowedDomains": [], "deniedDomains": [] }
+}
+```
+
+---
+
+### `PUT /api/runners/{runnerId}/sandbox-config`
+
+Update the sandbox configuration for a runner.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "mode": "basic",                       // "none" | "basic" | "full"
+  "filesystem": {
+    "denyRead": [],
+    "allowWrite": ["/tmp", "/Users/jordan/Projects"],
+    "denyWrite": ["/etc"]
+  },
+  "network": {
+    "allowedDomains": ["api.github.com"],
+    "deniedDomains": []
+  }
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true }
+```
+
+---
+
+### `GET /api/runners/{runnerId}/usage`
+
+Get token/cost usage statistics from the runner.
+
+**Auth:** Session cookie.
+
+**Query params:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `range` | string | `90d` | Time range: `7d`, `30d`, `90d`, or `all` |
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "totalInputTokens": 1234567,
+  "totalOutputTokens": 456789,
+  "totalCostUsd": 12.34,
+  "sessions": []
+}
+```
+
+---
+
+### `GET /api/runners/{runnerId}/triggers`
+
+List trigger definitions and active listeners for a runner.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{
+  "triggerDefs": [
+    { "type": "github_push", "description": "Fires on git push" }
+  ],
+  "listeners": [
+    { "triggerType": "github_push", "prompt": "Review the push", "cwd": "/project" }
+  ]
+}
+```
+
+---
+
+### `GET /api/runners/{runnerId}/trigger-listeners`
+
+List active trigger listeners (auto-spawn subscriptions) for a runner.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "listeners": [{ "triggerType": "github_push", "prompt": "...", "cwd": "..." }] }
+```
+
+---
+
+### `POST /api/runners/{runnerId}/trigger-listeners`
+
+Add a trigger listener that auto-spawns sessions when a trigger fires.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "triggerType": "github_push",
+  "prompt": "Review the changes",     // optional
+  "cwd": "/path/to/project",          // optional
+  "model": { "provider": "anthropic", "id": "claude-sonnet-4-20250514" },  // optional
+  "params": { "branch": "main" }      // optional filter params
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true }
+```
+
+---
+
+### `PUT /api/runners/{runnerId}/trigger-listeners/{triggerType}`
+
+Update an existing trigger listener's configuration.
+
+**Auth:** Session cookie.
+
+**Request body:** Same fields as POST (all optional).
+
+**Response:**
+
+```json
+{ "ok": true }
+```
+
+---
+
+### `DELETE /api/runners/{runnerId}/trigger-listeners/{triggerType}`
+
+Remove a trigger listener.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "ok": true, "removed": true }
+```
+
+---
+
+### `GET /api/runners/{runnerId}/agents`
+
+List available agent definitions on a runner (from Redis cache).
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "agents": ["reviewer", "deployer"] }
+```
+
+---
+
+### `GET /api/runners/{runnerId}/agents/{name}`
+
+Get the full content of a specific agent definition.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "name": "reviewer", "content": "# Agent definition..." }
+```
+
+---
+
+### `POST /api/runners/{runnerId}/agents`
+
+Create a new agent definition.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{ "name": "my-agent", "content": "# Agent instructions..." }
+```
+
+**Response:**
+
+```json
+{ "ok": true, "agents": ["my-agent", "reviewer"] }
+```
+
+---
+
+### `POST /api/runners/{runnerId}/agents/refresh`
+
+Ask the runner to re-scan agent definitions from disk.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "ok": true, "agents": ["reviewer", "deployer"] }
+```
+
+---
+
+### `PUT /api/runners/{runnerId}/agents/{name}`
+
+Update an existing agent definition.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{ "content": "# Updated agent content..." }
+```
+
+**Response:**
+
+```json
+{ "ok": true, "agents": ["reviewer", "deployer"] }
+```
+
+---
+
+### `DELETE /api/runners/{runnerId}/agents/{name}`
+
+Delete an agent definition.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "ok": true, "agents": ["deployer"] }
+```
+
+---
+
+### `GET /api/runners/{runnerId}/plugins`
+
+List Claude Code plugins available on the runner. Optionally pass `?cwd=` to scan from a specific directory.
+
+**Auth:** Session cookie.
+
+**Query params:**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `cwd` | string | Optional absolute path to scan for project-local plugins |
+
+**Response:**
+
+```json
+{ "plugins": [{ "name": "my-plugin", "path": "/path/to/plugin" }] }
+```
+
+---
+
+### `POST /api/runners/{runnerId}/plugins/refresh`
+
+Ask the runner to re-scan plugins from disk.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "ok": true, "plugins": [] }
+```
 
 ---
 
@@ -186,27 +750,461 @@ Get a Git diff for the runner's working directory.
 
 ### `GET /api/sessions`
 
-List all sessions for the authenticated user.
+List all sessions for the authenticated user, including both live (in-memory) and persisted sessions.
 
 **Auth:** Session cookie.
+
+**Query params:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `includePersisted` | string | `true` | Set to `false` or `0` to exclude persisted (historical) sessions |
+
+**Response:**
+
+```json
+{
+  "sessions": [
+    {
+      "sessionId": "session_x1y2z3",
+      "runnerId": "runner_a1b2c3",
+      "status": "running"
+    }
+  ],
+  "persistedSessions": []
+}
+```
+
+---
+
+### `GET /api/sessions/pinned`
+
+List pinned sessions for the authenticated user.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "pinnedSessions": [{ "sessionId": "session_x1y2z3", "isPinned": true }] }
+```
+
+---
+
+### `PUT /api/sessions/{sessionId}/pin`
+
+Pin a session so it persists in the session list.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "ok": true, "isPinned": true }
+```
+
+---
+
+### `DELETE /api/sessions/{sessionId}/pin`
+
+Unpin a session.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "ok": true, "isPinned": false }
+```
 
 ---
 
 ### `POST /api/sessions/{sessionId}/attachments`
 
-Upload a file attachment to a session (e.g. for the agent to process).
+Upload file attachments to a session (e.g. for the agent to process). Accepts one or more files.
 
 **Auth:** Session cookie.
 
 **Content-Type:** `multipart/form-data`
 
+**Form fields:** `file` or `files` (one or more `File` entries).
+
 **Max file size:** Configured by the server (default: 10 MB).
+
+**Response:**
+
+```json
+{
+  "attachments": [
+    {
+      "attachmentId": "att_uuid",
+      "filename": "screenshot.png",
+      "mimeType": "image/png",
+      "size": 54321,
+      "expiresAt": "2025-01-15T12:00:00Z"
+    }
+  ]
+}
+```
 
 ---
 
 ### `GET /api/attachments/{attachmentId}`
 
-Download a previously uploaded attachment.
+Download a previously uploaded attachment. Returns the file with appropriate content headers.
+
+**Auth:** Session cookie or API key (via `x-api-key` header or `?apiKey=` query param).
+
+**Response:** Binary file with headers:
+- `Content-Type` — the attachment's MIME type
+- `Content-Disposition` — `inline; filename="..."`
+- `X-Attachment-Id` — the attachment ID
+- `X-Attachment-Filename` — percent-encoded original filename
+
+---
+
+## Triggers
+
+### `POST /api/sessions/{sessionId}/trigger`
+
+Fire a trigger into a connected session. Used by external integrations to send events to running agents.
+
+**Auth:** API key (`x-api-key` header) or session cookie.
+
+**Request body:**
+
+```json
+{
+  "type": "webhook",                   // trigger type identifier
+  "payload": { "repo": "my/repo" },    // arbitrary payload object
+  "deliverAs": "steer",                // optional: "steer" (default, interrupts) or "followUp" (queues)
+  "expectsResponse": false,            // optional, default false
+  "source": "github",                  // optional source identifier
+  "summary": "New push to main"        // optional human-readable summary
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true, "triggerId": "ext_abc123" }
+```
+
+---
+
+### `GET /api/sessions/{sessionId}/triggers`
+
+List recent trigger history for a session.
+
+**Auth:** API key or session cookie.
+
+**Query params:**
+
+| Param | Type | Default | Description |
+|-------|------|---------|-------------|
+| `limit` | number | `50` | Max triggers to return (capped at 200) |
+
+**Response:**
+
+```json
+{
+  "triggers": [
+    {
+      "triggerId": "ext_abc123",
+      "type": "webhook",
+      "source": "external:github",
+      "summary": "New push to main",
+      "payload": {},
+      "deliverAs": "steer",
+      "ts": "2025-01-15T12:00:00Z",
+      "direction": "inbound"
+    }
+  ]
+}
+```
+
+---
+
+### `DELETE /api/sessions/{sessionId}/triggers`
+
+Clear trigger history for a session.
+
+**Auth:** API key or session cookie.
+
+**Response:**
+
+```json
+{ "ok": true }
+```
+
+---
+
+### `GET /api/sessions/{sessionId}/available-triggers`
+
+List trigger types available on the session's runner (from runner service catalog).
+
+**Auth:** API key or session cookie.
+
+**Response:**
+
+```json
+{
+  "triggerDefs": [
+    {
+      "type": "github_push",
+      "description": "Fires on git push events",
+      "params": [{ "name": "branch", "type": "string" }],
+      "schema": {}
+    }
+  ]
+}
+```
+
+---
+
+### `GET /api/sessions/{sessionId}/trigger-subscriptions`
+
+List active trigger subscriptions for a session.
+
+**Auth:** API key or session cookie.
+
+**Response:**
+
+```json
+{
+  "subscriptions": [
+    { "triggerType": "github_push", "runnerId": "runner_a1b2c3" }
+  ]
+}
+```
+
+---
+
+### `POST /api/sessions/{sessionId}/trigger-subscriptions`
+
+Subscribe a session to a trigger type. The trigger type must be available on the session's runner.
+
+**Auth:** API key or session cookie.
+
+**Request body:**
+
+```json
+{
+  "triggerType": "github_push",
+  "params": { "branch": "main" },           // optional, validated against trigger def
+  "filters": [                               // optional output filters
+    { "field": "repo", "value": "my/repo", "op": "eq" }
+  ],
+  "filterMode": "and"                        // optional: "and" (default) or "or"
+}
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "triggerType": "github_push",
+  "runnerId": "runner_a1b2c3"
+}
+```
+
+---
+
+### `PUT /api/sessions/{sessionId}/trigger-subscriptions/{triggerType}`
+
+Update params/filters on an existing trigger subscription.
+
+**Auth:** API key or session cookie.
+
+**Request body:**
+
+```json
+{
+  "params": { "branch": "develop" },
+  "filters": [{ "field": "author", "value": "bot", "op": "contains" }],
+  "filterMode": "and"
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true, "triggerType": "github_push", "runnerId": "runner_a1b2c3" }
+```
+
+---
+
+### `DELETE /api/sessions/{sessionId}/trigger-subscriptions/{triggerType}`
+
+Unsubscribe a session from a trigger type.
+
+**Auth:** API key or session cookie.
+
+**Response:**
+
+```json
+{ "ok": true, "triggerType": "github_push" }
+```
+
+---
+
+### `POST /api/runners/{runnerId}/trigger-broadcast`
+
+Broadcast a trigger to all sessions subscribed to a trigger type on this runner. Intended for runner services.
+
+**Auth:** API key only (`x-api-key` header).
+
+**Request body:**
+
+```json
+{
+  "type": "github_push",
+  "payload": { "repo": "my/repo", "branch": "main" },
+  "deliverAs": "steer",        // optional: "steer" or "followUp"
+  "source": "github",          // optional
+  "summary": "Push to main"    // optional
+}
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "delivered": 3,       // number of existing sessions that received the trigger
+  "spawned": 1,         // number of auto-spawned sessions from listeners
+  "triggerId": "ext_abc123"
+}
+```
+
+---
+
+## Webhooks
+
+Webhooks allow external services to spawn sessions and fire triggers via HMAC-authenticated HTTP requests.
+
+### `POST /api/webhooks`
+
+Create a new webhook.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "name": "Deploy on push",
+  "source": "github",
+  "runnerId": "runner_a1b2c3",     // optional — runner to spawn sessions on
+  "cwd": "/path/to/project",       // optional
+  "prompt": "Review the changes",   // optional — initial prompt for spawned sessions
+  "model": { "provider": "anthropic", "id": "claude-sonnet-4-20250514" },  // optional
+  "eventFilter": ["push", "pull_request"]  // optional — only fire for these event types
+}
+```
+
+**Response (201):**
+
+```json
+{
+  "webhook": {
+    "id": "wh_uuid",
+    "name": "Deploy on push",
+    "source": "github",
+    "secret": "whsec_...",
+    "enabled": true,
+    "runnerId": "runner_a1b2c3"
+  }
+}
+```
+
+---
+
+### `GET /api/webhooks`
+
+List all webhooks for the authenticated user.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "webhooks": [{ "id": "wh_uuid", "name": "Deploy on push", "source": "github", "enabled": true }] }
+```
+
+---
+
+### `GET /api/webhooks/{id}`
+
+Get details of a specific webhook.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "webhook": { "id": "wh_uuid", "name": "...", "source": "...", "secret": "whsec_...", "enabled": true } }
+```
+
+---
+
+### `PUT /api/webhooks/{id}`
+
+Update a webhook's configuration.
+
+**Auth:** Session cookie.
+
+**Request body:** Any subset of the creation fields (`name`, `source`, `runnerId`, `cwd`, `prompt`, `model`, `eventFilter`, `enabled`).
+
+**Response:**
+
+```json
+{ "webhook": { "id": "wh_uuid", "name": "Updated name", "enabled": true } }
+```
+
+---
+
+### `DELETE /api/webhooks/{id}`
+
+Delete a webhook.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "ok": true }
+```
+
+---
+
+### `POST /api/webhooks/{id}/fire`
+
+Fire a webhook — spawns a new session and delivers the payload as a trigger. **No session cookie required** — authenticated via HMAC signature.
+
+**Auth:** HMAC-SHA256 signature of the raw request body using the webhook's `secret`, sent in the `X-Webhook-Signature` header.
+
+**Request body:** Any JSON object. If the body contains a `type` field, it's checked against the webhook's `eventFilter`.
+
+**Headers:**
+
+```http
+X-Webhook-Signature: <hex-encoded HMAC-SHA256>
+Content-Type: application/json
+```
+
+**Response:**
+
+```json
+{ "ok": true, "triggerId": "wh_abc123", "sessionId": "session_x1y2z3" }
+```
+
+If the event type is filtered out:
+
+```json
+{ "ok": true, "filtered": true }
+```
 
 ---
 
@@ -214,20 +1212,214 @@ Download a previously uploaded attachment.
 
 ### `GET /api/push/vapid-public-key`
 
-Get the VAPID public key for Web Push subscription.
+Get the VAPID public key for Web Push subscription. No authentication required.
+
+**Response:**
+
+```json
+{ "publicKey": "BNx..." }
+```
+
+---
 
 ### `POST /api/push/subscribe`
 
 Subscribe the browser to push notifications.
 
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "endpoint": "https://fcm.googleapis.com/fcm/send/...",
+  "keys": {
+    "p256dh": "base64-encoded-key",
+    "auth": "base64-encoded-auth"
+  },
+  "enabledEvents": "question,error"   // optional comma-separated event list
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true, "id": "sub_uuid" }
+```
+
+---
+
 ### `POST /api/push/unsubscribe`
 
 Unsubscribe the browser from push notifications.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{ "endpoint": "https://fcm.googleapis.com/fcm/send/..." }
+```
+
+**Response:**
+
+```json
+{ "ok": true }
+```
+
+---
 
 ### `GET /api/push/subscriptions`
 
 List push subscriptions for the authenticated user.
 
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{
+  "subscriptions": [
+    {
+      "id": "sub_uuid",
+      "endpoint": "https://fcm.googleapis.com/...",
+      "createdAt": "2025-01-15T12:00:00Z",
+      "enabledEvents": "question,error",
+      "suppressChildNotifications": false
+    }
+  ]
+}
+```
+
+---
+
 ### `PUT /api/push/events`
 
-Update which events trigger push notifications.
+Update which events trigger push notifications for a subscription.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "endpoint": "https://fcm.googleapis.com/...",
+  "enabledEvents": "question,error,completion"
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true }
+```
+
+---
+
+### `PUT /api/push/child-notifications`
+
+Control whether child (sub-agent) sessions trigger push notifications.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "endpoint": "https://fcm.googleapis.com/...",
+  "suppress": true
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true }
+```
+
+---
+
+### `POST /api/push/answer`
+
+Answer a pending agent question directly from a push notification (e.g. from mobile).
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{
+  "sessionId": "session_x1y2z3",
+  "toolCallId": "tc_abc123",
+  "text": "Yes, proceed with the deployment"
+}
+```
+
+**Response:**
+
+```json
+{ "ok": true }
+```
+
+**Error codes:**
+- `409` — No question pending, or answer already submitted
+- `403` — Session not in collab mode
+- `502` — Runner not connected
+
+---
+
+## Settings
+
+### `GET /api/settings/hidden-models`
+
+Get the list of hidden (disabled) models for the authenticated user.
+
+**Auth:** Session cookie.
+
+**Response:**
+
+```json
+{ "hiddenModels": ["openai/gpt-4", "anthropic/claude-2"] }
+```
+
+---
+
+### `PUT /api/settings/hidden-models`
+
+Update the list of hidden models.
+
+**Auth:** Session cookie.
+
+**Request body:**
+
+```json
+{ "hiddenModels": ["openai/gpt-4"] }
+```
+
+**Response:**
+
+```json
+{ "ok": true, "hiddenModels": ["openai/gpt-4"] }
+```
+
+---
+
+## Tunnel (HTTP Proxy)
+
+The tunnel endpoints proxy HTTP requests to services running on the runner's localhost. This allows the web UI to access dev servers, databases, or any local service through the relay.
+
+### `* /api/tunnel/{sessionId}/{port}/*`
+
+Session-based tunnel proxy. All HTTP methods are supported (GET, POST, PUT, DELETE, PATCH, HEAD, OPTIONS).
+
+**Auth:** Session cookie (must be the session owner).
+
+The request is forwarded to `127.0.0.1:{port}` on the runner. HTML, JS, and CSS responses are rewritten to route absolute paths through the tunnel prefix. Auth headers (`Cookie`, `Authorization`, `x-api-key`) are stripped before forwarding.
+
+---
+
+### `* /api/tunnel/runner/{runnerId}/{port}/*`
+
+Runner-based tunnel proxy (preferred). Same as above but addressed by runner ID instead of session ID, making the URL stable across session restarts.
+
+**Auth:** Session cookie (must own the runner).

--- a/packages/docs/src/content/docs/reference/environment-variables.mdx
+++ b/packages/docs/src/content/docs/reference/environment-variables.mdx
@@ -39,6 +39,16 @@ These are set automatically by the runner daemon on spawned worker sessions.
 | `PIZZAPI_WORKER_CWD` | Working directory for the worker session. | — |
 | `PIZZAPI_WORKER_INITIAL_PROMPT` | Initial prompt to inject into the session. | — |
 
+### Session Attachment Variables
+
+These control where the runner stores session attachments (images and files sent from the web UI to the agent).
+
+| Variable | Description | Default |
+|---|---|---|
+| `PIZZAPI_SESSION_ATTACHMENTS_DIR` | Override the directory where session attachments are persisted on the runner. Each session gets a subdirectory keyed by session ID. Files are stored alongside a `.meta.json` sidecar containing the original filename, MIME type, size, and timestamp. | `~/.pizzapi/session-attachments/` |
+
+**Attachment pipeline:** When a user uploads a file via the web UI, the relay server stores it temporarily (see `PIZZAPI_ATTACHMENT_DIR` / `PIZZAPI_ATTACHMENT_TTL_MS` in the Server section). The runner's remote extension then downloads the attachment and persists it into the session attachments directory, making it available to the agent as a local file path. Attachments live as long as the session — there is no independent TTL on the runner side.
+
 ### Sandbox Variables
 
 These variables control the [Agent Sandbox](/PizzaPi/security/sandbox/) behavior.

--- a/packages/docs/src/content/docs/reference/protocol.mdx
+++ b/packages/docs/src/content/docs/reference/protocol.mdx
@@ -1,0 +1,417 @@
+---
+title: Protocol Package
+description: Shared wire protocol types for relay communication between runners, server, and web UI.
+sidebar:
+  order: 2
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+## Overview
+
+The `@pizzapi/protocol` package (`packages/protocol`) contains the shared TypeScript type definitions that every PizzaPi component — CLI runner, relay server, and web UI — uses to communicate over Socket.IO. It has **zero runtime dependencies** (dev-only `typescript`) and exports only types, constants, and small pure-function helpers.
+
+By keeping wire types in a single package, any breaking change to the protocol surfaces as a compile error everywhere it matters, before anything ships.
+
+```
+packages/protocol/
+├── src/
+│   ├── index.ts        # Re-exports everything
+│   ├── shared.ts       # Types used across multiple namespaces
+│   ├── relay.ts        # /relay namespace (CLI ↔ Server)
+│   ├── runner.ts       # /runner namespace (Runner daemon ↔ Server)
+│   ├── runners.ts      # /runners namespace (Browser runner feed)
+│   ├── viewer.ts       # /viewer namespace (Browser viewer ↔ Server)
+│   ├── hub.ts          # /hub namespace (Session list feed)
+│   ├── terminal.ts     # /terminal namespace (Browser terminal ↔ Server)
+│   ├── meta.ts         # Session meta-state & meta relay events
+│   ├── password.ts     # Password validation (shared UI/server/CLI)
+│   └── version.ts      # Socket protocol versioning & semver helpers
+└── package.json        # @pizzapi/protocol
+```
+
+## Socket.IO Namespaces
+
+PizzaPi uses **six Socket.IO namespaces**, each with strongly-typed event maps for client→server, server→client, inter-server (Redis adapter), and per-socket metadata. Every namespace interface follows the same four-interface pattern:
+
+| Interface suffix | Direction | Purpose |
+|---|---|---|
+| `ClientToServerEvents` | Client → Server | Events the client emits |
+| `ServerToClientEvents` | Server → Client | Events the server emits |
+| `InterServerEvents` | Server → Server | Reserved for Redis adapter cross-node communication |
+| `SocketData` | — | Per-socket metadata attached during handshake |
+
+### `/relay` — CLI Agent ↔ Server
+
+**File:** `relay.ts`
+
+The primary control channel between a running `pi` agent session (TUI) and the relay server. This is the highest-traffic namespace — every agent event (heartbeats, message updates, tool calls) flows through here.
+
+**Key client→server events:**
+
+| Event | Purpose |
+|---|---|
+| `register` | Register a new or existing session (sends `cwd`, `sessionName`, optional `parentSessionId`) |
+| `event` | Forward an agent event with a sequence number for ordering |
+| `session_end` | Signal that a session has ended |
+| `session_message` | Send an inter-session message (with optional `deliverAs: "input"`) |
+| `session_trigger` | Fire a child→parent trigger (questions, plans, completion) |
+| `trigger_response` | Parent responds to a child trigger |
+| `cleanup_child_session` | Request teardown of a completed child session |
+| `delink_children` | Sever all child links (e.g. on `/new`) |
+| `delink_own_parent` | Child severs its own parent link |
+| `exec_result` | Return the result of a remote exec command |
+
+**Key server→client events:**
+
+| Event | Purpose |
+|---|---|
+| `registered` | Confirm registration — returns `sessionId`, `token`, `shareUrl` |
+| `event_ack` | Acknowledge receipt of a sequenced event |
+| `input` | Deliver viewer input to the agent (with optional attachments) |
+| `model_set` | Instruct agent to switch model |
+| `exec` | Remote command execution request |
+| `session_trigger` | Deliver a child trigger to the target session |
+| `trigger_response` | Deliver a trigger response back to source child |
+| `parent_delinked` | Notify child that its parent ran `/new` |
+| `session_expired` | Notify that a session has expired |
+
+### `/viewer` — Browser ↔ Server
+
+**File:** `viewer.ts`
+
+Connects the web UI to a specific session. Viewers receive replayed event history on connect and live events afterwards.
+
+**Key client→server events:**
+
+| Event | Purpose |
+|---|---|
+| `switch_session` | Logically switch the socket to a different session (with generation counter) |
+| `resync` | Request a fresh snapshot replay |
+| `input` | Send user input (collab mode) |
+| `model_set` | Switch model (collab mode) |
+| `exec` | Remote exec command |
+| `service_message` | Forward a service message to the runner |
+| `trigger_response` | Human viewer responds to a child trigger (with Socket.IO ack) |
+| `mcp_oauth_paste` | Submit a pasted OAuth callback code for MCP servers |
+
+**Key server→client events:**
+
+| Event | Purpose |
+|---|---|
+| `connected` | Confirm viewer attachment — includes `lastSeq`, `replayOnly`, `isActive` |
+| `event` | Forward an agent event (with optional `replay` flag and `generation`) |
+| `disconnected` | Agent disconnected (with reason code) |
+| `service_message` | Service message from runner |
+| `service_announce` | Available services on the connected runner |
+| `trigger_error` | Error delivering a trigger response (carries `triggerId` for UI matching) |
+
+<Aside type="tip">
+  The `generation` field on viewer events prevents stale events from a previous session leaking into the current view after a `switch_session` call. The viewer discards any event whose generation doesn't match the latest requested switch.
+</Aside>
+
+### `/runner` — Runner Daemon ↔ Server
+
+**File:** `runner.ts`
+
+The largest namespace — handles runner lifecycle, session spawning, terminal management, file operations, skill/agent/plugin CRUD, model listing, usage data, and service messaging.
+
+**Key client→server events:**
+
+| Event | Purpose |
+|---|---|
+| `register_runner` | Register with name, roots, skills, agents, plugins, hooks, version, platform |
+| `runner_session_event` | Forward a session event from a worker process |
+| `session_ready` / `session_error` / `session_killed` | Worker lifecycle signals |
+| `skills_list` / `agents_list` / `plugins_list` | Respond to listing requests |
+| `skill_result` / `agent_result` / `file_result` | Respond to CRUD operations |
+| `models_list` | Return available models |
+| `usage_data` / `usage_error` | Usage dashboard data |
+| `service_message` / `service_announce` | Service communication and discovery |
+| `runner_warning` / `runner_warning_clear` | Report/clear runner warnings |
+| `terminal_ready` / `terminal_data` / `terminal_exit` / `terminal_error` | Terminal PTY output |
+| `disconnect_session` | Request relay to disconnect an adopted session |
+
+**Key server→client events:**
+
+| Event | Purpose |
+|---|---|
+| `runner_registered` | Confirm registration — includes `existingSessions` for re-adoption |
+| `new_session` | Spawn a session (with cwd, prompt, model, skills, agent config, hiddenModels) |
+| `kill_session` / `session_ended` | Session lifecycle commands |
+| `list_skills` / `create_skill` / `update_skill` / `delete_skill` / `get_skill` | Skill CRUD |
+| `list_agents` / `create_agent` / `update_agent` / `delete_agent` / `get_agent` | Agent CRUD |
+| `list_plugins` | Plugin discovery |
+| `list_files` / `search_files` / `read_file` | File operations |
+| `list_models` / `get_usage` | Model and usage queries |
+| `new_terminal` / `terminal_input` / `terminal_resize` / `kill_terminal` | Terminal PTY control |
+| `service_message` | Forward a service message from a viewer |
+| `sandbox_get_status` / `sandbox_update_config` | Sandbox configuration |
+| `restart` / `shutdown` / `ping` | Runner lifecycle |
+
+### `/hub` — Session List Feed
+
+**File:** `hub.ts`
+
+A mostly read-only feed that pushes session list updates to the web UI dashboard.
+
+**Server→client events:**
+
+| Event | Purpose |
+|---|---|
+| `sessions` | Full session list snapshot (sent on connect) |
+| `session_added` / `session_removed` | Session lifecycle |
+| `session_status` | Status change (active/inactive, model, runner, name) |
+| `state_snapshot` | Full `SessionMetaState` for a subscribed session |
+| `meta_event` | Incremental meta-state patch for a subscribed session |
+
+**Client→server events:**
+
+| Event | Purpose |
+|---|---|
+| `subscribe_session_meta` | Start receiving meta-state updates for a session |
+| `unsubscribe_session_meta` | Stop receiving meta-state updates |
+
+### `/runners` — Runner Feed
+
+**File:** `runners.ts`
+
+A read-only feed that pushes runner daemon status to the web UI. Clients emit no events.
+
+| Event | Purpose |
+|---|---|
+| `runners` | Full runner list snapshot (sent on connect) |
+| `runner_added` | A runner daemon connected |
+| `runner_removed` | A runner daemon disconnected |
+| `runner_updated` | Runner metadata changed (skills, agents, plugins, hooks, warnings) |
+
+### `/terminal` — Browser Terminal ↔ Server
+
+**File:** `terminal.ts`
+
+Connects the web UI's terminal panel to a PTY process spawned on the runner.
+
+**Client→server:** `terminal_input`, `terminal_resize`, `kill_terminal`
+
+**Server→client:** `terminal_connected`, `terminal_ready`, `terminal_data`, `terminal_exit`, `terminal_error`
+
+## Shared Types
+
+**File:** `shared.ts`
+
+Types used across multiple namespaces. These are the core data structures of the protocol.
+
+### Session & Runner Identity
+
+```ts
+interface SessionInfo {
+  sessionId: string;
+  shareUrl: string;
+  cwd: string;
+  startedAt: string;
+  sessionName: string | null;
+  isEphemeral: boolean;
+  isActive: boolean;
+  lastHeartbeatAt: string | null;
+  model: ModelInfo | null;
+  runnerId: string | null;
+  runnerName: string | null;
+  parentSessionId?: string | null;
+  viewerCount?: number;
+  userId?: string;
+  userName?: string;
+  expiresAt?: string | null;
+}
+
+interface ModelInfo {
+  provider: string;
+  id: string;
+  name?: string;
+}
+
+interface RunnerInfo {
+  runnerId: string;
+  name: string | null;
+  roots: string[];
+  sessionCount: number;
+  skills: RunnerSkill[];
+  agents: RunnerAgent[];
+  plugins?: RunnerPlugin[];
+  hooks?: RunnerHook[];
+  version: string | null;
+  platform?: string | null;
+  serviceIds?: string[];
+  panels?: ServicePanelInfo[];
+  triggerDefs?: ServiceTriggerDef[];
+  warnings?: string[];
+}
+```
+
+### Attachments
+
+```ts
+interface Attachment {
+  attachmentId?: string;
+  mediaType?: string;
+  filename?: string;
+  url?: string;
+}
+```
+
+### Service System
+
+The service system enables runner-side plugins to communicate with the web UI without the relay needing to understand service-specific semantics. Messages are wrapped in a generic `ServiceEnvelope`:
+
+```ts
+interface ServiceEnvelope {
+  serviceId: string;
+  type: string;
+  requestId?: string;
+  sessionId?: string;  // Attached by relay when forwarding viewer→runner
+  payload: unknown;
+}
+```
+
+Services can expose UI panels (proxied via WebSocket tunnels) and declare trigger types:
+
+```ts
+interface ServicePanelInfo {
+  serviceId: string;
+  port: number;       // Local port, proxied via tunnel
+  label: string;      // Button label in UI
+  icon: string;       // Lucide icon name
+}
+
+interface ServiceTriggerDef {
+  type: string;        // e.g. "godmother:idea_moved"
+  label: string;
+  description?: string;
+  schema?: Record<string, unknown>;   // JSON Schema for output payload
+  params?: ServiceTriggerParamDef[];  // Subscriber-provided config params
+}
+```
+
+### Tunnel Info
+
+```ts
+interface TunnelInfo {
+  port: number;
+  name?: string;
+  url: string;       // Relay tunnel URL fragment
+  pinned?: boolean;  // Auto-registered by daemon — hidden from UI tunnel list
+}
+```
+
+## Session Meta-State
+
+**File:** `meta.ts`
+
+The meta-state system tracks ephemeral session UI state — todo lists, pending questions, token usage, model info, etc. — and synchronizes it from CLI to server to viewers via discrete events.
+
+### `SessionMetaState`
+
+The authoritative shape stored in Redis. Key fields:
+
+| Field | Type | Description |
+|---|---|---|
+| `todoList` | `MetaTodoItem[]` | Agent's task list |
+| `pendingQuestion` | `MetaPendingQuestion \| null` | Active `AskUserQuestion` prompt |
+| `pendingPlan` | `MetaPendingPlan \| null` | Active plan awaiting approval |
+| `planModeEnabled` | `boolean` | Whether plan mode is on |
+| `isCompacting` | `boolean` | Context compaction in progress |
+| `retryState` | `MetaRetryState \| null` | API retry error info |
+| `pendingPluginTrust` | `MetaPluginTrustPrompt \| null` | Plugin trust prompt |
+| `mcpStartupReport` | `MetaMcpReport \| null` | MCP server startup timing/errors |
+| `tokenUsage` | `MetaTokenUsage \| null` | Input/output/cache token counts + cost |
+| `providerUsage` | `MetaProviderUsage \| null` | Per-provider usage breakdown |
+| `model` | `MetaModelInfo \| null` | Current model |
+| `version` | `number` | Monotonic counter for change ordering |
+
+### `MetaRelayEvent`
+
+A discriminated union of 17 event types. The CLI emits these as regular relay events; the server intercepts them (via `isMetaRelayEvent()`), applies them to Redis state (via `metaEventToPatch()`), and broadcasts to hub subscribers.
+
+Event types: `todo_updated`, `question_pending`, `question_cleared`, `plan_pending`, `plan_cleared`, `plan_mode_toggled`, `compact_started`, `compact_ended`, `retry_state_changed`, `plugin_trust_required`, `plugin_trust_resolved`, `mcp_startup_report`, `token_usage_updated`, `thinking_level_changed`, `auth_source_changed`, `model_changed`.
+
+## Password Validation
+
+**File:** `password.ts`
+
+Shared password validation used by the server, UI, and CLI. Ensures consistent enforcement of password rules everywhere.
+
+- Minimum 8 characters, maximum 128 characters (scrypt DoS protection)
+- At least one uppercase, one lowercase, and one digit
+- Uses Unicode codepoint counting (emoji = 1 character)
+
+Exports `validatePassword()` (detailed per-rule results) and `isValidPassword()` (simple boolean).
+
+## Protocol Versioning
+
+**File:** `version.ts`
+
+The `SOCKET_PROTOCOL_VERSION` constant (currently `1`) is sent during Socket.IO handshake. The server checks it via `isSocketProtocolCompatible()` — missing or unparseable versions are treated as compatible (graceful degradation), while mismatched integer versions are flagged so the UI can show an update banner.
+
+Also exports semver utilities (`parseSemverTriplet`, `compareSemver`) used for runner version comparisons.
+
+## Data Flow
+
+Here's how the pieces fit together:
+
+```
+CLI Agent                   Relay Server                  Web UI
+─────────                   ────────────                  ──────
+
+  /relay register ──────────►  Store in Redis  ◄──────── /hub sessions
+                               (session hash)
+
+  /relay event ─────────────►  Append to stream ────────► /viewer event
+   (seq N)                     event_ack(N)               (replay: false)
+                               ▼
+                            isMetaRelayEvent?
+                               ▼ yes
+                            metaEventToPatch()
+                               ▼
+                            Update Redis meta ──────────► /hub meta_event
+                                                          state_snapshot
+
+  Runner daemon              /runner namespace
+  register_runner ──────────►  Store RunnerInfo  ────────► /runners runner_added
+  service_announce ─────────►  Cache panels/triggers ───► /viewer service_announce
+  service_message ──────────►  Forward verbatim ────────► /viewer service_message
+                            ◄──────── /viewer service_message (reverse path)
+
+  /viewer input ────────────►  Forward to relay  ────────► /relay input → CLI
+  /viewer trigger_response ─►  Route to child    ────────► /relay trigger_response
+```
+
+## Extending the Protocol
+
+When adding new events or types:
+
+1. **Add the type in `packages/protocol/src/`** — put it in the appropriate namespace file, or `shared.ts` if used across namespaces.
+
+2. **Re-export from `index.ts`** — every public type must be re-exported.
+
+3. **Run typecheck across all packages** — `bun run typecheck` from the repo root. The server, UI, and CLI all import from `@pizzapi/protocol`, so any breaking change surfaces immediately.
+
+4. **Update both sides** — every event needs a sender and a handler. Adding a client→server event means updating the server's socket handler. Adding a server→client event means updating the consuming component (UI store, CLI handler, etc.).
+
+5. **Bump `SOCKET_PROTOCOL_VERSION`** only for handshake-level breaking changes (new required auth fields, incompatible connection semantics). New events added to existing namespaces do NOT require a version bump — unknown events are simply ignored by older clients.
+
+<Aside type="caution">
+  The protocol package has **zero runtime dependencies** by design. Do not add imports from `@pizzapi/server`, `@pizzapi/ui`, or any other package. Types flow outward from protocol — never inward.
+</Aside>
+
+## Relationship to Server & CLI
+
+| Protocol file | Server handler | CLI extension |
+|---|---|---|
+| `relay.ts` | `packages/server/src/socket/relay.ts` | Remote extension (`packages/cli/src/extensions/remote/`) |
+| `runner.ts` | `packages/server/src/socket/runner.ts` | Runner daemon (`packages/cli/src/runner/`) |
+| `viewer.ts` | `packages/server/src/socket/viewer.ts` | — (consumed by `packages/ui/`) |
+| `hub.ts` | `packages/server/src/socket/hub.ts` | — (consumed by `packages/ui/`) |
+| `runners.ts` | `packages/server/src/socket/runners.ts` | — (consumed by `packages/ui/`) |
+| `terminal.ts` | `packages/server/src/socket/terminal.ts` | Runner daemon terminal handler |
+| `meta.ts` | `packages/server/src/socket/relay.ts` (meta interception) | Remote extension (meta event emission) |
+| `password.ts` | Auth routes | CLI auth commands, UI signup/password forms |
+| `version.ts` | Socket handshake middleware | CLI/runner connect handshake |

--- a/packages/docs/src/content/docs/security/sandbox.mdx
+++ b/packages/docs/src/content/docs/security/sandbox.mdx
@@ -223,6 +223,161 @@ Use the `/sandbox` slash command in a session to view status and recent violatio
 
 ---
 
+## Runtime Inspection & Configuration API
+
+PizzaPi exposes REST endpoints and a slash command to inspect and update sandbox configuration at runtime — no restart required.
+
+### `GET /api/runners/{runnerId}/sandbox-status`
+
+Returns the current sandbox state for a runner. Requires an authenticated session owned by the runner's user.
+
+**Response:**
+
+```json
+{
+  "mode": "basic",
+  "active": true,
+  "platform": "darwin",
+  "violations": 3,
+  "recentViolations": [
+    {
+      "timestamp": "2026-03-29T14:22:01.000Z",
+      "operation": "read",
+      "target": "~/.ssh/id_ed25519",
+      "reason": "Path in denyRead"
+    }
+  ],
+  "config": { "mode": "basic", "filesystem": { "..." : "..." } }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `mode` | Active sandbox mode (`none`, `basic`, `full`) |
+| `active` | Whether enforcement is actually running (may be `false` on unsupported platforms) |
+| `platform` | Runner's OS (`darwin`, `linux`, `win32`) |
+| `violations` | Total violation count since runner start |
+| `recentViolations` | Last 20 violations (newest first) |
+| `config` | Fully resolved sandbox config (global + project merged) |
+
+### `PUT /api/runners/{runnerId}/sandbox-config`
+
+Update sandbox configuration at runtime without restarting the runner. The body is deep-merged with the existing global config in `~/.pizzapi/config.json`.
+
+**Request body:**
+
+```json
+{
+  "mode": "full",
+  "network": {
+    "allowedDomains": ["*.github.com", "api.anthropic.com"]
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "saved": true,
+  "resolvedConfig": { "..." : "..." },
+  "message": "Changes will apply on next session start."
+}
+```
+
+- Send `null` for a key to remove it from the config (e.g., clearing stale network rules when downgrading from `full` to `basic`).
+- Nested objects are shallow-merged; arrays and scalars are replaced.
+- Validation rejects invalid modes and non-string array entries with a `400` status.
+
+<Aside type="note">
+  Config changes are persisted to `~/.pizzapi/config.json` immediately but take effect on the **next session start** — active sessions keep their resolved config.
+</Aside>
+
+### Violation events in the web UI
+
+When a runner is connected to the PizzaPi relay, every `sandbox:violation` event is forwarded in real time. In the web UI:
+
+- Violations appear as **warning badges** in the session timeline.
+- The **runner detail panel** shows a live violation counter and a filterable violation log.
+- Clicking a violation expands it to show the full operation, target path, and denial reason.
+
+### `/sandbox` slash command
+
+The `/sandbox` command is available inside any active session:
+
+| Command | Description |
+|---------|-------------|
+| `/sandbox` | Status overview — mode, active state, platform, violation count |
+| `/sandbox violations` | Full violation log (last 100 entries) |
+| `/sandbox config` | Show the fully resolved config (global + project merged) |
+
+---
+
+## Runner Workspace Roots
+
+The `PIZZAPI_WORKSPACE_ROOTS` environment variable restricts which working directories the runner daemon will accept when spawning new sessions. Any spawn request whose `cwd` is outside the allowed roots is **rejected** before a session starts.
+
+This is useful for **shared or team runners** that should only work within specific project directories — e.g., a CI runner locked to `/srv/projects` or a team Mac Mini restricted to a few repos.
+
+### Setting workspace roots
+
+Set a comma-separated list of allowed directories:
+
+```bash
+export PIZZAPI_WORKSPACE_ROOTS="/Users/jordan/Projects,/tmp/scratch"
+```
+
+**Aliases** (checked in priority order):
+
+| Variable | Notes |
+|----------|-------|
+| `PIZZAPI_WORKSPACE_ROOTS` | Preferred — comma-separated list |
+| `PIZZAPI_WORKSPACE_ROOT` | Convenience alias for a single root |
+| `PIZZAPI_RUNNER_ROOTS` | Legacy alias (back-compat) |
+
+If `PIZZAPI_WORKSPACE_ROOTS` is set, the other variables are ignored. If none are set, the runner is **unscoped** and accepts any `cwd`.
+
+### Behavior
+
+- Paths are normalized — trailing slashes are stripped, symlinks are resolved.
+- A session's `cwd` must be **equal to or a subdirectory of** at least one root.
+- Path traversal attacks (`/../`) are neutralized via `realpathSync` before comparison.
+- On Windows, comparisons are case-insensitive.
+- The filesystem root (`/`) as a root allows everything (equivalent to unscoped).
+
+### LaunchAgent integration
+
+To persist workspace roots for the runner daemon, add them to the LaunchAgent plist:
+
+```xml
+<!-- ~/Library/LaunchAgents/com.pizzapi.runner.plist -->
+<key>EnvironmentVariables</key>
+<dict>
+  <key>PIZZAPI_WORKSPACE_ROOTS</key>
+  <string>/Users/jordan/Projects,/Users/jordan/Clients</string>
+</dict>
+```
+
+After editing the plist, reload the LaunchAgent:
+
+```bash
+launchctl unload ~/Library/LaunchAgents/com.pizzapi.runner.plist
+launchctl load ~/Library/LaunchAgents/com.pizzapi.runner.plist
+```
+
+### Relationship to sandbox filesystem restrictions
+
+Workspace roots and sandbox restrictions are **complementary**:
+
+| Mechanism | Scope | Enforces |
+|-----------|-------|----------|
+| Workspace roots | **Runner level** — controls which directories the daemon will start sessions in | Where sessions can be *created* |
+| Sandbox filesystem | **Session level** — controls what the agent can read/write during execution | What the agent can *access* at runtime |
+
+A session must pass **both** checks: the runner must allow the `cwd` (workspace roots), and then the sandbox must allow each individual file operation (filesystem rules). Neither replaces the other.
+
+---
+
 ## Troubleshooting
 
 ### "Sandbox blocked: Read denied"

--- a/packages/docs/src/content/docs/start-here/installation.mdx
+++ b/packages/docs/src/content/docs/start-here/installation.mdx
@@ -125,8 +125,27 @@ PizzaPi stores all its data under `~/.pizzapi/`. Here's what each file is for:
 | `~/.pizzapi/web/data/` | `pizzapi web` | Persistent SQLite database for user accounts |
 | `~/.pizzapi/web/repo/` | `pizzapi web` | Cloned PizzaPi source repo |
 | `~/.pizzapi/skills/` | manual | Global personal skills |
+| `~/.pizzapi/usage.db` | first session | SQLite database tracking token consumption, costs, and session analytics. Safe to delete (loses analytics history). |
+| `~/.pizzapi/session-list-cache.json` | `pizzapi runner` | Cache of session metadata with mtime-based invalidation. Safe to delete (rebuilds automatically on next session list). |
 
 Project-local config (`.pizzapi/config.json`) is stored in each project's directory and is not part of the global `~/.pizzapi/` tree.
+
+---
+
+## Upgrading from pi
+
+If you previously used the raw [`pi` coding agent](https://github.com/badlogic/pi-mono), PizzaPi automatically migrates your existing data on first startup. No manual steps are required.
+
+The migration runs in two phases:
+
+1. **Phase 1 — `~/.pi/agent/` → `~/.pizzapi/`**: Copies sessions, auth, and other data from a legacy `pi` install into the PizzaPi config directory.
+2. **Phase 2 — `~/.pizzapi/agent/` → `~/.pizzapi/`**: Flattens an older PizzaPi layout where data was nested under `~/.pizzapi/agent/` (caused by an earlier upstream `getAgentDir()` path). Files are merged into the flat `~/.pizzapi/` structure.
+
+Both phases are **idempotent** — they skip files that already exist at the destination and write a `.migrated` marker so they don't re-scan on subsequent startups. It's safe to re-run (e.g., if you reinstall).
+
+<Aside type="tip">
+  If something looks wrong after migration, you can safely delete `~/.pizzapi/agent/.migrated` and restart PizzaPi to re-run Phase 2. Phase 1 re-runs automatically if `~/.pizzapi/sessions/` doesn't exist yet.
+</Aside>
 
 ---
 

--- a/packages/docs/src/content/docs/web-ui/file-explorer.mdx
+++ b/packages/docs/src/content/docs/web-ui/file-explorer.mdx
@@ -1,0 +1,224 @@
+---
+title: File Explorer
+description: Browse, search, and read files on the runner machine from the PizzaPi web interface.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+The File Explorer lets you browse the runner's filesystem directly from the PizzaPi web UI — no terminal or SSH required. It appears as a docked side panel alongside the session viewer, showing the directory tree rooted at the agent's current working directory.
+
+---
+
+## Opening the File Explorer
+
+Toggle the File Explorer with the keyboard shortcut **⌘⇧E** (macOS) or **Ctrl+Shift+E** (Windows/Linux). You can also click the folder icon button in the session viewer header bar.
+
+The button only appears when the active session has a connected runner with a known working directory (`cwd`). If no runner is connected, the button is hidden.
+
+---
+
+## Panel Position
+
+On desktop, the File Explorer opens as a docked panel inside the combined panel area. You can reposition it to the **left**, **right**, or **bottom** of the session viewer using the position picker in the panel header. Your position preference persists across sessions.
+
+The panel also supports drag-to-reposition — click and hold the grip handle, then drag to a new edge.
+
+---
+
+## Navigating Directories
+
+The explorer displays the agent's working directory as a collapsible tree. Each entry shows:
+
+- **Folders** — click to expand and lazy-load the directory contents from the runner. Folders show an amber folder icon that switches between closed and open states.
+- **Files** — click to open a read-only preview. Files display a type-specific emoji icon (e.g. 🟦 for `.ts`, 🐍 for `.py`, 🎨 for `.css`) and their size in human-readable format.
+- **Symlinks** — indicated with a `→` suffix on the file name.
+
+The breadcrumb bar at the top shows the current root path (`cwd`). Use the **refresh** button (↻) to re-fetch the directory listing if the filesystem has changed.
+
+<Aside type="note">
+  The tree root is always the agent's working directory. You cannot navigate above it — the server enforces workspace root boundaries (see [Security](#workspace-root-enforcement) below).
+</Aside>
+
+---
+
+## Viewing Files
+
+Click any file to open it in the built-in viewer. Press **Escape** to return to the directory tree.
+
+### Text Files
+
+Text files open in a read-only monospaced preview with syntax-appropriate formatting. If the file exceeds **512 KB**, it is truncated and a warning banner appears:
+
+> File truncated (showing first 512 KB of _total size_)
+
+### Images
+
+Image files (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.svg`, `.bmp`, `.ico`, `.avif`) open in a dedicated image viewer with:
+
+- **Zoom controls** — zoom in, zoom out, and reset buttons with a percentage indicator
+- **Fit modes** — toggle between "fit to view" (contain) and "actual size"
+- **Transparency checkerboard** — images with alpha channels display over a checkerboard background
+- **Dimensions** — natural width × height shown in the header
+
+Images are fetched as base64-encoded data with a **10 MB** size limit.
+
+<Aside type="tip">
+  The file explorer is **read-only**. You cannot edit, rename, or delete files through it — it's designed for browsing and inspecting the agent's workspace. Use the agent itself (or a terminal) to make changes.
+</Aside>
+
+---
+
+## File Search (@ Mentions)
+
+The file search API powers the **@-mention** autocomplete in the message composer. When you type `@` followed by a filename fragment, PizzaPi searches the runner's workspace and presents matching files as suggestions. This uses the same `search-files` endpoint described below.
+
+---
+
+## REST API
+
+The File Explorer is backed by three server endpoints. All require an authenticated session (cookie-based auth) and verify that the requesting user owns the runner.
+
+### List files
+
+```
+POST /api/runners/:runnerId/files
+```
+
+**Request body:**
+
+```json
+{
+  "path": "/home/user/project/src"
+}
+```
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "files": [
+    {
+      "name": "index.ts",
+      "path": "/home/user/project/src/index.ts",
+      "isDirectory": false,
+      "isSymlink": false,
+      "size": 2048
+    },
+    {
+      "name": "components",
+      "path": "/home/user/project/src/components",
+      "isDirectory": true
+    }
+  ]
+}
+```
+
+Each entry in `files` includes `name`, `path`, `isDirectory`, an optional `isSymlink` flag, and `size` in bytes (for files).
+
+### Read file
+
+```
+POST /api/runners/:runnerId/read-file
+```
+
+**Request body:**
+
+```json
+{
+  "path": "/home/user/project/src/index.ts",
+  "encoding": "utf8"
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `path` | `string` | _(required)_ | Absolute path to the file |
+| `encoding` | `"utf8"` \| `"base64"` | `"utf8"` | Response encoding — use `base64` for images and binary files |
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "content": "import React from 'react';\n...",
+  "truncated": false,
+  "size": 2048
+}
+```
+
+Size limits depend on encoding:
+
+| Encoding | Max size | Timeout |
+|----------|----------|---------|
+| `utf8` | 512 KB | 15 s |
+| `base64` | 10 MB | 30 s |
+
+If the file exceeds the limit, `content` contains the first N bytes and `truncated` is `true`.
+
+### Search files
+
+```
+POST /api/runners/:runnerId/search-files
+```
+
+**Request body:**
+
+```json
+{
+  "cwd": "/home/user/project",
+  "query": "Button",
+  "limit": 50
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `cwd` | `string` | _(required)_ | Directory to search within |
+| `query` | `string` | _(required)_ | Filename search string (fuzzy match) |
+| `limit` | `number` | `100` | Maximum number of results to return |
+
+**Response:**
+
+```json
+{
+  "ok": true,
+  "files": [
+    { "name": "Button.tsx", "path": "/home/user/project/src/components/Button.tsx" },
+    { "name": "ButtonGroup.tsx", "path": "/home/user/project/src/components/ButtonGroup.tsx" }
+  ]
+}
+```
+
+If `query` is empty, the endpoint returns `{ "ok": true, "files": [] }` immediately without hitting the runner.
+
+---
+
+## Workspace Root Enforcement
+
+All three endpoints enforce **workspace root boundaries**. The server checks the runner's configured `roots` (the allowed workspace directories) and rejects any request where the `path` or `cwd` falls outside those roots.
+
+If a request targets a path outside the allowed roots, the server responds with:
+
+```json
+{
+  "error": "Runner cannot access path: /etc/passwd"
+}
+```
+
+This returns HTTP **400**. The check uses the `cwdMatchesRoots()` helper on the server side, ensuring that even crafted API requests cannot escape the workspace sandbox.
+
+<Aside type="caution">
+  Workspace roots are set by the runner when it connects. If a runner has no roots configured, path restrictions are not enforced — any absolute path is accessible. Configure roots in your runner setup for defense in depth.
+</Aside>
+
+---
+
+## Known Limitations
+
+- **Large text files** are truncated at 512 KB. The full file cannot be streamed through the explorer — use the agent's `read` tool or a terminal for large files.
+- **Binary files** (executables, archives, databases) will either fail to render or display garbled content in the text viewer. Only images have dedicated rendering support.
+- **No editing** — the explorer is strictly read-only. There is no write-back capability.
+- **No file search UI in the explorer panel** — file search is currently available only through the @-mention autocomplete in the composer. A dedicated search bar in the explorer panel is planned.
+- **Symlink targets** are indicated with a `→` marker but the target path is not displayed.
+- **No syntax highlighting** — text files render as plain monospaced text without language-aware coloring.

--- a/packages/docs/src/content/docs/web-ui/git-panel.mdx
+++ b/packages/docs/src/content/docs/web-ui/git-panel.mdx
@@ -1,0 +1,139 @@
+---
+title: Git Panel
+description: Stage, diff, and commit code changes from the PizzaPi web interface without leaving the browser.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+The Git panel gives you a visual overview of your repository's working tree and lets you stage files, review diffs, commit, push, and switch branches — all from the browser.
+
+## Opening the panel
+
+The Git panel is available whenever a session is connected to a runner with a working directory.
+
+- **Desktop** — click the **branch icon** button in the session header toolbar.
+- **Mobile** — open the session overflow menu (⋯) and tap **Git**.
+
+The panel opens as a docked side panel. You can drag it to reposition it (left, right, or bottom) just like the Files or Terminal panels. Click the branch icon again (or the panel's close button) to hide it.
+
+<Aside>
+The Git panel communicates with the runner's GitService over a real-time WebSocket channel — there are no REST endpoints involved. All operations are scoped to the session's working directory.
+</Aside>
+
+## Panel overview
+
+When the panel opens, it automatically fetches `git status` for the session's working directory and displays:
+
+- **Branch name** — shown at the top-left with a branch icon. Click it to open the branch selector.
+- **Ahead / behind badges** — green arrow-up (commits ahead of remote) and amber arrow-down (commits behind).
+- **Push / Publish button** — appears when you have commits to push. If the branch has no upstream tracking branch yet, the button reads **Publish** and sets the upstream automatically.
+- **Refresh button** — manually re-fetches git status at any time.
+
+Below the header, changes are split into two collapsible groups:
+
+| Section | What it shows |
+|---------|---------------|
+| **Staged Changes** | Files already added to the index (ready to commit). |
+| **Changes** | Modified, added, deleted, renamed, or untracked files in the working tree. |
+
+Each file row shows a status icon and letter code that matches `git status --porcelain` output:
+
+| Code | Meaning |
+|------|---------|
+| **M** | Modified |
+| **A** | Added |
+| **D** | Deleted |
+| **R** | Renamed |
+| **C** | Copied |
+| **??** | Untracked |
+| **MM** | Modified in both index and working tree |
+| **AM** | Added to index, then modified in working tree |
+
+When the working tree is clean, the panel shows a **"Working tree clean"** message.
+
+## Staging and unstaging files
+
+Each file row has a **+** (stage) or **−** (unstage) button on its left side:
+
+- Click **+** on an unstaged file to run `git add` on that file.
+- Click **−** on a staged file to run `git reset HEAD` on that file.
+
+Bulk actions are available in each section header:
+
+- **Stage All** — stages every file in the Changes section.
+- **Unstage All** — unstages every file in the Staged Changes section.
+
+After any stage/unstage operation, the panel automatically refreshes the status.
+
+## Writing a commit
+
+The commit form is pinned to the bottom of the panel whenever there are changes in the working tree.
+
+1. Stage the files you want to include.
+2. Type a commit message in the text area. It auto-resizes as you type (up to a maximum height).
+3. Click **Commit** or press <kbd>⌘</kbd><kbd>Enter</kbd> (macOS) / <kbd>Ctrl</kbd><kbd>Enter</kbd> (Windows/Linux).
+
+The Commit button is disabled until at least one file is staged and the message is non-empty. While the commit is in progress, a spinner replaces the button icon.
+
+After a successful commit, the message field clears and the status refreshes automatically.
+
+## Pushing changes
+
+When your local branch is ahead of the remote (or has no upstream at all), a push button appears in the header bar:
+
+- **Push** — pushes to the existing upstream branch.
+- **Publish** — pushes and sets the upstream tracking branch (`--set-upstream`) for branches that haven't been pushed before.
+
+If the push fails because there is no upstream, the panel shows a toast suggesting you click **Publish** to retry with `--set-upstream`.
+
+## Branch selector
+
+Click the branch name in the header to open the branch selector dropdown. It lists both local and remote branches, grouped under **Local** and **Remote** headings.
+
+- **Search** — a search field at the top filters branches by name as you type.
+- **Current branch** — highlighted with a green check mark.
+- **Switch branches** — click any branch to check it out. For remote branches, the panel creates a local tracking branch automatically.
+- **Keyboard** — press <kbd>Escape</kbd> to close the dropdown without switching.
+
+While a checkout is in progress, a spinner replaces the dropdown chevron. After a successful checkout, the panel refreshes to show the new branch's status.
+
+## Diff view
+
+Click any tracked file name in the staging area to open an inline diff view. (Untracked files don't have a diff to show, so their rows are not clickable.)
+
+The diff view displays a unified diff with color-coded lines:
+
+| Color | Meaning |
+|-------|---------|
+| **Green** | Added lines (`+`) |
+| **Red** | Removed lines (`-`) |
+| **Blue** | Hunk headers (`@@`) |
+| **Muted** | Context lines and diff metadata |
+
+The file path is shown in the header. Click the **back arrow** or press <kbd>Escape</kbd> to return to the staging area.
+
+You can view diffs for both staged and unstaged versions of a file — clicking a file in the **Staged Changes** section shows the staged diff, while clicking one in **Changes** shows the working-tree diff.
+
+## Toast notifications
+
+After each operation (commit, push, checkout, stage, unstage), a brief toast appears below the header:
+
+- **Green** — operation succeeded, with a short summary.
+- **Red** — operation failed, with the error message.
+
+Toasts dismiss automatically after 5 seconds or can be closed manually.
+
+## Limitations
+
+The Git panel covers common day-to-day operations but is not a full replacement for the terminal or the agent's own git usage:
+
+- **No interactive rebase, merge conflict resolution, or stash management.** Use the terminal panel or ask the agent for complex git workflows.
+- **No file-level discard (checkout -- file).** You can unstage files but cannot discard working-tree changes from the panel.
+- **No commit amend or history browsing.** The panel only shows the current working-tree state, not the commit log.
+- **No partial staging (hunk-level).** Staging operates on whole files — you cannot stage individual hunks or lines.
+- **Single-remote push only.** The push button pushes to the default remote; multi-remote setups need the terminal.
+- **Requires a connected runner.** The panel is unavailable in read-only or disconnected sessions because it needs the runner's GitService to execute commands.
+
+<Aside type="tip">
+For anything beyond basic stage-commit-push, use the **Terminal** panel or ask the agent directly — it has full git access and can handle rebases, cherry-picks, and conflict resolution.
+</Aside>

--- a/packages/docs/src/content/docs/web-ui/overview.mdx
+++ b/packages/docs/src/content/docs/web-ui/overview.mdx
@@ -1,0 +1,206 @@
+---
+title: Web UI Overview
+description: A tour of PizzaPi's web interface features — PWA support, keyboard shortcuts, panels, chat enhancements, and settings.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+PizzaPi's web UI is a React 19 PWA that works on desktop, tablet, and phone. This page covers the smaller features that don't have their own dedicated doc page — from install-to-home-screen to keyboard shortcuts to the animated pizza task tracker.
+
+## PWA & mobile
+
+PizzaPi is a Progressive Web App. You can install it to your home screen on any platform for a native-app-like experience:
+
+- **iOS**: Tap the Share button in Safari → **Add to Home Screen**.
+- **Android**: Tap the browser menu → **Install app** (or the install banner if shown).
+- **Desktop**: Click the install icon in the address bar (Chrome/Edge) or use **File → Install** in supported browsers.
+
+Once installed, PizzaPi opens in its own window without browser chrome. The app shell and UI assets are cached for fast startup, but an active network connection to the relay server is required for session streaming.
+
+### Haptic feedback
+
+On devices that support the [Vibration API](https://developer.mozilla.org/en-US/docs/Web/API/Vibration_API) (primarily Android), PizzaPi can provide haptic feedback as agent text streams in. The vibration pulse scales with the length of each text chunk — short tokens get a light tap, longer chunks get a bigger buzz.
+
+Toggle haptics with the vibration icon button in the toolbar, or from the mobile dropdown menu. A quick test buzz fires when you enable it. The preference is saved in `localStorage` and persists across sessions.
+
+<Aside type="note">
+iOS Safari ignores `navigator.vibrate()` silently, so the haptics toggle won't appear on iPhones or iPads.
+</Aside>
+
+## Keyboard shortcuts
+
+Press **<kbd>?</kbd>** anywhere in the UI to open the keyboard shortcuts dialog. The dialog automatically shows the correct modifier keys for your platform (⌘ on Mac, Ctrl on Windows/Linux).
+
+| Shortcut | Action |
+|----------|--------|
+| <kbd>⌘K</kbd> / <kbd>Ctrl+K</kbd> | Focus the prompt input |
+| <kbd>Ctrl+`</kbd> | Toggle the terminal panel |
+| <kbd>⌘⇧E</kbd> / <kbd>Ctrl+Shift+E</kbd> | Toggle the file explorer |
+| <kbd>⌘.</kbd> / <kbd>Ctrl+.</kbd> | Abort the active agent |
+| <kbd>?</kbd> | Show the shortcuts dialog |
+
+<Aside type="tip">
+The terminal shortcut intentionally uses <kbd>Ctrl</kbd> (not <kbd>⌘</kbd>) on macOS to avoid conflicting with the system's <kbd>⌘+`</kbd> window-switching shortcut.
+</Aside>
+
+## Panel positioning & resize
+
+Panels (terminal, file explorer, and any future panels) can be docked into a **9-zone grid** around the main session view:
+
+```
+┌────────────┬────────────┬────────────┐
+│ left-top   │ center-top │ right-top  │
+├────────────┼────────────┼────────────┤
+│ left-mid   │   (main)   │ right-mid  │
+├────────────┼────────────┼────────────┤
+│ left-btm   │ center-btm │ right-btm  │
+└────────────┴────────────┴────────────┘
+```
+
+The center cell is always the main session view and cannot hold a panel.
+
+### Moving panels
+
+There are three ways to reposition a panel:
+
+1. **Position picker** — Click the mini 3×3 grid icon in the panel toolbar. A dropdown shows all 8 available zones with the current one highlighted. Click a zone to move the panel there.
+2. **Drag handle** — Grab the grip handle (⠿) in the panel toolbar and drag the panel to a new zone.
+3. **Tab dragging** — Drag an individual tab out of a panel to detach it to a different zone.
+
+### Collapsing & resizing
+
+- **Double-click** a panel tab to collapse the panel down to just its tab bar (32px). Double-click again to expand.
+- **Drag the resize handle** between the panel and the main content area to adjust the panel's height (for top/bottom zones) or the column width (for left/right zones).
+- Panel sizes are remembered per-position. On mobile, panels display as full-screen overlays instead of docked zones.
+
+## Session pinning
+
+Pin important sessions so they stay accessible even after the agent finishes and the session would normally scroll out of view.
+
+- **Swipe left** on a session card in the sidebar to reveal action buttons, including **Pin**.
+- Pinned sessions float to the top of their project group in the sidebar.
+- Pinned sessions that have ended remain visible in the sidebar (fetched from the server) until you unpin them.
+- The pin state is stored server-side (`PUT /api/sessions/:id/pin` and `DELETE /api/sessions/:id/pin`), so your pins persist across browser tabs and devices.
+
+<Aside type="tip">
+Long-press a session card (500ms) to open the **End Session** confirmation dialog — useful on touch devices where swipe gestures may be awkward.
+</Aside>
+
+## Context window donut
+
+The **context donut** is a small ring indicator that shows how much of the model's context window the current session has consumed. It appears in the session toolbar whenever context token data is available.
+
+### Color coding
+
+| Usage | Color | Meaning |
+|-------|-------|---------|
+| < 65% | 🟢 Green | Plenty of room |
+| 65–84% | 🟡 Amber | Getting full |
+| ≥ 85% | 🔴 Red | Near capacity |
+
+### Tooltip details
+
+Hover over the donut to see a breakdown:
+
+- **Context** — tokens in the current context window vs. the model's maximum
+- **Output** — tokens generated by the model
+- **Cache read / write** — cache hit statistics (when available)
+
+### Compacting
+
+Click the donut to open a confirmation dialog for **context compaction**. Compacting summarizes the conversation so far and replaces it with a compact summary, freeing up context window space. The full history is preserved — the agent just sees the summary going forward. While compacting is in progress, the donut ring animates with a spin.
+
+<Aside type="caution">
+The donut only appears when the model reports `contextTokens` data. Cumulative input token counts are not used because they can be wildly inflated after compaction.
+</Aside>
+
+## Pizza progress tracker
+
+When an agent uses the `update_todo` tool, PizzaPi renders an animated **pizza** that builds itself as tasks are completed. Each todo item maps to a pizza-making stage:
+
+| Tasks done | Stage |
+|-----------|-------|
+| 0 | Empty plate — "get cooking!" |
+| 1 | Crust appears (animated expanding circle) |
+| 2 | Sauce layer |
+| 3 | Cheese (with texture blobs) |
+| 4+ | Toppings: pepperoni, mushrooms, olives, peppers, basil, onions |
+| Near end | Bake (golden overlay) |
+| All done | Serve — sparkle animation ✨ and "Pizza complete! 🎉" |
+
+The pizza scales its stages to match the total number of tasks. A 2-item todo gets "dough → bake"; a 3-item todo gets "crust → sauce & cheese → bake"; larger lists add individual toppings between the base layers and the final bake/serve stages.
+
+Each topping type has a distinct SVG rendering — red circles for pepperoni, tan ovals for mushrooms, dark rings for olives, green crescents for peppers, leaf shapes for basil, and purple rings for onions.
+
+## Web search results card
+
+When the agent performs a web search (via Anthropic's server-side web search tool), the results are rendered as a styled card in the conversation:
+
+- **Query card** — A compact inline pill showing the search query (e.g., *Searched for "bun test runner"*).
+- **Results card** — A list of results showing the page title, domain name, and a favicon fetched from Google's favicon service. Each result is a clickable link that opens in a new tab.
+
+The results card shows a count badge (e.g., "8 results") and groups results in a clean list with hover highlighting.
+
+## @mention & file attachment
+
+The chat input supports **@mentions** for referencing files and agents in your messages.
+
+### @mention popover
+
+Type **@** in the prompt to open the mention popover. It provides:
+
+- **File browsing** — Navigate the runner's filesystem with a directory browser. Folders show a → arrow and can be drilled into by clicking or pressing <kbd>Tab</kbd>. Files are shown with type-appropriate emoji icons (🟦 for `.ts`, 🐍 for `.py`, 🎨 for `.css`, etc.).
+- **Recursive search** — Type a query after `@` (without navigating into a directory) to search across all files recursively.
+- **Agent references** — Available agents appear at the top of the root-level popover. Select one to mention it in your prompt.
+
+### Navigation
+
+- <kbd>↑</kbd> / <kbd>↓</kbd> — Navigate the list
+- <kbd>Tab</kbd> — Drill into highlighted folder
+- <kbd>Backspace</kbd> (with empty filter) — Go up one directory
+- <kbd>Enter</kbd> — Select the highlighted file or agent
+- <kbd>Esc</kbd> — Close the popover
+
+A breadcrumb header shows your current location in the file tree, with a **Back** button for returning to the parent directory.
+
+### File attachments
+
+You can also attach files directly to your message using the file upload button in the chat input. Attachments are uploaded to the relay server and included in the agent's context.
+
+## Hidden models manager
+
+The **Model Visibility** dialog lets you control which models appear in the model selector dropdown. Open it from the settings panel.
+
+- Models are grouped by provider (Anthropic, OpenAI, etc.) with provider logos.
+- Click any model row to toggle its visibility — hidden models show a strikethrough and dimmed eye icon.
+- Click a **provider header** to hide/show all models from that provider at once.
+- Use the **search box** to filter models by name, ID, or provider.
+- A **"Show all"** button appears when any models are hidden, showing the count (e.g., "Show all (3 hidden)").
+
+Hidden model preferences are saved to both `localStorage` (for instant load) and the server (for cross-device sync). The server is the source of truth — on load, the UI fetches from the server and updates `localStorage` to match.
+
+## API keys & runner tokens
+
+PizzaPi provides two credential management panels in the settings area, each with its own card UI.
+
+### API keys
+
+The **API Keys** card manages personal access tokens for programmatic access to the PizzaPi API.
+
+- Create a new key with an optional name. Keys are generated with a `pzpe` prefix.
+- The full key value is shown **once** immediately after creation in a highlighted banner — copy it before dismissing, as it cannot be retrieved again.
+- Existing keys show their name, key prefix (first few characters), and expiry status.
+- Revoke a key with the trash icon — a "Sure?" confirmation appears for 3 seconds before auto-dismissing.
+- Pass API keys in the `x-api-key` HTTP header for authenticated requests.
+
+### Runner tokens
+
+The **Runner Tokens** card manages authentication tokens used by `pizzapi runner` to connect to the relay server.
+
+- Create tokens with one click. Runner tokens use the `ppru` prefix and are named `runner` by convention.
+- The card includes a **How to use** snippet showing the environment variables needed to configure a runner:
+  - `PIZZAPI_RELAY_URL` — the relay WebSocket URL
+  - `PIZZAPI_API_KEY` — the runner token
+  - `PIZZAPI_WORKSPACE_ROOT` — (optional) constrain allowed working directories
+
+Runner tokens are separated from API keys in the UI but share the same underlying key infrastructure. They're distinguished by their name prefix (`runner`, `runner:*`, or `runner-*`).

--- a/packages/docs/src/content/docs/web-ui/push-notifications.mdx
+++ b/packages/docs/src/content/docs/web-ui/push-notifications.mdx
@@ -1,0 +1,157 @@
+---
+title: Push Notifications
+description: Set up browser push notifications to stay informed about session events.
+---
+
+import { Aside, Steps } from "@astrojs/starlight/components";
+
+PizzaPi can send browser push notifications when your agent finishes a task, hits an error, or needs your input — even if you've closed the tab. Notifications are fully opt-in and work on any device with a modern browser.
+
+---
+
+## What Gets Notified
+
+Push notifications fire for three event types:
+
+| Event | Trigger | Notification |
+|---|---|---|
+| **Agent finished** (`agent_finished`) | Agent reaches the end of its task (`agent_end`) | _"Your agent in \{session\} has finished its task."_ |
+| **Input needed** (`agent_needs_input`) | Agent calls `AskUserQuestion` | _"Agent in \{session\} asks: \{question\}"_ |
+| **Agent error** (`agent_error`) | A `cli_error` event is emitted | _"Error in \{session\}: \{message\}"_ |
+
+<Aside type="tip">
+  Notifications are **only sent when no one is watching.** If at least one viewer has the session open in the web UI, push notifications are suppressed — you're already there.
+</Aside>
+
+### Quick Reply from Notifications
+
+When the agent asks a single question with multiple-choice options, the push notification includes **action buttons** so you can reply directly — no need to open the browser. Up to two option buttons plus an inline text reply are shown. Quick reply requires [collab mode](/PizzaPi/web-ui/terminal/) to be enabled on the session.
+
+---
+
+## Enabling Notifications
+
+<Steps>
+1. **Click the bell icon** in the top bar of the web UI. On mobile, open the menu and tap **Enable notifications**.
+
+2. **Grant browser permission** when prompted. If you've previously blocked notifications for the site, you'll need to reset the permission in your browser settings.
+
+3. That's it — you're subscribed. The bell icon changes from muted to active.
+</Steps>
+
+To **disable** notifications, click the active bell icon and select **Disable notifications** from the dropdown.
+
+---
+
+## Notification Preferences
+
+### Per-Event Filtering
+
+Each push subscription stores which event types it receives. By default all events (`*`) are enabled. You can update the enabled set per-device by calling the API directly:
+
+```bash
+# Enable only "agent_finished" and "agent_needs_input" for this subscription
+curl -X PUT https://your-server/api/push/events \
+  -H "Content-Type: application/json" \
+  -H "Cookie: <session-cookie>" \
+  -d '{
+    "endpoint": "<your-push-endpoint>",
+    "enabledEvents": "agent_finished,agent_needs_input"
+  }'
+```
+
+Set `enabledEvents` to `"*"` to re-enable all events.
+
+### Suppressing Child Session Notifications
+
+When an agent spawns sub-agents, each child session can generate its own notifications — potentially creating a storm of alerts. To prevent this, toggle **Suppress child session notifications** in the bell dropdown menu.
+
+When enabled, notifications from linked child sessions are silently skipped. The parent session's notifications still come through normally. This setting is per-subscription (per-device), so you can suppress on your phone but keep them on desktop.
+
+Under the hood this calls `PUT /api/push/child-notifications` with `{ "endpoint": "...", "suppress": true }`.
+
+<Aside>
+  Child suppression uses the session's linked parent relationship. If a child session is explicitly delinked from its parent, it's no longer considered a child for suppression purposes and notifications resume.
+</Aside>
+
+---
+
+## Self-Hosted Setup
+
+Push notifications require **VAPID keys** and **HTTPS**. Both are necessary for the Web Push protocol to work.
+
+### Generate VAPID Keys
+
+```bash
+bunx web-push generate-vapid-keys
+```
+
+This outputs a public/private key pair. Add them to your server environment.
+
+### Required Environment Variables
+
+| Variable | Description |
+|---|---|
+| `VAPID_PUBLIC_KEY` | The public key from the generated pair. |
+| `VAPID_PRIVATE_KEY` | The private key from the generated pair. Must decode to exactly 32 bytes (256-bit EC key). |
+| `VAPID_SUBJECT` | A `mailto:` URI identifying the server operator (e.g. `mailto:you@example.com`). Defaults to `mailto:admin@pizzapi.local`. |
+
+Add these to your Docker Compose environment, `.env` file, or however you configure the server:
+
+```yaml
+# docker-compose.yml (excerpt)
+services:
+  server:
+    environment:
+      VAPID_PUBLIC_KEY: "BEl62i..."
+      VAPID_PRIVATE_KEY: "UGhla..."
+      VAPID_SUBJECT: "mailto:you@example.com"
+```
+
+<Aside type="caution">
+  If VAPID keys are missing or invalid, the server falls back to **ephemeral keys** that are regenerated on every restart. This means all existing push subscriptions break after a server restart — fine for development, but not for production.
+</Aside>
+
+### HTTPS Requirement
+
+Service workers — which power push notifications — require a [secure context](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts). In practice this means:
+
+- **`localhost`** works without HTTPS (browsers treat it as secure).
+- **Any other hostname** requires HTTPS. Use a reverse proxy with TLS termination (e.g. Caddy, nginx) or [Tailscale HTTPS](/PizzaPi/deployment/tailscale/).
+
+If you access PizzaPi over plain HTTP on a non-localhost hostname, the notification toggle won't appear — the browser doesn't expose the Push API in insecure contexts.
+
+---
+
+## Troubleshooting
+
+### Notifications stopped working after server restart
+
+If you didn't set persistent VAPID keys, the server generated ephemeral ones that changed on restart. All existing subscriptions are now invalid.
+
+**Fix:** Generate permanent keys with `bunx web-push generate-vapid-keys`, set them as environment variables, and have users re-subscribe (click the bell icon off and on).
+
+### "Notifications blocked by browser"
+
+The user denied the notification permission prompt. PizzaPi can't override this.
+
+**Fix:** Reset the notification permission in browser settings for your PizzaPi URL, then click the bell icon again.
+
+### Bell icon doesn't appear
+
+The `NotificationToggle` component checks for browser support (`serviceWorker`, `PushManager`, and `Notification` APIs). If any are missing, the toggle is hidden.
+
+Common causes:
+- Accessing over plain HTTP on a non-localhost host (no secure context).
+- Using a browser that doesn't support Web Push (e.g. some in-app browsers).
+- Service worker failed to register — check the browser console for errors.
+
+### VAPID key mismatch after rotation
+
+If you change VAPID keys, all existing subscriptions become invalid. The server automatically cleans up stale subscriptions (410 Gone responses from push services), but users need to re-subscribe.
+
+**Fix:** After rotating keys, notify users to toggle notifications off and back on.
+
+### Push notifications fire for every sub-agent
+
+Toggle **Suppress child session notifications** in the bell dropdown. See [Suppressing Child Session Notifications](#suppressing-child-session-notifications) above.

--- a/packages/docs/src/content/docs/web-ui/terminal.mdx
+++ b/packages/docs/src/content/docs/web-ui/terminal.mdx
@@ -1,0 +1,80 @@
+---
+title: Web Terminal
+description: Access a full terminal on the runner machine directly from the PizzaPi web interface.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+The **Web Terminal** is a full terminal emulator embedded in the PizzaPi browser UI. It gives you shell access on the runner machine — no SSH client or separate terminal app required. You can run commands, inspect files, manage processes, and do anything you'd normally do in a local terminal, all from your phone or any browser.
+
+## Opening the terminal
+
+Toggle the terminal panel with the keyboard shortcut:
+
+- **<kbd>Ctrl</kbd> + <kbd>`</kbd>** (backtick) — works on both macOS and Linux. PizzaPi intentionally uses Ctrl (not Cmd) on macOS to avoid conflicting with the system's <kbd>Cmd</kbd> + <kbd>`</kbd> window-switching shortcut.
+
+You can also open it from the panel toggle controls in the session view. Once open, the terminal panel can be docked to the **bottom**, **left**, or **right** of the session view using the position picker in the panel toolbar, or dragged into position with the grip handle.
+
+## Tabs and sessions
+
+The terminal panel supports **multiple tabs**. Click the **+** button to open a new terminal. Each tab is an independent shell session.
+
+When you're viewing an agent session, new terminals automatically open on that session's runner and default to the session's working directory. If no session is active, a dialog lets you choose which runner to connect to and optionally set a working directory. Recent working directories are remembered per-runner for quick access.
+
+Terminal tabs are **scoped to the active session** — switching sessions in the sidebar shows only the terminals that belong to that session. Tabs from other sessions stay connected in the background so you don't lose your shell state.
+
+## How it works
+
+The Web Terminal connects a browser-side [xterm.js](https://xtermjs.org/) terminal emulator to a real PTY (pseudo-terminal) process running on the runner machine. The data path looks like this:
+
+```
+Browser (xterm.js) ↔ WebSocket ↔ PizzaPi relay server ↔ WebSocket ↔ Runner daemon ↔ PTY subprocess
+```
+
+1. When you open a terminal, the UI sends a `POST /api/runners/terminal` request to the relay server, which registers the terminal and forwards a `new_terminal` command to the runner.
+2. The runner daemon spawns an **isolated worker process** that owns the PTY. Each terminal gets its own worker — if a PTY crashes, it only affects that one terminal, not the daemon or any agent sessions.
+3. Terminal I/O (keystrokes and output) is base64-encoded and relayed over Socket.IO between the browser and the runner. Resize events are forwarded so the remote shell always knows the correct terminal dimensions.
+4. The runner auto-detects your default shell (`$SHELL`, or falls back to `/bin/zsh` on macOS, `/bin/bash` on Linux).
+
+<Aside type="tip">
+The terminal supports 10,000 lines of scrollback, clickable URLs, and both dark and light themes that follow your PizzaPi theme setting automatically.
+</Aside>
+
+## Mobile support
+
+On mobile devices, a **shortcut bar** appears below the terminal with buttons for keys that are hard to type on a virtual keyboard:
+
+**Tab**, **Esc**, **Ctrl+C**, **Ctrl+D**, **Ctrl+L**, **Ctrl+A**, **Ctrl+E**, arrow keys, **PgUp/PgDn**, and **Home/End**.
+
+The shortcut bar scrolls horizontally if it overflows. The virtual keyboard is not triggered when the terminal first connects — tap the terminal area to bring it up when you're ready to type.
+
+## Relationship to agent sessions
+
+The Web Terminal runs as a **completely separate process** from any agent session. It does not share a shell with the agent, does not appear in the agent's conversation, and does not consume agent tool calls. Think of it as an independent SSH session to the same machine.
+
+This means you can:
+
+- Inspect or modify files while the agent is working
+- Run build commands or tests in parallel with an agent session
+- Debug issues the agent is stuck on
+- Use the terminal even when no agent session is active
+
+## Security considerations
+
+<Aside type="caution">
+The Web Terminal provides **full shell access** with the same permissions as the runner daemon process. Anyone who can log into your PizzaPi instance and reach a runner can execute arbitrary commands on that machine.
+</Aside>
+
+Keep these points in mind:
+
+- **Authentication is required.** Terminal creation goes through the same session auth as the rest of the PizzaPi API — you must be logged in.
+- **Same permissions as the runner.** The shell runs as the same OS user that started the runner daemon. It can read, write, and execute anything that user can.
+- **Traffic is relayed.** All terminal I/O passes through the PizzaPi relay server. If your relay is exposed to the internet, use HTTPS (e.g., via [Tailscale](/deployment/tailscale/)) to encrypt the connection.
+- **No additional sandboxing.** Unlike agent sessions, which can run in a sandbox, the Web Terminal has no restrictions beyond OS-level user permissions.
+
+## Limitations
+
+- **Requires a running runner daemon.** The terminal needs a connected runner to spawn the PTY process. If no runners are online, you can't open a terminal.
+- **Latency depends on the relay.** Every keystroke round-trips through the relay server. On a local network this is imperceptible; over the internet you may notice slight input lag.
+- **One PTY per tab.** Each tab is a single shell. When the shell exits (e.g., you type `exit`), the tab shows a "Process exited" message and disconnects. Open a new tab to get a fresh shell.
+- **No persistent sessions.** Terminal state is not saved across page reloads or runner restarts. If you refresh the browser, running terminals are lost. For long-running processes, use `tmux` or `screen` inside the Web Terminal.

--- a/packages/docs/src/content/docs/web-ui/usage-dashboard.mdx
+++ b/packages/docs/src/content/docs/web-ui/usage-dashboard.mdx
@@ -1,0 +1,185 @@
+---
+title: Usage Dashboard
+description: Monitor token usage, costs, and session analytics from the PizzaPi web interface.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+The **Usage Dashboard** gives you a bird's-eye view of your token consumption, costs, and session activity across all projects on a runner. It's the fastest way to answer questions like "how much did I spend this week?" or "which model is eating my budget?"
+
+---
+
+## Opening the Dashboard
+
+1. Open the PizzaPi web UI.
+2. Navigate to a **runner detail** page (click a runner in the sidebar).
+3. Select the **Usage** tab.
+
+The dashboard loads data for the selected runner and defaults to the **90-day** view.
+
+---
+
+## Summary Cards
+
+At the top of the dashboard, four summary cards give you headline numbers for the selected period:
+
+| Card | What it shows |
+|------|--------------|
+| **Total Cost** | Sum of all token costs (input, output, cache read, cache write) across sessions that have cost data. Shows how many sessions had cost data out of the total. |
+| **Sessions** | Total session count, with average cost per session. |
+| **Total Tokens** | Combined input + output tokens (excludes cache read/write). |
+| **Avg Cost / Active Day** | Average daily spend on days that had at least one session. Inactive days are excluded, so this is higher than a simple calendar-day average. |
+
+Below the summary cards, a second row of **Session Stats** cards shows per-session averages:
+
+- **Avg Duration** — average wall-clock time per session
+- **Avg Tokens** — average total tokens per session
+- **Avg Cost** — average cost per session (only sessions with cost data)
+- **Avg Input Tokens** — average input tokens per session
+
+---
+
+## Charts
+
+### Cost Over Time
+
+A **stacked bar chart** showing daily cost broken down into four categories:
+
+- **Input Cost** — cost of input (prompt) tokens
+- **Output Cost** — cost of output (completion) tokens
+- **Cache Read Cost** — cost of reading from the prompt cache
+- **Cache Write Cost** — cost of writing to the prompt cache
+
+Hover over any bar to see the exact breakdown and daily total.
+
+### Token Usage Over Time
+
+An **area chart** showing daily token volume across four series:
+
+- **Input** — prompt tokens sent to the model
+- **Output** — completion tokens received
+- **Cache Read** — tokens served from the prompt cache
+- **Cache Write** — tokens written into the prompt cache
+
+Each series can be toggled on/off by clicking its name in the legend — useful when cache read volume dwarfs other series.
+
+---
+
+## Model Breakdown
+
+A **donut chart** with an accompanying table showing cost distribution across models. For each model you can see:
+
+- Provider name (e.g. Anthropic, OpenAI)
+- Total cost and percentage share
+- Number of sessions
+
+The top 20 models by cost are shown.
+
+---
+
+## Project Breakdown
+
+Two side-by-side **horizontal bar charts**:
+
+- **Sessions by Project** — which projects generated the most sessions
+- **Cost by Project** — which projects cost the most
+
+By default the top 8 projects are shown. Click **+N more** to expand the full list. Project names are shortened to the last path component (e.g. `/Users/jordan/Projects/PizzaPi` → `PizzaPi`).
+
+---
+
+## Recent Sessions Table
+
+A sortable table of the most recent 50 sessions in the selected period. Columns:
+
+| Column | Description |
+|--------|-------------|
+| **Session** | Session name (if set via `set_session_name`) or truncated session ID |
+| **Project** | Short project directory name |
+| **Model** | Primary model used (most-used model by message count) |
+| **Started** | Relative timestamp (e.g. "2h ago", "3d ago") — hover for absolute time |
+| **Cost** | Total session cost, or "—" if unavailable |
+| **Messages** | Number of assistant messages with usage data |
+
+Click any column header to sort ascending/descending.
+
+---
+
+## Period Selector
+
+The period selector appears at the top of the dashboard. Choose from:
+
+| Button | Date range |
+|--------|-----------|
+| **7 days** | Last 7 days |
+| **30 days** | Last 30 days |
+| **90 days** | Last 90 days (default) |
+| **All time** | Everything since the first recorded session |
+
+Changing the period re-fetches all charts and summaries for the new range.
+
+---
+
+## How Data Is Collected
+
+The usage pipeline works in three stages:
+
+1. **Session JSONL files** — Every pi session writes a JSONL log to `~/.pizzapi/sessions/<session-id>/`. Each assistant message includes a `usage` object with token counts and (when available) per-category costs.
+
+2. **Scanner → SQLite** — The runner periodically scans these JSONL files and extracts usage events into a local SQLite database at `~/.pizzapi/usage.db`. The scanner is incremental — it tracks byte offsets per file so re-scans only process new lines. A background scan triggers automatically if data is more than 60 seconds stale.
+
+3. **API → Charts** — The web UI fetches aggregated data from `GET /api/runners/:id/usage?range=<range>`. The server forwards this request to the runner over WebSocket, which queries SQLite and returns the result. The UI renders it with Recharts.
+
+<Aside type="tip">
+  The scanner also checks legacy session directories (`~/.pizzapi/agent/sessions/` and `~/.pi/agent/sessions/`) for installations that haven't been migrated.
+</Aside>
+
+---
+
+## CLI: `pizza usage`
+
+You can check **provider rate-limit usage** (not the same as the historical dashboard) from the command line:
+
+```bash
+# Show usage for all authenticated providers
+pizza usage
+
+# Show only Anthropic usage
+pizza usage anthropic
+
+# Show only Gemini usage
+pizza usage gemini
+
+# Output as JSON (for scripting)
+pizza usage --json
+pizza usage anthropic --json
+```
+
+For **Anthropic**, this shows your OAuth subscription rate-limit windows (5-hour, 7-day, Opus, Sonnet, co-work) with utilization bars and reset times. If extra usage is enabled, it also shows your monthly limit and credits used.
+
+For **Gemini** (Google Cloud Code Assist), this shows quota buckets with remaining fractions and reset times.
+
+<Aside type="note">
+  `pizza usage` queries **live provider APIs** for current rate-limit status. It does not read from `usage.db`. The Usage Dashboard in the web UI shows **historical** token and cost data from your local sessions.
+</Aside>
+
+---
+
+## Where Data Lives
+
+| Path | Contents |
+|------|----------|
+| `~/.pizzapi/usage.db` | SQLite database with `usage_events`, `sessions`, and `processing_state` tables. WAL mode enabled for concurrent reads. |
+| `~/.pizzapi/sessions/` | Raw session JSONL files that the scanner reads from. |
+
+The database is created automatically on first use. You can safely delete `usage.db` to reset all historical data — it will be rebuilt from the JSONL files on the next scan.
+
+---
+
+## Limitations
+
+- **Runner-scoped data** — The dashboard only shows sessions that ran on the selected runner. If you have multiple runners, each has its own `usage.db` with only its own sessions.
+- **Accumulates from first run** — Data starts accumulating from the first time the scanner runs. There is no way to import historical data from before PizzaPi was installed.
+- **Cost data depends on the provider** — Not all providers return per-token cost breakdowns. Sessions without cost data are counted in session/token totals but excluded from cost averages and charts.
+- **50-session cap on the recent table** — Only the 50 most recent sessions in the selected period are shown in the table. Aggregated charts and summaries include all sessions.
+- **Top 20 models/projects** — The model and project breakdowns are capped at the top 20 by cost.


### PR DESCRIPTION
## Summary

Addresses the **Documentation Coverage** epic (34 Godmother ideas) — a comprehensive audit revealed 12+ areas with no or insufficient documentation. This PR fills all of them.

### New Pages (14)

**Web UI section** (new sidebar group):
- **Web UI Overview** — PWA, keyboard shortcuts, panel positioning, session pinning, context donut, pizza progress, web search cards, @mention/attachments, hidden models, API key management
- **Web Terminal** — in-browser terminal feature
- **Git Panel** — staging, diff, commit from browser
- **File Explorer** — file browser + search API
- **Usage Dashboard** — token usage analytics
- **Push Notifications** — setup and configuration guide

**Features section** (new sidebar group):
- **Webhooks** — external HTTP triggers with HMAC-SHA256 auth
- **Tunnel Tools** — `create_tunnel` / `list_tunnels` / `close_tunnel`
- **Plan Mode** — read-only exploration and structured plan review
- **Slash Commands** — complete reference for all `/` commands
- **Multi-Agent Sessions** — `spawn_session`, triggers, messaging, orchestration patterns

**Customization section** (new pages):
- **Tool Search** — deferred MCP tool loading with `search_tools`
- **Prompt Templates** — `~/.pizzapi/prompts/` and `~/.pizzapi/commands/`

**Reference section** (new page):
- **Protocol Package** — shared wire protocol types

### Updated Pages (8)

- **API Reference** — filled in all stub endpoints with request/response schemas
- **Runner Services** — trigger subscription filters, trigger listeners, trigger history
- **Claude Plugins** — plugin `rules/` directory
- **Sandbox** — runtime config API, workspace roots (`PIZZAPI_WORKSPACE_ROOTS`)
- **Installation** — data migration (pi→pizzapi), file inventory (usage.db, session-list-cache.json)
- **Skills** — CRUD API for runtime management
- **Agent Definitions** — CRUD API for runtime management
- **Environment Variables** — `PIZZAPI_SESSION_ATTACHMENTS_DIR`

### Stats
- 23 files changed, ~4,950 lines added
- 14 new doc pages + 8 existing pages enriched
- 2 new sidebar sections (Web UI, Features)
- Docs build passing (55 HTML pages)

## Test Plan
- [x] `bun run build` in packages/docs passes
- [x] All 55 HTML pages generated
- [x] Search index built successfully
- [ ] Visual review of new pages on deployed site