### PR TITLE
fix(ui): restore allow-same-origin for tunnel iframes with TODO comment

### DIFF
--- a/packages/ui/src/components/TunnelPanel.tsx
+++ b/packages/ui/src/components/TunnelPanel.tsx
@@ -191,6 +191,7 @@ export function TunnelPanel({ sessionId, runnerId }: TunnelPanelProps) {
                             src={tunnelUrl(previewPort)}
                             className="w-full h-full border-0"
                             title={`Tunnel preview — port ${previewPort}`}
+                            // SECURITY: allow-same-origin is needed because tunnel content is same-origin. TODO: serve tunnel content from a separate origin to enable full sandbox isolation.
                             sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
                             onLoad={() => setIframeLoading(false)}
                             onLoadStart={() => setIframeLoading(true)}

--- a/packages/ui/src/components/service-panels/IframeServicePanel.tsx
+++ b/packages/ui/src/components/service-panels/IframeServicePanel.tsx
@@ -16,6 +16,7 @@ export function IframeServicePanel({ sessionId, port }: IframeServicePanelProps)
             src={`/api/tunnel/${sessionId}/${port}/`}
             className="w-full h-full border-0"
             title={`Service panel — port ${port}`}
+            // SECURITY: allow-same-origin is needed because tunnel content is same-origin. TODO: serve tunnel content from a separate origin to enable full sandbox isolation.
             sandbox="allow-scripts allow-forms allow-same-origin allow-popups"
         />
     );


### PR DESCRIPTION
## Problem

PR #413 removed `allow-same-origin` from both `TunnelPanel.tsx` and `IframeServicePanel.tsx` as part of the XSS hardening. However, both panels proxy content through `/api/tunnel/...` on **PizzaPi's own origin**. Without `allow-same-origin`, tunneled apps can't:

- Make `fetch()` calls to their own backend (also proxied through the tunnel)
- Access cookies or `localStorage`
- Use `postMessage` with a real origin

This breaks all tunnel preview functionality.

## What this PR does

- Keeps `allow-same-origin` in both `TunnelPanel.tsx` and `IframeServicePanel.tsx` (both are same-origin via the tunnel proxy)
- Adds a `// SECURITY:` comment to both iframes documenting *why* the flag is required and pointing to the long-term fix: serve tunnel content from a separate subdomain/origin so full sandbox isolation is possible

## Long-term fix

The real solution is to serve tunnel content from a dedicated origin (e.g. `tunnel.pizzapi.local`) so the iframe can drop `allow-same-origin` entirely. That's a bigger infrastructure change and is tracked in the TODO comment.