### PR TITLE
feat(go-runner): wire compat, MCP bridge, and guardrails into runtime

### DIFF
--- a/experimental/adk-go/go-runner/api_shims.go
+++ b/experimental/adk-go/go-runner/api_shims.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"sort"
+
+	bootstrap "github.com/pizzaface/pizzapi/experimental/adk-go/go-runner/internal/bootstrap"
+	reg "github.com/pizzaface/pizzapi/experimental/adk-go/go-runner/internal/registration"
+	relay "github.com/pizzaface/pizzapi/experimental/adk-go/go-runner/internal/relay"
+)
+
+type SIOClient = relay.SIOClient
+
+type SIOClientConfig = relay.SIOClientConfig
+
+var NewSIOClient = relay.NewSIOClient
+
+type RelaySession = relay.RelaySession
+
+var NewRelaySession = relay.NewRelaySession
+
+type RunnerSkill = reg.Skill
+
+type RunnerAgent = reg.Agent
+
+type registrationMetadata = reg.Metadata
+
+type sessionBootstrap = bootstrap.Session
+
+// runnerConfig aliases the bootstrap package's RunnerConfig for use in main.go.
+type runnerConfig = bootstrap.RunnerConfig
+
+func discoverRegistrationMetadata(cwd, homeDir string) (registrationMetadata, error) {
+	return reg.Discover(cwd, homeDir)
+}
+
+// resolveAgent looks up an agent by name across all compat locations and
+// returns its full markdown content.  ok is false when no agent matches.
+func resolveAgent(name, cwd, homeDir string) (content string, ok bool, err error) {
+	return reg.ResolveAgent(name, cwd, homeDir)
+}
+
+func buildSessionBootstrap(cwd, homeDir, tempDir string) (sessionBootstrap, error) {
+	return bootstrap.Build(cwd, homeDir, tempDir)
+}
+
+// loadRunnerConfig reads and merges the global and project-local PizzaPi
+// config.json files, returning a RunnerConfig with hooks and sandbox settings.
+func loadRunnerConfig(cwd, homeDir string) (runnerConfig, error) {
+	return bootstrap.LoadConfig(cwd, homeDir)
+}
+
+// marshalHooks converts the hooks map to the wire format expected by the relay.
+// Each entry becomes { "type": hookType, "matcher": matcher, "command": cmd }.
+// A nil or empty map produces an empty slice (never nil) for clean JSON serialisation.
+func marshalHooks(hooks map[string][]bootstrap.HookEntry) []any {
+	result := make([]any, 0)
+	hookTypes := make([]string, 0, len(hooks))
+	for hookType := range hooks {
+		hookTypes = append(hookTypes, hookType)
+	}
+	sort.Strings(hookTypes)
+	for _, hookType := range hookTypes {
+		for _, entry := range hooks[hookType] {
+			for _, cmd := range entry.Hooks {
+				result = append(result, map[string]any{
+					"type":    hookType,
+					"matcher": entry.Matcher,
+					"command": cmd.Command,
+				})
+			}
+		}
+	}
+	return result
+}
+
+func marshalRegistrationLists(skills []RunnerSkill, agents []RunnerAgent) ([]map[string]any, []map[string]any) {
+	skillMaps := make([]map[string]any, 0, len(skills))
+	for _, skill := range skills {
+		skillMaps = append(skillMaps, map[string]any{"name": skill.Name, "description": skill.Description, "filePath": skill.FilePath})
+	}
+	agentMaps := make([]map[string]any, 0, len(agents))
+	for _, agent := range agents {
+		agentMaps = append(agentMaps, map[string]any{"name": agent.Name, "description": agent.Description, "filePath": agent.FilePath})
+	}
+	return skillMaps, agentMaps
+}
+
+func stableRoots(roots []string) []string {
+	cp := append([]string(nil), roots...)
+	sort.Strings(cp)
+	return cp
+}
+
+func normalizeRunnerCwd(cwd string) string {
+	return reg.NormalizeCWD(cwd)
+}

--- a/experimental/adk-go/go-runner/api_shims.go
+++ b/experimental/adk-go/go-runner/api_shims.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"log"
+	"sort"
+
+	bootstrap "github.com/pizzaface/pizzapi/experimental/adk-go/go-runner/internal/bootstrap"
+	reg "github.com/pizzaface/pizzapi/experimental/adk-go/go-runner/internal/registration"
+	relay "github.com/pizzaface/pizzapi/experimental/adk-go/go-runner/internal/relay"
+)
+
+type SIOClient = relay.SIOClient
+
+type SIOClientConfig = relay.SIOClientConfig
+
+var NewSIOClient = relay.NewSIOClient
+
+type RelaySession = relay.RelaySession
+
+var NewRelaySession = relay.NewRelaySession
+
+type RunnerSkill = reg.Skill
+
+type RunnerAgent = reg.Agent
+
+type registrationMetadata = reg.Metadata
+
+type sessionBootstrap = bootstrap.Session
+
+// runnerConfig aliases the bootstrap package's RunnerConfig for use in main.go.
+type runnerConfig = bootstrap.RunnerConfig
+
+func discoverRegistrationMetadata(cwd, homeDir string) (registrationMetadata, error) {
+	return reg.Discover(cwd, homeDir)
+}
+
+// resolveAgent looks up an agent by name across all compat locations and
+// returns its full markdown content.  ok is false when no agent matches.
+func resolveAgent(name, cwd, homeDir string) (content string, ok bool, err error) {
+	return reg.ResolveAgent(name, cwd, homeDir)
+}
+
+func buildSessionBootstrap(cwd, homeDir, tempDir string) (sessionBootstrap, error) {
+	return bootstrap.Build(cwd, homeDir, tempDir)
+}
+
+// loadRunnerConfig reads and merges the global and project-local PizzaPi
+// config.json files, returning a RunnerConfig with hooks and sandbox settings.
+func loadRunnerConfig(cwd, homeDir string) (runnerConfig, error) {
+	return bootstrap.LoadConfig(cwd, homeDir)
+}
+
+// marshalHooks converts the hooks map to the wire format expected by the relay.
+// Each entry becomes { "type": hookType, "matcher": matcher, "command": cmd }.
+// A nil or empty map produces an empty slice (never nil) for clean JSON serialisation.
+func marshalHooks(hooks map[string][]bootstrap.HookEntry) []any {
+	result := make([]any, 0)
+	for hookType, entries := range hooks {
+		for _, entry := range entries {
+			for _, cmd := range entry.Hooks {
+				result = append(result, map[string]any{
+					"type":    hookType,
+					"matcher": entry.Matcher,
+					"command": cmd.Command,
+				})
+			}
+		}
+	}
+	return result
+}
+
+func marshalRegistrationLists(skills []RunnerSkill, agents []RunnerAgent) ([]map[string]any, []map[string]any) {
+	skillMaps := make([]map[string]any, 0, len(skills))
+	for _, skill := range skills {
+		skillMaps = append(skillMaps, map[string]any{"name": skill.Name, "description": skill.Description, "filePath": skill.FilePath})
+	}
+	agentMaps := make([]map[string]any, 0, len(agents))
+	for _, agent := range agents {
+		agentMaps = append(agentMaps, map[string]any{"name": agent.Name, "description": agent.Description, "filePath": agent.FilePath})
+	}
+	return skillMaps, agentMaps
+}
+
+func stableRoots(roots []string) []string {
+	cp := append([]string(nil), roots...)
+	sort.Strings(cp)
+	return cp
+}
+
+func normalizeRunnerCwd(cwd string) string {
+	return reg.NormalizeCWD(cwd)
+}
+
+func newDefaultProviderFactory() func(*log.Logger) Provider {
+	return func(logger *log.Logger) Provider { return NewClaudeCLIProvider(logger) }
+}

--- a/experimental/adk-go/go-runner/api_shims.go
+++ b/experimental/adk-go/go-runner/api_shims.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"log"
 	"sort"
 
 	bootstrap "github.com/pizzaface/pizzapi/experimental/adk-go/go-runner/internal/bootstrap"
