### PR TITLE
Improve git panel latency with caching, batching, and push updates

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -204,6 +204,12 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         registry.register(new TerminalService());
         registry.register(new FileExplorerService());
         registry.register(new GitService());
+        const cleanupGitSessionState = (sessionId: string) => {
+            const gitService = registry.get("git");
+            if (!gitService) return;
+            const maybeGitService = gitService as GitService & { handleSessionEnded?: (id: string) => void };
+            maybeGitService.handleSessionEnded?.(sessionId);
+        };
         const tunnelService = new TunnelService();
         registry.register(tunnelService);
         const timeService = new TimeService();
@@ -646,6 +652,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     socket.emit("disconnect_session", { sessionId });
                 }
                 runningSessions.delete(sessionId);
+                cleanupGitSessionState(sessionId);
                 logInfo(`killed session ${sessionId}${entry.adopted ? " (adopted)" : ""}`);
                 socket.emit("session_killed", { sessionId });
                 // Clean up persisted attachments for this session
@@ -699,6 +706,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 logInfo(`session_ended for unknown/already-removed session ${sessionId}`);
             }
             // else: duplicate session_ended for a session we already handled — silently ignore
+
+            cleanupGitSessionState(sessionId);
 
             // Clean up persisted attachments.  For spawned sessions child.on("exit")
             // already ran cleanup, so this is a no-op (idempotent).  For adopted sessions

--- a/packages/cli/src/runner/services/git-service.test.ts
+++ b/packages/cli/src/runner/services/git-service.test.ts
@@ -548,6 +548,89 @@ describe("GitService git_full_status", () => {
         expect(payload.worktrees[0].isMain).toBe(true);
     });
 
