### PR TITLE
fix: resolve builtin skills dir from execPath in compiled binaries

### DIFF
--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -13,8 +13,16 @@ import { expandHome } from "./config.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+/** Detect compiled Bun binary (assets live next to process.execPath, not import.meta.url). */
+const isCompiledBinary = import.meta.url.includes("$bunfs") || import.meta.url.includes("~BUN") || import.meta.url.includes("%7EBUN");
+
 /** Built-in skills shipped with the CLI package. */
 export function builtinSkillsDir(): string {
+    if (isCompiledBinary) {
+        // In a compiled binary, .md assets are copied next to the executable
+        // (not embedded in the virtual $bunfs filesystem).
+        return join(dirname(process.execPath), "skills");
+    }
     return join(__dirname, "skills");
 }
 


### PR DESCRIPTION
## Problem

`builtinSkillsDir()` in `skills.ts` uses `import.meta.url` to locate the `skills/` directory. In compiled Bun binaries, `import.meta.url` points inside the virtual `$bunfs` filesystem — but `.md` skill files aren't bundled TS modules, they're external assets copied next to the executable by `build-binaries.ts`. So the path resolved to nowhere and the `creating-runner-services` skill was invisible on installs.

## Fix

Added the same `isCompiledBinary` detection pattern used by `terminal.ts` and `supervisor.ts` — falls back to `dirname(process.execPath)` for the skills directory when running from a compiled binary.

## Testing

- All 928 tests pass
- Typecheck clean