### PR TITLE
feat: forward query/fragment params from deep links to service panel iframes

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -3721,7 +3721,7 @@ export function App() {
   // Runner service panels — dynamically discovered
   const { services: availableServices, panels: dynamicPanels, triggerDefs: runnerTriggerDefs, sigilDefs: runnerSigilDefs } = useRunnerServices(viewerSocket);
   const triggerCounts = useTriggerCount(activeSessionId, viewerSocket);
-  const { activePanelIds: activeServicePanels, togglePanel: toggleServicePanel, closePanelById: closeServicePanelById, closeAllPanels: closeAllServicePanels, getPanelPosition: getServicePanelPosition, setPanelPosition: setServicePanelPosition, setEphemeralPanelPosition: setEphemeralServicePanelPosition } = useServicePanelState();
+  const { activePanelIds: activeServicePanels, togglePanel: toggleServicePanel, closePanelById: closeServicePanelById, closeAllPanels: closeAllServicePanels, getPanelPosition: getServicePanelPosition, setPanelPosition: setServicePanelPosition, setEphemeralPanelPosition: setEphemeralServicePanelPosition, getNavParams: getServicePanelNavParams } = useServicePanelState();
 
   // Always-current ref so the runner-change effect below can read the active
   // panel set without listing it as a dependency (avoids a close→reopen loop).
@@ -3763,31 +3763,36 @@ export function App() {
     return () => { viewerSocket.off("service_message", handler); };
   }, [viewerSocket, activeServicePanels, toggleServicePanel]);
 