@@ -55,8 +54,13 @@ func loadRunnerConfig(cwd, homeDir string) (runnerConfig, error) {
 // A nil or empty map produces an empty slice (never nil) for clean JSON serialisation.
 func marshalHooks(hooks map[string][]bootstrap.HookEntry) []any {
 	result := make([]any, 0)
-	for hookType, entries := range hooks {
-		for _, entry := range entries {
+	hookTypes := make([]string, 0, len(hooks))
+	for hookType := range hooks {
+		hookTypes = append(hookTypes, hookType)
+	}
+	sort.Strings(hookTypes)
+	for _, hookType := range hookTypes {
+		for _, entry := range hooks[hookType] {
 			for _, cmd := range entry.Hooks {
 				result = append(result, map[string]any{
 					"type":    hookType,
@@ -89,8 +93,4 @@ func stableRoots(roots []string) []string {
 
 func normalizeRunnerCwd(cwd string) string {
 	return reg.NormalizeCWD(cwd)
-}
-
-func newDefaultProviderFactory() func(*log.Logger) Provider {
-	return func(logger *log.Logger) Provider { return NewClaudeCLIProvider(logger) }
 }

--- a/experimental/adk-go/go-runner/entrypoint.go
+++ b/experimental/adk-go/go-runner/entrypoint.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+)
+
+func main() {
+	relayURL := flag.String("relay-url", "", "PizzaPi relay URL (default: PIZZAPI_RELAY_URL or http://localhost:7492)")
+	runnerName := flag.String("runner-name", "", "Runner display name (default: hostname)")
+	runnerID := flag.String("runner-id", "", "Runner ID (default: go-runner-<hostname>)")
+	flag.Parse()
+
+	url := *relayURL
+	if url == "" {
+		url = os.Getenv("PIZZAPI_RELAY_URL")
+	}
+	if url == "" {
+		url = "http://localhost:7492"
+	}
+	if len(url) > 5 && url[:5] == "ws://" {
+		url = "http://" + url[5:]
+	} else if len(url) > 6 && url[:6] == "wss://" {
+		url = "https://" + url[6:]
+	}
+
+	apiKey := os.Getenv("PIZZAPI_API_KEY")
+	if apiKey == "" {
+		apiKey = os.Getenv("PIZZAPI_API_TOKEN")
+	}
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "error: PIZZAPI_API_KEY environment variable is required")
+		os.Exit(1)
+	}
+
+	id := *runnerID
+	if id == "" {
+		hostname, _ := os.Hostname()
+		id = "go-runner-" + hostname
+	}
+
+	runner := NewGoRunner(url, apiKey, id, *runnerName)
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := runner.Run(ctx); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/experimental/adk-go/go-runner/go.mod
+++ b/experimental/adk-go/go-runner/go.mod
@@ -4,7 +4,10 @@ go 1.22
 
 require (
 	github.com/gorilla/websocket v1.5.3
-	github.com/pizzaface/pizzapi/experimental/adk-go/claude-wrapper v0.0.0
+	github.com/pizzaface/pizzapi/experimental/adk-go/providers/claudecli v0.0.0
+	github.com/pizzaface/pizzapi/experimental/adk-go/runtime v0.0.0
 )
 
-replace github.com/pizzaface/pizzapi/experimental/adk-go/claude-wrapper => ../claude-wrapper
+replace github.com/pizzaface/pizzapi/experimental/adk-go/providers/claudecli => ../providers/claudecli
+
+replace github.com/pizzaface/pizzapi/experimental/adk-go/runtime => ../runtime

--- a/experimental/adk-go/go-runner/interceptor.go
+++ b/experimental/adk-go/go-runner/interceptor.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	bootstrap "github.com/pizzaface/pizzapi/experimental/adk-go/go-runner/internal/bootstrap"
+	"github.com/pizzaface/pizzapi/experimental/adk-go/runtime/guardrails"
+)
+
+// ToolCallInterceptor is a hook invoked before a native tool call is dispatched.
+// It returns (allowed=true, reason="") to permit, or (allowed=false, reason="...") to deny.
+// A nil interceptor means no interception — all calls pass through.
+type ToolCallInterceptor func(toolName string, args map[string]any) (allowed bool, reason string)
+
+// NewGuardrailsInterceptor builds a ToolCallInterceptor backed by the guardrails package.
+// The interceptor evaluates each tool call against the sandbox policy derived from the
+// PizzaPi config, the session CWD and home directory, and the current plan mode flag.
+//
+// The returned interceptor captures the environment at construction time. Plan mode
+// changes during a session require constructing a new interceptor.
+func NewGuardrailsInterceptor(sandboxCfg bootstrap.SandboxConfig, cwd, homeDir string, planMode bool) ToolCallInterceptor {
+	env := guardrails.EvalEnv{
+		CWD:     cwd,
+		HomeDir: homeDir,
+		Session: guardrails.SessionState{PlanMode: planMode},
+		Config:  mapSandboxConfig(sandboxCfg),
+	}
+	return func(toolName string, args map[string]any) (bool, string) {
+		decision := guardrails.EvaluateToolCall(guardrails.ToolCall{Name: toolName, Args: args}, env)
+		return decision.Allowed, decision.Reason
+	}
+}
+
+// mapSandboxConfig converts a bootstrap.SandboxConfig to a guardrails.SandboxConfig.
+// The bootstrap and guardrails packages use different mode naming conventions and
+// slightly different filesystem field semantics; this function bridges the gap.
+//
+// Bootstrap mode → guardrails mode:
+//
+//	"" / "off" / "none"           → ModeNone  (no enforcement)
+//	"full" / "restricted"         → ModeFull  (strict network + filesystem)
+//	anything else (e.g. "basic")  → ModeBasic (filesystem only by default)
+func mapSandboxConfig(cfg bootstrap.SandboxConfig) guardrails.SandboxConfig {
+	mode := mapSandboxMode(cfg.Mode)
+
+	var fs *guardrails.FilesystemConfig
+	if len(cfg.AllowedPaths) > 0 || len(cfg.BlockedPaths) > 0 {
+		fs = &guardrails.FilesystemConfig{
+			AllowWrite: cfg.AllowedPaths,
+			DenyRead:   cfg.BlockedPaths,
+			DenyWrite:  cfg.BlockedPaths,
+		}
+	}
+
+	var net *guardrails.NetworkConfig
+	if len(cfg.AllowedDomains) > 0 || len(cfg.BlockedDomains) > 0 {
+		net = &guardrails.NetworkConfig{
+			AllowedDomains: cfg.AllowedDomains,
+			DeniedDomains:  cfg.BlockedDomains,
+		}
+	}
+
+	return guardrails.SandboxConfig{
+		Mode:       mode,
+		Filesystem: fs,
+		Network:    net,
+	}
+}
+
+// mapSandboxMode maps PizzaPi config mode strings to guardrails.SandboxMode values.
+func mapSandboxMode(mode string) guardrails.SandboxMode {
+	switch mode {
+	case "none", "off", "":
+		return guardrails.ModeNone
+	case "full", "restricted":
+		return guardrails.ModeFull
+	default:
+		// "basic", "permissive", or any unrecognised value → basic enforcement
+		return guardrails.ModeBasic
+	}
+}
+
+// extractToolUseBlocks scans a relay event's content array for tool_use blocks
+// and returns their names and args. It is used in runSession to inspect
+// message_update events before forwarding them — the entry point for the future
+// native tool execution interception path.
+func extractToolUseBlocks(ev map[string]any) []toolUseBlock {
+	content, ok := ev["content"].([]any)
+	if !ok {
+		return nil
+	}
+	var blocks []toolUseBlock
+	for _, item := range content {
+		block, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+		if blockType, _ := block["type"].(string); blockType != "tool_use" {
+			continue
+		}
+		name, _ := block["name"].(string)
+		if name == "" {
+			continue
+		}
+		args, _ := block["input"].(map[string]any)
+		blocks = append(blocks, toolUseBlock{Name: name, Args: args})
+	}
+	return blocks
+}
+
+// toolUseBlock holds the extracted name and args from a tool_use content block.
+type toolUseBlock struct {
+	Name string
+	Args map[string]any
+}

--- a/experimental/adk-go/go-runner/interceptor.go
+++ b/experimental/adk-go/go-runner/interceptor.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+
 	bootstrap "github.com/pizzaface/pizzapi/experimental/adk-go/go-runner/internal/bootstrap"
 	"github.com/pizzaface/pizzapi/experimental/adk-go/runtime/guardrails"
 )
@@ -18,7 +20,7 @@ type ToolCallInterceptor func(toolName string, args map[string]any) (allowed boo
 // on every tool invocation so that mid-session toggle_plan_mode changes take effect
 // immediately without requiring a new interceptor to be constructed.
 func NewGuardrailsInterceptor(sandboxCfg bootstrap.SandboxConfig, cwd, homeDir string, planMode func() bool) ToolCallInterceptor {
-	baseCfg := mapSandboxConfig(sandboxCfg)
+	baseCfg := mapSandboxConfig(sandboxCfg, cwd)
 	return func(toolName string, args map[string]any) (bool, string) {
 		env := guardrails.EvalEnv{
 			CWD:     cwd,
@@ -40,13 +42,22 @@ func NewGuardrailsInterceptor(sandboxCfg bootstrap.SandboxConfig, cwd, homeDir s
 //	"" / "off" / "none"           → ModeNone  (no enforcement)
 //	"full" / "restricted"         → ModeFull  (strict network + filesystem)
 //	anything else (e.g. "basic")  → ModeBasic (filesystem only by default)
-func mapSandboxConfig(cfg bootstrap.SandboxConfig) guardrails.SandboxConfig {
+//
+// cwd is the session working directory. When AllowedPaths is set, cwd and
+// /tmp are always appended to the resulting AllowWrite list so that user
+// config additions never silently revoke the baseline write access the
+// session needs to function.
+func mapSandboxConfig(cfg bootstrap.SandboxConfig, cwd string) guardrails.SandboxConfig {
 	mode := mapSandboxMode(cfg.Mode)
 
 	var fs *guardrails.FilesystemConfig
 	if len(cfg.AllowedPaths) > 0 || len(cfg.BlockedPaths) > 0 {
+		// Always include the session CWD and /tmp as baseline write paths so
+		// that user-specified AllowedPaths additions do not strip them.
+		allowWrite := append([]string{}, cfg.AllowedPaths...)
+		allowWrite = append(allowWrite, cwd, os.TempDir())
 		fs = &guardrails.FilesystemConfig{
-			AllowWrite: cfg.AllowedPaths,
+			AllowWrite: allowWrite,
 			DenyRead:   cfg.BlockedPaths,
 			DenyWrite:  cfg.BlockedPaths,
 		}

--- a/experimental/adk-go/go-runner/interceptor.go
+++ b/experimental/adk-go/go-runner/interceptor.go
@@ -14,16 +14,18 @@ type ToolCallInterceptor func(toolName string, args map[string]any) (allowed boo
 // The interceptor evaluates each tool call against the sandbox policy derived from the
 // PizzaPi config, the session CWD and home directory, and the current plan mode flag.
 //
-// The returned interceptor captures the environment at construction time. Plan mode
-// changes during a session require constructing a new interceptor.
-func NewGuardrailsInterceptor(sandboxCfg bootstrap.SandboxConfig, cwd, homeDir string, planMode bool) ToolCallInterceptor {
-	env := guardrails.EvalEnv{
-		CWD:     cwd,
-		HomeDir: homeDir,
-		Session: guardrails.SessionState{PlanMode: planMode},
-		Config:  mapSandboxConfig(sandboxCfg),
-	}
+// planMode is a closure that returns the session's current plan mode state. It is called
+// on every tool invocation so that mid-session toggle_plan_mode changes take effect
+// immediately without requiring a new interceptor to be constructed.
+func NewGuardrailsInterceptor(sandboxCfg bootstrap.SandboxConfig, cwd, homeDir string, planMode func() bool) ToolCallInterceptor {
+	baseCfg := mapSandboxConfig(sandboxCfg)
 	return func(toolName string, args map[string]any) (bool, string) {
+		env := guardrails.EvalEnv{
+			CWD:     cwd,
+			HomeDir: homeDir,
+			Session: guardrails.SessionState{PlanMode: planMode()},
+			Config:  baseCfg,
+		}
 		decision := guardrails.EvaluateToolCall(guardrails.ToolCall{Name: toolName, Args: args}, env)
 		return decision.Allowed, decision.Reason
 	}
@@ -82,17 +84,35 @@ func mapSandboxMode(mode string) guardrails.SandboxMode {
 // and returns their names and args. It is used in runSession to inspect
 // message_update events before forwarding them — the entry point for the future
 // native tool execution interception path.
+//
+// The content field may arrive as either []any (when items were decoded into an
+// interface slice) or []map[string]any (when the JSON decoder infers a more
+// specific type). Both shapes are handled; the typed slice is tried first.
 func extractToolUseBlocks(ev map[string]any) []toolUseBlock {
-	content, ok := ev["content"].([]any)
-	if !ok {
+	contentRaw, exists := ev["content"]
+	if !exists || contentRaw == nil {
 		return nil
 	}
-	var blocks []toolUseBlock
-	for _, item := range content {
-		block, ok := item.(map[string]any)
-		if !ok {
-			continue
+
+	// Normalise both content shapes into a flat []map[string]any for uniform processing.
+	var items []map[string]any
+	switch typed := contentRaw.(type) {
+	case []map[string]any:
+		// More-specific type produced by some JSON decoders — use directly.
+		items = typed
+	case []any:
+		// Generic interface slice — extract the underlying map from each element.
+		for _, item := range typed {
+			if block, ok := item.(map[string]any); ok {
+				items = append(items, block)
+			}
 		}
+	default:
+		return nil
+	}
+
+	var blocks []toolUseBlock
+	for _, block := range items {
 		if blockType, _ := block["type"].(string); blockType != "tool_use" {
 			continue
 		}

--- a/experimental/adk-go/go-runner/interceptor_test.go
+++ b/experimental/adk-go/go-runner/interceptor_test.go
@@ -1,0 +1,376 @@
+package main
+
+import (
+	"testing"
+
+	bootstrap "github.com/pizzaface/pizzapi/experimental/adk-go/go-runner/internal/bootstrap"
+)
+
+// ---------------------------------------------------------------------------
+// NewGuardrailsInterceptor — unit tests
+// ---------------------------------------------------------------------------
+
+func TestInterceptor_BlocksBashWhenSandboxActive(t *testing.T) {
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{Mode: "basic"},
+		"/repo",
+		"/home/test",
+		false,
+	)
+
+	allowed, reason := interceptor("bash", map[string]any{"command": "cat /etc/passwd"})
+	if allowed {
+		t.Fatal("expected bash to be denied when sandbox is active")
+	}
+	if reason == "" {
+		t.Fatal("expected non-empty denial reason for bash")
+	}
+}
+
+func TestInterceptor_AllowsAllToolsWhenModeNone(t *testing.T) {
+	for _, modeName := range []string{"none", "off", ""} {
+		t.Run("mode="+modeName, func(t *testing.T) {
+			interceptor := NewGuardrailsInterceptor(
+				bootstrap.SandboxConfig{Mode: modeName},
+				"/repo",
+				"/home/test",
+				false,
+			)
+
+			// bash should be allowed
+			allowed, reason := interceptor("bash", map[string]any{"command": "echo hello"})
+			if !allowed {
+				t.Fatalf("expected bash to be allowed in mode=%q, got denied: %s", modeName, reason)
+			}
+
+			// write to arbitrary path should be allowed
+			allowed, reason = interceptor("write", map[string]any{"path": "/etc/hosts"})
+			if !allowed {
+				t.Fatalf("expected write to be allowed in mode=%q, got denied: %s", modeName, reason)
+			}
+		})
+	}
+}
+
+func TestInterceptor_AllowsReadWriteWithinAllowedPaths(t *testing.T) {
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{
+			Mode:         "basic",
+			AllowedPaths: []string{"/repo"},
+		},
+		"/repo",
+		"/home/test",
+		false,
+	)
+
+	// Read within allowed paths (not in denyRead)
+	allowed, reason := interceptor("read", map[string]any{"path": "/repo/src/main.go"})
+	if !allowed {
+		t.Fatalf("expected read within /repo to be allowed, got denied: %s", reason)
+	}
+
+	// Write within allowed paths
+	allowed, reason = interceptor("write", map[string]any{"path": "/repo/output.txt"})
+	if !allowed {
+		t.Fatalf("expected write within /repo to be allowed, got denied: %s", reason)
+	}
+}
+
+func TestInterceptor_DeniesWriteOutsideAllowedPaths(t *testing.T) {
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{
+			Mode:         "basic",
+			AllowedPaths: []string{"/repo"},
+		},
+		"/repo",
+		"/home/test",
+		false,
+	)
+
+	allowed, reason := interceptor("write", map[string]any{"path": "/etc/hosts"})
+	if allowed {
+		t.Fatal("expected write outside allowed paths to be denied")
+	}
+	if reason == "" {
+		t.Fatal("expected non-empty denial reason")
+	}
+}
+
+func TestInterceptor_DeniesBlockedPaths(t *testing.T) {
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{
+			Mode:         "basic",
+			BlockedPaths: []string{"/secrets"},
+		},
+		"/repo",
+		"/home/test",
+		false,
+	)
+
+	// Blocked path should be denied for read
+	allowed, reason := interceptor("read", map[string]any{"path": "/secrets/token.txt"})
+	if allowed {
+		t.Fatal("expected read of blocked path to be denied")
+	}
+	if reason == "" {
+		t.Fatal("expected non-empty denial reason for blocked path read")
+	}
+}
+
+func TestInterceptor_FullModeBlocksBashAndUnsafePaths(t *testing.T) {
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{Mode: "full"},
+		"/repo",
+		"/home/test",
+		false,
+	)
+
+	allowed, _ := interceptor("bash", map[string]any{"command": "ls"})
+	if allowed {
+		t.Fatal("expected bash to be denied in full/restricted mode")
+	}
+}
+
+func TestInterceptor_RestrictedMapsToFullMode(t *testing.T) {
+	// "restricted" mode in the bootstrap config should map to ModeFull in guardrails,
+	// which means bash is always denied.
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{Mode: "restricted"},
+		"/repo",
+		"/home/test",
+		false,
+	)
+
+	allowed, _ := interceptor("bash", map[string]any{"command": "echo hi"})
+	if allowed {
+		t.Fatal("expected bash to be denied in restricted (full) mode")
+	}
+}
+
+func TestInterceptor_PlanModeBlocksWriteTools(t *testing.T) {
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{Mode: "none"}, // sandbox off
+		"/repo",
+		"/home/test",
+		true, // plan mode on
+	)
+
+	allowed, reason := interceptor("write", map[string]any{"path": "/repo/notes.txt"})
+	if allowed {
+		t.Fatalf("expected write to be denied in plan mode, but was allowed")
+	}
+	if reason == "" {
+		t.Fatal("expected non-empty denial reason in plan mode")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractToolUseBlocks — unit tests
+// ---------------------------------------------------------------------------
+
+func TestExtractToolUseBlocks_ExtractsSingleBlock(t *testing.T) {
+	ev := map[string]any{
+		"type": "message_update",
+		"content": []any{
+			map[string]any{
+				"type": "text",
+				"text": "Let me run a command.",
+			},
+			map[string]any{
+				"type":  "tool_use",
+				"id":    "tool_abc123",
+				"name":  "bash",
+				"input": map[string]any{"command": "ls -la"},
+			},
+		},
+	}
+
+	blocks := extractToolUseBlocks(ev)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 tool_use block, got %d", len(blocks))
+	}
+	if blocks[0].Name != "bash" {
+		t.Fatalf("expected tool name 'bash', got %q", blocks[0].Name)
+	}
+	cmd, _ := blocks[0].Args["command"].(string)
+	if cmd != "ls -la" {
+		t.Fatalf("expected command 'ls -la', got %q", cmd)
+	}
+}
+
+func TestExtractToolUseBlocks_ExtractsMultipleBlocks(t *testing.T) {
+	ev := map[string]any{
+		"type": "message_update",
+		"content": []any{
+			map[string]any{
+				"type":  "tool_use",
+				"id":    "t1",
+				"name":  "read",
+				"input": map[string]any{"path": "/repo/main.go"},
+			},
+			map[string]any{
+				"type":  "tool_use",
+				"id":    "t2",
+				"name":  "write",
+				"input": map[string]any{"path": "/repo/out.go"},
+			},
+		},
+	}
+
+	blocks := extractToolUseBlocks(ev)
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 tool_use blocks, got %d", len(blocks))
+	}
+	if blocks[0].Name != "read" || blocks[1].Name != "write" {
+		t.Fatalf("unexpected block names: %q, %q", blocks[0].Name, blocks[1].Name)
+	}
+}
+
+func TestExtractToolUseBlocks_SkipsNonToolUseBlocks(t *testing.T) {
+	ev := map[string]any{
+		"type": "message_update",
+		"content": []any{
+			map[string]any{"type": "text", "text": "Hello"},
+			map[string]any{"type": "thinking", "thinking": "internal"},
+		},
+	}
+
+	blocks := extractToolUseBlocks(ev)
+	if len(blocks) != 0 {
+		t.Fatalf("expected no tool_use blocks, got %d", len(blocks))
+	}
+}
+
+func TestExtractToolUseBlocks_ReturnsNilForMissingContent(t *testing.T) {
+	ev := map[string]any{
+		"type":   "heartbeat",
+		"active": true,
+	}
+
+	blocks := extractToolUseBlocks(ev)
+	if len(blocks) != 0 {
+		t.Fatalf("expected no blocks from heartbeat event, got %d", len(blocks))
+	}
+}
+
+func TestExtractToolUseBlocks_SkipsBlocksWithEmptyName(t *testing.T) {
+	ev := map[string]any{
+		"type": "message_update",
+		"content": []any{
+			map[string]any{
+				"type":  "tool_use",
+				"id":    "t1",
+				"name":  "", // empty — should be skipped
+				"input": map[string]any{},
+			},
+			map[string]any{
+				"type":  "tool_use",
+				"id":    "t2",
+				"name":  "bash",
+				"input": map[string]any{"command": "echo"},
+			},
+		},
+	}
+
+	blocks := extractToolUseBlocks(ev)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block (empty name skipped), got %d", len(blocks))
+	}
+	if blocks[0].Name != "bash" {
+		t.Fatalf("expected 'bash', got %q", blocks[0].Name)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: event with tool_use → interceptor called
+// ---------------------------------------------------------------------------
+
+func TestInterceptorIntegration_DeniesToolUseFromEvent(t *testing.T) {
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{Mode: "basic"},
+		"/repo",
+		"/home/test",
+		false,
+	)
+
+	ev := map[string]any{
+		"type": "message_update",
+		"content": []any{
+			map[string]any{
+				"type":  "tool_use",
+				"id":    "tool_xyz",
+				"name":  "bash",
+				"input": map[string]any{"command": "rm -rf /"},
+			},
+		},
+	}
+
+	blocks := extractToolUseBlocks(ev)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 tool_use block from event, got %d", len(blocks))
+	}
+
+	allowed, reason := interceptor(blocks[0].Name, blocks[0].Args)
+	if allowed {
+		t.Fatal("expected bash to be denied by guardrails interceptor")
+	}
+	if reason == "" {
+		t.Fatal("expected non-empty denial reason from interceptor")
+	}
+}
+
+func TestInterceptorIntegration_AllowsSafeToolUseFromEvent(t *testing.T) {
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{Mode: "basic"},
+		"/repo",
+		"/home/test",
+		false,
+	)
+
+	ev := map[string]any{
+		"type": "message_update",
+		"content": []any{
+			map[string]any{
+				"type":  "tool_use",
+				"id":    "tool_safe",
+				"name":  "read",
+				"input": map[string]any{"path": "/repo/main.go"},
+			},
+		},
+	}
+
+	blocks := extractToolUseBlocks(ev)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 tool_use block from event, got %d", len(blocks))
+	}
+
+	allowed, reason := interceptor(blocks[0].Name, blocks[0].Args)
+	if !allowed {
+		t.Fatalf("expected read within /repo to be allowed, got denied: %s", reason)
+	}
+}
+
+func TestInterceptorIntegration_NonUpdateEventsHaveNoBlocks(t *testing.T) {
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{Mode: "basic"},
+		"/repo",
+		"/home/test",
+		false,
+	)
+
+	heartbeat := map[string]any{
+		"type":         "heartbeat",
+		"active":       true,
+		"isCompacting": false,
+	}
+
+	// Simulate the runSession check: only call extractToolUseBlocks on message_update
+	evType, _ := heartbeat["type"].(string)
+	if evType == "message_update" && interceptor != nil {
+		blocks := extractToolUseBlocks(heartbeat)
+		if len(blocks) != 0 {
+			t.Fatal("expected no tool_use blocks in heartbeat event")
+		}
+	}
+	// Test passes if the interceptor is not called for non-message_update events
+}

--- a/experimental/adk-go/go-runner/interceptor_test.go
+++ b/experimental/adk-go/go-runner/interceptor_test.go
@@ -15,7 +15,7 @@ func TestInterceptor_BlocksBashWhenSandboxActive(t *testing.T) {
 		bootstrap.SandboxConfig{Mode: "basic"},
 		"/repo",
 		"/home/test",
-		false,
+		func() bool { return false },
 	)
 
 	allowed, reason := interceptor("bash", map[string]any{"command": "cat /etc/passwd"})
@@ -34,7 +34,7 @@ func TestInterceptor_AllowsAllToolsWhenModeNone(t *testing.T) {
 				bootstrap.SandboxConfig{Mode: modeName},
 				"/repo",
 				"/home/test",
-				false,
+				func() bool { return false },
 			)
 
 			// bash should be allowed
@@ -60,7 +60,7 @@ func TestInterceptor_AllowsReadWriteWithinAllowedPaths(t *testing.T) {
 		},
 		"/repo",
 		"/home/test",
-		false,
+		func() bool { return false },
 	)
 
 	// Read within allowed paths (not in denyRead)
@@ -84,7 +84,7 @@ func TestInterceptor_DeniesWriteOutsideAllowedPaths(t *testing.T) {
 		},
 		"/repo",
 		"/home/test",
-		false,
+		func() bool { return false },
 	)
 
 	allowed, reason := interceptor("write", map[string]any{"path": "/etc/hosts"})
@@ -104,7 +104,7 @@ func TestInterceptor_DeniesBlockedPaths(t *testing.T) {
 		},
 		"/repo",
 		"/home/test",
-		false,
+		func() bool { return false },
 	)
 
 	// Blocked path should be denied for read
@@ -122,7 +122,7 @@ func TestInterceptor_FullModeBlocksBashAndUnsafePaths(t *testing.T) {
 		bootstrap.SandboxConfig{Mode: "full"},
 		"/repo",
 		"/home/test",
-		false,
+		func() bool { return false },
 	)
 
 	allowed, _ := interceptor("bash", map[string]any{"command": "ls"})
@@ -138,7 +138,7 @@ func TestInterceptor_RestrictedMapsToFullMode(t *testing.T) {
 		bootstrap.SandboxConfig{Mode: "restricted"},
 		"/repo",
 		"/home/test",
-		false,
+		func() bool { return false },
 	)
 
 	allowed, _ := interceptor("bash", map[string]any{"command": "echo hi"})
@@ -152,7 +152,7 @@ func TestInterceptor_PlanModeBlocksWriteTools(t *testing.T) {
 		bootstrap.SandboxConfig{Mode: "none"}, // sandbox off
 		"/repo",
 		"/home/test",
-		true, // plan mode on
+		func() bool { return true }, // plan mode on
 	)
 
 	allowed, reason := interceptor("write", map[string]any{"path": "/repo/notes.txt"})
@@ -282,6 +282,102 @@ func TestExtractToolUseBlocks_SkipsBlocksWithEmptyName(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// extractToolUseBlocks — typed []map[string]any shape (P2 regression test)
+// ---------------------------------------------------------------------------
+
+// TestExtractToolUseBlocks_TypedMapSliceShape verifies that extractToolUseBlocks
+// handles the []map[string]any content shape that some JSON decoders produce,
+// rather than silently returning nil as it did with the []any-only assertion.
+func TestExtractToolUseBlocks_TypedMapSliceShape(t *testing.T) {
+	ev := map[string]any{
+		"type": "message_update",
+		// Content as []map[string]any (more-specific type) — not []any.
+		"content": []map[string]any{
+			{
+				"type": "text",
+				"text": "Let me run that.",
+			},
+			{
+				"type":  "tool_use",
+				"id":    "tool_typed_001",
+				"name":  "bash",
+				"input": map[string]any{"command": "echo typed"},
+			},
+		},
+	}
+
+	blocks := extractToolUseBlocks(ev)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 tool_use block from []map[string]any content, got %d", len(blocks))
+	}
+	if blocks[0].Name != "bash" {
+		t.Fatalf("expected tool name 'bash', got %q", blocks[0].Name)
+	}
+	cmd, _ := blocks[0].Args["command"].(string)
+	if cmd != "echo typed" {
+		t.Fatalf("expected command 'echo typed', got %q", cmd)
+	}
+}
+
+// TestExtractToolUseBlocks_TypedMapSliceMultiple verifies multiple blocks from
+// the []map[string]any shape are all extracted.
+func TestExtractToolUseBlocks_TypedMapSliceMultiple(t *testing.T) {
+	ev := map[string]any{
+		"type": "message_update",
+		"content": []map[string]any{
+			{
+				"type":  "tool_use",
+				"id":    "t1",
+				"name":  "read",
+				"input": map[string]any{"path": "/repo/a.go"},
+			},
+			{
+				"type":  "tool_use",
+				"id":    "t2",
+				"name":  "write",
+				"input": map[string]any{"path": "/repo/b.go"},
+			},
+		},
+	}
+
+	blocks := extractToolUseBlocks(ev)
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 tool_use blocks from []map[string]any content, got %d", len(blocks))
+	}
+	if blocks[0].Name != "read" || blocks[1].Name != "write" {
+		t.Fatalf("unexpected names: %q, %q", blocks[0].Name, blocks[1].Name)
+	}
+}
+
+// TestInterceptor_PlanModeDynamic verifies that the planMode closure is
+// evaluated on each tool call, so mid-session changes take effect immediately.
+func TestInterceptor_PlanModeDynamic(t *testing.T) {
+	var planModeOn bool
+	interceptor := NewGuardrailsInterceptor(
+		bootstrap.SandboxConfig{Mode: "none"}, // sandbox off so only plan mode matters
+		"/repo",
+		"/home/test",
+		func() bool { return planModeOn },
+	)
+
+	// With plan mode off, writes should be allowed (sandbox is none).
+	allowed, _ := interceptor("write", map[string]any{"path": "/repo/notes.txt"})
+	if !allowed {
+		t.Fatal("expected write to be allowed when plan mode is off")
+	}
+
+	// Flip plan mode on — write should now be denied without constructing a new interceptor.
+	planModeOn = true
+	allowed, reason := interceptor("write", map[string]any{"path": "/repo/notes.txt"})
+	if allowed {
+		t.Fatalf("expected write to be denied after plan mode was toggled on, but was allowed")
+	}
+	if reason == "" {
+		t.Fatal("expected non-empty denial reason in plan mode")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Integration: event with tool_use → interceptor called
 // ---------------------------------------------------------------------------
 
@@ -290,7 +386,7 @@ func TestInterceptorIntegration_DeniesToolUseFromEvent(t *testing.T) {
 		bootstrap.SandboxConfig{Mode: "basic"},
 		"/repo",
 		"/home/test",
-		false,
+		func() bool { return false },
 	)
 
 	ev := map[string]any{
@@ -324,7 +420,7 @@ func TestInterceptorIntegration_AllowsSafeToolUseFromEvent(t *testing.T) {
 		bootstrap.SandboxConfig{Mode: "basic"},
 		"/repo",
 		"/home/test",
-		false,
+		func() bool { return false },
 	)
 
 	ev := map[string]any{
@@ -355,7 +451,7 @@ func TestInterceptorIntegration_NonUpdateEventsHaveNoBlocks(t *testing.T) {
 		bootstrap.SandboxConfig{Mode: "basic"},
 		"/repo",
 		"/home/test",
-		false,
+		func() bool { return false },
 	)
 
 	heartbeat := map[string]any{

--- a/experimental/adk-go/go-runner/internal/bootstrap/bootstrap.go
+++ b/experimental/adk-go/go-runner/internal/bootstrap/bootstrap.go
@@ -1,0 +1,238 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+
+	"github.com/pizzaface/pizzapi/experimental/adk-go/runtime/compat"
+	"github.com/pizzaface/pizzapi/experimental/adk-go/runtime/mcpconfig"
+)
+
+// ---------------------------------------------------------------------------
+// Session bootstrap (MCP config + system prompt for a new agent session)
+// ---------------------------------------------------------------------------
+
+// Session is the resolved bootstrap configuration for a single agent session.
+type Session struct {
+	SystemPrompt  string
+	MCPConfigPath string
+	Cleanup       func()
+}
+
+// Build resolves the MCP config and system prompt for a new agent session.
+// It discovers instruction docs (AGENTS.md, CLAUDE.md) and merges global +
+// project MCP server configurations into a temp file consumed by the Claude CLI.
+func Build(cwd, homeDir, tempDir string) (Session, error) {
+	locator := compat.NewLocator(homeDir, cwd)
+	docs, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		return Session{}, err
+	}
+
+	bootstrap := Session{Cleanup: func() {}}
+	if len(docs) > 0 {
+		parts := make([]string, 0, len(docs))
+		for _, doc := range docs {
+			parts = append(parts, strings.TrimSpace(doc.Content))
+		}
+		bootstrap.SystemPrompt = strings.Join(parts, "\n\n")
+	}
+
+	cfgPaths := locator.ConfigPaths()
+	globalCfg, err := parseMCPConfigFile(candidatePath(cfgPaths.PizzaPiConfig, compat.ScopeGlobal))
+	if err != nil {
+		return Session{}, err
+	}
+	projectCfg, err := parseMCPConfigFile(candidatePath(cfgPaths.PizzaPiConfig, compat.ScopeProject))
+	if err != nil {
+		return Session{}, err
+	}
+	merged := mcpconfig.Merge(globalCfg, projectCfg)
+	if len(merged.Servers) == 0 {
+		return bootstrap, nil
+	}
+
+	data, err := merged.MarshalClaudeConfigJSON()
+	if err != nil {
+		return Session{}, err
+	}
+	if err := os.MkdirAll(tempDir, 0o755); err != nil {
+		return Session{}, err
+	}
+	file, err := os.CreateTemp(tempDir, "claude-mcp-*.json")
+	if err != nil {
+		return Session{}, err
+	}
+	path := file.Name()
+	if _, err := file.Write(data); err != nil {
+		file.Close()
+		_ = os.Remove(path)
+		return Session{}, err
+	}
+	if err := file.Close(); err != nil {
+		_ = os.Remove(path)
+		return Session{}, err
+	}
+	bootstrap.MCPConfigPath = path
+	bootstrap.Cleanup = func() { _ = os.Remove(path) }
+	return bootstrap, nil
+}
+
+func candidatePath(candidates []compat.PathCandidate, scope compat.Scope) string {
+	for _, candidate := range candidates {
+		if candidate.Scope == scope {
+			return candidate.Path
+		}
+	}
+	return ""
+}
+
+func parseMCPConfigFile(path string) (mcpconfig.Config, error) {
+	if path == "" {
+		return mcpconfig.Config{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return mcpconfig.Config{}, nil
+		}
+		return mcpconfig.Config{}, err
+	}
+	return mcpconfig.ParsePizzaPiConfig(data)
+}
+
+// ---------------------------------------------------------------------------
+// Runner config (hooks + sandbox from PizzaPi config.json)
+// ---------------------------------------------------------------------------
+
+// HookEntry is a single hook matcher + script pair within a hook type.
+// PizzaPi config.json stores hooks as:
+//
+//	"hooks": {
+//	  "PreToolUse": [{ "matcher": "Bash", "hooks": [{ "type": "command", "command": "script.sh" }] }]
+//	}
+type HookEntry struct {
+	// Matcher is the tool or event pattern this hook applies to (e.g. "Bash", "*").
+	Matcher string `json:"matcher"`
+	// Hooks are the commands/scripts to execute when the matcher triggers.
+	Hooks []HookCommand `json:"hooks"`
+}
+
+// HookCommand describes a single executable hook.
+type HookCommand struct {
+	Type    string `json:"type"`    // "command" is the only type PizzaPi supports today
+	Command string `json:"command"` // shell command to execute
+}
+
+// SandboxConfig mirrors the "sandbox" section of ~/.pizzapi/config.json.
+type SandboxConfig struct {
+	// Mode controls overall sandbox behaviour: "off", "restricted", or "permissive".
+	Mode string `json:"mode"`
+	// AllowedPaths lists filesystem paths the sandbox permits read/write access to.
+	AllowedPaths []string `json:"allowedPaths"`
+	// BlockedPaths lists filesystem paths the sandbox explicitly denies access to.
+	BlockedPaths []string `json:"blockedPaths"`
+	// AllowedDomains lists network domains the sandbox permits outbound connections to.
+	AllowedDomains []string `json:"allowedDomains"`
+	// BlockedDomains lists network domains the sandbox explicitly denies.
+	BlockedDomains []string `json:"blockedDomains"`
+}
+
+// RunnerConfig is the merged configuration relevant to the Go runner itself
+// (hooks, sandbox, system prompt append). MCP servers are handled separately
+// by Build via the mcpconfig package.
+type RunnerConfig struct {
+	// Hooks maps hook-type names (e.g. "PreToolUse") to their ordered entries.
+	// Project hooks are only included when the global config enables AllowProjectHooks.
+	Hooks map[string][]HookEntry `json:"hooks"`
+	// Sandbox contains filesystem and network restrictions for the runner.
+	Sandbox SandboxConfig `json:"sandbox"`
+	// AppendSystemPrompt is extra text appended to every session's system prompt.
+	AppendSystemPrompt string `json:"appendSystemPrompt"`
+	// AllowProjectHooks signals whether project-local hook definitions are trusted.
+	// This is read from the GLOBAL config only (projects cannot self-authorize).
+	AllowProjectHooks bool `json:"allowProjectHooks"`
+}
+
+// rawPizzaPiConfig is the full on-disk shape of ~/.pizzapi/config.json.
+// Only the fields relevant to RunnerConfig are captured here.
+type rawPizzaPiConfig struct {
+	Hooks              map[string][]HookEntry `json:"hooks"`
+	Sandbox            SandboxConfig          `json:"sandbox"`
+	AppendSystemPrompt string                 `json:"appendSystemPrompt"`
+	AllowProjectHooks  bool                   `json:"allowProjectHooks"`
+}
+
+// LoadConfig reads and merges the global and project-local PizzaPi config.json
+// files, returning a RunnerConfig with hooks and sandbox settings.
+//
+// Merge rules:
+//   - Sandbox settings come from the global config only (project cannot override).
+//   - AppendSystemPrompt from global and project are joined with "\n\n".
+//   - Project hooks are only included when the global config sets AllowProjectHooks=true.
+//   - Hook lists are concatenated: global hooks run first, then project hooks.
+func LoadConfig(cwd, homeDir string) (RunnerConfig, error) {
+	locator := compat.NewLocator(homeDir, cwd)
+	cfgPaths := locator.ConfigPaths()
+
+	globalPath := candidatePath(cfgPaths.PizzaPiConfig, compat.ScopeGlobal)
+	projectPath := candidatePath(cfgPaths.PizzaPiConfig, compat.ScopeProject)
+
+	globalRaw, err := readRawConfig(globalPath)
+	if err != nil {
+		return RunnerConfig{}, err
+	}
+	projectRaw, err := readRawConfig(projectPath)
+	if err != nil {
+		return RunnerConfig{}, err
+	}
+
+	cfg := RunnerConfig{
+		Sandbox:           globalRaw.Sandbox, // sandbox from global only
+		AllowProjectHooks: globalRaw.AllowProjectHooks,
+		Hooks:             make(map[string][]HookEntry),
+	}
+
+	// Merge AppendSystemPrompt
+	var promptParts []string
+	if globalRaw.AppendSystemPrompt != "" {
+		promptParts = append(promptParts, globalRaw.AppendSystemPrompt)
+	}
+	if projectRaw.AppendSystemPrompt != "" {
+		promptParts = append(promptParts, projectRaw.AppendSystemPrompt)
+	}
+	cfg.AppendSystemPrompt = strings.Join(promptParts, "\n\n")
+
+	// Merge hooks: global first, then project (only if allowed).
+	for hookType, entries := range globalRaw.Hooks {
+		cfg.Hooks[hookType] = append(cfg.Hooks[hookType], entries...)
+	}
+	if globalRaw.AllowProjectHooks {
+		for hookType, entries := range projectRaw.Hooks {
+			cfg.Hooks[hookType] = append(cfg.Hooks[hookType], entries...)
+		}
+	}
+
+	return cfg, nil
+}
+
+// readRawConfig parses a PizzaPi config.json file into rawPizzaPiConfig.
+// Missing files are treated as an empty config — not an error.
+func readRawConfig(path string) (rawPizzaPiConfig, error) {
+	if path == "" {
+		return rawPizzaPiConfig{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return rawPizzaPiConfig{}, nil
+		}
+		return rawPizzaPiConfig{}, err
+	}
+	var raw rawPizzaPiConfig
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return rawPizzaPiConfig{}, err
+	}
+	return raw, nil
+}

--- a/experimental/adk-go/go-runner/internal/bootstrap/bootstrap_test.go
+++ b/experimental/adk-go/go-runner/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,330 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig — missing files
+// ---------------------------------------------------------------------------
+
+func TestLoadConfigBothMissing(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AllowProjectHooks {
+		t.Error("expected AllowProjectHooks=false when no config exists")
+	}
+	if len(cfg.Hooks) != 0 {
+		t.Errorf("expected no hooks, got %v", cfg.Hooks)
+	}
+	if cfg.AppendSystemPrompt != "" {
+		t.Errorf("expected empty AppendSystemPrompt, got %q", cfg.AppendSystemPrompt)
+	}
+}
+
+func TestLoadConfigGlobalOnlyMissing(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	// Write a project config — it should be ignored gracefully when global is absent.
+	projectCfg := map[string]any{
+		"appendSystemPrompt": "project prompt",
+	}
+	writeJSON(t, filepath.Join(cwd, ".pizzapi", "config.json"), projectCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Project prompt is loaded even without a global config.
+	// AllowProjectHooks defaults false so project hooks are not merged,
+	// but AppendSystemPrompt from project is always loaded.
+	if cfg.AppendSystemPrompt != "project prompt" {
+		t.Errorf("expected project prompt, got %q", cfg.AppendSystemPrompt)
+	}
+}
+
+func TestLoadConfigProjectMissing(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"appendSystemPrompt": "global prompt",
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AppendSystemPrompt != "global prompt" {
+		t.Errorf("expected %q, got %q", "global prompt", cfg.AppendSystemPrompt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig — sandbox
+// ---------------------------------------------------------------------------
+
+func TestLoadConfigSandboxFromGlobalOnly(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"sandbox": map[string]any{
+			"mode":           "restricted",
+			"allowedPaths":   []string{"/tmp"},
+			"blockedDomains": []string{"evil.com"},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	// Project config tries to override sandbox — should be ignored.
+	projectCfg := map[string]any{
+		"sandbox": map[string]any{
+			"mode": "off",
+		},
+	}
+	writeJSON(t, filepath.Join(cwd, ".pizzapi", "config.json"), projectCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Sandbox.Mode != "restricted" {
+		t.Errorf("expected sandbox mode=restricted, got %q", cfg.Sandbox.Mode)
+	}
+	if len(cfg.Sandbox.AllowedPaths) != 1 || cfg.Sandbox.AllowedPaths[0] != "/tmp" {
+		t.Errorf("unexpected AllowedPaths: %v", cfg.Sandbox.AllowedPaths)
+	}
+	if len(cfg.Sandbox.BlockedDomains) != 1 || cfg.Sandbox.BlockedDomains[0] != "evil.com" {
+		t.Errorf("unexpected BlockedDomains: %v", cfg.Sandbox.BlockedDomains)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig — hooks
+// ---------------------------------------------------------------------------
+
+func TestLoadConfigHooksGlobalOnly(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []map[string]any{
+				{
+					"matcher": "Bash",
+					"hooks": []map[string]any{
+						{"type": "command", "command": "echo pre"},
+					},
+				},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entries, ok := cfg.Hooks["PreToolUse"]
+	if !ok {
+		t.Fatal("expected PreToolUse hooks")
+	}
+	if len(entries) != 1 || entries[0].Matcher != "Bash" {
+		t.Errorf("unexpected hook entries: %v", entries)
+	}
+}
+
+func TestLoadConfigProjectHooksIgnoredWhenNotAllowed(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"allowProjectHooks": false,
+		"hooks": map[string]any{
+			"PreToolUse": []map[string]any{
+				{"matcher": "*", "hooks": []map[string]any{{"type": "command", "command": "global-hook"}}},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	projectCfg := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []map[string]any{
+				{"matcher": "Bash", "hooks": []map[string]any{{"type": "command", "command": "project-hook"}}},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(cwd, ".pizzapi", "config.json"), projectCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entries := cfg.Hooks["PreToolUse"]
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 hook (global only), got %d", len(entries))
+	}
+	if entries[0].Hooks[0].Command != "global-hook" {
+		t.Errorf("expected global-hook command, got %q", entries[0].Hooks[0].Command)
+	}
+}
+
+func TestLoadConfigProjectHooksMergedWhenAllowed(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"allowProjectHooks": true,
+		"hooks": map[string]any{
+			"PreToolUse": []map[string]any{
+				{"matcher": "*", "hooks": []map[string]any{{"type": "command", "command": "global-hook"}}},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	projectCfg := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []map[string]any{
+				{"matcher": "Bash", "hooks": []map[string]any{{"type": "command", "command": "project-hook"}}},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(cwd, ".pizzapi", "config.json"), projectCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.AllowProjectHooks {
+		t.Error("expected AllowProjectHooks=true")
+	}
+	entries := cfg.Hooks["PreToolUse"]
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 hooks (global + project), got %d", len(entries))
+	}
+	// Global hooks come first.
+	if entries[0].Hooks[0].Command != "global-hook" {
+		t.Errorf("expected global hook first, got %q", entries[0].Hooks[0].Command)
+	}
+	if entries[1].Hooks[0].Command != "project-hook" {
+		t.Errorf("expected project hook second, got %q", entries[1].Hooks[0].Command)
+	}
+}
+
+func TestLoadConfigDistinctHookTypes(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"allowProjectHooks": true,
+		"hooks": map[string]any{
+			"PreToolUse":  []map[string]any{{"matcher": "*", "hooks": []map[string]any{{"type": "command", "command": "pre"}}}},
+			"PostToolUse": []map[string]any{{"matcher": "*", "hooks": []map[string]any{{"type": "command", "command": "post"}}}},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := cfg.Hooks["PreToolUse"]; !ok {
+		t.Error("expected PreToolUse hooks")
+	}
+	if _, ok := cfg.Hooks["PostToolUse"]; !ok {
+		t.Error("expected PostToolUse hooks")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig — AppendSystemPrompt merging
+// ---------------------------------------------------------------------------
+
+func TestLoadConfigSystemPromptMerged(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{"appendSystemPrompt": "global extra"}
+	projectCfg := map[string]any{"appendSystemPrompt": "project extra"}
+
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+	writeJSON(t, filepath.Join(cwd, ".pizzapi", "config.json"), projectCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "global extra\n\nproject extra"
+	if cfg.AppendSystemPrompt != want {
+		t.Errorf("got %q, want %q", cfg.AppendSystemPrompt, want)
+	}
+}
+
+func TestLoadConfigSystemPromptGlobalOnly(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{"appendSystemPrompt": "only global"}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AppendSystemPrompt != "only global" {
+		t.Errorf("got %q", cfg.AppendSystemPrompt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig — malformed JSON
+// ---------------------------------------------------------------------------
+
+func TestLoadConfigMalformedGlobal(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	badPath := filepath.Join(home, ".pizzapi", "config.json")
+	if err := os.MkdirAll(filepath.Dir(badPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(badPath, []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(cwd, home)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}

--- a/experimental/adk-go/go-runner/internal/bootstrap/bootstrap_test.go
+++ b/experimental/adk-go/go-runner/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,593 @@
+package bootstrap
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func writeJSON(t *testing.T, path string, v any) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig — missing files
+// ---------------------------------------------------------------------------
+
+func TestLoadConfigBothMissing(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AllowProjectHooks {
+		t.Error("expected AllowProjectHooks=false when no config exists")
+	}
+	if len(cfg.Hooks) != 0 {
+		t.Errorf("expected no hooks, got %v", cfg.Hooks)
+	}
+	if cfg.AppendSystemPrompt != "" {
+		t.Errorf("expected empty AppendSystemPrompt, got %q", cfg.AppendSystemPrompt)
+	}
+}
+
+func TestLoadConfigGlobalOnlyMissing(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	// Write a project config — it should be ignored gracefully when global is absent.
+	projectCfg := map[string]any{
+		"appendSystemPrompt": "project prompt",
+	}
+	writeJSON(t, filepath.Join(cwd, ".pizzapi", "config.json"), projectCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Project prompt is loaded even without a global config.
+	// AllowProjectHooks defaults false so project hooks are not merged,
+	// but AppendSystemPrompt from project is always loaded.
+	if cfg.AppendSystemPrompt != "project prompt" {
+		t.Errorf("expected project prompt, got %q", cfg.AppendSystemPrompt)
+	}
+}
+
+func TestLoadConfigProjectMissing(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"appendSystemPrompt": "global prompt",
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AppendSystemPrompt != "global prompt" {
+		t.Errorf("expected %q, got %q", "global prompt", cfg.AppendSystemPrompt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig — sandbox
+// ---------------------------------------------------------------------------
+
+func TestLoadConfigSandboxFromGlobalOnly(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"sandbox": map[string]any{
+			"mode":           "restricted",
+			"allowedPaths":   []string{"/tmp"},
+			"blockedDomains": []string{"evil.com"},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	// Project config tries to override sandbox — should be ignored.
+	projectCfg := map[string]any{
+		"sandbox": map[string]any{
+			"mode": "off",
+		},
+	}
+	writeJSON(t, filepath.Join(cwd, ".pizzapi", "config.json"), projectCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Sandbox.Mode != "restricted" {
+		t.Errorf("expected sandbox mode=restricted, got %q", cfg.Sandbox.Mode)
+	}
+	if len(cfg.Sandbox.AllowedPaths) != 1 || cfg.Sandbox.AllowedPaths[0] != "/tmp" {
+		t.Errorf("unexpected AllowedPaths: %v", cfg.Sandbox.AllowedPaths)
+	}
+	if len(cfg.Sandbox.BlockedDomains) != 1 || cfg.Sandbox.BlockedDomains[0] != "evil.com" {
+		t.Errorf("unexpected BlockedDomains: %v", cfg.Sandbox.BlockedDomains)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig — hooks
+// ---------------------------------------------------------------------------
+
+func TestLoadConfigHooksGlobalOnly(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []map[string]any{
+				{
+					"matcher": "Bash",
+					"hooks": []map[string]any{
+						{"type": "command", "command": "echo pre"},
+					},
+				},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entries, ok := cfg.Hooks["PreToolUse"]
+	if !ok {
+		t.Fatal("expected PreToolUse hooks")
+	}
+	if len(entries) != 1 || entries[0].Matcher != "Bash" {
+		t.Errorf("unexpected hook entries: %v", entries)
+	}
+}
+
+func TestLoadConfigProjectHooksIgnoredWhenNotAllowed(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"allowProjectHooks": false,
+		"hooks": map[string]any{
+			"PreToolUse": []map[string]any{
+				{"matcher": "*", "hooks": []map[string]any{{"type": "command", "command": "global-hook"}}},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	projectCfg := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []map[string]any{
+				{"matcher": "Bash", "hooks": []map[string]any{{"type": "command", "command": "project-hook"}}},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(cwd, ".pizzapi", "config.json"), projectCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	entries := cfg.Hooks["PreToolUse"]
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 hook (global only), got %d", len(entries))
+	}
+	if entries[0].Hooks[0].Command != "global-hook" {
+		t.Errorf("expected global-hook command, got %q", entries[0].Hooks[0].Command)
+	}
+}
+
+func TestLoadConfigProjectHooksMergedWhenAllowed(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"allowProjectHooks": true,
+		"hooks": map[string]any{
+			"PreToolUse": []map[string]any{
+				{"matcher": "*", "hooks": []map[string]any{{"type": "command", "command": "global-hook"}}},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	projectCfg := map[string]any{
+		"hooks": map[string]any{
+			"PreToolUse": []map[string]any{
+				{"matcher": "Bash", "hooks": []map[string]any{{"type": "command", "command": "project-hook"}}},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(cwd, ".pizzapi", "config.json"), projectCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.AllowProjectHooks {
+		t.Error("expected AllowProjectHooks=true")
+	}
+	entries := cfg.Hooks["PreToolUse"]
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 hooks (global + project), got %d", len(entries))
+	}
+	// Global hooks come first.
+	if entries[0].Hooks[0].Command != "global-hook" {
+		t.Errorf("expected global hook first, got %q", entries[0].Hooks[0].Command)
+	}
+	if entries[1].Hooks[0].Command != "project-hook" {
+		t.Errorf("expected project hook second, got %q", entries[1].Hooks[0].Command)
+	}
+}
+
+func TestLoadConfigDistinctHookTypes(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{
+		"allowProjectHooks": true,
+		"hooks": map[string]any{
+			"PreToolUse":  []map[string]any{{"matcher": "*", "hooks": []map[string]any{{"type": "command", "command": "pre"}}}},
+			"PostToolUse": []map[string]any{{"matcher": "*", "hooks": []map[string]any{{"type": "command", "command": "post"}}}},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := cfg.Hooks["PreToolUse"]; !ok {
+		t.Error("expected PreToolUse hooks")
+	}
+	if _, ok := cfg.Hooks["PostToolUse"]; !ok {
+		t.Error("expected PostToolUse hooks")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig — AppendSystemPrompt merging
+// ---------------------------------------------------------------------------
+
+func TestLoadConfigSystemPromptMerged(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{"appendSystemPrompt": "global extra"}
+	projectCfg := map[string]any{"appendSystemPrompt": "project extra"}
+
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+	writeJSON(t, filepath.Join(cwd, ".pizzapi", "config.json"), projectCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := "global extra\n\nproject extra"
+	if cfg.AppendSystemPrompt != want {
+		t.Errorf("got %q, want %q", cfg.AppendSystemPrompt, want)
+	}
+}
+
+func TestLoadConfigSystemPromptGlobalOnly(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalCfg := map[string]any{"appendSystemPrompt": "only global"}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	cfg, err := LoadConfig(cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.AppendSystemPrompt != "only global" {
+		t.Errorf("got %q", cfg.AppendSystemPrompt)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LoadConfig — malformed JSON
+// ---------------------------------------------------------------------------
+
+func TestLoadConfigMalformedGlobal(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	badPath := filepath.Join(home, ".pizzapi", "config.json")
+	if err := os.MkdirAll(filepath.Dir(badPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(badPath, []byte("{not valid json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadConfig(cwd, home)
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Build — MCP config temp file creation
+// ---------------------------------------------------------------------------
+
+func TestBuildWithStdioMCPServerCreatesTempFile(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	tmp := t.TempDir()
+
+	// Write a global config with one stdio MCP server.
+	globalCfg := map[string]any{
+		"mcpServers": map[string]any{
+			"godmother": map[string]any{
+				"command": "godmother",
+				"args":    []string{"serve"},
+				"env":     map[string]string{"API_KEY": "secret"},
+				"cwd":     "/repo",
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	session, err := Build(cwd, home, tmp)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	defer session.Cleanup()
+
+	if session.MCPConfigPath == "" {
+		t.Fatal("expected MCPConfigPath to be set, got empty string")
+	}
+
+	// Verify the temp file exists and parses correctly.
+	data, err := os.ReadFile(session.MCPConfigPath)
+	if err != nil {
+		t.Fatalf("ReadFile(%q): %v", session.MCPConfigPath, err)
+	}
+
+	var out struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal temp file: %v", err)
+	}
+	if len(out.MCPServers) != 1 {
+		t.Fatalf("expected 1 server, got %d", len(out.MCPServers))
+	}
+	raw, ok := out.MCPServers["godmother"]
+	if !ok {
+		t.Fatal("expected 'godmother' entry in mcpServers")
+	}
+
+	// Claude CLI stdio shape: command + args (no url/type).
+	var entry struct {
+		Command string            `json:"command"`
+		Args    []string          `json:"args"`
+		Cwd     string            `json:"cwd"`
+		Env     map[string]string `json:"env"`
+		URL     string            `json:"url"`
+		Type    string            `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		t.Fatalf("unmarshal server entry: %v", err)
+	}
+	if entry.Command != "godmother" {
+		t.Errorf("command = %q, want %q", entry.Command, "godmother")
+	}
+	if len(entry.Args) != 1 || entry.Args[0] != "serve" {
+		t.Errorf("args = %v, want [serve]", entry.Args)
+	}
+	if entry.Cwd != "/repo" {
+		t.Errorf("cwd = %q, want /repo", entry.Cwd)
+	}
+	if entry.Env["API_KEY"] != "secret" {
+		t.Errorf("env.API_KEY = %q, want secret", entry.Env["API_KEY"])
+	}
+	// Stdio entries must NOT have url or type.
+	if entry.URL != "" {
+		t.Errorf("stdio entry should not have url, got %q", entry.URL)
+	}
+	if entry.Type != "" {
+		t.Errorf("stdio entry should not have type, got %q", entry.Type)
+	}
+}
+
+func TestBuildWithStreamableMCPServerCreatesTempFile(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	tmp := t.TempDir()
+
+	globalCfg := map[string]any{
+		"mcpServers": map[string]any{
+			"github": map[string]any{
+				"type":    "http",
+				"url":     "https://api.githubcopilot.com/mcp/",
+				"headers": map[string]string{"Authorization": "Bearer token"},
+			},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	session, err := Build(cwd, home, tmp)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	defer session.Cleanup()
+
+	if session.MCPConfigPath == "" {
+		t.Fatal("expected MCPConfigPath to be set")
+	}
+
+	data, err := os.ReadFile(session.MCPConfigPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+
+	var out struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	raw, ok := out.MCPServers["github"]
+	if !ok {
+		t.Fatal("expected 'github' entry in mcpServers")
+	}
+
+	// Claude CLI streamable shape: url + type="http" (no command).
+	var entry struct {
+		URL     string            `json:"url"`
+		Type    string            `json:"type"`
+		Headers map[string]string `json:"headers"`
+		Command string            `json:"command"`
+	}
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		t.Fatalf("unmarshal server entry: %v", err)
+	}
+	if entry.URL != "https://api.githubcopilot.com/mcp/" {
+		t.Errorf("url = %q, want https://api.githubcopilot.com/mcp/", entry.URL)
+	}
+	if entry.Type != "http" {
+		t.Errorf("type = %q, want http", entry.Type)
+	}
+	if entry.Headers["Authorization"] != "Bearer token" {
+		t.Errorf("headers.Authorization = %q, want 'Bearer token'", entry.Headers["Authorization"])
+	}
+	if entry.Command != "" {
+		t.Errorf("streamable entry should not have command, got %q", entry.Command)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Build — Cleanup removes temp file
+// ---------------------------------------------------------------------------
+
+func TestBuildCleanupRemovesTempFile(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	tmp := t.TempDir()
+
+	globalCfg := map[string]any{
+		"mcpServers": map[string]any{
+			"svc": map[string]any{"command": "svc"},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	session, err := Build(cwd, home, tmp)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	path := session.MCPConfigPath
+	if path == "" {
+		t.Fatal("expected MCPConfigPath to be set")
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("temp file should exist before Cleanup: %v", err)
+	}
+
+	session.Cleanup()
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("expected temp file to be removed after Cleanup, got err=%v", err)
+	}
+}
+
+func TestBuildCleanupTwiceDoesNotPanic(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	tmp := t.TempDir()
+
+	globalCfg := map[string]any{
+		"mcpServers": map[string]any{
+			"svc": map[string]any{"command": "svc"},
+		},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	session, err := Build(cwd, home, tmp)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	// Should not panic even when called twice.
+	session.Cleanup()
+	session.Cleanup()
+}
+
+// ---------------------------------------------------------------------------
+// Build — empty mcpServers produces no temp file
+// ---------------------------------------------------------------------------
+
+func TestBuildEmptyMCPServersNoTempFile(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	tmp := t.TempDir()
+
+	// Config with empty mcpServers map.
+	globalCfg := map[string]any{
+		"mcpServers": map[string]any{},
+	}
+	writeJSON(t, filepath.Join(home, ".pizzapi", "config.json"), globalCfg)
+
+	session, err := Build(cwd, home, tmp)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if session.MCPConfigPath != "" {
+		t.Errorf("expected no MCPConfigPath for empty mcpServers, got %q", session.MCPConfigPath)
+	}
+
+	// tempDir should be empty — no file was created.
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatalf("ReadDir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("expected no temp files for empty mcpServers, found %d", len(entries))
+	}
+
+	// Cleanup should be callable without panic even with no file.
+	session.Cleanup()
+}
+
+func TestBuildNoConfigNoTempFile(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	tmp := t.TempDir()
+
+	// No config files at all.
+	session, err := Build(cwd, home, tmp)
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if session.MCPConfigPath != "" {
+		t.Errorf("expected no MCPConfigPath when no config exists, got %q", session.MCPConfigPath)
+	}
+	session.Cleanup()
+}

--- a/experimental/adk-go/go-runner/internal/registration/registration.go
+++ b/experimental/adk-go/go-runner/internal/registration/registration.go
@@ -113,6 +113,9 @@ func resourceDescription(path, fallback string) string {
 // The key comparison is case-insensitive. An empty string is returned when
 // the document has no frontmatter or no description key.
 func frontmatterDescription(text string) string {
+	// Normalize CRLF to LF so Windows-style line endings don't bypass the check.
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+
 	// Frontmatter must start at byte 0 with "---\n".
 	if !strings.HasPrefix(text, "---\n") {
 		return ""

--- a/experimental/adk-go/go-runner/internal/registration/registration.go
+++ b/experimental/adk-go/go-runner/internal/registration/registration.go
@@ -1,0 +1,281 @@
+package registration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pizzaface/pizzapi/experimental/adk-go/runtime/compat"
+)
+
+type Skill struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	FilePath    string `json:"filePath"`
+}
+
+type Agent struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	FilePath    string `json:"filePath"`
+}
+
+type Metadata struct {
+	Roots  []string
+	Skills []Skill
+	Agents []Agent
+}
+
+// Discover collects all skills and agents discoverable from cwd and homeDir,
+// building a Metadata payload ready for registration.
+func Discover(cwd, homeDir string) (Metadata, error) {
+	locator := compat.NewLocator(homeDir, cwd)
+	skills, err := locator.DiscoverSkills()
+	if err != nil {
+		return Metadata{}, err
+	}
+	agents, err := locator.DiscoverAgents()
+	if err != nil {
+		return Metadata{}, err
+	}
+
+	meta := Metadata{Roots: []string{cwd}}
+	for _, skill := range skills {
+		meta.Skills = append(meta.Skills, Skill{
+			Name:        skill.Name,
+			Description: resourceDescription(skill.Path, skill.Name),
+			FilePath:    skill.Path,
+		})
+	}
+	for _, agent := range agents {
+		meta.Agents = append(meta.Agents, Agent{
+			Name:        agent.Name,
+			Description: resourceDescription(agent.Path, agent.Name),
+			FilePath:    agent.Path,
+		})
+	}
+	return meta, nil
+}
+
+// ResolveAgent looks up an agent by name across all compat locations (project then
+// global) and returns the full file contents. ok is false when no agent by that
+// name exists; an error is only returned when discovery or file-reading fails.
+func ResolveAgent(name, cwd, homeDir string) (content string, ok bool, err error) {
+	locator := compat.NewLocator(homeDir, cwd)
+	agents, err := locator.DiscoverAgents()
+	if err != nil {
+		return "", false, err
+	}
+	for _, agent := range agents {
+		if agent.Name == name {
+			data, err := os.ReadFile(agent.Path)
+			if err != nil {
+				return "", false, err
+			}
+			return string(data), true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// resourceDescription returns the description for a skill or agent file.
+// It first tries to extract a description from YAML frontmatter; if none is
+// found it falls back to the first non-empty, non-heading line of the file.
+func resourceDescription(path, fallback string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fallback
+	}
+	text := string(data)
+	if desc := frontmatterDescription(text); desc != "" {
+		return desc
+	}
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || line == "---" {
+			continue
+		}
+		return line
+	}
+	return fallback
+}
+
+// frontmatterDescription extracts the value of the "description" key from a
+// YAML frontmatter block (delimited by leading and trailing "---" lines).
+//
+// It handles the following value styles found in real agent/skill files:
+//   - Plain scalar:       description: some text
+//   - Double-quoted:      description: "some text"
+//   - Single-quoted:      description: 'some text'
+//   - Block literal (|):  multi-line joined with a space
+//   - Block folded (>):   multi-line joined with a space
+//
+// The key comparison is case-insensitive. An empty string is returned when
+// the document has no frontmatter or no description key.
+func frontmatterDescription(text string) string {
+	// Normalize CRLF to LF so Windows-style line endings don't bypass the check.
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+
+	// Frontmatter must start at byte 0 with "---\n".
+	if !strings.HasPrefix(text, "---\n") {
+		return ""
+	}
+
+	lines := strings.Split(text, "\n")
+
+	// Find the closing "---" (or "...") delimiter.
+	endLine := -1
+	for i := 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "---" || trimmed == "..." {
+			endLine = i
+			break
+		}
+	}
+	if endLine < 0 {
+		return "" // no closing delimiter — not valid frontmatter
+	}
+
+	fmLines := lines[1:endLine]
+
+	for i := 0; i < len(fmLines); i++ {
+		line := fmLines[i]
+
+		// Skip empty lines and comment lines.
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		colonIdx := strings.Index(line, ":")
+		if colonIdx < 0 {
+			continue
+		}
+
+		key := strings.TrimSpace(line[:colonIdx])
+		if !strings.EqualFold(key, "description") {
+			continue
+		}
+
+		// Everything after the colon is the raw value fragment.
+		raw := strings.TrimSpace(line[colonIdx+1:])
+
+		// Block scalar indicators.
+		switch raw {
+		case "|", "|-", "|+", ">", ">-", ">+":
+			return collectBlockScalar(fmLines[i+1:])
+		}
+
+		// Double-quoted string.
+		if strings.HasPrefix(raw, `"`) {
+			return parseDoubleQuoted(raw)
+		}
+
+		// Single-quoted string.
+		if strings.HasPrefix(raw, `'`) {
+			return parseSingleQuoted(raw)
+		}
+
+		// Plain scalar — strip inline comment (space + #).
+		if idx := strings.Index(raw, " #"); idx >= 0 {
+			raw = strings.TrimSpace(raw[:idx])
+		}
+		return raw
+	}
+
+	return ""
+}
+
+// collectBlockScalar gathers indented lines that form the body of a YAML block
+// scalar and joins them with spaces (we don't distinguish | from > here —
+// both are collapsed to a single-line description).
+func collectBlockScalar(remaining []string) string {
+	var parts []string
+	for _, line := range remaining {
+		// Block content is indented; a non-indented line ends the block.
+		if line == "" {
+			// Blank lines inside the block are preserved as spaces.
+			parts = append(parts, "")
+			continue
+		}
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			break
+		}
+		parts = append(parts, strings.TrimSpace(line))
+	}
+	// Trim trailing blank entries.
+	for len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	return strings.Join(parts, " ")
+}
+
+// parseDoubleQuoted extracts the content of a double-quoted YAML scalar,
+// handling \" escape sequences. The leading '"' must be included in raw.
+func parseDoubleQuoted(raw string) string {
+	s := raw[1:] // strip leading "
+	var sb strings.Builder
+	i := 0
+	for i < len(s) {
+		ch := s[i]
+		if ch == '"' {
+			break
+		}
+		if ch == '\\' && i+1 < len(s) {
+			next := s[i+1]
+			switch next {
+			case '"':
+				sb.WriteByte('"')
+			case '\\':
+				sb.WriteByte('\\')
+			case 'n':
+				sb.WriteByte('\n')
+			case 't':
+				sb.WriteByte('\t')
+			default:
+				sb.WriteByte('\\')
+				sb.WriteByte(next)
+			}
+			i += 2
+			continue
+		}
+		sb.WriteByte(ch)
+		i++
+	}
+	return sb.String()
+}
+
+// parseSingleQuoted extracts the content of a single-quoted YAML scalar.
+// In YAML single-quoted scalars, ” is the only escape sequence (for a
+// literal single quote). The leading "'" must be included in raw.
+func parseSingleQuoted(raw string) string {
+	s := raw[1:] // strip leading '
+	var sb strings.Builder
+	i := 0
+	for i < len(s) {
+		ch := s[i]
+		if ch == '\'' {
+			// '' is an escaped single quote; a lone ' is the closing delimiter.
+			if i+1 < len(s) && s[i+1] == '\'' {
+				sb.WriteByte('\'')
+				i += 2
+				continue
+			}
+			break
+		}
+		sb.WriteByte(ch)
+		i++
+	}
+	return sb.String()
+}
+
+// NormalizeCWD returns a clean absolute working directory path, defaulting to
+// os.Getwd() when cwd is empty.
+func NormalizeCWD(cwd string) string {
+	if cwd == "" {
+		if wd, err := os.Getwd(); err == nil {
+			return wd
+		}
+	}
+	return filepath.Clean(cwd)
+}

--- a/experimental/adk-go/go-runner/internal/registration/registration.go
+++ b/experimental/adk-go/go-runner/internal/registration/registration.go
@@ -1,0 +1,278 @@
+package registration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pizzaface/pizzapi/experimental/adk-go/runtime/compat"
+)
+
+type Skill struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	FilePath    string `json:"filePath"`
+}
+
+type Agent struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	FilePath    string `json:"filePath"`
+}
+
+type Metadata struct {
+	Roots  []string
+	Skills []Skill
+	Agents []Agent
+}
+
+// Discover collects all skills and agents discoverable from cwd and homeDir,
+// building a Metadata payload ready for registration.
+func Discover(cwd, homeDir string) (Metadata, error) {
+	locator := compat.NewLocator(homeDir, cwd)
+	skills, err := locator.DiscoverSkills()
+	if err != nil {
+		return Metadata{}, err
+	}
+	agents, err := locator.DiscoverAgents()
+	if err != nil {
+		return Metadata{}, err
+	}
+
+	meta := Metadata{Roots: []string{cwd}}
+	for _, skill := range skills {
+		meta.Skills = append(meta.Skills, Skill{
+			Name:        skill.Name,
+			Description: resourceDescription(skill.Path, skill.Name),
+			FilePath:    skill.Path,
+		})
+	}
+	for _, agent := range agents {
+		meta.Agents = append(meta.Agents, Agent{
+			Name:        agent.Name,
+			Description: resourceDescription(agent.Path, agent.Name),
+			FilePath:    agent.Path,
+		})
+	}
+	return meta, nil
+}
+
+// ResolveAgent looks up an agent by name across all compat locations (project then
+// global) and returns the full file contents. ok is false when no agent by that
+// name exists; an error is only returned when discovery or file-reading fails.
+func ResolveAgent(name, cwd, homeDir string) (content string, ok bool, err error) {
+	locator := compat.NewLocator(homeDir, cwd)
+	agents, err := locator.DiscoverAgents()
+	if err != nil {
+		return "", false, err
+	}
+	for _, agent := range agents {
+		if agent.Name == name {
+			data, err := os.ReadFile(agent.Path)
+			if err != nil {
+				return "", false, err
+			}
+			return string(data), true, nil
+		}
+	}
+	return "", false, nil
+}
+
+// resourceDescription returns the description for a skill or agent file.
+// It first tries to extract a description from YAML frontmatter; if none is
+// found it falls back to the first non-empty, non-heading line of the file.
+func resourceDescription(path, fallback string) string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fallback
+	}
+	text := string(data)
+	if desc := frontmatterDescription(text); desc != "" {
+		return desc
+	}
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || line == "---" {
+			continue
+		}
+		return line
+	}
+	return fallback
+}
+
+// frontmatterDescription extracts the value of the "description" key from a
+// YAML frontmatter block (delimited by leading and trailing "---" lines).
+//
+// It handles the following value styles found in real agent/skill files:
+//   - Plain scalar:       description: some text
+//   - Double-quoted:      description: "some text"
+//   - Single-quoted:      description: 'some text'
+//   - Block literal (|):  multi-line joined with a space
+//   - Block folded (>):   multi-line joined with a space
+//
+// The key comparison is case-insensitive. An empty string is returned when
+// the document has no frontmatter or no description key.
+func frontmatterDescription(text string) string {
+	// Frontmatter must start at byte 0 with "---\n".
+	if !strings.HasPrefix(text, "---\n") {
+		return ""
+	}
+
+	lines := strings.Split(text, "\n")
+
+	// Find the closing "---" (or "...") delimiter.
+	endLine := -1
+	for i := 1; i < len(lines); i++ {
+		trimmed := strings.TrimSpace(lines[i])
+		if trimmed == "---" || trimmed == "..." {
+			endLine = i
+			break
+		}
+	}
+	if endLine < 0 {
+		return "" // no closing delimiter — not valid frontmatter
+	}
+
+	fmLines := lines[1:endLine]
+
+	for i := 0; i < len(fmLines); i++ {
+		line := fmLines[i]
+
+		// Skip empty lines and comment lines.
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		colonIdx := strings.Index(line, ":")
+		if colonIdx < 0 {
+			continue
+		}
+
+		key := strings.TrimSpace(line[:colonIdx])
+		if !strings.EqualFold(key, "description") {
+			continue
+		}
+
+		// Everything after the colon is the raw value fragment.
+		raw := strings.TrimSpace(line[colonIdx+1:])
+
+		// Block scalar indicators.
+		switch raw {
+		case "|", "|-", "|+", ">", ">-", ">+":
+			return collectBlockScalar(fmLines[i+1:])
+		}
+
+		// Double-quoted string.
+		if strings.HasPrefix(raw, `"`) {
+			return parseDoubleQuoted(raw)
+		}
+
+		// Single-quoted string.
+		if strings.HasPrefix(raw, `'`) {
+			return parseSingleQuoted(raw)
+		}
+
+		// Plain scalar — strip inline comment (space + #).
+		if idx := strings.Index(raw, " #"); idx >= 0 {
+			raw = strings.TrimSpace(raw[:idx])
+		}
+		return raw
+	}
+
+	return ""
+}
+
+// collectBlockScalar gathers indented lines that form the body of a YAML block
+// scalar and joins them with spaces (we don't distinguish | from > here —
+// both are collapsed to a single-line description).
+func collectBlockScalar(remaining []string) string {
+	var parts []string
+	for _, line := range remaining {
+		// Block content is indented; a non-indented line ends the block.
+		if line == "" {
+			// Blank lines inside the block are preserved as spaces.
+			parts = append(parts, "")
+			continue
+		}
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			break
+		}
+		parts = append(parts, strings.TrimSpace(line))
+	}
+	// Trim trailing blank entries.
+	for len(parts) > 0 && parts[len(parts)-1] == "" {
+		parts = parts[:len(parts)-1]
+	}
+	return strings.Join(parts, " ")
+}
+
+// parseDoubleQuoted extracts the content of a double-quoted YAML scalar,
+// handling \" escape sequences. The leading '"' must be included in raw.
+func parseDoubleQuoted(raw string) string {
+	s := raw[1:] // strip leading "
+	var sb strings.Builder
+	i := 0
+	for i < len(s) {
+		ch := s[i]
+		if ch == '"' {
+			break
+		}
+		if ch == '\\' && i+1 < len(s) {
+			next := s[i+1]
+			switch next {
+			case '"':
+				sb.WriteByte('"')
+			case '\\':
+				sb.WriteByte('\\')
+			case 'n':
+				sb.WriteByte('\n')
+			case 't':
+				sb.WriteByte('\t')
+			default:
+				sb.WriteByte('\\')
+				sb.WriteByte(next)
+			}
+			i += 2
+			continue
+		}
+		sb.WriteByte(ch)
+		i++
+	}
+	return sb.String()
+}
+
+// parseSingleQuoted extracts the content of a single-quoted YAML scalar.
+// In YAML single-quoted scalars, ” is the only escape sequence (for a
+// literal single quote). The leading "'" must be included in raw.
+func parseSingleQuoted(raw string) string {
+	s := raw[1:] // strip leading '
+	var sb strings.Builder
+	i := 0
+	for i < len(s) {
+		ch := s[i]
+		if ch == '\'' {
+			// '' is an escaped single quote; a lone ' is the closing delimiter.
+			if i+1 < len(s) && s[i+1] == '\'' {
+				sb.WriteByte('\'')
+				i += 2
+				continue
+			}
+			break
+		}
+		sb.WriteByte(ch)
+		i++
+	}
+	return sb.String()
+}
+
+// NormalizeCWD returns a clean absolute working directory path, defaulting to
+// os.Getwd() when cwd is empty.
+func NormalizeCWD(cwd string) string {
+	if cwd == "" {
+		if wd, err := os.Getwd(); err == nil {
+			return wd
+		}
+	}
+	return filepath.Clean(cwd)
+}

--- a/experimental/adk-go/go-runner/internal/registration/registration_test.go
+++ b/experimental/adk-go/go-runner/internal/registration/registration_test.go
@@ -1,0 +1,307 @@
+package registration
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// frontmatterDescription
+// ---------------------------------------------------------------------------
+
+func TestFrontmatterDescriptionPlain(t *testing.T) {
+	text := "---\ndescription: Use this to do things\n---\n# Title\n"
+	got := frontmatterDescription(text)
+	want := "Use this to do things"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrontmatterDescriptionDoubleQuoted(t *testing.T) {
+	text := "---\ndescription: \"Quoted description\"\n---\n"
+	got := frontmatterDescription(text)
+	want := "Quoted description"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrontmatterDescriptionDoubleQuotedEscape(t *testing.T) {
+	text := `---` + "\n" + `description: "She said \"hello\""` + "\n" + `---` + "\n"
+	got := frontmatterDescription(text)
+	want := `She said "hello"`
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrontmatterDescriptionSingleQuoted(t *testing.T) {
+	text := "---\ndescription: 'It''s a test'\n---\n"
+	got := frontmatterDescription(text)
+	want := "It's a test"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrontmatterDescriptionBlockLiteral(t *testing.T) {
+	text := "---\ndescription: |\n  First line\n  Second line\n---\n"
+	got := frontmatterDescription(text)
+	want := "First line Second line"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrontmatterDescriptionBlockFolded(t *testing.T) {
+	text := "---\ndescription: >\n  Folded line one\n  Folded line two\n---\n"
+	got := frontmatterDescription(text)
+	want := "Folded line one Folded line two"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrontmatterDescriptionBlockLiteralChompStrip(t *testing.T) {
+	text := "---\ndescription: |-\n  Only line\n---\n"
+	got := frontmatterDescription(text)
+	want := "Only line"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrontmatterDescriptionCaseInsensitiveKey(t *testing.T) {
+	text := "---\nDescription: Mixed Case Key\n---\n"
+	got := frontmatterDescription(text)
+	want := "Mixed Case Key"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrontmatterDescriptionInlineComment(t *testing.T) {
+	text := "---\ndescription: plain value # ignore this\n---\n"
+	got := frontmatterDescription(text)
+	want := "plain value"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrontmatterDescriptionNoFrontmatter(t *testing.T) {
+	text := "# Just a markdown file\nNo frontmatter here.\n"
+	got := frontmatterDescription(text)
+	if got != "" {
+		t.Fatalf("expected empty string, got %q", got)
+	}
+}
+
+func TestFrontmatterDescriptionMissingClosingDelimiter(t *testing.T) {
+	text := "---\ndescription: open block\nno closing delimiter\n"
+	got := frontmatterDescription(text)
+	if got != "" {
+		t.Fatalf("expected empty string for unclosed frontmatter, got %q", got)
+	}
+}
+
+func TestFrontmatterDescriptionNoDescriptionKey(t *testing.T) {
+	text := "---\nname: my-agent\ntopics:\n  - testing\n---\n"
+	got := frontmatterDescription(text)
+	if got != "" {
+		t.Fatalf("expected empty string when no description key, got %q", got)
+	}
+}
+
+func TestFrontmatterDescriptionMultipleKeys(t *testing.T) {
+	text := "---\nname: agent\ndescription: Found it\nauthor: somebody\n---\n"
+	got := frontmatterDescription(text)
+	want := "Found it"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrontmatterDescriptionEmptyValue(t *testing.T) {
+	text := "---\ndescription:\nname: agent\n---\n"
+	got := frontmatterDescription(text)
+	// Empty value is valid — no fallback triggered from within frontmatterDescription
+	if got != "" {
+		t.Fatalf("expected empty string for empty description value, got %q", got)
+	}
+}
+
+func TestFrontmatterDescriptionDotDotDotDelimiter(t *testing.T) {
+	text := "---\ndescription: dot delimiter\n...\n"
+	got := frontmatterDescription(text)
+	want := "dot delimiter"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// resourceDescription (integration with frontmatterDescription + fallback)
+// ---------------------------------------------------------------------------
+
+func TestResourceDescriptionFallbackToFirstLine(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.md")
+	if err := os.WriteFile(path, []byte("# My Agent\nThis is the first body line.\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := resourceDescription(path, "fallback")
+	want := "This is the first body line."
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResourceDescriptionFallbackOnMissingFile(t *testing.T) {
+	got := resourceDescription("/no/such/file.md", "my-fallback")
+	if got != "my-fallback" {
+		t.Fatalf("expected fallback name, got %q", got)
+	}
+}
+
+func TestResourceDescriptionPrefersFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "agent.md")
+	content := "---\ndescription: Frontmatter wins\n---\n# Title\nBody line.\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := resourceDescription(path, "fallback")
+	want := "Frontmatter wins"
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveAgent
+// ---------------------------------------------------------------------------
+
+func writeAgentFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name+".md")
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestResolveAgentFound(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	agentDir := filepath.Join(home, ".pizzapi", "agents")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	wantContent := "# My Agent\nDoes stuff.\n"
+	writeAgentFile(t, agentDir, "my-agent", wantContent)
+
+	content, ok, err := ResolveAgent("my-agent", cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected agent to be found")
+	}
+	if content != wantContent {
+		t.Fatalf("got %q, want %q", content, wantContent)
+	}
+}
+
+func TestResolveAgentNotFound(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	content, ok, err := ResolveAgent("nonexistent", cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected agent not to be found")
+	}
+	if content != "" {
+		t.Fatalf("expected empty content, got %q", content)
+	}
+}
+
+func TestResolveAgentProjectOverridesGlobal(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+
+	globalDir := filepath.Join(home, ".pizzapi", "agents")
+	projectDir := filepath.Join(cwd, ".pizzapi", "agents")
+	if err := os.MkdirAll(globalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	writeAgentFile(t, globalDir, "shared", "# Global version\n")
+	writeAgentFile(t, projectDir, "shared", "# Project version\n")
+
+	content, ok, err := ResolveAgent("shared", cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !ok {
+		t.Fatal("expected agent to be found")
+	}
+	// Project takes precedence
+	if content != "# Project version\n" {
+		t.Fatalf("expected project version, got %q", content)
+	}
+}
+
+func TestResolveAgentEmptyDirectories(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	// No agents directories exist at all — should return not-found, no error.
+	_, ok, err := ResolveAgent("anything", cwd, home)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ok {
+		t.Fatal("expected not found")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Discover (integration)
+// ---------------------------------------------------------------------------
+
+func TestDiscoverIncludesDescriptions(t *testing.T) {
+	home := t.TempDir()
+	cwd := t.TempDir()
+	agentDir := filepath.Join(home, ".pizzapi", "agents")
+	if err := os.MkdirAll(agentDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	content := "---\ndescription: Test agent for testing\n---\n# Agent\n"
+	writeAgentFile(t, agentDir, "test-agent", content)
+
+	meta, err := Discover(cwd, home)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(meta.Agents) != 1 {
+		t.Fatalf("expected 1 agent, got %d", len(meta.Agents))
+	}
+	if meta.Agents[0].Description != "Test agent for testing" {
+		t.Fatalf("unexpected description: %q", meta.Agents[0].Description)
+	}
+	if meta.Roots[0] != cwd {
+		t.Fatalf("expected cwd in roots, got %v", meta.Roots)
+	}
+}

--- a/experimental/adk-go/go-runner/internal/relay/relay_session.go
+++ b/experimental/adk-go/go-runner/internal/relay/relay_session.go
@@ -1,4 +1,4 @@
-package main
+package relay
 
 import (
 	"encoding/json"
@@ -23,6 +23,10 @@ type RelaySession struct {
 	onInput   func(text string) // callback when user sends input from web UI
 	done      chan struct{}
 	closeOnce sync.Once
+}
+
+func (rs *RelaySession) SetInputHandler(handler func(text string)) {
+	rs.onInput = handler
 }
 
 // NewRelaySession creates and connects a relay session.

--- a/experimental/adk-go/go-runner/internal/relay/socketio.go
+++ b/experimental/adk-go/go-runner/internal/relay/socketio.go
@@ -10,7 +10,7 @@
 //
 // Example event: 42/runner,["event_name",{...}]
 
-package main
+package relay
 
 import (
 	"encoding/json"

--- a/experimental/adk-go/go-runner/main.go
+++ b/experimental/adk-go/go-runner/main.go
@@ -26,6 +26,14 @@ import (
 
 const version = "0.1.0-phase0"
 
+// shortID returns the first 8 characters of id, or the full string if shorter.
+func shortID(id string) string {
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
+}
+
 // session tracks a running provider session.
 type session struct {
 	sessionID    string
@@ -227,7 +235,7 @@ func (r *GoRunner) handleNewSession(data json.RawMessage) {
 
 	bootstrap, err := buildSessionBootstrap(payload.Cwd, r.homeDir, r.tempDir)
 	if err != nil {
-		r.logger.Printf("session %s bootstrap error: %v", sessionID[:8], err)
+		r.logger.Printf("session %s bootstrap error: %v", shortID(sessionID), err)
 		r.client.Emit("session_error", map[string]any{
 			"sessionId": sessionID,
 			"message":   fmt.Sprintf("session bootstrap failed: %v", err),
@@ -257,7 +265,7 @@ func (r *GoRunner) handleNewSession(data json.RawMessage) {
 		SystemPrompt:  bootstrap.SystemPrompt,
 		MCPConfigPath: bootstrap.MCPConfigPath,
 		OnStderr: func(line string) {
-			r.logger.Printf("[session:%s:stderr] %s", sessionID[:8], line)
+			r.logger.Printf("[session:%s:stderr] %s", shortID(sessionID), line)
 		},
 	})
 }
@@ -272,10 +280,10 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 
 	// Wire up user input from web UI → provider
 	relaySess.SetInputHandler(func(text string) {
-		r.logger.Printf("session %s: sending user input to provider", sessionID[:8])
+		r.logger.Printf("session %s: sending user input to provider", shortID(sessionID))
 
 		if err := sess.provider.SendMessage(text); err != nil {
-			r.logger.Printf("session %s: send message error: %v", sessionID[:8], err)
+			r.logger.Printf("session %s: send message error: %v", shortID(sessionID), err)
 			return
 		}
 
@@ -290,17 +298,18 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 			"sessionId": sessionID,
 			"event":     activeHB,
 		})
-		if relaySess != nil {
-			relaySess.EmitEvent(activeHB)
-		}
+		relaySess.EmitEvent(activeHB)
 	})
 
 	if err := relaySess.Connect(r.relayURL, r.apiKey, cwd); err != nil {
-		r.logger.Printf("session %s relay registration failed: %v", sessionID[:8], err)
+		r.logger.Printf("session %s relay registration failed: %v", shortID(sessionID), err)
 		r.client.Emit("session_error", map[string]any{
 			"sessionId": sessionID,
 			"message":   fmt.Sprintf("relay registration failed: %v", err),
 		})
+		if sess.cleanup != nil {
+			sess.cleanup()
+		}
 		r.sessions.Delete(sessionID)
 		return
 	}
@@ -309,12 +318,15 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 	// Start the provider
 	events, err := sess.provider.Start(pctx)
 	if err != nil {
-		r.logger.Printf("session %s start error: %v", sessionID[:8], err)
+		r.logger.Printf("session %s start error: %v", shortID(sessionID), err)
 		r.client.Emit("session_error", map[string]any{
 			"sessionId": sessionID,
 			"message":   err.Error(),
 		})
 		relaySess.Close()
+		if sess.cleanup != nil {
+			sess.cleanup()
+		}
 		r.sessions.Delete(sessionID)
 		return
 	}
@@ -323,7 +335,7 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 	r.client.Emit("session_ready", map[string]any{
 		"sessionId": sessionID,
 	})
-	r.logger.Printf("session %s ready", sessionID[:8])
+	r.logger.Printf("session %s ready", shortID(sessionID))
 
 	// Start a heartbeat ticker
 	heartbeatTicker := time.NewTicker(10 * time.Second)
@@ -340,7 +352,7 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 			}
 
 			evType, _ := ev["type"].(string)
-			r.logger.Printf("session %s relay event: %v", sessionID[:8], evType)
+			r.logger.Printf("session %s relay event: %v", shortID(sessionID), evType)
 
 			// Forward via the /relay session connection — this goes through
 			// the server's event pipeline (state caching, image stripping,
@@ -391,7 +403,7 @@ func (r *GoRunner) handleSessionExit(sess *session) {
 	<-sess.provider.Done()
 
 	exitCode := sess.provider.ExitCode()
-	r.logger.Printf("session %s exited (code=%d)", sessionID[:8], exitCode)
+	r.logger.Printf("session %s exited (code=%d)", shortID(sessionID), exitCode)
 
 	// Send final inactive heartbeat
 	r.client.Emit("runner_session_event", map[string]any{
@@ -426,11 +438,11 @@ func (r *GoRunner) handleKillSession(data json.RawMessage) {
 		return
 	}
 
-	r.logger.Printf("kill_session: %s", payload.SessionID[:8])
+	r.logger.Printf("kill_session: %s", shortID(payload.SessionID))
 
 	val, ok := r.sessions.Load(payload.SessionID)
 	if !ok {
-		r.logger.Printf("session %s not found for kill", payload.SessionID[:8])
+		r.logger.Printf("session %s not found for kill", shortID(payload.SessionID))
 		return
 	}
 
@@ -451,7 +463,7 @@ func (r *GoRunner) killSession(sess *session) {
 	select {
 	case <-sess.provider.Done():
 	case <-time.After(10 * time.Second):
-		r.logger.Printf("session %s did not exit after stop, force killed", sess.sessionID[:8])
+		r.logger.Printf("session %s did not exit after stop, force killed", shortID(sess.sessionID))
 	}
 }
 
@@ -463,7 +475,7 @@ func (r *GoRunner) handleSessionEnded(data json.RawMessage) {
 		r.logger.Printf("parse session_ended: %v", err)
 		return
 	}
-	r.logger.Printf("session_ended from relay: %s", payload.SessionID[:8])
+	r.logger.Printf("session_ended from relay: %s", shortID(payload.SessionID))
 	r.sessions.Delete(payload.SessionID)
 }
 

--- a/experimental/adk-go/go-runner/main.go
+++ b/experimental/adk-go/go-runner/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -42,6 +43,7 @@ type session struct {
 	cancel       context.CancelFunc
 	cleanup      func()
 	interceptor  ToolCallInterceptor // nil = no tool call interception
+	planMode     atomic.Bool         // updated dynamically by toggle_plan_mode tool calls
 	killed       bool
 	mu           sync.Mutex
 }
@@ -248,24 +250,27 @@ func (r *GoRunner) handleNewSession(data json.RawMessage) {
 	// Future: select provider based on model prefix, config, etc.
 	provider := r.providerFactory(r.logger)
 
-	// Build the tool call interceptor from runner config sandbox settings.
-	// Failures are non-fatal — the session runs without interception.
-	var interceptor ToolCallInterceptor
-	if cfg, cfgErr := loadRunnerConfig(payload.Cwd, r.homeDir); cfgErr != nil {
-		r.logger.Printf("session %s: load runner config for interceptor: %v", shortID(sessionID), cfgErr)
-	} else {
-		interceptor = NewGuardrailsInterceptor(cfg.Sandbox, payload.Cwd, r.homeDir, false)
-	}
-
-	// Create and track the session
+	// Create the session early so planMode can be closed over by the interceptor.
 	ctx, cancel := context.WithCancel(context.Background())
 	sess := &session{
-		sessionID:   sessionID,
-		provider:    provider,
-		cancel:      cancel,
-		cleanup:     bootstrap.Cleanup,
-		interceptor: interceptor,
+		sessionID: sessionID,
+		provider:  provider,
+		cancel:    cancel,
+		cleanup:   bootstrap.Cleanup,
 	}
+
+	// Build the tool call interceptor from runner config sandbox settings.
+	// On config failure we fall back to ModeBasic (fail-closed) rather than
+	// running without any sandbox enforcement (fail-open).
+	cfg, cfgErr := loadRunnerConfig(payload.Cwd, r.homeDir)
+	if cfgErr != nil {
+		r.logger.Printf("session %s: load runner config for interceptor: %v — enforcing basic sandbox (fail-closed)", shortID(sessionID), cfgErr)
+		cfg = runnerConfig{}
+		cfg.Sandbox.Mode = "basic"
+	}
+	sess.interceptor = NewGuardrailsInterceptor(cfg.Sandbox, payload.Cwd, r.homeDir, func() bool {
+		return sess.planMode.Load()
+	})
 	r.sessions.Store(sessionID, sess)
 
 	// Spawn the provider session
@@ -370,6 +375,13 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 			// will be enforced when the runner has its own native tool surface.
 			if evType == "message_update" && sess.interceptor != nil {
 				for _, block := range extractToolUseBlocks(ev) {
+					// Track plan mode changes so the interceptor sees the current state.
+					if block.Name == "toggle_plan_mode" {
+						if enabled, ok := block.Args["enabled"].(bool); ok {
+							sess.planMode.Store(enabled)
+							r.logger.Printf("session %s: plan mode → %v", shortID(sessionID), enabled)
+						}
+					}
 					if allowed, reason := sess.interceptor(block.Name, block.Args); !allowed {
 						r.logger.Printf("session %s: tool_use %q denied by interceptor: %s", shortID(sessionID), block.Name, reason)
 						// Future: emit tool_result error back to provider when native tool surface is wired.

--- a/experimental/adk-go/go-runner/main.go
+++ b/experimental/adk-go/go-runner/main.go
@@ -3,7 +3,7 @@
 // It connects to the PizzaPi relay server via Socket.IO, registers as a
 // runner, and spawns claude CLI subprocesses in response to new_session
 // events. Claude CLI events are converted to PizzaPi relay events via the
-// adapter from the claude-wrapper package and forwarded to the relay.
+// adapter from the providers/claudecli package and forwarded to the relay.
 //
 // This is the Phase 0 prototype: one session at a time, no compaction,
 // no triggers, no services, no hooks, no MCP, no PTY.
@@ -16,18 +16,23 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
 	"runtime"
 	"sync"
-	"syscall"
 	"time"
 )
 
 const version = "0.1.0-phase0"
+
+// shortID returns the first 8 characters of id, or the full string if shorter.
+func shortID(id string) string {
+	if len(id) <= 8 {
+		return id
+	}
+	return id[:8]
+}
 
 // session tracks a running provider session.
 type session struct {
@@ -35,6 +40,8 @@ type session struct {
 	provider     Provider      // LLM backend (Claude CLI, API, etc.)
 	relaySession *RelaySession // per-session /relay connection
 	cancel       context.CancelFunc
+	cleanup      func()
+	interceptor  ToolCallInterceptor // nil = no tool call interception
 	killed       bool
 	mu           sync.Mutex
 }
@@ -45,21 +52,31 @@ type GoRunner struct {
 	apiKey     string
 	runnerID   string
 	runnerName string
+	homeDir    string
+	workDir    string
+	tempDir    string
 
-	client   *SIOClient
-	sessions sync.Map // sessionID → *session
-	logger   *log.Logger
-	stop     context.CancelFunc // signals Run() to exit
+	providerFactory func(*log.Logger) Provider
+	client          *SIOClient
+	sessions        sync.Map // sessionID → *session
+	logger          *log.Logger
+	stop            context.CancelFunc // signals Run() to exit
 }
 
 // NewGoRunner creates a new runner daemon.
 func NewGoRunner(relayURL, apiKey, runnerID, runnerName string) *GoRunner {
+	homeDir, _ := os.UserHomeDir()
+	workDir, _ := os.Getwd()
 	return &GoRunner{
-		relayURL:   relayURL,
-		apiKey:     apiKey,
-		runnerID:   runnerID,
-		runnerName: runnerName,
-		logger:     log.New(os.Stderr, "[go-runner] ", log.LstdFlags|log.Lmsgprefix),
+		relayURL:        relayURL,
+		apiKey:          apiKey,
+		runnerID:        runnerID,
+		runnerName:      runnerName,
+		homeDir:         homeDir,
+		workDir:         normalizeRunnerCwd(workDir),
+		tempDir:         os.TempDir(),
+		providerFactory: func(logger *log.Logger) Provider { return NewClaudeCLIProvider(logger) },
+		logger:          log.New(os.Stderr, "[go-runner] ", log.LstdFlags|log.Lmsgprefix),
 	}
 }
 
@@ -129,14 +146,31 @@ func (r *GoRunner) emitRegister() {
 		name = hostname
 	}
 
+	meta, err := discoverRegistrationMetadata(r.workDir, r.homeDir)
+	if err != nil {
+		r.logger.Printf("discover registration metadata: %v", err)
+		meta = registrationMetadata{Roots: []string{r.workDir}}
+	}
+	skills, agents := marshalRegistrationLists(meta.Skills, meta.Agents)
+
+	// Load hooks from PizzaPi config for inclusion in the registration payload.
+	// Failures are non-fatal — the runner still registers without hook metadata.
+	hooksList := marshalHooks(nil)
+	cfg, cfgErr := loadRunnerConfig(r.workDir, r.homeDir)
+	if cfgErr != nil {
+		r.logger.Printf("load runner config: %v", cfgErr)
+	} else {
+		hooksList = marshalHooks(cfg.Hooks)
+	}
+
 	r.client.Emit("register_runner", map[string]any{
 		"runnerId": r.runnerID,
 		"name":     name,
-		"roots":    []string{},
-		"skills":   []any{},
-		"agents":   []any{},
+		"roots":    stableRoots(meta.Roots),
+		"skills":   skills,
+		"agents":   agents,
 		"plugins":  []any{},
-		"hooks":    []any{},
+		"hooks":    hooksList,
 		"version":  version,
 		"platform": runtime.GOOS,
 	})
@@ -165,10 +199,10 @@ func (r *GoRunner) handleRunnerRegistered(data json.RawMessage) {
 
 func (r *GoRunner) handleNewSession(data json.RawMessage) {
 	var payload struct {
-		SessionID       string `json:"sessionId"`
-		Cwd             string `json:"cwd"`
-		Prompt          string `json:"prompt"`
-		Model           *struct {
+		SessionID string `json:"sessionId"`
+		Cwd       string `json:"cwd"`
+		Prompt    string `json:"prompt"`
+		Model     *struct {
 			Provider string `json:"provider"`
 			ID       string `json:"id"`
 		} `json:"model"`
@@ -200,26 +234,49 @@ func (r *GoRunner) handleNewSession(data json.RawMessage) {
 		model = payload.Model.ID
 	}
 
+	bootstrap, err := buildSessionBootstrap(payload.Cwd, r.homeDir, r.tempDir)
+	if err != nil {
+		r.logger.Printf("session %s bootstrap error: %v", shortID(sessionID), err)
+		r.client.Emit("session_error", map[string]any{
+			"sessionId": sessionID,
+			"message":   fmt.Sprintf("session bootstrap failed: %v", err),
+		})
+		return
+	}
+
 	// Create provider — currently always Claude CLI.
 	// Future: select provider based on model prefix, config, etc.
-	provider := NewClaudeCLIProvider(r.logger)
+	provider := r.providerFactory(r.logger)
+
+	// Build the tool call interceptor from runner config sandbox settings.
+	// Failures are non-fatal — the session runs without interception.
+	var interceptor ToolCallInterceptor
+	if cfg, cfgErr := loadRunnerConfig(payload.Cwd, r.homeDir); cfgErr != nil {
+		r.logger.Printf("session %s: load runner config for interceptor: %v", shortID(sessionID), cfgErr)
+	} else {
+		interceptor = NewGuardrailsInterceptor(cfg.Sandbox, payload.Cwd, r.homeDir, false)
+	}
 
 	// Create and track the session
 	ctx, cancel := context.WithCancel(context.Background())
 	sess := &session{
-		sessionID: sessionID,
-		provider:  provider,
-		cancel:    cancel,
+		sessionID:   sessionID,
+		provider:    provider,
+		cancel:      cancel,
+		cleanup:     bootstrap.Cleanup,
+		interceptor: interceptor,
 	}
 	r.sessions.Store(sessionID, sess)
 
 	// Spawn the provider session
 	go r.runSession(ctx, sess, ProviderContext{
-		Prompt: prompt,
-		Cwd:    payload.Cwd,
-		Model:  model,
+		Prompt:        prompt,
+		Cwd:           payload.Cwd,
+		Model:         model,
+		SystemPrompt:  bootstrap.SystemPrompt,
+		MCPConfigPath: bootstrap.MCPConfigPath,
 		OnStderr: func(line string) {
-			r.logger.Printf("[session:%s:stderr] %s", sessionID[:8], line)
+			r.logger.Printf("[session:%s:stderr] %s", shortID(sessionID), line)
 		},
 	})
 }
@@ -233,11 +290,11 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 	relaySess := NewRelaySession(r.relayURL, r.apiKey, sessionID, cwd, r.logger)
 
 	// Wire up user input from web UI → provider
-	relaySess.onInput = func(text string) {
-		r.logger.Printf("session %s: sending user input to provider", sessionID[:8])
+	relaySess.SetInputHandler(func(text string) {
+		r.logger.Printf("session %s: sending user input to provider", shortID(sessionID))
 
 		if err := sess.provider.SendMessage(text); err != nil {
-			r.logger.Printf("session %s: send message error: %v", sessionID[:8], err)
+			r.logger.Printf("session %s: send message error: %v", shortID(sessionID), err)
 			return
 		}
 
@@ -252,17 +309,18 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 			"sessionId": sessionID,
 			"event":     activeHB,
 		})
-		if relaySess != nil {
-			relaySess.EmitEvent(activeHB)
-		}
-	}
+		relaySess.EmitEvent(activeHB)
+	})
 
 	if err := relaySess.Connect(r.relayURL, r.apiKey, cwd); err != nil {
-		r.logger.Printf("session %s relay registration failed: %v", sessionID[:8], err)
+		r.logger.Printf("session %s relay registration failed: %v", shortID(sessionID), err)
 		r.client.Emit("session_error", map[string]any{
 			"sessionId": sessionID,
 			"message":   fmt.Sprintf("relay registration failed: %v", err),
 		})
+		if sess.cleanup != nil {
+			sess.cleanup()
+		}
 		r.sessions.Delete(sessionID)
 		return
 	}
@@ -271,12 +329,15 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 	// Start the provider
 	events, err := sess.provider.Start(pctx)
 	if err != nil {
-		r.logger.Printf("session %s start error: %v", sessionID[:8], err)
+		r.logger.Printf("session %s start error: %v", shortID(sessionID), err)
 		r.client.Emit("session_error", map[string]any{
 			"sessionId": sessionID,
 			"message":   err.Error(),
 		})
 		relaySess.Close()
+		if sess.cleanup != nil {
+			sess.cleanup()
+		}
 		r.sessions.Delete(sessionID)
 		return
 	}
@@ -285,7 +346,7 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 	r.client.Emit("session_ready", map[string]any{
 		"sessionId": sessionID,
 	})
-	r.logger.Printf("session %s ready", sessionID[:8])
+	r.logger.Printf("session %s ready", shortID(sessionID))
 
 	// Start a heartbeat ticker
 	heartbeatTicker := time.NewTicker(10 * time.Second)
@@ -302,7 +363,19 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 			}
 
 			evType, _ := ev["type"].(string)
-			r.logger.Printf("session %s relay event: %v", sessionID[:8], evType)
+			r.logger.Printf("session %s relay event: %v", shortID(sessionID), evType)
+
+			// Intercept tool_use blocks in message_update events.
+			// The Claude CLI manages its own tool execution today; this boundary
+			// will be enforced when the runner has its own native tool surface.
+			if evType == "message_update" && sess.interceptor != nil {
+				for _, block := range extractToolUseBlocks(ev) {
+					if allowed, reason := sess.interceptor(block.Name, block.Args); !allowed {
+						r.logger.Printf("session %s: tool_use %q denied by interceptor: %s", shortID(sessionID), block.Name, reason)
+						// Future: emit tool_result error back to provider when native tool surface is wired.
+					}
+				}
+			}
 
 			// Forward via the /relay session connection — this goes through
 			// the server's event pipeline (state caching, image stripping,
@@ -345,12 +418,15 @@ func (r *GoRunner) handleSessionExit(sess *session) {
 	if sess.relaySession != nil {
 		sess.relaySession.Close()
 	}
+	if sess.cleanup != nil {
+		sess.cleanup()
+	}
 
 	// Wait for provider to fully exit
 	<-sess.provider.Done()
 
 	exitCode := sess.provider.ExitCode()
-	r.logger.Printf("session %s exited (code=%d)", sessionID[:8], exitCode)
+	r.logger.Printf("session %s exited (code=%d)", shortID(sessionID), exitCode)
 
 	// Send final inactive heartbeat
 	r.client.Emit("runner_session_event", map[string]any{
@@ -385,11 +461,11 @@ func (r *GoRunner) handleKillSession(data json.RawMessage) {
 		return
 	}
 
-	r.logger.Printf("kill_session: %s", payload.SessionID[:8])
+	r.logger.Printf("kill_session: %s", shortID(payload.SessionID))
 
 	val, ok := r.sessions.Load(payload.SessionID)
 	if !ok {
-		r.logger.Printf("session %s not found for kill", payload.SessionID[:8])
+		r.logger.Printf("session %s not found for kill", shortID(payload.SessionID))
 		return
 	}
 
@@ -410,7 +486,7 @@ func (r *GoRunner) killSession(sess *session) {
 	select {
 	case <-sess.provider.Done():
 	case <-time.After(10 * time.Second):
-		r.logger.Printf("session %s did not exit after stop, force killed", sess.sessionID[:8])
+		r.logger.Printf("session %s did not exit after stop, force killed", shortID(sess.sessionID))
 	}
 }
 
@@ -422,7 +498,7 @@ func (r *GoRunner) handleSessionEnded(data json.RawMessage) {
 		r.logger.Printf("parse session_ended: %v", err)
 		return
 	}
-	r.logger.Printf("session_ended from relay: %s", payload.SessionID[:8])
+	r.logger.Printf("session_ended from relay: %s", shortID(payload.SessionID))
 	r.sessions.Delete(payload.SessionID)
 }
 
@@ -474,53 +550,4 @@ func (r *GoRunner) handleError(data json.RawMessage) {
 		return
 	}
 	r.logger.Printf("relay error: %s", payload.Message)
-}
-
-func main() {
-	relayURL := flag.String("relay-url", "", "PizzaPi relay URL (default: PIZZAPI_RELAY_URL or http://localhost:7492)")
-	runnerName := flag.String("runner-name", "", "Runner display name (default: hostname)")
-	runnerID := flag.String("runner-id", "", "Runner ID (default: go-runner-<hostname>)")
-	flag.Parse()
-
-	// Resolve relay URL
-	url := *relayURL
-	if url == "" {
-		url = os.Getenv("PIZZAPI_RELAY_URL")
-	}
-	if url == "" {
-		url = "http://localhost:7492"
-	}
-	// Normalize ws:// to http:// for our client
-	if len(url) > 5 && url[:5] == "ws://" {
-		url = "http://" + url[5:]
-	} else if len(url) > 6 && url[:6] == "wss://" {
-		url = "https://" + url[6:]
-	}
-
-	// Resolve API key
-	apiKey := os.Getenv("PIZZAPI_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("PIZZAPI_API_TOKEN")
-	}
-	if apiKey == "" {
-		fmt.Fprintln(os.Stderr, "error: PIZZAPI_API_KEY environment variable is required")
-		os.Exit(1)
-	}
-
-	// Resolve runner ID
-	id := *runnerID
-	if id == "" {
-		hostname, _ := os.Hostname()
-		id = "go-runner-" + hostname
-	}
-
-	runner := NewGoRunner(url, apiKey, id, *runnerName)
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
-	if err := runner.Run(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
 }

--- a/experimental/adk-go/go-runner/main.go
+++ b/experimental/adk-go/go-runner/main.go
@@ -290,6 +290,17 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 	sessionID := sess.sessionID
 	cwd := pctx.Cwd
 
+	// Ensure MCP temp file and any other bootstrap resources are always
+	// released, regardless of which exit path is taken (normal exit,
+	// relay-connect error, provider-start error, or ctx.Done() kill path).
+	// cleanup is idempotent (os.Remove on a missing file is a no-op), so
+	// double-calls from handleSessionExit + this defer are safe.
+	defer func() {
+		if sess.cleanup != nil {
+			sess.cleanup()
+		}
+	}()
+
 	// Connect to /relay to register the session in the session store.
 	// This is what makes the session visible to the web UI.
 	relaySess := NewRelaySession(r.relayURL, r.apiKey, sessionID, cwd, r.logger)

--- a/experimental/adk-go/go-runner/main.go
+++ b/experimental/adk-go/go-runner/main.go
@@ -3,7 +3,7 @@
 // It connects to the PizzaPi relay server via Socket.IO, registers as a
 // runner, and spawns claude CLI subprocesses in response to new_session
 // events. Claude CLI events are converted to PizzaPi relay events via the
-// adapter from the claude-wrapper package and forwarded to the relay.
+// adapter from the providers/claudecli package and forwarded to the relay.
 //
 // This is the Phase 0 prototype: one session at a time, no compaction,
 // no triggers, no services, no hooks, no MCP, no PTY.
@@ -16,14 +16,11 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"flag"
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
 	"runtime"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -35,6 +32,7 @@ type session struct {
 	provider     Provider      // LLM backend (Claude CLI, API, etc.)
 	relaySession *RelaySession // per-session /relay connection
 	cancel       context.CancelFunc
+	cleanup      func()
 	killed       bool
 	mu           sync.Mutex
 }
@@ -45,21 +43,31 @@ type GoRunner struct {
 	apiKey     string
 	runnerID   string
 	runnerName string
+	homeDir    string
+	workDir    string
+	tempDir    string
 
-	client   *SIOClient
-	sessions sync.Map // sessionID → *session
-	logger   *log.Logger
-	stop     context.CancelFunc // signals Run() to exit
+	providerFactory func(*log.Logger) Provider
+	client          *SIOClient
+	sessions        sync.Map // sessionID → *session
+	logger          *log.Logger
+	stop            context.CancelFunc // signals Run() to exit
 }
 
 // NewGoRunner creates a new runner daemon.
 func NewGoRunner(relayURL, apiKey, runnerID, runnerName string) *GoRunner {
+	homeDir, _ := os.UserHomeDir()
+	workDir, _ := os.Getwd()
 	return &GoRunner{
-		relayURL:   relayURL,
-		apiKey:     apiKey,
-		runnerID:   runnerID,
-		runnerName: runnerName,
-		logger:     log.New(os.Stderr, "[go-runner] ", log.LstdFlags|log.Lmsgprefix),
+		relayURL:        relayURL,
+		apiKey:          apiKey,
+		runnerID:        runnerID,
+		runnerName:      runnerName,
+		homeDir:         homeDir,
+		workDir:         normalizeRunnerCwd(workDir),
+		tempDir:         os.TempDir(),
+		providerFactory: func(logger *log.Logger) Provider { return NewClaudeCLIProvider(logger) },
+		logger:          log.New(os.Stderr, "[go-runner] ", log.LstdFlags|log.Lmsgprefix),
 	}
 }
 
@@ -129,14 +137,31 @@ func (r *GoRunner) emitRegister() {
 		name = hostname
 	}
 
+	meta, err := discoverRegistrationMetadata(r.workDir, r.homeDir)
+	if err != nil {
+		r.logger.Printf("discover registration metadata: %v", err)
+		meta = registrationMetadata{Roots: []string{r.workDir}}
+	}
+	skills, agents := marshalRegistrationLists(meta.Skills, meta.Agents)
+
+	// Load hooks from PizzaPi config for inclusion in the registration payload.
+	// Failures are non-fatal — the runner still registers without hook metadata.
+	hooksList := marshalHooks(nil)
+	cfg, cfgErr := loadRunnerConfig(r.workDir, r.homeDir)
+	if cfgErr != nil {
+		r.logger.Printf("load runner config: %v", cfgErr)
+	} else {
+		hooksList = marshalHooks(cfg.Hooks)
+	}
+
 	r.client.Emit("register_runner", map[string]any{
 		"runnerId": r.runnerID,
 		"name":     name,
-		"roots":    []string{},
-		"skills":   []any{},
-		"agents":   []any{},
+		"roots":    stableRoots(meta.Roots),
+		"skills":   skills,
+		"agents":   agents,
 		"plugins":  []any{},
-		"hooks":    []any{},
+		"hooks":    hooksList,
 		"version":  version,
 		"platform": runtime.GOOS,
 	})
@@ -165,10 +190,10 @@ func (r *GoRunner) handleRunnerRegistered(data json.RawMessage) {
 
 func (r *GoRunner) handleNewSession(data json.RawMessage) {
 	var payload struct {
-		SessionID       string `json:"sessionId"`
-		Cwd             string `json:"cwd"`
-		Prompt          string `json:"prompt"`
-		Model           *struct {
+		SessionID string `json:"sessionId"`
+		Cwd       string `json:"cwd"`
+		Prompt    string `json:"prompt"`
+		Model     *struct {
 			Provider string `json:"provider"`
 			ID       string `json:"id"`
 		} `json:"model"`
@@ -200,9 +225,19 @@ func (r *GoRunner) handleNewSession(data json.RawMessage) {
 		model = payload.Model.ID
 	}
 
+	bootstrap, err := buildSessionBootstrap(payload.Cwd, r.homeDir, r.tempDir)
+	if err != nil {
+		r.logger.Printf("session %s bootstrap error: %v", sessionID[:8], err)
+		r.client.Emit("session_error", map[string]any{
+			"sessionId": sessionID,
+			"message":   fmt.Sprintf("session bootstrap failed: %v", err),
+		})
+		return
+	}
+
 	// Create provider — currently always Claude CLI.
 	// Future: select provider based on model prefix, config, etc.
-	provider := NewClaudeCLIProvider(r.logger)
+	provider := r.providerFactory(r.logger)
 
 	// Create and track the session
 	ctx, cancel := context.WithCancel(context.Background())
@@ -210,14 +245,17 @@ func (r *GoRunner) handleNewSession(data json.RawMessage) {
 		sessionID: sessionID,
 		provider:  provider,
 		cancel:    cancel,
+		cleanup:   bootstrap.Cleanup,
 	}
 	r.sessions.Store(sessionID, sess)
 
 	// Spawn the provider session
 	go r.runSession(ctx, sess, ProviderContext{
-		Prompt: prompt,
-		Cwd:    payload.Cwd,
-		Model:  model,
+		Prompt:        prompt,
+		Cwd:           payload.Cwd,
+		Model:         model,
+		SystemPrompt:  bootstrap.SystemPrompt,
+		MCPConfigPath: bootstrap.MCPConfigPath,
 		OnStderr: func(line string) {
 			r.logger.Printf("[session:%s:stderr] %s", sessionID[:8], line)
 		},
@@ -233,7 +271,7 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 	relaySess := NewRelaySession(r.relayURL, r.apiKey, sessionID, cwd, r.logger)
 
 	// Wire up user input from web UI → provider
-	relaySess.onInput = func(text string) {
+	relaySess.SetInputHandler(func(text string) {
 		r.logger.Printf("session %s: sending user input to provider", sessionID[:8])
 
 		if err := sess.provider.SendMessage(text); err != nil {
@@ -255,7 +293,7 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 		if relaySess != nil {
 			relaySess.EmitEvent(activeHB)
 		}
-	}
+	})
 
 	if err := relaySess.Connect(r.relayURL, r.apiKey, cwd); err != nil {
 		r.logger.Printf("session %s relay registration failed: %v", sessionID[:8], err)
@@ -344,6 +382,9 @@ func (r *GoRunner) handleSessionExit(sess *session) {
 	// Close the relay session connection
 	if sess.relaySession != nil {
 		sess.relaySession.Close()
+	}
+	if sess.cleanup != nil {
+		sess.cleanup()
 	}
 
 	// Wait for provider to fully exit
@@ -474,53 +515,4 @@ func (r *GoRunner) handleError(data json.RawMessage) {
 		return
 	}
 	r.logger.Printf("relay error: %s", payload.Message)
-}
-
-func main() {
-	relayURL := flag.String("relay-url", "", "PizzaPi relay URL (default: PIZZAPI_RELAY_URL or http://localhost:7492)")
-	runnerName := flag.String("runner-name", "", "Runner display name (default: hostname)")
-	runnerID := flag.String("runner-id", "", "Runner ID (default: go-runner-<hostname>)")
-	flag.Parse()
-
-	// Resolve relay URL
-	url := *relayURL
-	if url == "" {
-		url = os.Getenv("PIZZAPI_RELAY_URL")
-	}
-	if url == "" {
-		url = "http://localhost:7492"
-	}
-	// Normalize ws:// to http:// for our client
-	if len(url) > 5 && url[:5] == "ws://" {
-		url = "http://" + url[5:]
-	} else if len(url) > 6 && url[:6] == "wss://" {
-		url = "https://" + url[6:]
-	}
-
-	// Resolve API key
-	apiKey := os.Getenv("PIZZAPI_API_KEY")
-	if apiKey == "" {
-		apiKey = os.Getenv("PIZZAPI_API_TOKEN")
-	}
-	if apiKey == "" {
-		fmt.Fprintln(os.Stderr, "error: PIZZAPI_API_KEY environment variable is required")
-		os.Exit(1)
-	}
-
-	// Resolve runner ID
-	id := *runnerID
-	if id == "" {
-		hostname, _ := os.Hostname()
-		id = "go-runner-" + hostname
-	}
-
-	runner := NewGoRunner(url, apiKey, id, *runnerName)
-
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
-	if err := runner.Run(ctx); err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(1)
-	}
 }

--- a/experimental/adk-go/go-runner/provider.go
+++ b/experimental/adk-go/go-runner/provider.go
@@ -48,6 +48,10 @@ type ProviderContext struct {
 	// Model is the requested model ID (e.g. "claude-sonnet-4-20250514").
 	// Provider implementations map this to their native model identifiers.
 	Model string
+	// SystemPrompt is appended to the provider's built-in instructions.
+	SystemPrompt string
+	// MCPConfigPath points to a Claude-compatible temp config file for MCP servers.
+	MCPConfigPath string
 	// OnStderr is called with each line of stderr output (for logging).
 	OnStderr func(string)
 }

--- a/experimental/adk-go/go-runner/provider_claude.go
+++ b/experimental/adk-go/go-runner/provider_claude.go
@@ -7,18 +7,18 @@ import (
 	"log"
 	"sync"
 
-	claudewrapper "github.com/pizzaface/pizzapi/experimental/adk-go/claude-wrapper"
+	claudecli "github.com/pizzaface/pizzapi/experimental/adk-go/providers/claudecli"
 )
 
 // ClaudeCLIProvider implements Provider by spawning a Claude Code CLI
 // subprocess in interactive mode (--input-format stream-json).
 //
-// It owns the claude-wrapper Runner (subprocess lifecycle) and Adapter
+// It owns the providers/claudecli Runner (subprocess lifecycle) and Adapter
 // (NDJSON → RelayEvent translation). The go-runner never touches these
 // directly — it only sees the Provider interface.
 type ClaudeCLIProvider struct {
-	runner  *claudewrapper.Runner
-	adapter *claudewrapper.Adapter
+	runner  *claudecli.Runner
+	adapter *claudecli.Adapter
 	logger  *log.Logger
 
 	events chan RelayEvent // relay events produced by this provider
@@ -29,7 +29,7 @@ type ClaudeCLIProvider struct {
 // NewClaudeCLIProvider creates a new Claude CLI provider.
 func NewClaudeCLIProvider(logger *log.Logger) *ClaudeCLIProvider {
 	return &ClaudeCLIProvider{
-		adapter: claudewrapper.NewAdapter(),
+		adapter: claudecli.NewAdapter(),
 		logger:  logger,
 		events:  make(chan RelayEvent, 128),
 		done:    make(chan struct{}),
@@ -39,7 +39,7 @@ func NewClaudeCLIProvider(logger *log.Logger) *ClaudeCLIProvider {
 // Start launches the claude subprocess in interactive mode and begins
 // converting NDJSON events to RelayEvents on the returned channel.
 func (p *ClaudeCLIProvider) Start(pctx ProviderContext) (<-chan RelayEvent, error) {
-	cfg := claudewrapper.RunnerConfig{
+	cfg := claudecli.RunnerConfig{
 		OnStderr: pctx.OnStderr,
 	}
 	if pctx.Cwd != "" {
@@ -48,8 +48,14 @@ func (p *ClaudeCLIProvider) Start(pctx ProviderContext) (<-chan RelayEvent, erro
 	if pctx.Model != "" {
 		cfg.Model = pctx.Model
 	}
+	if pctx.SystemPrompt != "" {
+		cfg.SystemPrompt = pctx.SystemPrompt
+	}
+	if pctx.MCPConfigPath != "" {
+		cfg.MCPConfig = pctx.MCPConfigPath
+	}
 
-	p.runner = claudewrapper.NewRunner(cfg)
+	p.runner = claudecli.NewRunner(cfg)
 
 	// Record the initial user prompt for message accumulation
 	p.adapter.SetUserPrompt(pctx.Prompt)
@@ -64,16 +70,16 @@ func (p *ClaudeCLIProvider) Start(pctx ProviderContext) (<-chan RelayEvent, erro
 		return nil, fmt.Errorf("start claude: %w", err)
 	}
 
-	// Bridge goroutine: reads claude-wrapper events, converts via adapter,
+	// Bridge goroutine: reads providers/claudecli events, converts via adapter,
 	// and pushes relay events to the output channel.
 	go p.bridge(rawEvents)
 
 	return p.events, nil
 }
 
-// bridge reads from the claude-wrapper event channel, converts each event
+// bridge reads from the providers/claudecli event channel, converts each event
 // to zero or more RelayEvents via the adapter, and sends them on p.events.
-func (p *ClaudeCLIProvider) bridge(rawEvents <-chan claudewrapper.ClaudeEvent) {
+func (p *ClaudeCLIProvider) bridge(rawEvents <-chan claudecli.ClaudeEvent) {
 	defer close(p.events)
 	defer close(p.done)
 

--- a/experimental/adk-go/go-runner/runtime_integration_test.go
+++ b/experimental/adk-go/go-runner/runtime_integration_test.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDiscoverRegistrationMetadata(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(t.TempDir(), "repo")
+
+	mustWrite := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	mustWrite(filepath.Join(cwd, ".pizzapi", "skills", "local-skill", "SKILL.md"), "---\ndescription: Local skill desc\n---\n# Local Skill\n")
+	mustWrite(filepath.Join(home, ".claude", "skills", "global-skill.md"), "# Global skill\nGlobal skill body\n")
+	mustWrite(filepath.Join(cwd, ".claude", "agents", "local-agent.md"), "---\ndescription: Local agent desc\n---\n# Local Agent\n")
+
+	meta, err := discoverRegistrationMetadata(cwd, home)
+	if err != nil {
+		t.Fatalf("discoverRegistrationMetadata: %v", err)
+	}
+
+	if len(meta.Roots) != 1 || meta.Roots[0] != cwd {
+		t.Fatalf("unexpected roots: %#v", meta.Roots)
+	}
+	if len(meta.Skills) != 2 {
+		t.Fatalf("expected 2 skills, got %#v", meta.Skills)
+	}
+	if meta.Skills[0].Name != "local-skill" || meta.Skills[0].Description != "Local skill desc" {
+		t.Fatalf("unexpected first skill: %#v", meta.Skills[0])
+	}
+	if len(meta.Agents) != 1 || meta.Agents[0].Name != "local-agent" || meta.Agents[0].Description != "Local agent desc" {
+		t.Fatalf("unexpected agents: %#v", meta.Agents)
+	}
+}
+
+func TestBuildSessionBootstrapBuildsPromptAndMCPConfig(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(t.TempDir(), "repo")
+	tempDir := filepath.Join(t.TempDir(), "tmp")
+
+	mustWrite := func(path, content string) {
+		t.Helper()
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", path, err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", path, err)
+		}
+	}
+
+	mustWrite(filepath.Join(home, ".pizzapi", "AGENTS.md"), "Global instructions")
+	mustWrite(filepath.Join(cwd, "CLAUDE.md"), "Project instructions")
+	mustWrite(filepath.Join(home, ".pizzapi", "config.json"), `{
+  "mcpServers": {
+    "global": {"command": "uvx", "args": ["gm"]},
+    "shared": {"command": "global-cmd"}
+  }
+}`)
+	mustWrite(filepath.Join(cwd, ".pizzapi", "config.json"), `{
+  "mcpServers": {
+    "shared": {"command": "project-cmd"},
+    "remote": {"url": "https://example.com/mcp", "type": "http"}
+  }
+}`)
+
+	bootstrap, err := buildSessionBootstrap(cwd, home, tempDir)
+	if err != nil {
+		t.Fatalf("buildSessionBootstrap: %v", err)
+	}
+	defer bootstrap.Cleanup()
+
+	if !strings.Contains(bootstrap.SystemPrompt, "Project instructions") || !strings.Contains(bootstrap.SystemPrompt, "Global instructions") {
+		t.Fatalf("system prompt missing instruction docs: %q", bootstrap.SystemPrompt)
+	}
+	if strings.Index(bootstrap.SystemPrompt, "Project instructions") > strings.Index(bootstrap.SystemPrompt, "Global instructions") {
+		t.Fatalf("expected project instructions to come before global instructions: %q", bootstrap.SystemPrompt)
+	}
+	if bootstrap.MCPConfigPath == "" {
+		t.Fatal("expected MCP config path to be created")
+	}
+
+	data, err := os.ReadFile(bootstrap.MCPConfigPath)
+	if err != nil {
+		t.Fatalf("read mcp config: %v", err)
+	}
+	var decoded struct {
+		MCPServers map[string]map[string]any `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal mcp config: %v", err)
+	}
+	if decoded.MCPServers["shared"]["command"] != "project-cmd" {
+		t.Fatalf("expected project override for shared server, got %#v", decoded.MCPServers["shared"])
+	}
+	if decoded.MCPServers["remote"]["type"] != "http" {
+		t.Fatalf("expected streamable/http remote server, got %#v", decoded.MCPServers["remote"])
+	}
+
+	path := bootstrap.MCPConfigPath
+	bootstrap.Cleanup()
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Fatalf("expected cleanup to remove temp config, stat err=%v", err)
+	}
+}

--- a/experimental/adk-go/providers/claudecli/adapter.go
+++ b/experimental/adk-go/providers/claudecli/adapter.go
@@ -1,0 +1,369 @@
+package claudecli
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// RelayEvent is a PizzaPi relay-compatible event as a map.
+type RelayEvent map[string]any
+
+// Adapter accumulates streaming state and converts Claude events to relay events.
+type Adapter struct {
+	currentMessageID  string
+	model             AdapterModel
+	cwd               string
+	initialized       bool // true after first system event
+	contentBlocks     []map[string]any
+	messages          []map[string]any // accumulated conversation messages
+	pendingUserPrompt string           // user prompt to add when system event arrives
+	toolInputBuffers  map[int]string
+	toolUseBlocks     map[int]toolUseMeta
+	toolNamesByID     map[string]string
+	seq               int
+}
+
+type AdapterModel struct {
+	Provider string
+	ID       string
+}
+
+type toolUseMeta struct {
+	id   string
+	name string
+}
+
+func NewAdapter() *Adapter {
+	return &Adapter{
+		toolInputBuffers: map[int]string{},
+		toolUseBlocks:    map[int]toolUseMeta{},
+		toolNamesByID:    map[string]string{},
+	}
+}
+
+// SetUserPrompt records a user prompt so it appears in the accumulated
+// message list. For the initial prompt, this is called before Start and
+// the message is appended when the system event arrives. For follow-up
+// messages, the message is appended immediately.
+// SetUserPrompt records a user prompt. It will be added to the message
+// list when the next system event arrives (Claude emits a system event
+// at the start of every turn, including follow-ups).
+func (a *Adapter) SetUserPrompt(prompt string) {
+	a.pendingUserPrompt = prompt
+}
+
+func (a *Adapter) HandleEvent(ev ClaudeEvent) []RelayEvent {
+	switch e := ev.(type) {
+	case *SystemEvent:
+		a.model = AdapterModel{Provider: "anthropic", ID: e.Model}
+		a.cwd = e.Cwd
+		a.initialized = true
+		// If there's a pending user prompt, add it to the message list now
+		if a.pendingUserPrompt != "" {
+			a.seq++
+			a.messages = append(a.messages, map[string]any{
+				"role": "user",
+				"content": []any{
+					map[string]any{"type": "text", "text": a.pendingUserPrompt},
+				},
+				"messageId": fmt.Sprintf("user_%02d", a.seq),
+				"timestamp": nowMillis(),
+			})
+			a.pendingUserPrompt = ""
+		}
+		return []RelayEvent{
+			// Heartbeat to signal the session is active
+			{
+				"type":         "heartbeat",
+				"active":       true,
+				"isCompacting": false,
+				"ts":           nowMillis(),
+				"model":        a.modelMap(),
+				"sessionName":  nil,
+				"cwd":          e.Cwd,
+			},
+			// session_active with accumulated messages. On first init this is
+			// empty (unblocks the UI's awaitingSnapshot guard). On follow-up
+			// turns this preserves the conversation history.
+			{
+				"type": "session_active",
+				"state": map[string]any{
+					"messages": cloneMessages(a.messages),
+					"model":    a.modelMap(),
+					"cwd":      e.Cwd,
+				},
+			},
+		}
+	case *MessageStart:
+		a.currentMessageID = e.MessageID
+		if a.currentMessageID == "" {
+			a.currentMessageID = a.nextMessageID()
+		}
+		if e.Model != "" {
+			a.model = AdapterModel{Provider: "anthropic", ID: e.Model}
+		}
+		a.contentBlocks = nil
+		a.toolInputBuffers = map[int]string{}
+		a.toolUseBlocks = map[int]toolUseMeta{}
+		return nil
+	case *ContentBlockStart:
+		a.ensureContentIndex(e.Index)
+		switch e.BlockType {
+		case "text":
+			a.contentBlocks[e.Index] = map[string]any{"type": "text", "text": ""}
+		case "tool_use":
+			a.toolUseBlocks[e.Index] = toolUseMeta{id: e.ToolID, name: e.ToolName}
+			a.toolInputBuffers[e.Index] = ""
+			a.toolNamesByID[e.ToolID] = e.ToolName
+		case "thinking":
+			a.contentBlocks[e.Index] = map[string]any{"type": "thinking", "thinking": ""}
+		}
+		return nil
+	case *ContentBlockDelta:
+		switch e.DeltaType {
+		case "text_delta":
+			a.ensureContentIndex(e.Index)
+			if a.contentBlocks[e.Index] == nil {
+				a.contentBlocks[e.Index] = map[string]any{"type": "text", "text": ""}
+			}
+			text, _ := a.contentBlocks[e.Index]["text"].(string)
+			a.contentBlocks[e.Index]["text"] = text + e.Text
+			return []RelayEvent{a.messageUpdate(false)}
+		case "thinking_delta":
+			a.ensureContentIndex(e.Index)
+			if a.contentBlocks[e.Index] == nil {
+				a.contentBlocks[e.Index] = map[string]any{"type": "thinking", "thinking": ""}
+			}
+			thinking, _ := a.contentBlocks[e.Index]["thinking"].(string)
+			a.contentBlocks[e.Index]["thinking"] = thinking + e.Thinking
+			return nil // thinking streamed but not relayed until final message
+		case "signature_delta":
+			return nil // signature verification data — not relayed
+		case "input_json_delta":
+			a.toolInputBuffers[e.Index] += e.PartialJSON
+		}
+		return nil
+	case *ContentBlockStop:
+		if meta, ok := a.toolUseBlocks[e.Index]; ok {
+			a.ensureContentIndex(e.Index)
+			input := map[string]any{}
+			if raw := a.toolInputBuffers[e.Index]; raw != "" {
+				if err := json.Unmarshal([]byte(raw), &input); err != nil {
+					input = map[string]any{"_raw": raw, "_parseError": err.Error()}
+				}
+			}
+			a.contentBlocks[e.Index] = map[string]any{
+				"type":  "tool_use",
+				"id":    meta.id,
+				"name":  meta.name,
+				"input": input,
+			}
+		}
+		return nil
+	case *MessageDelta:
+		return nil
+	case *MessageStop:
+		return nil
+	case *AssistantMessage:
+		if len(e.Message) == 0 {
+			return nil
+		}
+		var payload struct {
+			ID      string           `json:"id"`
+			Role    string           `json:"role"`
+			Content []map[string]any `json:"content"`
+		}
+		if err := json.Unmarshal(e.Message, &payload); err == nil {
+			if len(payload.Content) == 0 {
+				return nil // skip empty assistant events
+			}
+			if payload.ID != "" {
+				a.currentMessageID = payload.ID
+			}
+			a.contentBlocks = cloneBlocks(payload.Content)
+			for _, block := range payload.Content {
+				if blockType, _ := block["type"].(string); blockType == "tool_use" {
+					id, _ := block["id"].(string)
+					name, _ := block["name"].(string)
+					if id != "" && name != "" {
+						a.toolNamesByID[id] = name
+					}
+				}
+			}
+		}
+		return []RelayEvent{a.messageUpdate(true)}
+	case *ToolUseEvent:
+		var input any = map[string]any{}
+		if len(e.Input) > 0 {
+			_ = json.Unmarshal(e.Input, &input)
+		}
+		a.toolNamesByID[e.ToolID] = e.Name
+		return []RelayEvent{{
+			"type":      "message_update",
+			"role":      "assistant",
+			"content":   []map[string]any{{"type": "tool_use", "id": e.ToolID, "name": e.Name, "input": input}},
+			"messageId": a.currentOrGeneratedMessageID(),
+		}}
+	case *ToolResultEvent:
+		toolMsg := RelayEvent{
+			"type":       "tool_result_message",
+			"role":       "tool_result",
+			"toolCallId": e.ToolID,
+			"toolName":   a.toolNamesByID[e.ToolID],
+			"content":    e.Content,
+			"isError":    e.IsError,
+			"timestamp":  nowMillis(),
+		}
+		a.messages = append(a.messages, map[string]any(toolMsg))
+		return []RelayEvent{toolMsg}
+	case *UserMessage:
+		// The Claude CLI reports tool results as "user" messages.
+		// Map them to tool_result_message for PizzaPi.
+		if e.ToolUseID != "" {
+			toolMsg := RelayEvent{
+				"type":       "tool_result_message",
+				"role":       "tool_result",
+				"toolCallId": e.ToolUseID,
+				"toolName":   a.toolNamesByID[e.ToolUseID],
+				"content":    e.Content,
+				"isError":    e.IsError,
+				"timestamp":  nowMillis(),
+			}
+			a.messages = append(a.messages, map[string]any(toolMsg))
+			return []RelayEvent{toolMsg}
+		}
+		return nil
+	case *RateLimitEvent:
+		// Rate limit info is logged but not forwarded to the relay.
+		return nil
+	case *ResultEvent:
+		if a.model.ID == "" {
+			a.model = AdapterModel{Provider: "anthropic", ID: ""}
+		}
+		// Build a complete session_active with the accumulated messages
+		// so the lastState in Redis has the full conversation for
+		// reconnecting viewers.
+		events := []RelayEvent{}
+
+		// Emit session_active with the assistant message to persist state
+		if len(a.contentBlocks) > 0 {
+			assistantMsg := map[string]any{
+				"role":      "assistant",
+				"content":   cloneBlocks(a.contentBlocks),
+				"messageId": a.currentOrGeneratedMessageID(),
+				"timestamp": nowMillis(),
+			}
+			// Accumulate the full message list
+			a.messages = append(a.messages, assistantMsg)
+			events = append(events, RelayEvent{
+				"type": "session_active",
+				"state": map[string]any{
+					"messages": cloneMessages(a.messages),
+					"model":    a.modelMap(),
+					"cwd":      a.cwd,
+				},
+			})
+		}
+
+		events = append(events, RelayEvent{
+			"type":  "session_metadata_update",
+			"model": a.modelMap(),
+			"usage": map[string]any{
+				"inputTokens":  e.InputTokens,
+				"outputTokens": e.OutputTokens,
+			},
+			"costUSD":    e.TotalCostUSD,
+			"durationMs": e.DurationMs,
+			"numTurns":   e.NumTurns,
+			"stopReason": e.StopReason,
+		})
+
+		// Signal that the agent is idle (turn complete)
+		events = append(events, RelayEvent{
+			"type":         "heartbeat",
+			"active":       false,
+			"isCompacting": false,
+			"ts":           nowMillis(),
+			"model":        a.modelMap(),
+			"cwd":          a.cwd,
+		})
+
+		return events
+	case *UnknownEvent, *ParseError:
+		return nil
+	default:
+		return nil
+	}
+}
+
+func (a *Adapter) currentOrGeneratedMessageID() string {
+	if a.currentMessageID == "" {
+		a.currentMessageID = a.nextMessageID()
+	}
+	return a.currentMessageID
+}
+
+func (a *Adapter) nextMessageID() string {
+	a.seq++
+	return fmt.Sprintf("msg_%02d", a.seq)
+}
+
+func (a *Adapter) ensureContentIndex(index int) {
+	for len(a.contentBlocks) <= index {
+		a.contentBlocks = append(a.contentBlocks, nil)
+	}
+}
+
+func (a *Adapter) messageUpdate(includeTimestamp bool) RelayEvent {
+	event := RelayEvent{
+		"type":      "message_update",
+		"role":      "assistant",
+		"content":   cloneBlocks(a.contentBlocks),
+		"messageId": a.currentOrGeneratedMessageID(),
+	}
+	if includeTimestamp {
+		event["timestamp"] = nowMillis()
+	}
+	return event
+}
+
+func (a *Adapter) modelMap() map[string]any {
+	return map[string]any{"provider": a.model.Provider, "id": a.model.ID}
+}
+
+// ModelMap returns the current model as a map (exported for callers).
+func (a *Adapter) ModelMap() map[string]any {
+	return a.modelMap()
+}
+
+func cloneMessages(msgs []map[string]any) []any {
+	out := make([]any, 0, len(msgs))
+	for _, msg := range msgs {
+		copy := make(map[string]any, len(msg))
+		for k, v := range msg {
+			copy[k] = v
+		}
+		out = append(out, copy)
+	}
+	return out
+}
+
+func cloneBlocks(blocks []map[string]any) []map[string]any {
+	out := make([]map[string]any, 0, len(blocks))
+	for _, block := range blocks {
+		if block == nil {
+			continue
+		}
+		copyBlock := make(map[string]any, len(block))
+		for k, v := range block {
+			copyBlock[k] = v
+		}
+		out = append(out, copyBlock)
+	}
+	return out
+}
+
+func nowMillis() int64 {
+	return time.Now().UnixMilli()
+}

--- a/experimental/adk-go/providers/claudecli/adapter_test.go
+++ b/experimental/adk-go/providers/claudecli/adapter_test.go
@@ -1,0 +1,278 @@
+package claudecli
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestAdapterSystemEventHeartbeat(t *testing.T) {
+	a := NewAdapter()
+	events := a.HandleEvent(&SystemEvent{Cwd: "/tmp", Model: "claude-sonnet-4-20250514"})
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (heartbeat + session_active), got %d", len(events))
+	}
+	if events[0]["type"] != "heartbeat" {
+		t.Fatalf("unexpected first event type: %+v", events[0])
+	}
+	if events[1]["type"] != "session_active" {
+		t.Fatalf("unexpected second event type: %+v", events[1])
+	}
+	if events[0]["active"] != true {
+		t.Fatalf("expected active=true: %+v", events[0])
+	}
+	model, ok := events[0]["model"].(map[string]any)
+	if !ok {
+		t.Fatalf("model missing: %+v", events[0])
+	}
+	if model["provider"] != "anthropic" || model["id"] != "claude-sonnet-4-20250514" {
+		t.Fatalf("unexpected model: %+v", model)
+	}
+}
+
+func TestAdapterStreamingTextMessageUpdate(t *testing.T) {
+	a := NewAdapter()
+	if got := a.HandleEvent(&MessageStart{MessageID: "msg_01", Role: "assistant"}); len(got) != 0 {
+		t.Fatalf("expected no events, got %+v", got)
+	}
+	if got := a.HandleEvent(&ContentBlockStart{Index: 0, BlockType: "text"}); len(got) != 0 {
+		t.Fatalf("expected no events, got %+v", got)
+	}
+
+	events := a.HandleEvent(&ContentBlockDelta{Index: 0, DeltaType: "text_delta", Text: "Hello"})
+	assertSingleTextUpdate(t, events, "msg_01", "Hello")
+
+	events = a.HandleEvent(&ContentBlockDelta{Index: 0, DeltaType: "text_delta", Text: " world"})
+	assertSingleTextUpdate(t, events, "msg_01", "Hello world")
+}
+
+func TestAdapterToolCallAssembly(t *testing.T) {
+	a := NewAdapter()
+	a.HandleEvent(&MessageStart{MessageID: "msg_01"})
+	if got := a.HandleEvent(&ContentBlockStart{Index: 1, BlockType: "tool_use", ToolID: "tool_abc", ToolName: "bash"}); len(got) != 0 {
+		t.Fatalf("expected no events, got %+v", got)
+	}
+	if got := a.HandleEvent(&ContentBlockDelta{Index: 1, DeltaType: "input_json_delta", PartialJSON: `{"command":"ls"}`}); len(got) != 0 {
+		t.Fatalf("expected no events, got %+v", got)
+	}
+	if got := a.HandleEvent(&ContentBlockStop{Index: 1}); len(got) != 0 {
+		t.Fatalf("expected no events, got %+v", got)
+	}
+
+	events := a.HandleEvent(&AssistantMessage{Message: mustJSON(t, map[string]any{
+		"id":   "msg_01",
+		"role": "assistant",
+		"content": []map[string]any{
+			{"type": "tool_use", "id": "tool_abc", "name": "bash", "input": map[string]any{"command": "ls"}},
+		},
+	})})
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	content := getContent(t, events[0])
+	if len(content) != 1 {
+		t.Fatalf("expected 1 content block, got %+v", content)
+	}
+	if content[0]["type"] != "tool_use" || content[0]["id"] != "tool_abc" || content[0]["name"] != "bash" {
+		t.Fatalf("unexpected tool block: %+v", content[0])
+	}
+	input, ok := content[0]["input"].(map[string]any)
+	if !ok || input["command"] != "ls" {
+		t.Fatalf("unexpected tool input: %+v", content[0]["input"])
+	}
+}
+
+func TestAdapterToolResultEvent(t *testing.T) {
+	a := NewAdapter()
+	a.HandleEvent(&ToolUseEvent{ToolID: "tool_abc", Name: "bash", Input: mustJSON(t, map[string]any{"command": "ls"})})
+	events := a.HandleEvent(&ToolResultEvent{ToolID: "tool_abc", Content: "file1.txt\nfile2.txt", IsError: false})
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev := events[0]
+	if ev["type"] != "tool_result_message" || ev["toolCallId"] != "tool_abc" || ev["toolName"] != "bash" || ev["content"] != "file1.txt\nfile2.txt" || ev["isError"] != false {
+		t.Fatalf("unexpected tool result event: %+v", ev)
+	}
+}
+
+func TestAdapterResultEventMetadata(t *testing.T) {
+	a := NewAdapter()
+	a.HandleEvent(&SystemEvent{Model: "claude-sonnet-4-20250514"})
+	events := a.HandleEvent(&ResultEvent{
+		InputTokens:  500,
+		OutputTokens: 200,
+		TotalCostUSD: 0.05,
+		DurationMs:   3000,
+		NumTurns:     1,
+		StopReason:   "end_turn",
+	})
+	if len(events) != 2 {
+		t.Fatalf("expected 2 events (metadata + idle heartbeat), got %d", len(events))
+	}
+	ev := events[0]
+	if ev["type"] != "session_metadata_update" || ev["costUSD"] != 0.05 {
+		t.Fatalf("unexpected metadata event: %+v", ev)
+	}
+	usage, ok := ev["usage"].(map[string]any)
+	if !ok || usage["inputTokens"] != 500 || usage["outputTokens"] != 200 {
+		t.Fatalf("unexpected usage: %+v", ev["usage"])
+	}
+	if ev["durationMs"] != 3000 || ev["numTurns"] != 1 || ev["stopReason"] != "end_turn" {
+		t.Fatalf("unexpected metadata fields: %+v", ev)
+	}
+}
+
+func TestAdapterFullConversationFlow(t *testing.T) {
+	a := NewAdapter()
+	var relayed []RelayEvent
+	appendEvents := func(in []RelayEvent) { relayed = append(relayed, in...) }
+
+	appendEvents(a.HandleEvent(&SystemEvent{Cwd: "/tmp", Model: "claude-sonnet-4-20250514"}))
+	appendEvents(a.HandleEvent(&MessageStart{MessageID: "msg_01", Role: "assistant"}))
+	appendEvents(a.HandleEvent(&ContentBlockStart{Index: 0, BlockType: "text"}))
+	appendEvents(a.HandleEvent(&ContentBlockDelta{Index: 0, DeltaType: "text_delta", Text: "Hello"}))
+	appendEvents(a.HandleEvent(&ContentBlockDelta{Index: 0, DeltaType: "text_delta", Text: " world"}))
+	appendEvents(a.HandleEvent(&ContentBlockStop{Index: 0}))
+	appendEvents(a.HandleEvent(&MessageStop{}))
+	appendEvents(a.HandleEvent(&AssistantMessage{Message: mustJSON(t, map[string]any{
+		"id":      "msg_01",
+		"role":    "assistant",
+		"content": []map[string]any{{"type": "text", "text": "Hello world"}},
+	})}))
+	appendEvents(a.HandleEvent(&ToolUseEvent{ToolID: "tool_abc", Name: "bash", Input: mustJSON(t, map[string]any{"command": "ls"})}))
+	appendEvents(a.HandleEvent(&ToolResultEvent{ToolID: "tool_abc", Content: "file1.txt\nfile2.txt", IsError: false}))
+	appendEvents(a.HandleEvent(&ResultEvent{InputTokens: 500, OutputTokens: 200, TotalCostUSD: 0.05}))
+
+	if len(relayed) != 10 {
+		t.Fatalf("expected 10 relay events, got %d: %+v", len(relayed), relayed)
+	}
+	assertEventType(t, relayed[0], "heartbeat")
+	assertEventType(t, relayed[1], "session_active") // initial empty snapshot
+	assertEventType(t, relayed[2], "message_update")
+	assertEventType(t, relayed[3], "message_update")
+	assertEventType(t, relayed[4], "message_update") // final assistant message
+	assertEventType(t, relayed[5], "message_update") // tool_use block
+	assertEventType(t, relayed[6], "tool_result_message")
+	assertEventType(t, relayed[7], "session_active") // final snapshot with messages
+	assertEventType(t, relayed[8], "session_metadata_update")
+	assertEventType(t, relayed[9], "heartbeat") // active=false (idle)
+	content := getContent(t, relayed[4])
+	if len(content) != 1 || content[0]["text"] != "Hello world" {
+		t.Fatalf("unexpected final assistant content: %+v", content)
+	}
+}
+
+func TestAdapterParseErrorNoOutput(t *testing.T) {
+	a := NewAdapter()
+	if got := a.HandleEvent(&ParseError{Message: "bad json"}); len(got) != 0 {
+		t.Fatalf("expected no events, got %+v", got)
+	}
+}
+
+func TestAdapterUnknownEventNoOutput(t *testing.T) {
+	a := NewAdapter()
+	if got := a.HandleEvent(&UnknownEvent{RawType: "mystery"}); len(got) != 0 {
+		t.Fatalf("expected no events, got %+v", got)
+	}
+}
+
+func assertSingleTextUpdate(t *testing.T, events []RelayEvent, messageID, expectedText string) {
+	t.Helper()
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev := events[0]
+	assertEventType(t, ev, "message_update")
+	if ev["messageId"] != messageID {
+		t.Fatalf("unexpected messageId: %+v", ev)
+	}
+	content := getContent(t, ev)
+	if len(content) != 1 || content[0]["type"] != "text" || content[0]["text"] != expectedText {
+		t.Fatalf("unexpected content: %+v", content)
+	}
+}
+
+func assertEventType(t *testing.T, ev RelayEvent, expected string) {
+	t.Helper()
+	if ev["type"] != expected {
+		t.Fatalf("expected type %q, got %+v", expected, ev)
+	}
+}
+
+func getContent(t *testing.T, ev RelayEvent) []map[string]any {
+	t.Helper()
+	raw, ok := ev["content"]
+	if !ok {
+		t.Fatalf("content missing: %+v", ev)
+	}
+	content, ok := raw.([]map[string]any)
+	if ok {
+		return content
+	}
+	asAny, ok := raw.([]any)
+	if !ok {
+		t.Fatalf("unexpected content type %T in %+v", raw, ev)
+	}
+	out := make([]map[string]any, 0, len(asAny))
+	for _, item := range asAny {
+		block, ok := item.(map[string]any)
+		if !ok {
+			t.Fatalf("unexpected block type %T", item)
+		}
+		out = append(out, block)
+	}
+	return out
+}
+
+func TestAdapterUserMessageToolResult(t *testing.T) {
+	a := NewAdapter()
+	// Register tool name first via a ToolUseEvent
+	a.HandleEvent(&AssistantMessage{Message: mustJSON(t, map[string]any{
+		"id":   "msg_01",
+		"role": "assistant",
+		"content": []map[string]any{
+			{"type": "tool_use", "id": "toolu_abc", "name": "Bash", "input": map[string]any{"command": "ls"}},
+		},
+	})})
+	events := a.HandleEvent(&UserMessage{
+		ToolUseID: "toolu_abc",
+		Content:   "file1.txt\nfile2.txt",
+		IsError:   false,
+	})
+	if len(events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(events))
+	}
+	ev := events[0]
+	if ev["type"] != "tool_result_message" {
+		t.Fatalf("unexpected type: %+v", ev)
+	}
+	if ev["toolCallId"] != "toolu_abc" || ev["toolName"] != "Bash" {
+		t.Fatalf("unexpected tool result: %+v", ev)
+	}
+}
+
+func TestAdapterRateLimitEventNoOutput(t *testing.T) {
+	a := NewAdapter()
+	events := a.HandleEvent(&RateLimitEvent{Status: "allowed", LimitType: "five_hour"})
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events for rate_limit_event, got %d", len(events))
+	}
+}
+
+func TestAdapterEmptyAssistantSkipped(t *testing.T) {
+	a := NewAdapter()
+	events := a.HandleEvent(&AssistantMessage{Message: mustJSON(t, map[string]any{
+		"id": "msg_01", "role": "assistant", "content": []any{},
+	})})
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events for empty assistant, got %d", len(events))
+	}
+}
+
+func mustJSON(t *testing.T, v any) json.RawMessage {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal json: %v", err)
+	}
+	return b
+}

--- a/experimental/adk-go/providers/claudecli/events.go
+++ b/experimental/adk-go/providers/claudecli/events.go
@@ -1,0 +1,143 @@
+package claudecli
+
+import "encoding/json"
+
+type ClaudeEvent interface {
+	EventType() string
+}
+
+type SystemEvent struct {
+	SessionID         string   `json:"session_id"`
+	Subtype           string   `json:"subtype"` // "init"
+	Tools             []string `json:"tools"`
+	Cwd               string   `json:"cwd"`
+	Model             string   `json:"model"`
+	ClaudeCodeVersion string   `json:"claude_code_version"`
+	PermissionMode    string   `json:"permission_mode"`
+}
+
+func (*SystemEvent) EventType() string { return "system" }
+
+type ContentBlockDelta struct {
+	Index       int    `json:"index"`
+	DeltaType   string `json:"delta_type"` // "text_delta", "input_json_delta", "thinking_delta", "signature_delta"
+	Text        string `json:"text"`
+	PartialJSON string `json:"partial_json"`
+	Thinking    string `json:"thinking"`  // for thinking_delta
+	Signature   string `json:"signature"` // for signature_delta
+}
+
+func (*ContentBlockDelta) EventType() string { return "content_block_delta" }
+
+type ContentBlockStart struct {
+	Index     int    `json:"index"`
+	BlockType string `json:"block_type"` // "text", "tool_use", "thinking"
+	ToolID    string `json:"tool_id"`
+	ToolName  string `json:"tool_name"`
+}
+
+func (*ContentBlockStart) EventType() string { return "content_block_start" }
+
+type ContentBlockStop struct {
+	Index int `json:"index"`
+}
+
+func (*ContentBlockStop) EventType() string { return "content_block_stop" }
+
+type MessageStart struct {
+	MessageID   string `json:"message_id"`
+	Role        string `json:"role"`
+	Model       string `json:"model"`
+	InputTokens int    `json:"input_tokens"`
+}
+
+func (*MessageStart) EventType() string { return "message_start" }
+
+type MessageDelta struct {
+	StopReason   string `json:"stop_reason"`
+	OutputTokens int    `json:"output_tokens"`
+}
+
+func (*MessageDelta) EventType() string { return "message_delta" }
+
+type MessageStop struct{}
+
+func (*MessageStop) EventType() string { return "message_stop" }
+
+type AssistantMessage struct {
+	Message json.RawMessage `json:"message"`
+}
+
+func (*AssistantMessage) EventType() string { return "assistant" }
+
+type ToolUseEvent struct {
+	ToolID string          `json:"tool_id"`
+	Name   string          `json:"name"`
+	Input  json.RawMessage `json:"input"`
+}
+
+func (*ToolUseEvent) EventType() string { return "tool_use" }
+
+type ToolResultEvent struct {
+	ToolID  string `json:"tool_id"`
+	Content string `json:"content"`
+	IsError bool   `json:"is_error"`
+}
+
+func (*ToolResultEvent) EventType() string { return "tool_result" }
+
+type ResultEvent struct {
+	SessionID    string  `json:"session_id"`
+	Subtype      string  `json:"subtype"` // "success" or "error"
+	IsError      bool    `json:"is_error"`
+	TotalCostUSD float64 `json:"total_cost_usd"`
+	DurationMs   int     `json:"duration_ms"`
+	NumTurns     int     `json:"num_turns"`
+	StopReason   string  `json:"stop_reason"`
+	Result       string  `json:"result"` // final text result
+	InputTokens  int     `json:"input_tokens"`
+	OutputTokens int     `json:"output_tokens"`
+}
+
+func (*ResultEvent) EventType() string { return "result" }
+
+// RateLimitEvent carries rate limit / quota info from the Claude CLI.
+type RateLimitEvent struct {
+	Status    string `json:"status"` // "allowed", "blocked"
+	ResetsAt  int64  `json:"resets_at"`
+	LimitType string `json:"limit_type"` // "five_hour"
+	IsOverage bool   `json:"is_overage"`
+}
+
+func (*RateLimitEvent) EventType() string { return "rate_limit_event" }
+
+// UserMessage carries tool results from the CLI (the CLI executes tools
+// internally and reports results as "user" type messages).
+type UserMessage struct {
+	Message json.RawMessage `json:"message"`
+	// Extracted tool result metadata for convenience
+	ToolUseID string `json:"tool_use_id"`
+	Content   string `json:"content"`
+	IsError   bool   `json:"is_error"`
+}
+
+func (*UserMessage) EventType() string { return "user" }
+
+type ProgressEvent struct{}
+
+func (*ProgressEvent) EventType() string { return "progress" }
+
+type UnknownEvent struct {
+	RawType string          `json:"raw_type"`
+	Raw     json.RawMessage `json:"raw"`
+}
+
+func (*UnknownEvent) EventType() string { return "unknown" }
+
+type ParseError struct {
+	Line    string `json:"line"`
+	Offset  int    `json:"offset"`
+	Message string `json:"message"`
+}
+
+func (*ParseError) EventType() string { return "parse_error" }

--- a/experimental/adk-go/providers/claudecli/go.mod
+++ b/experimental/adk-go/providers/claudecli/go.mod
@@ -1,0 +1,3 @@
+module github.com/pizzaface/pizzapi/experimental/adk-go/providers/claudecli
+
+go 1.22

--- a/experimental/adk-go/providers/claudecli/live_test.go
+++ b/experimental/adk-go/providers/claudecli/live_test.go
@@ -1,0 +1,75 @@
+package claudecli
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// runLiveFile parses a captured NDJSON file through the parser and adapter,
+// failing the test on any ParseError or UnknownEvent.
+func runLiveFile(t *testing.T, path string) {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("skipping: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	t.Logf("Parsing %d NDJSON lines from %s", len(lines), path)
+
+	adapter := NewAdapter()
+	var totalRelayEvents, unknowns, errors int
+
+	for i, line := range lines {
+		ev := ParseLine([]byte(line))
+
+		switch ev.(type) {
+		case *ParseError:
+			pe := ev.(*ParseError)
+			errors++
+			t.Errorf("line %d: ParseError: %s (line: %.100s)", i, pe.Message, pe.Line)
+		case *UnknownEvent:
+			ue := ev.(*UnknownEvent)
+			unknowns++
+			t.Errorf("line %d: UnknownEvent type=%q — parser needs update", i, ue.RawType)
+		default:
+			t.Logf("line %d: %s ✓", i, ev.EventType())
+		}
+
+		relayEvents := adapter.HandleEvent(ev)
+		for _, re := range relayEvents {
+			totalRelayEvents++
+			reType, _ := re["type"].(string)
+			t.Logf("  → relay event: %s", reType)
+		}
+	}
+
+	t.Logf("\nSummary: %d input → %d relay events, %d unknowns, %d errors",
+		len(lines), totalRelayEvents, unknowns, errors)
+}
+
+// TestLiveCLIOutput — simple text + tool use sessions.
+func TestLiveCLIOutput(t *testing.T) {
+	runLiveFile(t, "/tmp/claude-all.jsonl")
+}
+
+// TestLiveCLIPartialMessages — streaming with --include-partial-messages.
+func TestLiveCLIPartialMessages(t *testing.T) {
+	runLiveFile(t, "/tmp/claude-partial.jsonl")
+}
+
+// TestLiveCLIThinking — extended thinking blocks (sonnet model).
+func TestLiveCLIThinking(t *testing.T) {
+	runLiveFile(t, "/tmp/claude-thinking.jsonl")
+}
+
+// TestLiveCLIInteractive — TodoWrite, AskUserQuestion, EnterPlanMode tool calls.
+func TestLiveCLIInteractive(t *testing.T) {
+	runLiveFile(t, "/tmp/claude-interactive.jsonl")
+}
+
+// TestLiveCLIEverything — all captures combined (comprehensive coverage).
+func TestLiveCLIEverything(t *testing.T) {
+	runLiveFile(t, "/tmp/claude-everything.jsonl")
+}

--- a/experimental/adk-go/providers/claudecli/parser.go
+++ b/experimental/adk-go/providers/claudecli/parser.go
@@ -1,0 +1,332 @@
+package claudecli
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+func ParseLine(line []byte) ClaudeEvent {
+	var envelope struct {
+		Type string `json:"type"`
+	}
+	if err := json.Unmarshal(line, &envelope); err != nil {
+		return &ParseError{Line: string(line), Message: err.Error()}
+	}
+
+	switch envelope.Type {
+	case "system":
+		// Check subtype first — system/result is a legacy turn-completion event.
+		var subtypeCheck struct {
+			Subtype string `json:"subtype"`
+		}
+		json.Unmarshal(line, &subtypeCheck)
+		if subtypeCheck.Subtype == "result" {
+			var raw struct {
+				SessionID    string  `json:"session_id"`
+				Subtype      string  `json:"subtype"`
+				IsError      bool    `json:"is_error"`
+				TotalCostUSD float64 `json:"total_cost_usd"`
+				DurationMs   int     `json:"duration_ms"`
+				NumTurns     int     `json:"num_turns"`
+				StopReason   string  `json:"stop_reason"`
+				Result       string  `json:"result"`
+				Usage        struct {
+					InputTokens  int `json:"input_tokens"`
+					OutputTokens int `json:"output_tokens"`
+				} `json:"usage"`
+			}
+			if err := json.Unmarshal(line, &raw); err != nil {
+				return &ParseError{Line: string(line), Message: err.Error()}
+			}
+			result := raw.Result
+			var decoded string
+			if json.Unmarshal([]byte(result), &decoded) == nil {
+				result = decoded
+			}
+			return &ResultEvent{
+				SessionID:    raw.SessionID,
+				Subtype:      raw.Subtype,
+				IsError:      raw.IsError,
+				TotalCostUSD: raw.TotalCostUSD,
+				DurationMs:   raw.DurationMs,
+				NumTurns:     raw.NumTurns,
+				StopReason:   raw.StopReason,
+				Result:       result,
+				InputTokens:  raw.Usage.InputTokens,
+				OutputTokens: raw.Usage.OutputTokens,
+			}
+		}
+		var raw struct {
+			SessionID         string   `json:"session_id"`
+			Subtype           string   `json:"subtype"`
+			Tools             []string `json:"tools"`
+			Cwd               string   `json:"cwd"`
+			Model             string   `json:"model"`
+			ClaudeCodeVersion string   `json:"claude_code_version"`
+			PermissionMode    string   `json:"permissionMode"`
+		}
+		if err := json.Unmarshal(line, &raw); err != nil {
+			return &ParseError{Line: string(line), Message: err.Error()}
+		}
+		return &SystemEvent{
+			SessionID:         raw.SessionID,
+			Subtype:           raw.Subtype,
+			Tools:             raw.Tools,
+			Cwd:               raw.Cwd,
+			Model:             raw.Model,
+			ClaudeCodeVersion: raw.ClaudeCodeVersion,
+			PermissionMode:    raw.PermissionMode,
+		}
+	case "stream_event":
+		var stream struct {
+			Event struct {
+				Type string `json:"type"`
+			} `json:"event"`
+		}
+		if err := json.Unmarshal(line, &stream); err != nil {
+			return &ParseError{Line: string(line), Message: err.Error()}
+		}
+		switch stream.Event.Type {
+		case "message_start":
+			var raw struct {
+				Event struct {
+					Message struct {
+						ID    string `json:"id"`
+						Role  string `json:"role"`
+						Model string `json:"model"`
+						Usage struct {
+							InputTokens int `json:"input_tokens"`
+						} `json:"usage"`
+					} `json:"message"`
+				} `json:"event"`
+			}
+			if err := json.Unmarshal(line, &raw); err != nil {
+				return &ParseError{Line: string(line), Message: err.Error()}
+			}
+			return &MessageStart{MessageID: raw.Event.Message.ID, Role: raw.Event.Message.Role, Model: raw.Event.Message.Model, InputTokens: raw.Event.Message.Usage.InputTokens}
+		case "content_block_start":
+			var raw struct {
+				Event struct {
+					Index        int `json:"index"`
+					ContentBlock struct {
+						Type string `json:"type"`
+						ID   string `json:"id"`
+						Name string `json:"name"`
+					} `json:"content_block"`
+				} `json:"event"`
+			}
+			if err := json.Unmarshal(line, &raw); err != nil {
+				return &ParseError{Line: string(line), Message: err.Error()}
+			}
+			return &ContentBlockStart{Index: raw.Event.Index, BlockType: raw.Event.ContentBlock.Type, ToolID: raw.Event.ContentBlock.ID, ToolName: raw.Event.ContentBlock.Name}
+		case "content_block_delta":
+			var raw struct {
+				Event struct {
+					Index int `json:"index"`
+					Delta struct {
+						Type        string `json:"type"`
+						Text        string `json:"text"`
+						PartialJSON string `json:"partial_json"`
+						Thinking    string `json:"thinking"`
+						Signature   string `json:"signature"`
+					} `json:"delta"`
+				} `json:"event"`
+			}
+			if err := json.Unmarshal(line, &raw); err != nil {
+				return &ParseError{Line: string(line), Message: err.Error()}
+			}
+			return &ContentBlockDelta{
+				Index:       raw.Event.Index,
+				DeltaType:   raw.Event.Delta.Type,
+				Text:        raw.Event.Delta.Text,
+				PartialJSON: raw.Event.Delta.PartialJSON,
+				Thinking:    raw.Event.Delta.Thinking,
+				Signature:   raw.Event.Delta.Signature,
+			}
+		case "content_block_stop":
+			var raw struct {
+				Event struct {
+					Index int `json:"index"`
+				} `json:"event"`
+			}
+			if err := json.Unmarshal(line, &raw); err != nil {
+				return &ParseError{Line: string(line), Message: err.Error()}
+			}
+			return &ContentBlockStop{Index: raw.Event.Index}
+		case "message_delta":
+			var raw struct {
+				Event struct {
+					Delta struct {
+						StopReason string `json:"stop_reason"`
+					} `json:"delta"`
+					Usage struct {
+						OutputTokens int `json:"output_tokens"`
+					} `json:"usage"`
+				} `json:"event"`
+			}
+			if err := json.Unmarshal(line, &raw); err != nil {
+				return &ParseError{Line: string(line), Message: err.Error()}
+			}
+			return &MessageDelta{StopReason: raw.Event.Delta.StopReason, OutputTokens: raw.Event.Usage.OutputTokens}
+		case "message_stop":
+			return &MessageStop{}
+		default:
+			return &UnknownEvent{RawType: stream.Event.Type, Raw: json.RawMessage(append([]byte(nil), line...))}
+		}
+	case "assistant":
+		var raw struct {
+			Message json.RawMessage `json:"message"`
+		}
+		if err := json.Unmarshal(line, &raw); err != nil {
+			return &ParseError{Line: string(line), Message: err.Error()}
+		}
+		return &AssistantMessage{Message: raw.Message}
+	case "tool_use":
+		var raw struct {
+			ToolUseID string          `json:"tool_use_id"`
+			Name      string          `json:"name"`
+			Input     json.RawMessage `json:"input"`
+		}
+		if err := json.Unmarshal(line, &raw); err != nil {
+			return &ParseError{Line: string(line), Message: err.Error()}
+		}
+		return &ToolUseEvent{ToolID: raw.ToolUseID, Name: raw.Name, Input: raw.Input}
+	case "tool_result":
+		var raw struct {
+			ToolUseID string `json:"tool_use_id"`
+			Content   string `json:"content"`
+			IsError   bool   `json:"is_error"`
+		}
+		if err := json.Unmarshal(line, &raw); err != nil {
+			return &ParseError{Line: string(line), Message: err.Error()}
+		}
+		return &ToolResultEvent{ToolID: raw.ToolUseID, Content: raw.Content, IsError: raw.IsError}
+	case "user":
+		// The Claude CLI emits tool results as "user" type messages.
+		// Extract the first tool_result content block for convenience.
+		var raw struct {
+			Message json.RawMessage `json:"message"`
+		}
+		if err := json.Unmarshal(line, &raw); err != nil {
+			return &ParseError{Line: string(line), Message: err.Error()}
+		}
+		// Extract tool result from message.content[]
+		// content can be string, array of text blocks, array of tool_reference blocks, or null
+		var msg struct {
+			Content []struct {
+				ToolUseID string          `json:"tool_use_id"`
+				Type      string          `json:"type"`
+				Content   json.RawMessage `json:"content"`
+				IsError   bool            `json:"is_error"`
+			} `json:"content"`
+		}
+		toolUseID, content := "", ""
+		isError := false
+		if err := json.Unmarshal(raw.Message, &msg); err == nil {
+			for _, c := range msg.Content {
+				if c.Type == "tool_result" {
+					toolUseID = c.ToolUseID
+					isError = c.IsError
+					// content can be string, array of text/tool_reference blocks, or null
+					var s string
+					if json.Unmarshal(c.Content, &s) == nil {
+						content = s
+					} else {
+						// Try array of blocks
+						var blocks []struct {
+							Type     string `json:"type"`
+							Text     string `json:"text"`
+							ToolName string `json:"tool_name"`
+						}
+						if json.Unmarshal(c.Content, &blocks) == nil {
+							var parts []string
+							for _, b := range blocks {
+								switch b.Type {
+								case "text":
+									parts = append(parts, b.Text)
+								case "tool_reference":
+									parts = append(parts, "[tool:"+b.ToolName+"]")
+								}
+							}
+							content = strings.Join(parts, "\n")
+						}
+						// else null or unknown — leave content empty
+					}
+					break
+				}
+			}
+		}
+		return &UserMessage{Message: raw.Message, ToolUseID: toolUseID, Content: content, IsError: isError}
+	case "rate_limit_event":
+		var raw struct {
+			RateLimitInfo struct {
+				Status    string `json:"status"`
+				ResetsAt  int64  `json:"resetsAt"`
+				LimitType string `json:"rateLimitType"`
+				IsOverage bool   `json:"isUsingOverage"`
+			} `json:"rate_limit_info"`
+		}
+		if err := json.Unmarshal(line, &raw); err != nil {
+			return &ParseError{Line: string(line), Message: err.Error()}
+		}
+		return &RateLimitEvent{
+			Status:    raw.RateLimitInfo.Status,
+			ResetsAt:  raw.RateLimitInfo.ResetsAt,
+			LimitType: raw.RateLimitInfo.LimitType,
+			IsOverage: raw.RateLimitInfo.IsOverage,
+		}
+	case "progress":
+		return &ProgressEvent{}
+	case "result":
+		var raw struct {
+			SessionID    string  `json:"session_id"`
+			Subtype      string  `json:"subtype"`
+			IsError      bool    `json:"is_error"`
+			TotalCostUSD float64 `json:"total_cost_usd"`
+			DurationMs   int     `json:"duration_ms"`
+			NumTurns     int     `json:"num_turns"`
+			StopReason   string  `json:"stop_reason"`
+			Result       string  `json:"result"`
+			Usage        struct {
+				InputTokens  int `json:"input_tokens"`
+				OutputTokens int `json:"output_tokens"`
+			} `json:"usage"`
+		}
+		if err := json.Unmarshal(line, &raw); err != nil {
+			return &ParseError{Line: string(line), Message: err.Error()}
+		}
+		result := raw.Result
+		var decoded string
+		if json.Unmarshal([]byte(result), &decoded) == nil {
+			result = decoded
+		}
+		return &ResultEvent{
+			SessionID:    raw.SessionID,
+			Subtype:      raw.Subtype,
+			IsError:      raw.IsError,
+			TotalCostUSD: raw.TotalCostUSD,
+			DurationMs:   raw.DurationMs,
+			NumTurns:     raw.NumTurns,
+			StopReason:   raw.StopReason,
+			Result:       result,
+			InputTokens:  raw.Usage.InputTokens,
+			OutputTokens: raw.Usage.OutputTokens,
+		}
+	default:
+		return &UnknownEvent{RawType: envelope.Type, Raw: json.RawMessage(append([]byte(nil), line...))}
+	}
+}
+
+func ParseStream(r io.Reader, events chan<- ClaudeEvent) {
+	defer close(events)
+
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		events <- ParseLine(scanner.Bytes())
+	}
+	if err := scanner.Err(); err != nil {
+		events <- &ParseError{Message: err.Error()}
+	}
+}

--- a/experimental/adk-go/providers/claudecli/parser_test.go
+++ b/experimental/adk-go/providers/claudecli/parser_test.go
@@ -1,0 +1,359 @@
+package claudecli
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestParseLine(t *testing.T) {
+	tests := []struct {
+		name  string
+		line  string
+		check func(t *testing.T, event ClaudeEvent)
+	}{
+		{
+			name: "system event",
+			line: `{"type":"system","session_id":"sess_123","tools":["bash","read"],"cwd":"/tmp","model":"claude-sonnet-4-20250514"}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*SystemEvent)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.SessionID != "sess_123" || e.Cwd != "/tmp" || e.Model != "claude-sonnet-4-20250514" {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+				if len(e.Tools) != 2 || e.Tools[0] != "bash" || e.Tools[1] != "read" {
+					t.Fatalf("unexpected tools: %+v", e.Tools)
+				}
+			},
+		},
+		{
+			name: "text delta",
+			line: `{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ContentBlockDelta)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.Index != 0 || e.DeltaType != "text_delta" || e.Text != "Hello" {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "tool_use content_block_start",
+			line: `{"type":"stream_event","event":{"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"tool_abc","name":"bash"}}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ContentBlockStart)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.Index != 1 || e.BlockType != "tool_use" || e.ToolID != "tool_abc" || e.ToolName != "bash" {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "content_block_stop",
+			line: `{"type":"stream_event","event":{"type":"content_block_stop","index":0}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ContentBlockStop)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.Index != 0 {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "message_start",
+			line: `{"type":"stream_event","event":{"type":"message_start","message":{"id":"msg_01","role":"assistant","model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":0}}}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*MessageStart)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.MessageID != "msg_01" || e.Role != "assistant" || e.Model != "claude-sonnet-4-20250514" || e.InputTokens != 100 {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "message_delta",
+			line: `{"type":"stream_event","event":{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":50}}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*MessageDelta)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.StopReason != "end_turn" || e.OutputTokens != 50 {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "message_stop",
+			line: `{"type":"stream_event","event":{"type":"message_stop"}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				if _, ok := event.(*MessageStop); !ok {
+					t.Fatalf("got %T", event)
+				}
+			},
+		},
+		{
+			name: "assistant message",
+			line: `{"type":"assistant","message":{"id":"msg_01","role":"assistant","content":[{"type":"text","text":"Hello world"}]}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*AssistantMessage)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				var payload map[string]any
+				if err := json.Unmarshal(e.Message, &payload); err != nil {
+					t.Fatalf("unmarshal raw: %v", err)
+				}
+				if payload["id"] != "msg_01" {
+					t.Fatalf("unexpected raw payload: %+v", payload)
+				}
+			},
+		},
+		{
+			name: "tool_use event",
+			line: `{"type":"tool_use","tool_use_id":"tool_abc","name":"bash","input":{"command":"ls"}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ToolUseEvent)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.ToolID != "tool_abc" || e.Name != "bash" {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+				var payload map[string]any
+				if err := json.Unmarshal(e.Input, &payload); err != nil {
+					t.Fatalf("unmarshal input: %v", err)
+				}
+				if payload["command"] != "ls" {
+					t.Fatalf("unexpected input: %+v", payload)
+				}
+			},
+		},
+		{
+			name: "tool_result",
+			line: "{\"type\":\"tool_result\",\"tool_use_id\":\"tool_abc\",\"content\":\"file1.txt\\nfile2.txt\",\"is_error\":false}",
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ToolResultEvent)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.ToolID != "tool_abc" || e.Content != "file1.txt\nfile2.txt" || e.IsError {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "result event",
+			line: `{"type":"result","subtype":"success","is_error":false,"session_id":"sess_123","total_cost_usd":0.05,"duration_ms":3000,"num_turns":1,"stop_reason":"end_turn","result":"Hello world","usage":{"input_tokens":500,"output_tokens":200}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ResultEvent)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.SessionID != "sess_123" || e.TotalCostUSD != 0.05 || e.DurationMs != 3000 {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+				if e.InputTokens != 500 || e.OutputTokens != 200 {
+					t.Fatalf("unexpected tokens: %+v", e)
+				}
+				if e.Subtype != "success" || e.StopReason != "end_turn" || e.NumTurns != 1 {
+					t.Fatalf("unexpected meta: %+v", e)
+				}
+				if e.Result != "Hello world" {
+					t.Fatalf("unexpected result text: %q", e.Result)
+				}
+			},
+		},
+		{
+			name: "rate_limit_event",
+			line: `{"type":"rate_limit_event","rate_limit_info":{"status":"allowed","resetsAt":1775174400,"rateLimitType":"five_hour","isUsingOverage":false}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*RateLimitEvent)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.Status != "allowed" || e.LimitType != "five_hour" || e.IsOverage {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "user message (tool result)",
+			line: `{"type":"user","message":{"role":"user","content":[{"tool_use_id":"toolu_abc","type":"tool_result","content":"output","is_error":false}]}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*UserMessage)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.ToolUseID != "toolu_abc" || e.Content != "output" || e.IsError {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "thinking content_block_start",
+			line: `{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":"","signature":""}}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ContentBlockStart)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.Index != 0 || e.BlockType != "thinking" {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "thinking_delta",
+			line: `{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"Let me think"}}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ContentBlockDelta)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.DeltaType != "thinking_delta" || e.Thinking != "Let me think" {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "signature_delta",
+			line: `{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"signature_delta","signature":"abc123sig"}}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ContentBlockDelta)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.DeltaType != "signature_delta" || e.Signature != "abc123sig" {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "unknown type",
+			line: `{"type":"custom_event","data":"something"}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*UnknownEvent)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.RawType != "custom_event" {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "malformed JSON",
+			line: `{not valid json`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ParseError)
+				if !ok {
+					t.Fatalf("got %T", event)
+				}
+				if e.Line != `{not valid json` || e.Message == "" {
+					t.Fatalf("unexpected event: %+v", e)
+				}
+			},
+		},
+		{
+			name: "system/result legacy",
+			line: `{"type":"system","subtype":"result","session_id":"sess_123","result":"\"Here is the summary\"","is_error":false}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e, ok := event.(*ResultEvent)
+				if !ok {
+					t.Fatalf("got %T, want *ResultEvent", event)
+				}
+				if e.SessionID != "sess_123" {
+					t.Fatalf("session_id = %q", e.SessionID)
+				}
+				if e.Result != "Here is the summary" {
+					t.Fatalf("result = %q (should be un-double-encoded)", e.Result)
+				}
+			},
+		},
+		{
+			name: "progress event",
+			line: `{"type":"progress","data":"loading"}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				if _, ok := event.(*ProgressEvent); !ok {
+					t.Fatalf("got %T", event)
+				}
+			},
+		},
+		{
+			name: "result with double-encoded result field",
+			line: `{"type":"result","subtype":"success","session_id":"s","result":"\"Task completed.\"","is_error":false,"total_cost_usd":0.01,"duration_ms":100,"usage":{"input_tokens":1,"output_tokens":1}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e := event.(*ResultEvent)
+				if e.Result != "Task completed." {
+					t.Fatalf("result not un-double-encoded: %q", e.Result)
+				}
+			},
+		},
+		{
+			name: "user message with array-of-text-blocks content",
+			line: `{"type":"user","message":{"role":"user","content":[{"tool_use_id":"t1","type":"tool_result","content":[{"type":"text","text":"File edited"}],"is_error":false}]}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e := event.(*UserMessage)
+				if e.Content != "File edited" {
+					t.Fatalf("content = %q", e.Content)
+				}
+			},
+		},
+		{
+			name: "user message with null content",
+			line: `{"type":"user","message":{"role":"user","content":[{"tool_use_id":"t1","type":"tool_result","content":null,"is_error":false}]}}`,
+			check: func(t *testing.T, event ClaudeEvent) {
+				e := event.(*UserMessage)
+				if e.Content != "" {
+					t.Fatalf("content should be empty, got %q", e.Content)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(t, ParseLine([]byte(tt.line)))
+		})
+	}
+}
+
+func TestParseStream(t *testing.T) {
+	reader := strings.NewReader(strings.Join([]string{
+		`{"type":"system","session_id":"sess_123","tools":["bash"],"cwd":"/tmp","model":"claude-sonnet-4-20250514"}`,
+		`{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}}`,
+		`{"type":"result","subtype":"success","session_id":"sess_123","total_cost_usd":0.05,"duration_ms":3000,"usage":{"input_tokens":500,"output_tokens":200}}`,
+	}, "\n"))
+
+	events := make(chan ClaudeEvent)
+	go ParseStream(reader, events)
+
+	var got []ClaudeEvent
+	for event := range events {
+		got = append(got, event)
+	}
+
+	if len(got) != 3 {
+		t.Fatalf("expected 3 events, got %d", len(got))
+	}
+	if _, ok := got[0].(*SystemEvent); !ok {
+		t.Fatalf("first event = %T", got[0])
+	}
+	if _, ok := got[1].(*ContentBlockDelta); !ok {
+		t.Fatalf("second event = %T", got[1])
+	}
+	if _, ok := got[2].(*ResultEvent); !ok {
+		t.Fatalf("third event = %T", got[2])
+	}
+}

--- a/experimental/adk-go/providers/claudecli/runner.go
+++ b/experimental/adk-go/providers/claudecli/runner.go
@@ -1,0 +1,314 @@
+package claudecli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+	"sync"
+)
+
+// RunnerConfig configures a Claude CLI subprocess.
+type RunnerConfig struct {
+	// Path to the claude binary (default: "claude")
+	ClaudePath string
+	// Working directory for the subprocess
+	WorkDir string
+	// Model to use (e.g. "claude-sonnet-4-20250514")
+	Model string
+	// Maximum turns
+	MaxTurns int
+	// System prompt to append
+	SystemPrompt string
+	// Session ID to resume (empty for new session)
+	ResumeSessionID string
+	// MCP config file path
+	MCPConfig string
+	// Additional CLI flags
+	ExtraFlags []string
+	// Environment variables to set (on top of inherited env)
+	ExtraEnv []string
+	// Stderr callback — called with each stderr line
+	OnStderr func(line string)
+}
+
+// Runner manages a claude CLI subprocess lifecycle.
+type Runner struct {
+	config   RunnerConfig
+	cmd      *exec.Cmd
+	cancel   context.CancelFunc
+	stdin    io.WriteCloser // nil in one-shot mode, open in interactive mode
+	events   chan ClaudeEvent
+	stderr   *strings.Builder
+	done     chan struct{}
+	mu       sync.Mutex
+	exited   bool
+	exitCode int
+	exitErr  error
+}
+
+// NewRunner creates a Runner but does not start it.
+func NewRunner(cfg RunnerConfig) *Runner {
+	return &Runner{
+		config:   cfg,
+		exitCode: -1,
+		stderr:   &strings.Builder{},
+	}
+}
+
+// BuildArgs constructs the claude CLI argument list from config.
+func (r *Runner) BuildArgs() []string {
+	args := []string{
+		"--print",
+		"--output-format", "stream-json",
+		"--verbose",
+	}
+	if r.config.Model != "" {
+		args = append(args, "--model", r.config.Model)
+	}
+	if r.config.MaxTurns > 0 {
+		args = append(args, "--max-turns", fmt.Sprintf("%d", r.config.MaxTurns))
+	}
+	if r.config.SystemPrompt != "" {
+		args = append(args, "--append-system-prompt", r.config.SystemPrompt)
+	}
+	if r.config.ResumeSessionID != "" {
+		args = append(args, "--resume", r.config.ResumeSessionID)
+	}
+	if r.config.MCPConfig != "" {
+		args = append(args, "--mcp-config", r.config.MCPConfig)
+	}
+	args = append(args, r.config.ExtraFlags...)
+	return args
+}
+
+// Start launches the claude subprocess in one-shot mode (-p) and begins
+// parsing stdout. Returns a channel of ClaudeEvents. The channel is closed
+// when the process exits. Call Stop() or cancel the context to terminate.
+func (r *Runner) Start(ctx context.Context, prompt string) (<-chan ClaudeEvent, error) {
+	ctx, r.cancel = context.WithCancel(ctx)
+
+	claudePath := r.config.ClaudePath
+	if claudePath == "" {
+		claudePath = "claude"
+	}
+
+	args := r.BuildArgs()
+	args = append(args, "-p", prompt)
+
+	r.cmd = exec.CommandContext(ctx, claudePath, args...)
+	if r.config.WorkDir != "" {
+		r.cmd.Dir = r.config.WorkDir
+	}
+	if len(r.config.ExtraEnv) > 0 {
+		r.cmd.Env = append(r.cmd.Environ(), r.config.ExtraEnv...)
+	}
+
+	return r.startProcess()
+}
+
+// StartInteractive launches the claude subprocess in client mode
+// (--input-format stream-json) with stdin kept open for multi-turn
+// conversation. The initial prompt is sent as the first stdin message.
+// Use WriteStdin() to send follow-up messages and control responses.
+func (r *Runner) StartInteractive(ctx context.Context, prompt string) (<-chan ClaudeEvent, error) {
+	ctx, r.cancel = context.WithCancel(ctx)
+
+	claudePath := r.config.ClaudePath
+	if claudePath == "" {
+		claudePath = "claude"
+	}
+
+	args := r.BuildInteractiveArgs()
+
+	r.cmd = exec.CommandContext(ctx, claudePath, args...)
+	if r.config.WorkDir != "" {
+		r.cmd.Dir = r.config.WorkDir
+	}
+	if len(r.config.ExtraEnv) > 0 {
+		r.cmd.Env = append(r.cmd.Environ(), r.config.ExtraEnv...)
+	}
+
+	// Get stdin pipe before starting
+	stdinPipe, err := r.cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdin pipe: %w", err)
+	}
+	r.stdin = stdinPipe
+
+	events, err := r.startProcess()
+	if err != nil {
+		return nil, err
+	}
+
+	// Send the initial prompt as a user message via stdin.
+	// Use json.Marshal for correct JSON encoding of the content string.
+	if prompt != "" {
+		msg := map[string]any{
+			"type": "user",
+			"message": map[string]any{
+				"role":    "user",
+				"content": prompt,
+			},
+		}
+		msgBytes, err := json.Marshal(msg)
+		if err != nil {
+			return nil, fmt.Errorf("marshal initial prompt: %w", err)
+		}
+		msgBytes = append(msgBytes, '\n')
+		if err := r.WriteStdin(msgBytes); err != nil {
+			return nil, fmt.Errorf("send initial prompt: %w", err)
+		}
+	}
+
+	return events, nil
+}
+
+// BuildInteractiveArgs constructs CLI args for client mode (persistent session).
+func (r *Runner) BuildInteractiveArgs() []string {
+	args := []string{
+		"--output-format", "stream-json",
+		"--input-format", "stream-json",
+		"--verbose",
+		"--include-partial-messages",
+	}
+	if r.config.Model != "" {
+		args = append(args, "--model", r.config.Model)
+	}
+	if r.config.MaxTurns > 0 {
+		args = append(args, "--max-turns", fmt.Sprintf("%d", r.config.MaxTurns))
+	}
+	if r.config.SystemPrompt != "" {
+		args = append(args, "--append-system-prompt", r.config.SystemPrompt)
+	}
+	if r.config.ResumeSessionID != "" {
+		args = append(args, "--resume", r.config.ResumeSessionID)
+	}
+	if r.config.MCPConfig != "" {
+		args = append(args, "--mcp-config", r.config.MCPConfig)
+	}
+	args = append(args, r.config.ExtraFlags...)
+	return args
+}
+
+// WriteStdin sends a message to the claude process stdin.
+// The message should be a complete NDJSON line (including trailing newline).
+func (r *Runner) WriteStdin(msg []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.stdin == nil {
+		return fmt.Errorf("stdin not available (process not started in interactive mode)")
+	}
+	_, err := r.stdin.Write(msg)
+	return err
+}
+
+// startProcess is the shared implementation for Start and StartInteractive.
+func (r *Runner) startProcess() (<-chan ClaudeEvent, error) {
+	stdout, err := r.cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+
+	stderrPipe, err := r.cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stderr pipe: %w", err)
+	}
+
+	r.events = make(chan ClaudeEvent, 64)
+	r.done = make(chan struct{})
+	r.stderr = &strings.Builder{}
+	r.exitCode = -1
+	r.exited = false
+	r.exitErr = nil
+
+	if err := r.cmd.Start(); err != nil {
+		close(r.events)
+		close(r.done)
+		r.mu.Lock()
+		r.exited = true
+		r.exitErr = fmt.Errorf("start: %w", err)
+		r.mu.Unlock()
+		return nil, fmt.Errorf("start: %w", err)
+	}
+
+	go func() {
+		ParseStream(stdout, r.events)
+	}()
+
+	go r.collectStderr(stderrPipe)
+
+	go func() {
+		err := r.cmd.Wait()
+		r.mu.Lock()
+		r.exited = true
+		r.exitErr = err
+		if r.cmd.ProcessState != nil {
+			r.exitCode = r.cmd.ProcessState.ExitCode()
+		}
+		r.mu.Unlock()
+		close(r.done)
+	}()
+
+	return r.events, nil
+}
+
+func (r *Runner) collectStderr(pipe io.Reader) {
+	scanner := bufio.NewScanner(pipe)
+	for scanner.Scan() {
+		line := scanner.Text()
+		r.mu.Lock()
+		if r.stderr.Len() > 0 {
+			r.stderr.WriteByte('\n')
+		}
+		r.stderr.WriteString(line)
+		r.mu.Unlock()
+		if r.config.OnStderr != nil {
+			r.config.OnStderr(line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		r.mu.Lock()
+		if r.stderr.Len() > 0 {
+			r.stderr.WriteByte('\n')
+		}
+		r.stderr.WriteString(err.Error())
+		r.mu.Unlock()
+		if r.config.OnStderr != nil {
+			r.config.OnStderr(err.Error())
+		}
+	}
+}
+
+// Stop gracefully stops the subprocess (SIGTERM, then wait).
+func (r *Runner) Stop() error {
+	if r.cancel != nil {
+		r.cancel()
+	}
+	if r.done != nil {
+		<-r.done
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.exitErr
+}
+
+// Done returns a channel that closes when the process exits.
+func (r *Runner) Done() <-chan struct{} { return r.done }
+
+// ExitCode returns the process exit code (-1 if not exited yet).
+func (r *Runner) ExitCode() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.exitCode
+}
+
+// Stderr returns accumulated stderr output.
+func (r *Runner) Stderr() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.stderr.String()
+}

--- a/experimental/adk-go/providers/claudecli/runner_test.go
+++ b/experimental/adk-go/providers/claudecli/runner_test.go
@@ -1,0 +1,222 @@
+package claudecli
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildArgsBasic(t *testing.T) {
+	r := NewRunner(RunnerConfig{})
+	args := r.BuildArgs()
+
+	expectedPrefix := []string{"--print", "--output-format", "stream-json", "--verbose"}
+	if len(args) != len(expectedPrefix) {
+		t.Fatalf("expected %d args, got %d: %v", len(expectedPrefix), len(args), args)
+	}
+	if !reflect.DeepEqual(args, expectedPrefix) {
+		t.Fatalf("unexpected args: got %v want %v", args, expectedPrefix)
+	}
+	for _, forbidden := range []string{"--model", "--max-turns", "--resume", "--append-system-prompt", "--mcp-config"} {
+		for _, arg := range args {
+			if arg == forbidden {
+				t.Fatalf("did not expect %q in args: %v", forbidden, args)
+			}
+		}
+	}
+}
+
+func TestBuildArgsFull(t *testing.T) {
+	r := NewRunner(RunnerConfig{
+		Model:           "claude-sonnet-4-20250514",
+		MaxTurns:        10,
+		SystemPrompt:    "You are helpful",
+		ResumeSessionID: "sess_123",
+		MCPConfig:       "/tmp/mcp.json",
+		ExtraFlags:      []string{"--no-session-persistence"},
+	})
+
+	args := r.BuildArgs()
+	expected := []string{
+		"--print",
+		"--output-format", "stream-json",
+		"--verbose",
+		"--model", "claude-sonnet-4-20250514",
+		"--max-turns", "10",
+		"--append-system-prompt", "You are helpful",
+		"--resume", "sess_123",
+		"--mcp-config", "/tmp/mcp.json",
+		"--no-session-persistence",
+	}
+
+	if !reflect.DeepEqual(args, expected) {
+		t.Fatalf("unexpected args:\n got: %v\nwant: %v", args, expected)
+	}
+}
+
+func TestRunnerWorkDir(t *testing.T) {
+	r := NewRunner(RunnerConfig{WorkDir: "/tmp/test"})
+	if r.config.WorkDir != "/tmp/test" {
+		t.Fatalf("unexpected WorkDir: %q", r.config.WorkDir)
+	}
+}
+
+func TestRunnerStartWithEcho(t *testing.T) {
+	r := NewRunner(RunnerConfig{ClaudePath: "echo", ExtraFlags: []string{}})
+	if r.config.ClaudePath != "echo" {
+		t.Fatalf("unexpected ClaudePath: %q", r.config.ClaudePath)
+	}
+	args := r.BuildArgs()
+	if len(args) < 4 || args[0] != "--print" || args[1] != "--output-format" || args[2] != "stream-json" || args[3] != "--verbose" {
+		t.Fatalf("unexpected args: %v", args)
+	}
+}
+
+func TestRunnerWithFakeProcess(t *testing.T) {
+	script := `printf '{"type":"system","session_id":"test","tools":[],"cwd":"/tmp","model":"test"}\n{"type":"result","session_id":"test","cost_usd":0.01,"duration_secs":1.0,"usage":{"input_tokens":10,"output_tokens":5}}\n'`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	r := NewRunner(RunnerConfig{ClaudePath: "bash"})
+	if r.config.ClaudePath != "bash" {
+		t.Fatalf("unexpected ClaudePath: %q", r.config.ClaudePath)
+	}
+
+	cmdCtx, cmdCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cmdCancel()
+
+	cmd := exec.CommandContext(cmdCtx, "bash", "-c", script)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	events := make(chan ClaudeEvent, 64)
+	go ParseStream(stdout, events)
+
+	var received []ClaudeEvent
+	for ev := range events {
+		received = append(received, ev)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("wait: %v", err)
+	}
+
+	if len(received) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(received))
+	}
+	if received[0].EventType() != "system" {
+		t.Fatalf("first event type = %q", received[0].EventType())
+	}
+	if received[1].EventType() != "result" {
+		t.Fatalf("second event type = %q", received[1].EventType())
+	}
+}
+
+func TestRunnerStderrCollection(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "fake-claude.sh")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"echo '{\"type\":\"system\",\"session_id\":\"t\",\"tools\":[],\"cwd\":\"/\",\"model\":\"m\"}'",
+		"echo 'debug info' >&2",
+	}, "\n") + "\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	var stderrLines []string
+	r := NewRunner(RunnerConfig{
+		ClaudePath: scriptPath,
+		OnStderr: func(line string) {
+			stderrLines = append(stderrLines, line)
+		},
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	events, err := r.Start(ctx, "ignored")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	var received []ClaudeEvent
+	for ev := range events {
+		received = append(received, ev)
+	}
+	<-r.Done()
+
+	if len(received) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(received))
+	}
+	if received[0].EventType() != "system" {
+		t.Fatalf("unexpected event type: %q", received[0].EventType())
+	}
+	if got := r.Stderr(); !strings.Contains(got, "debug info") {
+		t.Fatalf("stderr missing debug info: %q", got)
+	}
+	if len(stderrLines) != 1 || stderrLines[0] != "debug info" {
+		t.Fatalf("unexpected stderr callback lines: %v", stderrLines)
+	}
+}
+
+func TestRunnerContextCancellation(t *testing.T) {
+	tmpDir := t.TempDir()
+	scriptPath := filepath.Join(tmpDir, "sleepy-claude.sh")
+	script := strings.Join([]string{
+		"#!/bin/sh",
+		"trap 'exit 0' TERM INT",
+		"echo '{\"type\":\"system\",\"session_id\":\"cancel\",\"tools\":[],\"cwd\":\"/tmp\",\"model\":\"test\"}'",
+		"sleep 60",
+	}, "\n") + "\n"
+	if err := os.WriteFile(scriptPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write script: %v", err)
+	}
+
+	r := NewRunner(RunnerConfig{ClaudePath: scriptPath})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	events, err := r.Start(ctx, "ignored")
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+
+	select {
+	case ev, ok := <-events:
+		if !ok {
+			t.Fatal("events channel closed before first event")
+		}
+		if ev.EventType() != "system" {
+			t.Fatalf("unexpected first event type: %q", ev.EventType())
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for first event")
+	}
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-r.Done():
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for runner to exit after cancellation")
+	}
+
+	for range events {
+	}
+
+	if err := r.Stop(); err != nil && !strings.Contains(err.Error(), "killed") && !strings.Contains(err.Error(), "signal: terminated") && !strings.Contains(err.Error(), "context canceled") {
+		t.Fatalf("unexpected stop error: %v", err)
+	}
+}

--- a/experimental/adk-go/runtime/compat/compat.go
+++ b/experimental/adk-go/runtime/compat/compat.go
@@ -1,0 +1,270 @@
+package compat
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// Family identifies which on-disk convention a resource came from.
+type Family string
+
+// Scope identifies whether a resource is project-local or global/user-level.
+type Scope string
+
+const (
+	FamilyPizzaPi Family = "pizzapi"
+	FamilyClaude  Family = "claude"
+
+	ScopeProject Scope = "project"
+	ScopeGlobal  Scope = "global"
+)
+
+// PathCandidate describes a candidate path in highest-precedence-first order.
+type PathCandidate struct {
+	Path     string
+	Family   Family
+	Scope    Scope
+	Priority int
+}
+
+// NamedResource is a deduplicated agent or skill discovered from disk.
+type NamedResource struct {
+	Name     string
+	Path     string
+	Family   Family
+	Scope    Scope
+	Priority int
+}
+
+// InstructionDoc is a discovered instruction document with file contents loaded.
+type InstructionDoc struct {
+	Path     string
+	Family   Family
+	Scope    Scope
+	Priority int
+	Content  string
+}
+
+// ConfigSet groups config/settings candidates in highest-precedence-first order.
+type ConfigSet struct {
+	PizzaPiConfig   []PathCandidate
+	PizzaPiSettings []PathCandidate
+	ClaudeSettings  []PathCandidate
+}
+
+// Locator resolves Claude/PizzaPi compatibility paths relative to a home dir and cwd.
+type Locator struct {
+	HomeDir string
+	Cwd     string
+}
+
+// NewLocator returns a normalized locator for deterministic path resolution in tests and runtime code.
+func NewLocator(homeDir, cwd string) Locator {
+	return Locator{
+		HomeDir: filepath.Clean(homeDir),
+		Cwd:     filepath.Clean(cwd),
+	}
+}
+
+// AgentRoots returns agent search roots in precedence order.
+func (l Locator) AgentRoots() []PathCandidate {
+	return []PathCandidate{
+		{Path: filepath.Join(l.Cwd, ".pizzapi", "agents"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(l.Cwd, ".claude", "agents"), Family: FamilyClaude, Scope: ScopeProject, Priority: 2},
+		{Path: filepath.Join(l.HomeDir, ".pizzapi", "agents"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 3},
+		{Path: filepath.Join(l.HomeDir, ".claude", "agents"), Family: FamilyClaude, Scope: ScopeGlobal, Priority: 4},
+	}
+}
+
+// SkillRoots returns skill search roots in precedence order.
+func (l Locator) SkillRoots() []PathCandidate {
+	return []PathCandidate{
+		{Path: filepath.Join(l.Cwd, ".pizzapi", "skills"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(l.Cwd, ".claude", "skills"), Family: FamilyClaude, Scope: ScopeProject, Priority: 2},
+		{Path: filepath.Join(l.HomeDir, ".pizzapi", "skills"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 3},
+		{Path: filepath.Join(l.HomeDir, ".claude", "skills"), Family: FamilyClaude, Scope: ScopeGlobal, Priority: 4},
+	}
+}
+
+// ConfigPaths returns config/settings candidates in merge precedence order.
+func (l Locator) ConfigPaths() ConfigSet {
+	return ConfigSet{
+		PizzaPiConfig: []PathCandidate{
+			{Path: filepath.Join(l.Cwd, ".pizzapi", "config.json"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+			{Path: filepath.Join(l.HomeDir, ".pizzapi", "config.json"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 2},
+		},
+		PizzaPiSettings: []PathCandidate{
+			{Path: filepath.Join(l.Cwd, ".pizzapi", "settings.json"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+			{Path: filepath.Join(l.HomeDir, ".pizzapi", "settings.json"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 2},
+		},
+		ClaudeSettings: []PathCandidate{
+			{Path: filepath.Join(l.Cwd, ".claude", "settings.local.json"), Family: FamilyClaude, Scope: ScopeProject, Priority: 1},
+			{Path: filepath.Join(l.Cwd, ".claude", "settings.json"), Family: FamilyClaude, Scope: ScopeProject, Priority: 2},
+			{Path: filepath.Join(l.HomeDir, ".claude", "settings.json"), Family: FamilyClaude, Scope: ScopeGlobal, Priority: 3},
+		},
+	}
+}
+
+// DiscoverAgents scans agent roots and keeps the first resource for each name.
+func (l Locator) DiscoverAgents() ([]NamedResource, error) {
+	return discoverNamedResources(l.AgentRoots(), false)
+}
+
+// DiscoverSkills scans skill roots and supports both <name>.md and <name>/SKILL.md layouts.
+func (l Locator) DiscoverSkills() ([]NamedResource, error) {
+	return discoverNamedResources(l.SkillRoots(), true)
+}
+
+// DiscoverInstructionDocs walks project ancestors first, then global dirs, loading any instruction docs that exist.
+func (l Locator) DiscoverInstructionDocs() ([]InstructionDoc, error) {
+	candidates := instructionCandidates(l.HomeDir, l.Cwd)
+	docs := make([]InstructionDoc, 0, len(candidates))
+	seen := map[string]struct{}{}
+	for _, candidate := range candidates {
+		normalized := filepath.Clean(candidate.Path)
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		content, err := os.ReadFile(normalized)
+		if err != nil {
+			if errorsIsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		seen[normalized] = struct{}{}
+		docs = append(docs, InstructionDoc{
+			Path:     normalized,
+			Family:   candidate.Family,
+			Scope:    candidate.Scope,
+			Priority: candidate.Priority,
+			Content:  string(content),
+		})
+	}
+	return docs, nil
+}
+
+func instructionCandidates(homeDir, cwd string) []PathCandidate {
+	var candidates []PathCandidate
+	priority := 1
+	for _, dir := range walkUpDirs(cwd) {
+		for _, rel := range []struct {
+			path   string
+			family Family
+		}{
+			{path: filepath.Join(".pizzapi", "AGENTS.md"), family: FamilyPizzaPi},
+			{path: filepath.Join(".pizzapi", "CLAUDE.md"), family: FamilyPizzaPi},
+			{path: filepath.Join(".claude", "AGENTS.md"), family: FamilyClaude},
+			{path: filepath.Join(".claude", "CLAUDE.md"), family: FamilyClaude},
+			{path: "AGENTS.md", family: FamilyPizzaPi},
+			{path: "CLAUDE.md", family: FamilyClaude},
+		} {
+			candidates = append(candidates, PathCandidate{
+				Path:     filepath.Join(dir, rel.path),
+				Family:   rel.family,
+				Scope:    ScopeProject,
+				Priority: priority,
+			})
+			priority++
+		}
+	}
+	for _, rel := range []struct {
+		path   string
+		family Family
+	}{
+		{path: filepath.Join(".pizzapi", "AGENTS.md"), family: FamilyPizzaPi},
+		{path: filepath.Join(".pizzapi", "CLAUDE.md"), family: FamilyPizzaPi},
+		{path: filepath.Join(".claude", "AGENTS.md"), family: FamilyClaude},
+		{path: filepath.Join(".claude", "CLAUDE.md"), family: FamilyClaude},
+	} {
+		candidates = append(candidates, PathCandidate{
+			Path:     filepath.Join(homeDir, rel.path),
+			Family:   rel.family,
+			Scope:    ScopeGlobal,
+			Priority: priority,
+		})
+		priority++
+	}
+	return candidates
+}
+
+func discoverNamedResources(roots []PathCandidate, allowSkillDirs bool) ([]NamedResource, error) {
+	seen := map[string]struct{}{}
+	resources := []NamedResource{}
+	for _, root := range roots {
+		entries, err := os.ReadDir(root.Path)
+		if err != nil {
+			if errorsIsNotExist(err) {
+				continue
+			}
+			return nil, err
+		}
+		for _, entry := range entries {
+			if strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			name, path, ok := resolveResourceEntry(root.Path, entry, allowSkillDirs)
+			if !ok {
+				continue
+			}
+			if _, exists := seen[name]; exists {
+				continue
+			}
+			seen[name] = struct{}{}
+			resources = append(resources, NamedResource{
+				Name:     name,
+				Path:     path,
+				Family:   root.Family,
+				Scope:    root.Scope,
+				Priority: root.Priority,
+			})
+		}
+	}
+	return resources, nil
+}
+
+func resolveResourceEntry(root string, entry fs.DirEntry, allowSkillDirs bool) (name string, path string, ok bool) {
+	fullPath := filepath.Join(root, entry.Name())
+	if entry.Type().IsRegular() && strings.HasSuffix(strings.ToLower(entry.Name()), ".md") {
+		return strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name())), fullPath, true
+	}
+	if allowSkillDirs && entry.IsDir() {
+		skillPath := filepath.Join(fullPath, "SKILL.md")
+		info, err := os.Stat(skillPath)
+		if err == nil && !info.IsDir() {
+			return entry.Name(), skillPath, true
+		}
+		if err != nil && !errorsIsNotExist(err) {
+			return "", "", false
+		}
+	}
+	return "", "", false
+}
+
+func walkUpDirs(start string) []string {
+	dirs := []string{}
+	current := filepath.Clean(start)
+	for {
+		dirs = append(dirs, current)
+		parent := filepath.Dir(current)
+		if parent == current {
+			break
+		}
+		current = parent
+	}
+	return dirs
+}
+
+func mkdirAll(path string) error {
+	return os.MkdirAll(path, 0o755)
+}
+
+func writeTextFile(path string, content []byte) error {
+	return os.WriteFile(path, content, 0o644)
+}
+
+func errorsIsNotExist(err error) bool {
+	return os.IsNotExist(err)
+}

--- a/experimental/adk-go/runtime/compat/compat_test.go
+++ b/experimental/adk-go/runtime/compat/compat_test.go
@@ -1,0 +1,190 @@
+package compat
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+	mustMkdirAll(t, filepath.Dir(path))
+	mustWriteFile(t, path, []byte(content))
+}
+
+func mustMkdirAll(t *testing.T, path string) {
+	t.Helper()
+	if err := mkdirAll(path); err != nil {
+		t.Fatalf("mkdirAll(%q): %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path string, content []byte) {
+	t.Helper()
+	if err := writeTextFile(path, content); err != nil {
+		t.Fatalf("writeTextFile(%q): %v", path, err)
+	}
+}
+
+func TestAgentRootsOrder(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(t.TempDir(), "repo", "app")
+	locator := NewLocator(home, cwd)
+
+	got := locator.AgentRoots()
+	want := []PathCandidate{
+		{Path: filepath.Join(cwd, ".pizzapi", "agents"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(cwd, ".claude", "agents"), Family: FamilyClaude, Scope: ScopeProject, Priority: 2},
+		{Path: filepath.Join(home, ".pizzapi", "agents"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 3},
+		{Path: filepath.Join(home, ".claude", "agents"), Family: FamilyClaude, Scope: ScopeGlobal, Priority: 4},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("AgentRoots() mismatch\n got: %#v\nwant: %#v", got, want)
+	}
+}
+
+func TestDiscoverAgentsPrecedence(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(t.TempDir(), "repo")
+	locator := NewLocator(home, cwd)
+
+	writeFile(t, filepath.Join(home, ".claude", "agents", "shared.md"), "# global claude")
+	writeFile(t, filepath.Join(home, ".pizzapi", "agents", "shared.md"), "# global pizzapi")
+	writeFile(t, filepath.Join(cwd, ".claude", "agents", "shared.md"), "# project claude")
+	writeFile(t, filepath.Join(cwd, ".pizzapi", "agents", "shared.md"), "# project pizzapi")
+	writeFile(t, filepath.Join(home, ".claude", "agents", "global-only.md"), "# global only")
+	writeFile(t, filepath.Join(cwd, ".claude", "agents", "project-only.md"), "# project only")
+
+	got, err := locator.DiscoverAgents()
+	if err != nil {
+		t.Fatalf("DiscoverAgents(): %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("expected 3 agents, got %d: %#v", len(got), got)
+	}
+
+	if got[0].Name != "shared" || got[0].Path != filepath.Join(cwd, ".pizzapi", "agents", "shared.md") {
+		t.Fatalf("shared agent precedence mismatch: %#v", got[0])
+	}
+	if got[1].Name != "project-only" || got[1].Scope != ScopeProject || got[1].Family != FamilyClaude {
+		t.Fatalf("project-only agent mismatch: %#v", got[1])
+	}
+	if got[2].Name != "global-only" || got[2].Scope != ScopeGlobal || got[2].Family != FamilyClaude {
+		t.Fatalf("global-only agent mismatch: %#v", got[2])
+	}
+}
+
+func TestDiscoverSkillsSupportsRootAndSubdirLayouts(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(t.TempDir(), "repo")
+	locator := NewLocator(home, cwd)
+
+	writeFile(t, filepath.Join(home, ".claude", "skills", "shared", "SKILL.md"), "# global claude skill")
+	writeFile(t, filepath.Join(cwd, ".claude", "skills", "shared.md"), "# project claude skill")
+	writeFile(t, filepath.Join(cwd, ".pizzapi", "skills", "shared", "SKILL.md"), "# project pizzapi skill")
+	writeFile(t, filepath.Join(cwd, ".claude", "skills", "solo.md"), "# solo")
+
+	got, err := locator.DiscoverSkills()
+	if err != nil {
+		t.Fatalf("DiscoverSkills(): %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 skills, got %d: %#v", len(got), got)
+	}
+
+	if got[0].Name != "shared" || got[0].Path != filepath.Join(cwd, ".pizzapi", "skills", "shared", "SKILL.md") {
+		t.Fatalf("shared skill precedence mismatch: %#v", got[0])
+	}
+	if got[1].Name != "solo" || got[1].Path != filepath.Join(cwd, ".claude", "skills", "solo.md") {
+		t.Fatalf("solo skill mismatch: %#v", got[1])
+	}
+}
+
+func TestDiscoverInstructionDocsPrecedence(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	repo := filepath.Join(t.TempDir(), "repo")
+	cwd := filepath.Join(repo, "apps", "api")
+	locator := NewLocator(home, cwd)
+
+	writeFile(t, filepath.Join(home, ".pizzapi", "AGENTS.md"), "global")
+	writeFile(t, filepath.Join(repo, ".claude", "CLAUDE.md"), "repo-claude")
+	writeFile(t, filepath.Join(repo, "apps", ".pizzapi", "AGENTS.md"), "apps-pizzapi")
+	writeFile(t, filepath.Join(cwd, "CLAUDE.md"), "cwd-root")
+
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+
+	wantPaths := []string{
+		filepath.Join(cwd, "CLAUDE.md"),
+		filepath.Join(repo, "apps", ".pizzapi", "AGENTS.md"),
+		filepath.Join(repo, ".claude", "CLAUDE.md"),
+		filepath.Join(home, ".pizzapi", "AGENTS.md"),
+	}
+	if len(got) != len(wantPaths) {
+		t.Fatalf("expected %d docs, got %d: %#v", len(wantPaths), len(got), got)
+	}
+	for i, want := range wantPaths {
+		if got[i].Path != want {
+			t.Fatalf("doc %d path mismatch: got %q want %q", i, got[i].Path, want)
+		}
+	}
+	if got[0].Content != "cwd-root" {
+		t.Fatalf("expected doc content to be loaded, got %#v", got[0])
+	}
+}
+
+func TestDiscoverInstructionDocsDedupesHomeCandidatesWhenCwdLivesUnderHome(t *testing.T) {
+	homeRoot := t.TempDir()
+	home := filepath.Join(homeRoot, "home")
+	cwd := filepath.Join(home, "src", "repo")
+	locator := NewLocator(home, cwd)
+
+	writeFile(t, filepath.Join(home, ".pizzapi", "AGENTS.md"), "global")
+
+	got, err := locator.DiscoverInstructionDocs()
+	if err != nil {
+		t.Fatalf("DiscoverInstructionDocs(): %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 deduped doc, got %d: %#v", len(got), got)
+	}
+	if got[0].Path != filepath.Join(home, ".pizzapi", "AGENTS.md") {
+		t.Fatalf("unexpected deduped doc path: %#v", got[0])
+	}
+}
+
+func TestConfigPathsPrecedence(t *testing.T) {
+	home := filepath.Join(t.TempDir(), "home")
+	cwd := filepath.Join(t.TempDir(), "repo")
+	locator := NewLocator(home, cwd)
+
+	got := locator.ConfigPaths()
+
+	wantPizzaPiConfig := []PathCandidate{
+		{Path: filepath.Join(cwd, ".pizzapi", "config.json"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(home, ".pizzapi", "config.json"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 2},
+	}
+	if !reflect.DeepEqual(got.PizzaPiConfig, wantPizzaPiConfig) {
+		t.Fatalf("PizzaPiConfig mismatch\n got: %#v\nwant: %#v", got.PizzaPiConfig, wantPizzaPiConfig)
+	}
+
+	wantPizzaPiSettings := []PathCandidate{
+		{Path: filepath.Join(cwd, ".pizzapi", "settings.json"), Family: FamilyPizzaPi, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(home, ".pizzapi", "settings.json"), Family: FamilyPizzaPi, Scope: ScopeGlobal, Priority: 2},
+	}
+	if !reflect.DeepEqual(got.PizzaPiSettings, wantPizzaPiSettings) {
+		t.Fatalf("PizzaPiSettings mismatch\n got: %#v\nwant: %#v", got.PizzaPiSettings, wantPizzaPiSettings)
+	}
+
+	wantClaudeSettings := []PathCandidate{
+		{Path: filepath.Join(cwd, ".claude", "settings.local.json"), Family: FamilyClaude, Scope: ScopeProject, Priority: 1},
+		{Path: filepath.Join(cwd, ".claude", "settings.json"), Family: FamilyClaude, Scope: ScopeProject, Priority: 2},
+		{Path: filepath.Join(home, ".claude", "settings.json"), Family: FamilyClaude, Scope: ScopeGlobal, Priority: 3},
+	}
+	if !reflect.DeepEqual(got.ClaudeSettings, wantClaudeSettings) {
+		t.Fatalf("ClaudeSettings mismatch\n got: %#v\nwant: %#v", got.ClaudeSettings, wantClaudeSettings)
+	}
+}

--- a/experimental/adk-go/runtime/go.mod
+++ b/experimental/adk-go/runtime/go.mod
@@ -1,0 +1,3 @@
+module github.com/pizzaface/pizzapi/experimental/adk-go/runtime
+
+go 1.22

--- a/experimental/adk-go/runtime/guardrails/guardrails.go
+++ b/experimental/adk-go/runtime/guardrails/guardrails.go
@@ -1,0 +1,622 @@
+package guardrails
+
+import (
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+type SandboxMode string
+
+const (
+	ModeNone  SandboxMode = "none"
+	ModeBasic SandboxMode = "basic"
+	ModeFull  SandboxMode = "full"
+)
+
+type ToolCall struct {
+	Name string
+	Args map[string]any
+}
+
+type SessionState struct {
+	PlanMode bool
+}
+
+type SandboxConfig struct {
+	Mode       SandboxMode
+	Filesystem *FilesystemConfig
+	Network    *NetworkConfig
+}
+
+type FilesystemConfig struct {
+	DenyRead   []string
+	AllowWrite []string
+	DenyWrite  []string
+}
+
+type NetworkConfig struct {
+	AllowedDomains []string
+	DeniedDomains  []string
+}
+
+type EvalEnv struct {
+	CWD     string
+	HomeDir string
+	Session SessionState
+	Config  SandboxConfig
+}
+
+type Decision struct {
+	Allowed bool
+	Reason  string
+	Policy  PolicyInfo
+}
+
+type PolicyInfo struct {
+	PlanMode        bool
+	SandboxMode     SandboxMode
+	SandboxActive   bool
+	NetworkEnforced bool
+	Filesystem      FilesystemPolicy
+	Network         NetworkPolicy
+}
+
+type FilesystemPolicy struct {
+	DenyRead   []string
+	AllowWrite []string
+	DenyWrite  []string
+}
+
+type NetworkPolicy struct {
+	AllowedDomains []string
+	DeniedDomains  []string
+}
+
+var writeBlockedToolNames = map[string]struct{}{
+	"edit":          {},
+	"write":         {},
+	"write_file":    {},
+	"subagent":      {},
+	"spawn_session": {},
+}
+
+var spawnBlockedToolNames = map[string]struct{}{
+	"subagent":      {},
+	"spawn_session": {},
+}
+
+var sandboxOnlyPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`^sudo$|^su$|^kill$|^pkill$|^killall$|^reboot$|^shutdown$`),
+	regexp.MustCompile(`^eval$|^source$|^\.$`),
+}
+
+var noSandboxMutatingCommands = map[string]struct{}{
+	"rm": {}, "rmdir": {}, "mv": {}, "cp": {}, "mkdir": {}, "touch": {},
+	"chmod": {}, "chown": {}, "chgrp": {}, "ln": {}, "tee": {}, "truncate": {},
+	"dd": {}, "shred": {}, "install": {}, "mkfifo": {}, "mknod": {},
+}
+
+var gitSafeSubcommands = map[string]struct{}{
+	"status": {}, "log": {}, "diff": {}, "show": {}, "blame": {}, "grep": {}, "shortlog": {},
+	"branch": {}, "tag": {}, "remote": {}, "stash": {}, "ls-files": {}, "ls-tree": {},
+	"ls-remote": {}, "cat-file": {}, "rev-parse": {}, "rev-list": {}, "for-each-ref": {},
+	"name-rev": {}, "describe": {}, "merge-base": {}, "count-objects": {}, "fsck": {},
+	"verify-commit": {}, "verify-tag": {}, "verify-pack": {}, "diff-tree": {}, "diff-files": {},
+	"diff-index": {}, "archive": {}, "cherry": {}, "range-diff": {}, "help": {}, "version": {},
+	"config": {}, "reflog": {}, "worktree": {},
+}
+
+func EvaluateToolCall(call ToolCall, env EvalEnv) Decision {
+	policy := resolvePolicy(env)
+
+	if call.Name == "bash" && policy.SandboxActive {
+		return deny(policy, "Sandbox deny: bash requires executor-level sandbox enforcement; argument-level policy checks cannot safely constrain shell filesystem or network access.")
+	}
+
+	if env.Session.PlanMode {
+		if call.Name == "toggle_plan_mode" || call.Name == "plan_mode" {
+			return allow(policy)
+		}
+		if _, blocked := writeBlockedToolNames[call.Name]; blocked {
+			if _, isSpawnTool := spawnBlockedToolNames[call.Name]; isSpawnTool {
+				return deny(policy, `Plan mode: "`+call.Name+`" is blocked — spawning sessions creates child contexts with full write access, bypassing plan mode. Use toggle_plan_mode to exit plan mode first.`)
+			}
+			return deny(policy, `Plan mode: "`+call.Name+`" is blocked in read-only mode. Use toggle_plan_mode to exit plan mode first.`)
+		}
+		if call.Name == "bash" {
+			command := stringArg(call.Args, "command")
+			if isDestructiveCommand(command, policy.SandboxActive) {
+				return deny(policy, "Plan mode: command blocked (matches destructive pattern). Use toggle_plan_mode to exit plan mode first.\nCommand: "+command)
+			}
+		}
+	}
+
+	if path, ok := firstString(call.Args, "path", "file", "filePath", "targetPath"); ok {
+		normalized := normalizePath(path, env.CWD, env.HomeDir)
+		switch accessKindForTool(call.Name) {
+		case accessRead:
+			if reason := validateReadPath(normalized, policy); reason != "" {
+				return deny(policy, reason)
+			}
+		case accessWrite:
+			if reason := validateWritePath(normalized, policy); reason != "" {
+				return deny(policy, reason)
+			}
+		}
+	}
+
+	if rawURL, ok := firstString(call.Args, "url", "uri", "endpoint"); ok {
+		if reason := validateURL(rawURL, policy); reason != "" {
+			return deny(policy, reason)
+		}
+	}
+
+	return allow(policy)
+}
+
+type accessKind int
+
+const (
+	accessNone accessKind = iota
+	accessRead
+	accessWrite
+)
+
+func accessKindForTool(toolName string) accessKind {
+	switch toolName {
+	case "read", "read_file":
+		return accessRead
+	case "write", "write_file", "edit":
+		return accessWrite
+	default:
+		return accessNone
+	}
+}
+
+func resolvePolicy(env EvalEnv) PolicyInfo {
+	mode := env.Config.Mode
+	if mode == "" {
+		mode = ModeBasic
+	}
+	if mode == ModeNone {
+		return PolicyInfo{PlanMode: env.Session.PlanMode, SandboxMode: mode}
+	}
+
+	fsDenyRead := []string{
+		normalizePath("~/.ssh", env.CWD, env.HomeDir),
+		normalizePath("~/.aws", env.CWD, env.HomeDir),
+		normalizePath("~/.gnupg", env.CWD, env.HomeDir),
+		normalizePath("~/.config/gcloud", env.CWD, env.HomeDir),
+		normalizePath("~/.docker/config.json", env.CWD, env.HomeDir),
+		normalizePath("~/Library/Application Support/Google/Chrome", env.CWD, env.HomeDir),
+		normalizePath("~/Library/Application Support/Firefox", env.CWD, env.HomeDir),
+		normalizePath("~/.mozilla/firefox", env.CWD, env.HomeDir),
+		normalizePath("~/.config/google-chrome", env.CWD, env.HomeDir),
+		normalizePath("~/.config/chromium", env.CWD, env.HomeDir),
+	}
+	fsDenyWrite := []string{
+		normalizePath(".env", env.CWD, env.HomeDir),
+		normalizePath(".env.local", env.CWD, env.HomeDir),
+		normalizePath("~/.ssh", env.CWD, env.HomeDir),
+	}
+	fsAllowWrite := []string{normalizePath(".", env.CWD, env.HomeDir), normalizePath("/tmp", env.CWD, env.HomeDir)}
+
+	if env.Config.Filesystem != nil {
+		fsDenyRead = append(fsDenyRead, normalizePaths(env.Config.Filesystem.DenyRead, env.CWD, env.HomeDir)...)
+		fsDenyWrite = append(fsDenyWrite, normalizePaths(env.Config.Filesystem.DenyWrite, env.CWD, env.HomeDir)...)
+		if env.Config.Filesystem.AllowWrite != nil {
+			fsAllowWrite = normalizePaths(env.Config.Filesystem.AllowWrite, env.CWD, env.HomeDir)
+		}
+	}
+
+	policy := PolicyInfo{
+		PlanMode:      env.Session.PlanMode,
+		SandboxMode:   mode,
+		SandboxActive: true,
+		Filesystem: FilesystemPolicy{
+			DenyRead:   dedupeSorted(fsDenyRead),
+			AllowWrite: dedupeSorted(fsAllowWrite),
+			DenyWrite:  dedupeSorted(fsDenyWrite),
+		},
+	}
+
+	if mode == ModeFull {
+		allowed := []string{}
+		denied := []string{}
+		if env.Config.Network != nil {
+			if env.Config.Network.AllowedDomains != nil {
+				allowed = normalizeDomains(env.Config.Network.AllowedDomains)
+			}
+			denied = append(denied, normalizeDomains(env.Config.Network.DeniedDomains)...)
+		}
+		policy.NetworkEnforced = true
+		policy.Network = NetworkPolicy{AllowedDomains: allowed, DeniedDomains: dedupeSorted(denied)}
+		return policy
+	}
+
+	if env.Config.Network != nil && env.Config.Network.AllowedDomains != nil {
+		policy.NetworkEnforced = true
+		policy.Network = NetworkPolicy{
+			AllowedDomains: normalizeDomains(env.Config.Network.AllowedDomains),
+			DeniedDomains:  dedupeSorted(normalizeDomains(env.Config.Network.DeniedDomains)),
+		}
+	}
+	return policy
+}
+
+func validateReadPath(path string, policy PolicyInfo) string {
+	if !policy.SandboxActive {
+		return ""
+	}
+	for _, denied := range policy.Filesystem.DenyRead {
+		if pathWithin(path, denied) {
+			return "Sandbox deny: read access to " + path + " is blocked by filesystem.denyRead."
+		}
+	}
+	return ""
+}
+
+func validateWritePath(path string, policy PolicyInfo) string {
+	if !policy.SandboxActive {
+		return ""
+	}
+	allowed := false
+	for _, prefix := range policy.Filesystem.AllowWrite {
+		if pathWithin(path, prefix) {
+			allowed = true
+			break
+		}
+	}
+	if !allowed {
+		return "Sandbox deny: write access to " + path + " is outside filesystem.allowWrite."
+	}
+	for _, denied := range policy.Filesystem.DenyWrite {
+		if pathWithin(path, denied) {
+			return "Sandbox deny: write access to " + path + " is blocked by filesystem.denyWrite."
+		}
+	}
+	return ""
+}
+
+func validateURL(rawURL string, policy PolicyInfo) string {
+	if !policy.SandboxActive || !policy.NetworkEnforced {
+		return ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return "Sandbox deny: invalid URL " + rawURL + "."
+	}
+	host := normalizeDomain(parsed.Hostname())
+	if host == "" {
+		return "Sandbox deny: invalid URL " + rawURL + "."
+	}
+	for _, denied := range policy.Network.DeniedDomains {
+		if hostMatchesDomain(host, denied) {
+			return "Sandbox deny: network access to " + host + " is blocked by network.deniedDomains."
+		}
+	}
+	if len(policy.Network.AllowedDomains) == 0 {
+		return "Sandbox deny: network access to " + host + " is blocked; no domains are allowed in the active sandbox policy."
+	}
+	for _, allowed := range policy.Network.AllowedDomains {
+		if hostMatchesDomain(host, allowed) {
+			return ""
+		}
+	}
+	return "Sandbox deny: network access to " + host + " is not in network.allowedDomains."
+}
+
+func isDestructiveCommand(command string, sandboxActive bool) bool {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return false
+	}
+	if strings.Contains(command, "$(") {
+		return true
+	}
+	if strings.Contains(command, "`") || strings.Contains(command, "\n") || strings.Contains(command, "<(") || strings.Contains(command, ">(") {
+		return true
+	}
+	for _, pattern := range sandboxOnlyPatterns {
+		if pattern.MatchString(command) {
+			return true
+		}
+	}
+	tokens := fields(command)
+	if len(tokens) == 0 {
+		return false
+	}
+	first := strings.ToLower(tokens[0])
+	if strings.HasPrefix(first, "git") {
+		return isDestructiveGit(tokens)
+	}
+	if first == "curl" {
+		return isMutatingCurl(tokens)
+	}
+	if first == "wget" {
+		return isMutatingWget(tokens)
+	}
+	if first == "npx" {
+		return true
+	}
+	if first == "npm" && len(tokens) > 1 && strings.EqualFold(tokens[1], "publish") {
+		return true
+	}
+	if first == "docker" && len(tokens) > 1 && strings.EqualFold(tokens[1], "push") {
+		return true
+	}
+	if first == "curl" || first == "wget" {
+		return false
+	}
+	if first == "gh" && len(tokens) > 2 {
+		group := strings.ToLower(tokens[1])
+		action := strings.ToLower(tokens[2])
+		if (group == "issue" || group == "pr" || group == "release") && (action == "create" || action == "edit" || action == "close" || action == "merge" || action == "delete" || action == "comment") {
+			return true
+		}
+	}
+	if sandboxActive {
+		return false
+	}
+	if _, ok := noSandboxMutatingCommands[first]; ok {
+		return true
+	}
+	if strings.Contains(command, ">>") || unsafeOutputRedirection(command) {
+		return true
+	}
+	return false
+}
+
+func isDestructiveGit(tokens []string) bool {
+	if len(tokens) < 2 {
+		return false
+	}
+	subcmd := strings.ToLower(tokens[1])
+	if _, ok := gitSafeSubcommands[subcmd]; !ok {
+		return true
+	}
+	rest := lowerSlice(tokens[2:])
+	switch subcmd {
+	case "branch":
+		for _, token := range rest {
+			if token == "-d" || token == "-D" || token == "-m" || token == "-M" || token == "-c" || token == "-C" {
+				return true
+			}
+		}
+	case "tag":
+		for _, token := range rest {
+			if strings.HasPrefix(token, "-") {
+				if token == "-d" || token == "-s" || token == "-a" || token == "-f" || token == "-u" || token == "--delete" {
+					return true
+				}
+				continue
+			}
+			return true
+		}
+	case "remote":
+		if len(rest) > 0 {
+			switch rest[0] {
+			case "add", "remove", "rm", "rename", "set-url", "set-head", "set-branches", "prune", "update":
+				return true
+			}
+		}
+	case "stash":
+		if len(rest) == 0 {
+			return true
+		}
+		switch rest[0] {
+		case "push", "save", "drop", "pop", "apply", "clear", "create", "store":
+			return true
+		}
+	case "config":
+		for _, token := range rest {
+			if strings.HasPrefix(token, "--unset") || token == "--remove-section" || token == "--rename-section" || token == "--replace-all" || token == "--add" {
+				return true
+			}
+		}
+		if len(rest) >= 2 && !strings.HasPrefix(rest[0], "--get") && rest[0] != "--list" && rest[0] != "--show-origin" && rest[0] != "--show-scope" {
+			return true
+		}
+	case "reflog":
+		if len(rest) > 0 && (rest[0] == "delete" || rest[0] == "expire") {
+			return true
+		}
+	case "worktree":
+		if len(rest) > 0 {
+			switch rest[0] {
+			case "add", "remove", "move", "repair", "lock", "unlock":
+				return true
+			}
+		}
+	case "archive":
+		for _, token := range rest {
+			if token == "-o" || strings.HasPrefix(token, "-o") || token == "--output" || strings.HasPrefix(token, "--output=") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func isMutatingCurl(tokens []string) bool {
+	for i, token := range tokens[1:] {
+		lower := strings.ToLower(token)
+		if strings.HasPrefix(lower, "-x") && lower != "-x" {
+			verb := strings.TrimPrefix(lower, "-x")
+			if isHTTPWriteVerb(verb) {
+				return true
+			}
+		}
+		if lower == "-x" && i+2 <= len(tokens[1:]) {
+			if isHTTPWriteVerb(tokens[i+2]) {
+				return true
+			}
+		}
+		if strings.HasPrefix(lower, "--request=") && isHTTPWriteVerb(strings.TrimPrefix(lower, "--request=")) {
+			return true
+		}
+		if lower == "--request" && i+2 <= len(tokens[1:]) {
+			if isHTTPWriteVerb(tokens[i+2]) {
+				return true
+			}
+		}
+		if lower == "-d" || strings.HasPrefix(lower, "--data") || lower == "--json" {
+			return true
+		}
+	}
+	return false
+}
+
+func isMutatingWget(tokens []string) bool {
+	for _, token := range tokens[1:] {
+		lower := strings.ToLower(token)
+		if lower == "--post-data" || lower == "--post-file" || strings.HasPrefix(lower, "--post-data=") || strings.HasPrefix(lower, "--post-file=") {
+			return true
+		}
+	}
+	return false
+}
+
+func isHTTPWriteVerb(value string) bool {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "POST", "PUT", "DELETE", "PATCH":
+		return true
+	default:
+		return false
+	}
+}
+
+func unsafeOutputRedirection(command string) bool {
+	for i := 0; i < len(command); i++ {
+		if command[i] != '>' {
+			continue
+		}
+		if i > 0 && command[i-1] == '>' {
+			continue
+		}
+		target := strings.TrimSpace(command[i+1:])
+		if strings.HasPrefix(target, "/dev/null") {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func normalizePath(path, cwd, home string) string {
+	if strings.HasPrefix(path, "~/") {
+		path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	} else if path == "~" {
+		path = home
+	} else if path == "." {
+		path = cwd
+	} else if !filepath.IsAbs(path) {
+		path = filepath.Join(cwd, path)
+	}
+	return filepath.Clean(path)
+}
+
+func normalizePaths(paths []string, cwd, home string) []string {
+	out := make([]string, 0, len(paths))
+	for _, path := range paths {
+		out = append(out, normalizePath(path, cwd, home))
+	}
+	return out
+}
+
+func pathWithin(path, prefix string) bool {
+	path = filepath.Clean(path)
+	prefix = filepath.Clean(prefix)
+	if path == prefix {
+		return true
+	}
+	rel, err := filepath.Rel(prefix, path)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+func normalizeDomains(domains []string) []string {
+	out := make([]string, 0, len(domains))
+	for _, domain := range domains {
+		if normalized := normalizeDomain(domain); normalized != "" {
+			out = append(out, normalized)
+		}
+	}
+	return out
+}
+
+func normalizeDomain(domain string) string {
+	domain = strings.ToLower(strings.TrimSpace(domain))
+	return strings.TrimSuffix(domain, ".")
+}
+
+func hostMatchesDomain(host, domain string) bool {
+	host = normalizeDomain(host)
+	domain = normalizeDomain(domain)
+	return host == domain || strings.HasSuffix(host, "."+domain)
+}
+
+func firstString(args map[string]any, keys ...string) (string, bool) {
+	for _, key := range keys {
+		if value, ok := args[key]; ok {
+			if text, ok := value.(string); ok && text != "" {
+				return text, true
+			}
+		}
+	}
+	return "", false
+}
+
+func stringArg(args map[string]any, key string) string {
+	if args == nil {
+		return ""
+	}
+	if value, ok := args[key]; ok {
+		if text, ok := value.(string); ok {
+			return text
+		}
+	}
+	return ""
+}
+
+func allow(policy PolicyInfo) Decision {
+	return Decision{Allowed: true, Policy: policy}
+}
+
+func deny(policy PolicyInfo, reason string) Decision {
+	return Decision{Allowed: false, Reason: reason, Policy: policy}
+}
+
+func dedupeSorted(items []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		out = append(out, item)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func fields(s string) []string {
+	return strings.Fields(strings.TrimSpace(s))
+}
+
+func lowerSlice(items []string) []string {
+	out := make([]string, len(items))
+	for i, item := range items {
+		out[i] = strings.ToLower(item)
+	}
+	return out
+}

--- a/experimental/adk-go/runtime/guardrails/guardrails_test.go
+++ b/experimental/adk-go/runtime/guardrails/guardrails_test.go
@@ -1,0 +1,263 @@
+package guardrails
+
+import "testing"
+
+func TestEvaluateToolCall_PlanModeToolAllowlist(t *testing.T) {
+	env := EvalEnv{
+		CWD:     "/repo",
+		HomeDir: "/home/test",
+		Session: SessionState{PlanMode: true},
+	}
+
+	for _, toolName := range []string{"toggle_plan_mode", "plan_mode", "read"} {
+		decision := EvaluateToolCall(ToolCall{Name: toolName}, env)
+		if !decision.Allowed {
+			t.Fatalf("expected %s to be allowed in plan mode, got denied: %s", toolName, decision.Reason)
+		}
+	}
+}
+
+func TestEvaluateToolCall_PlanModeBlocksMutatingTools(t *testing.T) {
+	env := EvalEnv{
+		CWD:     "/repo",
+		HomeDir: "/home/test",
+		Session: SessionState{PlanMode: true},
+	}
+
+	decision := EvaluateToolCall(ToolCall{
+		Name: "write",
+		Args: map[string]any{"path": "notes.txt"},
+	}, env)
+
+	if decision.Allowed {
+		t.Fatal("expected write to be denied in plan mode")
+	}
+	want := "Plan mode: \"write\" is blocked in read-only mode. Use toggle_plan_mode to exit plan mode first."
+	if decision.Reason != want {
+		t.Fatalf("unexpected denial reason\nwant: %q\ngot:  %q", want, decision.Reason)
+	}
+}
+
+func TestEvaluateToolCall_PlanModeBlocksSpawningTools(t *testing.T) {
+	env := EvalEnv{
+		CWD:     "/repo",
+		HomeDir: "/home/test",
+		Session: SessionState{PlanMode: true},
+	}
+
+	decision := EvaluateToolCall(ToolCall{Name: "spawn_session"}, env)
+	if decision.Allowed {
+		t.Fatal("expected spawn_session to be denied in plan mode")
+	}
+	want := "Plan mode: \"spawn_session\" is blocked — spawning sessions creates child contexts with full write access, bypassing plan mode. Use toggle_plan_mode to exit plan mode first."
+	if decision.Reason != want {
+		t.Fatalf("unexpected denial reason\nwant: %q\ngot:  %q", want, decision.Reason)
+	}
+}
+
+func TestEvaluateToolCall_PlanModeBashGuardrails(t *testing.T) {
+	t.Run("no sandbox blocks filesystem mutation", func(t *testing.T) {
+		env := EvalEnv{
+			CWD:     "/repo",
+			HomeDir: "/home/test",
+			Session: SessionState{PlanMode: true},
+			Config:  SandboxConfig{Mode: ModeNone},
+		}
+
+		decision := EvaluateToolCall(ToolCall{
+			Name: "bash",
+			Args: map[string]any{"command": "rm -rf build"},
+		}, env)
+		if decision.Allowed {
+			t.Fatal("expected destructive bash command to be denied without sandbox")
+		}
+		want := "Plan mode: command blocked (matches destructive pattern). Use toggle_plan_mode to exit plan mode first.\nCommand: rm -rf build"
+		if decision.Reason != want {
+			t.Fatalf("unexpected denial reason\nwant: %q\ngot:  %q", want, decision.Reason)
+		}
+	})
+
+	t.Run("sandbox denies bash because shell access bypasses structured policy checks", func(t *testing.T) {
+		env := EvalEnv{
+			CWD:     "/repo",
+			HomeDir: "/home/test",
+			Session: SessionState{PlanMode: true},
+			Config:  SandboxConfig{Mode: ModeBasic},
+		}
+
+		decision := EvaluateToolCall(ToolCall{
+			Name: "bash",
+			Args: map[string]any{"command": "rm -rf build"},
+		}, env)
+		if decision.Allowed {
+			t.Fatal("expected bash to be denied when sandbox policy is active")
+		}
+		want := "Sandbox deny: bash requires executor-level sandbox enforcement; argument-level policy checks cannot safely constrain shell filesystem or network access."
+		if decision.Reason != want {
+			t.Fatalf("unexpected denial reason\nwant: %q\ngot:  %q", want, decision.Reason)
+		}
+	})
+}
+
+func TestEvaluateToolCall_SandboxFilesystemPolicy(t *testing.T) {
+	env := EvalEnv{
+		CWD:     "/repo",
+		HomeDir: "/home/test",
+		Config:  SandboxConfig{Mode: ModeBasic},
+	}
+
+	readDenied := EvaluateToolCall(ToolCall{
+		Name: "read",
+		Args: map[string]any{"path": "~/.ssh/config"},
+	}, env)
+	if readDenied.Allowed {
+		t.Fatal("expected sensitive read path to be denied")
+	}
+	if readDenied.Reason != "Sandbox deny: read access to /home/test/.ssh/config is blocked by filesystem.denyRead." {
+		t.Fatalf("unexpected read denial reason: %q", readDenied.Reason)
+	}
+
+	writeAllowed := EvaluateToolCall(ToolCall{
+		Name: "write",
+		Args: map[string]any{"path": "notes/todo.txt"},
+	}, env)
+	if !writeAllowed.Allowed {
+		t.Fatalf("expected repo write path to be allowed, got denied: %s", writeAllowed.Reason)
+	}
+
+	writeOutside := EvaluateToolCall(ToolCall{
+		Name: "write",
+		Args: map[string]any{"path": "/etc/hosts"},
+	}, env)
+	if writeOutside.Allowed {
+		t.Fatal("expected write outside allowWrite to be denied")
+	}
+	if writeOutside.Reason != "Sandbox deny: write access to /etc/hosts is outside filesystem.allowWrite." {
+		t.Fatalf("unexpected allowWrite denial reason: %q", writeOutside.Reason)
+	}
+
+	writeDotEnv := EvaluateToolCall(ToolCall{
+		Name: "write",
+		Args: map[string]any{"path": ".env"},
+	}, env)
+	if writeDotEnv.Allowed {
+		t.Fatal("expected .env write to be denied")
+	}
+	if writeDotEnv.Reason != "Sandbox deny: write access to /repo/.env is blocked by filesystem.denyWrite." {
+		t.Fatalf("unexpected denyWrite denial reason: %q", writeDotEnv.Reason)
+	}
+}
+
+func TestEvaluateToolCall_SandboxBashBypassIsDenied(t *testing.T) {
+	env := EvalEnv{
+		CWD:     "/repo",
+		HomeDir: "/home/test",
+		Config: SandboxConfig{
+			Mode:       ModeFull,
+			Filesystem: &FilesystemConfig{DenyRead: []string{"~/.ssh"}},
+			Network:    &NetworkConfig{AllowedDomains: []string{"example.com"}},
+		},
+	}
+
+	for _, tc := range []struct {
+		name    string
+		command string
+	}{
+		{name: "filesystem read", command: "cat ~/.ssh/id_rsa"},
+		{name: "network egress", command: "curl https://evil.com/pwn"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			decision := EvaluateToolCall(ToolCall{Name: "bash", Args: map[string]any{"command": tc.command}}, env)
+			if decision.Allowed {
+				t.Fatalf("expected bash command %q to be denied under sandbox policy", tc.command)
+			}
+		})
+	}
+}
+
+func TestEvaluateToolCall_SandboxNetworkPolicy(t *testing.T) {
+	t.Run("basic without allowedDomains leaves network unrestricted", func(t *testing.T) {
+		env := EvalEnv{
+			CWD:     "/repo",
+			HomeDir: "/home/test",
+			Config:  SandboxConfig{Mode: ModeBasic},
+		}
+
+		decision := EvaluateToolCall(ToolCall{
+			Name: "fetch_url",
+			Args: map[string]any{"url": "https://api.example.com/v1"},
+		}, env)
+		if !decision.Allowed {
+			t.Fatalf("expected unrestricted basic-mode network call to be allowed, got denied: %s", decision.Reason)
+		}
+		if decision.Policy.NetworkEnforced {
+			t.Fatal("expected network sandbox to stay disabled in basic mode without allowedDomains")
+		}
+	})
+
+	t.Run("allowed and denied domains are enforced when network policy is active", func(t *testing.T) {
+		env := EvalEnv{
+			CWD:     "/repo",
+			HomeDir: "/home/test",
+			Config: SandboxConfig{
+				Mode: ModeBasic,
+				Network: &NetworkConfig{
+					AllowedDomains: []string{"example.com"},
+					DeniedDomains:  []string{"blocked.example.com"},
+				},
+			},
+		}
+
+		allowed := EvaluateToolCall(ToolCall{
+			Name: "fetch_url",
+			Args: map[string]any{"url": "https://api.example.com/v1"},
+		}, env)
+		if !allowed.Allowed {
+			t.Fatalf("expected subdomain on allowlist to be allowed, got denied: %s", allowed.Reason)
+		}
+		if !allowed.Policy.NetworkEnforced {
+			t.Fatal("expected network sandbox to be active when allowedDomains is set")
+		}
+
+		blockedByAllowlist := EvaluateToolCall(ToolCall{
+			Name: "fetch_url",
+			Args: map[string]any{"url": "https://evil.com/pwn"},
+		}, env)
+		if blockedByAllowlist.Allowed {
+			t.Fatal("expected non-allowlisted domain to be denied")
+		}
+		if blockedByAllowlist.Reason != "Sandbox deny: network access to evil.com is not in network.allowedDomains." {
+			t.Fatalf("unexpected allowlist denial reason: %q", blockedByAllowlist.Reason)
+		}
+
+		blockedByDenylist := EvaluateToolCall(ToolCall{
+			Name: "fetch_url",
+			Args: map[string]any{"url": "https://blocked.example.com/pwn"},
+		}, env)
+		if blockedByDenylist.Allowed {
+			t.Fatal("expected explicitly denied domain to be blocked")
+		}
+		if blockedByDenylist.Reason != "Sandbox deny: network access to blocked.example.com is blocked by network.deniedDomains." {
+			t.Fatalf("unexpected denylist denial reason: %q", blockedByDenylist.Reason)
+		}
+	})
+
+	t.Run("full mode denies all outbound network by default", func(t *testing.T) {
+		env := EvalEnv{
+			CWD:     "/repo",
+			HomeDir: "/home/test",
+			Config:  SandboxConfig{Mode: ModeFull},
+		}
+
+		decision := EvaluateToolCall(ToolCall{
+			Name: "fetch_url",
+			Args: map[string]any{"url": "https://api.example.com/v1"},
+		}, env)
+		if decision.Allowed {
+			t.Fatal("expected full-mode default network deny-all to block outbound access")
+		}
+		if decision.Reason != "Sandbox deny: network access to api.example.com is blocked; no domains are allowed in the active sandbox policy." {
+			t.Fatalf("unexpected full-mode denial reason: %q", decision.Reason)
+		}
+	})
+}

--- a/experimental/adk-go/runtime/mcpconfig/mcpconfig.go
+++ b/experimental/adk-go/runtime/mcpconfig/mcpconfig.go
@@ -1,0 +1,204 @@
+package mcpconfig
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Transport identifies the normalized MCP transport PizzaPi config uses.
+type Transport string
+
+const (
+	TransportStdio      Transport = "stdio"
+	TransportSSE        Transport = "sse"
+	TransportStreamable Transport = "streamable"
+)
+
+// Server is the normalized Go model for a single PizzaPi mcpServers entry.
+type Server struct {
+	Name      string
+	Transport Transport
+	Command   string
+	Args      []string
+	Env       map[string]string
+	Cwd       string
+	URL       string
+	Headers   map[string]string
+}
+
+// Config is the normalized Go model for PizzaPi's mcpServers{} shape.
+type Config struct {
+	Servers map[string]Server
+}
+
+// ParsePizzaPiConfig parses the top-level PizzaPi config JSON and extracts the
+// normalized mcpServers{} model.
+func ParsePizzaPiConfig(data []byte) (Config, error) {
+	var raw struct {
+		MCPServers map[string]json.RawMessage `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return Config{}, err
+	}
+
+	cfg := Config{Servers: map[string]Server{}}
+	for name, entry := range raw.MCPServers {
+		server, err := parseServer(name, entry)
+		if err != nil {
+			return Config{}, err
+		}
+		cfg.Servers[name] = server
+	}
+	return cfg, nil
+}
+
+// Merge deep-merges two parsed configs by server name. Project entries overwrite
+// global entries with the same name, matching PizzaPi's precedence behavior.
+func Merge(global, project Config) Config {
+	merged := Config{Servers: map[string]Server{}}
+	for name, server := range global.Servers {
+		merged.Servers[name] = cloneServer(server)
+	}
+	for name, server := range project.Servers {
+		merged.Servers[name] = cloneServer(server)
+	}
+	return merged
+}
+
+// MarshalClaudeConfigJSON emits the Claude CLI --mcp-config JSON shape.
+func (c Config) MarshalClaudeConfigJSON() ([]byte, error) {
+	claude := struct {
+		MCPServers map[string]any `json:"mcpServers"`
+	}{MCPServers: map[string]any{}}
+
+	for name, server := range c.Servers {
+		switch server.Transport {
+		case TransportStdio:
+			entry := struct {
+				Args    []string          `json:"args,omitempty"`
+				Command string            `json:"command"`
+				Cwd     string            `json:"cwd,omitempty"`
+				Env     map[string]string `json:"env,omitempty"`
+			}{
+				Args:    cloneStringSlice(server.Args),
+				Command: server.Command,
+				Cwd:     server.Cwd,
+				Env:     cloneStringMap(server.Env),
+			}
+			claude.MCPServers[name] = entry
+		case TransportStreamable:
+			entry := struct {
+				Headers map[string]string `json:"headers,omitempty"`
+				Type    string            `json:"type"`
+				URL     string            `json:"url"`
+			}{
+				Headers: cloneStringMap(server.Headers),
+				Type:    "http",
+				URL:     server.URL,
+			}
+			claude.MCPServers[name] = entry
+		case TransportSSE:
+			entry := struct {
+				Headers map[string]string `json:"headers,omitempty"`
+				Type    string            `json:"type"`
+				URL     string            `json:"url"`
+			}{
+				Headers: cloneStringMap(server.Headers),
+				Type:    "sse",
+				URL:     server.URL,
+			}
+			claude.MCPServers[name] = entry
+		default:
+			return nil, fmt.Errorf("server %q has unsupported transport %q", name, server.Transport)
+		}
+	}
+
+	return json.MarshalIndent(claude, "", "  ")
+}
+
+type rawServer struct {
+	Command   string            `json:"command"`
+	Args      []string          `json:"args"`
+	Env       map[string]string `json:"env"`
+	Cwd       string            `json:"cwd"`
+	URL       string            `json:"url"`
+	Headers   map[string]string `json:"headers"`
+	Transport string            `json:"transport"`
+	Type      string            `json:"type"`
+}
+
+func parseServer(name string, data []byte) (Server, error) {
+	var raw rawServer
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return Server{}, fmt.Errorf("parse mcpServers.%s: %w", name, err)
+	}
+
+	if raw.Command != "" {
+		return Server{
+			Name:      name,
+			Transport: TransportStdio,
+			Command:   raw.Command,
+			Args:      cloneStringSlice(raw.Args),
+			Env:       cloneStringMap(raw.Env),
+			Cwd:       raw.Cwd,
+		}, nil
+	}
+	if raw.URL != "" {
+		transport := normalizeRemoteTransport(raw.Transport, raw.Type)
+		return Server{
+			Name:      name,
+			Transport: transport,
+			URL:       raw.URL,
+			Headers:   cloneStringMap(raw.Headers),
+		}, nil
+	}
+
+	return Server{}, fmt.Errorf("parse mcpServers.%s: entry must contain either command or url", name)
+}
+
+func normalizeRemoteTransport(rawTransport, rawType string) Transport {
+	switch rawTransport {
+	case "streamable":
+		return TransportStreamable
+	case "sse", "http", "":
+		// Fall through to type-based normalization below.
+	default:
+		return TransportSSE
+	}
+
+	switch rawType {
+	case "http":
+		return TransportStreamable
+	case "sse", "":
+		return TransportSSE
+	default:
+		return TransportSSE
+	}
+}
+
+func cloneServer(server Server) Server {
+	server.Args = cloneStringSlice(server.Args)
+	server.Env = cloneStringMap(server.Env)
+	server.Headers = cloneStringMap(server.Headers)
+	return server
+}
+
+func cloneStringSlice(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make([]string, len(values))
+	copy(cloned, values)
+	return cloned
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if len(values) == 0 {
+		return nil
+	}
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/experimental/adk-go/runtime/mcpconfig/mcpconfig_test.go
+++ b/experimental/adk-go/runtime/mcpconfig/mcpconfig_test.go
@@ -1,0 +1,258 @@
+package mcpconfig
+
+import (
+	"testing"
+)
+
+func TestParsePizzaPiConfigParsesStdioAndStreamableServers(t *testing.T) {
+	cfg, err := ParsePizzaPiConfig([]byte(`{
+		"mcpServers": {
+			"godmother": {
+				"command": "godmother",
+				"args": ["serve"],
+				"env": {"API_KEY": "secret"},
+				"cwd": "/repo"
+			},
+			"github": {
+				"type": "http",
+				"url": "https://api.githubcopilot.com/mcp/",
+				"headers": {"Authorization": "Bearer token"}
+			},
+			"remote": {
+				"transport": "streamable",
+				"url": "https://example.com/mcp",
+				"headers": {"X-Test": "1"}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParsePizzaPiConfig() error = %v", err)
+	}
+
+	godmother, ok := cfg.Servers["godmother"]
+	if !ok {
+		t.Fatalf("missing godmother server")
+	}
+	if godmother.Transport != TransportStdio {
+		t.Fatalf("godmother transport = %q, want %q", godmother.Transport, TransportStdio)
+	}
+	if godmother.Command != "godmother" {
+		t.Fatalf("godmother command = %q", godmother.Command)
+	}
+	if len(godmother.Args) != 1 || godmother.Args[0] != "serve" {
+		t.Fatalf("godmother args = %#v", godmother.Args)
+	}
+	if godmother.Env["API_KEY"] != "secret" {
+		t.Fatalf("godmother env = %#v", godmother.Env)
+	}
+	if godmother.Cwd != "/repo" {
+		t.Fatalf("godmother cwd = %q", godmother.Cwd)
+	}
+
+	github, ok := cfg.Servers["github"]
+	if !ok {
+		t.Fatalf("missing github server")
+	}
+	if github.Transport != TransportStreamable {
+		t.Fatalf("github transport = %q, want %q", github.Transport, TransportStreamable)
+	}
+	if github.URL != "https://api.githubcopilot.com/mcp/" {
+		t.Fatalf("github url = %q", github.URL)
+	}
+	if github.Headers["Authorization"] != "Bearer token" {
+		t.Fatalf("github headers = %#v", github.Headers)
+	}
+
+	remote, ok := cfg.Servers["remote"]
+	if !ok {
+		t.Fatalf("missing remote server")
+	}
+	if remote.Transport != TransportStreamable {
+		t.Fatalf("remote transport = %q, want %q", remote.Transport, TransportStreamable)
+	}
+	if remote.Headers["X-Test"] != "1" {
+		t.Fatalf("remote headers = %#v", remote.Headers)
+	}
+}
+
+func TestMergeProjectPrecedencePreservesGlobalOnlyServers(t *testing.T) {
+	global, err := ParsePizzaPiConfig([]byte(`{
+		"mcpServers": {
+			"godmother": {"command": "godmother", "args": ["serve"]},
+			"shared": {"command": "global-version"}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("parse global: %v", err)
+	}
+	project, err := ParsePizzaPiConfig([]byte(`{
+		"mcpServers": {
+			"playwright": {"command": "npx", "args": ["@playwright/mcp"]},
+			"shared": {"type": "http", "url": "https://project.example/mcp"}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("parse project: %v", err)
+	}
+
+	merged := Merge(global, project)
+	if len(merged.Servers) != 3 {
+		t.Fatalf("len(merged.Servers) = %d, want 3", len(merged.Servers))
+	}
+	if merged.Servers["godmother"].Command != "godmother" {
+		t.Fatalf("global-only server was not preserved: %#v", merged.Servers["godmother"])
+	}
+	if merged.Servers["playwright"].Command != "npx" {
+		t.Fatalf("project-only server missing: %#v", merged.Servers["playwright"])
+	}
+	if merged.Servers["shared"].Transport != TransportStreamable {
+		t.Fatalf("shared transport = %q, want %q", merged.Servers["shared"].Transport, TransportStreamable)
+	}
+	if merged.Servers["shared"].URL != "https://project.example/mcp" {
+		t.Fatalf("project override did not win: %#v", merged.Servers["shared"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ParsePizzaPiConfig — malformed / edge-case inputs
+// ---------------------------------------------------------------------------
+
+func TestParsePizzaPiConfigInvalidTopLevelJSON(t *testing.T) {
+	_, err := ParsePizzaPiConfig([]byte(`{not valid json`))
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestParsePizzaPiConfigEmptyMCPServers(t *testing.T) {
+	cfg, err := ParsePizzaPiConfig([]byte(`{"mcpServers": {}}`))
+	if err != nil {
+		t.Fatalf("expected no error for empty mcpServers, got %v", err)
+	}
+	if len(cfg.Servers) != 0 {
+		t.Errorf("expected 0 servers, got %d", len(cfg.Servers))
+	}
+}
+
+func TestParsePizzaPiConfigNoMCPServersField(t *testing.T) {
+	// Config with no mcpServers key at all — should return empty config.
+	cfg, err := ParsePizzaPiConfig([]byte(`{"appendSystemPrompt": "hello"}`))
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if len(cfg.Servers) != 0 {
+		t.Errorf("expected 0 servers, got %d", len(cfg.Servers))
+	}
+}
+
+func TestParsePizzaPiConfigServerMissingCommandAndURL(t *testing.T) {
+	_, err := ParsePizzaPiConfig([]byte(`{
+		"mcpServers": {
+			"broken": {"env": {"FOO": "bar"}}
+		}
+	}`))
+	if err == nil {
+		t.Fatal("expected error for server missing command and url, got nil")
+	}
+}
+
+func TestParsePizzaPiConfigServerInvalidEntryJSON(t *testing.T) {
+	// Server entry value is not an object — unmarshal should fail.
+	_, err := ParsePizzaPiConfig([]byte(`{
+		"mcpServers": {
+			"bad": "not-an-object"
+		}
+	}`))
+	if err == nil {
+		t.Fatal("expected error for non-object server entry, got nil")
+	}
+}
+
+func TestParsePizzaPiConfigNullServerEntry(t *testing.T) {
+	// Null server entry: json.RawMessage will be `null`.
+	// Unmarshalling null into rawServer gives an empty struct,
+	// which fails the command/url check.
+	_, err := ParsePizzaPiConfig([]byte(`{
+		"mcpServers": {
+			"nullsvc": null
+		}
+	}`))
+	if err == nil {
+		t.Fatal("expected error for null server entry, got nil")
+	}
+}
+
+func TestParsePizzaPiConfigNullMCPServersField(t *testing.T) {
+	// null mcpServers value — should parse without error and produce empty config.
+	cfg, err := ParsePizzaPiConfig([]byte(`{"mcpServers": null}`))
+	if err != nil {
+		t.Fatalf("expected no error for null mcpServers, got %v", err)
+	}
+	if len(cfg.Servers) != 0 {
+		t.Errorf("expected 0 servers, got %d", len(cfg.Servers))
+	}
+}
+
+func TestMarshalClaudeConfigJSONUsesStableOrderingAndClaudeShape(t *testing.T) {
+	cfg := Config{Servers: map[string]Server{
+		"remote": {
+			Name:      "remote",
+			Transport: TransportStreamable,
+			URL:       "https://example.com/mcp",
+			Headers: map[string]string{
+				"X-Trace":       "1",
+				"Authorization": "Bearer token",
+			},
+		},
+		"godmother": {
+			Name:      "godmother",
+			Transport: TransportStdio,
+			Command:   "godmother",
+			Args:      []string{"serve"},
+			Env: map[string]string{
+				"B": "2",
+				"A": "1",
+			},
+			Cwd: "/repo",
+		},
+	}}
+
+	got, err := cfg.MarshalClaudeConfigJSON()
+	if err != nil {
+		t.Fatalf("MarshalClaudeConfigJSON() error = %v", err)
+	}
+	gotAgain, err := cfg.MarshalClaudeConfigJSON()
+	if err != nil {
+		t.Fatalf("MarshalClaudeConfigJSON() second error = %v", err)
+	}
+	if string(got) != string(gotAgain) {
+		t.Fatalf("MarshalClaudeConfigJSON() was not stable across calls\nfirst:\n%s\nsecond:\n%s", got, gotAgain)
+	}
+
+	want := `{
+  "mcpServers": {
+    "godmother": {
+      "args": [
+        "serve"
+      ],
+      "command": "godmother",
+      "cwd": "/repo",
+      "env": {
+        "A": "1",
+        "B": "2"
+      }
+    },
+    "remote": {
+      "headers": {
+        "Authorization": "Bearer token",
+        "X-Trace": "1"
+      },
+      "type": "http",
+      "url": "https://example.com/mcp"
+    }
+  }
+}`
+	if string(got) != want {
+		t.Fatalf("MarshalClaudeConfigJSON() mismatch\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}

--- a/experimental/adk-go/runtime/mcpconfig/mcpconfig_test.go
+++ b/experimental/adk-go/runtime/mcpconfig/mcpconfig_test.go
@@ -1,0 +1,178 @@
+package mcpconfig
+
+import (
+	"testing"
+)
+
+func TestParsePizzaPiConfigParsesStdioAndStreamableServers(t *testing.T) {
+	cfg, err := ParsePizzaPiConfig([]byte(`{
+		"mcpServers": {
+			"godmother": {
+				"command": "godmother",
+				"args": ["serve"],
+				"env": {"API_KEY": "secret"},
+				"cwd": "/repo"
+			},
+			"github": {
+				"type": "http",
+				"url": "https://api.githubcopilot.com/mcp/",
+				"headers": {"Authorization": "Bearer token"}
+			},
+			"remote": {
+				"transport": "streamable",
+				"url": "https://example.com/mcp",
+				"headers": {"X-Test": "1"}
+			}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("ParsePizzaPiConfig() error = %v", err)
+	}
+
+	godmother, ok := cfg.Servers["godmother"]
+	if !ok {
+		t.Fatalf("missing godmother server")
+	}
+	if godmother.Transport != TransportStdio {
+		t.Fatalf("godmother transport = %q, want %q", godmother.Transport, TransportStdio)
+	}
+	if godmother.Command != "godmother" {
+		t.Fatalf("godmother command = %q", godmother.Command)
+	}
+	if len(godmother.Args) != 1 || godmother.Args[0] != "serve" {
+		t.Fatalf("godmother args = %#v", godmother.Args)
+	}
+	if godmother.Env["API_KEY"] != "secret" {
+		t.Fatalf("godmother env = %#v", godmother.Env)
+	}
+	if godmother.Cwd != "/repo" {
+		t.Fatalf("godmother cwd = %q", godmother.Cwd)
+	}
+
+	github, ok := cfg.Servers["github"]
+	if !ok {
+		t.Fatalf("missing github server")
+	}
+	if github.Transport != TransportStreamable {
+		t.Fatalf("github transport = %q, want %q", github.Transport, TransportStreamable)
+	}
+	if github.URL != "https://api.githubcopilot.com/mcp/" {
+		t.Fatalf("github url = %q", github.URL)
+	}
+	if github.Headers["Authorization"] != "Bearer token" {
+		t.Fatalf("github headers = %#v", github.Headers)
+	}
+
+	remote, ok := cfg.Servers["remote"]
+	if !ok {
+		t.Fatalf("missing remote server")
+	}
+	if remote.Transport != TransportStreamable {
+		t.Fatalf("remote transport = %q, want %q", remote.Transport, TransportStreamable)
+	}
+	if remote.Headers["X-Test"] != "1" {
+		t.Fatalf("remote headers = %#v", remote.Headers)
+	}
+}
+
+func TestMergeProjectPrecedencePreservesGlobalOnlyServers(t *testing.T) {
+	global, err := ParsePizzaPiConfig([]byte(`{
+		"mcpServers": {
+			"godmother": {"command": "godmother", "args": ["serve"]},
+			"shared": {"command": "global-version"}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("parse global: %v", err)
+	}
+	project, err := ParsePizzaPiConfig([]byte(`{
+		"mcpServers": {
+			"playwright": {"command": "npx", "args": ["@playwright/mcp"]},
+			"shared": {"type": "http", "url": "https://project.example/mcp"}
+		}
+	}`))
+	if err != nil {
+		t.Fatalf("parse project: %v", err)
+	}
+
+	merged := Merge(global, project)
+	if len(merged.Servers) != 3 {
+		t.Fatalf("len(merged.Servers) = %d, want 3", len(merged.Servers))
+	}
+	if merged.Servers["godmother"].Command != "godmother" {
+		t.Fatalf("global-only server was not preserved: %#v", merged.Servers["godmother"])
+	}
+	if merged.Servers["playwright"].Command != "npx" {
+		t.Fatalf("project-only server missing: %#v", merged.Servers["playwright"])
+	}
+	if merged.Servers["shared"].Transport != TransportStreamable {
+		t.Fatalf("shared transport = %q, want %q", merged.Servers["shared"].Transport, TransportStreamable)
+	}
+	if merged.Servers["shared"].URL != "https://project.example/mcp" {
+		t.Fatalf("project override did not win: %#v", merged.Servers["shared"])
+	}
+}
+
+func TestMarshalClaudeConfigJSONUsesStableOrderingAndClaudeShape(t *testing.T) {
+	cfg := Config{Servers: map[string]Server{
+		"remote": {
+			Name:      "remote",
+			Transport: TransportStreamable,
+			URL:       "https://example.com/mcp",
+			Headers: map[string]string{
+				"X-Trace":       "1",
+				"Authorization": "Bearer token",
+			},
+		},
+		"godmother": {
+			Name:      "godmother",
+			Transport: TransportStdio,
+			Command:   "godmother",
+			Args:      []string{"serve"},
+			Env: map[string]string{
+				"B": "2",
+				"A": "1",
+			},
+			Cwd: "/repo",
+		},
+	}}
+
+	got, err := cfg.MarshalClaudeConfigJSON()
+	if err != nil {
+		t.Fatalf("MarshalClaudeConfigJSON() error = %v", err)
+	}
+	gotAgain, err := cfg.MarshalClaudeConfigJSON()
+	if err != nil {
+		t.Fatalf("MarshalClaudeConfigJSON() second error = %v", err)
+	}
+	if string(got) != string(gotAgain) {
+		t.Fatalf("MarshalClaudeConfigJSON() was not stable across calls\nfirst:\n%s\nsecond:\n%s", got, gotAgain)
+	}
+
+	want := `{
+  "mcpServers": {
+    "godmother": {
+      "args": [
+        "serve"
+      ],
+      "command": "godmother",
+      "cwd": "/repo",
+      "env": {
+        "A": "1",
+        "B": "2"
+      }
+    },
+    "remote": {
+      "headers": {
+        "Authorization": "Bearer token",
+        "X-Trace": "1"
+      },
+      "type": "http",
+      "url": "https://example.com/mcp"
+    }
+  }
+}`
+	if string(got) != want {
+		t.Fatalf("MarshalClaudeConfigJSON() mismatch\nwant:\n%s\n\ngot:\n%s", want, got)
+	}
+}


### PR DESCRIPTION
Night Shift pairing: runtime-wiring

Dishes:
- 001: Wire compat + registration into runner startup (iCMOKeIo)
- 002: Wire MCP bridge into Claude provider spawn (KqbiLpzH)  
- 003: Wire guardrails into tool boundary with bash deny (oKJJeL36)

Combined PR — all three dishes passed per-dish Ramsey expo and were merged into a single branch.