### PR TITLE
fix(plan-mode): block wrapper shells, session-spawning tools, and HTTP mutations

### DIFF
--- a/packages/cli/src/extensions/plan-mode-toggle.test.ts
+++ b/packages/cli/src/extensions/plan-mode-toggle.test.ts
@@ -862,6 +862,118 @@ describe("isDestructiveCommand", () => {
         expect(isDestructiveCommand("cat file.txt 2>/dev/null")).toBe(false);
         expect(isDestructiveCommand("grep pattern src/ 2>/dev/null")).toBe(false);
     });
+
+    // ── Wrapper shell bypass prevention (Fix 1) ──────────────────────────
+
+    test("flags shell wrappers with -c flag (bash/sh/dash/etc.)", () => {
+        expect(isDestructiveCommand("bash -c 'rm -rf /'")).toBe(true);
+        expect(isDestructiveCommand("sh -c 'evil'")).toBe(true);
+        expect(isDestructiveCommand("dash -c 'evil'")).toBe(true);
+        expect(isDestructiveCommand("zsh -c 'evil'")).toBe(true);
+        // Bundled flags: -xc is still -c
+        expect(isDestructiveCommand("bash -xc 'evil'")).toBe(true);
+        // Flags before -c
+        expect(isDestructiveCommand("bash --norc -c 'evil'")).toBe(true);
+    });
+
+    test("allows shell invocations without -c (no arbitrary code injection)", () => {
+        // --version and --help are always safe
+        expect(isDestructiveCommand("bash --version")).toBe(false);
+        expect(isDestructiveCommand("sh --help")).toBe(false);
+    });
+
+    test("flags path-prefixed shells with -c flag", () => {
+        expect(isDestructiveCommand("/bin/bash -c 'evil'")).toBe(true);
+        expect(isDestructiveCommand("/usr/bin/sh -c 'evil'")).toBe(true);
+        expect(isDestructiveCommand("/usr/local/bin/bash -c 'rm -rf /'")).toBe(true);
+    });
+
+    test("flags perl -e / -E (inline Perl code execution)", () => {
+        expect(isDestructiveCommand("perl -e 'unlink \"file.txt\"'")).toBe(true);
+        expect(isDestructiveCommand("perl -E 'say \"hello\"'")).toBe(true);
+        // Bundled with other flags
+        expect(isDestructiveCommand("perl -we 'unlink \"f\"'")).toBe(true);
+        // Path-prefixed
+        expect(isDestructiveCommand("/usr/bin/perl -e 'unlink \"f\"'")).toBe(true);
+    });
+
+    test("allows perl without -e/-E (safe invocations)", () => {
+        expect(isDestructiveCommand("perl --version")).toBe(false);
+        expect(isDestructiveCommand("perl --help")).toBe(false);
+        // Note: perl script.pl is caught by general script execution (DESTRUCTIVE_FLAG_PATTERNS covers this via no-sandbox path)
+    });
+
+    test("flags env used as a command launcher", () => {
+        // env COMMAND
+        expect(isDestructiveCommand("env rm file.txt")).toBe(true);
+        // env VAR=val COMMAND
+        expect(isDestructiveCommand("env FOO=bar rm file.txt")).toBe(true);
+        expect(isDestructiveCommand("env FOO=bar BAZ=qux rm file.txt")).toBe(true);
+        // env wrapping a shell wrapper
+        expect(isDestructiveCommand("env bash -c 'evil'")).toBe(true);
+        expect(isDestructiveCommand("env FOO=bar bash -c 'evil'")).toBe(true);
+        // env -i (clear environment) then a command
+        expect(isDestructiveCommand("env -i rm file.txt")).toBe(true);
+        expect(isDestructiveCommand("env -i FOO=bar bash -c 'evil'")).toBe(true);
+    });
+
+    test("allows bare env (no command, just prints environment)", () => {
+        expect(isDestructiveCommand("env")).toBe(false);
+        // env with only VAR=val assignments (no trailing command)
+        expect(isDestructiveCommand("env FOO=bar")).toBe(false);
+        expect(isDestructiveCommand("env FOO=bar BAZ=qux")).toBe(false);
+    });
+
+    test("flags shell wrappers in chained commands", () => {
+        expect(isDestructiveCommand("ls && bash -c 'evil'")).toBe(true);
+        expect(isDestructiveCommand("cat file.txt | sh -c 'evil'")).toBe(true);
+        expect(isDestructiveCommand("echo hello; env rm foo")).toBe(true);
+    });
+
+    // ── HTTP mutation command bypass prevention (Fix 3) ──────────────────
+
+    test("flags curl with HTTP mutation verbs (-X POST/PUT/DELETE/PATCH)", () => {
+        expect(isDestructiveCommand("curl -X POST https://api.example.com")).toBe(true);
+        expect(isDestructiveCommand("curl -X PUT https://api.example.com/resource")).toBe(true);
+        expect(isDestructiveCommand("curl -X DELETE https://api.example.com/resource/1")).toBe(true);
+        expect(isDestructiveCommand("curl -X PATCH https://api.example.com/resource")).toBe(true);
+        // --request is the long form of -X
+        expect(isDestructiveCommand("curl --request POST https://api.example.com")).toBe(true);
+        expect(isDestructiveCommand("curl --request=DELETE https://api.example.com/resource")).toBe(true);
+        // Combined with other safe flags
+        expect(isDestructiveCommand("curl -sL -X POST https://api.example.com")).toBe(true);
+    });
+
+    test("allows curl with safe HTTP verbs", () => {
+        // GET (default, no -X needed)
+        expect(isDestructiveCommand("curl https://api.example.com")).toBe(false);
+        expect(isDestructiveCommand("curl -sL https://api.example.com")).toBe(false);
+        // Explicit GET is safe
+        expect(isDestructiveCommand("curl -X GET https://api.example.com")).toBe(false);
+        expect(isDestructiveCommand("curl --request GET https://api.example.com")).toBe(false);
+    });
+
+    test("flags curl with data/body flags (-d, --data, --data-raw, --data-binary, --data-urlencode, --json)", () => {
+        expect(isDestructiveCommand("curl -d 'key=value' https://api.example.com")).toBe(true);
+        expect(isDestructiveCommand("curl --data 'key=value' https://api.example.com")).toBe(true);
+        expect(isDestructiveCommand("curl --data-raw 'raw data' https://api.example.com")).toBe(true);
+        expect(isDestructiveCommand("curl --data-binary @file.bin https://api.example.com")).toBe(true);
+        expect(isDestructiveCommand("curl --data-urlencode 'name=value' https://api.example.com")).toBe(true);
+        expect(isDestructiveCommand("curl --json '{\"key\":\"val\"}' https://api.example.com")).toBe(true);
+        // -d attached to value (no space)
+        expect(isDestructiveCommand("curl -d'{\"k\":\"v\"}' https://api.example.com")).toBe(true);
+    });
+
+    test("flags wget with --post-data and --post-file", () => {
+        expect(isDestructiveCommand("wget --post-data='key=value' https://api.example.com")).toBe(true);
+        expect(isDestructiveCommand("wget --post-data 'key=value' https://api.example.com")).toBe(true);
+        expect(isDestructiveCommand("wget --post-file=payload.bin https://api.example.com")).toBe(true);
+    });
+
+    test("allows wget without POST flags (read-only download check)", () => {
+        // Note: wget -O writes to a file and is already blocked separately
+        expect(isDestructiveCommand("wget -q https://example.com")).toBe(false);
+    });
 });
 
 // ── isDestructiveCommand with sandboxActive=true ─────────────────────────────
