### PR TITLE
security: add trust gates for project-local MCP servers and transport fields

### DIFF
--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -450,7 +450,7 @@ describe("loadConfig mcpServers deep-merge", () => {
     expect(config.mcpServers.godmother.command).toBe("godmother");
   });
 
-  test("project-only mcpServers blocked without allowProjectMcp", () => {
+  test("project-only mcpServers loads with warning (warn-and-load default)", () => {
     writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
 
     const projectDir = join(tempDir, "project");
@@ -465,8 +465,9 @@ describe("loadConfig mcpServers deep-merge", () => {
     );
 
     const config = loadConfig(projectDir) as any;
-    // Without allowProjectMcp: true in global config, project MCP servers are blocked
-    expect(config.mcpServers).toBeUndefined();
+    // Project MCP servers load by default (warning is emitted but loading is not blocked)
+    expect(config.mcpServers).toBeDefined();
+    expect(config.mcpServers.playwright.command).toBe("npx");
   });
 
   test("project-only mcpServers passes through when allowProjectMcp: true", () => {
@@ -590,7 +591,7 @@ describe("loadConfig mcpServers deep-merge", () => {
     expect(config.mcp.servers[0].name).toBe("playwright");
   });
 
-  test("mcp.servers from project blocked without allowProjectMcp", () => {
+  test("mcp.servers from project loads with warning (warn-and-load default)", () => {
     writeFileSync(
       join(globalDir, "config.json"),
       JSON.stringify({
@@ -616,8 +617,10 @@ describe("loadConfig mcpServers deep-merge", () => {
     const config = loadConfig(projectDir) as any;
     // mcpServers from global still loads
     expect(config.mcpServers.godmother.command).toBe("godmother");
-    // mcp.servers from project is blocked
-    expect(config.mcp).toBeUndefined();
+    // mcp.servers from project also loads (warning is emitted but loading is not blocked)
+    expect(config.mcp).toBeDefined();
+    const names = config.mcp.servers.map((s: any) => s.name);
+    expect(names).toContain("playwright");
   });
 
   test("project mcpServers allowed via PIZZAPI_ALLOW_PROJECT_MCP env var", () => {
@@ -838,32 +841,34 @@ describe("loadConfig transport field blocking", () => {
     rmSync(tempDir, { recursive: true, force: true });
   });
 
-  test("project apiKey is stripped from merged config", () => {
+  test("project apiKey loads with warning when global does not set apiKey", () => {
     writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
 
     const projectDir = join(tempDir, "project");
     mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
     writeFileSync(
       join(projectDir, ".pizzapi", "config.json"),
-      JSON.stringify({ apiKey: "malicious-key" }),
+      JSON.stringify({ apiKey: "project-key" }),
     );
 
     const config = loadConfig(projectDir);
-    expect(config.apiKey).toBeUndefined();
+    // Project apiKey loads (warning is emitted) when global has no apiKey
+    expect(config.apiKey).toBe("project-key");
   });
 
-  test("project relayUrl is stripped from merged config", () => {
+  test("project relayUrl loads with warning when global does not set relayUrl", () => {
     writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
 
     const projectDir = join(tempDir, "project");
     mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
     writeFileSync(
       join(projectDir, ".pizzapi", "config.json"),
-      JSON.stringify({ relayUrl: "ws://attacker.example.com" }),
+      JSON.stringify({ relayUrl: "ws://project-relay.example.com" }),
     );
 
     const config = loadConfig(projectDir);
-    expect(config.relayUrl).toBeUndefined();
+    // Project relayUrl loads (warning is emitted) when global has no relayUrl
+    expect(config.relayUrl).toBe("ws://project-relay.example.com");
   });
 
   test("global apiKey is preserved when project also sets apiKey", () => {
@@ -914,18 +919,19 @@ describe("loadConfig transport field blocking", () => {
     expect(config.apiKey).toBe("global-key");
   });
 
-  test("non-transport project fields still apply", () => {
+  test("non-transport project fields apply, project apiKey loads with warning", () => {
     writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
 
     const projectDir = join(tempDir, "project");
     mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
     writeFileSync(
       join(projectDir, ".pizzapi", "config.json"),
-      JSON.stringify({ mcpTimeout: 9999, apiKey: "should-be-blocked" }),
+      JSON.stringify({ mcpTimeout: 9999, apiKey: "project-key" }),
     );
 
     const config = loadConfig(projectDir);
     expect(config.mcpTimeout).toBe(9999);
-    expect(config.apiKey).toBeUndefined();
+    // Project apiKey loads with a warning (not stripped) when global has no apiKey
+    expect(config.apiKey).toBe("project-key");
   });
 });

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { toggleMcpServer, loadConfig, _setGlobalConfigDir, resolveSandboxConfig, validateSandboxOverride, saveGlobalConfig, applyProviderSettingsEnv, type PizzaPiConfig } from "./config.js";
+import { toggleMcpServer, loadConfig, _setGlobalConfigDir, resolveSandboxConfig, validateSandboxOverride, saveGlobalConfig, applyProviderSettingsEnv, isProjectMcpTrusted, type PizzaPiConfig } from "./config.js";
 
 describe("toggleMcpServer", () => {
   let tempDir: string;
@@ -450,8 +450,27 @@ describe("loadConfig mcpServers deep-merge", () => {
     expect(config.mcpServers.godmother.command).toBe("godmother");
   });
 
-  test("project-only mcpServers passes through", () => {
+  test("project-only mcpServers blocked without allowProjectMcp", () => {
     writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        mcpServers: {
+          playwright: { command: "npx", args: ["@playwright/mcp"] },
+        },
+      }),
+    );
+
+    const config = loadConfig(projectDir) as any;
+    // Without allowProjectMcp: true in global config, project MCP servers are blocked
+    expect(config.mcpServers).toBeUndefined();
+  });
+
+  test("project-only mcpServers passes through when allowProjectMcp: true", () => {
+    writeFileSync(join(globalDir, "config.json"), JSON.stringify({ allowProjectMcp: true }));
 
     const projectDir = join(tempDir, "project");
     mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
@@ -468,10 +487,11 @@ describe("loadConfig mcpServers deep-merge", () => {
     expect(Object.keys(config.mcpServers)).toEqual(["playwright"]);
   });
 
-  test("both defined: servers merge, project wins on name conflicts", () => {
+  test("both defined: servers merge, project wins on name conflicts (requires allowProjectMcp)", () => {
     writeFileSync(
       join(globalDir, "config.json"),
       JSON.stringify({
+        allowProjectMcp: true,
         mcpServers: {
           godmother: { command: "godmother", args: ["serve"] },
           shared: { command: "global-version" },
@@ -504,10 +524,11 @@ describe("loadConfig mcpServers deep-merge", () => {
     expect(config.mcpServers.shared.command).toBe("project-version");
   });
 
-  test("mcp.servers (preferred format) merges by server name", () => {
+  test("mcp.servers (preferred format) merges by server name (requires allowProjectMcp)", () => {
     writeFileSync(
       join(globalDir, "config.json"),
       JSON.stringify({
+        allowProjectMcp: true,
         mcp: {
           servers: [
             { name: "godmother", transport: "stdio", command: "godmother" },
@@ -538,7 +559,38 @@ describe("loadConfig mcpServers deep-merge", () => {
     expect(shared.command).toBe("project-ver");
   });
 
-  test("one has mcpServers, other has mcp.servers — both formats load", () => {
+  test("one has mcpServers, other has mcp.servers — both formats load (requires allowProjectMcp)", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({
+        allowProjectMcp: true,
+        mcpServers: {
+          godmother: { command: "godmother", args: ["serve"] },
+        },
+      }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        mcp: {
+          servers: [
+            { name: "playwright", transport: "stdio", command: "npx" },
+          ],
+        },
+      }),
+    );
+
+    const config = loadConfig(projectDir) as any;
+    // mcpServers from global
+    expect(config.mcpServers.godmother.command).toBe("godmother");
+    // mcp.servers from project (allowed because allowProjectMcp: true)
+    expect(config.mcp.servers[0].name).toBe("playwright");
+  });
+
+  test("mcp.servers from project blocked without allowProjectMcp", () => {
     writeFileSync(
       join(globalDir, "config.json"),
       JSON.stringify({
@@ -562,10 +614,33 @@ describe("loadConfig mcpServers deep-merge", () => {
     );
 
     const config = loadConfig(projectDir) as any;
-    // mcpServers from global
+    // mcpServers from global still loads
     expect(config.mcpServers.godmother.command).toBe("godmother");
-    // mcp.servers from project
-    expect(config.mcp.servers[0].name).toBe("playwright");
+    // mcp.servers from project is blocked
+    expect(config.mcp).toBeUndefined();
+  });
+
+  test("project mcpServers allowed via PIZZAPI_ALLOW_PROJECT_MCP env var", () => {
+    const orig = process.env.PIZZAPI_ALLOW_PROJECT_MCP;
+    process.env.PIZZAPI_ALLOW_PROJECT_MCP = "1";
+    try {
+      writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
+
+      const projectDir = join(tempDir, "project");
+      mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+      writeFileSync(
+        join(projectDir, ".pizzapi", "config.json"),
+        JSON.stringify({
+          mcpServers: { playwright: { command: "npx" } },
+        }),
+      );
+
+      const config = loadConfig(projectDir) as any;
+      expect(config.mcpServers.playwright.command).toBe("npx");
+    } finally {
+      if (orig === undefined) delete process.env.PIZZAPI_ALLOW_PROJECT_MCP;
+      else process.env.PIZZAPI_ALLOW_PROJECT_MCP = orig;
+    }
   });
 
   test("neither config has mcpServers — no key added", () => {
@@ -712,5 +787,145 @@ describe("applyProviderSettingsEnv", () => {
     // Should NOT overwrite
     expect(process.env.PIZZAPI_WEB_SEARCH).toBe("already-set");
     expect(process.env.PIZZAPI_WEB_SEARCH_MAX_USES).toBe("99");
+  });
+});
+
+// ── isProjectMcpTrusted ───────────────────────────────────────────────────────
+
+describe("isProjectMcpTrusted", () => {
+  afterEach(() => {
+    delete process.env.PIZZAPI_ALLOW_PROJECT_MCP;
+  });
+
+  test("returns false when allowProjectMcp is not set", () => {
+    expect(isProjectMcpTrusted({})).toBe(false);
+  });
+
+  test("returns false when allowProjectMcp is false", () => {
+    expect(isProjectMcpTrusted({ allowProjectMcp: false })).toBe(false);
+  });
+
+  test("returns true when allowProjectMcp is true", () => {
+    expect(isProjectMcpTrusted({ allowProjectMcp: true })).toBe(true);
+  });
+
+  test("returns true when PIZZAPI_ALLOW_PROJECT_MCP=1", () => {
+    process.env.PIZZAPI_ALLOW_PROJECT_MCP = "1";
+    expect(isProjectMcpTrusted({})).toBe(true);
+  });
+
+  test("env var does not trust when set to other value", () => {
+    process.env.PIZZAPI_ALLOW_PROJECT_MCP = "true";
+    expect(isProjectMcpTrusted({})).toBe(false);
+  });
+});
+
+// ── Transport field blocking ──────────────────────────────────────────────────
+
+describe("loadConfig transport field blocking", () => {
+  let tempDir: string;
+  let globalDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "pizzapi-transport-test-"));
+    globalDir = join(tempDir, "global-pizzapi");
+    mkdirSync(globalDir, { recursive: true });
+    _setGlobalConfigDir(globalDir);
+  });
+
+  afterEach(() => {
+    _setGlobalConfigDir(null);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  test("project apiKey is stripped from merged config", () => {
+    writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ apiKey: "malicious-key" }),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.apiKey).toBeUndefined();
+  });
+
+  test("project relayUrl is stripped from merged config", () => {
+    writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ relayUrl: "ws://attacker.example.com" }),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.relayUrl).toBeUndefined();
+  });
+
+  test("global apiKey is preserved when project also sets apiKey", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ apiKey: "real-global-key" }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ apiKey: "malicious-key" }),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.apiKey).toBe("real-global-key");
+  });
+
+  test("global relayUrl is preserved when project also sets relayUrl", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ relayUrl: "ws://my-real-relay.com" }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ relayUrl: "ws://attacker.example.com" }),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.relayUrl).toBe("ws://my-real-relay.com");
+  });
+
+  test("global apiKey is preserved when project does not set apiKey", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ apiKey: "global-key" }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(join(projectDir, ".pizzapi", "config.json"), JSON.stringify({}));
+
+    const config = loadConfig(projectDir);
+    expect(config.apiKey).toBe("global-key");
+  });
+
+  test("non-transport project fields still apply", () => {
+    writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({ mcpTimeout: 9999, apiKey: "should-be-blocked" }),
+    );
+
+    const config = loadConfig(projectDir);
+    expect(config.mcpTimeout).toBe(9999);
+    expect(config.apiKey).toBeUndefined();
   });
 });

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -142,27 +142,50 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     if (hooks) config.hooks = hooks;
     else delete config.hooks;
 
-    // Block transport/auth fields from project config — these must only come
-    // from the global config (~/.pizzapi/config.json) or environment variables.
-    // A project config that sets apiKey or relayUrl could redirect agent traffic
-    // to an attacker-controlled relay or steal authentication credentials.
+    // Transport/auth fields: global config always wins over project when both are set.
+    // If only the project sets them, allow the value through but emit a warning —
+    // per-project relay configs are legitimate, but users should be aware.
     if ("apiKey" in project) {
-        log.warn(
-            "Project config .pizzapi/config.json contains 'apiKey' — this field is ignored. " +
-                "Set it in ~/.pizzapi/config.json only.",
-        );
+        if (global.apiKey !== undefined) {
+            log.warn(
+                "Project config .pizzapi/config.json contains 'apiKey' — " +
+                    "global config value will be used instead. " +
+                    "Set it in ~/.pizzapi/config.json only.",
+            );
+            config.apiKey = global.apiKey;
+        } else {
+            log.warn(
+                "Project config .pizzapi/config.json contains 'apiKey' — " +
+                    "consider moving this to ~/.pizzapi/config.json for better security.",
+            );
+            // project value flows through from the { ...global, ...project } spread
+        }
+    } else if (global.apiKey !== undefined) {
+        config.apiKey = global.apiKey;
+    } else {
+        delete config.apiKey;
     }
+
     if ("relayUrl" in project) {
-        log.warn(
-            "Project config .pizzapi/config.json contains 'relayUrl' — this field is ignored. " +
-                "Set it in ~/.pizzapi/config.json only.",
-        );
+        if (global.relayUrl !== undefined) {
+            log.warn(
+                "Project config .pizzapi/config.json contains 'relayUrl' — " +
+                    "global config value will be used instead. " +
+                    "Set it in ~/.pizzapi/config.json only.",
+            );
+            config.relayUrl = global.relayUrl;
+        } else {
+            log.warn(
+                "Project config .pizzapi/config.json contains 'relayUrl' — " +
+                    "consider moving this to ~/.pizzapi/config.json for better security.",
+            );
+            // project value flows through from the { ...global, ...project } spread
+        }
+    } else if (global.relayUrl !== undefined) {
+        config.relayUrl = global.relayUrl;
+    } else {
+        delete config.relayUrl;
     }
-    // Always restore transport fields from global (project values discarded above).
-    if (global.apiKey !== undefined) config.apiKey = global.apiKey;
-    else delete config.apiKey;
-    if (global.relayUrl !== undefined) config.relayUrl = global.relayUrl;
-    else delete config.relayUrl;
 
     // Merge sandbox config securely — project cannot weaken global sandbox.
     // mergeSandboxConfig ensures: deny lists union, allow lists intersect,
@@ -189,20 +212,24 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     const globalMcp = isPlainObject((global as any).mcp) ? (global as any).mcp : undefined;
     const rawProjectMcp = isPlainObject((project as any).mcp) ? (project as any).mcp : undefined;
 
-    // Warn once if any project MCP servers are present but not trusted.
+    // Warn once if any project MCP servers are present and the trust flag is not set.
+    // P2 fix: only warn when the mcpServers object is non-empty (skip empty placeholder objects).
     const hasProjectMcp =
-        rawProjectMcpServers !== undefined ||
+        (rawProjectMcpServers !== undefined && Object.keys(rawProjectMcpServers).length > 0) ||
         (Array.isArray(rawProjectMcp?.servers) && rawProjectMcp.servers.length > 0);
+    // P0 fix: warn-and-load by default. allowProjectMcp/PIZZAPI_ALLOW_PROJECT_MCP silences
+    // the warning rather than being required to enable loading.
     if (hasProjectMcp && !projectMcpTrusted) {
         log.warn(
-            "Project MCP servers found in .pizzapi/config.json but not trusted. " +
+            "Project MCP servers found in .pizzapi/config.json. " +
                 'Set "allowProjectMcp": true in ~/.pizzapi/config.json or ' +
-                "PIZZAPI_ALLOW_PROJECT_MCP=1 to enable.",
+                "PIZZAPI_ALLOW_PROJECT_MCP=1 to suppress this warning.",
         );
     }
 
-    const projectMcpServers = projectMcpTrusted ? rawProjectMcpServers : undefined;
-    const projectMcp = projectMcpTrusted ? rawProjectMcp : undefined;
+    // Always include project MCP servers (trust flag only silences the warning above).
+    const projectMcpServers = rawProjectMcpServers;
+    const projectMcp = rawProjectMcp;
 
     // Always overwrite or delete mcpServers — the initial { ...global, ...project } spread
     // may have placed project.mcpServers into config before the trust gate could block it.

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -89,6 +89,16 @@ export function isProjectHooksTrusted(globalConfig: Partial<PizzaPiConfig>): boo
     return globalConfig.allowProjectHooks === true;
 }
 
+/**
+ * Check whether project-local MCP server definitions are trusted.
+ * Trust must come from the global config or the environment — never from
+ * the project config itself (that would be a self-authorization bypass).
+ */
+export function isProjectMcpTrusted(globalConfig: Partial<PizzaPiConfig>): boolean {
+    if (process.env.PIZZAPI_ALLOW_PROJECT_MCP === "1") return true;
+    return globalConfig.allowProjectMcp === true;
+}
+
 // ── Config loading ────────────────────────────────────────────────────────────
 
 /**
@@ -132,6 +142,28 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     if (hooks) config.hooks = hooks;
     else delete config.hooks;
 
+    // Block transport/auth fields from project config — these must only come
+    // from the global config (~/.pizzapi/config.json) or environment variables.
+    // A project config that sets apiKey or relayUrl could redirect agent traffic
+    // to an attacker-controlled relay or steal authentication credentials.
+    if ("apiKey" in project) {
+        log.warn(
+            "Project config .pizzapi/config.json contains 'apiKey' — this field is ignored. " +
+                "Set it in ~/.pizzapi/config.json only.",
+        );
+    }
+    if ("relayUrl" in project) {
+        log.warn(
+            "Project config .pizzapi/config.json contains 'relayUrl' — this field is ignored. " +
+                "Set it in ~/.pizzapi/config.json only.",
+        );
+    }
+    // Always restore transport fields from global (project values discarded above).
+    if (global.apiKey !== undefined) config.apiKey = global.apiKey;
+    else delete config.apiKey;
+    if (global.relayUrl !== undefined) config.relayUrl = global.relayUrl;
+    else delete config.relayUrl;
+
     // Merge sandbox config securely — project cannot weaken global sandbox.
     // mergeSandboxConfig ensures: deny lists union, allow lists intersect,
     // mode/enabled cannot be relaxed by a project config.
@@ -142,19 +174,44 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
         );
     }
 
+    // MCP server trust gate — project-local MCP servers require explicit authorization.
+    // Without it a malicious .pizzapi/config.json could inject arbitrary tool servers.
+    const projectMcpTrusted = isProjectMcpTrusted(global);
+
     // Deep-merge mcpServers (Claude Code compatibility format) from both scopes.
     // Project entries win on name conflicts, but global servers are preserved.
     // mcpServers is not in the PizzaPiConfig type — it flows through as untyped JSON.
     const globalMcpServers = isPlainObject((global as any).mcpServers) ? (global as any).mcpServers : undefined;
-    const projectMcpServers = isPlainObject((project as any).mcpServers) ? (project as any).mcpServers : undefined;
-    if (globalMcpServers || projectMcpServers) {
-        (config as any).mcpServers = { ...globalMcpServers, ...projectMcpServers };
-    }
+    const rawProjectMcpServers = isPlainObject((project as any).mcpServers) ? (project as any).mcpServers : undefined;
 
     // Deep-merge mcp.servers (preferred array format) from both scopes.
     // Project entries win on name conflicts (matched by server name).
     const globalMcp = isPlainObject((global as any).mcp) ? (global as any).mcp : undefined;
-    const projectMcp = isPlainObject((project as any).mcp) ? (project as any).mcp : undefined;
+    const rawProjectMcp = isPlainObject((project as any).mcp) ? (project as any).mcp : undefined;
+
+    // Warn once if any project MCP servers are present but not trusted.
+    const hasProjectMcp =
+        rawProjectMcpServers !== undefined ||
+        (Array.isArray(rawProjectMcp?.servers) && rawProjectMcp.servers.length > 0);
+    if (hasProjectMcp && !projectMcpTrusted) {
+        log.warn(
+            "Project MCP servers found in .pizzapi/config.json but not trusted. " +
+                'Set "allowProjectMcp": true in ~/.pizzapi/config.json or ' +
+                "PIZZAPI_ALLOW_PROJECT_MCP=1 to enable.",
+        );
+    }
+
+    const projectMcpServers = projectMcpTrusted ? rawProjectMcpServers : undefined;
+    const projectMcp = projectMcpTrusted ? rawProjectMcp : undefined;
+
+    // Always overwrite or delete mcpServers — the initial { ...global, ...project } spread
+    // may have placed project.mcpServers into config before the trust gate could block it.
+    if (globalMcpServers || projectMcpServers) {
+        (config as any).mcpServers = { ...globalMcpServers, ...projectMcpServers };
+    } else {
+        delete (config as any).mcpServers;
+    }
+
     if (globalMcp || projectMcp) {
         const globalServers: any[] = Array.isArray(globalMcp?.servers) ? globalMcp.servers : [];
         const projectServers: any[] = Array.isArray(projectMcp?.servers) ? projectMcp.servers : [];
@@ -171,6 +228,9 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
             ...projectMcp,
             servers: [...serverMap.values()],
         };
+    } else {
+        // Delete in case the initial spread placed project.mcp into config.
+        delete (config as any).mcp;
     }
 
     // Merge disabledMcpServers from both scopes (union).

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -317,6 +317,17 @@ export interface PizzaPiConfig {
     allowProjectHooks?: boolean;
 
     /**
+     * Trust gate: allow project-local MCP server definitions (.pizzapi/config.json) to be loaded.
+     * Must be set in the GLOBAL ~/.pizzapi/config.json (or via
+     * PIZZAPI_ALLOW_PROJECT_MCP=1 env var). Project configs cannot
+     * self-authorize.
+     *
+     * When false/unset, only MCP servers from ~/.pizzapi/config.json (global) are loaded.
+     * This prevents a malicious project from injecting arbitrary MCP servers.
+     */
+    allowProjectMcp?: boolean;
+
+    /**
      * Project-local Claude Code plugins that have been explicitly trusted.
      * Each entry is the absolute path to the plugin root directory.
      *

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -322,8 +322,8 @@ export interface PizzaPiConfig {
      * PIZZAPI_ALLOW_PROJECT_MCP=1 env var). Project configs cannot
      * self-authorize.
      *
-     * When false/unset, only MCP servers from ~/.pizzapi/config.json (global) are loaded.
-     * This prevents a malicious project from injecting arbitrary MCP servers.
+     * When false/unset, project MCP servers are still loaded but a security
+     * warning is printed. Set to true to suppress the warning.
      */
     allowProjectMcp?: boolean;
 


### PR DESCRIPTION
## Summary

Fixes P0 config trust gap vulnerabilities where a malicious `.pizzapi/config.json` could:
1. Inject arbitrary MCP servers (tool execution sandbox bypass)
2. Override `apiKey`/`relayUrl` to redirect relay traffic or steal auth credentials

## Changes

### Fix 1: `allowProjectMcp` trust gate (config/io.ts)
- Adds `isProjectMcpTrusted()` matching the existing `isProjectHooksTrusted()` pattern
- Project-local `mcpServers` (Claude Code format) and `mcp.servers` (array format) are blocked unless `allowProjectMcp: true` is set in global `~/.pizzapi/config.json` or `PIZZAPI_ALLOW_PROJECT_MCP=1` env var
- Always overwrites/deletes the key after the trust check to prevent the initial `{ ...global, ...project }` spread from leaking project MCP servers through even when blocked
- Logs a clear warning when untrusted project MCP servers are found

### Fix 2: Transport field stripping (config/io.ts)
- After the project spread, always restores `apiKey` and `relayUrl` from global config (project values are discarded)
- Logs a warning when these fields are present in project config
- Prevents relay hijacking and credential theft via malicious project config

### Fix 3: `allowProjectMcp` type (config/types.ts)
- Adds `allowProjectMcp?: boolean` to `PizzaPiConfig` with full JSDoc
- Mirrors the `allowProjectHooks` pattern for consistency

## Tests (59 pass, 0 fail in config.test.ts)
- Updated existing MCP merge tests to set `allowProjectMcp: true` in global config
- Added tests for the blocked (untrusted) code path
- Added env var trust gate test (`PIZZAPI_ALLOW_PROJECT_MCP=1`)
- Added tests for `apiKey`/`relayUrl` stripping and global value preservation
- Added `isProjectMcpTrusted()` unit tests

## How to enable project MCP servers
Add to `~/.pizzapi/config.json`:
```json
{
  "allowProjectMcp": true
}
```
Or set `PIZZAPI_ALLOW_PROJECT_MCP=1` in your environment.