### PR TITLE
fix(subagent): return full output for parallel mode instead of 100-char truncation

### DIFF
--- a/packages/cli/src/extensions/subagent.test.ts
+++ b/packages/cli/src/extensions/subagent.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { formatTokens, formatUsageStats, toFinitePositiveInt } from "./subagent.js";
+import { formatTokens, formatUsageStats, toFinitePositiveInt, PARALLEL_SPILL_THRESHOLD } from "./subagent.js";
 import { _setGlobalConfigDir, loadConfig, loadGlobalConfig } from "../config.js";
 
 /**
@@ -182,6 +182,19 @@ describe("toFinitePositiveInt", () => {
         expect(toFinitePositiveInt([], 99)).toBe(99);
         expect(toFinitePositiveInt(null, 99)).toBe(99);
         expect(toFinitePositiveInt(undefined, 99)).toBe(99);
+    });
+});
+
+describe("PARALLEL_SPILL_THRESHOLD", () => {
+    test("is exported and equals 100KB", () => {
+        expect(PARALLEL_SPILL_THRESHOLD).toBe(100 * 1024);
+    });
+
+    test("is a reasonable threshold for context window management", () => {
+        // Should be at least 10KB (too small = unnecessary file I/O)
+        expect(PARALLEL_SPILL_THRESHOLD).toBeGreaterThanOrEqual(10 * 1024);
+        // Should be at most 1MB (too large = blows up context)
+        expect(PARALLEL_SPILL_THRESHOLD).toBeLessThanOrEqual(1024 * 1024);
     });
 });
 

--- a/packages/cli/src/extensions/subagent/index.ts
+++ b/packages/cli/src/extensions/subagent/index.ts
@@ -18,6 +18,9 @@
  * `details` payloads for web UI consumption.
  */
 
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 import { type ExtensionAPI } from "@mariozechner/pi-coding-agent";
 import { type AgentScope, discoverAgents } from "../subagent-agents.js";
 import { getPluginAgentPaths } from "../claude-plugins.js";
@@ -25,6 +28,7 @@ import { loadGlobalConfig } from "../../config.js";
 import {
     DEFAULT_MAX_PARALLEL_TASKS,
     DEFAULT_MAX_CONCURRENCY,
+    PARALLEL_SPILL_THRESHOLD,
     toFinitePositiveInt,
     isFailed,
     getFinalOutput,
@@ -285,16 +289,36 @@ export const subagentExtension = (pi: ExtensionAPI) => {
                 });
 
                 const successCount = results.filter((r) => !isFailed(r)).length;
-                const summaries = results.map((r) => {
-                    const output = getFinalOutput(r.messages);
-                    const preview = output.slice(0, 100) + (output.length > 100 ? "..." : "");
-                    return `[${r.agent}] ${isFailed(r) ? "failed" : "completed"}: ${preview || "(no output)"}`;
-                });
                 const hasFailures = results.some(isFailed);
+
+                // Build full output per task
+                const sections = results.map((r) => {
+                    const output = getFinalOutput(r.messages);
+                    const status = isFailed(r) ? "failed" : "completed";
+                    return `## [${r.agent}] ${status}\n\n${output || "(no output)"}`;
+                });
+                const fullText = `Parallel: ${successCount}/${results.length} succeeded\n\n${sections.join("\n\n---\n\n")}`;
+
+                // If combined output is very large, spill each task's output to a temp file
+                // so the LLM can selectively read what it needs without blowing up context
+                let contentText: string;
+                if (fullText.length > PARALLEL_SPILL_THRESHOLD) {
+                    const spillDir = mkdtempSync(join(tmpdir(), "subagent-parallel-"));
+                    const fileSummaries = results.map((r, i) => {
+                        const output = getFinalOutput(r.messages);
+                        const status = isFailed(r) ? "failed" : "completed";
+                        const filePath = join(spillDir, `${i}-${r.agent}.md`);
+                        writeFileSync(filePath, `# [${r.agent}] ${status}\n\nTask: ${r.task}\n\n${output || "(no output)"}`);
+                        const preview = output.slice(0, 200) + (output.length > 200 ? "..." : "");
+                        return `[${r.agent}] ${status} (${output.length} chars) → ${filePath}\n${preview}`;
+                    });
+                    contentText = `Parallel: ${successCount}/${results.length} succeeded\n\nOutputs exceeded ${Math.round(PARALLEL_SPILL_THRESHOLD / 1024)}KB — full results saved to temp files. Use \`read\` to access them.\n\n${fileSummaries.join("\n\n")}`;
+                } else {
+                    contentText = fullText;
+                }
+
                 return {
-                    content: [
-                        { type: "text", text: `Parallel: ${successCount}/${results.length} succeeded\n\n${summaries.join("\n\n")}` },
-                    ],
+                    content: [{ type: "text", text: contentText }],
                     details: makeDetails("parallel")(results),
                     ...(hasFailures && { isError: true }),
                 };

--- a/packages/cli/src/extensions/subagent/types.ts
+++ b/packages/cli/src/extensions/subagent/types.ts
@@ -11,6 +11,8 @@ import type { AgentScope } from "../subagent-agents.js";
 export const DEFAULT_MAX_PARALLEL_TASKS = 8;
 export const DEFAULT_MAX_CONCURRENCY = 4;
 export const COLLAPSED_ITEM_COUNT = 10;
+/** Byte threshold for spilling parallel results to temp files instead of inline. */
+export const PARALLEL_SPILL_THRESHOLD = 100 * 1024; // 100KB
 
 /** Coerce an unknown config value to a finite positive integer, or return the fallback. */
 export function toFinitePositiveInt(value: unknown, fallback: number): number {


### PR DESCRIPTION
## Summary

- **Bug**: Subagent parallel mode (`tasks` array) truncated each task's output to 100 characters in the `content` returned to the LLM, making it impossible to read complete review findings, verdicts, or structured output
- **Fix**: Return full output per task in labeled markdown sections, matching single/chain mode behavior
- **Spillover**: When combined output exceeds 100KB, results spill to temp files with 200-char previews and file paths — the LLM can selectively `read` what it needs without blowing up context

## Changes

| File | Change |
|------|--------|
| `packages/cli/src/extensions/subagent/index.ts` | Replace 100-char `.slice()` with full output; add temp file spillover path |
| `packages/cli/src/extensions/subagent/types.ts` | Add `PARALLEL_SPILL_THRESHOLD` constant (100KB) |
| `packages/cli/src/extensions/subagent.test.ts` | Add tests for new constant export |

## Test Plan

- [x] All 822 tests pass
- [x] Typecheck clean
- [x] New `PARALLEL_SPILL_THRESHOLD` tests pass

Fixes Godmother idea `9wBlDxiM`