### PR TITLE
feat: sigils system — parser, renderer, resolve, actions, and runner service integration

### DIFF
--- a/packages/cli/scripts/compile-prompt.ts
+++ b/packages/cli/scripts/compile-prompt.ts
@@ -71,6 +71,8 @@ export interface SystemPromptContext {
     gitWorktree?: string;
     /** Current working directory */
     cwd?: string;
+    /** Whether running inside a PizzaPi runner (enables runner-only sections) */
+    isRunner?: boolean;
 }
 
 /**

--- a/packages/cli/src/config/system-prompt.test.ts
+++ b/packages/cli/src/config/system-prompt.test.ts
@@ -80,6 +80,7 @@ describe("buildSystemPrompt", () => {
         expect(result).toContain("AskUserQuestion");
         expect(result).toContain("create_tunnel");
         expect(result).toContain("subscribe_trigger");
+        expect(result).toContain("list_available_sigils");
     });
 
     test("contains PizzaPi config paths", () => {

--- a/packages/cli/src/config/system-prompt.test.ts
+++ b/packages/cli/src/config/system-prompt.test.ts
@@ -46,8 +46,8 @@ describe("buildSystemPrompt", () => {
         expect(result).toContain("Git branch:");
     });
 
-    test("contains all major sections as pseudo-XML", () => {
-        const result = buildSystemPrompt();
+    test("contains all major sections as pseudo-XML when isRunner is true", () => {
+        const result = buildSystemPrompt({ isRunner: true });
         const sections = [
             'section name="spawning-sessions"',
             'section name="subagent-tool"',
@@ -56,12 +56,30 @@ describe("buildSystemPrompt", () => {
             'section name="asking-questions"',
             'section name="tunnels"',
             'section name="service-triggers"',
+            'section name="sigil-discovery"',
             'section name="sandbox"',
             'section name="pizzapi-configuration"',
         ];
         for (const section of sections) {
             expect(result).toContain(section);
         }
+    });
+
+    test("omits runner-only sections when isRunner is false/omitted", () => {
+        const result = buildSystemPrompt();
+        const runnerOnlySections = [
+            'section name="spawning-sessions"',
+            'section name="tunnels"',
+            'section name="service-triggers"',
+            'section name="sigil-discovery"',
+        ];
+        for (const section of runnerOnlySections) {
+            expect(result).not.toContain(section);
+        }
+        // Non-runner sections should still be present
+        expect(result).toContain('section name="subagent-tool"');
+        expect(result).toContain('section name="plan-mode"');
+        expect(result).toContain('section name="sandbox"');
     });
 
     test("contains AskUserQuestion type descriptions", () => {
@@ -71,8 +89,8 @@ describe("buildSystemPrompt", () => {
         expect(result).toContain('"ranked"');
     });
 
-    test("contains key tool names", () => {
-        const result = buildSystemPrompt();
+    test("contains key tool names when isRunner is true", () => {
+        const result = buildSystemPrompt({ isRunner: true });
         expect(result).toContain("spawn_session");
         expect(result).toContain("subagent");
         expect(result).toContain("plan_mode");
@@ -81,6 +99,13 @@ describe("buildSystemPrompt", () => {
         expect(result).toContain("create_tunnel");
         expect(result).toContain("subscribe_trigger");
         expect(result).toContain("list_available_sigils");
+    });
+
+    test("contains sigil-discovery instruction to call after set_session_name", () => {
+        const result = buildSystemPrompt({ isRunner: true });
+        expect(result).toContain("set_session_name");
+        expect(result).toContain("list_available_sigils");
+        expect(result).toContain('section name="sigil-discovery"');
     });
 
     test("contains PizzaPi config paths", () => {
@@ -103,8 +128,9 @@ describe("BUILTIN_SYSTEM_PROMPT (compat export)", () => {
         expect(BUILTIN_SYSTEM_PROMPT.length).toBeGreaterThan(0);
     });
 
-    test("matches buildSystemPrompt() output structure", () => {
-        expect(BUILTIN_SYSTEM_PROMPT).toContain('section name="spawning-sessions"');
+    test("matches buildSystemPrompt() output structure (non-runner default)", () => {
+        // Default export is non-runner, so runner-only sections are absent
+        expect(BUILTIN_SYSTEM_PROMPT).not.toContain('section name="spawning-sessions"');
         expect(BUILTIN_SYSTEM_PROMPT).toContain('section name="sandbox"');
     });
 });

--- a/packages/cli/src/config/system-prompt.ts
+++ b/packages/cli/src/config/system-prompt.ts
@@ -57,6 +57,7 @@ export function buildSystemPrompt(ctx?: Partial<SystemPromptContext>): string {
         gitBranch: ctx?.gitBranch ?? gitCtx.gitBranch,
         gitWorktree: ctx?.gitWorktree ?? gitCtx.gitWorktree,
         cwd: ctx?.cwd,
+        isRunner: ctx?.isRunner,
     });
 }
 

--- a/packages/cli/src/config/templates/system-prompt.hbs
+++ b/packages/cli/src/config/templates/system-prompt.hbs
@@ -37,6 +37,8 @@ Use `create_tunnel`, `list_tunnels`, and `close_tunnel` to expose local ports th
 
 <section name="service-triggers">
 Runner services can advertise custom trigger types that sessions can subscribe to. Use `list_available_triggers` to discover what triggers are available on your runner — it also shows which ones you're currently subscribed to. Use `subscribe_trigger(triggerType)` to start receiving events, `unsubscribe_trigger(triggerType)` to stop, and `update_trigger_subscription(triggerType, \{{ params, filters }})` to change params/filters on an existing subscription without missing events. Some triggers accept `params` that are forwarded to the service (e.g. configuring which repo to watch). Use `filters` to control which events you receive based on the trigger's output schema (e.g. `filters: [{ field: 'status', value: 'shipped' }]`). Use `filterMode: 'and'` (default) or `'or'` to combine multiple filters. Subscribed triggers arrive as injected messages in your conversation. Use `fire_trigger` to send a trigger into any session (not just children).
+
+Runner services can also advertise sigil types for inline references like `[[type:id]]`. Use `list_available_sigils` to discover which sigils are available on your runner before generating them.
 </section>
 
 <section name="sandbox">

--- a/packages/cli/src/config/templates/system-prompt.hbs
+++ b/packages/cli/src/config/templates/system-prompt.hbs
@@ -45,7 +45,31 @@ Runner services can also advertise sigil types for inline references like `[[typ
 </section>
 
 <section name="sigil-discovery">
-After naming the conversation with `set_session_name`, immediately call `list_available_sigils` to discover which sigil types (e.g. `[[type:id]]`) are available on this runner. This lets you use inline references in your responses from the start.
+After naming the conversation with `set_session_name`, immediately call `list_available_sigils` to discover which sigil types (e.g. `[[type:id]]`) are available on this runner.
+
+**Sigils are NOT built-in.** They are provided by runner services and may not exist on every runner. If `list_available_sigils` returns an empty list, do NOT emit `[[type:id]]` syntax — it will render as broken plain text. Only use sigil types that were explicitly returned by the discovery call.
+
+If sigils ARE available, follow these rules for the rest of the conversation:
+
+<topic name="prefer-sigils-over-fetching">
+Sigils let you relay rich, interactive data to the user WITHOUT fetching it yourself. The UI resolves sigils into live pills with title, status, and links — so you don't need to call GitHub APIs or look up details. Just emit the sigil and the UI does the rest.
+
+- **Instead of fetching PR details**, write `[[pr:123]]` — the UI renders the title, status, and a link.
+- **Instead of listing issues**, write `[[issue:45]]` `[[issue:46]]` — each renders with its current state.
+- **Instead of describing a branch**, write `[[branch:feat/foo]]` — it renders as a badge.
+- **Instead of quoting a commit message**, write `[[commit:abc123]]` — the UI shows the truncated SHA with a diff link.
+- **Instead of summarizing an idea**, write `[[idea:abc123]]` — it renders with the idea's summary and status.
+
+This is faster, always up-to-date, and more interactive than prose. Use sigils aggressively — every reference to a PR, issue, branch, commit, idea, or epic should be a sigil, not plain text.
+</topic>
+
+<topic name="sigils-as-actions">
+You can use sigils to present options the user can click on, instead of asking them to type. For example, when the user asks "show me my open PRs", emit a list of `[[pr:ID]]` sigils — each is clickable and inspectable. If you need to ask "which PR should I look at?", list the sigils and let the user tap one rather than forcing them to remember a number.
+</topic>
+
+<topic name="when-not-to-sigil">
+Sigils relay *references* — they don't replace analysis. If the user asks you to *compare* two PRs, *debug* a CI failure, or *summarize* what changed, you still need to fetch and reason about the data. Use sigils for the references in your response, but do the analytical work yourself.
+</topic>
 </section>
 {{/if}}
 

--- a/packages/cli/src/config/templates/system-prompt.hbs
+++ b/packages/cli/src/config/templates/system-prompt.hbs
@@ -1,3 +1,4 @@
+{{#if isRunner}}
 <section name="spawning-sessions">
 Use the `spawn_session` tool to spawn long-running agent sessions (e.g., tasks that run in the background). Spawned sessions are automatically linked to you as children. Child session events (questions, plans, completion) are delivered as trigger messages in your conversation. No manual session ID plumbing needed — linking is automatic. Triggers arrive automatically as injected messages in your conversation — do NOT poll or wait for them. Do NOT stall your conversation with `sleep` loops or idle waits while a child is running. Simply stop responding — your session will automatically resume when the child's trigger arrives.
 
@@ -12,6 +13,7 @@ Use the `spawn_session` tool to spawn long-running agent sessions (e.g., tasks t
 - Use `tell_child(sessionId, message)` to proactively send a message or instruction to a child session.
 </topic>
 </section>
+{{/if}}
 
 <section name="subagent-tool">
 Use the `subagent` tool to delegate tasks to specialized agents with isolated context. A built-in `task` agent is always available for general-purpose work — use `subagent(agent: "task", task: "...")` to delegate any task without needing an agents folder. Additional agents are defined as markdown files in `~/.pizzapi/agents/` or `~/.claude/agents/` (user scope) and `.pizzapi/agents/` or `.claude/agents/` (project scope). Modes: single (`agent` + `task`), parallel (`tasks` array), chain (`chain` array with `\{{previous}}` placeholder). Set `agentScope: "both"` to include project-local agents.
@@ -31,6 +33,7 @@ Use the `toggle_plan_mode` tool to enter or exit read-only plan mode. Call with 
 
 {{> ask-user-question}}
 
+{{#if isRunner}}
 <section name="tunnels">
 Use `create_tunnel`, `list_tunnels`, and `close_tunnel` to expose local ports through the PizzaPi relay. After starting a dev server (e.g. on port 3000), call `create_tunnel` with that port to get a public URL. The tunnel proxies HTTP and WebSocket traffic through the relay so the web UI can preview it. Tunnels only work when connected to a relay — they are unavailable in offline/local-only sessions.
 </section>
@@ -40,6 +43,11 @@ Runner services can advertise custom trigger types that sessions can subscribe t
 
 Runner services can also advertise sigil types for inline references like `[[type:id]]`. Use `list_available_sigils` to discover which sigils are available on your runner before generating them.
 </section>
+
+<section name="sigil-discovery">
+After naming the conversation with `set_session_name`, immediately call `list_available_sigils` to discover which sigil types (e.g. `[[type:id]]`) are available on this runner. This lets you use inline references in your responses from the start.
+</section>
+{{/if}}
 
 <section name="sandbox">
 This session may run with OS-level sandbox restrictions that control which files you can read/write and which network domains are accessible. If a tool call is blocked by the sandbox, the error message will explain what was blocked and suggest updating the sandbox configuration. Do not attempt to circumvent sandbox restrictions — they are enforced at the OS level.

--- a/packages/cli/src/extensions/trigger-client.test.ts
+++ b/packages/cli/src/extensions/trigger-client.test.ts
@@ -14,6 +14,7 @@ import {
     fireTrigger,
     createTriggerClient,
     getAvailableTriggers,
+    getAvailableSigils,
     subscribeTrigger,
     listTriggerSubscriptions,
     unsubscribeTrigger,
@@ -592,6 +593,46 @@ describe("getAvailableTriggers", () => {
         await getAvailableTriggers("session-abc", deps);
         expect(captured).toHaveLength(1);
         expect(captured[0].url).toBe("http://localhost:7492/api/sessions/session-abc/available-triggers");
+        expect(captured[0].headers["x-api-key"]).toBe("test-api-key");
+    });
+});
+
+describe("getAvailableSigils", () => {
+    test("returns sigil defs from the runner", async () => {
+        const deps = subsDeps(async (_url, _init) => ({
+            ok: true,
+            status: 200,
+            json: async () => ({
+                sigilDefs: [
+                    { type: "pr", label: "Pull Request", aliases: ["mr"] },
+                    { type: "commit", label: "Commit" },
+                ],
+            }),
+        } as Response));
+
+        const defs = await getAvailableSigils("session-1", deps);
+        expect(defs).toHaveLength(2);
+        expect(defs[0].type).toBe("pr");
+        expect(defs[0].aliases).toEqual(["mr"]);
+        expect(defs[1].label).toBe("Commit");
+    });
+
+    test("returns empty array when response is not ok", async () => {
+        const deps = subsDeps(async () => ({ ok: false, status: 404, json: async () => ({}) } as Response));
+        const defs = await getAvailableSigils("session-1", deps);
+        expect(defs).toEqual([]);
+    });
+
+    test("sends request to correct endpoint with API key", async () => {
+        const captured: Array<{ url: string; headers: Record<string, string> }> = [];
+        const deps = subsDeps(async (url, init) => {
+            captured.push({ url, headers: (init?.headers ?? {}) as Record<string, string> });
+            return { ok: true, status: 200, json: async () => ({ sigilDefs: [] }) } as Response;
+        });
+
+        await getAvailableSigils("session-abc", deps);
+        expect(captured).toHaveLength(1);
+        expect(captured[0].url).toBe("http://localhost:7492/api/sessions/session-abc/available-sigils");
         expect(captured[0].headers["x-api-key"]).toBe("test-api-key");
     });
 });

--- a/packages/cli/src/extensions/trigger-client.ts
+++ b/packages/cli/src/extensions/trigger-client.ts
@@ -27,6 +27,7 @@
 
 import { randomUUID } from "node:crypto";
 import { createLogger } from "@pizzapi/tools";
+import type { ServiceSigilDef } from "@pizzapi/protocol";
 import { getRelaySocket as getRelaySocketDefault } from "./remote.js";
 import { loadConfig } from "../config.js";
 
@@ -306,6 +307,8 @@ export interface TriggerSubscription {
     runnerId: string;
 }
 
+export type SigilDef = ServiceSigilDef;
+
 export interface SubscriptionResult {
     ok: boolean;
     triggerType?: string;
@@ -339,6 +342,36 @@ export async function getAvailableTriggers(
         return data.triggerDefs ?? [];
     } catch (err) {
         log.info(`getAvailableTriggers failed: ${err instanceof Error ? err.message : String(err)}`);
+        return [];
+    }
+}
+
+/**
+ * Get available sigil types for a session (from its runner's service catalog).
+ */
+export async function getAvailableSigils(
+    sessionId: string,
+    deps: Partial<TriggerClientDeps> = {},
+): Promise<SigilDef[]> {
+    const d: TriggerClientDeps = { ...defaultDeps, ...deps };
+    const baseUrl = d.getRelayHttpBaseUrl();
+    const apiKey = d.getApiKey();
+
+    if (!baseUrl || !apiKey) {
+        log.info(`getAvailableSigils: no baseUrl/apiKey, returning empty`);
+        return [];
+    }
+
+    try {
+        const url = `${baseUrl}/api/sessions/${encodeURIComponent(sessionId)}/available-sigils`;
+        const response = await d.fetch(url, {
+            headers: { "x-api-key": apiKey },
+        });
+        if (!response.ok) return [];
+        const data = await response.json() as { sigilDefs?: SigilDef[] };
+        return data.sigilDefs ?? [];
+    } catch (err) {
+        log.info(`getAvailableSigils failed: ${err instanceof Error ? err.message : String(err)}`);
         return [];
     }
 }

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -14,6 +14,7 @@ import { getRelaySocket, getRelaySessionId } from "../remote.js";
 import {
     fireTrigger,
     getAvailableTriggers,
+    getAvailableSigils,
     subscribeTrigger,
     listTriggerSubscriptions,
     unsubscribeTrigger,
@@ -536,6 +537,68 @@ export const triggersExtension: ExtensionFactory = (pi) => {
             const subCount = (text.match(/✅/g) ?? []).length;
             const subLabel = subCount > 0 ? `, ${subCount} subscribed` : "";
             return new Text(theme.fg("success", "✓ ") + theme.fg("dim", `${count} trigger(s) available${subLabel}`), 0, 0);
+        },
+    });
+
+    // ── list_available_sigils ───────────────────────────────────────────
+    pi.registerTool({
+        name: "list_available_sigils",
+        label: "List Available Sigils",
+        description:
+            "List sigil types available on this session's runner. " +
+            "Shows all sigils declared by runner services that can be used in [[type:id]] references.",
+        parameters: {
+            type: "object",
+            properties: {
+                sessionId: {
+                    type: "string",
+                    description: "Session ID to query. Defaults to the current session if omitted.",
+                },
+            },
+            required: [],
+        } as any,
+        async execute(_toolCallId, rawParams) {
+            const params = rawParams as { sessionId?: string };
+            const targetId = params.sessionId ?? getOwnSessionId() ?? "";
+            if (!targetId) {
+                return { content: [{ type: "text" as const, text: "Error: Could not determine session ID." }], details: null as any };
+            }
+
+            const defs = await getAvailableSigils(targetId);
+            if (defs.length === 0) {
+                return {
+                    content: [{ type: "text" as const, text: "No sigil types available. The runner may not have any services with declared sigils." }],
+                    details: null as any,
+                };
+            }
+
+            const lines = defs.map((d) => {
+                const aliases = d.aliases && d.aliases.length > 0 ? `\n  Aliases: ${d.aliases.join(", ")}` : "";
+                const resolver = d.resolve ? `\n  Resolve: ${d.resolve}` : "";
+                const service = d.serviceId ? `\n  Service: ${d.serviceId}` : "";
+                return `• ${d.type} — ${d.label}${d.description ? `\n  ${d.description}` : ""}${aliases}${resolver}${service}`;
+            });
+            return {
+                content: [{ type: "text" as const, text: `Available sigils (${defs.length}):\n${lines.join("\n")}` }],
+                details: null as any,
+            };
+        },
+        renderCall: (args: any, theme: any) => {
+            const sid = args.sessionId ? shortId(args.sessionId, 8) : "self";
+            return new Text(
+                theme.fg("accent", "⌘") + " " +
+                theme.fg("muted", "list sigils for ") +
+                theme.fg("dim", sid),
+                0, 0,
+            );
+        },
+        renderResult: (result: any, _opts: any, theme: any) => {
+            const text: string = result?.content?.[0]?.text ?? "";
+            if (text.startsWith("Error") || text.startsWith("No sigil")) {
+                return new Text(theme.fg("muted", preview(text, 60)), 0, 0);
+            }
+            const count = text.match(/Available sigils \((\d+)\)/)?.[1] ?? "?";
+            return new Text(theme.fg("success", "✓ ") + theme.fg("dim", `${count} sigil(s) available`), 0, 0);
         },
     });
 

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -21,7 +21,7 @@ import { TunnelClient } from "@pizzapi/tunnel";
 import { loadGlobalConfig, defaultAgentDir, expandHome, loadConfig } from "../config.js";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
-import type { ServiceTriggerDef } from "@pizzapi/protocol";
+import type { ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
 import { defaultStatePath, acquireStateAndIdentity, releaseStateLock } from "./runner-state.js";
@@ -235,6 +235,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             port?: number;
             /** Trigger types declared in this service's manifest */
             triggers?: ServiceTriggerDef[];
+            /** Sigil types declared in this service's manifest */
+            sigils?: ServiceSigilDef[];
         };
         const panelEntries = new Map<string, PanelEntry>();
 
@@ -243,17 +245,22 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             const allServiceIds = registry.getAll().map((s) => s.id);
             const panels = Array.from(panelEntries.values())
                 .filter((p): p is PanelEntry & { port: number } => p.port != null);
-            // Collect all trigger defs across all services with manifests
+            // Collect all trigger defs and sigil defs across all services with manifests
             const allTriggerDefs: ServiceTriggerDef[] = [];
+            const allSigilDefs: ServiceSigilDef[] = [];
             for (const entry of panelEntries.values()) {
                 if (entry.triggers && entry.triggers.length > 0) {
                     allTriggerDefs.push(...entry.triggers);
+                }
+                if (entry.sigils && entry.sigils.length > 0) {
+                    allSigilDefs.push(...entry.sigils);
                 }
             }
             (socket as any).emit("service_announce", {
                 serviceIds: allServiceIds,
                 ...(panels.length > 0 ? { panels } : {}),
                 ...(allTriggerDefs.length > 0 ? { triggerDefs: allTriggerDefs } : {}),
+                ...(allSigilDefs.length > 0 ? { sigilDefs: allSigilDefs } : {}),
             });
         };
 
@@ -268,7 +275,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     registry.register(handler);
                     logInfo(`[services] loaded plugin service "${handler.id}" from ${source.pluginName ?? source.path}`);
                     // Track panel metadata and trigger defs from folder-based services
