### PR TITLE
fix: include built-in skills/ in binary and npm distribution

### DIFF
--- a/packages/cli/build-binaries.ts
+++ b/packages/cli/build-binaries.ts
@@ -84,6 +84,12 @@ function copyAssets(piPkgDir: string, outDir: string): void {
     if (existsSync(templatesSrc)) {
         cpSync(templatesSrc, join(outDir, "templates"), { recursive: true });
     }
+
+    // 5. skills/ — built-in SKILL.md files shipped with the CLI
+    const skillsSrc = join(import.meta.dirname ?? __dirname, "src", "skills");
+    if (existsSync(skillsSrc)) {
+        cpSync(skillsSrc, join(outDir, "skills"), { recursive: true });
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/npm/build-npm.ts
+++ b/packages/npm/build-npm.ts
@@ -142,7 +142,7 @@ for (const platform of PLATFORMS) {
 
     // Copy assets (package.json from pi, theme/, export-html/, PTY native lib)
     const assetDir = join(BINARIES_DIR, platform.binaryDir);
-    for (const asset of ["package.json", "theme", "export-html", "templates"]) {
+    for (const asset of ["package.json", "theme", "export-html", "templates", "skills"]) {
         const src = join(assetDir, asset);
         if (existsSync(src)) {
             cpSync(src, join(binDir, asset), { recursive: true });


### PR DESCRIPTION
## Problem

`builtinSkillsDir()` resolves to `join(__dirname, 'skills')` but the `skills/` directory was never copied into binary outputs (`build-binaries.ts`) or npm platform packages (`build-npm.ts`). This meant client installations via `npx pizzapi` or standalone binaries had no built-in skills (e.g. `creating-runner-services`).

## Fix

- **`packages/cli/build-binaries.ts`** — add skills/ copy step in `copyAssets()`
- **`packages/npm/build-npm.ts`** — add `"skills"` to the asset copy list