### PR TITLE
fix(worker): gate relay-delivered turns until worker startup completes

### DIFF
--- a/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
+++ b/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
@@ -1,0 +1,298 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+
+class FakeSocket {
+    handlers = new Map<string, Array<(data: any) => void>>();
+    ioHandlers = new Map<string, Array<(data: any) => void>>();
+    connected = true;
+    emit = mock((_event: string, _data?: any) => {});
+    removeAllListeners = mock(() => {
+        this.handlers.clear();
+    });
+    disconnect = mock(() => {
+        this.connected = false;
+    });
+    on(event: string, handler: (data: any) => void) {
+        const list = this.handlers.get(event) ?? [];
+        list.push(handler);
+        this.handlers.set(event, list);
+        return this;
+    }
+    off(event: string, handler?: (data: any) => void) {
+        if (!handler) {
+            this.handlers.delete(event);
+            return this;
+        }
+        const list = this.handlers.get(event) ?? [];
+        this.handlers.set(event, list.filter((h) => h !== handler));
+        return this;
+    }
+    trigger(event: string, data?: any) {
+        for (const handler of this.handlers.get(event) ?? []) handler(data);
+    }
+    io = {
+        on: (event: string, handler: (data: any) => void) => {
+            const list = this.ioHandlers.get(event) ?? [];
+            list.push(handler);
+            this.ioHandlers.set(event, list);
+            return this.io;
+        },
+    };
+}
+
+let lastSocket: FakeSocket | null = null;
+
+mock.module("socket.io-client", () => ({
+    io: mock(() => {
+        lastSocket = new FakeSocket();
+        return lastSocket;
+    }),
+}));
+
+mock.module("../../config.js", () => ({
+    loadConfig: mock(() => ({ relayUrl: "ws://relay.test" })),
+}));
+
+mock.module("../../backoff.js", () => ({
+    RELAY_BACKOFF_DEFAULTS: { baseMs: 1000, maxMs: 30000, jitterFactor: 0.25 },
+    computeBackoffDelay: mock(() => 1000),
+}));
+
+mock.module("../mcp-bridge.js", () => ({ getMcpBridge: mock(() => null) }));
+mock.module("../session-message-bus.js", () => ({
+    messageBus: {
+        setOwnSessionId: mock(() => {}),
+        setSendFn: mock(() => {}),
+        receive: mock(() => {}),
+    },
+}));
+mock.module("../remote-provider-usage.js", () => ({ refreshAllUsage: mock(async () => {}) }));
+mock.module("../remote-heartbeat.js", () => ({ startHeartbeat: mock(() => {}), stopHeartbeat: mock(() => {}) }));
+mock.module("../remote-meta-events.js", () => ({
+    emitAuthSourceChanged: mock(() => {}),
+    emitThinkingLevelChanged: mock(() => {}),
+    emitMcpStartupReport: mock(() => {}),
+}));
+mock.module("../remote-auth-source.js", () => ({ getAuthSource: mock(() => null) }));
+mock.module("../remote-ask-user.js", () => ({
+    cancelPendingAskUserQuestion: mock(() => {}),
+    consumePendingAskUserQuestionFromWeb: mock(() => false),
+}));
+mock.module("../remote-plan-mode.js", () => ({
+    cancelPendingPlanMode: mock(() => {}),
+    consumePendingPlanModeFromWeb: mock(() => false),
+}));
+mock.module("../remote-input.js", () => ({
+    normalizeRemoteInputAttachments: mock(() => []),
+    buildUserMessageFromRemoteInput: mock(async (text: string) => text),
+}));
+mock.module("../remote-exec-handler.js", () => ({ handleExecFromWeb: mock(async () => {}) }));
+mock.module("../triggers/registry.js", () => ({
+    renderTrigger: mock(() => "rendered trigger"),
+    renderTriggerBatch: mock(() => "rendered trigger batch"),
+}));
+mock.module("../triggers/extension.js", () => ({
+    trackReceivedTrigger: mock(() => {}),
+    receivedTriggers: new Map(),
+}));
+mock.module("./chunked-delivery.js", () => ({ emitSessionActive: mock(() => {}) }));
+mock.module("./registration-gate.js", () => ({
+    resetRelayRegistrationGate: mock(() => {}),
+    signalRelayRegistered: mock(() => {}),
+}));
+mock.module("../remote-registered-parent-state.js", () => ({
+    decideRegisteredParentState: mock(() => ({ kind: "no_change" })),
+}));
+
+const { connect } = await import("./connection.js");
+const {
+    armWorkerStartupGate,
+    markWorkerStartupComplete,
+    _resetWorkerStartupGateForTesting,
+} = await import("../worker-startup-gate.js");
+
+function sleep(ms: number) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+describe("remote connection startup gate", () => {
+    beforeEach(() => {
+        lastSocket = null;
+        _resetWorkerStartupGateForTesting();
+    });
+
+    afterEach(() => {
+        _resetWorkerStartupGateForTesting();
+    });
+
+    test("buffers trigger-delivered turns until worker startup completes", async () => {
+        armWorkerStartupGate();
+
+        const sendUserMessage = mock(() => {});
+        const rctx = {
+            shuttingDown: false,
+            sioSocket: null,
+            relay: null,
+            relaySessionId: null,
+            apiKey: () => "test-key",
+            relayUrl: () => "ws://relay.test",
+            disconnectedStatusText: () => "Disconnected",
+            setRelayStatus: mock(() => {}),
+            getCurrentSessionName: () => null,
+            forwardEvent: mock(() => {}),
+            buildCapabilitiesState: () => ({ type: "capabilities" }),
+        } as any;
+        const handlers = {
+            clearFollowUpGrace: mock(() => {}),
+            setModelFromWeb: mock(async () => {}),
+            sendUserMessage,
+            isPendingDelinkOwnParent: () => false,
+            setServerClockOffset: mock(() => {}),
+            isStaleChild: () => false,
+            getStalePrimaryParentId: () => null,
+            onParentExplicitlyDelinked: mock(() => {}),
+            onParentTransientlyOffline: mock(() => {}),
+            onParentDelinked: mock(() => {}),
+            flushDeferredDelinks: mock(() => {}),
+            onDelinkDisconnect: mock(() => {}),
+            onSocketTeardown: mock(() => {}),
+            getParentSessionIdForRegister: () => undefined,
+        } as any;
+
+        connect(rctx, handlers);
+        expect(lastSocket).toBeTruthy();
+
+        lastSocket!.trigger("session_trigger", {
+            trigger: {
+                type: "github:pr_comment",
+                sourceSessionId: "external:github",
+                sourceSessionName: "GitHub",
+                triggerId: "trig_1",
+                payload: { body: "please fix this" },
+                deliverAs: "steer",
+                ts: new Date().toISOString(),
+            },
+        });
+
+        await sleep(120);
+        expect(sendUserMessage).not.toHaveBeenCalled();
+
+        markWorkerStartupComplete();
+        await Promise.resolve();
+        await sleep(0);
+
+        expect(sendUserMessage).toHaveBeenCalledTimes(1);
+        const firstCall = sendUserMessage.mock.calls[0] as unknown as [string, { deliverAs?: "followUp" | "steer" }?];
+        expect(firstCall[0]).toBe("rendered trigger batch");
+    });
+
+    test("buffers remote input until worker startup completes", async () => {
+        armWorkerStartupGate();
+
+        const sendUserMessage = mock(() => {});
+        const rctx = {
+            shuttingDown: false,
+            sioSocket: null,
+            relay: null,
+            relaySessionId: null,
+            apiKey: () => "test-key",
+            relayUrl: () => "ws://relay.test",
+            disconnectedStatusText: () => "Disconnected",
+            setRelayStatus: mock(() => {}),
+            getCurrentSessionName: () => null,
+            getCurrentThinkingLevel: () => null,
+            forwardEvent: mock(() => {}),
+            buildCapabilitiesState: () => ({ type: "capabilities" }),
+            buildHeartbeat: () => ({ type: "heartbeat" }),
+            relayHttpBaseUrl: () => "http://relay.test",
+        } as any;
+        const handlers = {
+            clearFollowUpGrace: mock(() => {}),
+            setModelFromWeb: mock(async () => {}),
+            sendUserMessage,
+            isPendingDelinkOwnParent: () => false,
+            setServerClockOffset: mock(() => {}),
+            isStaleChild: () => false,
+            getStalePrimaryParentId: () => null,
+            onParentExplicitlyDelinked: mock(() => {}),
+            onParentTransientlyOffline: mock(() => {}),
+            onParentDelinked: mock(() => {}),
+            flushDeferredDelinks: mock(() => {}),
+            onDelinkDisconnect: mock(() => {}),
+            onSocketTeardown: mock(() => {}),
+            getParentSessionIdForRegister: () => undefined,
+        } as any;
+
+        connect(rctx, handlers);
+        expect(lastSocket).toBeTruthy();
+
+        // Simulate remote input arriving before boot completes
+        lastSocket!.trigger("input", {
+            text: "fix the flaky test please",
+        });
+
+        // Give the async handler time to run (it awaits the gate)
+        await sleep(50);
+        expect(sendUserMessage).not.toHaveBeenCalled();
+
+        markWorkerStartupComplete();
+        // Let the awaited promise chain resolve
+        await sleep(50);
+
+        expect(sendUserMessage).toHaveBeenCalledTimes(1);
+        const firstCall = sendUserMessage.mock.calls[0] as unknown as [string];
+        expect(firstCall[0]).toBe("fix the flaky test please");
+    });
+
+    test("delivers immediately when gate is not armed (normal CLI session)", async () => {
+        // Don't arm the gate — simulates a normal interactive CLI session
+        const sendUserMessage = mock(() => {});
+        const rctx = {
+            shuttingDown: false,
+            sioSocket: null,
+            relay: null,
+            relaySessionId: null,
+            apiKey: () => "test-key",
+            relayUrl: () => "ws://relay.test",
+            disconnectedStatusText: () => "Disconnected",
+            setRelayStatus: mock(() => {}),
+            getCurrentSessionName: () => null,
+            forwardEvent: mock(() => {}),
+            buildCapabilitiesState: () => ({ type: "capabilities" }),
+        } as any;
+        const handlers = {
+            clearFollowUpGrace: mock(() => {}),
+            setModelFromWeb: mock(async () => {}),
+            sendUserMessage,
+            isPendingDelinkOwnParent: () => false,
+            setServerClockOffset: mock(() => {}),
+            isStaleChild: () => false,
+            getStalePrimaryParentId: () => null,
+            onParentExplicitlyDelinked: mock(() => {}),
+            onParentTransientlyOffline: mock(() => {}),
+            onParentDelinked: mock(() => {}),
+            flushDeferredDelinks: mock(() => {}),
+            onDelinkDisconnect: mock(() => {}),
+            onSocketTeardown: mock(() => {}),
+            getParentSessionIdForRegister: () => undefined,
+        } as any;
+
+        connect(rctx, handlers);
+        expect(lastSocket).toBeTruthy();
+
+        lastSocket!.trigger("session_trigger", {
+            trigger: {
+                type: "github:pr_comment",
+                sourceSessionId: "external:github",
+                sourceSessionName: "GitHub",
+                triggerId: "trig_2",
+                payload: { body: "looks good" },
+                deliverAs: "steer",
+                ts: new Date().toISOString(),
+            },
+        });
+
+        // Trigger batch debounce is 80ms
+        await sleep(120);
+        expect(sendUserMessage).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
+++ b/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
@@ -86,10 +86,6 @@ mock.module("../remote-input.js", () => ({
     buildUserMessageFromRemoteInput: mock(async (text: string) => text),
 }));
 mock.module("../remote-exec-handler.js", () => ({ handleExecFromWeb: mock(async () => {}) }));
-mock.module("../triggers/extension.js", () => ({
-    trackReceivedTrigger: mock(() => {}),
-    receivedTriggers: new Map(),
-}));
 mock.module("./registration-gate.js", () => ({
     resetRelayRegistrationGate: mock(() => {}),
     signalRelayRegistered: mock(() => {}),

--- a/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
+++ b/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
@@ -86,15 +86,10 @@ mock.module("../remote-input.js", () => ({
     buildUserMessageFromRemoteInput: mock(async (text: string) => text),
 }));
 mock.module("../remote-exec-handler.js", () => ({ handleExecFromWeb: mock(async () => {}) }));
-mock.module("../triggers/registry.js", () => ({
-    renderTrigger: mock(() => "rendered trigger"),
-    renderTriggerBatch: mock(() => "rendered trigger batch"),
-}));
 mock.module("../triggers/extension.js", () => ({
     trackReceivedTrigger: mock(() => {}),
     receivedTriggers: new Map(),
 }));
-mock.module("./chunked-delivery.js", () => ({ emitSessionActive: mock(() => {}) }));
 mock.module("./registration-gate.js", () => ({
     resetRelayRegistrationGate: mock(() => {}),
     signalRelayRegistered: mock(() => {}),
@@ -182,7 +177,8 @@ describe("remote connection startup gate", () => {
 
         expect(sendUserMessage).toHaveBeenCalledTimes(1);
         const firstCall = sendUserMessage.mock.calls[0] as unknown as [string, { deliverAs?: "followUp" | "steer" }?];
-        expect(firstCall[0]).toBe("rendered trigger batch");
+        expect(firstCall[0]).toContain("<!-- trigger:trig_1");
+        expect(firstCall[0]).toContain("GitHub");
     });
 
     test("buffers remote input until worker startup completes", async () => {

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -27,6 +27,7 @@ import type { RelayContext } from "../remote-types.js";
 import { emitSessionActive } from "./chunked-delivery.js";
 import { resetRelayRegistrationGate, signalRelayRegistered } from "./registration-gate.js";
 import { decideRegisteredParentState } from "../remote-registered-parent-state.js";
+import { waitForWorkerStartupComplete } from "../worker-startup-gate.js";
 
 // ── Module-level singletons (safe: one relay extension per process) ───────────
 
@@ -218,7 +219,9 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         // Prefer "followUp" delivery if any trigger requested it; otherwise "steer".
         const deliverAs = batch.some((b) => b.deliverAs === "followUp") ? "followUp" as const : "steer" as const;
         const rendered = renderTriggerBatch(batch.map((b) => b.trigger));
-        handlers.sendUserMessage(rendered, { deliverAs });
+        void waitForWorkerStartupComplete().then(() => {
+            handlers.sendUserMessage(rendered, { deliverAs });
+        });
     };
 
     // ── Backoff / reconnection logging (Manager-level events) ─────────────
@@ -381,6 +384,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
                 const key = rctx.apiKey();
                 const relaySessionId = rctx.relay?.sessionId;
                 const message = await buildUserMessageFromRemoteInput(inputText, attachments, httpBase, key ?? "", relaySessionId);
+                await waitForWorkerStartupComplete();
                 handlers.sendUserMessage(message, deliverAs ? { deliverAs } : undefined);
             } catch (err) {
                 log.error(`pizzapi: failed to deliver remote input: ${err instanceof Error ? err.message : String(err)}`);

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -219,9 +219,14 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         // Prefer "followUp" delivery if any trigger requested it; otherwise "steer".
         const deliverAs = batch.some((b) => b.deliverAs === "followUp") ? "followUp" as const : "steer" as const;
         const rendered = renderTriggerBatch(batch.map((b) => b.trigger));
-        void waitForWorkerStartupComplete().then(() => {
-            handlers.sendUserMessage(rendered, { deliverAs });
-        });
+        void (async () => {
+            try {
+                await waitForWorkerStartupComplete();
+                handlers.sendUserMessage(rendered, { deliverAs });
+            } catch (err) {
+                log.error(`pizzapi: failed to deliver trigger batch: ${err instanceof Error ? err.message : String(err)}`);
+            }
+        })();
     };
 
     // ── Backoff / reconnection logging (Manager-level events) ─────────────

--- a/packages/cli/src/extensions/worker-startup-gate.ts
+++ b/packages/cli/src/extensions/worker-startup-gate.ts
@@ -9,8 +9,16 @@ let readyPromise: Promise<void> = Promise.resolve();
  * While armed, inbound relay-delivered turns (session triggers, remote input)
  * should wait until markWorkerStartupComplete() is called. Sessions that never
  * arm the gate (normal CLI sessions) remain ungated.
+ *
+ * Must only be called once per worker process — calling twice before the gate
+ * is released would orphan any callers already awaiting the old promise.
  */
 export function armWorkerStartupGate(): void {
+    if (armed && !ready) {
+        throw new Error(
+            "Worker startup gate already armed — armWorkerStartupGate() must not be called twice before markWorkerStartupComplete()",
+        );
+    }
     armed = true;
     ready = false;
     readyPromise = new Promise<void>((resolve) => {

--- a/packages/cli/src/extensions/worker-startup-gate.ts
+++ b/packages/cli/src/extensions/worker-startup-gate.ts
@@ -1,0 +1,41 @@
+let armed = false;
+let ready = false;
+let resolveReady: (() => void) | null = null;
+let readyPromise: Promise<void> = Promise.resolve();
+
+/**
+ * Arm the startup gate for runner workers.
+ *
+ * While armed, inbound relay-delivered turns (session triggers, remote input)
+ * should wait until markWorkerStartupComplete() is called. Sessions that never
+ * arm the gate (normal CLI sessions) remain ungated.
+ */
+export function armWorkerStartupGate(): void {
+    armed = true;
+    ready = false;
+    readyPromise = new Promise<void>((resolve) => {
+        resolveReady = resolve;
+    });
+}
+
+/** Mark worker startup complete and release any queued inbound work. */
+export function markWorkerStartupComplete(): void {
+    if (!armed || ready) return;
+    ready = true;
+    resolveReady?.();
+    resolveReady = null;
+}
+
+/** Wait until startup is complete if the gate is armed, otherwise resolve immediately. */
+export function waitForWorkerStartupComplete(): Promise<void> {
+    if (!armed || ready) return Promise.resolve();
+    return readyPromise;
+}
+
+/** @internal Test-only helper. */
+export function _resetWorkerStartupGateForTesting(): void {
+    armed = false;
+    ready = false;
+    resolveReady = null;
+    readyPromise = Promise.resolve();
+}

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -343,6 +343,7 @@ async function main(): Promise<void> {
     // work (notably MCP initialization) has completed.
     armWorkerStartupGate();
     bootTimer.start("[boot] bind-extensions");
+    try {
     await session.bindExtensions({
         commandContextActions: {
             waitForIdle: () => session.agent.waitForIdle(),
@@ -384,7 +385,12 @@ async function main(): Promise<void> {
             forwardCliError(err.error, err.extensionPath);
         },
     });
-    markWorkerStartupComplete();
+    } finally {
+        // Always release the gate — even if bindExtensions() throws — so that
+        // any callers already waiting on waitForWorkerStartupComplete() are not
+        // stranded forever. The worker will crash/exit on throw anyway.
+        markWorkerStartupComplete();
+    }
     bootTimer.end("[boot] bind-extensions");
 
     bootTimer.end("[boot] total");

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -164,6 +164,7 @@ function buildPromptPaths(cwd: string): string[] {
 }
 import { forwardCliError } from "../extensions/remote.js";
 import { buildPizzaPiExtensionFactories } from "../extensions/factories.js";
+import { armWorkerStartupGate, markWorkerStartupComplete } from "../extensions/worker-startup-gate.js";
 
 /**
  * Headless session worker.
@@ -337,6 +338,10 @@ async function main(): Promise<void> {
     bootTimer.end("[boot] create-session");
 
     // Bind extensions in headless mode (no UI context)
+    // Arm the startup gate before session_start handlers run so inbound relay
+    // triggers / remote input cannot start the first turn until all startup
+    // work (notably MCP initialization) has completed.
+    armWorkerStartupGate();
     bootTimer.start("[boot] bind-extensions");
     await session.bindExtensions({
         commandContextActions: {
@@ -379,6 +384,7 @@ async function main(): Promise<void> {
             forwardCliError(err.error, err.extensionPath);
         },
     });
+    markWorkerStartupComplete();
     bootTimer.end("[boot] bind-extensions");
 
     bootTimer.end("[boot] total");


### PR DESCRIPTION
## Problem

Auto-spawned trigger sessions (e.g. GitHub comment handlers) could receive and process their first agent turn **before MCP and other extensions finished loading**.

The relay socket registered during `session_start`, but MCP initialization also runs in `session_start` — and the remote extension's handler fires first (registration order), opening a window where triggers/input arrive before MCP tools are available.

### Impact
- Triggered automation could miss MCP tools (GitHub, Godmother, etc.) on the first turn
- Behavior differed between the first and subsequent turns
- Most visible when MCP startup is slow or involves remote/OAuth servers

## Fix

Add a **worker startup gate** that arms before `bindExtensions()` and releases after it completes. The relay connection's `session_trigger` and `input` handlers now `await` the gate before calling `sendUserMessage()`, ensuring the first agent turn never starts until all startup work (MCP, plugins, hooks, etc.) has finished.

The gate is only armed for runner workers — normal CLI sessions are ungated and behave exactly as before.

### Changed files
| File | Change |
|------|--------|
| `packages/cli/src/extensions/worker-startup-gate.ts` | **New** — arm/mark/wait primitives |
| `packages/cli/src/runner/worker.ts` | Arm gate before `bindExtensions()`, release after |
| `packages/cli/src/extensions/remote/connection.ts` | Await gate before delivering triggers and input |
| `packages/cli/src/extensions/remote/connection.startup-gate.test.ts` | **New** — 3 regression tests |

## Tests

1. ✅ Trigger-delivered turns are buffered until startup completes
2. ✅ Remote input is buffered until startup completes
3. ✅ Ungated sessions (normal CLI) deliver immediately

## Verification

- `bun run typecheck` — clean
- All related tests pass
- Pre-existing failures in MCP HTTP smoke tests and chunked-delivery are unrelated

Closes idea: wNXa7QPF