### PR TITLE
fix: unify CLI and Runner loading parity for skills, agents, and prompts

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,12 +6,11 @@ import {
     InteractiveMode,
     ModelRegistry,
 } from "@mariozechner/pi-coding-agent";
-import { existsSync } from "fs";
-import { readFile, readdir } from "fs/promises";
 import { join } from "path";
 import { buildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
 import { c, usageBar, colorPct, colorRemaining } from "./cli-colors.js";
-import { buildInteractiveSkillPaths } from "./skills.js";
+import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "./skills.js";
+import { getPluginSkillPaths } from "./extensions/claude-plugins.js";
 import { buildPizzaPiExtensionFactories } from "./extensions/factories.js";
 import { migrateAgentDir } from "./migrations.js";
 import { runSetup } from "./setup.js";
@@ -490,37 +489,9 @@ async function main() {
         log.warn("pizzapi: sandbox was requested but is not active (platform unsupported or init failed)");
     }
 
-    // Load AGENTS.md from cwd (if present)
-    const agentFiles: Array<{ path: string; content: string }> = [];
-    const agentsMdPath = join(cwd, "AGENTS.md");
-    if (existsSync(agentsMdPath)) {
-        try {
-            const content = await readFile(agentsMdPath, "utf-8");
-            agentFiles.push({ path: agentsMdPath, content });
-        } catch (err) {
-            log.warn(`Warning: skipping unreadable ${agentsMdPath}: ${err instanceof Error ? err.message : String(err)}`);
-        }
-    }
-
-    // Load .agents/*.md files from cwd
-    const dotAgentsDir = join(cwd, ".agents");
-    if (existsSync(dotAgentsDir)) {
-        const files = await readdir(dotAgentsDir);
-        const mdFiles = files.filter((file) => file.endsWith(".md"));
-        const loadedAgents = (await Promise.all(
-            mdFiles.map(async (file) => {
-                const filePath = join(dotAgentsDir, file);
-                try {
-                    const content = await readFile(filePath, "utf-8");
-                    return { path: filePath, content };
-                } catch (err) {
-                    log.warn(`Warning: skipping unreadable agent file ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
-                    return null;
-                }
-            })
-        )).filter((f): f is { path: string; content: string } => f !== null);
-        agentFiles.push(...loadedAgents);
-    }
+    // Build shared agentsFilesOverride (loads AGENTS.md + .agents/*.md from cwd,
+    // deduplicating against what DefaultResourceLoader already discovers).
+    const agentsFilesOverride = createAgentsFilesOverride(cwd);
 
     // Override relay URL if --no-relay was passed
     if (noRelay) {
@@ -540,16 +511,16 @@ async function main() {
         cwd,
         agentDir,
         extensionFactories,
-        additionalSkillPaths: buildInteractiveSkillPaths(cwd, config.skills),
+        additionalSkillPaths: [
+            ...buildSkillPaths(cwd, config.skills),
+            ...(noPlugins ? [] : getPluginSkillPaths(cwd)),
+        ],
+        additionalPromptTemplatePaths: buildPromptTemplatePaths(cwd),
         ...(config.systemPrompt !== undefined && {
             systemPromptOverride: () => config.systemPrompt,
         }),
         appendSystemPrompt: [buildSystemPrompt({ cwd }), config.appendSystemPrompt].filter(Boolean).join("\n\n"),
-        ...(agentFiles.length > 0 && {
-            agentsFilesOverride: (base) => ({
-                agentsFiles: [...base.agentsFiles, ...agentFiles],
-            }),
-        }),
+        ...(agentsFilesOverride && { agentsFilesOverride }),
     });
     await loader.reload();
 

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -1,9 +1,8 @@
 import { createAgentSession, DefaultResourceLoader, AuthStorage } from "@mariozechner/pi-coding-agent";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { homedir } from "node:os";
 import { buildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "../config.js";
-import { buildWorkerSkillPaths } from "../skills.js";
+import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "../skills.js";
 import { getPluginSkillPaths } from "../extensions/claude-plugins.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 import { createBootTimer } from "./boot-timing.js";
@@ -147,21 +146,7 @@ async function createAuthStorageWithRetry(authPath: string, maxAttempts = 5): Pr
     return AuthStorage.create(authPath);
 }
 
-/**
- * Build additional prompt template paths for the headless worker.
- *
- * ~/.pizzapi/prompts/ is already discovered via agentDir, so we only need
- * the project-local .pizzapi/prompts/ plus Claude-style commands/ directories
- * (both global and project-local) which map to pi prompt templates.
- */
-function buildPromptPaths(cwd: string): string[] {
-    return [
-        join(cwd, ".pizzapi", "prompts"),
-        join(homedir(), ".pizzapi", "commands"),
-        join(cwd, ".pizzapi", "commands"),
-        join(cwd, ".agents", "commands"),
-    ];
-}
+// buildPromptPaths moved to ../skills.ts as buildPromptTemplatePaths
 import { forwardCliError } from "../extensions/remote.js";
 import { buildPizzaPiExtensionFactories } from "../extensions/factories.js";
 import { armWorkerStartupGate, markWorkerStartupComplete } from "../extensions/worker-startup-gate.js";
@@ -249,21 +234,9 @@ async function main(): Promise<void> {
     const agentSystemPrompt = process.env.PIZZAPI_WORKER_AGENT_SYSTEM_PROMPT?.trim() || undefined;
     // Don't clear — agent config should persist across restarts (exit code 43).
 
-    // Load .agents/*.md files from cwd (same behavior as CLI)
-    const dotAgentsDir = join(cwd, ".agents");
-    const agentFiles: Array<{ path: string; content: string }> = [];
-    if (existsSync(dotAgentsDir)) {
-        for (const file of readdirSync(dotAgentsDir)) {
-            if (file.endsWith(".md")) {
-                const filePath = join(dotAgentsDir, file);
-                try {
-                    agentFiles.push({ path: filePath, content: readFileSync(filePath, "utf-8") });
-                } catch (err) {
-                    logWarn(`skipping unreadable agent file ${filePath}: ${err instanceof Error ? err.message : String(err)}`);
-                }
-            }
-        }
-    }
+    // Build shared agentsFilesOverride (loads AGENTS.md + .agents/*.md from cwd,
+    // deduplicating against what DefaultResourceLoader already discovers).
+    const agentsFilesOverride = createAgentsFilesOverride(cwd);
 
     bootTimer.start("[boot] resource-loader");
     const loader = new DefaultResourceLoader({
@@ -278,19 +251,15 @@ async function main(): Promise<void> {
             skipRelay: process.env.PIZZAPI_NO_RELAY === "1",
         }),
         additionalSkillPaths: [
-            ...buildWorkerSkillPaths(cwd, config.skills),
+            ...buildSkillPaths(cwd, config.skills),
             ...(skipPlugins ? [] : getPluginSkillPaths(cwd)),
         ],
-        additionalPromptTemplatePaths: buildPromptPaths(cwd),
+        additionalPromptTemplatePaths: buildPromptTemplatePaths(cwd),
         ...(config.systemPrompt !== undefined && {
             systemPromptOverride: () => config.systemPrompt,
         }),
         appendSystemPrompt: [buildSystemPrompt({ cwd, isRunner: true }), config.appendSystemPrompt, agentSystemPrompt].filter(Boolean).join("\n\n"),
-        ...(agentFiles.length > 0 && {
-            agentsFilesOverride: (base) => ({
-                agentsFiles: [...base.agentsFiles, ...agentFiles],
-            }),
-        }),
+        ...(agentsFilesOverride && { agentsFilesOverride }),
     });
     await loader.reload();
     bootTimer.end("[boot] resource-loader");

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -10,8 +10,12 @@ import {
     writeSkill,
     deleteSkill,
     builtinSkillsDir,
+    buildSkillPaths,
+    buildPromptTemplatePaths,
     buildInteractiveSkillPaths,
     buildWorkerSkillPaths,
+    loadProjectAgentFiles,
+    createAgentsFilesOverride,
 } from "./skills.js";
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -412,78 +416,180 @@ describe("deleteSkill", () => {
     });
 });
 
-// ── buildInteractiveSkillPaths ────────────────────────────────────────────────
+// ── buildSkillPaths (unified) ─────────────────────────────────────────────────
 
-describe("buildInteractiveSkillPaths", () => {
-    test("includes global and project-local .pizzapi/skills dirs", () => {
-        const paths = buildInteractiveSkillPaths("/projects/my-app");
+describe("buildSkillPaths", () => {
+    test("includes all expected default paths", () => {
         const home = require("os").homedir();
+        const paths = buildSkillPaths("/projects/my-app");
+        // Global paths
         expect(paths).toContain(join(home, ".pizzapi", "skills"));
-        expect(paths).toContain(join("/projects/my-app", ".pizzapi", "skills"));
-    });
-
-    test("appends config skill paths", () => {
-        const paths = buildInteractiveSkillPaths("/projects/my-app", [
-            "/extra/skills",
-            "~/my-skills",
-        ]);
-        expect(paths).toContain("/extra/skills");
-        // ~ should be expanded
-        const home = require("os").homedir();
-        expect(paths).toContain(join(home, "my-skills"));
-    });
-
-    test("filters out empty and whitespace-only config entries", () => {
-        const paths = buildInteractiveSkillPaths("/tmp", ["", "  ", "/valid"]);
-        // Should have 3 default paths (builtin + global + project) + 1 valid config path
-        expect(paths).toHaveLength(4);
-        expect(paths[3]).toBe("/valid");
-    });
-
-    test("handles undefined configSkills", () => {
-        const paths = buildInteractiveSkillPaths("/tmp");
-        expect(paths).toHaveLength(3);
-    });
-
-    test("handles empty configSkills array", () => {
-        const paths = buildInteractiveSkillPaths("/tmp", []);
-        expect(paths).toHaveLength(3);
-    });
-});
-
-// ── buildWorkerSkillPaths ─────────────────────────────────────────────────────
-
-describe("buildWorkerSkillPaths", () => {
-    test("includes expected default paths", () => {
-        const home = require("os").homedir();
-        const paths = buildWorkerSkillPaths("/projects/my-app");
-        expect(paths).toContain(join("/projects/my-app", ".pizzapi", "skills"));
         expect(paths).toContain(join(home, ".pizzapi", "agents"));
+        // Project-local paths
+        expect(paths).toContain(join("/projects/my-app", ".pizzapi", "skills"));
         expect(paths).toContain(join("/projects/my-app", ".pizzapi", "agents"));
         expect(paths).toContain(join("/projects/my-app", ".agents", "skills"));
         expect(paths).toContain(join("/projects/my-app", ".agents", "agents"));
     });
 
-    test("does NOT include global ~/.pizzapi/skills (discovered via agentDir)", () => {
-        const home = require("os").homedir();
-        const paths = buildWorkerSkillPaths("/projects/my-app");
-        expect(paths).not.toContain(join(home, ".pizzapi", "skills"));
+    test("includes builtin skills dir", () => {
+        const paths = buildSkillPaths("/tmp");
+        expect(paths[0]).toBe(builtinSkillsDir());
     });
 
     test("appends config skill paths", () => {
-        const paths = buildWorkerSkillPaths("/tmp", ["/custom/path"]);
-        expect(paths).toContain("/custom/path");
+        const paths = buildSkillPaths("/projects/my-app", [
+            "/extra/skills",
+            "~/my-skills",
+        ]);
+        expect(paths).toContain("/extra/skills");
+        const home = require("os").homedir();
+        expect(paths).toContain(join(home, "my-skills"));
     });
 
-    test("expands tilde in config paths", () => {
-        const home = require("os").homedir();
-        const paths = buildWorkerSkillPaths("/tmp", ["~/custom"]);
-        expect(paths).toContain(join(home, "custom"));
+    test("filters out empty and whitespace-only config entries", () => {
+        const paths = buildSkillPaths("/tmp", ["", "  ", "/valid"]);
+        // 7 default paths + 1 valid config path
+        expect(paths).toHaveLength(8);
+        expect(paths).toContain("/valid");
     });
 
     test("handles undefined configSkills", () => {
-        const paths = buildWorkerSkillPaths("/tmp");
-        expect(paths).toHaveLength(6); // 6 default paths (builtin + 5 existing)
+        const paths = buildSkillPaths("/tmp");
+        expect(paths).toHaveLength(7); // builtin + 6 directory paths
+    });
+
+    test("handles empty configSkills array", () => {
+        const paths = buildSkillPaths("/tmp", []);
+        expect(paths).toHaveLength(7);
+    });
+});
+
+// ── buildPromptTemplatePaths ──────────────────────────────────────────────────
+
+describe("buildPromptTemplatePaths", () => {
+    test("includes all expected paths", () => {
+        const home = require("os").homedir();
+        const paths = buildPromptTemplatePaths("/projects/my-app");
+        expect(paths).toContain(join("/projects/my-app", ".pizzapi", "prompts"));
+        expect(paths).toContain(join(home, ".pizzapi", "commands"));
+        expect(paths).toContain(join("/projects/my-app", ".pizzapi", "commands"));
+        expect(paths).toContain(join("/projects/my-app", ".agents", "commands"));
+    });
+
+    test("returns exactly 4 paths", () => {
+        const paths = buildPromptTemplatePaths("/tmp");
+        expect(paths).toHaveLength(4);
+    });
+});
+
+// ── Deprecated wrapper parity ─────────────────────────────────────────────────
+
+describe("deprecated buildInteractiveSkillPaths / buildWorkerSkillPaths", () => {
+    test("buildInteractiveSkillPaths delegates to buildSkillPaths", () => {
+        const unified = buildSkillPaths("/tmp", ["/extra"]);
+        const interactive = buildInteractiveSkillPaths("/tmp", ["/extra"]);
+        expect(interactive).toEqual(unified);
+    });
+
+    test("buildWorkerSkillPaths delegates to buildSkillPaths", () => {
+        const unified = buildSkillPaths("/tmp", ["/extra"]);
+        const worker = buildWorkerSkillPaths("/tmp", ["/extra"]);
+        expect(worker).toEqual(unified);
+    });
+});
+
+// ── loadProjectAgentFiles ─────────────────────────────────────────────────────
+
+describe("loadProjectAgentFiles", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = makeTmpDir();
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("loads AGENTS.md from cwd", () => {
+        writeFileSync(join(dir, "AGENTS.md"), "# Project Agents", "utf-8");
+        const files = loadProjectAgentFiles(dir);
+        expect(files).toHaveLength(1);
+        expect(files[0].path).toBe(join(dir, "AGENTS.md"));
+        expect(files[0].content).toBe("# Project Agents");
+    });
+
+    test("loads .agents/*.md from cwd", () => {
+        mkdirSync(join(dir, ".agents"), { recursive: true });
+        writeFileSync(join(dir, ".agents", "custom.md"), "# Custom", "utf-8");
+        writeFileSync(join(dir, ".agents", "another.md"), "# Another", "utf-8");
+        writeFileSync(join(dir, ".agents", "readme.txt"), "ignore", "utf-8");
+        const files = loadProjectAgentFiles(dir);
+        expect(files).toHaveLength(2);
+        const names = files.map(f => f.path).sort();
+        expect(names).toContain(join(dir, ".agents", "another.md"));
+        expect(names).toContain(join(dir, ".agents", "custom.md"));
+    });
+
+    test("loads both AGENTS.md and .agents/*.md", () => {
+        writeFileSync(join(dir, "AGENTS.md"), "# Main", "utf-8");
+        mkdirSync(join(dir, ".agents"), { recursive: true });
+        writeFileSync(join(dir, ".agents", "extra.md"), "# Extra", "utf-8");
+        const files = loadProjectAgentFiles(dir);
+        expect(files).toHaveLength(2);
+    });
+
+    test("returns empty array when nothing exists", () => {
+        const files = loadProjectAgentFiles(dir);
+        expect(files).toEqual([]);
+    });
+});
+
+// ── createAgentsFilesOverride ─────────────────────────────────────────────────
+
+describe("createAgentsFilesOverride", () => {
+    let dir: string;
+
+    beforeEach(() => {
+        dir = makeTmpDir();
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+
+    test("returns null when no additional files exist", () => {
+        const override = createAgentsFilesOverride(dir);
+        expect(override).toBeNull();
+    });
+
+    test("returns override function when files exist", () => {
+        writeFileSync(join(dir, "AGENTS.md"), "# Agents", "utf-8");
+        const override = createAgentsFilesOverride(dir);
+        expect(override).toBeInstanceOf(Function);
+    });
+
+    test("deduplicates by path against base files", () => {
+        writeFileSync(join(dir, "AGENTS.md"), "# Agents", "utf-8");
+        const override = createAgentsFilesOverride(dir)!;
+        const base = {
+            agentsFiles: [{ path: join(dir, "AGENTS.md"), content: "# Agents (base)" }],
+        };
+        const result = override(base);
+        // AGENTS.md was already in base — should NOT be duplicated
+        expect(result.agentsFiles).toHaveLength(1);
+        expect(result.agentsFiles[0].content).toBe("# Agents (base)");
+    });
+
+    test("adds new files not in base", () => {
+        mkdirSync(join(dir, ".agents"), { recursive: true });
+        writeFileSync(join(dir, ".agents", "extra.md"), "# Extra", "utf-8");
+        const override = createAgentsFilesOverride(dir)!;
+        const base = { agentsFiles: [{ path: "/other/AGENTS.md", content: "# Other" }] };
+        const result = override(base);
+        expect(result.agentsFiles).toHaveLength(2);
+        expect(result.agentsFiles[1].path).toBe(join(dir, ".agents", "extra.md"));
     });
 });
 

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -192,43 +192,118 @@ export function deleteSkill(name: string, dir?: string): boolean {
     return false;
 }
 
+// ── Project agent files loader ─────────────────────────────────────────────────
+
+export interface AgentFile {
+    path: string;
+    content: string;
+}
+
+/**
+ * Load project-level agent files that the upstream `DefaultResourceLoader`
+ * does NOT discover on its own.
+ *
+ * The upstream `loadProjectContextFiles()` already handles:
+ *   - AGENTS.md / CLAUDE.md from the agentDir (~/.pizzapi/)
+ *   - AGENTS.md / CLAUDE.md from cwd and all ancestor directories
+ *
+ * This function loads the ADDITIONAL files that PizzaPi supports:
+ *   - <cwd>/AGENTS.md          (explicit project-dir load — ensures parity)
+ *   - <cwd>/.agents/*.md       (Claude Code style agent context files)
+ *
+ * Both the interactive CLI and the headless runner worker should use this
+ * via `agentsFilesOverride` on `DefaultResourceLoader`.
+ *
+ * NOTE: The upstream already loads <cwd>/AGENTS.md via ancestor walk.
+ * To avoid duplicates, callers use this with `agentsFilesOverride` which
+ * receives the base list — we deduplicate by path.
+ */
+export function loadProjectAgentFiles(cwd: string): AgentFile[] {
+    const files: AgentFile[] = [];
+
+    // Load AGENTS.md from cwd (also loaded by upstream, but we include it
+    // to guarantee it's present — deduplication happens in agentsFilesOverride)
+    const agentsMdPath = join(cwd, "AGENTS.md");
+    if (existsSync(agentsMdPath)) {
+        try {
+            const content = readFileSync(agentsMdPath, "utf-8");
+            files.push({ path: agentsMdPath, content });
+        } catch {
+            // Skip unreadable files
+        }
+    }
+
+    // Load .agents/*.md from cwd
+    const dotAgentsDir = join(cwd, ".agents");
+    if (existsSync(dotAgentsDir)) {
+        let entries: string[];
+        try {
+            entries = readdirSync(dotAgentsDir);
+        } catch {
+            entries = [];
+        }
+        for (const file of entries) {
+            if (!file.endsWith(".md")) continue;
+            const filePath = join(dotAgentsDir, file);
+            try {
+                const content = readFileSync(filePath, "utf-8");
+                files.push({ path: filePath, content });
+            } catch {
+                // Skip unreadable files
+            }
+        }
+    }
+
+    return files;
+}
+
+/**
+ * Create an `agentsFilesOverride` function for `DefaultResourceLoader`
+ * that merges the upstream-discovered agent files with PizzaPi's
+ * additional project agent files, deduplicating by path.
+ *
+ * Returns null if there are no additional files to add.
+ */
+export function createAgentsFilesOverride(
+    cwd: string,
+): ((base: { agentsFiles: AgentFile[] }) => { agentsFiles: AgentFile[] }) | null {
+    const additionalFiles = loadProjectAgentFiles(cwd);
+    if (additionalFiles.length === 0) return null;
+
+    return (base) => {
+        const seenPaths = new Set(base.agentsFiles.map(f => f.path));
+        const deduped = additionalFiles.filter(f => !seenPaths.has(f.path));
+        return {
+            agentsFiles: [...base.agentsFiles, ...deduped],
+        };
+    };
+}
+
 // ── Skill path builders ───────────────────────────────────────────────────────
 
 // expandHome is imported from config.ts
 
 /**
- * Build the list of additional skill paths for the interactive CLI.
- * Always includes:
- *   - ~/.pizzapi/skills/  (global PizzaPi skills)
- *   - <cwd>/.pizzapi/skills/  (project-local PizzaPi skills)
- * Plus any paths declared in config.skills.
+ * Build the unified list of additional skill paths.
+ *
+ * Used by BOTH the interactive CLI and the headless runner worker so that
+ * skills are discoverable identically regardless of how the session was
+ * started.
+ *
+ * Includes:
+ *   - Built-in skills shipped with the CLI package
+ *   - ~/.pizzapi/skills/        (global PizzaPi skills)
+ *   - <cwd>/.pizzapi/skills/    (project-local PizzaPi skills)
+ *   - ~/.pizzapi/agents/        (global agents treated as skills)
+ *   - <cwd>/.pizzapi/agents/    (project-local agents treated as skills)
+ *   - <cwd>/.agents/skills/     (Claude Code compatible project skills)
+ *   - <cwd>/.agents/agents/     (Claude Code compatible project agents)
+ *   - Paths declared in config.skills
  */
-export function buildInteractiveSkillPaths(cwd: string, configSkills?: string[]): string[] {
+export function buildSkillPaths(cwd: string, configSkills?: string[]): string[] {
     const paths: string[] = [
         builtinSkillsDir(),
         join(homedir(), ".pizzapi", "skills"),
-        join(cwd, ".pizzapi", "skills"),
-    ];
-    if (Array.isArray(configSkills)) {
-        for (const p of configSkills) {
-            if (typeof p === "string" && p.trim()) {
-                paths.push(expandHome(p.trim()));
-            }
-        }
-    }
-    return paths;
-}
-
-/**
- * Build additional skill paths for the headless worker.
- *
- * ~/.pizzapi/skills/ is already discovered via agentDir, so we only need
- * the project-local .pizzapi/skills/ plus Claude-style agents/ directories
- * (both global and project-local) which map to pi skills.
- */
-export function buildWorkerSkillPaths(cwd: string, configSkills?: string[]): string[] {
-    const paths: string[] = [
-        builtinSkillsDir(),
         join(cwd, ".pizzapi", "skills"),
         join(homedir(), ".pizzapi", "agents"),
         join(cwd, ".pizzapi", "agents"),
@@ -243,4 +318,40 @@ export function buildWorkerSkillPaths(cwd: string, configSkills?: string[]): str
         }
     }
     return paths;
+}
+
+/**
+ * @deprecated Use `buildSkillPaths` instead. Kept for backward compatibility.
+ */
+export function buildInteractiveSkillPaths(cwd: string, configSkills?: string[]): string[] {
+    return buildSkillPaths(cwd, configSkills);
+}
+
+/**
+ * @deprecated Use `buildSkillPaths` instead. Kept for backward compatibility.
+ */
+export function buildWorkerSkillPaths(cwd: string, configSkills?: string[]): string[] {
+    return buildSkillPaths(cwd, configSkills);
+}
+
+// ── Prompt template path builders ─────────────────────────────────────────────
+
+/**
+ * Build the list of additional prompt template / command paths.
+ *
+ * Used by BOTH the interactive CLI and the headless runner worker.
+ *
+ * Includes:
+ *   - <cwd>/.pizzapi/prompts/   (project-local prompt templates)
+ *   - ~/.pizzapi/commands/       (global commands — Claude Code compatible)
+ *   - <cwd>/.pizzapi/commands/   (project-local commands)
+ *   - <cwd>/.agents/commands/    (Claude Code compatible project commands)
+ */
+export function buildPromptTemplatePaths(cwd: string): string[] {
+    return [
+        join(cwd, ".pizzapi", "prompts"),
+        join(homedir(), ".pizzapi", "commands"),
+        join(cwd, ".pizzapi", "commands"),
+        join(cwd, ".agents", "commands"),
+    ];
 }


### PR DESCRIPTION
## Summary

Ensures CLI interactive mode and Runner headless mode load skills, plugins, agents, rules, and prompt templates **identically** — so running without a runner gives ~90% functionality.

## Problem

The CLI and Runner had divergent loading paths:

| Feature | CLI Before | Runner Before |
|---|---|---|
| `~/.pizzapi/skills/` | ✅ | ❌ |
| `~/.pizzapi/agents/` as skills | ❌ | ✅ |
| `<cwd>/.agents/skills/` | ❌ | ✅ |
| `<cwd>/.agents/agents/` | ❌ | ✅ |
| Plugin skill paths | ❌ | ✅ |
| Prompt template paths | ❌ | ✅ |
| `AGENTS.md` from cwd | ✅ (duplicated) | ❌ (upstream only) |

## Solution

### New shared functions in `skills.ts`

- **`buildSkillPaths(cwd, configSkills)`** — Unified replacement for `buildInteractiveSkillPaths` / `buildWorkerSkillPaths`. Includes all 7 directories from both old functions.
- **`buildPromptTemplatePaths(cwd)`** — Extracted from the worker's inline function. Both CLI and worker now use it.
- **`loadProjectAgentFiles(cwd)`** — Loads `AGENTS.md` + `.agents/*.md` from cwd.
- **`createAgentsFilesOverride(cwd)`** — Returns a deduplicating override function for `DefaultResourceLoader`, or `null` if nothing to add.

### Entry point changes

- **CLI (`index.ts`)**: Now uses `buildSkillPaths`, adds `getPluginSkillPaths`, adds `additionalPromptTemplatePaths`, uses shared `createAgentsFilesOverride`.
- **Worker (`worker.ts`)**: Now uses `buildSkillPaths`, shared `buildPromptTemplatePaths`, shared `createAgentsFilesOverride` (which adds `AGENTS.md` loading it was missing).

### After

| Feature | CLI | Runner |
|---|---|---|
| `~/.pizzapi/skills/` | ✅ | ✅ |
| `~/.pizzapi/agents/` as skills | ✅ | ✅ |
| `<cwd>/.agents/skills/` | ✅ | ✅ |
| `<cwd>/.agents/agents/` | ✅ | ✅ |
| Plugin skill paths | ✅ | ✅ |
| Prompt template paths | ✅ | ✅ |
| `AGENTS.md` from cwd | ✅ (deduped) | ✅ (deduped) |
| `.agents/*.md` from cwd | ✅ | ✅ |

## Tests

- 55 tests passing in `skills.test.ts`
- 928 total tests passing across 59 files
- New tests for `buildSkillPaths`, `buildPromptTemplatePaths`, deprecated wrapper parity, `loadProjectAgentFiles`, `createAgentsFilesOverride` deduplication
