### PR TITLE
fix(go-runner): prevent sessionID panic and socketio double-close race

### DIFF
--- a/experimental/adk-go/go-runner/main.go
+++ b/experimental/adk-go/go-runner/main.go
@@ -219,7 +219,7 @@ func (r *GoRunner) handleNewSession(data json.RawMessage) {
 		Cwd:    payload.Cwd,
 		Model:  model,
 		OnStderr: func(line string) {
-			r.logger.Printf("[session:%s:stderr] %s", sessionID[:8], line)
+			r.logger.Printf("[session:%s:stderr] %s", shortID(sessionID), line)
 		},
 	})
 }
@@ -234,10 +234,10 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 
 	// Wire up user input from web UI → provider
 	relaySess.onInput = func(text string) {
-		r.logger.Printf("session %s: sending user input to provider", sessionID[:8])
+		r.logger.Printf("session %s: sending user input to provider", shortID(sessionID))
 
 		if err := sess.provider.SendMessage(text); err != nil {
-			r.logger.Printf("session %s: send message error: %v", sessionID[:8], err)
+			r.logger.Printf("session %s: send message error: %v", shortID(sessionID), err)
 			return
 		}
 
@@ -258,7 +258,7 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 	}
 
 	if err := relaySess.Connect(r.relayURL, r.apiKey, cwd); err != nil {
-		r.logger.Printf("session %s relay registration failed: %v", sessionID[:8], err)
+		r.logger.Printf("session %s relay registration failed: %v", shortID(sessionID), err)
 		r.client.Emit("session_error", map[string]any{
 			"sessionId": sessionID,
 			"message":   fmt.Sprintf("relay registration failed: %v", err),
@@ -271,7 +271,7 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 	// Start the provider
 	events, err := sess.provider.Start(pctx)
 	if err != nil {
-		r.logger.Printf("session %s start error: %v", sessionID[:8], err)
+		r.logger.Printf("session %s start error: %v", shortID(sessionID), err)
 		r.client.Emit("session_error", map[string]any{
 			"sessionId": sessionID,
 			"message":   err.Error(),
@@ -285,7 +285,7 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 	r.client.Emit("session_ready", map[string]any{
 		"sessionId": sessionID,
 	})
-	r.logger.Printf("session %s ready", sessionID[:8])
+	r.logger.Printf("session %s ready", shortID(sessionID))
 
 	// Start a heartbeat ticker
 	heartbeatTicker := time.NewTicker(10 * time.Second)
@@ -302,7 +302,7 @@ func (r *GoRunner) runSession(ctx context.Context, sess *session, pctx ProviderC
 			}
 
 			evType, _ := ev["type"].(string)
-			r.logger.Printf("session %s relay event: %v", sessionID[:8], evType)
+			r.logger.Printf("session %s relay event: %v", shortID(sessionID), evType)
 
 			// Forward via the /relay session connection — this goes through
 			// the server's event pipeline (state caching, image stripping,
@@ -350,7 +350,7 @@ func (r *GoRunner) handleSessionExit(sess *session) {
 	<-sess.provider.Done()
 
 	exitCode := sess.provider.ExitCode()
-	r.logger.Printf("session %s exited (code=%d)", sessionID[:8], exitCode)
+	r.logger.Printf("session %s exited (code=%d)", shortID(sessionID), exitCode)
 
 	// Send final inactive heartbeat
 	r.client.Emit("runner_session_event", map[string]any{
@@ -385,11 +385,11 @@ func (r *GoRunner) handleKillSession(data json.RawMessage) {
 		return
 	}
 
-	r.logger.Printf("kill_session: %s", payload.SessionID[:8])
+	r.logger.Printf("kill_session: %s", shortID(payload.SessionID))
 
 	val, ok := r.sessions.Load(payload.SessionID)
 	if !ok {
-		r.logger.Printf("session %s not found for kill", payload.SessionID[:8])
+		r.logger.Printf("session %s not found for kill", shortID(payload.SessionID))
 		return
 	}
 
@@ -410,7 +410,7 @@ func (r *GoRunner) killSession(sess *session) {
 	select {
 	case <-sess.provider.Done():
 	case <-time.After(10 * time.Second):
-		r.logger.Printf("session %s did not exit after stop, force killed", sess.sessionID[:8])
+		r.logger.Printf("session %s did not exit after stop, force killed", shortID(sess.sessionID))
 	}
 }
 
@@ -422,7 +422,7 @@ func (r *GoRunner) handleSessionEnded(data json.RawMessage) {
 		r.logger.Printf("parse session_ended: %v", err)
 		return
 	}
-	r.logger.Printf("session_ended from relay: %s", payload.SessionID[:8])
+	r.logger.Printf("session_ended from relay: %s", shortID(payload.SessionID))
 	r.sessions.Delete(payload.SessionID)
 }
 

--- a/experimental/adk-go/go-runner/relay_session.go
+++ b/experimental/adk-go/go-runner/relay_session.go
@@ -47,7 +47,7 @@ func (rs *RelaySession) Connect(relayURL, apiKey, cwd string) error {
 		},
 		Logger: rs.logger,
 		OnConnect: func() {
-			rs.logger.Printf("session %s: relay /relay connected, registering", rs.sessionID[:8])
+			rs.logger.Printf("session %s: relay /relay connected, registering", shortID(rs.sessionID))
 			rs.client.Emit("register", map[string]any{
 				"sessionId":  rs.sessionID,
 				"cwd":        cwd,
@@ -65,9 +65,9 @@ func (rs *RelaySession) Connect(relayURL, apiKey, cwd string) error {
 		}
 		if err := json.Unmarshal(data, &payload); err == nil {
 			rs.token = payload.Token
-			rs.logger.Printf("session %s: relay session registered (shareUrl=%s)", rs.sessionID[:8], payload.ShareURL)
+			rs.logger.Printf("session %s: relay session registered (shareUrl=%s)", shortID(rs.sessionID), payload.ShareURL)
 		} else {
-			rs.logger.Printf("session %s: relay session registered (token parse error: %v)", rs.sessionID[:8], err)
+			rs.logger.Printf("session %s: relay session registered (token parse error: %v)", shortID(rs.sessionID), err)
 		}
 		select {
 		case registered <- struct{}{}:
@@ -76,11 +76,11 @@ func (rs *RelaySession) Connect(relayURL, apiKey, cwd string) error {
 	})
 
 	rs.client.On("error", func(data json.RawMessage) {
-		rs.logger.Printf("session %s: relay error: %s", rs.sessionID[:8], string(data))
+		rs.logger.Printf("session %s: relay error: %s", shortID(rs.sessionID), string(data))
 	})
 
 	rs.client.On("exec", func(data json.RawMessage) {
-		rs.logger.Printf("session %s: received exec: %s", rs.sessionID[:8], string(data))
+		rs.logger.Printf("session %s: received exec: %s", shortID(rs.sessionID), string(data))
 	})
 
 	// Handle user input from the web UI (collab mode)
@@ -89,10 +89,10 @@ func (rs *RelaySession) Connect(relayURL, apiKey, cwd string) error {
 			Text string `json:"text"`
 		}
 		if err := json.Unmarshal(data, &payload); err != nil {
-			rs.logger.Printf("session %s: failed to parse input: %v", rs.sessionID[:8], err)
+			rs.logger.Printf("session %s: failed to parse input: %v", shortID(rs.sessionID), err)
 			return
 		}
-		rs.logger.Printf("session %s: received user input: %s", rs.sessionID[:8], payload.Text[:min(len(payload.Text), 80)])
+		rs.logger.Printf("session %s: received user input: %s", shortID(rs.sessionID), payload.Text[:min(len(payload.Text), 80)])
 		if rs.onInput != nil {
 			rs.onInput(payload.Text)
 		}
@@ -132,9 +132,11 @@ func (rs *RelaySession) Done() <-chan struct{} {
 	return rs.done
 }
 
-func min(a, b int) int {
-	if a < b {
-		return a
+// shortID returns the first 8 characters of s, or s itself if shorter.
+// Safe against empty strings and short IDs (e.g. from malformed relay messages).
+func shortID(s string) string {
+	if len(s) > 8 {
+		return s[:8]
 	}
-	return b
+	return s
 }

--- a/experimental/adk-go/go-runner/runner_test.go
+++ b/experimental/adk-go/go-runner/runner_test.go
@@ -236,3 +236,23 @@ func TestGoRunnerSessionEnded(t *testing.T) {
 	server.sendEvent("session_ended", map[string]any{"sessionId": "phantom-session"})
 	time.Sleep(100 * time.Millisecond)
 }
+
+// TestShortID verifies that shortID never panics and returns correct truncations.
+func TestShortID(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"", ""},
+		{"abc", "abc"},
+		{"abcdefgh", "abcdefgh"},           // exactly 8 — returned as-is
+		{"abcdefghi", "abcdefgh"},          // 9 chars — truncated
+		{"abc-def-ghi-jkl", "abc-def-"},   // long ID — first 8
+	}
+	for _, tt := range tests {
+		got := shortID(tt.input)
+		if got != tt.want {
+			t.Errorf("shortID(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/experimental/adk-go/go-runner/socketio.go
+++ b/experimental/adk-go/go-runner/socketio.go
@@ -273,8 +273,7 @@ func (c *SIOClient) buildWSURL() (string, error) {
 
 func (c *SIOClient) readLoop() {
 	defer func() {
-		if !c.closed.Load() {
-			c.closed.Store(true)
+		if c.closed.CompareAndSwap(false, true) {
 			close(c.done)
 		}
 		if c.onDisconnect != nil {

--- a/experimental/adk-go/go-runner/socketio_test.go
+++ b/experimental/adk-go/go-runner/socketio_test.go
@@ -265,6 +265,58 @@ func TestSIOClientPingPong(t *testing.T) {
 	}
 }
 
+// TestSIOClientCloseReadLoopRace exercises the race window between Close() and
+// readLoop's defer path. Both paths must use CompareAndSwap so only one closes
+// the done channel. Run with -race to detect the data race.
+func TestSIOClientCloseReadLoopRace(t *testing.T) {
+	for i := 0; i < 20; i++ {
+		server := newFakeSIOServer(t)
+
+		client := NewSIOClient(SIOClientConfig{
+			URL:       server.URL(),
+			Namespace: "/runner",
+			Auth:      map[string]any{"apiKey": "test"},
+		})
+
+		if err := client.Connect(); err != nil {
+			server.Close()
+			t.Fatalf("iteration %d: connect error: %v", i, err)
+		}
+
+		// Fire Close() and server-side disconnect simultaneously to race the
+		// readLoop defer path against the explicit Close() call.
+		var wg sync.WaitGroup
+		wg.Add(2)
+
+		go func() {
+			defer wg.Done()
+			client.Close()
+		}()
+
+		go func() {
+			defer wg.Done()
+			// Close the server connection to force readLoop to exit
+			server.connMu.Lock()
+			if server.conn != nil {
+				server.conn.Close()
+			}
+			server.connMu.Unlock()
+		}()
+
+		wg.Wait()
+
+		// Wait for the client to fully settle — done channel must be closed exactly once.
+		select {
+		case <-client.Done():
+			// OK
+		case <-time.After(2 * time.Second):
+			t.Fatalf("iteration %d: timed out waiting for client done", i)
+		}
+
+		server.Close()
+	}
+}
+
 func TestSIOClientDisconnect(t *testing.T) {
 	server := newFakeSIOServer(t)
 	defer server.Close()


### PR DESCRIPTION
Night Shift pairing: go-runner-safety

## Dishes
- **003:** sessionID[:8] panic sweep — replaces ~20 unbounded slices with safe shortID() helper, removes redundant min() shadow
- **004:** socketio.go double-close race — uses CAS in readLoop defer to match Close()

## Health Inspector Origin
Both bugs found by Health Inspector audit of shift 20260403-210228. sessionID[:8] was a P1 citation across PRs 458/461. Double-close race was a P2 citation on PR 458.

## Tests
- TestShortID: empty, short, exact-8, long strings
- TestSIOClientCloseReadLoopRace: concurrent Close()/readLoop race exercise