-                    if (manifest?.panel || (manifest?.triggers && manifest.triggers.length > 0)) {
+                    if (manifest?.panel || (manifest?.triggers && manifest.triggers.length > 0) || (manifest?.sigils && manifest.sigils.length > 0)) {
                         const existing = panelEntries.get(handler.id);
                         panelEntries.set(handler.id, {
                             serviceId: handler.id,
@@ -277,6 +284,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                             ...(existing?.port !== undefined ? { port: existing.port } : {}),
                             ...(manifest.triggers && manifest.triggers.length > 0
                                 ? { triggers: manifest.triggers }
+                                : {}),
+                            ...(manifest.sigils && manifest.sigils.length > 0
+                                ? { sigils: manifest.sigils }
                                 : {}),
                         });
                     }

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -253,7 +253,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     allTriggerDefs.push(...entry.triggers);
                 }
                 if (entry.sigils && entry.sigils.length > 0) {
-                    allSigilDefs.push(...entry.sigils);
+                    // Stamp serviceId onto each sigil def so the UI can route resolve calls
+                    for (const sigil of entry.sigils) {
+                        allSigilDefs.push({ ...sigil, serviceId: entry.serviceId });
+                    }
                 }
             }
             (socket as any).emit("service_announce", {

--- a/packages/cli/src/runner/service-loader.test.ts
+++ b/packages/cli/src/runner/service-loader.test.ts
@@ -786,4 +786,231 @@ describe("discoverServices — folder-based services", () => {
         const trigger = result.services[0].manifest!.triggers![0];
         expect(trigger.params![0].enum).toEqual(["valid", "also-valid"]);
     });
+
+    // ── Split-file loading tests ──────────────────────────────────────────
+
+    test("triggers.json overrides inline triggers in manifest", async () => {
+        const dir = join(servicesDir, "split-triggers");
+        mkdirSync(dir, { recursive: true });
+        // manifest has inline triggers
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "split-triggers",
+            label: "Split Triggers",
+            triggers: [
+                { type: "inline:event", label: "Inline Event" },
+            ],
+        }));
+        // triggers.json overrides
+        writeFileSync(join(dir, "triggers.json"), JSON.stringify([
+            { type: "file:event_a", label: "File Event A" },
+            { type: "file:event_b", label: "File Event B" },
+        ]));
+        writeFileSync(join(dir, "index.ts"),
+            `export default { id: "split-triggers", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.errors).toHaveLength(0);
+        expect(result.services).toHaveLength(1);
+        const triggers = result.services[0].manifest!.triggers!;
+        expect(triggers).toHaveLength(2);
+        expect(triggers[0].type).toBe("file:event_a");
+        expect(triggers[1].type).toBe("file:event_b");
+    });
+
+    test("sigils.json loads sigil definitions", async () => {
+        const dir = join(servicesDir, "with-sigils");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "with-sigils",
+            label: "With Sigils",
+        }));
+        writeFileSync(join(dir, "sigils.json"), JSON.stringify([
+            {
+                type: "pr",
+                label: "Pull Request",
+                description: "A GitHub pull request",
+                resolve: "/api/resolve/pr/{id}",
+                aliases: ["pull-request", "mr"],
+            },
+            {
+                type: "commit",
+                label: "Commit",
+                resolve: "/api/resolve/commit/{id}",
+            },
+        ]));
+        writeFileSync(join(dir, "index.ts"),
+            `export default { id: "with-sigils", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.errors).toHaveLength(0);
+        expect(result.services).toHaveLength(1);
+        const sigils = result.services[0].manifest!.sigils!;
+        expect(sigils).toHaveLength(2);
+        expect(sigils[0].type).toBe("pr");
+        expect(sigils[0].label).toBe("Pull Request");
+        expect(sigils[0].resolve).toBe("/api/resolve/pr/{id}");
+        expect(sigils[0].aliases).toEqual(["pull-request", "mr"]);
+        expect(sigils[1].type).toBe("commit");
+        expect(sigils[1].aliases).toBeUndefined();
+    });
+
+    test("inline sigils in manifest.json work when no sigils.json exists", async () => {
+        const dir = join(servicesDir, "inline-sigils");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "inline-sigils",
+            label: "Inline Sigils",
+            sigils: [
+                { type: "cost", label: "Cost" },
+            ],
+        }));
+        writeFileSync(join(dir, "index.ts"),
+            `export default { id: "inline-sigils", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.services).toHaveLength(1);
+        expect(result.services[0].manifest!.sigils).toHaveLength(1);
+        expect(result.services[0].manifest!.sigils![0].type).toBe("cost");
+    });
+
+    test("sigils.json overrides inline sigils in manifest", async () => {
+        const dir = join(servicesDir, "sigil-override");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "sigil-override",
+            label: "Sigil Override",
+            sigils: [{ type: "inline", label: "Inline Sigil" }],
+        }));
+        writeFileSync(join(dir, "sigils.json"), JSON.stringify([
+            { type: "file-sigil", label: "File Sigil" },
+        ]));
+        writeFileSync(join(dir, "index.ts"),
+            `export default { id: "sigil-override", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.services).toHaveLength(1);
+        const sigils = result.services[0].manifest!.sigils!;
+        expect(sigils).toHaveLength(1);
+        expect(sigils[0].type).toBe("file-sigil");
+    });
+
+    test("triggers.json supports { triggers: [...] } object format", async () => {
+        const dir = join(servicesDir, "triggers-obj");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "triggers-obj",
+            label: "Triggers Object",
+        }));
+        writeFileSync(join(dir, "triggers.json"), JSON.stringify({
+            triggers: [
+                { type: "obj:event", label: "Object Event" },
+            ],
+        }));
+        writeFileSync(join(dir, "index.ts"),
+            `export default { id: "triggers-obj", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.services).toHaveLength(1);
+        expect(result.services[0].manifest!.triggers).toHaveLength(1);
+        expect(result.services[0].manifest!.triggers![0].type).toBe("obj:event");
+    });
+
+    test("sigils.json supports { sigils: [...] } object format", async () => {
+        const dir = join(servicesDir, "sigils-obj");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "sigils-obj",
+            label: "Sigils Object",
+        }));
+        writeFileSync(join(dir, "sigils.json"), JSON.stringify({
+            sigils: [
+                { type: "cost", label: "Cost" },
+            ],
+        }));
+        writeFileSync(join(dir, "index.ts"),
+            `export default { id: "sigils-obj", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.services).toHaveLength(1);
+        expect(result.services[0].manifest!.sigils).toHaveLength(1);
+        expect(result.services[0].manifest!.sigils![0].type).toBe("cost");
+    });
+
+    test("skips invalid sigil entries (missing type or label)", async () => {
+        const dir = join(servicesDir, "bad-sigils");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "bad-sigils",
+            label: "Bad Sigils",
+        }));
+        writeFileSync(join(dir, "sigils.json"), JSON.stringify([
+            { type: "valid", label: "Valid Sigil" },
+            { type: "no-label" },
+            { label: "No Type" },
+            null,
+            { type: 42, label: "Bad Type Field" },
+            { type: "also-valid", label: "Also Valid", description: 99 },
+        ]));
+        writeFileSync(join(dir, "index.ts"),
+            `export default { id: "bad-sigils", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.services).toHaveLength(1);
+        const sigils = result.services[0].manifest!.sigils!;
+        expect(sigils).toHaveLength(2);
+        expect(sigils[0].type).toBe("valid");
+        expect(sigils[1].type).toBe("also-valid");
+        expect(sigils[1].description).toBeUndefined();
+    });
+
+    test("malformed triggers.json falls through to inline manifest triggers", async () => {
+        const dir = join(servicesDir, "bad-json");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "bad-json",
+            label: "Bad JSON",
+            triggers: [{ type: "fallback:event", label: "Fallback" }],
+        }));
+        writeFileSync(join(dir, "triggers.json"), "this is not json {{{");
+        writeFileSync(join(dir, "index.ts"),
+            `export default { id: "bad-json", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.services).toHaveLength(1);
+        // Falls back to inline triggers
+        expect(result.services[0].manifest!.triggers).toHaveLength(1);
+        expect(result.services[0].manifest!.triggers![0].type).toBe("fallback:event");
+    });
+
+    test("triggers.json and sigils.json both load alongside manifest", async () => {
+        const dir = join(servicesDir, "full-split");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({
+            id: "full-split",
+            label: "Full Split",
+            icon: "github",
+            panel: { dir: "./panel" },
+        }));
+        writeFileSync(join(dir, "triggers.json"), JSON.stringify([
+            { type: "full:trigger_a", label: "Trigger A" },
+        ]));
+        writeFileSync(join(dir, "sigils.json"), JSON.stringify([
+            { type: "pr", label: "Pull Request", resolve: "/api/resolve/pr/{id}" },
+        ]));
+        writeFileSync(join(dir, "index.ts"),
+            `export default { id: "full-split", init() {}, dispose() {} };`);
+
+        const result = await discoverServices();
+        expect(result.errors).toHaveLength(0);
+        expect(result.services).toHaveLength(1);
+        const m = result.services[0].manifest!;
+        expect(m.id).toBe("full-split");
+        expect(m.icon).toBe("github");
+        expect(m.panel).toEqual({ dir: "./panel" });
+        expect(m.triggers).toHaveLength(1);
+        expect(m.triggers![0].type).toBe("full:trigger_a");
+        expect(m.sigils).toHaveLength(1);
+        expect(m.sigils![0].type).toBe("pr");
+        expect(m.sigils![0].resolve).toBe("/api/resolve/pr/{id}");
+    });
 });

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -17,7 +17,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, extname, join, resolve } from "node:path";
 import type { ServiceHandler } from "./service-handler.js";
