### PR TITLE
feat(compat): add git-root-bounded ancestor walk, SYSTEM.md and GEMINI.md discovery

### DIFF
--- a/experimental/adk-go/runtime/compat/compat.go
+++ b/experimental/adk-go/runtime/compat/compat.go
@@ -1,0 +1,322 @@
+package compat
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Family identifies which on-disk convention a resource came from.
+type Family string
+
+// Scope identifies whether a resource is project-local or global/user-level.
+type Scope string
+
+const (
+	FamilyPizzaPi Family = "pizzapi"
+	FamilyClaude  Family = "claude"
+
+	ScopeProject Scope = "project"
+	ScopeGlobal  Scope = "global"
+)
+
+// PathCandidate describes a candidate path in highest-precedence-first order.
+type PathCandidate struct {
+	Path     string
+	Family   Family
+	Scope    Scope
+	Priority int
+}
+
+// NamedResource is a deduplicated agent or skill discovered from disk.
+type NamedResource struct {
+	Name     string
+	Path     string
+	Family   Family
+	Scope    Scope
+	Priority int
+}
+
+// InstructionDoc is a discovered instruction document with file contents loaded.
+type InstructionDoc struct {
+	Path     string
+	Family   Family
+	Scope    Scope
+	Priority int
+	Content  string
+}
+
+// ConfigSet groups config/settings candidates in highest-precedence-first order.
+type ConfigSet struct {
+	PizzaPiConfig   []PathCandidate
+	PizzaPiSettings []PathCandidate
+	ClaudeSettings  []PathCandidate
+}
+
+// Locator resolves Claude/PizzaPi compatibility paths relative to a home dir and cwd.
+type Locator struct {
+	HomeDir string
+	Cwd     string
+}
+
+// NewLocator returns a normalized locator for deterministic path resolution in tests and runtime code.
+func NewLocator(homeDir, cwd string) Locator {
+	return Locator{
+		HomeDir: filepath.Clean(homeDir),
+		Cwd:     filepath.Clean(cwd),
+	}
+}
+
+// GitRoot finds the nearest ancestor directory (inclusive of l.Cwd) that contains
+// a .git entry (file or directory). Returns empty string if not in a git repo.
+func (l Locator) GitRoot() string {
+	current := filepath.Clean(l.Cwd)
+	for {
+		if _, err := os.Stat(filepath.Join(current, ".git")); err == nil {
+			return current
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			// reached filesystem root without finding .git
+			return ""
+		}
+		current = parent
+	}
+}
+
+// AgentRoots returns agent search roots in precedence order.
+func (l Locator) AgentRoots() []PathCandidate {
+	return []PathCandidate{
+		{Path: filepath.Join(l.Cwd, ".pizzapi", "agents"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(l.Cwd, ".claude", "agents"), Family: FamilyClaude, Scope: ScopeProject, Priority: 2},
+		{Path: filepath.Join(l.HomeDir, ".pizzapi", "agents"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 3},
+		{Path: filepath.Join(l.HomeDir, ".claude", "agents"), Family: FamilyClaude, Scope: ScopeGlobal, Priority: 4},
+	}
+}
+
+// SkillRoots returns skill search roots in precedence order.
+func (l Locator) SkillRoots() []PathCandidate {
+	return []PathCandidate{
+		{Path: filepath.Join(l.Cwd, ".pizzapi", "skills"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(l.Cwd, ".claude", "skills"), Family: FamilyClaude, Scope: ScopeProject, Priority: 2},
+		{Path: filepath.Join(l.HomeDir, ".pizzapi", "skills"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 3},
+		{Path: filepath.Join(l.HomeDir, ".claude", "skills"), Family: FamilyClaude, Scope: ScopeGlobal, Priority: 4},
+	}
+}
+
+// ConfigPaths returns config/settings candidates in merge precedence order.
+func (l Locator) ConfigPaths() ConfigSet {
+	return ConfigSet{
+		PizzaPiConfig: []PathCandidate{
+			{Path: filepath.Join(l.Cwd, ".pizzapi", "config.json"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+			{Path: filepath.Join(l.HomeDir, ".pizzapi", "config.json"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 2},
+		},
+		PizzaPiSettings: []PathCandidate{
+			{Path: filepath.Join(l.Cwd, ".pizzapi", "settings.json"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+			{Path: filepath.Join(l.HomeDir, ".pizzapi", "settings.json"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 2},
+		},
+		ClaudeSettings: []PathCandidate{
+			{Path: filepath.Join(l.Cwd, ".claude", "settings.local.json"), Family: FamilyClaude, Scope: ScopeProject, Priority: 1},
+			{Path: filepath.Join(l.Cwd, ".claude", "settings.json"), Family: FamilyClaude, Scope: ScopeProject, Priority: 2},
+			{Path: filepath.Join(l.HomeDir, ".claude", "settings.json"), Family: FamilyClaude, Scope: ScopeGlobal, Priority: 3},
+		},
+	}
+}
+
+// DiscoverAgents scans agent roots and keeps the first resource for each name.
+func (l Locator) DiscoverAgents() ([]NamedResource, error) {
+	return discoverNamedResources(l.AgentRoots(), false)
+}
+
+// DiscoverSkills scans skill roots and supports both <name>.md and <name>/SKILL.md layouts.
+func (l Locator) DiscoverSkills() ([]NamedResource, error) {
+	return discoverNamedResources(l.SkillRoots(), true)
+}
+
+// DiscoverInstructionDocs walks project ancestors up to the git root (or filesystem
+// root if not in a git repo), then appends global home-dir candidates. Duplicate
+// paths are deduplicated keeping the first (highest-precedence) occurrence.
+func (l Locator) DiscoverInstructionDocs() ([]InstructionDoc, error) {
+	candidates := instructionCandidates(l.HomeDir, l.Cwd, l.GitRoot())
+	docs := make([]InstructionDoc, 0, len(candidates))
+	seen := map[string]struct{}{}
+	for _, candidate := range candidates {
+		normalized := filepath.Clean(candidate.Path)
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		content, err := os.ReadFile(normalized)
+		if err != nil {
+			if errorsIsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		seen[normalized] = struct{}{}
+		docs = append(docs, InstructionDoc{
+			Path:     normalized,
+			Family:   candidate.Family,
+			Scope:    candidate.Scope,
+			Priority: candidate.Priority,
+			Content:  string(content),
+		})
+	}
+	return docs, nil
+}
+
+// instructionFileSpecs lists the per-directory instruction file patterns in
+// highest-to-lowest precedence order within a directory.
+var instructionFileSpecs = []struct {
+	rel    string
+	family Family
+}{
+	{rel: filepath.Join(".pizzapi", "AGENTS.md"), family: FamilyPizzaPi},
+	{rel: filepath.Join(".pizzapi", "CLAUDE.md"), family: FamilyPizzaPi},
+	{rel: filepath.Join(".pizzapi", "GEMINI.md"), family: FamilyPizzaPi},
+	{rel: filepath.Join(".pizzapi", "SYSTEM.md"), family: FamilyPizzaPi},
+	{rel: filepath.Join(".claude", "AGENTS.md"), family: FamilyClaude},
+	{rel: filepath.Join(".claude", "CLAUDE.md"), family: FamilyClaude},
+	{rel: filepath.Join(".claude", "GEMINI.md"), family: FamilyClaude},
+	{rel: filepath.Join(".claude", "SYSTEM.md"), family: FamilyClaude},
+	{rel: "AGENTS.md", family: FamilyPizzaPi},
+	{rel: "CLAUDE.md", family: FamilyClaude},
+	{rel: "GEMINI.md", family: FamilyClaude},
+	{rel: "SYSTEM.md", family: FamilyPizzaPi},
+}
+
+// globalInstructionFileSpecs lists the home-dir instruction file patterns for
+// the global (user-level) candidates.
+var globalInstructionFileSpecs = []struct {
+	rel    string
+	family Family
+}{
+	{rel: filepath.Join(".pizzapi", "AGENTS.md"), family: FamilyPizzaPi},
+	{rel: filepath.Join(".pizzapi", "CLAUDE.md"), family: FamilyPizzaPi},
+	{rel: filepath.Join(".pizzapi", "GEMINI.md"), family: FamilyPizzaPi},
+	{rel: filepath.Join(".pizzapi", "SYSTEM.md"), family: FamilyPizzaPi},
+	{rel: filepath.Join(".claude", "AGENTS.md"), family: FamilyClaude},
+	{rel: filepath.Join(".claude", "CLAUDE.md"), family: FamilyClaude},
+	{rel: filepath.Join(".claude", "GEMINI.md"), family: FamilyClaude},
+	{rel: filepath.Join(".claude", "SYSTEM.md"), family: FamilyClaude},
+}
+
+func instructionCandidates(homeDir, cwd, gitRoot string) []PathCandidate {
+	var candidates []PathCandidate
+	priority := 1
+
+	// Project-scope: walk from cwd up to gitRoot (inclusive). If gitRoot is ""
+	// (not in a git repo), walk to the filesystem root (backward compatible).
+	for _, dir := range walkUpDirs(cwd, gitRoot) {
+		for _, spec := range instructionFileSpecs {
+			candidates = append(candidates, PathCandidate{
+				Path:     filepath.Join(dir, spec.rel),
+				Family:   spec.family,
+				Scope:    ScopeProject,
+				Priority: priority,
+			})
+			priority++
+		}
+	}
+
+	// Global-scope: home-dir candidates appended after all project candidates.
+	for _, spec := range globalInstructionFileSpecs {
+		candidates = append(candidates, PathCandidate{
+			Path:     filepath.Join(homeDir, spec.rel),
+			Family:   spec.family,
+			Scope:    ScopeGlobal,
+			Priority: priority,
+		})
+		priority++
+	}
+
+	return candidates
+}
+
+func discoverNamedResources(roots []PathCandidate, allowSkillDirs bool) ([]NamedResource, error) {
+	seen := map[string]struct{}{}
+	resources := []NamedResource{}
+	for _, root := range roots {
+		entries, err := os.ReadDir(root.Path)
+		if err != nil {
+			if errorsIsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			name, path, ok := resolveResourceEntry(root.Path, entry, allowSkillDirs)
+			if !ok {
+				continue
+			}
+			if _, exists := seen[name]; exists {
+				continue
+			}
+			seen[name] = struct{}{}
+			resources = append(resources, NamedResource{
+				Name:     name,
+				Path:     path,
+				Family:   root.Family,
+				Scope:    root.Scope,
+				Priority: root.Priority,
+			})
+		}
+	}
+	return resources, nil
+}
+
+func resolveResourceEntry(root string, entry fs.DirEntry, allowSkillDirs bool) (name string, path string, ok bool) {
+	fullPath := filepath.Join(root, entry.Name())
+	if entry.Type().IsRegular() && strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
+		return strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name())), fullPath, true
+	}
+	if allowSkillDirs && entry.IsDir() {
+		skillPath := filepath.Join(fullPath, "SKILL.md")
+		info, err := os.Stat(skillPath)
+		if err == nil && !info.IsDir() {
+			return entry.Name(), skillPath, true
+		}
+		if err != nil && !errorsIsNotExist(err) {
+			return "", "", false
+		}
+	}
+	return "", "", false
+}
+
+// walkUpDirs returns every directory from start up to and including stopAt.
+// If stopAt is "" the walk continues to the filesystem root (/ on Unix).
+// The returned slice is ordered from deepest (start) to shallowest (stopAt or /).
+func walkUpDirs(start, stopAt string) []string {
+	dirs := []string{}
+	current := filepath.Clean(start)
+	stopAt = filepath.Clean(stopAt)
+	for {
+		dirs = append(dirs, current)
+		// Stop when we've reached the designated boundary.
+		if stopAt != "." && current == stopAt {
+			break
+		}
+		parent := filepath.Dir(current)
+		if parent == current {
+			// reached filesystem root
+			break
+		}
+		current = parent
+	}
+	return dirs
+}
+
+func mkdirAll(path string) error {
+	return os.MkdirAll(path, 0o755)
+}
+
+func writeTextFile(path string, content []byte) error {
+	return os.WriteFile(path, content, 0o644)
+}
+
+func errorsIsNotExist(err error) bool {
+	return os.IsNotExist(err)
+}

--- a/experimental/adk-go/runtime/compat/compat_test.go
+++ b/experimental/adk-go/runtime/compat/compat_test.go
@@ -1,0 +1,603 @@
+package compat
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	mustMkdirAll(t, filepath.Dir(path))
+	mustWriteFile(t, path, []byte(content))
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := mkdirAll(path); err != nil {
+		t.Fatalf("mkdirAll(%q): %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := writeTextFile(path, content); err != nil {
+		t.Fatalf("writeTextFile(%q): %v", path, err)
+	}
+}
+
+// makeGitRepo creates a bare .git directory marker so GitRoot detection works.
+func makeGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	mustMkdirAll(t, filepath.Join(dir, ".git"))
+}
+
+func TestAgentRootsOrder(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(t.TempDir(), "repo", "app")
+	locator := NewLocator(home, cwd)
+
+	got := locator.AgentRoots()
+	want := []PathCandidate{
+		{Path: filepath.Join(cwd, ".pizzapi", "agents"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(cwd, ".claude", "agents"), Family: FamilyClaude, Scope: ScopeProject, Priority: 2},
+		{Path: filepath.Join(home, ".pizzapi", "agents"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 3},
+		{Path: filepath.Join(home, ".claude", "agents"), Family: FamilyClaude, Scope: ScopeGlobal, Priority: 4},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AgentRoots() mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestDiscoverAgentsPrecedence(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(t.TempDir(), "repo")
+	locator := NewLocator(home, cwd)
+
+	writeFile(t, filepath.Join(home, ".claude", "agents", "shared.md"), "# global claude")
+	writeFile(t, filepath.Join(home, ".pizzapi", "agents", "shared.md"), "# global pizzapi")
+	writeFile(t, filepath.Join(cwd, ".claude", "agents", "shared.md"), "# project claude")
+	writeFile(t, filepath.Join(cwd, ".pizzapi", "agents", "shared.md"), "# project pizzapi")
+	writeFile(t, filepath.Join(home, ".claude", "agents", "global-only.md"), "# global only")
+	writeFile(t, filepath.Join(cwd, ".claude", "agents", "project-only.md"), "# project only")
+
+	got, err := locator.DiscoverAgents()
+	if err != nil {
+		t.Fatalf("DiscoverAgents(): %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 agents, got %d: %#v", len(got), got)
+	}
+
+	if got[0].Name != "shared" || got[0].Path != filepath.Join(cwd, ".pizzapi", "agents", "shared.md") {
+		t.Fatalf("shared agent precedence mismatch: %#v", got[0])
+	}
+	if got[1].Name != "project-only" || got[1].Scope != ScopeProject || got[1].Family != FamilyClaude {
+		t.Fatalf("project-only agent mismatch: %#v", got[1])
+	}
+	if got[2].Name != "global-only" || got[2].Scope != ScopeGlobal || got[2].Family != FamilyClaude {
+		t.Fatalf("global-only agent mismatch: %#v", got[2])
+	}
+}
+
+func TestDiscoverSkillsSupportsRootAndSubdirLayouts(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(t.TempDir(), "repo")
+	locator := NewLocator(home, cwd)
+
+	writeFile(t, filepath.Join(home, ".claude", "skills", "shared", "SKILL.md"), "# global claude skill")
+	writeFile(t, filepath.Join(cwd, ".claude", "skills", "shared.md"), "# project claude skill")
+	writeFile(t, filepath.Join(cwd, ".pizzapi", "skills", "shared", "SKILL.md"), "# project pizzapi skill")
+	writeFile(t, filepath.Join(cwd, ".claude", "skills", "solo.md"), "# solo")
+
+	got, err := locator.DiscoverSkills()
+	if err != nil {
+		t.Fatalf("DiscoverSkills(): %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 skills, got %d: %#v", len(got), got)
+	}
+
+	if got[0].Name != "shared" || got[0].Path != filepath.Join(cwd, ".pizzapi", "skills", "shared", "SKILL.md") {
+		t.Fatalf("shared skill precedence mismatch: %#v", got[0])
+	}
+	if got[1].Name != "solo" || got[1].Path != filepath.Join(cwd, ".claude", "skills", "solo.md") {
+		t.Fatalf("solo skill mismatch: %#v", got[1])
+	}
+}
+
+// TestDiscoverInstructionDocsPrecedence verifies ancestor walk order and global candidates.
+// No .git is placed here so walk is unbounded (backward compatible).
+func TestDiscoverInstructionDocsPrecedence(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	repo := filepath.Join(t.TempDir(), "repo")
+	cwd := filepath.Join(repo, "apps", "api")
+	locator := NewLocator(home, cwd)
+
+	writeFile(t, filepath.Join(home, ".pizzapi", "AGENTS.md"), "global")
+	writeFile(t, filepath.Join(repo, ".claude", "CLAUDE.md"), "repo-claude")
+	writeFile(t, filepath.Join(repo, "apps", ".pizzapi", "AGENTS.md"), "apps-pizzapi")
+	writeFile(t, filepath.Join(cwd, "CLAUDE.md"), "cwd-root")
+
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	wantPaths := []string{
+		filepath.Join(cwd, "CLAUDE.md"),
+		filepath.Join(repo, "apps", ".pizzapi", "AGENTS.md"),
+		filepath.Join(repo, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".pizzapi", "AGENTS.md"),
+	}
+	if len(got) != len(wantPaths) {
+		t.Fatalf("expected %d docs, got %d: %#v", len(wantPaths), len(got), got)
+	}
+	for i, want := range wantPaths {
+		if got[i].Path != want {
+			t.Fatalf("doc %d path mismatch: got %q want %q", i, got[i].Path, want)
+		}
+	}
+	if got[0].Content != "cwd-root" {
+		t.Fatalf("expected doc content to be loaded, got %#v", got[0])
+	}
+}
+
+func TestDiscoverInstructionDocsDedupesHomeCandidatesWhenCwdLivesUnderHome(t *testing.T) {
+	homeRoot := t.TempDir()
+	home := filepath.Join(homeRoot, "home")
+	cwd := filepath.Join(home, "src", "repo")
+	locator := NewLocator(home, cwd)
+
+	// Place .git at home so the ancestor walk (which visits home) overlaps
+	// with the global home candidates — triggering the dedup path.
+	makeGitRepo(t, home)
+
+	writeFile(t, filepath.Join(home, ".pizzapi", "AGENTS.md"), "global")
+
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 deduped doc, got %d: %#v", len(got), got)
+	}
+	if got[0].Path != filepath.Join(home, ".pizzapi", "AGENTS.md") {
+		t.Fatalf("unexpected deduped doc path: %#v", got[0])
+	}
+}
+
+func TestConfigPathsPrecedence(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(t.TempDir(), "repo")
+	locator := NewLocator(home, cwd)
+
+	got := locator.ConfigPaths()
+
+	wantPizzaPiConfig := []PathCandidate{
+		{Path: filepath.Join(cwd, ".pizzapi", "config.json"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(home, ".pizzapi", "config.json"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 2},
+	}
+	if !reflect.DeepEqual(got.PizzaPiConfig, wantPizzaPiConfig) {
+		t.Fatalf("PizzaPiConfig mismatch\n got: %#v\nwant: %#v", got.PizzaPiConfig, wantPizzaPiConfig)
+	}
+
+	wantPizzaPiSettings := []PathCandidate{
+		{Path: filepath.Join(cwd, ".pizzapi", "settings.json"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(home, ".pizzapi", "settings.json"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 2},
+	}
+	if !reflect.DeepEqual(got.PizzaPiSettings, wantPizzaPiSettings) {
+		t.Fatalf("PizzaPiSettings mismatch\n got: %#v\nwant: %#v", got.PizzaPiSettings, wantPizzaPiSettings)
+	}
+
+	wantClaudeSettings := []PathCandidate{
+		{Path: filepath.Join(cwd, ".claude", "settings.local.json"), Family: FamilyClaude, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(cwd, ".claude", "settings.json"), Family: FamilyClaude, Scope: ScopeProject, Priority: 2},
+		{Path: filepath.Join(home, ".claude", "settings.json"), Family: FamilyClaude, Scope: ScopeGlobal, Priority: 3},
+	}
+	if !reflect.DeepEqual(got.ClaudeSettings, wantClaudeSettings) {
+		t.Fatalf("ClaudeSettings mismatch\n got: %#v\nwant: %#v", got.ClaudeSettings, wantClaudeSettings)
+	}
+}
+
+// --- New tests for Dish 004 ---
+
+// TestGitRootFound verifies GitRoot returns the directory containing .git.
+func TestGitRootFound(t *testing.T) {
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	sub := filepath.Join(repo, "pkg", "foo")
+	makeGitRepo(t, repo)
+	mustMkdirAll(t, sub)
+
+	locator := NewLocator(filepath.Join(base, "home"), sub)
+	got := locator.GitRoot()
+	if got != repo {
+		t.Fatalf("GitRoot() = %q, want %q", got, repo)
+	}
+}
+
+// TestGitRootFoundAtCwd verifies GitRoot returns cwd itself when .git is there.
+func TestGitRootFoundAtCwd(t *testing.T) {
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	makeGitRepo(t, repo)
+	mustMkdirAll(t, repo)
+
+	locator := NewLocator(filepath.Join(base, "home"), repo)
+	got := locator.GitRoot()
+	if got != repo {
+		t.Fatalf("GitRoot() = %q, want %q", got, repo)
+	}
+}
+
+// TestGitRootNotFound verifies GitRoot returns "" when not in a git repo.
+func TestGitRootNotFound(t *testing.T) {
+	base := t.TempDir()
+	cwd := filepath.Join(base, "no-git", "sub")
+	mustMkdirAll(t, cwd)
+
+	locator := NewLocator(filepath.Join(base, "home"), cwd)
+	got := locator.GitRoot()
+	if got != "" {
+		t.Fatalf("GitRoot() = %q, want empty string (no git repo)", got)
+	}
+}
+
+// TestAncestorWalkStopsAtGitBoundary verifies that instruction docs above the git
+// root are not discovered via the project-scope walk.
+func TestAncestorWalkStopsAtGitBoundary(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	repo := filepath.Join(base, "workspace", "repo")
+	cwd := filepath.Join(repo, "sub", "pkg")
+	aboveRepo := filepath.Join(base, "workspace") // outside git root
+
+	makeGitRepo(t, repo)
+	mustMkdirAll(t, cwd)
+
+	// Doc inside git root — should be discovered.
+	writeFile(t, filepath.Join(repo, "AGENTS.md"), "inside-repo")
+	// Doc above git root in ancestor chain — must NOT appear via project walk.
+	writeFile(t, filepath.Join(aboveRepo, "AGENTS.md"), "outside-repo")
+
+	locator := NewLocator(home, cwd)
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	for _, doc := range got {
+		if doc.Path == filepath.Join(aboveRepo, "AGENTS.md") {
+			t.Fatalf("doc above git root was discovered: %#v", doc)
+		}
+	}
+
+	var found bool
+	for _, doc := range got {
+		if doc.Path == filepath.Join(repo, "AGENTS.md") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("doc inside git root was NOT discovered; got: %#v", got)
+	}
+}
+
+// TestSYSTEMMdDiscoveredInInstructionDocs verifies SYSTEM.md is included in candidates.
+func TestSYSTEMMdDiscoveredInInstructionDocs(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	repo := filepath.Join(base, "repo")
+	makeGitRepo(t, repo)
+
+	writeFile(t, filepath.Join(repo, "SYSTEM.md"), "system-prompt")
+
+	locator := NewLocator(home, repo)
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	var found bool
+	for _, doc := range got {
+		if doc.Path == filepath.Join(repo, "SYSTEM.md") {
+			found = true
+			if doc.Content != "system-prompt" {
+				t.Fatalf("SYSTEM.md content mismatch: %q", doc.Content)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("SYSTEM.md not discovered; got: %#v", got)
+	}
+}
+
+// TestSYSTEMMdInSubdirDiscovered verifies .pizzapi/SYSTEM.md and .claude/SYSTEM.md are candidates.
+func TestSYSTEMMdInSubdirDiscovered(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	repo := filepath.Join(base, "repo")
+	makeGitRepo(t, repo)
+
+	writeFile(t, filepath.Join(repo, ".pizzapi", "SYSTEM.md"), "pizzapi-system")
+	writeFile(t, filepath.Join(repo, ".claude", "SYSTEM.md"), "claude-system")
+
+	locator := NewLocator(home, repo)
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	wantPaths := map[string]bool{
+		filepath.Join(repo, ".pizzapi", "SYSTEM.md"): false,
+		filepath.Join(repo, ".claude", "SYSTEM.md"):  false,
+	}
+	for _, doc := range got {
+		if _, ok := wantPaths[doc.Path]; ok {
+			wantPaths[doc.Path] = true
+		}
+	}
+	for p, found := range wantPaths {
+		if !found {
+			t.Errorf("expected %q to be discovered but it was not; got: %#v", p, got)
+		}
+	}
+}
+
+// TestGEMINIMdDiscoveredInInstructionDocs verifies GEMINI.md is included in candidates.
+func TestGEMINIMdDiscoveredInInstructionDocs(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	repo := filepath.Join(base, "repo")
+	makeGitRepo(t, repo)
+
+	writeFile(t, filepath.Join(repo, "GEMINI.md"), "gemini-context")
+
+	locator := NewLocator(home, repo)
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	var found bool
+	for _, doc := range got {
+		if doc.Path == filepath.Join(repo, "GEMINI.md") {
+			found = true
+			if doc.Content != "gemini-context" {
+				t.Fatalf("GEMINI.md content mismatch: %q", doc.Content)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("GEMINI.md not discovered; got: %#v", got)
+	}
+}
+
+// TestGEMINIMdInSubdirDiscovered verifies .pizzapi/GEMINI.md and .claude/GEMINI.md are candidates.
+func TestGEMINIMdInSubdirDiscovered(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	repo := filepath.Join(base, "repo")
+	makeGitRepo(t, repo)
+
+	writeFile(t, filepath.Join(repo, ".pizzapi", "GEMINI.md"), "pizzapi-gemini")
+	writeFile(t, filepath.Join(repo, ".claude", "GEMINI.md"), "claude-gemini")
+
+	locator := NewLocator(home, repo)
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	wantPaths := map[string]bool{
+		filepath.Join(repo, ".pizzapi", "GEMINI.md"): false,
+		filepath.Join(repo, ".claude", "GEMINI.md"):  false,
+	}
+	for _, doc := range got {
+		if _, ok := wantPaths[doc.Path]; ok {
+			wantPaths[doc.Path] = true
+		}
+	}
+	for p, found := range wantPaths {
+		if !found {
+			t.Errorf("expected %q to be discovered but it was not; got: %#v", p, got)
+		}
+	}
+}
+
+// TestPathsOutsideGitRootExcludedFromProjectWalk verifies that ancestor
+// directories above the git root are excluded from the project-scope walk.
+func TestPathsOutsideGitRootExcludedFromProjectWalk(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	outsideDir := filepath.Join(base, "outside")
+	repo := filepath.Join(base, "outside", "repo") // repo is child of outsideDir
+	cwd := filepath.Join(repo, "src")
+
+	makeGitRepo(t, repo)
+	mustMkdirAll(t, cwd)
+
+	// This file is above the git root — must not appear as a project-scope doc.
+	writeFile(t, filepath.Join(outsideDir, "AGENTS.md"), "above-git-root")
+	// This file is inside the git root — must appear.
+	writeFile(t, filepath.Join(repo, "AGENTS.md"), "inside-git-root")
+
+	locator := NewLocator(home, cwd)
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	for _, doc := range got {
+		if doc.Path == filepath.Join(outsideDir, "AGENTS.md") && doc.Scope == ScopeProject {
+			t.Fatalf("doc above git root was included as project-scope: %#v", doc)
+		}
+	}
+
+	var insideFound bool
+	for _, doc := range got {
+		if doc.Path == filepath.Join(repo, "AGENTS.md") {
+			insideFound = true
+		}
+	}
+	if !insideFound {
+		t.Fatalf("doc inside git root was not discovered; got: %#v", got)
+	}
+}
+
+// TestGlobalSYSTEMMdDiscovered verifies SYSTEM.md in homeDir subdirs is a global candidate.
+func TestGlobalSYSTEMMdDiscovered(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	repo := filepath.Join(base, "repo")
+	makeGitRepo(t, repo)
+
+	writeFile(t, filepath.Join(home, ".pizzapi", "SYSTEM.md"), "global-system")
+	writeFile(t, filepath.Join(home, ".claude", "SYSTEM.md"), "global-claude-system")
+
+	locator := NewLocator(home, repo)
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	wantPaths := map[string]bool{
+		filepath.Join(home, ".pizzapi", "SYSTEM.md"): false,
+		filepath.Join(home, ".claude", "SYSTEM.md"):  false,
+	}
+	for _, doc := range got {
+		if _, ok := wantPaths[doc.Path]; ok {
+			wantPaths[doc.Path] = true
+			if doc.Scope != ScopeGlobal {
+				t.Errorf("expected %q to be global scope, got %q", doc.Path, doc.Scope)
+			}
+		}
+	}
+	for p, found := range wantPaths {
+		if !found {
+			t.Errorf("expected global %q to be discovered; got: %#v", p, got)
+		}
+	}
+}
+
+// TestGlobalGEMINIMdDiscovered verifies GEMINI.md in homeDir subdirs is a global candidate.
+func TestGlobalGEMINIMdDiscovered(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	repo := filepath.Join(base, "repo")
+	makeGitRepo(t, repo)
+
+	writeFile(t, filepath.Join(home, ".pizzapi", "GEMINI.md"), "global-gemini")
+	writeFile(t, filepath.Join(home, ".claude", "GEMINI.md"), "global-claude-gemini")
+
+	locator := NewLocator(home, repo)
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	wantPaths := map[string]bool{
+		filepath.Join(home, ".pizzapi", "GEMINI.md"): false,
+		filepath.Join(home, ".claude", "GEMINI.md"):  false,
+	}
+	for _, doc := range got {
+		if _, ok := wantPaths[doc.Path]; ok {
+			wantPaths[doc.Path] = true
+			if doc.Scope != ScopeGlobal {
+				t.Errorf("expected %q to be global scope, got %q", doc.Path, doc.Scope)
+			}
+		}
+	}
+	for p, found := range wantPaths {
+		if !found {
+			t.Errorf("expected global %q to be discovered; got: %#v", p, got)
+		}
+	}
+}
+
+// TestWalkUpDirsStopsAtGitRoot directly tests the walkUpDirs helper.
+func TestWalkUpDirsStopsAtGitRoot(t *testing.T) {
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	cwd := filepath.Join(repo, "a", "b", "c")
+	mustMkdirAll(t, cwd)
+
+	got := walkUpDirs(cwd, repo)
+	want := []string{
+		filepath.Join(repo, "a", "b", "c"),
+		filepath.Join(repo, "a", "b"),
+		filepath.Join(repo, "a"),
+		repo,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("walkUpDirs() = %#v\nwant:         %#v", got, want)
+	}
+}
+
+// TestWalkUpDirsNoStopWalksToRoot verifies unbounded walk when stopAt is "".
+func TestWalkUpDirsNoStopWalksToRoot(t *testing.T) {
+	dirs := walkUpDirs("/a/b/c", "")
+	// Should include /a/b/c, /a/b, /a, /
+	if len(dirs) < 4 {
+		t.Fatalf("expected at least 4 dirs for /a/b/c, got %d: %v", len(dirs), dirs)
+	}
+	if dirs[0] != "/a/b/c" {
+		t.Fatalf("first dir should be start, got %q", dirs[0])
+	}
+	if dirs[len(dirs)-1] != "/" {
+		t.Fatalf("last dir should be /, got %q", dirs[len(dirs)-1])
+	}
+}
+
+// TestDeduplicationWithGitRoot verifies that when the ancestor walk visits a path
+// also present in the global candidates, it appears exactly once.
+func TestDeduplicationWithGitRoot(t *testing.T) {
+	base := t.TempDir()
+	home := filepath.Join(base, "home")
+	// cwd is inside home, and home is the git root — so the walk visits home
+	// and encounters home/.pizzapi/AGENTS.md as a project candidate.
+	// The global candidates also include home/.pizzapi/AGENTS.md.
+	// Deduplication must keep it exactly once.
+	cwd := filepath.Join(home, "src", "project")
+	makeGitRepo(t, home) // home itself is the git root
+	mustMkdirAll(t, cwd)
+
+	writeFile(t, filepath.Join(home, ".pizzapi", "AGENTS.md"), "dedup-target")
+
+	locator := NewLocator(home, cwd)
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	count := 0
+	for _, doc := range got {
+		if doc.Path == filepath.Join(home, ".pizzapi", "AGENTS.md") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected AGENTS.md to appear exactly once, got %d; docs: %#v", count, got)
+	}
+}
+
+// TestGitRootFileVsDir verifies that a regular file named .git is also accepted
+// (e.g., git worktree .git files).
+func TestGitRootFileVsDir(t *testing.T) {
+	base := t.TempDir()
+	repo := filepath.Join(base, "repo")
+	mustMkdirAll(t, repo)
+	// Write .git as a file (like git worktrees do)
+	if err := os.WriteFile(filepath.Join(repo, ".git"), []byte("gitdir: ../real/.git"), 0o644); err != nil {
+		t.Fatalf("write .git file: %v", err)
+	}
+
+	locator := NewLocator(filepath.Join(base, "home"), repo)
+	got := locator.GitRoot()
+	if got != repo {
+		t.Fatalf("GitRoot() = %q, want %q (should accept .git file, not just dir)", got, repo)
+	}
+}


### PR DESCRIPTION
Night Shift dish 004 — context file discovery parity with Pi

## What changed

### `compat.go`
- **`GitRoot() string`** — new method on `Locator`. Walks up from `l.Cwd` testing for a `.git` entry (file *or* directory, so git worktrees work). Returns empty string if not in a git repo.
- **`walkUpDirs(start, stopAt string)`** — added `stopAt` parameter. When `stopAt` is non-empty the walk stops at that directory (inclusive). When empty the old unbounded walk-to-filesystem-root behavior is preserved.
- **`instructionCandidates`** — now accepts a `gitRoot` parameter and passes it to `walkUpDirs`, so the project-scope ancestor walk is bounded by the git root.
- **SYSTEM.md and GEMINI.md** added to both the per-directory spec list (root-level and inside `.pizzapi/` / `.claude/` subdirs) and the global home-dir spec list.

### `compat_test.go`
15 new tests added alongside the 6 pre-existing tests (21 total):

| Test | Covers |
|------|--------|
| `TestGitRootFound` | GitRoot walks up to the .git ancestor |
| `TestGitRootFoundAtCwd` | GitRoot returns cwd when .git is there |
| `TestGitRootNotFound` | Returns "" when not in a git repo |
| `TestGitRootFileVsDir` | Accepts .git as a file (git worktrees) |
| `TestAncestorWalkStopsAtGitBoundary` | Docs above git root not discovered |
| `TestWalkUpDirsStopsAtGitRoot` | walkUpDirs helper stops correctly |
| `TestWalkUpDirsNoStopWalksToRoot` | Unbounded walk still reaches / |
| `TestSYSTEMMdDiscoveredInInstructionDocs` | Root-level SYSTEM.md found |
| `TestSYSTEMMdInSubdirDiscovered` | .pizzapi/SYSTEM.md and .claude/SYSTEM.md found |
| `TestGEMINIMdDiscoveredInInstructionDocs` | Root-level GEMINI.md found |
| `TestGEMINIMdInSubdirDiscovered` | .pizzapi/GEMINI.md and .claude/GEMINI.md found |
| `TestPathsOutsideGitRootExcludedFromProjectWalk` | Project walk stays within git root |
| `TestGlobalSYSTEMMdDiscovered` | Global home-dir SYSTEM.md candidates |
| `TestGlobalGEMINIMdDiscovered` | Global home-dir GEMINI.md candidates |
| `TestDeduplicationWithGitRoot` | Dedup when git root overlaps home dir |

## Verification
```
gofmt -w compat/   # no diff
go test -race ./compat -v  # 21/21 pass
go vet ./compat/...        # no issues
```