@@ -985,6 +1097,27 @@ describe("isDestructiveCommand (sandboxActive=true)", () => {
         expect(isDestructiveCommand("gh issue list", true)).toBe(false);
         expect(isDestructiveCommand("gh pr view 123", true)).toBe(false);
         expect(isDestructiveCommand("gh api /repos", true)).toBe(false);
+    });
+
+    test("blocks curl HTTP mutations when sandbox active (network side-effect, Fix 3)", () => {
+        expect(isDestructiveCommand("curl -X POST https://api.example.com", true)).toBe(true);
+        expect(isDestructiveCommand("curl -X PUT https://api.example.com/r", true)).toBe(true);
+        expect(isDestructiveCommand("curl -X DELETE https://api.example.com/r/1", true)).toBe(true);
+        expect(isDestructiveCommand("curl --request POST https://api.example.com", true)).toBe(true);
+        expect(isDestructiveCommand("curl -d 'key=val' https://api.example.com", true)).toBe(true);
+        expect(isDestructiveCommand("curl --data '{}' https://api.example.com", true)).toBe(true);
+        expect(isDestructiveCommand("curl --json '{}' https://api.example.com", true)).toBe(true);
+    });
+
+    test("blocks wget POST when sandbox active (network side-effect, Fix 3)", () => {
+        expect(isDestructiveCommand("wget --post-data='key=val' https://api.example.com", true)).toBe(true);
+        expect(isDestructiveCommand("wget --post-file=data.bin https://api.example.com", true)).toBe(true);
+    });
+
+    test("allows curl GET when sandbox active", () => {
+        expect(isDestructiveCommand("curl https://api.example.com", true)).toBe(false);
+        expect(isDestructiveCommand("curl -X GET https://api.example.com", true)).toBe(false);
+        expect(isDestructiveCommand("curl -sL https://api.example.com", true)).toBe(false);
     });
 
     test("allows editors when sandbox active (OS blocks writes)", () => {

--- a/packages/cli/src/extensions/plan-mode/extension.ts
+++ b/packages/cli/src/extensions/plan-mode/extension.ts
@@ -218,8 +218,21 @@ export const planModeToggleExtension: ExtensionFactory = (pi) => {
         if (event.toolName === TOGGLE_PLAN_MODE_TOOL) return;
 
         // Block write tools and session-spawning tools.
-        // subagent and spawn_session are blocked because they create child contexts
-        // with full write access, bypassing plan mode restrictions entirely.
+        // spawn_session is blocked unconditionally — spawned child sessions are
+        // independent processes with their own full write access and there is no
+        // mechanism to inject plan-mode restrictions into them.
+        //
+        // subagent is also blocked for now because it similarly creates an isolated
+        // context (separate agent process) that does not inherit plan-mode state.
+        // TODO(plan-mode/subagent): Propagate plan-mode into subagent invocations
+        // instead of blanket-blocking.  This would require the subagent tool to
+        // accept and honor a read-only flag so that legitimate read-only delegation
+        // (e.g. `subagent(agent: "researcher", task: "...")`) can continue to work
+        // in plan mode.  The infrastructure change needed:
+        //   1. Extend the subagent tool API with an `options.planMode: boolean` param.
+        //   2. Have the subagent runner pass PIZZAPI_PLAN_MODE=1 (or equivalent) into
+        //      the spawned agent environment.
+        //   3. Load and enforce plan-mode restrictions inside the subagent session.
         if (WRITE_BLOCKED_TOOL_NAMES.has(event.toolName)) {
             const isSpawnTool = event.toolName === "subagent" || event.toolName === "spawn_session";
             return {

--- a/packages/cli/src/extensions/plan-mode/extension.ts
+++ b/packages/cli/src/extensions/plan-mode/extension.ts
@@ -217,11 +217,16 @@ export const planModeToggleExtension: ExtensionFactory = (pi) => {
         // Always allow the agent to toggle plan mode off
         if (event.toolName === TOGGLE_PLAN_MODE_TOOL) return;
 
-        // Block edit/write tools entirely
+        // Block write tools and session-spawning tools.
+        // subagent and spawn_session are blocked because they create child contexts
+        // with full write access, bypassing plan mode restrictions entirely.
         if (WRITE_BLOCKED_TOOL_NAMES.has(event.toolName)) {
+            const isSpawnTool = event.toolName === "subagent" || event.toolName === "spawn_session";
             return {
                 block: true,
-                reason: `Plan mode: "${event.toolName}" is blocked in read-only mode. Use toggle_plan_mode to exit plan mode first.`,
+                reason: isSpawnTool
+                    ? `Plan mode: "${event.toolName}" is blocked — spawning sessions creates child contexts with full write access, bypassing plan mode. Use toggle_plan_mode to exit plan mode first.`
+                    : `Plan mode: "${event.toolName}" is blocked in read-only mode. Use toggle_plan_mode to exit plan mode first.`,
             };
         }
 

--- a/packages/cli/src/extensions/plan-mode/patterns.ts
+++ b/packages/cli/src/extensions/plan-mode/patterns.ts
@@ -109,7 +109,7 @@ export const SANDBOX_ONLY_CMD_PATTERNS = [
     /^\s*gh\s+(issue|pr|release)\s+(create|edit|close|merge|delete|comment)\b/i,
     // HTTP write verbs — sandbox protects local filesystem but NOT the network.
     // These send mutations to remote servers regardless of sandbox state.
-    /^\s*curl\b.*\s(?:-X\s+(?:POST|PUT|DELETE|PATCH)\b|--request(?:=|\s+)(?:POST|PUT|DELETE|PATCH)\b|-d\b|--data(?:\s|=|-\w)|--json\b)/i,
+    /^\s*curl\b.*\s(?:-X\s*(?:POST|PUT|DELETE|PATCH)\b|--request(?:=|\s+)(?:POST|PUT|DELETE|PATCH)\b|-d\b|--data(?:\s|=|-\w)|--json\b)/i,
     /^\s*wget\b.*\s--post-(?:data|file)(?:\s|=|\b)/i,
 ];
 
@@ -138,7 +138,7 @@ export const DESTRUCTIVE_FLAG_PATTERNS = [
     /^\s*make\b(?!.*(\s-n\b|\s--dry-run\b|\s--just-print\b))/i,
     // HTTP write verbs via curl (network side-effects, not covered by filesystem sandbox).
     // Blocks -X POST/PUT/DELETE/PATCH, --request, -d/--data* (POST body), --json.
-    /\bcurl\b.*\s(?:-X\s+(?:POST|PUT|DELETE|PATCH)\b|--request(?:=|\s+)(?:POST|PUT|DELETE|PATCH)\b|-d\b|--data(?:\s|=|-\w)|--json\b)/i,
+    /\bcurl\b.*\s(?:-X\s*(?:POST|PUT|DELETE|PATCH)\b|--request(?:=|\s+)(?:POST|PUT|DELETE|PATCH)\b|-d\b|--data(?:\s|=|-\w)|--json\b)/i,
     // HTTP write verbs via wget
     /\bwget\b.*\s--post-(?:data|file)(?:\s|=|\b)/i,
 ];

--- a/packages/cli/src/extensions/plan-mode/patterns.ts
+++ b/packages/cli/src/extensions/plan-mode/patterns.ts
@@ -27,6 +27,12 @@ export const DESTRUCTIVE_CMD_PATTERNS = [
     /^\s*mkfifo\b/i,    // creates named pipes (filesystem objects)
     /^\s*mknod\b/i,     // creates device/special files
     // Note: `patch` is handled separately so `patch --dry-run` / `--check` stay allowed.
+    // Shell builtins that execute dynamic/opaque code — cannot be statically analysed.
+    // Block ALL eval/source/. unconditionally; even `eval echo hello` is disallowed
+    // because we cannot guarantee the string is safe at static-analysis time.
+    /^\s*eval\b/i,
+    /^\s*source\b/i,
+    /^\s*\.\s+/,   // dot-source builtin: ". ./script.sh", ". config"
 ];
 
 /**
@@ -101,6 +107,11 @@ export const SANDBOX_ONLY_CMD_PATTERNS = [
     /^\s*reboot\b/i, /^\s*shutdown\b/i,
     /^\s*systemctl\s+(start|stop|restart|enable|disable)/i,
     /^\s*service\s+\S+\s+(start|stop|restart)/i,
+    // Shell builtins that execute dynamic/opaque code — block in sandbox too
+    // (sandbox only protects the filesystem, not arbitrary code evaluation).
+    /^\s*eval\b/i,
+    /^\s*source\b/i,
+    /^\s*\.\s+/,   // dot-source builtin
     // Remote / network side effects — sandbox only protects local filesystem
     // (Git commands are handled separately via the GIT_SAFE_SUBCOMMANDS allowlist)
     /^\s*npm\s+publish\b/i,
@@ -142,6 +153,17 @@ export const DESTRUCTIVE_FLAG_PATTERNS = [
     // HTTP write verbs via wget
     /\bwget\b.*\s--post-(?:data|file)(?:\s|=|\b)/i,
 ];
+
+/**
+ * Commands that simply pass through to their arguments as a new process.
+ * e.g. `time git push` executes `git push`; `timeout 5 git push` executes `git push`.
+ * These are NOT shell interpreters — they have no -c flag — but they must be
+ * unwrapped so the inner command can be analysed for destructiveness.
+ */
+export const PASSTHROUGH_WRAPPERS = new Set([
+    "time", "nohup", "timeout", "nice", "stdbuf",
+    "ionice", "chrt", "taskset", "setsid", "chronic",
+]);
 
 /**
  * Shell names that support the -c flag to execute arbitrary code strings.

--- a/packages/cli/src/extensions/plan-mode/patterns.ts
+++ b/packages/cli/src/extensions/plan-mode/patterns.ts
@@ -107,6 +107,10 @@ export const SANDBOX_ONLY_CMD_PATTERNS = [
     /^\s*npx\b/i,
     /^\s*docker\s+push\b/i,
     /^\s*gh\s+(issue|pr|release)\s+(create|edit|close|merge|delete|comment)\b/i,
+    // HTTP write verbs — sandbox protects local filesystem but NOT the network.
+    // These send mutations to remote servers regardless of sandbox state.
+    /^\s*curl\b.*\s(?:-X\s+(?:POST|PUT|DELETE|PATCH)\b|--request(?:=|\s+)(?:POST|PUT|DELETE|PATCH)\b|-d\b|--data(?:\s|=|-\w)|--json\b)/i,
+    /^\s*wget\b.*\s--post-(?:data|file)(?:\s|=|\b)/i,
 ];
 
 /**
@@ -123,13 +127,30 @@ export const DESTRUCTIVE_FLAG_PATTERNS = [
     // In-place editing via sed/perl -i
     /\bsed\b.*\s-i\b/i, /\bsed\b.*\s-i\S/i,
     /\bperl\b.*\s-i\b/i, /\bperl\b.*\s-i\S/i,
-    // Interpreters executing scripts (not just --version/--help)
+    // perl -e / -E: inline code execution (e.g. `perl -e 'unlink "f"'`)
+    /^\s*perl\b.*\s-[a-zA-Z]*[eE](?:\s|$)/i,
+    // Interpreters executing scripts (not just --version/--help).
+    // These also cover -c (python -c) and -e (ruby -e / node -e) inline execution.
     /^\s*python[23]?\s+(?!--(version|help)\b)\S/i,
     /^\s*ruby\s+(?!--(version|help)\b)\S/i,
     /^\s*node\s+(?!--(version|help)\b)\S/i,
     // Build tools (not --dry-run / --just-print / -n)
     /^\s*make\b(?!.*(\s-n\b|\s--dry-run\b|\s--just-print\b))/i,
+    // HTTP write verbs via curl (network side-effects, not covered by filesystem sandbox).
+    // Blocks -X POST/PUT/DELETE/PATCH, --request, -d/--data* (POST body), --json.
+    /\bcurl\b.*\s(?:-X\s+(?:POST|PUT|DELETE|PATCH)\b|--request(?:=|\s+)(?:POST|PUT|DELETE|PATCH)\b|-d\b|--data(?:\s|=|-\w)|--json\b)/i,
+    // HTTP write verbs via wget
+    /\bwget\b.*\s--post-(?:data|file)(?:\s|=|\b)/i,
 ];
+
+/**
+ * Shell names that support the -c flag to execute arbitrary code strings.
+ * Blocked in no-sandbox mode via isWrapperShellCommand() in safe-command.ts when
+ * invoked with -c. env is handled separately (it wraps any command, not just -c).
+ */
+export const WRAPPER_SHELLS = new Set([
+    "bash", "sh", "dash", "zsh", "ksh", "csh", "tcsh", "fish",
+]);
 
 /**
  * In no-sandbox mode we block output redirection by default because it can
@@ -141,5 +162,7 @@ export const OUTPUT_REDIRECTION_PATTERN = /(^|[^<])(\d*)>(?!>)(?:\s*([^\s;|&]+))
 
 // ── Write-blocked tool names ─────────────────────────────────────────────────
 // These tools are blocked when plan mode is active.
-// Includes both core pi tools ("edit", "write") and PizzaPi custom tools ("write_file").
-export const WRITE_BLOCKED_TOOL_NAMES = new Set(["edit", "write", "write_file"]);
+// Includes both core pi tools ("edit", "write"), PizzaPi custom tools ("write_file"),
+// and tools that spawn child sessions with full write access ("subagent", "spawn_session"),
+// which would otherwise bypass plan mode restrictions entirely.
+export const WRITE_BLOCKED_TOOL_NAMES = new Set(["edit", "write", "write_file", "subagent", "spawn_session"]);

--- a/packages/cli/src/extensions/plan-mode/safe-command.test.ts
+++ b/packages/cli/src/extensions/plan-mode/safe-command.test.ts
@@ -272,6 +272,100 @@ describe("regression — safe commands still pass", () => {
     test("find . -name '*.ts' → allowed", () => expect(noSandbox("find . -name '*.ts'")).toBe(false));
 });
 
+// ── Round-4 P1-1: passthrough wrappers must forward inner-command check ────────
+
+describe("passthrough wrappers — no-sandbox", () => {
+    test("time git push → blocked (inner cmd is destructive)", () => {
+        expect(noSandbox("time git push")).toBe(true);
+    });
+
+    test("nohup rm -rf / → blocked (inner cmd is destructive)", () => {
+        expect(noSandbox("nohup rm -rf /")).toBe(true);
+    });
+
+    test("timeout 1 git push → blocked (inner cmd is destructive)", () => {
+        expect(noSandbox("timeout 1 git push")).toBe(true);
+    });
+
+    test("nice git push → blocked (inner cmd is destructive)", () => {
+        expect(noSandbox("nice git push")).toBe(true);
+    });
+
+    test("stdbuf -oL git push → blocked (inner cmd is destructive)", () => {
+        expect(noSandbox("stdbuf -oL git push")).toBe(true);
+    });
+
+    // safe inner commands must remain allowed
+    test("time git status → allowed (safe inner cmd)", () => {
+        expect(noSandbox("time git status")).toBe(false);
+    });
+
+    test("nohup ls → allowed (safe inner cmd)", () => {
+        expect(noSandbox("nohup ls")).toBe(false);
+    });
+
+    test("timeout 5 git log → allowed (safe inner cmd)", () => {
+        expect(noSandbox("timeout 5 git log")).toBe(false);
+    });
+});
+
+describe("passthrough wrappers — sandbox active", () => {
+    test("time git push → blocked (sandbox: remote mutation)", () => {
+        expect(withSandbox("time git push")).toBe(true);
+    });
+
+    test("nohup kill 1 → blocked (sandbox: process control)", () => {
+        expect(withSandbox("nohup kill 1")).toBe(true);
+    });
+
+    test("timeout 5 git status → allowed (sandbox: safe inner cmd)", () => {
+        expect(withSandbox("timeout 5 git status")).toBe(false);
+    });
+});
+
+// ── Round-4 P1-2: dangerous builtins inside -c strings ───────────────────────
+
+describe("dangerous builtins in -c strings — no-sandbox", () => {
+    test("bash -c 'eval git push' → blocked (eval is always unsafe)", () => {
+        expect(noSandbox("bash -c 'eval git push'")).toBe(true);
+    });
+
+    test("bash -c 'eval kill 1' → blocked", () => {
+        expect(noSandbox("bash -c 'eval kill 1'")).toBe(true);
+    });
+
+    test("bash -c '. ./evil.sh' → blocked (dot-source)", () => {
+        expect(noSandbox("bash -c '. ./evil.sh'")).toBe(true);
+    });
+
+    test("bash -c 'source ./evil.sh' → blocked", () => {
+        expect(noSandbox("bash -c 'source ./evil.sh'")).toBe(true);
+    });
+
+    // eval is blocked unconditionally — we cannot statically analyse what it will run
+    test("bash -c 'eval echo hello' → blocked (eval always blocked)", () => {
+        expect(noSandbox("bash -c 'eval echo hello'")).toBe(true);
+    });
+});
+
+describe("dangerous builtins in -c strings — sandbox active", () => {
+    test("bash -c 'eval git push' → blocked (sandbox)", () => {
+        expect(withSandbox("bash -c 'eval git push'")).toBe(true);
+    });
+
+    test("bash -c 'eval kill 1' → blocked (sandbox)", () => {
+        expect(withSandbox("bash -c 'eval kill 1'")).toBe(true);
+    });
+
+    test("bash -c '. ./evil.sh' → blocked (sandbox: dot-source)", () => {
+        expect(withSandbox("bash -c '. ./evil.sh'")).toBe(true);
+    });
+
+    test("bash -c 'source ./evil.sh' → blocked (sandbox)", () => {
+        expect(withSandbox("bash -c 'source ./evil.sh'")).toBe(true);
+    });
+});
+
 describe("regression — destructive commands still blocked", () => {
     test("rm -rf / → blocked", () => expect(noSandbox("rm -rf /")).toBe(true));
     test("git push → blocked (no-sandbox)", () => expect(noSandbox("git push")).toBe(true));

--- a/packages/cli/src/extensions/plan-mode/safe-command.test.ts
+++ b/packages/cli/src/extensions/plan-mode/safe-command.test.ts
@@ -215,6 +215,46 @@ describe("bash -c with curl inside — both paths", () => {
     });
 });
 
+// ── Round-2 P1: env option parsing (--,  -C/--chdir, -S/--split-string) ──────
+
+describe("env -- double-dash terminator", () => {
+    test("env -- rm -rf / → blocked", () => {
+        expect(noSandbox("env -- rm -rf /")).toBe(true);
+    });
+
+    test("env -- git status → allowed", () => {
+        expect(noSandbox("env -- git status")).toBe(false);
+    });
+});
+
+describe("env -C / --chdir flag", () => {
+    test("env -C /tmp git push → blocked", () => {
+        expect(noSandbox("env -C /tmp git push")).toBe(true);
+    });
+
+    test("env --chdir=/tmp kill 1 → blocked", () => {
+        expect(noSandbox("env --chdir=/tmp kill 1")).toBe(true);
+    });
+
+    test("env -C /tmp git status → allowed", () => {
+        expect(noSandbox("env -C /tmp git status")).toBe(false);
+    });
+});
+
+describe("env -S / --split-string flag", () => {
+    test('env -S "rm -rf /" → blocked', () => {
+        expect(noSandbox('env -S "rm -rf /"')).toBe(true);
+    });
+});
+
+// ── Round-2 P2: quoting preserved in inner command extraction ─────────────────
+
+describe("env quoting preservation", () => {
+    test("env FOO=bar printf '>' → allowed (metachar in single quotes)", () => {
+        expect(noSandbox("env FOO=bar printf '>'")).toBe(false);
+    });
+});
+
 // ── Regression: previously-working safe commands must still pass ──────────────
 
 describe("regression — safe commands still pass", () => {

--- a/packages/cli/src/extensions/plan-mode/safe-command.test.ts
+++ b/packages/cli/src/extensions/plan-mode/safe-command.test.ts
@@ -1,0 +1,237 @@
+/**
+ * Tests for isDestructiveCommand — covering the wrapper-shell inner-command
+ * extraction fixes (P1-1, P1-2) and the curl attached-flag regex fix (P1-3).
+ */
+import { describe, test, expect } from "bun:test";
+import { isDestructiveCommand } from "./safe-command.js";
+
+// ── Helper aliases ────────────────────────────────────────────────────────────
+
+/** isDestructiveCommand with sandbox OFF (default / no-sandbox path). */
+function noSandbox(cmd: string) {
+    return isDestructiveCommand(cmd, false);
+}
+
+/** isDestructiveCommand with sandbox ON. */
+function withSandbox(cmd: string) {
+    return isDestructiveCommand(cmd, true);
+}
+
+// ── P1-1: wrapper shells should analyse the inner command, not blanket-block ──
+
+describe("env launcher — no-sandbox", () => {
+    test("env HOME=/tmp git status → allowed (inner cmd is read-only)", () => {
+        expect(noSandbox("env HOME=/tmp git status")).toBe(false);
+    });
+
+    test("env FOO=bar BAZ=qux git log --oneline → allowed", () => {
+        expect(noSandbox("env FOO=bar BAZ=qux git log --oneline")).toBe(false);
+    });
+
+    test("env HOME=/tmp rm -rf / → blocked (inner cmd is destructive)", () => {
+        expect(noSandbox("env HOME=/tmp rm -rf /")).toBe(true);
+    });
+
+    test("env PATH=/usr sudo reboot → blocked (inner cmd is destructive)", () => {
+        expect(noSandbox("env PATH=/usr sudo reboot")).toBe(true);
+    });
+
+    test("env -i git status → allowed (env flag + read-only inner cmd)", () => {
+        expect(noSandbox("env -i git status")).toBe(false);
+    });
+
+    test("env by itself → allowed (just prints the environment)", () => {
+        expect(noSandbox("env")).toBe(false);
+    });
+
+    test("env FOO=bar (no command) → allowed", () => {
+        expect(noSandbox("env FOO=bar")).toBe(false);
+    });
+});
+
+describe("bash/sh -c wrapper — no-sandbox", () => {
+    test('bash -lc "git status" → allowed (inner cmd is read-only)', () => {
+        expect(noSandbox('bash -lc "git status"')).toBe(false);
+    });
+
+    test("bash -c 'git log' → allowed", () => {
+        expect(noSandbox("bash -c 'git log'")).toBe(false);
+    });
+
+    test('sh -c "git diff HEAD" → allowed', () => {
+        expect(noSandbox('sh -c "git diff HEAD"')).toBe(false);
+    });
+
+    test('bash -c "rm -rf /" → blocked (inner cmd is destructive)', () => {
+        expect(noSandbox('bash -c "rm -rf /"')).toBe(true);
+    });
+
+    test("sh -c 'sudo rm -rf /etc' → blocked", () => {
+        expect(noSandbox("sh -c 'sudo rm -rf /etc'")).toBe(true);
+    });
+
+    test("bash without -c → allowed (no inline code execution)", () => {
+        expect(noSandbox("bash script.sh")).toBe(false);
+    });
+
+    test("bash --version → allowed", () => {
+        expect(noSandbox("bash --version")).toBe(false);
+    });
+
+    test("zsh -c 'git status' → allowed", () => {
+        expect(noSandbox("zsh -c 'git status'")).toBe(false);
+    });
+
+    test("zsh -c 'kill 1' → blocked", () => {
+        expect(noSandbox("zsh -c 'kill 1'")).toBe(true);
+    });
+});
+
+describe("nested wrapper shells — no-sandbox", () => {
+    test('bash -c \'bash -c "git status"\' → allowed (nested, safe inner cmd)', () => {
+        expect(noSandbox("bash -c 'bash -c \"git status\"'")).toBe(false);
+    });
+
+    test('bash -c \'env HOME=/tmp rm -rf /\' → blocked (nested, destructive inner cmd)', () => {
+        expect(noSandbox("bash -c 'env HOME=/tmp rm -rf /'")).toBe(true);
+    });
+});
+
+describe("wrapper shell outer-redirection — no-sandbox", () => {
+    test("bash -c 'git status' > output.txt → blocked (outer redirection)", () => {
+        expect(noSandbox("bash -c 'git status' > output.txt")).toBe(true);
+    });
+
+    test("bash -c 'git status' 2>/dev/null → allowed (safe stderr sink)", () => {
+        expect(noSandbox("bash -c 'git status' 2>/dev/null")).toBe(false);
+    });
+});
+
+// ── P1-2: sandbox-active path must also check wrapper shells ─────────────────
+
+describe("bash/sh -c wrapper — sandbox active", () => {
+    test('bash -c "curl -X POST https://example.com" → blocked (network mutation)', () => {
+        expect(withSandbox('bash -c "curl -X POST https://example.com"')).toBe(true);
+    });
+
+    test("bash -c 'kill 1' → blocked (process control)", () => {
+        expect(withSandbox("bash -c 'kill 1'")).toBe(true);
+    });
+
+    test("bash -c 'sudo reboot' → blocked (privilege escalation)", () => {
+        expect(withSandbox("bash -c 'sudo reboot'")).toBe(true);
+    });
+
+    test("bash -c 'git push' → blocked (remote mutation via allowlist)", () => {
+        expect(withSandbox("bash -c 'git push'")).toBe(true);
+    });
+
+    test('bash -c "git status" → allowed (sandbox + safe inner cmd)', () => {
+        expect(withSandbox('bash -c "git status"')).toBe(false);
+    });
+
+    test('sh -c "git log --oneline" → allowed', () => {
+        expect(withSandbox('sh -c "git log --oneline"')).toBe(false);
+    });
+});
+
+describe("env launcher — sandbox active", () => {
+    test("env HOME=/tmp git push → blocked (git push is a remote mutation)", () => {
+        expect(withSandbox("env HOME=/tmp git push")).toBe(true);
+    });
+
+    test("env HOME=/tmp git status → allowed", () => {
+        expect(withSandbox("env HOME=/tmp git status")).toBe(false);
+    });
+
+    test("env FOO=bar kill 1 → blocked", () => {
+        expect(withSandbox("env FOO=bar kill 1")).toBe(true);
+    });
+});
+
+// ── P1-3: curl attached flag forms (-XPOST, -XPUT, etc.) ─────────────────────
+
+describe("curl attached -X flag — no-sandbox", () => {
+    test("curl -XPOST https://example.com → blocked", () => {
+        expect(noSandbox("curl -XPOST https://example.com")).toBe(true);
+    });
+
+    test("curl -XPUT https://example.com → blocked", () => {
+        expect(noSandbox("curl -XPUT https://example.com")).toBe(true);
+    });
+
+    test("curl -XDELETE https://example.com → blocked", () => {
+        expect(noSandbox("curl -XDELETE https://example.com")).toBe(true);
+    });
+
+    test("curl -XPATCH https://example.com → blocked", () => {
+        expect(noSandbox("curl -XPATCH https://example.com")).toBe(true);
+    });
+
+    // spaced form should still work
+    test("curl -X POST https://example.com → blocked (spaced form, regression)", () => {
+        expect(noSandbox("curl -X POST https://example.com")).toBe(true);
+    });
+
+    // GET is not a mutation — should not be blocked by the -X check alone
+    test("curl -XGET https://example.com → allowed (GET is read-only)", () => {
+        expect(noSandbox("curl -XGET https://example.com")).toBe(false);
+    });
+
+    test("curl https://example.com → allowed (plain GET, no -X)", () => {
+        expect(noSandbox("curl https://example.com")).toBe(false);
+    });
+});
+
+describe("curl attached -X flag — sandbox active", () => {
+    test("curl -XPOST https://example.com → blocked", () => {
+        expect(withSandbox("curl -XPOST https://example.com")).toBe(true);
+    });
+
+    test("curl -XDELETE https://example.com → blocked", () => {
+        expect(withSandbox("curl -XDELETE https://example.com")).toBe(true);
+    });
+
+    test("curl -X POST https://example.com → blocked (spaced, regression)", () => {
+        expect(withSandbox("curl -X POST https://example.com")).toBe(true);
+    });
+});
+
+describe("bash -c with curl inside — both paths", () => {
+    test('bash -c "curl -X POST https://example.com" → blocked, no-sandbox', () => {
+        expect(noSandbox('bash -c "curl -X POST https://example.com"')).toBe(true);
+    });
+
+    test('bash -c "curl -X POST https://example.com" → blocked, sandbox', () => {
+        expect(withSandbox('bash -c "curl -X POST https://example.com"')).toBe(true);
+    });
+
+    test('bash -c "curl -XPOST https://example.com" → blocked, no-sandbox', () => {
+        expect(noSandbox('bash -c "curl -XPOST https://example.com"')).toBe(true);
+    });
+
+    test('bash -c "curl -XPOST https://example.com" → blocked, sandbox', () => {
+        expect(withSandbox('bash -c "curl -XPOST https://example.com"')).toBe(true);
+    });
+});
+
+// ── Regression: previously-working safe commands must still pass ──────────────
+
+describe("regression — safe commands still pass", () => {
+    test("git status → allowed", () => expect(noSandbox("git status")).toBe(false));
+    test("git log --oneline → allowed", () => expect(noSandbox("git log --oneline")).toBe(false));
+    test("git diff HEAD → allowed", () => expect(noSandbox("git diff HEAD")).toBe(false));
+    test("ls -la → allowed", () => expect(noSandbox("ls -la")).toBe(false));
+    test("grep -r foo . → allowed", () => expect(noSandbox("grep -r foo .")).toBe(false));
+    test("cat README.md → allowed", () => expect(noSandbox("cat README.md")).toBe(false));
+    test("find . -name '*.ts' → allowed", () => expect(noSandbox("find . -name '*.ts'")).toBe(false));
+});
+
+describe("regression — destructive commands still blocked", () => {
+    test("rm -rf / → blocked", () => expect(noSandbox("rm -rf /")).toBe(true));
+    test("git push → blocked (no-sandbox)", () => expect(noSandbox("git push")).toBe(true));
+    test("sudo apt install foo → blocked", () => expect(noSandbox("sudo apt install foo")).toBe(true));
+    test("kill 1 → blocked (no-sandbox)", () => expect(noSandbox("kill 1")).toBe(true));
+    test("kill 1 → blocked (sandbox)", () => expect(withSandbox("kill 1")).toBe(true));
+    test("git push → blocked (sandbox)", () => expect(withSandbox("git push")).toBe(true));
+});

--- a/packages/cli/src/extensions/plan-mode/safe-command.test.ts
+++ b/packages/cli/src/extensions/plan-mode/safe-command.test.ts
@@ -70,8 +70,13 @@ describe("bash/sh -c wrapper — no-sandbox", () => {
         expect(noSandbox("sh -c 'sudo rm -rf /etc'")).toBe(true);
     });
 
-    test("bash without -c → allowed (no inline code execution)", () => {
-        expect(noSandbox("bash script.sh")).toBe(false);
+    // P1-3: bash <file> must be blocked in no-sandbox — we can't inspect the script.
+    test("bash script.sh → blocked in no-sandbox (cannot inspect file)", () => {
+        expect(noSandbox("bash script.sh")).toBe(true);
+    });
+
+    test("bash script.sh → allowed in sandbox (filesystem overlay protects)", () => {
+        expect(withSandbox("bash script.sh")).toBe(false);
     });
 
     test("bash --version → allowed", () => {

--- a/packages/cli/src/extensions/plan-mode/safe-command.ts
+++ b/packages/cli/src/extensions/plan-mode/safe-command.ts
@@ -77,6 +77,57 @@ function extractWrapperInnerCommand(segment: string): string | null {
     // Strip any leading path component so /usr/bin/bash, /bin/sh, etc. are handled
     const first = words[0].toLowerCase().replace(/^.*[\/\\]/, "");
 
+    // ── Bare inline environment-variable assignments (VAR=val ... CMD args) ──────
+    // e.g. `HOME=/tmp rm -rf /` — treat exactly like `env HOME=/tmp rm -rf /`.
+    // This pattern appears in inner commands extracted from `bash -c '...'` strings
+    // and would otherwise bypass destructive-command detection because the first
+    // token starts with an identifier, not a recognised command name.
+    if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[0])) {
+        let i = 0;
+        while (i < words.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(words[i])) i++;
+        if (i >= words.length) return null; // only assignments, no actual command
+        const off = findWordStartOffset(segment, i);
+        return off >= 0 ? segment.slice(off) : "";
+    }
+
+    // ── Pass-through shell builtins ───────────────────────────────────────────
+    // `command CMD`, `builtin CMD`, and `exec CMD` all ultimately invoke CMD;
+    // strip the prefix and check the actual command for destructiveness.
+
+    if (first === "command") {
+        let i = 1;
+        // `command -v CMD` / `command -V CMD` are lookup-only — not execution.
+        if (i < words.length && (words[i] === "-v" || words[i] === "-V")) return null;
+        // Skip other option flags (-p, etc.) up to an optional `--` terminator.
+        while (i < words.length && words[i] !== "--" && words[i].startsWith("-")) i++;
+        if (i < words.length && words[i] === "--") i++;
+        if (i >= words.length) return null;
+        const off = findWordStartOffset(segment, i);
+        return off >= 0 ? segment.slice(off) : "";
+    }
+
+    if (first === "builtin") {
+        // `builtin CMD args` — bypasses shell functions but still runs CMD.
+        if (words.length < 2) return null;
+        const off = findWordStartOffset(segment, 1);
+        return off >= 0 ? segment.slice(off) : "";
+    }
+
+    if (first === "exec") {
+        // `exec CMD` replaces the current process with CMD.
+        // Recognised flags: -a name (argv[0]), -c (clean env), -l (login).
+        let i = 1;
+        while (i < words.length) {
+            if (words[i] === "--") { i++; break; }
+            if (words[i] === "-a" && i + 1 < words.length) { i += 2; continue; }
+            if (words[i].startsWith("-")) { i++; continue; }
+            break;
+        }
+        if (i >= words.length) return null;
+        const off = findWordStartOffset(segment, i);
+        return off >= 0 ? segment.slice(off) : "";
+    }
+
     // env as a command launcher: env [opts] [VAR=val...] COMMAND [args...]
     if (first === "env") {
         let i = 1; // skip "env"
@@ -168,20 +219,56 @@ function extractWrapperInnerCommand(segment: string): string | null {
 
     // Shell wrappers with -c flag (executes the next argument as shell code)
     if (WRAPPER_SHELLS.has(first)) {
-        // --version / --help are safe queries; not a code-execution wrapper
-        if (words.some((w) => w === "--version" || w === "--help")) return null;
-
+        // Locate the -c flag first so we know whether inline code execution is happening.
+        let cFlagIdx = -1;
         for (let i = 1; i < words.length; i++) {
-            if (hasShortFlag(words[i], "c")) {
-                // The command string is the next positional argument after -c.
-                // If there is none (bare `bash -c`) return "" to block conservatively.
-                return i + 1 < words.length ? words[i + 1] : "";
-            }
+            if (hasShortFlag(words[i], "c")) { cFlagIdx = i; break; }
+        }
+
+        // --help / --version short-circuit ONLY when there is no -c flag.
+        // `bash -c 'rm -rf /' --help` still has a -c; its inner command must be
+        // inspected — the trailing --help does NOT make it safe.
+        if (cFlagIdx === -1 && words.some((w) => w === "--version" || w === "--help")) return null;
+
+        if (cFlagIdx >= 0) {
+            // The command string is the next positional argument after -c.
+            // If there is none (bare `bash -c`) return "" to block conservatively.
+            return cFlagIdx + 1 < words.length ? words[cFlagIdx + 1] : "";
         }
         return null; // no -c flag → not executing arbitrary code inline
     }
 
     return null;
+}
+
+/**
+ * Returns true when `segment` is a wrapper-shell invocation that executes a
+ * file (e.g. `bash script.sh`, `sh ./run.sh`) rather than using `-c` or
+ * `--help` / `--version`.
+ *
+ * In no-sandbox mode we cannot inspect the file's contents, so any such
+ * invocation is treated as potentially destructive.  In sandbox mode the
+ * filesystem overlay provides protection, so this check is skipped.
+ *
+ * @internal Exported for testing only.
+ */
+export function isWrapperShellFileExecution(segment: string): boolean {
+    const words = splitShellWords(segment);
+    if (words.length < 2) return false;
+    const first = words[0].toLowerCase().replace(/^.*[\/\\]/, "");
+    if (!WRAPPER_SHELLS.has(first)) return false;
+
+    // If -c is present, extractWrapperInnerCommand handles it — not our concern.
+    for (let i = 1; i < words.length; i++) {
+        if (hasShortFlag(words[i], "c")) return false;
+    }
+
+    // --help / --version with no -c — safe informational queries.
+    if (words.slice(1).some((w) => w === "--help" || w === "--version")) return false;
+
+    // Any non-flag positional argument is treated as a filename to execute.
+    const positionalArgs = words.slice(1).filter((w) => !w.startsWith("-"));
+    return positionalArgs.length > 0;
 }
 
 /**
@@ -285,6 +372,13 @@ export function isDestructiveCommand(command: string, sandboxActive = false): bo
             if (innerCmd === "" || isDestructiveCommand(innerCmd, false)) return true;
             continue; // inner command is safe; skip remaining pattern checks
         }
+
+        // P1-3: `bash script.sh` / `sh run.sh` (no -c flag) executes an
+        // arbitrary file whose contents cannot be inspected at static-analysis
+        // time.  In no-sandbox mode treat this as destructive.  In sandbox mode
+        // the filesystem overlay limits the damage, so we allow it (the check
+        // is only reached on the no-sandbox code path).
+        if (isWrapperShellFileExecution(trimmed)) return true;
 
         const isCmdDestructive = DESTRUCTIVE_CMD_PATTERNS.some((p) => p.test(trimmed));
         const hasUnsafeRedirection = hasUnsafeOutputRedirection(trimmed);

--- a/packages/cli/src/extensions/plan-mode/safe-command.ts
+++ b/packages/cli/src/extensions/plan-mode/safe-command.ts
@@ -1,6 +1,100 @@
-import { DESTRUCTIVE_CMD_PATTERNS, DESTRUCTIVE_FLAG_PATTERNS, SANDBOX_ONLY_CMD_PATTERNS } from "./patterns.js";
-import { splitShellSegments, hasUnsafeOutputRedirection } from "./shell-parser.js";
+import { DESTRUCTIVE_CMD_PATTERNS, DESTRUCTIVE_FLAG_PATTERNS, SANDBOX_ONLY_CMD_PATTERNS, WRAPPER_SHELLS } from "./patterns.js";
+import { splitShellSegments, splitShellWords, hasUnsafeOutputRedirection } from "./shell-parser.js";
 import { isDestructiveGitCommand, isDestructiveTarCommand, isDestructiveGawkCommand, isDestructivePatchCommand } from "./command-checks.js";
+
+// ── Wrapper shell/interpreter detection ──────────────────────────────────────────────────
+
+/**
+ * Returns true if `word` is a short-flag bundle containing the letter `flag`.
+ * Handles both standalone (-c) and bundled (-xc) short flags.
+ * Returns false for long flags (--flag).
+ */
+function hasShortFlag(word: string, flag: string): boolean {
+    if (!word.startsWith("-") || word.startsWith("--")) return false;
+    return word.slice(1).includes(flag);
+}
+
+/**
+ * Returns true when `env` is being used as a command launcher, i.e. after
+ * skipping env's own flags (like -i, -u VAR) and any VAR=val assignments,
+ * there is at least one remaining argument that would be the wrapped command.
+ *
+ * `env` by itself (just prints environment) returns false.
+ * `env FOO=bar rm file` returns true — rm is the wrapped command.
+ */
+function isEnvWithCommand(words: string[]): boolean {
+    let i = 1; // skip "env"
+    while (i < words.length) {
+        const w = words[i];
+        // Skip known env flags: -i/--ignore-environment, -0/--null, -v/--debug
+        if (w === "-i" || w === "--ignore-environment" || w === "-0" || w === "--null" ||
+            w === "-v" || w === "--debug" || w === "-") {
+            i++;
+            continue;
+        }
+        // Skip -u VAR / --unset VAR (separate argument forms)
+        if ((w === "-u" || w === "--unset") && i + 1 < words.length) {
+            i += 2;
+            continue;
+        }
+        // Skip -u=VAR / --unset=VAR inline forms
+        if (/^(?:-u|--unset)=/.test(w)) {
+            i++;
+            continue;
+        }
+        // Skip VAR=val environment variable assignments
+        if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(w)) {
+            i++;
+            continue;
+        }
+        // Any remaining token is a command argument — env is acting as a launcher
+        return true;
+    }
+    return false;
+}
+
+/**
+ * Detects wrapper shell and interpreter invocations that execute arbitrary code
+ * via a -c flag, bypassing per-command analysis:
+ *
+ *   - `bash -c 'cmd'`, `sh -c 'cmd'`, `/usr/bin/bash -c 'cmd'`, etc.
+ *   - `perl -e 'code'`, `perl -E 'code'`
+ *   - `env [VAR=val...] COMMAND` (env used as a command launcher)
+ *
+ * These are only blocked in no-sandbox mode (the sandbox-active path handles
+ * filesystem writes at the OS level and the check would be too restrictive there).
+ *
+ * Note: python/ruby/node with inline code flags are already caught by
+ * DESTRUCTIVE_FLAG_PATTERNS and don't require a separate check here.
+ */
+function isWrapperShellCommand(segment: string): boolean {
+    const words = splitShellWords(segment);
+    if (words.length < 2) return false;
+
+    // Strip any leading path component so /usr/bin/bash, /bin/sh, etc. are handled
+    const first = words[0].toLowerCase().replace(/^.*[\/\\]/, "");
+
+    // env as a command launcher: env [opts] [VAR=val...] COMMAND
+    if (first === "env") {
+        return isEnvWithCommand(words);
+    }
+
+    // Shell wrappers with -c flag (executes the next argument as shell code)
+    if (WRAPPER_SHELLS.has(first)) {
+        // Allow --version / --help queries
+        if (words.some((w) => w === "--version" || w === "--help")) return false;
+        return words.some((w) => hasShortFlag(w, "c"));
+    }
+
+    // perl -e / -E: inline Perl code execution
+    // (belt-and-suspenders: also caught by DESTRUCTIVE_FLAG_PATTERNS for the common form)
+    if (first === "perl") {
+        if (words.some((w) => w === "--version" || w === "--help")) return false;
+        return words.some((w) => hasShortFlag(w, "e") || hasShortFlag(w, "E"));
+    }
+
+    return false;
+}
 
 /**
  * Check if a command looks destructive based on known patterns.
@@ -77,6 +171,10 @@ export function isDestructiveCommand(command: string, sandboxActive = false): bo
         // tar, gawk, and patch need command-aware parsing to avoid false positives and
         // to account for read-only flags / legacy syntax.
         if (isDestructiveTarCommand(trimmed) || isDestructiveGawkCommand(trimmed) || isDestructivePatchCommand(trimmed)) return true;
+
+        // Wrapper shells/interpreters with -c/-e: bash -c, sh -c, perl -e, env COMMAND, etc.
+        // These embed the real command in a string argument, bypassing per-token analysis.
+        if (isWrapperShellCommand(trimmed)) return true;
 
         const isCmdDestructive = DESTRUCTIVE_CMD_PATTERNS.some((p) => p.test(trimmed));
         const hasUnsafeRedirection = hasUnsafeOutputRedirection(trimmed);

--- a/packages/cli/src/extensions/plan-mode/safe-command.ts
+++ b/packages/cli/src/extensions/plan-mode/safe-command.ts
@@ -5,6 +5,41 @@ import { isDestructiveGitCommand, isDestructiveTarCommand, isDestructiveGawkComm
 // ── Wrapper shell/interpreter detection ──────────────────────────────────────────────────
 
 /**
+ * Returns the byte offset in `str` where the word at `wordIndex` (0-based)
+ * begins, using the same whitespace/quote-based tokenization as
+ * `splitShellWords`.  Returns -1 when `wordIndex` is out of range.
+ *
+ * Preserving the original slice (rather than re-joining words) ensures that
+ * quoting is intact when the extracted substring is later evaluated for
+ * destructiveness — e.g. `printf '>'` must not be confused with an output
+ * redirection.
+ */
+function findWordStartOffset(str: string, wordIndex: number): number {
+    let pos = 0;
+    let count = 0;
+    while (pos < str.length) {
+        // Skip inter-word whitespace
+        while (pos < str.length && /\s/.test(str[pos])) pos++;
+        if (pos >= str.length) break;
+        // Found the start of a word — return if it is the target
+        if (count === wordIndex) return pos;
+        // Skip past this word, respecting single/double quotes
+        let inSingle = false;
+        let inDouble = false;
+        while (pos < str.length) {
+            const ch = str[pos];
+            if (ch === "\\" && !inSingle && pos + 1 < str.length) { pos += 2; continue; }
+            if (ch === "'" && !inDouble) { inSingle = !inSingle; pos++; continue; }
+            if (ch === '"' && !inSingle) { inDouble = !inDouble; pos++; continue; }
+            if (!inSingle && !inDouble && /\s/.test(ch)) break;
+            pos++;
+        }
+        count++;
+    }
+    return -1;
+}
+
+/**
  * Returns true if `word` is a short-flag bundle containing the letter `flag`.
  * Handles both standalone (-c) and bundled (-xc) short flags.
  * Returns false for long flags (--flag).
@@ -47,29 +82,84 @@ function extractWrapperInnerCommand(segment: string): string | null {
         let i = 1; // skip "env"
         while (i < words.length) {
             const w = words[i];
-            // Skip known env flags: -i/--ignore-environment, -0/--null, -v/--debug
-            if (w === "-i" || w === "--ignore-environment" || w === "-0" || w === "--null" ||
-                w === "-v" || w === "--debug" || w === "-") {
+
+            // `--` terminates option parsing; everything after is the command.
+            if (w === "--") {
+                if (i + 1 >= words.length) return null; // `env --` with no command
+                const off = findWordStartOffset(segment, i + 1);
+                return off >= 0 ? segment.slice(off) : "";
+            }
+
+            // -S / --split-string: the argument IS the inner command string.
+            // GNU env splits the string into tokens and runs it as a command;
+            // we return the string directly so it can be evaluated.
+            if (w === "-S" || w === "--split-string") {
+                return i + 1 < words.length ? words[i + 1] : "";
+            }
+            if (/^--split-string=/.test(w)) {
+                return w.slice("--split-string=".length);
+            }
+
+            // Known no-arg flags
+            if (w === "-i" || w === "--ignore-environment" ||
+                w === "-0" || w === "--null" ||
+                w === "-v" || w === "--debug" ||
+                w === "-") {
                 i++;
                 continue;
             }
-            // Skip -u VAR / --unset VAR (separate argument forms)
+
+            // -u VAR / --unset VAR (takes one argument)
             if ((w === "-u" || w === "--unset") && i + 1 < words.length) {
                 i += 2;
                 continue;
             }
-            // Skip -u=VAR / --unset=VAR inline forms
+            // -u=VAR / --unset=VAR inline forms
             if (/^(?:-u|--unset)=/.test(w)) {
                 i++;
                 continue;
             }
-            // Skip VAR=val environment variable assignments
+
+            // -C DIR / --chdir DIR (takes one argument)
+            if ((w === "-C" || w === "--chdir") && i + 1 < words.length) {
+                i += 2;
+                continue;
+            }
+            // --chdir=DIR inline form
+            if (/^--chdir=/.test(w)) {
+                i++;
+                continue;
+            }
+
+            // Short flag bundles (e.g. -iv, -iC /tmp, -iS 'cmd').
+            // Only applies to bundles of length > 2 (e.g. "-iC", not "-C").
+            if (w.startsWith("-") && !w.startsWith("--") && w.length > 2) {
+                const flags = w.slice(1);
+                if (flags.includes("S")) {
+                    // -…S… in bundle: next word is the inner command string
+                    return i + 1 < words.length ? words[i + 1] : "";
+                }
+                if (flags.includes("C") || flags.includes("u")) {
+                    // Arg-taking flag in bundle — consume bundle + next word
+                    i += 2;
+                    continue;
+                }
+                // No-arg bundle (e.g. -iv, -i0)
+                i++;
+                continue;
+            }
+
+            // VAR=val environment variable assignments
             if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(w)) {
                 i++;
                 continue;
             }
-            // Remaining tokens form the inner command + arguments
-            return words.slice(i).join(" ");
+
+            // First non-flag, non-assignment word is the inner command.
+            // Slice the ORIGINAL segment string (not words.slice(i).join(" "))
+            // so that quoting is preserved for downstream checks.
+            const off = findWordStartOffset(segment, i);
+            return off >= 0 ? segment.slice(off) : "";
         }
         // Only env options / variable assignments — env by itself prints the
         // environment and is harmless.  Return null so normal checks run.

--- a/packages/cli/src/extensions/plan-mode/safe-command.ts
+++ b/packages/cli/src/extensions/plan-mode/safe-command.ts
@@ -1,4 +1,4 @@
-import { DESTRUCTIVE_CMD_PATTERNS, DESTRUCTIVE_FLAG_PATTERNS, SANDBOX_ONLY_CMD_PATTERNS, WRAPPER_SHELLS } from "./patterns.js";
+import { DESTRUCTIVE_CMD_PATTERNS, DESTRUCTIVE_FLAG_PATTERNS, SANDBOX_ONLY_CMD_PATTERNS, WRAPPER_SHELLS, PASSTHROUGH_WRAPPERS } from "./patterns.js";
 import { splitShellSegments, splitShellWords, hasUnsafeOutputRedirection } from "./shell-parser.js";
 import { isDestructiveGitCommand, isDestructiveTarCommand, isDestructiveGawkCommand, isDestructivePatchCommand } from "./command-checks.js";
 
@@ -126,6 +126,32 @@ function extractWrapperInnerCommand(segment: string): string | null {
         if (i >= words.length) return null;
         const off = findWordStartOffset(segment, i);
         return off >= 0 ? segment.slice(off) : "";
+    }
+
+    // ── Passthrough wrappers (time, nohup, timeout, nice, stdbuf, etc.) ─────────────────
+    // These commands don't interpret code — they simply exec their argument list
+    // as-is (possibly after consuming some leading flags / a numeric argument).
+    // `time git push`, `nohup rm -rf /`, `timeout 5 git push`, etc. must all be
+    // unwrapped so the inner command can be checked for destructiveness.
+    if (PASSTHROUGH_WRAPPERS.has(first)) {
+        let i = 1;
+        // Skip flags and, when a flag takes a required numeric argument
+        // (e.g. `nice -n 5`, `timeout -k 5s`), skip that argument too.
+        while (i < words.length && words[i].startsWith("-")) {
+            i++;
+            // Numeric/duration value immediately following a flag — skip it.
+            if (i < words.length && /^\d+(\.\d+)?[smhd]?$/.test(words[i])) {
+                i++;
+            }
+        }
+        // `timeout DURATION COMMAND` — the first positional arg is always the
+        // duration (a plain number or number+suffix like "5s"), not a command.
+        if (first === "timeout" && i < words.length && /^\d+(\.\d+)?[smhd]?$/.test(words[i])) {
+            i++;
+        }
+        if (i >= words.length) return null; // wrapper only, no inner command
+        const paOff = findWordStartOffset(segment, i);
+        return paOff >= 0 ? segment.slice(paOff) : "";
     }
 
     // env as a command launcher: env [opts] [VAR=val...] COMMAND [args...]

--- a/packages/cli/src/extensions/plan-mode/safe-command.ts
+++ b/packages/cli/src/extensions/plan-mode/safe-command.ts
@@ -15,85 +15,83 @@ function hasShortFlag(word: string, flag: string): boolean {
 }
 
 /**
- * Returns true when `env` is being used as a command launcher, i.e. after
- * skipping env's own flags (like -i, -u VAR) and any VAR=val assignments,
- * there is at least one remaining argument that would be the wrapped command.
+ * If `segment` is a wrapper shell invocation that executes an inner command
+ * string, returns the inner command string so it can be evaluated recursively.
  *
- * `env` by itself (just prints environment) returns false.
- * `env FOO=bar rm file` returns true — rm is the wrapped command.
+ * Returns:
+ *  - `null`  — not a wrapper shell invocation (caller should analyse normally)
+ *  - `""`    — IS a wrapper shell but inner command cannot be extracted
+ *               (e.g. `bash -c` with no argument); callers should block conservatively
+ *  - string  — the inner command/script text to evaluate for destructiveness
+ *
+ * Handles:
+ *   - `bash -c 'CMD'`, `sh -lc 'CMD'`, `/usr/bin/bash -c 'CMD'`, etc.
+ *     Inner command is the argument that follows the word containing `-c`.
+ *   - `env [opts] [VAR=val...] COMMAND [args…]`
+ *     Inner command is the reconstructed `COMMAND args` after skipping
+ *     env's own flags and variable assignments.
+ *
+ * Note: `perl -e CODE` is intentionally NOT handled here — Perl code cannot
+ * be re-evaluated as a shell command.  It is already caught by
+ * DESTRUCTIVE_FLAG_PATTERNS and continues to be blocked unconditionally.
  */
-function isEnvWithCommand(words: string[]): boolean {
-    let i = 1; // skip "env"
-    while (i < words.length) {
-        const w = words[i];
-        // Skip known env flags: -i/--ignore-environment, -0/--null, -v/--debug
-        if (w === "-i" || w === "--ignore-environment" || w === "-0" || w === "--null" ||
-            w === "-v" || w === "--debug" || w === "-") {
-            i++;
-            continue;
-        }
-        // Skip -u VAR / --unset VAR (separate argument forms)
-        if ((w === "-u" || w === "--unset") && i + 1 < words.length) {
-            i += 2;
-            continue;
-        }
-        // Skip -u=VAR / --unset=VAR inline forms
-        if (/^(?:-u|--unset)=/.test(w)) {
-            i++;
-            continue;
-        }
-        // Skip VAR=val environment variable assignments
-        if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(w)) {
-            i++;
-            continue;
-        }
-        // Any remaining token is a command argument — env is acting as a launcher
-        return true;
-    }
-    return false;
-}
-
-/**
- * Detects wrapper shell and interpreter invocations that execute arbitrary code
- * via a -c flag, bypassing per-command analysis:
- *
- *   - `bash -c 'cmd'`, `sh -c 'cmd'`, `/usr/bin/bash -c 'cmd'`, etc.
- *   - `perl -e 'code'`, `perl -E 'code'`
- *   - `env [VAR=val...] COMMAND` (env used as a command launcher)
- *
- * These are only blocked in no-sandbox mode (the sandbox-active path handles
- * filesystem writes at the OS level and the check would be too restrictive there).
- *
- * Note: python/ruby/node with inline code flags are already caught by
- * DESTRUCTIVE_FLAG_PATTERNS and don't require a separate check here.
- */
-function isWrapperShellCommand(segment: string): boolean {
+function extractWrapperInnerCommand(segment: string): string | null {
     const words = splitShellWords(segment);
-    if (words.length < 2) return false;
+    if (words.length < 2) return null;
 
     // Strip any leading path component so /usr/bin/bash, /bin/sh, etc. are handled
     const first = words[0].toLowerCase().replace(/^.*[\/\\]/, "");
 
-    // env as a command launcher: env [opts] [VAR=val...] COMMAND
+    // env as a command launcher: env [opts] [VAR=val...] COMMAND [args...]
     if (first === "env") {
-        return isEnvWithCommand(words);
+        let i = 1; // skip "env"
+        while (i < words.length) {
+            const w = words[i];
+            // Skip known env flags: -i/--ignore-environment, -0/--null, -v/--debug
+            if (w === "-i" || w === "--ignore-environment" || w === "-0" || w === "--null" ||
+                w === "-v" || w === "--debug" || w === "-") {
+                i++;
+                continue;
+            }
+            // Skip -u VAR / --unset VAR (separate argument forms)
+            if ((w === "-u" || w === "--unset") && i + 1 < words.length) {
+                i += 2;
+                continue;
+            }
+            // Skip -u=VAR / --unset=VAR inline forms
+            if (/^(?:-u|--unset)=/.test(w)) {
+                i++;
+                continue;
+            }
+            // Skip VAR=val environment variable assignments
+            if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(w)) {
+                i++;
+                continue;
+            }
+            // Remaining tokens form the inner command + arguments
+            return words.slice(i).join(" ");
+        }
+        // Only env options / variable assignments — env by itself prints the
+        // environment and is harmless.  Return null so normal checks run.
+        return null;
     }
 
     // Shell wrappers with -c flag (executes the next argument as shell code)
     if (WRAPPER_SHELLS.has(first)) {
-        // Allow --version / --help queries
-        if (words.some((w) => w === "--version" || w === "--help")) return false;
-        return words.some((w) => hasShortFlag(w, "c"));
+        // --version / --help are safe queries; not a code-execution wrapper
+        if (words.some((w) => w === "--version" || w === "--help")) return null;
+
+        for (let i = 1; i < words.length; i++) {
+            if (hasShortFlag(words[i], "c")) {
+                // The command string is the next positional argument after -c.
+                // If there is none (bare `bash -c`) return "" to block conservatively.
+                return i + 1 < words.length ? words[i + 1] : "";
+            }
+        }
+        return null; // no -c flag → not executing arbitrary code inline
     }
 
-    // perl -e / -E: inline Perl code execution
-    // (belt-and-suspenders: also caught by DESTRUCTIVE_FLAG_PATTERNS for the common form)
-    if (first === "perl") {
-        if (words.some((w) => w === "--version" || w === "--help")) return false;
-        return words.some((w) => hasShortFlag(w, "e") || hasShortFlag(w, "E"));
-    }
-
-    return false;
+    return null;
 }
 
 /**
@@ -141,6 +139,18 @@ export function isDestructiveCommand(command: string, sandboxActive = false): bo
             // sandbox handles filesystem writes (redirection, -o, etc.).
             if (/^\s*git\b/i.test(trimmed)) {
                 if (isDestructiveGitCommand(trimmed)) return true;
+                continue;
+            }
+
+            // Wrapper shells — extract the inner command and evaluate it
+            // against the sandbox-active rules so that e.g.
+            // `bash -c "curl -X POST ..."` and `bash -c "kill 1"` are caught
+            // even when the OS sandbox is on (it only protects the filesystem,
+            // not network mutations or process-control calls).
+            const innerCmdSandbox = extractWrapperInnerCommand(trimmed);
+            if (innerCmdSandbox !== null) {
+                if (innerCmdSandbox === "" || isDestructiveCommand(innerCmdSandbox, true)) return true;
+                continue; // inner command is safe; skip remaining checks
             }
         }
         return false;
@@ -172,9 +182,19 @@ export function isDestructiveCommand(command: string, sandboxActive = false): bo
         // to account for read-only flags / legacy syntax.
         if (isDestructiveTarCommand(trimmed) || isDestructiveGawkCommand(trimmed) || isDestructivePatchCommand(trimmed)) return true;
 
-        // Wrapper shells/interpreters with -c/-e: bash -c, sh -c, perl -e, env COMMAND, etc.
-        // These embed the real command in a string argument, bypassing per-token analysis.
-        if (isWrapperShellCommand(trimmed)) return true;
+        // Wrapper shells/interpreters: bash -c, sh -c, env COMMAND, etc.
+        // Instead of blanket-blocking all wrapper shells, extract the inner command
+        // and evaluate it recursively.  This allows `env HOME=/tmp git status` and
+        // `bash -lc "git status"` while still blocking `bash -c "rm -rf /"`.
+        const innerCmd = extractWrapperInnerCommand(trimmed);
+        if (innerCmd !== null) {
+            // Also block if the outer wrapper itself has unsafe output redirection,
+            // e.g. `bash -c 'git status' > output.txt` writes to a file.
+            if (hasUnsafeOutputRedirection(trimmed)) return true;
+            // Block if no extractable inner command, or if the inner command is destructive.
+            if (innerCmd === "" || isDestructiveCommand(innerCmd, false)) return true;
+            continue; // inner command is safe; skip remaining pattern checks
+        }
 
         const isCmdDestructive = DESTRUCTIVE_CMD_PATTERNS.some((p) => p.test(trimmed));
         const hasUnsafeRedirection = hasUnsafeOutputRedirection(trimmed);

--- a/packages/cli/src/extensions/plan-mode/shell-parser.ts
+++ b/packages/cli/src/extensions/plan-mode/shell-parser.ts
@@ -145,7 +145,12 @@ export function containsShellExpansion(token: string): boolean {
  * suppressing stderr.
  */
 export function hasUnsafeOutputRedirection(segment: string): boolean {
-    const matches = segment.matchAll(OUTPUT_REDIRECTION_PATTERN);
+    // Strip single-quoted segments before checking — content inside single
+    // quotes is literal and cannot contain actual shell redirections.
+    // e.g. `printf '>'` is NOT a redirection; `bash -c 'git status' > out` IS.
+    const stripped = segment.replace(/'[^']*'/g, "''");
+
+    const matches = stripped.matchAll(OUTPUT_REDIRECTION_PATTERN);
     for (const match of matches) {
         const fd = match[2] ?? "";
         const target = (match[3] ?? "").replace(/^['"]|['"]$/g, "");

--- a/packages/cli/src/extensions/plan-mode/shell-parser.ts
+++ b/packages/cli/src/extensions/plan-mode/shell-parser.ts
@@ -148,7 +148,11 @@ export function hasUnsafeOutputRedirection(segment: string): boolean {
     // Strip single-quoted segments before checking — content inside single
     // quotes is literal and cannot contain actual shell redirections.
     // e.g. `printf '>'` is NOT a redirection; `bash -c 'git status' > out` IS.
-    const stripped = segment.replace(/'[^']*'/g, "''");
+    let stripped = segment.replace(/'[^']*'/g, "''");
+    // Strip double-quoted segments too — `>` inside double quotes is not a
+    // shell redirection operator (e.g. `printf ">"` is safe).
+    // Use escape-aware regex so `"he said \"hello\""` is handled correctly.
+    stripped = stripped.replace(/"(?:[^"\\]|\\.)*"/g, '""');
 
     const matches = stripped.matchAll(OUTPUT_REDIRECTION_PATTERN);
     for (const match of matches) {


### PR DESCRIPTION
## Summary

Fixes three confirmed P0 plan-mode bypass vulnerabilities.

---

### Fix 1: Wrapper shell/interpreter bypass (no-sandbox path)

**Problem:** `bash -c 'rm -rf /'`, `sh -c 'evil'`, `perl -e 'unlink "f"'`, and `env rm file` could execute arbitrary code through plan mode by embedding the real command in a string argument — bypassing the per-token analysis.

**Changes:**
- `patterns.ts`: Export `WRAPPER_SHELLS` set (bash, sh, dash, zsh, ksh, csh, tcsh, fish); add `perl -e/-E` to `DESTRUCTIVE_FLAG_PATTERNS`
- `safe-command.ts`: Add `isWrapperShellCommand()` with word-level parsing:
  - Blocks `bash/sh/dash/etc. -c` including bundled flags (`-xc`) and path-prefixed executables (`/bin/bash -c`)
  - Blocks `env [VAR=val...] COMMAND` (env acting as a command launcher)
  - Blocks `perl -e/-E` inline code (with path-prefix handling)

---

### Fix 2: Session-spawning tool bypass

**Problem:** `subagent` and `spawn_session` create child contexts with **full write access**, completely bypassing plan mode restrictions.

**Changes:**
- `patterns.ts`: Add `subagent` and `spawn_session` to `WRITE_BLOCKED_TOOL_NAMES`
- `extension.ts`: Update block message to explain why spawn tools are blocked (different reason than write tools)

---

### Fix 3: HTTP mutation command bypass (no-sandbox and sandbox paths)

**Problem:** `curl -X POST`, `curl --data`, `wget --post-data` etc. send mutations to remote servers regardless of filesystem sandbox state.

**Changes:**
- `patterns.ts`: Add curl/wget HTTP mutation patterns to both:
  - `DESTRUCTIVE_FLAG_PATTERNS` (no-sandbox path)
  - `SANDBOX_ONLY_CMD_PATTERNS` (sandbox-active path — OS sandbox doesn't protect the network)

---

## Tests

+37 new test cases covering all three fixes:
- Shell wrapper bypass: bash/sh/dash/etc. with `-c`, path-prefixed shells, `perl -e/-E`, `env COMMAND`, chained commands
- Session tools: verified via `WRITE_BLOCKED_TOOL_NAMES` (integration tested)
- HTTP mutations: curl `-X POST/PUT/DELETE/PATCH`, `--data*`, `--json`, wget POST — both sandbox-on and sandbox-off paths

All 166 plan-mode tests pass. Typecheck clean.