### PR TITLE
Fix ask-user-question stepper crash on prompt updates

### DIFF
--- a/packages/ui/src/components/ai-elements/multiple-choice.test.tsx
+++ b/packages/ui/src/components/ai-elements/multiple-choice.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { render, fireEvent, cleanup } from "@testing-library/react";
+import React from "react";
+
+const win = new Window({ url: "http://localhost/" });
+(win as unknown as { SyntaxError?: typeof SyntaxError }).SyntaxError = SyntaxError;
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+(globalThis as any).SyntaxError = win.SyntaxError;
+(globalThis as any).ResizeObserver = class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
+
+const { MultipleChoiceQuestions } = await import("./multiple-choice");
+
+describe("MultipleChoiceQuestions", () => {
+  test("does not crash when the current step becomes out of bounds after a prompt update", () => {
+    const onSubmit = () => true;
+    const promptKey = "ask-1";
+
+    const { container, rerender } = render(
+      <MultipleChoiceQuestions
+        promptKey={promptKey}
+        onSubmit={onSubmit}
+        questions={[
+          { question: "First?", options: ["A", "B"] },
+          { question: "Second?", options: ["C", "D"] },
+        ]}
+      />,
+    );
+
+    const firstOption = container.querySelector('input[type="radio"]') as HTMLInputElement | null;
+    expect(firstOption).not.toBeNull();
+    fireEvent.click(firstOption!);
+
+    const nextButton = Array.from(container.querySelectorAll("button")).find((button) =>
+      button.textContent?.includes("Next"),
+    ) as HTMLButtonElement | undefined;
+    expect(nextButton).toBeDefined();
+    fireEvent.click(nextButton!);
+
+    expect(container.textContent).toContain("Question 2 of 2");
+    expect(container.textContent).toContain("Second?");
+
+    rerender(
+      <MultipleChoiceQuestions
+        promptKey={promptKey}
+        onSubmit={onSubmit}
+        questions={[
+          { question: "First?", options: ["A", "B"] },
+        ]}
+      />,
+    );
+
+    expect(container.textContent).toContain("Question 1 of 1");
+    expect(container.textContent).toContain("First?");
+  });
+});

--- a/packages/ui/src/components/ai-elements/multiple-choice.tsx
+++ b/packages/ui/src/components/ai-elements/multiple-choice.tsx
@@ -73,6 +73,12 @@ export function MultipleChoiceQuestions({
       clearTimeout(submitTimeoutRef.current);
       submitTimeoutRef.current = null;
     }
+    return () => {
+      if (submitTimeoutRef.current !== null) {
+        clearTimeout(submitTimeoutRef.current);
+        submitTimeoutRef.current = null;
+      }
+    };
   }, [promptKey]);
 
   React.useEffect(() => {
@@ -109,9 +115,12 @@ export function MultipleChoiceQuestions({
     return true;
   };
 
+  const safeCurrentStep = questions.length > 0
+    ? Math.min(currentStep, questions.length - 1)
+    : 0;
   const allAnswered = questions.every((_, idx) => isQuestionAnswered(idx));
-  const currentQuestionAnswered = isQuestionAnswered(currentStep);
-  const isLastStep = currentStep >= questions.length - 1;
+  const currentQuestionAnswered = isQuestionAnswered(safeCurrentStep);
+  const isLastStep = safeCurrentStep >= questions.length - 1;
 
   // ── Handlers ───────────────────────────────────────────────────────────────
 
@@ -178,7 +187,7 @@ export function MultipleChoiceQuestions({
   };
 
   const handleNext = () => {
-    if (!currentQuestionAnswered) return;
+    if (!currentQuestionAnswered || questions.length === 0) return;
     setCurrentStep((prev) => Math.min(prev + 1, questions.length - 1));
   };
 
@@ -212,7 +221,8 @@ export function MultipleChoiceQuestions({
     }
 
     // Radio
-    const sel = selections.get(qIdx)!;
+    const sel = selections.get(qIdx);
+    if (sel === undefined) return "";
     return sel === q.options.length
       ? (customTexts.get(qIdx) ?? "").trim()
       : q.options[sel];
@@ -525,20 +535,20 @@ export function MultipleChoiceQuestions({
         <div className="flex size-6 items-center justify-center rounded-full bg-violet-500/15">
           <MessageCircleQuestion className="size-3.5 text-violet-400" />
         </div>
-        <span className="text-xs font-medium text-violet-300">Question {currentStep + 1} of {questions.length}</span>
+        <span className="text-xs font-medium text-violet-300">Question {questions.length > 0 ? safeCurrentStep + 1 : 0} of {questions.length}</span>
       </div>
 
       <div className="shrink-0 px-3 pt-2.5">
         <div className="h-1.5 w-full overflow-hidden rounded-full bg-violet-500/15">
           <div
             className="h-full rounded-full bg-violet-500/60 transition-all"
-            style={{ width: `${((currentStep + 1) / Math.max(questions.length, 1)) * 100}%` }}
+            style={{ width: `${((questions.length > 0 ? safeCurrentStep + 1 : 0) / Math.max(questions.length, 1)) * 100}%` }}
           />
         </div>
       </div>
 
       <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
-        {questions.length > 0 && renderQuestion(questions[currentStep]!, currentStep)}
+        {questions.length > 0 && renderQuestion(questions[safeCurrentStep]!, safeCurrentStep)}
       </div>
 
       <div className="flex shrink-0 items-center gap-2 border-t border-violet-500/15 px-3 py-2.5">
@@ -546,7 +556,7 @@ export function MultipleChoiceQuestions({
           size="sm"
           variant="outline"
           onClick={handleBack}
-          disabled={currentStep === 0 || isSubmitting}
+          disabled={safeCurrentStep === 0 || isSubmitting}
           className="gap-1.5"
         >
           <ArrowLeft className="size-3.5" />
@@ -572,7 +582,7 @@ export function MultipleChoiceQuestions({
           <Button
             size="sm"
             onClick={handleSubmit}
-            disabled={!allAnswered || isSubmitting}
+            disabled={questions.length === 0 || !allAnswered || isSubmitting}
             className={cn(
               "ml-auto gap-2",
               allAnswered && !isSubmitting


### PR DESCRIPTION
## Summary
- clamp the active ask-user-question step index before rendering so streaming prompt updates cannot index past the current questions array
- harden the multiple-choice panel against empty-question/transient prompt states and clean up submit timeout teardown
- add a regression test that rerenders the same prompt with fewer questions and verifies the UI no longer crashes

## Testing
- cd packages/ui && bun test src/components/ai-elements/multiple-choice.test.tsx src/App.hook-order.test.ts
- bun run typecheck
- bun run build