-import type { ServiceTriggerDef, ServiceTriggerParamDef } from "@pizzapi/protocol";
+import type { ServiceTriggerDef, ServiceTriggerParamDef, ServiceSigilDef } from "@pizzapi/protocol";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -30,8 +30,10 @@ export interface ServiceManifest {
     panel?: {
         dir?: string;
     };
-    /** Trigger types this service can emit. Declared statically in manifest.json. */
+    /** Trigger types this service can emit. Declared in triggers.json or manifest.json. */
     triggers?: ServiceTriggerDef[];
+    /** Sigil types this service defines. Declared in sigils.json or manifest.json. */
+    sigils?: ServiceSigilDef[];
 }
 
 export interface ServicePluginResult {

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -416,6 +416,7 @@ function parseSigils(raw: unknown): ServiceSigilDef[] {
             type: s.type,
             label: s.label,
             description: typeof s.description === "string" ? s.description : undefined,
+            icon: typeof s.icon === "string" ? s.icon : undefined,
             resolve: typeof s.resolve === "string" ? s.resolve : undefined,
             schema: s.schema && typeof s.schema === "object" && !Array.isArray(s.schema)
                 ? s.schema as Record<string, unknown>

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -395,6 +395,36 @@ function parseTriggers(raw: unknown): ServiceTriggerDef[] {
     return triggers;
 }
 
+/**
+ * Parse a raw sigils array (from manifest.json or sigils.json).
+ * Invalid entries are skipped defensively.
+ */
+function parseSigils(raw: unknown): ServiceSigilDef[] {
+    if (!Array.isArray(raw)) return [];
+    const sigils: ServiceSigilDef[] = [];
+    for (const s of raw) {
+        if (!s || typeof s !== "object") continue;
+        if (typeof s.type !== "string" || !s.type) continue;
+        if (typeof s.label !== "string" || !s.label) continue;
+        let aliases: string[] | undefined;
+        if (Array.isArray(s.aliases)) {
+            const valid = s.aliases.filter((a: unknown) => typeof a === "string" && a.length > 0) as string[];
+            if (valid.length > 0) aliases = valid;
+        }
+        sigils.push({
+            type: s.type,
+            label: s.label,
+            description: typeof s.description === "string" ? s.description : undefined,
+            resolve: typeof s.resolve === "string" ? s.resolve : undefined,
+            schema: s.schema && typeof s.schema === "object" && !Array.isArray(s.schema)
+                ? s.schema as Record<string, unknown>
+                : undefined,
+            ...(aliases ? { aliases } : {}),
+        });
+    }
+    return sigils;
+}
+
 function parseServiceManifest(manifestPath: string): ServiceManifest {
     const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
     if (!raw || typeof raw !== "object") {

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -341,6 +341,60 @@ function readServiceDeclarations(pluginDir: string, pluginName: string): Service
 
 // ── Service manifest parsing ──────────────────────────────────────────────────
 
+/**
+ * Parse a raw triggers array (from manifest.json or triggers.json).
+ * Invalid entries are skipped defensively.
+ */
+function parseTriggers(raw: unknown): ServiceTriggerDef[] {
+    if (!Array.isArray(raw)) return [];
+    const triggers: ServiceTriggerDef[] = [];
+    for (const t of raw) {
+        if (!t || typeof t !== "object") continue;
+        if (typeof t.type !== "string" || !t.type) continue;
+        if (typeof t.label !== "string" || !t.label) continue;
+        const params: ServiceTriggerParamDef[] = [];
+        if (Array.isArray(t.params)) {
+            for (const p of t.params) {
+                if (!p || typeof p !== "object") continue;
+                if (typeof p.name !== "string" || !p.name) continue;
+                if (typeof p.label !== "string" || !p.label) continue;
+                const pType = typeof p.type === "string" && ["string", "number", "boolean"].includes(p.type)
+                    ? p.type as "string" | "number" | "boolean"
+                    : "string";
+                let enumVals: Array<string | number | boolean> | undefined;
+                if (Array.isArray(p.enum) && p.enum.length > 0) {
+                    const valid = p.enum.filter(
+                        (v: unknown) => typeof v === "string" || typeof v === "number" || typeof v === "boolean",
+                    ) as Array<string | number | boolean>;
+                    if (valid.length > 0) enumVals = valid;
+                }
+                params.push({
+                    name: p.name,
+                    label: p.label,
+                    type: pType,
+                    description: typeof p.description === "string" ? p.description : undefined,
+                    required: typeof p.required === "boolean" ? p.required : undefined,
+                    default: (typeof p.default === "string" || typeof p.default === "number" || typeof p.default === "boolean")
+                        ? p.default
+                        : undefined,
+                    ...(enumVals ? { enum: enumVals } : {}),
+                    ...(enumVals && p.multiselect === true ? { multiselect: true } : {}),
+                });
+            }
+        }
+        triggers.push({
+            type: t.type,
+            label: t.label,
+            description: typeof t.description === "string" ? t.description : undefined,
+            schema: t.schema && typeof t.schema === "object" && !Array.isArray(t.schema)
+                ? t.schema as Record<string, unknown>
+                : undefined,
+            ...(params.length > 0 ? { params } : {}),
+        });
+    }
+    return triggers;
+}
+
 function parseServiceManifest(manifestPath: string): ServiceManifest {
     const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
     if (!raw || typeof raw !== "object") {
@@ -353,60 +407,7 @@ function parseServiceManifest(manifestPath: string): ServiceManifest {
         throw new Error('manifest.json missing required "label" field');
     }
 
-    // Parse triggers[] — each entry must have a string `type` and `label`.
-    // Invalid entries are skipped (defensive; bad manifests shouldn't crash the daemon).
-    const triggers: ServiceTriggerDef[] = [];
-    if (Array.isArray(raw.triggers)) {
-        for (const t of raw.triggers) {
-            if (!t || typeof t !== "object") continue;
-            if (typeof t.type !== "string" || !t.type) continue;
-            if (typeof t.label !== "string" || !t.label) continue;
-            // Parse params[] — configurable parameters subscribers provide.
-            const params: ServiceTriggerParamDef[] = [];
-            if (Array.isArray(t.params)) {
-                for (const p of t.params) {
-                    if (!p || typeof p !== "object") continue;
-                    if (typeof p.name !== "string" || !p.name) continue;
-                    if (typeof p.label !== "string" || !p.label) continue;
-                    const pType = typeof p.type === "string" && ["string", "number", "boolean"].includes(p.type)
-                        ? p.type as "string" | "number" | "boolean"
-                        : "string";
-                    // Parse enum — must be an array of primitives matching the param type.
-                    let enumVals: Array<string | number | boolean> | undefined;
-                    if (Array.isArray(p.enum) && p.enum.length > 0) {
-                        const valid = p.enum.filter(
-                            (v: unknown) => typeof v === "string" || typeof v === "number" || typeof v === "boolean",
-                        ) as Array<string | number | boolean>;
-                        if (valid.length > 0) enumVals = valid;
-                    }
-
-                    params.push({
-                        name: p.name,
-                        label: p.label,
-                        type: pType,
-                        description: typeof p.description === "string" ? p.description : undefined,
-                        required: typeof p.required === "boolean" ? p.required : undefined,
-                        default: (typeof p.default === "string" || typeof p.default === "number" || typeof p.default === "boolean")
-                            ? p.default
-                            : undefined,
-                        ...(enumVals ? { enum: enumVals } : {}),
-                        // multiselect only makes sense with enum
-                        ...(enumVals && p.multiselect === true ? { multiselect: true } : {}),
-                    });
-                }
-            }
-
-            triggers.push({
-                type: t.type,
-                label: t.label,
-                description: typeof t.description === "string" ? t.description : undefined,
-                schema: t.schema && typeof t.schema === "object" && !Array.isArray(t.schema)
-                    ? t.schema as Record<string, unknown>
-                    : undefined,
-                ...(params.length > 0 ? { params } : {}),
-            });
-        }
-    }
+    const triggers = parseTriggers(raw.triggers);
 
     return {
         id: raw.id,

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -123,7 +123,8 @@ async function loadServicesFromDir(
 
             try {
                 const manifest = parseServiceManifest(manifestPath);
-                const moduleEntry = manifest.entry ?? findDefaultEntry(entryPath);
+                const mergedManifest = loadSplitConfigs(entryPath, manifest);
+                const moduleEntry = mergedManifest.entry ?? findDefaultEntry(entryPath);
                 if (!moduleEntry) {
                     errors.push({
                         path: entryPath,
@@ -145,7 +146,7 @@ async function loadServicesFromDir(
                     services.push({
                         handler,
                         source: { origin, path: entryPath },
-                        manifest,
+                        manifest: mergedManifest,
                     });
                 } else {
                     errors.push({
@@ -438,6 +439,7 @@ function parseServiceManifest(manifestPath: string): ServiceManifest {
     }
 
     const triggers = parseTriggers(raw.triggers);
+    const sigils = parseSigils(raw.sigils);
 
     return {
         id: raw.id,
@@ -448,7 +450,45 @@ function parseServiceManifest(manifestPath: string): ServiceManifest {
             ? { dir: typeof raw.panel.dir === "string" ? raw.panel.dir : undefined }
             : undefined,
         triggers: triggers.length > 0 ? triggers : undefined,
+        sigils: sigils.length > 0 ? sigils : undefined,
     };
+}
+
+/**
+ * Load optional split config files for a folder-based service.
+ * Split files (triggers.json, sigils.json) take precedence over inline
+ * arrays in manifest.json when present.
+ */
+function loadSplitConfigs(serviceDir: string, manifest: ServiceManifest): ServiceManifest {
+    // triggers.json overrides manifest.triggers
+    const triggersPath = join(serviceDir, "triggers.json");
+    if (existsSync(triggersPath)) {
+        try {
+            const raw = JSON.parse(readFileSync(triggersPath, "utf-8"));
+            // triggers.json can be a bare array or { triggers: [...] }
+            const arr = Array.isArray(raw) ? raw : (raw?.triggers ?? raw);
+            const parsed = parseTriggers(arr);
+            manifest = { ...manifest, triggers: parsed.length > 0 ? parsed : undefined };
+        } catch {
+            // Invalid JSON — fall through to manifest.triggers (if any)
+        }
+    }
+
+    // sigils.json overrides manifest.sigils
+    const sigilsPath = join(serviceDir, "sigils.json");
+    if (existsSync(sigilsPath)) {
+        try {
+            const raw = JSON.parse(readFileSync(sigilsPath, "utf-8"));
+            // sigils.json can be a bare array or { sigils: [...] }
+            const arr = Array.isArray(raw) ? raw : (raw?.sigils ?? raw);
+            const parsed = parseSigils(arr);
+            manifest = { ...manifest, sigils: parsed.length > 0 ? parsed : undefined };
+        } catch {
+            // Invalid JSON — fall through to manifest.sigils (if any)
+        }
+    }
+
+    return manifest;
 }
 
 const DEFAULT_ENTRIES = ["index.ts", "index.js", "index.mts", "index.mjs"];

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -284,7 +284,7 @@ async function main(): Promise<void> {
         ...(config.systemPrompt !== undefined && {
             systemPromptOverride: () => config.systemPrompt,
         }),
-        appendSystemPrompt: [buildSystemPrompt({ cwd }), config.appendSystemPrompt, agentSystemPrompt].filter(Boolean).join("\n\n"),
+        appendSystemPrompt: [buildSystemPrompt({ cwd, isRunner: true }), config.appendSystemPrompt, agentSystemPrompt].filter(Boolean).join("\n\n"),
         ...(agentFiles.length > 0 && {
             agentsFilesOverride: (base) => ({
                 agentsFiles: [...base.agentsFiles, ...agentFiles],

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: creating-runner-services
-description: Use when building a new runner service — background processes with optional UI panels and custom triggers that agents can subscribe to
+description: Use when building a new runner service — background processes with optional UI panels, custom triggers agents can subscribe to, or sigils that render inline references in the UI
 ---
 
 # Creating Runner Services
@@ -9,6 +9,7 @@ Runner services are background processes on the runner daemon. They can:
 
 - **Expose a UI panel** — an iframe in the PizzaPi web interface (no React needed)
 - **Advertise custom triggers** — agents discover and subscribe to them at runtime
+- **Define sigils** — teach the UI how to render `[[type:id]]` inline references
 - **Fire triggers** — broadcast events to all subscribed agent sessions via the relay API
 
 ## Folder Structure
@@ -56,6 +57,14 @@ Runner services are background processes on the runner daemon. They can:
           "required": false
         }
       ]
+    }
+  ],
+  "sigils": [
+    {
+      "type": "item",
+      "label": "Item",
+      "description": "Reference an item from My Service",
+      "resolve": "/api/resolve/item/{id}"
     }
   ]
 }
@@ -257,6 +266,17 @@ class MyService {
                     });
                 }
 
+                if (url.pathname.endsWith("/api/resolve/item/abc-123")) {
+                    return Response.json({
+                        id: "abc-123",
+                        title: "Example Item",
+                        href: "https://example.com/items/abc-123",
+                        subtitle: "Open in My Service",
+                    }, {
+                        headers: { "Access-Control-Allow-Origin": "*" },
+                    });
+                }
+
                 if (url.pathname.endsWith("/api/do-thing") && req.method === "POST") {
                     // Fire a trigger when something happens
                     void broadcastTrigger("my-service:something_happened", {
@@ -379,6 +399,7 @@ A service doesn't need a panel. Omit `panel` from manifest.json and skip the `an
 |------|-----|
 | Declare triggers | Add `triggers[]` to `manifest.json` or `triggers.json` |
 | Declare sigils | Add `sigils[]` to `manifest.json` or `sigils.json` |
+| Resolve sigils | Expose an API route matching each sigil's `resolve` template |
 | Fire a trigger | `POST /api/runners/{runnerId}/trigger-broadcast` with API key |
 | Serve static files | `Bun.serve()` with `readFileSync` for index.html |
 | Expose an API | Add route checks in the `fetch` handler |
@@ -392,6 +413,7 @@ A service doesn't need a panel. Omit `panel` from manifest.json and skip the `an
 | Mistake | Fix |
 |---------|-----|
 | Triggers declared but never fired | Use the relay broadcast API — `console.log` doesn't deliver triggers |
+| Sigils declared but not resolvable | Implement the `resolve` API route or omit `resolve` until you have one |
 | Missing runnerId or apiKey | Read from `~/.pizzapi/runner.json` and env vars at call time, not init time |
 | Forgetting `announcePanel()` | Panel won't appear in UI — always call it after server starts |
 | Using absolute API URLs | Tunnel proxy rewrites paths; use relative URLs (`./api/...`) |

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -15,7 +15,9 @@ Runner services are background processes on the runner daemon. They can:
 
 ```
 ~/.pizzapi/services/<service-name>/
-  manifest.json       # Required — declares metadata, panel config, and triggers
+  manifest.json       # Required — core identity (id, label, icon, entry, panel)
+  triggers.json       # Optional — trigger definitions (overrides manifest.triggers)
+  sigils.json         # Optional — sigil type definitions (overrides manifest.sigils)
   index.ts            # ServiceHandler module (default export)
   panel/              # Optional — only needed if the service has a UI panel
     index.html        # Self-contained UI (HTML/CSS/JS)
@@ -66,7 +68,8 @@ Runner services are background processes on the runner daemon. They can:
 | `icon` | No | `"square"` | [Lucide](https://lucide.dev/icons) icon name (kebab-case) |
 | `entry` | No | `./index.ts` | Service module path relative to folder |
 | `panel.dir` | No | `./panel` | Panel static files directory (omit if no panel) |
-| `triggers` | No | `[]` | Array of trigger type definitions (see below) |
+| `triggers` | No | `[]` | Array of trigger type definitions (see below). Can also live in `triggers.json`. |
+| `sigils` | No | `[]` | Array of sigil type definitions (see below). Can also live in `sigils.json`. |
 
 ### Trigger Definitions
 
@@ -135,6 +138,41 @@ Array-valued payload fields also work with scalar subscription params: if the pa
 For substring filtering, name the param with a `Contains` suffix. For example, a trigger with `bodyContains` will match when the payload's `body` field includes the subscriber's text.
 
 Trigger types are advertised to agents via `service_announce` so they can be discovered with `list_available_triggers()` and subscribed to with `subscribe_trigger()`.
+
+> **Split file note:** Triggers can live in a separate `triggers.json` file (bare array or `{ "triggers": [...] }` format). When `triggers.json` exists, it takes precedence over inline `triggers` in `manifest.json`.
+
+## sigils.json
+
+Define sigil types the service teaches the UI to render as `[[type:id]]` inline tokens.
+Can be a bare array or wrapped in `{ "sigils": [...] }`.
+
+```json
+[
+  {
+    "type": "pr",
+    "label": "Pull Request",
+    "description": "A GitHub pull request reference",
+    "resolve": "/api/resolve/pr/{id}",
+    "aliases": ["pull-request", "mr"]
+  },
+  {
+    "type": "commit",
+    "label": "Commit",
+    "resolve": "/api/resolve/commit/{id}"
+  }
+]
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes | Sigil type name used in `[[type:id]]` syntax |
+| `label` | Yes | Human-readable label for the UI |
+| `description` | No | What this sigil represents |
+| `resolve` | No | API path to resolve a sigil ID to display data (e.g. PR number → title) |
+| `schema` | No | JSON Schema for valid sigil params |
+| `aliases` | No | Alternative type names that resolve to this sigil |
+
+When `sigils.json` exists, it takes precedence over inline `sigils` in `manifest.json`.
 
 ## ServiceHandler Template
 
@@ -328,8 +366,8 @@ A service doesn't need a panel. Omit `panel` from manifest.json and skip the `an
 2. Reads manifest.json → extracts panel metadata + trigger definitions
 3. Loads service module → calls init(socket, { announcePanel })
 4. Service starts Bun.serve() on port 0 → calls announcePanel(port)
-5. Daemon aggregates all trigger defs from all services
-6. Daemon emits service_announce with panels[] + triggerDefs[]
+5. Daemon aggregates all trigger defs and sigil defs from all services
+6. Daemon emits service_announce with panels[] + triggerDefs[] + sigilDefs[]
 7. UI renders iframe; agents discover triggers via list_available_triggers()
 8. Service fires triggers via POST /api/runners/{runnerId}/trigger-broadcast
 9. Relay fans out to all subscribed sessions
@@ -339,7 +377,8 @@ A service doesn't need a panel. Omit `panel` from manifest.json and skip the `an
 
 | Task | How |
 |------|-----|
-| Declare triggers | Add `triggers[]` array to `manifest.json` |
+| Declare triggers | Add `triggers[]` to `manifest.json` or `triggers.json` |
+| Declare sigils | Add `sigils[]` to `manifest.json` or `sigils.json` |
 | Fire a trigger | `POST /api/runners/{runnerId}/trigger-broadcast` with API key |
 | Serve static files | `Bun.serve()` with `readFileSync` for index.html |
 | Expose an API | Add route checks in the `fetch` handler |

--- a/packages/docs/src/content/docs/customization/runner-services.mdx
+++ b/packages/docs/src/content/docs/customization/runner-services.mdx
@@ -1,6 +1,6 @@
 ---
 title: Runner Services
-description: Create custom runner services with UI panels and custom triggers that agents can discover and subscribe to.
+description: Create custom runner services with UI panels, custom triggers, and sigils that agents can discover and subscribe to.
 ---
 
 import { Aside, FileTree, Steps } from "@astrojs/starlight/components";
@@ -113,7 +113,145 @@ Services can also be bundled inside Claude Code plugins:
 | `icon` | No | `"square"` | [Lucide](https://lucide.dev/icons) icon name (kebab-case) |
 | `entry` | No | `"./index.ts"` | Service module path relative to the service folder |
 | `panel.dir` | No | `"./panel"` | Panel static files directory (omit if no panel) |
-| `triggers` | No | `[]` | Trigger type definitions (see below) |
+| `triggers` | No | `[]` | Trigger type definitions (see [Custom Triggers](#custom-triggers) below, or use `triggers.json`) |
+| `sigils` | No | `[]` | Sigil type definitions (see [Custom Sigils](#custom-sigils) below, or use `sigils.json`) |
+
+---
+
+## Split Configuration Files
+
+For services with many triggers or sigils, you can split configuration into separate files. Split files take precedence over inline arrays in `manifest.json`.
+
+<FileTree>
+- ~/.pizzapi/services/my-service/
+  - manifest.json — core identity (id, label, icon, entry, panel)
+  - triggers.json — trigger definitions (optional, overrides manifest triggers)
+  - sigils.json — sigil type definitions (optional, overrides manifest sigils)
+  - index.ts — ServiceHandler module
+  - panel/
+    - index.html — self-contained UI (HTML/CSS/JS)
+</FileTree>
+
+### triggers.json
+
+Can be a bare array or an object with a `triggers` key:
+
+```json
+[
+  {
+    "type": "my-service:event_happened",
+    "label": "Event Happened",
+    "description": "Fired when an event occurs",
+    "schema": {
+      "type": "object",
+      "properties": {
+        "path": { "type": "string" }
+      }
+    }
+  }
+]
+```
+
+Or wrapped in an object:
+
+```json
+{
+  "triggers": [
+    {
+      "type": "my-service:event_happened",
+      "label": "Event Happened"
+    }
+  ]
+}
+```
+
+### sigils.json
+
+Defines sigil types this service teaches the UI to render. Can be a bare array or an object with a `sigils` key:
+
+```json
+[
+  {
+    "type": "pr",
+    "label": "Pull Request",
+    "description": "A GitHub pull request reference",
+    "resolve": "/api/resolve/pr/{id}",
+    "aliases": ["pull-request", "mr"]
+  },
+  {
+    "type": "commit",
+    "label": "Commit",
+    "resolve": "/api/resolve/commit/{id}"
+  }
+]
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes | Sigil type name (used in `[[type:id]]` syntax) |
+| `label` | Yes | Human-readable label |
+| `description` | No | What this sigil represents |
+| `resolve` | No | API endpoint path for resolving sigil IDs to display data |
+| `schema` | No | JSON Schema for sigil params |
+| `aliases` | No | Alternative type names that resolve to this sigil |
+
+<Aside type="tip">
+  Split files are optional — inline `triggers` and `sigils` arrays in `manifest.json` continue to work. Use split files when your trigger or sigil definitions are large enough to make `manifest.json` hard to read.
+</Aside>
+
+### Migrating to Split Files
+
+To split an existing `manifest.json`:
+
+<Steps>
+
+1. **Copy the `triggers` array** from `manifest.json` into a new `triggers.json` file (as a bare JSON array).
+
+2. **Remove the `triggers` key** from `manifest.json`.
+
+3. **(Optional)** Create `sigils.json` with any sigil definitions.
+
+4. **Restart the runner** — the daemon will load split files automatically.
+
+</Steps>
+
+**Before** — everything in one file:
+
+```json
+// manifest.json
+{
+  "id": "my-service",
+  "label": "My Service",
+  "icon": "activity",
+  "entry": "./index.ts",
+  "panel": { "dir": "./panel" },
+  "triggers": [
+    { "type": "my-service:event_a", "label": "Event A" },
+    { "type": "my-service:event_b", "label": "Event B" }
+  ]
+}
+```
+
+**After** — split into focused files:
+
+```json
+// manifest.json
+{
+  "id": "my-service",
+  "label": "My Service",
+  "icon": "activity",
+  "entry": "./index.ts",
+  "panel": { "dir": "./panel" }
+}
+```
+
+```json
+// triggers.json
+[
+  { "type": "my-service:event_a", "label": "Event A" },
+  { "type": "my-service:event_b", "label": "Event B" }
+]
+```
 
 ---
 
@@ -393,6 +531,65 @@ The **Triggers panel** in the session viewer shows the live trigger history for 
 
 ---
 
+---
+
+## Custom Sigils
+
+Sigils are `[[type:id]]` tokens in agent output that render as interactive UI elements — clickable chips, status badges, or rich previews. Services define sigil types so the UI knows how to recognise and render them.
+
+<Aside type="note">
+  The Sigils system was originally conceived by [Allen Anthes](https://github.com/AllenAnthes).
+</Aside>
+
+### Declaring Sigils
+
+Add a `sigils` array to `manifest.json`, or create a standalone `sigils.json` file (see [Split Configuration Files](#split-configuration-files)).
+
+Each entry describes a sigil type using the `ServiceSigilDef` schema:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `type` | Yes | Sigil type name — the token in `[[type:id]]` syntax, e.g. `"pr"` |
+| `label` | Yes | Human-readable label shown in the UI, e.g. `"Pull Request"` |
+| `description` | No | What this sigil represents |
+| `resolve` | No | API endpoint path to resolve a sigil ID to display data (e.g. PR number → title/status) |
+| `schema` | No | JSON Schema for sigil params (`[[type:id key=val]]`) |
+| `aliases` | No | Alternative type names that resolve to this sigil (e.g. `["pull-request", "mr"]`) |
+
+### Example: GitHub Service Sigils
+
+A GitHub integration service might define `pr` and `commit` sigil types:
+
+```json
+{
+  "id": "github",
+  "label": "GitHub",
+  "icon": "github",
+  "entry": "./index.ts",
+  "sigils": [
+    {
+      "type": "pr",
+      "label": "Pull Request",
+      "description": "A GitHub pull request — renders as a clickable chip with status",
+      "resolve": "/api/resolve/pr/{id}",
+      "aliases": ["pull-request", "mr"]
+    },
+    {
+      "type": "commit",
+      "label": "Commit",
+      "description": "A Git commit hash — renders with short SHA and message",
+      "resolve": "/api/resolve/commit/{id}"
+    }
+  ]
+}
+```
+
+With these definitions registered, when an agent writes `[[pr:42]]` or `[[commit:abc1234]]` in its output, the UI renders them as interactive elements instead of plain text.
+
+Sigil types are advertised to all connected viewers via the `service_announce` event, the same way trigger definitions are.
+
+---
+
 ### Services Without Panels
 
 A service doesn't need a UI panel. Omit `panel` from the manifest and skip `announcePanel()`. The service still runs in the background and can fire triggers:
@@ -561,8 +758,8 @@ Panels render inside a **280px-tall iframe** in the PizzaPi web interface. Key c
 2. It reads `manifest.json` for panel metadata and trigger definitions
 3. It loads the service module and calls `init(socket, { announcePanel })`
 4. The service starts `Bun.serve()` on port 0 and calls `announcePanel(port)`
-5. The daemon aggregates all trigger defs from all loaded services
-6. The daemon emits a `service_announce` event with the panels and trigger defs
+5. The daemon aggregates all trigger defs and sigil defs from all loaded services
+6. The daemon emits a `service_announce` event with panels, trigger defs, and sigil defs
 7. The UI renders panel iframes; agents discover triggers via `list_available_triggers()`
 8. When a service fires a trigger via `POST /api/runners/{runnerId}/trigger-broadcast`, the relay fans it out to all subscribed sessions
 
@@ -572,7 +769,8 @@ Panels render inside a **280px-tall iframe** in the PizzaPi web interface. Key c
 
 | Task | How |
 |------|-----|
-| Declare triggers | Add `triggers[]` array to `manifest.json` |
+| Declare triggers | Add `triggers[]` to `manifest.json` or `triggers.json` |
+| Declare sigils | Add `sigils[]` to `manifest.json` or `sigils.json` |
 | Fire a trigger | `POST /api/runners/{runnerId}/trigger-broadcast` with API key |
 | Serve static files | `Bun.serve()` with `readFileSync` for `index.html` |
 | Expose an API | Add route checks in the `fetch` handler |

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -19,6 +19,7 @@ export type {
   ServicePanelInfo,
   ServiceTriggerDef,
   ServiceTriggerParamDef,
+  ServiceSigilDef,
   TriggerFilter,
   TriggerFilterMode,
   ServiceAnnounceData,

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -67,6 +67,8 @@ export interface RunnerInfo {
   panels?: ServicePanelInfo[];
   /** Trigger types declared by services on this runner (from service_announce). */
   triggerDefs?: ServiceTriggerDef[];
+  /** Sigil types declared by services on this runner (from service_announce). */
+  sigilDefs?: ServiceSigilDef[];
   /** Active warnings from the runner daemon (e.g. tunnel connection failures). */
   warnings?: string[];
 }
@@ -213,6 +215,38 @@ export interface TriggerFilter {
 /** How multiple filters combine: "and" = all must match, "or" = any must match. */
 export type TriggerFilterMode = "and" | "or";
 
+// ── Service sigil types ───────────────────────────────────────────────────
+
+/**
+ * A sigil type that a service can define.
+ * Declared in a service's sigils.json (or manifest.json) and forwarded via
+ * service_announce so the UI knows how to render [[type:id]] tokens.
+ */
+export interface ServiceSigilDef {
+  /** Sigil type name, e.g. "pr", "commit", "cost" */
+  type: string;
+  /** Human-readable label, e.g. "Pull Request" */
+  label: string;
+  /** Optional description of what this sigil represents */
+  description?: string;
+  /**
+   * Optional resolve endpoint path (relative to service panel).
+   * The UI can call this to enrich display data for a sigil ID.
+   * e.g. "/api/resolve/pr/{id}" → resolves PR number to title/status
+   */
+  resolve?: string;
+  /**
+   * JSON Schema for the sigil's params (key-value pairs in [[type:id key=val]]).
+   * Defines what params are valid for this sigil type.
+   */
+  schema?: Record<string, unknown>;
+  /**
+   * Type aliases — alternative type names that resolve to this sigil.
+   * e.g. ["pull-request", "mr"] for a "pr" sigil type.
+   */
+  aliases?: string[];
+}
+
 /** Payload for the service_announce event. */
 export interface ServiceAnnounceData {
   serviceIds: string[];
@@ -220,6 +254,8 @@ export interface ServiceAnnounceData {
   panels?: ServicePanelInfo[];
   /** Trigger types declared by services on this runner. */
   triggerDefs?: ServiceTriggerDef[];
+  /** Sigil types declared by services on this runner. */
+  sigilDefs?: ServiceSigilDef[];
 }
 
 // ── Tunnel service types ──────────────────────────────────────────────────────

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -230,6 +230,11 @@ export interface ServiceSigilDef {
   /** Optional description of what this sigil represents */
   description?: string;
   /**
+   * Lucide icon name for rendering, e.g. "git-pull-request", "git-branch".
+   * See https://lucide.dev/icons for the full list.
+   */
+  icon?: string;
+  /**
    * Optional resolve endpoint path (relative to service panel).
    * The UI can call this to enrich display data for a sigil ID.
    * e.g. "/api/resolve/pr/{id}" → resolves PR number to title/status

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -227,6 +227,12 @@ export interface ServiceSigilDef {
   type: string;
   /** Human-readable label, e.g. "Pull Request" */
   label: string;
+  /**
+   * ID of the service that registered this sigil type.
+   * Populated by the daemon during aggregation — not set in sigils.json.
+   * Used by the UI to route resolve calls to the correct service panel.
+   */
+  serviceId?: string;
   /** Optional description of what this sigil represents */
   description?: string;
   /**

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -468,6 +468,73 @@ describe("GET /api/sessions/:id/available-triggers", () => {
     });
 });
 
+describe("GET /api/sessions/:id/available-sigils", () => {
+    beforeEach(() => {
+        mockGetSharedSession.mockReset();
+        mockGetRunnerServices.mockReset();
+        mockRequireSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", userName: "TestUser" }),
+        );
+    });
+
+    test("returns sigilDefs from the session's runner", async () => {
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: "runner-A" } as any),
+        );
+        mockGetRunnerServices.mockReturnValue(Promise.resolve({
+            serviceIds: ["github"],
+            sigilDefs: [
+                { type: "pr", label: "Pull Request", aliases: ["mr"] },
+                { type: "commit", label: "Commit" },
+            ],
+        }));
+
+        const [req, url] = makeReq("GET", "/api/sessions/sess-1/available-sigils");
+        const res = await handleTriggersRoute(req, url);
+        expect(res).toBeDefined();
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.sigilDefs).toHaveLength(2);
+        expect(body.sigilDefs[0].type).toBe("pr");
+        expect(body.sigilDefs[0].aliases).toEqual(["mr"]);
+    });
+
+    test("returns empty array when session has no runner", async () => {
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: null } as any),
+        );
+
+        const [req, url] = makeReq("GET", "/api/sessions/sess-1/available-sigils");
+        const res = await handleTriggersRoute(req, url);
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.sigilDefs).toHaveLength(0);
+    });
+
+    test("returns 404 for wrong user", async () => {
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-2", sessionId: "sess-1" } as any),
+        );
+
+        const [req, url] = makeReq("GET", "/api/sessions/sess-1/available-sigils");
+        const res = await handleTriggersRoute(req, url);
+        expect(res!.status).toBe(404);
+    });
+
+    test("returns empty array when runner has no sigil defs", async () => {
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: "runner-A" } as any),
+        );
+        mockGetRunnerServices.mockReturnValue(Promise.resolve({ serviceIds: ["terminal"] }));
+
+        const [req, url] = makeReq("GET", "/api/sessions/sess-1/available-sigils");
+        const res = await handleTriggersRoute(req, url);
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.sigilDefs).toHaveLength(0);
+    });
+});
+
 describe("GET /api/sessions/:id/trigger-subscriptions", () => {
     beforeEach(() => {
         mockGetSharedSession.mockReset();

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -350,6 +350,28 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         return Response.json({ triggerDefs: services?.triggerDefs ?? [] });
     }
 
+    // ── GET /api/sessions/:id/available-sigils ──────────────────────
+    // Returns sigil defs from the session's runner.
+    const availableSigilsMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/available-sigils$/);
+    if (availableSigilsMatch && req.method === "GET") {
+        const identity = await authenticate(req);
+        if (identity instanceof Response) return identity;
+
+        const sessionId = decodeURIComponent(availableSigilsMatch[1]);
+
+        const session = await getSharedSession(sessionId);
+        if (!session || session.userId !== identity.userId) {
+            return Response.json({ error: "Session not found" }, { status: 404 });
+        }
+
+        if (!session.runnerId) {
+            return Response.json({ sigilDefs: [] });
+        }
+
+        const services = await getRunnerServices(session.runnerId);
+        return Response.json({ sigilDefs: services?.sigilDefs ?? [] });
+    }
+
     // ── GET /POST /api/sessions/:id/trigger-subscriptions ────────────
     const subsMatch = url.pathname.match(/^\/api\/sessions\/([^/]+)\/trigger-subscriptions$/);
     if (subsMatch && req.method === "GET") {

--- a/packages/server/src/ws/namespaces/runner.service-announce.test.ts
+++ b/packages/server/src/ws/namespaces/runner.service-announce.test.ts
@@ -151,4 +151,52 @@ describe("isSameServiceAnnounce", () => {
 
         expect(isSameServiceAnnounce(left, right)).toBe(false);
     });
+
+    // ── sigilDefs comparison ─────────────────────────────────────────────
+
+    test("returns true when sigilDefs are identical", () => {
+        const base = {
+            serviceIds: ["github"],
+            sigilDefs: [
+                { type: "pr", label: "PR", icon: "git-pull-request", serviceId: "github", resolve: "/api/resolve/pr/{id}" },
+            ],
+        };
+        expect(isSameServiceAnnounce(base, { ...base })).toBe(true);
+    });
+
+    test("returns false when sigilDef type differs", () => {
+        const left = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR" }] };
+        const right = { serviceIds: ["github"], sigilDefs: [{ type: "issue", label: "PR" }] };
+        expect(isSameServiceAnnounce(left, right)).toBe(false);
+    });
+
+    test("returns false when sigilDef count differs", () => {
+        const left = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR" }] };
+        const right = { serviceIds: ["github"], sigilDefs: [] };
+        expect(isSameServiceAnnounce(left, right)).toBe(false);
+    });
+
+    test("returns false when sigilDef serviceId differs", () => {
+        const left = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR", serviceId: "github" }] };
+        const right = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR", serviceId: "gitlab" }] };
+        expect(isSameServiceAnnounce(left, right)).toBe(false);
+    });
+
+    test("returns false when sigilDef icon differs", () => {
+        const left = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR", icon: "git-pull-request" }] };
+        const right = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR", icon: "circle-dot" }] };
+        expect(isSameServiceAnnounce(left, right)).toBe(false);
+    });
+
+    test("returns false when sigilDef resolve differs", () => {
+        const left = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR", resolve: "/api/v1" }] };
+        const right = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR", resolve: "/api/v2" }] };
+        expect(isSameServiceAnnounce(left, right)).toBe(false);
+    });
+
+    test("treats absent sigilDefs as empty array", () => {
+        const left = { serviceIds: ["github"] };
+        const right = { serviceIds: ["github"], sigilDefs: [] };
+        expect(isSameServiceAnnounce(left, right)).toBe(true);
+    });
 });

--- a/packages/server/src/ws/namespaces/runner.service-announce.ts
+++ b/packages/server/src/ws/namespaces/runner.service-announce.ts
@@ -65,5 +65,30 @@ export function isSameServiceAnnounce(
         }
     }
 
+    // Compare sigil defs
+    const aSigils = a.sigilDefs ?? [];
+    const bSigils = b.sigilDefs ?? [];
+    if (aSigils.length !== bSigils.length) return false;
+    for (let i = 0; i < aSigils.length; i++) {
+        const left = aSigils[i];
+        const right = bSigils[i];
+        if (
+            left.type !== right.type ||
+            left.label !== right.label ||
+            left.description !== right.description ||
+            left.icon !== right.icon ||
+            left.serviceId !== right.serviceId ||
+            left.resolve !== right.resolve
+        ) {
+            return false;
+        }
+        const leftAliases = left.aliases !== undefined ? JSON.stringify(left.aliases) : undefined;
+        const rightAliases = right.aliases !== undefined ? JSON.stringify(right.aliases) : undefined;
+        if (leftAliases !== rightAliases) return false;
+        const leftSchema = left.schema !== undefined ? JSON.stringify(left.schema) : undefined;
+        const rightSchema = right.schema !== undefined ? JSON.stringify(right.schema) : undefined;
+        if (leftSchema !== rightSchema) return false;
+    }
+
     return true;
 }

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -244,6 +244,7 @@ export async function seedServiceAnnounceCache(runnerId: string): Promise<void> 
             serviceIds: persisted.serviceIds,
             panels: persisted.panels,
             triggerDefs: persisted.triggerDefs,
+            sigilDefs: persisted.sigilDefs,
         });
     }
 }
@@ -697,7 +698,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             // Cache in memory for fast lookups
             runnerServiceAnnounce.set(runnerId, data);
             // Persist to Redis so the data survives server restarts
-            void updateRunnerServices(runnerId, data.serviceIds, data.panels, data.triggerDefs).catch((err) => {
+            void updateRunnerServices(runnerId, data.serviceIds, data.panels, data.triggerDefs, data.sigilDefs).catch((err) => {
                 log.error(`failed to persist service_announce to Redis for ${runnerId}:`, err);
             });
             const sessionIds = runnerSessionIds.get(runnerId);

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -325,6 +325,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             // Look up sessions still connected to the relay that belong to this runner.
             // This allows the daemon to re-adopt orphaned worker processes after a restart.
             const existingSessions = await getConnectedSessionsForRunner(result);
+            log.info(`[runner reconnect] runner=${result} existingSessions=${existingSessions.length}`);
 
             // Seed runnerSessionIds so that service_message / service_announce
             // forwarding works immediately for sessions that existed before this
@@ -337,6 +338,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 for (const sid of existingSessions) {
                     sessionSet.add(sid.sessionId);
                 }
+                log.info(`[runner reconnect] runner=${result} seeded runnerSessionIds=[${Array.from(sessionSet).join(",")}]`);
             }
 
             // Seed in-memory service announce cache from Redis.
@@ -686,14 +688,17 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
         // ── service_announce — runner announces available services ────────────
         // Forward to all viewers watching sessions on this runner so they know
         // which services are available.
-        socket.on("service_announce", (data: ServiceAnnounceData) => {
+        socket.on("service_announce", async (data: ServiceAnnounceData) => {
             const runnerId = socket.data.runnerId;
             if (!runnerId) return;
 
             const previous = runnerServiceAnnounce.get(runnerId);
             // Skip no-op announces to avoid redundant Redis writes and fan-out
             // to every viewer on this runner when nothing actually changed.
-            if (isSameServiceAnnounce(previous, data)) return;
+            if (isSameServiceAnnounce(previous, data)) {
+                log.info(`[service_announce] runner=${runnerId} skipped (no-op)`);
+                return;
+            }
 
             // Cache in memory for fast lookups
             runnerServiceAnnounce.set(runnerId, data);
@@ -701,9 +706,28 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             void updateRunnerServices(runnerId, data.serviceIds, data.panels, data.triggerDefs, data.sigilDefs).catch((err) => {
                 log.error(`failed to persist service_announce to Redis for ${runnerId}:`, err);
             });
-            const sessionIds = runnerSessionIds.get(runnerId);
+
+            let sessionIds = runnerSessionIds.get(runnerId);
+            log.info(`[service_announce] runner=${runnerId} initial sessionIds=${sessionIds ? Array.from(sessionIds).join(",") : "<none>"}`);
+
+            // Fallback: after a server restart, the in-memory runnerSessionIds map
+            // can be empty even though relay sessions for this runner are still
+            // connected. Reseed from Redis instead of dropping the fresh announce.
+            if (!sessionIds || sessionIds.size === 0) {
+                const existingSessions = await getConnectedSessionsForRunner(runnerId);
+                if (existingSessions.length > 0) {
+                    const reseeded = new Set(existingSessions.map((s) => s.sessionId));
+                    runnerSessionIds.set(runnerId, reseeded);
+                    sessionIds = reseeded;
+                    log.info(`[service_announce] runner=${runnerId} reseeded sessionIds=${Array.from(reseeded).join(",")}`);
+                } else {
+                    log.info(`[service_announce] runner=${runnerId} no connected sessions after fallback reseed`);
+                }
+            }
+
             if (!sessionIds || sessionIds.size === 0) return;
             for (const sessionId of sessionIds) {
+                log.info(`[service_announce] runner=${runnerId} fanout -> session=${sessionId}`);
                 broadcastToSessionViewers(sessionId, "service_announce", data);
             }
         });

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -276,7 +276,7 @@ export async function updateRunnerServices(
     serviceIds: string[],
     panels?: Array<{ serviceId: string; port: number; label: string; icon: string }>,
     triggerDefs?: Array<{ type: string; label: string; description?: string; schema?: Record<string, unknown> }>,
-    sigilDefs?: Array<{ type: string; label: string; description?: string; resolve?: string; schema?: Record<string, unknown>; aliases?: string[] }>,
+    sigilDefs?: Array<{ type: string; label: string; description?: string; icon?: string; serviceId?: string; resolve?: string; schema?: Record<string, unknown>; aliases?: string[] }>,
 ): Promise<void> {
     const fields: Record<string, string> = {
         serviceIds: JSON.stringify(serviceIds),

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -26,7 +26,7 @@ import {
     deleteRunnerAssociation,
 } from "../sio-state/index.js";
 import { updateRelaySessionRunner } from "../../sessions/store.js";
-import type { RunnerInfo, RunnerSkill, RunnerAgent, RunnerHook, ServiceTriggerDef } from "@pizzapi/protocol";
+import type { RunnerInfo, RunnerSkill, RunnerAgent, RunnerHook, ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
 import {
     localTuiSockets,
     localRunnerSockets,
@@ -276,6 +276,7 @@ export async function updateRunnerServices(
     serviceIds: string[],
     panels?: Array<{ serviceId: string; port: number; label: string; icon: string }>,
     triggerDefs?: Array<{ type: string; label: string; description?: string; schema?: Record<string, unknown> }>,
+    sigilDefs?: Array<{ type: string; label: string; description?: string; resolve?: string; schema?: Record<string, unknown>; aliases?: string[] }>,
 ): Promise<void> {
     const fields: Record<string, string> = {
         serviceIds: JSON.stringify(serviceIds),
@@ -289,6 +290,11 @@ export async function updateRunnerServices(
         fields.triggerDefs = JSON.stringify(triggerDefs);
     } else {
         fields.triggerDefs = "[]";
+    }
+    if (sigilDefs && sigilDefs.length > 0) {
+        fields.sigilDefs = JSON.stringify(sigilDefs);
+    } else {
+        fields.sigilDefs = "[]";
     }
     await updateRunnerFields(runnerId, fields);
     // No broadcast here — service_announce is already forwarded to viewers
@@ -305,6 +311,7 @@ export async function getRunnerServices(
     serviceIds: string[];
     panels?: Array<{ serviceId: string; port: number; label: string; icon: string }>;
     triggerDefs?: ServiceTriggerDef[];
+    sigilDefs?: ServiceSigilDef[];
 } | null> {
     const runner = await getRunnerState(runnerId);
     if (!runner?.serviceIds) return null;
@@ -312,10 +319,12 @@ export async function getRunnerServices(
     if (serviceIds.length === 0) return null;
     const panels = runner.panels ? safeJsonParse(runner.panels) ?? undefined : undefined;
     const triggerDefs = runner.triggerDefs ? safeJsonParse(runner.triggerDefs) ?? undefined : undefined;
+    const sigilDefs = runner.sigilDefs ? safeJsonParse(runner.sigilDefs) ?? undefined : undefined;
     return {
         serviceIds,
         ...(panels && panels.length > 0 ? { panels } : {}),
         ...(triggerDefs && triggerDefs.length > 0 ? { triggerDefs } : {}),
+        ...(sigilDefs && sigilDefs.length > 0 ? { sigilDefs } : {}),
     };
 }
 
@@ -410,6 +419,7 @@ function runnerDataToInfo(r: RedisRunnerData): RunnerInfo {
     const serviceIds: string[] | undefined = r.serviceIds ? safeJsonParse(r.serviceIds) ?? undefined : undefined;
     const panels = r.panels ? safeJsonParse(r.panels) ?? undefined : undefined;
     const triggerDefs = r.triggerDefs ? safeJsonParse(r.triggerDefs) ?? undefined : undefined;
+    const sigilDefs = r.sigilDefs ? safeJsonParse(r.sigilDefs) ?? undefined : undefined;
     const warnings: string[] | undefined = r.warnings ? safeJsonParse(r.warnings) ?? undefined : undefined;
     return {
         runnerId: r.runnerId,
@@ -425,6 +435,7 @@ function runnerDataToInfo(r: RedisRunnerData): RunnerInfo {
         ...(serviceIds ? { serviceIds } : {}),
         ...(panels ? { panels } : {}),
         ...(triggerDefs && triggerDefs.length > 0 ? { triggerDefs } : {}),
+        ...(sigilDefs && sigilDefs.length > 0 ? { sigilDefs } : {}),
         ...(warnings && warnings.length > 0 ? { warnings } : {}),
     };
 }

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -241,6 +241,8 @@ export interface RedisRunnerData {
     panels?: string;
     /** JSON-stringified ServiceTriggerDef[] — trigger defs from last service_announce */
     triggerDefs?: string;
+    /** JSON-stringified ServiceSigilDef[] — sigil defs from last service_announce */
+    sigilDefs?: string;
     /** JSON-stringified string[] — active warnings from the runner daemon */
     warnings?: string;
 }
@@ -377,6 +379,7 @@ function parseRunnerFromHash(hash: Record<string, string>): RedisRunnerData | nu
         serviceIds: hash.serviceIds || undefined,
         panels: hash.panels || undefined,
         triggerDefs: hash.triggerDefs || undefined,
+        sigilDefs: hash.sigilDefs || undefined,
     };
 }
 

--- a/packages/server/src/ws/sio-state/types.ts
+++ b/packages/server/src/ws/sio-state/types.ts
@@ -116,6 +116,8 @@ export interface RedisRunnerData {
     panels?: string;
     /** JSON-stringified ServiceTriggerDef[] — trigger defs from last service_announce */
     triggerDefs?: string;
+    /** JSON-stringified ServiceSigilDef[] — sigil defs from last service_announce */
+    sigilDefs?: string;
     /** JSON-stringified string[] — active warnings from the runner daemon */
     warnings?: string;
 }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4339,7 +4339,7 @@ export function App() {
                     />
                   ) : (
                     <ErrorBoundary level="section" resetKeys={[activeSessionId]}>
-                      <SigilProvider sigilDefs={runnerSigilDefs}>
+                      <SigilProvider sigilDefs={runnerSigilDefs} panels={dynamicPanels} runnerId={activeSessionInfo?.runnerId ?? undefined}>
                       <SessionViewer
                         sessionId={activeSessionId}
                         sessionName={sessionName}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -70,6 +70,7 @@ import { mapUserError } from "@/lib/user-error-message";
 import { getConfirmedMetaSubscriptionTargets } from "@/lib/meta-subscriptions";
 import { evaluateVersionNegotiation } from "@/lib/version-negotiation";
 import { useRunnerServices, attachServiceAnnounceListener, seedServiceCache, setViewerSwitchGeneration } from "@/hooks/useRunnerServices";
+import { SigilProvider } from "@/components/sigils/SigilContext";
 import { ServicePanelButtons, useServicePanelState } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
@@ -3717,7 +3718,7 @@ export function App() {
   }, [activeSessionId, activeSessionInfo?.runnerId, liveSessions]);
 
   // Runner service panels — dynamically discovered
-  const { services: availableServices, panels: dynamicPanels, triggerDefs: runnerTriggerDefs } = useRunnerServices(viewerSocket);
+  const { services: availableServices, panels: dynamicPanels, triggerDefs: runnerTriggerDefs, sigilDefs: runnerSigilDefs } = useRunnerServices(viewerSocket);
   const triggerCounts = useTriggerCount(activeSessionId, viewerSocket);
   const { activePanelIds: activeServicePanels, togglePanel: toggleServicePanel, closePanelById: closeServicePanelById, closeAllPanels: closeAllServicePanels, getPanelPosition: getServicePanelPosition, setPanelPosition: setServicePanelPosition, setEphemeralPanelPosition: setEphemeralServicePanelPosition } = useServicePanelState();
 
@@ -4338,6 +4339,7 @@ export function App() {
                     />
                   ) : (
                     <ErrorBoundary level="section" resetKeys={[activeSessionId]}>
+                      <SigilProvider sigilDefs={runnerSigilDefs}>
                       <SessionViewer
                         sessionId={activeSessionId}
                         sessionName={sessionName}
@@ -4445,6 +4447,7 @@ export function App() {
                           }
                         }}
                       />
+                      </SigilProvider>
                     </ErrorBoundary>
                   )}
                 </div>

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -158,6 +158,19 @@ export function SessionViewer({
 }: SessionViewerProps) {
   // ── Misc local state ──────────────────────────────────────────────────────
   const [composerError, setComposerError] = React.useState<string | null>(null);
+
+  const sendActionSigilResponse = React.useCallback(
+    async (text: string): Promise<boolean> => {
+      if (!onSendInput || !sessionId) return false;
+      try {
+        const result = await Promise.resolve(onSendInput(text));
+        return result !== false;
+      } catch {
+        return false;
+      }
+    },
+    [onSendInput, sessionId],
+  );
   const [showEndSessionDialog, setShowEndSessionDialog] = React.useState(false);
   const [incompleteTriggers, setIncompleteTriggers] = React.useState<IncompleteTriggerItem[]>([]);
   const [showIncompleteTriggerDialog, setShowIncompleteTriggerDialog] = React.useState(false);
@@ -678,6 +691,7 @@ export function SessionViewer({
                       agentActive={agentActive}
                       isLast={index === renderedMessages.length - 1}
                       onTriggerResponse={onTriggerResponse}
+                      onActionSigilResponse={sendActionSigilResponse}
                     />
                   ))}
                 </ConversationContent>

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -19,6 +19,8 @@ import { cjk } from "@streamdown/cjk";
 import { code } from "@streamdown/code";
 import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
+import { rehypeSigils } from "@/lib/sigils/rehype-sigils";
+import { SigilInline } from "@/components/sigils/SigilPill";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import {
   createContext,
@@ -324,6 +326,18 @@ export type MessageResponseProps = ComponentProps<typeof Streamdown>;
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const sigilRehypePlugins = [[rehypeSigils]] as any;
+const sigilAllowedTags = {
+  sigil: [
+    "data-sigil-type",
+    "data-sigil-id",
+    "data-sigil-params",
+    "data-sigil-raw",
+  ],
+};
+const sigilComponents = { sigil: SigilInline };
+
 export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (
     <Streamdown
@@ -332,6 +346,9 @@ export const MessageResponse = memo(
         className
       )}
       plugins={streamdownPlugins}
+      rehypePlugins={sigilRehypePlugins}
+      allowedTags={sigilAllowedTags}
+      components={sigilComponents}
       {...props}
     />
   ),

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -21,6 +21,7 @@ import { math } from "@streamdown/math";
 import { mermaid } from "@streamdown/mermaid";
 import { rehypeSigils } from "@/lib/sigils/rehype-sigils";
 import { SigilInline } from "@/components/sigils/SigilPill";
+import { ActionSigilProvider } from "@/components/sigils/ActionSigilContext";
 import { ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
 import {
   createContext,
@@ -322,7 +323,11 @@ export const MessageBranchPage = ({
   );
 };
 
-export type MessageResponseProps = ComponentProps<typeof Streamdown>;
+export type MessageResponseProps = ComponentProps<typeof Streamdown> & {
+  sigilCanInteract?: boolean;
+  sigilMessageComplete?: boolean;
+  onActionSigilResponse?: (text: string) => Promise<boolean>;
+};
 
 const streamdownPlugins = { cjk, code, math, mermaid };
 
@@ -347,19 +352,31 @@ function SpanOrSigil(props: any) {
 const sigilComponents = { span: SpanOrSigil };
 
 export const MessageResponse = memo(
-  ({ className, ...props }: MessageResponseProps) => (
-    <Streamdown
-      className={cn(
-        "size-full break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
-        className
-      )}
-      plugins={streamdownPlugins}
-      rehypePlugins={sigilRehypePlugins}
-      components={sigilComponents}
-      {...props}
-    />
+  ({ className, sigilCanInteract = false, sigilMessageComplete = true, onActionSigilResponse, ...props }: MessageResponseProps) => (
+    <ActionSigilProvider
+      value={{
+        canInteract: sigilCanInteract,
+        isMessageComplete: sigilMessageComplete,
+        sendResponse: onActionSigilResponse,
+      }}
+    >
+      <Streamdown
+        className={cn(
+          "size-full break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0",
+          className
+        )}
+        plugins={streamdownPlugins}
+        rehypePlugins={sigilRehypePlugins}
+        components={sigilComponents}
+        {...props}
+      />
+    </ActionSigilProvider>
   ),
-  (prevProps, nextProps) => prevProps.children === nextProps.children
+  (prevProps, nextProps) =>
+    prevProps.children === nextProps.children &&
+    prevProps.sigilCanInteract === nextProps.sigilCanInteract &&
+    prevProps.sigilMessageComplete === nextProps.sigilMessageComplete &&
+    prevProps.onActionSigilResponse === nextProps.onActionSigilResponse
 );
 
 MessageResponse.displayName = "MessageResponse";

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -329,10 +329,17 @@ const streamdownPlugins = { cjk, code, math, mermaid };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const sigilRehypePlugins = [[rehypeSigils]] as any;
 
-/** Span override that renders sigil pills when data-sigil-type is present. */
+/** Span override that renders sigil pills or sigil groups. */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function SpanOrSigil(props: any) {
   if (props["data-sigil-type"]) return <SigilInline {...props} />;
+  if (props["data-sigil-group"]) {
+    return (
+      <span className="inline-flex items-center gap-0.5 align-baseline">
+        {props.children}
+      </span>
+    );
+  }
   const { node: _node, ...rest } = props;
   return <span {...rest} />;
 }

--- a/packages/ui/src/components/ai-elements/message.tsx
+++ b/packages/ui/src/components/ai-elements/message.tsx
@@ -328,15 +328,16 @@ const streamdownPlugins = { cjk, code, math, mermaid };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const sigilRehypePlugins = [[rehypeSigils]] as any;
-const sigilAllowedTags = {
-  sigil: [
-    "data-sigil-type",
-    "data-sigil-id",
-    "data-sigil-params",
-    "data-sigil-raw",
-  ],
-};
-const sigilComponents = { sigil: SigilInline };
+
+/** Span override that renders sigil pills when data-sigil-type is present. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function SpanOrSigil(props: any) {
+  if (props["data-sigil-type"]) return <SigilInline {...props} />;
+  const { node: _node, ...rest } = props;
+  return <span {...rest} />;
+}
+
+const sigilComponents = { span: SpanOrSigil };
 
 export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (
@@ -347,7 +348,6 @@ export const MessageResponse = memo(
       )}
       plugins={streamdownPlugins}
       rehypePlugins={sigilRehypePlugins}
-      allowedTags={sigilAllowedTags}
       components={sigilComponents}
       {...props}
     />

--- a/packages/ui/src/components/session-viewer/message-item.tsx
+++ b/packages/ui/src/components/session-viewer/message-item.tsx
@@ -30,6 +30,7 @@ interface SessionMessageItemProps {
     action?: string,
     sourceSessionId?: string,
   ) => boolean | void | Promise<boolean>;
+  onActionSigilResponse?: (text: string) => Promise<boolean>;
 }
 
 /**
@@ -46,6 +47,7 @@ export const SessionMessageItem = React.memo(
     agentActive,
     isLast,
     onTriggerResponse,
+    onActionSigilResponse,
   }: SessionMessageItemProps) => {
     // System messages with structured command result data → standalone card
     if (message.role === "system" && isCommandResult(message.content)) {
@@ -88,6 +90,7 @@ export const SessionMessageItem = React.memo(
               undefined,
               message.details,
               onTriggerResponse,
+              onActionSigilResponse,
             )}
           </div>
         );
@@ -112,6 +115,7 @@ export const SessionMessageItem = React.memo(
             message.subAgentTurns,
             message.details,
             onTriggerResponse,
+            onActionSigilResponse,
           )}
         </div>
       );
@@ -169,6 +173,7 @@ export const SessionMessageItem = React.memo(
               undefined, // subAgentTurns
               message.details,
               onTriggerResponse,
+              onActionSigilResponse,
             )}
             {message.stopReason === "error" && message.errorMessage && (
               <div className="mt-2 flex items-start gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">
@@ -187,6 +192,7 @@ export const SessionMessageItem = React.memo(
     if ((prev.isLast || next.isLast) && prev.agentActive !== next.agentActive) return false;
     if (prev.activeToolCalls !== next.activeToolCalls) return false;
     if (prev.onTriggerResponse !== next.onTriggerResponse) return false;
+    if (prev.onActionSigilResponse !== next.onActionSigilResponse) return false;
     return true;
   },
 );

--- a/packages/ui/src/components/session-viewer/rendering.tsx
+++ b/packages/ui/src/components/session-viewer/rendering.tsx
@@ -104,6 +104,7 @@ export function renderContent(
   subAgentTurns?: SubAgentTurn[],
   details?: unknown,
   onTriggerResponse?: (triggerId: string, response: string, action?: string, sourceSessionId?: string) => boolean | void | Promise<boolean>,
+  onActionSigilResponse?: (text: string) => Promise<boolean>,
 ) {
   // Structured command result cards (MCP, plugins, skills)
   if (role === "system" && isCommandResult(content)) {
@@ -160,7 +161,15 @@ export function renderContent(
         />
       );
     }
-    return <MessageResponse>{content}</MessageResponse>;
+    return (
+      <MessageResponse
+        sigilCanInteract={role === "assistant"}
+        sigilMessageComplete={!isThinkingActive}
+        onActionSigilResponse={onActionSigilResponse}
+      >
+        {content}
+      </MessageResponse>
+    );
   }
 
   if (Array.isArray(content)) {
@@ -186,7 +195,12 @@ export function renderContent(
             if (serverToolCard) return serverToolCard;
 
             return (
-              <MessageResponse key={i}>
+              <MessageResponse
+                key={i}
+                sigilCanInteract={role === "assistant"}
+                sigilMessageComplete={!isThinkingActive}
+                onActionSigilResponse={onActionSigilResponse}
+              >
                 {typeof b.text === "string" ? b.text : ""}
               </MessageResponse>
             );

--- a/packages/ui/src/components/sigils/ActionSigil.tsx
+++ b/packages/ui/src/components/sigils/ActionSigil.tsx
@@ -1,0 +1,129 @@
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
+import { buildActionResponse, parseActionSigil } from "@/lib/sigils/actions";
+import { useActionSigilRuntime } from "./ActionSigilContext";
+
+export interface ActionSigilProps {
+  variant: string;
+  params: Record<string, string>;
+  raw: string;
+}
+
+export function ActionSigil({ variant, params, raw }: ActionSigilProps) {
+  const runtime = useActionSigilRuntime();
+  const parsed = useMemo(() => parseActionSigil(variant, params), [variant, params]);
+  const [pending, setPending] = useState(false);
+  const [submittedValue, setSubmittedValue] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [inputValue, setInputValue] = useState("");
+
+  if (!parsed.ok) {
+    return <RawActionSigil raw={raw} />;
+  }
+
+  const action = parsed.action;
+
+  if (!runtime.canInteract && runtime.isMessageComplete) {
+    return <RawActionSigil raw={raw} />;
+  }
+
+  const disabled = pending || submittedValue !== null || !runtime.canInteract || !runtime.isMessageComplete;
+
+  const submit = async (value: string) => {
+    if (disabled || !runtime.sendResponse) return;
+    setPending(true);
+    setError(null);
+    const ok = await runtime.sendResponse(buildActionResponse(action, value)).catch(() => false);
+    if (ok) {
+      setSubmittedValue(value);
+      setPending(false);
+      return;
+    }
+    setPending(false);
+    setError("Failed to send response.");
+  };
+
+  return (
+    <span className="inline-flex max-w-full align-baseline">
+      <span
+        className={cn(
+          "inline-flex max-w-full flex-wrap items-center gap-1.5 rounded-xl border px-2 py-1 text-xs",
+          "bg-muted/50 text-foreground border-border",
+        )}
+        data-sigil={raw}
+      >
+        <span className="font-medium text-muted-foreground">{action.question}</span>
+        {action.kind === "confirm" && (
+          <>
+            <Button size="sm" type="button" disabled={disabled} onClick={() => void submit("confirm")}>
+              Confirm
+            </Button>
+            <Button size="sm" type="button" variant="outline" disabled={disabled} onClick={() => void submit("cancel")}>
+              Cancel
+            </Button>
+          </>
+        )}
+        {action.kind === "choose" && action.options.map((option) => (
+          <Button
+            key={option}
+            size="sm"
+            type="button"
+            variant="outline"
+            disabled={disabled}
+            onClick={() => void submit(option)}
+          >
+            {option}
+          </Button>
+        ))}
+        {action.kind === "input" && (
+          <>
+            <Input
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              placeholder={action.placeholder}
+              disabled={disabled}
+              className="h-8 w-40"
+              aria-label={action.question}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  const value = inputValue.trim();
+                  if (!value || disabled) return;
+                  void submit(value);
+                }
+              }}
+            />
+            <Button
+              size="sm"
+              type="button"
+              disabled={disabled || inputValue.trim().length === 0}
+              onClick={() => void submit(inputValue.trim())}
+            >
+              Submit
+            </Button>
+          </>
+        )}
+        {pending && <span className="text-[11px] text-muted-foreground">Sending…</span>}
+        {submittedValue !== null && (
+          <span className="rounded-full bg-primary/10 px-2 py-0.5 text-[11px] font-medium text-primary">
+            Sent: {submittedValue}
+          </span>
+        )}
+        {!runtime.isMessageComplete && (
+          <span className="text-[11px] text-muted-foreground">Waiting for message to finish…</span>
+        )}
+        {error && <span className="text-[11px] text-destructive">{error}</span>}
+      </span>
+    </span>
+  );
+}
+
+function RawActionSigil({ raw }: { raw: string }) {
+  return (
+    <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px] text-muted-foreground">
+      {raw}
+    </code>
+  );
+}

--- a/packages/ui/src/components/sigils/ActionSigilContext.tsx
+++ b/packages/ui/src/components/sigils/ActionSigilContext.tsx
@@ -1,0 +1,26 @@
+import { createContext, useContext, type ReactNode } from "react";
+
+export interface ActionSigilRuntime {
+  canInteract: boolean;
+  isMessageComplete: boolean;
+  sendResponse?: (text: string) => Promise<boolean>;
+}
+
+const ActionSigilContext = createContext<ActionSigilRuntime>({
+  canInteract: false,
+  isMessageComplete: false,
+});
+
+export function ActionSigilProvider({
+  value,
+  children,
+}: {
+  value: ActionSigilRuntime;
+  children: ReactNode;
+}) {
+  return <ActionSigilContext.Provider value={value}>{children}</ActionSigilContext.Provider>;
+}
+
+export function useActionSigilRuntime() {
+  return useContext(ActionSigilContext);
+}

--- a/packages/ui/src/components/sigils/SigilContext.tsx
+++ b/packages/ui/src/components/sigils/SigilContext.tsx
@@ -74,7 +74,7 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
   // Resolve cache: keyed by "type:id". Lives in a ref for instant reads.
   // A version counter in state triggers re-renders when data arrives.
   const cacheRef = useRef(new Map<string, SigilResolveState>());
-  const [, setVersion] = useState(0);
+  const [version, setVersion] = useState(0);
   const bump = useCallback(() => setVersion((v) => v + 1), []);
 
   // Build panel port lookup: serviceId → port
@@ -130,9 +130,11 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
     [registry, panelPortMap, runnerId, bump],
   );
 
+  // Include version so consumers re-render when resolve data arrives
   const contextValue = useMemo<SigilContextValue>(
     () => ({ registry, resolve, triggerResolve }),
-    [registry, resolve, triggerResolve],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [registry, resolve, triggerResolve, version],
   );
 
   return <SigilCtx.Provider value={contextValue}>{children}</SigilCtx.Provider>;

--- a/packages/ui/src/components/sigils/SigilContext.tsx
+++ b/packages/ui/src/components/sigils/SigilContext.tsx
@@ -1,0 +1,34 @@
+/**
+ * SigilContext — provides the SigilRegistry to sigil components.
+ *
+ * Wrap your message rendering tree in <SigilProvider> and sigil pills
+ * will automatically pick up type configs and service definitions.
+ */
+import { createContext, useContext, useMemo } from "react";
+import type { ServiceSigilDef } from "@pizzapi/protocol";
+import { SigilRegistry, createRegistry } from "@/lib/sigils/registry";
+
+const SigilRegistryContext = createContext<SigilRegistry>(createRegistry());
+
+export function useSigilRegistry(): SigilRegistry {
+  return useContext(SigilRegistryContext);
+}
+
+interface SigilProviderProps {
+  sigilDefs: ServiceSigilDef[];
+  children: React.ReactNode;
+}
+
+/**
+ * Provider that creates a SigilRegistry from service definitions
+ * and makes it available to all SigilPill components in the tree.
+ */
+export function SigilProvider({ sigilDefs, children }: SigilProviderProps) {
+  const registry = useMemo(() => createRegistry(sigilDefs), [sigilDefs]);
+
+  return (
+    <SigilRegistryContext.Provider value={registry}>
+      {children}
+    </SigilRegistryContext.Provider>
+  );
+}

--- a/packages/ui/src/components/sigils/SigilContext.tsx
+++ b/packages/ui/src/components/sigils/SigilContext.tsx
@@ -32,14 +32,23 @@ interface SigilResolveState {
 
 interface SigilContextValue {
   registry: SigilRegistry;
+  /** Read current resolve state for a sigil. */
   resolve: (type: string, id: string) => SigilResolveState;
+  /** Kick off a resolve fetch (no-op if already cached). */
   triggerResolve: (type: string, id: string, params?: Record<string, string>) => void;
+  /**
+   * Monotonically increasing counter that bumps whenever infrastructure
+   * changes (server restart, reconnect) or resolve data arrives.
+   * Pills include this in useEffect deps to re-trigger resolve after cache invalidation.
+   */
+  generation: number;
 }
 
 const SigilCtx = createContext<SigilContextValue>({
   registry: createRegistry(),
   resolve: () => ({ loading: false }),
   triggerResolve: () => {},
+  generation: 0,
 });
 
 export function useSigilRegistry(): SigilRegistry {
@@ -53,6 +62,10 @@ export function useSigilResolve(type: string, id: string) {
 
 export function useSigilTriggerResolve() {
   return useContext(SigilCtx).triggerResolve;
+}
+
+export function useSigilGeneration() {
+  return useContext(SigilCtx).generation;
 }
 
 // ── Provider ─────────────────────────────────────────────────────────────────
@@ -71,18 +84,9 @@ interface SigilProviderProps {
 export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilProviderProps) {
   const registry = useMemo(() => createRegistry(sigilDefs), [sigilDefs]);
 
-  // Resolve cache: keyed by "type:id". Lives in a ref for instant reads.
-  // A version counter in state triggers re-renders when data arrives.
+  // Resolve cache: keyed by "gen:type:id". Lives in a ref for instant reads.
   const cacheRef = useRef(new Map<string, SigilResolveState>());
-  const [version, setVersion] = useState(0);
-  const bump = useCallback(() => setVersion((v) => v + 1), []);
-
-  // Clear cache when infrastructure changes (server restart, reconnect)
-  // so stale entries don't block re-fetching with new panel ports.
-  useEffect(() => {
-    cacheRef.current.clear();
-    bump();
-  }, [panels, runnerId, sigilDefs, bump]);
+  const [generation, setGeneration] = useState(0);
 
   // Build panel port lookup: serviceId → port
   const panelPortMap = useMemo(() => {
@@ -90,6 +94,20 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
     for (const p of panels) map.set(p.serviceId, p.port);
     return map;
   }, [panels]);
+
+  // Bump generation and clear cache when infrastructure changes.
+  // This invalidates all cached entries and causes pills to re-trigger
+  // resolve via the generation dep in their useEffect.
+  const prevInfraRef = useRef({ panels, runnerId, sigilDefs });
+  useEffect(() => {
+    const prev = prevInfraRef.current;
+    // Skip the initial mount — only invalidate on actual changes
+    if (prev.panels !== panels || prev.runnerId !== runnerId || prev.sigilDefs !== sigilDefs) {
+      cacheRef.current.clear();
+      setGeneration((g) => g + 1);
+    }
+    prevInfraRef.current = { panels, runnerId, sigilDefs };
+  }, [panels, runnerId, sigilDefs]);
 
   const resolve = useCallback(
     (type: string, id: string): SigilResolveState => {
@@ -118,35 +136,33 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
       const resolvePath = def.resolve.replace("{id}", encodeURIComponent(id));
       const qs = params && Object.keys(params).length > 0
         ? "?" + new URLSearchParams(
-            Object.entries(params).filter(([k]) => !['label', 'link', 'href'].includes(k))
+            Object.entries(params).filter(([k]) => !["label", "link", "href"].includes(k)),
           ).toString()
         : "";
       const url = `/api/tunnel/runner/${encodeURIComponent(runnerId)}/${port}${resolvePath}${qs}`;
 
       // Mark as loading
       cache.set(key, { loading: true });
-      bump();
+      setGeneration((g) => g + 1);
 
       fetch(url)
         .then(async (res) => {
           if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
           const data = (await res.json()) as SigilResolveData;
           cache.set(key, { data, loading: false });
-          bump();
+          setGeneration((g) => g + 1);
         })
         .catch((err) => {
           cache.set(key, { loading: false, error: String(err) });
-          bump();
+          setGeneration((g) => g + 1);
         });
     },
-    [registry, panelPortMap, runnerId, bump],
+    [registry, panelPortMap, runnerId],
   );
 
-  // Include version so consumers re-render when resolve data arrives
   const contextValue = useMemo<SigilContextValue>(
-    () => ({ registry, resolve, triggerResolve }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [registry, resolve, triggerResolve, version],
+    () => ({ registry, resolve, triggerResolve, generation }),
+    [registry, resolve, triggerResolve, generation],
   );
 
   return <SigilCtx.Provider value={contextValue}>{children}</SigilCtx.Provider>;

--- a/packages/ui/src/components/sigils/SigilContext.tsx
+++ b/packages/ui/src/components/sigils/SigilContext.tsx
@@ -33,7 +33,7 @@ interface SigilResolveState {
 interface SigilContextValue {
   registry: SigilRegistry;
   resolve: (type: string, id: string) => SigilResolveState;
-  triggerResolve: (type: string, id: string) => void;
+  triggerResolve: (type: string, id: string, params?: Record<string, string>) => void;
 }
 
 const SigilCtx = createContext<SigilContextValue>({
@@ -93,7 +93,7 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
   );
 
   const triggerResolve = useCallback(
-    (type: string, id: string) => {
+    (type: string, id: string, params?: Record<string, string>) => {
       const key = `${type}:${id}`;
       const cache = cacheRef.current;
 
@@ -107,9 +107,14 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
       const port = panelPortMap.get(def.serviceId);
       if (!port) return;
 
-      // Build the resolve URL through the tunnel proxy
+      // Build the resolve URL through the tunnel proxy, forwarding params as query string
       const resolvePath = def.resolve.replace("{id}", encodeURIComponent(id));
-      const url = `/api/tunnel/runner/${encodeURIComponent(runnerId)}/${port}${resolvePath}`;
+      const qs = params && Object.keys(params).length > 0
+        ? "?" + new URLSearchParams(
+            Object.entries(params).filter(([k]) => !['label', 'link', 'href'].includes(k))
+          ).toString()
+        : "";
+      const url = `/api/tunnel/runner/${encodeURIComponent(runnerId)}/${port}${resolvePath}${qs}`;
 
       // Mark as loading
       cache.set(key, { loading: true });

--- a/packages/ui/src/components/sigils/SigilContext.tsx
+++ b/packages/ui/src/components/sigils/SigilContext.tsx
@@ -1,34 +1,135 @@
 /**
- * SigilContext — provides the SigilRegistry to sigil components.
+ * SigilContext — provides the SigilRegistry and resolve infrastructure
+ * to sigil components.
  *
  * Wrap your message rendering tree in <SigilProvider> and sigil pills
- * will automatically pick up type configs and service definitions.
+ * will automatically pick up type configs, service definitions, and
+ * resolve enriched data from service endpoints.
  */
-import { createContext, useContext, useMemo } from "react";
-import type { ServiceSigilDef } from "@pizzapi/protocol";
+import { createContext, useCallback, useContext, useMemo, useRef } from "react";
+import type { ServiceSigilDef, ServicePanelInfo } from "@pizzapi/protocol";
 import { SigilRegistry, createRegistry } from "@/lib/sigils/registry";
 
-const SigilRegistryContext = createContext<SigilRegistry>(createRegistry());
+// ── Resolve types ────────────────────────────────────────────────────────────
+
+export interface SigilResolveData {
+  title?: string;
+  status?: string;
+  author?: string;
+  url?: string;
+  description?: string;
+  icon?: string;
+  [key: string]: unknown;
+}
+
+interface SigilResolveState {
+  data?: SigilResolveData;
+  loading: boolean;
+  error?: string;
+}
+
+// ── Context ──────────────────────────────────────────────────────────────────
+
+interface SigilContextValue {
+  registry: SigilRegistry;
+  resolve: (type: string, id: string) => SigilResolveState;
+  triggerResolve: (type: string, id: string) => void;
+}
+
+const SigilCtx = createContext<SigilContextValue>({
+  registry: createRegistry(),
+  resolve: () => ({ loading: false }),
+  triggerResolve: () => {},
+});
 
 export function useSigilRegistry(): SigilRegistry {
-  return useContext(SigilRegistryContext);
+  return useContext(SigilCtx).registry;
 }
+
+export function useSigilResolve(type: string, id: string) {
+  const ctx = useContext(SigilCtx);
+  return ctx.resolve(type, id);
+}
+
+export function useSigilTriggerResolve() {
+  return useContext(SigilCtx).triggerResolve;
+}
+
+// ── Provider ─────────────────────────────────────────────────────────────────
 
 interface SigilProviderProps {
   sigilDefs: ServiceSigilDef[];
+  panels: ServicePanelInfo[];
+  runnerId?: string;
   children: React.ReactNode;
 }
 
 /**
  * Provider that creates a SigilRegistry from service definitions
- * and makes it available to all SigilPill components in the tree.
+ * and manages resolve endpoint calls for enriching sigil display data.
  */
-export function SigilProvider({ sigilDefs, children }: SigilProviderProps) {
+export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilProviderProps) {
   const registry = useMemo(() => createRegistry(sigilDefs), [sigilDefs]);
 
-  return (
-    <SigilRegistryContext.Provider value={registry}>
-      {children}
-    </SigilRegistryContext.Provider>
+  // Resolve cache: keyed by "type:id"
+  const cacheRef = useRef(new Map<string, SigilResolveState>());
+  // Force re-render tracking
+  const subscribersRef = useRef(new Set<() => void>());
+
+  // Build panel port lookup: serviceId → port
+  const panelPortMap = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const p of panels) map.set(p.serviceId, p.port);
+    return map;
+  }, [panels]);
+
+  const resolve = useCallback(
+    (type: string, id: string): SigilResolveState => {
+      const key = `${type}:${id}`;
+      return cacheRef.current.get(key) ?? { loading: false };
+    },
+    [],
   );
+
+  const triggerResolve = useCallback(
+    (type: string, id: string) => {
+      const key = `${type}:${id}`;
+      const cache = cacheRef.current;
+
+      // Already resolved or in-flight
+      if (cache.has(key)) return;
+
+      const canonical = registry.resolveType(type);
+      const def = registry.getServiceDef(canonical);
+      if (!def?.resolve || !def.serviceId || !runnerId) return;
+
+      const port = panelPortMap.get(def.serviceId);
+      if (!port) return;
+
+      // Build the resolve URL through the tunnel proxy
+      const resolvePath = def.resolve.replace("{id}", encodeURIComponent(id));
+      const url = `/api/tunnel/runner/${encodeURIComponent(runnerId)}/${port}${resolvePath}`;
+
+      // Mark as loading
+      cache.set(key, { loading: true });
+
+      fetch(url)
+        .then(async (res) => {
+          if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+          const data = (await res.json()) as SigilResolveData;
+          cache.set(key, { data, loading: false });
+        })
+        .catch((err) => {
+          cache.set(key, { loading: false, error: String(err) });
+        });
+    },
+    [registry, panelPortMap, runnerId],
+  );
+
+  const contextValue = useMemo<SigilContextValue>(
+    () => ({ registry, resolve, triggerResolve }),
+    [registry, resolve, triggerResolve],
+  );
+
+  return <SigilCtx.Provider value={contextValue}>{children}</SigilCtx.Provider>;
 }

--- a/packages/ui/src/components/sigils/SigilContext.tsx
+++ b/packages/ui/src/components/sigils/SigilContext.tsx
@@ -6,7 +6,7 @@
  * will automatically pick up type configs, service definitions, and
  * resolve enriched data from service endpoints.
  */
-import { createContext, useCallback, useContext, useMemo, useRef } from "react";
+import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
 import type { ServiceSigilDef, ServicePanelInfo } from "@pizzapi/protocol";
 import { SigilRegistry, createRegistry } from "@/lib/sigils/registry";
 
@@ -71,10 +71,11 @@ interface SigilProviderProps {
 export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilProviderProps) {
   const registry = useMemo(() => createRegistry(sigilDefs), [sigilDefs]);
 
-  // Resolve cache: keyed by "type:id"
+  // Resolve cache: keyed by "type:id". Lives in a ref for instant reads.
+  // A version counter in state triggers re-renders when data arrives.
   const cacheRef = useRef(new Map<string, SigilResolveState>());
-  // Force re-render tracking
-  const subscribersRef = useRef(new Set<() => void>());
+  const [, setVersion] = useState(0);
+  const bump = useCallback(() => setVersion((v) => v + 1), []);
 
   // Build panel port lookup: serviceId → port
   const panelPortMap = useMemo(() => {
@@ -112,18 +113,21 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
 
       // Mark as loading
       cache.set(key, { loading: true });
+      bump();
 
       fetch(url)
         .then(async (res) => {
           if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
           const data = (await res.json()) as SigilResolveData;
           cache.set(key, { data, loading: false });
+          bump();
         })
         .catch((err) => {
           cache.set(key, { loading: false, error: String(err) });
+          bump();
         });
     },
-    [registry, panelPortMap, runnerId],
+    [registry, panelPortMap, runnerId, bump],
   );
 
   const contextValue = useMemo<SigilContextValue>(

--- a/packages/ui/src/components/sigils/SigilContext.tsx
+++ b/packages/ui/src/components/sigils/SigilContext.tsx
@@ -6,7 +6,7 @@
  * will automatically pick up type configs, service definitions, and
  * resolve enriched data from service endpoints.
  */
-import { createContext, useCallback, useContext, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import type { ServiceSigilDef, ServicePanelInfo } from "@pizzapi/protocol";
 import { SigilRegistry, createRegistry } from "@/lib/sigils/registry";
 
@@ -76,6 +76,13 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
   const cacheRef = useRef(new Map<string, SigilResolveState>());
   const [version, setVersion] = useState(0);
   const bump = useCallback(() => setVersion((v) => v + 1), []);
+
+  // Clear cache when infrastructure changes (server restart, reconnect)
+  // so stale entries don't block re-fetching with new panel ports.
+  useEffect(() => {
+    cacheRef.current.clear();
+    bump();
+  }, [panels, runnerId, sigilDefs, bump]);
 
   // Build panel port lookup: serviceId → port
   const panelPortMap = useMemo(() => {

--- a/packages/ui/src/components/sigils/SigilIcon.tsx
+++ b/packages/ui/src/components/sigils/SigilIcon.tsx
@@ -1,0 +1,92 @@
+/**
+ * SigilIcon — renders a Lucide icon by string name.
+ *
+ * Uses a static map of icons commonly used by sigil types. Service-provided
+ * icon names that aren't in the map fall back to HashIcon.
+ *
+ * To add support for more icons, just add them to ICON_MAP — they're
+ * tree-shaken by Vite so only imported icons ship in the bundle.
+ */
+import type { ComponentProps } from "react";
+import {
+  FileIcon,
+  GitPullRequestIcon,
+  CircleDotIcon,
+  GitCommitHorizontalIcon,
+  GitBranchIcon,
+  BookMarkedIcon,
+  CheckCircleIcon,
+  CircleIcon,
+  AlertTriangleIcon,
+  DollarSignIcon,
+  ClockIcon,
+  TerminalIcon,
+  BrainIcon,
+  TerminalSquareIcon,
+  TagIcon,
+  FlaskConicalIcon,
+  ExternalLinkIcon,
+  DiffIcon,
+  HashIcon,
+  GithubIcon,
+  PackageIcon,
+  ShieldIcon,
+  ZapIcon,
+  DatabaseIcon,
+  GlobeIcon,
+  KeyIcon,
+  LockIcon,
+  UserIcon,
+  FolderIcon,
+  SettingsIcon,
+  ServerIcon,
+  ActivityIcon,
+  BellIcon,
+  MessageSquareIcon,
+} from "lucide-react";
+
+type IconProps = ComponentProps<typeof HashIcon>;
+
+const ICON_MAP: Record<string, React.ComponentType<IconProps>> = {
+  // Core sigil icons
+  file: FileIcon,
+  "git-pull-request": GitPullRequestIcon,
+  "circle-dot": CircleDotIcon,
+  "git-commit-horizontal": GitCommitHorizontalIcon,
+  "git-branch": GitBranchIcon,
+  "book-marked": BookMarkedIcon,
+  "check-circle": CheckCircleIcon,
+  circle: CircleIcon,
+  "alert-triangle": AlertTriangleIcon,
+  "dollar-sign": DollarSignIcon,
+  clock: ClockIcon,
+  terminal: TerminalIcon,
+  brain: BrainIcon,
+  "terminal-square": TerminalSquareIcon,
+  tag: TagIcon,
+  "flask-conical": FlaskConicalIcon,
+  "external-link": ExternalLinkIcon,
+  diff: DiffIcon,
+  hash: HashIcon,
+  // Extended icons for service-provided sigils
+  github: GithubIcon,
+  package: PackageIcon,
+  shield: ShieldIcon,
+  zap: ZapIcon,
+  database: DatabaseIcon,
+  globe: GlobeIcon,
+  key: KeyIcon,
+  lock: LockIcon,
+  user: UserIcon,
+  folder: FolderIcon,
+  settings: SettingsIcon,
+  server: ServerIcon,
+  activity: ActivityIcon,
+  bell: BellIcon,
+  "message-square": MessageSquareIcon,
+};
+
+export function SigilIcon({ name, ...props }: IconProps & { name: string }) {
+  const Icon = ICON_MAP[name] ?? HashIcon;
+  return <Icon {...props} />;
+}

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -196,6 +196,11 @@ export function SigilPill({ type, id, params, raw }: SigilPillProps) {
               <span className="truncate">{prettifyUrl(href)}</span>
             </div>
           )}
+
+          {/* Raw sigil syntax */}
+          <code className="mt-0.5 block rounded bg-muted/60 px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground/50 select-all">
+            {raw}
+          </code>
         </div>
       </HoverCardContent>
     </HoverCard>

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -59,8 +59,8 @@ export function SigilPill({ type, id, params, raw }: SigilPillProps) {
   const triggerResolve = useSigilTriggerResolve();
   const resolved = useSigilResolve(canonicalType, id);
   useEffect(() => {
-    if (id) triggerResolve(canonicalType, id);
-  }, [canonicalType, id, triggerResolve]);
+    if (id) triggerResolve(canonicalType, id, params);
+  }, [canonicalType, id, triggerResolve, params]);
 
   // Build display text: prefer resolved title > label param > raw id
   const displayId = resolved.data?.title ?? params.label ?? (id || canonicalType);

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -15,7 +15,7 @@ import {
   HoverCardTrigger,
 } from "@/components/ui/hover-card";
 import { cn } from "@/lib/utils";
-import { useSigilRegistry, useSigilResolve, useSigilTriggerResolve } from "./SigilContext";
+import { useSigilRegistry, useSigilResolve, useSigilTriggerResolve, useSigilGeneration } from "./SigilContext";
 import { SigilIcon } from "./SigilIcon";
 import { ExternalLinkIcon, CheckIcon, CopyIcon } from "lucide-react";
 
@@ -54,12 +54,16 @@ export function SigilPill({ type, id, params, raw }: SigilPillProps) {
   const canonicalType = registry.resolveType(type);
   const typeLabel = params.label ?? registry.getLabel(type);
 
-  // Resolve enrichment data
+  // Resolve enrichment data.
+  // `generation` changes on server restart/reconnect (cache invalidation),
+  // ensuring the effect re-fires even when type/id/params haven't changed.
   const triggerResolve = useSigilTriggerResolve();
+  const generation = useSigilGeneration();
   const resolved = useSigilResolve(canonicalType, id);
   useEffect(() => {
     if (id) triggerResolve(canonicalType, id, params);
-  }, [canonicalType, id, triggerResolve, params]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [canonicalType, id, triggerResolve, params, generation]);
 
   const displayText = resolved.data?.title ?? params.label ?? (id || canonicalType);
   const statusParam = resolved.data?.status ?? params.status ?? params.conclusion;

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -4,7 +4,7 @@
  * Renders as a compact pill with an icon, label, and optional tooltip.
  * Styling is driven by the SigilRegistry based on type.
  */
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import {
   Tooltip,
   TooltipContent,
@@ -12,7 +12,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import { useSigilRegistry } from "./SigilContext";
+import { useSigilRegistry, useSigilResolve, useSigilTriggerResolve } from "./SigilContext";
 import { SigilIcon } from "./SigilIcon";
 
 export interface SigilPillProps {
@@ -55,11 +55,18 @@ export function SigilPill({ type, id, params, raw }: SigilPillProps) {
   const label = params.label ?? registry.getLabel(type);
   const description = registry.getDescription(type);
 
-  // Build display text: prefer a label param, otherwise show the id
-  const displayId = id || canonicalType;
+  // Trigger resolve for enrichment data
+  const triggerResolve = useSigilTriggerResolve();
+  const resolved = useSigilResolve(canonicalType, id);
+  useEffect(() => {
+    if (id) triggerResolve(canonicalType, id);
+  }, [canonicalType, id, triggerResolve]);
 
-  // Status-specific coloring for check/pr types
-  const statusParam = params.status ?? params.conclusion;
+  // Build display text: prefer resolved title > label param > raw id
+  const displayId = resolved.data?.title ?? params.label ?? (id || canonicalType);
+
+  // Status: prefer resolved status > param
+  const statusParam = resolved.data?.status ?? params.status ?? params.conclusion;
   const statusColorClass = statusParam ? getStatusColor(statusParam) : undefined;
 
   const pill = (
@@ -82,7 +89,7 @@ export function SigilPill({ type, id, params, raw }: SigilPillProps) {
   );
 
   // Wrap in tooltip if there's a description or extra params
-  const tooltipLines = buildTooltipLines(label, description, params, canonicalType, id);
+  const tooltipLines = buildTooltipLines(label, description, params, canonicalType, id, resolved.data);
   if (tooltipLines.length === 0) return pill;
 
   return (
@@ -137,6 +144,7 @@ function buildTooltipLines(
   params: Record<string, string>,
   type: string,
   id: string,
+  resolvedData?: Record<string, unknown>,
 ): string[] {
   const lines: string[] = [];
 
@@ -145,6 +153,16 @@ function buildTooltipLines(
     lines.push(`${label}: ${id}`);
   } else {
     lines.push(label);
+  }
+
+  // Resolved title (if different from id)
+  if (resolvedData?.title && resolvedData.title !== id) {
+    lines.push(String(resolvedData.title));
+  }
+
+  // Resolved author
+  if (resolvedData?.author) {
+    lines.push(`by ${resolvedData.author}`);
   }
 
   // Description from service def

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -18,6 +18,7 @@ import { cn } from "@/lib/utils";
 import { useSigilRegistry, useSigilResolve, useSigilTriggerResolve, useSigilGeneration } from "./SigilContext";
 import { SigilIcon } from "./SigilIcon";
 import { ExternalLinkIcon, CheckIcon, CopyIcon } from "lucide-react";
+import { ActionSigil } from "./ActionSigil";
 
 // ── SigilInline (Streamdown bridge) ──────────────────────────────────────────
 
@@ -42,6 +43,10 @@ export function SigilInline(props: Record<string, unknown>) {
       return {};
     }
   }, [paramsJson]);
+
+  if (type === "action") {
+    return <ActionSigil variant={id} params={params} raw={raw} />;
+  }
 
   return <SigilPill type={type} id={id} params={params} raw={raw} />;
 }

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -69,22 +69,42 @@ export function SigilPill({ type, id, params, raw }: SigilPillProps) {
   const statusParam = resolved.data?.status ?? params.status ?? params.conclusion;
   const statusColorClass = statusParam ? getStatusColor(statusParam) : undefined;
 
-  const pill = (
-    <span
-      className={cn(
-        "inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5",
-        "text-xs font-medium leading-none align-baseline",
-        "cursor-default select-none whitespace-nowrap",
-        "transition-colors hover:brightness-110",
-        statusColorClass ?? config.colorClass,
-      )}
-      data-sigil={raw}
-    >
+  // Link: explicit param > resolved url
+  const href = params.link ?? params.href ?? (resolved.data?.url ? String(resolved.data.url) : undefined);
+
+  const pillClasses = cn(
+    "inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5",
+    "text-xs font-medium leading-none align-baseline",
+    "select-none whitespace-nowrap",
+    "transition-colors hover:brightness-110",
+    href ? "cursor-pointer no-underline hover:brightness-125" : "cursor-default",
+    statusColorClass ?? config.colorClass,
+  );
+
+  const pillContent = (
+    <>
       <SigilIcon name={config.icon ?? "hash"} className="size-3 shrink-0" />
       <span className="truncate max-w-[20ch]">{displayId}</span>
       {statusParam && (
         <span className="opacity-70 text-[10px]">{statusParam}</span>
       )}
+    </>
+  );
+
+  const pill = href ? (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={pillClasses}
+      data-sigil={raw}
+      onClick={(e) => e.stopPropagation()}
+    >
+      {pillContent}
+    </a>
+  ) : (
+    <span className={pillClasses} data-sigil={raw}>
+      {pillContent}
     </span>
   );
 
@@ -172,7 +192,7 @@ function buildTooltipLines(
 
   // Non-label, non-status params as extra info
   const extraParams = Object.entries(params).filter(
-    ([k]) => k !== "label" && k !== "status" && k !== "conclusion",
+    ([k]) => !["label", "status", "conclusion", "link", "href"].includes(k),
   );
   for (const [key, val] of extraParams) {
     lines.push(`${key}: ${val}`);

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -1,0 +1,164 @@
+/**
+ * SigilPill — inline rendered component for [[type:id params]] tokens.
+ *
+ * Renders as a compact pill with an icon, label, and optional tooltip.
+ * Styling is driven by the SigilRegistry based on type.
+ */
+import { useMemo } from "react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { useSigilRegistry } from "./SigilContext";
+import { SigilIcon } from "./SigilIcon";
+
+export interface SigilPillProps {
+  /** Sigil type (after alias resolution) */
+  type: string;
+  /** Primary identifier */
+  id: string;
+  /** Key-value params */
+  params: Record<string, string>;
+  /** Original raw text for copy/debug */
+  raw: string;
+}
+
+/**
+ * The component rendered by Streamdown for <sigil> elements.
+ * Reads data attributes set by the rehype plugin.
+ */
+export function SigilInline(props: Record<string, unknown>) {
+  const type = (props["data-sigil-type"] as string) ?? "";
+  const id = (props["data-sigil-id"] as string) ?? "";
+  const raw = (props["data-sigil-raw"] as string) ?? "";
+  const paramsJson = props["data-sigil-params"] as string | undefined;
+
+  const params = useMemo(() => {
+    if (!paramsJson) return {};
+    try {
+      return JSON.parse(paramsJson) as Record<string, string>;
+    } catch {
+      return {};
+    }
+  }, [paramsJson]);
+
+  return <SigilPill type={type} id={id} params={params} raw={raw} />;
+}
+
+export function SigilPill({ type, id, params, raw }: SigilPillProps) {
+  const registry = useSigilRegistry();
+  const config = registry.getConfig(type);
+  const canonicalType = registry.resolveType(type);
+  const label = params.label ?? registry.getLabel(type);
+  const description = registry.getDescription(type);
+
+  // Build display text: prefer a label param, otherwise show the id
+  const displayId = id || canonicalType;
+
+  // Status-specific coloring for check/pr types
+  const statusParam = params.status ?? params.conclusion;
+  const statusColorClass = statusParam ? getStatusColor(statusParam) : undefined;
+
+  const pill = (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5",
+        "text-xs font-medium leading-none align-baseline",
+        "cursor-default select-none whitespace-nowrap",
+        "transition-colors hover:brightness-110",
+        statusColorClass ?? config.colorClass,
+      )}
+      data-sigil={raw}
+    >
+      <SigilIcon name={config.icon ?? "hash"} className="size-3 shrink-0" />
+      <span className="truncate max-w-[20ch]">{displayId}</span>
+      {statusParam && (
+        <span className="opacity-70 text-[10px]">{statusParam}</span>
+      )}
+    </span>
+  );
+
+  // Wrap in tooltip if there's a description or extra params
+  const tooltipLines = buildTooltipLines(label, description, params, canonicalType, id);
+  if (tooltipLines.length === 0) return pill;
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>{pill}</TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs text-xs">
+          {tooltipLines.map((line, i) => (
+            <div key={i} className={i === 0 ? "font-medium" : "opacity-80"}>
+              {line}
+            </div>
+          ))}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function getStatusColor(status: string): string | undefined {
+  switch (status) {
+    case "success":
+    case "merged":
+    case "passed":
+    case "healthy":
+      return "bg-green-500/15 text-green-700 dark:text-green-400 border-green-500/25";
+    case "failure":
+    case "failed":
+    case "error":
+    case "closed":
+      return "bg-red-500/15 text-red-700 dark:text-red-400 border-red-500/25";
+    case "open":
+    case "running":
+    case "pending":
+      return "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/25";
+    case "draft":
+    case "neutral":
+    case "skipped":
+      return "bg-zinc-500/15 text-zinc-700 dark:text-zinc-400 border-zinc-500/25";
+    case "cancelled":
+    case "timed_out":
+      return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/25";
+    default:
+      return undefined;
+  }
+}
+
+function buildTooltipLines(
+  label: string,
+  description: string | undefined,
+  params: Record<string, string>,
+  type: string,
+  id: string,
+): string[] {
+  const lines: string[] = [];
+
+  // Title line: "Pull Request #55" or "Branch: main"
+  if (id) {
+    lines.push(`${label}: ${id}`);
+  } else {
+    lines.push(label);
+  }
+
+  // Description from service def
+  if (description) {
+    lines.push(description);
+  }
+
+  // Non-label, non-status params as extra info
+  const extraParams = Object.entries(params).filter(
+    ([k]) => k !== "label" && k !== "status" && k !== "conclusion",
+  );
+  for (const [key, val] of extraParams) {
+    lines.push(`${key}: ${val}`);
+  }
+
+  return lines;
+}

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -1,35 +1,33 @@
 /**
  * SigilPill — inline rendered component for [[type:id params]] tokens.
  *
- * Renders as a compact pill with an icon, label, and optional tooltip.
- * Styling is driven by the SigilRegistry based on type.
+ * Renders as a compact, interactive pill with:
+ * - Type-colored background with icon
+ * - Rich HoverCard preview with resolved metadata
+ * - Clickable link when a URL is available
+ * - Loading shimmer during resolve
+ * - Status-aware coloring
  */
 import { useEffect, useMemo } from "react";
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from "@/components/ui/hover-card";
 import { cn } from "@/lib/utils";
 import { useSigilRegistry, useSigilResolve, useSigilTriggerResolve } from "./SigilContext";
 import { SigilIcon } from "./SigilIcon";
+import { ExternalLinkIcon } from "lucide-react";
+
+// ── SigilInline (Streamdown bridge) ──────────────────────────────────────────
 
 export interface SigilPillProps {
-  /** Sigil type (after alias resolution) */
   type: string;
-  /** Primary identifier */
   id: string;
-  /** Key-value params */
   params: Record<string, string>;
-  /** Original raw text for copy/debug */
   raw: string;
 }
 
-/**
- * The component rendered by Streamdown for <sigil> elements.
- * Reads data attributes set by the rehype plugin.
- */
 export function SigilInline(props: Record<string, unknown>) {
   const type = (props["data-sigil-type"] as string) ?? "";
   const id = (props["data-sigil-id"] as string) ?? "";
@@ -48,46 +46,65 @@ export function SigilInline(props: Record<string, unknown>) {
   return <SigilPill type={type} id={id} params={params} raw={raw} />;
 }
 
+// ── SigilPill ────────────────────────────────────────────────────────────────
+
 export function SigilPill({ type, id, params, raw }: SigilPillProps) {
   const registry = useSigilRegistry();
   const config = registry.getConfig(type);
   const canonicalType = registry.resolveType(type);
-  const label = params.label ?? registry.getLabel(type);
-  const description = registry.getDescription(type);
+  const typeLabel = params.label ?? registry.getLabel(type);
 
-  // Trigger resolve for enrichment data
+  // Resolve enrichment data
   const triggerResolve = useSigilTriggerResolve();
   const resolved = useSigilResolve(canonicalType, id);
   useEffect(() => {
     if (id) triggerResolve(canonicalType, id, params);
   }, [canonicalType, id, triggerResolve, params]);
 
-  // Build display text: prefer resolved title > label param > raw id
-  const displayId = resolved.data?.title ?? params.label ?? (id || canonicalType);
-
-  // Status: prefer resolved status > param
+  const displayText = resolved.data?.title ?? params.label ?? (id || canonicalType);
   const statusParam = resolved.data?.status ?? params.status ?? params.conclusion;
-  const statusColorClass = statusParam ? getStatusColor(statusParam) : undefined;
-
-  // Link: explicit param > resolved url
+  const statusColor = statusParam ? getStatusColor(statusParam) : undefined;
   const href = params.link ?? params.href ?? (resolved.data?.url ? String(resolved.data.url) : undefined);
+  const author = resolved.data?.author ? String(resolved.data.author) : undefined;
+  const description = resolved.data?.description
+    ? String(resolved.data.description)
+    : registry.getDescription(type);
+  const isLoading = resolved.loading;
+
+  // ── Pill element ───────────────────────────────────────────────────────
 
   const pillClasses = cn(
-    "inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5",
-    "text-xs font-medium leading-none align-baseline",
+    // Layout
+    "inline-flex items-center gap-1 rounded-full px-2 py-0.5",
+    // Typography
+    "text-[11px] font-semibold leading-tight align-baseline",
+    // Interaction
     "select-none whitespace-nowrap",
-    "transition-colors hover:brightness-110",
-    href ? "cursor-pointer no-underline hover:brightness-125" : "cursor-default",
-    statusColorClass ?? config.colorClass,
+    "transition-all duration-150 ease-out",
+    // Border
+    "ring-1 ring-inset",
+    // Loading shimmer
+    isLoading && "animate-pulse",
+    // Status or type color
+    statusColor ?? config.colorClass,
+    // Link-specific
+    href && "cursor-pointer no-underline hover:scale-[1.03] hover:shadow-sm active:scale-[0.98]",
+    !href && "cursor-default",
   );
 
-  const pillContent = (
+  const pillInner = (
     <>
-      <SigilIcon name={config.icon ?? "hash"} className="size-3 shrink-0" />
-      <span className="truncate max-w-[20ch]">{displayId}</span>
+      <SigilIcon name={config.icon ?? "hash"} className="size-3 shrink-0 opacity-80" />
+      <span className="truncate max-w-[24ch]">{displayText}</span>
       {statusParam && (
-        <span className="opacity-70 text-[10px]">{statusParam}</span>
+        <span className={cn(
+          "rounded-full px-1 py-px text-[9px] font-bold uppercase tracking-wider",
+          "bg-black/10 dark:bg-white/10",
+        )}>
+          {statusParam}
+        </span>
       )}
+      {href && <ExternalLinkIcon className="size-2.5 shrink-0 opacity-50" />}
     </>
   );
 
@@ -100,31 +117,88 @@ export function SigilPill({ type, id, params, raw }: SigilPillProps) {
       data-sigil={raw}
       onClick={(e) => e.stopPropagation()}
     >
-      {pillContent}
+      {pillInner}
     </a>
   ) : (
     <span className={pillClasses} data-sigil={raw}>
-      {pillContent}
+      {pillInner}
     </span>
   );
 
-  // Wrap in tooltip if there's a description or extra params
-  const tooltipLines = buildTooltipLines(label, description, params, canonicalType, id, resolved.data);
-  if (tooltipLines.length === 0) return pill;
+  // ── HoverCard preview ──────────────────────────────────────────────────
+
+  const hasPreview = id || description || author || statusParam;
+  if (!hasPreview) return pill;
 
   return (
-    <TooltipProvider delayDuration={300}>
-      <Tooltip>
-        <TooltipTrigger asChild>{pill}</TooltipTrigger>
-        <TooltipContent side="top" className="max-w-xs text-xs">
-          {tooltipLines.map((line, i) => (
-            <div key={i} className={i === 0 ? "font-medium" : "opacity-80"}>
-              {line}
+    <HoverCard openDelay={400} closeDelay={100}>
+      <HoverCardTrigger asChild>{pill}</HoverCardTrigger>
+      <HoverCardContent
+        side="top"
+        align="center"
+        className="w-auto min-w-[180px] max-w-[280px] p-3"
+      >
+        <div className="flex flex-col gap-1.5">
+          {/* Header: icon + type label */}
+          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <SigilIcon name={config.icon ?? "hash"} className="size-3.5 opacity-60" />
+            <span className="font-medium">{typeLabel}</span>
+          </div>
+
+          {/* Title / ID */}
+          {id && (
+            <div className="text-sm font-semibold text-foreground leading-snug">
+              {resolved.data?.title && resolved.data.title !== id ? (
+                <>
+                  <span>{String(resolved.data.title)}</span>
+                  <span className="ml-1.5 text-xs font-normal text-muted-foreground">
+                    #{id}
+                  </span>
+                </>
+              ) : (
+                <span className="font-mono">{id}</span>
+              )}
             </div>
-          ))}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+          )}
+
+          {/* Description */}
+          {description && (
+            <p className="text-xs text-muted-foreground leading-relaxed line-clamp-2">
+              {description}
+            </p>
+          )}
+
+          {/* Meta row: author + status */}
+          {(author || statusParam) && (
+            <div className="flex items-center gap-2 pt-0.5">
+              {author && (
+                <span className="text-[11px] text-muted-foreground">
+                  by <span className="font-medium text-foreground">{author}</span>
+                </span>
+              )}
+              {statusParam && (
+                <span className={cn(
+                  "inline-flex items-center rounded-full px-1.5 py-px",
+                  "text-[10px] font-bold uppercase tracking-wider",
+                  "ring-1 ring-inset",
+                  getStatusColor(statusParam) ?? "bg-muted text-muted-foreground ring-border",
+                )}>
+                  {statusParam}
+                </span>
+              )}
+            </div>
+          )}
+
+          {/* Link hint */}
+          {href && (
+            <div className="flex items-center gap-1 pt-0.5 text-[10px] text-muted-foreground/60">
+              <ExternalLinkIcon className="size-2.5" />
+              <span className="truncate">{prettifyUrl(href)}</span>
+            </div>
+          )}
+        </div>
+      </HoverCardContent>
+    </HoverCard>
   );
 }
 
@@ -136,67 +210,30 @@ function getStatusColor(status: string): string | undefined {
     case "merged":
     case "passed":
     case "healthy":
-      return "bg-green-500/15 text-green-700 dark:text-green-400 border-green-500/25";
+      return "bg-green-500/15 text-green-700 dark:text-green-400 ring-green-500/25";
     case "failure":
     case "failed":
     case "error":
+      return "bg-red-500/15 text-red-700 dark:text-red-400 ring-red-500/25";
     case "closed":
-      return "bg-red-500/15 text-red-700 dark:text-red-400 border-red-500/25";
+      return "bg-red-500/10 text-red-600 dark:text-red-400 ring-red-500/20";
     case "open":
     case "running":
     case "pending":
-      return "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/25";
+      return "bg-blue-500/15 text-blue-700 dark:text-blue-400 ring-blue-500/25";
     case "draft":
     case "neutral":
     case "skipped":
-      return "bg-zinc-500/15 text-zinc-700 dark:text-zinc-400 border-zinc-500/25";
+      return "bg-zinc-500/15 text-zinc-700 dark:text-zinc-400 ring-zinc-500/25";
     case "cancelled":
     case "timed_out":
-      return "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/25";
+      return "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/25";
     default:
       return undefined;
   }
 }
 
-function buildTooltipLines(
-  label: string,
-  description: string | undefined,
-  params: Record<string, string>,
-  type: string,
-  id: string,
-  resolvedData?: Record<string, unknown>,
-): string[] {
-  const lines: string[] = [];
-
-  // Title line: "Pull Request #55" or "Branch: main"
-  if (id) {
-    lines.push(`${label}: ${id}`);
-  } else {
-    lines.push(label);
-  }
-
-  // Resolved title (if different from id)
-  if (resolvedData?.title && resolvedData.title !== id) {
-    lines.push(String(resolvedData.title));
-  }
-
-  // Resolved author
-  if (resolvedData?.author) {
-    lines.push(`by ${resolvedData.author}`);
-  }
-
-  // Description from service def
-  if (description) {
-    lines.push(description);
-  }
-
-  // Non-label, non-status params as extra info
-  const extraParams = Object.entries(params).filter(
-    ([k]) => !["label", "status", "conclusion", "link", "href"].includes(k),
-  );
-  for (const [key, val] of extraParams) {
-    lines.push(`${key}: ${val}`);
-  }
-
-  return lines;
+/** Shorten a URL for display: strip protocol, trailing slash. */
+function prettifyUrl(url: string): string {
+  return url.replace(/^https?:\/\//, "").replace(/\/$/, "");
 }

--- a/packages/ui/src/components/sigils/SigilPill.tsx
+++ b/packages/ui/src/components/sigils/SigilPill.tsx
@@ -8,7 +8,7 @@
  * - Loading shimmer during resolve
  * - Status-aware coloring
  */
-import { useEffect, useMemo } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   HoverCard,
   HoverCardContent,
@@ -17,7 +17,7 @@ import {
 import { cn } from "@/lib/utils";
 import { useSigilRegistry, useSigilResolve, useSigilTriggerResolve } from "./SigilContext";
 import { SigilIcon } from "./SigilIcon";
-import { ExternalLinkIcon } from "lucide-react";
+import { ExternalLinkIcon, CheckIcon, CopyIcon } from "lucide-react";
 
 // ── SigilInline (Streamdown bridge) ──────────────────────────────────────────
 
@@ -198,9 +198,10 @@ export function SigilPill({ type, id, params, raw }: SigilPillProps) {
           )}
 
           {/* Raw sigil syntax */}
-          <code className="mt-0.5 block rounded bg-muted/60 px-1.5 py-0.5 text-[10px] font-mono text-muted-foreground/50 select-all">
-            {raw}
-          </code>
+          <div className="flex items-center gap-1 pt-0.5 text-[10px] text-muted-foreground/50">
+            <code className="truncate font-mono">{raw}</code>
+            <CopyButton text={raw} />
+          </div>
         </div>
       </HoverCardContent>
     </HoverCard>
@@ -241,4 +242,29 @@ function getStatusColor(status: string): string | undefined {
 /** Shorten a URL for display: strip protocol, trailing slash. */
 function prettifyUrl(url: string): string {
   return url.replace(/^https?:\/\//, "").replace(/\/$/, "");
+}
+
+/** Tiny copy-to-clipboard button with check feedback. */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  }, [text]);
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); handleCopy(); }}
+      className="shrink-0 rounded p-0.5 hover:bg-muted transition-colors"
+      aria-label="Copy sigil"
+    >
+      {copied
+        ? <CheckIcon className="size-2.5 text-green-500" />
+        : <CopyIcon className="size-2.5 opacity-60 hover:opacity-100" />
+      }
+    </button>
+  );
 }

--- a/packages/ui/src/components/sigils/index.ts
+++ b/packages/ui/src/components/sigils/index.ts
@@ -1,0 +1,3 @@
+export { SigilPill, SigilInline } from "./SigilPill";
+export { SigilIcon } from "./SigilIcon";
+export { SigilProvider, useSigilRegistry } from "./SigilContext";

--- a/packages/ui/src/components/sigils/index.ts
+++ b/packages/ui/src/components/sigils/index.ts
@@ -1,4 +1,4 @@
 export { SigilPill, SigilInline } from "./SigilPill";
 export { SigilIcon } from "./SigilIcon";
-export { SigilProvider, useSigilRegistry, useSigilResolve, useSigilTriggerResolve } from "./SigilContext";
+export { SigilProvider, useSigilRegistry, useSigilResolve, useSigilTriggerResolve, useSigilGeneration } from "./SigilContext";
 export type { SigilResolveData } from "./SigilContext";

--- a/packages/ui/src/components/sigils/index.ts
+++ b/packages/ui/src/components/sigils/index.ts
@@ -1,3 +1,4 @@
 export { SigilPill, SigilInline } from "./SigilPill";
 export { SigilIcon } from "./SigilIcon";
-export { SigilProvider, useSigilRegistry } from "./SigilContext";
+export { SigilProvider, useSigilRegistry, useSigilResolve, useSigilTriggerResolve } from "./SigilContext";
+export type { SigilResolveData } from "./SigilContext";

--- a/packages/ui/src/components/sigils/index.ts
+++ b/packages/ui/src/components/sigils/index.ts
@@ -1,4 +1,6 @@
 export { SigilPill, SigilInline } from "./SigilPill";
+export { ActionSigil } from "./ActionSigil";
+export { ActionSigilProvider, useActionSigilRuntime } from "./ActionSigilContext";
 export { SigilIcon } from "./SigilIcon";
 export { SigilProvider, useSigilRegistry, useSigilResolve, useSigilTriggerResolve, useSigilGeneration } from "./SigilContext";
 export type { SigilResolveData } from "./SigilContext";

--- a/packages/ui/src/hooks/useRunnerServices.ts
+++ b/packages/ui/src/hooks/useRunnerServices.ts
@@ -16,12 +16,13 @@
  */
 import { useState, useEffect, useRef } from "react";
 import type { Socket } from "socket.io-client";
-import type { ServiceAnnounceData, ServicePanelInfo, ServiceTriggerDef } from "@pizzapi/protocol";
+import type { ServiceAnnounceData, ServicePanelInfo, ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
 import { matchesViewerGeneration } from "@/lib/viewer-switch";
 
 const SERVICE_IDS_KEY = "__serviceIds" as const;
 const PANELS_KEY = "__panels" as const;
 const TRIGGER_DEFS_KEY = "__triggerDefs" as const;
+const SIGIL_DEFS_KEY = "__sigilDefs" as const;
 const VIEWER_SWITCH_GENERATION_KEY = "__viewerSwitchGeneration" as const;
 
 /**
@@ -38,11 +39,13 @@ export function attachServiceAnnounceListener(socket: Socket): void {
         (socket as any)[SERVICE_IDS_KEY] = data.serviceIds;
         (socket as any)[PANELS_KEY] = data.panels;
         (socket as any)[TRIGGER_DEFS_KEY] = data.triggerDefs;
+        (socket as any)[SIGIL_DEFS_KEY] = data.sigilDefs;
     });
     socket.on("disconnect", () => {
         (socket as any)[SERVICE_IDS_KEY] = undefined;
         (socket as any)[PANELS_KEY] = undefined;
         (socket as any)[TRIGGER_DEFS_KEY] = undefined;
+        (socket as any)[SIGIL_DEFS_KEY] = undefined;
     });
 }
 
@@ -56,9 +59,11 @@ export function seedServiceCache(newSocket: Socket, prevSocket: Socket | null): 
     const ids = (prevSocket as any)[SERVICE_IDS_KEY] as string[] | undefined;
     const panels = (prevSocket as any)[PANELS_KEY] as ServicePanelInfo[] | undefined;
     const triggerDefs = (prevSocket as any)[TRIGGER_DEFS_KEY] as ServiceTriggerDef[] | undefined;
+    const sigilDefs = (prevSocket as any)[SIGIL_DEFS_KEY] as ServiceSigilDef[] | undefined;
     if (ids) (newSocket as any)[SERVICE_IDS_KEY] = ids;
     if (panels) (newSocket as any)[PANELS_KEY] = panels;
     if (triggerDefs) (newSocket as any)[TRIGGER_DEFS_KEY] = triggerDefs;
+    if (sigilDefs) (newSocket as any)[SIGIL_DEFS_KEY] = sigilDefs;
 }
 
 export function setViewerSwitchGeneration(socket: Socket, generation: number): void {
@@ -81,16 +86,23 @@ function getEagerTriggerDefs(socket: Socket | null): ServiceTriggerDef[] {
     return (socket ? (socket as any)[TRIGGER_DEFS_KEY] as ServiceTriggerDef[] | undefined : undefined) ?? [];
 }
 
+/** Read any already-captured sigil defs from the socket. */
+function getEagerSigilDefs(socket: Socket | null): ServiceSigilDef[] {
+    return (socket ? (socket as any)[SIGIL_DEFS_KEY] as ServiceSigilDef[] | undefined : undefined) ?? [];
+}
+
 export interface RunnerServicesState {
     services: Set<string>;
     panels: ServicePanelInfo[];
     triggerDefs: ServiceTriggerDef[];
+    sigilDefs: ServiceSigilDef[];
 }
 
 export function useRunnerServices(socket: Socket | null): RunnerServicesState {
     const [services, setServices] = useState<Set<string>>(() => getEagerServiceIds(socket));
     const [panels, setPanels] = useState<ServicePanelInfo[]>(() => getEagerPanels(socket));
     const [triggerDefs, setTriggerDefs] = useState<ServiceTriggerDef[]>(() => getEagerTriggerDefs(socket));
+    const [sigilDefs, setSigilDefs] = useState<ServiceSigilDef[]>(() => getEagerSigilDefs(socket));
     const prevSocketRef = useRef(socket);
 
     if (socket !== prevSocketRef.current) {
@@ -102,6 +114,7 @@ export function useRunnerServices(socket: Socket | null): RunnerServicesState {
             setServices(new Set());
             setPanels([]);
             setTriggerDefs([]);
+            setSigilDefs([]);
             return;
         }
 
@@ -119,6 +132,10 @@ export function useRunnerServices(socket: Socket | null): RunnerServicesState {
         if (cachedDefs.length > 0) {
             setTriggerDefs(cachedDefs);
         }
+        const cachedSigilDefs = getEagerSigilDefs(socket);
+        if (cachedSigilDefs.length > 0) {
+            setSigilDefs(cachedSigilDefs);
+        }
 
         const handleAnnounce = (data: ServiceAnnounceData & { generation?: number }) => {
             const currentGeneration = (socket as any)[VIEWER_SWITCH_GENERATION_KEY] as number | undefined;
@@ -128,6 +145,7 @@ export function useRunnerServices(socket: Socket | null): RunnerServicesState {
             setServices(new Set(data.serviceIds));
             setPanels(data.panels ?? []);
             setTriggerDefs(data.triggerDefs ?? []);
+            setSigilDefs(data.sigilDefs ?? []);
         };
 
         // NOTE: No handleDisconnect listener — we intentionally preserve
@@ -146,5 +164,5 @@ export function useRunnerServices(socket: Socket | null): RunnerServicesState {
         };
     }, [socket]);
 
-    return { services, panels, triggerDefs };
+    return { services, panels, triggerDefs, sigilDefs };
 }

--- a/packages/ui/src/lib/sigils/actions.test.ts
+++ b/packages/ui/src/lib/sigils/actions.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+import { buildActionResponse, parseActionOptions, parseActionSigil } from "./actions";
+
+describe("parseActionSigil", () => {
+  test("parses confirm with required question", () => {
+    expect(parseActionSigil("confirm", { question: "Deploy to production?" })).toEqual({
+      ok: true,
+      action: { kind: "confirm", question: "Deploy to production?" },
+    });
+  });
+
+  test("parses choose options", () => {
+    expect(parseActionSigil("choose", {
+      question: "Merge strategy?",
+      options: "merge,rebase,squash",
+    })).toEqual({
+      ok: true,
+      action: { kind: "choose", question: "Merge strategy?", options: ["merge", "rebase", "squash"] },
+    });
+  });
+
+  test("choose drops empty options and rejects all-empty input", () => {
+    expect(parseActionOptions("merge, ,squash ,, ")).toEqual(["merge", "squash"]);
+    expect(parseActionSigil("choose", {
+      question: "Merge strategy?",
+      options: "  , , ",
+    })).toEqual({ ok: false, error: "missing_options" });
+  });
+
+  test("parses input with optional placeholder", () => {
+    expect(parseActionSigil("input", {
+      question: "Branch name?",
+      placeholder: "feat/...",
+    })).toEqual({
+      ok: true,
+      action: { kind: "input", question: "Branch name?", placeholder: "feat/..." },
+    });
+  });
+
+  test("rejects unknown variant", () => {
+    expect(parseActionSigil("wat", { question: "Hi?" })).toEqual({ ok: false, error: "unknown_variant" });
+  });
+
+  test("rejects missing question", () => {
+    expect(parseActionSigil("confirm", {})).toEqual({ ok: false, error: "missing_question" });
+  });
+
+  test("formats confirm and cancel responses", () => {
+    const parsed = parseActionSigil("confirm", { question: "Deploy to production?" });
+    if (!parsed.ok) throw new Error("expected parsed action");
+    expect(buildActionResponse(parsed.action, "confirm")).toBe([
+      "Action sigil response",
+      "variant=confirm",
+      "question=Deploy to production?",
+      "value=confirm",
+    ].join("\n"));
+    expect(buildActionResponse(parsed.action, "cancel")).toBe([
+      "Action sigil response",
+      "variant=confirm",
+      "question=Deploy to production?",
+      "value=cancel",
+    ].join("\n"));
+  });
+
+  test("formats input values with punctuation safely as multiline text", () => {
+    const parsed = parseActionSigil("input", { question: "Branch name?" });
+    if (!parsed.ok) throw new Error("expected parsed action");
+    expect(buildActionResponse(parsed.action, "feat/a|b=c")).toBe([
+      "Action sigil response",
+      "variant=input",
+      "question=Branch name?",
+      "value=feat/a|b=c",
+    ].join("\n"));
+  });
+});

--- a/packages/ui/src/lib/sigils/actions.ts
+++ b/packages/ui/src/lib/sigils/actions.ts
@@ -1,0 +1,52 @@
+export type ParsedActionSigil =
+  | { kind: "confirm"; question: string }
+  | { kind: "choose"; question: string; options: string[] }
+  | { kind: "input"; question: string; placeholder?: string };
+
+export type ActionParseResult =
+  | { ok: true; action: ParsedActionSigil }
+  | { ok: false; error: string };
+
+export function parseActionSigil(
+  variant: string,
+  params: Record<string, string>,
+): ActionParseResult {
+  const question = params.question?.trim();
+  if (!question) return { ok: false, error: "missing_question" };
+
+  switch (variant) {
+    case "confirm":
+      return { ok: true, action: { kind: "confirm", question } };
+    case "choose": {
+      const options = parseActionOptions(params.options);
+      if (options.length === 0) return { ok: false, error: "missing_options" };
+      return { ok: true, action: { kind: "choose", question, options } };
+    }
+    case "input": {
+      const placeholder = params.placeholder?.trim();
+      return {
+        ok: true,
+        action: { kind: "input", question, ...(placeholder ? { placeholder } : {}) },
+      };
+    }
+    default:
+      return { ok: false, error: "unknown_variant" };
+  }
+}
+
+export function parseActionOptions(raw?: string): string[] {
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((option) => option.trim())
+    .filter(Boolean);
+}
+
+export function buildActionResponse(action: ParsedActionSigil, value: string): string {
+  return [
+    "Action sigil response",
+    `variant=${action.kind}`,
+    `question=${action.question}`,
+    `value=${value}`,
+  ].join("\n");
+}

--- a/packages/ui/src/lib/sigils/index.ts
+++ b/packages/ui/src/lib/sigils/index.ts
@@ -1,0 +1,4 @@
+export { parseSigils } from "./parser";
+export { rehypeSigils } from "./rehype-sigils";
+export { SigilRegistry, createRegistry } from "./registry";
+export type { SigilMatch, SigilRenderConfig } from "./types";

--- a/packages/ui/src/lib/sigils/parser.test.ts
+++ b/packages/ui/src/lib/sigils/parser.test.ts
@@ -116,4 +116,12 @@ describe("parseSigils", () => {
     expect(matches[0].id).toBe("typecheck");
     expect(matches[0].params).toEqual({ conclusion: "success", repo: "Foo/Bar" });
   });
+
+  test("parses action sigils as type action with variant id", () => {
+    const matches = parseSigils('[[action:confirm question="Deploy?"]]');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].type).toBe("action");
+    expect(matches[0].id).toBe("confirm");
+    expect(matches[0].params).toEqual({ question: "Deploy?" });
+  });
 });

--- a/packages/ui/src/lib/sigils/parser.test.ts
+++ b/packages/ui/src/lib/sigils/parser.test.ts
@@ -1,0 +1,119 @@
+import { describe, test, expect } from "bun:test";
+import { parseSigils } from "./parser";
+
+describe("parseSigils", () => {
+  test("returns empty for text without sigils", () => {
+    expect(parseSigils("hello world")).toEqual([]);
+    expect(parseSigils("")).toEqual([]);
+    expect(parseSigils("some [[incomplete")).toEqual([]);
+  });
+
+  test("parses basic sigil", () => {
+    const matches = parseSigils("See [[pr:55]]");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].type).toBe("pr");
+    expect(matches[0].id).toBe("55");
+    expect(matches[0].params).toEqual({});
+    expect(matches[0].raw).toBe("[[pr:55]]");
+  });
+
+  test("parses sigil with no id", () => {
+    const matches = parseSigils("[[status:]]");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].type).toBe("status");
+    expect(matches[0].id).toBe("");
+  });
+
+  test("parses file paths as id", () => {
+    const matches = parseSigils("[[file:src/auth/login.ts]]");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].type).toBe("file");
+    expect(matches[0].id).toBe("src/auth/login.ts");
+  });
+
+  test("parses unquoted params", () => {
+    const matches = parseSigils("[[pr:55 status=merged]]");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].params).toEqual({ status: "merged" });
+  });
+
+  test("parses quoted params", () => {
+    const matches = parseSigils('[[pr:55 label="Add auth flow"]]');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].params).toEqual({ label: "Add auth flow" });
+  });
+
+  test("parses multiple params", () => {
+    const matches = parseSigils('[[pr:55 status=merged label="Add auth"]]');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].params).toEqual({ status: "merged", label: "Add auth" });
+  });
+
+  test("parses multiple sigils in one string", () => {
+    const matches = parseSigils("Branch [[branch:main]] has [[pr:55]]");
+    expect(matches).toHaveLength(2);
+    expect(matches[0].type).toBe("branch");
+    expect(matches[0].id).toBe("main");
+    expect(matches[1].type).toBe("pr");
+    expect(matches[1].id).toBe("55");
+  });
+
+  test("normalizes type to lowercase", () => {
+    const matches = parseSigils("[[PR:55]]");
+    expect(matches[0].type).toBe("pr");
+  });
+
+  test("handles hyphenated types", () => {
+    const matches = parseSigils("[[pull-request:55]]");
+    expect(matches[0].type).toBe("pull-request");
+  });
+
+  test("records correct offsets", () => {
+    const text = "see [[pr:55]] here";
+    const matches = parseSigils(text);
+    expect(matches[0].start).toBe(4);
+    expect(matches[0].end).toBe(13);
+    expect(text.slice(matches[0].start, matches[0].end)).toBe("[[pr:55]]");
+  });
+
+  test("skips sigils inside inline code", () => {
+    const matches = parseSigils("Use `[[pr:55]]` in your text");
+    expect(matches).toHaveLength(0);
+  });
+
+  test("skips sigils inside fenced code blocks", () => {
+    const text = "Before\n```\n[[pr:55]]\n```\nAfter [[branch:main]]";
+    const matches = parseSigils(text);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].type).toBe("branch");
+  });
+
+  test("rejects nested brackets", () => {
+    // [[foo:[[bar]]]] should not match as a valid sigil
+    const matches = parseSigils("[[foo:[[bar]]]]");
+    // The regex won't match this as a single sigil — it might partially match
+    // but should not produce a clean foo:[[bar]] match
+    for (const m of matches) {
+      expect(m.id).not.toContain("[[");
+    }
+  });
+
+  test("handles sigil at start and end of string", () => {
+    const matches = parseSigils("[[pr:1]]");
+    expect(matches).toHaveLength(1);
+    expect(matches[0].start).toBe(0);
+    expect(matches[0].end).toBe(8);
+  });
+
+  test("handles URLs in id", () => {
+    const matches = parseSigils("[[repo:Pizzaface/PizzaPi]]");
+    expect(matches[0].id).toBe("Pizzaface/PizzaPi");
+  });
+
+  test("handles complex params mix", () => {
+    const matches = parseSigils('[[check:typecheck conclusion=success repo="Foo/Bar"]]');
+    expect(matches[0].type).toBe("check");
+    expect(matches[0].id).toBe("typecheck");
+    expect(matches[0].params).toEqual({ conclusion: "success", repo: "Foo/Bar" });
+  });
+});

--- a/packages/ui/src/lib/sigils/parser.ts
+++ b/packages/ui/src/lib/sigils/parser.ts
@@ -9,7 +9,7 @@ import type { SigilMatch } from "./types";
  *
  * Does NOT handle nested brackets — [[foo:[[bar]]]] is invalid.
  */
-const SIGIL_RE = /\[\[([a-zA-Z][\w-]*):([^\s\]\[]*)((?:\s+[a-zA-Z][\w-]*=(?:"[^"]*"|[^\s\]]+))*)\s*\]\]/g;
+const SIGIL_RE = /\[\[([a-zA-Z][\w-]*):([^\s\]\[]*)((?:\s+[a-zA-Z][\w-]*=(?:"[^"]*"|[^\s\]"]+))*)\s*\]\]/g;
 
 /**
  * Regex to match individual key=value or key="quoted value" params.

--- a/packages/ui/src/lib/sigils/parser.ts
+++ b/packages/ui/src/lib/sigils/parser.ts
@@ -1,0 +1,98 @@
+import type { SigilMatch } from "./types";
+
+/**
+ * Regex to match sigil tokens: [[type:id ...params]]
+ *
+ * - type: word characters, hyphens
+ * - id: everything up to the first space or ]] (must not contain `[`)
+ * - params: optional key=value or key="quoted value" pairs
+ *
+ * Does NOT handle nested brackets — [[foo:[[bar]]]] is invalid.
+ */
+const SIGIL_RE = /\[\[([a-zA-Z][\w-]*):([^\s\]\[]*)((?:\s+[a-zA-Z][\w-]*=(?:"[^"]*"|[^\s\]]+))*)\s*\]\]/g;
+
+/**
+ * Regex to match individual key=value or key="quoted value" params.
+ */
+const PARAM_RE = /([a-zA-Z][\w-]*)=(?:"([^"]*)"|([^\s\]]+))/g;
+
+/**
+ * Parse key=value params from a param string.
+ */
+function parseParams(raw: string): Record<string, string> {
+  const params: Record<string, string> = {};
+  if (!raw) return params;
+  let m: RegExpExecArray | null;
+  PARAM_RE.lastIndex = 0;
+  while ((m = PARAM_RE.exec(raw)) !== null) {
+    // m[2] is quoted value, m[3] is unquoted value
+    params[m[1]] = m[2] ?? m[3];
+  }
+  return params;
+}
+
+/**
+ * Build a set of ranges that are inside code spans or fenced code blocks.
+ * Sigils inside these ranges should be skipped.
+ */
+function buildCodeRanges(text: string): Array<[number, number]> {
+  const ranges: Array<[number, number]> = [];
+
+  // Fenced code blocks: ``` or ~~~
+  const fencedRe = /^(`{3,}|~{3,}).*\n[\s\S]*?\n\1\s*$/gm;
+  let m: RegExpExecArray | null;
+  fencedRe.lastIndex = 0;
+  while ((m = fencedRe.exec(text)) !== null) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+
+  // Inline code spans: `...` (but not inside fenced blocks)
+  const codeSpanRe = /`([^`\n]+)`/g;
+  codeSpanRe.lastIndex = 0;
+  while ((m = codeSpanRe.exec(text)) !== null) {
+    const start = m.index;
+    const end = start + m[0].length;
+    // Only add if not already inside a fenced block
+    const insideFenced = ranges.some(([fs, fe]) => start >= fs && end <= fe);
+    if (!insideFenced) {
+      ranges.push([start, end]);
+    }
+  }
+
+  return ranges;
+}
+
+/**
+ * Check if a position falls inside any code range.
+ */
+function isInsideCode(pos: number, ranges: Array<[number, number]>): boolean {
+  return ranges.some(([start, end]) => pos >= start && pos < end);
+}
+
+/**
+ * Parse all sigil tokens from a text string.
+ * Skips sigils inside code spans and fenced code blocks.
+ */
+export function parseSigils(text: string): SigilMatch[] {
+  if (!text || !text.includes("[[")) return [];
+
+  const codeRanges = buildCodeRanges(text);
+  const matches: SigilMatch[] = [];
+
+  SIGIL_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SIGIL_RE.exec(text)) !== null) {
+    if (isInsideCode(m.index, codeRanges)) continue;
+
+    matches.push({
+      type: m[1].toLowerCase(),
+      id: m[2],
+      params: parseParams(m[3]),
+      start: m.index,
+      end: m.index + m[0].length,
+      raw: m[0],
+    });
+  }
+
+  return matches;
+}

--- a/packages/ui/src/lib/sigils/registry.ts
+++ b/packages/ui/src/lib/sigils/registry.ts
@@ -7,92 +7,92 @@ const BUILTIN_CONFIGS: Record<string, SigilRenderConfig> = {
   file: {
     label: "File",
     icon: "file",
-    colorClass: "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/25",
+    colorClass: "bg-blue-500/15 text-blue-700 dark:text-blue-400 ring-blue-500/25",
   },
   pr: {
     label: "PR",
     icon: "git-pull-request",
-    colorClass: "bg-purple-500/15 text-purple-700 dark:text-purple-400 border-purple-500/25",
+    colorClass: "bg-purple-500/15 text-purple-700 dark:text-purple-400 ring-purple-500/25",
   },
   issue: {
     label: "Issue",
     icon: "circle-dot",
-    colorClass: "bg-green-500/15 text-green-700 dark:text-green-400 border-green-500/25",
+    colorClass: "bg-green-500/15 text-green-700 dark:text-green-400 ring-green-500/25",
   },
   commit: {
     label: "Commit",
     icon: "git-commit-horizontal",
-    colorClass: "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/25",
+    colorClass: "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/25",
   },
   branch: {
     label: "Branch",
     icon: "git-branch",
-    colorClass: "bg-cyan-500/15 text-cyan-700 dark:text-cyan-400 border-cyan-500/25",
+    colorClass: "bg-cyan-500/15 text-cyan-700 dark:text-cyan-400 ring-cyan-500/25",
   },
   repo: {
     label: "Repo",
     icon: "book-marked",
-    colorClass: "bg-slate-500/15 text-slate-700 dark:text-slate-400 border-slate-500/25",
+    colorClass: "bg-slate-500/15 text-slate-700 dark:text-slate-400 ring-slate-500/25",
   },
   check: {
     label: "CI Check",
     icon: "check-circle",
-    colorClass: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/25",
+    colorClass: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
   },
   status: {
     label: "Status",
     icon: "circle",
-    colorClass: "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/25",
+    colorClass: "bg-blue-500/15 text-blue-700 dark:text-blue-400 ring-blue-500/25",
   },
   error: {
     label: "Error",
     icon: "alert-triangle",
-    colorClass: "bg-red-500/15 text-red-700 dark:text-red-400 border-red-500/25",
+    colorClass: "bg-red-500/15 text-red-700 dark:text-red-400 ring-red-500/25",
   },
   cost: {
     label: "Cost",
     icon: "dollar-sign",
-    colorClass: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/25",
+    colorClass: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 ring-emerald-500/25",
   },
   duration: {
     label: "Duration",
     icon: "clock",
-    colorClass: "bg-indigo-500/15 text-indigo-700 dark:text-indigo-400 border-indigo-500/25",
+    colorClass: "bg-indigo-500/15 text-indigo-700 dark:text-indigo-400 ring-indigo-500/25",
   },
   session: {
     label: "Session",
     icon: "terminal",
-    colorClass: "bg-violet-500/15 text-violet-700 dark:text-violet-400 border-violet-500/25",
+    colorClass: "bg-violet-500/15 text-violet-700 dark:text-violet-400 ring-violet-500/25",
   },
   model: {
     label: "Model",
     icon: "brain",
-    colorClass: "bg-pink-500/15 text-pink-700 dark:text-pink-400 border-pink-500/25",
+    colorClass: "bg-pink-500/15 text-pink-700 dark:text-pink-400 ring-pink-500/25",
   },
   cmd: {
     label: "Command",
     icon: "terminal-square",
-    colorClass: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-400 border-zinc-500/25",
+    colorClass: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-400 ring-zinc-500/25",
   },
   tag: {
     label: "Tag",
     icon: "tag",
-    colorClass: "bg-orange-500/15 text-orange-700 dark:text-orange-400 border-orange-500/25",
+    colorClass: "bg-orange-500/15 text-orange-700 dark:text-orange-400 ring-orange-500/25",
   },
   test: {
     label: "Test",
     icon: "flask-conical",
-    colorClass: "bg-teal-500/15 text-teal-700 dark:text-teal-400 border-teal-500/25",
+    colorClass: "bg-teal-500/15 text-teal-700 dark:text-teal-400 ring-teal-500/25",
   },
   link: {
     label: "Link",
     icon: "external-link",
-    colorClass: "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/25",
+    colorClass: "bg-blue-500/15 text-blue-700 dark:text-blue-400 ring-blue-500/25",
   },
   diff: {
     label: "Diff",
     icon: "diff",
-    colorClass: "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/25",
+    colorClass: "bg-amber-500/15 text-amber-700 dark:text-amber-400 ring-amber-500/25",
   },
 };
 
@@ -132,7 +132,7 @@ const BUILTIN_ALIASES: Record<string, string> = {
 const FALLBACK_CONFIG: SigilRenderConfig = {
   label: "Reference",
   icon: "hash",
-  colorClass: "bg-muted text-muted-foreground border-border",
+  colorClass: "bg-muted text-muted-foreground ring-border",
 };
 
 // ── Registry class ───────────────────────────────────────────────────────────

--- a/packages/ui/src/lib/sigils/registry.ts
+++ b/packages/ui/src/lib/sigils/registry.ts
@@ -1,0 +1,222 @@
+import type { SigilRenderConfig } from "./types";
+import type { ServiceSigilDef } from "@pizzapi/protocol";
+
+// ── Built-in type configurations ─────────────────────────────────────────────
+
+const BUILTIN_CONFIGS: Record<string, SigilRenderConfig> = {
+  file: {
+    label: "File",
+    icon: "file",
+    colorClass: "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/25",
+  },
+  pr: {
+    label: "PR",
+    icon: "git-pull-request",
+    colorClass: "bg-purple-500/15 text-purple-700 dark:text-purple-400 border-purple-500/25",
+  },
+  issue: {
+    label: "Issue",
+    icon: "circle-dot",
+    colorClass: "bg-green-500/15 text-green-700 dark:text-green-400 border-green-500/25",
+  },
+  commit: {
+    label: "Commit",
+    icon: "git-commit-horizontal",
+    colorClass: "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/25",
+  },
+  branch: {
+    label: "Branch",
+    icon: "git-branch",
+    colorClass: "bg-cyan-500/15 text-cyan-700 dark:text-cyan-400 border-cyan-500/25",
+  },
+  repo: {
+    label: "Repo",
+    icon: "book-marked",
+    colorClass: "bg-slate-500/15 text-slate-700 dark:text-slate-400 border-slate-500/25",
+  },
+  check: {
+    label: "CI Check",
+    icon: "check-circle",
+    colorClass: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/25",
+  },
+  status: {
+    label: "Status",
+    icon: "circle",
+    colorClass: "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/25",
+  },
+  error: {
+    label: "Error",
+    icon: "alert-triangle",
+    colorClass: "bg-red-500/15 text-red-700 dark:text-red-400 border-red-500/25",
+  },
+  cost: {
+    label: "Cost",
+    icon: "dollar-sign",
+    colorClass: "bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 border-emerald-500/25",
+  },
+  duration: {
+    label: "Duration",
+    icon: "clock",
+    colorClass: "bg-indigo-500/15 text-indigo-700 dark:text-indigo-400 border-indigo-500/25",
+  },
+  session: {
+    label: "Session",
+    icon: "terminal",
+    colorClass: "bg-violet-500/15 text-violet-700 dark:text-violet-400 border-violet-500/25",
+  },
+  model: {
+    label: "Model",
+    icon: "brain",
+    colorClass: "bg-pink-500/15 text-pink-700 dark:text-pink-400 border-pink-500/25",
+  },
+  cmd: {
+    label: "Command",
+    icon: "terminal-square",
+    colorClass: "bg-zinc-500/15 text-zinc-700 dark:text-zinc-400 border-zinc-500/25",
+  },
+  tag: {
+    label: "Tag",
+    icon: "tag",
+    colorClass: "bg-orange-500/15 text-orange-700 dark:text-orange-400 border-orange-500/25",
+  },
+  test: {
+    label: "Test",
+    icon: "flask-conical",
+    colorClass: "bg-teal-500/15 text-teal-700 dark:text-teal-400 border-teal-500/25",
+  },
+  link: {
+    label: "Link",
+    icon: "external-link",
+    colorClass: "bg-blue-500/15 text-blue-700 dark:text-blue-400 border-blue-500/25",
+  },
+  diff: {
+    label: "Diff",
+    icon: "diff",
+    colorClass: "bg-amber-500/15 text-amber-700 dark:text-amber-400 border-amber-500/25",
+  },
+};
+
+// ── Alias map ────────────────────────────────────────────────────────────────
+
+/** Built-in type aliases: alternative names → canonical type. */
+const BUILTIN_ALIASES: Record<string, string> = {
+  "pull-request": "pr",
+  mr: "pr",
+  sha: "commit",
+  "git-branch": "branch",
+  ref: "branch",
+  "git-commit": "commit",
+  repository: "repo",
+  ci: "check",
+  workflow: "check",
+  bash: "cmd",
+  shell: "cmd",
+  bug: "issue",
+  ticket: "issue",
+  url: "link",
+  href: "link",
+  price: "cost",
+  budget: "cost",
+  time: "duration",
+  elapsed: "duration",
+  environment: "link",
+  env: "link",
+  agent: "model",
+  llm: "model",
+  warn: "error",
+  notice: "error",
+};
+
+// ── Fallback config ──────────────────────────────────────────────────────────
+
+const FALLBACK_CONFIG: SigilRenderConfig = {
+  label: "Reference",
+  icon: "hash",
+  colorClass: "bg-muted text-muted-foreground border-border",
+};
+
+// ── Registry class ───────────────────────────────────────────────────────────
+
+export class SigilRegistry {
+  private configs: Map<string, SigilRenderConfig>;
+  private aliases: Map<string, string>;
+  private serviceDefs: Map<string, ServiceSigilDef>;
+
+  constructor() {
+    this.configs = new Map(Object.entries(BUILTIN_CONFIGS));
+    this.aliases = new Map(Object.entries(BUILTIN_ALIASES));
+    this.serviceDefs = new Map();
+  }
+
+  /**
+   * Seed the registry with sigil definitions from runner services.
+   * Service defs provide metadata (label, description) and alias overrides.
+   */
+  seedFromServiceDefs(defs: ServiceSigilDef[]): void {
+    this.serviceDefs.clear();
+    for (const def of defs) {
+      this.serviceDefs.set(def.type, def);
+
+      // Register aliases from service defs
+      if (def.aliases) {
+        for (const alias of def.aliases) {
+          this.aliases.set(alias, def.type);
+        }
+      }
+
+      // If the service provides a label and there's no built-in config,
+      // create one with the fallback styling
+      if (!this.configs.has(def.type)) {
+        this.configs.set(def.type, {
+          label: def.label,
+          icon: def.icon ?? FALLBACK_CONFIG.icon,
+          colorClass: FALLBACK_CONFIG.colorClass,
+        });
+      } else if (def.icon) {
+        // Service-provided icon overrides the built-in icon
+        const existing = this.configs.get(def.type)!;
+        this.configs.set(def.type, { ...existing, icon: def.icon });
+      }
+    }
+  }
+
+  /** Resolve a type name through aliases to its canonical type. */
+  resolveType(type: string): string {
+    return this.aliases.get(type) ?? type;
+  }
+
+  /** Get the render config for a type (after alias resolution). */
+  getConfig(type: string): SigilRenderConfig {
+    const canonical = this.resolveType(type);
+    return this.configs.get(canonical) ?? FALLBACK_CONFIG;
+  }
+
+  /** Get the service definition for a type (if registered by a service). */
+  getServiceDef(type: string): ServiceSigilDef | undefined {
+    const canonical = this.resolveType(type);
+    return this.serviceDefs.get(canonical);
+  }
+
+  /** Get the label for display — prefer service def label, fall back to config. */
+  getLabel(type: string): string {
+    const canonical = this.resolveType(type);
+    const serviceDef = this.serviceDefs.get(canonical);
+    if (serviceDef?.label) return serviceDef.label;
+    return this.configs.get(canonical)?.label ?? type;
+  }
+
+  /** Get the description (from service def only). */
+  getDescription(type: string): string | undefined {
+    const canonical = this.resolveType(type);
+    return this.serviceDefs.get(canonical)?.description;
+  }
+}
+
+/** Create a fresh registry, optionally seeded with service defs. */
+export function createRegistry(defs?: ServiceSigilDef[]): SigilRegistry {
+  const registry = new SigilRegistry();
+  if (defs && defs.length > 0) {
+    registry.seedFromServiceDefs(defs);
+  }
+  return registry;
+}

--- a/packages/ui/src/lib/sigils/rehype-sigils.ts
+++ b/packages/ui/src/lib/sigils/rehype-sigils.ts
@@ -79,9 +79,73 @@ function walkText(
 
 // ── Plugin ───────────────────────────────────────────────────────────────────
 
+// ── Sigil span builder ───────────────────────────────────────────────────────
+
+function buildSigilSpan(match: import("./types").SigilMatch): HastElement {
+  const properties: Record<string, unknown> = {
+    "data-sigil-type": match.type,
+    "data-sigil-id": match.id,
+    "data-sigil-raw": match.raw,
+  };
+  if (Object.keys(match.params).length > 0) {
+    properties["data-sigil-params"] = JSON.stringify(match.params);
+  }
+  return { type: "element", tagName: "span", properties, children: [] };
+}
+
+// ── Coalescing ───────────────────────────────────────────────────────────────
+
+/**
+ * Group consecutive sigil nodes (with only whitespace between them)
+ * into a single wrapper span with data-sigil-group="true".
+ */
+function coalesceNodes(nodes: HastNode[]): HastNode[] {
+  const result: HastNode[] = [];
+  let group: HastElement[] = [];
+
+  function flushGroup() {
+    if (group.length === 0) return;
+    if (group.length === 1) {
+      result.push(group[0]);
+    } else {
+      result.push({
+        type: "element",
+        tagName: "span",
+        properties: { "data-sigil-group": "true" },
+        children: group as HastNode[],
+      });
+    }
+    group = [];
+  }
+
+  for (const node of nodes) {
+    const isSigil =
+      node.type === "element" &&
+      (node as HastElement).properties?.["data-sigil-type"];
+
+    const isWhitespaceOnly =
+      node.type === "text" && /^\s+$/.test((node as HastText).value);
+
+    if (isSigil) {
+      group.push(node as HastElement);
+    } else if (isWhitespaceOnly && group.length > 0) {
+      // Whitespace between sigils — absorb into group, will be rendered as gap
+      continue;
+    } else {
+      flushGroup();
+      result.push(node);
+    }
+  }
+
+  flushGroup();
+  return result;
+}
+
+// ── Plugin ───────────────────────────────────────────────────────────────────
+
 /**
  * Rehype plugin factory. Returns a transformer that replaces sigil tokens
- * in text nodes with <sigil> elements.
+ * in text nodes with <span> elements, coalescing adjacent sigils into groups.
  */
 export function rehypeSigils() {
   return (tree: HastRoot) => {
@@ -101,24 +165,7 @@ export function rehypeSigils() {
         if (match.start > cursor) {
           nodes.push({ type: "text", value: text.slice(cursor, match.start) });
         }
-
-        // Serialize params as JSON for the component to parse
-        const properties: Record<string, unknown> = {
-          "data-sigil-type": match.type,
-          "data-sigil-id": match.id,
-          "data-sigil-raw": match.raw,
-        };
-        if (Object.keys(match.params).length > 0) {
-          properties["data-sigil-params"] = JSON.stringify(match.params);
-        }
-
-        nodes.push({
-          type: "element",
-          tagName: "span",
-          properties,
-          children: [],
-        } as HastElement);
-
+        nodes.push(buildSigilSpan(match));
         cursor = match.end;
       }
 
@@ -127,7 +174,7 @@ export function rehypeSigils() {
         nodes.push({ type: "text", value: text.slice(cursor) });
       }
 
-      return nodes;
+      return coalesceNodes(nodes);
     });
   };
 }

--- a/packages/ui/src/lib/sigils/rehype-sigils.ts
+++ b/packages/ui/src/lib/sigils/rehype-sigils.ts
@@ -1,0 +1,133 @@
+/**
+ * Rehype plugin that transforms [[type:id params]] tokens in text nodes
+ * into <sigil> elements for Streamdown's component renderer.
+ *
+ * Skips text inside <code> and <pre> elements (code blocks/spans).
+ * No external dependencies — walks the hast tree manually.
+ */
+import { parseSigils } from "./parser";
+
+// ── Minimal hast types (avoids @types/hast dependency) ───────────────────────
+
+interface HastText {
+  type: "text";
+  value: string;
+}
+
+interface HastElement {
+  type: "element";
+  tagName: string;
+  properties: Record<string, unknown>;
+  children: HastNode[];
+}
+
+interface HastRoot {
+  type: "root";
+  children: HastNode[];
+}
+
+type HastNode = HastText | HastElement | HastRoot | { type: string; [key: string]: unknown };
+
+// ── Code-ancestor detection ──────────────────────────────────────────────────
+
+const CODE_TAGS = new Set(["code", "pre"]);
+
+function isElement(node: HastNode): node is HastElement {
+  return node.type === "element";
+}
+
+function hasCodeAncestor(ancestors: HastNode[]): boolean {
+  return ancestors.some((n) => isElement(n) && CODE_TAGS.has(n.tagName));
+}
+
+// ── Tree walker ──────────────────────────────────────────────────────────────
+
+/**
+ * Walk a hast tree depth-first, calling `fn` on every text node
+ * with its list of ancestors. `fn` can return replacement nodes.
+ */
+function walkText(
+  node: HastNode,
+  ancestors: HastNode[],
+  fn: (text: HastText, ancestors: HastNode[]) => HastNode[] | null,
+): void {
+  if (!("children" in node) || !Array.isArray(node.children)) return;
+
+  const parent = node as HastElement | HastRoot;
+  const newChildren: HastNode[] = [];
+  let changed = false;
+
+  for (const child of parent.children) {
+    if (child.type === "text") {
+      const replacement = fn(child as HastText, ancestors);
+      if (replacement) {
+        newChildren.push(...replacement);
+        changed = true;
+      } else {
+        newChildren.push(child);
+      }
+    } else {
+      newChildren.push(child);
+      walkText(child, [...ancestors, parent], fn);
+    }
+  }
+
+  if (changed) {
+    parent.children = newChildren;
+  }
+}
+
+// ── Plugin ───────────────────────────────────────────────────────────────────
+
+/**
+ * Rehype plugin factory. Returns a transformer that replaces sigil tokens
+ * in text nodes with <sigil> elements.
+ */
+export function rehypeSigils() {
+  return (tree: HastRoot) => {
+    walkText(tree, [], (textNode, ancestors) => {
+      if (hasCodeAncestor(ancestors)) return null;
+
+      const text = textNode.value;
+      const matches = parseSigils(text);
+      if (matches.length === 0) return null;
+
+      // Build replacement nodes: interleave text segments and sigil elements
+      const nodes: HastNode[] = [];
+      let cursor = 0;
+
+      for (const match of matches) {
+        // Text before this sigil
+        if (match.start > cursor) {
+          nodes.push({ type: "text", value: text.slice(cursor, match.start) });
+        }
+
+        // Serialize params as JSON for the component to parse
+        const properties: Record<string, unknown> = {
+          "data-sigil-type": match.type,
+          "data-sigil-id": match.id,
+          "data-sigil-raw": match.raw,
+        };
+        if (Object.keys(match.params).length > 0) {
+          properties["data-sigil-params"] = JSON.stringify(match.params);
+        }
+
+        nodes.push({
+          type: "element",
+          tagName: "sigil",
+          properties,
+          children: [],
+        } as HastElement);
+
+        cursor = match.end;
+      }
+
+      // Remaining text after last sigil
+      if (cursor < text.length) {
+        nodes.push({ type: "text", value: text.slice(cursor) });
+      }
+
+      return nodes;
+    });
+  };
+}

--- a/packages/ui/src/lib/sigils/rehype-sigils.ts
+++ b/packages/ui/src/lib/sigils/rehype-sigils.ts
@@ -114,7 +114,7 @@ export function rehypeSigils() {
 
         nodes.push({
           type: "element",
-          tagName: "sigil",
+          tagName: "span",
           properties,
           children: [],
         } as HastElement);

--- a/packages/ui/src/lib/sigils/types.ts
+++ b/packages/ui/src/lib/sigils/types.ts
@@ -1,0 +1,27 @@
+/** A parsed sigil token from text. */
+export interface SigilMatch {
+  /** Sigil type name, e.g. "pr", "file", "commit" */
+  type: string;
+  /** Primary identifier, e.g. "55", "src/auth.ts", "abc123" */
+  id: string;
+  /** Optional key-value params, e.g. { status: "merged", label: "Add auth" } */
+  params: Record<string, string>;
+  /** Start offset in the source text (inclusive) */
+  start: number;
+  /** End offset in the source text (exclusive) */
+  end: number;
+  /** The original raw text, e.g. '[[pr:55 status=merged]]' */
+  raw: string;
+}
+
+/** Configuration for rendering a sigil type. */
+export interface SigilRenderConfig {
+  /** Display label for the type, e.g. "Pull Request" */
+  label: string;
+  /** Lucide icon name */
+  icon?: string;
+  /** Tailwind color classes for the pill background */
+  colorClass?: string;
+  /** URL template — {id} and {param} are replaced. Return undefined to skip linking. */
+  href?: (id: string, params: Record<string, string>) => string | undefined;
+}


### PR DESCRIPTION
## Summary

Full sigils implementation for PizzaPi:

- **Parser & rehype plugin** — detects `[[type:id]]` syntax in markdown, renders inline sigil pills
- **Registry & resolve** — client-side resolve cache with generation-based invalidation, coalesced batch requests to runner services
- **SigilPill UI** — hover cards with preview data, clickable links, copy-to-clipboard for raw syntax
- **Action sigils** — sigils that trigger actions (e.g. `[[action:approve]]`) instead of navigating
- **Server integration** — stores/forwards `sigilDefs` from `service_announce`, reseeds fanout targets on reconnect
- **Reconnect resilience** — clears resolve cache and bumps generation counter on server restart

### 40 files changed, ~2,600 additions

## Test Plan
- [x] Typecheck passes
- [x] All tests pass (1 pre-existing flaky failure unrelated)
- [ ] Manual: verify sigil pills render in chat messages
- [ ] Manual: verify hover cards show resolved data
- [ ] Manual: verify reconnect clears stale sigil state