### PR TITLE
feat: trigger subscription reconciliation protocol

### DIFF
--- a/packages/cli/src/runner/daemon.trigger-reconciliation.test.ts
+++ b/packages/cli/src/runner/daemon.trigger-reconciliation.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, test } from "bun:test";
+import type { TriggerSubscriptionEntry } from "@pizzapi/protocol";
+import { reconcileSnapshotSubscriptions } from "./daemon.js";
+import { ServiceRegistry, type ServiceHandler, type ServiceInitOptions, type ReconcileOptions } from "./service-handler.js";
+import type { Socket } from "socket.io-client";
+
+class ReconcilingService implements ServiceHandler {
+    readonly calls: TriggerSubscriptionEntry[][] = [];
+
+    constructor(readonly id: string) {}
+
+    init(_socket: Socket, _options: ServiceInitOptions): void {}
+    dispose(): void {}
+
+    reconcileSubscriptions(subscriptions: TriggerSubscriptionEntry[], _options?: ReconcileOptions): { applied: number; errors?: string[] } {
+        this.calls.push(subscriptions);
+        return { applied: subscriptions.length };
+    }
+}
+
+class PassiveService implements ServiceHandler {
+    constructor(readonly id: string) {}
+
+    init(_socket: Socket, _options: ServiceInitOptions): void {}
+    dispose(): void {}
+}
+
+function entry(sessionId: string, triggerType: string): TriggerSubscriptionEntry {
+    return {
+        sessionId,
+        triggerType,
+        runnerId: "runner-test",
+        params: {},
+    };
+}
+
+describe("reconcileSnapshotSubscriptions", () => {
+    test("reconciles loaded services with an empty snapshot subset when absent", () => {
+        const registry = new ServiceRegistry();
+        const timeService = new ReconcilingService("time");
+        const gitService = new ReconcilingService("git");
+        registry.register(timeService);
+        registry.register(gitService);
+
+        const snapshot = [entry("session-1", "git:status_changed")];
+        const logs = { info: [] as string[], warn: [] as string[], error: [] as string[] };
+
+        const result = reconcileSnapshotSubscriptions(registry, snapshot, {
+            info: (message) => logs.info.push(message),
+            warn: (message) => logs.warn.push(message),
+            error: (message) => logs.error.push(message),
+        });
+
+        expect(gitService.calls).toEqual([[snapshot[0]]]);
+        expect(timeService.calls).toEqual([[]]);
+        expect(result).toEqual({ applied: 1, errors: [] });
+        expect(logs).toEqual({ info: [], warn: [], error: [] });
+    });
+
+    test("warns for unknown prefixes and still reconciles known services", () => {
+        const registry = new ServiceRegistry();
+        const timeService = new ReconcilingService("time");
+        registry.register(timeService);
+        registry.register(new PassiveService("terminal"));
+
+        const snapshot = [
+            entry("session-1", "ghost:event"),
+            entry("session-2", "terminal:finished"),
+        ];
+        const logs = { info: [] as string[], warn: [] as string[], error: [] as string[] };
+
+        const result = reconcileSnapshotSubscriptions(registry, snapshot, {
+            info: (message) => logs.info.push(message),
+            warn: (message) => logs.warn.push(message),
+            error: (message) => logs.error.push(message),
+        });
+
+        expect(timeService.calls).toEqual([[]]);
+        expect(result).toEqual({ applied: 0, errors: [] });
+        expect(logs.warn).toEqual([
+            '[trigger-reconciliation] no service found for prefix "ghost" (1 subscriptions)',
+        ]);
+        expect(logs.info).toEqual([
+            '[trigger-reconciliation] service "terminal" does not implement reconcileSubscriptions, skipping 1 subscriptions',
+        ]);
+        expect(logs.error).toEqual([]);
+    });
+});

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -22,7 +22,7 @@ import { TunnelClient } from "@pizzapi/tunnel";
 import { loadGlobalConfig, defaultAgentDir, expandHome, loadConfig } from "../config.js";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
 import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
