### PR TITLE
fix(security): sanitize config sent to UI and allowlist worker env vars

### DIFF
--- a/packages/cli/src/runner/daemon-config-sanitize.test.ts
+++ b/packages/cli/src/runner/daemon-config-sanitize.test.ts
@@ -1,0 +1,305 @@
+import { describe, test, expect } from "bun:test";
+import {
+    sanitizeConfigForUI,
+    restoreMaskedServerEntry,
+    SENSITIVE_NAME_RE,
+    MASK_SENTINEL,
+} from "./daemon-config-sanitize.js";
+
+// ── SENSITIVE_NAME_RE ─────────────────────────────────────────────────────────
+
+describe("SENSITIVE_NAME_RE", () => {
+    test("matches common secret key names", () => {
+        for (const name of [
+            "API_KEY",
+            "apikey",
+            "auth_token",
+            "SECRET",
+            "password",
+            "CREDENTIAL",
+            "Authorization",
+            "cookie",
+            "PAT",
+            "bearer_token",
+        ]) {
+            expect(SENSITIVE_NAME_RE.test(name)).toBe(true);
+        }
+    });
+
+    test("does not match safe field names", () => {
+        for (const name of ["command", "args", "url", "name", "transport", "timeout"]) {
+            expect(SENSITIVE_NAME_RE.test(name)).toBe(false);
+        }
+    });
+});
+
+// ── sanitizeConfigForUI — apiKey / relayUrl removal ───────────────────────────
+
+describe("sanitizeConfigForUI — top-level key removal", () => {
+    test("removes apiKey and relayUrl", () => {
+        const result = sanitizeConfigForUI({ apiKey: "secret", relayUrl: "https://relay.example.com" });
+        expect(result).not.toHaveProperty("apiKey");
+        expect(result).not.toHaveProperty("relayUrl");
+    });
+
+    test("leaves unrelated keys intact", () => {
+        const result = sanitizeConfigForUI({ appendSystemPrompt: "hello", sandbox: { mode: "ask" } });
+        expect(result.appendSystemPrompt).toBe("hello");
+        expect((result.sandbox as any).mode).toBe("ask");
+    });
+});
+
+// ── sanitizeConfigForUI — mcpServers{} (object / compatibility format) ────────
+
+describe("sanitizeConfigForUI — mcpServers{} format", () => {
+    test("masks sensitive env keys in an mcpServers entry", () => {
+        const config = {
+            mcpServers: {
+                myServer: {
+                    command: "npx",
+                    args: ["mcp-server"],
+                    env: { API_KEY: "super-secret", NODE_ENV: "production" },
+                },
+            },
+        };
+        const result = sanitizeConfigForUI(config);
+        const env = (result.mcpServers as any).myServer.env;
+        expect(env.API_KEY).toBe(MASK_SENTINEL);
+        expect(env.NODE_ENV).toBe("production");
+    });
+
+    test("masks sensitive header keys in an mcpServers entry", () => {
+        const config = {
+            mcpServers: {
+                myServer: {
+                    url: "https://mcp.example.com",
+                    headers: { Authorization: "Bearer tok", "Content-Type": "application/json" },
+                },
+            },
+        };
+        const result = sanitizeConfigForUI(config);
+        const headers = (result.mcpServers as any).myServer.headers;
+        expect(headers.Authorization).toBe(MASK_SENTINEL);
+        expect(headers["Content-Type"]).toBe("application/json");
+    });
+
+    test("leaves entries without env/headers unchanged", () => {
+        const config = {
+            mcpServers: {
+                simple: { command: "npx", args: ["x"] },
+            },
+        };
+        const result = sanitizeConfigForUI(config);
+        expect((result.mcpServers as any).simple).toEqual({ command: "npx", args: ["x"] });
+    });
+
+    test("handles non-object entries gracefully", () => {
+        const config = {
+            mcpServers: { broken: null },
+        };
+        const result = sanitizeConfigForUI(config as any);
+        expect((result.mcpServers as any).broken).toBeNull();
+    });
+});
+
+// ── sanitizeConfigForUI — mcp.servers[] (preferred array format) ──────────────
+
+describe("sanitizeConfigForUI — mcp.servers[] format", () => {
+    test("masks sensitive env keys in mcp.servers entries", () => {
+        const config = {
+            mcp: {
+                servers: [
+                    {
+                        name: "playwright",
+                        command: "npx",
+                        args: ["playwright-mcp"],
+                        env: { PLAYWRIGHT_API_TOKEN: "s3cr3t", DEBUG: "pw:api" },
+                    },
+                ],
+            },
+        };
+        const result = sanitizeConfigForUI(config);
+        const servers = (result.mcp as any).servers as any[];
+        expect(servers[0].env.PLAYWRIGHT_API_TOKEN).toBe(MASK_SENTINEL);
+        expect(servers[0].env.DEBUG).toBe("pw:api");
+    });
+
+    test("masks sensitive header keys in mcp.servers entries", () => {
+        const config = {
+            mcp: {
+                servers: [
+                    {
+                        name: "httpServer",
+                        url: "https://mcp.example.com",
+                        headers: {
+                            Authorization: "Bearer mytoken",
+                            "X-Request-Id": "abc123",
+                        },
+                    },
+                ],
+            },
+        };
+        const result = sanitizeConfigForUI(config);
+        const servers = (result.mcp as any).servers as any[];
+        expect(servers[0].headers.Authorization).toBe(MASK_SENTINEL);
+        expect(servers[0].headers["X-Request-Id"]).toBe("abc123");
+    });
+
+    test("does not mutate the original config", () => {
+        const original = {
+            mcp: {
+                servers: [{ name: "s", command: "x", env: { API_KEY: "real" } }],
+            },
+        };
+        sanitizeConfigForUI(original);
+        expect(original.mcp.servers[0].env.API_KEY).toBe("real");
+    });
+
+    test("leaves entries without env/headers unchanged", () => {
+        const config = {
+            mcp: {
+                servers: [{ name: "simple", command: "npx", args: ["x"] }],
+            },
+        };
+        const result = sanitizeConfigForUI(config);
+        const servers = (result.mcp as any).servers as any[];
+        expect(servers[0]).toEqual({ name: "simple", command: "npx", args: ["x"] });
+    });
+
+    test("passes through non-object array entries unchanged", () => {
+        const config = {
+            mcp: { servers: [null, "bad-entry"] },
+        };
+        const result = sanitizeConfigForUI(config as any);
+        const servers = (result.mcp as any).servers as any[];
+        expect(servers[0]).toBeNull();
+        expect(servers[1]).toBe("bad-entry");
+    });
+
+    test("handles mcp with no servers array", () => {
+        const config = { mcp: { timeout: 30 } };
+        const result = sanitizeConfigForUI(config as any);
+        expect((result.mcp as any).timeout).toBe(30);
+    });
+
+    test("handles multiple servers, each masked independently", () => {
+        const config = {
+            mcp: {
+                servers: [
+                    { name: "a", command: "x", env: { API_KEY: "secA", KEEP: "v" } },
+                    { name: "b", command: "y", env: { TOKEN: "secB", ALSO_KEEP: "w" } },
+                ],
+            },
+        };
+        const result = sanitizeConfigForUI(config);
+        const [a, b] = (result.mcp as any).servers as any[];
+        expect(a.env.API_KEY).toBe(MASK_SENTINEL);
+        expect(a.env.KEEP).toBe("v");
+        expect(b.env.TOKEN).toBe(MASK_SENTINEL);
+        expect(b.env.ALSO_KEEP).toBe("w");
+    });
+
+    test("both mcp.servers[] and mcpServers{} are masked in the same config", () => {
+        const config = {
+            mcpServers: { objServer: { command: "a", env: { API_KEY: "s1" } } },
+            mcp: {
+                servers: [{ name: "arrServer", command: "b", env: { API_KEY: "s2" } }],
+            },
+        };
+        const result = sanitizeConfigForUI(config);
+        expect((result.mcpServers as any).objServer.env.API_KEY).toBe(MASK_SENTINEL);
+        expect((result.mcp as any).servers[0].env.API_KEY).toBe(MASK_SENTINEL);
+    });
+});
+
+// ── sanitizeConfigForUI — envOverrides ────────────────────────────────────────
+
+describe("sanitizeConfigForUI — envOverrides", () => {
+    test("masks sensitive keys in envOverrides", () => {
+        const result = sanitizeConfigForUI({
+            envOverrides: { ANTHROPIC_API_KEY: "sk-xxx", EDITOR: "vim" },
+        });
+        const ov = result.envOverrides as any;
+        expect(ov.ANTHROPIC_API_KEY).toBe(MASK_SENTINEL);
+        expect(ov.EDITOR).toBe("vim");
+    });
+});
+
+// ── restoreMaskedServerEntry ──────────────────────────────────────────────────
+
+describe("restoreMaskedServerEntry", () => {
+    test("restores masked env value from on-disk entry", () => {
+        const incoming = { name: "s", command: "x", env: { API_KEY: MASK_SENTINEL, DEBUG: "1" } };
+        const existing = { name: "s", command: "x", env: { API_KEY: "real-secret", DEBUG: "0" } };
+        const result = restoreMaskedServerEntry(incoming, existing);
+        expect((result.env as any).API_KEY).toBe("real-secret");
+        // Non-sentinel values are kept as-is from incoming
+        expect((result.env as any).DEBUG).toBe("1");
+    });
+
+    test("restores masked header value from on-disk entry", () => {
+        const incoming = {
+            name: "s",
+            url: "https://x.com",
+            headers: { Authorization: MASK_SENTINEL, "Content-Type": "application/json" },
+        };
+        const existing = {
+            name: "s",
+            url: "https://x.com",
+            headers: { Authorization: "Bearer token123", "Content-Type": "text/plain" },
+        };
+        const result = restoreMaskedServerEntry(incoming, existing);
+        expect((result.headers as any).Authorization).toBe("Bearer token123");
+        expect((result.headers as any)["Content-Type"]).toBe("application/json");
+    });
+
+    test("leaves sentinel as-is if existing entry has no value for that key", () => {
+        const incoming = { name: "s", env: { API_KEY: MASK_SENTINEL } };
+        const existing = { name: "s", env: {} }; // no API_KEY on disk
+        const result = restoreMaskedServerEntry(incoming, existing);
+        expect((result.env as any).API_KEY).toBe(MASK_SENTINEL);
+    });
+
+    test("returns incoming unchanged when existing is undefined (new server)", () => {
+        const incoming = { name: "new", command: "x", env: { TOKEN: MASK_SENTINEL } };
+        const result = restoreMaskedServerEntry(incoming, undefined);
+        expect(result).toEqual(incoming);
+    });
+
+    test("does not restore when incoming value is not the sentinel", () => {
+        const incoming = { name: "s", env: { API_KEY: "user-typed-new-value" } };
+        const existing = { name: "s", env: { API_KEY: "old-secret" } };
+        const result = restoreMaskedServerEntry(incoming, existing);
+        expect((result.env as any).API_KEY).toBe("user-typed-new-value");
+    });
+
+    test("does not mutate the incoming object", () => {
+        const incoming = { name: "s", env: { API_KEY: MASK_SENTINEL } };
+        const existing = { name: "s", env: { API_KEY: "real" } };
+        restoreMaskedServerEntry(incoming, existing);
+        expect(incoming.env.API_KEY).toBe(MASK_SENTINEL);
+    });
+
+    test("handles entries with no env or headers gracefully", () => {
+        const incoming = { name: "s", command: "x" };
+        const existing = { name: "s", command: "x" };
+        const result = restoreMaskedServerEntry(incoming, existing);
+        expect(result).toEqual({ name: "s", command: "x" });
+    });
+
+    test("restores both env and headers in a single call", () => {
+        const incoming = {
+            name: "s",
+            env: { TOKEN: MASK_SENTINEL },
+            headers: { Authorization: MASK_SENTINEL },
+        };
+        const existing = {
+            name: "s",
+            env: { TOKEN: "tok123" },
+            headers: { Authorization: "Bearer abc" },
+        };
+        const result = restoreMaskedServerEntry(incoming, existing);
+        expect((result.env as any).TOKEN).toBe("tok123");
+        expect((result.headers as any).Authorization).toBe("Bearer abc");
+    });
+});