-  const handleToggleServicePanel = React.useCallback((serviceId: string) => {
-    if (activeServicePanels.has(serviceId)) {
+  const handleToggleServicePanel = React.useCallback((serviceId: string, query?: string, fragment?: string) => {
+    // When called with nav params on an already-open panel, update params
+    // and re-navigate rather than closing.
+    const hasNavParams = !!(query || fragment);
+    if (activeServicePanels.has(serviceId) && !hasNavParams) {
       closeServicePanelById(serviceId);
     } else {
-      // Resolve the correct position for the new panel using the shared pure
-      // helper (also tested in ServicePanels.test.ts).  When the currently-
-      // active tab is a service panel, the new panel inherits that panel's
-      // position so both appear together rather than in separate dock groups.
-      const newPosition = resolveNewPanelPosition(
-        serviceId,
-        combinedActiveTab,
-        activeServicePanels,
-        getServicePanelPosition,
-      );
-      if (activeServicePanels.has(combinedActiveTab)) {
-        // Auto-placement: the position was derived from another panel, not from
-        // this panel's own saved preference.  Store it as an ephemeral override
-        // so it is used for rendering this session but does NOT overwrite the
-        // panel's persisted dock preference in localStorage.
-        setEphemeralServicePanelPosition(serviceId, newPosition);
+      if (!activeServicePanels.has(serviceId)) {
+        // Resolve the correct position for the new panel using the shared pure
+        // helper (also tested in ServicePanels.test.ts).  When the currently-
+        // active tab is a service panel, the new panel inherits that panel's
+        // position so both appear together rather than in separate dock groups.
+        const newPosition = resolveNewPanelPosition(
+          serviceId,
+          combinedActiveTab,
+          activeServicePanels,
+          getServicePanelPosition,
+        );
+        if (activeServicePanels.has(combinedActiveTab)) {
+          // Auto-placement: the position was derived from another panel, not from
+          // this panel's own saved preference.  Store it as an ephemeral override
+          // so it is used for rendering this session but does NOT overwrite the
+          // panel's persisted dock preference in localStorage.
+          setEphemeralServicePanelPosition(serviceId, newPosition);
+        }
       }
       // When the active tab is NOT a service panel, newPosition equals the
       // panel's own stored/default preference — no action needed, getPanelPosition
       // will already return the correct value.
-      toggleServicePanel(serviceId);
+      toggleServicePanel(serviceId, query, fragment);
       handleCombinedTabChange(serviceId);
     }
   }, [activeServicePanels, closeServicePanelById, toggleServicePanel, handleCombinedTabChange, combinedActiveTab, setEphemeralServicePanelPosition, getServicePanelPosition]);
@@ -3882,9 +3887,10 @@ export function App() {
 
       const label = staticDef?.label ?? dynamicDef!.label;
       const icon = staticDef?.icon ?? <DynamicLucideIcon name={dynamicDef!.icon} />;
+      const navParams = getServicePanelNavParams(serviceId);
       const content = staticDef
         ? <staticDef.component sessionId={effectiveSessionId} runnerId={activeSessionInfo?.runnerId ?? undefined} />
-        : <IframeServicePanel sessionId={effectiveSessionId} port={dynamicDef!.port} />;
+        : <IframeServicePanel sessionId={effectiveSessionId} port={dynamicDef!.port} query={navParams?.query} fragment={navParams?.fragment} />;
 
       tabs.push({
         id: serviceId,
@@ -3901,7 +3907,7 @@ export function App() {
       });
     }
     return tabs;
-  }, [activeServicePanels, tunnelSessionId, activeSessionId, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById, handleCombinedTabChange]);
+  }, [activeServicePanels, tunnelSessionId, activeSessionId, dynamicPanels, startPanelDragWith, setServicePanelPosition, closeServicePanelById, handleCombinedTabChange, getServicePanelNavParams]);
 
   const panelGroups = React.useMemo(() => {
     type PG = import("@/hooks/usePanelLayout").PanelPosition;

--- a/packages/ui/src/components/service-panels/IframeServicePanel.tsx
+++ b/packages/ui/src/components/service-panels/IframeServicePanel.tsx
@@ -3,17 +3,33 @@
  *
  * Renders the service's self-hosted UI inside an iframe,
  * proxied through the tunnel system at /api/tunnel/{sessionId}/{port}/.
+ *
+ * Query and fragment parameters from `pizzapi://panel/...` deep links
+ * are forwarded to the iframe URL so the panel can read them via
+ * `location.search` and `location.hash`.
  */
+import { useMemo } from "react";
 
 interface IframeServicePanelProps {
     sessionId: string;
     port: number;
+    /** Query string (without leading "?") forwarded from a deep link. */
+    query?: string;
+    /** Hash fragment (without leading "#") forwarded from a deep link. */
+    fragment?: string;
 }
 
-export function IframeServicePanel({ sessionId, port }: IframeServicePanelProps) {
+export function IframeServicePanel({ sessionId, port, query, fragment }: IframeServicePanelProps) {
+    const src = useMemo(() => {
+        let url = `/api/tunnel/${sessionId}/${port}/`;
+        if (query) url += `?${query}`;
+        if (fragment) url += `#${fragment}`;
+        return url;
+    }, [sessionId, port, query, fragment]);
+
     return (
         <iframe
-            src={`/api/tunnel/${sessionId}/${port}/`}
+            src={src}
             className="w-full h-full border-0"
             title={`Service panel — port ${port}`}
             // SECURITY: allow-same-origin is needed because tunnel content is same-origin. TODO: serve tunnel content from a separate origin to enable full sandbox isolation.

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -167,6 +167,12 @@ function savePanelPositions(positions: Map<string, PanelPosition>) {
     try { localStorage.setItem(SERVICE_PANEL_POSITIONS_KEY, JSON.stringify([...positions])); } catch { /* ignore */ }
 }
 
+/** Query + fragment forwarded from a `pizzapi://panel/...` deep link. */
+export interface PanelNavParams {
+    query?: string;
+    fragment?: string;
+}
+
 export function useServicePanelState() {
     const [activePanelIds, setActivePanelIds] = useState<Set<string>>(new Set());
     const [panelPositions, setPanelPositions] = useState<Map<string, PanelPosition>>(loadPanelPositions);
@@ -175,15 +181,36 @@ export function useServicePanelState() {
     // session is stored here rather than in panelPositions / localStorage.
     // The override is cleared when the panel is closed.
     const [ephemeralPositions, setEphemeralPositions] = useState<Map<string, PanelPosition>>(new Map());
+    // Per-panel navigation params from deep links (query string + hash fragment).
+    // Set when a panel is opened via a `pizzapi://panel/...` URL, consumed by
+    // IframeServicePanel to append to the iframe src.
+    const [panelNavParams, setPanelNavParams] = useState<Map<string, PanelNavParams>>(new Map());
 
-    const togglePanel = useCallback((serviceId: string) => {
+    const togglePanel = useCallback((serviceId: string, query?: string, fragment?: string) => {
         setActivePanelIds(prev => {
             const next = new Set(prev);
             if (next.has(serviceId)) {
-                next.delete(serviceId);
+                // When toggling OFF with no new nav params, just close.
+                // When toggling with new nav params, keep open and update params.
+                if (!query && !fragment) {
+                    next.delete(serviceId);
+                }
             } else {
                 next.add(serviceId);
             }
+            return next;
+        });
+        // Store nav params when opening (or updating) a panel.
+        // Clear them when closing (no query/fragment passed).
+        setPanelNavParams(prev => {
+            if (query || fragment) {
+                const next = new Map(prev);
+                next.set(serviceId, { query, fragment });
+                return next;
+            }
+            if (!prev.has(serviceId)) return prev;
+            const next = new Map(prev);
+            next.delete(serviceId);
             return next;
         });
         // Clear ephemeral override when closing so that the next open uses the
@@ -202,6 +229,13 @@ export function useServicePanelState() {
             next.delete(serviceId);
             return next;
         });
+        // Clear nav params on close.
+        setPanelNavParams(prev => {
+            if (!prev.has(serviceId)) return prev;
+            const next = new Map(prev);
+            next.delete(serviceId);
+            return next;
+        });
         // Clear ephemeral override on explicit close as well.
         setEphemeralPositions(prev => {
             if (!prev.has(serviceId)) return prev;
@@ -214,6 +248,7 @@ export function useServicePanelState() {
     const closeAllPanels = useCallback(() => {
         setActivePanelIds(new Set());
         setEphemeralPositions(new Map());
+        setPanelNavParams(new Map());
     }, []);
 
     const getPanelPosition = useCallback((serviceId: string): PanelPosition => {
@@ -255,5 +290,9 @@ export function useServicePanelState() {
         });
     }, []);
 
-    return { activePanelIds, togglePanel, closePanelById, closeAllPanels, getPanelPosition, setPanelPosition, setEphemeralPanelPosition };
+    const getNavParams = useCallback((serviceId: string): PanelNavParams | undefined => {
+        return panelNavParams.get(serviceId);
+    }, [panelNavParams]);
+
+    return { activePanelIds, togglePanel, closePanelById, closeAllPanels, getPanelPosition, setPanelPosition, setEphemeralPanelPosition, getNavParams };
 }


### PR DESCRIPTION
## Problem

The `pizzapi://panel/{serviceId}?key=val#fragment` deep link mechanism (used by sigil resolve URLs like `[[idea:abc123]]`) correctly **parsed** query and fragment in `PizzaPiNavContext`, but they were **silently dropped** at two points:

1. **`handleToggleServicePanel`** in `App.tsx` only accepted `(serviceId: string)` — the `query` and `fragment` args from `PizzaPiNavActions.toggleServicePanel` were ignored
2. **`IframeServicePanel`** hard-coded the iframe src to `/api/tunnel/{sessionId}/{port}/` with no params appended

The godmother-panel's `readStartupState()` already reads from `location.search` and `location.hash`, but those were always empty because the params never reached the iframe URL.

## Fix

| File | Change |
|------|--------|
| `IframeServicePanel.tsx` | Accept optional `query`/`fragment` props, append to iframe `src` URL |
| `ServicePanels.tsx` | Added `PanelNavParams` type and `panelNavParams` state map to `useServicePanelState`; `togglePanel` now accepts `query/fragment`; exposed `getNavParams()` |
| `App.tsx` | `handleToggleServicePanel` now accepts & forwards `query/fragment`; when called with nav params on an already-open panel, updates params instead of closing; `servicePanelTabs` memo reads nav params and passes to `IframeServicePanel` |

## How it works now

1. `PizzaPiNavContext.navigate()` parses `pizzapi://panel/godmother-panel?project=PizzaPi#idea/abc123`
2. Calls `toggleServicePanel("godmother-panel", "project=PizzaPi", "idea/abc123")`
3. `useServicePanelState.togglePanel` stores nav params and opens panel
4. `servicePanelTabs` reads `getNavParams("godmother-panel")` → `{ query, fragment }`
5. `IframeServicePanel` renders: `<iframe src="/api/tunnel/{sid}/{port}/?project=PizzaPi#idea/abc123" />`
6. Panel's JS reads `location.search` and `location.hash` ✓

## Testing

- All existing tests pass (service panels, panel layout helpers, tunnel panel, godmother-panel)
- Zero new type errors (`tsc --noEmit` clean)
