### PR TITLE
fix: harden webhook runner ownership and replay checks

### DIFF
--- a/packages/docs/src/content/docs/features/webhooks.mdx
+++ b/packages/docs/src/content/docs/features/webhooks.mdx
@@ -99,10 +99,23 @@ POST /api/webhooks/:id/fire
 
 ### Headers
 
+**Enhanced mode (recommended — includes replay protection):**
+
 | Header | Required | Description |
 |--------|----------|-------------|
 | `Content-Type` | Yes | Must be `application/json` |
-| `X-Webhook-Signature` | Yes | HMAC-SHA256 hex digest of the raw request body, using the webhook's secret as the key |
+| `X-Webhook-Signature` | Yes | HMAC-SHA256 hex digest of `${timestamp}.${nonce}.${rawBody}` |
+| `X-Webhook-Timestamp` | Yes | ISO 8601 / RFC 3339 timestamp (e.g. `2025-01-15T10:30:00Z`). Must be within ±5 minutes of server time. |
+| `X-Webhook-Nonce` | Yes | Unique string per delivery (e.g. random hex). Prevents replay within the 5-minute window. |
+
+**Legacy mode (backward compatible — no replay protection):**
+
+| Header | Required | Description |
+|--------|----------|-------------|
+| `Content-Type` | Yes | Must be `application/json` |
+| `X-Webhook-Signature` | Yes | HMAC-SHA256 hex digest of the **raw request body** only |
+
+Legacy mode is supported for callers that don't send `X-Webhook-Timestamp` or `X-Webhook-Nonce`. Enhanced mode is strongly recommended for new integrations.
 
 ### Request body
 
@@ -135,19 +148,24 @@ Any valid JSON object. If you're using event filters, include a `type` field:
 
 | Status | Meaning |
 |--------|---------|
-| `401` | Missing `X-Webhook-Signature` header, or signature doesn't match |
+| `401` | Missing/invalid signature headers, or signature doesn't match, or timestamp too old/future |
+| `409` | Nonce already used within the 5-minute replay window (enhanced mode only) |
 | `400` | Invalid JSON body |
 | `404` | Webhook not found or disabled |
 | `500` | Webhook has no runner assigned |
 | `502` | Runner rejected the spawn request or is unreachable |
-| `503` | Runner is not connected to the server |
+| `503` | Runner is offline or not connected to the server |
 | `504` | Session was spawned but didn't connect within the timeout (~15s) |
 
 ---
 
 ## Computing the HMAC signature
 
-The signature is an HMAC-SHA256 hex digest of the **raw request body** using the webhook secret as the key.
+PizzaPi supports two signing modes. **Enhanced mode** (recommended) adds a timestamp and nonce to the HMAC input, providing replay protection. **Legacy mode** signs the raw body only and is supported for backward compatibility with existing integrations.
+
+### Enhanced mode (recommended)
+
+The signature is an HMAC-SHA256 hex digest of `${timestamp}.${nonce}.${rawBody}`.
 
 <Tabs>
   <TabItem label="Bash (curl)">
@@ -156,31 +174,41 @@ The signature is an HMAC-SHA256 hex digest of the **raw request body** using the
     WEBHOOK_URL="https://pizza.example.com/api/webhooks/YOUR_WEBHOOK_ID/fire"
     SECRET="your-64-char-hex-secret"
     BODY='{"type":"deploy","repo":"myorg/myapp","status":"failure"}'
+    TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    NONCE=$(openssl rand -hex 16)
 
-    # Compute HMAC-SHA256 signature
+    # Compute HMAC-SHA256 over timestamp.nonce.body
     # Works with both LibreSSL (macOS default) and OpenSSL 3.x
-    SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.*= //')
+    SIG=$(echo -n "$TIMESTAMP.$NONCE.$BODY" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.*= //')
 
     # Fire the webhook
     curl -X POST "$WEBHOOK_URL" \
       -H "Content-Type: application/json" \
       -H "X-Webhook-Signature: $SIG" \
+      -H "X-Webhook-Timestamp: $TIMESTAMP" \
+      -H "X-Webhook-Nonce: $NONCE" \
       -d "$BODY"
     ```
   </TabItem>
   <TabItem label="Node.js">
     ```javascript
-    import { createHmac } from "crypto";
+    import { createHmac, randomBytes } from "crypto";
 
     const secret = "your-64-char-hex-secret";
     const body = JSON.stringify({ type: "deploy", repo: "myorg/myapp", status: "failure" });
-    const signature = createHmac("sha256", secret).update(body).digest("hex");
+    const timestamp = new Date().toISOString();
+    const nonce = randomBytes(16).toString("hex");
+    const signature = createHmac("sha256", secret)
+      .update(`${timestamp}.${nonce}.${body}`)
+      .digest("hex");
 
     const res = await fetch("https://pizza.example.com/api/webhooks/YOUR_WEBHOOK_ID/fire", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
         "X-Webhook-Signature": signature,
+        "X-Webhook-Timestamp": timestamp,
+        "X-Webhook-Nonce": nonce,
       },
       body,
     });
@@ -189,17 +217,26 @@ The signature is an HMAC-SHA256 hex digest of the **raw request body** using the
   </TabItem>
   <TabItem label="Python">
     ```python
-    import hmac, hashlib, json, requests
+    import hmac, hashlib, json, secrets, requests
+    from datetime import datetime, timezone
 
-    secret = "your-64-char-hex-secret"
+    secret_key = "your-64-char-hex-secret"
     body = json.dumps({"type": "deploy", "repo": "myorg/myapp", "status": "failure"})
-    signature = hmac.new(secret.encode(), body.encode(), hashlib.sha256).hexdigest()
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    nonce = secrets.token_hex(16)
+    signature = hmac.new(
+        secret_key.encode(),
+        f"{timestamp}.{nonce}.{body}".encode(),
+        hashlib.sha256,
+    ).hexdigest()
 
     res = requests.post(
         "https://pizza.example.com/api/webhooks/YOUR_WEBHOOK_ID/fire",
         headers={
             "Content-Type": "application/json",
             "X-Webhook-Signature": signature,
+            "X-Webhook-Timestamp": timestamp,
+            "X-Webhook-Nonce": nonce,
         },
         data=body,
     )
@@ -208,8 +245,21 @@ The signature is an HMAC-SHA256 hex digest of the **raw request body** using the
   </TabItem>
 </Tabs>
 
+### Legacy mode (backward compatible)
+
+The signature is an HMAC-SHA256 hex digest of the **raw request body** only. No timestamp or nonce headers are sent. This mode has no replay protection but is still accepted for callers that pre-date the enhanced format.
+
+```bash
+SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.*= //')
+
+curl -X POST "$WEBHOOK_URL" \
+  -H "Content-Type: application/json" \
+  -H "X-Webhook-Signature: $SIG" \
+  -d "$BODY"
+```
+
 <Aside type="tip">
-  The signature is compared using **timing-safe comparison** on the server, which prevents timing attacks that could leak the secret.
+  The signature is compared using **timing-safe comparison** on the server, preventing timing attacks that could leak the secret.
 </Aside>
 
 ---
@@ -244,11 +294,15 @@ jobs:
             --arg run_url "${{ github.event.workflow_run.html_url }}" \
             '{type: $type, repo: $repo, branch: $branch, commit: $commit, run_url: $run_url}')
 
-          SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/^.*= //')
+          TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          NONCE=$(openssl rand -hex 16)
+          SIG=$(echo -n "$TIMESTAMP.$NONCE.$BODY" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/^.*= //')
 
           curl -sf -X POST "$WEBHOOK_URL" \
             -H "Content-Type: application/json" \
             -H "X-Webhook-Signature: $SIG" \
+            -H "X-Webhook-Timestamp: $TIMESTAMP" \
+            -H "X-Webhook-Nonce: $NONCE" \
             -d "$BODY"
     ```
 
@@ -387,10 +441,12 @@ A webhook **must have a runner assigned** (`runnerId`) to fire successfully. If 
 
 | Symptom | Likely cause |
 |---------|-------------|
-| `401 Invalid signature` | Secret mismatch, or the body was modified between signing and sending (e.g., re-serialized by a proxy). Sign the **exact** bytes you send. |
-| `401 Missing X-Webhook-Signature` | The header name is case-insensitive but must be present. Check for typos. |
+| `401 Invalid signature` | Secret mismatch, or the body was modified between signing and sending (e.g., re-serialized by a proxy). Sign the **exact** bytes you send. In enhanced mode the signed string is `${timestamp}.${nonce}.${rawBody}`. |
+| `401 Missing X-Webhook-Timestamp` | Using enhanced mode but forgot the timestamp header. Either add it (recommended) or omit both `X-Webhook-Timestamp` and `X-Webhook-Nonce` entirely to use legacy mode. |
+| `401 Webhook timestamp is too old` | The timestamp in `X-Webhook-Timestamp` is more than 5 minutes from server time. Check system clock synchronization. |
+| `409 Webhook nonce has already been used` | A replay was detected — the same nonce was used for a successful delivery within the last 5 minutes. Generate a fresh nonce per request. |
 | `404 Webhook not found` | Webhook ID is wrong, webhook was deleted, or webhook is disabled. |
 | `500 Webhook has no runner assigned` | The webhook's `runnerId` is `null`. Update it via the API or recreate from the runner detail view. |