-import type { ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
+import type { ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
 import { sanitizeConfigForUI, restoreMaskedServerEntry, MASK_SENTINEL } from "./daemon-config-sanitize.js";
@@ -69,6 +69,61 @@ function resolveConfigRelayUrl(): string | undefined {
     const cfg = loadGlobalConfig();
     const url = cfg.relayUrl;
     return url && url !== "off" ? url : undefined;
+}
+
+type TriggerReconciliationLogger = {
+    info: (message: string) => void;
+    warn: (message: string) => void;
+    error: (message: string) => void;
+};
+
+export function reconcileSnapshotSubscriptions(
+    registry: ServiceRegistry,
+    subscriptions: TriggerSubscriptionEntry[],
+    logger: TriggerReconciliationLogger = {
+        info: logInfo,
+        warn: logWarn,
+        error: logError,
+    },
+): { applied: number; errors: string[] } {
+    const byServicePrefix = new Map<string, TriggerSubscriptionEntry[]>();
+    for (const sub of subscriptions) {
+        const prefix = sub.triggerType?.split(":")[0];
+        if (!prefix) continue;
+        if (!byServicePrefix.has(prefix)) byServicePrefix.set(prefix, []);
+        byServicePrefix.get(prefix)!.push(sub);
+    }
+
+    for (const [prefix, subs] of byServicePrefix) {
+        const service = registry.get(prefix);
+        if (!service) {
+            logger.warn(`[trigger-reconciliation] no service found for prefix "${prefix}" (${subs.length} subscriptions)`);
+            continue;
+        }
+        if (typeof service.reconcileSubscriptions !== "function") {
+            logger.info(`[trigger-reconciliation] service "${prefix}" does not implement reconcileSubscriptions, skipping ${subs.length} subscriptions`);
+        }
+    }
+
+    let totalApplied = 0;
+    const allErrors: string[] = [];
+
+    for (const service of registry.getAll()) {
+        if (typeof service.reconcileSubscriptions !== "function") continue;
+
+        const subs = byServicePrefix.get(service.id) ?? [];
+        try {
+            const result = service.reconcileSubscriptions(subs, { mode: "snapshot" });
+            totalApplied += result.applied;
+            if (result.errors?.length) allErrors.push(...result.errors);
+        } catch (err) {
+            const msg = `service "${service.id}" reconcile failed: ${err instanceof Error ? err.message : String(err)}`;
+            logger.error(`[trigger-reconciliation] ${msg}`);
+            allErrors.push(msg);
+        }
+    }
+
+    return { applied: totalApplied, errors: allErrors };
 }
 
 /**
@@ -467,6 +522,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             // daemon in a half-initialized state.
             try {
                 runnerId = data.runnerId;
+                lastAppliedRevision = -1;
                 if (runnerId !== identity.runnerId) {
                     logWarn(`server assigned unexpected ID ${runnerId} (expected ${identity.runnerId})`);
                 }
@@ -549,6 +605,104 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 void sweepOrphanedAttachments(new Set(runningSessions.keys())).catch(() => {});
             } catch (err) {
                 logError(`[daemon] runner_registered handler failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+            }
+        });
+
+        // ── Trigger subscription reconciliation ──────────────────────────
+
+        // Track the last applied revision to ignore stale/duplicate messages.
+        // -1 means "accept the next snapshot/delta regardless of revision" and is
+        // used on initial startup and after relay re-registration, because the
+        // server-side revision counter is process-local and restarts from 0/1.
+        let lastAppliedRevision = -1;
+
+        (socket as any).on("trigger_subscriptions_snapshot", (data: any) => {
+            if (isShuttingDown) return;
+            try {
+                const { revision, subscriptions } = data ?? {};
+                if (typeof revision !== "number" || !Array.isArray(subscriptions)) {
+                    logWarn("[trigger-reconciliation] invalid snapshot payload");
+                    return;
+                }
+
+                // Ignore stale snapshots (e.g. from a retransmission).
+                if (revision <= lastAppliedRevision) {
+                    logInfo(`[trigger-reconciliation] ignoring stale snapshot revision=${revision} (last=${lastAppliedRevision})`);
+                    return;
+                }
+                lastAppliedRevision = revision;
+
+                logInfo(`[trigger-reconciliation] received snapshot revision=${revision} with ${subscriptions.length} subscriptions`);
+
+                const { applied: totalApplied, errors: allErrors } = reconcileSnapshotSubscriptions(registry, subscriptions);
+
+                // Ack back to the server
+                socket.emit("trigger_subscriptions_applied" as any, {
+                    revision,
+                    applied: totalApplied,
+                    ...(allErrors.length > 0 ? { errors: allErrors } : {}),
+                });
+
+                logInfo(`[trigger-reconciliation] applied ${totalApplied} subscriptions from snapshot revision=${revision}${allErrors.length ? `, ${allErrors.length} errors` : ""}`);
+            } catch (err) {
+                logError(`[trigger-reconciliation] snapshot handler failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
+            }
+        });
+
+        (socket as any).on("trigger_subscription_delta", (data: any) => {
+            if (isShuttingDown) return;
+            try {
+                const { revision, action, subscription } = data ?? {};
+                if (
+                    typeof revision !== "number" ||
+                    (action !== "subscribe" && action !== "update" && action !== "unsubscribe") ||
+                    !subscription?.triggerType
+                ) {
+                    logWarn("[trigger-reconciliation] invalid delta payload");
+                    return;
+                }
+
+                // Ignore stale deltas.
+                if (revision <= lastAppliedRevision) {
+                    logInfo(`[trigger-reconciliation] ignoring stale delta revision=${revision} (last=${lastAppliedRevision})`);
+                    return;
+                }
+                lastAppliedRevision = revision;
+
+                const prefix = subscription.triggerType.split(":")[0];
+                if (!prefix) return;
+
+                let applied = 0;
+                const errors: string[] = [];
+                const service = registry.get(prefix);
+                if (!service) {
+                    logWarn(`[trigger-reconciliation] no service found for prefix "${prefix}" (delta ${action})`);
+                } else if (typeof service.reconcileSubscriptions !== "function") {
+                    logInfo(`[trigger-reconciliation] service "${prefix}" does not implement reconcileSubscriptions, skipping delta ${action}`);
+                } else {
+                    try {
+                        const result = service.reconcileSubscriptions([subscription], {
+                            mode: "delta",
+                            action,
+                        });
+                        applied += result.applied;
+                        if (result.errors?.length) errors.push(...result.errors);
+                    } catch (err) {
+                        const msg = `service "${prefix}" reconcile failed: ${err instanceof Error ? err.message : String(err)}`;
+                        logError(`[trigger-reconciliation] ${msg}`);
+                        errors.push(msg);
+                    }
+                }
+
+                socket.emit("trigger_subscriptions_applied" as any, {
+                    revision,
+                    applied,
+                    ...(errors.length > 0 ? { errors } : {}),
+                });
+
+                logInfo(`[trigger-reconciliation] delta: ${action} ${subscription.triggerType} for session ${subscription.sessionId} applied=${applied}${errors.length ? ` errors=${errors.length}` : ""}`);
+            } catch (err) {
+                logError(`[trigger-reconciliation] delta handler failed: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`);
             }
         });
 

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -77,6 +77,18 @@ type TriggerReconciliationLogger = {
     error: (message: string) => void;
 };
 
+/**
+ * Reconcile all active subscriptions from a full snapshot into each registered
+ * service. Called once after a runner registers with the server so that
+ * in-memory state (timers, crons, etc.) is rebuilt from the server's source of
+ * truth.
+ *
+ * @note This function assumes **at most one active subscription per
+ * (sessionId, triggerType) pair**. The snapshot uses
+ * `${sessionId}\0${triggerType}` as a dedup key, so if multiple entries exist
+ * for the same pair, only the last one processed will take effect. This
+ * constraint is enforced by the protocol layer — see `TriggerSubscriptionEntry`.
+ */
 export function reconcileSnapshotSubscriptions(
     registry: ServiceRegistry,
     subscriptions: TriggerSubscriptionEntry[],

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -631,10 +631,29 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         (socket as any).on("trigger_subscriptions_snapshot", (data: any) => {
             if (isShuttingDown) return;
             try {
-                const { revision, subscriptions } = data ?? {};
+                const { revision, subscriptions, isReconnect } = data ?? {};
                 if (typeof revision !== "number" || !Array.isArray(subscriptions)) {
                     logWarn("[trigger-reconciliation] invalid snapshot payload");
                     return;
+                }
+
+                // Reconnect snapshots are authoritative full baselines: they must be
+                // applied unconditionally regardless of any revision the daemon has
+                // already seen.  Without this, the following lost-baseline race can
+                // occur on reconnect:
+                //   1. Server reserves snapshotRevision=N BEFORE the async read.
+                //   2. A concurrent delta fires at revision=N+1 (higher, as intended).
+                //   3. The delta reaches the daemon first → lastAppliedRevision = N+1.
+                //   4. The snapshot arrives at revision=N → dropped as stale (N ≤ N+1).
+                //   5. All pre-existing subscriptions NOT covered by the delta are
+                //      silently missing after reconnect.
+                //
+                // By resetting lastAppliedRevision to 0 when isReconnect=true we force
+                // the snapshot to be accepted, while still allowing any subsequent
+                // delta (revision > snapshotRevision) to be applied on top of it.
+                if (isReconnect) {
+                    lastAppliedRevision = 0;
+                    logInfo(`[trigger-reconciliation] accepting reconnect snapshot revision=${revision} as authoritative baseline (resetting stale-drop counter)`);
                 }
 
                 // Ignore stale snapshots (e.g. from a retransmission).

--- a/packages/cli/src/runner/service-handler.ts
+++ b/packages/cli/src/runner/service-handler.ts
@@ -1,4 +1,5 @@
 import type { Socket } from "socket.io-client";
+import type { TriggerSubscriptionDelta, TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import { logError } from "./logger.js";
 
 /**
@@ -20,6 +21,33 @@ export interface ServiceHandler {
      * Called on socket disconnect or daemon shutdown.
      */
     dispose(): void;
+
+    /**
+     * Reconcile in-memory subscription state against a full snapshot from the server.
+     * Called after runner reconnection with the subset of subscriptions relevant to
+     * this service's trigger types. Services that manage runtime state per subscription
+     * (e.g. timers, watchers) should implement this to rebuild that state.
+     *
+     * Optional — services that don't manage per-subscription state can skip this.
+     */
+    reconcileSubscriptions?(subscriptions: TriggerSubscriptionEntry[], options?: ReconcileOptions): ReconcileResult;
+}
+
+/**
+ * Result of a reconcileSubscriptions call.
+ */
+export interface ReconcileResult {
+    /** Number of subscriptions successfully reconciled. */
+    applied: number;
+    /** Optional error messages for subscriptions that failed. */
+    errors?: string[];
+}
+
+export interface ReconcileOptions {
+    /** Full snapshot rebuild vs. single live delta application. */
+    mode?: "snapshot" | "delta";
+    /** Delta action when mode === "delta". */
+    action?: TriggerSubscriptionDelta["action"];
 }
 
 export interface ServiceInitOptions {

--- a/packages/cli/src/runner/services/time-service.reconcile.test.ts
+++ b/packages/cli/src/runner/services/time-service.reconcile.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Tests for TimeService.reconcileSubscriptions().
+ *
+ * reconcileSubscriptions() rebuilds in-memory timer/cron state from a
+ * TriggerSubscriptionEntry snapshot. These tests verify:
+ *   - returns { applied, errors? } shape
+ *   - counts applied correctly for timer_fired, time:at, and time:cron subs
+ *   - ignores subscriptions for trigger types owned by other services
+ *   - stale timers/crons are cleared when not present in a new snapshot
+ *   - handles missing or invalid params gracefully (no throw, warning only)
+ *
+ * Note: TimeService can be instantiated and reconcileSubscriptions() called
+ * without init() — the method only accesses internal Maps, not the socket
+ * or HTTP server. dispose() is called at the end of each test to clear any
+ * scheduled timers.
+ */
+
+import { describe, test, expect, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { TimeService } from "./time-service.js";
+import type { TriggerSubscriptionEntry } from "@pizzapi/protocol";
+
+// Shared service instance — reset after each test.
+let service: TimeService;
+const originalHome = process.env.HOME;
+const originalRelayUrl = process.env.PIZZAPI_RELAY_URL;
+const originalApiKey = process.env.PIZZAPI_RUNNER_API_KEY;
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+    // dispose() is safe without init() — guarded for null socket/server.
+    service?.dispose();
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalRelayUrl === undefined) delete process.env.PIZZAPI_RELAY_URL;
+    else process.env.PIZZAPI_RELAY_URL = originalRelayUrl;
+    if (originalApiKey === undefined) delete process.env.PIZZAPI_RUNNER_API_KEY;
+    else process.env.PIZZAPI_RUNNER_API_KEY = originalApiKey;
+    globalThis.fetch = originalFetch;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function entry(
+    sessionId: string,
+    triggerType: string,
+    params?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+): TriggerSubscriptionEntry {
+    return { sessionId, triggerType, runnerId: "runner-test", params };
+}
+
+function setupBroadcastEnv(): void {
+    const home = mkdtempSync(join(tmpdir(), "pizzapi-time-service-"));
+    mkdirSync(join(home, ".pizzapi"), { recursive: true });
+    writeFileSync(
+        join(home, ".pizzapi", "runner.json"),
+        JSON.stringify({ runnerId: "runner-test" }),
+        "utf-8",
+    );
+    process.env.HOME = home;
+    process.env.PIZZAPI_RELAY_URL = "http://relay.test";
+    process.env.PIZZAPI_RUNNER_API_KEY = "test-api-key";
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("TimeService.reconcileSubscriptions()", () => {
+    describe("return shape", () => {
+        test("returns { applied: 0 } for an empty snapshot", () => {
+            service = new TimeService();
+            const result = service.reconcileSubscriptions([]);
+            expect(result.applied).toBe(0);
+            expect(result.errors).toBeUndefined();
+        });
+
+        test("returns { applied } with no errors when all subs are valid", () => {
+            service = new TimeService();
+            const result = service.reconcileSubscriptions([
+                entry("s1", "time:timer_fired", { duration: "1h" }),
+                entry("s2", "time:cron", { cron: "0 * * * *" }),
+            ]);
+            expect(result.applied).toBe(2);
+            expect(result.errors).toBeUndefined();
+        });
+    });
+
+    describe("time:timer_fired subscriptions", () => {
+        test("counts a valid timer_fired subscription as applied", () => {
+            service = new TimeService();
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", { duration: "30m" }),
+            ]);
+            expect(result.applied).toBe(1);
+        });
+
+        test("counts missing duration as applied (handler warns, does not throw)", () => {
+            service = new TimeService();
+            // duration param is required by the trigger def but the handler just
+            // logs a warning and returns rather than throwing — so it still counts.
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", {}),
+            ]);
+            // No throw → applied still incremented
+            expect(result.applied).toBe(1);
+            expect(result.errors).toBeUndefined();
+        });
+
+        test("handles multiple sessions with timer_fired", () => {
+            service = new TimeService();
+            const result = service.reconcileSubscriptions([
+                entry("sess-A", "time:timer_fired", { duration: "1h" }),
+                entry("sess-B", "time:timer_fired", { duration: "2h" }),
+                entry("sess-C", "time:timer_fired", { duration: "30m" }),
+            ]);
+            expect(result.applied).toBe(3);
+        });
+    });
+
+    describe("time:at subscriptions", () => {
+        test("counts a valid future time:at subscription as applied", () => {
+            service = new TimeService();
+            // Use a future date within 20 days so setTimeout doesn't overflow 32-bit int.
+            // The timer won't fire during the test since dispose() clears it immediately.
+            const futureMs = Date.now() + 20 * 24 * 60 * 60 * 1000; // 20 days from now
+            const at = new Date(futureMs).toISOString();
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "time:at", { at }),
+            ]);
+            expect(result.applied).toBe(1);
+        });
+
+        test("counts a past time:at subscription as applied (fires immediately via async)", () => {
+            service = new TimeService();
+            // Past date — the handler fires immediately (void async) but doesn't throw
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "time:at", { at: "2020-01-01T00:00:00Z" }),
+            ]);
+            expect(result.applied).toBe(1);
+        });
+
+        test("counts missing 'at' param as applied (handler warns, does not throw)", () => {
+            service = new TimeService();
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "time:at", {}),
+            ]);
+            expect(result.applied).toBe(1);
+        });
+    });
+
+    describe("time:cron subscriptions", () => {
+        test("counts a valid cron subscription as applied", () => {
+            service = new TimeService();
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "time:cron", { cron: "0 9 * * *" }),
+            ]);
+            expect(result.applied).toBe(1);
+        });
+
+        test("counts an invalid cron expression as applied (handler warns, does not throw)", () => {
+            service = new TimeService();
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "time:cron", { cron: "not-a-cron" }),
+            ]);
+            expect(result.applied).toBe(1);
+        });
+    });
+
+    describe("filtering to time trigger types only", () => {
+        test("ignores subscriptions for other services' trigger types", () => {
+            service = new TimeService();
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "github:pr_opened", { repo: "org/repo" }),
+                entry("sess-2", "godmother:idea_moved"),
+                entry("sess-3", "time:timer_fired", { duration: "1h" }),
+            ]);
+            // Only time:timer_fired counts
+            expect(result.applied).toBe(1);
+        });
+
+        test("returns applied=0 when snapshot contains only non-time subscriptions", () => {
+            service = new TimeService();
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "github:pr_opened"),
+                entry("sess-2", "custom:event"),
+            ]);
+            expect(result.applied).toBe(0);
+        });
+    });
+
+    describe("stale timer removal", () => {
+        test("second reconcile with empty snapshot removes previously created timers", () => {
+            service = new TimeService();
+
+            // First snapshot: create a timer
+            const r1 = service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", { duration: "1h" }),
+            ]);
+            expect(r1.applied).toBe(1);
+
+            // Second snapshot: empty — stale timer must be removed, applied = 0
+            const r2 = service.reconcileSubscriptions([]);
+            expect(r2.applied).toBe(0);
+        });
+
+        test("second reconcile replaces existing timer for same session", () => {
+            service = new TimeService();
+
+            // First snapshot
+            const r1 = service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", { duration: "1h" }),
+                entry("sess-2", "time:timer_fired", { duration: "2h" }),
+            ]);
+            expect(r1.applied).toBe(2);
+
+            // Second snapshot: only sess-1 remains, sess-2 is stale
+            const r2 = service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", { duration: "30m" }),
+            ]);
+            expect(r2.applied).toBe(1);
+        });
+
+        test("second reconcile with empty snapshot removes crons", () => {
+            service = new TimeService();
+
+            const r1 = service.reconcileSubscriptions([
+                entry("sess-1", "time:cron", { cron: "*/30 * * * *" }),
+            ]);
+            expect(r1.applied).toBe(1);
+
+            // Remove the cron via empty snapshot
+            const r2 = service.reconcileSubscriptions([]);
+            expect(r2.applied).toBe(0);
+        });
+    });
+
+    describe("mixed subscription types in one snapshot", () => {
+        test("handles all three time trigger types together", () => {
+            service = new TimeService();
+            // Use a near-future at-time so setTimeout stays within 32-bit range
+            const futureMs = Date.now() + 15 * 24 * 60 * 60 * 1000; // 15 days
+            const at = new Date(futureMs).toISOString();
+            const result = service.reconcileSubscriptions([
+                entry("sess-timer", "time:timer_fired", { duration: "1h" }),
+                entry("sess-at", "time:at", { at }),
+                entry("sess-cron", "time:cron", { cron: "0 0 * * *" }),
+            ]);
+            expect(result.applied).toBe(3);
+            expect(result.errors).toBeUndefined();
+        });
+
+        test("counts correctly when time subs are mixed with other service subs", () => {
+            service = new TimeService();
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", { duration: "5m", label: "reminder" }),
+                entry("sess-1", "github:pr_opened"),          // ignored
+                entry("sess-2", "time:cron", { cron: "0 8 * * 1-5" }),
+                entry("sess-2", "godmother:idea_shipped"),    // ignored
+            ]);
+            // Only 2 time subscriptions applied
+            expect(result.applied).toBe(2);
+        });
+    });
+
+    describe("delta reconciliation", () => {
+        test("unsubscribe delta removes an existing timer", async () => {
+            setupBroadcastEnv();
+            const fetchCalls: Array<{ url: string; body: string }> = [];
+            globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+                fetchCalls.push({
+                    url: typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+                    body: typeof init?.body === "string" ? init.body : "",
+                });
+                return new Response(null, { status: 200 });
+            }) as typeof fetch;
+
+            service = new TimeService();
+            service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", { duration: "0.02s", label: "short" }),
+            ], { mode: "delta", action: "subscribe" });
+
+            const result = service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired"),
+            ], { mode: "delta", action: "unsubscribe" });
+
+            expect(result.applied).toBe(1);
+            await new Promise((resolve) => setTimeout(resolve, 60));
+            expect(fetchCalls).toHaveLength(0);
+        });
+
+        test("single-subscription delta does not remove unrelated timers", async () => {
+            setupBroadcastEnv();
+            const fetchCalls: Array<{ url: string; body: string }> = [];
+            globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+                fetchCalls.push({
+                    url: typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url,
+                    body: typeof init?.body === "string" ? init.body : "",
+                });
+                return new Response(null, { status: 200 });
+            }) as typeof fetch;
+
+            service = new TimeService();
+            service.reconcileSubscriptions([
+                entry("sess-a", "time:timer_fired", { duration: "0.2s", label: "long" }),
+                entry("sess-b", "time:timer_fired", { duration: "0.02s", label: "short" }),
+            ]);
+
+            const result = service.reconcileSubscriptions([
+                entry("sess-a", "time:timer_fired", { duration: "0.2s", label: "long-updated" }),
+            ], { mode: "delta", action: "update" });
+
+            expect(result.applied).toBe(1);
+            await new Promise((resolve) => setTimeout(resolve, 70));
+            expect(fetchCalls).toHaveLength(1);
+            expect(fetchCalls[0]?.url).toBe("http://relay.test/api/runners/runner-test/trigger-broadcast");
+            expect(fetchCalls[0]?.body).toContain('"label":"short"');
+        });
+    });
+
+    describe("dispose after reconcile", () => {
+        test("dispose() cleans up without errors after reconcileSubscriptions", () => {
+            service = new TimeService();
+            service.reconcileSubscriptions([
+                entry("sess-1", "time:timer_fired", { duration: "1h" }),
+                entry("sess-2", "time:cron", { cron: "*/15 * * * *" }),
+            ]);
+            // Should not throw
+            expect(() => service.dispose()).not.toThrow();
+        });
+    });
+});

