### PR TITLE
feat: add folder browser to new session wizard

### DIFF
--- a/packages/cli/src/runner/services/file-explorer-service.test.ts
+++ b/packages/cli/src/runner/services/file-explorer-service.test.ts
@@ -1,0 +1,190 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { FileExplorerService } from "./file-explorer-service.js";
+
+// ── Mock workspace module ──────────────────────────────────────────────────
+// Separate controls so tests can independently configure path access vs roots.
+let mockCwdAllowed = true;
+let mockRoots: string[] = [];
+mock.module("../workspace.js", () => ({
+    isCwdAllowed: (_cwd: string) => mockCwdAllowed,
+    getWorkspaceRoots: () => mockRoots,
+}));
+
+// ── Fake socket ─────────────────────────────────────────────────────────────
+function createFakeSocket() {
+    const listeners = new Map<string, ((...args: any[]) => void)[]>();
+    const emitted: { event: string; data: any }[] = [];
+
+    return {
+        on(event: string, fn: (...args: any[]) => void) {
+            const list = listeners.get(event) ?? [];
+            list.push(fn);
+            listeners.set(event, list);
+        },
+        off(event: string, fn: (...args: any[]) => void) {
+            const list = listeners.get(event) ?? [];
+            listeners.set(event, list.filter((f) => f !== fn));
+        },
+        emit(event: string, data: any) {
+            emitted.push({ event, data });
+        },
+        listeners,
+        emitted,
+        async trigger(event: string, data: any) {
+            const fns = listeners.get(event) ?? [];
+            for (const fn of fns) await fn(data);
+        },
+        serviceMessages(): any[] {
+            return emitted
+                .filter((e) => e.event === "service_message" && e.data?.serviceId === "file-explorer")
+                .map((e) => e.data);
+        },
+    };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe("FileExplorerService — browse_directory", () => {
+    let tmpDir: string;
+    let socket: ReturnType<typeof createFakeSocket>;
+    let service: FileExplorerService;
+
+    beforeEach(() => {
+        mockCwdAllowed = true;
+        mockRoots = [];
+
+        tmpDir = mkdtempSync(join(tmpdir(), "browse-test-"));
+
+        // tmpDir/
+        //   project-a/
+        //   project-b/
+        //   .git/
+        //   node_modules/
+        //   .ssh/           (sensitive)
+        //   .config/        (sensitive)
+        //   regular-file.txt
+        //   symlink-to-dir -> project-a
+        //   symlink-broken -> nonexistent
+        mkdirSync(join(tmpDir, "project-a"));
+        mkdirSync(join(tmpDir, "project-b"));
+        mkdirSync(join(tmpDir, ".git"));
+        mkdirSync(join(tmpDir, "node_modules"));
+        mkdirSync(join(tmpDir, ".ssh"));
+        mkdirSync(join(tmpDir, ".config"));
+        writeFileSync(join(tmpDir, "regular-file.txt"), "hello");
+        symlinkSync(join(tmpDir, "project-a"), join(tmpDir, "symlink-to-dir"));
+        symlinkSync(join(tmpDir, "nonexistent"), join(tmpDir, "symlink-broken"));
+
+        socket = createFakeSocket();
+        service = new FileExplorerService();
+        service.init(socket as any, { isShuttingDown: () => false });
+    });
+
+    afterEach(() => {
+        service.dispose();
+        rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    function getLastDirNames(): string[] {
+        const msg = socket.serviceMessages().pop();
+        return (msg?.payload?.directories as any[])?.map((d: any) => d.name) ?? [];
+    }
+
+    test("lists only directories, excludes files", async () => {
+        await socket.trigger("browse_directory", { requestId: "r1", path: tmpDir });
+        const names = getLastDirNames();
+        expect(names).toContain("project-a");
+        expect(names).toContain("project-b");
+        expect(names).not.toContain("regular-file.txt");
+    });
+
+    test("excludes .git and node_modules", async () => {
+        await socket.trigger("browse_directory", { requestId: "r2", path: tmpDir });
+        const names = getLastDirNames();
+        expect(names).not.toContain(".git");
+        expect(names).not.toContain("node_modules");
+    });
+
+    test("includes symlinks to directories", async () => {
+        await socket.trigger("browse_directory", { requestId: "r3", path: tmpDir });
+        const names = getLastDirNames();
+        expect(names).toContain("symlink-to-dir");
+    });
+
+    test("excludes broken symlinks", async () => {
+        await socket.trigger("browse_directory", { requestId: "r4", path: tmpDir });
+        const names = getLastDirNames();
+        expect(names).not.toContain("symlink-broken");
+    });
+
+    test("filters sensitive dotfolders when outside workspace roots", async () => {
+        // Roots configured but tmpDir is NOT under any of them → insideRoot=false
+        mockRoots = ["/some/other/root"];
+
+        await socket.trigger("browse_directory", { requestId: "r5", path: tmpDir });
+        const names = getLastDirNames();
+        expect(names).not.toContain(".ssh");
+        expect(names).not.toContain(".config");
+        expect(names).toContain("project-a");
+        expect(names).toContain("project-b");
+    });
+
+    test("shows all dotfolders when inside workspace root", async () => {
+        mockRoots = [tmpDir];
+
+        await socket.trigger("browse_directory", { requestId: "r6", path: tmpDir });
+        const names = getLastDirNames();
+        expect(names).toContain(".ssh");
+        expect(names).toContain(".config");
+    });
+
+    test("shows all dotfolders when no roots configured (unscoped)", async () => {
+        mockRoots = [];
+
+        await socket.trigger("browse_directory", { requestId: "r6b", path: tmpDir });
+        const names = getLastDirNames();
+        expect(names).toContain(".ssh");
+        expect(names).toContain(".config");
+    });
+
+    test("returns error for missing path", async () => {
+        await socket.trigger("browse_directory", { requestId: "r7", path: "" });
+        const msg = socket.serviceMessages().pop();
+        expect(msg?.payload?.ok).toBe(false);
+        expect(msg?.payload?.message).toBe("Missing path");
+    });
+
+    test("returns error for disallowed path", async () => {
+        mockCwdAllowed = false;
+
+        await socket.trigger("browse_directory", { requestId: "r8", path: "/etc" });
+        const msg = socket.serviceMessages().pop();
+        expect(msg?.payload?.ok).toBe(false);
+        expect(msg?.payload?.message).toBe("Path outside allowed roots");
+    });
+
+    test("returns error for non-existent path", async () => {
+        await socket.trigger("browse_directory", { requestId: "r9", path: join(tmpDir, "nonexistent") });
+        const msg = socket.serviceMessages().pop();
+        expect(msg?.payload?.ok).toBe(false);
+        expect(msg?.payload?.message).toContain("ENOENT");
+    });
+
+    test("results are sorted alphabetically", async () => {
+        await socket.trigger("browse_directory", { requestId: "r10", path: tmpDir });
+        const names = getLastDirNames();
+        const sorted = [...names].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+        expect(names).toEqual(sorted);
+    });
+
+    test("dispose removes listener", () => {
+        const before = socket.listeners.get("browse_directory")?.length ?? 0;
+        expect(before).toBeGreaterThan(0);
+        service.dispose();
+        const after = socket.listeners.get("browse_directory")?.length ?? 0;
+        expect(after).toBe(0);
+    });
+});

--- a/packages/cli/src/runner/services/file-explorer-service.ts
+++ b/packages/cli/src/runner/services/file-explorer-service.ts
@@ -1,10 +1,17 @@
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
-import { readdir, stat } from "node:fs/promises";
+import { readdir, stat, realpath } from "node:fs/promises";
 import { join } from "node:path";
 import type { Socket } from "socket.io-client";
 import type { ServiceHandler, ServiceInitOptions } from "../service-handler.js";
-import { isCwdAllowed } from "../workspace.js";
+import { isCwdAllowed, getWorkspaceRoots } from "../workspace.js";
+
+// Sensitive dotfolders that should never appear in the folder browser
+// when browsing outside configured workspace roots.
+const SENSITIVE_DOTDIRS = new Set([
+    ".ssh", ".gnupg", ".gpg", ".aws", ".docker", ".kube",
+    ".config", ".local", ".cache", ".npm", ".bun",
+]);
 
 const execFileAsync = promisify(execFile);
 
@@ -104,19 +111,44 @@ export class FileExplorerService implements ServiceHandler {
             }
             try {
                 const entries = await readdir(dirPath, { withFileTypes: true });
-                const dirs = entries
-                    .filter((e) => {
-                        if (!e.isDirectory()) return false;
-                        // Hide .git and other noisy dotfolders
-                        if (e.name === ".git" || e.name === "node_modules") return false;
-                        return true;
-                    })
-                    .map((e) => ({
-                        name: e.name,
-                        path: join(dirPath, e.name),
-                    }))
-                    .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
-                emitFileResult({ requestId, ok: true, directories: dirs });
+
+                // Determine if we're inside a workspace root (if any are configured).
+                // When outside roots, filter sensitive dotfolders for safety.
+                const roots = getWorkspaceRoots();
+                const insideRoot = roots.length === 0 || roots.some((root) => {
+                    const nRoot = root.replace(/\/+$/, "") || "/";
+                    const nDir = dirPath.replace(/\/+$/, "") || "/";
+                    return nDir === nRoot || nDir.startsWith(nRoot + "/");
+                });
+
+                // Resolve entries: include directories and symlinks-to-directories
+                const dirResults: { name: string; path: string }[] = [];
+                for (const e of entries) {
+                    // Always skip .git and node_modules
+                    if (e.name === ".git" || e.name === "node_modules") continue;
+                    // Filter sensitive dotfolders when outside workspace roots
+                    if (!insideRoot && SENSITIVE_DOTDIRS.has(e.name)) continue;
+
+                    const fullPath = join(dirPath, e.name);
+
+                    if (e.isDirectory()) {
+                        dirResults.push({ name: e.name, path: fullPath });
+                    } else if (e.isSymbolicLink()) {
+                        // Resolve symlink to check if it points to a directory
+                        try {
+                            const resolved = await realpath(fullPath);
+                            const s = await stat(resolved);
+                            if (s.isDirectory()) {
+                                dirResults.push({ name: e.name, path: fullPath });
+                            }
+                        } catch {
+                            // Broken symlink or permission error — skip
+                        }
+                    }
+                }
+
+                dirResults.sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+                emitFileResult({ requestId, ok: true, directories: dirResults });
             } catch (err) {
                 emitFileResult({
                     requestId,

--- a/packages/cli/src/runner/services/file-explorer-service.ts
+++ b/packages/cli/src/runner/services/file-explorer-service.ts
@@ -19,6 +19,7 @@ export class FileExplorerService implements ServiceHandler {
     private _onListFiles: ((data: any) => void) | null = null;
     private _onSearchFiles: ((data: any) => void) | null = null;
     private _onReadFile: ((data: any) => void) | null = null;
+    private _onBrowseDirectory: ((data: any) => void) | null = null;
 
     init(socket: Socket, { isShuttingDown }: ServiceInitOptions): void {
         this._socket = socket;
@@ -87,6 +88,44 @@ export class FileExplorerService implements ServiceHandler {
             }
         };
         socket.on("list_files", this._onListFiles);
+
+        // browse_directory — lists only subdirectories at a given path (for folder picker UI)
+        this._onBrowseDirectory = async (data: any) => {
+            if (isShuttingDown()) return;
+            const requestId = data.requestId;
+            const dirPath = data.path ?? "";
+            if (!dirPath) {
+                emitFileResult({ requestId, ok: false, message: "Missing path" });
+                return;
+            }
+            if (!isCwdAllowed(dirPath)) {
+                emitFileResult({ requestId, ok: false, message: "Path outside allowed roots" });
+                return;
+            }
+            try {
+                const entries = await readdir(dirPath, { withFileTypes: true });
+                const dirs = entries
+                    .filter((e) => {
+                        if (!e.isDirectory()) return false;
+                        // Hide .git and other noisy dotfolders
+                        if (e.name === ".git" || e.name === "node_modules") return false;
+                        return true;
+                    })
+                    .map((e) => ({
+                        name: e.name,
+                        path: join(dirPath, e.name),
+                    }))
+                    .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: "base" }));
+                emitFileResult({ requestId, ok: true, directories: dirs });
+            } catch (err) {
+                emitFileResult({
+                    requestId,
+                    ok: false,
+                    message: err instanceof Error ? err.message : String(err),
+                });
+            }
+        };
+        socket.on("browse_directory", this._onBrowseDirectory);
 
         this._onSearchFiles = async (data: any) => {
             if (isShuttingDown()) return;
@@ -209,10 +248,12 @@ export class FileExplorerService implements ServiceHandler {
             if (this._onListFiles) (this._socket as any).off("list_files", this._onListFiles);
             if (this._onSearchFiles) (this._socket as any).off("search_files", this._onSearchFiles);
             if (this._onReadFile) (this._socket as any).off("read_file", this._onReadFile);
+            if (this._onBrowseDirectory) (this._socket as any).off("browse_directory", this._onBrowseDirectory);
             this._socket = null;
         }
         this._onListFiles = null;
         this._onSearchFiles = null;
         this._onReadFile = null;
+        this._onBrowseDirectory = null;
     }
 }

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -310,6 +310,35 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         return undefined;
     }
 
+    // ── Browse directory (folder picker) ───────────────────────────
+    const browseMatch = url.pathname.match(/^\/api\/runners\/([^/]+)\/browse$/);
+    if (browseMatch && req.method === "GET") {
+        const identity = await requireSession(req);
+        if (identity instanceof Response) return identity;
+
+        const runnerId = decodeURIComponent(browseMatch[1]);
+        const runner = await getRunnerData(runnerId);
+        if (!runner) return Response.json({ error: "Runner not found" }, { status: 404 });
+        if (runner.userId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
+
+        const path = url.searchParams.get("path") || "/";
+        try {
+            const result = await sendRunnerCommand(runnerId, {
+                type: "browse_directory",
+                path,
+            }, 10_000) as any;
+            if (!result.ok) {
+                return Response.json({ error: result.message || "Browse failed" }, { status: 400 });
+            }
+            return Response.json({ directories: result.directories ?? [] });
+        } catch (err) {
+            return Response.json(
+                { error: err instanceof Error ? err.message : "Browse failed" },
+                { status: 502 },
+            );
+        }
+    }
+
     // ── Available models ───────────────────────────────────────────
     const modelsMatch = url.pathname.match(/^\/api\/runners\/([^/]+)\/models$/);
     if (modelsMatch && req.method === "GET") {

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -322,6 +322,13 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         if (runner.userId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
 
         const path = url.searchParams.get("path") || "/";
+
+        // Enforce workspace roots at the server layer (defense-in-depth).
+        const roots = parseJsonArray(runner.roots);
+        if (roots.length > 0 && !cwdMatchesRoots(roots, path)) {
+            return Response.json({ error: "Path outside allowed workspace roots" }, { status: 400 });
+        }
+
         try {
             const result = await sendRunnerCommand(runnerId, {
                 type: "browse_directory",

--- a/packages/ui/src/components/FolderBrowser.tsx
+++ b/packages/ui/src/components/FolderBrowser.tsx
@@ -15,8 +15,10 @@ export interface FolderBrowserProps {
     onSelect: (path: string) => void;
     /** Called when user clicks "Cancel" to go back to recent projects. */
     onCancel: () => void;
-    /** Initial path to browse from. */
+    /** Initial path to browse from. Defaults to first workspace root or "/". */
     initialPath?: string;
+    /** Runner workspace roots — used to pick a sensible default start path. */
+    roots?: string[];
     disabled?: boolean;
 }
 
@@ -29,10 +31,13 @@ export function FolderBrowser({
     runnerId,
     onSelect,
     onCancel,
-    initialPath = "/",
+    initialPath,
+    roots,
     disabled = false,
 }: FolderBrowserProps) {
-    const [currentPath, setCurrentPath] = React.useState(initialPath);
+    // Pick a sensible default: explicit initialPath > first workspace root > "/"
+    const defaultPath = initialPath || (roots && roots.length > 0 ? roots[0] : "/");
+    const [currentPath, setCurrentPath] = React.useState(defaultPath);
     const [directories, setDirectories] = React.useState<DirEntry[]>([]);
     const [loading, setLoading] = React.useState(false);
     const [error, setError] = React.useState<string | null>(null);
@@ -40,31 +45,31 @@ export function FolderBrowser({
 
     // Fetch directories whenever currentPath changes
     React.useEffect(() => {
-        let cancelled = false;
+        const controller = new AbortController();
         setLoading(true);
         setError(null);
 
         fetch(
             `/api/runners/${encodeURIComponent(runnerId)}/browse?path=${encodeURIComponent(currentPath)}`,
-            { credentials: "include" },
+            { credentials: "include", signal: controller.signal },
         )
             .then((res) => {
                 if (!res.ok) return res.json().then((b) => { throw new Error(b.error || `HTTP ${res.status}`); });
                 return res.json();
             })
             .then((body: any) => {
-                if (cancelled) return;
+                if (controller.signal.aborted) return;
                 setDirectories(Array.isArray(body?.directories) ? body.directories : []);
             })
             .catch((err) => {
-                if (cancelled) return;
+                if (controller.signal.aborted) return;
                 setError(err instanceof Error ? err.message : "Failed to browse directory");
             })
             .finally(() => {
-                if (!cancelled) setLoading(false);
+                if (!controller.signal.aborted) setLoading(false);
             });
 
-        return () => { cancelled = true; };
+        return () => { controller.abort(); };
     }, [runnerId, currentPath]);
 
     // Scroll to top when navigating

--- a/packages/ui/src/components/FolderBrowser.tsx
+++ b/packages/ui/src/components/FolderBrowser.tsx
@@ -1,0 +1,198 @@
+/**
+ * FolderBrowser — inline directory navigator for the new-session wizard.
+ *
+ * Fetches subdirectories from the runner via REST and lets the user
+ * click through the filesystem to pick a working directory.
+ */
+import * as React from "react";
+import { Folder, FolderOpen, ChevronRight, Loader2, AlertCircle, ArrowUp } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+export interface FolderBrowserProps {
+    runnerId: string;
+    /** Called when the user selects (confirms) a directory. */
+    onSelect: (path: string) => void;
+    /** Called when user clicks "Cancel" to go back to recent projects. */
+    onCancel: () => void;
+    /** Initial path to browse from. */
+    initialPath?: string;
+    disabled?: boolean;
+}
+
+interface DirEntry {
+    name: string;
+    path: string;
+}
+
+export function FolderBrowser({
+    runnerId,
+    onSelect,
+    onCancel,
+    initialPath = "/",
+    disabled = false,
+}: FolderBrowserProps) {
+    const [currentPath, setCurrentPath] = React.useState(initialPath);
+    const [directories, setDirectories] = React.useState<DirEntry[]>([]);
+    const [loading, setLoading] = React.useState(false);
+    const [error, setError] = React.useState<string | null>(null);
+    const listRef = React.useRef<HTMLDivElement>(null);
+
+    // Fetch directories whenever currentPath changes
+    React.useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+        setError(null);
+
+        fetch(
+            `/api/runners/${encodeURIComponent(runnerId)}/browse?path=${encodeURIComponent(currentPath)}`,
+            { credentials: "include" },
+        )
+            .then((res) => {
+                if (!res.ok) return res.json().then((b) => { throw new Error(b.error || `HTTP ${res.status}`); });
+                return res.json();
+            })
+            .then((body: any) => {
+                if (cancelled) return;
+                setDirectories(Array.isArray(body?.directories) ? body.directories : []);
+            })
+            .catch((err) => {
+                if (cancelled) return;
+                setError(err instanceof Error ? err.message : "Failed to browse directory");
+            })
+            .finally(() => {
+                if (!cancelled) setLoading(false);
+            });
+
+        return () => { cancelled = true; };
+    }, [runnerId, currentPath]);
+
+    // Scroll to top when navigating
+    React.useEffect(() => {
+        listRef.current?.scrollTo(0, 0);
+    }, [currentPath]);
+
+    function navigateTo(path: string) {
+        if (!disabled) setCurrentPath(path);
+    }
+
+    function navigateUp() {
+        if (currentPath === "/") return;
+        const parent = currentPath.replace(/\/[^/]+\/?$/, "") || "/";
+        navigateTo(parent);
+    }
+
+    // Build breadcrumb segments
+    const segments = React.useMemo(() => {
+        const parts = currentPath.split("/").filter(Boolean);
+        const result: { label: string; path: string }[] = [{ label: "/", path: "/" }];
+        let acc = "";
+        for (const part of parts) {
+            acc += "/" + part;
+            result.push({ label: part, path: acc });
+        }
+        return result;
+    }, [currentPath]);
+
+    return (
+        <div className="flex flex-col gap-2">
+            {/* Breadcrumb navigation */}
+            <div className="flex items-center gap-1 text-xs text-muted-foreground overflow-x-auto min-h-[24px] flex-shrink-0">
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0 flex-shrink-0"
+                    onClick={navigateUp}
+                    disabled={disabled || currentPath === "/"}
+                    title="Go up"
+                >
+                    <ArrowUp className="h-3 w-3" />
+                </Button>
+                {segments.map((seg, i) => (
+                    <React.Fragment key={seg.path}>
+                        {i > 0 && <ChevronRight className="h-3 w-3 flex-shrink-0 opacity-40" />}
+                        <button
+                            type="button"
+                            onClick={() => navigateTo(seg.path)}
+                            disabled={disabled}
+                            className={cn(
+                                "font-mono hover:text-foreground transition-colors whitespace-nowrap",
+                                i === segments.length - 1 ? "text-foreground font-medium" : "",
+                            )}
+                        >
+                            {seg.label}
+                        </button>
+                    </React.Fragment>
+                ))}
+            </div>
+
+            {/* Directory listing */}
+            <div
+                ref={listRef}
+                className="rounded-md border border-border overflow-y-auto"
+                style={{ maxHeight: 280 }}
+            >
+                {loading && (
+                    <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Loading…
+                    </div>
+                )}
+
+                {!loading && error && (
+                    <div className="flex items-center gap-2 px-3 py-4 text-sm text-destructive">
+                        <AlertCircle className="h-4 w-4 flex-shrink-0" />
+                        {error}
+                    </div>
+                )}
+
+                {!loading && !error && directories.length === 0 && (
+                    <p className="px-3 py-4 text-xs text-muted-foreground text-center">
+                        No subdirectories
+                    </p>
+                )}
+
+                {!loading && !error && directories.length > 0 && (
+                    <div className="flex flex-col">
+                        {directories.map((dir) => (
+                            <button
+                                key={dir.path}
+                                type="button"
+                                onClick={() => navigateTo(dir.path)}
+                                disabled={disabled}
+                                className={cn(
+                                    "flex items-center gap-2 px-3 py-2 text-left text-sm",
+                                    "hover:bg-muted transition-colors",
+                                )}
+                            >
+                                <Folder className="h-3.5 w-3.5 flex-shrink-0 opacity-60" />
+                                <span className="font-mono truncate">{dir.name}</span>
+                            </button>
+                        ))}
+                    </div>
+                )}
+            </div>
+
+            {/* Actions */}
+            <div className="flex items-center justify-between">
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={onCancel}
+                    disabled={disabled}
+                >
+                    Back to recent
+                </Button>
+                <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => onSelect(currentPath)}
+                    disabled={disabled}
+                >
+                    <FolderOpen className="h-3.5 w-3.5 mr-1.5" />
+                    Select this folder
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -402,7 +402,8 @@ export function NewSessionWizardDialog({
                         {browsing && selectedRunnerId && (
                             <FolderBrowser
                                 runnerId={selectedRunnerId}
-                                initialPath={cwd.trim() || "/"}
+                                initialPath={cwd.trim() || undefined}
+                                roots={selectedRunner?.roots}
                                 onSelect={(path) => {
                                     setCwd(path);
                                     setBrowsing(false);

--- a/packages/ui/src/components/NewSessionWizardDialog.tsx
+++ b/packages/ui/src/components/NewSessionWizardDialog.tsx
@@ -7,11 +7,12 @@
  */
 import * as React from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { FolderOpen, Loader2, X, ChevronLeft, Monitor } from "lucide-react";
+import { FolderOpen, FolderSearch, Loader2, X, ChevronLeft, Monitor } from "lucide-react";
 import { SiApple, SiLinux } from "react-icons/si";
 import { cn } from "@/lib/utils";
 import { formatPathTail } from "@/lib/path";
 import { filterFolders } from "@/lib/filterFolders";
+import { FolderBrowser } from "@/components/FolderBrowser";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -126,6 +127,9 @@ export function NewSessionWizardDialog({
     const [recentFoldersLoading, setRecentFoldersLoading] = React.useState(false);
     const [recentFoldersError, setRecentFoldersError] = React.useState<string | null>(null);
 
+    // Folder browser mode
+    const [browsing, setBrowsing] = React.useState(false);
+
     // Filtered list (derived)
     const filteredFolders = React.useMemo(
         () => filterFolders(recentFolders, cwd),
@@ -152,6 +156,7 @@ export function NewSessionWizardDialog({
         setSpawnError(null);
         setDisconnectedMsg(null);
         setRecentFolders([]);
+        setBrowsing(false);
     }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // Fetch recent folders when entering Step 2
@@ -220,6 +225,7 @@ export function NewSessionWizardDialog({
         setStep("runner");
         setRecentFolders([]);
         setSpawnError(null);
+        setBrowsing(false);
     }
 
     function handleSelectRecent(folder: string) {
@@ -364,35 +370,62 @@ export function NewSessionWizardDialog({
                                 Working directory{" "}
                                 <span className="text-muted-foreground font-normal">(optional)</span>
                             </Label>
-                            <Input
-                                id="wizard-cwd"
-                                value={cwd}
-                                onChange={(e) => setCwd(e.target.value)}
-                                onKeyDown={(e) => { if (e.key === "Enter") void handleSpawn(); }}
-                                placeholder="/path/to/project"
-                                className="font-mono text-sm"
-                                disabled={spawning}
-                                autoFocus
-                            />
+                            <div className="flex gap-1.5">
+                                <Input
+                                    id="wizard-cwd"
+                                    value={cwd}
+                                    onChange={(e) => setCwd(e.target.value)}
+                                    onKeyDown={(e) => { if (e.key === "Enter") void handleSpawn(); }}
+                                    placeholder="/path/to/project"
+                                    className="font-mono text-sm flex-1"
+                                    disabled={spawning}
+                                    autoFocus
+                                />
+                                <Button
+                                    type="button"
+                                    variant={browsing ? "secondary" : "outline"}
+                                    size="icon"
+                                    onClick={() => setBrowsing(!browsing)}
+                                    disabled={spawning}
+                                    title="Browse folders"
+                                    className="flex-shrink-0"
+                                >
+                                    <FolderSearch className="h-4 w-4" />
+                                </Button>
+                            </div>
                             <p className="text-xs text-muted-foreground">
                                 This is the path on the runner machine.
                             </p>
                         </div>
 
-                        {/* Recent projects */}
-                        {recentFoldersLoading && (
+                        {/* Folder browser */}
+                        {browsing && selectedRunnerId && (
+                            <FolderBrowser
+                                runnerId={selectedRunnerId}
+                                initialPath={cwd.trim() || "/"}
+                                onSelect={(path) => {
+                                    setCwd(path);
+                                    setBrowsing(false);
+                                }}
+                                onCancel={() => setBrowsing(false)}
+                                disabled={spawning}
+                            />
+                        )}
+
+                        {/* Recent projects (hidden when browsing) */}
+                        {!browsing && recentFoldersLoading && (
                             <div className="flex items-center gap-2 text-xs text-muted-foreground">
                                 <Loader2 className="h-3 w-3 animate-spin" />
                                 Loading recent projects…
                             </div>
                         )}
-                        {!recentFoldersLoading && recentFoldersError && (
+                        {!browsing && !recentFoldersLoading && recentFoldersError && (
                             <p className="text-xs text-destructive">{recentFoldersError}</p>
                         )}
-                        {!recentFoldersLoading && !recentFoldersError && recentFolders.length === 0 && (
+                        {!browsing && !recentFoldersLoading && !recentFoldersError && recentFolders.length === 0 && (
                             <p className="text-xs text-muted-foreground">No recent projects yet.</p>
                         )}
-                        {!recentFoldersLoading && !recentFoldersError && recentFolders.length > 0 && (
+                        {!browsing && !recentFoldersLoading && !recentFoldersError && recentFolders.length > 0 && (
                             <div className="flex flex-col gap-1">
                                 <p className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
                                     Recent projects


### PR DESCRIPTION
Adds a browsable folder picker to the New Session dialog so you don't have to type paths manually.

## Changes

- **Runner**: New `browse_directory` handler on the file-explorer service — lists only subdirectories, filters out `.git`/`node_modules`, respects workspace root restrictions
- **Server**: New `GET /api/runners/:id/browse?path=...` REST endpoint with auth + ownership checks (10s timeout)
- **UI**: New `FolderBrowser` component with breadcrumb navigation, directory listing, and select/cancel actions
- **Wizard integration**: Browse button next to the working directory input toggles the folder browser inline, replacing the recent projects list. Selecting a folder populates the cwd input.

## How it works

1. Click the browse button next to the path input
2. Navigate the runner's filesystem by clicking folders
3. Use breadcrumbs or the up-arrow to go back
4. Click "Select this folder" to confirm — populates the path input
5. Click "Back to recent" to return to the recent projects list