-| `503 Runner is not connected` | The assigned runner is offline. Start the runner daemon or check connectivity. |
+| `503 Runner is offline` | The assigned runner has disconnected. Start the runner daemon or check connectivity. |
 | `504 Session did not connect in time` | The session was spawned on the runner but didn't register with the server within ~15 seconds. Check runner logs for errors. |
 | Session spawns but agent does nothing | The webhook's **prompt** field is empty, so the agent has no instructions. Set a prompt that tells the agent what to do with the payload. |

--- a/packages/docs/src/content/docs/features/webhooks.mdx
+++ b/packages/docs/src/content/docs/features/webhooks.mdx
@@ -99,14 +99,14 @@ POST /api/webhooks/:id/fire
 
 ### Headers
 
-**Enhanced mode (recommended — includes replay protection):**
+**Enhanced mode (recommended — includes per-process replay protection):**
 
 | Header | Required | Description |
 |--------|----------|-------------|
 | `Content-Type` | Yes | Must be `application/json` |
 | `X-Webhook-Signature` | Yes | HMAC-SHA256 hex digest of `${timestamp}.${nonce}.${rawBody}` |
 | `X-Webhook-Timestamp` | Yes | ISO 8601 / RFC 3339 timestamp (e.g. `2025-01-15T10:30:00Z`). Must be within ±5 minutes of server time. |
-| `X-Webhook-Nonce` | Yes | Unique string per delivery (e.g. random hex). Prevents replay within the 5-minute window. |
+| `X-Webhook-Nonce` | Yes | Unique string per delivery (e.g. random hex). Prevents replay within the 5-minute window (per server process; multi-node deployments need shared storage). |
 
 **Legacy mode (backward compatible — no replay protection):**
 

--- a/packages/server/src/routes/webhooks.test.ts
+++ b/packages/server/src/routes/webhooks.test.ts
@@ -930,6 +930,43 @@ describe("POST /api/webhooks/:id/fire — nonce consumed only on success", () =>
         // Session should not have been triggered again
         expect(sessionEmitMock).toHaveBeenCalledTimes(1);
     });
