### PR TITLE
fix(csp): whitelist inline FOUC-prevention script via SHA-256 hash

### DIFF
--- a/packages/server/src/handler.test.ts
+++ b/packages/server/src/handler.test.ts
@@ -362,7 +362,7 @@ describe("withSecurityHeaders", () => {
         const csp = res.headers.get("Content-Security-Policy");
         expect(csp).not.toBeNull();
         expect(csp).toContain("default-src 'self'");
-        expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval'");
+        expect(csp).toContain("script-src 'self' 'wasm-unsafe-eval' 'sha256-4gSUsZcLv5hWmJpSRF6gl939rcZJHXery+eyOKMEgaQ='");
         expect(csp).toContain("connect-src 'self' ws: wss: blob:");
         expect(csp).toContain("object-src 'none'");
     });

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -183,9 +183,12 @@ export function withSecurityHeaders(res: Response): Response {
         // would block. The iframe sandbox attribute provides defence-in-depth.
     } else {
         headers.set("X-Frame-Options", "DENY");
+        // The sha256 hash whitelists the inline FOUC-prevention <script> in
+        // packages/ui/index.html.  If that script changes, regenerate the hash:
+        //   python3 -c "import re,hashlib,base64;html=open('packages/ui/index.html').read();m=re.search(r'<script>(.*?)</script>',html,re.DOTALL);print('sha256-'+base64.b64encode(hashlib.sha256(m.group(1).encode()).digest()).decode())"
         headers.set(
             "Content-Security-Policy",
-            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval' 'sha256-4gSUsZcLv5hWmJpSRF6gl939rcZJHXery+eyOKMEgaQ='; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
         );
     }
 


### PR DESCRIPTION
## Problem

The Content-Security-Policy header blocked the inline `<script>` in `index.html` that prevents flash-of-unstyled-content (FOUC). The CSP's `script-src` directive only allowed `'self'` and `'wasm-unsafe-eval'`, but the theme initialization script runs as an inline script before any module loads.

This caused:
- A console error: `Executing inline script violates the following Content Security Policy directive 'script-src 'self' 'wasm-unsafe-eval''`
- The theme/accent/font-size/density/radius/code-font initialization to silently fail on first load (before the React app takes over)

## Fix

Add the SHA-256 hash (`sha256-4gSUsZcLv5hWmJpSRF6gl939rcZJHXery+eyOKMEgaQ=`) of the inline script to the CSP `script-src` directive. This lets the browser verify and execute the specific inline script while keeping the strict CSP policy for all other scripts.

Also includes a comment with the hash regeneration command for when the inline script content changes.

## Files Changed

- `packages/server/src/handler.ts` — Added SHA-256 hash to CSP `script-src`
- `packages/server/src/handler.test.ts` — Updated test expectation

## Testing

- ✅ All 33 handler tests pass
- ✅ Full typecheck clean
- ✅ Verified via playwright: 0 console errors after fix (was 1 error before)
- ✅ Deployed with `pizza web --build` and confirmed fix in production