### PR TITLE
fix: define missing bump callback in SigilContext

### DIFF
--- a/packages/ui/src/components/sigils/SigilContext.tsx
+++ b/packages/ui/src/components/sigils/SigilContext.tsx
@@ -87,6 +87,7 @@ export function SigilProvider({ sigilDefs, panels, runnerId, children }: SigilPr
   // Resolve cache: keyed by "gen:type:id". Lives in a ref for instant reads.
   const cacheRef = useRef(new Map<string, SigilResolveState>());
   const [generation, setGeneration] = useState(0);
+  const bump = useCallback(() => setGeneration((g) => g + 1), []);
 
   // Clear cache when infrastructure changes (server restart, reconnect)
   // so stale entries don't block re-fetching with new panel ports.


### PR DESCRIPTION
Adds the missing `bump` callback that was referenced but never defined in `SigilProvider`, causing a runtime error. Simply defines it as `useCallback(() => setGeneration((g) => g + 1), [])`.