+
+    test("concurrent same-nonce requests — second gets 409", async () => {
+        // Tests the optimistic-consume fix: the nonce is set BEFORE any async work,
+        // so two requests with the same nonce running concurrently can't both win.
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+        const { sessionEmitMock } = setupSpawnAndDeliverMocks();
+
+        const timestamp = new Date().toISOString();
+        const nonce = `nonce-concurrent-${Date.now()}`;
+        const body = { event: "deploy" };
+
+        const [req1, url1] = makeFireReq(
+            "/api/webhooks/wh-1/fire",
+            body,
+            ACTIVE_WEBHOOK.secret,
+            { "x-webhook-timestamp": timestamp, "x-webhook-nonce": nonce },
+        );
+        const [req2, url2] = makeFireReq(
+            "/api/webhooks/wh-1/fire",
+            body,
+            ACTIVE_WEBHOOK.secret,
+            { "x-webhook-timestamp": timestamp, "x-webhook-nonce": nonce },
+        );
+
+        // Fire both concurrently. Because the nonce is consumed eagerly (before the
+        // first await), the second request will see the occupied nonce and return 409
+        // even though both started before either received a response.
+        const [res1, res2] = await Promise.all([
+            handleWebhooksRoute(req1, url1),
+            handleWebhooksRoute(req2, url2),
+        ]);
+
+        const statuses = [res1?.status, res2?.status].sort((a, b) => (a ?? 0) - (b ?? 0));
+        expect(statuses).toEqual([200, 409]);
+        // Only one delivery must have fired
+        expect(sessionEmitMock).toHaveBeenCalledTimes(1);
+    });
 });
 
 describe("POST /api/webhooks/:id/fire — event filtering", () => {

--- a/packages/server/src/routes/webhooks.test.ts
+++ b/packages/server/src/routes/webhooks.test.ts
@@ -11,8 +11,10 @@ afterAll(() => mock.restore());
 import { createHmac } from "crypto";
 
 // ── Helper: compute HMAC-SHA256 ──────────────────────────────────────────────
-function signBody(secret: string, body: string): string {
-    return createHmac("sha256", secret).update(body).digest("hex");
+function signBody(secret: string, timestamp: string, nonce: string, body: string): string {
+    return createHmac("sha256", secret)
+        .update(`${timestamp}.${nonce}.${body}`)
+        .digest("hex");
 }
 
 // ── Mock webhook store ───────────────────────────────────────────────────────
@@ -44,6 +46,13 @@ mock.module("../webhooks/store.js", () => ({
     listWebhooksForUser: mockListWebhooksForUser,
     updateWebhook: mockUpdateWebhook,
     deleteWebhook: mockDeleteWebhook,
+    toPublicWebhook: (webhook: any) => ({
+        ...webhook,
+        secret:
+            typeof webhook?.secret === "string" && webhook.secret.length > 8
+                ? `${webhook.secret.slice(0, 4)}…${webhook.secret.slice(-4)}`
+                : "",
+    }),
 }));
 
 // ── Mock sio-registry ────────────────────────────────────────────────────────
@@ -56,6 +65,9 @@ const mockBroadcastToSessionViewers = mock((_sid: string, _event: string, _data:
 const mockGetLocalRunnerSocket = mock((_runnerId: string) => null as any);
 const mockRecordRunnerSession = mock((_runnerId: string, _sessionId: string) => Promise.resolve());
 const mockLinkSessionToRunner = mock((_runnerId: string, _sessionId: string) => Promise.resolve());
+const mockGetRunnerData = mock((_runnerId: string) =>
+    Promise.resolve({ runnerId: "runner-1", userId: "user-1" } as any),
+);
 
 mock.module("../ws/sio-registry.js", () => ({
     getSharedSession: mockGetSharedSession,
@@ -65,6 +77,7 @@ mock.module("../ws/sio-registry.js", () => ({
     getLocalRunnerSocket: mockGetLocalRunnerSocket,
     recordRunnerSession: mockRecordRunnerSession,
     linkSessionToRunner: mockLinkSessionToRunner,
+    getRunnerData: mockGetRunnerData,
 }));
 
 // ── Mock runner-control ──────────────────────────────────────────────────────
@@ -121,9 +134,14 @@ function makeFireReq(
     extraHeaders?: Record<string, string>,
 ): [Request, URL] {
     const rawBody = JSON.stringify(body);
-    const sig = signBody(secret, rawBody);
+    const timestamp = extraHeaders?.["x-webhook-timestamp"] ?? new Date().toISOString();
+    const nonce =
+        extraHeaders?.["x-webhook-nonce"] ?? `nonce-${Math.random().toString(36).slice(2)}`;
+    const sig = signBody(secret, timestamp, nonce, rawBody);
     return makeReq("POST", path, rawBody, {
         "x-webhook-signature": sig,
+        "x-webhook-timestamp": timestamp,
+        "x-webhook-nonce": nonce,
         ...extraHeaders,
     });
 }
@@ -134,6 +152,10 @@ describe("POST /api/webhooks — create webhook", () => {
     beforeEach(() => {
         mockRequireSession.mockReset();
         mockCreateWebhook.mockReset();
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(
+            Promise.resolve({ runnerId: "runner-1", userId: "user-1" }),
+        );
         mockRequireSession.mockReturnValue(
             Promise.resolve({ userId: "user-1", userName: "TestUser" }),
         );
@@ -172,6 +194,19 @@ describe("POST /api/webhooks — create webhook", () => {
         });
         const res = await handleWebhooksRoute(req, url);
         expect(res?.status).toBe(400);
+    });
+
+    test("returns 403 when runnerId does not belong to authenticated user", async () => {
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ runnerId: "runner-x", userId: "user-2" }));
+
+        const [req, url] = makeReq("POST", "/api/webhooks", {
+            name: "Hook",
+            source: "custom",
+            runnerId: "runner-x",
+        });
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(403);
+        expect(mockCreateWebhook).not.toHaveBeenCalled();
     });
 
     test("creates webhook and returns 201", async () => {
@@ -292,6 +327,7 @@ describe("GET /api/webhooks — list webhooks", () => {
                     id: "wh-1",
                     userId: "user-1",
                     name: "Hook 1",
+                    secret: "0123456789abcdef",
                     source: "custom",
                     enabled: true,
                 },
@@ -303,6 +339,7 @@ describe("GET /api/webhooks — list webhooks", () => {
         const body = await res!.json();
         expect(body.webhooks).toHaveLength(1);
         expect(body.webhooks[0].id).toBe("wh-1");
+        expect(body.webhooks[0].secret).toBe("0123…cdef");
     });
 });
 
@@ -332,13 +369,21 @@ describe("GET /api/webhooks/:id — get webhook", () => {
     });
 
     test("returns webhook details", async () => {
-        const hook = { id: "wh-1", userId: "user-1", name: "Hook 1", source: "custom", enabled: true };
+        const hook = {
+            id: "wh-1",
+            userId: "user-1",
+            name: "Hook 1",
+            secret: "fedcba9876543210",
+            source: "custom",
+            enabled: true,
+        };
         mockGetWebhook.mockReturnValue(Promise.resolve(hook));
         const [req, url] = makeReq("GET", "/api/webhooks/wh-1");
         const res = await handleWebhooksRoute(req, url);
         expect(res?.status).toBe(200);
         const body = await res!.json();
         expect(body.webhook.id).toBe("wh-1");
+        expect(body.webhook.secret).toBe("fedc…3210");
     });
 });
 
@@ -347,6 +392,10 @@ describe("PUT /api/webhooks/:id — update webhook", () => {
         mockRequireSession.mockReset();
         mockGetWebhook.mockReset();
         mockUpdateWebhook.mockReset();
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(
+            Promise.resolve({ runnerId: "runner-1", userId: "user-1" }),
+        );
         mockRequireSession.mockReturnValue(
             Promise.resolve({ userId: "user-1", userName: "TestUser" }),
         );
@@ -368,11 +417,30 @@ describe("PUT /api/webhooks/:id — update webhook", () => {
         expect(res?.status).toBe(400);
     });
 
+    test("returns 403 when updating to a runner not owned by authenticated user", async () => {
+        mockGetWebhook.mockReturnValue(
+            Promise.resolve({ id: "wh-1", userId: "user-1", name: "Hook" }),
+        );
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ runnerId: "runner-x", userId: "user-2" }));
+
+        const [req, url] = makeReq("PUT", "/api/webhooks/wh-1", { runnerId: "runner-x" });
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(403);
+        expect(mockUpdateWebhook).not.toHaveBeenCalled();
+    });
+
     test("updates webhook", async () => {
         mockGetWebhook.mockReturnValue(
             Promise.resolve({ id: "wh-1", userId: "user-1", name: "Hook" }),
         );
-        const updated = { id: "wh-1", userId: "user-1", name: "Updated", source: "custom", enabled: true };
+        const updated = {
+            id: "wh-1",
+            userId: "user-1",
+            name: "Updated",
+            secret: "abcd1234efgh5678",
+            source: "custom",
+            enabled: true,
+        };
         mockUpdateWebhook.mockReturnValue(Promise.resolve(updated));
 
         const [req, url] = makeReq("PUT", "/api/webhooks/wh-1", { name: "Updated", enabled: false });
@@ -380,6 +448,7 @@ describe("PUT /api/webhooks/:id — update webhook", () => {
         expect(res?.status).toBe(200);
         const body = await res!.json();
         expect(body.webhook.id).toBe("wh-1");
+        expect(body.webhook.secret).toBe("abcd…5678");
     });
 
     test("updates cwd and prompt", async () => {
@@ -488,6 +557,10 @@ describe("POST /api/webhooks/:id/fire — HMAC validation", () => {
         mockWaitForSpawnAck.mockReset();
         mockRecordRunnerSession.mockReset();
         mockLinkSessionToRunner.mockReset();
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(
+            Promise.resolve({ runnerId: "runner-1", userId: "user-1" }),
+        );
     });
 
     test("returns 404 for unknown webhook", async () => {
@@ -506,13 +579,67 @@ describe("POST /api/webhooks/:id/fire — HMAC validation", () => {
         expect(res?.status).toBe(404);
     });
 
+    test("returns 401 when X-Webhook-Timestamp is missing", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+        const [req, url] = makeReq(
+            "POST",
+            "/api/webhooks/wh-1/fire",
+            { event: "test" },
+            { "x-webhook-signature": "anything", "x-webhook-nonce": "nonce-a" },
+        );
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(401);
+        const body = await res!.json();
+        expect(body.error).toContain("X-Webhook-Timestamp");
+    });
+
+    test("returns 401 when X-Webhook-Nonce is missing", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+        const [req, url] = makeReq(
+            "POST",
+            "/api/webhooks/wh-1/fire",
+            { event: "test" },
+            {
+                "x-webhook-signature": "anything",
+                "x-webhook-timestamp": new Date().toISOString(),
+            },
+        );
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(401);
+        const body = await res!.json();
+        expect(body.error).toContain("X-Webhook-Nonce");
+    });
+
     test("returns 401 when X-Webhook-Signature is missing", async () => {
         mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
-        const [req, url] = makeReq("POST", "/api/webhooks/wh-1/fire", { event: "test" });
+        const [req, url] = makeReq(
+            "POST",
+            "/api/webhooks/wh-1/fire",
+            { event: "test" },
+            {
+                "x-webhook-timestamp": new Date().toISOString(),
+                "x-webhook-nonce": "nonce-sig-missing",
+            },
+        );
         const res = await handleWebhooksRoute(req, url);
         expect(res?.status).toBe(401);
         const body = await res!.json();
         expect(body.error).toContain("X-Webhook-Signature");
+    });
+
+    test("returns 401 when timestamp is stale", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+        const stale = new Date(Date.now() - 10 * 60 * 1000).toISOString();
+        const [req, url] = makeFireReq(
+            "/api/webhooks/wh-1/fire",
+            { event: "test" },
+            ACTIVE_WEBHOOK.secret,
+            { "x-webhook-timestamp": stale, "x-webhook-nonce": "nonce-stale" },
+        );
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(401);
+        const body = await res!.json();
+        expect(body.error).toContain("too old");
     });
 
     test("returns 401 when signature is invalid", async () => {
@@ -521,7 +648,11 @@ describe("POST /api/webhooks/:id/fire — HMAC validation", () => {
             "POST",
             "/api/webhooks/wh-1/fire",
             JSON.stringify({ event: "test" }),
-            { "x-webhook-signature": "bad-signature" },
+            {
+                "x-webhook-signature": "bad-signature",
+                "x-webhook-timestamp": new Date().toISOString(),
+                "x-webhook-nonce": "nonce-bad-sig",
+            },
         );
         const res = await handleWebhooksRoute(req, url);
         expect(res?.status).toBe(401);
@@ -548,6 +679,44 @@ describe("POST /api/webhooks/:id/fire — HMAC validation", () => {
         // Runner spawn should have been called
         expect(mockRecordRunnerSession).toHaveBeenCalledTimes(1);
         expect(mockLinkSessionToRunner).toHaveBeenCalledTimes(1);
+    });
+
+    test("returns 409 when nonce is reused", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+        const { sessionEmitMock } = setupSpawnAndDeliverMocks();
+
+        const timestamp = new Date().toISOString();
+        const nonce = "nonce-reused";
+        const body = { event: "deploy" };
+
+        const [req1, url1] = makeFireReq(
+            "/api/webhooks/wh-1/fire",
+            body,
+            ACTIVE_WEBHOOK.secret,
+            { "x-webhook-timestamp": timestamp, "x-webhook-nonce": nonce },
+        );
+        const res1 = await handleWebhooksRoute(req1, url1);
+        expect(res1?.status).toBe(200);
+
+        const [req2, url2] = makeFireReq(
+            "/api/webhooks/wh-1/fire",
+            body,
+            ACTIVE_WEBHOOK.secret,
+            { "x-webhook-timestamp": timestamp, "x-webhook-nonce": nonce },
+        );
+        const res2 = await handleWebhooksRoute(req2, url2);
+        expect(res2?.status).toBe(409);
+        expect(sessionEmitMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("returns 403 when runner is not owned by webhook user", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ runnerId: "runner-1", userId: "user-2" }));
+
+        const body = { event: "test" };
+        const [req, url] = makeFireReq("/api/webhooks/wh-1/fire", body, ACTIVE_WEBHOOK.secret);
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(403);
     });
 
     test("returns 503 when runner is not connected", async () => {
@@ -585,6 +754,10 @@ describe("POST /api/webhooks/:id/fire — event filtering", () => {
         mockWaitForSpawnAck.mockReset();
         mockRecordRunnerSession.mockReset();
         mockLinkSessionToRunner.mockReset();
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(
+            Promise.resolve({ runnerId: "runner-1", userId: "user-1" }),
+        );
     });
 
     const FILTERED_WEBHOOK = {
@@ -634,6 +807,10 @@ describe("POST /api/webhooks/:id/fire — spawn behavior", () => {
         mockWaitForSpawnAck.mockReset();
         mockRecordRunnerSession.mockReset();
         mockLinkSessionToRunner.mockReset();
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(
+            Promise.resolve({ runnerId: "runner-1", userId: "user-1" }),
+        );
     });
 
     test("passes cwd and prompt to runner spawn", async () => {

--- a/packages/server/src/routes/webhooks.test.ts
+++ b/packages/server/src/routes/webhooks.test.ts
@@ -320,7 +320,7 @@ describe("GET /api/webhooks — list webhooks", () => {
         expect(body.webhooks).toEqual([]);
     });
 
-    test("returns user's webhooks", async () => {
+    test("returns user's webhooks with real (unmasked) secrets", async () => {
         mockListWebhooksForUser.mockReturnValue(
             Promise.resolve([
                 {
@@ -339,7 +339,8 @@ describe("GET /api/webhooks — list webhooks", () => {
         const body = await res!.json();
         expect(body.webhooks).toHaveLength(1);
         expect(body.webhooks[0].id).toBe("wh-1");
-        expect(body.webhooks[0].secret).toBe("0123…cdef");
+        // Secrets are returned in full on authenticated GET (behind auth cookie)
+        expect(body.webhooks[0].secret).toBe("0123456789abcdef");
     });
 });
 
@@ -368,7 +369,7 @@ describe("GET /api/webhooks/:id — get webhook", () => {
         expect(res?.status).toBe(404);
     });
 
-    test("returns webhook details", async () => {
+    test("returns webhook details with real (unmasked) secret", async () => {
         const hook = {
             id: "wh-1",
             userId: "user-1",
@@ -383,7 +384,8 @@ describe("GET /api/webhooks/:id — get webhook", () => {
         expect(res?.status).toBe(200);
         const body = await res!.json();
         expect(body.webhook.id).toBe("wh-1");
-        expect(body.webhook.secret).toBe("fedc…3210");
+        // Secrets are returned in full on authenticated GET (behind auth cookie)
+        expect(body.webhook.secret).toBe("fedcba9876543210");
     });
 });
 
@@ -429,7 +431,7 @@ describe("PUT /api/webhooks/:id — update webhook", () => {
         expect(mockUpdateWebhook).not.toHaveBeenCalled();
     });
 
-    test("updates webhook", async () => {
+    test("updates webhook with real (unmasked) secret in response", async () => {
         mockGetWebhook.mockReturnValue(
             Promise.resolve({ id: "wh-1", userId: "user-1", name: "Hook" }),
         );
@@ -448,7 +450,8 @@ describe("PUT /api/webhooks/:id — update webhook", () => {
         expect(res?.status).toBe(200);
         const body = await res!.json();
         expect(body.webhook.id).toBe("wh-1");
-        expect(body.webhook.secret).toBe("abcd…5678");
+        // Secrets are returned in full on authenticated PUT (behind auth cookie)
+        expect(body.webhook.secret).toBe("abcd1234efgh5678");
     });
 
     test("updates cwd and prompt", async () => {
@@ -717,6 +720,22 @@ describe("POST /api/webhooks/:id/fire — HMAC validation", () => {
         const [req, url] = makeFireReq("/api/webhooks/wh-1/fire", body, ACTIVE_WEBHOOK.secret);
         const res = await handleWebhooksRoute(req, url);
         expect(res?.status).toBe(403);
+        const resBody = await res!.json();
+        expect(resBody.error).toContain("not owned");
+    });
+
+    test("returns 503 when runner data is absent (runner offline/disconnected)", async () => {
+        // When a runner disconnects its Redis state is deleted, so getRunnerData returns null.
+        // This should be a 503 (temporarily unavailable), not a 403 (unauthorized).
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+        mockGetRunnerData.mockReturnValue(Promise.resolve(null));
+
+        const body = { event: "test" };
+        const [req, url] = makeFireReq("/api/webhooks/wh-1/fire", body, ACTIVE_WEBHOOK.secret);
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(503);
+        const resBody = await res!.json();
+        expect(resBody.error).toMatch(/offline|not available/i);
     });
 
     test("returns 503 when runner is not connected", async () => {
@@ -740,6 +759,176 @@ describe("POST /api/webhooks/:id/fire — HMAC validation", () => {
         expect(res?.status).toBe(500);
         const resBody = await res!.json();
         expect(resBody.error).toContain("no runner");
+    });
+});
+
+describe("POST /api/webhooks/:id/fire — backward-compat legacy signing", () => {
+    beforeEach(() => {
+        mockGetWebhook.mockReset();
+        mockGetSharedSession.mockReset();
+        mockGetLocalTuiSocket.mockReset();
+        mockEmitToRelaySessionVerified.mockReset();
+        mockPushTriggerHistory.mockReset();
+        mockGetLocalRunnerSocket.mockReset();
+        mockWaitForSpawnAck.mockReset();
+        mockRecordRunnerSession.mockReset();
+        mockLinkSessionToRunner.mockReset();
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(
+            Promise.resolve({ runnerId: "runner-1", userId: "user-1" }),
+        );
+    });
+
+    /**
+     * Legacy callers send only X-Webhook-Signature with HMAC of raw body.
+     * The server must still accept these to avoid breaking existing integrations.
+     */
+    test("legacy: accepts HMAC of raw body when no timestamp/nonce headers", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+        const { sessionEmitMock } = setupSpawnAndDeliverMocks();
+
+        const rawBody = JSON.stringify({ event: "deploy", repo: "myorg/app" });
+        const legacySig = createHmac("sha256", ACTIVE_WEBHOOK.secret).update(rawBody).digest("hex");
+
+        const [req, url] = makeReq("POST", "/api/webhooks/wh-1/fire", rawBody, {
+            "x-webhook-signature": legacySig,
+        });
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(200);
+        const resBody = await res!.json();
+        expect(resBody.ok).toBe(true);
+        expect(resBody.triggerId).toMatch(/^wh_/);
+        expect(sessionEmitMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("legacy: returns 401 for invalid HMAC of raw body", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+
+        const rawBody = JSON.stringify({ event: "deploy" });
+        const [req, url] = makeReq("POST", "/api/webhooks/wh-1/fire", rawBody, {
+            "x-webhook-signature": "deadbeef",
+        });
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(401);
+        const resBody = await res!.json();
+        expect(resBody.error).toContain("signature");
+    });
+
+    test("legacy: rejects partial headers (nonce present but no timestamp)", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+
+        const rawBody = JSON.stringify({ event: "deploy" });
+        const [req, url] = makeReq("POST", "/api/webhooks/wh-1/fire", rawBody, {
+            "x-webhook-signature": "anything",
+            "x-webhook-nonce": "some-nonce",
+            // No x-webhook-timestamp
+        });
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(401);
+        const resBody = await res!.json();
+        expect(resBody.error).toContain("X-Webhook-Timestamp");
+    });
+
+    test("legacy: rejects partial headers (timestamp present but no nonce)", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+
+        const rawBody = JSON.stringify({ event: "deploy" });
+        const [req, url] = makeReq("POST", "/api/webhooks/wh-1/fire", rawBody, {
+            "x-webhook-signature": "anything",
+            "x-webhook-timestamp": new Date().toISOString(),
+            // No x-webhook-nonce
+        });
+        const res = await handleWebhooksRoute(req, url);
+        expect(res?.status).toBe(401);
+        const resBody = await res!.json();
+        expect(resBody.error).toContain("X-Webhook-Nonce");
+    });
+});
+
+describe("POST /api/webhooks/:id/fire — nonce consumed only on success", () => {
+    beforeEach(() => {
+        mockGetWebhook.mockReset();
+        mockGetSharedSession.mockReset();
+        mockGetLocalTuiSocket.mockReset();
+        mockEmitToRelaySessionVerified.mockReset();
+        mockPushTriggerHistory.mockReset();
+        mockGetLocalRunnerSocket.mockReset();
+        mockWaitForSpawnAck.mockReset();
+        mockRecordRunnerSession.mockReset();
+        mockLinkSessionToRunner.mockReset();
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(
+            Promise.resolve({ runnerId: "runner-1", userId: "user-1" }),
+        );
+    });
+
+    test("nonce is NOT consumed when delivery fails (502), allowing retry", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+
+        // Spawn succeeds but runner rejects the spawn request → 502
+        const runnerEmitMock = mock(() => {});
+        mockGetLocalRunnerSocket.mockReturnValue({ emit: runnerEmitMock });
+        mockWaitForSpawnAck.mockReturnValue(Promise.resolve({ ok: false, message: "busy" }));
+
+        const timestamp = new Date().toISOString();
+        const nonce = `nonce-retry-test-${Date.now()}`;
+        const body = { event: "deploy" };
+
+        const [req1, url1] = makeFireReq(
+            "/api/webhooks/wh-1/fire",
+            body,
+            ACTIVE_WEBHOOK.secret,
+            { "x-webhook-timestamp": timestamp, "x-webhook-nonce": nonce },
+        );
+        const res1 = await handleWebhooksRoute(req1, url1);
+        // 502 from runner rejection — nonce should NOT be consumed
+        expect(res1?.status).toBe(502);
+
+        // Retry with the same nonce — runner now accepts
+        mockWaitForSpawnAck.mockReturnValue(Promise.resolve({ ok: true }));
+        const sessionEmitMock = mock(() => {});
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: sessionEmitMock });
+
+        const [req2, url2] = makeFireReq(
+            "/api/webhooks/wh-1/fire",
+            body,
+            ACTIVE_WEBHOOK.secret,
+            { "x-webhook-timestamp": timestamp, "x-webhook-nonce": nonce },
+        );
+        const res2 = await handleWebhooksRoute(req2, url2);
+        expect(res2?.status).toBe(200);
+        expect(sessionEmitMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("nonce IS consumed after successful delivery, preventing replay", async () => {
+        mockGetWebhook.mockReturnValue(Promise.resolve(ACTIVE_WEBHOOK));
+        const { sessionEmitMock } = setupSpawnAndDeliverMocks();
+
+        const timestamp = new Date().toISOString();
+        const nonce = `nonce-consumed-test-${Date.now()}`;
+        const body = { event: "deploy" };
+
+        const [req1, url1] = makeFireReq(
+            "/api/webhooks/wh-1/fire",
+            body,
+            ACTIVE_WEBHOOK.secret,
+            { "x-webhook-timestamp": timestamp, "x-webhook-nonce": nonce },
+        );
+        const res1 = await handleWebhooksRoute(req1, url1);
+        expect(res1?.status).toBe(200);
+        expect(sessionEmitMock).toHaveBeenCalledTimes(1);
+
+        // Replay attempt with the same nonce must be rejected
+        const [req2, url2] = makeFireReq(
+            "/api/webhooks/wh-1/fire",
+            body,
+            ACTIVE_WEBHOOK.secret,
+            { "x-webhook-timestamp": timestamp, "x-webhook-nonce": nonce },
+        );
+        const res2 = await handleWebhooksRoute(req2, url2);
+        expect(res2?.status).toBe(409);
+        // Session should not have been triggered again
+        expect(sessionEmitMock).toHaveBeenCalledTimes(1);
     });
 });
 

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -44,7 +44,6 @@ import {
     listWebhooksForUser,
     updateWebhook,
     deleteWebhook,
-    toPublicWebhook,
 } from "../webhooks/store.js";
 
 const log = createLogger("webhooks-api");
@@ -58,7 +57,14 @@ const SESSION_CONNECT_TIMEOUT_MS = 15_000;
 /** Maximum accepted age/skew for webhook timestamp headers (ms). */
 const WEBHOOK_REPLAY_WINDOW_MS = 5 * 60 * 1000;
 
-/** In-memory replay guard: (webhookId:nonce) -> first-seen timestamp. */
+/**
+ * In-memory replay guard: (webhookId:nonce) -> first-seen timestamp.
+ *
+ * TODO(multi-node): This store is process-local and invisible to other server
+ * nodes. In a multi-node deployment, replay attacks are possible if requests
+ * route to different nodes within the 5-minute replay window. Replace with a
+ * Redis-backed nonce store (SETNX + TTL) to prevent cross-node replay attacks.
+ */
 const consumedWebhookNonces = new Map<string, number>();
 
 function pruneConsumedWebhookNonces(nowMs: number): void {
@@ -105,9 +111,17 @@ async function spawnSessionForWebhook(
     model: { provider: string; id: string } | null,
 ): Promise<{ sessionId: string } | Response> {
     const runner = await getRunnerData(runnerId);
-    if (!runner || runner.userId !== webhookUserId) {
+    // Distinguish "runner offline/deleted" (503) from "runner owned by someone else" (403).
+    // Runner state is removed from Redis on disconnect, so !runner means temporarily offline.
+    if (!runner) {
         return Response.json(
-            { error: "Runner not found or not owned by webhook owner" },
+            { error: "Runner is offline or not available" },
+            { status: 503 },
+        );
+    }
+    if (runner.userId !== webhookUserId) {
+        return Response.json(
+            { error: "Runner is not owned by webhook owner" },
             { status: 403 },
         );
     }
@@ -338,7 +352,7 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
         if (identity instanceof Response) return identity;
 
         const webhooks = await listWebhooksForUser(identity.userId);
-        return Response.json({ webhooks: webhooks.map(toPublicWebhook) });
+        return Response.json({ webhooks });
     }
 
     // ── GET /api/webhooks/:id ──────────────────────────────────────────────
@@ -354,7 +368,7 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Webhook not found" }, { status: 404 });
         }
 
-        return Response.json({ webhook: toPublicWebhook(webhook) });
+        return Response.json({ webhook });
     }
 
     // ── PUT /api/webhooks/:id ──────────────────────────────────────────────
@@ -436,7 +450,7 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Webhook not found" }, { status: 404 });
         }
 
-        return Response.json({ webhook: toPublicWebhook(updated) });
+        return Response.json({ webhook: updated });
     }
 
     // ── DELETE /api/webhooks/:id ───────────────────────────────────────────
@@ -476,48 +490,75 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
         } catch {
             return Response.json({ error: "Failed to read request body" }, { status: 400 });
         }
+        const rawBodyText = new TextDecoder().decode(rawBody);
 
-        // Replay protection: require timestamp + nonce headers.
+        // ── Determine signing mode ────────────────────────────────────────────
+        // Enhanced mode (recommended): caller sends X-Webhook-Timestamp +
+        // X-Webhook-Nonce; HMAC covers `${timestamp}.${nonce}.${body}`.
+        // Legacy mode (backward compat): neither header present; HMAC covers
+        // raw body only — no replay protection.
+        // Partial headers (one but not both) → 401 to avoid silent misconfiguration.
         const timestampHeader = req.headers.get("x-webhook-timestamp");
-        if (!timestampHeader) {
-            return Response.json({ error: "Missing X-Webhook-Timestamp header" }, { status: 401 });
-        }
-
-        const timestampMs = Date.parse(timestampHeader);
-        if (!Number.isFinite(timestampMs)) {
-            return Response.json({ error: "Invalid X-Webhook-Timestamp header" }, { status: 401 });
-        }
-
-        const nowMs = Date.now();
-        if (Math.abs(nowMs - timestampMs) > WEBHOOK_REPLAY_WINDOW_MS) {
-            return Response.json({ error: "Webhook timestamp is too old or too far in the future" }, { status: 401 });
-        }
-
         const nonceHeader = req.headers.get("x-webhook-nonce");
-        const nonce = typeof nonceHeader === "string" ? nonceHeader.trim() : "";
-        if (!nonce) {
+        const hasTimestamp = timestampHeader !== null && timestampHeader.trim() !== "";
+        const hasNonce = nonceHeader !== null && nonceHeader.trim() !== "";
+        const useEnhanced = hasTimestamp && hasNonce;
+        const useLegacy = !hasTimestamp && !hasNonce;
+
+        if (!useEnhanced && !useLegacy) {
+            // Partial enhanced headers — likely a misconfiguration, reject clearly.
+            if (!hasTimestamp) {
+                return Response.json({ error: "Missing X-Webhook-Timestamp header" }, { status: 401 });
+            }
             return Response.json({ error: "Missing X-Webhook-Nonce header" }, { status: 401 });
         }
 
-        // Validate HMAC signature.
         const signature = req.headers.get("x-webhook-signature");
         if (!signature) {
             return Response.json({ error: "Missing X-Webhook-Signature header" }, { status: 401 });
         }
 
-        const rawBodyText = new TextDecoder().decode(rawBody);
-        const expected = computeHmac(webhook.secret, `${timestampHeader}.${nonce}.${rawBodyText}`);
-        if (!hmacEqual(signature, expected)) {
-            log.warn(`Invalid HMAC for webhook ${webhookId}`);
-            return Response.json({ error: "Invalid signature" }, { status: 401 });
-        }
+        // Enhanced-mode timestamp + nonce validation
+        let nonceKey = "";
+        let nowMs = 0;
+        if (useEnhanced) {
+            nowMs = Date.now();
+            const timestampMs = Date.parse(timestampHeader!);
+            if (!Number.isFinite(timestampMs)) {
+                return Response.json({ error: "Invalid X-Webhook-Timestamp header" }, { status: 401 });
+            }
+            if (Math.abs(nowMs - timestampMs) > WEBHOOK_REPLAY_WINDOW_MS) {
+                return Response.json(
+                    { error: "Webhook timestamp is too old or too far in the future" },
+                    { status: 401 },
+                );
+            }
 
-        pruneConsumedWebhookNonces(nowMs);
-        const nonceKey = `${webhookId}:${nonce}`;
-        if (consumedWebhookNonces.has(nonceKey)) {
-            return Response.json({ error: "Webhook nonce has already been used" }, { status: 409 });
+            const nonce = nonceHeader!.trim();
+            const expected = computeHmac(
+                webhook.secret,
+                `${timestampHeader!}.${nonce}.${rawBodyText}`,
+            );
+            if (!hmacEqual(signature, expected)) {
+                log.warn(`Invalid HMAC for webhook ${webhookId}`);
+                return Response.json({ error: "Invalid signature" }, { status: 401 });
+            }
+
+            // Replay check — nonce is only consumed after successful delivery (below).
+            // This allows legitimate retries if delivery fails transiently (502/503/504).
+            pruneConsumedWebhookNonces(nowMs);
+            nonceKey = `${webhookId}:${nonce}`;
+            if (consumedWebhookNonces.has(nonceKey)) {
+                return Response.json({ error: "Webhook nonce has already been used" }, { status: 409 });
+            }
+        } else {
+            // Legacy mode: HMAC of raw body only — no replay protection.
+            const expected = computeHmac(webhook.secret, rawBodyText);
+            if (!hmacEqual(signature, expected)) {
+                log.warn(`Invalid HMAC for webhook ${webhookId} (legacy mode)`);
+                return Response.json({ error: "Invalid signature" }, { status: 401 });
+            }
         }
-        consumedWebhookNonces.set(nonceKey, nowMs);
 
         // Parse body JSON
         let body: Record<string, unknown>;
@@ -568,7 +609,7 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             );
         }
 
-        return fireWebhookTrigger(
+        const fireResponse = await fireWebhookTrigger(
             webhook.id,
             webhook.name,
             webhook.source,
@@ -577,6 +618,15 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             body,
             webhook.prompt,
         );
+
+        // Consume the nonce only after a successful delivery.
+        // If delivery fails transiently (502/503/504), the caller can retry
+        // with the same nonce within the replay window.
+        if (useEnhanced && nonceKey && fireResponse.status >= 200 && fireResponse.status < 300) {
+            consumedWebhookNonces.set(nonceKey, nowMs);
+        }
+
+        return fireResponse;
     }
 
     return undefined;

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -11,8 +11,11 @@
  * Fire endpoint (no auth cookie — validated via HMAC):
  *   POST /api/webhooks/:id/fire     — spawn a new session + fire trigger
  *
- * HMAC validation: SHA-256 of raw request body using webhook.secret.
- * The caller must send the hex digest in X-Webhook-Signature header.
+ * HMAC validation: SHA-256 of `${timestamp}.${nonce}.${rawBody}` using webhook.secret.
+ * Caller must send:
+ *   - X-Webhook-Signature (hex digest)
+ *   - X-Webhook-Timestamp (ISO string or RFC3339 date)
+ *   - X-Webhook-Nonce (unique per delivery)
  *
  * Every fire spawns a fresh session on the user's connected runner,
  * then delivers the webhook payload as a trigger into that session.
@@ -27,6 +30,7 @@ import {
     getLocalRunnerSocket,
     recordRunnerSession,
     linkSessionToRunner,
+    getRunnerData,
 } from "../ws/sio-registry.js";
 import { waitForSpawnAck } from "../ws/runner-control.js";
 import type { RouteHandler } from "./types.js";
@@ -40,6 +44,7 @@ import {
     listWebhooksForUser,
     updateWebhook,
     deleteWebhook,
+    toPublicWebhook,
 } from "../webhooks/store.js";
 
 const log = createLogger("webhooks-api");
@@ -49,6 +54,19 @@ const SPAWN_ACK_TIMEOUT_MS = 10_000;
 
 /** How long to wait after spawn for the session socket to appear (ms). */
 const SESSION_CONNECT_TIMEOUT_MS = 15_000;
+
+/** Maximum accepted age/skew for webhook timestamp headers (ms). */
+const WEBHOOK_REPLAY_WINDOW_MS = 5 * 60 * 1000;
+
+/** In-memory replay guard: (webhookId:nonce) -> first-seen timestamp. */
+const consumedWebhookNonces = new Map<string, number>();
+
+function pruneConsumedWebhookNonces(nowMs: number): void {
+    const cutoff = nowMs - WEBHOOK_REPLAY_WINDOW_MS;
+    for (const [key, ts] of consumedWebhookNonces) {
+        if (ts < cutoff) consumedWebhookNonces.delete(key);
+    }
+}
 
 // ── HMAC helpers ─────────────────────────────────────────────────────────────
 
@@ -81,10 +99,19 @@ function hmacEqual(a: string, b: string): boolean {
  */
 async function spawnSessionForWebhook(
     runnerId: string,
+    webhookUserId: string,
     cwd: string | null,
     prompt: string | null,
     model: { provider: string; id: string } | null,
 ): Promise<{ sessionId: string } | Response> {
+    const runner = await getRunnerData(runnerId);
+    if (!runner || runner.userId !== webhookUserId) {
+        return Response.json(
+            { error: "Runner not found or not owned by webhook owner" },
+            { status: 403 },
+        );
+    }
+
     const runnerSocket = getLocalRunnerSocket(runnerId);
     if (!runnerSocket) {
         return Response.json(
@@ -271,6 +298,16 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
                 ? body.prompt.trim()
                 : null;
 
+        if (runnerId) {
+            const runner = await getRunnerData(runnerId);
+            if (!runner || runner.userId !== identity.userId) {
+                return Response.json(
+                    { error: "Runner not found or not owned by you" },
+                    { status: 403 },
+                );
+            }
+        }
+
         // Validate model if provided
         let model: { provider: string; id: string } | null = null;
         if (body.model && typeof body.model === "object") {
@@ -301,7 +338,7 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
         if (identity instanceof Response) return identity;
 
         const webhooks = await listWebhooksForUser(identity.userId);
-        return Response.json({ webhooks });
+        return Response.json({ webhooks: webhooks.map(toPublicWebhook) });
     }
 
     // ── GET /api/webhooks/:id ──────────────────────────────────────────────
@@ -317,7 +354,7 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Webhook not found" }, { status: 404 });
         }
 
-        return Response.json({ webhook });
+        return Response.json({ webhook: toPublicWebhook(webhook) });
     }
 
     // ── PUT /api/webhooks/:id ──────────────────────────────────────────────
@@ -366,6 +403,15 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
         if (typeof body.enabled === "boolean") updates.enabled = body.enabled;
         if ("runnerId" in body) {
             updates.runnerId = typeof body.runnerId === "string" && body.runnerId.trim() ? body.runnerId.trim() : null;
+            if (typeof updates.runnerId === "string") {
+                const runner = await getRunnerData(updates.runnerId);
+                if (!runner || runner.userId !== identity.userId) {
+                    return Response.json(
+                        { error: "Runner not found or not owned by you" },
+                        { status: 403 },
+                    );
+                }
+            }
         }
         if ("cwd" in body) {
             updates.cwd = typeof body.cwd === "string" && body.cwd.trim() ? body.cwd.trim() : null;
@@ -390,7 +436,7 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Webhook not found" }, { status: 404 });
         }
 
-        return Response.json({ webhook: updated });
+        return Response.json({ webhook: toPublicWebhook(updated) });
     }
 
     // ── DELETE /api/webhooks/:id ───────────────────────────────────────────
@@ -431,22 +477,52 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Failed to read request body" }, { status: 400 });
         }
 
+        // Replay protection: require timestamp + nonce headers.
+        const timestampHeader = req.headers.get("x-webhook-timestamp");
+        if (!timestampHeader) {
+            return Response.json({ error: "Missing X-Webhook-Timestamp header" }, { status: 401 });
+        }
+
+        const timestampMs = Date.parse(timestampHeader);
+        if (!Number.isFinite(timestampMs)) {
+            return Response.json({ error: "Invalid X-Webhook-Timestamp header" }, { status: 401 });
+        }
+
+        const nowMs = Date.now();
+        if (Math.abs(nowMs - timestampMs) > WEBHOOK_REPLAY_WINDOW_MS) {
+            return Response.json({ error: "Webhook timestamp is too old or too far in the future" }, { status: 401 });
+        }
+
+        const nonceHeader = req.headers.get("x-webhook-nonce");
+        const nonce = typeof nonceHeader === "string" ? nonceHeader.trim() : "";
+        if (!nonce) {
+            return Response.json({ error: "Missing X-Webhook-Nonce header" }, { status: 401 });
+        }
+
         // Validate HMAC signature.
         const signature = req.headers.get("x-webhook-signature");
         if (!signature) {
             return Response.json({ error: "Missing X-Webhook-Signature header" }, { status: 401 });
         }
 
-        const expected = computeHmac(webhook.secret, new Uint8Array(rawBody));
+        const rawBodyText = new TextDecoder().decode(rawBody);
+        const expected = computeHmac(webhook.secret, `${timestampHeader}.${nonce}.${rawBodyText}`);
         if (!hmacEqual(signature, expected)) {
             log.warn(`Invalid HMAC for webhook ${webhookId}`);
             return Response.json({ error: "Invalid signature" }, { status: 401 });
         }
 
+        pruneConsumedWebhookNonces(nowMs);
+        const nonceKey = `${webhookId}:${nonce}`;
+        if (consumedWebhookNonces.has(nonceKey)) {
+            return Response.json({ error: "Webhook nonce has already been used" }, { status: 409 });
+        }
+        consumedWebhookNonces.set(nonceKey, nowMs);
+
         // Parse body JSON
         let body: Record<string, unknown>;
         try {
-            body = JSON.parse(new TextDecoder().decode(rawBody)) as Record<string, unknown>;
+            body = JSON.parse(rawBodyText) as Record<string, unknown>;
         } catch {
             return Response.json({ error: "Invalid JSON body" }, { status: 400 });
         }
@@ -472,6 +548,7 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
         // Spawn a new session on the webhook's designated runner
         const spawnResult = await spawnSessionForWebhook(
             webhook.runnerId,
+            webhook.userId,
             webhook.cwd,
             webhook.prompt,
             webhook.model,

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -544,13 +544,17 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
                 return Response.json({ error: "Invalid signature" }, { status: 401 });
             }
 
-            // Replay check — nonce is only consumed after successful delivery (below).
-            // This allows legitimate retries if delivery fails transiently (502/503/504).
+            // Replay check — eagerly consume the nonce BEFORE any async work to close
+            // the concurrent-request race window (two same-nonce requests arriving in
+            // parallel both pass has() before either sets the nonce).
+            // Transient failures (502/503/504) below roll the nonce back so retries work.
+            // Permanent failures and success keep it consumed.
             pruneConsumedWebhookNonces(nowMs);
             nonceKey = `${webhookId}:${nonce}`;
             if (consumedWebhookNonces.has(nonceKey)) {
                 return Response.json({ error: "Webhook nonce has already been used" }, { status: 409 });
             }
+            consumedWebhookNonces.set(nonceKey, nowMs);
         } else {
             // Legacy mode: HMAC of raw body only — no replay protection.
             const expected = computeHmac(webhook.secret, rawBodyText);
@@ -594,7 +598,13 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             webhook.prompt,
             webhook.model,
         );
-        if (spawnResult instanceof Response) return spawnResult;
+        if (spawnResult instanceof Response) {
+            // Roll back nonce for transient spawn failures (502/503) so the caller can retry.
+            if (useEnhanced && nonceKey && (spawnResult.status === 502 || spawnResult.status === 503)) {
+                consumedWebhookNonces.delete(nonceKey);
+            }
+            return spawnResult;
+        }
 
         const { sessionId } = spawnResult;
         log.info(`Webhook ${webhookId} spawned session ${sessionId}`);
@@ -603,6 +613,10 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
         const connected = await waitForSessionSocket(sessionId);
         if (!connected) {
             log.warn(`Webhook ${webhookId}: session ${sessionId} spawned but never connected`);
+            // 504 is transient — roll back nonce so the caller can retry.
+            if (useEnhanced && nonceKey) {
+                consumedWebhookNonces.delete(nonceKey);
+            }
             return Response.json(
                 { error: "Session was spawned but did not connect in time" },
                 { status: 504 },
@@ -619,11 +633,14 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             webhook.prompt,
         );
 
-        // Consume the nonce only after a successful delivery.
-        // If delivery fails transiently (502/503/504), the caller can retry
-        // with the same nonce within the replay window.
-        if (useEnhanced && nonceKey && fireResponse.status >= 200 && fireResponse.status < 300) {
-            consumedWebhookNonces.set(nonceKey, nowMs);
+        // Roll back nonce for transient delivery failures (502/503/504) so retries work.
+        // For permanent failures (4xx other than transient) and success, nonce stays consumed.
+        if (
+            useEnhanced &&
+            nonceKey &&
+            (fireResponse.status === 502 || fireResponse.status === 503 || fireResponse.status === 504)
+        ) {
+            consumedWebhookNonces.delete(nonceKey);
         }
 
         return fireResponse;

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -527,11 +527,14 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             if (!Number.isFinite(timestampMs)) {
                 return Response.json({ error: "Invalid X-Webhook-Timestamp header" }, { status: 401 });
             }
-            if (Math.abs(nowMs - timestampMs) > WEBHOOK_REPLAY_WINDOW_MS) {
-                return Response.json(
-                    { error: "Webhook timestamp is too old or too far in the future" },
-                    { status: 401 },
-                );
+            // Reject future timestamps entirely — accepting them creates a nonce
+            // replay window: nonce pruned at T0+WINDOW but future timestamp still
+            // valid until T0+2*WINDOW.
+            if (timestampMs > nowMs) {
+                return Response.json({ error: "Webhook timestamp is in the future" }, { status: 401 });
+            }
+            if (nowMs - timestampMs > WEBHOOK_REPLAY_WINDOW_MS) {
+                return Response.json({ error: "Webhook timestamp is too old" }, { status: 401 });
             }
 
             const nonce = nonceHeader!.trim();

--- a/packages/server/src/routes/webhooks.ts
+++ b/packages/server/src/routes/webhooks.ts
@@ -56,6 +56,8 @@ const SESSION_CONNECT_TIMEOUT_MS = 15_000;
 
 /** Maximum accepted age/skew for webhook timestamp headers (ms). */
 const WEBHOOK_REPLAY_WINDOW_MS = 5 * 60 * 1000;
+/** Allow up to 30s of clock skew (NTP drift) before rejecting as "future". */
+const WEBHOOK_CLOCK_SKEW_MS = 30 * 1000;
 
 /**
  * In-memory replay guard: (webhookId:nonce) -> first-seen timestamp.
@@ -527,10 +529,11 @@ export const handleWebhooksRoute: RouteHandler = async (req, url) => {
             if (!Number.isFinite(timestampMs)) {
                 return Response.json({ error: "Invalid X-Webhook-Timestamp header" }, { status: 401 });
             }
-            // Reject future timestamps entirely — accepting them creates a nonce
-            // replay window: nonce pruned at T0+WINDOW but future timestamp still
-            // valid until T0+2*WINDOW.
-            if (timestampMs > nowMs) {
+            // Reject timestamps too far in the future. A small tolerance (30s)
+            // accommodates NTP drift without reopening the replay window —
+            // nonces are retained for the full REPLAY_WINDOW after first seen,
+            // which far exceeds the skew allowance.
+            if (timestampMs > nowMs + WEBHOOK_CLOCK_SKEW_MS) {
                 return Response.json({ error: "Webhook timestamp is in the future" }, { status: 401 });
             }
             if (nowMs - timestampMs > WEBHOOK_REPLAY_WINDOW_MS) {

--- a/packages/server/src/webhooks/store.ts
+++ b/packages/server/src/webhooks/store.ts
@@ -111,6 +111,24 @@ function generateSecret(): string {
     return randomBytes(32).toString("hex");
 }
 
+/**
+ * Mask a webhook secret for API responses after creation.
+ * Keeps short prefix/suffix for identification without leaking the full value.
+ */
+export function maskWebhookSecret(secret: string): string {
+    if (!secret) return "";
+    if (secret.length <= 8) return "*".repeat(secret.length);
+    return `${secret.slice(0, 4)}…${secret.slice(-4)}`;
+}
+
+/** Return a webhook object with its secret masked. */
+export function toPublicWebhook(webhook: Webhook): Webhook {
+    return {
+        ...webhook,
+        secret: maskWebhookSecret(webhook.secret),
+    };
+}
+
 function rowToWebhook(row: {
     id: string;
     userId: string;

--- a/packages/ui/src/components/WebhooksManager.tsx
+++ b/packages/ui/src/components/WebhooksManager.tsx
@@ -243,12 +243,16 @@ function WebhookRow({
     const curlSnippet = [
         `BODY='{"type":"example","data":{}}'`,
         `SECRET="${webhook.secret}"`,
+        `TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")`,
+        `NONCE=$(openssl rand -hex 16)`,
         `# Works with both LibreSSL (macOS default) and OpenSSL 3.x`,
-        `SIG=$(echo -n "$BODY" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.*= //')`,
+        `SIG=$(echo -n "$TIMESTAMP.$NONCE.$BODY" | openssl dgst -sha256 -hmac "$SECRET" | sed 's/^.*= //')`,
         ``,
         `curl -X POST ${fireUrl} \\`,
         `  -H "Content-Type: application/json" \\`,
         `  -H "X-Webhook-Signature: $SIG" \\`,
+        `  -H "X-Webhook-Timestamp: $TIMESTAMP" \\`,
+        `  -H "X-Webhook-Nonce: $NONCE" \\`,
         `  -d "$BODY"`,
     ].join("\n");
 


### PR DESCRIPTION
## Summary
- validate webhook  ownership on create/update and re-check owner on fire before spawning
- mask webhook secrets in non-create responses via 
- require  +  and include them in HMAC signature payload
- reject stale timestamps (>5 min skew) and reused nonces
- add/expand webhook route tests for ownership validation, masked secrets, and replay protection

## Verification
- ✓ Precompiled system prompt → /Users/jordan/Documents/Projects/PizzaPi/packages/cli/src/config/system-prompt.precompiled.ts
- bun test v1.3.10 (30e609e0)
2026-03-30T11:34:49.656Z [webhooks-api] Webhook wh-1 spawned session 330b3d84-e170-4d84-bef4-7f94ee2345ea
2026-03-30T11:34:49.656Z [webhooks-api] Webhook trigger wh_ee7777e2047e413b delivered to session 330b3d84-e170-4d84-bef4-7f94ee2345ea
2026-03-30T11:34:49.657Z [webhooks-api] Webhook wh-1 spawned session 91b7c943-c1c7-499f-996d-66016305fd20
2026-03-30T11:34:49.657Z [webhooks-api] Webhook trigger wh_55d9538df4e64b54 delivered to session 91b7c943-c1c7-499f-996d-66016305fd20
2026-03-30T11:34:49.657Z [webhooks-api] Webhook wh-1 spawned session 451b642c-45eb-48b4-bfe1-c3d53437c1d5
2026-03-30T11:34:49.657Z [webhooks-api] Webhook trigger wh_145d0d69b87b4bcd delivered to session 451b642c-45eb-48b4-bfe1-c3d53437c1d5
2026-03-30T11:34:49.657Z [webhooks-api] Webhook wh-1 spawned session 811566d7-950f-4998-bb0d-72ceb2d90b2a
2026-03-30T11:34:49.657Z [webhooks-api] Webhook trigger wh_150eadcbdb6943d3 delivered to session 811566d7-950f-4998-bb0d-72ceb2d90b2a
2026-03-30T11:34:49.657Z [webhooks-api] Webhook wh-1 spawned session 5f6f76a7-98b2-44bc-a6c2-9cea862f0c0b
2026-03-30T11:34:49.657Z [webhooks-api] Webhook trigger wh_ed174032764a4c37 delivered cross-node to session 5f6f76a7-98b2-44bc-a6c2-9cea862f0c0b
- bun test v1.3.10 (30e609e0)
2026-03-30T11:34:49.981Z [static] Serving UI from /Users/jordan/Documents/Projects/PizzaPi/packages/ui/dist
Time for 1000 touchRelaySession calls: 411.21ms
Average time per call: 0.4112ms
2026-03-30T11:34:51.220Z [static] Serving UI from /Users/jordan/Documents/Projects/PizzaPi/packages/ui/dist
2026-03-30T11:34:51.350Z [redis-client] Redis client connected at redis://127.0.0.1:6379.
2026-03-30T11:34:51.350Z [redis] Relay Redis cache connected at redis://127.0.0.1:6379.
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.362Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.363Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.363Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.375Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.375Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.376Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.376Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.376Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.376Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.376Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.376Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.376Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.376Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.376Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.376Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.377Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.378Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.378Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.378Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.378Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.378Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.378Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.378Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.379Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.379Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.379Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.476Z [webhooks/store] Webhook table ready.
2026-03-30T11:34:57.476Z [startup] All database migrations complete.
2026-03-30T11:34:57.484Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:57.732Z [sio/relay] connected: V8CKNUShcTjRIZvnAAAB
2026-03-30T11:34:57.737Z [redis-client] Redis client connected at redis://127.0.0.1:6379.
2026-03-30T11:34:57.839Z [redis-client] Redis client connected at redis://127.0.0.1:6379.
2026-03-30T11:34:57.893Z [sio/relay] disconnected: V8CKNUShcTjRIZvnAAAB (client namespace disconnect)
2026-03-30T11:34:58.166Z [webhooks/store] Webhook table ready.
2026-03-30T11:34:58.166Z [startup] All database migrations complete.
2026-03-30T11:34:58.175Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:58.382Z [sio/relay] connected: IIsQn_RMITJ-WHCOAAAD
2026-03-30T11:34:58.384Z [sio/relay] disconnected: IIsQn_RMITJ-WHCOAAAD (client namespace disconnect)
2026-03-30T11:34:58.638Z [webhooks/store] Webhook table ready.
2026-03-30T11:34:58.638Z [startup] All database migrations complete.
2026-03-30T11:34:58.641Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:58.869Z [sio/relay] connected: JeaMGRltCETeftdgAAAF
2026-03-30T11:34:58.975Z [sio/relay] disconnected: JeaMGRltCETeftdgAAAF (client namespace disconnect)
2026-03-30T11:34:59.219Z [webhooks/store] Webhook table ready.
2026-03-30T11:34:59.219Z [startup] All database migrations complete.
2026-03-30T11:34:59.224Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:34:59.445Z [sio/relay] connected: dnt8JiH7AWduat0EAAAH
2026-03-30T11:34:59.647Z [sio/relay] disconnected: dnt8JiH7AWduat0EAAAH (client namespace disconnect)
2026-03-30T11:34:59.994Z [webhooks/store] Webhook table ready.
2026-03-30T11:34:59.995Z [startup] All database migrations complete.
2026-03-30T11:34:59.998Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:35:00.204Z [sio/runner] connected: wg3zQddAx1jO0PhKAAAJ
2026-03-30T11:35:00.249Z [webhooks/store] Webhook table ready.
2026-03-30T11:35:00.250Z [startup] All database migrations complete.
2026-03-30T11:35:00.250Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:35:00.891Z [webhooks/store] Webhook table ready.
2026-03-30T11:35:00.891Z [startup] All database migrations complete.
2026-03-30T11:35:01.114Z [webhooks/store] Webhook table ready.
2026-03-30T11:35:01.114Z [startup] All database migrations complete.
2026-03-30T11:35:01.431Z [webhooks/store] Webhook table ready.
2026-03-30T11:35:01.432Z [startup] All database migrations complete.
2026-03-30T11:35:02.051Z [runner-trigger-listener-store] Added runner trigger listener: runner-1 → svc:event
2026-03-30T11:35:02.052Z [runner-trigger-listener-store] Added runner trigger listener: runner-1 → svc:event
2026-03-30T11:35:02.052Z [runner-trigger-listener-store] Updated runner trigger listener: runner-1 → svc:event
2026-03-30T11:35:02.052Z [runner-trigger-listener-store] Added runner trigger listener: runner-1 → svc:event
2026-03-30T11:35:02.052Z [runner-trigger-listener-store] Removed runner trigger listener: runner-1 → svc:event
2026-03-30T11:35:02.053Z [runner-trigger-listener-store] Added runner trigger listener: runner-1 → svc:one
2026-03-30T11:35:02.053Z [runner-trigger-listener-store] Added runner trigger listener: runner-1 → svc:two
2026-03-30T11:35:02.062Z [redis] Relay Redis cache connected at redis://127.0.0.1:6379.
2026-03-30T11:35:02.065Z [redis] Relay Redis cache connected at redis://127.0.0.1:6379.
2026-03-30T11:35:02.065Z [redis] Relay Redis cache connected at redis://127.0.0.1:6379.
2026-03-30T11:35:02.065Z [redis] Relay Redis cache connected at redis://127.0.0.1:6379.
2026-03-30T11:35:02.079Z [webhooks-api] Webhook wh-1 spawned session a9c5d43c-efee-452a-bf7e-93d187a67f2c
2026-03-30T11:35:02.079Z [webhooks-api] Webhook trigger wh_93f31ab714484168 delivered to session a9c5d43c-efee-452a-bf7e-93d187a67f2c
2026-03-30T11:35:02.080Z [webhooks-api] Webhook wh-1 spawned session c717cb4f-8a8e-49f9-82d1-88ee69adf5fc
2026-03-30T11:35:02.080Z [webhooks-api] Webhook trigger wh_dc43d25e3c8949fb delivered to session c717cb4f-8a8e-49f9-82d1-88ee69adf5fc
2026-03-30T11:35:02.081Z [webhooks-api] Webhook wh-1 spawned session e8c67ca6-7104-4032-809d-b0dbd03096e6
2026-03-30T11:35:02.081Z [webhooks-api] Webhook trigger wh_db8dd62cce674b59 delivered to session e8c67ca6-7104-4032-809d-b0dbd03096e6
2026-03-30T11:35:02.081Z [webhooks-api] Webhook wh-1 spawned session c5158901-754d-46e9-9c99-dd8585787255
2026-03-30T11:35:02.081Z [webhooks-api] Webhook trigger wh_3fa82de6e3eb4272 delivered to session c5158901-754d-46e9-9c99-dd8585787255
2026-03-30T11:35:02.081Z [webhooks-api] Webhook wh-1 spawned session a72ba48b-5e45-4f15-b577-1a7072f22eb9
2026-03-30T11:35:02.081Z [webhooks-api] Webhook trigger wh_f4f918e7f0ea41a3 delivered cross-node to session a72ba48b-5e45-4f15-b577-1a7072f22eb9
2026-03-30T11:35:02.554Z [triggers-api] External trigger ext_ac672e379bbf4192 delivered to session sess-1
2026-03-30T11:35:02.554Z [triggers-api] External trigger ext_98059613d7594479 delivered cross-node to session sess-1
2026-03-30T11:35:02.556Z [triggers-api] External trigger ext_3b1f47871f644a3c delivered to session sess-1
2026-03-30T11:35:02.561Z [triggers-api] Session sess-1 subscribed to trigger type 'godmother:idea_moved' on runner runner-A
2026-03-30T11:35:02.562Z [triggers-api] Session sess-1 unsubscribed from trigger type 'godmother:idea_moved'
2026-03-30T11:35:02.563Z [triggers-api] Broadcast trigger ext_1b6b1deb4aa74d6a (type=svc:event) to 0/0 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.563Z [triggers-api] Broadcast trigger ext_b62817e93c334c14 (type=svc:event) to 2/2 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.563Z [triggers-api] Broadcast trigger ext_58adf2208eff41be (type=svc:event) to 1/2 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.563Z [triggers-api] Broadcast trigger ext_7b05fecf8b284229 (type=svc:event) to 1/1 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.564Z [triggers-api] Broadcast trigger ext_1ac4185e30d8411d (type=github:pr_comment) to 2/3 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.564Z [triggers-api] Broadcast trigger ext_9a4dab8812064c83 (type=demo:message_sent) to 2/3 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.564Z [triggers-api] Broadcast trigger ext_2979e472d2ff487a (type=github:pr_comment) to 2/3 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.564Z [triggers-api] Broadcast trigger ext_24d4032e1c8846bc (type=svc:event) to 3/4 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.565Z [triggers-api] Broadcast trigger ext_206ccfbc9e7843c3 (type=svc:event) to 1/2 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.565Z [triggers-api] Broadcast trigger ext_01b1cf25e5444aa6 (type=svc:event) to 1/1 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.565Z [triggers-api] Broadcast trigger ext_9bbb61fa95ee4e1e (type=github:pr_comment) to 1/1 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.565Z [triggers-api] Broadcast trigger ext_0b19fc6a4b404af1 (type=github:pr_comment) to 0/1 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.565Z [triggers-api] Broadcast trigger ext_5edc8fabcaae4505 (type=svc:event) to 1/1 subscribers + 0 spawned on runner runner-A
2026-03-30T11:35:02.565Z [triggers-api] Session session-1 updated subscription for 'svc:event' with params={"repo":"pizzapi"}
2026-03-30T11:35:02.566Z [triggers-api] Session session-1 updated subscription for 'svc:event' with filters=[{"field":"status","value":"shipped","op":"eq"}] mode=or
2026-03-30T11:35:02.566Z [triggers-api] Session session-1 updated subscription for 'svc:event' with params={"repo":"new"}
2026-03-30T11:35:02.566Z [triggers-api] Auto-spawned session 6b7f3621-2f31-4fff-8b24-7fee61efda19 for listener svc:event on runner runner-A
2026-03-30T11:35:02.566Z [triggers-api] Broadcast trigger ext_90aedb89406e433b (type=svc:event) to 0/0 subscribers + 1 spawned on runner runner-A
2026-03-30T11:35:02.625Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:35:02.628Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:35:02.636Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:35:02.636Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:35:02.636Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:35:02.637Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:35:02.637Z [sio-state] Redis connected at redis://localhost:6379
2026-03-30T11:35:02.637Z [sio-state] Redis connected at redis://localhost:6379 *(currently has unrelated pre-existing failures in this workspace, including runner-control race test and integration/environment failures)*