### PR TITLE
fix: include availableCommands in session_active so skills show in /skill: popover

### DIFF
--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -74,8 +74,7 @@ export async function handleExecFromWeb(
 
     try {
         if (req.command === "get_commands") {
-            const commands = (rctx.pi.getCommands?.() ?? []).map((c: any) => ({ name: c.name, description: c.description, source: c.source }));
-            replyOk({ commands });
+            replyOk({ commands: rctx.getAvailableCommands() });
             return;
         }
 

--- a/packages/cli/src/extensions/remote-types.ts
+++ b/packages/cli/src/extensions/remote-types.ts
@@ -227,6 +227,7 @@ export interface RelayContext {
     buildHeartbeat(): any;
     buildCapabilitiesState(): any;
     getConfiguredModels(): RelayModelInfo[];
+    getAvailableCommands(): Array<{ name: string; description?: string; source?: string }>;
     getCurrentSessionName(): string | null;
     getCurrentThinkingLevel(): string | null;
 

--- a/packages/cli/src/extensions/remote/chunked-delivery.test.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.test.ts
@@ -93,6 +93,7 @@ function makeContext(opts: {
         buildHeartbeat: () => ({}),
         buildCapabilitiesState: () => ({}),
         getConfiguredModels: () => [],
+        getAvailableCommands: () => [],
         getCurrentSessionName: () => opts.sessionName ?? null,
         getCurrentThinkingLevel: () => opts.thinkingLevel ?? null,
 
@@ -277,6 +278,7 @@ describe("emitSessionMetadataUpdate", () => {
         expect(keys).toContain("thinkingLevel");
         expect(keys).toContain("todoList");
         expect(keys).toContain("availableModels");
+        expect(keys).toContain("availableCommands");
     });
 
     test("session_active prefers the live current model over transcript-derived state", () => {

--- a/packages/cli/src/extensions/remote/chunked-delivery.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.ts
@@ -306,6 +306,7 @@ export function emitSessionActive(rctx: RelayContext): void {
         sessionName: rctx.getCurrentSessionName(),
         cwd: rctx.latestCtx.cwd,
         availableModels: rctx.getConfiguredModels(),
+        availableCommands: rctx.getAvailableCommands(),
         todoList: getCurrentTodoList(),
     };
 
@@ -380,6 +381,7 @@ export function emitSessionMetadataUpdate(rctx: RelayContext): void {
             thinkingLevel: rctx.getCurrentThinkingLevel(),
             sessionName: rctx.getCurrentSessionName(),
             availableModels: rctx.getConfiguredModels(),
+            availableCommands: rctx.getAvailableCommands(),
             todoList: getCurrentTodoList(),
         },
     });

--- a/packages/cli/src/extensions/remote/relay-context-factory.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.ts
@@ -150,19 +150,20 @@ export function createRelayContext(
             return buildHeartbeat(rctx);
         },
 
-        buildCapabilitiesState() {
-            if (!rctx.latestCtx) {
-                return { type: "capabilities", models: [], commands: [] };
-            }
-            const commands = ((pi as any).getCommands?.() ?? []).map((c: any) => ({
+        getAvailableCommands(): Array<{ name: string; description?: string; source?: string }> {
+            if (!rctx.latestCtx) return [];
+            return ((pi as any).getCommands?.() ?? []).map((c: any) => ({
                 name: c.name,
                 description: c.description,
                 source: c.source,
             }));
+        },
+
+        buildCapabilitiesState() {
             return {
                 type: "capabilities",
                 models: rctx.getConfiguredModels(),
-                commands,
+                commands: rctx.getAvailableCommands(),
             };
         },
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -123,6 +123,7 @@ import {
   normalizeSessionName,
   augmentThinkingDurations,
   normalizeModelList,
+  normalizeCommandList,
   mergeChunkSnapshot,
 } from "@/lib/message-helpers";
 import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
@@ -1517,10 +1518,7 @@ export function App() {
       const commandsRaw = Array.isArray(evt.commands) ? (evt.commands as unknown[]) : [];
 
       const normalizedModels = normalizeModelList(modelsRaw);
-      const normalizedCommands = commandsRaw
-        .filter((c): c is Record<string, unknown> => c !== null && typeof c === "object" && typeof (c as Record<string, unknown>).name === "string")
-        .map((c) => ({ name: String(c.name), description: typeof c.description === "string" ? c.description : undefined, source: typeof c.source === "string" ? c.source : undefined }))
-        .sort((a, b) => a.name.localeCompare(b.name));
+      const normalizedCommands = normalizeCommandList(commandsRaw);
 
       // Keep model state in sync with capability snapshots too.
       setAvailableModels(normalizedModels);
@@ -1554,6 +1552,14 @@ export function App() {
       if (metaModels) {
         setAvailableModels(metaModels);
         cachePatch.availableModels = metaModels;
+      }
+
+      const metaCommands = Array.isArray(meta.availableCommands)
+        ? normalizeCommandList(meta.availableCommands as unknown[])
+        : null;
+      if (metaCommands) {
+        setAvailableCommands(metaCommands);
+        cachePatch.availableCommands = metaCommands;
       }
 
       if (Object.prototype.hasOwnProperty.call(meta, "sessionName")) {
@@ -1614,6 +1620,15 @@ export function App() {
         }
       }
       setAvailableModels(stateModels);
+
+      // Extract commands from session_active state so cache-first hydration
+      // (which only replays snapshot events) populates the command picker.
+      const stateCommands = Array.isArray(state?.availableCommands)
+        ? normalizeCommandList(state.availableCommands as unknown[])
+        : [];
+      if (stateCommands.length > 0) {
+        setAvailableCommands(stateCommands);
+      }
 
       // Track chunked delivery state — messages arrive as subsequent
       // session_messages_chunk events when the session is large.
@@ -1691,6 +1706,7 @@ export function App() {
           activeModel: stateModel,
           ...(hasSessionName ? { sessionName: nextSessionName } : {}),
           availableModels: stateModels,
+          ...(stateCommands.length > 0 ? { availableCommands: stateCommands } : {}),
           effortLevel: thinkingLevel,
           todoList: stateTodos,
         });
@@ -1698,6 +1714,7 @@ export function App() {
         patchSessionCache({
           messages: normalizedMessages,
           availableModels: stateModels,
+          ...(stateCommands.length > 0 ? { availableCommands: stateCommands } : {}),
         });
       }
       return;

--- a/packages/ui/src/lib/message-helpers.test.ts
+++ b/packages/ui/src/lib/message-helpers.test.ts
@@ -7,6 +7,7 @@ import {
   normalizeSessionName,
   augmentThinkingDurations,
   normalizeModelList,
+  normalizeCommandList,
   mergeChunkSnapshot,
 } from "./message-helpers";
 import type { RelayMessage } from "@/components/session-viewer/types";
@@ -416,6 +417,42 @@ describe("normalizeModelList", () => {
     const result = normalizeModelList(models);
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe("Second");
+  });
+});
+
+// ── normalizeCommandList ──────────────────────────────────────────────────────
+
+describe("normalizeCommandList", () => {
+  test("returns empty array for empty input", () => {
+    expect(normalizeCommandList([])).toEqual([]);
+  });
+
+  test("filters out invalid entries", () => {
+    const result = normalizeCommandList([null, undefined, "string", 42, { description: "no name" }]);
+    expect(result).toHaveLength(0);
+  });
+
+  test("normalizes valid command entries", () => {
+    const result = normalizeCommandList([
+      { name: "skill:double-check", description: "Double check", source: "skill" },
+      { name: "remote", description: "Show relay URL", source: "extension" },
+    ]);
+    expect(result).toHaveLength(2);
+    expect(result[0]).toEqual({ name: "remote", description: "Show relay URL", source: "extension" });
+    expect(result[1]).toEqual({ name: "skill:double-check", description: "Double check", source: "skill" });
+  });
+
+  test("sorts by name", () => {
+    const result = normalizeCommandList([
+      { name: "zebra", source: "extension" },
+      { name: "alpha", source: "skill" },
+    ]);
+    expect(result.map((c) => c.name)).toEqual(["alpha", "zebra"]);
+  });
+
+  test("handles missing optional fields", () => {
+    const result = normalizeCommandList([{ name: "test" }]);
+    expect(result).toEqual([{ name: "test", description: undefined, source: undefined }]);
   });
 });
 

--- a/packages/ui/src/lib/message-helpers.ts
+++ b/packages/ui/src/lib/message-helpers.ts
@@ -223,3 +223,22 @@ export function normalizeModelList(rawModels: unknown[]): ConfiguredModelInfo[] 
     return a.id.localeCompare(b.id);
   });
 }
+
+/** Normalize a raw commands array from capabilities / session_active events. */
+export function normalizeCommandList(
+  rawCommands: unknown[],
+): Array<{ name: string; description?: string; source?: string }> {
+  return rawCommands
+    .filter(
+      (c): c is Record<string, unknown> =>
+        c !== null &&
+        typeof c === "object" &&
+        typeof (c as Record<string, unknown>).name === "string",
+    )
+    .map((c) => ({
+      name: String(c.name),
+      description: typeof c.description === "string" ? c.description : undefined,
+      source: typeof c.source === "string" ? c.source : undefined,
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}


### PR DESCRIPTION
## Problem

The `/skill:` command picker in the web UI was empty — skills never appeared in the popover when typing `/skill:` or `/`.

## Root Cause

Commands (including skills) are sent via a `capabilities` event with `type: "capabilities"`. However, the cache-first viewer hydration path (`hydrateViewerFromCache`) only replays **snapshot events** (`session_active` or `agent_end`). The `capabilities` event is not a snapshot event, so:

1. Fresh viewer connections get `session_active` (which has `availableModels` but NOT commands)
2. After cache hit, `suppressRunnerSignal = true` prevents the runner from re-sending capabilities
3. `availableCommands` stays empty → `skillCommands` empty → no skills in popover

## Fix

Include `availableCommands` in `session_active.state` and `session_metadata_update.metadata` alongside `availableModels`, so commands/skills are always available from snapshot hydration.

### Changes
- **CLI**: Add `getAvailableCommands()` to `RelayContext`, include commands in `session_active` and `session_metadata_update` payloads
- **UI**: Extract `normalizeCommandList` helper, read commands from `session_active` and `session_metadata_update` events
- **Tests**: Add `normalizeCommandList` tests, update metadata key assertions

The `capabilities` event is retained for live updates (e.g. when a plugin loads and adds new commands).

## Testing
- `bun run typecheck` ✅
- `bun run test` ✅ (923 tests)
- `bun run build` ✅