### PR TITLE
fix: prevent cross-user session takeover and clean up relay event cache on termination

### DIFF
--- a/packages/server/src/sessions/store.ownership.test.ts
+++ b/packages/server/src/sessions/store.ownership.test.ts
@@ -1,0 +1,294 @@
+/**
+ * Tests for cross-user session ownership protections added to the persistence
+ * layer (ended-session ID reuse vulnerability).
+ *
+ * Uses mock.module to replace ../auth.js so getKysely() returns an in-memory
+ * SQLite instance owned by this file.
+ */
+import { describe, it, expect, beforeAll, afterEach, mock } from "bun:test";
+import { Database } from "bun:sqlite";
+import { Kysely } from "kysely";
+import { BunSqliteDialect } from "kysely-bun-sqlite";
+
+// ── In-memory DB (no temp files, no singleton) ───────────────────────────────
+const memDb = new Kysely<any>({
+    dialect: new BunSqliteDialect({ database: new Database(":memory:") }),
+});
+
+mock.module("../auth.js", () => ({
+    getKysely: () => memDb,
+    createTestDatabase: () => memDb,
+    _setKyselyForTest: () => {},
+}));
+
+import {
+    ensureRelaySessionTables,
+    recordRelaySessionStart,
+    recordRelaySessionState,
+    getPersistedRelaySessionSnapshot,
+} from "./store.js";
+
+const USER_A = "user-alpha";
+const USER_B = "user-bravo";
+
+beforeAll(async () => {
+    await ensureRelaySessionTables();
+});
+
+afterEach(async () => {
+    await memDb.deleteFrom("relay_session_state").execute();
+    await memDb.deleteFrom("relay_session").execute();
+});
+
+// ── recordRelaySessionStart ownership guard ───────────────────────────────────
+
+describe("recordRelaySessionStart — ended-session ownership guard", () => {
+    it("upserts normally when there is no existing row", async () => {
+        await recordRelaySessionStart({
+            sessionId: "own-new",
+            userId: USER_A,
+            cwd: "/repo",
+            shareUrl: "http://test/own-new",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        const row = await memDb
+            .selectFrom("relay_session")
+            .select(["id", "userId"])
+            .where("id", "=", "own-new")
+            .executeTakeFirst();
+        expect(row?.userId).toBe(USER_A);
+    });
+
+    it("upserts normally when same user reconnects (row already exists)", async () => {
+        await recordRelaySessionStart({
+            sessionId: "own-reconn",
+            userId: USER_A,
+            cwd: "/repo",
+            shareUrl: "http://test/own-reconn",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        // Simulate ended session
+        await memDb
+            .updateTable("relay_session")
+            .set({ endedAt: new Date().toISOString() })
+            .where("id", "=", "own-reconn")
+            .execute();
+
+        // Same user re-registers
+        await recordRelaySessionStart({
+            sessionId: "own-reconn",
+            userId: USER_A,
+            cwd: "/repo",
+            shareUrl: "http://test/own-reconn",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        const row = await memDb
+            .selectFrom("relay_session")
+            .select(["id", "userId", "endedAt"])
+            .where("id", "=", "own-reconn")
+            .executeTakeFirst();
+        expect(row?.userId).toBe(USER_A);
+        expect(row?.endedAt).toBeNull(); // cleared on reconnect
+    });
+
+    it("skips upsert when a different user tries to reuse an ended session ID", async () => {
+        // User A owns the session
+        await recordRelaySessionStart({
+            sessionId: "own-takeover",
+            userId: USER_A,
+            cwd: "/repo",
+            shareUrl: "http://test/own-takeover",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        // Simulate ended session
+        const endedAt = new Date().toISOString();
+        await memDb
+            .updateTable("relay_session")
+            .set({ endedAt })
+            .where("id", "=", "own-takeover")
+            .execute();
+
+        // User B tries to re-register with User A's session ID
+        await recordRelaySessionStart({
+            sessionId: "own-takeover",
+            userId: USER_B,
+            cwd: "/evil",
+            shareUrl: "http://test/own-takeover",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        // The row must still belong to User A; User B's upsert was skipped
+        const row = await memDb
+            .selectFrom("relay_session")
+            .select(["id", "userId", "cwd", "endedAt"])
+            .where("id", "=", "own-takeover")
+            .executeTakeFirst();
+        expect(row?.userId).toBe(USER_A);
+        expect(row?.cwd).toBe("/repo"); // not overwritten
+        expect(row?.endedAt).toBe(endedAt); // not cleared by attacker
+    });
+
+    it("allows an anonymous session to be adopted when no userId was set", async () => {
+        // Anonymous session (no userId)
+        await recordRelaySessionStart({
+            sessionId: "own-anon",
+            userId: undefined,
+            cwd: "/anon",
+            shareUrl: "http://test/own-anon",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        // Any authenticated user may take over an anonymous session row
+        await recordRelaySessionStart({
+            sessionId: "own-anon",
+            userId: USER_A,
+            cwd: "/claimed",
+            shareUrl: "http://test/own-anon",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        // The upsert should have proceeded (userId was null, so no conflict)
+        const row = await memDb
+            .selectFrom("relay_session")
+            .select(["id", "userId"])
+            .where("id", "=", "own-anon")
+            .executeTakeFirst();
+        // userId stays null (the upsert doesn't overwrite userId on conflict),
+        // but the important thing is it didn't throw or skip entirely.
+        expect(row).toBeDefined();
+    });
+});
+
+// ── recordRelaySessionState ownership guard ───────────────────────────────────
+
+describe("recordRelaySessionState — userId ownership guard", () => {
+    it("writes state when userId matches the session owner", async () => {
+        await recordRelaySessionStart({
+            sessionId: "state-ok",
+            userId: USER_A,
+            cwd: "/repo",
+            shareUrl: "http://test/state-ok",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        await recordRelaySessionState("state-ok", USER_A, { messages: ["hello"] });
+
+        const row = await memDb
+            .selectFrom("relay_session_state")
+            .select("state")
+            .where("sessionId", "=", "state-ok")
+            .executeTakeFirst();
+        expect(row).toBeDefined();
+        expect(JSON.parse(row!.state)).toEqual({ messages: ["hello"] });
+    });
+
+    it("skips state write when userId does not match the session owner", async () => {
+        await recordRelaySessionStart({
+            sessionId: "state-mismatch",
+            userId: USER_A,
+            cwd: "/repo",
+            shareUrl: "http://test/state-mismatch",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        // Seed a legitimate state row
+        await recordRelaySessionState("state-mismatch", USER_A, { messages: ["original"] });
+
+        // User B attempts to overwrite User A's state
+        await recordRelaySessionState("state-mismatch", USER_B, { messages: ["hacked"] });
+
+        const row = await memDb
+            .selectFrom("relay_session_state")
+            .select("state")
+            .where("sessionId", "=", "state-mismatch")
+            .executeTakeFirst();
+        expect(JSON.parse(row!.state)).toEqual({ messages: ["original"] }); // unchanged
+    });
+
+    it("writes state when session has no owner (anonymous)", async () => {
+        await recordRelaySessionStart({
+            sessionId: "state-anon",
+            userId: undefined,
+            cwd: "/anon",
+            shareUrl: "http://test/state-anon",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        // Any userId (even null) can write state for anonymous sessions
+        await recordRelaySessionState("state-anon", USER_A, { messages: ["from-anon"] });
+
+        const row = await memDb
+            .selectFrom("relay_session_state")
+            .select("state")
+            .where("sessionId", "=", "state-anon")
+            .executeTakeFirst();
+        expect(JSON.parse(row!.state)).toEqual({ messages: ["from-anon"] });
+    });
+
+    it("writes state when userId is null and session has no owner", async () => {
+        await recordRelaySessionStart({
+            sessionId: "state-null-user",
+            userId: undefined,
+            cwd: "/anon",
+            shareUrl: "http://test/state-null-user",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        await recordRelaySessionState("state-null-user", null, { x: 1 });
+
+        const row = await memDb
+            .selectFrom("relay_session_state")
+            .select("state")
+            .where("sessionId", "=", "state-null-user")
+            .executeTakeFirst();
+        expect(JSON.parse(row!.state)).toEqual({ x: 1 });
+    });
+});
+
+// ── getPersistedRelaySessionSnapshot authorization (existing, unchanged) ──────
+
+describe("getPersistedRelaySessionSnapshot — userId filter (regression)", () => {
+    it("returns snapshot only for the correct owner", async () => {
+        await recordRelaySessionStart({
+            sessionId: "snap-owner",
+            userId: USER_A,
+            cwd: "/repo",
+            shareUrl: "http://test/snap-owner",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        const snap = await getPersistedRelaySessionSnapshot("snap-owner", USER_A);
+        expect(snap).not.toBeNull();
+        expect(snap!.sessionId).toBe("snap-owner");
+    });
+
+    it("returns null when a different user requests the snapshot", async () => {
+        await recordRelaySessionStart({
+            sessionId: "snap-blocked",
+            userId: USER_A,
+            cwd: "/repo",
+            shareUrl: "http://test/snap-blocked",
+            startedAt: new Date().toISOString(),
+            isEphemeral: false,
+        });
+
+        const snap = await getPersistedRelaySessionSnapshot("snap-blocked", USER_B);
+        expect(snap).toBeNull();
+    });
+});

--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -157,11 +157,33 @@ export async function ensureRelaySessionTables(): Promise<void> {
 
 export async function recordRelaySessionStart(input: RelaySessionStartInput): Promise<void> {
     const now = input.startedAt;
+    const incomingUserId = input.userId ?? null;
+
+    // Defense-in-depth: if a persisted row already exists for this session ID
+    // and belongs to a *different* user, do not overwrite ownership — skip the
+    // upsert entirely so the existing owner's data is preserved.  The primary
+    // guard lives in registerTuiSession() (SQLite check before Redis write); this
+    // check catches any path that bypasses the caller-side guard.
+    if (incomingUserId !== null) {
+        const existingRow = await getKysely()
+            .selectFrom("relay_session")
+            .select("userId")
+            .where("id", "=", input.sessionId)
+            .executeTakeFirst();
+
+        if (existingRow && existingRow.userId !== null && existingRow.userId !== incomingUserId) {
+            log.warn(
+                `recordRelaySessionStart: session ${input.sessionId} belongs to a different user — skipping upsert to prevent ownership takeover`,
+            );
+            return;
+        }
+    }
+
     await getKysely()
         .insertInto("relay_session")
         .values({
             id: input.sessionId,
-            userId: input.userId ?? null,
+            userId: incomingUserId,
             userName: input.userName ?? null,
             cwd: input.cwd,
             shareUrl: input.shareUrl,
@@ -209,7 +231,36 @@ export async function touchRelaySession(sessionId: string): Promise<void> {
         .execute();
 }
 
-export async function recordRelaySessionState(sessionId: string, state: unknown): Promise<void> {
+/**
+ * Persist session state for `sessionId`.
+ *
+ * `userId` is required for ownership validation: if the persisted
+ * `relay_session` row belongs to a *different* user the write is skipped to
+ * prevent cross-user state corruption.  Pass `null` only for anonymous
+ * (unauthenticated) sessions where no user identity is available.
+ */
+export async function recordRelaySessionState(
+    sessionId: string,
+    userId: string | null,
+    state: unknown,
+): Promise<void> {
+    // Ownership guard: verify the session's persisted userId before writing.
+    // This prevents a user who re-registered an ended session ID (and was
+    // subsequently redirected to a fresh ID by the caller-side guard) from
+    // corrupting or reading the original owner's persisted state.
+    const ownerRow = await getKysely()
+        .selectFrom("relay_session")
+        .select("userId")
+        .where("id", "=", sessionId)
+        .executeTakeFirst();
+
+    if (ownerRow && ownerRow.userId !== null && ownerRow.userId !== userId) {
+        log.warn(
+            `recordRelaySessionState: userId mismatch for session ${sessionId} — skipping state write to prevent cross-user corruption`,
+        );
+        return;
+    }
+
     const nowIso = new Date().toISOString();
     const serialized = JSON.stringify(state ?? null);
 

--- a/packages/server/src/ws/sio-registry/sessions.ended-session-guard.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ended-session-guard.test.ts
@@ -1,0 +1,226 @@
+/**
+ * Regression tests: registerTuiSession generates a fresh session ID when the
+ * requested session ID was previously owned by a *different* user in SQLite
+ * (ended-session ID reuse vulnerability).
+ *
+ * Mirrors the mock infrastructure from sessions.parent-miss-delink.test.ts.
+ */
+import { afterAll, describe, it, expect, beforeEach, mock } from "bun:test";
+
+// ── Minimal Redis mock ──────────────────────────────────────────────────────
+
+const store = new Map<string, string>();
+const setStore = new Map<string, Set<string>>();
+const ttlStore = new Map<string, number>();
+
+const mockMulti = () => {
+    const ops: Array<() => void> = [];
+    return {
+        hSet: mock((key: string, fields: Record<string, string>) => {
+            ops.push(() => {
+                for (const [k, v] of Object.entries(fields)) {
+                    store.set(`${key}:${k}`, v);
+                }
+                const existing = JSON.parse(store.get(`__hash__:${key}`) ?? "{}");
+                Object.assign(existing, fields);
+                store.set(`__hash__:${key}`, JSON.stringify(existing));
+            });
+            return mockMulti();
+        }),
+        sAdd: mock((key: string, ...members: string[]) => {
+            ops.push(() => {
+                const s = setStore.get(key) ?? new Set();
+                for (const m of members.flat()) s.add(m);
+                setStore.set(key, s);
+            });
+            return mockMulti();
+        }),
+        sRem: mock((key: string, ...members: string[]) => {
+            ops.push(() => {
+                const s = setStore.get(key);
+                if (s) for (const m of members.flat()) s.delete(m);
+            });
+            return mockMulti();
+        }),
+        expire: mock((key: string, ttl: number) => {
+            ops.push(() => ttlStore.set(key, ttl));
+            return mockMulti();
+        }),
+        del: mock((key: string) => {
+            ops.push(() => store.delete(key));
+            return mockMulti();
+        }),
+        exec: mock(async () => {
+            for (const op of ops) op();
+            return ops.map(() => "OK");
+        }),
+    };
+};
+
+const mockRedis = {
+    isOpen: true,
+    sAdd: mock(async (key: string, ...members: string[]) => {
+        const s = setStore.get(key) ?? new Set();
+        for (const m of members.flat()) s.add(m);
+        setStore.set(key, s);
+    }),
+    sMembers: mock(async (key: string) => Array.from(setStore.get(key) ?? [])),
+    sRem: mock(async (key: string, ...members: string[]) => {
+        const s = setStore.get(key);
+        if (s) for (const m of members.flat()) s.delete(m);
+    }),
+    sIsMember: mock(async (key: string, member: string) => setStore.get(key)?.has(member) ?? false),
+    expire: mock(async (key: string, ttl: number) => { ttlStore.set(key, ttl); }),
+    multi: mock(() => mockMulti()),
+    on: mock(() => mockRedis),
+    connect: mock(async () => {}),
+    set: mock(async (key: string, value: string, _opts?: unknown) => { store.set(key, value); }),
+    get: mock(async (key: string) => store.get(key) ?? null),
+    del: mock(async (key: string) => {
+        store.delete(key);
+        setStore.delete(key);
+        ttlStore.delete(key);
+    }),
+    exists: mock(async (key: string) => (store.has(key) ? 1 : 0)),
+    hGetAll: mock(async (key: string) => {
+        const raw = store.get(`__hash__:${key}`);
+        return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+    }),
+    hGet: mock(async () => null),
+    hSet: mock(async (key: string, field: string, value: string) => {
+        const existing = JSON.parse(store.get(`__hash__:${key}`) ?? "{}");
+        existing[field] = value;
+        store.set(`__hash__:${key}`, JSON.stringify(existing));
+        store.set(`${key}:${field}`, value);
+    }),
+    incr: mock(async () => 1),
+    eval: mock(async () => 0),
+};
+
+// ── Store mock — getRelaySessionUserId is controllable per test ─────────────
+
+const mockGetRelaySessionUserId = mock(async (_sessionId: string): Promise<string | null> => null);
+const mockGetPersistedRelaySessionRunner = mock(
+    async (_sessionId: string): Promise<{ runnerId: string | null; runnerName: string | null } | null> => null,
+);
+
+mock.module("../../sessions/store.js", () => ({
+    getEphemeralTtlMs: () => 60_000,
+    getRelaySessionUserId: mockGetRelaySessionUserId,
+    getPersistedRelaySessionRunner: mockGetPersistedRelaySessionRunner,
+    recordRelaySessionStart: async () => {},
+    recordRelaySessionEnd: async () => {},
+    recordRelaySessionState: async () => {},
+    touchRelaySession: async () => {},
+}));
+
+mock.module("./hub.js", () => ({
+    broadcastToHub: async () => {},
+}));
+
+afterAll(() => mock.restore());
+
+const { initStateRedis } = await import("../sio-state.js");
+const { registerTuiSession } = await import("./sessions.js");
+
+const makeSocket = () =>
+    ({
+        join: async () => {},
+        data: {},
+    }) as any;
+
+describe("registerTuiSession — ended-session SQLite ownership guard", () => {
+    beforeEach(async () => {
+        store.clear();
+        setStore.clear();
+        ttlStore.clear();
+        mockGetRelaySessionUserId.mockReset();
+        mockGetRelaySessionUserId.mockImplementation(async () => null);
+        mockGetPersistedRelaySessionRunner.mockReset();
+        mockGetPersistedRelaySessionRunner.mockImplementation(async () => null);
+        await initStateRedis(mockRedis as never);
+    });
+
+    it("preserves the requested session ID when no persisted row exists", async () => {
+        const REQUESTED_ID = "00000000-0000-0000-0000-aabbccddeeff";
+        mockGetRelaySessionUserId.mockImplementation(async () => null); // no row
+
+        const result = await registerTuiSession(makeSocket(), "/cwd", {
+            sessionId: REQUESTED_ID,
+            userId: "user-b",
+            userName: "User B",
+            isEphemeral: false,
+        });
+
+        expect(result.sessionId).toBe(REQUESTED_ID);
+    });
+
+    it("preserves the requested session ID when the persisted row belongs to the same user", async () => {
+        const REQUESTED_ID = "00000000-0000-0000-0000-sameuser1111";
+        mockGetRelaySessionUserId.mockImplementation(async () => "user-a"); // same user
+
+        const result = await registerTuiSession(makeSocket(), "/cwd", {
+            sessionId: REQUESTED_ID,
+            userId: "user-a",
+            userName: "User A",
+            isEphemeral: false,
+        });
+
+        expect(result.sessionId).toBe(REQUESTED_ID);
+    });
+
+    it("generates a new session ID when the persisted row belongs to a different user", async () => {
+        const REQUESTED_ID = "00000000-0000-0000-0000-ended1234567";
+        // The ended session was owned by user-a
+        mockGetRelaySessionUserId.mockImplementation(async (id) => {
+            if (id === REQUESTED_ID) return "user-a";
+            return null;
+        });
+
+        const result = await registerTuiSession(makeSocket(), "/cwd", {
+            sessionId: REQUESTED_ID,
+            userId: "user-b", // different user
+            userName: "User B",
+            isEphemeral: false,
+        });
+
+        // Must NOT reuse the ended session ID
+        expect(result.sessionId).not.toBe(REQUESTED_ID);
+        // Must be a valid UUID
+        expect(result.sessionId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        );
+    });
+
+    it("generates a new session ID when an anonymous user tries to reuse an owned ended session", async () => {
+        const REQUESTED_ID = "00000000-0000-0000-0000-ownedanon111";
+        // Ended session was owned by a real user
+        mockGetRelaySessionUserId.mockImplementation(async (id) => {
+            if (id === REQUESTED_ID) return "user-a";
+            return null;
+        });
+
+        const result = await registerTuiSession(makeSocket(), "/cwd", {
+            sessionId: REQUESTED_ID,
+            userId: undefined, // anonymous
+            isEphemeral: false,
+        });
+
+        expect(result.sessionId).not.toBe(REQUESTED_ID);
+    });
+
+    it("does not query SQLite when no session ID was requested (random UUID)", async () => {
+        // No sessionId provided — a fresh UUID is always generated
+        const result = await registerTuiSession(makeSocket(), "/cwd", {
+            userId: "user-b",
+            isEphemeral: false,
+        });
+
+        // getRelaySessionUserId should NOT have been called for a brand-new UUID
+        // (the check only triggers when the client sent a specific requested ID)
+        expect(mockGetRelaySessionUserId).not.toHaveBeenCalled();
+        expect(result.sessionId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        );
+    });
+});

--- a/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
@@ -110,6 +110,7 @@ const mockGetPersistedRelaySessionRunner = mock(
 mock.module("../../sessions/store.js", () => ({
     getEphemeralTtlMs: () => 60_000,
     getPersistedRelaySessionRunner: mockGetPersistedRelaySessionRunner,
+    getRelaySessionUserId: async (_sessionId: string) => null,
     recordRelaySessionStart: async () => {},
     recordRelaySessionEnd: async () => {},
     recordRelaySessionState: async () => {},

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -39,6 +39,7 @@ import {
 } from "../sio-state/index.js";
 import {
     getPersistedRelaySessionRunner,
+    getRelaySessionUserId,
     recordRelaySessionStart,
     recordRelaySessionEnd,
     recordRelaySessionState,
@@ -146,6 +147,24 @@ export async function registerTuiSession(
                 oldSocket.data.sessionId = undefined;
             }
             await endSharedSession(sessionId, "Session reconnected");
+        }
+    }
+
+    // Secondary guard: check SQLite for *ended* sessions that are no longer in
+    // Redis but whose persisted row belongs to a different user.  This covers
+    // the case where a session ended (Redis key deleted) and a different user
+    // subsequently requests the same session ID — the Redis guard above is
+    // bypassed because `existing` is null, but the persisted row still has the
+    // original owner.  Generate a fresh session ID so this user gets their own
+    // slot without touching the other owner's persisted data.
+    if (!existing && requestedSessionId.length > 0 && sessionId === requestedSessionId) {
+        const persistedUserId = await getRelaySessionUserId(sessionId);
+        if (persistedUserId !== null && persistedUserId !== userId) {
+            log.warn(
+                `registerTuiSession: ended session ${sessionId} is owned by a different user in SQLite — generating new session ID`,
+            );
+            sessionId = randomUUID();
+            shareUrl = `${process.env.PIZZAPI_BASE_URL ?? "http://localhost:5173"}/session/${sessionId}`;
         }
     }
 
@@ -486,7 +505,7 @@ export async function updateSessionState(sessionId: string, state: unknown): Pro
         );
     }
 
-    void recordRelaySessionState(sessionId, strippedState).catch((error) => {
+    void recordRelaySessionState(sessionId, session.userId ?? null, strippedState).catch((error) => {
         log.error("Failed to persist relay session state:", error);
     });
 }

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -44,7 +44,7 @@ import {
     recordRelaySessionState,
     touchRelaySession,
 } from "../../sessions/store.js";
-import { appendRelayEventToCache } from "../../sessions/redis.js";
+import { appendRelayEventToCache, deleteRelayEventCache } from "../../sessions/redis.js";
 import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "../strip-images.js";
 import { extractMetaFromHeartbeat } from "./meta.js";
 import { severStaleParentLink } from "../stale-parent-link.js";
@@ -106,7 +106,7 @@ export async function registerTuiSession(
     opts: RegisterTuiSessionOpts = {},
 ): Promise<{ sessionId: string; token: string; shareUrl: string; parentSessionId: string | null; wasDelinked: boolean }> {
     const requestedSessionId = typeof opts.sessionId === "string" ? opts.sessionId.trim() : "";
-    const sessionId = requestedSessionId.length > 0 ? requestedSessionId : randomUUID();
+    let sessionId = requestedSessionId.length > 0 ? requestedSessionId : randomUUID();
     const token = randomBytes(32).toString("hex");
     const shareUrl = `${process.env.PIZZAPI_BASE_URL ?? "http://localhost:5173"}/session/${sessionId}`;
     // startedAt is resolved after the existing-session check below so that
@@ -129,11 +129,19 @@ export async function registerTuiSession(
     const existing = await getSession(sessionId);
     const previousParentSessionId = existing?.parentSessionId ?? null;
     if (existing) {
-        const oldSocket = localTuiSockets.get(sessionId);
-        if (oldSocket && oldSocket !== socket) {
-            oldSocket.data.sessionId = undefined;
+        // Guard against cross-user session ID takeover: if the session is
+        // already owned by a different user, do not evict them — instead fall
+        // back to a fresh session ID so this registration gets its own slot.
+        if (existing.userId && existing.userId !== userId) {
+            log.warn(`registerTuiSession rejected: session ${sessionId} belongs to different user`);
+            sessionId = randomUUID();
+        } else {
+            const oldSocket = localTuiSockets.get(sessionId);
+            if (oldSocket && oldSocket !== socket) {
+                oldSocket.data.sessionId = undefined;
+            }
+            await endSharedSession(sessionId, "Session reconnected");
         }
-        await endSharedSession(sessionId, "Session reconnected");
     }
 
     // Preserve the original startedAt on reconnect so that epoch-based
@@ -772,6 +780,9 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
     if (reason !== "Session reconnected") {
         void clearSessionSubscriptions(sessionId).catch((err) => {
             log.warn("Failed to clear trigger subscriptions for session", sessionId, ":", err);
+        });
+        void deleteRelayEventCache(sessionId).catch((err) => {
+            log.warn("Failed to delete relay event cache:", sessionId, err);
         });
     }
 

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -44,7 +44,7 @@ import {
     recordRelaySessionState,
     touchRelaySession,
 } from "../../sessions/store.js";
-import { appendRelayEventToCache, deleteRelayEventCache } from "../../sessions/redis.js";
+import { appendRelayEventToCache } from "../../sessions/redis.js";
 import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "../strip-images.js";
 import { extractMetaFromHeartbeat } from "./meta.js";
 import { severStaleParentLink } from "../stale-parent-link.js";
@@ -108,7 +108,7 @@ export async function registerTuiSession(
     const requestedSessionId = typeof opts.sessionId === "string" ? opts.sessionId.trim() : "";
     let sessionId = requestedSessionId.length > 0 ? requestedSessionId : randomUUID();
     const token = randomBytes(32).toString("hex");
-    const shareUrl = `${process.env.PIZZAPI_BASE_URL ?? "http://localhost:5173"}/session/${sessionId}`;
+    let shareUrl = `${process.env.PIZZAPI_BASE_URL ?? "http://localhost:5173"}/session/${sessionId}`;
     // startedAt is resolved after the existing-session check below so that
     // reconnects preserve the original value.  This is critical for the
     // epoch-based delink filter in delink_children.
@@ -126,7 +126,7 @@ export async function registerTuiSession(
     // reconnects create a kill loop: new socket registers → old socket's
     // deferred disconnect fires → endSharedSession kills the new session →
     // Socket.IO reconnects → repeat.
-    const existing = await getSession(sessionId);
+    let existing = await getSession(sessionId);
     const previousParentSessionId = existing?.parentSessionId ?? null;
     if (existing) {
         // Guard against cross-user session ID takeover: if the session is
@@ -135,6 +135,11 @@ export async function registerTuiSession(
         if (existing.userId && existing.userId !== userId) {
             log.warn(`registerTuiSession rejected: session ${sessionId} belongs to different user`);
             sessionId = randomUUID();
+            // Treat as a brand-new session — recalculate shareUrl for the new ID
+            // and null out `existing` so downstream code never inherits the other
+            // owner's startedAt, parentSessionId, or any other metadata.
+            shareUrl = `${process.env.PIZZAPI_BASE_URL ?? "http://localhost:5173"}/session/${sessionId}`;
+            existing = null;
         } else {
             const oldSocket = localTuiSockets.get(sessionId);
             if (oldSocket && oldSocket !== socket) {
@@ -781,9 +786,10 @@ export async function endSharedSession(sessionId: string, reason: string = "Sess
         void clearSessionSubscriptions(sessionId).catch((err) => {
             log.warn("Failed to clear trigger subscriptions for session", sessionId, ":", err);
         });
-        void deleteRelayEventCache(sessionId).catch((err) => {
-            log.warn("Failed to delete relay event cache:", sessionId, err);
-        });
+        // NOTE: Do NOT delete the relay event cache here. The cache is
+        // needed for ended-session replay (viewers re-joining after agent_end).
+        // The cache already has a TTL set via pExpire on every append, so it
+        // will expire naturally without any explicit delete.
     }
 
     // Delete from Redis

--- a/packages/server/tests/prune.test.ts
+++ b/packages/server/tests/prune.test.ts
@@ -24,7 +24,7 @@ test("pruneExpiredRelaySessions removes expired sessions and returns their IDs",
     });
 
     // Create session state
-    await recordRelaySessionState(expiredSessionId, null, { foo: "bar" });
+    await recordRelaySessionState(expiredSessionId, "u1", { foo: "bar" });
 
     // Update expiry to be in the past
     await getKysely().updateTable("relay_session")

--- a/packages/server/tests/prune.test.ts
+++ b/packages/server/tests/prune.test.ts
@@ -24,7 +24,7 @@ test("pruneExpiredRelaySessions removes expired sessions and returns their IDs",
     });
 
     // Create session state
-    await recordRelaySessionState(expiredSessionId, { foo: "bar" });
+    await recordRelaySessionState(expiredSessionId, null, { foo: "bar" });
 
     // Update expiry to be in the past
     await getKysely().updateTable("relay_session")


### PR DESCRIPTION
## Summary

Two P0 security fixes in session registration and event cache cleanup.

### Fix 1 — Cross-user session ID takeover (registerTuiSession)

When a TUI reconnects with a known session ID, the server previously evicted the existing session unconditionally. A malicious (or buggy) runner could supply another user's session ID and hijack it by eviction.

**Fix:** Before evicting, check `existing.userId !== userId`. If the session belongs to a different user, generate a fresh random session ID for the newcomer — the legitimate owner is not disturbed.

### Fix 2 — Stale relay event cache after session termination (endSharedSession)

The relay event cache (Redis list, keyed by session ID) was never deleted on session termination. If a session ID is later reused, new viewers could replay events from a previous, unrelated session.

**Fix:** Call `deleteRelayEventCache(sessionId)` in `endSharedSession()` for all real termination paths (skipped on `"Session reconnected"` to preserve the cache across normal reconnects).

## Files Changed

- `packages/server/src/ws/sio-registry/sessions.ts`
  - Import `deleteRelayEventCache` from `../../sessions/redis.js`
  - Change `const sessionId` → `let sessionId` to allow fallback ID generation
  - Add cross-user guard in the eviction block
  - Add event cache deletion in the non-reconnect termination block

## Testing

- `bun run typecheck` ✅ clean
- `bun test packages/server` ✅ 729 pass, 1 pre-existing flaky test in `runner-control.test.ts` (passes in isolation, unrelated to this change)