### PR TITLE
fix: rehydrate runner services after relay restart

### DIFF
--- a/packages/server/src/ws/namespaces/runner.service-announce.test.ts
+++ b/packages/server/src/ws/namespaces/runner.service-announce.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { isSameServiceAnnounce } from "./runner.service-announce.js";
+import { chooseServiceAnnounceSeed, isSameServiceAnnounce, shouldSkipServiceAnnounceFanout } from "./runner.service-announce.js";
 
 describe("isSameServiceAnnounce", () => {
     test("returns true when serviceIds and panels are identical", () => {
@@ -194,9 +194,76 @@ describe("isSameServiceAnnounce", () => {
         expect(isSameServiceAnnounce(left, right)).toBe(false);
     });
 
+    test("returns false when sigilDef resolvePort differs", () => {
+        const left = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR", resolvePort: 4173 }] };
+        const right = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR", resolvePort: 8080 }] };
+        expect(isSameServiceAnnounce(left, right)).toBe(false);
+    });
+
     test("treats absent sigilDefs as empty array", () => {
         const left = { serviceIds: ["github"] };
         const right = { serviceIds: ["github"], sigilDefs: [] };
         expect(isSameServiceAnnounce(left, right)).toBe(true);
+    });
+});
+
+describe("chooseServiceAnnounceSeed", () => {
+    test("uses persisted data when no live announce is cached", () => {
+        const persisted = { serviceIds: ["github"] };
+        expect(chooseServiceAnnounceSeed(null, persisted)).toEqual(persisted);
+    });
+
+    test("keeps the live announce when async seeding loses a race to reconnect", () => {
+        const live = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR", resolvePort: 4173 }] };
+        const persisted = { serviceIds: ["github"], sigilDefs: [{ type: "pr", label: "PR", resolvePort: 8080 }] };
+        expect(chooseServiceAnnounceSeed(live, persisted)).toEqual(live);
+    });
+});
+
+describe("shouldSkipServiceAnnounceFanout", () => {
+    const announce = {
+        serviceIds: ["github"],
+        sigilDefs: [{ type: "pr", label: "PR", serviceId: "github", resolve: "/api/resolve/pr/{id}" }],
+    };
+
+    test("does not skip the first live announce after reconnect when payload matches cached state", () => {
+        expect(shouldSkipServiceAnnounceFanout({
+            previous: announce,
+            next: announce,
+            hasBroadcastLiveAnnounce: false,
+        })).toBe(false);
+    });
+
+    test("skips redundant announces after a live announce was already broadcast", () => {
+        expect(shouldSkipServiceAnnounceFanout({
+            previous: announce,
+            next: announce,
+            hasBroadcastLiveAnnounce: true,
+        })).toBe(true);
+    });
+
+    test("does not skip when payload changed", () => {
+        expect(shouldSkipServiceAnnounceFanout({
+            previous: announce,
+            next: {
+                ...announce,
+                sigilDefs: [{ type: "issue", label: "Issue", serviceId: "github", resolve: "/api/resolve/issue/{id}" }],
+            },
+            hasBroadcastLiveAnnounce: true,
+        })).toBe(false);
+    });
+
+    test("does not skip when only sigil resolvePort changed", () => {
+        expect(shouldSkipServiceAnnounceFanout({
+            previous: {
+                serviceIds: ["github"],
+                sigilDefs: [{ type: "pr", label: "PR", serviceId: "github", resolve: "/api/resolve/pr/{id}", resolvePort: 4173 }],
+            },
+            next: {
+                serviceIds: ["github"],
+                sigilDefs: [{ type: "pr", label: "PR", serviceId: "github", resolve: "/api/resolve/pr/{id}", resolvePort: 8080 }],
+            },
+            hasBroadcastLiveAnnounce: true,
+        })).toBe(false);
     });
 });

--- a/packages/server/src/ws/namespaces/runner.service-announce.ts
+++ b/packages/server/src/ws/namespaces/runner.service-announce.ts
@@ -5,6 +5,13 @@
  */
 import type { ServiceAnnounceData } from "@pizzapi/protocol";
 
+export function chooseServiceAnnounceSeed(
+    current: ServiceAnnounceData | null | undefined,
+    persisted: ServiceAnnounceData | null | undefined,
+): ServiceAnnounceData | null {
+    return current ?? persisted ?? null;
+}
+
 /**
  * Returns true when two ServiceAnnounceData payloads are semantically
  * identical (same serviceIds in the same order, same panel metadata,
@@ -78,7 +85,8 @@ export function isSameServiceAnnounce(
             left.description !== right.description ||
             left.icon !== right.icon ||
             left.serviceId !== right.serviceId ||
-            left.resolve !== right.resolve
+            left.resolve !== right.resolve ||
+            left.resolvePort !== right.resolvePort
         ) {
             return false;
         }
@@ -91,4 +99,16 @@ export function isSameServiceAnnounce(
     }
 
     return true;
+}
+
+export function shouldSkipServiceAnnounceFanout({
+    previous,
+    next,
+    hasBroadcastLiveAnnounce,
+}: {
+    previous: ServiceAnnounceData | null | undefined;
+    next: ServiceAnnounceData | null | undefined;
+    hasBroadcastLiveAnnounce: boolean;
+}): boolean {
+    return hasBroadcastLiveAnnounce && isSameServiceAnnounce(previous, next);
 }

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -217,8 +217,8 @@ export async function sendRunnerCommand(
 // restart) can receive the data without waiting for a fresh announce.
 import type { ServiceAnnounceData } from "@pizzapi/protocol";
 import { updateRunnerServices, getRunnerServices, addRunnerWarning, clearRunnerWarnings } from "../sio-registry/index.js";
-import { isSameServiceAnnounce } from "./runner.service-announce.js";
-export { isSameServiceAnnounce };
+import { chooseServiceAnnounceSeed, isSameServiceAnnounce, shouldSkipServiceAnnounceFanout } from "./runner.service-announce.js";
+export { chooseServiceAnnounceSeed, isSameServiceAnnounce, shouldSkipServiceAnnounceFanout };
 
 const runnerServiceAnnounce = new Map<string, ServiceAnnounceData>();
 
@@ -240,13 +240,19 @@ export function getRunnerServiceAnnounce(runnerId: string): ServiceAnnounceData 
 export async function seedServiceAnnounceCache(runnerId: string): Promise<void> {
     if (runnerServiceAnnounce.has(runnerId)) return; // already cached
     const persisted = await getRunnerServices(runnerId);
-    if (persisted) {
-        runnerServiceAnnounce.set(runnerId, {
-            serviceIds: persisted.serviceIds,
-            panels: persisted.panels,
-            triggerDefs: persisted.triggerDefs,
-            sigilDefs: persisted.sigilDefs,
-        });
+    const next = chooseServiceAnnounceSeed(
+        runnerServiceAnnounce.get(runnerId),
+        persisted
+            ? {
+                serviceIds: persisted.serviceIds,
+                panels: persisted.panels,
+                triggerDefs: persisted.triggerDefs,
+                sigilDefs: persisted.sigilDefs,
+            }
+            : null,
+    );
+    if (next && !runnerServiceAnnounce.has(runnerId)) {
+        runnerServiceAnnounce.set(runnerId, next);
     }
 }
 
@@ -270,6 +276,11 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
     // in Redis, but is kept in-memory here to avoid async Redis reads on every
     // service_message event (which may be high-frequency terminal output).
     const runnerSessionIds = new Map<string, Set<string>>();
+    // Tracks whether this process has already fanned out a live
+    // service_announce from the currently connected runner. Redis can seed
+    // cached service metadata after a relay restart, but viewers still need
+    // the first live announce to rehydrate service panels, triggers, and sigils.
+    const runnerHasBroadcastLiveServiceAnnounce = new Set<string>();
     // Maps runnerId → Set<terminalId>. Mirrors terminal ownership already in
     // Redis but kept in-memory for fast O(1) checks on high-frequency
     // terminal_data events without a Redis round-trip per packet.
@@ -338,6 +349,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             }
 
             socket.data.runnerId = result;
+            runnerHasBroadcastLiveServiceAnnounce.delete(result);
 
             // Start periodic Redis TTL refresh for this runner
             if (runnerTtlTimer) clearInterval(runnerTtlTimer);
@@ -379,11 +391,11 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 log.info(`[runner reconnect] runner=${result} seeded runnerTerminalIds=[${existingTerminalIds.join(",")}]`);
             }
 
-            // Seed in-memory service announce cache from Redis.
-            // On reconnect the runner will emit a fresh service_announce after
-            // service init, but this ensures viewers connecting in the gap
-            // between registration and announce still get service data.
-            void seedServiceAnnounceCache(result).catch(() => {});
+            // Seed in-memory service announce cache from Redis before the
+            // runner proceeds with service init. This closes the gap where a
+            // viewer can reconnect after runner registration but before the
+            // fresh live service_announce arrives.
+            await seedServiceAnnounceCache(result);
 
             socket.emit("runner_registered", {
                 runnerId: result,
@@ -932,19 +944,29 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             if (!runnerId) return;
 
             const previous = runnerServiceAnnounce.get(runnerId);
-            // Skip no-op announces to avoid redundant Redis writes and fan-out
-            // to every viewer on this runner when nothing actually changed.
-            if (isSameServiceAnnounce(previous, data)) {
+            const sameAsCached = isSameServiceAnnounce(previous, data);
+            // Skip redundant fanout only after this process has already
+            // broadcast a live announce from the current runner connection.
+            // After a relay restart the cache may be warm from Redis, but
+            // viewers still need the first live announce to rehydrate.
+            if (shouldSkipServiceAnnounceFanout({
+                previous,
+                next: data,
+                hasBroadcastLiveAnnounce: runnerHasBroadcastLiveServiceAnnounce.has(runnerId),
+            })) {
                 log.info(`[service_announce] runner=${runnerId} skipped (no-op)`);
                 return;
             }
 
             // Cache in memory for fast lookups
             runnerServiceAnnounce.set(runnerId, data);
-            // Persist to Redis so the data survives server restarts
-            void updateRunnerServices(runnerId, data.serviceIds, data.panels, data.triggerDefs, data.sigilDefs).catch((err) => {
-                log.error(`failed to persist service_announce to Redis for ${runnerId}:`, err);
-            });
+            // Persist to Redis so the data survives server restarts.
+            // Identical payloads can skip the write; viewers still need fanout.
+            if (!sameAsCached) {
+                void updateRunnerServices(runnerId, data.serviceIds, data.panels, data.triggerDefs, data.sigilDefs).catch((err) => {
+                    log.error(`failed to persist service_announce to Redis for ${runnerId}:`, err);
+                });
+            }
 
             let sessionIds = runnerSessionIds.get(runnerId);
             log.info(`[service_announce] runner=${runnerId} initial sessionIds=${sessionIds ? Array.from(sessionIds).join(",") : "<none>"}`);
@@ -965,6 +987,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
             }
 
             if (!sessionIds || sessionIds.size === 0) return;
+            runnerHasBroadcastLiveServiceAnnounce.add(runnerId);
             for (const sessionId of sessionIds) {
                 log.info(`[service_announce] runner=${runnerId} fanout -> session=${sessionId}`);
                 broadcastToSessionViewers(sessionId, "service_announce", data);
@@ -1015,6 +1038,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 }
                 runnerTerminalIds.delete(runnerId);
                 runnerServiceAnnounce.delete(runnerId);
+                runnerHasBroadcastLiveServiceAnnounce.delete(runnerId);
                 // Clean up any terminals owned by this runner
                 const terminalIds = await getTerminalIdsForRunner(runnerId);
                 for (const tid of terminalIds) {


### PR DESCRIPTION
## Summary
- re-broadcast the first live `service_announce` after runner reconnect even when it matches Redis-cached state
- await cached service metadata seeding before completing runner registration so viewers can rehydrate during the reconnect gap
- cover dedupe/rehydration edge cases including `resolvePort` changes for sigils

## Testing
- bun test packages/server/src/ws/namespaces/runner.service-announce.test.ts
- bun run typecheck