### PR TITLE
perf: server-owned cache-first viewer hydration

### DIFF
--- a/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
@@ -3,9 +3,15 @@ import {
     applyChunkToPendingState,
     canFinalizeChunkedSnapshot,
     enqueueSessionEvent,
+    finalizeChunkedSnapshot,
     sessionEventQueues,
     type ChunkedSessionState,
 } from "./event-pipeline.js";
+import {
+    consumePendingRecovery,
+    markPendingRecovery,
+    pendingRecoverySessionIds,
+} from "../../sio-registry/viewer-recovery.js";
 
 async function flushQueue(): Promise<void> {
     for (let i = 0; i < 5; i++) {
@@ -53,6 +59,10 @@ describe("enqueueSessionEvent", () => {
 });
 
 describe("chunked snapshot assembly", () => {
+    afterEach(() => {
+        pendingRecoverySessionIds.clear();
+    });
+
     test("duplicate chunk retransmits are idempotent", () => {
         const pending = createPendingState();
 
@@ -172,5 +182,51 @@ describe("chunked snapshot assembly", () => {
         // the original server-side ordering.
         const assembled = pending.chunks.flat();
         expect(assembled).toEqual(["c0", "c1", "c2"]);
+    });
+
+    test("chunked finalization consumes and clears the recovery flag", async () => {
+        const pending: ChunkedSessionState = {
+            snapshotId: "snap-recovery",
+            metadata: { sessionName: "Recovered" },
+            chunks: [[{ id: "m1" }], [{ id: "m2" }]],
+            totalChunks: 2,
+            receivedChunkIndexes: new Set<number>([0, 1]),
+            finalChunkSeen: true,
+        };
+        const updateSessionState = spyOn({
+            updateSessionState: async () => {},
+        }, "updateSessionState");
+        const getSharedSession = spyOn({
+            getSharedSession: async () => ({ userId: "user-1", isEphemeral: false }),
+        }, "getSharedSession");
+        const storeAndReplaceImagesInEvent = spyOn({
+            storeAndReplaceImagesInEvent: async (event: unknown) => event,
+        }, "storeAndReplaceImagesInEvent");
+        const appendRelayEventToCache = spyOn({
+            appendRelayEventToCache: async () => {},
+        }, "appendRelayEventToCache");
+
+        markPendingRecovery("sess-chunked-recovery");
+
+        const fullState = await finalizeChunkedSnapshot("sess-chunked-recovery", pending, {
+            consumePendingRecovery,
+            updateSessionState: updateSessionState as any,
+            getSharedSession: getSharedSession as any,
+            storeAndReplaceImagesInEvent: storeAndReplaceImagesInEvent as any,
+            appendRelayEventToCache: appendRelayEventToCache as any,
+        });
+
+        expect(fullState).toEqual({
+            sessionName: "Recovered",
+            messages: [{ id: "m1" }, { id: "m2" }],
+        });
+        expect(updateSessionState).toHaveBeenCalledWith(
+            "sess-chunked-recovery",
+            fullState,
+            { isRecovery: true },
+        );
+        expect(pendingRecoverySessionIds.has("sess-chunked-recovery")).toBe(false);
+        expect(consumePendingRecovery("sess-chunked-recovery")).toBe(false);
+        expect(appendRelayEventToCache).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
@@ -10,7 +10,8 @@ import {
 import {
     consumePendingRecovery,
     markPendingRecovery,
-    pendingRecoverySessionIds,
+    hasPendingRecovery,
+    _resetPendingRecoveriesForTesting,
 } from "../../sio-registry/viewer-recovery.js";
 
 async function flushQueue(): Promise<void> {
@@ -60,7 +61,7 @@ describe("enqueueSessionEvent", () => {
 
 describe("chunked snapshot assembly", () => {
     afterEach(() => {
-        pendingRecoverySessionIds.clear();
+        _resetPendingRecoveriesForTesting();
     });
 
     test("duplicate chunk retransmits are idempotent", () => {
@@ -225,7 +226,7 @@ describe("chunked snapshot assembly", () => {
             fullState,
             { isRecovery: true },
         );
-        expect(pendingRecoverySessionIds.has("sess-chunked-recovery")).toBe(false);
+        expect(hasPendingRecovery("sess-chunked-recovery")).toBe(false);
         expect(consumePendingRecovery("sess-chunked-recovery")).toBe(false);
         expect(appendRelayEventToCache).toHaveBeenCalledTimes(1);
     });

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -10,6 +10,7 @@ import {
     getSharedSession,
     broadcastSessionEventToViewers,
     publishSessionEvent,
+    consumePendingRecovery,
 } from "../../sio-registry.js";
 import { appendRelayEventToCache } from "../../../sessions/redis.js";
 import { storeAndReplaceImagesInEvent, stripImagesFromPipelineEvent } from "../../strip-images.js";
@@ -81,6 +82,66 @@ export function hasAllChunkIndexes(pending: ChunkedSessionState): boolean {
 
 export function canFinalizeChunkedSnapshot(pending: ChunkedSessionState): boolean {
     return pending.finalChunkSeen && hasAllChunkIndexes(pending);
+}
+
+export interface FinalizeChunkedSnapshotDeps {
+    consumePendingRecovery: typeof consumePendingRecovery;
+    updateSessionState: typeof updateSessionState;
+    getSharedSession: typeof getSharedSession;
+    storeAndReplaceImagesInEvent: typeof storeAndReplaceImagesInEvent;
+    appendRelayEventToCache: typeof appendRelayEventToCache;
+}
+
+const defaultFinalizeChunkedSnapshotDeps: FinalizeChunkedSnapshotDeps = {
+    consumePendingRecovery,
+    updateSessionState,
+    getSharedSession,
+    storeAndReplaceImagesInEvent,
+    appendRelayEventToCache,
+};
+
+export async function finalizeChunkedSnapshot(
+    sessionId: string,
+    pending: ChunkedSessionState,
+    deps: FinalizeChunkedSnapshotDeps = defaultFinalizeChunkedSnapshotDeps,
+): Promise<Record<string, unknown>> {
+    const allMessages = pending.chunks.flat();
+    const fullState = { ...pending.metadata, messages: allMessages };
+    const isRecovery = deps.consumePendingRecovery(sessionId);
+    await deps.updateSessionState(sessionId, fullState, { isRecovery });
+
+    // Append a full session_active to the Redis replay cache
+    // so that findLatestSnapshotEvent() finds the assembled
+    // state instead of the metadata-only SA from chunk start.
+    // We do NOT use publishSessionEvent() here because that
+    // would broadcast the full assembled state as a single
+    // oversized frame to all viewers — the same transport
+    // issue chunking was designed to avoid.  Viewers already
+    // have the complete data from the chunk stream.
+    // Strip inline images before caching to keep the cache
+    // entry small and consistent with publishSessionEvent's
+    // image-stripping pipeline.
+    const session = await deps.getSharedSession(sessionId);
+    const userId = session?.userId ?? "unknown";
+    const snapshotEvent = { type: "session_active" as const, state: fullState };
+    let eventToCache: unknown = snapshotEvent;
+    try {
+        eventToCache = await deps.storeAndReplaceImagesInEvent(
+            snapshotEvent, sessionId, userId,
+        );
+    } catch {
+        // Fall back to original if image stripping fails
+    }
+    // Do NOT call incrementSeq() here — this entry is never
+    // broadcast to viewers.  Advancing the shared counter
+    // would create a seq gap that triggers unnecessary
+    // viewer resyncs (viewers would expect seq N but the
+    // next broadcast would be N+1).
+    await deps.appendRelayEventToCache(sessionId, eventToCache, {
+        isEphemeral: session?.isEphemeral,
+    });
+
+    return fullState;
 }
 
 // ── Per-session event serialization ──────────────────────────────────────────
@@ -195,9 +256,13 @@ export function registerEventHandler(socket: RelaySocket): void {
                 // Touch activity but DON'T update lastState yet
                 await touchSessionActivity(sessionId);
             } else {
-                // Non-chunked: persist immediately (original path)
+                // Non-chunked: persist immediately (original path).
+                // Check if this session_active was triggered by a viewer
+                // reconnect (cold-start fallback) — if so, skip the SQLite
+                // write since it's redundant recovery data.
+                const isRecovery = consumePendingRecovery(sessionId);
                 pendingChunkedStates.delete(sessionId);
-                await updateSessionState(sessionId, event.state);
+                await updateSessionState(sessionId, event.state, { isRecovery });
             }
         } else if (event.type === "session_messages_chunk") {
             // Accumulate chunk into the pending state.  When the final
@@ -219,41 +284,8 @@ export function registerEventHandler(socket: RelaySocket): void {
 
                 if (canFinalizeChunkedSnapshot(pending)) {
                     // All chunks received — assemble and persist the full state
-                    const allMessages = pending.chunks.flat();
-                    const fullState = { ...pending.metadata, messages: allMessages };
                     pendingChunkedStates.delete(sessionId);
-                    await updateSessionState(sessionId, fullState);
-
-                    // Append a full session_active to the Redis replay cache
-                    // so that findLatestSnapshotEvent() finds the assembled
-                    // state instead of the metadata-only SA from chunk start.
-                    // We do NOT use publishSessionEvent() here because that
-                    // would broadcast the full assembled state as a single
-                    // oversized frame to all viewers — the same transport
-                    // issue chunking was designed to avoid.  Viewers already
-                    // have the complete data from the chunk stream.
-                    // Strip inline images before caching to keep the cache
-                    // entry small and consistent with publishSessionEvent's
-                    // image-stripping pipeline.
-                    const session = await getSharedSession(sessionId);
-                    const userId = session?.userId ?? "unknown";
-                    const snapshotEvent = { type: "session_active" as const, state: fullState };
-                    let eventToCache: unknown = snapshotEvent;
-                    try {
-                        eventToCache = await storeAndReplaceImagesInEvent(
-                            snapshotEvent, sessionId, userId,
-                        );
-                    } catch {
-                        // Fall back to original if image stripping fails
-                    }
-                    // Do NOT call incrementSeq() here — this entry is never
-                    // broadcast to viewers.  Advancing the shared counter
-                    // would create a seq gap that triggers unnecessary
-                    // viewer resyncs (viewers would expect seq N but the
-                    // next broadcast would be N+1).
-                    await appendRelayEventToCache(sessionId, eventToCache, {
-                        isEphemeral: session?.isEphemeral,
-                    });
+                    await finalizeChunkedSnapshot(sessionId, pending);
                 } else {
                     await touchSessionActivity(sessionId);
                 }

--- a/packages/server/src/ws/namespaces/viewer-cache.ts
+++ b/packages/server/src/ws/namespaces/viewer-cache.ts
@@ -87,16 +87,25 @@ export async function hydrateViewerFromCache(
     } = {},
     deps: ViewerCacheDeps = defaultViewerCacheDeps,
 ): Promise<boolean> {
-    if (opts.lastSeq !== undefined) {
-        const deltaOk = await sendDeltaReplayFromCache(
-            socket,
-            sessionId,
-            opts.lastSeq,
-            opts.generation,
-            deps,
-        );
-        if (deltaOk) return true;
-    }
+    try {
+        if (opts.lastSeq !== undefined) {
+            const deltaOk = await sendDeltaReplayFromCache(
+                socket,
+                sessionId,
+                opts.lastSeq,
+                opts.generation,
+                deps,
+            );
+            if (deltaOk) return true;
+        }
 
-    return sendLatestSnapshotFromCache(socket, sessionId, opts.generation, deps);
+        return sendLatestSnapshotFromCache(socket, sessionId, opts.generation, deps);
+    } catch (err) {
+        // Log and fall through to runner-driven recovery
+        const errMsg = err instanceof Error ? err.message : String(err);
+        console.warn(
+            `[viewer-cache] hydrateViewerFromCache failed for ${sessionId}, falling back to runner recovery: ${errMsg}`,
+        );
+        return false;
+    }
 }

--- a/packages/server/src/ws/namespaces/viewer-cache.ts
+++ b/packages/server/src/ws/namespaces/viewer-cache.ts
@@ -1,0 +1,102 @@
+// ============================================================================
+// viewer-cache.ts — cache-first viewer hydration helpers
+//
+// Pure-ish helpers extracted from viewer.ts so they can be tested without
+// loading the full namespace module or relying on global mock.module state.
+// ============================================================================
+
+import { getCachedRelayEventsAfterSeq, getLatestCachedSnapshotEvent } from "../../sessions/redis.js";
+
+type ViewerEventEmitter = {
+    emit: any;
+};
+
+export type CachedRelayEvent = {
+    seq?: number;
+    event: unknown;
+};
+
+export interface ViewerCacheDeps {
+    getCachedRelayEventsAfterSeq: (sessionId: string, afterSeq: number) => Promise<CachedRelayEvent[]>;
+    getLatestCachedSnapshotEvent: (sessionId: string) => Promise<Record<string, unknown> | null>;
+}
+
+const defaultViewerCacheDeps: ViewerCacheDeps = {
+    getCachedRelayEventsAfterSeq,
+    getLatestCachedSnapshotEvent,
+};
+
+export async function sendLatestSnapshotFromCache(
+    socket: ViewerEventEmitter,
+    sessionId: string,
+    generation: number | undefined,
+    deps: ViewerCacheDeps = defaultViewerCacheDeps,
+): Promise<boolean> {
+    const snapshotEvent = await deps.getLatestCachedSnapshotEvent(sessionId);
+    if (!snapshotEvent) return false;
+
+    socket.emit("event", { event: snapshotEvent, replay: true, generation });
+    return true;
+}
+
+export function sendCachedDeltaReplayEvents(
+    socket: ViewerEventEmitter,
+    cachedEvents: CachedRelayEvent[],
+    generation?: number,
+): boolean {
+    let sentAny = false;
+
+    for (const cachedEvent of cachedEvents) {
+        if (typeof cachedEvent.seq !== "number" || !Number.isFinite(cachedEvent.seq)) {
+            continue;
+        }
+        sentAny = true;
+        socket.emit("event", {
+            event: cachedEvent.event,
+            seq: cachedEvent.seq,
+            replay: true,
+            deltaReplay: true,
+            generation,
+        });
+    }
+
+    return sentAny;
+}
+
+async function sendDeltaReplayFromCache(
+    socket: ViewerEventEmitter,
+    sessionId: string,
+    afterSeq: number,
+    generation: number | undefined,
+    deps: ViewerCacheDeps,
+): Promise<boolean> {
+    const cachedEvents = await deps.getCachedRelayEventsAfterSeq(sessionId, afterSeq);
+    return sendCachedDeltaReplayEvents(socket, cachedEvents, generation);
+}
+
+/**
+ * Try to hydrate a single viewer socket from the server-side Redis cache,
+ * avoiding the expensive runner round-trip.
+ */
+export async function hydrateViewerFromCache(
+    socket: ViewerEventEmitter,
+    sessionId: string,
+    opts: {
+        lastSeq?: number;
+        generation?: number;
+    } = {},
+    deps: ViewerCacheDeps = defaultViewerCacheDeps,
+): Promise<boolean> {
+    if (opts.lastSeq !== undefined) {
+        const deltaOk = await sendDeltaReplayFromCache(
+            socket,
+            sessionId,
+            opts.lastSeq,
+            opts.generation,
+            deps,
+        );
+        if (deltaOk) return true;
+    }
+
+    return sendLatestSnapshotFromCache(socket, sessionId, opts.generation, deps);
+}

--- a/packages/server/src/ws/namespaces/viewer-cache.ts
+++ b/packages/server/src/ws/namespaces/viewer-cache.ts
@@ -97,6 +97,12 @@ export async function hydrateViewerFromCache(
                 deps,
             );
             if (deltaOk) return true;
+            // Delta replay was requested but unavailable (seq gap too large /
+            // events evicted).  Return false so the caller triggers runner
+            // recovery rather than treating the snapshot fallback as
+            // authoritative — a snapshot has no seq, so it can roll back the
+            // client's transcript or cause missed updates.
+            return false;
         }
 
         return sendLatestSnapshotFromCache(socket, sessionId, opts.generation, deps);

--- a/packages/server/src/ws/namespaces/viewer.hydration.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.hydration.test.ts
@@ -1,0 +1,247 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import {
+    hydrateViewerFromCache,
+    sendCachedDeltaReplayEvents,
+    type CachedRelayEvent,
+    type ViewerCacheDeps,
+} from "./viewer-cache.js";
+
+interface EmittedCall {
+    event: string;
+    payload: unknown;
+}
+
+function createMockSocket(): { emit: ReturnType<typeof mock>; calls: EmittedCall[] } {
+    const calls: EmittedCall[] = [];
+    const emit = mock((event: string, payload: unknown) => {
+        calls.push({ event, payload });
+        return true;
+    });
+    return { emit, calls };
+}
+
+function createDeps(overrides: Partial<ViewerCacheDeps> = {}): ViewerCacheDeps {
+    return {
+        getCachedRelayEventsAfterSeq: overrides.getCachedRelayEventsAfterSeq ?? mock(async () => [] as CachedRelayEvent[]),
+        getLatestCachedSnapshotEvent: overrides.getLatestCachedSnapshotEvent ?? mock(async () => null),
+    };
+}
+
+describe("hydrateViewerFromCache — snapshot path", () => {
+    let deps: ViewerCacheDeps;
+
+    beforeEach(() => {
+        deps = createDeps();
+    });
+
+    test("returns true and emits event when Redis has a session_active snapshot", async () => {
+        const snapshot = { type: "session_active", state: { messages: [{ role: "user" }] } };
+        deps = createDeps({ getLatestCachedSnapshotEvent: mock(async () => snapshot) });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-001", {}, deps);
+
+        expect(result).toBe(true);
+        expect(calls.length).toBe(1);
+        expect(calls[0].event).toBe("event");
+        expect(calls[0].payload).toMatchObject({ event: snapshot, replay: true });
+    });
+
+    test("returns true and emits with generation when generation is provided", async () => {
+        const snapshot = { type: "agent_end", messages: [{ role: "assistant" }] };
+        deps = createDeps({ getLatestCachedSnapshotEvent: mock(async () => snapshot) });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-002", { generation: 7 }, deps);
+
+        expect(result).toBe(true);
+        expect(calls[0].payload).toMatchObject({ event: snapshot, replay: true, generation: 7 });
+    });
+
+    test("returns false when cache is empty — viewer needs runner fallback", async () => {
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-003", {}, deps);
+
+        expect(result).toBe(false);
+        expect(calls.length).toBe(0);
+    });
+
+    test("does NOT call getCachedRelayEventsAfterSeq when no lastSeq provided", async () => {
+        const getCachedRelayEventsAfterSeq = mock(async () => [] as CachedRelayEvent[]);
+        deps = createDeps({ getCachedRelayEventsAfterSeq });
+
+        const { emit } = createMockSocket();
+        await hydrateViewerFromCache({ emit }, "sess-004", {}, deps);
+
+        expect(getCachedRelayEventsAfterSeq).not.toHaveBeenCalled();
+    });
+
+    test("works for agent_end snapshot (full session end)", async () => {
+        const snapshot = { type: "agent_end", messages: [{ role: "user" }, { role: "assistant" }] };
+        deps = createDeps({ getLatestCachedSnapshotEvent: mock(async () => snapshot) });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-005", {}, deps);
+
+        expect(result).toBe(true);
+        expect(calls[0].payload).toMatchObject({ event: snapshot, replay: true });
+    });
+});
+
+describe("hydrateViewerFromCache — delta resume path", () => {
+    test("returns true via delta resume when events exist after lastSeq", async () => {
+        const deltaEvents = [
+            { seq: 11, event: { type: "message_start" } },
+            { seq: 12, event: { type: "message_end" } },
+        ];
+        const getLatestCachedSnapshotEvent = mock(async () => null);
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => deltaEvents),
+            getLatestCachedSnapshotEvent,
+        });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-010", { lastSeq: 10, generation: 3 }, deps);
+
+        expect(result).toBe(true);
+        expect(calls.length).toBe(2);
+        expect(calls[0].payload).toMatchObject({ seq: 11, replay: true, deltaReplay: true, generation: 3 });
+        expect(calls[1].payload).toMatchObject({ seq: 12, replay: true, deltaReplay: true, generation: 3 });
+        expect(getLatestCachedSnapshotEvent).not.toHaveBeenCalled();
+    });
+
+    test("falls back to snapshot when delta returns no events after lastSeq", async () => {
+        const snapshot = { type: "session_active", state: { messages: [] } };
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent: mock(async () => snapshot),
+        });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-011", { lastSeq: 5 }, deps);
+
+        expect(result).toBe(true);
+        expect(calls.length).toBe(1);
+        expect(calls[0].payload).toMatchObject({ event: snapshot, replay: true });
+        expect((calls[0].payload as Record<string, unknown>).deltaReplay).toBeUndefined();
+    });
+
+    test("returns false when both delta and snapshot are empty — cold start", async () => {
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+            getLatestCachedSnapshotEvent: mock(async () => null),
+        });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-012", { lastSeq: 99 }, deps);
+
+        expect(result).toBe(false);
+        expect(calls.length).toBe(0);
+    });
+
+    test("skips events without seq in delta resume", async () => {
+        const deltaEvents = [
+            { event: { type: "legacy_no_seq" } },
+            { seq: 42, event: { type: "message_delta" } },
+        ];
+        const deps = createDeps({ getCachedRelayEventsAfterSeq: mock(async () => deltaEvents) });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-013", { lastSeq: 41 }, deps);
+
+        expect(result).toBe(true);
+        expect(calls.length).toBe(1);
+        expect(calls[0].payload).toMatchObject({ seq: 42, deltaReplay: true });
+    });
+
+    test("falls back to snapshot when all delta events lack seq (legacy cache)", async () => {
+        const snapshot = { type: "session_active", state: { messages: [{ role: "assistant" }] } };
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => [{ event: { type: "old_event" } }]),
+            getLatestCachedSnapshotEvent: mock(async () => snapshot),
+        });
+
+        const { emit, calls } = createMockSocket();
+        const result = await hydrateViewerFromCache({ emit }, "sess-014", { lastSeq: 3 }, deps);
+
+        expect(result).toBe(true);
+        expect(calls.length).toBe(1);
+        expect(calls[0].payload).toMatchObject({ event: snapshot, replay: true });
+    });
+});
+
+describe("cache-first → runner signal suppression invariant", () => {
+    test("cache HIT: returns true → activateSession sets suppressRunnerSignal=true (no runner signal)", async () => {
+        const deps = createDeps({
+            getLatestCachedSnapshotEvent: mock(async () => ({ type: "session_active", state: { messages: [] } })),
+        });
+
+        const { emit } = createMockSocket();
+        const cacheHit = await hydrateViewerFromCache({ emit }, "sess-020", {}, deps);
+
+        expect(cacheHit).toBe(true);
+    });
+
+    test("cache MISS: returns false → activateSession calls emitToRelaySession (runner fallback)", async () => {
+        const deps = createDeps({
+            getLatestCachedSnapshotEvent: mock(async () => null),
+            getCachedRelayEventsAfterSeq: mock(async () => []),
+        });
+
+        const { emit } = createMockSocket();
+        const cacheHit = await hydrateViewerFromCache({ emit }, "sess-021", {}, deps);
+
+        expect(cacheHit).toBe(false);
+    });
+
+    test("cache HIT via delta: also returns true → runner signal suppressed", async () => {
+        const deps = createDeps({
+            getCachedRelayEventsAfterSeq: mock(async () => [{ seq: 8, event: { type: "message_end" } }]),
+            getLatestCachedSnapshotEvent: mock(async () => null),
+        });
+
+        const { emit } = createMockSocket();
+        const cacheHit = await hydrateViewerFromCache({ emit }, "sess-022", { lastSeq: 7 }, deps);
+
+        expect(cacheHit).toBe(true);
+    });
+});
+
+describe("sendCachedDeltaReplayEvents (re-exported helper)", () => {
+    test("emits deltaReplay events in order with generation tag", () => {
+        const socket = createMockSocket();
+
+        const sent = sendCachedDeltaReplayEvents(socket, [
+            { seq: 3, event: { type: "message_start" } },
+            { seq: 4, event: { type: "message_end" } },
+        ], 12);
+
+        expect(sent).toBe(true);
+        expect(socket.calls.map((call) => call.payload)).toEqual([
+            { event: { type: "message_start" }, seq: 3, replay: true, deltaReplay: true, generation: 12 },
+            { event: { type: "message_end" }, seq: 4, replay: true, deltaReplay: true, generation: 12 },
+        ]);
+    });
+
+    test("returns false and emits nothing for empty event list", () => {
+        const socket = createMockSocket();
+        const sent = sendCachedDeltaReplayEvents(socket, []);
+
+        expect(sent).toBe(false);
+        expect(socket.calls.length).toBe(0);
+    });
+
+    test("omits generation from payload when undefined", () => {
+        const socket = createMockSocket();
+        sendCachedDeltaReplayEvents(socket, [{ seq: 1, event: {} }]);
+
+        expect(socket.calls[0].payload).toEqual({
+            event: {},
+            seq: 1,
+            replay: true,
+            deltaReplay: true,
+            generation: undefined,
+        });
+    });
+});

--- a/packages/server/src/ws/namespaces/viewer.hydration.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.hydration.test.ts
@@ -111,7 +111,10 @@ describe("hydrateViewerFromCache — delta resume path", () => {
         expect(getLatestCachedSnapshotEvent).not.toHaveBeenCalled();
     });
 
-    test("falls back to snapshot when delta returns no events after lastSeq", async () => {
+    test("returns false (runner recovery) when delta returns no events after lastSeq", async () => {
+        // When lastSeq is provided but delta replay yields nothing, we must NOT fall back
+        // to a snapshot — it has no seq and could roll back the client transcript.
+        // Return false so the caller triggers runner-driven recovery instead.
         const snapshot = { type: "session_active", state: { messages: [] } };
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => []),
@@ -121,10 +124,8 @@ describe("hydrateViewerFromCache — delta resume path", () => {
         const { emit, calls } = createMockSocket();
         const result = await hydrateViewerFromCache({ emit }, "sess-011", { lastSeq: 5 }, deps);
 
-        expect(result).toBe(true);
-        expect(calls.length).toBe(1);
-        expect(calls[0].payload).toMatchObject({ event: snapshot, replay: true });
-        expect((calls[0].payload as Record<string, unknown>).deltaReplay).toBeUndefined();
+        expect(result).toBe(false);
+        expect(calls.length).toBe(0);
     });
 
     test("returns false when both delta and snapshot are empty — cold start", async () => {
@@ -155,7 +156,10 @@ describe("hydrateViewerFromCache — delta resume path", () => {
         expect(calls[0].payload).toMatchObject({ seq: 42, deltaReplay: true });
     });
 
-    test("falls back to snapshot when all delta events lack seq (legacy cache)", async () => {
+    test("returns false (runner recovery) when all delta events lack seq (legacy cache)", async () => {
+        // All cached events pre-date seq stamping — none have a seq field, so delta
+        // replay emits nothing.  Same reasoning as above: don't snapshot-fallback;
+        // return false and let the caller request runner recovery.
         const snapshot = { type: "session_active", state: { messages: [{ role: "assistant" }] } };
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => [{ event: { type: "old_event" } }]),
@@ -165,9 +169,8 @@ describe("hydrateViewerFromCache — delta resume path", () => {
         const { emit, calls } = createMockSocket();
         const result = await hydrateViewerFromCache({ emit }, "sess-014", { lastSeq: 3 }, deps);
 
-        expect(result).toBe(true);
-        expect(calls.length).toBe(1);
-        expect(calls[0].payload).toMatchObject({ event: snapshot, replay: true });
+        expect(result).toBe(false);
+        expect(calls.length).toBe(0);
     });
 });
 

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -14,6 +14,7 @@ import {
     onViewerConnectedSignal,
     onViewerReadyForRunnerSignal,
     isViewerSwitchCurrent,
+    forwardRecoveryConnectedSignal,
     withHubMetaSource,
     withMetaViaHubHint,
     withLivenessOnlyHint,
@@ -171,6 +172,30 @@ describe("viewer connected signal gating", () => {
         });
     });
 
+    test("socket.on(\"connected\") forwarding marks recovery before emitting to relay", () => {
+        const calls: string[] = [];
+        const next = onViewerConnectedSignal(true, false);
+
+        expect(next).toEqual({
+            pendingConnectedSignal: false,
+            forwardNow: true,
+        });
+
+        forwardRecoveryConnectedSignal("sess-connected", {
+            markPendingRecovery: mock((sessionId: string) => {
+                calls.push(`mark:${sessionId}`);
+            }),
+            emitToRelaySession: mock((sessionId: string, event: string) => {
+                calls.push(`emit:${event}:${sessionId}`);
+            }) as any,
+        });
+
+        expect(calls).toEqual([
+            "mark:sess-connected",
+            "emit:connected:sess-connected",
+        ]);
+    });
+
     test("flushes pending signal when viewer becomes ready", () => {
         expect(onViewerReadyForRunnerSignal(true)).toEqual({
             pendingConnectedSignal: false,
@@ -183,6 +208,30 @@ describe("viewer connected signal gating", () => {
             pendingConnectedSignal: false,
             forwardNow: false,
         });
+    });
+
+    test("ready-transition forwarding also marks recovery before emitting to relay", () => {
+        const calls: string[] = [];
+        const flush = onViewerReadyForRunnerSignal(true);
+
+        expect(flush).toEqual({
+            pendingConnectedSignal: false,
+            forwardNow: true,
+        });
+
+        forwardRecoveryConnectedSignal("sess-pending", {
+            markPendingRecovery: mock((sessionId: string) => {
+                calls.push(`mark:${sessionId}`);
+            }),
+            emitToRelaySession: mock((sessionId: string, event: string) => {
+                calls.push(`emit:${event}:${sessionId}`);
+            }) as any,
+        });
+
+        expect(calls).toEqual([
+            "mark:sess-pending",
+            "emit:connected:sess-pending",
+        ]);
     });
 });
 

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -291,6 +291,12 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             typeof socket.data.generation === "number" ? socket.data.generation : undefined;
 
         const activateSession = async (nextSessionId: string, generation?: number, lastSeq?: number): Promise<void> => {
+            // Reset on every session switch so a prior cache-hit's
+            // suppressRunnerSignal=true cannot bleed into a subsequent
+            // cache-miss session and silently drop the runner "connected"
+            // signal, leaving the viewer on stale state.
+            suppressRunnerSignal = false;
+
             if (!nextSessionId) {
                 socket.data.sessionId = undefined;
                 return;

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -34,13 +34,16 @@ import {
     emitToRelaySessionVerified,
     emitToRunner,
     broadcastToSessionViewers,
+    markPendingRecovery,
 } from "../sio-registry.js";
 import { isChildOfParent } from "../sio-state/index.js";
 import { getPendingChunkedSnapshot } from "./relay/index.js";
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
-import { getCachedRelayEventsAfterSeq, getLatestCachedSnapshotEvent } from "../../sessions/redis.js";
 import { recordTriggerResponse } from "../../sessions/trigger-store.js";
 import { createLogger } from "@pizzapi/tools";
+import { hydrateViewerFromCache, sendCachedDeltaReplayEvents, sendLatestSnapshotFromCache } from "./viewer-cache.js";
+
+export { hydrateViewerFromCache, sendCachedDeltaReplayEvents } from "./viewer-cache.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -142,54 +145,23 @@ export function isViewerSwitchCurrent(currentGeneration: number | undefined, req
     return requestedGeneration === undefined || currentGeneration === requestedGeneration;
 }
 
-/**
- * Try to send the latest snapshot event from the Redis event cache.
- * Returns true if a snapshot was sent, false otherwise.
- */
-async function sendLatestSnapshotFromCache(
-    socket: ViewerSocket,
-    sessionId: string,
-    generation?: number,
-): Promise<boolean> {
-    const snapshotEvent = await getLatestCachedSnapshotEvent(sessionId);
-    if (!snapshotEvent) return false;
-
-    socket.emit("event", { event: snapshotEvent, replay: true, generation });
-    return true;
+export interface RecoveryConnectedSignalDeps {
+    markPendingRecovery: typeof markPendingRecovery;
+    emitToRelaySession: typeof emitToRelaySession;
 }
 
-export function sendCachedDeltaReplayEvents(
-    socket: Pick<ViewerSocket, "emit">,
-    cachedEvents: Array<{ seq?: number; event: unknown }>,
-    generation?: number,
-): boolean {
-    let sentAny = false;
+const defaultRecoveryConnectedSignalDeps: RecoveryConnectedSignalDeps = {
+    markPendingRecovery,
+    emitToRelaySession,
+};
 
-    for (const cachedEvent of cachedEvents) {
-        if (typeof cachedEvent.seq !== "number" || !Number.isFinite(cachedEvent.seq)) {
-            continue;
-        }
-        sentAny = true;
-        socket.emit("event", {
-            event: cachedEvent.event,
-            seq: cachedEvent.seq,
-            replay: true,
-            deltaReplay: true,
-            generation,
-        });
-    }
-
-    return sentAny;
-}
-
-async function sendDeltaReplayFromCache(
-    socket: ViewerSocket,
+/** @internal — exported for unit tests only */
+export function forwardRecoveryConnectedSignal(
     sessionId: string,
-    afterSeq: number,
-    generation?: number,
-): Promise<boolean> {
-    const cachedEvents = await getCachedRelayEventsAfterSeq(sessionId, afterSeq);
-    return sendCachedDeltaReplayEvents(socket, cachedEvents, generation);
+    deps: RecoveryConnectedSignalDeps = defaultRecoveryConnectedSignalDeps,
+): void {
+    deps.markPendingRecovery(sessionId);
+    deps.emitToRelaySession(sessionId, "connected" as string, {});
 }
 
 /**
@@ -309,6 +281,10 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         // before addViewer() completes, forcing a resync and visible startup lag.
         let viewerReadyForRunnerSignal = false;
         let pendingConnectedSignal = false;
+        // Set by cache-first hydration to prevent the client's "connected" echo
+        // from triggering a runner signal when the viewer was already hydrated
+        // from the server-side Redis cache.
+        let suppressRunnerSignal = false;
 
         const getCurrentSessionId = (): string | null => socket.data.sessionId ?? null;
         const getCurrentGeneration = (): number | undefined =>
@@ -362,19 +338,12 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             }
 
             socket.data.sessionId = nextSessionId;
-            viewerReadyForRunnerSignal = true;
-            const flush = onViewerReadyForRunnerSignal(pendingConnectedSignal);
-            pendingConnectedSignal = flush.pendingConnectedSignal;
-            if (flush.forwardNow) {
-                emitToRelaySession(nextSessionId, "connected" as string, {});
-            }
 
-            // Re-fetch session state and seq AFTER addViewer() to avoid emitting
-            // stale data. Between the initial fetch and here, the runner may have
-            // published a newer session_active (especially for chunked delivery).
-            // Using the old lastState + old lastSeq would overwrite the fresh
-            // snapshot and rewind lastSeqRef on the client, triggering a bogus
-            // resync on actively changing sessions.
+            // ── Cache-first hydration ────────────────────────────────────
+            // Re-fetch session state and seq AFTER addViewer() to avoid
+            // emitting stale data. Between the initial fetch and here, the
+            // runner may have published a newer session_active (especially
+            // for chunked delivery).
             const [freshSession, freshSeq] = await Promise.all([
                 getSharedSession(nextSessionId),
                 getSessionSeq(nextSessionId),
@@ -418,16 +387,48 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 }
             }
 
+            // ── Try server-side cache before signaling the runner ────────
+            // This is the core optimization: hydrate the joining viewer from
+            // the existing Redis snapshot/delta cache instead of asking the
+            // runner to rebuild and rebroadcast the full transcript.
+            //
+            // Benefits:
+            //   • Read-path only — no write amplification to Redis/SQLite
+            //   • Per-socket emit — no room-wide broadcast to other viewers
+            //   • Avoids runner CPU cost of rebuilding the transcript
+            //
+            // Fallback: if the cache is empty or stale (cold start, eviction),
+            // we fall through to the existing runner-signal path.
             const chunkedPending = getPendingChunkedSnapshot(nextSessionId);
-            if (requestedLastSeq !== undefined && !chunkedPending) {
-                const deltaReplaySent = await sendDeltaReplayFromCache(socket, nextSessionId, requestedLastSeq, generation);
-                if (deltaReplaySent) {
+            if (!chunkedPending) {
+                const cacheHydrated = await hydrateViewerFromCache(socket, nextSessionId, {
+                    lastSeq: requestedLastSeq,
+                    generation,
+                });
+                if (cacheHydrated) {
+                    // Cache hit — viewer is fully hydrated.  Suppress the
+                    // runner "connected" signal so it doesn't rebuild and
+                    // broadcast to all viewers in the room.
+                    suppressRunnerSignal = true;
+                    log.info(`cache-first hydration: sessionId=${nextSessionId} viewer=${socket.id} (${requestedLastSeq !== undefined ? "delta" : "snapshot"})`);
                     return;
                 }
             }
 
-            // Emit an immediate heartbeat snapshot while the runner pushes a fresh
-            // session_active in response to "connected".
+            // ── Cache miss — cold-start fallback ─────────────────────────
+            // Signal the runner so it rebuilds and emits session_active.
+            // This is the existing pre-optimization path.
+            log.info(`cache miss fallback: sessionId=${nextSessionId} viewer=${socket.id}`);
+            suppressRunnerSignal = false;
+            viewerReadyForRunnerSignal = true;
+            const flush = onViewerReadyForRunnerSignal(pendingConnectedSignal);
+            pendingConnectedSignal = flush.pendingConnectedSignal;
+            if (flush.forwardNow) {
+                forwardRecoveryConnectedSignal(nextSessionId);
+            }
+
+            // Emit an immediate heartbeat snapshot while the runner pushes a
+            // fresh session_active in response to "connected".
             if (freshSession.lastHeartbeat) {
                 try {
                     socket.emit("event", {
@@ -458,7 +459,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
                 // non-chunked SA events, set lastCompletedSnapshotRef, and cause
                 // the UI to reject subsequent chunks from the active stream.
                 // The runner re-emits a fresh snapshot on the "connected" event
-                // below, which will properly restart chunked delivery.
+                // above, which will properly restart chunked delivery.
                 await sendLatestSnapshotFromCache(socket, nextSessionId, generation);
             }
         };
@@ -479,10 +480,14 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
         socket.on("connected", () => {
             const currentSessionId = getCurrentSessionId();
             if (!currentSessionId) return;
+            // When the viewer was hydrated from the server-side cache,
+            // suppress the runner signal — the runner doesn't need to
+            // rebuild and rebroadcast the transcript.
+            if (suppressRunnerSignal) return;
             const next = onViewerConnectedSignal(viewerReadyForRunnerSignal, pendingConnectedSignal);
             pendingConnectedSignal = next.pendingConnectedSignal;
             if (next.forwardNow) {
-                emitToRelaySession(currentSessionId, "connected" as string, {});
+                forwardRecoveryConnectedSignal(currentSessionId);
             }
         });
 
@@ -507,8 +512,11 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             const requestedLastSeq = typeof data?.lastSeq === "number" && Number.isFinite(data.lastSeq) ? data.lastSeq : undefined;
             const resyncChunkedPending = getPendingChunkedSnapshot(currentSessionId);
             if (requestedLastSeq !== undefined && !resyncChunkedPending) {
-                const deltaReplaySent = await sendDeltaReplayFromCache(socket, currentSessionId, requestedLastSeq, getCurrentGeneration());
-                if (deltaReplaySent) {
+                const cacheHydrated = await hydrateViewerFromCache(socket, currentSessionId, {
+                    lastSeq: requestedLastSeq,
+                    generation: getCurrentGeneration(),
+                });
+                if (cacheHydrated) {
                     return;
                 }
             }

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -291,11 +291,18 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             typeof socket.data.generation === "number" ? socket.data.generation : undefined;
 
         const activateSession = async (nextSessionId: string, generation?: number, lastSeq?: number): Promise<void> => {
-            // Reset on every session switch so a prior cache-hit's
-            // suppressRunnerSignal=true cannot bleed into a subsequent
-            // cache-miss session and silently drop the runner "connected"
-            // signal, leaving the viewer on stale state.
+            // Reset on every session switch so a prior session's signal state
+            // cannot bleed into the new session.  Specifically:
+            //   - suppressRunnerSignal=true (cache hit) must not silence the
+            //     runner signal for a subsequent cache-miss session.
+            //   - viewerReadyForRunnerSignal=true (cache miss) must not cause
+            //     the client "connected" echo to forward a runner signal before
+            //     cache hydration has had a chance to run on the new session.
+            //   - pendingConnectedSignal=true must not carry over and trigger
+            //     forwardRecoveryConnectedSignal() against the wrong session.
             suppressRunnerSignal = false;
+            viewerReadyForRunnerSignal = false;
+            pendingConnectedSignal = false;
 
             if (!nextSessionId) {
                 socket.data.sessionId = undefined;

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -7,7 +7,7 @@
 
 export { initSioRegistry, emitToRunner, emitToRelaySession, emitToRelaySessionVerified, emitToRelaySessionAwaitingAck, runnersUserRoom, broadcastToSessionViewers } from "./context.js";
 export { broadcastToHub, addHubClient, removeHubClient } from "./hub.js";
-export type { RegisterTuiSessionOpts } from "./sessions.js";
+export type { RegisterTuiSessionOpts, UpdateSessionStateOpts } from "./sessions.js";
 export {
     registerTuiSession,
     getLocalTuiSocket,
@@ -31,6 +31,8 @@ export {
     removeViewer,
     broadcastToViewers,
     getViewerCount,
+    markPendingRecovery,
+    consumePendingRecovery,
 } from "./sessions.js";
 export type { RegisterRunnerOpts } from "./runners.js";
 export {

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -33,6 +33,7 @@ export {
     getViewerCount,
     markPendingRecovery,
     consumePendingRecovery,
+    hasPendingRecovery,
 } from "./sessions.js";
 export type { RegisterRunnerOpts } from "./runners.js";
 export {

--- a/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
@@ -120,6 +120,7 @@ mock.module("../../sessions/store.js", () => ({
 }));
 
 mock.module("../sio-state/index.js", () => ({
+    initStateRedis: async () => {},
     setSession: async (sessionId: string, data: Record<string, unknown>) => {
         store.set(`__hash__:pizzapi:sio:session:${sessionId}`, JSON.stringify(data));
     },
@@ -131,6 +132,7 @@ mock.module("../sio-state/index.js", () => ({
         const raw = store.get(`__hash__:pizzapi:sio:session:${sessionId}`);
         return raw ? (JSON.parse(raw) as Record<string, unknown>) : null;
     },
+    getSessionField: async () => null,
     updateSessionFields: async (sessionId: string, fields: Record<string, unknown>) => {
         const raw = store.get(`__hash__:pizzapi:sio:session:${sessionId}`);
         if (!raw) return;
@@ -179,6 +181,9 @@ mock.module("../sio-state/index.js", () => ({
     },
     refreshChildSessionsTTL: async () => {},
     removePendingParentDelinkChild: async () => {},
+    markChildAsDelinked: async (childSessionId: string) => {
+        store.set(`pizzapi:sio:delinked:${childSessionId}`, "1");
+    },
     getRunner: async () => null,
 }));
 
@@ -193,7 +198,7 @@ afterAll(() => mock.restore());
 // Dynamic imports so that mock.module("../../sessions/store.js", …) is in place
 // before sessions.js (and its transitive store.js dependency) is resolved.
 // The redis mock has been removed — mockRedis is injected via initStateRedis() instead.
-const { initStateRedis, markChildAsDelinked } = await import("../sio-state.js");
+const { initStateRedis, markChildAsDelinked } = await import("../sio-state/index.js");
 const { registerTuiSession } = await import("./sessions.js");
 
 describe("registerTuiSession parent resolution", () => {

--- a/packages/server/src/ws/sio-registry/sessions.recovery.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.recovery.test.ts
@@ -1,0 +1,57 @@
+// ============================================================================
+// sessions.recovery.test.ts — Unit tests for viewer-recovery SQLite-skip path
+//
+// When a viewer join triggers the cold-start runner fallback (cache miss),
+// markPendingRecovery() flags the session in pendingRecoverySessionIds.
+// The event-pipeline's consumePendingRecovery() clears the flag and passes
+// isRecovery:true to updateSessionState(), which skips the SQLite write.
+//
+// Imports directly from viewer-recovery.ts — a tiny zero-dependency module.
+// No mocking needed: the functions are pure Set operations with no I/O.
+// ============================================================================
+
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+    markPendingRecovery,
+    consumePendingRecovery,
+    pendingRecoverySessionIds,
+} from "./viewer-recovery.js";
+
+describe("viewer-recovery SQLite-skip path (pendingRecoverySessionIds)", () => {
+    beforeEach(() => {
+        pendingRecoverySessionIds.clear();
+    });
+
+    test("markPendingRecovery flags a session for recovery", () => {
+        markPendingRecovery("sess-recover-1");
+        expect(pendingRecoverySessionIds.has("sess-recover-1")).toBe(true);
+    });
+
+    test("consumePendingRecovery returns true and clears the flag", () => {
+        markPendingRecovery("sess-recover-2");
+        const wasRecovery = consumePendingRecovery("sess-recover-2");
+        expect(wasRecovery).toBe(true);
+        expect(pendingRecoverySessionIds.has("sess-recover-2")).toBe(false);
+    });
+
+    test("consumePendingRecovery returns false for sessions not marked", () => {
+        const wasRecovery = consumePendingRecovery("sess-not-marked");
+        expect(wasRecovery).toBe(false);
+    });
+
+    test("consumePendingRecovery is idempotent — second call returns false", () => {
+        markPendingRecovery("sess-recover-3");
+        expect(consumePendingRecovery("sess-recover-3")).toBe(true);
+        expect(consumePendingRecovery("sess-recover-3")).toBe(false); // already consumed
+    });
+
+    test("multiple sessions tracked independently", () => {
+        markPendingRecovery("sess-a");
+        markPendingRecovery("sess-b");
+
+        expect(consumePendingRecovery("sess-a")).toBe(true);
+        expect(pendingRecoverySessionIds.has("sess-b")).toBe(true); // unaffected
+        expect(consumePendingRecovery("sess-b")).toBe(true);
+        expect(pendingRecoverySessionIds.size).toBe(0);
+    });
+});

--- a/packages/server/src/ws/sio-registry/sessions.recovery.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.recovery.test.ts
@@ -2,36 +2,37 @@
 // sessions.recovery.test.ts — Unit tests for viewer-recovery SQLite-skip path
 //
 // When a viewer join triggers the cold-start runner fallback (cache miss),
-// markPendingRecovery() flags the session in pendingRecoverySessionIds.
+// markPendingRecovery() flags the session in the pending-recovery map.
 // The event-pipeline's consumePendingRecovery() clears the flag and passes
 // isRecovery:true to updateSessionState(), which skips the SQLite write.
 //
 // Imports directly from viewer-recovery.ts — a tiny zero-dependency module.
-// No mocking needed: the functions are pure Set operations with no I/O.
+// No mocking needed: the functions are pure Map operations with no I/O.
 // ============================================================================
 
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
     markPendingRecovery,
     consumePendingRecovery,
-    pendingRecoverySessionIds,
+    hasPendingRecovery,
+    _resetPendingRecoveriesForTesting,
 } from "./viewer-recovery.js";
 
 describe("viewer-recovery SQLite-skip path (pendingRecoverySessionIds)", () => {
     beforeEach(() => {
-        pendingRecoverySessionIds.clear();
+        _resetPendingRecoveriesForTesting();
     });
 
     test("markPendingRecovery flags a session for recovery", () => {
         markPendingRecovery("sess-recover-1");
-        expect(pendingRecoverySessionIds.has("sess-recover-1")).toBe(true);
+        expect(hasPendingRecovery("sess-recover-1")).toBe(true);
     });
 
     test("consumePendingRecovery returns true and clears the flag", () => {
         markPendingRecovery("sess-recover-2");
         const wasRecovery = consumePendingRecovery("sess-recover-2");
         expect(wasRecovery).toBe(true);
-        expect(pendingRecoverySessionIds.has("sess-recover-2")).toBe(false);
+        expect(hasPendingRecovery("sess-recover-2")).toBe(false);
     });
 
     test("consumePendingRecovery returns false for sessions not marked", () => {
@@ -50,8 +51,9 @@ describe("viewer-recovery SQLite-skip path (pendingRecoverySessionIds)", () => {
         markPendingRecovery("sess-b");
 
         expect(consumePendingRecovery("sess-a")).toBe(true);
-        expect(pendingRecoverySessionIds.has("sess-b")).toBe(true); // unaffected
+        expect(hasPendingRecovery("sess-b")).toBe(true); // unaffected
         expect(consumePendingRecovery("sess-b")).toBe(true);
-        expect(pendingRecoverySessionIds.size).toBe(0);
+        expect(hasPendingRecovery("sess-a")).toBe(false);
+        expect(hasPendingRecovery("sess-b")).toBe(false);
     });
 });

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -68,7 +68,7 @@ import { createLogger } from "@pizzapi/tools";
 import { clearSessionSubscriptions } from "../../sessions/trigger-subscription-store.js";
 import { pushTriggerHistory } from "../../sessions/trigger-store.js";
 
-export { pendingRecoverySessionIds, markPendingRecovery, consumePendingRecovery } from "./viewer-recovery.js";
+export { markPendingRecovery, consumePendingRecovery, hasPendingRecovery, _resetPendingRecoveriesForTesting } from "./viewer-recovery.js";
 
 const log = createLogger("sio-registry");
 const lastRelaySessionStateWriteTimes = new Map<string, number>();

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -68,6 +68,8 @@ import { createLogger } from "@pizzapi/tools";
 import { clearSessionSubscriptions } from "../../sessions/trigger-subscription-store.js";
 import { pushTriggerHistory } from "../../sessions/trigger-store.js";
 
+export { pendingRecoverySessionIds, markPendingRecovery, consumePendingRecovery } from "./viewer-recovery.js";
+
 const log = createLogger("sio-registry");
 const lastRelaySessionStateWriteTimes = new Map<string, number>();
 const SQLITE_STATE_WRITE_THROTTLE_MS = 30_000;
@@ -462,8 +464,17 @@ export async function getSharedSessionSummary(sessionId: string): Promise<RedisS
     return getSessionSummary(sessionId);
 }
 
+export interface UpdateSessionStateOpts {
+    /**
+     * When true, skip the SQLite persistence write.  Used for viewer-recovery
+     * paths where the runner re-sends the same state in response to a
+     * reconnecting viewer.  Redis is still updated for fast cache reads.
+     */
+    isRecovery?: boolean;
+}
+
 /** Update session state (lastState + sessionName detection). */
-export async function updateSessionState(sessionId: string, state: unknown): Promise<void> {
+export async function updateSessionState(sessionId: string, state: unknown, opts?: UpdateSessionStateOpts): Promise<void> {
     const session = await getSession(sessionId);
     if (!session) return;
 
@@ -502,7 +513,10 @@ export async function updateSessionState(sessionId: string, state: unknown): Pro
         stateMessages !== null && stateMessages.length > 0 ||
         now - (lastRelaySessionStateWriteTimes.get(sessionId) ?? 0) >= SQLITE_STATE_WRITE_THROTTLE_MS;
 
-    if (shouldPersistState) {
+    // Skip SQLite write for viewer-recovery events.  The runner re-sent the
+    // same state in response to a reconnecting viewer — Redis already has the
+    // data and SQLite doesn't need another write for identical content.
+    if (shouldPersistState && !opts?.isRecovery) {
         lastRelaySessionStateWriteTimes.set(sessionId, now);
         void recordRelaySessionState(sessionId, session.userId ?? null, strippedState).catch((error) => {
             log.error("Failed to persist relay session state:", error);

--- a/packages/server/src/ws/sio-registry/viewer-recovery.ts
+++ b/packages/server/src/ws/sio-registry/viewer-recovery.ts
@@ -1,0 +1,23 @@
+// ============================================================================
+// viewer-recovery.ts — in-memory flags for viewer-triggered session recovery
+//
+// When a viewer cache miss forces the server to ask the runner for a fresh
+// session_active snapshot, the follow-up event is recovery data rather than
+// new agent activity. These helpers track that one-shot condition so the event
+// pipeline can skip redundant SQLite writes.
+// ============================================================================
+
+export const pendingRecoverySessionIds = new Set<string>();
+
+/** Mark a session as expecting a recovery-origin session_active. */
+export function markPendingRecovery(sessionId: string): void {
+    pendingRecoverySessionIds.add(sessionId);
+}
+
+/**
+ * Check and consume the recovery flag for a session.
+ * Returns true (and removes the flag) if the session had a pending recovery.
+ */
+export function consumePendingRecovery(sessionId: string): boolean {
+    return pendingRecoverySessionIds.delete(sessionId);
+}

--- a/packages/server/src/ws/sio-registry/viewer-recovery.ts
+++ b/packages/server/src/ws/sio-registry/viewer-recovery.ts
@@ -27,17 +27,29 @@ export function markPendingRecovery(sessionId: string): void {
 
 /**
  * Check and consume the recovery flag for a session.
- * Returns true (and removes the flag) if the session had a pending recovery.
+ * Returns true (and removes the flag) if the session had a non-stale pending recovery.
+ * Stale entries (older than RECOVERY_FLAG_TTL_MS) are evicted and treated as absent,
+ * so a missed recovery snapshot never permanently marks a session as recovering.
  */
 export function consumePendingRecovery(sessionId: string): boolean {
-    const has = pendingRecoveryTimestamps.has(sessionId);
+    const ts = pendingRecoveryTimestamps.get(sessionId);
+    if (ts === undefined) return false;
     pendingRecoveryTimestamps.delete(sessionId);
-    return has;
+    return Date.now() - ts <= RECOVERY_FLAG_TTL_MS;
 }
 
-/** Check whether a session has a pending recovery flag (non-consuming). */
+/**
+ * Check whether a session has a pending recovery flag (non-consuming).
+ * Evicts the entry if it is stale (older than RECOVERY_FLAG_TTL_MS).
+ */
 export function hasPendingRecovery(sessionId: string): boolean {
-    return pendingRecoveryTimestamps.has(sessionId);
+    const ts = pendingRecoveryTimestamps.get(sessionId);
+    if (ts === undefined) return false;
+    if (Date.now() - ts > RECOVERY_FLAG_TTL_MS) {
+        pendingRecoveryTimestamps.delete(sessionId);
+        return false;
+    }
+    return true;
 }
 
 /** Clear all pending recovery flags. For test isolation only. */

--- a/packages/server/src/ws/sio-registry/viewer-recovery.ts
+++ b/packages/server/src/ws/sio-registry/viewer-recovery.ts
@@ -7,11 +7,22 @@
 // pipeline can skip redundant SQLite writes.
 // ============================================================================
 
-export const pendingRecoverySessionIds = new Set<string>();
+const pendingRecoveryTimestamps = new Map<string, number>();
+const RECOVERY_FLAG_TTL_MS = 60_000;
+
+function sweepStalePendingRecoveries(): void {
+    const now = Date.now();
+    for (const [sessionId, ts] of pendingRecoveryTimestamps) {
+        if (now - ts > RECOVERY_FLAG_TTL_MS) {
+            pendingRecoveryTimestamps.delete(sessionId);
+        }
+    }
+}
 
 /** Mark a session as expecting a recovery-origin session_active. */
 export function markPendingRecovery(sessionId: string): void {
-    pendingRecoverySessionIds.add(sessionId);
+    sweepStalePendingRecoveries();
+    pendingRecoveryTimestamps.set(sessionId, Date.now());
 }
 
 /**
@@ -19,5 +30,17 @@ export function markPendingRecovery(sessionId: string): void {
  * Returns true (and removes the flag) if the session had a pending recovery.
  */
 export function consumePendingRecovery(sessionId: string): boolean {
-    return pendingRecoverySessionIds.delete(sessionId);
+    const has = pendingRecoveryTimestamps.has(sessionId);
+    pendingRecoveryTimestamps.delete(sessionId);
+    return has;
+}
+
+/** Check whether a session has a pending recovery flag (non-consuming). */
+export function hasPendingRecovery(sessionId: string): boolean {
+    return pendingRecoveryTimestamps.has(sessionId);
+}
+
+/** Clear all pending recovery flags. For test isolation only. */
+export function _resetPendingRecoveriesForTesting(): void {
+    pendingRecoveryTimestamps.clear();
 }


### PR DESCRIPTION
## Summary

Makes viewer hydration cache-first: the server serves joining viewers directly from Redis cache instead of signaling the runner to rebuild and rebroadcast the full session transcript. Viewer join was previously a write-heavy, broadcast-heavy workflow that scaled with transcript size, viewer count, and reconnect frequency rather than actual session changes.

## Changes

### New modules
- `packages/server/src/ws/namespaces/viewer-cache.ts` — `hydrateViewerFromCache()`: tries delta resume (seq-based) first, falls back to full cached snapshot; emits only to the joining socket (not the room)
- `packages/server/src/ws/sio-registry/viewer-recovery.ts` — per-session recovery flag helpers (`markPendingRecovery`, `consumePendingRecovery`)

### Viewer namespace (`viewer.ts`)
- `activateSession` is now cache-first: calls `hydrateViewerFromCache()` before signaling the runner
- `suppressRunnerSignal` flag prevents runner signal when cache hydration succeeds
- `forwardRecoveryConnectedSignal()` marks recovery on both the deferred-flush and `socket.on("connected")` paths
- Cold-start fallback: runner signal still fires when cache is empty or stale

### Event pipeline (`event-pipeline.ts`)
- Recovery-tagged events skip redundant SQLite persistence writes
- `finalizeChunkedSnapshot()` consumes the recovery flag on chunked `session_active` completion (prevents stale flag misclassifying next real update)

### Tests
- `viewer.hydration.test.ts` — cache hit serves socket-only, cache miss falls through to runner
- `sessions.recovery.test.ts` — recovery flag set/consume/clear lifecycle
- Chunked recovery flag consumption

## Quality
- Typecheck: clean
- Tests: 0 fail in server package (better than main's 26 pre-existing)
- Ramsey: PASS (2 rounds)

## Origin
Night Shift critic-first session — ordered by Performance Critic (GPT-5.4) after deep codebase review.