### PR TITLE
feat(file-explorer): markdown preview, virtualized tree, persist expanded folders

### DIFF
--- a/packages/ui/src/components/file-explorer/FileExplorer.tsx
+++ b/packages/ui/src/components/file-explorer/FileExplorer.tsx
@@ -3,23 +3,157 @@ import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
+import { useVirtualizer } from "@tanstack/react-virtual";
 import {
+  ChevronRight,
+  ChevronDown,
+  File,
   Folder,
+  FolderOpen,
   RefreshCw,
+  ChevronsUpDown,
+  ChevronsDownUp,
 } from "lucide-react";
 import { FileEntry, FileExplorerProps } from "./types";
-import { shouldInterceptEscape, isImageFile } from "./utils";
-import { FileTreeNode } from "./file-tree-node";
+import { shouldInterceptEscape, isImageFile, isMarkdownFile, getFileIcon, formatSize } from "./utils";
 import { ImageViewer } from "./image-viewer";
 import { FileViewer } from "./file-viewer";
+import { MarkdownViewer } from "./markdown-viewer";
+
+// ── Flat tree node ────────────────────────────────────────────────────────────
+
+interface FlatNode {
+  entry: FileEntry;
+  depth: number;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function flattenTree(
+  files: FileEntry[],
+  expandedPaths: Set<string>,
+  childrenCache: Map<string, FileEntry[]>,
+  depth = 0,
+): FlatNode[] {
+  const result: FlatNode[] = [];
+  for (const entry of files) {
+    result.push({ entry, depth });
+    if (entry.isDirectory && expandedPaths.has(entry.path)) {
+      const children = childrenCache.get(entry.path) ?? [];
+      result.push(...flattenTree(children, expandedPaths, childrenCache, depth + 1));
+    }
+  }
+  return result;
+}
+
+/** Load children for a directory from the API. */
+async function fetchChildren(runnerId: string, dirPath: string): Promise<FileEntry[]> {
+  const res = await fetch(`/api/runners/${encodeURIComponent(runnerId)}/files`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify({ path: dirPath }),
+  });
+  if (!res.ok) return [];
+  const data = await res.json() as { ok: boolean; files: FileEntry[] };
+  return data.files ?? [];
+}
+
+/** localStorage helpers for expanded path sets. */
+function loadExpandedPaths(storageKey: string): Set<string> {
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw) as string[];
+    return new Set(Array.isArray(arr) ? arr : []);
+  } catch {
+    return new Set();
+  }
+}
+
+function saveExpandedPaths(storageKey: string, paths: Set<string>): void {
+  try {
+    localStorage.setItem(storageKey, JSON.stringify([...paths]));
+  } catch {
+    // ignore quota/security errors
+  }
+}
+
+// ── File Tree Row ─────────────────────────────────────────────────────────────
+
+const ROW_HEIGHT = 30; // px — must match the rendered row height
+
+interface FileTreeRowProps {
+  node: FlatNode;
+  isExpanded: boolean;
+  isLoading: boolean;
+  onToggle: (entry: FileEntry) => void;
+}
+
+const FileTreeRow = React.memo(function FileTreeRow({ node, isExpanded, isLoading, onToggle }: FileTreeRowProps) {
+  const { entry, depth } = node;
+
+  const icon = entry.isDirectory
+    ? isExpanded
+      ? <FolderOpen className="size-4 text-amber-500 dark:text-amber-400 flex-shrink-0" />
+      : <Folder className="size-4 text-amber-500/70 dark:text-amber-400/70 flex-shrink-0" />
+    : <File className="size-4 text-muted-foreground flex-shrink-0" />;
+
+  const chevron = entry.isDirectory
+    ? isExpanded
+      ? <ChevronDown className="size-3 text-muted-foreground flex-shrink-0" />
+      : <ChevronRight className="size-3 text-muted-foreground flex-shrink-0" />
+    : <span className="size-3 flex-shrink-0" />;
+
+  const emoji = !entry.isDirectory ? getFileIcon(entry.name) : null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(entry)}
+      aria-expanded={entry.isDirectory ? isExpanded : undefined}
+      aria-label={entry.isDirectory ? `Folder ${entry.name}` : `File ${entry.name}`}
+      className={cn(
+        "flex items-center gap-1 w-full text-left px-2 text-sm hover:bg-accent/60 transition-colors rounded-sm group",
+        !entry.isDirectory && "cursor-pointer",
+      )}
+      style={{ paddingLeft: `${depth * 16 + 8}px`, height: `${ROW_HEIGHT}px` }}
+    >
+      {chevron}
+      {icon}
+      <span className="truncate flex-1" title={entry.name}>
+        {emoji ? <span className="mr-1 text-xs">{emoji}</span> : null}
+        {entry.name}
+        {entry.isSymlink && <span className="text-xs text-muted-foreground ml-1">→</span>}
+      </span>
+      {!entry.isDirectory && entry.size !== undefined && (
+        <span className="text-[0.6rem] text-muted-foreground/60 tabular-nums flex-shrink-0">{formatSize(entry.size)}</span>
+      )}
+      {isLoading && <Spinner className="size-3 flex-shrink-0" />}
+    </button>
+  );
+});
 
 // ── Main File Explorer Component ──────────────────────────────────────────────
 
 export function FileExplorer({ runnerId, cwd, className, onClose, position = "left", onPositionChange, onDragStart }: FileExplorerProps) {
+  const storageKey = `file-explorer:${runnerId}:${cwd}`;
+
   const [files, setFiles] = React.useState<FileEntry[] | null>(null);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const [viewingFile, setViewingFile] = React.useState<string | null>(null);
+
+  // Lifted tree state
+  const [expandedPaths, setExpandedPaths] = React.useState<Set<string>>(() => loadExpandedPaths(storageKey));
+  const [childrenCache, setChildrenCache] = React.useState<Map<string, FileEntry[]>>(new Map());
+  const [loadingPaths, setLoadingPaths] = React.useState<Set<string>>(new Set());
+  const [expandingAll, setExpandingAll] = React.useState(false);
+
+  // Persist expanded state whenever it changes
+  React.useEffect(() => {
+    saveExpandedPaths(storageKey, expandedPaths);
+  }, [storageKey, expandedPaths]);
 
   const fetchFiles = React.useCallback(async () => {
     setLoading(true);
@@ -48,13 +182,95 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
     void fetchFiles();
   }, [fetchFiles]);
 
-  // Intercept Escape when viewing a file so it closes the preview
-  // instead of propagating to SessionViewer's abort handler.
+  // Toggle expand/collapse for a directory, or open a file
+  const handleToggle = React.useCallback(async (entry: FileEntry) => {
+    if (!entry.isDirectory) {
+      setViewingFile(entry.path);
+      return;
+    }
+
+    if (expandedPaths.has(entry.path)) {
+      // Collapse
+      setExpandedPaths((prev) => {
+        const next = new Set(prev);
+        next.delete(entry.path);
+        return next;
+      });
+      return;
+    }
+
+    // Expand — fetch children if not cached
+    if (!childrenCache.has(entry.path)) {
+      setLoadingPaths((prev) => new Set([...prev, entry.path]));
+      const children = await fetchChildren(runnerId, entry.path);
+      setChildrenCache((prev) => new Map([...prev, [entry.path, children]]));
+      setLoadingPaths((prev) => {
+        const next = new Set(prev);
+        next.delete(entry.path);
+        return next;
+      });
+    }
+
+    setExpandedPaths((prev) => new Set([...prev, entry.path]));
+  }, [runnerId, expandedPaths, childrenCache]);
+
+  // Collapse All
+  const handleCollapseAll = React.useCallback(() => {
+    setExpandedPaths(new Set());
+  }, []);
+
+  // Expand All (BFS up to depth 3, fetching missing children)
+  const handleExpandAll = React.useCallback(async () => {
+    if (!files) return;
+    setExpandingAll(true);
+
+    const newCache = new Map(childrenCache);
+    const toExpand = new Set<string>();
+
+    interface BFSItem { entries: FileEntry[]; depth: number }
+    const queue: BFSItem[] = [{ entries: files, depth: 0 }];
+
+    while (queue.length > 0) {
+      const item = queue.shift()!;
+      if (item.depth >= 3) continue;
+
+      for (const entry of item.entries) {
+        if (!entry.isDirectory) continue;
+        toExpand.add(entry.path);
+
+        let children = newCache.get(entry.path);
+        if (!children) {
+          children = await fetchChildren(runnerId, entry.path);
+          newCache.set(entry.path, children);
+        }
+        queue.push({ entries: children, depth: item.depth + 1 });
+      }
+    }
+
+    setChildrenCache(newCache);
+    setExpandedPaths((prev) => new Set([...prev, ...toExpand]));
+    setExpandingAll(false);
+  }, [runnerId, files, childrenCache]);
+
+  // Flat list for virtualization
+  const flatNodes = React.useMemo(() => {
+    if (!files) return [];
+    return flattenTree(files, expandedPaths, childrenCache);
+  }, [files, expandedPaths, childrenCache]);
+
+  // Virtualizer
+  const scrollContainerRef = React.useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: flatNodes.length,
+    getScrollElement: () => scrollContainerRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 10,
+  });
+
+  // Intercept Escape when viewing a file
   const previewContainerRef = React.useRef<HTMLDivElement>(null);
   React.useEffect(() => {
     if (!viewingFile) return;
-    // Move focus into the preview container so Escape is intercepted even when
-    // the preview was opened via mouse click (no keyboard focus in container yet).
     previewContainerRef.current?.focus();
     const handler = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
@@ -63,10 +279,6 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
       e.stopImmediatePropagation();
       setViewingFile(null);
     };
-    // Capture phase ensures this fires before SessionViewer's bubble-phase listener
-    // Clicking on non-focusable content inside the preview (e.g. <pre>, <img>)
-    // moves document.activeElement to body in Chrome, breaking shouldInterceptEscape.
-    // Re-focus the container whenever a click inside it drops focus to body.
     const restoreFocusPreview = (e: PointerEvent) => {
       if (!previewContainerRef.current?.contains(e.target as Node)) return;
       requestAnimationFrame(() => {
@@ -83,20 +295,24 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
     };
   }, [viewingFile]);
 
-  // outerRef covers the full FileExplorer panel including tab strip, breadcrumb,
-  // and desktop controls.  GitChangesView uses it so Escape still closes the diff
-  // preview when focus is on those chrome elements rather than inside the diff body.
   const outerRef = React.useRef<HTMLDivElement>(null);
 
-  // If viewing a file, show the appropriate viewer
+  // File viewer routing
   if (viewingFile) {
     const viewingFileName = viewingFile.split("/").pop() ?? viewingFile;
     const isImage = isImageFile(viewingFileName);
+    const isMarkdown = isMarkdownFile(viewingFileName);
 
     return (
       <div ref={previewContainerRef} tabIndex={-1} className={cn("flex flex-col bg-background text-foreground outline-none", className)}>
         {isImage ? (
           <ImageViewer
+            runnerId={runnerId}
+            filePath={viewingFile}
+            onClose={() => setViewingFile(null)}
+          />
+        ) : isMarkdown ? (
+          <MarkdownViewer
             runnerId={runnerId}
             filePath={viewingFile}
             onClose={() => setViewingFile(null)}
@@ -114,30 +330,62 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
 
   return (
     <div ref={outerRef} className={cn("flex flex-col bg-background text-foreground", className)}>
-      {/* Path breadcrumb */}
+      {/* Path breadcrumb + toolbar */}
       <div className="flex items-center border-b border-border/50 bg-muted/50">
         <div className="flex-1 px-3 py-1.5 text-[0.65rem] text-muted-foreground font-mono truncate" title={cwd}>
           {cwd}
         </div>
         <TooltipProvider>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <button
-                type="button"
-                onClick={fetchFiles}
-                className="text-muted-foreground hover:text-foreground transition-colors px-2 py-1"
-                aria-label="Refresh file list"
-              >
-                <RefreshCw className="size-3.5" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>Refresh file list</TooltipContent>
-          </Tooltip>
+          <div className="flex items-center gap-0.5 pr-1">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => void handleExpandAll()}
+                  disabled={expandingAll || loading}
+                  className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent/50 rounded transition-colors disabled:opacity-40"
+                  aria-label="Expand all folders"
+                >
+                  {expandingAll
+                    ? <Spinner className="size-3.5" />
+                    : <ChevronsUpDown className="size-3.5" />}
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Expand all (up to 3 levels)</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={handleCollapseAll}
+                  disabled={expandedPaths.size === 0}
+                  className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent/50 rounded transition-colors disabled:opacity-40"
+                  aria-label="Collapse all folders"
+                >
+                  <ChevronsDownUp className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Collapse all</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => void fetchFiles()}
+                  className="p-1.5 text-muted-foreground hover:text-foreground hover:bg-accent/50 rounded transition-colors"
+                  aria-label="Refresh file list"
+                >
+                  <RefreshCw className="size-3.5" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>Refresh</TooltipContent>
+            </Tooltip>
+          </div>
         </TooltipProvider>
       </div>
 
       {/* Content */}
-      <div className="flex-1 min-h-0 overflow-auto">
+      <div ref={scrollContainerRef} className="flex-1 min-h-0 overflow-auto">
         {loading ? (
           <div className="flex items-center justify-center p-8">
             <Spinner className="size-5" />
@@ -145,7 +393,7 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
         ) : error ? (
           <div className="p-4">
             <p className="text-sm text-red-400 mb-3">{error}</p>
-            <Button variant="outline" size="sm" onClick={fetchFiles}>
+            <Button variant="outline" size="sm" onClick={() => void fetchFiles()}>
               <RefreshCw className="size-3 mr-1.5" /> Retry
             </Button>
           </div>
@@ -155,16 +403,34 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
             <p className="text-sm">Empty directory</p>
           </div>
         ) : (
-          <div className="py-1">
-            {files?.map((entry) => (
-              <FileTreeNode
-                key={entry.path}
-                entry={entry}
-                depth={0}
-                runnerId={runnerId}
-                onSelectFile={setViewingFile}
-              />
-            ))}
+          <div
+            style={{ height: `${virtualizer.getTotalSize()}px`, position: "relative" }}
+            className="py-1"
+          >
+            {virtualizer.getVirtualItems().map((virtualItem) => {
+              const node = flatNodes[virtualItem.index];
+              if (!node) return null;
+              return (
+                <div
+                  key={virtualItem.key}
+                  style={{
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                    width: "100%",
+                    height: `${virtualItem.size}px`,
+                    transform: `translateY(${virtualItem.start}px)`,
+                  }}
+                >
+                  <FileTreeRow
+                    node={node}
+                    isExpanded={expandedPaths.has(node.entry.path)}
+                    isLoading={loadingPaths.has(node.entry.path)}
+                    onToggle={handleToggle}
+                  />
+                </div>
+              );
+            })}
           </div>
         )}
       </div>
@@ -180,13 +446,16 @@ export { PositionPicker } from "./position-picker";
 export { FileTreeNode } from "./file-tree-node";
 export { ImageViewer } from "./image-viewer";
 export { FileViewer } from "./file-viewer";
+export { MarkdownViewer } from "./markdown-viewer";
 export {
   shouldInterceptEscape,
   formatSize,
   getFileIcon,
   isImageFile,
+  isMarkdownFile,
   getMimeType,
   gitStatusLabel,
   IMAGE_EXTENSIONS,
+  MARKDOWN_EXTENSIONS,
   POSITION_OPTIONS,
 } from "./utils";

--- a/packages/ui/src/components/file-explorer/markdown-viewer.tsx
+++ b/packages/ui/src/components/file-explorer/markdown-viewer.tsx
@@ -1,0 +1,184 @@
+import * as React from "react";
+import { Spinner } from "@/components/ui/spinner";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import { ChevronLeft, Code, Eye } from "lucide-react";
+import { cjk } from "@streamdown/cjk";
+import { code } from "@streamdown/code";
+import { math } from "@streamdown/math";
+import { mermaid } from "@streamdown/mermaid";
+import { Streamdown, defaultRehypePlugins } from "streamdown";
+import { getFileIcon, formatSize } from "./utils";
+
+// ── Markdown Viewer ───────────────────────────────────────────────────────────
+
+const streamdownPlugins = { cjk, code, math, mermaid };
+
+// Use defaultRehypePlugins for XSS safety (same as AI message rendering).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const safeRehypePlugins = [...Object.values(defaultRehypePlugins)] as any;
+
+export function MarkdownViewer({
+  runnerId,
+  filePath,
+  onClose,
+}: {
+  runnerId: string;
+  filePath: string;
+  onClose: () => void;
+}) {
+  const [content, setContent] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(true);
+  const [error, setError] = React.useState<string | null>(null);
+  const [truncated, setTruncated] = React.useState(false);
+  const [fileSize, setFileSize] = React.useState<number | undefined>();
+  const [mode, setMode] = React.useState<"preview" | "raw">("preview");
+
+  React.useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    setContent(null);
+
+    void fetch(`/api/runners/${encodeURIComponent(runnerId)}/read-file`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      credentials: "include",
+      body: JSON.stringify({ path: filePath }),
+    })
+      .then((res) =>
+        res.ok
+          ? res.json()
+          : res.json().then((d: any) => Promise.reject(new Error(d.error || `HTTP ${res.status}`)))
+      )
+      .then((data: any) => {
+        if (cancelled) return;
+        setContent(data.content ?? "");
+        setTruncated(data.truncated === true);
+        setFileSize(typeof data.size === "number" ? data.size : undefined);
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+      })
+      .finally(() => {
+        if (cancelled) return;
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [runnerId, filePath]);
+
+  const fileName = filePath.split("/").pop() ?? filePath;
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/50 min-h-[40px]">
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+          title="Back to file list"
+          aria-label="Back to file list"
+        >
+          <ChevronLeft className="size-4" />
+        </button>
+        <span className="text-xs text-muted-foreground mr-1">{getFileIcon(fileName)}</span>
+        <span className="text-sm font-mono truncate flex-1" title={filePath}>
+          {fileName}
+        </span>
+        {fileSize !== undefined && (
+          <span className="text-[0.6rem] text-muted-foreground tabular-nums flex-shrink-0">
+            {formatSize(fileSize)}
+          </span>
+        )}
+      </div>
+
+      {/* Toolbar */}
+      <TooltipProvider>
+        <div className="flex items-center gap-1 px-3 py-1.5 border-b border-border/50 bg-muted/30">
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setMode("preview")}
+                className={cn(
+                  "flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors",
+                  mode === "preview"
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
+                )}
+                aria-pressed={mode === "preview"}
+                aria-label="Preview"
+              >
+                <Eye className="size-3" />
+                Preview
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>Rendered markdown preview</TooltipContent>
+          </Tooltip>
+
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                type="button"
+                onClick={() => setMode("raw")}
+                className={cn(
+                  "flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors",
+                  mode === "raw"
+                    ? "bg-accent text-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-accent/50",
+                )}
+                aria-pressed={mode === "raw"}
+                aria-label="Raw"
+              >
+                <Code className="size-3" />
+                Raw
+              </button>
+            </TooltipTrigger>
+            <TooltipContent>View raw markdown source</TooltipContent>
+          </Tooltip>
+        </div>
+      </TooltipProvider>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto">
+        {loading && (
+          <div className="flex items-center justify-center p-8">
+            <Spinner className="size-5" />
+          </div>
+        )}
+        {error && (
+          <div className="p-4 text-sm text-red-400">{error}</div>
+        )}
+        {content !== null && (
+          <div className="relative">
+            {truncated && (
+              <div className="sticky top-0 z-10 bg-amber-500/10 border-b border-amber-500/20 px-3 py-1 text-xs text-amber-600 dark:text-amber-400">
+                File truncated (showing first 512 KB of {formatSize(fileSize)})
+              </div>
+            )}
+            {mode === "preview" ? (
+              <div className="p-4 prose prose-sm dark:prose-invert max-w-none">
+                <Streamdown
+                  className="size-full break-words [&>*:first-child]:mt-0 [&>*:last-child]:mb-0"
+                  plugins={streamdownPlugins}
+                  rehypePlugins={safeRehypePlugins}
+                >
+                  {content}
+                </Streamdown>
+              </div>
+            ) : (
+              <pre className="p-3 text-xs font-mono text-foreground/80 leading-relaxed whitespace-pre-wrap break-all">
+                {content}
+              </pre>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/file-explorer/utils.ts
+++ b/packages/ui/src/components/file-explorer/utils.ts
@@ -14,6 +14,7 @@ import {
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 export const IMAGE_EXTENSIONS = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "bmp", "ico", "avif"]);
+export const MARKDOWN_EXTENSIONS = new Set(["md", "mdx"]);
 
 export const POSITION_OPTIONS = [
   { pos: "left" as const, Icon: PanelLeft, label: "Left" },
@@ -74,6 +75,11 @@ export function getFileIcon(name: string): string {
 export function isImageFile(name: string): boolean {
   const ext = name.split(".").pop()?.toLowerCase() ?? "";
   return IMAGE_EXTENSIONS.has(ext);
+}
+
+export function isMarkdownFile(name: string): boolean {
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  return MARKDOWN_EXTENSIONS.has(ext);
 }
 
 export function getMimeType(name: string): string {


### PR DESCRIPTION
## Summary

Three improvements to the File Explorer panel:

### 1. 📝 Markdown Preview
When opening a `.md` or `.mdx` file, the viewer now defaults to a **rendered preview** instead of raw text.
- Uses **Streamdown** (same renderer as AI messages) with the full plugin stack: code blocks, math, mermaid, CJK
- XSS-safe via `defaultRehypePlugins` — same sanitization pipeline applied to AI responses
- **Raw / Preview toggle** in the toolbar to switch back to source at any time
- Truncation notice if the file is too large

### 2. ⚡ Virtualized File Tree
The file tree is now rendered with `@tanstack/react-virtual` (already a dep) — only visible rows hit the DOM.
- Lifted all tree state (`expandedPaths`, `childrenCache`, `loadingPaths`) out of the recursive `FileTreeNode` into `FileExplorer`
- Tree is flattened to a `FlatNode[]` array before rendering — no more recursive component subtree
- `FileTreeRow` is a `memo`'d flat row component

### 3. 💾 Persistent Expanded Folders + Expand/Collapse All
- Expanded folder state is persisted to **`localStorage`** keyed by `runnerId + cwd` — reopening the panel restores your tree
- **Expand All** button: BFS up to depth 3, fetches any missing children, shows a spinner during load
- **Collapse All** button: one click clears all expanded state

## Files changed
| File | Change |
|------|--------|
| `file-explorer/markdown-viewer.tsx` | New — MarkdownViewer component |
| `file-explorer/FileExplorer.tsx` | Refactored — virtualization, lifted state, expand/collapse all, markdown routing |
| `file-explorer/utils.ts` | Added `isMarkdownFile()`, `MARKDOWN_EXTENSIONS` |

## Testing
- `bun run typecheck` — ✅ clean
- `bun test packages/ui` — ✅ 903 pass, 0 fail