--- a/packages/cli/src/runner/daemon-config-sanitize.ts
+++ b/packages/cli/src/runner/daemon-config-sanitize.ts
@@ -1,0 +1,161 @@
+/**
+ * Utilities for sanitizing/restoring PizzaPi config objects when they transit
+ * between the daemon and the browser UI.  Extracted as pure, stateless helpers
+ * so they can be unit-tested independently of the daemon's socket event loop.
+ *
+ * MUST be kept in sync with the sentinel-restore logic in
+ * settings_update_section (daemon.ts).
+ */
+
+/** Regex matching key/header names that should be treated as sensitive secrets. */
+export const SENSITIVE_NAME_RE =
+    /key|token|secret|password|credential|authorization|cookie|pat|bearer/i;
+
+/** Placeholder written in place of secret values when sending config to the UI. */
+export const MASK_SENTINEL = "***";
+
+// ── Internal helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Return a shallow-copied server entry with `env` and `headers` masked.
+ * Only key names matching SENSITIVE_NAME_RE get the "***" treatment.
+ */
+function maskServerEntry(server: Record<string, unknown>): Record<string, unknown> {
+    let sanitized: Record<string, unknown> = { ...server };
+
+    if ("env" in sanitized && sanitized.env && typeof sanitized.env === "object") {
+        const rawEnv = sanitized.env as Record<string, string>;
+        const maskedEnv: Record<string, string> = {};
+        for (const [k, v] of Object.entries(rawEnv)) {
+            maskedEnv[k] = SENSITIVE_NAME_RE.test(k) ? MASK_SENTINEL : v;
+        }
+        sanitized = { ...sanitized, env: maskedEnv };
+    }
+
+    if ("headers" in sanitized && sanitized.headers && typeof sanitized.headers === "object") {
+        const rawHeaders = sanitized.headers as Record<string, string>;
+        const maskedHeaders: Record<string, string> = {};
+        for (const [k, v] of Object.entries(rawHeaders)) {
+            maskedHeaders[k] = SENSITIVE_NAME_RE.test(k) ? MASK_SENTINEL : v;
+        }
+        sanitized = { ...sanitized, headers: maskedHeaders };
+    }
+
+    return sanitized;
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Mask sensitive fields in a PizzaPi config object before sending to the UI.
+ *
+ * - Removes `apiKey` and `relayUrl` (not needed in UI).
+ * - Replaces sensitive env/header values with MASK_SENTINEL ("***") in:
+ *   - `mcpServers` (Claude Code / compatibility object format)
+ *   - `mcp.servers[]` (preferred array format)
+ *   - `envOverrides`
+ *
+ * Must be kept in sync with the sentinel-restore logic in
+ * `settings_update_section` (daemon.ts).
+ */
+export function sanitizeConfigForUI(config: Record<string, unknown>): Record<string, unknown> {
+    const sanitized: any = { ...config };
+    delete sanitized.apiKey;
+    delete sanitized.relayUrl;
+
+    // ── mcpServers{} — Claude Code / compatibility object format ─────────────
+    if (sanitized.mcpServers && typeof sanitized.mcpServers === "object") {
+        const sanitizedMcp: Record<string, unknown> = {};
+        for (const [name, server] of Object.entries(
+            sanitized.mcpServers as Record<string, unknown>,
+        )) {
+            if (server && typeof server === "object") {
+                sanitizedMcp[name] = maskServerEntry(server as Record<string, unknown>);
+            } else {
+                sanitizedMcp[name] = server;
+            }
+        }
+        sanitized.mcpServers = sanitizedMcp;
+    }
+
+    // ── mcp.servers[] — preferred array format ───────────────────────────────
+    if (sanitized.mcp && typeof sanitized.mcp === "object") {
+        const mcp = sanitized.mcp as Record<string, unknown>;
+        if (Array.isArray(mcp.servers)) {
+            const sanitizedServers = mcp.servers.map((entry: unknown) => {
+                if (!entry || typeof entry !== "object") return entry;
+                return maskServerEntry(entry as Record<string, unknown>);
+            });
+            sanitized.mcp = { ...mcp, servers: sanitizedServers };
+        }
+    }
+
+    // ── envOverrides ─────────────────────────────────────────────────────────
+    if (sanitized.envOverrides && typeof sanitized.envOverrides === "object") {
+        const rawOverrides = sanitized.envOverrides as Record<string, string>;
+        const maskedOverrides: Record<string, string> = {};
+        for (const [k, v] of Object.entries(rawOverrides)) {
+            maskedOverrides[k] = SENSITIVE_NAME_RE.test(k) ? MASK_SENTINEL : v;
+        }
+        sanitized.envOverrides = maskedOverrides;
+    }
+
+    return sanitized;
+}
+
+/**
+ * Restore masked sentinel values in `env`/`headers` of a single MCP server entry.
+ *
+ * When the UI sends back a config that was previously sanitised, placeholder
+ * "***" values must NOT be written to disk — they would overwrite the real
+ * secrets.  This helper substitutes the original on-disk value for every key
+ * still carrying the sentinel.
+ *
+ * If the existing (on-disk) entry doesn't have a value for the key, the
+ * sentinel is passed through as-is, which is visible-but-recoverable.
+ */
+export function restoreMaskedServerEntry(
+    incoming: Record<string, unknown>,
+    existing: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+    if (!existing) return incoming;
+    let merged: Record<string, unknown> = { ...incoming };
+
+    if (
+        "env" in merged &&
+        merged.env &&
+        typeof merged.env === "object" &&
+        existing.env &&
+        typeof existing.env === "object"
+    ) {
+        const incomingEnv = merged.env as Record<string, string>;
+        const existingEnv = existing.env as Record<string, string>;
+        const restoredEnv: Record<string, string> = { ...incomingEnv };
+        for (const [k, v] of Object.entries(incomingEnv)) {
+            if (v === MASK_SENTINEL && typeof existingEnv[k] === "string") {
+                restoredEnv[k] = existingEnv[k];
+            }
+        }
+        merged = { ...merged, env: restoredEnv };
+    }
+
+    if (
+        "headers" in merged &&
+        merged.headers &&
+        typeof merged.headers === "object" &&
+        existing.headers &&
+        typeof existing.headers === "object"
+    ) {
+        const incomingHeaders = merged.headers as Record<string, string>;
+        const existingHeaders = existing.headers as Record<string, string>;
+        const restoredHeaders: Record<string, string> = { ...incomingHeaders };
+        for (const [k, v] of Object.entries(incomingHeaders)) {
+            if (v === MASK_SENTINEL && typeof existingHeaders[k] === "string") {
+                restoredHeaders[k] = existingHeaders[k];
+            }
+        }
+        merged = { ...merged, headers: restoredHeaders };
+    }
+
+    return merged;
+}

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1166,10 +1166,32 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     // AGENTS.md may not exist yet
                 }
 