+    test("re-collects branches/worktrees when generation changes mid full-status", async () => {
+        const cwd = "/repo";
+        let branchName = "main";
+        let releaseStatus: () => void = () => {
+            throw new Error("Expected status gate release function");
+        };
+        const statusGate = new Promise<void>((resolve) => {
+            releaseStatus = resolve;
+        });
+
+        const service = new GitService({
+            execGit: async (args, options) => {
+                const cmd = args[0];
+
+                if (cmd === "rev-parse" && args[1] === "--abbrev-ref") {
+                    return { stdout: `${branchName}\n`, stderr: "" };
+                }
+                if (cmd === "rev-parse" && args[1] === "--show-toplevel") {
+                    return { stdout: `${cwd}\n`, stderr: "" };
+                }
+                if (cmd === "status" && args.includes("-z")) {
+                    await statusGate;
+                    return { stdout: " M src/index.ts\0", stderr: "" };
+                }
+                if (cmd === "status") {
+                    return { stdout: " M src/index.ts\n", stderr: "" };
+                }
+                if (cmd === "diff") return { stdout: "", stderr: "" };
+                if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                if (cmd === "for-each-ref" && args.includes("refs/heads")) {
+                    if (branchName === "feature/new") {
+                        return { stdout: "feature/new\tabc1234\tjust now\t*\nmain\tdef5678\t1 day ago\t\n", stderr: "" };
+                    }
+                    return { stdout: "main\tdef5678\t1 day ago\t*\nfeature/new\tabc1234\tjust now\t\n", stderr: "" };
+                }
+                if (cmd === "for-each-ref" && args.includes("refs/remotes")) {
+                    return { stdout: "origin/main\tdef5678\t1 day ago\norigin/feature/new\tabc1234\tjust now\n", stderr: "" };
+                }
+                if (cmd === "worktree") {
+                    return {
+                        stdout: `worktree ${cwd}\nHEAD abc123456789\nbranch refs/heads/${branchName}\n`,
+                        stderr: "",
+                    };
+                }
+                if (cmd === "checkout") {
+                    branchName = args[1] ?? branchName;
+                    return { stdout: "", stderr: "" };
+                }
+
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_full_status",
+            requestId: "full-race",
+            payload: { cwd },
+        });
+
+        // Bump status generation while full-status is in-flight.
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_checkout",
+            requestId: "checkout-race",
+            payload: { cwd, branch: "feature/new", isRemote: false },
+        });
+        await waitForResult(socket, "checkout-race", "git_checkout_result");
+
+        releaseStatus();
+
+        const result = await waitForResult(socket, "full-race", "git_full_status_result");
+        const payload = result.payload as any;
+
+        expect(payload.ok).toBe(true);
+        expect(payload.status.branch).toBe("feature/new");
+        expect(payload.currentBranch).toBe("feature/new");
+        expect(payload.worktrees[0].branch).toBe("feature/new");
+    });
+
     test("returns git_full_status_result error for missing cwd", async () => {
         const service = new GitService();
         const socket = createMockSocket();

--- a/packages/cli/src/runner/services/git-service.test.ts
+++ b/packages/cli/src/runner/services/git-service.test.ts
@@ -1,0 +1,469 @@
+import { describe, test, expect } from "bun:test";
+import type { ServiceEnvelope } from "../service-handler.js";
+import { GitService } from "./git-service.js";
+
+function createMockSocket() {
+    const emitted: ServiceEnvelope[] = [];
+    const listeners = new Map<string, Function[]>();
+
+    return {
+        emitted,
+        listeners,
+        emit: (event: string, envelope: ServiceEnvelope) => {
+            if (event === "service_message") emitted.push(envelope);
+        },
+        on: (event: string, handler: Function) => {
+            listeners.set(event, [...(listeners.get(event) ?? []), handler]);
+        },
+        off: (event: string, handler: Function) => {
+            listeners.set(event, (listeners.get(event) ?? []).filter((fn) => fn !== handler));
+        },
+    };
+}
+
+function dispatchServiceMessage(socket: ReturnType<typeof createMockSocket>, envelope: ServiceEnvelope): void {
+    const handlers = socket.listeners.get("service_message") ?? [];
+    for (const handler of handlers) handler(envelope);
+}
+
+async function waitForResult(
+    socket: ReturnType<typeof createMockSocket>,
+    requestId: string,
+    type: string,
+): Promise<ServiceEnvelope> {
+    for (let i = 0; i < 200; i++) {
+        const hit = socket.emitted.find((e) => e.requestId === requestId && e.type === type);
+        if (hit) return hit;
+        await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    throw new Error(`Timed out waiting for ${type} (${requestId})`);
+}
+
+async function waitForEnvelope(
+    socket: ReturnType<typeof createMockSocket>,
+    matcher: (envelope: ServiceEnvelope) => boolean,
+    timeoutMs = 2_000,
+): Promise<ServiceEnvelope> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        const hit = socket.emitted.find(matcher);
+        if (hit) return hit;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    throw new Error(`Timed out waiting for matching envelope after ${timeoutMs}ms`);
+}
+
+async function waitForCondition(check: () => boolean, timeoutMs = 2_000): Promise<void> {
+    const start = Date.now();
+    while (Date.now() - start < timeoutMs) {
+        if (check()) return;
+        await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+    throw new Error(`Condition was not met within ${timeoutMs}ms`);
+}
+
+describe("GitService status caching", () => {
+    test("caches status for a short TTL and refreshes after expiry", async () => {
+        let now = 1_000;
+        let statusCalls = 0;
+
+        const service = new GitService({
+            now: () => now,
+            execGit: async (args) => {
+                switch (args[0]) {
+                    case "rev-parse":
+                        if (args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
+                        return { stdout: "/repo\n", stderr: "" };
+                    case "status":
+                        statusCalls++;
+                        return { stdout: ` M file-${statusCalls}.ts\0`, stderr: "" };
+                    case "diff":
+                        return { stdout: "", stderr: "" };
+                    case "rev-list":
+                        return { stdout: "0 0\n", stderr: "" };
+                    default:
+                        throw new Error(`Unexpected git args: ${args.join(" ")}`);
+                }
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "r1",
+            payload: { cwd: "/repo" },
+        });
+        const r1 = await waitForResult(socket, "r1", "git_status_result");
+
+        now += 500;
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "r2",
+            payload: { cwd: "/repo" },
+        });
+        const r2 = await waitForResult(socket, "r2", "git_status_result");
+
+        expect(statusCalls).toBe(1);
+        expect((r1.payload as any).changes[0].path).toBe("file-1.ts");
+        expect((r2.payload as any).changes[0].path).toBe("file-1.ts");
+
+        now += 2_600;
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "r3",
+            payload: { cwd: "/repo" },
+        });
+        const r3 = await waitForResult(socket, "r3", "git_status_result");
+
+        expect(statusCalls).toBe(2);
+        expect((r3.payload as any).changes[0].path).toBe("file-2.ts");
+    });
+
+    test("dedupes in-flight status requests by cwd", async () => {
+        let statusCalls = 0;
+        let releaseStatus: () => void = () => {
+            throw new Error("Expected releaseStatus resolver to be set");
+        };
+        const statusGate = new Promise<void>((resolve) => {
+            releaseStatus = resolve;
+        });
+
+        const service = new GitService({
+            execGit: async (args) => {
+                switch (args[0]) {
+                    case "rev-parse":
+                        if (args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
+                        return { stdout: "/repo\n", stderr: "" };
+                    case "status":
+                        statusCalls++;
+                        await statusGate;
+                        return { stdout: " M shared.ts\0", stderr: "" };
+                    case "diff":
+                        return { stdout: "", stderr: "" };
+                    case "rev-list":
+                        return { stdout: "0 0\n", stderr: "" };
+                    default:
+                        throw new Error(`Unexpected git args: ${args.join(" ")}`);
+                }
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "a",
+            payload: { cwd: "/repo" },
+        });
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "b",
+            payload: { cwd: "/repo" },
+        });
+
+        expect(statusCalls).toBe(1);
+
+        releaseStatus();
+
+        const a = await waitForResult(socket, "a", "git_status_result");
+        const b = await waitForResult(socket, "b", "git_status_result");
+
+        expect((a.payload as any).ok).toBe(true);
+        expect((b.payload as any).ok).toBe(true);
+        expect(statusCalls).toBe(1);
+    });
+
+    test("invalidates cached status after git mutations", async () => {
+        const cwd = "/repo";
+        let statusCalls = 0;
+
+        const service = new GitService({
+            execGit: async (args) => {
+                const cmd = args[0];
+                if (cmd === "rev-parse") {
+                    if (args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
+                    return { stdout: `${cwd}\n`, stderr: "" };
+                }
+                if (cmd === "status") {
+                    statusCalls++;
+                    return { stdout: ` M state-${statusCalls}.ts\0`, stderr: "" };
+                }
+                if (cmd === "diff") return { stdout: "", stderr: "" };
+                if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                if (cmd === "add" || cmd === "restore" || cmd === "checkout") return { stdout: "", stderr: "" };
+                if (cmd === "commit") return { stdout: "[main abc1234] message\n", stderr: "" };
+                if (cmd === "pull" || cmd === "push") return { stdout: "ok", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        let req = 0;
+        const askStatus = async () => {
+            req++;
+            const requestId = `status-${req}`;
+            dispatchServiceMessage(socket, {
+                serviceId: "git",
+                type: "git_status",
+                requestId,
+                payload: { cwd },
+            });
+            return waitForResult(socket, requestId, "git_status_result");
+        };
+
+        // Prime cache and verify it hits.
+        await askStatus();
+        await askStatus();
+        expect(statusCalls).toBe(1);
+
+        const operations: Array<{ type: string; payload: Record<string, unknown>; resultType: string }> = [
+            { type: "git_stage", payload: { cwd, all: true }, resultType: "git_stage_result" },
+            { type: "git_unstage", payload: { cwd, all: true }, resultType: "git_unstage_result" },
+            { type: "git_commit", payload: { cwd, message: "msg" }, resultType: "git_commit_result" },
+            { type: "git_checkout", payload: { cwd, branch: "main", isRemote: false }, resultType: "git_checkout_result" },
+            { type: "git_push", payload: { cwd, setUpstream: false }, resultType: "git_push_result" },
+            { type: "git_pull", payload: { cwd }, resultType: "git_pull_result" },
+        ];
+
+        for (const op of operations) {
+            req++;
+            const requestId = `op-${req}`;
+            dispatchServiceMessage(socket, {
+                serviceId: "git",
+                type: op.type,
+                requestId,
+                payload: op.payload,
+            });
+
+            const opResult = await waitForResult(socket, requestId, op.resultType);
+            expect((opResult.payload as any).ok).toBe(true);
+
+            await askStatus();
+            expect(statusCalls).toBeGreaterThan(1);
+        }
+
+        // 1 initial fetch + one refresh after each mutation.
+        expect(statusCalls).toBe(1 + operations.length);
+    });
+});
+
+describe("GitService git metadata watchers", () => {
+    test("tracks subscribers by session cwd and cleans up stale repo watchers", async () => {
+        const watchListeners = new Map<string, () => void>();
+        const closedPaths: string[] = [];
+
+        const service = new GitService({
+            watchFs: (path, listener) => {
+                watchListeners.set(path, listener);
+                return {
+                    close: () => {
+                        closedPaths.push(path);
+                        watchListeners.delete(path);
+                    },
+                };
+            },
+            execGit: async (args, options) => {
+                if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
+                if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return { stdout: `${options.cwd}\n`, stderr: "" };
+                if (args[0] === "rev-parse" && args[1] === "--git-path") return { stdout: `${options.cwd}/.git/${args[2]}\n`, stderr: "" };
+                if (args[0] === "status") return { stdout: " M watched.ts\0", stderr: "" };
+                if (args[0] === "diff") return { stdout: "", stderr: "" };
+                if (args[0] === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "repo-a",
+            sessionId: "session-1",
+            payload: { cwd: "/repo-a" },
+        });
+        await waitForResult(socket, "repo-a", "git_status_result");
+
+        await waitForCondition(() => Array.from(watchListeners.keys()).some((p) => p.startsWith("/repo-a/.git/")));
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "repo-b",
+            sessionId: "session-1",
+            payload: { cwd: "/repo-b" },
+        });
+        await waitForResult(socket, "repo-b", "git_status_result");
+
+        await waitForCondition(() => closedPaths.some((p) => p.startsWith("/repo-a/.git/")));
+        expect(Array.from(watchListeners.keys()).some((p) => p.startsWith("/repo-a/.git/"))).toBe(false);
+        expect(Array.from(watchListeners.keys()).some((p) => p.startsWith("/repo-b/.git/"))).toBe(true);
+
+        service.dispose();
+        expect(Array.from(watchListeners.keys()).length).toBe(0);
+    });
+
+    test("debounces metadata fs events and pushes status only to interested cwd subscribers", async () => {
+        const watchListeners = new Map<string, () => void>();
+        const statusCalls = new Map<string, number>();
+
+        const service = new GitService({
+            watchFs: (path, listener) => {
+                watchListeners.set(path, listener);
+                return {
+                    close: () => {
+                        watchListeners.delete(path);
+                    },
+                };
+            },
+            execGit: async (args, options) => {
+                if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
+                if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return { stdout: `${options.cwd}\n`, stderr: "" };
+                if (args[0] === "rev-parse" && args[1] === "--git-path") return { stdout: `${options.cwd}/.git/${args[2]}\n`, stderr: "" };
+                if (args[0] === "status") {
+                    const next = (statusCalls.get(options.cwd) ?? 0) + 1;
+                    statusCalls.set(options.cwd, next);
+                    return { stdout: ` M ${options.cwd.replaceAll("/", "_")}-${next}.ts\0`, stderr: "" };
+                }
+                if (args[0] === "diff") return { stdout: "", stderr: "" };
+                if (args[0] === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "seed-a",
+            sessionId: "session-a",
+            payload: { cwd: "/repo-a" },
+        });
+        await waitForResult(socket, "seed-a", "git_status_result");
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "seed-b",
+            sessionId: "session-b",
+            payload: { cwd: "/repo-b" },
+        });
+        await waitForResult(socket, "seed-b", "git_status_result");
+
+        await waitForCondition(() => watchListeners.has("/repo-a/.git/HEAD"));
+
+        socket.emitted.length = 0;
+        const headWatcher = watchListeners.get("/repo-a/.git/HEAD");
+        expect(headWatcher).toBeDefined();
+
+        headWatcher?.();
+        headWatcher?.();
+
+        const pushed = await waitForEnvelope(
+            socket,
+            (envelope) => envelope.type === "git_status_result" && (envelope as any).sessionId === "session-a" && envelope.requestId === undefined,
+        );
+
+        expect((pushed.payload as any).ok).toBe(true);
+        expect(socket.emitted.some((e) => e.type === "git_status_result" && (e as any).sessionId === "session-b" && e.requestId === undefined)).toBe(false);
+
+        await new Promise((resolve) => setTimeout(resolve, 450));
+        expect(statusCalls.get("/repo-a")).toBe(2); // one initial request + one debounced push
+    });
+});
+
+describe("GitService git_full_status", () => {
+    test("returns status + branches + worktrees in one response", async () => {
+        const cwd = "/repo";
+
+        const service = new GitService({
+            execGit: async (args, options) => {
+                const cmd = args[0];
+
+                if (cmd === "rev-parse" && args[1] === "--abbrev-ref") {
+                    return { stdout: "main\n", stderr: "" };
+                }
+                if (cmd === "rev-parse" && args[1] === "--show-toplevel") {
+                    return { stdout: `${cwd}\n`, stderr: "" };
+                }
+                if (cmd === "status" && args.includes("-z")) {
+                    return { stdout: " M src/index.ts\0", stderr: "" };
+                }
+                if (cmd === "status") {
+                    return { stdout: " M src/index.ts\n", stderr: "" };
+                }
+                if (cmd === "diff") {
+                    return { stdout: "", stderr: "" };
+                }
+                if (cmd === "rev-list") {
+                    if (options.cwd === cwd) return { stdout: "2 1\n", stderr: "" };
+                    return { stdout: "1 0\n", stderr: "" };
+                }
+                if (cmd === "for-each-ref" && args.includes("refs/heads")) {
+                    return { stdout: "main\tabc1234\t2 hours ago\t*\nfeature/test\tdef5678\t1 day ago\t\n", stderr: "" };
+                }
+                if (cmd === "for-each-ref" && args.includes("refs/remotes")) {
+                    return { stdout: "origin/main\tabc1234\t2 hours ago\n", stderr: "" };
+                }
+                if (cmd === "worktree") {
+                    return {
+                        stdout: `worktree ${cwd}\nHEAD abc123456789\nbranch refs/heads/main\n\nworktree ${cwd}/.worktrees/feature-test\nHEAD def56789abcd\nbranch refs/heads/feature/test\n`,
+                        stderr: "",
+                    };
+                }
+
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_full_status",
+            requestId: "full-1",
+            payload: { cwd },
+        });
+
+        const result = await waitForResult(socket, "full-1", "git_full_status_result");
+        const payload = result.payload as any;
+
+        expect(payload.ok).toBe(true);
+        expect(payload.status.branch).toBe("main");
+        expect(payload.status.changes).toEqual([{ status: " M", path: "src/index.ts" }]);
+        expect(payload.currentBranch).toBe("main");
+        expect(payload.branches.length).toBe(3);
+        expect(payload.worktrees.length).toBe(2);
+        expect(payload.worktrees[0].isMain).toBe(true);
+    });
+
+    test("returns git_full_status_result error for missing cwd", async () => {
+        const service = new GitService();
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_full_status",
+            requestId: "full-missing-cwd",
+            payload: {},
+        });
+
+        const result = await waitForResult(socket, "full-missing-cwd", "git_full_status_result");
+        expect(result.payload).toEqual({ ok: false, message: "Missing cwd" });
+    });
+});

--- a/packages/cli/src/runner/services/git-service.test.ts
+++ b/packages/cli/src/runner/services/git-service.test.ts
@@ -371,7 +371,17 @@ describe("GitService git metadata watchers", () => {
                     if (key === "HEAD") return { stdout: "../.git/HEAD\n", stderr: "" };
                     if (key === "index") return { stdout: "../.git/index\n", stderr: "" };
                     if (key === "packed-refs") return { stdout: "../.git/packed-refs\n", stderr: "" };
-                    if (key === "refs") return { stdout: "../.git/refs\n", stderr: "" };
+                    if (key === "FETCH_HEAD") return { stdout: "../.git/FETCH_HEAD\n", stderr: "" };
+                    if (key === "refs/heads") return { stdout: "../.git/refs/heads\n", stderr: "" };
+                    if (key === "refs/remotes") return { stdout: "../.git/refs/remotes\n", stderr: "" };
+                    if (key === "refs/heads/main") return { stdout: "../.git/refs/heads/main\n", stderr: "" };
+                    if (key === "refs/remotes/origin/main") return { stdout: "../.git/refs/remotes/origin/main\n", stderr: "" };
+                }
+                if (args[0] === "symbolic-ref" && args[1] === "-q" && args[2] === "HEAD") {
+                    return { stdout: "refs/heads/main\n", stderr: "" };
+                }
+                if (args[0] === "rev-parse" && args[1] === "--symbolic-full-name" && args[2] === "@{u}") {
+                    return { stdout: "refs/remotes/origin/main\n", stderr: "" };
                 }
                 if (args[0] === "status") return { stdout: " M watched.ts\0", stderr: "" };
                 if (args[0] === "diff") return { stdout: "", stderr: "" };
@@ -396,7 +406,9 @@ describe("GitService git metadata watchers", () => {
         expect(watchPaths).toContain("/repo/.git/HEAD");
         expect(watchPaths).toContain("/repo/.git/index");
         expect(watchPaths).toContain("/repo/.git/packed-refs");
-        expect(watchPaths).toContain("/repo/.git/refs");
+        expect(watchPaths).toContain("/repo/.git/FETCH_HEAD");
+        expect(watchPaths).toContain("/repo/.git/refs/heads");
+        expect(watchPaths).toContain("/repo/.git/refs/remotes");
     });
 
     test("debounces metadata fs events and pushes status only to interested cwd subscribers", async () => {

--- a/packages/cli/src/runner/services/git-service.test.ts
+++ b/packages/cli/src/runner/services/git-service.test.ts
@@ -314,6 +314,47 @@ describe("GitService git metadata watchers", () => {
         expect(Array.from(watchListeners.keys()).length).toBe(0);
     });
 
+    test("removes repo subscriptions/watchers when a session ends", async () => {
+        const watchListeners = new Map<string, () => void>();
+
+        const service = new GitService({
+            watchFs: (path, listener) => {
+                watchListeners.set(path, listener);
+                return {
+                    close: () => {
+                        watchListeners.delete(path);
+                    },
+                };
+            },
+            execGit: async (args, options) => {
+                if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
+                if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return { stdout: `${options.cwd}\n`, stderr: "" };
+                if (args[0] === "rev-parse" && args[1] === "--git-path") return { stdout: `${options.cwd}/.git/${args[2]}\n`, stderr: "" };
+                if (args[0] === "status") return { stdout: " M watched.ts\0", stderr: "" };
+                if (args[0] === "diff") return { stdout: "", stderr: "" };
+                if (args[0] === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "repo-a",
+            sessionId: "session-1",
+            payload: { cwd: "/repo-a" },
+        });
+        await waitForResult(socket, "repo-a", "git_status_result");
+        await waitForCondition(() => Array.from(watchListeners.keys()).some((p) => p.startsWith("/repo-a/.git/")));
+
+        service.handleSessionEnded("session-1");
+
+        expect(Array.from(watchListeners.keys()).some((p) => p.startsWith("/repo-a/.git/"))).toBe(false);
+    });
+
     test("debounces metadata fs events and pushes status only to interested cwd subscribers", async () => {
         const watchListeners = new Map<string, () => void>();
         const statusCalls = new Map<string, number>();

--- a/packages/cli/src/runner/services/git-service.test.ts
+++ b/packages/cli/src/runner/services/git-service.test.ts
@@ -355,6 +355,50 @@ describe("GitService git metadata watchers", () => {
         expect(Array.from(watchListeners.keys()).some((p) => p.startsWith("/repo-a/.git/"))).toBe(false);
     });
 
+    test("normalizes relative git metadata paths to absolute paths before watching", async () => {
+        const watchPaths: string[] = [];
+
+        const service = new GitService({
+            watchFs: (path) => {
+                watchPaths.push(path);
+                return { close: () => {} };
+            },
+            execGit: async (args, options) => {
+                if (args[0] === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
+                if (args[0] === "rev-parse" && args[1] === "--show-toplevel") return { stdout: "/repo\n", stderr: "" };
+                if (args[0] === "rev-parse" && args[1] === "--git-path") {
+                    const key = args[2];
+                    if (key === "HEAD") return { stdout: "../.git/HEAD\n", stderr: "" };
+                    if (key === "index") return { stdout: "../.git/index\n", stderr: "" };
+                    if (key === "packed-refs") return { stdout: "../.git/packed-refs\n", stderr: "" };
+                    if (key === "refs") return { stdout: "../.git/refs\n", stderr: "" };
+                }
+                if (args[0] === "status") return { stdout: " M watched.ts\0", stderr: "" };
+                if (args[0] === "diff") return { stdout: "", stderr: "" };
+                if (args[0] === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "repo-subdir",
+            sessionId: "session-1",
+            payload: { cwd: "/repo/subdir" },
+        });
+        await waitForResult(socket, "repo-subdir", "git_status_result");
+        await waitForCondition(() => watchPaths.length > 0);
+
+        expect(watchPaths).toContain("/repo/.git/HEAD");
+        expect(watchPaths).toContain("/repo/.git/index");
+        expect(watchPaths).toContain("/repo/.git/packed-refs");
+        expect(watchPaths).toContain("/repo/.git/refs");
+    });
+
     test("debounces metadata fs events and pushes status only to interested cwd subscribers", async () => {
         const watchListeners = new Map<string, () => void>();
         const statusCalls = new Map<string, number>();

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -286,7 +286,9 @@ export class GitService implements ServiceHandler {
         // If the repoRoot self-mapping (repoRoot → repoRoot) is no longer referenced
         // by any remaining active cwd, evict it too.
         if (repoRoot && repoRoot !== cwd) {
-            const stillReferenced = [...this._cwdRepoRoot.values()].some((r) => r === repoRoot);
+            const stillReferenced = [...this._cwdRepoRoot.entries()].some(
+                ([k, v]) => v === repoRoot && k !== repoRoot // exclude the repoRoot→repoRoot self-mapping
+            );
             if (!stillReferenced) {
                 this._cwdRepoRoot.delete(repoRoot);
                 this._statusCache.delete(repoRoot);

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -175,6 +175,9 @@ export class GitService implements ServiceHandler {
                 case "git_pull":
                     void this.handlePull(payload, requestId, sessionId);
                     break;
+                case "git_merge":
+                    void this.handleMerge(payload, requestId, sessionId);
+                    break;
                 case "git_worktrees":
                     void this.handleWorktrees(payload, requestId, sessionId);
                     break;
@@ -1077,9 +1080,11 @@ export class GitService implements ServiceHandler {
     ): Promise<void> {
         const cwd = this.validateCwd(payload.cwd, "git_pull_result", requestId, sessionId);
         if (!cwd) return;
+        const rebase = payload.rebase === true;
 
         try {
-            const result = await this._execGit(["pull"], { cwd, timeout: 60000 });
+            const args = rebase ? ["pull", "--rebase"] : ["pull"];
+            const result = await this._execGit(args, { cwd, timeout: 60000 });
             const output = (result.stdout + "\n" + result.stderr).trim();
             await this.invalidateStatusCacheFamily(cwd);
 
@@ -1089,6 +1094,37 @@ export class GitService implements ServiceHandler {
             }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_pull_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        }
+    }
+
+    private async handleMerge(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_merge_result", requestId, sessionId);
+        if (!cwd) return;
+        const branch = typeof payload.branch === "string" ? payload.branch : "";
+        if (!branch || !isValidBranchName(branch)) {
+            this.emitError("git_merge_result", "Invalid branch name", requestId, sessionId);
+            return;
+        }
+
+        try {
+            // Prevent merging current branch into itself
+            const { stdout: currentBranchOut } = await this._execGit(["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 });
+            const currentBranch = currentBranchOut.trim();
+            if (currentBranch && currentBranch === branch) {
+                this.emit("git_merge_result", { ok: false, message: "Cannot merge branch into itself." }, requestId, sessionId);
+                return;
+            }
+
+            const result = await this._execGit(["merge", branch], { cwd, timeout: 60000 });
+            const output = (result.stdout + "\n" + result.stderr).trim();
+            await this.invalidateStatusCacheFamily(cwd);
+            this.emit("git_merge_result", { ok: true, output }, requestId, sessionId);
+        } catch (err) {
+            this.emitError("git_merge_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         }
     }
 

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -349,7 +349,7 @@ export class GitService implements ServiceHandler {
 
         watchState.refreshInFlight = true;
         try {
-            this.invalidateStatusCache(cwd);
+            await this.invalidateStatusCacheFamily(cwd);
             const status = await this.getStatusSnapshot(cwd);
             for (const sessionId of subscribers) {
                 const sessionCwd = this._sessionCwd.get(sessionId) ?? status.cwd;
@@ -696,11 +696,23 @@ export class GitService implements ServiceHandler {
         this.registerSubscriber(cwd, sessionId);
 
         try {
-            const [status, branchData, worktreeData] = await Promise.all([
+            const [statusResult, branchResult, worktreeResult] = await Promise.allSettled([
                 this.getStatusSnapshot(cwd),
                 this.collectBranches(cwd),
                 this.collectWorktrees(cwd),
             ]);
+
+            if (statusResult.status !== "fulfilled") {
+                throw statusResult.reason;
+            }
+
+            const status = statusResult.value;
+            const branchData = branchResult.status === "fulfilled"
+                ? branchResult.value
+                : { currentBranch: status.branch, branches: [] };
+            const worktreeData = worktreeResult.status === "fulfilled"
+                ? worktreeResult.value
+                : { worktrees: [] };
 
             this.emit("git_full_status_result", {
                 ok: true,

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -723,22 +723,39 @@ export class GitService implements ServiceHandler {
             }
 
             let statusSnapshot = statusResult.value;
-            if (statusSnapshot.generation !== (this._statusGeneration.get(cwd) ?? 0)) {
-                statusSnapshot = await this.getStatusSnapshot(cwd);
-            }
-            const status = statusSnapshot.payload;
-            const branchData = branchResult.status === "fulfilled"
+            let branchData = branchResult.status === "fulfilled"
                 ? branchResult.value
-                : { currentBranch: status.branch, branches: [] };
-            const worktreeData = worktreeResult.status === "fulfilled"
+                : null;
+            let worktreeData = worktreeResult.status === "fulfilled"
                 ? worktreeResult.value
-                : { worktrees: [] };
+                : null;
+
+            if (statusSnapshot.generation !== (this._statusGeneration.get(cwd) ?? 0)) {
+                // Full-status collection crossed an invalidation boundary.
+                // Re-read all components so we don't mix fresh status with stale metadata.
+                const [freshStatus, freshBranches, freshWorktrees] = await Promise.allSettled([
+                    this.getStatusSnapshot(cwd),
+                    this.collectBranches(cwd),
+                    this.collectWorktrees(cwd),
+                ]);
+
+                if (freshStatus.status !== "fulfilled") {
+                    throw freshStatus.reason;
+                }
+                statusSnapshot = freshStatus.value;
+                branchData = freshBranches.status === "fulfilled" ? freshBranches.value : null;
+                worktreeData = freshWorktrees.status === "fulfilled" ? freshWorktrees.value : null;
+            }
+
+            const status = statusSnapshot.payload;
+            const safeBranchData = branchData ?? { currentBranch: status.branch, branches: [] };
+            const safeWorktreeData = worktreeData ?? { worktrees: [] };
 
             this.emit("git_full_status_result", {
                 ok: true,
                 status,
-                ...branchData,
-                ...worktreeData,
+                ...safeBranchData,
+                ...safeWorktreeData,
             }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_full_status_result", err instanceof Error ? err.message : String(err), requestId, sessionId);

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -199,6 +199,10 @@ export class GitService implements ServiceHandler {
         }
         this._cwdSubscribers.clear();
         this._sessionCwd.clear();
+        this._cwdRepoRoot.clear();
+        this._statusCache.clear();
+        this._statusGeneration.clear();
+        this._statusInFlight.clear();
         this._socket = null;
         this._onServiceMessage = null;
     }
@@ -263,6 +267,33 @@ export class GitService implements ServiceHandler {
         if (subscribers.size > 0) return;
         this._cwdSubscribers.delete(cwd);
         this.stopWatchingRepo(cwd);
+        // Evict all cache entries for this cwd so maps stay bounded across sessions.
+        this.evictCwdCacheEntries(cwd);
+    }
+
+    /**
+     * Evict all cwd-keyed cache state when the last subscriber for a cwd leaves.
+     * Without this, _cwdRepoRoot / _statusCache / _statusGeneration grow unboundedly
+     * and invalidateStatusCacheFamily() degrades to an O(N) scan over dead entries.
+     */
+    private evictCwdCacheEntries(cwd: string): void {
+        const repoRoot = this._cwdRepoRoot.get(cwd);
+        this._cwdRepoRoot.delete(cwd);
+        this._statusCache.delete(cwd);
+        this._statusGeneration.delete(cwd);
+        this._statusInFlight.delete(cwd);
+
+        // If the repoRoot self-mapping (repoRoot → repoRoot) is no longer referenced
+        // by any remaining active cwd, evict it too.
+        if (repoRoot && repoRoot !== cwd) {
+            const stillReferenced = [...this._cwdRepoRoot.values()].some((r) => r === repoRoot);
+            if (!stillReferenced) {
+                this._cwdRepoRoot.delete(repoRoot);
+                this._statusCache.delete(repoRoot);
+                this._statusGeneration.delete(repoRoot);
+                this._statusInFlight.delete(repoRoot);
+            }
+        }
     }
 
     /** Cleanup subscriber/watcher state when a session ends. */

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -74,6 +74,9 @@ type RepoWatchState = {
 /** Validate that a branch name doesn't contain shell-dangerous characters. */
 function isValidBranchName(name: string): boolean {
     if (!name || name.length > 256) return false;
+    // Reject names starting with "-": they are never valid branch refs and
+    // would be interpreted as git options (e.g. --abort, --continue).
+    if (name.startsWith("-")) return false;
     // Reject control chars, space-only, "..", "~", "^", ":", "\\", NUL
     if (/[\x00-\x1f\x7f~^:\\]/.test(name)) return false;
     if (name.includes("..")) return false;
@@ -1119,7 +1122,9 @@ export class GitService implements ServiceHandler {
                 return;
             }
 
-            const result = await this._execGit(["merge", branch], { cwd, timeout: 60000 });
+            // Use "--" end-of-options separator so `branch` is always treated as
+            // a ref, never as a git option (guards against e.g. "--abort" injection).
+            const result = await this._execGit(["merge", "--", branch], { cwd, timeout: 60000 });
             const output = (result.stdout + "\n" + result.stderr).trim();
             await this.invalidateStatusCacheFamily(cwd);
             this.emit("git_merge_result", { ok: true, output }, requestId, sessionId);

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -253,6 +253,14 @@ export class GitService implements ServiceHandler {
         this.stopWatchingRepo(cwd);
     }
 
+    /** Cleanup subscriber/watcher state when a session ends. */
+    handleSessionEnded(sessionId: string): void {
+        const cwd = this._sessionCwd.get(sessionId);
+        if (!cwd) return;
+        this._sessionCwd.delete(sessionId);
+        this.removeSubscriber(cwd, sessionId);
+    }
+
     private async startWatchingRepo(cwd: string): Promise<void> {
         if (this._repoWatchers.has(cwd)) return;
 

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -352,7 +352,8 @@ export class GitService implements ServiceHandler {
             this.invalidateStatusCache(cwd);
             const status = await this.getStatusSnapshot(cwd);
             for (const sessionId of subscribers) {
-                this.emit("git_status_result", status, undefined, sessionId);
+                const sessionCwd = this._sessionCwd.get(sessionId) ?? status.cwd;
+                this.emit("git_status_result", { ...status, cwd: sessionCwd }, undefined, sessionId);
             }
         } catch {
             // Ignore transient git/fs failures from proactive refresh.
@@ -381,12 +382,36 @@ export class GitService implements ServiceHandler {
         const head = await resolvePath("HEAD");
         const index = await resolvePath("index");
         const packedRefs = await resolvePath("packed-refs");
-        const refsDir = await resolvePath("refs");
+        const fetchHead = await resolvePath("FETCH_HEAD");
+        const headsDir = await resolvePath("refs/heads");
+        const remotesDir = await resolvePath("refs/remotes");
+
+        let currentBranchRef: string | null = null;
+        try {
+            const { stdout } = await this._execGit(["symbolic-ref", "-q", "HEAD"], { cwd, timeout: 5000 });
+            const ref = stdout.trim();
+            if (ref.startsWith("refs/")) currentBranchRef = await resolvePath(ref);
+        } catch {
+            // Detached HEAD or missing ref info.
+        }
+
+        let upstreamRefPath: string | null = null;
+        try {
+            const { stdout } = await this._execGit(["rev-parse", "--symbolic-full-name", "@{u}"], { cwd, timeout: 5000 });
+            const upstreamRef = stdout.trim();
+            if (upstreamRef.startsWith("refs/")) upstreamRefPath = await resolvePath(upstreamRef);
+        } catch {
+            // Branch may have no upstream.
+        }
 
         if (head) paths.add(head);
         if (index) paths.add(index);
         if (packedRefs) paths.add(packedRefs);
-        if (refsDir) paths.add(refsDir);
+        if (fetchHead) paths.add(fetchHead);
+        if (headsDir) paths.add(headsDir);
+        if (remotesDir) paths.add(remotesDir);
+        if (currentBranchRef) paths.add(currentBranchRef);
+        if (upstreamRefPath) paths.add(upstreamRefPath);
 
         return [...paths];
     }
@@ -399,10 +424,40 @@ export class GitService implements ServiceHandler {
         return next;
     }
 
+    private readonly _cwdRepoRoot = new Map<string, string>();
+
     private invalidateStatusCache(cwd: string): void {
         this.bumpStatusGeneration(cwd);
         this._statusCache.delete(cwd);
         this._statusInFlight.delete(cwd);
+    }
+
+    private async resolveRepoRoot(cwd: string): Promise<string> {
+        try {
+            const { stdout } = await this._execGit(["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 });
+            return stdout.trim() || cwd;
+        } catch {
+            return cwd;
+        }
+    }
+
+    private async invalidateStatusCacheFamily(cwd: string): Promise<void> {
+        const repoRoot = await this.resolveRepoRoot(cwd);
+        this._cwdRepoRoot.set(cwd, repoRoot);
+
+        const seen = new Set<string>();
+        const invalidateKey = (key: string) => {
+            if (seen.has(key)) return;
+            seen.add(key);
+            this.invalidateStatusCache(key);
+        };
+
+        invalidateKey(cwd);
+        invalidateKey(repoRoot);
+
+        for (const [knownCwd, knownRoot] of this._cwdRepoRoot.entries()) {
+            if (knownRoot === repoRoot) invalidateKey(knownCwd);
+        }
     }
 
     private async getStatusSnapshot(cwd: string): Promise<GitStatusResultPayload> {
@@ -438,6 +493,8 @@ export class GitService implements ServiceHandler {
 
         const branch = branchResult.status === "fulfilled" ? branchResult.value.stdout.trim() : "";
         const repoRoot = toplevelResult.status === "fulfilled" ? toplevelResult.value.stdout.trim() : cwd;
+        this._cwdRepoRoot.set(cwd, repoRoot || cwd);
+        if (repoRoot) this._cwdRepoRoot.set(repoRoot, repoRoot);
         const statusOutput = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
         const diffStaged = diffStagedResult.status === "fulfilled" ? diffStagedResult.value.stdout : "";
 
@@ -702,7 +759,7 @@ export class GitService implements ServiceHandler {
             }
 
             await this._execGit(args, { cwd, timeout: 15000 });
-            this.invalidateStatusCache(cwd);
+            await this.invalidateStatusCacheFamily(cwd);
 
             this.emit("git_checkout_result", {
                 ok: true,
@@ -750,7 +807,7 @@ export class GitService implements ServiceHandler {
 
             const args = all ? ["add", "--all"] : ["add", "--", ...paths];
             await this._execGit(args, { cwd: repoRoot, timeout: 15000 });
-            this.invalidateStatusCache(cwd);
+            await this.invalidateStatusCacheFamily(cwd);
             this.emit("git_stage_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_stage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
@@ -796,7 +853,7 @@ export class GitService implements ServiceHandler {
                 ? ["restore", "--staged", ":/"]
                 : ["restore", "--staged", "--", ...paths];
             await this._execGit(args, { cwd: repoRoot, timeout: 15000 });
-            this.invalidateStatusCache(cwd);
+            await this.invalidateStatusCacheFamily(cwd);
             this.emit("git_unstage_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_unstage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
@@ -826,7 +883,7 @@ export class GitService implements ServiceHandler {
 
             // Parse the short summary (e.g. "[main abc1234] Fix thing\n 1 file changed...")
             const firstLine = stdout.split("\n")[0] ?? "";
-            this.invalidateStatusCache(cwd);
+            await this.invalidateStatusCacheFamily(cwd);
 
             this.emit("git_commit_result", {
                 ok: true,
@@ -975,7 +1032,7 @@ export class GitService implements ServiceHandler {
         try {
             const result = await this._execGit(["pull"], { cwd, timeout: 60000 });
             const output = (result.stdout + "\n" + result.stderr).trim();
-            this.invalidateStatusCache(cwd);
+            await this.invalidateStatusCacheFamily(cwd);
 
             this.emit("git_pull_result", {
                 ok: true,
@@ -1033,7 +1090,7 @@ export class GitService implements ServiceHandler {
             // git push writes to stderr (progress), use a larger timeout for network ops
             const result = await this._execGit(args, { cwd, timeout: 60000 });
             const output = (result.stdout + "\n" + result.stderr).trim();
-            this.invalidateStatusCache(cwd);
+            await this.invalidateStatusCacheFamily(cwd);
 
             this.emit("git_push_result", {
                 ok: true,

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -1,7 +1,7 @@
 import { execFile } from "node:child_process";
 import { watch } from "node:fs";
 import { promisify } from "node:util";
-import { normalize } from "node:path";
+import { isAbsolute, normalize, resolve } from "node:path";
 import type { Socket } from "socket.io-client";
 import type { ServiceHandler, ServiceInitOptions, ServiceEnvelope } from "../service-handler.js";
 import { isCwdAllowed } from "../workspace.js";
@@ -22,6 +22,7 @@ type GitExec = (
 
 type GitStatusResultPayload = {
     ok: true;
+    cwd: string;
     branch: string;
     repoRoot: string;
     changes: Array<{ status: string; path: string; originalPath?: string }>;
@@ -368,8 +369,9 @@ export class GitService implements ServiceHandler {
         const resolvePath = async (gitPath: string): Promise<string | null> => {
             try {
                 const { stdout } = await this._execGit(["rev-parse", "--git-path", gitPath], { cwd, timeout: 5000 });
-                const resolved = stdout.trim();
-                return resolved || null;
+                const gitPathResult = stdout.trim();
+                if (!gitPathResult) return null;
+                return isAbsolute(gitPathResult) ? gitPathResult : resolve(cwd, gitPathResult);
             } catch {
                 return null;
             }
@@ -473,6 +475,7 @@ export class GitService implements ServiceHandler {
 
         const result: GitStatusResultPayload = {
             ok: true,
+            cwd,
             branch,
             repoRoot,
             changes,

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -355,7 +355,10 @@ export class GitService implements ServiceHandler {
         watchState.refreshInFlight = true;
         try {
             await this.invalidateStatusCacheFamily(cwd);
-            const snapshot = await this.getStatusSnapshot(cwd);
+            let snapshot = await this.getStatusSnapshot(cwd);
+            if (snapshot.generation !== (this._statusGeneration.get(cwd) ?? 0)) {
+                snapshot = await this.getStatusSnapshot(cwd);
+            }
             const status = snapshot.payload;
             for (const sessionId of subscribers) {
                 const sessionCwd = this._sessionCwd.get(sessionId) ?? status.cwd;

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -1,11 +1,67 @@
 import { execFile } from "node:child_process";
+import { watch } from "node:fs";
 import { promisify } from "node:util";
-import { resolve, normalize } from "node:path";
+import { normalize } from "node:path";
 import type { Socket } from "socket.io-client";
 import type { ServiceHandler, ServiceInitOptions, ServiceEnvelope } from "../service-handler.js";
 import { isCwdAllowed } from "../workspace.js";
 
 const execFileAsync = promisify(execFile);
+const STATUS_CACHE_TTL_MS = 2_500;
+const METADATA_DEBOUNCE_MS = 300;
+
+type WatchHandle = { close(): void };
+type WatchFs = (path: string, listener: () => void) => WatchHandle;
+type SetTimeoutFn = (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+type ClearTimeoutFn = (timeout: ReturnType<typeof setTimeout>) => void;
+
+type GitExec = (
+    args: string[],
+    options: { cwd: string; timeout: number },
+) => Promise<{ stdout: string; stderr: string }>;
+
+type GitStatusResultPayload = {
+    ok: true;
+    branch: string;
+    repoRoot: string;
+    changes: Array<{ status: string; path: string; originalPath?: string }>;
+    ahead: number;
+    behind: number;
+    hasUpstream: boolean;
+    diffStaged: string;
+};
+
+type GitBranchResultPayload = {
+    currentBranch: string;
+    branches: Array<{
+        name: string;
+        shortHash: string;
+        lastCommit: string;
+        isCurrent: boolean;
+        isRemote: boolean;
+    }>;
+};
+
+type GitWorktreeResultPayload = {
+    worktrees: Array<{
+        path: string;
+        displayPath: string;
+        branch: string;
+        shortHash: string;
+        isDetached: boolean;
+        isMain: boolean;
+        changeCount: number;
+        ahead: number;
+        behind: number;
+    }>;
+};
+
+type RepoWatchState = {
+    watchers: WatchHandle[];
+    debounceTimer: ReturnType<typeof setTimeout> | null;
+    refreshInFlight: boolean;
+    needsRefresh: boolean;
+};
 
 // ── Validation helpers ──────────────────────────────────────────────────────
 
@@ -44,6 +100,31 @@ export class GitService implements ServiceHandler {
     private _socket: Socket | null = null;
     private _onServiceMessage: ((envelope: ServiceEnvelope) => void) | null = null;
     private _isShuttingDown: () => boolean = () => false;
+    private readonly _execGit: GitExec;
+    private readonly _watchFs: WatchFs;
+    private readonly _setTimeout: SetTimeoutFn;
+    private readonly _clearTimeout: ClearTimeoutFn;
+    private readonly _now: () => number;
+    private readonly _statusCache = new Map<string, { expiresAt: number; generation: number; payload: GitStatusResultPayload }>();
+    private readonly _statusInFlight = new Map<string, Promise<GitStatusResultPayload>>();
+    private readonly _statusGeneration = new Map<string, number>();
+    private readonly _cwdSubscribers = new Map<string, Set<string>>();
+    private readonly _sessionCwd = new Map<string, string>();
+    private readonly _repoWatchers = new Map<string, RepoWatchState>();
+
+    constructor(options?: {
+        execGit?: GitExec;
+        watchFs?: WatchFs;
+        setTimeoutFn?: SetTimeoutFn;
+        clearTimeoutFn?: ClearTimeoutFn;
+        now?: () => number;
+    }) {
+        this._execGit = options?.execGit ?? ((args, execOptions) => execFileAsync("git", args, execOptions));
+        this._watchFs = options?.watchFs ?? ((path, listener) => watch(path, { persistent: false }, listener));
+        this._setTimeout = options?.setTimeoutFn ?? ((callback, delayMs) => setTimeout(callback, delayMs));
+        this._clearTimeout = options?.clearTimeoutFn ?? ((timeout) => clearTimeout(timeout));
+        this._now = options?.now ?? (() => Date.now());
+    }
 
     init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
         this._socket = socket;
@@ -66,6 +147,9 @@ export class GitService implements ServiceHandler {
                     break;
                 case "git_branches":
                     void this.handleBranches(payload, requestId, sessionId);
+                    break;
+                case "git_full_status":
+                    void this.handleFullStatus(payload, requestId, sessionId);
                     break;
                 case "git_checkout":
                     void this.handleCheckout(payload, requestId, sessionId);
@@ -98,6 +182,11 @@ export class GitService implements ServiceHandler {
         if (this._socket && this._onServiceMessage) {
             (this._socket as any).off("service_message", this._onServiceMessage);
         }
+        for (const cwd of this._repoWatchers.keys()) {
+            this.stopWatchingRepo(cwd);
+        }
+        this._cwdSubscribers.clear();
+        this._sessionCwd.clear();
         this._socket = null;
         this._onServiceMessage = null;
     }
@@ -134,7 +223,267 @@ export class GitService implements ServiceHandler {
         return cwd;
     }
 
+    private registerSubscriber(cwd: string, sessionId?: string): void {
+        if (!sessionId) return;
+
+        const previousCwd = this._sessionCwd.get(sessionId);
+        if (previousCwd && previousCwd !== cwd) {
+            this.removeSubscriber(previousCwd, sessionId);
+        }
+
+        this._sessionCwd.set(sessionId, cwd);
+        let subscribers = this._cwdSubscribers.get(cwd);
+        if (!subscribers) {
+            subscribers = new Set<string>();
+            this._cwdSubscribers.set(cwd, subscribers);
+        }
+        subscribers.add(sessionId);
+
+        if (!this._repoWatchers.has(cwd)) {
+            void this.startWatchingRepo(cwd);
+        }
+    }
+
+    private removeSubscriber(cwd: string, sessionId: string): void {
+        const subscribers = this._cwdSubscribers.get(cwd);
+        if (!subscribers) return;
+        subscribers.delete(sessionId);
+        if (subscribers.size > 0) return;
+        this._cwdSubscribers.delete(cwd);
+        this.stopWatchingRepo(cwd);
+    }
+
+    private async startWatchingRepo(cwd: string): Promise<void> {
+        if (this._repoWatchers.has(cwd)) return;
+
+        const watchState: RepoWatchState = {
+            watchers: [],
+            debounceTimer: null,
+            refreshInFlight: false,
+            needsRefresh: false,
+        };
+        this._repoWatchers.set(cwd, watchState);
+
+        try {
+            const metadataPaths = await this.resolveGitMetadataWatchPaths(cwd);
+            if (this._repoWatchers.get(cwd) !== watchState) return;
+
+            for (const path of metadataPaths) {
+                try {
+                    const handle = this._watchFs(path, () => this.scheduleRepoRefresh(cwd));
+                    if (this._repoWatchers.get(cwd) !== watchState) {
+                        handle.close();
+                        return;
+                    }
+                    watchState.watchers.push(handle);
+                } catch {
+                    // Best-effort watcher registration: metadata paths vary by repo layout.
+                }
+            }
+        } catch {
+            // If git metadata paths can't be resolved, keep service functional.
+        }
+
+        if (this._repoWatchers.get(cwd) === watchState && watchState.watchers.length === 0) {
+            this.stopWatchingRepo(cwd);
+        }
+    }
+
+    private stopWatchingRepo(cwd: string): void {
+        const watchState = this._repoWatchers.get(cwd);
+        if (!watchState) return;
+
+        if (watchState.debounceTimer) {
+            this._clearTimeout(watchState.debounceTimer);
+            watchState.debounceTimer = null;
+        }
+
+        for (const watcher of watchState.watchers) {
+            try {
+                watcher.close();
+            } catch {
+                // Ignore close failures.
+            }
+        }
+
+        this._repoWatchers.delete(cwd);
+    }
+
+    private scheduleRepoRefresh(cwd: string): void {
+        const watchState = this._repoWatchers.get(cwd);
+        if (!watchState) return;
+
+        if (watchState.debounceTimer) {
+            this._clearTimeout(watchState.debounceTimer);
+        }
+
+        watchState.debounceTimer = this._setTimeout(() => {
+            watchState.debounceTimer = null;
+            void this.pushStatusUpdateForSubscribers(cwd);
+        }, METADATA_DEBOUNCE_MS);
+    }
+
+    private async pushStatusUpdateForSubscribers(cwd: string): Promise<void> {
+        const watchState = this._repoWatchers.get(cwd);
+        if (!watchState) return;
+
+        if (watchState.refreshInFlight) {
+            watchState.needsRefresh = true;
+            return;
+        }
+
+        const subscribers = this._cwdSubscribers.get(cwd);
+        if (!subscribers || subscribers.size === 0) {
+            this.stopWatchingRepo(cwd);
+            return;
+        }
+
+        watchState.refreshInFlight = true;
+        try {
+            this.invalidateStatusCache(cwd);
+            const status = await this.getStatusSnapshot(cwd);
+            for (const sessionId of subscribers) {
+                this.emit("git_status_result", status, undefined, sessionId);
+            }
+        } catch {
+            // Ignore transient git/fs failures from proactive refresh.
+        } finally {
+            watchState.refreshInFlight = false;
+            if (watchState.needsRefresh) {
+                watchState.needsRefresh = false;
+                this.scheduleRepoRefresh(cwd);
+            }
+        }
+    }
+
+    private async resolveGitMetadataWatchPaths(cwd: string): Promise<string[]> {
+        const resolvePath = async (gitPath: string): Promise<string | null> => {
+            try {
+                const { stdout } = await this._execGit(["rev-parse", "--git-path", gitPath], { cwd, timeout: 5000 });
+                const resolved = stdout.trim();
+                return resolved || null;
+            } catch {
+                return null;
+            }
+        };
+
+        const paths = new Set<string>();
+        const head = await resolvePath("HEAD");
+        const index = await resolvePath("index");
+        const packedRefs = await resolvePath("packed-refs");
+        const refsDir = await resolvePath("refs");
+
+        if (head) paths.add(head);
+        if (index) paths.add(index);
+        if (packedRefs) paths.add(packedRefs);
+        if (refsDir) paths.add(refsDir);
+
+        return [...paths];
+    }
+
     // ── git status ──────────────────────────────────────────────────────
+
+    private bumpStatusGeneration(cwd: string): number {
+        const next = (this._statusGeneration.get(cwd) ?? 0) + 1;
+        this._statusGeneration.set(cwd, next);
+        return next;
+    }
+
+    private invalidateStatusCache(cwd: string): void {
+        this.bumpStatusGeneration(cwd);
+        this._statusCache.delete(cwd);
+        this._statusInFlight.delete(cwd);
+    }
+
+    private async getStatusSnapshot(cwd: string): Promise<GitStatusResultPayload> {
+        const now = this._now();
+        const generation = this._statusGeneration.get(cwd) ?? 0;
+
+        const cached = this._statusCache.get(cwd);
+        if (cached && cached.generation === generation && cached.expiresAt > now) {
+            return cached.payload;
+        }
+
+        const existing = this._statusInFlight.get(cwd);
+        if (existing) return existing;
+
+        const pending = this.collectStatus(cwd, generation).finally(() => {
+            const current = this._statusInFlight.get(cwd);
+            if (current === pending) this._statusInFlight.delete(cwd);
+        });
+        this._statusInFlight.set(cwd, pending);
+        return pending;
+    }
+
+    private async collectStatus(cwd: string, generationAtStart: number): Promise<GitStatusResultPayload> {
+        const [branchResult, toplevelResult, statusResult, diffStagedResult, abResult] = await Promise.allSettled([
+            this._execGit(["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 }),
+            this._execGit(["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 }),
+            // Use -z for NUL-delimited output — avoids C-quoting of filenames
+            // with spaces/special chars and makes parsing unambiguous.
+            this._execGit(["status", "--porcelain=v1", "-uall", "-z"], { cwd, timeout: 10000 }),
+            this._execGit(["diff", "--cached", "--stat"], { cwd, timeout: 10000 }),
+            this._execGit(["rev-list", "--left-right", "--count", "HEAD...@{u}"], { cwd, timeout: 5000 }),
+        ]);
+
+        const branch = branchResult.status === "fulfilled" ? branchResult.value.stdout.trim() : "";
+        const repoRoot = toplevelResult.status === "fulfilled" ? toplevelResult.value.stdout.trim() : cwd;
+        const statusOutput = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
+        const diffStaged = diffStagedResult.status === "fulfilled" ? diffStagedResult.value.stdout : "";
+
+        // Parse porcelain v1 -z output (NUL-delimited).
+        // Format: XY PATH\0 (for renames: XY ORIG\0NEW\0)
+        // IMPORTANT: preserve the raw 2-char XY status (e.g. " M", "M ", "MM", "??").
+        const changes: Array<{ status: string; path: string; originalPath?: string }> = [];
+        const entries = statusOutput.split("\0");
+        let i = 0;
+        while (i < entries.length) {
+            const entry = entries[i];
+            if (!entry || entry.length < 3) { i++; continue; }
+            const xy = entry.substring(0, 2);
+            const path = entry.substring(3);
+            // Renames (R/C) have a second NUL-delimited field for the new path
+            if (xy[0] === "R" || xy[0] === "C") {
+                const newPath = entries[i + 1] ?? path;
+                changes.push({ status: xy, path: newPath, originalPath: path });
+                i += 2;
+            } else {
+                changes.push({ status: xy, path });
+                i++;
+            }
+        }
+
+        let ahead = 0;
+        let behind = 0;
+        // If rev-list against @{u} failed, the branch has no upstream
+        const hasUpstream = abResult.status === "fulfilled";
+        if (hasUpstream) {
+            const [a, b] = abResult.value.stdout.trim().split(/\s+/);
+            ahead = parseInt(a, 10) || 0;
+            behind = parseInt(b, 10) || 0;
+        }
+
+        const result: GitStatusResultPayload = {
+            ok: true,
+            branch,
+            repoRoot,
+            changes,
+            ahead,
+            behind,
+            hasUpstream,
+            diffStaged,
+        };
+
+        if ((this._statusGeneration.get(cwd) ?? 0) === generationAtStart) {
+            this._statusCache.set(cwd, {
+                generation: generationAtStart,
+                payload: result,
+                expiresAt: this._now() + STATUS_CACHE_TTL_MS,
+            });
+        }
+
+        return result;
+    }
 
     private async handleStatus(
         payload: Record<string, unknown>,
@@ -143,65 +492,11 @@ export class GitService implements ServiceHandler {
     ): Promise<void> {
         const cwd = this.validateCwd(payload.cwd, "git_status_result", requestId, sessionId);
         if (!cwd) return;
+        this.registerSubscriber(cwd, sessionId);
 
         try {
-            const [branchResult, toplevelResult, statusResult, diffStagedResult, abResult] = await Promise.allSettled([
-                execFileAsync("git", ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 }),
-                execFileAsync("git", ["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 }),
-                // Use -z for NUL-delimited output — avoids C-quoting of filenames
-                // with spaces/special chars and makes parsing unambiguous.
-                execFileAsync("git", ["status", "--porcelain=v1", "-uall", "-z"], { cwd, timeout: 10000 }),
-                execFileAsync("git", ["diff", "--cached", "--stat"], { cwd, timeout: 10000 }),
-                execFileAsync("git", ["rev-list", "--left-right", "--count", "HEAD...@{u}"], { cwd, timeout: 5000 }),
-            ]);
-
-            const branch = branchResult.status === "fulfilled" ? branchResult.value.stdout.trim() : "";
-            const repoRoot = toplevelResult.status === "fulfilled" ? toplevelResult.value.stdout.trim() : cwd;
-            const statusOutput = statusResult.status === "fulfilled" ? statusResult.value.stdout : "";
-            const diffStaged = diffStagedResult.status === "fulfilled" ? diffStagedResult.value.stdout : "";
-
-            // Parse porcelain v1 -z output (NUL-delimited).
-            // Format: XY PATH\0 (for renames: XY ORIG\0NEW\0)
-            // IMPORTANT: preserve the raw 2-char XY status (e.g. " M", "M ", "MM", "??").
-            const changes: Array<{ status: string; path: string; originalPath?: string }> = [];
-            const entries = statusOutput.split("\0");
-            let i = 0;
-            while (i < entries.length) {
-                const entry = entries[i];
-                if (!entry || entry.length < 3) { i++; continue; }
-                const xy = entry.substring(0, 2);
-                const path = entry.substring(3);
-                // Renames (R/C) have a second NUL-delimited field for the new path
-                if (xy[0] === "R" || xy[0] === "C") {
-                    const newPath = entries[i + 1] ?? path;
-                    changes.push({ status: xy, path: newPath, originalPath: path });
-                    i += 2;
-                } else {
-                    changes.push({ status: xy, path });
-                    i++;
-                }
-            }
-
-            let ahead = 0;
-            let behind = 0;
-            // If rev-list against @{u} failed, the branch has no upstream
-            const hasUpstream = abResult.status === "fulfilled";
-            if (hasUpstream) {
-                const [a, b] = abResult.value.stdout.trim().split(/\s+/);
-                ahead = parseInt(a, 10) || 0;
-                behind = parseInt(b, 10) || 0;
-            }
-
-            this.emit("git_status_result", {
-                ok: true,
-                branch,
-                repoRoot,
-                changes,
-                ahead,
-                behind,
-                hasUpstream,
-                diffStaged,
-            }, requestId, sessionId);
+            const status = await this.getStatusSnapshot(cwd);
+            this.emit("git_status_result", status, requestId, sessionId);
         } catch (err) {
             this.emitError("git_status_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         }
@@ -228,22 +523,80 @@ export class GitService implements ServiceHandler {
         try {
             // Resolve repo root — paths from git status are repo-root-relative,
             // so diff must run from repo root for paths to resolve correctly.
-            const { stdout: toplevel } = await execFileAsync(
-                "git", ["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
+            const { stdout: toplevel } = await this._execGit(["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
             );
             const repoRoot = toplevel.trim() || cwd;
 
             const args = staged
                 ? ["diff", "--cached", "--", filePath]
                 : ["diff", "--", filePath];
-            const { stdout: diff } = await execFileAsync("git", args, { cwd: repoRoot, timeout: 10000 });
+            const { stdout: diff } = await this._execGit(args, { cwd: repoRoot, timeout: 10000 });
             this.emit("git_diff_result", { ok: true, diff }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_diff_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         }
     }
 
-    // ── git branches ────────────────────────────────────────────────────
+    // ── git branches / full status ───────────────────────────────────────
+
+    private async collectBranches(cwd: string): Promise<GitBranchResultPayload> {
+        const { stdout: currentBranch } = await this._execGit(["rev-parse", "--abbrev-ref", "HEAD"],
+            { cwd, timeout: 5000 },
+        );
+
+        // Use for-each-ref for reliable branch listing with ref-type awareness.
+        // List local branches from refs/heads and remote branches from refs/remotes,
+        // excluding remote HEAD aliases (e.g. refs/remotes/origin/HEAD).
+        const [localResult, remoteResult] = await Promise.allSettled([
+            this._execGit(["for-each-ref", "--sort=-committerdate",
+                    "--format=%(refname:short)\t%(objectname:short)\t%(committerdate:relative)\t%(HEAD)",
+                    "refs/heads"],
+                { cwd, timeout: 10000 },
+            ),
+            this._execGit(["for-each-ref", "--sort=-committerdate",
+                    "--format=%(refname:short)\t%(objectname:short)\t%(committerdate:relative)",
+                    "refs/remotes", "--exclude=refs/remotes/*/HEAD"],
+                { cwd, timeout: 10000 },
+            ),
+        ]);
+
+        const branches: GitBranchResultPayload["branches"] = [];
+
+        // Parse local branches
+        const localOutput = localResult.status === "fulfilled" ? localResult.value.stdout : "";
+        for (const line of localOutput.split("\n")) {
+            if (!line.trim()) continue;
+            const [name, shortHash, lastCommit, head] = line.split("\t");
+            if (!name) continue;
+            branches.push({
+                name: name.trim(),
+                shortHash: shortHash?.trim() ?? "",
+                lastCommit: lastCommit?.trim() ?? "",
+                isCurrent: head?.trim() === "*",
+                isRemote: false,
+            });
+        }
+
+        // Parse remote branches
+        const remoteOutput = remoteResult.status === "fulfilled" ? remoteResult.value.stdout : "";
+        for (const line of remoteOutput.split("\n")) {
+            if (!line.trim()) continue;
+            const [name, shortHash, lastCommit] = line.split("\t");
+            if (!name) continue;
+            branches.push({
+                name: name.trim(),
+                shortHash: shortHash?.trim() ?? "",
+                lastCommit: lastCommit?.trim() ?? "",
+                isCurrent: false,
+                isRemote: true,
+            });
+        }
+
+        return {
+            currentBranch: currentBranch.trim(),
+            branches,
+        };
+    }
 
     private async handleBranches(
         payload: Record<string, unknown>,
@@ -252,79 +605,43 @@ export class GitService implements ServiceHandler {
     ): Promise<void> {
         const cwd = this.validateCwd(payload.cwd, "git_branches_result", requestId, sessionId);
         if (!cwd) return;
+        this.registerSubscriber(cwd, sessionId);
 
         try {
-            // Get current branch
-            const { stdout: currentBranch } = await execFileAsync(
-                "git", ["rev-parse", "--abbrev-ref", "HEAD"],
-                { cwd, timeout: 5000 },
-            );
-
-            // Use for-each-ref for reliable branch listing with ref-type awareness.
-            // List local branches from refs/heads and remote branches from refs/remotes,
-            // excluding remote HEAD aliases (e.g. refs/remotes/origin/HEAD).
-            const [localResult, remoteResult] = await Promise.allSettled([
-                execFileAsync(
-                    "git",
-                    ["for-each-ref", "--sort=-committerdate",
-                     "--format=%(refname:short)\t%(objectname:short)\t%(committerdate:relative)\t%(HEAD)",
-                     "refs/heads"],
-                    { cwd, timeout: 10000 },
-                ),
-                execFileAsync(
-                    "git",
-                    ["for-each-ref", "--sort=-committerdate",
-                     "--format=%(refname:short)\t%(objectname:short)\t%(committerdate:relative)",
-                     "refs/remotes", "--exclude=refs/remotes/*/HEAD"],
-                    { cwd, timeout: 10000 },
-                ),
-            ]);
-
-            const branches: Array<{
-                name: string;
-                shortHash: string;
-                lastCommit: string;
-                isCurrent: boolean;
-                isRemote: boolean;
-            }> = [];
-
-            // Parse local branches
-            const localOutput = localResult.status === "fulfilled" ? localResult.value.stdout : "";
-            for (const line of localOutput.split("\n")) {
-                if (!line.trim()) continue;
-                const [name, shortHash, lastCommit, head] = line.split("\t");
-                if (!name) continue;
-                branches.push({
-                    name: name.trim(),
-                    shortHash: shortHash?.trim() ?? "",
-                    lastCommit: lastCommit?.trim() ?? "",
-                    isCurrent: head?.trim() === "*",
-                    isRemote: false,
-                });
-            }
-
-            // Parse remote branches
-            const remoteOutput = remoteResult.status === "fulfilled" ? remoteResult.value.stdout : "";
-            for (const line of remoteOutput.split("\n")) {
-                if (!line.trim()) continue;
-                const [name, shortHash, lastCommit] = line.split("\t");
-                if (!name) continue;
-                branches.push({
-                    name: name.trim(),
-                    shortHash: shortHash?.trim() ?? "",
-                    lastCommit: lastCommit?.trim() ?? "",
-                    isCurrent: false,
-                    isRemote: true,
-                });
-            }
-
+            const branchData = await this.collectBranches(cwd);
             this.emit("git_branches_result", {
                 ok: true,
-                currentBranch: currentBranch.trim(),
-                branches,
+                ...branchData,
             }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_branches_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        }
+    }
+
+    private async handleFullStatus(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_full_status_result", requestId, sessionId);
+        if (!cwd) return;
+        this.registerSubscriber(cwd, sessionId);
+
+        try {
+            const [status, branchData, worktreeData] = await Promise.all([
+                this.getStatusSnapshot(cwd),
+                this.collectBranches(cwd),
+                this.collectWorktrees(cwd),
+            ]);
+
+            this.emit("git_full_status_result", {
+                ok: true,
+                status,
+                ...branchData,
+                ...worktreeData,
+            }, requestId, sessionId);
+        } catch (err) {
+            this.emitError("git_full_status_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         }
     }
 
@@ -361,7 +678,7 @@ export class GitService implements ServiceHandler {
                 }
                 // Check if a local branch with this name already exists
                 try {
-                    await execFileAsync("git", ["rev-parse", "--verify", `refs/heads/${targetBranch}`], { cwd, timeout: 5000 });
+                    await this._execGit(["rev-parse", "--verify", `refs/heads/${targetBranch}`], { cwd, timeout: 5000 });
                     // Local branch exists, just check it out
                     args.push("checkout", targetBranch);
                 } catch {
@@ -373,7 +690,8 @@ export class GitService implements ServiceHandler {
                 args.push("checkout", targetBranch);
             }
 
-            await execFileAsync("git", args, { cwd, timeout: 15000 });
+            await this._execGit(args, { cwd, timeout: 15000 });
+            this.invalidateStatusCache(cwd);
 
             this.emit("git_checkout_result", {
                 ok: true,
@@ -415,13 +733,13 @@ export class GitService implements ServiceHandler {
         try {
             // Resolve repo root — paths from git status are repo-root-relative,
             // so operations must run from repo root for paths to resolve correctly.
-            const { stdout: toplevel } = await execFileAsync(
-                "git", ["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
+            const { stdout: toplevel } = await this._execGit(["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
             );
             const repoRoot = toplevel.trim() || cwd;
 
             const args = all ? ["add", "--all"] : ["add", "--", ...paths];
-            await execFileAsync("git", args, { cwd: repoRoot, timeout: 15000 });
+            await this._execGit(args, { cwd: repoRoot, timeout: 15000 });
+            this.invalidateStatusCache(cwd);
             this.emit("git_stage_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_stage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
@@ -459,15 +777,15 @@ export class GitService implements ServiceHandler {
             // Resolve repo root — run from there so repo-root-relative paths work.
             // For unstage-all, use ":/" pathspec (magic "repo root") instead of "."
             // which would only cover the cwd subtree.
-            const { stdout: toplevel } = await execFileAsync(
-                "git", ["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
+            const { stdout: toplevel } = await this._execGit(["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
             );
             const repoRoot = toplevel.trim() || cwd;
 
             const args = all
                 ? ["restore", "--staged", ":/"]
                 : ["restore", "--staged", "--", ...paths];
-            await execFileAsync("git", args, { cwd: repoRoot, timeout: 15000 });
+            await this._execGit(args, { cwd: repoRoot, timeout: 15000 });
+            this.invalidateStatusCache(cwd);
             this.emit("git_unstage_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_unstage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
@@ -491,13 +809,13 @@ export class GitService implements ServiceHandler {
         }
 
         try {
-            const { stdout } = await execFileAsync(
-                "git", ["commit", "-m", message],
+            const { stdout } = await this._execGit(["commit", "-m", message],
                 { cwd, timeout: 30000 },
             );
 
             // Parse the short summary (e.g. "[main abc1234] Fix thing\n 1 file changed...")
             const firstLine = stdout.split("\n")[0] ?? "";
+            this.invalidateStatusCache(cwd);
 
             this.emit("git_commit_result", {
                 ok: true,
@@ -510,6 +828,109 @@ export class GitService implements ServiceHandler {
 
     // ── git worktrees ─────────────────────────────────────────────────
 
+    private async collectWorktrees(cwd: string): Promise<GitWorktreeResultPayload> {
+        // Get repo root so we can show relative paths
+        const { stdout: toplevel } = await this._execGit(["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
+        );
+        const repoRoot = toplevel.trim();
+
+        // Parse porcelain output — each worktree block is separated by a blank line
+        const { stdout: listOutput } = await this._execGit(["worktree", "list", "--porcelain"],
+            { cwd, timeout: 10000 },
+        );
+
+        interface WorktreeEntry {
+            path: string;
+            head: string;
+            branch: string;
+            isBare: boolean;
+            isDetached: boolean;
+        }
+
+        const worktrees: WorktreeEntry[] = [];
+        let current: Partial<WorktreeEntry> = {};
+
+        for (const line of listOutput.split("\n")) {
+            if (line === "") {
+                if (current.path) {
+                    worktrees.push({
+                        path: current.path,
+                        head: current.head ?? "",
+                        branch: current.branch ?? "",
+                        isBare: current.isBare ?? false,
+                        isDetached: current.isDetached ?? false,
+                    });
+                }
+                current = {};
+                continue;
+            }
+            if (line.startsWith("worktree ")) current.path = line.substring(9);
+            else if (line.startsWith("HEAD ")) current.head = line.substring(5);
+            else if (line.startsWith("branch ")) {
+                // Strip refs/heads/ prefix for display
+                const ref = line.substring(7);
+                current.branch = ref.startsWith("refs/heads/") ? ref.substring(11) : ref;
+            } else if (line === "bare") current.isBare = true;
+            else if (line === "detached") current.isDetached = true;
+        }
+        // Handle last entry if no trailing newline
+        if (current.path) {
+            worktrees.push({
+                path: current.path,
+                head: current.head ?? "",
+                branch: current.branch ?? "",
+                isBare: current.isBare ?? false,
+                isDetached: current.isDetached ?? false,
+            });
+        }
+
+        // For each worktree, get change count in parallel
+        const enriched = await Promise.all(
+            worktrees.filter((w) => !w.isBare).map(async (wt) => {
+                let changeCount = 0;
+                let ahead = 0;
+                let behind = 0;
+                try {
+                    const { stdout } = await this._execGit(["status", "--porcelain=v1", "-uall"],
+                        { cwd: wt.path, timeout: 5000 },
+                    );
+                    changeCount = stdout.split("\n").filter((l) => l.length > 0).length;
+                } catch { /* ignore — worktree might be mid-operation */ }
+
+                try {
+                    const { stdout } = await this._execGit(["rev-list", "--left-right", "--count", "HEAD...@{u}"],
+                        { cwd: wt.path, timeout: 5000 },
+                    );
+                    const [a, b] = stdout.trim().split(/\s+/);
+                    ahead = parseInt(a, 10) || 0;
+                    behind = parseInt(b, 10) || 0;
+                } catch { /* no upstream */ }
+
+                // Build a relative display path from the repo root
+                let displayPath = wt.path;
+                if (wt.path.startsWith(repoRoot)) {
+                    const rel = wt.path.substring(repoRoot.length);
+                    displayPath = rel.startsWith("/") ? rel.substring(1) : rel;
+                    if (!displayPath) displayPath = "."; // main worktree
+                }
+
+                return {
+                    path: wt.path,
+                    displayPath,
+                    branch: wt.branch,
+                    shortHash: wt.head.substring(0, 7),
+                    isDetached: wt.isDetached,
+                    isMain: wt.path === repoRoot,
+                    changeCount,
+                    ahead,
+                    behind,
+                };
+            }),
+        );
+
+        return { worktrees: enriched };
+    }
+
     private async handleWorktrees(
         payload: Record<string, unknown>,
         requestId?: string,
@@ -517,114 +938,13 @@ export class GitService implements ServiceHandler {
     ): Promise<void> {
         const cwd = this.validateCwd(payload.cwd, "git_worktrees_result", requestId, sessionId);
         if (!cwd) return;
+        this.registerSubscriber(cwd, sessionId);
 
         try {
-            // Get repo root so we can show relative paths
-            const { stdout: toplevel } = await execFileAsync(
-                "git", ["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 },
-            );
-            const repoRoot = toplevel.trim();
-
-            // Parse porcelain output — each worktree block is separated by a blank line
-            const { stdout: listOutput } = await execFileAsync(
-                "git", ["worktree", "list", "--porcelain"],
-                { cwd, timeout: 10000 },
-            );
-
-            interface WorktreeEntry {
-                path: string;
-                head: string;
-                branch: string;
-                isBare: boolean;
-                isDetached: boolean;
-            }
-
-            const worktrees: WorktreeEntry[] = [];
-            let current: Partial<WorktreeEntry> = {};
-
-            for (const line of listOutput.split("\n")) {
-                if (line === "") {
-                    if (current.path) {
-                        worktrees.push({
-                            path: current.path,
-                            head: current.head ?? "",
-                            branch: current.branch ?? "",
-                            isBare: current.isBare ?? false,
-                            isDetached: current.isDetached ?? false,
-                        });
-                    }
-                    current = {};
-                    continue;
-                }
-                if (line.startsWith("worktree ")) current.path = line.substring(9);
-                else if (line.startsWith("HEAD ")) current.head = line.substring(5);
-                else if (line.startsWith("branch ")) {
-                    // Strip refs/heads/ prefix for display
-                    const ref = line.substring(7);
-                    current.branch = ref.startsWith("refs/heads/") ? ref.substring(11) : ref;
-                } else if (line === "bare") current.isBare = true;
-                else if (line === "detached") current.isDetached = true;
-            }
-            // Handle last entry if no trailing newline
-            if (current.path) {
-                worktrees.push({
-                    path: current.path,
-                    head: current.head ?? "",
-                    branch: current.branch ?? "",
-                    isBare: current.isBare ?? false,
-                    isDetached: current.isDetached ?? false,
-                });
-            }
-
-            // For each worktree, get change count in parallel
-            const enriched = await Promise.all(
-                worktrees.filter((w) => !w.isBare).map(async (wt) => {
-                    let changeCount = 0;
-                    let ahead = 0;
-                    let behind = 0;
-                    try {
-                        const { stdout } = await execFileAsync(
-                            "git", ["status", "--porcelain=v1", "-uall"],
-                            { cwd: wt.path, timeout: 5000 },
-                        );
-                        changeCount = stdout.split("\n").filter((l) => l.length > 0).length;
-                    } catch { /* ignore — worktree might be mid-operation */ }
-
-                    try {
-                        const { stdout } = await execFileAsync(
-                            "git", ["rev-list", "--left-right", "--count", "HEAD...@{u}"],
-                            { cwd: wt.path, timeout: 5000 },
-                        );
-                        const [a, b] = stdout.trim().split(/\s+/);
-                        ahead = parseInt(a, 10) || 0;
-                        behind = parseInt(b, 10) || 0;
-                    } catch { /* no upstream */ }
-
-                    // Build a relative display path from the repo root
-                    let displayPath = wt.path;
-                    if (wt.path.startsWith(repoRoot)) {
-                        const rel = wt.path.substring(repoRoot.length);
-                        displayPath = rel.startsWith("/") ? rel.substring(1) : rel;
-                        if (!displayPath) displayPath = "."; // main worktree
-                    }
-
-                    return {
-                        path: wt.path,
-                        displayPath,
-                        branch: wt.branch,
-                        shortHash: wt.head.substring(0, 7),
-                        isDetached: wt.isDetached,
-                        isMain: wt.path === repoRoot,
-                        changeCount,
-                        ahead,
-                        behind,
-                    };
-                }),
-            );
-
+            const worktreeData = await this.collectWorktrees(cwd);
             this.emit("git_worktrees_result", {
                 ok: true,
-                worktrees: enriched,
+                ...worktreeData,
             }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_worktrees_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
@@ -642,8 +962,9 @@ export class GitService implements ServiceHandler {
         if (!cwd) return;
 
         try {
-            const result = await execFileAsync("git", ["pull"], { cwd, timeout: 60000 });
+            const result = await this._execGit(["pull"], { cwd, timeout: 60000 });
             const output = (result.stdout + "\n" + result.stderr).trim();
+            this.invalidateStatusCache(cwd);
 
             this.emit("git_pull_result", {
                 ok: true,
@@ -668,8 +989,7 @@ export class GitService implements ServiceHandler {
 
         try {
             // Determine current branch for --set-upstream
-            const { stdout: branchName } = await execFileAsync(
-                "git", ["rev-parse", "--abbrev-ref", "HEAD"],
+            const { stdout: branchName } = await this._execGit(["rev-parse", "--abbrev-ref", "HEAD"],
                 { cwd, timeout: 5000 },
             );
             const branch = branchName.trim();
@@ -680,16 +1000,14 @@ export class GitService implements ServiceHandler {
                 // Try the configured push remote, then fall back to the first remote.
                 let remote = "origin";
                 try {
-                    const { stdout } = await execFileAsync(
-                        "git", ["config", "--get", `branch.${branch}.remote`],
+                    const { stdout } = await this._execGit(["config", "--get", `branch.${branch}.remote`],
                         { cwd, timeout: 5000 },
                     );
                     if (stdout.trim()) remote = stdout.trim();
                 } catch {
                     // No tracked remote — try first remote in list
                     try {
-                        const { stdout } = await execFileAsync(
-                            "git", ["remote"],
+                        const { stdout } = await this._execGit(["remote"],
                             { cwd, timeout: 5000 },
                         );
                         const firstRemote = stdout.trim().split("\n")[0]?.trim();
@@ -702,8 +1020,9 @@ export class GitService implements ServiceHandler {
             }
 
             // git push writes to stderr (progress), use a larger timeout for network ops
-            const result = await execFileAsync("git", args, { cwd, timeout: 60000 });
+            const result = await this._execGit(args, { cwd, timeout: 60000 });
             const output = (result.stdout + "\n" + result.stderr).trim();
+            this.invalidateStatusCache(cwd);
 
             this.emit("git_push_result", {
                 ok: true,

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -32,6 +32,11 @@ type GitStatusResultPayload = {
     diffStaged: string;
 };
 
+type GitStatusSnapshot = {
+    generation: number;
+    payload: GitStatusResultPayload;
+};
+
 type GitBranchResultPayload = {
     currentBranch: string;
     branches: Array<{
@@ -106,8 +111,8 @@ export class GitService implements ServiceHandler {
     private readonly _setTimeout: SetTimeoutFn;
     private readonly _clearTimeout: ClearTimeoutFn;
     private readonly _now: () => number;
-    private readonly _statusCache = new Map<string, { expiresAt: number; generation: number; payload: GitStatusResultPayload }>();
-    private readonly _statusInFlight = new Map<string, Promise<GitStatusResultPayload>>();
+    private readonly _statusCache = new Map<string, { expiresAt: number; snapshot: GitStatusSnapshot }>();
+    private readonly _statusInFlight = new Map<string, Promise<GitStatusSnapshot>>();
     private readonly _statusGeneration = new Map<string, number>();
     private readonly _cwdSubscribers = new Map<string, Set<string>>();
     private readonly _sessionCwd = new Map<string, string>();
@@ -350,7 +355,8 @@ export class GitService implements ServiceHandler {
         watchState.refreshInFlight = true;
         try {
             await this.invalidateStatusCacheFamily(cwd);
-            const status = await this.getStatusSnapshot(cwd);
+            const snapshot = await this.getStatusSnapshot(cwd);
+            const status = snapshot.payload;
             for (const sessionId of subscribers) {
                 const sessionCwd = this._sessionCwd.get(sessionId) ?? status.cwd;
                 this.emit("git_status_result", { ...status, cwd: sessionCwd }, undefined, sessionId);
@@ -460,13 +466,13 @@ export class GitService implements ServiceHandler {
         }
     }
 
-    private async getStatusSnapshot(cwd: string): Promise<GitStatusResultPayload> {
+    private async getStatusSnapshot(cwd: string): Promise<GitStatusSnapshot> {
         const now = this._now();
         const generation = this._statusGeneration.get(cwd) ?? 0;
 
         const cached = this._statusCache.get(cwd);
-        if (cached && cached.generation === generation && cached.expiresAt > now) {
-            return cached.payload;
+        if (cached && cached.snapshot.generation === generation && cached.expiresAt > now) {
+            return cached.snapshot;
         }
 
         const existing = this._statusInFlight.get(cwd);
@@ -480,7 +486,7 @@ export class GitService implements ServiceHandler {
         return pending;
     }
 
-    private async collectStatus(cwd: string, generationAtStart: number): Promise<GitStatusResultPayload> {
+    private async collectStatus(cwd: string, generationAtStart: number): Promise<GitStatusSnapshot> {
         const [branchResult, toplevelResult, statusResult, diffStagedResult, abResult] = await Promise.allSettled([
             this._execGit(["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 }),
             this._execGit(["rev-parse", "--show-toplevel"], { cwd, timeout: 5000 }),
@@ -530,7 +536,7 @@ export class GitService implements ServiceHandler {
             behind = parseInt(b, 10) || 0;
         }
 
-        const result: GitStatusResultPayload = {
+        const payload: GitStatusResultPayload = {
             ok: true,
             cwd,
             branch,
@@ -542,15 +548,19 @@ export class GitService implements ServiceHandler {
             diffStaged,
         };
 
+        const snapshot: GitStatusSnapshot = {
+            generation: generationAtStart,
+            payload,
+        };
+
         if ((this._statusGeneration.get(cwd) ?? 0) === generationAtStart) {
             this._statusCache.set(cwd, {
-                generation: generationAtStart,
-                payload: result,
+                snapshot,
                 expiresAt: this._now() + STATUS_CACHE_TTL_MS,
             });
         }
 
-        return result;
+        return snapshot;
     }
 
     private async handleStatus(
@@ -563,8 +573,11 @@ export class GitService implements ServiceHandler {
         this.registerSubscriber(cwd, sessionId);
 
         try {
-            const status = await this.getStatusSnapshot(cwd);
-            this.emit("git_status_result", status, requestId, sessionId);
+            let snapshot = await this.getStatusSnapshot(cwd);
+            if (snapshot.generation !== (this._statusGeneration.get(cwd) ?? 0)) {
+                snapshot = await this.getStatusSnapshot(cwd);
+            }
+            this.emit("git_status_result", snapshot.payload, requestId, sessionId);
         } catch (err) {
             this.emitError("git_status_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         }
@@ -706,7 +719,11 @@ export class GitService implements ServiceHandler {
                 throw statusResult.reason;
             }
 
-            const status = statusResult.value;
+            let statusSnapshot = statusResult.value;
+            if (statusSnapshot.generation !== (this._statusGeneration.get(cwd) ?? 0)) {
+                statusSnapshot = await this.getStatusSnapshot(cwd);
+            }
+            const status = statusSnapshot.payload;
             const branchData = branchResult.status === "fulfilled"
                 ? branchResult.value
                 : { currentBranch: status.branch, branches: [] };

--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -876,6 +876,43 @@ export async function createMockRunner(
                 });
                 break;
             }
+            case "git_full_status": {
+                const cwd = payload.cwd;
+                if (!cwd) {
+                    emitGit("git_full_status_result", { ok: false, message: "Missing cwd" });
+                    return;
+                }
+                emitGit("git_full_status_result", {
+                    ok: true,
+                    status: {
+                        branch: gitStatus.branch,
+                        changes: gitStatus.changes,
+                        ahead: gitStatus.ahead,
+                        behind: gitStatus.behind,
+                        hasUpstream: true,
+                        diffStaged: gitStatus.diffStaged,
+                    },
+                    currentBranch: gitStatus.branch,
+                    branches: [
+                        { name: gitStatus.branch, shortHash: "abc1234", lastCommit: "2 hours ago", isCurrent: true, isRemote: false },
+                        { name: "main", shortHash: "def5678", lastCommit: "1 day ago", isCurrent: false, isRemote: false },
+                    ],
+                    worktrees: [
+                        {
+                            path: cwd,
+                            displayPath: ".",
+                            branch: gitStatus.branch,
+                            shortHash: "abc1234",
+                            isDetached: false,
+                            isMain: true,
+                            changeCount: gitStatus.changes.length,
+                            ahead: gitStatus.ahead,
+                            behind: gitStatus.behind,
+                        },
+                    ],
+                });
+                break;
+            }
             case "git_diff": {
                 const cwd = payload.cwd;
                 const filePath = payload.path;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2811,7 +2811,14 @@ export function App() {
       });
 
       nextSocket.on("event", (data) => {
-        if (!matchesViewerGeneration(viewerSwitchGenerationRef.current, data.generation)) {
+        // During session switch, only accept events that explicitly match our generation.
+        // This prevents events without generation tags from old sessions being processed
+        // while we're awaiting the snapshot for the new session.
+        if (awaitingSnapshotRef.current) {
+          if (data.generation !== viewerSwitchGenerationRef.current) {
+            return;
+          }
+        } else if (!matchesViewerGeneration(viewerSwitchGenerationRef.current, data.generation)) {
           return;
         }
         if (!activeSessionRef.current) return;
@@ -2854,7 +2861,14 @@ export function App() {
       });
 
       nextSocket.on("exec_result", (data) => {
+        // Important: check generation to prevent exec_result events from old sessions
+        // being processed after a session switch. Unlike other events, exec_result doesn't
+        // always include generation data, so we also guard with a recent-switch check.
         if (!activeSessionRef.current) return;
+        // If we're in the initial phase of a session switch (awaiting snapshot), reject
+        // any exec_results that might be from the old session. We'll start accepting them
+        // once the "connected" event confirms we're synchronized with the new session.
+        if (awaitingSnapshotRef.current) return;
         lastViewerEventAtRef.current = Date.now();
         handleRelayEvent({ type: "exec_result", ...data });
       });

--- a/packages/ui/src/components/git/GitBranchSelector.tsx
+++ b/packages/ui/src/components/git/GitBranchSelector.tsx
@@ -1,11 +1,13 @@
-import { useState, useMemo, useRef, useEffect } from "react";
+import { useState, useMemo, useRef, useEffect, useLayoutEffect } from "react";
+import { createPortal } from "react-dom";
 import { cn } from "@/lib/utils";
-import { GitBranch as GitBranchIcon, ChevronDown, Search, Check, Globe, Loader2 } from "lucide-react";
-import type { GitBranch } from "@/hooks/useGitService";
+import { GitBranch as GitBranchIcon, ChevronDown, Search, Check, Globe, Loader2, AlertCircle } from "lucide-react";
+import type { GitBranch, BranchesState } from "@/hooks/useGitService";
 
 interface GitBranchSelectorProps {
     currentBranch: string;
     branches: GitBranch[];
+    branchesState: BranchesState;
     onCheckout: (branch: string, isRemote: boolean) => void;
     onOpen: () => void;
     disabled?: boolean;
@@ -15,6 +17,7 @@ interface GitBranchSelectorProps {
 export function GitBranchSelector({
     currentBranch,
     branches,
+    branchesState,
     onCheckout,
     onOpen,
     disabled,
@@ -23,16 +26,19 @@ export function GitBranchSelector({
     const [open, setOpen] = useState(false);
     const [search, setSearch] = useState("");
     const containerRef = useRef<HTMLDivElement>(null);
+    const dropdownRef = useRef<HTMLDivElement>(null);
     const searchInputRef = useRef<HTMLInputElement>(null);
+    const [dropdownStyle, setDropdownStyle] = useState<{ top: number; left: number; width: number }>({ top: 0, left: 0, width: 0 });
 
     // Close on click outside
     useEffect(() => {
         if (!open) return;
         const handler = (e: PointerEvent) => {
-            if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
-                setOpen(false);
-                setSearch("");
-            }
+            const target = e.target as Node;
+            if (containerRef.current && containerRef.current.contains(target)) return;
+            if (dropdownRef.current && dropdownRef.current.contains(target)) return;
+            setOpen(false);
+            setSearch("");
         };
         document.addEventListener("pointerdown", handler, true);
         return () => document.removeEventListener("pointerdown", handler, true);
@@ -57,6 +63,28 @@ export function GitBranchSelector({
         if (open) {
             searchInputRef.current?.focus();
         }
+    }, [open]);
+
+    // Position dropdown on open/resize/scroll
+    useLayoutEffect(() => {
+        if (!open) return;
+        const updatePosition = () => {
+            const trigger = containerRef.current;
+            if (!trigger) return;
+            const rect = trigger.getBoundingClientRect();
+            setDropdownStyle({
+                top: rect.bottom + window.scrollY,
+                left: rect.left + window.scrollX,
+                width: rect.width,
+            });
+        };
+        updatePosition();
+        window.addEventListener("resize", updatePosition);
+        window.addEventListener("scroll", updatePosition, true);
+        return () => {
+            window.removeEventListener("resize", updatePosition);
+            window.removeEventListener("scroll", updatePosition, true);
+        };
     }, [open]);
 
     const handleOpen = () => {
@@ -106,9 +134,20 @@ export function GitBranchSelector({
                 )}
             </button>
 
-            {open && (
-                <div className="absolute top-full left-0 mt-1 w-72 max-h-80 bg-popover border border-border rounded-lg shadow-xl z-50 flex flex-col overflow-hidden animate-in fade-in zoom-in-95 duration-100">
-                    {/* Search */}
+            {open && createPortal(
+                <div
+                    ref={dropdownRef}
+                    style={{
+                        position: "absolute",
+                        top: dropdownStyle.top,
+                        left: dropdownStyle.left,
+                        minWidth: dropdownStyle.width || 260,
+                        maxWidth: "90vw",
+                        zIndex: 60,
+                    }}
+                    className="mt-1 w-72 max-h-80 bg-popover border border-border rounded-lg shadow-xl flex flex-col overflow-hidden animate-in fade-in zoom-in-95 duration-100"
+                >
+                    {/* Search / header */}
                     <div className="flex items-center gap-2 px-3 py-2 border-b border-border/50">
                         <Search className="size-3.5 text-muted-foreground flex-shrink-0" />
                         <input
@@ -119,15 +158,34 @@ export function GitBranchSelector({
                             placeholder="Find a branch…"
                             className="flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground/60"
                         />
+                        {branchesState.loading && <Loader2 className="size-3 animate-spin text-muted-foreground" />}
                     </div>
+
+                    {/* Status bar for partial/error */}
+                    {(branchesState.partial || branchesState.error) && (
+                        <div className={cn(
+                            "px-3 py-1 text-[0.7rem] border-b",
+                            branchesState.error ? "text-red-500 border-border/50" : "text-muted-foreground border-border/50",
+                        )}>
+                            {branchesState.error ? (
+                                <span className="inline-flex items-center gap-1"><AlertCircle className="size-3" />{branchesState.error}</span>
+                            ) : (
+                                "Partial data – status refresh needed for behind/ahead."
+                            )}
+                        </div>
+                    )}
 
                     {/* Branch list */}
                     <div className="flex-1 overflow-auto py-1">
-                        {filtered.length === 0 && (
+                        {branchesState.loading ? (
+                            <div className="px-3 py-4 text-center text-xs text-muted-foreground flex items-center justify-center gap-2">
+                                <Loader2 className="size-3 animate-spin" /> Loading branches…
+                            </div>
+                        ) : filtered.length === 0 ? (
                             <div className="px-3 py-4 text-center text-xs text-muted-foreground">
                                 No branches found
                             </div>
-                        )}
+                        ) : null}
 
                         {localBranches.length > 0 && (
                             <div>
@@ -159,7 +217,8 @@ export function GitBranchSelector({
                             </div>
                         )}
                     </div>
-                </div>
+                </div>,
+                document.body,
             )}
         </div>
     );

--- a/packages/ui/src/components/git/GitBranchSelector.tsx
+++ b/packages/ui/src/components/git/GitBranchSelector.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useRef, useEffect, useLayoutEffect } from "react";
-import { createPortal } from "react-dom";
+import * as ReactDOM from "react-dom";
 import { cn } from "@/lib/utils";
 import { GitBranch as GitBranchIcon, ChevronDown, Search, Check, Globe, Loader2, AlertCircle } from "lucide-react";
 import type { GitBranch, BranchesState } from "@/hooks/useGitService";
@@ -134,7 +134,7 @@ export function GitBranchSelector({
                 )}
             </button>
 
-            {open && createPortal(
+            {open && ReactDOM.createPortal(
                 <div
                     ref={dropdownRef}
                     style={{

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -5,6 +5,7 @@
  * service_message channel (no REST routes). Session-scoped via cwd.
  */
 import { useState, useCallback, useRef, useEffect } from "react";
+import * as ReactDOM from "react-dom";
 import { cn } from "@/lib/utils";
 import {
     ArrowUp,
@@ -250,8 +251,17 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                     >
                         <MoreHorizontal className="size-3" /> Sync
                     </button>
-                    {syncMenuOpen && (
-                        <div className="absolute right-0 mt-1 w-48 bg-popover border border-border rounded-md shadow-lg z-40 text-sm">
+                    {syncMenuOpen && ReactDOM.createPortal(
+                        <div
+                            style={{
+                                position: "fixed",
+                                top: syncMenuRef.current ? syncMenuRef.current.getBoundingClientRect().bottom : 0,
+                                left: syncMenuRef.current ? syncMenuRef.current.getBoundingClientRect().left : 0,
+                                zIndex: 100,
+                                minWidth: 180,
+                            }}
+                            className="mt-1 w-48 bg-popover border border-border rounded-md shadow-lg text-sm"
+                        >
                             <button
                                 type="button"
                                 onClick={() => {
@@ -285,7 +295,8 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                             >
                                 <div className="flex items-center gap-2"><GitMerge className="size-3" /> Merge into current…</div>
                             </button>
-                        </div>
+                        </div>,
+                        document.body,
                     )}
                 </div>
 

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -50,6 +50,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
     const [toast, setToast] = useState<{ type: "success" | "error"; message: string } | null>(null);
     const [syncMenuOpen, setSyncMenuOpen] = useState(false);
     const syncMenuRef = useRef<HTMLDivElement>(null);
+    const syncMenuContentRef = useRef<HTMLDivElement>(null);
 
     // Show toast when operation completes
     useEffect(() => {
@@ -85,7 +86,8 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
         if (!syncMenuOpen) return;
         const handler = (e: PointerEvent) => {
             const target = e.target as Node;
-            if (syncMenuRef.current && syncMenuRef.current.contains(target)) return;
+            if (syncMenuRef.current?.contains(target)) return;
+            if (syncMenuContentRef.current?.contains(target)) return;
             setSyncMenuOpen(false);
         };
         document.addEventListener("pointerdown", handler, true);
@@ -253,6 +255,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                     </button>
                     {syncMenuOpen && ReactDOM.createPortal(
                         <div
+                            ref={syncMenuContentRef}
                             style={{
                                 position: "fixed",
                                 top: syncMenuRef.current ? syncMenuRef.current.getBoundingClientRect().bottom : 0,

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -16,6 +16,8 @@ import {
     Loader2,
     Check,
     AlertCircle,
+    MoreHorizontal,
+    GitMerge,
 } from "lucide-react";
 import { Spinner } from "@/components/ui/spinner";
 import { Button } from "@/components/ui/button";
@@ -45,6 +47,8 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
 
     // Toast-style feedback for operations
     const [toast, setToast] = useState<{ type: "success" | "error"; message: string } | null>(null);
+    const [syncMenuOpen, setSyncMenuOpen] = useState(false);
+    const syncMenuRef = useRef<HTMLDivElement>(null);
 
     // Show toast when operation completes
     useEffect(() => {
@@ -75,6 +79,18 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
         return () => clearTimeout(timer);
     }, [git.lastOperationResult]);
 
+    // Close sync menu on outside click
+    useEffect(() => {
+        if (!syncMenuOpen) return;
+        const handler = (e: PointerEvent) => {
+            const target = e.target as Node;
+            if (syncMenuRef.current && syncMenuRef.current.contains(target)) return;
+            setSyncMenuOpen(false);
+        };
+        document.addEventListener("pointerdown", handler, true);
+        return () => document.removeEventListener("pointerdown", handler, true);
+    }, [syncMenuOpen]);
+
     // ── Diff viewing ────────────────────────────────────────────────────
 
     const viewDiff = useCallback(
@@ -91,6 +107,17 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
         },
         [git],
     );
+
+    const handleMerge = useCallback(() => {
+        const current = git.status?.branch ?? "";
+        const branchName = window.prompt("Merge which branch into current?", "");
+        if (!branchName) return;
+        if (branchName === current) {
+            setToast({ type: "error", message: "Cannot merge the current branch into itself." });
+            return;
+        }
+        git.merge(branchName);
+    }, [git, setToast]);
 
     // Intercept Escape in diff view
     useEffect(() => {
@@ -182,6 +209,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                 <GitBranchSelector
                     currentBranch={git.status.branch}
                     branches={git.branches}
+                    branchesState={git.branchesState}
                     onCheckout={git.checkout}
                     onOpen={git.fetchBranches}
                     isCheckingOut={git.operationInProgress === "checkout"}
@@ -206,6 +234,60 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                         <ArrowDown className="size-3" /> {git.status.behind}
                     </span>
                 )}
+
+                {/* Sync dropdown */}
+                <div className="relative" ref={syncMenuRef}>
+                    <button
+                        type="button"
+                        onClick={() => setSyncMenuOpen((o) => !o)}
+                        disabled={git.operationInProgress === "pull" || git.operationInProgress === "merge"}
+                        className={cn(
+                            "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors",
+                            "bg-muted/60 hover:bg-muted text-foreground",
+                            git.operationInProgress && "opacity-70",
+                        )}
+                        title="Sync options"
+                    >
+                        <MoreHorizontal className="size-3" /> Sync
+                    </button>
+                    {syncMenuOpen && (
+                        <div className="absolute right-0 mt-1 w-48 bg-popover border border-border rounded-md shadow-lg z-40 text-sm">
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setSyncMenuOpen(false);
+                                    git.pull(false);
+                                }}
+                                className="w-full text-left px-3 py-2 hover:bg-accent/50 disabled:opacity-50"
+                                disabled={git.operationInProgress !== null}
+                            >
+                                <div className="flex items-center gap-2"><Download className="size-3" /> Pull (fast-forward)</div>
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setSyncMenuOpen(false);
+                                    git.pull(true);
+                                }}
+                                className="w-full text-left px-3 py-2 hover:bg-accent/50 disabled:opacity-50"
+                                disabled={git.operationInProgress !== null}
+                            >
+                                <div className="flex items-center gap-2"><Download className="size-3" /> Pull --rebase</div>
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    setSyncMenuOpen(false);
+                                    handleMerge();
+                                }}
+                                className="w-full text-left px-3 py-2 hover:bg-accent/50 disabled:opacity-50"
+                                disabled={git.operationInProgress !== null}
+                            >
+                                <div className="flex items-center gap-2"><GitMerge className="size-3" /> Merge into current…</div>
+                            </button>
+                        </div>
+                    )}
+                </div>
 
                 {/* Pull button */}
                 {showPull && (

--- a/packages/ui/src/hooks/git-optimistic-status.test.ts
+++ b/packages/ui/src/hooks/git-optimistic-status.test.ts
@@ -23,6 +23,7 @@ describe("applyOptimisticMutation", () => {
             { status: " M", path: "src/a.ts" },
             { status: "??", path: "src/new.ts" },
             { status: "M ", path: "src/already-staged.ts" },
+            { status: "AM", path: "src/new-and-modified.ts" },
         ]);
 
         const next = applyOptimisticMutation(status, {
@@ -34,6 +35,7 @@ describe("applyOptimisticMutation", () => {
             { status: "M ", path: "src/a.ts" },
             { status: "A ", path: "src/new.ts" },
             { status: "M ", path: "src/already-staged.ts" },
+            { status: "AM", path: "src/new-and-modified.ts" },
         ]);
     });
 
@@ -41,6 +43,7 @@ describe("applyOptimisticMutation", () => {
         const status = makeStatus([
             { status: " M", path: "src/a.ts" },
             { status: "MM", path: "src/b.ts" },
+            { status: "AM", path: "src/already-added.ts" },
             { status: "??", path: "src/c.ts" },
             { status: "M ", path: "src/staged.ts" },
         ]);
@@ -53,6 +56,7 @@ describe("applyOptimisticMutation", () => {
         expect(next?.changes).toEqual([
             { status: "M ", path: "src/a.ts" },
             { status: "M ", path: "src/b.ts" },
+            { status: "A ", path: "src/already-added.ts" },
             { status: "A ", path: "src/c.ts" },
             { status: "M ", path: "src/staged.ts" },
         ]);

--- a/packages/ui/src/hooks/git-optimistic-status.test.ts
+++ b/packages/ui/src/hooks/git-optimistic-status.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, test } from "bun:test";
+import type { GitStatus } from "./useGitService";
+import {
+    applyOptimisticMutation,
+    cloneStatusSnapshot,
+    consumeRollbackSnapshot,
+} from "./git-optimistic-status";
+
+function makeStatus(changes: GitStatus["changes"]): GitStatus {
+    return {
+        branch: "feat/optimistic",
+        changes,
+        ahead: 0,
+        behind: 0,
+        hasUpstream: true,
+        diffStaged: "",
+    };
+}
+
+describe("applyOptimisticMutation", () => {
+    test("optimistically stages selected paths", () => {
+        const status = makeStatus([
+            { status: " M", path: "src/a.ts" },
+            { status: "??", path: "src/new.ts" },
+            { status: "M ", path: "src/already-staged.ts" },
+        ]);
+
+        const next = applyOptimisticMutation(status, {
+            type: "stage",
+            paths: ["src/a.ts", "src/new.ts"],
+        });
+
+        expect(next?.changes).toEqual([
+            { status: "M ", path: "src/a.ts" },
+            { status: "A ", path: "src/new.ts" },
+            { status: "M ", path: "src/already-staged.ts" },
+        ]);
+    });
+
+    test("optimistically stageAll stages all unstaged changes", () => {
+        const status = makeStatus([
+            { status: " M", path: "src/a.ts" },
+            { status: "MM", path: "src/b.ts" },
+            { status: "??", path: "src/c.ts" },
+            { status: "M ", path: "src/staged.ts" },
+        ]);
+
+        const next = applyOptimisticMutation(status, {
+            type: "stage",
+            all: true,
+        });
+
+        expect(next?.changes).toEqual([
+            { status: "M ", path: "src/a.ts" },
+            { status: "M ", path: "src/b.ts" },
+            { status: "A ", path: "src/c.ts" },
+            { status: "M ", path: "src/staged.ts" },
+        ]);
+    });
+
+    test("optimistically unstages selected paths", () => {
+        const status = makeStatus([
+            { status: "M ", path: "src/a.ts" },
+            { status: "A ", path: "src/new.ts" },
+            { status: "MM", path: "src/both.ts" },
+        ]);
+
+        const next = applyOptimisticMutation(status, {
+            type: "unstage",
+            paths: ["src/a.ts", "src/new.ts", "src/both.ts"],
+        });
+
+        expect(next?.changes).toEqual([
+            { status: " M", path: "src/a.ts" },
+            { status: "??", path: "src/new.ts" },
+            { status: " M", path: "src/both.ts" },
+        ]);
+    });
+
+    test("optimistically unstageAll removes staged-only added+deleted files", () => {
+        const status = makeStatus([
+            { status: "AD", path: "src/temp.ts" },
+            { status: "D ", path: "src/remove.ts" },
+        ]);
+
+        const next = applyOptimisticMutation(status, {
+            type: "unstage",
+            all: true,
+        });
+
+        expect(next?.changes).toEqual([
+            { status: " D", path: "src/remove.ts" },
+        ]);
+    });
+});
+
+describe("consumeRollbackSnapshot", () => {
+    test("returns previous snapshot and clears it on failure", () => {
+        const previous = makeStatus([{ status: " M", path: "src/a.ts" }]);
+        const pending = new Map<string, GitStatus | null>();
+        pending.set("req-1", cloneStatusSnapshot(previous));
+
+        const rollback = consumeRollbackSnapshot(pending, "req-1", false);
+
+        expect(rollback).toEqual(previous);
+        expect(pending.has("req-1")).toBe(false);
+    });
+
+    test("does not rollback on success and still clears snapshot", () => {
+        const pending = new Map<string, GitStatus | null>();
+        pending.set("req-1", makeStatus([{ status: " M", path: "src/a.ts" }]));
+
+        const rollback = consumeRollbackSnapshot(pending, "req-1", true);
+
+        expect(rollback).toBeUndefined();
+        expect(pending.has("req-1")).toBe(false);
+    });
+
+    test("ignores unknown request ids", () => {
+        const pending = new Map<string, GitStatus | null>();
+
+        const rollback = consumeRollbackSnapshot(pending, "missing", false);
+
+        expect(rollback).toBeUndefined();
+        expect(pending.size).toBe(0);
+    });
+});

--- a/packages/ui/src/hooks/git-optimistic-status.ts
+++ b/packages/ui/src/hooks/git-optimistic-status.ts
@@ -35,12 +35,14 @@ function applyOptimisticStage(change: GitChange): GitChange {
 
     if (change.status.length !== 2) return change;
 
+    const indexStatus = change.status[0];
     const worktreeStatus = change.status[1];
     if (worktreeStatus === " " || worktreeStatus === "?" || worktreeStatus === "!") {
         return change;
     }
 
-    return { ...change, status: `${worktreeStatus} ` };
+    const hasExistingIndexStatus = indexStatus !== " " && indexStatus !== "?" && indexStatus !== "!";
+    return { ...change, status: `${hasExistingIndexStatus ? indexStatus : worktreeStatus} ` };
 }
 
 function applyOptimisticUnstage(change: GitChange): GitChange | null {

--- a/packages/ui/src/hooks/git-optimistic-status.ts
+++ b/packages/ui/src/hooks/git-optimistic-status.ts
@@ -1,0 +1,121 @@
+import type { GitChange, GitStatus } from "./useGitService";
+
+export type GitOptimisticMutation =
+    | { type: "stage"; paths?: string[]; all?: boolean }
+    | { type: "unstage"; paths?: string[]; all?: boolean };
+
+function hasStagedChanges(status: string): boolean {
+    return status.length === 2 && status[0] !== " " && status[0] !== "?" && status[0] !== "!";
+}
+
+function hasUnstagedChanges(status: string): boolean {
+    return status === "??" || (status.length === 2 && status[1] !== " ");
+}
+
+function cloneChange(change: GitChange): GitChange {
+    return change.originalPath
+        ? { status: change.status, path: change.path, originalPath: change.originalPath }
+        : { status: change.status, path: change.path };
+}
+
+export function cloneStatusSnapshot(status: GitStatus | null): GitStatus | null {
+    if (!status) return null;
+    return {
+        ...status,
+        changes: status.changes.map(cloneChange),
+    };
+}
+
+function applyOptimisticStage(change: GitChange): GitChange {
+    if (!hasUnstagedChanges(change.status)) return change;
+
+    if (change.status === "??") {
+        return { ...change, status: "A " };
+    }
+
+    if (change.status.length !== 2) return change;
+
+    const worktreeStatus = change.status[1];
+    if (worktreeStatus === " " || worktreeStatus === "?" || worktreeStatus === "!") {
+        return change;
+    }
+
+    return { ...change, status: `${worktreeStatus} ` };
+}
+
+function applyOptimisticUnstage(change: GitChange): GitChange | null {
+    if (!hasStagedChanges(change.status)) return change;
+
+    if (change.status.length !== 2) return change;
+
+    const indexStatus = change.status[0];
+
+    if (indexStatus === "A") {
+        if (change.status[1] === "D") return null;
+        return { ...change, status: "??" };
+    }
+
+    if (indexStatus === " " || indexStatus === "?" || indexStatus === "!") return change;
+
+    return { ...change, status: ` ${indexStatus}` };
+}
+
+function shouldMutatePath(changePath: string, mutation: GitOptimisticMutation): boolean {
+    if (mutation.all) return true;
+    const paths = mutation.paths ?? [];
+    if (paths.length === 0) return false;
+    return paths.includes(changePath);
+}
+
+export function applyOptimisticMutation(
+    status: GitStatus | null,
+    mutation: GitOptimisticMutation,
+): GitStatus | null {
+    if (!status) return status;
+
+    const nextChanges: GitChange[] = [];
+    let changed = false;
+
+    for (const change of status.changes) {
+        if (!shouldMutatePath(change.path, mutation)) {
+            nextChanges.push(change);
+            continue;
+        }
+
+        const transformed = mutation.type === "stage"
+            ? applyOptimisticStage(change)
+            : applyOptimisticUnstage(change);
+
+        if (transformed === null) {
+            changed = true;
+            continue;
+        }
+
+        nextChanges.push(transformed);
+        if (transformed.status !== change.status || transformed.path !== change.path || transformed.originalPath !== change.originalPath) {
+            changed = true;
+        }
+    }
+
+    if (!changed) return status;
+
+    return {
+        ...status,
+        changes: nextChanges,
+    };
+}
+
+export function consumeRollbackSnapshot(
+    snapshots: Map<string, GitStatus | null>,
+    requestId: string | undefined,
+    ok: boolean,
+): GitStatus | null | undefined {
+    if (!requestId) return undefined;
+    if (!snapshots.has(requestId)) return undefined;
+
+    const previous = snapshots.get(requestId);
+    snapshots.delete(requestId);
+
+    if (ok) return undefined;
+    return previous;
+}

--- a/packages/ui/src/hooks/git-status-refresh-scheduler.test.ts
+++ b/packages/ui/src/hooks/git-status-refresh-scheduler.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from "bun:test";
+import { createPostMutationRefreshScheduler } from "./git-status-refresh-scheduler";
+
+type TimerId = ReturnType<typeof setTimeout>;
+
+function createFakeTimers() {
+    let nextId = 1;
+    const callbacks = new Map<number, () => void>();
+
+    const setTimer = (callback: () => void) => {
+        const id = nextId++;
+        callbacks.set(id, callback);
+        return id as TimerId;
+    };
+
+    const clearTimer = (timerId: TimerId) => {
+        callbacks.delete(timerId as unknown as number);
+    };
+
+    const runAll = () => {
+        const pending = Array.from(callbacks.entries());
+        callbacks.clear();
+        for (const [, callback] of pending) callback();
+    };
+
+    const pendingCount = () => callbacks.size;
+
+    return { setTimer, clearTimer, runAll, pendingCount };
+}
+
+describe("createPostMutationRefreshScheduler", () => {
+    test("coalesces rapid schedules into one trailing refresh", () => {
+        const fakeTimers = createFakeTimers();
+        let refreshCount = 0;
+        const scheduler = createPostMutationRefreshScheduler({
+            debounceMs: 100,
+            getGeneration: () => 1,
+            isStatusRequestInFlight: () => false,
+            triggerRefresh: () => {
+                refreshCount += 1;
+            },
+            setTimer: fakeTimers.setTimer,
+            clearTimer: fakeTimers.clearTimer,
+        });
+
+        scheduler.schedule();
+        scheduler.schedule();
+        scheduler.schedule();
+
+        expect(fakeTimers.pendingCount()).toBe(1);
+        fakeTimers.runAll();
+        expect(refreshCount).toBe(1);
+    });
+
+    test("does not schedule while a status request is already in flight", () => {
+        const fakeTimers = createFakeTimers();
+        let inFlight = true;
+        let refreshCount = 0;
+        const scheduler = createPostMutationRefreshScheduler({
+            debounceMs: 100,
+            getGeneration: () => 1,
+            isStatusRequestInFlight: () => inFlight,
+            triggerRefresh: () => {
+                refreshCount += 1;
+            },
+            setTimer: fakeTimers.setTimer,
+            clearTimer: fakeTimers.clearTimer,
+        });
+
+        scheduler.schedule();
+        expect(fakeTimers.pendingCount()).toBe(0);
+
+        inFlight = false;
+        scheduler.schedule();
+        expect(fakeTimers.pendingCount()).toBe(1);
+        fakeTimers.runAll();
+        expect(refreshCount).toBe(1);
+    });
+
+    test("skips triggering when a request becomes in flight before timer fires", () => {
+        const fakeTimers = createFakeTimers();
+        let inFlight = false;
+        let refreshCount = 0;
+        const scheduler = createPostMutationRefreshScheduler({
+            debounceMs: 100,
+            getGeneration: () => 1,
+            isStatusRequestInFlight: () => inFlight,
+            triggerRefresh: () => {
+                refreshCount += 1;
+            },
+            setTimer: fakeTimers.setTimer,
+            clearTimer: fakeTimers.clearTimer,
+        });
+
+        scheduler.schedule();
+        inFlight = true;
+        fakeTimers.runAll();
+
+        expect(refreshCount).toBe(0);
+    });
+
+    test("drops scheduled refresh when generation changes", () => {
+        const fakeTimers = createFakeTimers();
+        let generation = 1;
+        let refreshCount = 0;
+        const scheduler = createPostMutationRefreshScheduler({
+            debounceMs: 100,
+            getGeneration: () => generation,
+            isStatusRequestInFlight: () => false,
+            triggerRefresh: () => {
+                refreshCount += 1;
+            },
+            setTimer: fakeTimers.setTimer,
+            clearTimer: fakeTimers.clearTimer,
+        });
+
+        scheduler.schedule();
+        generation = 2;
+        fakeTimers.runAll();
+
+        expect(refreshCount).toBe(0);
+    });
+
+    test("dispose cancels pending timers and future schedules", () => {
+        const fakeTimers = createFakeTimers();
+        let refreshCount = 0;
+        const scheduler = createPostMutationRefreshScheduler({
+            debounceMs: 100,
+            getGeneration: () => 1,
+            isStatusRequestInFlight: () => false,
+            triggerRefresh: () => {
+                refreshCount += 1;
+            },
+            setTimer: fakeTimers.setTimer,
+            clearTimer: fakeTimers.clearTimer,
+        });
+
+        scheduler.schedule();
+        expect(fakeTimers.pendingCount()).toBe(1);
+
+        scheduler.dispose();
+        expect(fakeTimers.pendingCount()).toBe(0);
+
+        scheduler.schedule();
+        expect(fakeTimers.pendingCount()).toBe(0);
+
+        fakeTimers.runAll();
+        expect(refreshCount).toBe(0);
+    });
+});

--- a/packages/ui/src/hooks/git-status-refresh-scheduler.test.ts
+++ b/packages/ui/src/hooks/git-status-refresh-scheduler.test.ts
@@ -52,7 +52,7 @@ describe("createPostMutationRefreshScheduler", () => {
         expect(refreshCount).toBe(1);
     });
 
-    test("does not schedule while a status request is already in flight", () => {
+    test("keeps a pending refresh while status is in flight and runs trailing refresh after settle", () => {
         const fakeTimers = createFakeTimers();
         let inFlight = true;
         let refreshCount = 0;
@@ -68,16 +68,21 @@ describe("createPostMutationRefreshScheduler", () => {
         });
 
         scheduler.schedule();
-        expect(fakeTimers.pendingCount()).toBe(0);
-
-        inFlight = false;
-        scheduler.schedule();
         expect(fakeTimers.pendingCount()).toBe(1);
+
+        // First tick sees in-flight and reschedules.
+        fakeTimers.runAll();
+        expect(refreshCount).toBe(0);
+        expect(fakeTimers.pendingCount()).toBe(1);
+
+        // Once settled, next tick triggers the trailing refresh.
+        inFlight = false;
         fakeTimers.runAll();
         expect(refreshCount).toBe(1);
+        expect(fakeTimers.pendingCount()).toBe(0);
     });
 
-    test("skips triggering when a request becomes in flight before timer fires", () => {
+    test("retries later when a request becomes in flight before timer fires", () => {
         const fakeTimers = createFakeTimers();
         let inFlight = false;
         let refreshCount = 0;
@@ -97,6 +102,11 @@ describe("createPostMutationRefreshScheduler", () => {
         fakeTimers.runAll();
 
         expect(refreshCount).toBe(0);
+        expect(fakeTimers.pendingCount()).toBe(1);
+
+        inFlight = false;
+        fakeTimers.runAll();
+        expect(refreshCount).toBe(1);
     });
 
     test("drops scheduled refresh when generation changes", () => {

--- a/packages/ui/src/hooks/git-status-refresh-scheduler.ts
+++ b/packages/ui/src/hooks/git-status-refresh-scheduler.ts
@@ -1,0 +1,55 @@
+export interface PostMutationRefreshScheduler {
+    schedule: () => void;
+    cancel: () => void;
+    dispose: () => void;
+}
+
+interface CreatePostMutationRefreshSchedulerOptions {
+    debounceMs: number;
+    getGeneration: () => number;
+    isStatusRequestInFlight: () => boolean;
+    triggerRefresh: () => void;
+    setTimer?: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+    clearTimer?: (timerId: ReturnType<typeof setTimeout>) => void;
+}
+
+export function createPostMutationRefreshScheduler({
+    debounceMs,
+    getGeneration,
+    isStatusRequestInFlight,
+    triggerRefresh,
+    setTimer = setTimeout,
+    clearTimer = clearTimeout,
+}: CreatePostMutationRefreshSchedulerOptions): PostMutationRefreshScheduler {
+    let timerId: ReturnType<typeof setTimeout> | null = null;
+    let disposed = false;
+
+    const cancel = () => {
+        if (!timerId) return;
+        clearTimer(timerId);
+        timerId = null;
+    };
+
+    const schedule = () => {
+        if (disposed) return;
+        if (isStatusRequestInFlight()) return;
+
+        const generationAtSchedule = getGeneration();
+        cancel();
+
+        timerId = setTimer(() => {
+            timerId = null;
+            if (disposed) return;
+            if (getGeneration() !== generationAtSchedule) return;
+            if (isStatusRequestInFlight()) return;
+            triggerRefresh();
+        }, debounceMs);
+    };
+
+    const dispose = () => {
+        disposed = true;
+        cancel();
+    };
+
+    return { schedule, cancel, dispose };
+}

--- a/packages/ui/src/hooks/git-status-refresh-scheduler.ts
+++ b/packages/ui/src/hooks/git-status-refresh-scheduler.ts
@@ -23,8 +23,28 @@ export function createPostMutationRefreshScheduler({
 }: CreatePostMutationRefreshSchedulerOptions): PostMutationRefreshScheduler {
     let timerId: ReturnType<typeof setTimeout> | null = null;
     let disposed = false;
+    let hasPendingRefresh = false;
+
+    const runWhenReady = (generationAtSchedule: number) => {
+        timerId = null;
+        if (disposed) return;
+        if (getGeneration() !== generationAtSchedule) {
+            hasPendingRefresh = false;
+            return;
+        }
+        if (!hasPendingRefresh) return;
+
+        if (isStatusRequestInFlight()) {
+            timerId = setTimer(() => runWhenReady(generationAtSchedule), debounceMs);
+            return;
+        }
+
+        hasPendingRefresh = false;
+        triggerRefresh();
+    };
 
     const cancel = () => {
+        hasPendingRefresh = false;
         if (!timerId) return;
         clearTimer(timerId);
         timerId = null;
@@ -32,18 +52,12 @@ export function createPostMutationRefreshScheduler({
 
     const schedule = () => {
         if (disposed) return;
-        if (isStatusRequestInFlight()) return;
+        hasPendingRefresh = true;
 
         const generationAtSchedule = getGeneration();
-        cancel();
+        if (timerId) clearTimer(timerId);
 
-        timerId = setTimer(() => {
-            timerId = null;
-            if (disposed) return;
-            if (getGeneration() !== generationAtSchedule) return;
-            if (isStatusRequestInFlight()) return;
-            triggerRefresh();
-        }, debounceMs);
+        timerId = setTimer(() => runWhenReady(generationAtSchedule), debounceMs);
     };
 
     const dispose = () => {

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -60,12 +60,19 @@ export interface GitOperationResult {
 
 // ── Hook ────────────────────────────────────────────────────────────────────
 
+export interface BranchesState {
+    loading: boolean;
+    error: string | null;
+    partial: boolean; // true when branches loaded via fallback (full-status failed)
+}
+
 export interface UseGitServiceReturn {
     available: boolean;
 
     // State
     status: GitStatus | null;
     branches: GitBranch[];
+    branchesState: BranchesState;
     worktrees: GitWorktree[];
     currentBranch: string;
     loading: boolean;
@@ -87,7 +94,8 @@ export interface UseGitServiceReturn {
     unstageAll: () => void;
     commit: (message: string) => void;
     push: (setUpstream?: boolean) => void;
-    pull: () => void;
+    pull: (rebase?: boolean) => void;
+    merge: (branch: string) => void;
     clearOperationResult: () => void;
 }
 
@@ -96,6 +104,7 @@ const POST_MUTATION_STATUS_REFRESH_DEBOUNCE_MS = 100;
 export function useGitService(cwd: string): UseGitServiceReturn {
     const [status, setStatus] = useState<GitStatus | null>(null);
     const [branches, setBranches] = useState<GitBranch[]>([]);
+    const [branchesState, setBranchesState] = useState<BranchesState>({ loading: false, error: null, partial: false });
     const [worktrees, setWorktrees] = useState<GitWorktree[]>([]);
     const [currentBranch, setCurrentBranch] = useState("");
     const [loading, setLoading] = useState(false);
@@ -112,6 +121,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     const statusRequestsInFlightRef = useRef(new Set<string>());
     const optimisticSnapshotsRef = useRef(new Map<string, GitStatus | null>());
     const requestGenerationRef = useRef(new Map<string, number>());
+    const lastBranchFetchRef = useRef(0);
 
     // Generation counter — incremented on cwd change. Responses from stale
     // generations are discarded so a slow response from the old cwd doesn't
@@ -186,10 +196,11 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         sendRef.current("git_worktrees", { cwd: targetCwd }, worktreesReqId);
     }, [makeRequestId, registerRequestGeneration, sendStatusRequest]);
 
-    const sendFullStatusRequest = useCallback((targetCwd: string, options?: { asInitial?: boolean; fallbackToStatus?: boolean; fallbackMs?: number }) => {
+    const sendFullStatusRequest = useCallback((targetCwd: string, options?: { asInitial?: boolean; fallbackToStatus?: boolean; fallbackMs?: number; markBranchLoad?: boolean }) => {
         const asInitial = options?.asInitial === true;
         const fallbackToStatus = options?.fallbackToStatus === true;
         const fallbackMs = options?.fallbackMs ?? 1200;
+        const markBranchLoad = options?.markBranchLoad === true;
 
         statusGenRef.current = generationRef.current;
         const requestId = makeRequestId();
@@ -197,6 +208,9 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         markStatusRequestInFlight(requestId);
         if (asInitial) {
             pendingFullStatusRequestRef.current = requestId;
+        }
+        if (markBranchLoad) {
+            setBranchesState({ loading: true, error: null, partial: false });
         }
         setLoading(true);
         setError(null);
@@ -312,8 +326,10 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                         setCurrentBranch((payload.currentBranch as string) ?? "");
                         setWorktrees((payload.worktrees as GitWorktree[]) ?? []);
                         setError(null);
+                        setBranchesState((prev) => ({ ...prev, loading: false, error: null, partial: false }));
                     } else {
                         setError((payload.message as string) ?? "Failed to get git status");
+                        setBranchesState((prev) => ({ ...prev, loading: false, error: (payload.message as string) ?? "Failed to get git status", partial: prev.partial }));
                         sendLegacySnapshotRequests(cwdRef.current);
                     }
                     break;
@@ -341,6 +357,9 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     if (payload.ok) {
                         setBranches((payload.branches as GitBranch[]) ?? []);
                         setCurrentBranch((payload.currentBranch as string) ?? "");
+                        setBranchesState({ loading: false, error: null, partial: true });
+                    } else {
+                        setBranchesState({ loading: false, error: (payload.message as string) ?? "Failed to load branches", partial: false });
                     }
                     break;
                 }
@@ -354,7 +373,8 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 case "git_checkout_result":
                 case "git_commit_result":
                 case "git_push_result":
-                case "git_pull_result": {
+                case "git_pull_result":
+                case "git_merge_result": {
                     if (!isRequestCurrentGeneration(requestId)) break;
                     setOperationInProgress(null);
                     setLastOperationResult(payload as GitOperationResult);
@@ -382,7 +402,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     } else {
                         // Avoid stale rollback races across overlapping optimistic mutations.
                         // Re-sync from authoritative runner state instead.
-                        sendStatusRequest(cwdRef.current);
+                        sendFullStatusRequest(cwdRef.current, { asInitial: false, fallbackToStatus: true, fallbackMs: 1200 });
                     }
                     break;
                 }
@@ -445,10 +465,11 @@ export function useGitService(cwd: string): UseGitServiceReturn {
 
     const fetchBranches = useCallback(() => {
         if (!available) return;
-        const requestId = makeRequestId();
-        registerRequestGeneration(requestId);
-        send("git_branches", { cwd }, requestId);
-    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
+        const now = Date.now();
+        if (now - lastBranchFetchRef.current < 500) return;
+        lastBranchFetchRef.current = now;
+        sendFullStatusRequest(cwd, { asInitial: false, fallbackToStatus: true, fallbackMs: 1200, markBranchLoad: true });
+    }, [available, cwd, sendFullStatusRequest]);
 
     const fetchWorktrees = useCallback(() => {
         if (!available) return;
@@ -536,13 +557,22 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         send("git_push", { cwd, setUpstream }, requestId);
     }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
-    const pull = useCallback(() => {
+    const pull = useCallback((rebase = false) => {
         if (!available) return;
         const requestId = makeRequestId();
         registerRequestGeneration(requestId);
         setOperationInProgress("pull");
         setLastOperationResult(null);
-        send("git_pull", { cwd }, requestId);
+        send("git_pull", { cwd, rebase }, requestId);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
+
+    const merge = useCallback((branch: string) => {
+        if (!available || !branch) return;
+        const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
+        setOperationInProgress("merge");
+        setLastOperationResult(null);
+        send("git_merge", { cwd, branch }, requestId);
     }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const clearOperationResult = useCallback(() => {
@@ -556,6 +586,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         // Clear state immediately so old data doesn't flash
         setStatus(null);
         setBranches([]);
+        setBranchesState({ loading: false, error: null, partial: false });
         setWorktrees([]);
         setCurrentBranch("");
         setError(null);
@@ -593,6 +624,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         available,
         status,
         branches,
+        branchesState,
         worktrees,
         currentBranch,
         loading,
@@ -611,6 +643,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         commit,
         push,
         pull,
+        merge,
         clearOperationResult,
     };
 }

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -238,20 +238,19 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                         setLoading(false);
                     }
 
+                    // Ignore late full-status responses once initial request was superseded.
+                    if (!isInitialFullStatus) break;
+
                     if (payload.ok) {
-                        // After fallback, still accept late full-status for auxiliary data
-                        // (branches/worktrees/currentBranch) without overwriting fresher status.
-                        if (isInitialFullStatus) {
-                            const statusPayload = (payload.status as Record<string, unknown> | undefined) ?? payload;
-                            setStatus({
-                                branch: (statusPayload.branch as string) ?? "",
-                                changes: (statusPayload.changes as GitChange[]) ?? [],
-                                ahead: (statusPayload.ahead as number) ?? 0,
-                                behind: (statusPayload.behind as number) ?? 0,
-                                hasUpstream: (statusPayload.hasUpstream as boolean) ?? false,
-                                diffStaged: (statusPayload.diffStaged as string) ?? "",
-                            });
-                        }
+                        const statusPayload = (payload.status as Record<string, unknown> | undefined) ?? payload;
+                        setStatus({
+                            branch: (statusPayload.branch as string) ?? "",
+                            changes: (statusPayload.changes as GitChange[]) ?? [],
+                            ahead: (statusPayload.ahead as number) ?? 0,
+                            behind: (statusPayload.behind as number) ?? 0,
+                            hasUpstream: (statusPayload.hasUpstream as boolean) ?? false,
+                            diffStaged: (statusPayload.diffStaged as string) ?? "",
+                        });
                         setBranches((payload.branches as GitBranch[]) ?? []);
                         setCurrentBranch((payload.currentBranch as string) ?? "");
                         setWorktrees((payload.worktrees as GitWorktree[]) ?? []);

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -258,6 +258,8 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                         setError(null);
                     } else if (isInitialFullStatus) {
                         setError((payload.message as string) ?? "Failed to get git status");
+                        // Explicit failure from full-status should immediately fall back.
+                        sendStatusRequest(cwdRef.current);
                     }
                     break;
                 }

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -180,6 +180,12 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             statusRequestRetireTimersRef.current.delete(requestId);
             requestGenerationRef.current.delete(requestId);
             markStatusRequestSettled(requestId);
+            // If no other status requests are still in-flight, clear the loading
+            // state so the panel doesn't stay stuck in an indefinite loading state
+            // when this request is abandoned before a response arrives.
+            if (statusRequestsInFlightRef.current.size === 0) {
+                setLoading(false);
+            }
         }, 8000);
         statusRequestRetireTimersRef.current.set(requestId, retireTimer);
     }, [makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, registerRequestGeneration]);

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -105,10 +105,12 @@ export function useGitService(cwd: string): UseGitServiceReturn {
 
     // Track pending diff requests: requestId → resolve callback
     const pendingDiffsRef = useRef(new Map<string, (diff: string) => void>());
+    const pendingDiffTimeoutsRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
     const pendingFullStatusRequestRef = useRef<string | null>(null);
     const fullStatusFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const statusRequestsInFlightRef = useRef(new Set<string>());
     const optimisticSnapshotsRef = useRef(new Map<string, GitStatus | null>());
+    const requestGenerationRef = useRef(new Map<string, number>());
 
     // Generation counter — incremented on cwd change. Responses from stale
     // generations are discarded so a slow response from the old cwd doesn't
@@ -137,14 +139,32 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         statusRequestsInFlightRef.current.delete(requestId);
     }, []);
 
+    const registerRequestGeneration = useCallback((requestId: string) => {
+        requestGenerationRef.current.set(requestId, generationRef.current);
+    }, []);
+
+    const consumeRequestGeneration = useCallback((requestId?: string): number | null => {
+        if (!requestId) return null;
+        const generation = requestGenerationRef.current.get(requestId) ?? null;
+        requestGenerationRef.current.delete(requestId);
+        return generation;
+    }, []);
+
+    const isRequestCurrentGeneration = useCallback((requestId?: string): boolean => {
+        const requestGeneration = consumeRequestGeneration(requestId);
+        if (requestGeneration === null) return false;
+        return requestGeneration === generationRef.current;
+    }, [consumeRequestGeneration]);
+
     const sendStatusRequest = useCallback((targetCwd: string) => {
         statusGenRef.current = generationRef.current;
         const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
         markStatusRequestInFlight(requestId);
         setLoading(true);
         setError(null);
         sendRef.current("git_status", { cwd: targetCwd }, requestId);
-    }, [makeRequestId, markStatusRequestInFlight]);
+    }, [makeRequestId, markStatusRequestInFlight, registerRequestGeneration]);
 
     const postMutationRefreshSchedulerRef = useRef(
         createPostMutationRefreshScheduler({
@@ -163,7 +183,10 @@ export function useGitService(cwd: string): UseGitServiceReturn {
 
             switch (type) {
                 case "git_status_result": {
-                    markStatusRequestSettled(requestId);
+                    if (requestId) {
+                        if (!isRequestCurrentGeneration(requestId)) break;
+                        markStatusRequestSettled(requestId);
+                    }
                     // Ignore stale responses from a previous cwd
                     if (statusGenRef.current !== generationRef.current) break;
                     setLoading(false);
@@ -183,15 +206,16 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     break;
                 }
                 case "git_full_status_result": {
+                    if (!isRequestCurrentGeneration(requestId)) break;
                     markStatusRequestSettled(requestId);
                     // Ignore stale responses from a previous cwd
                     if (statusGenRef.current !== generationRef.current) break;
-                    if (requestId && pendingFullStatusRequestRef.current === requestId) {
-                        pendingFullStatusRequestRef.current = null;
-                        if (fullStatusFallbackTimerRef.current) {
-                            clearTimeout(fullStatusFallbackTimerRef.current);
-                            fullStatusFallbackTimerRef.current = null;
-                        }
+                    // Ignore late/abandoned full-status responses once fallback has moved on.
+                    if (!requestId || pendingFullStatusRequestRef.current !== requestId) break;
+                    pendingFullStatusRequestRef.current = null;
+                    if (fullStatusFallbackTimerRef.current) {
+                        clearTimeout(fullStatusFallbackTimerRef.current);
+                        fullStatusFallbackTimerRef.current = null;
                     }
 
                     setLoading(false);
@@ -216,6 +240,11 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 }
                 case "git_diff_result": {
                     if (requestId && pendingDiffsRef.current.has(requestId)) {
+                        const timeoutId = pendingDiffTimeoutsRef.current.get(requestId);
+                        if (timeoutId) {
+                            clearTimeout(timeoutId);
+                            pendingDiffTimeoutsRef.current.delete(requestId);
+                        }
                         const resolve = pendingDiffsRef.current.get(requestId)!;
                         pendingDiffsRef.current.delete(requestId);
                         resolve(
@@ -227,6 +256,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     break;
                 }
                 case "git_branches_result": {
+                    if (!isRequestCurrentGeneration(requestId)) break;
                     if (payload.ok) {
                         setBranches((payload.branches as GitBranch[]) ?? []);
                         setCurrentBranch((payload.currentBranch as string) ?? "");
@@ -234,6 +264,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     break;
                 }
                 case "git_worktrees_result": {
+                    if (!isRequestCurrentGeneration(requestId)) break;
                     if (payload.ok) {
                         setWorktrees((payload.worktrees as GitWorktree[]) ?? []);
                     }
@@ -243,6 +274,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 case "git_commit_result":
                 case "git_push_result":
                 case "git_pull_result": {
+                    if (!isRequestCurrentGeneration(requestId)) break;
                     setOperationInProgress(null);
                     setLastOperationResult(payload as GitOperationResult);
                     // Auto-refresh status after successful mutating operations.
@@ -254,6 +286,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 }
                 case "git_stage_result":
                 case "git_unstage_result": {
+                    if (!isRequestCurrentGeneration(requestId)) break;
                     setOperationInProgress(null);
                     setLastOperationResult(payload as GitOperationResult);
 
@@ -281,9 +314,14 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     // Clean up pending diffs on unmount
     useEffect(() => {
         return () => {
+            for (const timeoutId of pendingDiffTimeoutsRef.current.values()) {
+                clearTimeout(timeoutId);
+            }
+            pendingDiffTimeoutsRef.current.clear();
             pendingDiffsRef.current.clear();
             optimisticSnapshotsRef.current.clear();
             statusRequestsInFlightRef.current.clear();
+            requestGenerationRef.current.clear();
             postMutationRefreshSchedulerRef.current.dispose();
             if (fullStatusFallbackTimerRef.current) {
                 clearTimeout(fullStatusFallbackTimerRef.current);
@@ -306,39 +344,50 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 return;
             }
             const reqId = makeRequestId();
+            registerRequestGeneration(reqId);
             pendingDiffsRef.current.set(reqId, resolve);
             send("git_diff", { cwd, path, staged }, reqId);
 
             // Timeout after 15s
-            setTimeout(() => {
+            const timeoutId = setTimeout(() => {
+                pendingDiffTimeoutsRef.current.delete(reqId);
+                requestGenerationRef.current.delete(reqId);
                 if (pendingDiffsRef.current.has(reqId)) {
                     pendingDiffsRef.current.delete(reqId);
                     resolve("(diff request timed out)");
                 }
             }, 15000);
+            pendingDiffTimeoutsRef.current.set(reqId, timeoutId);
         });
-    }, [available, send, cwd, makeRequestId]);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const fetchBranches = useCallback(() => {
         if (!available) return;
-        send("git_branches", { cwd }, makeRequestId());
-    }, [available, send, cwd, makeRequestId]);
+        const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
+        send("git_branches", { cwd }, requestId);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const fetchWorktrees = useCallback(() => {
         if (!available) return;
-        send("git_worktrees", { cwd }, makeRequestId());
-    }, [available, send, cwd, makeRequestId]);
+        const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
+        send("git_worktrees", { cwd }, requestId);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const checkout = useCallback((branch: string, isRemote = false) => {
         if (!available) return;
+        const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
         setOperationInProgress("checkout");
         setLastOperationResult(null);
-        send("git_checkout", { cwd, branch, isRemote }, makeRequestId());
-    }, [available, send, cwd, makeRequestId]);
+        send("git_checkout", { cwd, branch, isRemote }, requestId);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const stage = useCallback((paths: string[]) => {
         if (!available) return;
         const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
         setOperationInProgress("stage");
         setLastOperationResult(null);
         setStatus((prev: GitStatus | null) => {
@@ -346,11 +395,12 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             return applyOptimisticMutation(prev, { type: "stage", paths });
         });
         send("git_stage", { cwd, paths }, requestId);
-    }, [available, send, cwd, makeRequestId]);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const stageAll = useCallback(() => {
         if (!available) return;
         const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
         setOperationInProgress("stage");
         setLastOperationResult(null);
         setStatus((prev: GitStatus | null) => {
@@ -358,11 +408,12 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             return applyOptimisticMutation(prev, { type: "stage", all: true });
         });
         send("git_stage", { cwd, all: true }, requestId);
-    }, [available, send, cwd, makeRequestId]);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const unstage = useCallback((paths: string[]) => {
         if (!available) return;
         const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
         setOperationInProgress("unstage");
         setLastOperationResult(null);
         setStatus((prev: GitStatus | null) => {
@@ -370,11 +421,12 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             return applyOptimisticMutation(prev, { type: "unstage", paths });
         });
         send("git_unstage", { cwd, paths }, requestId);
-    }, [available, send, cwd, makeRequestId]);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const unstageAll = useCallback(() => {
         if (!available) return;
         const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
         setOperationInProgress("unstage");
         setLastOperationResult(null);
         setStatus((prev: GitStatus | null) => {
@@ -382,28 +434,34 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             return applyOptimisticMutation(prev, { type: "unstage", all: true });
         });
         send("git_unstage", { cwd, all: true }, requestId);
-    }, [available, send, cwd, makeRequestId]);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const commit = useCallback((message: string) => {
         if (!available) return;
+        const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
         setOperationInProgress("commit");
         setLastOperationResult(null);
-        send("git_commit", { cwd, message }, makeRequestId());
-    }, [available, send, cwd, makeRequestId]);
+        send("git_commit", { cwd, message }, requestId);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const push = useCallback((setUpstream = false) => {
         if (!available) return;
+        const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
         setOperationInProgress("push");
         setLastOperationResult(null);
-        send("git_push", { cwd, setUpstream }, makeRequestId());
-    }, [available, send, cwd, makeRequestId]);
+        send("git_push", { cwd, setUpstream }, requestId);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const pull = useCallback(() => {
         if (!available) return;
+        const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
         setOperationInProgress("pull");
         setLastOperationResult(null);
-        send("git_pull", { cwd }, makeRequestId());
-    }, [available, send, cwd, makeRequestId]);
+        send("git_pull", { cwd }, requestId);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
     const clearOperationResult = useCallback(() => {
         setLastOperationResult(null);
@@ -421,7 +479,12 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         setError(null);
         setOperationInProgress(null);
         setLastOperationResult(null);
+        for (const timeoutId of pendingDiffTimeoutsRef.current.values()) {
+            clearTimeout(timeoutId);
+        }
+        pendingDiffTimeoutsRef.current.clear();
         pendingDiffsRef.current.clear();
+        requestGenerationRef.current.clear();
         pendingFullStatusRequestRef.current = null;
         optimisticSnapshotsRef.current.clear();
         postMutationRefreshSchedulerRef.current.cancel();
@@ -439,6 +502,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             // Compatibility fallback: if an older runner doesn't support git_full_status,
             // fall back to git_status after a short delay.
             const requestId = makeRequestId();
+            registerRequestGeneration(requestId);
             pendingFullStatusRequestRef.current = requestId;
             markStatusRequestInFlight(requestId);
             send("git_full_status", { cwd }, requestId);
@@ -455,7 +519,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         } else {
             setLoading(false);
         }
-    }, [available, cwd, makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, send, sendStatusRequest]);
+    }, [available, cwd, makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, registerRequestGeneration, send, sendStatusRequest]);
 
     return {
         available,

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -166,6 +166,19 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         sendRef.current("git_status", { cwd: targetCwd }, requestId);
     }, [makeRequestId, markStatusRequestInFlight, registerRequestGeneration]);
 
+    const clearPendingDiffs = useCallback((resolution: string) => {
+        for (const timeoutId of pendingDiffTimeoutsRef.current.values()) {
+            clearTimeout(timeoutId);
+        }
+        pendingDiffTimeoutsRef.current.clear();
+
+        for (const [requestId, resolveDiff] of pendingDiffsRef.current.entries()) {
+            requestGenerationRef.current.delete(requestId);
+            resolveDiff(resolution);
+        }
+        pendingDiffsRef.current.clear();
+    }, []);
+
     const postMutationRefreshSchedulerRef = useRef(
         createPostMutationRefreshScheduler({
             debounceMs: POST_MUTATION_STATUS_REFRESH_DEBOUNCE_MS,
@@ -186,6 +199,10 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     if (requestId) {
                         if (!isRequestCurrentGeneration(requestId)) break;
                         markStatusRequestSettled(requestId);
+                    } else {
+                        // Proactive push with no requestId: accept only for current cwd.
+                        const payloadCwd = typeof payload.cwd === "string" ? payload.cwd : null;
+                        if (!payloadCwd || payloadCwd !== cwdRef.current) break;
                     }
                     // Ignore stale responses from a previous cwd
                     if (statusGenRef.current !== generationRef.current) break;
@@ -245,6 +262,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                             clearTimeout(timeoutId);
                             pendingDiffTimeoutsRef.current.delete(requestId);
                         }
+                        requestGenerationRef.current.delete(requestId);
                         const resolve = pendingDiffsRef.current.get(requestId)!;
                         pendingDiffsRef.current.delete(requestId);
                         resolve(
@@ -314,11 +332,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     // Clean up pending diffs on unmount
     useEffect(() => {
         return () => {
-            for (const timeoutId of pendingDiffTimeoutsRef.current.values()) {
-                clearTimeout(timeoutId);
-            }
-            pendingDiffTimeoutsRef.current.clear();
-            pendingDiffsRef.current.clear();
+            clearPendingDiffs("(diff request cancelled)");
             optimisticSnapshotsRef.current.clear();
             statusRequestsInFlightRef.current.clear();
             requestGenerationRef.current.clear();
@@ -328,7 +342,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 fullStatusFallbackTimerRef.current = null;
             }
         };
-    }, []);
+    }, [clearPendingDiffs]);
 
     // ── Actions ─────────────────────────────────────────────────────────
 
@@ -479,11 +493,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         setError(null);
         setOperationInProgress(null);
         setLastOperationResult(null);
-        for (const timeoutId of pendingDiffTimeoutsRef.current.values()) {
-            clearTimeout(timeoutId);
-        }
-        pendingDiffTimeoutsRef.current.clear();
-        pendingDiffsRef.current.clear();
+        clearPendingDiffs("(diff request cancelled)");
         requestGenerationRef.current.clear();
         pendingFullStatusRequestRef.current = null;
         optimisticSnapshotsRef.current.clear();
@@ -519,7 +529,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         } else {
             setLoading(false);
         }
-    }, [available, cwd, makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, registerRequestGeneration, send, sendStatusRequest]);
+    }, [available, clearPendingDiffs, cwd, makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, registerRequestGeneration, send, sendStatusRequest]);
 
     return {
         available,

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -7,6 +7,12 @@
  */
 import { useState, useCallback, useRef, useEffect } from "react";
 import { useServiceChannel } from "./useServiceChannel";
+import { createPostMutationRefreshScheduler } from "./git-status-refresh-scheduler";
+import {
+    applyOptimisticMutation,
+    cloneStatusSnapshot,
+    consumeRollbackSnapshot,
+} from "./git-optimistic-status";
 
 // ── Types ───────────────────────────────────────────────────────────────────
 
@@ -85,6 +91,8 @@ export interface UseGitServiceReturn {
     clearOperationResult: () => void;
 }
 
+const POST_MUTATION_STATUS_REFRESH_DEBOUNCE_MS = 100;
+
 export function useGitService(cwd: string): UseGitServiceReturn {
     const [status, setStatus] = useState<GitStatus | null>(null);
     const [branches, setBranches] = useState<GitBranch[]>([]);
@@ -97,6 +105,10 @@ export function useGitService(cwd: string): UseGitServiceReturn {
 
     // Track pending diff requests: requestId → resolve callback
     const pendingDiffsRef = useRef(new Map<string, (diff: string) => void>());
+    const pendingFullStatusRequestRef = useRef<string | null>(null);
+    const fullStatusFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const statusRequestsInFlightRef = useRef(0);
+    const optimisticSnapshotsRef = useRef(new Map<string, GitStatus | null>());
 
     // Generation counter — incremented on cwd change. Responses from stale
     // generations are discarded so a slow response from the old cwd doesn't
@@ -116,12 +128,32 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     // Ref for sendGit so callbacks can access latest version
     const sendRef = useRef<(type: string, payload: unknown, requestId?: string) => void>(() => {});
 
+    const sendStatusRequest = useCallback((targetCwd: string) => {
+        statusGenRef.current = generationRef.current;
+        statusRequestsInFlightRef.current += 1;
+        setLoading(true);
+        setError(null);
+        sendRef.current("git_status", { cwd: targetCwd }, makeRequestId());
+    }, [makeRequestId]);
+
+    const postMutationRefreshSchedulerRef = useRef(
+        createPostMutationRefreshScheduler({
+            debounceMs: POST_MUTATION_STATUS_REFRESH_DEBOUNCE_MS,
+            getGeneration: () => generationRef.current,
+            isStatusRequestInFlight: () => statusRequestsInFlightRef.current > 0,
+            triggerRefresh: () => {
+                sendStatusRequest(cwdRef.current);
+            },
+        })
+    );
+
     const { send, available } = useServiceChannel<unknown, unknown>("git", {
         onMessage: (type, rawPayload, requestId) => {
             const payload = rawPayload as Record<string, unknown>;
 
             switch (type) {
                 case "git_status_result": {
+                    statusRequestsInFlightRef.current = Math.max(0, statusRequestsInFlightRef.current - 1);
                     // Ignore stale responses from a previous cwd
                     if (statusGenRef.current !== generationRef.current) break;
                     setLoading(false);
@@ -134,6 +166,38 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                             hasUpstream: (payload.hasUpstream as boolean) ?? false,
                             diffStaged: (payload.diffStaged as string) ?? "",
                         });
+                        setError(null);
+                    } else {
+                        setError((payload.message as string) ?? "Failed to get git status");
+                    }
+                    break;
+                }
+                case "git_full_status_result": {
+                    statusRequestsInFlightRef.current = Math.max(0, statusRequestsInFlightRef.current - 1);
+                    // Ignore stale responses from a previous cwd
+                    if (statusGenRef.current !== generationRef.current) break;
+                    if (requestId && pendingFullStatusRequestRef.current === requestId) {
+                        pendingFullStatusRequestRef.current = null;
+                        if (fullStatusFallbackTimerRef.current) {
+                            clearTimeout(fullStatusFallbackTimerRef.current);
+                            fullStatusFallbackTimerRef.current = null;
+                        }
+                    }
+
+                    setLoading(false);
+                    if (payload.ok) {
+                        const statusPayload = (payload.status as Record<string, unknown> | undefined) ?? payload;
+                        setStatus({
+                            branch: (statusPayload.branch as string) ?? "",
+                            changes: (statusPayload.changes as GitChange[]) ?? [],
+                            ahead: (statusPayload.ahead as number) ?? 0,
+                            behind: (statusPayload.behind as number) ?? 0,
+                            hasUpstream: (statusPayload.hasUpstream as boolean) ?? false,
+                            diffStaged: (statusPayload.diffStaged as string) ?? "",
+                        });
+                        setBranches((payload.branches as GitBranch[]) ?? []);
+                        setCurrentBranch((payload.currentBranch as string) ?? "");
+                        setWorktrees((payload.worktrees as GitWorktree[]) ?? []);
                         setError(null);
                     } else {
                         setError((payload.message as string) ?? "Failed to get git status");
@@ -166,18 +230,34 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     break;
                 }
                 case "git_checkout_result":
-                case "git_stage_result":
-                case "git_unstage_result":
                 case "git_commit_result":
                 case "git_push_result":
                 case "git_pull_result": {
                     setOperationInProgress(null);
                     setLastOperationResult(payload as GitOperationResult);
-                    // Auto-refresh status after mutating operations
+                    // Auto-refresh status after successful mutating operations.
+                    // Debounced/coalesced to avoid hammering git status during rapid updates.
                     if (payload.ok) {
-                        setTimeout(() => {
-                            sendRef.current("git_status", { cwd: cwdRef.current });
-                        }, 100);
+                        postMutationRefreshSchedulerRef.current.schedule();
+                    }
+                    break;
+                }
+                case "git_stage_result":
+                case "git_unstage_result": {
+                    setOperationInProgress(null);
+                    setLastOperationResult(payload as GitOperationResult);
+
+                    const rollbackStatus = consumeRollbackSnapshot(
+                        optimisticSnapshotsRef.current,
+                        requestId,
+                        payload.ok === true,
+                    );
+                    if (payload.ok !== true && rollbackStatus !== undefined) {
+                        setStatus(rollbackStatus);
+                    }
+
+                    if (payload.ok) {
+                        postMutationRefreshSchedulerRef.current.schedule();
                     }
                     break;
                 }
@@ -192,6 +272,12 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     useEffect(() => {
         return () => {
             pendingDiffsRef.current.clear();
+            optimisticSnapshotsRef.current.clear();
+            postMutationRefreshSchedulerRef.current.dispose();
+            if (fullStatusFallbackTimerRef.current) {
+                clearTimeout(fullStatusFallbackTimerRef.current);
+                fullStatusFallbackTimerRef.current = null;
+            }
         };
     }, []);
 
@@ -199,11 +285,8 @@ export function useGitService(cwd: string): UseGitServiceReturn {
 
     const fetchStatus = useCallback(() => {
         if (!available) return;
-        statusGenRef.current = generationRef.current;
-        setLoading(true);
-        setError(null);
-        send("git_status", { cwd }, makeRequestId());
-    }, [available, send, cwd, makeRequestId]);
+        sendStatusRequest(cwd);
+    }, [available, sendStatusRequest, cwd]);
 
     const fetchDiff = useCallback((path: string, staged = false): Promise<string> => {
         return new Promise((resolve) => {
@@ -244,30 +327,50 @@ export function useGitService(cwd: string): UseGitServiceReturn {
 
     const stage = useCallback((paths: string[]) => {
         if (!available) return;
+        const requestId = makeRequestId();
         setOperationInProgress("stage");
         setLastOperationResult(null);
-        send("git_stage", { cwd, paths }, makeRequestId());
+        setStatus((prev: GitStatus | null) => {
+            optimisticSnapshotsRef.current.set(requestId, cloneStatusSnapshot(prev));
+            return applyOptimisticMutation(prev, { type: "stage", paths });
+        });
+        send("git_stage", { cwd, paths }, requestId);
     }, [available, send, cwd, makeRequestId]);
 
     const stageAll = useCallback(() => {
         if (!available) return;
+        const requestId = makeRequestId();
         setOperationInProgress("stage");
         setLastOperationResult(null);
-        send("git_stage", { cwd, all: true }, makeRequestId());
+        setStatus((prev: GitStatus | null) => {
+            optimisticSnapshotsRef.current.set(requestId, cloneStatusSnapshot(prev));
+            return applyOptimisticMutation(prev, { type: "stage", all: true });
+        });
+        send("git_stage", { cwd, all: true }, requestId);
     }, [available, send, cwd, makeRequestId]);
 
     const unstage = useCallback((paths: string[]) => {
         if (!available) return;
+        const requestId = makeRequestId();
         setOperationInProgress("unstage");
         setLastOperationResult(null);
-        send("git_unstage", { cwd, paths }, makeRequestId());
+        setStatus((prev: GitStatus | null) => {
+            optimisticSnapshotsRef.current.set(requestId, cloneStatusSnapshot(prev));
+            return applyOptimisticMutation(prev, { type: "unstage", paths });
+        });
+        send("git_unstage", { cwd, paths }, requestId);
     }, [available, send, cwd, makeRequestId]);
 
     const unstageAll = useCallback(() => {
         if (!available) return;
+        const requestId = makeRequestId();
         setOperationInProgress("unstage");
         setLastOperationResult(null);
-        send("git_unstage", { cwd, all: true }, makeRequestId());
+        setStatus((prev: GitStatus | null) => {
+            optimisticSnapshotsRef.current.set(requestId, cloneStatusSnapshot(prev));
+            return applyOptimisticMutation(prev, { type: "unstage", all: true });
+        });
+        send("git_unstage", { cwd, all: true }, requestId);
     }, [available, send, cwd, makeRequestId]);
 
     const commit = useCallback((message: string) => {
@@ -308,11 +411,36 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         setOperationInProgress(null);
         setLastOperationResult(null);
         pendingDiffsRef.current.clear();
+        pendingFullStatusRequestRef.current = null;
+        optimisticSnapshotsRef.current.clear();
+        postMutationRefreshSchedulerRef.current.cancel();
+        statusRequestsInFlightRef.current = 0;
+        if (fullStatusFallbackTimerRef.current) {
+            clearTimeout(fullStatusFallbackTimerRef.current);
+            fullStatusFallbackTimerRef.current = null;
+        }
 
         if (available && cwd) {
             statusGenRef.current = generationRef.current;
+            statusRequestsInFlightRef.current += 1;
             setLoading(true);
-            send("git_status", { cwd }, makeRequestId());
+
+            // Initial load optimization: request status + branches + worktrees in one round-trip.
+            // Compatibility fallback: if an older runner doesn't support git_full_status,
+            // fall back to git_status after a short delay.
+            const requestId = makeRequestId();
+            pendingFullStatusRequestRef.current = requestId;
+            send("git_full_status", { cwd }, requestId);
+
+            fullStatusFallbackTimerRef.current = setTimeout(() => {
+                fullStatusFallbackTimerRef.current = null;
+                if (statusGenRef.current !== generationRef.current) return;
+                if (!pendingFullStatusRequestRef.current) return;
+                pendingFullStatusRequestRef.current = null;
+                sendStatusRequest(cwdRef.current);
+            }, 1200);
+        } else {
+            setLoading(false);
         }
     }, [available, cwd]); // eslint-disable-line react-hooks/exhaustive-deps
 

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -583,6 +583,9 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     // Bump generation so in-flight responses from the old cwd are discarded.
     useEffect(() => {
         generationRef.current++;
+        // Reset branch-fetch throttle so the first fetch in the new context
+        // always runs immediately, even if the previous fetch happened <500ms ago.
+        lastBranchFetchRef.current = 0;
         // Clear state immediately so old data doesn't flash
         setStatus(null);
         setBranches([]);

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -227,30 +227,36 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     markStatusRequestSettled(requestId);
                     // Ignore stale responses from a previous cwd
                     if (statusGenRef.current !== generationRef.current) break;
-                    // Ignore late/abandoned full-status responses once fallback has moved on.
-                    if (!requestId || pendingFullStatusRequestRef.current !== requestId) break;
-                    pendingFullStatusRequestRef.current = null;
-                    if (fullStatusFallbackTimerRef.current) {
-                        clearTimeout(fullStatusFallbackTimerRef.current);
-                        fullStatusFallbackTimerRef.current = null;
+
+                    const isInitialFullStatus = !!requestId && pendingFullStatusRequestRef.current === requestId;
+                    if (isInitialFullStatus) {
+                        pendingFullStatusRequestRef.current = null;
+                        if (fullStatusFallbackTimerRef.current) {
+                            clearTimeout(fullStatusFallbackTimerRef.current);
+                            fullStatusFallbackTimerRef.current = null;
+                        }
+                        setLoading(false);
                     }
 
-                    setLoading(false);
                     if (payload.ok) {
-                        const statusPayload = (payload.status as Record<string, unknown> | undefined) ?? payload;
-                        setStatus({
-                            branch: (statusPayload.branch as string) ?? "",
-                            changes: (statusPayload.changes as GitChange[]) ?? [],
-                            ahead: (statusPayload.ahead as number) ?? 0,
-                            behind: (statusPayload.behind as number) ?? 0,
-                            hasUpstream: (statusPayload.hasUpstream as boolean) ?? false,
-                            diffStaged: (statusPayload.diffStaged as string) ?? "",
-                        });
+                        // After fallback, still accept late full-status for auxiliary data
+                        // (branches/worktrees/currentBranch) without overwriting fresher status.
+                        if (isInitialFullStatus) {
+                            const statusPayload = (payload.status as Record<string, unknown> | undefined) ?? payload;
+                            setStatus({
+                                branch: (statusPayload.branch as string) ?? "",
+                                changes: (statusPayload.changes as GitChange[]) ?? [],
+                                ahead: (statusPayload.ahead as number) ?? 0,
+                                behind: (statusPayload.behind as number) ?? 0,
+                                hasUpstream: (statusPayload.hasUpstream as boolean) ?? false,
+                                diffStaged: (statusPayload.diffStaged as string) ?? "",
+                            });
+                        }
                         setBranches((payload.branches as GitBranch[]) ?? []);
                         setCurrentBranch((payload.currentBranch as string) ?? "");
                         setWorktrees((payload.worktrees as GitWorktree[]) ?? []);
                         setError(null);
-                    } else {
+                    } else if (isInitialFullStatus) {
                         setError((payload.message as string) ?? "Failed to get git status");
                     }
                     break;

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -107,7 +107,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     const pendingDiffsRef = useRef(new Map<string, (diff: string) => void>());
     const pendingDiffTimeoutsRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
     const pendingFullStatusRequestRef = useRef<string | null>(null);
-    const fullStatusFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const fullStatusFallbackTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
     const statusRequestsInFlightRef = useRef(new Set<string>());
     const optimisticSnapshotsRef = useRef(new Map<string, GitStatus | null>());
     const requestGenerationRef = useRef(new Map<string, number>());
@@ -166,7 +166,11 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         sendRef.current("git_status", { cwd: targetCwd }, requestId);
     }, [makeRequestId, markStatusRequestInFlight, registerRequestGeneration]);
 
-    const sendFullStatusRequest = useCallback((targetCwd: string, asInitial = false) => {
+    const sendFullStatusRequest = useCallback((targetCwd: string, options?: { asInitial?: boolean; fallbackToStatus?: boolean; fallbackMs?: number }) => {
+        const asInitial = options?.asInitial === true;
+        const fallbackToStatus = options?.fallbackToStatus === true;
+        const fallbackMs = options?.fallbackMs ?? 1200;
+
         statusGenRef.current = generationRef.current;
         const requestId = makeRequestId();
         registerRequestGeneration(requestId);
@@ -177,7 +181,21 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         setLoading(true);
         setError(null);
         sendRef.current("git_full_status", { cwd: targetCwd }, requestId);
-    }, [makeRequestId, markStatusRequestInFlight, registerRequestGeneration]);
+
+        if (fallbackToStatus) {
+            const timerId = setTimeout(() => {
+                fullStatusFallbackTimersRef.current.delete(requestId);
+                if (statusGenRef.current !== generationRef.current) return;
+                if (asInitial && pendingFullStatusRequestRef.current !== requestId) return;
+                if (asInitial) pendingFullStatusRequestRef.current = null;
+                markStatusRequestSettled(requestId);
+                sendStatusRequest(cwdRef.current);
+            }, fallbackMs);
+            fullStatusFallbackTimersRef.current.set(requestId, timerId);
+        }
+
+        return requestId;
+    }, [makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, registerRequestGeneration, sendStatusRequest]);
 
     const clearPendingDiffs = useCallback((resolution: string) => {
         for (const timeoutId of pendingDiffTimeoutsRef.current.values()) {
@@ -198,7 +216,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             getGeneration: () => generationRef.current,
             isStatusRequestInFlight: () => statusRequestsInFlightRef.current.size > 0,
             triggerRefresh: () => {
-                sendFullStatusRequest(cwdRef.current, false);
+                sendFullStatusRequest(cwdRef.current, { asInitial: false, fallbackToStatus: true, fallbackMs: 1200 });
             },
         })
     );
@@ -238,40 +256,38 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 case "git_full_status_result": {
                     if (!isRequestCurrentGeneration(requestId)) break;
                     markStatusRequestSettled(requestId);
+                    if (requestId) {
+                        const timerId = fullStatusFallbackTimersRef.current.get(requestId);
+                        if (timerId) {
+                            clearTimeout(timerId);
+                            fullStatusFallbackTimersRef.current.delete(requestId);
+                        }
+                    }
                     // Ignore stale responses from a previous cwd
                     if (statusGenRef.current !== generationRef.current) break;
 
                     const isInitialFullStatus = !!requestId && pendingFullStatusRequestRef.current === requestId;
                     if (isInitialFullStatus) {
                         pendingFullStatusRequestRef.current = null;
-                        if (fullStatusFallbackTimerRef.current) {
-                            clearTimeout(fullStatusFallbackTimerRef.current);
-                            fullStatusFallbackTimerRef.current = null;
-                        }
-                        setLoading(false);
                     }
 
+                    setLoading(false);
                     if (payload.ok) {
-                        if (isInitialFullStatus) {
-                            const statusPayload = (payload.status as Record<string, unknown> | undefined) ?? payload;
-                            setStatus({
-                                branch: (statusPayload.branch as string) ?? "",
-                                changes: (statusPayload.changes as GitChange[]) ?? [],
-                                ahead: (statusPayload.ahead as number) ?? 0,
-                                behind: (statusPayload.behind as number) ?? 0,
-                                hasUpstream: (statusPayload.hasUpstream as boolean) ?? false,
-                                diffStaged: (statusPayload.diffStaged as string) ?? "",
-                            });
-                        }
-                        // Late same-generation full-status can still provide fresh
-                        // branches/worktrees metadata after fallback/manual refresh.
+                        const statusPayload = (payload.status as Record<string, unknown> | undefined) ?? payload;
+                        setStatus({
+                            branch: (statusPayload.branch as string) ?? "",
+                            changes: (statusPayload.changes as GitChange[]) ?? [],
+                            ahead: (statusPayload.ahead as number) ?? 0,
+                            behind: (statusPayload.behind as number) ?? 0,
+                            hasUpstream: (statusPayload.hasUpstream as boolean) ?? false,
+                            diffStaged: (statusPayload.diffStaged as string) ?? "",
+                        });
                         setBranches((payload.branches as GitBranch[]) ?? []);
                         setCurrentBranch((payload.currentBranch as string) ?? "");
                         setWorktrees((payload.worktrees as GitWorktree[]) ?? []);
                         setError(null);
-                    } else if (isInitialFullStatus) {
+                    } else {
                         setError((payload.message as string) ?? "Failed to get git status");
-                        // Explicit failure from full-status should immediately fall back.
                         sendStatusRequest(cwdRef.current);
                     }
                     break;
@@ -359,10 +375,10 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             statusRequestsInFlightRef.current.clear();
             requestGenerationRef.current.clear();
             postMutationRefreshSchedulerRef.current.dispose();
-            if (fullStatusFallbackTimerRef.current) {
-                clearTimeout(fullStatusFallbackTimerRef.current);
-                fullStatusFallbackTimerRef.current = null;
+            for (const timerId of fullStatusFallbackTimersRef.current.values()) {
+                clearTimeout(timerId);
             }
+            fullStatusFallbackTimersRef.current.clear();
         };
     }, [clearPendingDiffs]);
 
@@ -521,10 +537,10 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         optimisticSnapshotsRef.current.clear();
         postMutationRefreshSchedulerRef.current.cancel();
         statusRequestsInFlightRef.current.clear();
-        if (fullStatusFallbackTimerRef.current) {
-            clearTimeout(fullStatusFallbackTimerRef.current);
-            fullStatusFallbackTimerRef.current = null;
+        for (const timerId of fullStatusFallbackTimersRef.current.values()) {
+            clearTimeout(timerId);
         }
+        fullStatusFallbackTimersRef.current.clear();
 
         if (available && cwd) {
             statusGenRef.current = generationRef.current;
@@ -533,17 +549,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             // Initial load optimization: request status + branches + worktrees in one round-trip.
             // Compatibility fallback: if an older runner doesn't support git_full_status,
             // fall back to git_status after a short delay.
-            sendFullStatusRequest(cwd, true);
-
-            fullStatusFallbackTimerRef.current = setTimeout(() => {
-                fullStatusFallbackTimerRef.current = null;
-                if (statusGenRef.current !== generationRef.current) return;
-                const abandonedRequestId = pendingFullStatusRequestRef.current;
-                if (!abandonedRequestId) return;
-                pendingFullStatusRequestRef.current = null;
-                markStatusRequestSettled(abandonedRequestId);
-                sendStatusRequest(cwdRef.current);
-            }, 1200);
+            sendFullStatusRequest(cwd, { asInitial: true, fallbackToStatus: true, fallbackMs: 1200 });
         } else {
             setLoading(false);
         }

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -108,6 +108,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     const pendingDiffTimeoutsRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
     const pendingFullStatusRequestRef = useRef<string | null>(null);
     const fullStatusFallbackTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
+    const statusRequestRetireTimersRef = useRef(new Map<string, ReturnType<typeof setTimeout>>());
     const statusRequestsInFlightRef = useRef(new Set<string>());
     const optimisticSnapshotsRef = useRef(new Map<string, GitStatus | null>());
     const requestGenerationRef = useRef(new Map<string, number>());
@@ -164,7 +165,14 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         setLoading(true);
         setError(null);
         sendRef.current("git_status", { cwd: targetCwd }, requestId);
-    }, [makeRequestId, markStatusRequestInFlight, registerRequestGeneration]);
+
+        const retireTimer = setTimeout(() => {
+            statusRequestRetireTimersRef.current.delete(requestId);
+            requestGenerationRef.current.delete(requestId);
+            markStatusRequestSettled(requestId);
+        }, 8000);
+        statusRequestRetireTimersRef.current.set(requestId, retireTimer);
+    }, [makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, registerRequestGeneration]);
 
     const sendLegacySnapshotRequests = useCallback((targetCwd: string) => {
         sendStatusRequest(targetCwd);
@@ -241,6 +249,11 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             switch (type) {
                 case "git_status_result": {
                     if (requestId) {
+                        const timerId = statusRequestRetireTimersRef.current.get(requestId);
+                        if (timerId) {
+                            clearTimeout(timerId);
+                            statusRequestRetireTimersRef.current.delete(requestId);
+                        }
                         if (!isRequestCurrentGeneration(requestId)) break;
                         markStatusRequestSettled(requestId);
                     } else {
@@ -392,6 +405,10 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 clearTimeout(timerId);
             }
             fullStatusFallbackTimersRef.current.clear();
+            for (const timerId of statusRequestRetireTimersRef.current.values()) {
+                clearTimeout(timerId);
+            }
+            statusRequestRetireTimersRef.current.clear();
         };
     }, [clearPendingDiffs]);
 
@@ -554,6 +571,10 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             clearTimeout(timerId);
         }
         fullStatusFallbackTimersRef.current.clear();
+        for (const timerId of statusRequestRetireTimersRef.current.values()) {
+            clearTimeout(timerId);
+        }
+        statusRequestRetireTimersRef.current.clear();
 
         if (available && cwd) {
             statusGenRef.current = generationRef.current;

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -200,6 +200,8 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 if (statusGenRef.current !== generationRef.current) return;
                 if (asInitial && pendingFullStatusRequestRef.current !== requestId) return;
                 if (asInitial) pendingFullStatusRequestRef.current = null;
+                // Retire this full-status request so late responses are ignored.
+                requestGenerationRef.current.delete(requestId);
                 markStatusRequestSettled(requestId);
                 sendLegacySnapshotRequests(cwdRef.current);
             }, fallbackMs);

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -166,6 +166,19 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         sendRef.current("git_status", { cwd: targetCwd }, requestId);
     }, [makeRequestId, markStatusRequestInFlight, registerRequestGeneration]);
 
+    const sendFullStatusRequest = useCallback((targetCwd: string, asInitial = false) => {
+        statusGenRef.current = generationRef.current;
+        const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
+        markStatusRequestInFlight(requestId);
+        if (asInitial) {
+            pendingFullStatusRequestRef.current = requestId;
+        }
+        setLoading(true);
+        setError(null);
+        sendRef.current("git_full_status", { cwd: targetCwd }, requestId);
+    }, [makeRequestId, markStatusRequestInFlight, registerRequestGeneration]);
+
     const clearPendingDiffs = useCallback((resolution: string) => {
         for (const timeoutId of pendingDiffTimeoutsRef.current.values()) {
             clearTimeout(timeoutId);
@@ -185,7 +198,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             getGeneration: () => generationRef.current,
             isStatusRequestInFlight: () => statusRequestsInFlightRef.current.size > 0,
             triggerRefresh: () => {
-                sendStatusRequest(cwdRef.current);
+                sendFullStatusRequest(cwdRef.current, false);
             },
         })
     );
@@ -238,19 +251,20 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                         setLoading(false);
                     }
 
-                    // Ignore late full-status responses once initial request was superseded.
-                    if (!isInitialFullStatus) break;
-
                     if (payload.ok) {
-                        const statusPayload = (payload.status as Record<string, unknown> | undefined) ?? payload;
-                        setStatus({
-                            branch: (statusPayload.branch as string) ?? "",
-                            changes: (statusPayload.changes as GitChange[]) ?? [],
-                            ahead: (statusPayload.ahead as number) ?? 0,
-                            behind: (statusPayload.behind as number) ?? 0,
-                            hasUpstream: (statusPayload.hasUpstream as boolean) ?? false,
-                            diffStaged: (statusPayload.diffStaged as string) ?? "",
-                        });
+                        if (isInitialFullStatus) {
+                            const statusPayload = (payload.status as Record<string, unknown> | undefined) ?? payload;
+                            setStatus({
+                                branch: (statusPayload.branch as string) ?? "",
+                                changes: (statusPayload.changes as GitChange[]) ?? [],
+                                ahead: (statusPayload.ahead as number) ?? 0,
+                                behind: (statusPayload.behind as number) ?? 0,
+                                hasUpstream: (statusPayload.hasUpstream as boolean) ?? false,
+                                diffStaged: (statusPayload.diffStaged as string) ?? "",
+                            });
+                        }
+                        // Late same-generation full-status can still provide fresh
+                        // branches/worktrees metadata after fallback/manual refresh.
                         setBranches((payload.branches as GitBranch[]) ?? []);
                         setCurrentBranch((payload.currentBranch as string) ?? "");
                         setWorktrees((payload.worktrees as GitWorktree[]) ?? []);
@@ -315,17 +329,18 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     setOperationInProgress(null);
                     setLastOperationResult(payload as GitOperationResult);
 
-                    const rollbackStatus = consumeRollbackSnapshot(
+                    consumeRollbackSnapshot(
                         optimisticSnapshotsRef.current,
                         requestId,
                         payload.ok === true,
                     );
-                    if (payload.ok !== true && rollbackStatus !== undefined) {
-                        setStatus(rollbackStatus);
-                    }
 
                     if (payload.ok) {
                         postMutationRefreshSchedulerRef.current.schedule();
+                    } else {
+                        // Avoid stale rollback races across overlapping optimistic mutations.
+                        // Re-sync from authoritative runner state instead.
+                        sendStatusRequest(cwdRef.current);
                     }
                     break;
                 }
@@ -518,11 +533,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             // Initial load optimization: request status + branches + worktrees in one round-trip.
             // Compatibility fallback: if an older runner doesn't support git_full_status,
             // fall back to git_status after a short delay.
-            const requestId = makeRequestId();
-            registerRequestGeneration(requestId);
-            pendingFullStatusRequestRef.current = requestId;
-            markStatusRequestInFlight(requestId);
-            send("git_full_status", { cwd }, requestId);
+            sendFullStatusRequest(cwd, true);
 
             fullStatusFallbackTimerRef.current = setTimeout(() => {
                 fullStatusFallbackTimerRef.current = null;
@@ -536,7 +547,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         } else {
             setLoading(false);
         }
-    }, [available, clearPendingDiffs, cwd, makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, registerRequestGeneration, send, sendStatusRequest]);
+    }, [available, clearPendingDiffs, cwd, markStatusRequestSettled, sendFullStatusRequest, sendStatusRequest]);
 
     return {
         available,

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -107,7 +107,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     const pendingDiffsRef = useRef(new Map<string, (diff: string) => void>());
     const pendingFullStatusRequestRef = useRef<string | null>(null);
     const fullStatusFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const statusRequestsInFlightRef = useRef(0);
+    const statusRequestsInFlightRef = useRef(new Set<string>());
     const optimisticSnapshotsRef = useRef(new Map<string, GitStatus | null>());
 
     // Generation counter — incremented on cwd change. Responses from stale
@@ -128,19 +128,29 @@ export function useGitService(cwd: string): UseGitServiceReturn {
     // Ref for sendGit so callbacks can access latest version
     const sendRef = useRef<(type: string, payload: unknown, requestId?: string) => void>(() => {});
 
+    const markStatusRequestInFlight = useCallback((requestId: string) => {
+        statusRequestsInFlightRef.current.add(requestId);
+    }, []);
+
+    const markStatusRequestSettled = useCallback((requestId?: string) => {
+        if (!requestId) return;
+        statusRequestsInFlightRef.current.delete(requestId);
+    }, []);
+
     const sendStatusRequest = useCallback((targetCwd: string) => {
         statusGenRef.current = generationRef.current;
-        statusRequestsInFlightRef.current += 1;
+        const requestId = makeRequestId();
+        markStatusRequestInFlight(requestId);
         setLoading(true);
         setError(null);
-        sendRef.current("git_status", { cwd: targetCwd }, makeRequestId());
-    }, [makeRequestId]);
+        sendRef.current("git_status", { cwd: targetCwd }, requestId);
+    }, [makeRequestId, markStatusRequestInFlight]);
 
     const postMutationRefreshSchedulerRef = useRef(
         createPostMutationRefreshScheduler({
             debounceMs: POST_MUTATION_STATUS_REFRESH_DEBOUNCE_MS,
             getGeneration: () => generationRef.current,
-            isStatusRequestInFlight: () => statusRequestsInFlightRef.current > 0,
+            isStatusRequestInFlight: () => statusRequestsInFlightRef.current.size > 0,
             triggerRefresh: () => {
                 sendStatusRequest(cwdRef.current);
             },
@@ -153,7 +163,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
 
             switch (type) {
                 case "git_status_result": {
-                    statusRequestsInFlightRef.current = Math.max(0, statusRequestsInFlightRef.current - 1);
+                    markStatusRequestSettled(requestId);
                     // Ignore stale responses from a previous cwd
                     if (statusGenRef.current !== generationRef.current) break;
                     setLoading(false);
@@ -173,7 +183,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                     break;
                 }
                 case "git_full_status_result": {
-                    statusRequestsInFlightRef.current = Math.max(0, statusRequestsInFlightRef.current - 1);
+                    markStatusRequestSettled(requestId);
                     // Ignore stale responses from a previous cwd
                     if (statusGenRef.current !== generationRef.current) break;
                     if (requestId && pendingFullStatusRequestRef.current === requestId) {
@@ -273,6 +283,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         return () => {
             pendingDiffsRef.current.clear();
             optimisticSnapshotsRef.current.clear();
+            statusRequestsInFlightRef.current.clear();
             postMutationRefreshSchedulerRef.current.dispose();
             if (fullStatusFallbackTimerRef.current) {
                 clearTimeout(fullStatusFallbackTimerRef.current);
@@ -414,7 +425,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         pendingFullStatusRequestRef.current = null;
         optimisticSnapshotsRef.current.clear();
         postMutationRefreshSchedulerRef.current.cancel();
-        statusRequestsInFlightRef.current = 0;
+        statusRequestsInFlightRef.current.clear();
         if (fullStatusFallbackTimerRef.current) {
             clearTimeout(fullStatusFallbackTimerRef.current);
             fullStatusFallbackTimerRef.current = null;
@@ -422,7 +433,6 @@ export function useGitService(cwd: string): UseGitServiceReturn {
 
         if (available && cwd) {
             statusGenRef.current = generationRef.current;
-            statusRequestsInFlightRef.current += 1;
             setLoading(true);
 
             // Initial load optimization: request status + branches + worktrees in one round-trip.
@@ -430,19 +440,22 @@ export function useGitService(cwd: string): UseGitServiceReturn {
             // fall back to git_status after a short delay.
             const requestId = makeRequestId();
             pendingFullStatusRequestRef.current = requestId;
+            markStatusRequestInFlight(requestId);
             send("git_full_status", { cwd }, requestId);
 
             fullStatusFallbackTimerRef.current = setTimeout(() => {
                 fullStatusFallbackTimerRef.current = null;
                 if (statusGenRef.current !== generationRef.current) return;
-                if (!pendingFullStatusRequestRef.current) return;
+                const abandonedRequestId = pendingFullStatusRequestRef.current;
+                if (!abandonedRequestId) return;
                 pendingFullStatusRequestRef.current = null;
+                markStatusRequestSettled(abandonedRequestId);
                 sendStatusRequest(cwdRef.current);
             }, 1200);
         } else {
             setLoading(false);
         }
-    }, [available, cwd]); // eslint-disable-line react-hooks/exhaustive-deps
+    }, [available, cwd, makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, send, sendStatusRequest]);
 
     return {
         available,

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -166,6 +166,18 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         sendRef.current("git_status", { cwd: targetCwd }, requestId);
     }, [makeRequestId, markStatusRequestInFlight, registerRequestGeneration]);
 
+    const sendLegacySnapshotRequests = useCallback((targetCwd: string) => {
+        sendStatusRequest(targetCwd);
+
+        const branchesReqId = makeRequestId();
+        registerRequestGeneration(branchesReqId);
+        sendRef.current("git_branches", { cwd: targetCwd }, branchesReqId);
+
+        const worktreesReqId = makeRequestId();
+        registerRequestGeneration(worktreesReqId);
+        sendRef.current("git_worktrees", { cwd: targetCwd }, worktreesReqId);
+    }, [makeRequestId, registerRequestGeneration, sendStatusRequest]);
+
     const sendFullStatusRequest = useCallback((targetCwd: string, options?: { asInitial?: boolean; fallbackToStatus?: boolean; fallbackMs?: number }) => {
         const asInitial = options?.asInitial === true;
         const fallbackToStatus = options?.fallbackToStatus === true;
@@ -189,14 +201,13 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 if (asInitial && pendingFullStatusRequestRef.current !== requestId) return;
                 if (asInitial) pendingFullStatusRequestRef.current = null;
                 markStatusRequestSettled(requestId);
-                sendStatusRequest(cwdRef.current);
+                sendLegacySnapshotRequests(cwdRef.current);
             }, fallbackMs);
             fullStatusFallbackTimersRef.current.set(requestId, timerId);
         }
 
         return requestId;
-    }, [makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, registerRequestGeneration, sendStatusRequest]);
-
+    }, [makeRequestId, markStatusRequestInFlight, markStatusRequestSettled, registerRequestGeneration, sendLegacySnapshotRequests]);
     const clearPendingDiffs = useCallback((resolution: string) => {
         for (const timeoutId of pendingDiffTimeoutsRef.current.values()) {
             clearTimeout(timeoutId);
@@ -288,7 +299,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                         setError(null);
                     } else {
                         setError((payload.message as string) ?? "Failed to get git status");
-                        sendStatusRequest(cwdRef.current);
+                        sendLegacySnapshotRequests(cwdRef.current);
                     }
                     break;
                 }


### PR DESCRIPTION
## Summary
- add runner-side `git_status` cache (2.5s TTL) with in-flight request dedupe and mutation invalidation
- add `git_full_status` to batch status + branches + worktrees in one round-trip and wire initial git panel load to use it with fallback
- debounce/coalesce post-mutation status refreshes and skip refreshes while status is already in flight
- add optimistic UI updates for stage/unstage/stageAll/unstageAll with rollback on failure
- add best-effort git metadata watchers (`HEAD`, `index`, `packed-refs`, `refs`) to push `git_status_result` updates to subscribed sessions
- add tests for git service caching/dedupe/invalidation/full-status/watchers and UI optimistic/debounce helpers

## Validation
- `bun run typecheck`
- `cd packages/cli && bun test src/runner/services/git-service.test.ts`
- `cd packages/ui && bun test src/hooks/git-status-refresh-scheduler.test.ts src/hooks/git-optimistic-status.test.ts`

## Godmother
- Epic: QBUq5p0ICe8TQFTg0ZQjB
- Ideas: 3vxU87oo, krlcp7CA, sMMKs3hy, D3jV5XHw, zwWhgNtK
