### PR TITLE
fix(ui): prevent git panel toolbar from overflowing container

### DIFF
--- a/packages/ui/src/components/TriggersPanel.tsx
+++ b/packages/ui/src/components/TriggersPanel.tsx
@@ -1962,7 +1962,7 @@ export function TriggersPanel({ sessionId, triggerDefs = [], viewerSocket }: Tri
   const pendingCount = pendingGroups.length;
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full overflow-hidden">
       {/* Toolbar with tabs */}
       <div className="flex items-center border-b border-border bg-muted/20 shrink-0">
         {/* Tab buttons */}

--- a/packages/ui/src/components/TunnelPanel.tsx
+++ b/packages/ui/src/components/TunnelPanel.tsx
@@ -85,7 +85,7 @@ export function TunnelPanel({ sessionId, runnerId }: TunnelPanelProps) {
             : `/api/tunnel/${sessionId}/${port}/`;
 
     return (
-        <div className="flex flex-col h-full">
+        <div className="flex flex-col h-full overflow-hidden">
             {/* Toolbar: tunnel list + controls */}
             <div className="flex items-center gap-1.5 px-3 py-1.5 border-b border-border bg-muted/20 shrink-0 flex-wrap">
                 {/* Tunnel tabs */}

--- a/packages/ui/src/components/file-explorer/file-viewer.tsx
+++ b/packages/ui/src/components/file-explorer/file-viewer.tsx
@@ -53,7 +53,7 @@ export function FileViewer({
   const fileName = filePath.split("/").pop() ?? filePath;
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full overflow-hidden">
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/50 min-h-[40px]">
         <button
           type="button"

--- a/packages/ui/src/components/file-explorer/git-changes-view.tsx
+++ b/packages/ui/src/components/file-explorer/git-changes-view.tsx
@@ -155,7 +155,7 @@ export function GitChangesView({
 
   if (selectedDiff) {
     return (
-      <div ref={diffContainerRef} tabIndex={-1} className="flex flex-col h-full outline-none">
+      <div ref={diffContainerRef} tabIndex={-1} className="flex flex-col h-full overflow-hidden outline-none">
         <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/50">
           <button
             type="button"
@@ -193,7 +193,7 @@ export function GitChangesView({
   const hasChanges = gitStatus.changes.length > 0;
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full overflow-hidden">
       {/* Branch header */}
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/50">
         <GitBranch className="size-4 text-green-600 dark:text-green-400" />

--- a/packages/ui/src/components/file-explorer/image-viewer.tsx
+++ b/packages/ui/src/components/file-explorer/image-viewer.tsx
@@ -93,7 +93,7 @@ export function ImageViewer({
   const fileName = filePath.split("/").pop() ?? filePath;
 
   return (
-    <div className="flex flex-col h-full">
+    <div className="flex flex-col h-full overflow-hidden">
       {/* Header */}
       <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/50 min-h-[40px]">
         <button

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -176,9 +176,9 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
     const showPull = git.status.behind > 0 && git.status.hasUpstream;
 
     return (
-        <div className={cn("flex flex-col h-full", className)}>
+        <div className={cn("flex flex-col h-full overflow-hidden", className)}>
             {/* Branch header */}
-            <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border bg-muted/50 min-h-[40px]">
+            <div className="flex items-center gap-1 px-2 py-1.5 border-b border-border bg-muted/50 min-h-[40px] overflow-hidden">
                 <GitBranchSelector
                     currentBranch={git.status.branch}
                     branches={git.branches}


### PR DESCRIPTION
When the Git panel is docked in a narrow side column, the branch toolbar items (branch selector, ahead/behind badges, Pull/Push buttons) overflow past the panel boundary.

**Fix:** Add `overflow-hidden` to both the GitPanel outer container and the branch toolbar row so content clips properly instead of escaping.