+                // Strip sensitive fields before sending to UI
+                const sanitizedConfig: any = { ...globalConfig };
+                delete sanitizedConfig.apiKey;
+                delete sanitizedConfig.relayUrl;
+                // Strip sensitive env values from MCP server definitions
+                // (mcpServers is not in PizzaPiConfig type — it flows through as untyped JSON)
+                if (sanitizedConfig.mcpServers && typeof sanitizedConfig.mcpServers === "object") {
+                    const sanitizedMcp: Record<string, unknown> = {};
+                    for (const [name, server] of Object.entries(sanitizedConfig.mcpServers as Record<string, unknown>)) {
+                        if (server && typeof server === "object" && "env" in server) {
+                            const rawEnv = (server as { env: Record<string, string> }).env;
+                            const maskedEnv: Record<string, string> = {};
+                            for (const [k, v] of Object.entries(rawEnv)) {
+                                maskedEnv[k] = /key|token|secret|password|credential/i.test(k) ? "***" : v;
+                            }
+                            sanitizedMcp[name] = { ...server, env: maskedEnv };
+                        } else {
+                            sanitizedMcp[name] = server;
+                        }
+                    }
+                    sanitizedConfig.mcpServers = sanitizedMcp;
+                }
                 socket.emit("file_result", {
                     requestId,
                     ok: true,
-                    config: globalConfig,
+                    config: sanitizedConfig,
                     tuiSettings,
                     agentsMd,
                 });

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1170,23 +1170,55 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 const sanitizedConfig: any = { ...globalConfig };
                 delete sanitizedConfig.apiKey;
                 delete sanitizedConfig.relayUrl;