--- a/packages/cli/src/runner/services/time-service.ts
+++ b/packages/cli/src/runner/services/time-service.ts
@@ -290,6 +290,12 @@ export class TimeService implements ServiceHandler {
      * For time:timer_fired and time:cron, the timer restarts from scratch (no elapsed
      * time is preserved across restarts). For time:at, the target time is absolute, so
      * the timer fires at the right time (or immediately if already past).
+     *
+     * @note This implementation assumes **at most one active subscription per
+     * (sessionId, triggerType) pair**. The internal timer keys are keyed as
+     * `timer:<sessionId>`, `at:<sessionId>`, and `cron:<sessionId>`, which allows
+     * only one slot per session per type. A second subscription for the same
+     * (sessionId, triggerType) will silently overwrite the first.
      */
     reconcileSubscriptions(subscriptions: TriggerSubscriptionEntry[], options: ReconcileOptions = {}): { applied: number; errors?: string[] } {
         const mode = options.mode ?? "snapshot";

--- a/packages/cli/src/runner/services/time-service.ts
+++ b/packages/cli/src/runner/services/time-service.ts
@@ -18,8 +18,8 @@ import { homedir } from "node:os";
 import type { Socket } from "socket.io-client";
 // Bun's Server generic requires a WebSocketData type param; we don't use WS so `unknown` suffices.
 type BunServer = import("bun").Server<unknown>;
-import type { ServiceHandler, ServiceInitOptions } from "../service-handler.js";
-import type { ServiceTriggerDef, ServiceSigilDef } from "@pizzapi/protocol";
+import type { ReconcileOptions, ServiceHandler, ServiceInitOptions } from "../service-handler.js";
+import type { ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import {
     parseDuration,
     formatDuration,
@@ -283,6 +283,74 @@ export class TimeService implements ServiceHandler {
         logInfo(`[time] service started, resolve server on port ${this.#server.port}`);
     }
 
+    /**
+     * Reconcile in-memory timer/cron state from either a full subscription snapshot
+     * or a single live delta.
+     *
+     * For time:timer_fired and time:cron, the timer restarts from scratch (no elapsed
+     * time is preserved across restarts). For time:at, the target time is absolute, so
+     * the timer fires at the right time (or immediately if already past).
+     */
+    reconcileSubscriptions(subscriptions: TriggerSubscriptionEntry[], options: ReconcileOptions = {}): { applied: number; errors?: string[] } {
+        const mode = options.mode ?? "snapshot";
+        const action = options.action ?? "subscribe";
+
+        // Only handle our trigger types
+        const timeSubs = subscriptions.filter(
+            (s) =>
+                s.triggerType === "time:timer_fired" ||
+                s.triggerType === "time:at" ||
+                s.triggerType === "time:cron",
+        );
+
+        if (mode === "snapshot") {
+            // Build a lookup of (sessionId + triggerType) → entry for the snapshot
+            const snapshotKeys = new Set(timeSubs.map((s) => `${s.sessionId}\0${s.triggerType}`));
+
+            // Remove any timers/crons NOT present in the snapshot (stale from a previous connection)
+            for (const [key, timer] of this.#timers) {
+                // Key format: "timer:<sessionId>" or "at:<sessionId>"
+                const colonIdx = key.indexOf(":");
+                const typePrefix = key.slice(0, colonIdx); // "timer" | "at"
+                const sessionId = key.slice(colonIdx + 1);
+                const triggerType = typePrefix === "timer" ? "time:timer_fired" : "time:at";
+                if (!snapshotKeys.has(`${sessionId}\0${triggerType}`)) {
+                    clearTimeout(timer.handle);
+                    this.#timers.delete(key);
+                    logInfo(`[time] reconcile: removed stale timer ${key}`);
+                }
+            }
+            for (const [key, cron] of this.#crons) {
+                // Key format: "cron:<sessionId>"
+                const sessionId = key.slice("cron:".length);
+                if (!snapshotKeys.has(`${sessionId}\0time:cron`)) {
+                    clearInterval(cron.handle);
+                    this.#crons.delete(key);
+                    this.#cronIterations.delete(key);
+                    logInfo(`[time] reconcile: removed stale cron ${key}`);
+                }
+            }
+        }
+
+        // Create/update/remove timers for the relevant subscriptions.
+        let applied = 0;
+        const errors: string[] = [];
+
+        for (const sub of timeSubs) {
+            try {
+                this.#applySubscription(sub, mode === "delta" ? action : "subscribe");
+                applied++;
+            } catch (err) {
+                const msg = `${sub.sessionId}/${sub.triggerType}: ${err instanceof Error ? err.message : String(err)}`;
+                logWarn(`[time] reconcile error: ${msg}`);
+                errors.push(msg);
+            }
+        }
+
+        logInfo(`[time] reconciled ${applied}/${timeSubs.length} subscriptions from ${mode}${mode === "delta" ? ` (${action})` : ""}`);
+        return { applied, ...(errors.length > 0 ? { errors } : {}) };
+    }
+
     dispose(): void {
         // Clear all timers
         for (const timer of this.#timers.values()) {
@@ -369,6 +437,17 @@ export class TimeService implements ServiceHandler {
     }
 
     // ── Timer subscription handlers ──────────────────────────────────────
+
+    #applySubscription(sub: TriggerSubscriptionEntry, action: "subscribe" | "update" | "unsubscribe"): void {
+        const { sessionId, triggerType, params } = sub;
+        if (triggerType === "time:timer_fired") {
+            this.#handleTimerSubscription(sessionId, params, action);
+        } else if (triggerType === "time:at") {
+            this.#handleAtSubscription(sessionId, params, action);
+        } else if (triggerType === "time:cron") {
+            this.#handleCronSubscription(sessionId, params, action);
+        }
+    }
 
     #handleTimerSubscription(sessionId: string, params: any, action: string): void {
         const key = `timer:${sessionId}`;

--- a/packages/cli/src/runner/services/time-service.ts
+++ b/packages/cli/src/runner/services/time-service.ts
@@ -213,8 +213,6 @@ export class TimeService implements ServiceHandler {
     #timers = new Map<string, TimerEntry>();
     #crons = new Map<string, CronEntry>();
     #cronIterations = new Map<string, number>();
-    #onSubscriptionChanged: ((data: any) => void) | null = null;
-
     init(socket: Socket, { announceSigilServer }: ServiceInitOptions): void {
         this.#socket = socket;
 
@@ -263,22 +261,9 @@ export class TimeService implements ServiceHandler {
             announceSigilServer(port);
         }
 
-        // Listen for subscription changes to start/stop timers
-        this.#onSubscriptionChanged = (data: any) => {
-            if (!data || typeof data !== "object") return;
-            const { sessionId, triggerType, params, action } = data;
-            if (typeof triggerType !== "string" || typeof sessionId !== "string") return;
-
-            if (triggerType === "time:timer_fired") {
-                this.#handleTimerSubscription(sessionId, params, action);
-            } else if (triggerType === "time:at") {
-                this.#handleAtSubscription(sessionId, params, action);
-            } else if (triggerType === "time:cron") {
-                this.#handleCronSubscription(sessionId, params, action);
-            }
-        };
-
-        (socket as any).on("subscription_params_changed", this.#onSubscriptionChanged);
+        // Subscription changes are delivered via trigger_subscription_delta and
+        // handled through reconcileSubscriptions() — no socket listener needed here.
+        // (The legacy subscription_params_changed event has been removed from the server.)
 
         logInfo(`[time] service started, resolve server on port ${this.#server.port}`);
     }
@@ -371,10 +356,7 @@ export class TimeService implements ServiceHandler {
         this.#crons.clear();
         this.#cronIterations.clear();
 
-        // Remove socket listener
-        if (this.#socket && this.#onSubscriptionChanged) {
-            (this.#socket as any).off("subscription_params_changed", this.#onSubscriptionChanged);
-        }
+        // No socket listener to remove — subscription changes come via reconcileSubscriptions().
         this.#socket = null;
 
         // Stop HTTP server

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -59,6 +59,10 @@ export type {
   RunnerServerToClientEvents,
   RunnerInterServerEvents,
   RunnerSocketData,
+  TriggerSubscriptionEntry,
+  TriggerSubscriptionsSnapshot,
+  TriggerSubscriptionDelta,
+  TriggerSubscriptionsApplied,
 } from "./runner.js";
 
 // /terminal namespace (Browser terminal viewer ↔ Server)

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -11,6 +11,12 @@ import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook, ServiceAnnounc
 /**
  * A single trigger subscription entry used in reconciliation snapshots/deltas.
  * Mirrors the data stored in Redis by trigger-subscription-store.ts.
+ *
+ * @note The reconciliation protocol currently assumes **at most one active
+ * subscription per (sessionId, triggerType) pair**. Multiple subscriptions to
+ * the same trigger type from the same session are not supported — the last
+ * subscription wins. The dedup key `${sessionId}\0${triggerType}` used in
+ * snapshot reconciliation enforces this at the protocol layer.
  */
 export interface TriggerSubscriptionEntry {
   sessionId: string;

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -2,7 +2,60 @@
 // /runner namespace — Runner daemon ↔ Server
 // ============================================================================
 
-import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook, ServiceAnnounceData, ServiceEnvelope, SocketClientMetadata } from "./shared.js";
+import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook, ServiceAnnounceData, ServiceEnvelope, SocketClientMetadata, TriggerFilter, TriggerFilterMode } from "./shared.js";
+
+// ---------------------------------------------------------------------------
+// Trigger subscription reconciliation types
+// ---------------------------------------------------------------------------
+
+/**
+ * A single trigger subscription entry used in reconciliation snapshots/deltas.
+ * Mirrors the data stored in Redis by trigger-subscription-store.ts.
+ */
+export interface TriggerSubscriptionEntry {
+  sessionId: string;
+  triggerType: string;
+  runnerId: string;
+  params?: Record<string, string | number | boolean | Array<string | number | boolean>>;
+  filters?: TriggerFilter[];
+  filterMode?: TriggerFilterMode;
+}
+
+/**
+ * Full snapshot of all active subscriptions for a runner's sessions.
+ * Sent server → runner after registration so the runner can rebuild state.
+ */
+export interface TriggerSubscriptionsSnapshot {
+  /** Monotonic revision number for ordering. */
+  revision: number;
+  /** All active subscriptions for sessions on this runner. */
+  subscriptions: TriggerSubscriptionEntry[];
+}
+
+/**
+ * A single subscription change (add/update/remove).
+ * Sent server → runner when a subscription changes at runtime.
+ */
+export interface TriggerSubscriptionDelta {
+  /** Monotonic revision number for ordering. */
+  revision: number;
+  /** The type of change. */
+  action: "subscribe" | "update" | "unsubscribe";
+  /** The affected subscription entry. For unsubscribe, only sessionId + triggerType are required. */
+  subscription: TriggerSubscriptionEntry;
+}
+
+/**
+ * Ack from runner → server confirming it applied a snapshot or delta.
+ */
+export interface TriggerSubscriptionsApplied {
+  /** The revision number that was applied. */
+  revision: number;
+  /** Number of subscriptions successfully reconciled. */
+  applied: number;
+  /** Optional error messages for subscriptions that failed to reconcile. */
+  errors?: string[];
+}
 
 // ---------------------------------------------------------------------------
 // Client → Server (Runner daemon sends to server)
@@ -126,6 +179,9 @@ export interface RunnerClientToServerEvents {
   disconnect_session: (data: {
     sessionId: string;
   }) => void;
+
+  /** Ack that the runner applied a trigger subscription snapshot or delta. */
+  trigger_subscriptions_applied: (data: TriggerSubscriptionsApplied) => void;
 
   /** Generic service message from runner → relay → viewer.
    *  The relay forwards this verbatim; it does not inspect serviceId. */
@@ -385,6 +441,14 @@ export interface RunnerServerToClientEvents {
     /** The new value for that section */
     value: unknown;
   }) => void;
+
+  /** Full snapshot of active trigger subscriptions for this runner's sessions.
+   *  Sent after runner_registered so the runner can rebuild subscription state. */
+  trigger_subscriptions_snapshot: (data: TriggerSubscriptionsSnapshot) => void;
+
+  /** Single subscription change (add/update/remove).
+   *  Sent at runtime when a session subscribes, updates, or unsubscribes. */
+  trigger_subscription_delta: (data: TriggerSubscriptionDelta) => void;
 
   /** Generic service message from viewer → relay → runner.
    *  The relay forwards this verbatim; it does not inspect serviceId. */

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -36,6 +36,15 @@ export interface TriggerSubscriptionsSnapshot {
   revision: number;
   /** All active subscriptions for sessions on this runner. */
   subscriptions: TriggerSubscriptionEntry[];
+  /**
+   * True when this snapshot is sent as part of a reconnect/re-registration
+   * handshake. The runner must treat it as an authoritative full baseline and
+   * apply it unconditionally, ignoring any previously cached revision number.
+   * This prevents the lost-baseline race where a concurrent delta arrives with
+   * a higher revision before the snapshot, causing the snapshot to be dropped
+   * as stale even though it contains the complete pre-existing state.
+   */
+  isReconnect?: boolean;
 }
 
 /**

--- a/packages/protocol/src/trigger-reconciliation.test.ts
+++ b/packages/protocol/src/trigger-reconciliation.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the trigger subscription reconciliation types added to @pizzapi/protocol.
+ *
+ * Verifies that the new types are exported with the expected shapes.
+ */
+
+import { describe, test, expect } from "bun:test";
+import type {
+    TriggerSubscriptionEntry,
+    TriggerSubscriptionsSnapshot,
+    TriggerSubscriptionDelta,
+    TriggerSubscriptionsApplied,
+} from "./index.js";
+
+describe("TriggerSubscriptionEntry", () => {
+    test("accepts a minimal entry with only required fields", () => {
+        const entry: TriggerSubscriptionEntry = {
+            sessionId: "session-1",
+            triggerType: "time:timer_fired",
+            runnerId: "runner-abc",
+        };
+        expect(entry.sessionId).toBe("session-1");
+        expect(entry.triggerType).toBe("time:timer_fired");
+        expect(entry.runnerId).toBe("runner-abc");
+    });
+
+    test("accepts a full entry with all optional fields", () => {
+        const entry: TriggerSubscriptionEntry = {
+            sessionId: "session-2",
+            triggerType: "github:pr_opened",
+            runnerId: "runner-abc",
+            params: { repo: "org/repo", branch: "main", count: 5, active: true },
+            filters: [
+                { field: "status", value: "open", op: "eq" },
+                { field: "title", value: "fix", op: "contains" },
+            ],
+            filterMode: "and",
+        };
+        expect(entry.params?.repo).toBe("org/repo");
+        expect(entry.params?.count).toBe(5);
+        expect(entry.filters).toHaveLength(2);
+        expect(entry.filterMode).toBe("and");
+    });
+
+    test("params can contain array values", () => {
+        const entry: TriggerSubscriptionEntry = {
+            sessionId: "s",
+            triggerType: "t",
+            runnerId: "r",
+            params: { tags: ["bug", "urgent"] },
+        };
+        expect(Array.isArray(entry.params?.tags)).toBe(true);
+    });
+
+    test("filterMode can be 'or'", () => {
+        const entry: TriggerSubscriptionEntry = {
+            sessionId: "s",
+            triggerType: "t",
+            runnerId: "r",
+            filterMode: "or",
+        };
+        expect(entry.filterMode).toBe("or");
+    });
+});
+
+describe("TriggerSubscriptionsSnapshot", () => {
+    test("has revision and subscriptions array", () => {
+        const snapshot: TriggerSubscriptionsSnapshot = {
+            revision: 1,
+            subscriptions: [],
+        };
+        expect(snapshot.revision).toBe(1);
+        expect(Array.isArray(snapshot.subscriptions)).toBe(true);
+    });
+
+    test("contains TriggerSubscriptionEntry items", () => {
+        const snapshot: TriggerSubscriptionsSnapshot = {
+            revision: 5,
+            subscriptions: [
+                { sessionId: "s1", triggerType: "time:cron", runnerId: "r1" },
+                { sessionId: "s2", triggerType: "time:at", runnerId: "r1", params: { at: "2026-01-01T00:00Z" } },
+            ],
+        };
+        expect(snapshot.subscriptions).toHaveLength(2);
+        expect(snapshot.subscriptions[0].sessionId).toBe("s1");
+        expect(snapshot.subscriptions[1].params?.at).toBe("2026-01-01T00:00Z");
+    });
+});
+
+describe("TriggerSubscriptionDelta", () => {
+    test("subscribe delta has all required fields", () => {
+        const delta: TriggerSubscriptionDelta = {
+            revision: 2,
+            action: "subscribe",
+            subscription: {
+                sessionId: "s1",
+                triggerType: "time:timer_fired",
+                runnerId: "r1",
+                params: { duration: "10m" },
+            },
+        };
+        expect(delta.action).toBe("subscribe");
+        expect(delta.revision).toBe(2);
+        expect(delta.subscription.params?.duration).toBe("10m");
+    });
+
+    test("update delta is valid", () => {
+        const delta: TriggerSubscriptionDelta = {
+            revision: 3,
+            action: "update",
+            subscription: {
+                sessionId: "s1",
+                triggerType: "github:pr_comment",
+                runnerId: "r1",
+                filters: [{ field: "repo", value: "org/repo" }],
+                filterMode: "and",
+            },
+        };
+        expect(delta.action).toBe("update");
+        expect(delta.subscription.filters?.[0].field).toBe("repo");
+    });
+
+    test("unsubscribe delta only requires sessionId and triggerType", () => {
+        const delta: TriggerSubscriptionDelta = {
+            revision: 4,
+            action: "unsubscribe",
+            subscription: {
+                sessionId: "s1",
+                triggerType: "time:timer_fired",
+                runnerId: "r1",
+            },
+        };
+        expect(delta.action).toBe("unsubscribe");
+        expect(delta.subscription.params).toBeUndefined();
+        expect(delta.subscription.filters).toBeUndefined();
+    });
+});
+
+describe("TriggerSubscriptionsApplied", () => {
+    test("has revision and applied count", () => {
+        const ack: TriggerSubscriptionsApplied = {
+            revision: 1,
+            applied: 3,
+        };
+        expect(ack.revision).toBe(1);
+        expect(ack.applied).toBe(3);
+    });
+
+    test("can include optional errors", () => {
+        const ack: TriggerSubscriptionsApplied = {
+            revision: 2,
+            applied: 1,
+            errors: ["session-x/time:cron: invalid cron expression"],
+        };
+        expect(ack.errors).toHaveLength(1);
+        expect(ack.errors![0]).toContain("invalid cron expression");
+    });
+
+    test("errors is optional and can be undefined", () => {
+        const ack: TriggerSubscriptionsApplied = {
+            revision: 5,
+            applied: 0,
+        };
+        expect(ack.errors).toBeUndefined();
+    });
+});
+
+describe("type exports from @pizzapi/protocol index", () => {
+    test("all four types are importable as values (runtime check via object shape)", () => {
+        // TypeScript type-only imports can't be introspected at runtime,
+        // but we can verify that the shapes constructed above compile and hold
+        // the expected field values — this confirms the types exist and are correct.
+        const entry: TriggerSubscriptionEntry = { sessionId: "x", triggerType: "t", runnerId: "r" };
+        const snapshot: TriggerSubscriptionsSnapshot = { revision: 0, subscriptions: [entry] };
+        const delta: TriggerSubscriptionDelta = { revision: 1, action: "subscribe", subscription: entry };
+        const applied: TriggerSubscriptionsApplied = { revision: 1, applied: 1 };
+
+        expect(snapshot.subscriptions[0]).toEqual(entry);
+        expect(delta.subscription).toEqual(entry);
+        expect(applied.applied).toBe(1);
+    });
+});

--- a/packages/server/src/routes/triggers.reconciliation.test.ts
+++ b/packages/server/src/routes/triggers.reconciliation.test.ts
@@ -187,7 +187,7 @@ describe("trigger subscription reconciliation — delta emission", () => {
                     {
                         type: "time:timer_fired",
                         label: "Timer Fired",
-                        params: [{ name: "duration", type: "string", required: true }],
+                        params: [{ name: "duration", label: "Duration", type: "string", required: true }],
                     },
                     {
                         type: "godmother:idea_moved",

--- a/packages/server/src/routes/triggers.reconciliation.test.ts
+++ b/packages/server/src/routes/triggers.reconciliation.test.ts
@@ -1,0 +1,329 @@
+/**
+ * Focused tests for trigger subscription reconciliation behaviour in the triggers route:
+ *
+ * 1. DELETE (unsubscribe) emits a TriggerSubscriptionDelta with action="unsubscribe"
+ * 2. POST (subscribe) always emits a delta, even when no params are provided
+ * 3. PUT (update) emits a delta with action="update"
+ *
+ * These tests mock all external dependencies so they run with no Redis or Socket.IO.
+ */
+
+import { describe, test, expect, beforeEach, mock } from "bun:test";
+
+// ── Mock emitTriggerSubscriptionDelta ────────────────────────────────────────
+// Must be declared before the dynamic import of the route handler so the
+// module registry picks up the mock when triggers.ts is first evaluated.
+const mockEmitDelta = mock((_runnerId: string, _delta: any) => {});
+
+mock.module("../ws/namespaces/runner.js", () => ({
+    emitTriggerSubscriptionDelta: mockEmitDelta,
+}));
+
+// ── Mock sio-registry ────────────────────────────────────────────────────────
+const mockGetSharedSession = mock((_id: string) => Promise.resolve(null as any));
+const mockGetLocalTuiSocket = mock((_id: string) => null as any);
+const mockEmitToRelaySessionVerified = mock(() => Promise.resolve(false));
+const mockBroadcastToSessionViewers = mock(() => {});
+const mockGetLocalRunnerSocket = mock((_runnerId: string) => null as any);
+const mockRecordRunnerSession = mock(() => Promise.resolve());
+const mockLinkSessionToRunner = mock(() => Promise.resolve());
+
+mock.module("../ws/sio-registry.js", () => ({
+    getSharedSession: mockGetSharedSession,
+    getLocalTuiSocket: mockGetLocalTuiSocket,
+    emitToRelaySessionVerified: mockEmitToRelaySessionVerified,
+    broadcastToSessionViewers: mockBroadcastToSessionViewers,
+    getLocalRunnerSocket: mockGetLocalRunnerSocket,
+    recordRunnerSession: mockRecordRunnerSession,
+    linkSessionToRunner: mockLinkSessionToRunner,
+}));
+
+// ── Mock middleware ──────────────────────────────────────────────────────────
+const mockRequireSession = mock((_req: Request) =>
+    Promise.resolve({ userId: "user-1", userName: "TestUser" } as any),
+);
+const mockValidateApiKey = mock((_req: Request, _key?: string) =>
+    Promise.resolve({ userId: "user-1", userName: "TestUser" } as any),
+);
+mock.module("../middleware.js", () => ({
+    requireSession: mockRequireSession,
+    validateApiKey: mockValidateApiKey,
+}));
+
+// ── Mock trigger stores ──────────────────────────────────────────────────────
+const mockSubscribeSessionToTrigger = mock(() => Promise.resolve());
+const mockUnsubscribeSessionFromTrigger = mock(() => Promise.resolve());
+const mockListSessionSubscriptions = mock(() => Promise.resolve([] as any[]));
+const mockGetSubscribersForTrigger = mock(() => Promise.resolve([] as string[]));
+const mockGetSubscriptionParams = mock(() => Promise.resolve(undefined as any));
+const mockGetSubscriptionFilters = mock(() => Promise.resolve(undefined as any));
+const mockUpdateSessionSubscription = mock(() => Promise.resolve({ updated: true, runnerId: "runner-A" } as any));
+
+mock.module("../sessions/trigger-subscription-store.js", () => ({
+    subscribeSessionToTrigger: mockSubscribeSessionToTrigger,
+    unsubscribeSessionFromTrigger: mockUnsubscribeSessionFromTrigger,
+    listSessionSubscriptions: mockListSessionSubscriptions,
+    getSubscribersForTrigger: mockGetSubscribersForTrigger,
+    getSubscriptionParams: mockGetSubscriptionParams,
+    getSubscriptionFilters: mockGetSubscriptionFilters,
+    updateSessionSubscription: mockUpdateSessionSubscription,
+}));
+
+mock.module("../sessions/trigger-store.js", () => ({
+    pushTriggerHistory: mock(() => Promise.resolve()),
+    getTriggerHistory: mock(() => Promise.resolve([])),
+    clearTriggerHistory: mock(() => Promise.resolve()),
+}));
+
+mock.module("../sessions/runner-trigger-listener-store.js", () => ({
+    getRunnerListenerTypes: mock(() => Promise.resolve([])),
+    getRunnerTriggerListener: mock(() => Promise.resolve(null)),
+    updateRunnerTriggerListener: mock(() => Promise.resolve(false)),
+}));
+
+mock.module("../ws/runner-control.js", () => ({
+    waitForSpawnAck: mock(() => Promise.resolve({ ok: true })),
+}));
+
+// ── Mock runners registry (spyOn not viable across modules; use mock.module) ──
+import * as _runnersModule from "../ws/sio-registry/runners.js";
+
+// Default: no runner services. Individual tests override as needed.
+const mockGetRunnerServices = mock((_rid: string) => Promise.resolve(null as any));
+const mockGetRunnerData = mock(() => Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
+
+mock.module("../ws/sio-registry/runners.js", () => ({
+    ..._runnersModule,
+    getRunnerServices: mockGetRunnerServices,
+    getRunnerData: mockGetRunnerData,
+}));
+
+// ── Import route handler (after mocks) ──────────────────────────────────────
+const { handleTriggersRoute } = await import("./triggers.js");
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeReq(method: string, path: string, body?: object): [Request, URL] {
+    const url = new URL(`http://localhost${path}`);
+    const init: RequestInit = {
+        method,
+        headers: { "content-type": "application/json" },
+    };
+    if (body) init.body = JSON.stringify(body);
+    return [new Request(url.toString(), init), url];
+}
+
+const SESSION_WITH_RUNNER = {
+    userId: "user-1",
+    sessionId: "sess-1",
+    runnerId: "runner-A",
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("trigger subscription reconciliation — delta emission", () => {
+    beforeEach(() => {
+        mockEmitDelta.mockClear();
+        mockGetSharedSession.mockReset();
+        mockRequireSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", userName: "TestUser" }),
+        );
+        mockGetRunnerServices.mockReturnValue(Promise.resolve(null));
+    });
+
+    // ── DELETE (unsubscribe) ──────────────────────────────────────────────
+
+    describe("DELETE /api/sessions/:id/trigger-subscriptions/:triggerType", () => {
+        test("emits an unsubscribe delta to the runner", async () => {
+            mockGetSharedSession.mockReturnValue(
+                Promise.resolve({ ...SESSION_WITH_RUNNER } as any),
+            );
+
+            const [req, url] = makeReq(
+                "DELETE",
+                "/api/sessions/sess-1/trigger-subscriptions/time:timer_fired",
+            );
+            const res = await handleTriggersRoute(req, url);
+            expect(res!.status).toBe(200);
+
+            // emitTriggerSubscriptionDelta must have been called once
+            expect(mockEmitDelta).toHaveBeenCalledTimes(1);
+
+            const [runnerId, delta] = mockEmitDelta.mock.calls[0] as [string, any];
+            expect(runnerId).toBe("runner-A");
+            expect(delta.action).toBe("unsubscribe");
+            expect(delta.subscription.sessionId).toBe("sess-1");
+            expect(delta.subscription.triggerType).toBe("time:timer_fired");
+            expect(delta.subscription.runnerId).toBe("runner-A");
+        });
+
+        test("does NOT emit a delta when session has no runner", async () => {
+            mockGetSharedSession.mockReturnValue(
+                Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: null } as any),
+            );
+
+            const [req, url] = makeReq(
+                "DELETE",
+                "/api/sessions/sess-1/trigger-subscriptions/time:timer_fired",
+            );
+            await handleTriggersRoute(req, url);
+
+            expect(mockEmitDelta).not.toHaveBeenCalled();
+        });
+    });
+
+    // ── POST (subscribe) ──────────────────────────────────────────────────
+
+    describe("POST /api/sessions/:id/trigger-subscriptions", () => {
+        beforeEach(() => {
+            // Provide a valid trigger catalog so the POST route proceeds past validation
+            mockGetRunnerServices.mockReturnValue(Promise.resolve({
+                serviceIds: ["time"],
+                triggerDefs: [
+                    {
+                        type: "time:timer_fired",
+                        label: "Timer Fired",
+                        params: [{ name: "duration", type: "string", required: true }],
+                    },
+                    {
+                        type: "godmother:idea_moved",
+                        label: "Idea Moved",
+                        // no required params
+                    },
+                ],
+            }));
+        });
+
+        test("emits a subscribe delta even when no params are supplied", async () => {
+            mockGetSharedSession.mockReturnValue(
+                Promise.resolve({ ...SESSION_WITH_RUNNER } as any),
+            );
+
+            // godmother:idea_moved has no required params — subscribe with bare triggerType
+            const [req, url] = makeReq(
+                "POST",
+                "/api/sessions/sess-1/trigger-subscriptions",
+                { triggerType: "godmother:idea_moved" },
+            );
+            const res = await handleTriggersRoute(req, url);
+            expect(res!.status).toBe(200);
+
+            expect(mockEmitDelta).toHaveBeenCalledTimes(1);
+            const [runnerId, delta] = mockEmitDelta.mock.calls[0] as [string, any];
+            expect(runnerId).toBe("runner-A");
+            expect(delta.action).toBe("subscribe");
+            expect(delta.subscription.sessionId).toBe("sess-1");
+            expect(delta.subscription.triggerType).toBe("godmother:idea_moved");
+            expect(delta.subscription.runnerId).toBe("runner-A");
+            // No params in the delta when none were supplied
+            expect(delta.subscription.params).toBeUndefined();
+        });
+
+        test("emits a subscribe delta with params when params are supplied", async () => {
+            mockGetSharedSession.mockReturnValue(
+                Promise.resolve({ ...SESSION_WITH_RUNNER } as any),
+            );
+
+            const [req, url] = makeReq(
+                "POST",
+                "/api/sessions/sess-1/trigger-subscriptions",
+                { triggerType: "time:timer_fired", params: { duration: "10m" } },
+            );
+            const res = await handleTriggersRoute(req, url);
+            expect(res!.status).toBe(200);
+
+            expect(mockEmitDelta).toHaveBeenCalledTimes(1);
+            const [, delta] = mockEmitDelta.mock.calls[0] as [string, any];
+            expect(delta.action).toBe("subscribe");
+            expect(delta.subscription.params?.duration).toBe("10m");
+        });
+
+        test("emits a subscribe delta with filters when filters are supplied", async () => {
+            mockGetSharedSession.mockReturnValue(
+                Promise.resolve({ ...SESSION_WITH_RUNNER } as any),
+            );
+
+            const [req, url] = makeReq(
+                "POST",
+                "/api/sessions/sess-1/trigger-subscriptions",
+                {
+                    triggerType: "godmother:idea_moved",
+                    filters: [{ field: "status", value: "shipped" }],
+                    filterMode: "and",
+                },
+            );
+            const res = await handleTriggersRoute(req, url);
+            expect(res!.status).toBe(200);
+
+            const [, delta] = mockEmitDelta.mock.calls[0] as [string, any];
+            expect(delta.action).toBe("subscribe");
+            expect(delta.subscription.filters?.[0].field).toBe("status");
+            expect(delta.subscription.filterMode).toBe("and");
+        });
+
+        test("does NOT emit a delta when session has no runner", async () => {
+            mockGetSharedSession.mockReturnValue(
+                // No runnerId → session has no runner
+                Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: null } as any),
+            );
+
+            const [req, url] = makeReq(
+                "POST",
+                "/api/sessions/sess-1/trigger-subscriptions",
+                { triggerType: "godmother:idea_moved" },
+            );
+            // Route returns 422 "no associated runner" before reaching the delta emit
+            const res = await handleTriggersRoute(req, url);
+            expect(res!.status).toBe(422);
+            expect(mockEmitDelta).not.toHaveBeenCalled();
+        });
+    });
+
+    // ── PUT (update) ──────────────────────────────────────────────────────
+
+    describe("PUT /api/sessions/:id/trigger-subscriptions/:triggerType", () => {
+        test("emits an update delta to the runner", async () => {
+            mockGetSharedSession.mockReturnValue(
+                Promise.resolve({ ...SESSION_WITH_RUNNER } as any),
+            );
+            // updateSessionSubscription returns updated=true
+            mockUpdateSessionSubscription.mockReturnValue(
+                Promise.resolve({ updated: true, runnerId: "runner-A" }),
+            );
+
+            const [req, url] = makeReq(
+                "PUT",
+                "/api/sessions/sess-1/trigger-subscriptions/time:cron",
+                { params: { cron: "0 * * * *" } },
+            );
+            const res = await handleTriggersRoute(req, url);
+            expect(res!.status).toBe(200);
+
+            expect(mockEmitDelta).toHaveBeenCalledTimes(1);
+            const [runnerId, delta] = mockEmitDelta.mock.calls[0] as [string, any];
+            expect(runnerId).toBe("runner-A");
+            expect(delta.action).toBe("update");
+            expect(delta.subscription.sessionId).toBe("sess-1");
+            expect(delta.subscription.triggerType).toBe("time:cron");
+        });
+
+        test("does NOT emit a delta when subscription not found", async () => {
+            mockGetSharedSession.mockReturnValue(
+                Promise.resolve({ ...SESSION_WITH_RUNNER } as any),
+            );
+            mockUpdateSessionSubscription.mockReturnValue(
+                Promise.resolve({ updated: false }),
+            );
+
+            const [req, url] = makeReq(
+                "PUT",
+                "/api/sessions/sess-1/trigger-subscriptions/time:cron",
+                {},
+            );
+            const res = await handleTriggersRoute(req, url);
+            // Returns 404 when subscription not found
+            expect(res!.status).toBe(404);
+            expect(mockEmitDelta).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/server/src/routes/triggers.reconciliation.test.ts
+++ b/packages/server/src/routes/triggers.reconciliation.test.ts
@@ -8,7 +8,7 @@
  * These tests mock all external dependencies so they run with no Redis or Socket.IO.
  */
 
-import { describe, test, expect, beforeEach, mock } from "bun:test";
+import { afterAll, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
 
 // ── Mock emitTriggerSubscriptionDelta ────────────────────────────────────────
 // Must be declared before the dynamic import of the route handler so the
@@ -85,20 +85,24 @@ mock.module("../ws/runner-control.js", () => ({
     waitForSpawnAck: mock(() => Promise.resolve({ ok: true })),
 }));
 
-// ── Mock runners registry (spyOn not viable across modules; use mock.module) ──
+// ── Mock runners registry ──────────────────────────────────────────────────
+// Use spyOn instead of mock.module so this file cannot poison the module cache
+// for later test files that import runners.js in the same Bun worker.
 import * as _runnersModule from "../ws/sio-registry/runners.js";
 
 // Default: no runner services. Individual tests override as needed.
-const mockGetRunnerServices = mock((_rid: string) => Promise.resolve(null as any));
-const mockGetRunnerData = mock(() => Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
-
-mock.module("../ws/sio-registry/runners.js", () => ({
-    ..._runnersModule,
-    getRunnerServices: mockGetRunnerServices,
-    getRunnerData: mockGetRunnerData,
-}));
+const mockGetRunnerServices = spyOn(_runnersModule, "getRunnerServices")
+    .mockImplementation((_rid: string) => Promise.resolve(null as any));
+const mockGetRunnerData = spyOn(_runnersModule, "getRunnerData")
+    .mockImplementation(() => Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
 
 // ── Import route handler (after mocks) ──────────────────────────────────────
+afterAll(() => {
+    mockGetRunnerServices.mockRestore();
+    mockGetRunnerData.mockRestore();
+    mock.restore();
+});
+
 const { handleTriggersRoute } = await import("./triggers.js");
 
 // ── Helpers ──────────────────────────────────────────────────────────────────

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -4,7 +4,7 @@
  * Tests the route handler logic with mocked dependencies (Redis, SIO registry).
  */
 
-import { describe, test, expect, beforeEach, afterAll, mock, spyOn } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, afterAll, mock, spyOn } from "bun:test";
 
 const isCI = !!process.env.CI;
 
@@ -73,6 +73,8 @@ const mockGetSubscribersForTrigger = mock((_rid: string, _type: string) => Promi
 const mockGetSubscriptionParams = mock((_sid: string, _type: string) => Promise.resolve(undefined as any));
 const mockGetSubscriptionFilters = mock((_sid: string, _type: string) => Promise.resolve(undefined as any));
 const mockUpdateSessionSubscription = mock((_sid: string, _type: string, _updates: any) => Promise.resolve({ updated: false } as any));
+const mockClearSessionSubscriptions = mock((_sid: string) => Promise.resolve());
+const mockGetSubscriptionsForRunnerSessions = mock((_runnerId: string, _sessionIds: string[]) => Promise.resolve([] as any[]));
 mock.module("../sessions/trigger-subscription-store.js", () => ({
     subscribeSessionToTrigger: mockSubscribeSessionToTrigger,
     unsubscribeSessionFromTrigger: mockUnsubscribeSessionFromTrigger,
@@ -81,16 +83,28 @@ mock.module("../sessions/trigger-subscription-store.js", () => ({
     getSubscriptionParams: mockGetSubscriptionParams,
     getSubscriptionFilters: mockGetSubscriptionFilters,
     updateSessionSubscription: mockUpdateSessionSubscription,
+    clearSessionSubscriptions: mockClearSessionSubscriptions,
+    getSubscriptionsForRunnerSessions: mockGetSubscriptionsForRunnerSessions,
 }));
 
 // ── Mock runners registry ────────────────────────────────────────────────
-// Use spyOn instead of mock.module to avoid poisoning the module cache
-// for other test files that import runners.js in the same Bun process.
+// Use per-test spyOn setup instead of a file-global spy so mocked runner
+// helpers cannot leak into later test files running in the same Bun worker.
 import * as _runnersModule from "../ws/sio-registry/runners.js";
-const mockGetRunnerServices = spyOn(_runnersModule, "getRunnerServices")
-    .mockImplementation((_rid: string) => Promise.resolve(null as any));
-const mockGetRunnerData = spyOn(_runnersModule, "getRunnerData")
-    .mockImplementation((_rid: string) => Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
+let mockGetRunnerServices: ReturnType<typeof spyOn>;
+let mockGetRunnerData: ReturnType<typeof spyOn>;
+
+beforeEach(() => {
+    mockGetRunnerServices = spyOn(_runnersModule, "getRunnerServices")
+        .mockImplementation((_rid: string) => Promise.resolve(null as any));
+    mockGetRunnerData = spyOn(_runnersModule, "getRunnerData")
+        .mockImplementation((_rid: string) => Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
+});
+
+afterEach(() => {
+    mockGetRunnerServices.mockRestore();
+    mockGetRunnerData.mockRestore();
+});
 
 // ── Mock logger ──────────────────────────────────────────────────────────
 // NOTE: @pizzapi/tools mock removed — log calls in tests are harmless,

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -616,7 +616,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         // Also emit the legacy subscription_params_changed event for backward
         // compat with runners that haven't been updated yet.
         if (session.runnerId) {
-            emitTriggerSubscriptionDelta(session.runnerId, {
+            void emitTriggerSubscriptionDelta(session.runnerId, {
                 action: "subscribe",
                 subscription: {
                     sessionId,
@@ -674,7 +674,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         // Notify the runner via typed delta so it can clean up runtime state
         // (e.g. cancel timers). Uses cluster-safe emitTriggerSubscriptionDelta.
         if (session.runnerId) {
-            emitTriggerSubscriptionDelta(session.runnerId, {
+            void emitTriggerSubscriptionDelta(session.runnerId, {
                 action: "unsubscribe",
                 subscription: {
                     sessionId,
@@ -824,7 +824,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
 
         // Notify the runner via typed delta and legacy event
         if (session.runnerId) {
-            emitTriggerSubscriptionDelta(session.runnerId, {
+            void emitTriggerSubscriptionDelta(session.runnerId, {
                 action: "update",
                 subscription: {
                     sessionId,

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -613,8 +613,10 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         broadcastToSessionViewers(sessionId, "trigger_subscriptions_changed", { triggerType, action: "subscribe" });
 
         // Notify the runner via typed delta (always, even without params).
-        // Also emit the legacy subscription_params_changed event for backward
-        // compat with runners that haven't been updated yet.
+        // The reconciliation protocol (trigger_subscription_delta) is the
+        // authoritative path — services use reconcileSubscriptions() to apply it.
+        // The legacy subscription_params_changed event has been removed to
+        // prevent double-apply when both server and runner are updated.
         if (session.runnerId) {
             void emitTriggerSubscriptionDelta(session.runnerId, {
                 action: "subscribe",
@@ -627,20 +629,6 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                     ...(subFilterMode ? { filterMode: subFilterMode } : {}),
                 },
             });
-            // Legacy: subscription_params_changed for older runners
-            if (subParams) {
-                const runnerSocket = getLocalRunnerSocket(session.runnerId);
-                if (runnerSocket) {
-                    runnerSocket.emit("subscription_params_changed" as any, {
-                        sessionId,
-                        triggerType,
-                        params: subParams,
-                        filters: subFilters ?? [],
-                        filterMode: subFilterMode ?? "and",
-                        action: "subscribe",
-                    });
-                }
-            }
         }
 
         return Response.json({
@@ -822,7 +810,10 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         log.info(`Session ${sessionId} updated subscription for '${triggerType}'${logParts.length > 0 ? ` with ${logParts.join(", ")}` : ""}`);
         broadcastToSessionViewers(sessionId, "trigger_subscriptions_changed", { triggerType, action: "update" });
 
-        // Notify the runner via typed delta and legacy event
+        // Notify the runner via typed delta.
+        // The reconciliation protocol (trigger_subscription_delta) is the
+        // authoritative path — the legacy subscription_params_changed event
+        // has been removed to prevent double-apply.
         if (session.runnerId) {
             void emitTriggerSubscriptionDelta(session.runnerId, {
                 action: "update",
@@ -835,17 +826,6 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                     ...(subFilterMode ? { filterMode: subFilterMode } : {}),
                 },
             });
-            // Legacy: subscription_params_changed for older runners
-            const runnerSocket = getLocalRunnerSocket(session.runnerId);
-            if (runnerSocket) {
-                runnerSocket.emit("subscription_params_changed" as any, {
-                    sessionId,
-                    triggerType,
-                    params: subParams ?? {},
-                    filters: subFilters ?? [],
-                    filterMode: subFilterMode ?? "and",
-                });
-            }
         }
 
         return Response.json({

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -43,6 +43,7 @@ import {
     linkSessionToRunner,
 } from "../ws/sio-registry.js";
 import { getRunnerServices, getRunnerData } from "../ws/sio-registry/runners.js";
+import { emitTriggerSubscriptionDelta } from "../ws/namespaces/runner.js";
 import type { RouteHandler } from "./types.js";
 import { randomUUID } from "crypto";
 import { createLogger } from "@pizzapi/tools";
@@ -611,18 +612,34 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         log.info(`Session ${sessionId} subscribed to trigger type '${triggerType}' on runner ${session.runnerId}${logParts.length > 0 ? ` with ${logParts.join(", ")}` : ""}`);
         broadcastToSessionViewers(sessionId, "trigger_subscriptions_changed", { triggerType, action: "subscribe" });
 
-        // Notify the runner service about the new subscription params
-        if (subParams && session.runnerId) {
-            const runnerSocket = getLocalRunnerSocket(session.runnerId);
-            if (runnerSocket) {
-                runnerSocket.emit("subscription_params_changed" as any, {
+        // Notify the runner via typed delta (always, even without params).
+        // Also emit the legacy subscription_params_changed event for backward
+        // compat with runners that haven't been updated yet.
+        if (session.runnerId) {
+            emitTriggerSubscriptionDelta(session.runnerId, {
+                action: "subscribe",
+                subscription: {
                     sessionId,
                     triggerType,
-                    params: subParams,
-                    filters: subFilters ?? [],
-                    filterMode: subFilterMode ?? "and",
-                    action: "subscribe",
-                });
+                    runnerId: session.runnerId,
+                    ...(subParams ? { params: subParams } : {}),
+                    ...(subFilters ? { filters: subFilters } : {}),
+                    ...(subFilterMode ? { filterMode: subFilterMode } : {}),
+                },
+            });
+            // Legacy: subscription_params_changed for older runners
+            if (subParams) {
+                const runnerSocket = getLocalRunnerSocket(session.runnerId);
+                if (runnerSocket) {
+                    runnerSocket.emit("subscription_params_changed" as any, {
+                        sessionId,
+                        triggerType,
+                        params: subParams,
+                        filters: subFilters ?? [],
+                        filterMode: subFilterMode ?? "and",
+                        action: "subscribe",
+                    });
+                }
             }
         }
 
@@ -653,6 +670,20 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         await unsubscribeSessionFromTrigger(sessionId, triggerType);
         log.info(`Session ${sessionId} unsubscribed from trigger type '${triggerType}'`);
         broadcastToSessionViewers(sessionId, "trigger_subscriptions_changed", { triggerType, action: "unsubscribe" });
+
+        // Notify the runner via typed delta so it can clean up runtime state
+        // (e.g. cancel timers). Uses cluster-safe emitTriggerSubscriptionDelta.
+        if (session.runnerId) {
+            emitTriggerSubscriptionDelta(session.runnerId, {
+                action: "unsubscribe",
+                subscription: {
+                    sessionId,
+                    triggerType,
+                    runnerId: session.runnerId,
+                },
+            });
+        }
+
         return Response.json({ ok: true, triggerType });
     }
 
@@ -791,8 +822,20 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         log.info(`Session ${sessionId} updated subscription for '${triggerType}'${logParts.length > 0 ? ` with ${logParts.join(", ")}` : ""}`);
         broadcastToSessionViewers(sessionId, "trigger_subscriptions_changed", { triggerType, action: "update" });
 
-        // Notify the runner service about param changes so it can react
+        // Notify the runner via typed delta and legacy event
         if (session.runnerId) {
+            emitTriggerSubscriptionDelta(session.runnerId, {
+                action: "update",
+                subscription: {
+                    sessionId,
+                    triggerType,
+                    runnerId: session.runnerId,
+                    ...(subParams ? { params: subParams } : {}),
+                    ...(subFilters ? { filters: subFilters } : {}),
+                    ...(subFilterMode ? { filterMode: subFilterMode } : {}),
+                },
+            });
+            // Legacy: subscription_params_changed for older runners
             const runnerSocket = getLocalRunnerSocket(session.runnerId);
             if (runnerSocket) {
                 runnerSocket.emit("subscription_params_changed" as any, {

--- a/packages/server/src/sessions/trigger-subscription-store.ts
+++ b/packages/server/src/sessions/trigger-subscription-store.ts
@@ -72,6 +72,13 @@ const DEFAULT_TTL_SECONDS = 24 * 60 * 60; // 24 hours
 // Process-local fallback counter used only when Redis is unavailable.
 let _localRevision = 0;
 
+// Tracks the highest revision successfully returned by Redis INCR.
+// When Redis becomes unavailable, _localRevision is seeded from this value
+// so fallback revisions are always strictly greater than any previously
+// issued Redis revision. Without this, a runner that has already applied
+// revision N (from Redis) would drop all fallback revisions 1..N as stale.
+let _lastKnownRedisRevision = 0;
+
 /**
  * Atomically increment and return the global trigger subscription revision.
  *
@@ -80,16 +87,25 @@ let _localRevision = 0;
  * discarding valid deltas that originated on a different server node.
  *
  * Falls back to a process-local counter when Redis is unavailable (single-node
- * mode or during startup before Redis connects).
+ * mode or during startup before Redis connects). The fallback is seeded from
+ * _lastKnownRedisRevision so it never issues a revision that a runner would
+ * treat as stale.
  */
 export async function nextTriggerSubRevision(): Promise<number> {
     const redis = await getClient();
     if (redis) {
         try {
-            return await redis.incr(TRIGGER_SUB_REVISION_KEY);
+            const rev = await redis.incr(TRIGGER_SUB_REVISION_KEY);
+            _lastKnownRedisRevision = rev;
+            return rev;
         } catch (err) {
             log.warn("Failed to increment trigger sub revision in Redis, using local counter:", err);
         }
+    }
+    // Seed the local counter from the last known Redis value so fallback
+    // revisions are always > any revision the runner has already applied.
+    if (_localRevision < _lastKnownRedisRevision) {
+        _localRevision = _lastKnownRedisRevision;
     }
     return ++_localRevision;
 }

--- a/packages/server/src/sessions/trigger-subscription-store.ts
+++ b/packages/server/src/sessions/trigger-subscription-store.ts
@@ -61,7 +61,38 @@ const SESSION_SUBS_KEY = (sessionId: string) =>
 const RUNNER_TYPE_INDEX_KEY = (runnerId: string, triggerType: string) =>
     `pizzapi:trigger-subs:runner:${runnerId}:${triggerType}`;
 
+// Shared Redis key for the globally monotonic revision counter.
+// All server nodes INCR the same key so revisions are ordered cluster-wide.
+const TRIGGER_SUB_REVISION_KEY = "pizzapi:trigger-sub-revision";
+
 const DEFAULT_TTL_SECONDS = 24 * 60 * 60; // 24 hours
+
+// ── Global revision counter ──────────────────────────────────────────────────
+
+// Process-local fallback counter used only when Redis is unavailable.
+let _localRevision = 0;
+
+/**
+ * Atomically increment and return the global trigger subscription revision.
+ *
+ * Uses Redis INCR so the counter is monotonically increasing across ALL server
+ * nodes in a cluster. This prevents the runner's stale-drop filter from
+ * discarding valid deltas that originated on a different server node.
+ *
+ * Falls back to a process-local counter when Redis is unavailable (single-node
+ * mode or during startup before Redis connects).
+ */
+export async function nextTriggerSubRevision(): Promise<number> {
+    const redis = await getClient();
+    if (redis) {
+        try {
+            return await redis.incr(TRIGGER_SUB_REVISION_KEY);
+        } catch (err) {
+            log.warn("Failed to increment trigger sub revision in Redis, using local counter:", err);
+        }
+    }
+    return ++_localRevision;
+}
 
 // ── Public API ───────────────────────────────────────────────────────────
 

--- a/packages/server/src/sessions/trigger-subscription-store.ts
+++ b/packages/server/src/sessions/trigger-subscription-store.ts
@@ -402,20 +402,18 @@ export async function getSubscriptionsForRunnerSessions(
     const redis = await getClient();
     if (!redis) return [];
 
-    const results: Array<{ sessionId: string; triggerType: string; runnerId: string; params?: SubscriptionParams; filters?: SubscriptionFilter[]; filterMode?: SubscriptionFilterMode }> = [];
-
-    for (const sessionId of sessionIds) {
-        try {
-            const subs = await listSessionSubscriptions(sessionId);
-            for (const sub of subs) {
-                results.push({ sessionId, ...sub });
+    const perSessionResults = await Promise.all(
+        sessionIds.map(async (sessionId) => {
+            try {
+                const subs = await listSessionSubscriptions(sessionId);
+                return subs.map(sub => ({ sessionId, ...sub }));
+            } catch (err) {
+                log.warn(`Failed to list subscriptions for session ${sessionId}:`, err);
+                return [];
             }
-        } catch (err) {
-            log.warn(`Failed to list subscriptions for session ${sessionId}:`, err);
-        }
-    }
-
-    return results;
+        })
+    );
+    return perSessionResults.flat();
 }
 
 /** @deprecated Use `_resetRedisForTesting` instead. */

--- a/packages/server/src/sessions/trigger-subscription-store.ts
+++ b/packages/server/src/sessions/trigger-subscription-store.ts
@@ -388,6 +388,36 @@ export async function clearSessionSubscriptions(sessionId: string): Promise<void
     }
 }
 
+/**
+ * Get all active subscriptions for all sessions on a specific runner.
+ * Used to build the trigger_subscriptions_snapshot sent after runner registration.
+ *
+ * This scans all sessions connected to the runner and collects their subscriptions.
+ * The sessionIds parameter should come from getConnectedSessionsForRunner().
+ */
+export async function getSubscriptionsForRunnerSessions(
+    sessionIds: string[],
+): Promise<Array<{ sessionId: string; triggerType: string; runnerId: string; params?: SubscriptionParams; filters?: SubscriptionFilter[]; filterMode?: SubscriptionFilterMode }>> {
+    if (sessionIds.length === 0) return [];
+    const redis = await getClient();
+    if (!redis) return [];
+
+    const results: Array<{ sessionId: string; triggerType: string; runnerId: string; params?: SubscriptionParams; filters?: SubscriptionFilter[]; filterMode?: SubscriptionFilterMode }> = [];
+
+    for (const sessionId of sessionIds) {
+        try {
+            const subs = await listSessionSubscriptions(sessionId);
+            for (const sub of subs) {
+                results.push({ sessionId, ...sub });
+            }
+        } catch (err) {
+            log.warn(`Failed to list subscriptions for session ${sessionId}:`, err);
+        }
+    }
+
+    return results;
+}
+
 /** @deprecated Use `_resetRedisForTesting` instead. */
 export function _resetTriggerSubscriptionStoreForTesting(): void {
     _resetRedisForTesting();

--- a/packages/server/src/sessions/trigger-subscription-store.ts
+++ b/packages/server/src/sessions/trigger-subscription-store.ts
@@ -54,6 +54,9 @@ export function _injectRedisForTesting(client: unknown): void {
 export function _resetRedisForTesting(): void {
     _redis = null;
     _initPromise = null;
+    // Reset revision counters so revision-order assertions don't leak across tests.
+    _localRevision = 0;
+    _lastKnownRedisRevision = 0;
 }
 
 const SESSION_SUBS_KEY = (sessionId: string) =>

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -460,6 +460,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                     const allSubs = await getSubscriptionsForRunnerSessions(sessionIdsList);
                     socket.emit("trigger_subscriptions_snapshot" as any, {
                         revision: snapshotRevision,
+                        isReconnect: true,
                         subscriptions: allSubs.map(s => ({
                             sessionId: s.sessionId,
                             triggerType: s.triggerType,
@@ -469,14 +470,15 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                             ...(s.filterMode ? { filterMode: s.filterMode } : {}),
                         })),
                     });
-                    log.info(`[trigger-reconciliation] sent snapshot with ${allSubs.length} subscriptions to runner ${result}`);
+                    log.info(`[trigger-reconciliation] sent reconnect snapshot with ${allSubs.length} subscriptions to runner ${result}`);
                 } else {
                     // No sessions — send empty snapshot so runner knows state is clean
                     socket.emit("trigger_subscriptions_snapshot" as any, {
                         revision: snapshotRevision,
+                        isReconnect: true,
                         subscriptions: [],
                     });
-                    log.info(`[trigger-reconciliation] sent empty snapshot to runner ${result}`);
+                    log.info(`[trigger-reconciliation] sent empty reconnect snapshot to runner ${result}`);
                 }
             } catch (err) {
                 log.warn(`[trigger-reconciliation] failed to send snapshot to runner ${result}:`, err);

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -18,15 +18,45 @@ import type {
     RunnerSocketData,
     RunnerSkill,
     RunnerAgent,
+    TriggerSubscriptionEntry,
+    TriggerSubscriptionDelta,
 } from "@pizzapi/protocol";
 import { shouldPreserveOnSocketDisconnect } from "../../health.js";
 import { apiKeyAuthMiddleware } from "./auth.js";
+import { getSubscriptionsForRunnerSessions } from "../../sessions/trigger-subscription-store.js";
 
 // Inline definitions mirror packages/protocol/src/shared.ts.
 // Using local aliases avoids a cross-worktree symlink resolution issue where
 // node_modules/@pizzapi/protocol points to the main branch's dist, not this
 // worktree's updated dist.
 type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
+
+// ── Trigger subscription reconciliation ──────────────────────────────────────
+// Monotonic revision counter for ordering snapshots and deltas.
+// Starts at 1 so that revision 0 is reserved for "never seen a snapshot".
+let triggerSubRevision = 0;
+
+/** Get the next revision number for trigger subscription events. */
+function nextTriggerSubRevision(): number {
+    return ++triggerSubRevision;
+}
+
+/**
+ * Emit a trigger_subscription_delta to a runner. Exported so the triggers
+ * REST API can notify runners of subscribe/update/unsubscribe changes.
+ */
+export function emitTriggerSubscriptionDelta(
+    runnerId: string,
+    delta: Omit<TriggerSubscriptionDelta, "revision">,
+): void {
+    emitToRunnerRoom(runnerId, "trigger_subscription_delta", {
+        ...delta,
+        revision: nextTriggerSubRevision(),
+    });
+}
+
+// Forward declaration — filled in during registerRunnerNamespace() below.
+let emitToRunnerRoom: (runnerId: string, event: string, data: unknown) => void = () => {};
 import {
     registerRunner,
     updateRunnerSkills,
@@ -216,7 +246,7 @@ export async function sendRunnerCommand(
 // via updateRunnerServices() so late-joining viewers (or viewers after a server
 // restart) can receive the data without waiting for a fresh announce.
 import type { ServiceAnnounceData } from "@pizzapi/protocol";
-import { updateRunnerServices, getRunnerServices, addRunnerWarning, clearRunnerWarnings } from "../sio-registry/index.js";
+import { updateRunnerServices, getRunnerServices, addRunnerWarning, clearRunnerWarnings, emitToRunner } from "../sio-registry/index.js";
 import { chooseServiceAnnounceSeed, isSameServiceAnnounce, shouldSkipServiceAnnounceFanout, computeServiceAnnounceDelta, isEmptyDelta } from "./runner.service-announce.js";
 import { withRunnerRefHint } from "./runner-ref.js";
 export { chooseServiceAnnounceSeed, isSameServiceAnnounce, shouldSkipServiceAnnounceFanout, computeServiceAnnounceDelta, isEmptyDelta };
@@ -269,6 +299,11 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
 
     // Auth: validate API key from handshake
     runner.use(apiKeyAuthMiddleware() as Parameters<typeof runner.use>[0]);
+
+    // Wire up the cluster-wide emitToRunnerRoom helper now that we have `io`.
+    emitToRunnerRoom = (runnerId: string, event: string, data: unknown) => {
+        emitToRunner(runnerId, event, data);
+    };
 
     // ── Per-runner session tracking (in-memory) ──────────────────────────────
     // Maps runnerId → Set<sessionId>. Used to broadcast service_message and
@@ -402,6 +437,46 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 runnerId: result,
                 ...(existingSessions.length > 0 ? { existingSessions } : {}),
             });
+
+            // ── Send trigger subscriptions snapshot ──────────────────────────
+            // After runner_registered, send a full snapshot of all active trigger
+            // subscriptions for this runner's sessions so the runner can rebuild
+            // its in-memory subscription state (timers, watchers, etc.).
+            try {
+                const sessionIdsList = existingSessions.map((s: { sessionId: string }) => s.sessionId);
+                // Also include sessions from our in-memory tracking (may include sessions
+                // not in existingSessions if they were already connected before this registration).
+                const trackedSessions = runnerSessionIds.get(result);
+                if (trackedSessions) {
+                    for (const sid of trackedSessions) {
+                        if (!sessionIdsList.includes(sid)) sessionIdsList.push(sid);
+                    }
+                }
+                if (sessionIdsList.length > 0) {
+                    const allSubs = await getSubscriptionsForRunnerSessions(sessionIdsList);
+                    socket.emit("trigger_subscriptions_snapshot" as any, {
+                        revision: nextTriggerSubRevision(),
+                        subscriptions: allSubs.map(s => ({
+                            sessionId: s.sessionId,
+                            triggerType: s.triggerType,
+                            runnerId: s.runnerId,
+                            ...(s.params ? { params: s.params } : {}),
+                            ...(s.filters && s.filters.length > 0 ? { filters: s.filters } : {}),
+                            ...(s.filterMode ? { filterMode: s.filterMode } : {}),
+                        })),
+                    });
+                    log.info(`[trigger-reconciliation] sent snapshot with ${allSubs.length} subscriptions to runner ${result}`);
+                } else {
+                    // No sessions — send empty snapshot so runner knows state is clean
+                    socket.emit("trigger_subscriptions_snapshot" as any, {
+                        revision: nextTriggerSubRevision(),
+                        subscriptions: [],
+                    });
+                    log.info(`[trigger-reconciliation] sent empty snapshot to runner ${result}`);
+                }
+            } catch (err) {
+                log.warn(`[trigger-reconciliation] failed to send snapshot to runner ${result}:`, err);
+            }
         });
 
         // ── skills_list — runner reports updated skills ──────────────────────
@@ -598,6 +673,13 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 return;
             }
             await publishSessionEvent(data.sessionId, data.event);
+        });
+
+        // ── trigger_subscriptions_applied — runner ack ───────────────────────
+        socket.on("trigger_subscriptions_applied" as any, (data: any) => {
+            const runnerId = socket.data.runnerId;
+            if (!runnerId) return;
+            log.info(`[trigger-reconciliation] runner ${runnerId} applied revision ${data?.revision}, ${data?.applied ?? 0} subscriptions${data?.errors?.length ? `, ${data.errors.length} errors` : ""}`);
         });
 
         // ── session_ready — worker session connected ─────────────────────────

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -23,7 +23,7 @@ import type {
 } from "@pizzapi/protocol";
 import { shouldPreserveOnSocketDisconnect } from "../../health.js";
 import { apiKeyAuthMiddleware } from "./auth.js";
-import { getSubscriptionsForRunnerSessions } from "../../sessions/trigger-subscription-store.js";
+import { getSubscriptionsForRunnerSessions, nextTriggerSubRevision } from "../../sessions/trigger-subscription-store.js";
 
 // Inline definitions mirror packages/protocol/src/shared.ts.
 // Using local aliases avoids a cross-worktree symlink resolution issue where
@@ -32,26 +32,24 @@ import { getSubscriptionsForRunnerSessions } from "../../sessions/trigger-subscr
 type ServiceEnvelope = { serviceId: string; type: string; requestId?: string; payload: unknown };
 
 // ── Trigger subscription reconciliation ──────────────────────────────────────
-// Monotonic revision counter for ordering snapshots and deltas.
-// Starts at 1 so that revision 0 is reserved for "never seen a snapshot".
-let triggerSubRevision = 0;
-
-/** Get the next revision number for trigger subscription events. */
-function nextTriggerSubRevision(): number {
-    return ++triggerSubRevision;
-}
+// Revision counter is now Redis-backed (globally monotonic across all server
+// nodes). See nextTriggerSubRevision() in trigger-subscription-store.ts.
 
 /**
  * Emit a trigger_subscription_delta to a runner. Exported so the triggers
  * REST API can notify runners of subscribe/update/unsubscribe changes.
+ *
+ * Async because the revision is fetched from Redis INCR to ensure it is
+ * globally monotonic across all server nodes in a cluster.
  */
-export function emitTriggerSubscriptionDelta(
+export async function emitTriggerSubscriptionDelta(
     runnerId: string,
     delta: Omit<TriggerSubscriptionDelta, "revision">,
-): void {
+): Promise<void> {
+    const revision = await nextTriggerSubRevision();
     emitToRunnerRoom(runnerId, "trigger_subscription_delta", {
         ...delta,
-        revision: nextTriggerSubRevision(),
+        revision,
     });
 }
 
@@ -452,10 +450,16 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                         if (!sessionIdsList.includes(sid)) sessionIdsList.push(sid);
                     }
                 }
+                // P1 fix: capture the revision BEFORE the async snapshot read.
+                // Any delta emitted concurrently will call nextTriggerSubRevision()
+                // after this point and therefore receive a strictly higher revision,
+                // so the runner will never overwrite delta-applied state with a stale
+                // snapshot.
+                const snapshotRevision = await nextTriggerSubRevision();
                 if (sessionIdsList.length > 0) {
                     const allSubs = await getSubscriptionsForRunnerSessions(sessionIdsList);
                     socket.emit("trigger_subscriptions_snapshot" as any, {
-                        revision: nextTriggerSubRevision(),
+                        revision: snapshotRevision,
                         subscriptions: allSubs.map(s => ({
                             sessionId: s.sessionId,
                             triggerType: s.triggerType,
@@ -469,7 +473,7 @@ export function registerRunnerNamespace(io: SocketIOServer): void {
                 } else {
                     // No sessions — send empty snapshot so runner knows state is clean
                     socket.emit("trigger_subscriptions_snapshot" as any, {
-                        revision: nextTriggerSubRevision(),
+                        revision: snapshotRevision,
                         subscriptions: [],
                     });
                     log.info(`[trigger-reconciliation] sent empty snapshot to runner ${result}`);

--- a/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
+++ b/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
@@ -94,6 +94,10 @@ afterAll(() => mock.restore());
 // Instead of mocking ./runners-broadcast.js (which is brittle if another test
 // imports it first), we provide a fake Socket.IO server via initSioRegistry()
 // and assert on emitted events.
+//
+// Reset any spies/mocks that may have leaked from previously-loaded test files
+// before importing the real runners module for this file.
+mock.restore();
 
 type EmitCall = {
     namespace: string;


### PR DESCRIPTION
## Summary

Builds a typed trigger subscription reconciliation protocol between the PizzaPi relay server and runner daemon. Previously, runner services received subscriptions via untyped, unacked, local-only socket events not replayed on reconnect. After a runner reconnect, the UI showed "subscribed" while the runner service had forgotten the subscription.

## Changes

### Protocol
- New typed events in `packages/protocol/src/runner.ts`: `trigger_subscriptions_snapshot` (server→runner), `trigger_subscription_delta` (server→runner), `trigger_subscriptions_applied` (runner→server)

### Server
- Snapshot delivery on runner connect: after `runner_registered`, relay sends full subscription snapshot to the runner
- Fixed subscribe, update, and **unsubscribe** to emit `trigger_subscription_delta` to runner (unsubscribe was previously silent)
- Single emit path via `emitToRunner()` (removed duplicate local emit)

### Runner
- `reconcileSubscriptions()` hook added to `ServiceHandler` interface
- Daemon consumes snapshot on connect, groups by service prefix, calls `reconcileSubscriptions()` on all loaded services including those with zero subscriptions
- Delta handler applies live changes via `reconcileSubscriptions()`
- `lastAppliedRevision` resets to `-1` on reconnect (relay-restart safe)
- `TimeService` implements `reconcileSubscriptions()` for both full snapshot and incremental delta modes

### Tests
- Protocol type shape tests
- Server delta emission tests (subscribe/unsubscribe/update all emit)
- TimeService reconciliation tests (snapshot rebuild, delta apply, stale cleanup)
- Daemon snapshot fanout tests (absent services get empty snapshot)

## Quality
- Typecheck: clean
- Tests: 69 fail on branch vs 70 on main (net -1, no regressions)
- Ramsey: PASS (3 rounds)

## Origin
Night Shift critic-first session — ordered by Protocol Critic (GPT-5.4) after deep codebase review.