### PR TITLE
fix(git): rework GitPanel pull as explicit upstream sync

### DIFF
--- a/packages/cli/src/runner/services/git-service.test.ts
+++ b/packages/cli/src/runner/services/git-service.test.ts
@@ -905,7 +905,7 @@ describe("GitService pull/merge", () => {
         expect(result.payload).toMatchObject({ ok: false, reason: "conflict" });
     });
 
-    test("rejects overlapping repo mutations with a busy error", async () => {
+    test("rejects overlapping repo mutations with a busy error even across different cwd values in the same repo", async () => {
         let checkoutStarted = false;
         let releaseCheckout: () => void = () => {
             throw new Error("Expected checkout release function");
@@ -915,7 +915,7 @@ describe("GitService pull/merge", () => {
         });
 
         const service = new GitService({
-            execGit: async (args) => {
+            execGit: async (args, options) => {
                 const cmd = args[0];
                 if (cmd === "checkout") {
                     checkoutStarted = true;
@@ -923,7 +923,8 @@ describe("GitService pull/merge", () => {
                     return { stdout: "", stderr: "" };
                 }
                 if (cmd === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
-                if (cmd === "rev-parse") return { stdout: "/tmp/pizzapi-test\n", stderr: "" };
+                if (cmd === "rev-parse" && args[1] === "--show-toplevel") return { stdout: "/tmp/pizzapi-test\n", stderr: "" };
+                if (cmd === "rev-parse") return { stdout: `${options.cwd}\n`, stderr: "" };
                 if (cmd === "status") return { stdout: "", stderr: "" };
                 if (cmd === "diff") return { stdout: "", stderr: "" };
                 if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
@@ -942,7 +943,7 @@ describe("GitService pull/merge", () => {
             serviceId: "git",
             type: "git_checkout",
             requestId: "checkout-busy-1",
-            payload: { cwd: "/tmp/pizzapi-test", branch: "main", isRemote: false },
+            payload: { cwd: "/tmp/pizzapi-test/packages/ui", branch: "main", isRemote: false },
         });
 
         await waitForCondition(() => checkoutStarted);

--- a/packages/cli/src/runner/services/git-service.test.ts
+++ b/packages/cli/src/runner/services/git-service.test.ts
@@ -200,7 +200,10 @@ describe("GitService status caching", () => {
                 if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
                 if (cmd === "add" || cmd === "restore" || cmd === "checkout") return { stdout: "", stderr: "" };
                 if (cmd === "commit") return { stdout: "[main abc1234] message\n", stderr: "" };
-                if (cmd === "pull" || cmd === "push") return { stdout: "ok", stderr: "" };
+                if (cmd === "fetch" || cmd === "pull" || cmd === "push" || cmd === "rebase") return { stdout: "ok", stderr: "" };
+                if (cmd === "config" && args[2]?.endsWith(".remote")) return { stdout: "origin\n", stderr: "" };
+                if (cmd === "config" && args[2]?.endsWith(".merge")) return { stdout: "refs/heads/main\n", stderr: "" };
+                if (cmd === "remote") return { stdout: "origin\n", stderr: "" };
                 throw new Error(`Unexpected git args: ${args.join(" ")}`);
             },
         });
@@ -649,16 +652,19 @@ describe("GitService git_full_status", () => {
 });
 
 describe("GitService pull/merge", () => {
-    test("pull defaults to --rebase and ff-only can be requested", async () => {
+    test("pull uses fetch + rebase with explicit remote-tracking ref", async () => {
         const gitCalls: string[][] = [];
 
         const service = new GitService({
             execGit: async (args) => {
                 gitCalls.push([...args]);
                 const cmd = args[0];
-                if (cmd === "pull") return { stdout: "ok", stderr: "" };
+                if (cmd === "fetch") return { stdout: "", stderr: "" };
+                if (cmd === "rebase") return { stdout: "Applied 2 commits\n", stderr: "" };
+                if (cmd === "merge") return { stdout: "Fast-forward\n", stderr: "" };
                 if (cmd === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
-                if (cmd === "merge") return { stdout: "merged\n", stderr: "" };
+                if (cmd === "config" && args[2] === "branch.main.remote") return { stdout: "origin\n", stderr: "" };
+                if (cmd === "config" && args[2] === "branch.main.merge") return { stdout: "refs/heads/main\n", stderr: "" };
                 if (cmd === "rev-parse") return { stdout: "/tmp/pizzapi-test\n", stderr: "" };
                 if (cmd === "status") return { stdout: "", stderr: "" };
                 if (cmd === "diff") return { stdout: "", stderr: "" };
@@ -670,7 +676,7 @@ describe("GitService pull/merge", () => {
         const socket = createMockSocket();
         service.init(socket as any, { isShuttingDown: () => false });
 
-        // Default pull should use --rebase
+        // Default pull (rebase) should fetch then rebase onto remote-tracking ref
         dispatchServiceMessage(socket, {
             serviceId: "git",
             type: "git_pull",
@@ -679,11 +685,12 @@ describe("GitService pull/merge", () => {
         });
         const r1 = await waitForResult(socket, "pull-1", "git_pull_result");
         expect((r1.payload as any).ok).toBe(true);
-        expect(gitCalls.some((c) => c[0] === "pull" && c[1] === "--rebase")).toBe(true);
+        expect(gitCalls.some((c) => c[0] === "fetch" && c[1] === "origin" && c[2] === "main")).toBe(true);
+        expect(gitCalls.some((c) => c[0] === "rebase" && c[1] === "origin/main")).toBe(true);
 
         gitCalls.length = 0;
 
-        // Explicit rebase: false should use --ff-only
+        // ff-only should fetch then merge --ff-only onto remote-tracking ref
         dispatchServiceMessage(socket, {
             serviceId: "git",
             type: "git_pull",
@@ -692,7 +699,45 @@ describe("GitService pull/merge", () => {
         });
         const r2 = await waitForResult(socket, "pull-2", "git_pull_result");
         expect((r2.payload as any).ok).toBe(true);
-        expect(gitCalls.some((c) => c[0] === "pull" && c[1] === "--ff-only")).toBe(true);
+        expect(gitCalls.some((c) => c[0] === "fetch" && c[1] === "origin" && c[2] === "main")).toBe(true);
+        expect(gitCalls.some((c) => c[0] === "merge" && c[1] === "--ff-only" && c[2] === "origin/main")).toBe(true);
+    });
+
+    test("pull falls back to first remote and local branch name when no tracking config", async () => {
+        const gitCalls: string[][] = [];
+
+        const service = new GitService({
+            execGit: async (args) => {
+                gitCalls.push([...args]);
+                const cmd = args[0];
+                if (cmd === "fetch") return { stdout: "", stderr: "" };
+                if (cmd === "rebase") return { stdout: "ok\n", stderr: "" };
+                if (cmd === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "feature/no-upstream\n", stderr: "" };
+                if (cmd === "config" && args[2] === "branch.feature/no-upstream.remote") throw new Error("not found");
+                if (cmd === "config" && args[2] === "branch.feature/no-upstream.merge") throw new Error("not found");
+                if (cmd === "remote") return { stdout: "upstream\norigin\n", stderr: "" };
+                if (cmd === "rev-parse") return { stdout: "/tmp/pizzapi-test\n", stderr: "" };
+                if (cmd === "status") return { stdout: "", stderr: "" };
+                if (cmd === "diff") return { stdout: "", stderr: "" };
+                if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_pull",
+            requestId: "pull-fallback",
+            payload: { cwd: "/tmp/pizzapi-test" },
+        });
+        const r = await waitForResult(socket, "pull-fallback", "git_pull_result");
+        expect((r.payload as any).ok).toBe(true);
+        // Falls back to first remote + local branch name as merge branch
+        expect(gitCalls.some((c) => c[0] === "fetch" && c[1] === "upstream" && c[2] === "feature/no-upstream")).toBe(true);
+        expect(gitCalls.some((c) => c[0] === "rebase" && c[1] === "upstream/feature/no-upstream")).toBe(true);
     });
 
     test("merge uses end-of-options separator", async () => {

--- a/packages/cli/src/runner/services/git-service.test.ts
+++ b/packages/cli/src/runner/services/git-service.test.ts
@@ -905,6 +905,62 @@ describe("GitService pull/merge", () => {
         expect(result.payload).toMatchObject({ ok: false, reason: "conflict" });
     });
 
+    test("rejects overlapping repo mutations with a busy error", async () => {
+        let checkoutStarted = false;
+        let releaseCheckout: () => void = () => {
+            throw new Error("Expected checkout release function");
+        };
+        const checkoutGate = new Promise<void>((resolve) => {
+            releaseCheckout = resolve;
+        });
+
+        const service = new GitService({
+            execGit: async (args) => {
+                const cmd = args[0];
+                if (cmd === "checkout") {
+                    checkoutStarted = true;
+                    await checkoutGate;
+                    return { stdout: "", stderr: "" };
+                }
+                if (cmd === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
+                if (cmd === "rev-parse") return { stdout: "/tmp/pizzapi-test\n", stderr: "" };
+                if (cmd === "status") return { stdout: "", stderr: "" };
+                if (cmd === "diff") return { stdout: "", stderr: "" };
+                if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                if (cmd === "config" && args[2] === "branch.main.remote") return { stdout: "origin\n", stderr: "" };
+                if (cmd === "config" && args[2] === "branch.main.merge") return { stdout: "refs/heads/main\n", stderr: "" };
+                if (cmd === "fetch") return { stdout: "", stderr: "" };
+                if (cmd === "rebase") return { stdout: "", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_checkout",
+            requestId: "checkout-busy-1",
+            payload: { cwd: "/tmp/pizzapi-test", branch: "main", isRemote: false },
+        });
+
+        await waitForCondition(() => checkoutStarted);
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_pull",
+            requestId: "pull-busy-1",
+            payload: { cwd: "/tmp/pizzapi-test" },
+        });
+        const busyResult = await waitForResult(socket, "pull-busy-1", "git_pull_result");
+        expect(busyResult.payload).toMatchObject({ ok: false, reason: "busy" });
+
+        releaseCheckout();
+        const checkoutResult = await waitForResult(socket, "checkout-busy-1", "git_checkout_result");
+        expect((checkoutResult.payload as any).ok).toBe(true);
+    });
+
     test("merge uses end-of-options separator", async () => {
         const gitCalls: string[][] = [];
 

--- a/packages/cli/src/runner/services/git-service.test.ts
+++ b/packages/cli/src/runner/services/git-service.test.ts
@@ -652,7 +652,7 @@ describe("GitService git_full_status", () => {
 });
 
 describe("GitService pull/merge", () => {
-    test("pull uses fetch + rebase with explicit remote-tracking ref", async () => {
+    test("pull uses fetch + rebase with explicit upstream", async () => {
         const gitCalls: string[][] = [];
 
         const service = new GitService({
@@ -676,7 +676,6 @@ describe("GitService pull/merge", () => {
         const socket = createMockSocket();
         service.init(socket as any, { isShuttingDown: () => false });
 
-        // Default pull (rebase) should fetch then rebase onto remote-tracking ref
         dispatchServiceMessage(socket, {
             serviceId: "git",
             type: "git_pull",
@@ -685,12 +684,11 @@ describe("GitService pull/merge", () => {
         });
         const r1 = await waitForResult(socket, "pull-1", "git_pull_result");
         expect((r1.payload as any).ok).toBe(true);
-        expect(gitCalls.some((c) => c[0] === "fetch" && c[1] === "origin" && c[2] === "main")).toBe(true);
-        expect(gitCalls.some((c) => c[0] === "rebase" && c[1] === "origin/main")).toBe(true);
+        expect(gitCalls).toContainEqual(["fetch", "origin", "main"]);
+        expect(gitCalls).toContainEqual(["rebase", "origin/main"]);
 
         gitCalls.length = 0;
 
-        // ff-only should fetch then merge --ff-only onto remote-tracking ref
         dispatchServiceMessage(socket, {
             serviceId: "git",
             type: "git_pull",
@@ -699,23 +697,19 @@ describe("GitService pull/merge", () => {
         });
         const r2 = await waitForResult(socket, "pull-2", "git_pull_result");
         expect((r2.payload as any).ok).toBe(true);
-        expect(gitCalls.some((c) => c[0] === "fetch" && c[1] === "origin" && c[2] === "main")).toBe(true);
-        expect(gitCalls.some((c) => c[0] === "merge" && c[1] === "--ff-only" && c[2] === "origin/main")).toBe(true);
+        expect(gitCalls).toContainEqual(["fetch", "origin", "main"]);
+        expect(gitCalls).toContainEqual(["merge", "--ff-only", "origin/main"]);
     });
 
-    test("pull falls back to first remote and local branch name when no tracking config", async () => {
+    test("pull fails with missingUpstream when tracking config is incomplete", async () => {
         const gitCalls: string[][] = [];
 
         const service = new GitService({
             execGit: async (args) => {
                 gitCalls.push([...args]);
                 const cmd = args[0];
-                if (cmd === "fetch") return { stdout: "", stderr: "" };
-                if (cmd === "rebase") return { stdout: "ok\n", stderr: "" };
                 if (cmd === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "feature/no-upstream\n", stderr: "" };
-                if (cmd === "config" && args[2] === "branch.feature/no-upstream.remote") throw new Error("not found");
-                if (cmd === "config" && args[2] === "branch.feature/no-upstream.merge") throw new Error("not found");
-                if (cmd === "remote") return { stdout: "upstream\norigin\n", stderr: "" };
+                if (cmd === "config") return { stdout: "", stderr: "" };
                 if (cmd === "rev-parse") return { stdout: "/tmp/pizzapi-test\n", stderr: "" };
                 if (cmd === "status") return { stdout: "", stderr: "" };
                 if (cmd === "diff") return { stdout: "", stderr: "" };
@@ -730,14 +724,185 @@ describe("GitService pull/merge", () => {
         dispatchServiceMessage(socket, {
             serviceId: "git",
             type: "git_pull",
-            requestId: "pull-fallback",
+            requestId: "pull-missing-upstream",
             payload: { cwd: "/tmp/pizzapi-test" },
         });
-        const r = await waitForResult(socket, "pull-fallback", "git_pull_result");
-        expect((r.payload as any).ok).toBe(true);
-        // Falls back to first remote + local branch name as merge branch
-        expect(gitCalls.some((c) => c[0] === "fetch" && c[1] === "upstream" && c[2] === "feature/no-upstream")).toBe(true);
-        expect(gitCalls.some((c) => c[0] === "rebase" && c[1] === "upstream/feature/no-upstream")).toBe(true);
+        const result = await waitForResult(socket, "pull-missing-upstream", "git_pull_result");
+        expect(result.payload).toMatchObject({ ok: false, reason: "missingUpstream", branch: "feature/no-upstream" });
+        expect(gitCalls.some((call) => call[0] === "fetch")).toBe(false);
+    });
+
+    test("pull fails with ambiguousUpstream when multiple merge targets exist", async () => {
+        const service = new GitService({
+            execGit: async (args) => {
+                const cmd = args[0];
+                if (cmd === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "feature/multi\n", stderr: "" };
+                if (cmd === "config" && args[2] === "branch.feature/multi.remote") return { stdout: "origin\n", stderr: "" };
+                if (cmd === "config" && args[2] === "branch.feature/multi.merge") {
+                    return { stdout: "refs/heads/main\nrefs/heads/release\n", stderr: "" };
+                }
+                if (cmd === "rev-parse") return { stdout: "/tmp/pizzapi-test\n", stderr: "" };
+                if (cmd === "status") return { stdout: "", stderr: "" };
+                if (cmd === "diff") return { stdout: "", stderr: "" };
+                if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_pull",
+            requestId: "pull-ambiguous-upstream",
+            payload: { cwd: "/tmp/pizzapi-test" },
+        });
+        const result = await waitForResult(socket, "pull-ambiguous-upstream", "git_pull_result");
+        expect(result.payload).toMatchObject({
+            ok: false,
+            reason: "ambiguousUpstream",
+            branch: "feature/multi",
+            mergeBranches: ["refs/heads/main", "refs/heads/release"],
+        });
+    });
+
+    test("pull fails with detachedHead when no branch is checked out", async () => {
+        const service = new GitService({
+            execGit: async (args) => {
+                const cmd = args[0];
+                if (cmd === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "HEAD\n", stderr: "" };
+                if (cmd === "rev-parse") return { stdout: "/tmp/pizzapi-test\n", stderr: "" };
+                if (cmd === "status") return { stdout: "", stderr: "" };
+                if (cmd === "diff") return { stdout: "", stderr: "" };
+                if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_pull",
+            requestId: "pull-detached",
+            payload: { cwd: "/tmp/pizzapi-test" },
+        });
+        const result = await waitForResult(socket, "pull-detached", "git_pull_result");
+        expect(result.payload).toMatchObject({ ok: false, reason: "detachedHead" });
+    });
+
+    test("set_upstream configures the current branch tracking ref", async () => {
+        const gitCalls: string[][] = [];
+
+        const service = new GitService({
+            execGit: async (args) => {
+                gitCalls.push([...args]);
+                const cmd = args[0];
+                if (cmd === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "feature/test\n", stderr: "" };
+                if (cmd === "branch" && args[1] === "--set-upstream-to=origin/main") return { stdout: "", stderr: "" };
+                if (cmd === "rev-parse") return { stdout: "/tmp/pizzapi-test\n", stderr: "" };
+                if (cmd === "status") return { stdout: "", stderr: "" };
+                if (cmd === "diff") return { stdout: "", stderr: "" };
+                if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_set_upstream",
+            requestId: "set-upstream-1",
+            payload: { cwd: "/tmp/pizzapi-test", remote: "origin", branch: "main" },
+        });
+        const result = await waitForResult(socket, "set-upstream-1", "git_set_upstream_result");
+        expect((result.payload as any).ok).toBe(true);
+        expect(gitCalls).toContainEqual(["branch", "--set-upstream-to=origin/main", "feature/test"]);
+    });
+
+    test("pull conflict returns structured reason and invalidates cached status", async () => {
+        const cwd = "/tmp/pizzapi-test";
+        let statusCalls = 0;
+
+        const service = new GitService({
+            execGit: async (args) => {
+                const cmd = args[0];
+                if (cmd === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
+                if (cmd === "rev-parse") return { stdout: `${cwd}\n`, stderr: "" };
+                if (cmd === "config" && args[2] === "branch.main.remote") return { stdout: "origin\n", stderr: "" };
+                if (cmd === "config" && args[2] === "branch.main.merge") return { stdout: "refs/heads/main\n", stderr: "" };
+                if (cmd === "fetch") return { stdout: "", stderr: "" };
+                if (cmd === "rebase") throw new Error("CONFLICT (content): Merge conflict in src/app.ts");
+                if (cmd === "status") {
+                    statusCalls++;
+                    return { stdout: ` M conflict-${statusCalls}.ts\0`, stderr: "" };
+                }
+                if (cmd === "diff") return { stdout: "", stderr: "" };
+                if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "status-before-conflict",
+            payload: { cwd },
+        });
+        await waitForResult(socket, "status-before-conflict", "git_status_result");
+        expect(statusCalls).toBe(1);
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_pull",
+            requestId: "pull-conflict",
+            payload: { cwd },
+        });
+        const conflictResult = await waitForResult(socket, "pull-conflict", "git_pull_result");
+        expect(conflictResult.payload).toMatchObject({ ok: false, reason: "conflict" });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_status",
+            requestId: "status-after-conflict",
+            payload: { cwd },
+        });
+        await waitForResult(socket, "status-after-conflict", "git_status_result");
+        expect(statusCalls).toBe(2);
+    });
+
+    test("merge conflict returns structured reason", async () => {
+        const service = new GitService({
+            execGit: async (args) => {
+                const cmd = args[0];
+                if (cmd === "rev-parse" && args[1] === "--abbrev-ref") return { stdout: "main\n", stderr: "" };
+                if (cmd === "rev-parse") return { stdout: "/tmp/pizzapi-test\n", stderr: "" };
+                if (cmd === "merge") throw new Error("CONFLICT (content): Merge conflict in src/app.ts");
+                if (cmd === "status") return { stdout: "", stderr: "" };
+                if (cmd === "diff") return { stdout: "", stderr: "" };
+                if (cmd === "rev-list") return { stdout: "0 0\n", stderr: "" };
+                throw new Error(`Unexpected git args: ${args.join(" ")}`);
+            },
+        });
+
+        const socket = createMockSocket();
+        service.init(socket as any, { isShuttingDown: () => false });
+
+        dispatchServiceMessage(socket, {
+            serviceId: "git",
+            type: "git_merge",
+            requestId: "merge-conflict",
+            payload: { cwd: "/tmp/pizzapi-test", branch: "feature-sync-menu" },
+        });
+        const result = await waitForResult(socket, "merge-conflict", "git_merge_result");
+        expect(result.payload).toMatchObject({ ok: false, reason: "conflict" });
     });
 
     test("merge uses end-of-options separator", async () => {

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -257,14 +257,15 @@ export class GitService implements ServiceHandler {
         this.emit(type, { ok: false, message }, requestId, sessionId);
     }
 
-    private beginRepoMutation(
+    private async beginRepoMutation(
         cwd: string,
         type: string,
         mutationName: string,
         requestId?: string,
         sessionId?: string,
-    ): string | null {
-        const activeMutation = this._activeRepoMutations.get(cwd);
+    ): Promise<{ key: string; token: string } | null> {
+        const key = await this.resolveRepoRoot(cwd);
+        const activeMutation = this._activeRepoMutations.get(key);
         if (activeMutation) {
             this.emit(type, {
                 ok: false,
@@ -275,14 +276,14 @@ export class GitService implements ServiceHandler {
         }
 
         const token = `${mutationName}:${requestId ?? `${Date.now()}`}`;
-        this._activeRepoMutations.set(cwd, token);
-        return token;
+        this._activeRepoMutations.set(key, token);
+        return { key, token };
     }
 
-    private endRepoMutation(cwd: string, token: string | null): void {
-        if (!token) return;
-        if (this._activeRepoMutations.get(cwd) === token) {
-            this._activeRepoMutations.delete(cwd);
+    private endRepoMutation(mutation: { key: string; token: string } | null): void {
+        if (!mutation) return;
+        if (this._activeRepoMutations.get(mutation.key) === mutation.token) {
+            this._activeRepoMutations.delete(mutation.key);
         }
     }
 
@@ -882,8 +883,8 @@ export class GitService implements ServiceHandler {
         // clicked (local vs remote). This avoids name heuristics that misclassify
         // local branches like "feature/foo" when a remote named "feature" exists.
         const isRemote = payload.isRemote === true;
-        const mutationToken = this.beginRepoMutation(cwd, "git_checkout_result", "checkout", requestId, sessionId);
-        if (!mutationToken) return;
+        const mutation = await this.beginRepoMutation(cwd, "git_checkout_result", "checkout", requestId, sessionId);
+        if (!mutation) return;
 
         try {
             let targetBranch = branch;
@@ -919,7 +920,7 @@ export class GitService implements ServiceHandler {
         } catch (err) {
             this.emitError("git_checkout_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         } finally {
-            this.endRepoMutation(cwd, mutationToken);
+            this.endRepoMutation(mutation);
         }
     }
 
@@ -951,8 +952,8 @@ export class GitService implements ServiceHandler {
             }
         }
 
-        const mutationToken = this.beginRepoMutation(cwd, "git_stage_result", "stage", requestId, sessionId);
-        if (!mutationToken) return;
+        const mutation = await this.beginRepoMutation(cwd, "git_stage_result", "stage", requestId, sessionId);
+        if (!mutation) return;
 
         try {
             // Resolve repo root — paths from git status are repo-root-relative,
@@ -968,7 +969,7 @@ export class GitService implements ServiceHandler {
         } catch (err) {
             this.emitError("git_stage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         } finally {
-            this.endRepoMutation(cwd, mutationToken);
+            this.endRepoMutation(mutation);
         }
     }
 
@@ -999,8 +1000,8 @@ export class GitService implements ServiceHandler {
             }
         }
 
-        const mutationToken = this.beginRepoMutation(cwd, "git_unstage_result", "unstage", requestId, sessionId);
-        if (!mutationToken) return;
+        const mutation = await this.beginRepoMutation(cwd, "git_unstage_result", "unstage", requestId, sessionId);
+        if (!mutation) return;
 
         try {
             // Resolve repo root — run from there so repo-root-relative paths work.
@@ -1019,7 +1020,7 @@ export class GitService implements ServiceHandler {
         } catch (err) {
             this.emitError("git_unstage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         } finally {
-            this.endRepoMutation(cwd, mutationToken);
+            this.endRepoMutation(mutation);
         }
     }
 
@@ -1039,8 +1040,8 @@ export class GitService implements ServiceHandler {
             return;
         }
 
-        const mutationToken = this.beginRepoMutation(cwd, "git_commit_result", "commit", requestId, sessionId);
-        if (!mutationToken) return;
+        const mutation = await this.beginRepoMutation(cwd, "git_commit_result", "commit", requestId, sessionId);
+        if (!mutation) return;
 
         try {
             const { stdout } = await this._execGit(["commit", "-m", message],
@@ -1058,7 +1059,7 @@ export class GitService implements ServiceHandler {
         } catch (err) {
             this.emitError("git_commit_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         } finally {
-            this.endRepoMutation(cwd, mutationToken);
+            this.endRepoMutation(mutation);
         }
     }
 
@@ -1286,8 +1287,8 @@ export class GitService implements ServiceHandler {
         const cwd = this.validateCwd(payload.cwd, "git_pull_result", requestId, sessionId);
         if (!cwd) return;
         const rebase = payload.rebase !== false;
-        const mutationToken = this.beginRepoMutation(cwd, "git_pull_result", "pull", requestId, sessionId);
-        if (!mutationToken) return;
+        const mutation = await this.beginRepoMutation(cwd, "git_pull_result", "pull", requestId, sessionId);
+        if (!mutation) return;
 
         try {
             const upstream = await this.resolveUpstream(cwd);
@@ -1342,7 +1343,7 @@ export class GitService implements ServiceHandler {
                 output: message,
             }, requestId, sessionId);
         } finally {
-            this.endRepoMutation(cwd, mutationToken);
+            this.endRepoMutation(mutation);
         }
     }
 
@@ -1365,8 +1366,8 @@ export class GitService implements ServiceHandler {
             return;
         }
 
-        const mutationToken = this.beginRepoMutation(cwd, "git_set_upstream_result", "set-upstream", requestId, sessionId);
-        if (!mutationToken) return;
+        const mutation = await this.beginRepoMutation(cwd, "git_set_upstream_result", "set-upstream", requestId, sessionId);
+        if (!mutation) return;
 
         try {
             const { stdout } = await this._execGit(["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 });
@@ -1391,7 +1392,7 @@ export class GitService implements ServiceHandler {
         } catch (err) {
             this.emitError("git_set_upstream_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         } finally {
-            this.endRepoMutation(cwd, mutationToken);
+            this.endRepoMutation(mutation);
         }
     }
 
@@ -1411,8 +1412,8 @@ export class GitService implements ServiceHandler {
             return;
         }
 
-        const mutationToken = this.beginRepoMutation(cwd, "git_merge_result", "merge", requestId, sessionId);
-        if (!mutationToken) return;
+        const mutation = await this.beginRepoMutation(cwd, "git_merge_result", "merge", requestId, sessionId);
+        if (!mutation) return;
 
         try {
             // Prevent merging current branch into itself
@@ -1442,7 +1443,7 @@ export class GitService implements ServiceHandler {
                 output: message,
             }, requestId, sessionId);
         } finally {
-            this.endRepoMutation(cwd, mutationToken);
+            this.endRepoMutation(mutation);
         }
     }
 
@@ -1457,8 +1458,8 @@ export class GitService implements ServiceHandler {
         if (!cwd) return;
 
         const setUpstream = payload.setUpstream === true;
-        const mutationToken = this.beginRepoMutation(cwd, "git_push_result", "push", requestId, sessionId);
-        if (!mutationToken) return;
+        const mutation = await this.beginRepoMutation(cwd, "git_push_result", "push", requestId, sessionId);
+        if (!mutation) return;
 
         try {
             // Determine current branch for --set-upstream
@@ -1511,7 +1512,7 @@ export class GitService implements ServiceHandler {
                 noUpstream,
             }, requestId, sessionId);
         } finally {
-            this.endRepoMutation(cwd, mutationToken);
+            this.endRepoMutation(mutation);
         }
     }
 }

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -1119,9 +1119,78 @@ export class GitService implements ServiceHandler {
         const rebase = payload.rebase !== false;
 
         try {
-            const args = rebase ? ["pull", "--rebase"] : ["pull", "--ff-only"];
-            const result = await this._execGit(args, { cwd, timeout: 60000 });
-            const output = (result.stdout + "\n" + result.stderr).trim();
+            // Avoid "Cannot rebase onto multiple branches" by splitting into
+            // explicit fetch + rebase/merge steps instead of using `git pull`.
+            // `git pull --rebase` parses FETCH_HEAD internally and fails when
+            // multiple entries are marked for merge — even with an explicit
+            // remote and branch. Using `git fetch` then `git rebase <ref>`
+            // sidesteps FETCH_HEAD entirely.
+
+            // 1. Resolve the upstream remote and branch.
+            let remote: string | null = null;
+            let mergeBranch: string | null = null;
+            let localBranch: string | null = null;
+            try {
+                const { stdout: branchName } = await this._execGit(
+                    ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 },
+                );
+                localBranch = branchName.trim() || null;
+                if (localBranch && localBranch !== "HEAD") {
+                    try {
+                        const { stdout } = await this._execGit(
+                            ["config", "--get", `branch.${localBranch}.remote`], { cwd, timeout: 5000 },
+                        );
+                        if (stdout.trim()) remote = stdout.trim();
+                    } catch { /* no tracking remote configured */ }
+
+                    try {
+                        const { stdout } = await this._execGit(
+                            ["config", "--get", `branch.${localBranch}.merge`], { cwd, timeout: 5000 },
+                        );
+                        const ref = stdout.trim();
+                        if (ref) {
+                            mergeBranch = ref.startsWith("refs/heads/") ? ref.slice(11) : ref;
+                        }
+                    } catch { /* no merge ref configured */ }
+                }
+            } catch { /* detached HEAD */ }
+
+            // Fall back to first listed remote.
+            if (!remote) {
+                try {
+                    const { stdout } = await this._execGit(["remote"], { cwd, timeout: 5000 });
+                    const firstRemote = stdout.trim().split("\n")[0]?.trim();
+                    if (firstRemote) remote = firstRemote;
+                } catch { /* no remotes */ }
+            }
+
+            // If no merge branch is configured, assume the remote branch
+            // has the same name as the local branch (common convention).
+            if (!mergeBranch && localBranch && localBranch !== "HEAD") {
+                mergeBranch = localBranch;
+            }
+
+            // 2. Fetch from remote.
+            const fetchArgs = ["fetch"];
+            if (remote) {
+                fetchArgs.push(remote);
+                if (mergeBranch) fetchArgs.push(mergeBranch);
+            }
+            const fetchResult = await this._execGit(fetchArgs, { cwd, timeout: 60000 });
+
+            // 3. Rebase or merge onto the explicit remote-tracking ref.
+            //    Using <remote>/<branch> avoids FETCH_HEAD ambiguity entirely.
+            const targetRef = remote && mergeBranch ? `${remote}/${mergeBranch}` : "FETCH_HEAD";
+            const integrateArgs = rebase
+                ? ["rebase", targetRef]
+                : ["merge", "--ff-only", targetRef];
+            const integrateResult = await this._execGit(integrateArgs, { cwd, timeout: 60000 });
+
+            const output = [
+                fetchResult.stdout, fetchResult.stderr,
+                integrateResult.stdout, integrateResult.stderr,
+            ].join("\n").trim();
+
             await this.invalidateStatusCacheFamily(cwd);
 
             this.emit("git_pull_result", {

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -147,6 +147,7 @@ export class GitService implements ServiceHandler {
     private readonly _cwdSubscribers = new Map<string, Set<string>>();
     private readonly _sessionCwd = new Map<string, string>();
     private readonly _repoWatchers = new Map<string, RepoWatchState>();
+    private readonly _activeRepoMutations = new Map<string, string>();
 
     constructor(options?: {
         execGit?: GitExec;
@@ -233,6 +234,7 @@ export class GitService implements ServiceHandler {
         this._statusCache.clear();
         this._statusGeneration.clear();
         this._statusInFlight.clear();
+        this._activeRepoMutations.clear();
         this._socket = null;
         this._onServiceMessage = null;
     }
@@ -253,6 +255,35 @@ export class GitService implements ServiceHandler {
 
     private emitError(type: string, message: string, requestId?: string, sessionId?: string): void {
         this.emit(type, { ok: false, message }, requestId, sessionId);
+    }
+
+    private beginRepoMutation(
+        cwd: string,
+        type: string,
+        mutationName: string,
+        requestId?: string,
+        sessionId?: string,
+    ): string | null {
+        const activeMutation = this._activeRepoMutations.get(cwd);
+        if (activeMutation) {
+            this.emit(type, {
+                ok: false,
+                reason: "busy",
+                message: `Another git operation (${activeMutation}) is already running for this repository. Wait for it to finish and try again.`,
+            }, requestId, sessionId);
+            return null;
+        }
+
+        const token = `${mutationName}:${requestId ?? `${Date.now()}`}`;
+        this._activeRepoMutations.set(cwd, token);
+        return token;
+    }
+
+    private endRepoMutation(cwd: string, token: string | null): void {
+        if (!token) return;
+        if (this._activeRepoMutations.get(cwd) === token) {
+            this._activeRepoMutations.delete(cwd);
+        }
     }
 
     // ── cwd validation ──────────────────────────────────────────────────
@@ -851,6 +882,8 @@ export class GitService implements ServiceHandler {
         // clicked (local vs remote). This avoids name heuristics that misclassify
         // local branches like "feature/foo" when a remote named "feature" exists.
         const isRemote = payload.isRemote === true;
+        const mutationToken = this.beginRepoMutation(cwd, "git_checkout_result", "checkout", requestId, sessionId);
+        if (!mutationToken) return;
 
         try {
             let targetBranch = branch;
@@ -885,6 +918,8 @@ export class GitService implements ServiceHandler {
             }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_checkout_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        } finally {
+            this.endRepoMutation(cwd, mutationToken);
         }
     }
 
@@ -916,6 +951,9 @@ export class GitService implements ServiceHandler {
             }
         }
 
+        const mutationToken = this.beginRepoMutation(cwd, "git_stage_result", "stage", requestId, sessionId);
+        if (!mutationToken) return;
+
         try {
             // Resolve repo root — paths from git status are repo-root-relative,
             // so operations must run from repo root for paths to resolve correctly.
@@ -929,6 +967,8 @@ export class GitService implements ServiceHandler {
             this.emit("git_stage_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_stage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        } finally {
+            this.endRepoMutation(cwd, mutationToken);
         }
     }
 
@@ -959,6 +999,9 @@ export class GitService implements ServiceHandler {
             }
         }
 
+        const mutationToken = this.beginRepoMutation(cwd, "git_unstage_result", "unstage", requestId, sessionId);
+        if (!mutationToken) return;
+
         try {
             // Resolve repo root — run from there so repo-root-relative paths work.
             // For unstage-all, use ":/" pathspec (magic "repo root") instead of "."
@@ -975,6 +1018,8 @@ export class GitService implements ServiceHandler {
             this.emit("git_unstage_result", { ok: true }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_unstage_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        } finally {
+            this.endRepoMutation(cwd, mutationToken);
         }
     }
 
@@ -994,6 +1039,9 @@ export class GitService implements ServiceHandler {
             return;
         }
 
+        const mutationToken = this.beginRepoMutation(cwd, "git_commit_result", "commit", requestId, sessionId);
+        if (!mutationToken) return;
+
         try {
             const { stdout } = await this._execGit(["commit", "-m", message],
                 { cwd, timeout: 30000 },
@@ -1009,6 +1057,8 @@ export class GitService implements ServiceHandler {
             }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_commit_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        } finally {
+            this.endRepoMutation(cwd, mutationToken);
         }
     }
 
@@ -1236,6 +1286,8 @@ export class GitService implements ServiceHandler {
         const cwd = this.validateCwd(payload.cwd, "git_pull_result", requestId, sessionId);
         if (!cwd) return;
         const rebase = payload.rebase !== false;
+        const mutationToken = this.beginRepoMutation(cwd, "git_pull_result", "pull", requestId, sessionId);
+        if (!mutationToken) return;
 
         try {
             const upstream = await this.resolveUpstream(cwd);
@@ -1289,6 +1341,8 @@ export class GitService implements ServiceHandler {
                 message: classified.message,
                 output: message,
             }, requestId, sessionId);
+        } finally {
+            this.endRepoMutation(cwd, mutationToken);
         }
     }
 
@@ -1310,6 +1364,9 @@ export class GitService implements ServiceHandler {
             this.emitError("git_set_upstream_result", "Invalid branch name", requestId, sessionId);
             return;
         }
+
+        const mutationToken = this.beginRepoMutation(cwd, "git_set_upstream_result", "set-upstream", requestId, sessionId);
+        if (!mutationToken) return;
 
         try {
             const { stdout } = await this._execGit(["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 });
@@ -1333,6 +1390,8 @@ export class GitService implements ServiceHandler {
             }, requestId, sessionId);
         } catch (err) {
             this.emitError("git_set_upstream_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+        } finally {
+            this.endRepoMutation(cwd, mutationToken);
         }
     }
 
@@ -1351,6 +1410,9 @@ export class GitService implements ServiceHandler {
             this.emitError("git_merge_result", "Invalid branch name", requestId, sessionId);
             return;
         }
+
+        const mutationToken = this.beginRepoMutation(cwd, "git_merge_result", "merge", requestId, sessionId);
+        if (!mutationToken) return;
 
         try {
             // Prevent merging current branch into itself
@@ -1379,6 +1441,8 @@ export class GitService implements ServiceHandler {
                 message: classified.message,
                 output: message,
             }, requestId, sessionId);
+        } finally {
+            this.endRepoMutation(cwd, mutationToken);
         }
     }
 
@@ -1393,6 +1457,8 @@ export class GitService implements ServiceHandler {
         if (!cwd) return;
 
         const setUpstream = payload.setUpstream === true;
+        const mutationToken = this.beginRepoMutation(cwd, "git_push_result", "push", requestId, sessionId);
+        if (!mutationToken) return;
 
         try {
             // Determine current branch for --set-upstream
@@ -1444,6 +1510,8 @@ export class GitService implements ServiceHandler {
                 message,
                 noUpstream,
             }, requestId, sessionId);
+        } finally {
+            this.endRepoMutation(cwd, mutationToken);
         }
     }
 }

--- a/packages/cli/src/runner/services/git-service.ts
+++ b/packages/cli/src/runner/services/git-service.ts
@@ -69,6 +69,25 @@ type RepoWatchState = {
     needsRefresh: boolean;
 };
 
+type GitUpstreamFailureReason = "detachedHead" | "missingUpstream" | "ambiguousUpstream";
+
+type GitUpstreamResolution =
+    | {
+        ok: true;
+        localBranch: string;
+        remote: string;
+        mergeBranch: string;
+        trackingRef: string;
+    }
+    | {
+        ok: false;
+        reason: GitUpstreamFailureReason;
+        message: string;
+        localBranch?: string;
+        remote?: string;
+        mergeBranches?: string[];
+    };
+
 // ── Validation helpers ──────────────────────────────────────────────────────
 
 /** Validate that a branch name doesn't contain shell-dangerous characters. */
@@ -82,6 +101,14 @@ function isValidBranchName(name: string): boolean {
     if (name.includes("..")) return false;
     if (name.includes("@{")) return false;
     if (name.endsWith(".lock") || name.endsWith(".") || name.endsWith("/") || name.startsWith("/")) return false;
+    return true;
+}
+
+/** Validate remote names used in git commands/config. */
+function isValidRemoteName(name: string): boolean {
+    if (!name || name.length > 256) return false;
+    if (name.startsWith("-")) return false;
+    if (/[^A-Za-z0-9._/-]/.test(name)) return false;
     return true;
 }
 
@@ -180,6 +207,9 @@ export class GitService implements ServiceHandler {
                     break;
                 case "git_merge":
                     void this.handleMerge(payload, requestId, sessionId);
+                    break;
+                case "git_set_upstream":
+                    void this.handleSetUpstream(payload, requestId, sessionId);
                     break;
                 case "git_worktrees":
                     void this.handleWorktrees(payload, requestId, sessionId);
@@ -1107,6 +1137,95 @@ export class GitService implements ServiceHandler {
         }
     }
 
+    // ── upstream resolution / sync helpers ──────────────────────────────
+
+    private async readGitConfigValues(cwd: string, key: string): Promise<string[]> {
+        try {
+            const { stdout } = await this._execGit(["config", "--get-all", key], { cwd, timeout: 5000 });
+            return stdout
+                .split("\n")
+                .map((value) => value.trim())
+                .filter(Boolean);
+        } catch {
+            return [];
+        }
+    }
+
+    private async resolveUpstream(cwd: string): Promise<GitUpstreamResolution> {
+        let localBranch = "";
+        try {
+            const { stdout } = await this._execGit(["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 });
+            localBranch = stdout.trim();
+        } catch (err) {
+            return {
+                ok: false,
+                reason: "detachedHead",
+                message: err instanceof Error ? err.message : String(err),
+            };
+        }
+
+        if (!localBranch || localBranch === "HEAD") {
+            return {
+                ok: false,
+                reason: "detachedHead",
+                message: "Cannot sync a detached HEAD. Check out a branch first.",
+            };
+        }
+
+        const [remotes, mergeRefs] = await Promise.all([
+            this.readGitConfigValues(cwd, `branch.${localBranch}.remote`),
+            this.readGitConfigValues(cwd, `branch.${localBranch}.merge`),
+        ]);
+
+        if (remotes.length > 1 || mergeRefs.length > 1) {
+            return {
+                ok: false,
+                reason: "ambiguousUpstream",
+                message: `Branch ${localBranch} has multiple upstream targets configured. Repair its upstream before pulling.`,
+                localBranch,
+                remote: remotes[0],
+                mergeBranches: mergeRefs,
+            };
+        }
+
+        const remote = remotes[0] ?? "";
+        const mergeRef = mergeRefs[0] ?? "";
+        const mergeBranch = mergeRef.startsWith("refs/heads/") ? mergeRef.slice(11) : mergeRef;
+
+        if (!remote || !mergeBranch) {
+            return {
+                ok: false,
+                reason: "missingUpstream",
+                message: `Branch ${localBranch} does not have exactly one upstream configured. Set its tracking branch first.`,
+                localBranch,
+                remote: remote || undefined,
+            };
+        }
+
+        return {
+            ok: true,
+            localBranch,
+            remote,
+            mergeBranch,
+            trackingRef: `${remote}/${mergeBranch}`,
+        };
+    }
+
+    private classifySyncFailure(message: string): { reason?: "conflict"; message: string } {
+        if (
+            message.includes("CONFLICT")
+            || message.includes("Resolve all conflicts manually")
+            || message.includes("could not apply")
+            || message.includes("Not possible to fast-forward")
+        ) {
+            return {
+                reason: "conflict",
+                message: "Sync stopped because of conflicts. Resolve them in git, then try again.",
+            };
+        }
+        return { message };
+    }
+
     // ── git pull ────────────────────────────────────────────────────────
 
     private async handlePull(
@@ -1119,76 +1238,34 @@ export class GitService implements ServiceHandler {
         const rebase = payload.rebase !== false;
 
         try {
-            // Avoid "Cannot rebase onto multiple branches" by splitting into
-            // explicit fetch + rebase/merge steps instead of using `git pull`.
-            // `git pull --rebase` parses FETCH_HEAD internally and fails when
-            // multiple entries are marked for merge — even with an explicit
-            // remote and branch. Using `git fetch` then `git rebase <ref>`
-            // sidesteps FETCH_HEAD entirely.
-
-            // 1. Resolve the upstream remote and branch.
-            let remote: string | null = null;
-            let mergeBranch: string | null = null;
-            let localBranch: string | null = null;
-            try {
-                const { stdout: branchName } = await this._execGit(
-                    ["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 },
-                );
-                localBranch = branchName.trim() || null;
-                if (localBranch && localBranch !== "HEAD") {
-                    try {
-                        const { stdout } = await this._execGit(
-                            ["config", "--get", `branch.${localBranch}.remote`], { cwd, timeout: 5000 },
-                        );
-                        if (stdout.trim()) remote = stdout.trim();
-                    } catch { /* no tracking remote configured */ }
-
-                    try {
-                        const { stdout } = await this._execGit(
-                            ["config", "--get", `branch.${localBranch}.merge`], { cwd, timeout: 5000 },
-                        );
-                        const ref = stdout.trim();
-                        if (ref) {
-                            mergeBranch = ref.startsWith("refs/heads/") ? ref.slice(11) : ref;
-                        }
-                    } catch { /* no merge ref configured */ }
-                }
-            } catch { /* detached HEAD */ }
-
-            // Fall back to first listed remote.
-            if (!remote) {
-                try {
-                    const { stdout } = await this._execGit(["remote"], { cwd, timeout: 5000 });
-                    const firstRemote = stdout.trim().split("\n")[0]?.trim();
-                    if (firstRemote) remote = firstRemote;
-                } catch { /* no remotes */ }
+            const upstream = await this.resolveUpstream(cwd);
+            if (!upstream.ok) {
+                this.emit("git_pull_result", {
+                    ok: false,
+                    reason: upstream.reason,
+                    message: upstream.message,
+                    branch: upstream.localBranch,
+                    remote: upstream.remote,
+                    mergeBranches: upstream.mergeBranches,
+                }, requestId, sessionId);
+                return;
             }
 
-            // If no merge branch is configured, assume the remote branch
-            // has the same name as the local branch (common convention).
-            if (!mergeBranch && localBranch && localBranch !== "HEAD") {
-                mergeBranch = localBranch;
-            }
+            const fetchResult = await this._execGit(
+                ["fetch", upstream.remote, upstream.mergeBranch],
+                { cwd, timeout: 60000 },
+            );
 
-            // 2. Fetch from remote.
-            const fetchArgs = ["fetch"];
-            if (remote) {
-                fetchArgs.push(remote);
-                if (mergeBranch) fetchArgs.push(mergeBranch);
-            }
-            const fetchResult = await this._execGit(fetchArgs, { cwd, timeout: 60000 });
-
-            // 3. Rebase or merge onto the explicit remote-tracking ref.
-            //    Using <remote>/<branch> avoids FETCH_HEAD ambiguity entirely.
-            const targetRef = remote && mergeBranch ? `${remote}/${mergeBranch}` : "FETCH_HEAD";
             const integrateArgs = rebase
-                ? ["rebase", targetRef]
-                : ["merge", "--ff-only", targetRef];
+                ? ["rebase", upstream.trackingRef]
+                : ["merge", "--ff-only", upstream.trackingRef];
             const integrateResult = await this._execGit(integrateArgs, { cwd, timeout: 60000 });
 
             const output = [
-                fetchResult.stdout, fetchResult.stderr,
-                integrateResult.stdout, integrateResult.stderr,
+                fetchResult.stdout,
+                fetchResult.stderr,
+                integrateResult.stdout,
+                integrateResult.stderr,
             ].join("\n").trim();
 
             await this.invalidateStatusCacheFamily(cwd);
@@ -1196,9 +1273,66 @@ export class GitService implements ServiceHandler {
             this.emit("git_pull_result", {
                 ok: true,
                 output,
+                branch: upstream.localBranch,
+                remote: upstream.remote,
+                upstream: upstream.trackingRef,
             }, requestId, sessionId);
         } catch (err) {
-            this.emitError("git_pull_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+            const message = err instanceof Error ? err.message : String(err);
+            const classified = this.classifySyncFailure(message);
+            if (classified.reason === "conflict") {
+                await this.invalidateStatusCacheFamily(cwd);
+            }
+            this.emit("git_pull_result", {
+                ok: false,
+                reason: classified.reason,
+                message: classified.message,
+                output: message,
+            }, requestId, sessionId);
+        }
+    }
+
+    private async handleSetUpstream(
+        payload: Record<string, unknown>,
+        requestId?: string,
+        sessionId?: string,
+    ): Promise<void> {
+        const cwd = this.validateCwd(payload.cwd, "git_set_upstream_result", requestId, sessionId);
+        if (!cwd) return;
+
+        const remote = typeof payload.remote === "string" ? payload.remote.trim() : "";
+        const branch = typeof payload.branch === "string" ? payload.branch.trim() : "";
+        if (!isValidRemoteName(remote)) {
+            this.emitError("git_set_upstream_result", "Invalid remote name", requestId, sessionId);
+            return;
+        }
+        if (!isValidBranchName(branch)) {
+            this.emitError("git_set_upstream_result", "Invalid branch name", requestId, sessionId);
+            return;
+        }
+
+        try {
+            const { stdout } = await this._execGit(["rev-parse", "--abbrev-ref", "HEAD"], { cwd, timeout: 5000 });
+            const localBranch = stdout.trim();
+            if (!localBranch || localBranch === "HEAD") {
+                this.emit("git_set_upstream_result", {
+                    ok: false,
+                    reason: "detachedHead",
+                    message: "Cannot set upstream while HEAD is detached.",
+                }, requestId, sessionId);
+                return;
+            }
+
+            await this._execGit(["branch", `--set-upstream-to=${remote}/${branch}`, localBranch], { cwd, timeout: 15000 });
+            await this.invalidateStatusCacheFamily(cwd);
+            this.emit("git_set_upstream_result", {
+                ok: true,
+                summary: `Branch ${localBranch} now tracks ${remote}/${branch}`,
+                branch: localBranch,
+                upstream: `${remote}/${branch}`,
+            }, requestId, sessionId);
+        } catch (err) {
+            this.emitError("git_set_upstream_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
         }
     }
 
@@ -1234,7 +1368,17 @@ export class GitService implements ServiceHandler {
             await this.invalidateStatusCacheFamily(cwd);
             this.emit("git_merge_result", { ok: true, output }, requestId, sessionId);
         } catch (err) {
-            this.emitError("git_merge_result", err instanceof Error ? err.message : String(err), requestId, sessionId);
+            const message = err instanceof Error ? err.message : String(err);
+            const classified = this.classifySyncFailure(message);
+            if (classified.reason === "conflict") {
+                await this.invalidateStatusCacheFamily(cwd);
+            }
+            this.emit("git_merge_result", {
+                ok: false,
+                reason: classified.reason,
+                message: classified.message,
+                output: message,
+            }, requestId, sessionId);
         }
     }
 

--- a/packages/ui/src/components/git/GitCommitForm.tsx
+++ b/packages/ui/src/components/git/GitCommitForm.tsx
@@ -6,13 +6,14 @@ interface GitCommitFormProps {
     hasStagedChanges: boolean;
     onCommit: (message: string) => void;
     isCommitting: boolean;
+    disabled?: boolean;
 }
 
-export function GitCommitForm({ hasStagedChanges, onCommit, isCommitting }: GitCommitFormProps) {
+export function GitCommitForm({ hasStagedChanges, onCommit, isCommitting, disabled = false }: GitCommitFormProps) {
     const [message, setMessage] = useState("");
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-    const canCommit = hasStagedChanges && message.trim().length > 0 && !isCommitting;
+    const canCommit = hasStagedChanges && message.trim().length > 0 && !isCommitting && !disabled;
 
     const handleCommit = useCallback(() => {
         if (!canCommit) return;
@@ -47,7 +48,7 @@ export function GitCommitForm({ hasStagedChanges, onCommit, isCommitting }: GitC
                 onChange={(e) => setMessage(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={hasStagedChanges ? "Commit message…" : "Stage changes to commit"}
-                disabled={!hasStagedChanges || isCommitting}
+                disabled={!hasStagedChanges || isCommitting || disabled}
                 rows={1}
                 className={cn(
                     "w-full resize-none rounded border border-border bg-background px-2 py-1.5",

--- a/packages/ui/src/components/git/GitPanel.test.tsx
+++ b/packages/ui/src/components/git/GitPanel.test.tsx
@@ -1,0 +1,124 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+
+const win = new Window({ url: "http://localhost/" });
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+(globalThis as any).SyntaxError = SyntaxError;
+(win as any).SyntaxError = SyntaxError;
+(globalThis as any).ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+};
+
+const gitState = {
+    available: true,
+    status: {
+        branch: "feature/test",
+        changes: [],
+        ahead: 1,
+        behind: 1,
+        hasUpstream: true,
+        diffStaged: "",
+    },
+    branches: [],
+    branchesState: { loading: false, error: null, partial: false },
+    worktrees: [],
+    currentBranch: "feature/test",
+    loading: false,
+    error: null,
+    operationInProgress: null as string | null,
+    lastOperationResult: null,
+    fetchStatus: mock(() => {}),
+    fetchWorktrees: mock(() => {}),
+    fetchDiff: mock(async () => ""),
+    fetchBranches: mock(() => {}),
+    checkout: mock(() => {}),
+    stage: mock(() => {}),
+    stageAll: mock(() => {}),
+    unstage: mock(() => {}),
+    unstageAll: mock(() => {}),
+    commit: mock(() => {}),
+    push: mock(() => {}),
+    pull: mock(() => {}),
+    setUpstream: mock(() => {}),
+    merge: mock(() => {}),
+    clearOperationResult: mock(() => {}),
+};
+
+mock.module("@/lib/utils", () => ({
+    cn: (...values: Array<string | false | null | undefined>) => values.filter(Boolean).join(" "),
+}));
+
+mock.module("@/components/ui/spinner", () => ({
+    Spinner: () => <div data-testid="spinner" />,
+}));
+
+mock.module("@/components/ui/button", () => ({
+    Button: ({ children, ...props }: React.ButtonHTMLAttributes<HTMLButtonElement>) => (
+        <button type="button" {...props}>{children}</button>
+    ),
+}));
+
+mock.module("@/hooks/useGitService", () => ({
+    useGitService: () => gitState,
+}));
+
+mock.module("./GitBranchSelector", () => ({
+    GitBranchSelector: ({ disabled }: { disabled?: boolean }) => (
+        <button type="button" data-testid="branch-selector" data-disabled={String(Boolean(disabled))}>
+            branch
+        </button>
+    ),
+}));
+
+mock.module("./GitStagingArea", () => ({
+    partitionChanges: () => ({ staged: [], unstaged: [] }),
+    GitStagingArea: () => <div data-testid="staging-area" />,
+}));
+
+mock.module("./GitCommitForm", () => ({
+    GitCommitForm: () => <div data-testid="commit-form" />,
+}));
+
+mock.module("./GitDiffView", () => ({
+    GitDiffView: () => <div data-testid="diff-view" />,
+}));
+
+mock.module("./GitWorktreeList", () => ({
+    GitWorktreeList: () => <div data-testid="worktree-list" />,
+}));
+
+afterAll(() => mock.restore());
+
+const { GitPanel } = await import("./GitPanel");
+
+afterEach(() => {
+    cleanup();
+    gitState.operationInProgress = null;
+    gitState.status.changes = [];
+    document.body.innerHTML = "";
+});
+
+describe("GitPanel", () => {
+    test("disables branch selector and sync controls while any mutation is running", () => {
+        gitState.operationInProgress = "commit";
+
+        const { getByTestId, getByText } = render(<GitPanel cwd="/repo" />);
+
+        expect(getByTestId("branch-selector").getAttribute("data-disabled")).toBe("true");
+        expect((getByText("Pull").closest("button") as HTMLButtonElement).disabled).toBe(true);
+        expect((getByText("Push").closest("button") as HTMLButtonElement).disabled).toBe(true);
+        expect((getByText("Sync").closest("button") as HTMLButtonElement).disabled).toBe(true);
+    });
+});

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -28,6 +28,7 @@ import { GitStagingArea, partitionChanges } from "./GitStagingArea";
 import { GitCommitForm } from "./GitCommitForm";
 import { GitDiffView } from "./GitDiffView";
 import { GitWorktreeList } from "./GitWorktreeList";
+import { getGitOperationFeedback, parseUpstreamRef } from "./git-operation-feedback";
 
 // ── Props ───────────────────────────────────────────────────────────────────
 
@@ -47,35 +48,37 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
     const diffContainerRef = useRef<HTMLDivElement>(null);
 
     // Toast-style feedback for operations
-    const [toast, setToast] = useState<{ type: "success" | "error"; message: string } | null>(null);
+    const [toast, setToast] = useState<{
+        type: "success" | "error";
+        message: string;
+        action?: "setUpstream";
+    } | null>(null);
     const [syncMenuOpen, setSyncMenuOpen] = useState(false);
     const syncMenuRef = useRef<HTMLDivElement>(null);
     const syncMenuContentRef = useRef<HTMLDivElement>(null);
 
+    const handleSetUpstream = useCallback(() => {
+        const currentBranch = git.status?.branch?.trim();
+        const suggestion = currentBranch ? `origin/${currentBranch}` : "origin/main";
+        const response = window.prompt("Set upstream to which remote branch?", suggestion);
+        if (!response) return;
+
+        const parsed = parseUpstreamRef(response);
+        if (!parsed) {
+            setToast({
+                type: "error",
+                message: "Enter the upstream as remote/branch, for example origin/main.",
+            });
+            return;
+        }
+
+        git.setUpstream(parsed.remote, parsed.branch);
+    }, [git]);
+
     // Show toast when operation completes
     useEffect(() => {
         if (!git.lastOperationResult) return;
-        const result = git.lastOperationResult;
-        if (result.ok) {
-            const msg = (result.summary as string)
-                ?? (result.output as string)
-                ?? (result.branch ? `Switched to ${result.branch as string}` : null)
-                ?? "Done";
-            setToast({ type: "success", message: msg });
-        } else {
-            // If push failed because no upstream, offer to retry with --set-upstream
-            if (result.noUpstream) {
-                setToast({
-                    type: "error",
-                    message: "No upstream branch. Click Publish to push and set upstream.",
-                });
-            } else {
-                setToast({
-                    type: "error",
-                    message: (result.message as string) ?? "Operation failed",
-                });
-            }
-        }
+        setToast(getGitOperationFeedback(git.lastOperationResult));
 
         const timer = setTimeout(() => setToast(null), 5000);
         return () => clearTimeout(timer);
@@ -364,6 +367,15 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                 >
                     {toast.type === "success" ? <Check className="size-3" /> : <AlertCircle className="size-3" />}
                     <span className="truncate flex-1">{toast.message}</span>
+                    {toast.action === "setUpstream" && (
+                        <button
+                            type="button"
+                            onClick={handleSetUpstream}
+                            className="text-current underline underline-offset-2 hover:no-underline"
+                        >
+                            Set upstream…
+                        </button>
+                    )}
                     <button
                         type="button"
                         onClick={() => setToast(null)}

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -202,6 +202,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
 
     const { staged } = partitionChanges(git.status.changes);
     const hasChanges = git.status.changes.length > 0;
+    const isMutating = git.operationInProgress !== null;
     const isPushing = git.operationInProgress === "push";
     const isPulling = git.operationInProgress === "pull";
     // Show push when ahead of remote OR on a branch with no upstream yet
@@ -218,6 +219,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                     branchesState={git.branchesState}
                     onCheckout={git.checkout}
                     onOpen={git.fetchBranches}
+                    disabled={isMutating}
                     isCheckingOut={git.operationInProgress === "checkout"}
                 />
 
@@ -246,7 +248,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                     <button
                         type="button"
                         onClick={() => setSyncMenuOpen((o) => !o)}
-                        disabled={git.operationInProgress === "pull" || git.operationInProgress === "merge"}
+                        disabled={isMutating}
                         className={cn(
                             "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors",
                             "bg-muted/60 hover:bg-muted text-foreground",
@@ -311,7 +313,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                     <button
                         type="button"
                         onClick={() => git.pull()}
-                        disabled={isPulling}
+                        disabled={isMutating}
                         className={cn(
                             "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors",
                             "bg-amber-500/20 text-amber-600 dark:text-amber-400 hover:bg-amber-500/30",
@@ -329,7 +331,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                     <button
                         type="button"
                         onClick={() => git.push(!git.status!.hasUpstream)}
-                        disabled={isPushing}
+                        disabled={isMutating}
                         className={cn(
                             "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors",
                             "bg-green-600/20 text-green-600 dark:text-green-400 hover:bg-green-600/30",
@@ -418,6 +420,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                     hasStagedChanges={staged.length > 0}
                     onCommit={git.commit}
                     isCommitting={git.operationInProgress === "commit"}
+                    disabled={isMutating}
                 />
             )}
 

--- a/packages/ui/src/components/git/GitStagingArea.tsx
+++ b/packages/ui/src/components/git/GitStagingArea.tsx
@@ -75,7 +75,7 @@ export function GitStagingArea({
     operationInProgress,
 }: GitStagingAreaProps) {
     const { staged, unstaged } = partitionChanges(changes);
-    const isBusy = operationInProgress === "stage" || operationInProgress === "unstage";
+    const isBusy = operationInProgress !== null;
 
     return (
         <div className="py-1">

--- a/packages/ui/src/components/git/git-operation-feedback.test.ts
+++ b/packages/ui/src/components/git/git-operation-feedback.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { getGitOperationFeedback, parseUpstreamRef } from "./git-operation-feedback";
+
+describe("git-operation-feedback", () => {
+    test("maps missing upstream to repair action", () => {
+        expect(getGitOperationFeedback({ ok: false, reason: "missingUpstream" })).toEqual({
+            type: "error",
+            message: "This branch has no upstream configured. Set an upstream branch, then pull again.",
+            action: "setUpstream",
+        });
+    });
+
+    test("maps ambiguous upstream to repair action", () => {
+        expect(getGitOperationFeedback({ ok: false, reason: "ambiguousUpstream" })).toEqual({
+            type: "error",
+            message: "This branch has an ambiguous upstream configuration. Repair it by setting exactly one upstream branch.",
+            action: "setUpstream",
+        });
+    });
+
+    test("parses remote/branch upstream refs", () => {
+        expect(parseUpstreamRef("origin/feature/test")).toEqual({ remote: "origin", branch: "feature/test" });
+        expect(parseUpstreamRef("origin")).toBeNull();
+        expect(parseUpstreamRef("/main")).toBeNull();
+    });
+});

--- a/packages/ui/src/components/git/git-operation-feedback.test.ts
+++ b/packages/ui/src/components/git/git-operation-feedback.test.ts
@@ -18,6 +18,13 @@ describe("git-operation-feedback", () => {
         });
     });
 
+    test("maps busy repo state to a retry message", () => {
+        expect(getGitOperationFeedback({ ok: false, reason: "busy" })).toEqual({
+            type: "error",
+            message: "Another git operation is already running for this repo. Wait a moment, then try again.",
+        });
+    });
+
     test("parses remote/branch upstream refs", () => {
         expect(parseUpstreamRef("origin/feature/test")).toEqual({ remote: "origin", branch: "feature/test" });
         expect(parseUpstreamRef("origin")).toBeNull();

--- a/packages/ui/src/components/git/git-operation-feedback.ts
+++ b/packages/ui/src/components/git/git-operation-feedback.ts
@@ -1,0 +1,65 @@
+import type { GitOperationResult } from "@/hooks/useGitService";
+
+export type GitToastAction = "setUpstream";
+
+export interface GitOperationFeedback {
+    type: "success" | "error";
+    message: string;
+    action?: GitToastAction;
+}
+
+export function parseUpstreamRef(input: string): { remote: string; branch: string } | null {
+    const value = input.trim();
+    const slashIndex = value.indexOf("/");
+    if (slashIndex <= 0 || slashIndex === value.length - 1) return null;
+
+    const remote = value.slice(0, slashIndex).trim();
+    const branch = value.slice(slashIndex + 1).trim();
+    if (!remote || !branch) return null;
+    return { remote, branch };
+}
+
+export function getGitOperationFeedback(result: GitOperationResult): GitOperationFeedback {
+    if (result.ok) {
+        const message = (result.summary as string)
+            ?? (result.output as string)
+            ?? (result.branch ? `Switched to ${result.branch as string}` : null)
+            ?? "Done";
+        return { type: "success", message };
+    }
+
+    if (result.noUpstream || result.reason === "missingUpstream") {
+        return {
+            type: "error",
+            message: "This branch has no upstream configured. Set an upstream branch, then pull again.",
+            action: "setUpstream",
+        };
+    }
+
+    if (result.reason === "ambiguousUpstream") {
+        return {
+            type: "error",
+            message: "This branch has an ambiguous upstream configuration. Repair it by setting exactly one upstream branch.",
+            action: "setUpstream",
+        };
+    }
+
+    if (result.reason === "detachedHead") {
+        return {
+            type: "error",
+            message: "Cannot sync while HEAD is detached. Check out a branch first.",
+        };
+    }
+
+    if (result.reason === "conflict") {
+        return {
+            type: "error",
+            message: (result.message as string) ?? "Sync stopped because of conflicts.",
+        };
+    }
+
+    return {
+        type: "error",
+        message: (result.message as string) ?? "Operation failed",
+    };
+}

--- a/packages/ui/src/components/git/git-operation-feedback.ts
+++ b/packages/ui/src/components/git/git-operation-feedback.ts
@@ -51,6 +51,13 @@ export function getGitOperationFeedback(result: GitOperationResult): GitOperatio
         };
     }
 
+    if (result.reason === "busy") {
+        return {
+            type: "error",
+            message: "Another git operation is already running for this repo. Wait a moment, then try again.",
+        };
+    }
+
     if (result.reason === "conflict") {
         return {
             type: "error",

--- a/packages/ui/src/hooks/useGitService.ts
+++ b/packages/ui/src/hooks/useGitService.ts
@@ -95,6 +95,7 @@ export interface UseGitServiceReturn {
     commit: (message: string) => void;
     push: (setUpstream?: boolean) => void;
     pull: (rebase?: boolean) => void;
+    setUpstream: (remote: string, branch: string) => void;
     merge: (branch: string) => void;
     clearOperationResult: () => void;
 }
@@ -380,13 +381,18 @@ export function useGitService(cwd: string): UseGitServiceReturn {
                 case "git_commit_result":
                 case "git_push_result":
                 case "git_pull_result":
-                case "git_merge_result": {
+                case "git_merge_result":
+                case "git_set_upstream_result": {
                     if (!isRequestCurrentGeneration(requestId)) break;
                     setOperationInProgress(null);
                     setLastOperationResult(payload as GitOperationResult);
-                    // Auto-refresh status after successful mutating operations.
-                    // Debounced/coalesced to avoid hammering git status during rapid updates.
-                    if (payload.ok) {
+                    // Auto-refresh after successful mutating operations, and
+                    // after pull/merge conflicts because rebase/merge may have
+                    // changed the worktree/index even though the operation failed.
+                    if (
+                        payload.ok
+                        || ((type === "git_pull_result" || type === "git_merge_result") && payload.reason === "conflict")
+                    ) {
                         postMutationRefreshSchedulerRef.current.schedule();
                     }
                     break;
@@ -572,6 +578,15 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         send("git_pull", { cwd, rebase }, requestId);
     }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
 
+    const setUpstream = useCallback((remote: string, branch: string) => {
+        if (!available || !remote || !branch) return;
+        const requestId = makeRequestId();
+        registerRequestGeneration(requestId);
+        setOperationInProgress("set-upstream");
+        setLastOperationResult(null);
+        send("git_set_upstream", { cwd, remote, branch }, requestId);
+    }, [available, send, cwd, makeRequestId, registerRequestGeneration]);
+
     const merge = useCallback((branch: string) => {
         if (!available || !branch) return;
         const requestId = makeRequestId();
@@ -652,6 +667,7 @@ export function useGitService(cwd: string): UseGitServiceReturn {
         commit,
         push,
         pull,
+        setUpstream,
         merge,
         clearOperationResult,
     };


### PR DESCRIPTION
## Summary
- replace raw `git pull` handling with explicit upstream resolution plus fetch+rebase / fetch+ff-only integration
- return structured pull failure reasons (`missingUpstream`, `ambiguousUpstream`, `detachedHead`, `conflict`) and add a minimal `Set upstream…` repair path in GitPanel
- add regression coverage for upstream resolution, conflicted sync flows, and UI feedback parsing

## Test Plan
- [x] `bun test packages/cli/src/runner/services/git-service.test.ts packages/ui/src/components/git/git-operation-feedback.test.ts`
- [x] `bun run typecheck`