+
+                // Regex for sensitive key/header names -- covers common secret patterns plus
+                // HTTP auth headers (Authorization, Cookie) and common PAT/Bearer naming.
+                const SENSITIVE_NAME_RE = /key|token|secret|password|credential|authorization|cookie|pat|bearer/i;
+
                 // Strip sensitive env values from MCP server definitions
-                // (mcpServers is not in PizzaPiConfig type — it flows through as untyped JSON)
+                // (mcpServers is not in PizzaPiConfig type -- it flows through as untyped JSON)
                 if (sanitizedConfig.mcpServers && typeof sanitizedConfig.mcpServers === "object") {
                     const sanitizedMcp: Record<string, unknown> = {};
                     for (const [name, server] of Object.entries(sanitizedConfig.mcpServers as Record<string, unknown>)) {
-                        if (server && typeof server === "object" && "env" in server) {
-                            const rawEnv = (server as { env: Record<string, string> }).env;
-                            const maskedEnv: Record<string, string> = {};
-                            for (const [k, v] of Object.entries(rawEnv)) {
-                                maskedEnv[k] = /key|token|secret|password|credential/i.test(k) ? "***" : v;
+                        if (server && typeof server === "object") {
+                            let sanitizedServer: Record<string, unknown> = { ...(server as Record<string, unknown>) };
+
+                            // Mask sensitive env var values
+                            if ("env" in sanitizedServer && sanitizedServer.env && typeof sanitizedServer.env === "object") {
+                                const rawEnv = sanitizedServer.env as Record<string, string>;
+                                const maskedEnv: Record<string, string> = {};
+                                for (const [k, v] of Object.entries(rawEnv)) {
+                                    maskedEnv[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
+                                }
+                                sanitizedServer = { ...sanitizedServer, env: maskedEnv };
                             }
-                            sanitizedMcp[name] = { ...server, env: maskedEnv };
+
+                            // Mask sensitive HTTP header values (e.g. Authorization, Cookie, X-Api-Key)
+                            if ("headers" in sanitizedServer && sanitizedServer.headers && typeof sanitizedServer.headers === "object") {
+                                const rawHeaders = sanitizedServer.headers as Record<string, string>;
+                                const maskedHeaders: Record<string, string> = {};
+                                for (const [k, v] of Object.entries(rawHeaders)) {
+                                    maskedHeaders[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
+                                }
+                                sanitizedServer = { ...sanitizedServer, headers: maskedHeaders };
+                            }
+
+                            sanitizedMcp[name] = sanitizedServer;
                         } else {
                             sanitizedMcp[name] = server;
                         }
                     }
                     sanitizedConfig.mcpServers = sanitizedMcp;
+                }
+
+                // Mask sensitive envOverrides values (top-level env var section)
+                if (sanitizedConfig.envOverrides && typeof sanitizedConfig.envOverrides === "object") {
+                    const rawOverrides = sanitizedConfig.envOverrides as Record<string, string>;
+                    const maskedOverrides: Record<string, string> = {};
+                    for (const [k, v] of Object.entries(rawOverrides)) {
+                        maskedOverrides[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
+                    }
+                    sanitizedConfig.envOverrides = maskedOverrides;
                 }
                 socket.emit("file_result", {
                     requestId,
@@ -1290,8 +1322,19 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         if (v?.skills !== undefined) updates.skills = v.skills;
                         saveGlobal(updates);
                     } else if (section === "envVars") {
-                        // Env vars are stored in a custom key in config.json
-                        const updates: Record<string, any> = { envOverrides: value };
+                        // Env vars are stored in a custom key in config.json.
+                        // Restore any masked ("***") sentinel values from the on-disk config
+                        // so we don't overwrite real secrets with the placeholder.
+                        const MASK_SENTINEL = "***";
+                        const existingOverrides = ((existing as any).envOverrides ?? {}) as Record<string, string>;
+                        const incomingOverrides = (value ?? {}) as Record<string, string>;
+                        const restoredOverrides: Record<string, string> = { ...incomingOverrides };
+                        for (const [k, v] of Object.entries(incomingOverrides)) {
+                            if (v === MASK_SENTINEL && typeof existingOverrides[k] === "string") {
+                                restoredOverrides[k] = existingOverrides[k];
+                            }
+                        }
+                        const updates: Record<string, any> = { envOverrides: restoredOverrides };
                         saveGlobal(updates);
                     } else if (section === "webSearch") {
                         // Web search config goes into providerSettings
@@ -1333,38 +1376,69 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                             return;
                         }
 
-                        // The settings API masks sensitive env var values (e.g. tokens/keys)
+                        // The settings API masks sensitive env var and header values (e.g. tokens/keys)
                         // with "***" before sending them to the UI so they aren't exposed in
                         // transit.  When the UI sends the config back on save, those masked
-                        // values must NOT be written to disk — that would overwrite the real
+                        // values must NOT be written to disk -- that would overwrite the real
                         // secrets with the placeholder string.
                         //
-                        // Strategy: for every env entry whose value is exactly "***", check
+                        // Strategy: for every env/header entry whose value is exactly "***", check
                         // whether the on-disk config already has a real value for that key and
                         // keep the original instead.
+                        //
+                        // TODO(P2): Rename edge case -- if an MCP server is renamed in the UI
+                        // before saving, the masked "***" values can't be matched to the old
+                        // on-disk entry (key lookup by new name finds no existing server).
+                        // Those entries will be written as literal "***", which the user will
+                        // notice as obviously broken credentials.  A full fix requires tracking
+                        // server identity across renames (e.g. a stable ID field or a diff
+                        // protocol).  For now the failure is visible and recoverable by the user.
                         const MASK_SENTINEL = "***";
                         const existingMcpServers = ((existing as any).mcpServers ?? {}) as Record<string, any>;
                         const mergedServers: Record<string, any> = {};
                         for (const [name, entry] of Object.entries(servers)) {
                             const existingServer = existingMcpServers[name];
-                            if (
-                                entry &&
-                                typeof entry === "object" &&
-                                "env" in entry &&
-                                entry.env &&
-                                typeof entry.env === "object" &&
-                                existingServer?.env &&
-                                typeof existingServer.env === "object"
-                            ) {
+
+                            if (entry && typeof entry === "object") {
+                                let mergedEntry: Record<string, any> = { ...entry };
+
                                 // Restore any env var that still carries the mask sentinel
-                                const incomingEnv = entry.env as Record<string, string>;
-                                const restoredEnv: Record<string, string> = { ...incomingEnv };
-                                for (const [k, v] of Object.entries(incomingEnv)) {
-                                    if (v === MASK_SENTINEL && typeof existingServer.env[k] === "string") {
-                                        restoredEnv[k] = existingServer.env[k] as string;
+                                if (
+                                    "env" in mergedEntry &&
+                                    mergedEntry.env &&
+                                    typeof mergedEntry.env === "object" &&
+                                    existingServer?.env &&
+                                    typeof existingServer.env === "object"
+                                ) {
+                                    const incomingEnv = mergedEntry.env as Record<string, string>;
+                                    const restoredEnv: Record<string, string> = { ...incomingEnv };
+                                    for (const [k, v] of Object.entries(incomingEnv)) {
+                                        if (v === MASK_SENTINEL && typeof existingServer.env[k] === "string") {
+                                            restoredEnv[k] = existingServer.env[k] as string;
+                                        }
                                     }
+                                    mergedEntry = { ...mergedEntry, env: restoredEnv };
                                 }
-                                mergedServers[name] = { ...entry, env: restoredEnv };
+
+                                // Restore any header that still carries the mask sentinel
+                                if (
+                                    "headers" in mergedEntry &&
+                                    mergedEntry.headers &&
+                                    typeof mergedEntry.headers === "object" &&
+                                    existingServer?.headers &&
+                                    typeof existingServer.headers === "object"
+                                ) {
+                                    const incomingHeaders = mergedEntry.headers as Record<string, string>;
+                                    const restoredHeaders: Record<string, string> = { ...incomingHeaders };
+                                    for (const [k, v] of Object.entries(incomingHeaders)) {
+                                        if (v === MASK_SENTINEL && typeof existingServer.headers[k] === "string") {
+                                            restoredHeaders[k] = existingServer.headers[k] as string;
+                                        }
+                                    }
+                                    mergedEntry = { ...mergedEntry, headers: restoredHeaders };
+                                }
+
+                                mergedServers[name] = mergedEntry;
                             } else {
                                 mergedServers[name] = entry;
                             }

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1135,6 +1135,66 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
         // ── Settings ───────────────────────────────────────────────────────
 
+        /**
+         * Mask sensitive fields in a PizzaPi config object before sending to the UI.
+         * Removes apiKey/relayUrl and replaces sensitive env/header values with "***".
+         * Must be kept in sync with the sentinel-restore logic in settings_update_section.
+         */
+        function sanitizeConfigForUI(config: Record<string, unknown>): Record<string, unknown> {
+            const sanitized: any = { ...config };
+            delete sanitized.apiKey;
+            delete sanitized.relayUrl;
+
+            // Regex for sensitive key/header names — covers common secret patterns plus
+            // HTTP auth headers (Authorization, Cookie) and common PAT/Bearer naming.
+            const SENSITIVE_NAME_RE = /key|token|secret|password|credential|authorization|cookie|pat|bearer/i;
+
+            // Strip sensitive env values from MCP server definitions
+            if (sanitized.mcpServers && typeof sanitized.mcpServers === "object") {
+                const sanitizedMcp: Record<string, unknown> = {};
+                for (const [name, server] of Object.entries(sanitized.mcpServers as Record<string, unknown>)) {
+                    if (server && typeof server === "object") {
+                        let sanitizedServer: Record<string, unknown> = { ...(server as Record<string, unknown>) };
+
+                        if ("env" in sanitizedServer && sanitizedServer.env && typeof sanitizedServer.env === "object") {
+                            const rawEnv = sanitizedServer.env as Record<string, string>;
+                            const maskedEnv: Record<string, string> = {};
+                            for (const [k, v] of Object.entries(rawEnv)) {
+                                maskedEnv[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
+                            }
+                            sanitizedServer = { ...sanitizedServer, env: maskedEnv };
+                        }
+
+                        if ("headers" in sanitizedServer && sanitizedServer.headers && typeof sanitizedServer.headers === "object") {
+                            const rawHeaders = sanitizedServer.headers as Record<string, string>;
+                            const maskedHeaders: Record<string, string> = {};
+                            for (const [k, v] of Object.entries(rawHeaders)) {
+                                maskedHeaders[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
+                            }
+                            sanitizedServer = { ...sanitizedServer, headers: maskedHeaders };
+                        }
+
+                        sanitizedMcp[name] = sanitizedServer;
+                    } else {
+                        sanitizedMcp[name] = server;
+                    }
+                }
+                sanitized.mcpServers = sanitizedMcp;
+            }
+
+            // Mask sensitive envOverrides values
+            if (sanitized.envOverrides && typeof sanitized.envOverrides === "object") {
+                const rawOverrides = sanitized.envOverrides as Record<string, string>;
+                const maskedOverrides: Record<string, string> = {};
+                for (const [k, v] of Object.entries(rawOverrides)) {
+                    maskedOverrides[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
+                }
+                sanitized.envOverrides = maskedOverrides;
+            }
+
+            return sanitized;
+        }
+
         socket.on("settings_get_config", async (data: any) => {
             if (isShuttingDown) return;
             const requestId = data?.requestId;
@@ -1167,59 +1227,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 }
 
                 // Strip sensitive fields before sending to UI
-                const sanitizedConfig: any = { ...globalConfig };
-                delete sanitizedConfig.apiKey;
-                delete sanitizedConfig.relayUrl;
-
-                // Regex for sensitive key/header names -- covers common secret patterns plus
-                // HTTP auth headers (Authorization, Cookie) and common PAT/Bearer naming.
-                const SENSITIVE_NAME_RE = /key|token|secret|password|credential|authorization|cookie|pat|bearer/i;
-
-                // Strip sensitive env values from MCP server definitions
-                // (mcpServers is not in PizzaPiConfig type -- it flows through as untyped JSON)
-                if (sanitizedConfig.mcpServers && typeof sanitizedConfig.mcpServers === "object") {
-                    const sanitizedMcp: Record<string, unknown> = {};
-                    for (const [name, server] of Object.entries(sanitizedConfig.mcpServers as Record<string, unknown>)) {
-                        if (server && typeof server === "object") {
-                            let sanitizedServer: Record<string, unknown> = { ...(server as Record<string, unknown>) };
-
-                            // Mask sensitive env var values
-                            if ("env" in sanitizedServer && sanitizedServer.env && typeof sanitizedServer.env === "object") {
-                                const rawEnv = sanitizedServer.env as Record<string, string>;
-                                const maskedEnv: Record<string, string> = {};
-                                for (const [k, v] of Object.entries(rawEnv)) {
-                                    maskedEnv[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
-                                }
-                                sanitizedServer = { ...sanitizedServer, env: maskedEnv };
-                            }
-
-                            // Mask sensitive HTTP header values (e.g. Authorization, Cookie, X-Api-Key)
-                            if ("headers" in sanitizedServer && sanitizedServer.headers && typeof sanitizedServer.headers === "object") {
-                                const rawHeaders = sanitizedServer.headers as Record<string, string>;
-                                const maskedHeaders: Record<string, string> = {};
-                                for (const [k, v] of Object.entries(rawHeaders)) {
-                                    maskedHeaders[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
-                                }
-                                sanitizedServer = { ...sanitizedServer, headers: maskedHeaders };
-                            }
-
-                            sanitizedMcp[name] = sanitizedServer;
-                        } else {
-                            sanitizedMcp[name] = server;
-                        }
-                    }
-                    sanitizedConfig.mcpServers = sanitizedMcp;
-                }
-
-                // Mask sensitive envOverrides values (top-level env var section)
-                if (sanitizedConfig.envOverrides && typeof sanitizedConfig.envOverrides === "object") {
-                    const rawOverrides = sanitizedConfig.envOverrides as Record<string, string>;
-                    const maskedOverrides: Record<string, string> = {};
-                    for (const [k, v] of Object.entries(rawOverrides)) {
-                        maskedOverrides[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
-                    }
-                    sanitizedConfig.envOverrides = maskedOverrides;
-                }
+                const sanitizedConfig = sanitizeConfigForUI(globalConfig as Record<string, unknown>);
                 socket.emit("file_result", {
                     requestId,
                     ok: true,
@@ -1449,8 +1457,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         saveGlobal({ [configKey]: value } as any);
                     }
 
-                    // Reload and return the updated config
-                    const updatedConfig = loadGlobal();
+                    // Reload and return the updated config — mask secrets before sending to browser
+                    const updatedConfig = sanitizeConfigForUI(loadGlobal() as Record<string, unknown>);
                     const reloadHint = section === "mcpServers"
                         ? "MCP server config saved. Active sessions can run /mcp reload to pick up changes."
                         : "Settings saved. Changes apply on next session start.";

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1332,7 +1332,44 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                             });
                             return;
                         }
-                        saveGlobal({ mcpServers: servers } as any);
+
+                        // The settings API masks sensitive env var values (e.g. tokens/keys)
+                        // with "***" before sending them to the UI so they aren't exposed in
+                        // transit.  When the UI sends the config back on save, those masked
+                        // values must NOT be written to disk — that would overwrite the real
+                        // secrets with the placeholder string.
+                        //
+                        // Strategy: for every env entry whose value is exactly "***", check
+                        // whether the on-disk config already has a real value for that key and
+                        // keep the original instead.
+                        const MASK_SENTINEL = "***";
+                        const existingMcpServers = ((existing as any).mcpServers ?? {}) as Record<string, any>;
+                        const mergedServers: Record<string, any> = {};
+                        for (const [name, entry] of Object.entries(servers)) {
+                            const existingServer = existingMcpServers[name];
+                            if (
+                                entry &&
+                                typeof entry === "object" &&
+                                "env" in entry &&
+                                entry.env &&
+                                typeof entry.env === "object" &&
+                                existingServer?.env &&
+                                typeof existingServer.env === "object"
+                            ) {
+                                // Restore any env var that still carries the mask sentinel
+                                const incomingEnv = entry.env as Record<string, string>;
+                                const restoredEnv: Record<string, string> = { ...incomingEnv };
+                                for (const [k, v] of Object.entries(incomingEnv)) {
+                                    if (v === MASK_SENTINEL && typeof existingServer.env[k] === "string") {
+                                        restoredEnv[k] = existingServer.env[k] as string;
+                                    }
+                                }
+                                mergedServers[name] = { ...entry, env: restoredEnv };
+                            } else {
+                                mergedServers[name] = entry;
+                            }
+                        }
+                        saveGlobal({ mcpServers: mergedServers } as any);
                     } else {
                         // Direct key mapping
                         saveGlobal({ [configKey]: value } as any);

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -25,6 +25,7 @@ import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
+import { sanitizeConfigForUI, restoreMaskedServerEntry, MASK_SENTINEL } from "./daemon-config-sanitize.js";
 import { defaultStatePath, acquireStateAndIdentity, releaseStateLock } from "./runner-state.js";
 import { startUsageRefreshLoop, stopUsageRefreshLoop } from "./runner-usage-cache.js";
 import { getWorkspaceRoots, isCwdAllowed } from "./workspace.js";
@@ -1135,65 +1136,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
         // ── Settings ───────────────────────────────────────────────────────
 
-        /**
-         * Mask sensitive fields in a PizzaPi config object before sending to the UI.
-         * Removes apiKey/relayUrl and replaces sensitive env/header values with "***".
-         * Must be kept in sync with the sentinel-restore logic in settings_update_section.
-         */
-        function sanitizeConfigForUI(config: Record<string, unknown>): Record<string, unknown> {
-            const sanitized: any = { ...config };
-            delete sanitized.apiKey;
-            delete sanitized.relayUrl;
-
-            // Regex for sensitive key/header names — covers common secret patterns plus
-            // HTTP auth headers (Authorization, Cookie) and common PAT/Bearer naming.
-            const SENSITIVE_NAME_RE = /key|token|secret|password|credential|authorization|cookie|pat|bearer/i;
-
-            // Strip sensitive env values from MCP server definitions
-            if (sanitized.mcpServers && typeof sanitized.mcpServers === "object") {
-                const sanitizedMcp: Record<string, unknown> = {};
-                for (const [name, server] of Object.entries(sanitized.mcpServers as Record<string, unknown>)) {
-                    if (server && typeof server === "object") {
-                        let sanitizedServer: Record<string, unknown> = { ...(server as Record<string, unknown>) };
-
-                        if ("env" in sanitizedServer && sanitizedServer.env && typeof sanitizedServer.env === "object") {
-                            const rawEnv = sanitizedServer.env as Record<string, string>;
-                            const maskedEnv: Record<string, string> = {};
-                            for (const [k, v] of Object.entries(rawEnv)) {
-                                maskedEnv[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
-                            }
-                            sanitizedServer = { ...sanitizedServer, env: maskedEnv };
-                        }
-
-                        if ("headers" in sanitizedServer && sanitizedServer.headers && typeof sanitizedServer.headers === "object") {
-                            const rawHeaders = sanitizedServer.headers as Record<string, string>;
-                            const maskedHeaders: Record<string, string> = {};
-                            for (const [k, v] of Object.entries(rawHeaders)) {
-                                maskedHeaders[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
-                            }
-                            sanitizedServer = { ...sanitizedServer, headers: maskedHeaders };
-                        }
-
-                        sanitizedMcp[name] = sanitizedServer;
-                    } else {
-                        sanitizedMcp[name] = server;
-                    }
-                }
-                sanitized.mcpServers = sanitizedMcp;
-            }
-
-            // Mask sensitive envOverrides values
-            if (sanitized.envOverrides && typeof sanitized.envOverrides === "object") {
-                const rawOverrides = sanitized.envOverrides as Record<string, string>;
-                const maskedOverrides: Record<string, string> = {};
-                for (const [k, v] of Object.entries(rawOverrides)) {
-                    maskedOverrides[k] = SENSITIVE_NAME_RE.test(k) ? "***" : v;
-                }
-                sanitized.envOverrides = maskedOverrides;
-            }
-
-            return sanitized;
-        }
+        // sanitizeConfigForUI is imported from ./daemon-config-sanitize.js
 
         socket.on("settings_get_config", async (data: any) => {
             if (isShuttingDown) return;
@@ -1385,14 +1328,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         }
 
                         // The settings API masks sensitive env var and header values (e.g. tokens/keys)
-                        // with "***" before sending them to the UI so they aren't exposed in
-                        // transit.  When the UI sends the config back on save, those masked
-                        // values must NOT be written to disk -- that would overwrite the real
-                        // secrets with the placeholder string.
-                        //
-                        // Strategy: for every env/header entry whose value is exactly "***", check
-                        // whether the on-disk config already has a real value for that key and
-                        // keep the original instead.
+                        // with MASK_SENTINEL ("***") before sending them to the UI so they aren't
+                        // exposed in transit.  When the UI sends the config back on save, those
+                        // masked values must NOT be written to disk — restoreMaskedServerEntry()
+                        // substitutes the original on-disk secret for each key still carrying the
+                        // sentinel.
                         //
                         // TODO(P2): Rename edge case -- if an MCP server is renamed in the UI
                         // before saving, the masked "***" values can't be matched to the old
@@ -1401,57 +1341,55 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         // notice as obviously broken credentials.  A full fix requires tracking
                         // server identity across renames (e.g. a stable ID field or a diff
                         // protocol).  For now the failure is visible and recoverable by the user.
-                        const MASK_SENTINEL = "***";
                         const existingMcpServers = ((existing as any).mcpServers ?? {}) as Record<string, any>;
                         const mergedServers: Record<string, any> = {};
                         for (const [name, entry] of Object.entries(servers)) {
-                            const existingServer = existingMcpServers[name];
-
                             if (entry && typeof entry === "object") {
-                                let mergedEntry: Record<string, any> = { ...entry };
-
-                                // Restore any env var that still carries the mask sentinel
-                                if (
-                                    "env" in mergedEntry &&
-                                    mergedEntry.env &&
-                                    typeof mergedEntry.env === "object" &&
-                                    existingServer?.env &&
-                                    typeof existingServer.env === "object"
-                                ) {
-                                    const incomingEnv = mergedEntry.env as Record<string, string>;
-                                    const restoredEnv: Record<string, string> = { ...incomingEnv };
-                                    for (const [k, v] of Object.entries(incomingEnv)) {
-                                        if (v === MASK_SENTINEL && typeof existingServer.env[k] === "string") {
-                                            restoredEnv[k] = existingServer.env[k] as string;
-                                        }
-                                    }
-                                    mergedEntry = { ...mergedEntry, env: restoredEnv };
-                                }
-
-                                // Restore any header that still carries the mask sentinel
-                                if (
-                                    "headers" in mergedEntry &&
-                                    mergedEntry.headers &&
-                                    typeof mergedEntry.headers === "object" &&
-                                    existingServer?.headers &&
-                                    typeof existingServer.headers === "object"
-                                ) {
-                                    const incomingHeaders = mergedEntry.headers as Record<string, string>;
-                                    const restoredHeaders: Record<string, string> = { ...incomingHeaders };
-                                    for (const [k, v] of Object.entries(incomingHeaders)) {
-                                        if (v === MASK_SENTINEL && typeof existingServer.headers[k] === "string") {
-                                            restoredHeaders[k] = existingServer.headers[k] as string;
-                                        }
-                                    }
-                                    mergedEntry = { ...mergedEntry, headers: restoredHeaders };
-                                }
-
-                                mergedServers[name] = mergedEntry;
+                                mergedServers[name] = restoreMaskedServerEntry(
+                                    entry as Record<string, unknown>,
+                                    existingMcpServers[name],
+                                );
                             } else {
                                 mergedServers[name] = entry;
                             }
                         }
                         saveGlobal({ mcpServers: mergedServers } as any);
+                    } else if (section === "mcp") {
+                        // mcp.servers[] (preferred array format) — restore masked sentinel values
+                        // before writing to disk.  We look up each server by its `name` field in
+                        // the on-disk array so we can restore the original secret.
+                        //
+                        // TODO(P2): Same rename edge case as mcpServers — if a server's name is
+                        // changed in the UI the lookup by name will find nothing and the sentinel
+                        // will be written as-is.  Visible and recoverable by the user.
+                        const incomingMcp = (value ?? {}) as { servers?: any[] };
+                        const existingMcp = ((existing as any).mcp ?? {}) as { servers?: any[] };
+
+                        // Build name → entry map for O(1) lookup against the on-disk array.
+                        const existingByName = new Map<string, Record<string, unknown>>();
+                        if (Array.isArray(existingMcp.servers)) {
+                            for (const s of existingMcp.servers) {
+                                if (s && typeof s === "object" && typeof (s as any).name === "string") {
+                                    existingByName.set((s as any).name as string, s as Record<string, unknown>);
+                                }
+                            }
+                        }
+
+                        const mergedMcpServers: any[] = Array.isArray(incomingMcp.servers)
+                            ? incomingMcp.servers.map((entry: any) => {
+                                  if (!entry || typeof entry !== "object") return entry;
+                                  const existingEntry =
+                                      typeof entry.name === "string"
+                                          ? existingByName.get(entry.name)
+                                          : undefined;
+                                  return restoreMaskedServerEntry(
+                                      entry as Record<string, unknown>,
+                                      existingEntry,
+                                  );
+                              })
+                            : [];
+
+                        saveGlobal({ mcp: { ...incomingMcp, servers: mergedMcpServers } } as any);
                     } else {
                         // Direct key mapping
                         saveGlobal({ [configKey]: value } as any);
@@ -1459,7 +1397,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
                     // Reload and return the updated config — mask secrets before sending to browser
                     const updatedConfig = sanitizeConfigForUI(loadGlobal() as Record<string, unknown>);
-                    const reloadHint = section === "mcpServers"
+                    const isMcpSection = section === "mcpServers" || section === "mcp";
+                    const reloadHint = isMcpSection
                         ? "MCP server config saved. Active sessions can run /mcp reload to pick up changes."
                         : "Settings saved. Changes apply on next session start.";
                     socket.emit("file_result", {
@@ -1468,7 +1407,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         saved: true,
                         config: updatedConfig,
                         message: reloadHint,
-                        reloadHint: section === "mcpServers",
+                        reloadHint: isMcpSection,
                     });
                 }
             } catch (err) {

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -93,8 +93,32 @@ export function spawnSession(
 
     const workerArgs = resolveWorkerSpawnArgs();
 
+    // Build a safe base environment using an explicit allowlist instead of
+    // spreading the full process.env (which would leak arbitrary secrets such
+    // as SSH keys, AWS credentials, etc. that happen to be in the daemon env).
+    const SAFE_ENV_KEYS = [
+        // Standard POSIX / shell vars needed by most CLI tools
+        "PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TERM", "USER", "LOGNAME",
+        "SHELL", "TMPDIR", "TEMP", "TMP", "XDG_RUNTIME_DIR",
+        // macOS Keychain / certificate store access
+        "SSL_CERT_FILE", "SSL_CERT_DIR",
+        // Git identity (needed for git operations inside sessions)
+        "GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
+    ];
+    const baseEnv: Record<string, string> = {};
+    for (const key of SAFE_ENV_KEYS) {
+        if (typeof process.env[key] === "string") baseEnv[key] = process.env[key]!;
+    }
+    // Forward all PIZZAPI_* vars set by the daemon (e.g. web-search flags
+    // applied by loadGlobalConfig) so workers inherit runtime config.
+    for (const [key, val] of Object.entries(process.env)) {
+        if (key.startsWith("PIZZAPI_") && typeof val === "string") {
+            baseEnv[key] = val;
+        }
+    }
+
     const env: Record<string, string> = {
-        ...Object.fromEntries(Object.entries(process.env).filter(([, v]) => typeof v === "string")) as any,
+        ...baseEnv,
         // Use the daemon's resolved relay URL so workers always connect to the
         // same relay the daemon is using (not a potentially-changed config file).
         PIZZAPI_RELAY_URL: relayUrl,

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -114,6 +114,7 @@ export function spawnSession(
         "PIZZAPI_RUNNER_TOKEN",
         "PIZZAPI_RUNNER_API_KEY",
         "NODE_OPTIONS",
+        "BUN_OPTIONS",           // Bun equivalent of NODE_OPTIONS — can inject code via --preload
         "LD_PRELOAD",
         "DYLD_INSERT_LIBRARIES",
         "DYLD_FORCE_FLAT_NAMESPACE",

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -93,26 +93,35 @@ export function spawnSession(
 
     const workerArgs = resolveWorkerSpawnArgs();
 
-    // Build a safe base environment using an explicit allowlist instead of
-    // spreading the full process.env (which would leak arbitrary secrets such
-    // as SSH keys, AWS credentials, etc. that happen to be in the daemon env).
-    const SAFE_ENV_KEYS = [
-        // Standard POSIX / shell vars needed by most CLI tools
-        "PATH", "HOME", "LANG", "LC_ALL", "LC_CTYPE", "TERM", "USER", "LOGNAME",
-        "SHELL", "TMPDIR", "TEMP", "TMP", "XDG_RUNTIME_DIR",
-        // macOS Keychain / certificate store access
-        "SSL_CERT_FILE", "SSL_CERT_DIR",
-        // Git identity (needed for git operations inside sessions)
-        "GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL", "GIT_COMMITTER_NAME", "GIT_COMMITTER_EMAIL",
-    ];
+    // Build the worker environment using a denylist approach: forward everything
+    // from the daemon's environment EXCEPT a small set of daemon-internal
+    // secrets and code-injection vectors that workers must never inherit.
+    //
+    // An allowlist was tried first but it proved too fragile — it silently
+    // dropped ANTHROPIC_API_KEY, OPENAI_API_KEY, GITHUB_TOKEN, MCP_TOKEN, and
+    // every other provider/MCP auth var that workers legitimately need.
+    //
+    // Daemon-internal vars that workers must NOT receive:
+    //   PIZZAPI_RUNNER_TOKEN     – relay auth token used only by the daemon
+    //   PIZZAPI_RUNNER_API_KEY   – daemon-level API key; each worker gets its own
+    //
+    // Code/library injection vectors that should never be inherited:
+    //   NODE_OPTIONS             – could inject arbitrary code via --require
+    //   LD_PRELOAD               – shared-library injection (Linux)
+    //   DYLD_INSERT_LIBRARIES    – shared-library injection (macOS)
+    //   DYLD_FORCE_FLAT_NAMESPACE
+    const WORKER_ENV_DENYLIST = new Set([
+        "PIZZAPI_RUNNER_TOKEN",
+        "PIZZAPI_RUNNER_API_KEY",
+        "NODE_OPTIONS",
+        "LD_PRELOAD",
+        "DYLD_INSERT_LIBRARIES",
+        "DYLD_FORCE_FLAT_NAMESPACE",
+    ]);
+
     const baseEnv: Record<string, string> = {};
-    for (const key of SAFE_ENV_KEYS) {
-        if (typeof process.env[key] === "string") baseEnv[key] = process.env[key]!;
-    }
-    // Forward all PIZZAPI_* vars set by the daemon (e.g. web-search flags
-    // applied by loadGlobalConfig) so workers inherit runtime config.
     for (const [key, val] of Object.entries(process.env)) {
-        if (key.startsWith("PIZZAPI_") && typeof val === "string") {
+        if (!WORKER_ENV_DENYLIST.has(key) && typeof val === "string") {
             baseEnv[key] = val;
         }
     }


### PR DESCRIPTION
## Summary

Two P0 security fixes for the settings API and worker spawning.

### Fix 1: Strip sensitive fields from `settings_get_config` response

**File:** `packages/cli/src/runner/daemon.ts`

Before sending the global config to the web UI, the handler now:
- Deletes `apiKey` and `relayUrl` from the config object
- Iterates over MCP server definitions and masks any env var whose key matches `/key|token|secret|password|credential/i` with `***`

This prevents the relay API key and any MCP server tokens/secrets from being exposed to the browser.

### Fix 2: Allowlist env vars for worker subprocess spawning

**File:** `packages/cli/src/runner/session-spawner.ts`

Replaces the blanket `...process.env` spread with:
- An explicit allowlist of safe system vars (`PATH`, `HOME`, `LANG`, `TERM`, `SHELL`, `TMPDIR`, git identity vars, SSL cert paths)
- A forward-pass of all `PIZZAPI_*` vars so runtime config (web search flags, changelog path, etc.) is preserved in workers

This prevents arbitrary secrets that happen to be set in the daemon's environment (AWS credentials, SSH passphrases, other API keys, etc.) from leaking into worker subprocesses.

## Testing

- `bun run typecheck` passes cleanly ✅

Closes idea/2ohxE7RK