### PR TITLE
feat(runtime/sessions): JSONL append-only session persistence

### DIFF
--- a/experimental/adk-go/runtime/go.mod
+++ b/experimental/adk-go/runtime/go.mod
@@ -1,0 +1,3 @@
+module github.com/pizzaface/pizzapi/experimental/adk-go/runtime
+
+go 1.22

--- a/experimental/adk-go/runtime/sessions/export_test.go
+++ b/experimental/adk-go/runtime/sessions/export_test.go
@@ -1,0 +1,7 @@
+package sessions
+
+// SessionsDirForTest exposes the internal sessionsDir helper to the external
+// test package (sessions_test). It is only compiled during `go test`.
+func (s *JSONLStore) SessionsDirForTest(cwd string) string {
+	return s.sessionsDir(cwd)
+}

--- a/experimental/adk-go/runtime/sessions/jsonl.go
+++ b/experimental/adk-go/runtime/sessions/jsonl.go
@@ -1,0 +1,286 @@
+package sessions
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+)
+
+// JSONLStore is a SessionStore backed by append-only JSONL files.
+//
+// File layout:
+//
+//	<baseDir>/sessions/<encoded-cwd>/<session-id>.jsonl
+//
+// Line 1  – Session metadata JSON
+// Line 2+ – Event JSON objects (one per line), appended over time
+type JSONLStore struct {
+	baseDir string
+	mu      sync.RWMutex // guards all file operations
+}
+
+// NewJSONLStore creates a new JSONLStore rooted at baseDir.
+// The directory is created (including parents) if it does not exist.
+func NewJSONLStore(baseDir string) *JSONLStore {
+	return &JSONLStore{baseDir: baseDir}
+}
+
+// encodeCWD converts an absolute (or relative) cwd path into a string that is
+// safe to use as a directory name on any OS. We use URL percent-encoding so the
+// result is reversible, human-readable in simple cases, and avoids the path
+// separator ('/') as well as other special characters.
+func encodeCWD(cwd string) string {
+	return url.PathEscape(cwd)
+}
+
+// sessionsDir returns the per-cwd directory that holds all session files for
+// that working directory.
+func (s *JSONLStore) sessionsDir(cwd string) string {
+	return filepath.Join(s.baseDir, "sessions", encodeCWD(cwd))
+}
+
+// sessionPath returns the full path to a session's JSONL file.
+// It looks up the session file by scanning all cwd subdirectories.
+// For Create/AppendEvents/Delete where the cwd is known, use sessionPathForCWD.
+func (s *JSONLStore) sessionPathForCWD(cwd, id string) string {
+	return filepath.Join(s.sessionsDir(cwd), id+".jsonl")
+}
+
+// findSessionPath searches all cwd-encoded subdirectories for a file named
+// <id>.jsonl. Returns an error if not found.
+func (s *JSONLStore) findSessionPath(id string) (string, error) {
+	sessionsRoot := filepath.Join(s.baseDir, "sessions")
+	entries, err := os.ReadDir(sessionsRoot)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return "", fmt.Errorf("session %q not found", id)
+		}
+		return "", err
+	}
+	target := id + ".jsonl"
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(sessionsRoot, entry.Name(), target)
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("session %q not found", id)
+}
+
+// Create writes session metadata as the first line of a new JSONL file.
+// Returns an error if a file for this session already exists.
+func (s *JSONLStore) Create(_ context.Context, session *Session) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	dir := s.sessionsDir(session.CWD)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("sessions.Create: mkdir: %w", err)
+	}
+
+	path := s.sessionPathForCWD(session.CWD, session.ID)
+	// O_EXCL ensures we fail if the file already exists.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
+	if err != nil {
+		if errors.Is(err, os.ErrExist) {
+			return fmt.Errorf("sessions.Create: session %q already exists", session.ID)
+		}
+		return fmt.Errorf("sessions.Create: open: %w", err)
+	}
+	defer f.Close()
+
+	line, err := json.Marshal(session)
+	if err != nil {
+		return fmt.Errorf("sessions.Create: marshal: %w", err)
+	}
+	if _, err := f.Write(append(line, '\n')); err != nil {
+		return fmt.Errorf("sessions.Create: write: %w", err)
+	}
+	return nil
+}
+
+// Get reads the first line of the session JSONL file and returns the metadata.
+func (s *JSONLStore) Get(_ context.Context, id string) (*Session, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	path, err := s.findSessionPath(id)
+	if err != nil {
+		return nil, fmt.Errorf("sessions.Get: %w", err)
+	}
+	return readSessionMeta(path)
+}
+
+// List returns metadata for all sessions stored under the given cwd, sorted by
+// Updated descending. Returns an empty (non-nil) slice when none exist.
+func (s *JSONLStore) List(_ context.Context, cwd string) ([]*SessionMeta, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	dir := s.sessionsDir(cwd)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return []*SessionMeta{}, nil
+		}
+		return nil, fmt.Errorf("sessions.List: readdir: %w", err)
+	}
+
+	var metas []*SessionMeta
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		sess, err := readSessionMeta(path)
+		if err != nil {
+			// Skip corrupt/empty files; don't abort the whole list.
+			continue
+		}
+		metas = append(metas, &SessionMeta{
+			ID:      sess.ID,
+			CWD:     sess.CWD,
+			Model:   sess.Model,
+			Created: sess.Created,
+			Updated: sess.Updated,
+		})
+	}
+
+	sort.Slice(metas, func(i, j int) bool {
+		return metas[i].Updated.After(metas[j].Updated)
+	})
+	return metas, nil
+}
+
+// AppendEvents opens the session JSONL file in append mode and writes each
+// event as an individual JSON line.
+func (s *JSONLStore) AppendEvents(_ context.Context, id string, events []Event) error {
+	if len(events) == 0 {
+		return nil
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path, err := s.findSessionPath(id)
+	if err != nil {
+		return fmt.Errorf("sessions.AppendEvents: %w", err)
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("sessions.AppendEvents: open: %w", err)
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	for _, ev := range events {
+		line, err := json.Marshal(ev)
+		if err != nil {
+			return fmt.Errorf("sessions.AppendEvents: marshal: %w", err)
+		}
+		if _, err := w.Write(append(line, '\n')); err != nil {
+			return fmt.Errorf("sessions.AppendEvents: write: %w", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return fmt.Errorf("sessions.AppendEvents: flush: %w", err)
+	}
+	return nil
+}
+
+// LoadEvents reads all event lines (lines 2+) from the session JSONL file.
+func (s *JSONLStore) LoadEvents(_ context.Context, id string) ([]Event, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	path, err := s.findSessionPath(id)
+	if err != nil {
+		return nil, fmt.Errorf("sessions.LoadEvents: %w", err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("sessions.LoadEvents: open: %w", err)
+	}
+	defer f.Close()
+
+	var events []Event
+	scanner := bufio.NewScanner(f)
+	// Set a large buffer to handle potentially large event JSON.
+	scanner.Buffer(make([]byte, 1024*1024), 16*1024*1024)
+
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		if lineNum == 1 {
+			// Skip the metadata line.
+			continue
+		}
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+		var ev Event
+		if err := json.Unmarshal(line, &ev); err != nil {
+			return nil, fmt.Errorf("sessions.LoadEvents: parse line %d: %w", lineNum, err)
+		}
+		events = append(events, ev)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("sessions.LoadEvents: scan: %w", err)
+	}
+	return events, nil
+}
+
+// Delete removes the JSONL file for the given session ID.
+func (s *JSONLStore) Delete(_ context.Context, id string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	path, err := s.findSessionPath(id)
+	if err != nil {
+		return fmt.Errorf("sessions.Delete: %w", err)
+	}
+	if err := os.Remove(path); err != nil {
+		return fmt.Errorf("sessions.Delete: remove: %w", err)
+	}
+	return nil
+}
+
+// readSessionMeta reads and parses only the first line of a JSONL session file.
+func readSessionMeta(path string) (*Session, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("readSessionMeta: open %s: %w", path, err)
+	}
+	defer f.Close()
+
+	r := bufio.NewReader(f)
+	line, err := r.ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return nil, fmt.Errorf("readSessionMeta: read %s: %w", path, err)
+	}
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return nil, fmt.Errorf("readSessionMeta: empty file %s", path)
+	}
+
+	var sess Session
+	if err := json.Unmarshal([]byte(line), &sess); err != nil {
+		return nil, fmt.Errorf("readSessionMeta: parse %s: %w", path, err)
+	}
+	return &sess, nil
+}

--- a/experimental/adk-go/runtime/sessions/jsonl.go
+++ b/experimental/adk-go/runtime/sessions/jsonl.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 )
 
 // JSONLStore is a SessionStore backed by append-only JSONL files.
@@ -21,8 +22,13 @@ import (
 //
 //	<baseDir>/sessions/<encoded-cwd>/<session-id>.jsonl
 //
-// Line 1  – Session metadata JSON
+// Line 1  – Session metadata JSON (Updated reflects creation time only)
 // Line 2+ – Event JSON objects (one per line), appended over time
+//
+// Concurrency: the embedded mutex provides safe concurrent access within a
+// single process. Multi-process access to the same baseDir is NOT safe without
+// external file locking (e.g. flock(2)) — the mutex has no cross-process
+// visibility.
 type JSONLStore struct {
 	baseDir string
 	mu      sync.RWMutex // guards all file operations
@@ -80,8 +86,13 @@ func (s *JSONLStore) findSessionPath(id string) (string, error) {
 }
 
 // Create writes session metadata as the first line of a new JSONL file.
-// Returns an error if a file for this session already exists.
+// Returns an error if session.CWD is empty or if a file for this session
+// already exists.
 func (s *JSONLStore) Create(_ context.Context, session *Session) error {
+	if session.CWD == "" {
+		return fmt.Errorf("sessions.Create: CWD must not be empty")
+	}
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -124,7 +135,11 @@ func (s *JSONLStore) Get(_ context.Context, id string) (*Session, error) {
 }
 
 // List returns metadata for all sessions stored under the given cwd, sorted by
-// Updated descending. Returns an empty (non-nil) slice when none exist.
+// file modification time descending (most-recently written first).
+// Note: the Updated field inside each Session reflects creation time only;
+// recency ordering is determined by the file's OS mtime, which advances on
+// every AppendEvents call.
+// Returns an empty (non-nil) slice when none exist.
 func (s *JSONLStore) List(_ context.Context, cwd string) ([]*SessionMeta, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -138,9 +153,18 @@ func (s *JSONLStore) List(_ context.Context, cwd string) ([]*SessionMeta, error)
 		return nil, fmt.Errorf("sessions.List: readdir: %w", err)
 	}
 
-	var metas []*SessionMeta
+	type sessionWithMtime struct {
+		meta  *SessionMeta
+		mtime time.Time
+	}
+
+	var items []sessionWithMtime
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".jsonl") {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
 			continue
 		}
 		path := filepath.Join(dir, entry.Name())
@@ -149,18 +173,20 @@ func (s *JSONLStore) List(_ context.Context, cwd string) ([]*SessionMeta, error)
 			// Skip corrupt/empty files; don't abort the whole list.
 			continue
 		}
-		metas = append(metas, &SessionMeta{
-			ID:      sess.ID,
-			CWD:     sess.CWD,
-			Model:   sess.Model,
-			Created: sess.Created,
-			Updated: sess.Updated,
+		items = append(items, sessionWithMtime{
+			meta:  sess,
+			mtime: info.ModTime(),
 		})
 	}
 
-	sort.Slice(metas, func(i, j int) bool {
-		return metas[i].Updated.After(metas[j].Updated)
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].mtime.After(items[j].mtime)
 	})
+
+	metas := make([]*SessionMeta, len(items))
+	for i, item := range items {
+		metas[i] = item.meta
+	}
 	return metas, nil
 }
 
@@ -202,6 +228,8 @@ func (s *JSONLStore) AppendEvents(_ context.Context, id string, events []Event) 
 }
 
 // LoadEvents reads all event lines (lines 2+) from the session JSONL file.
+// Corrupt or truncated lines (e.g. from a crash mid-flush) are skipped with a
+// warning to stderr; all valid events before and after such lines are returned.
 func (s *JSONLStore) LoadEvents(_ context.Context, id string) ([]Event, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -235,7 +263,10 @@ func (s *JSONLStore) LoadEvents(_ context.Context, id string) ([]Event, error) {
 		}
 		var ev Event
 		if err := json.Unmarshal(line, &ev); err != nil {
-			return nil, fmt.Errorf("sessions.LoadEvents: parse line %d: %w", lineNum, err)
+			// Skip corrupt/truncated lines (e.g. from a crash mid-flush).
+			// All valid events before and after this line are still returned.
+			fmt.Fprintf(os.Stderr, "sessions.LoadEvents: skipping corrupt line %d in %s: %v\n", lineNum, path, err)
+			continue
 		}
 		events = append(events, ev)
 	}

--- a/experimental/adk-go/runtime/sessions/jsonl_test.go
+++ b/experimental/adk-go/runtime/sessions/jsonl_test.go
@@ -1,0 +1,470 @@
+package sessions_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pizzaface/pizzapi/experimental/adk-go/runtime/sessions"
+)
+
+// newStore creates a JSONLStore backed by a temporary directory that is cleaned
+// up automatically when the test finishes.
+func newStore(t *testing.T) *sessions.JSONLStore {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "sessions-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+	return sessions.NewJSONLStore(dir)
+}
+
+func makeSession(id, cwd, model string) *sessions.Session {
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	return &sessions.Session{
+		ID:      id,
+		CWD:     cwd,
+		Model:   model,
+		Created: now,
+		Updated: now,
+	}
+}
+
+func makeEvent(typ, payload string) sessions.Event {
+	return sessions.Event{
+		Type:      typ,
+		Timestamp: time.Now().UTC().Truncate(time.Millisecond),
+		Data:      json.RawMessage(`"` + payload + `"`),
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Create + Get round-trip
+// ---------------------------------------------------------------------------
+
+func TestCreateGet(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	sess := makeSession("abc123", "/home/user/project", "claude-3")
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	got, err := store.Get(ctx, "abc123")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.ID != sess.ID {
+		t.Errorf("ID: got %q, want %q", got.ID, sess.ID)
+	}
+	if got.CWD != sess.CWD {
+		t.Errorf("CWD: got %q, want %q", got.CWD, sess.CWD)
+	}
+	if got.Model != sess.Model {
+		t.Errorf("Model: got %q, want %q", got.Model, sess.Model)
+	}
+	if !got.Created.Equal(sess.Created) {
+		t.Errorf("Created: got %v, want %v", got.Created, sess.Created)
+	}
+}
+
+func TestCreateDuplicate(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	sess := makeSession("dup1", "/tmp/proj", "gpt-4")
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+	if err := store.Create(ctx, sess); err == nil {
+		t.Fatal("expected error on duplicate Create, got nil")
+	}
+}
+
+func TestGetNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	_, err := store.Get(ctx, "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for nonexistent session, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AppendEvents + LoadEvents
+// ---------------------------------------------------------------------------
+
+func TestAppendLoadEvents(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	sess := makeSession("evt1", "/tmp/evts", "claude-3")
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	events := []sessions.Event{
+		makeEvent("message", "hello"),
+		makeEvent("tool_use", "bash"),
+		makeEvent("tool_result", "ok"),
+	}
+	if err := store.AppendEvents(ctx, "evt1", events); err != nil {
+		t.Fatalf("AppendEvents: %v", err)
+	}
+
+	loaded, err := store.LoadEvents(ctx, "evt1")
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(loaded) != len(events) {
+		t.Fatalf("event count: got %d, want %d", len(loaded), len(events))
+	}
+	for i, ev := range loaded {
+		if ev.Type != events[i].Type {
+			t.Errorf("event[%d].Type: got %q, want %q", i, ev.Type, events[i].Type)
+		}
+	}
+}
+
+func TestAppendMultipleBatches(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	sess := makeSession("batch1", "/tmp/batch", "claude-3")
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	for i := 0; i < 5; i++ {
+		batch := []sessions.Event{
+			makeEvent("message", fmt.Sprintf("msg-%d", i)),
+		}
+		if err := store.AppendEvents(ctx, "batch1", batch); err != nil {
+			t.Fatalf("AppendEvents batch %d: %v", i, err)
+		}
+	}
+
+	loaded, err := store.LoadEvents(ctx, "batch1")
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(loaded) != 5 {
+		t.Fatalf("event count: got %d, want 5", len(loaded))
+	}
+}
+
+func TestLoadEventsEmpty(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	sess := makeSession("empty1", "/tmp/empty", "claude-3")
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	events, err := store.LoadEvents(ctx, "empty1")
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	if len(events) != 0 {
+		t.Fatalf("expected 0 events, got %d", len(events))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// List sessions with cwd encoding
+// ---------------------------------------------------------------------------
+
+func TestListSessions(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	cwd := "/Users/alice/my project/с unicode"
+	sess1 := makeSession("s1", cwd, "claude-3")
+	sess1.Updated = time.Now().UTC().Add(-time.Hour)
+	sess2 := makeSession("s2", cwd, "gpt-4")
+	sess2.Updated = time.Now().UTC()
+
+	if err := store.Create(ctx, sess1); err != nil {
+		t.Fatalf("Create s1: %v", err)
+	}
+	if err := store.Create(ctx, sess2); err != nil {
+		t.Fatalf("Create s2: %v", err)
+	}
+
+	list, err := store.List(ctx, cwd)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("list count: got %d, want 2", len(list))
+	}
+	// Sorted by Updated desc — s2 should be first.
+	if list[0].ID != "s2" {
+		t.Errorf("first item: got %q, want s2", list[0].ID)
+	}
+	if list[1].ID != "s1" {
+		t.Errorf("second item: got %q, want s1", list[1].ID)
+	}
+}
+
+func TestListEmptyCWD(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	list, err := store.List(ctx, "/nonexistent/cwd")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if list == nil {
+		t.Fatal("List returned nil, want empty slice")
+	}
+	if len(list) != 0 {
+		t.Fatalf("expected empty list, got %d items", len(list))
+	}
+}
+
+func TestListDifferentCWDs(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	cwd1 := "/home/user/proj1"
+	cwd2 := "/home/user/proj2"
+
+	if err := store.Create(ctx, makeSession("p1a", cwd1, "m")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Create(ctx, makeSession("p2a", cwd2, "m")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Create(ctx, makeSession("p2b", cwd2, "m")); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	list1, err := store.List(ctx, cwd1)
+	if err != nil {
+		t.Fatalf("List cwd1: %v", err)
+	}
+	if len(list1) != 1 {
+		t.Fatalf("cwd1 count: got %d, want 1", len(list1))
+	}
+
+	list2, err := store.List(ctx, cwd2)
+	if err != nil {
+		t.Fatalf("List cwd2: %v", err)
+	}
+	if len(list2) != 2 {
+		t.Fatalf("cwd2 count: got %d, want 2", len(list2))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Concurrent append safety
+// ---------------------------------------------------------------------------
+
+func TestConcurrentAppend(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	sess := makeSession("concurrent1", "/tmp/concurrent", "claude-3")
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	const goroutines = 10
+	const eventsPerGoroutine = 20
+
+	var wg sync.WaitGroup
+	for g := 0; g < goroutines; g++ {
+		wg.Add(1)
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < eventsPerGoroutine; i++ {
+				ev := []sessions.Event{
+					makeEvent("message", fmt.Sprintf("g%d-i%d", g, i)),
+				}
+				if err := store.AppendEvents(ctx, "concurrent1", ev); err != nil {
+					t.Errorf("AppendEvents g%d i%d: %v", g, i, err)
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+
+	loaded, err := store.LoadEvents(ctx, "concurrent1")
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	want := goroutines * eventsPerGoroutine
+	if len(loaded) != want {
+		t.Fatalf("event count: got %d, want %d", len(loaded), want)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Corrupt / empty file handling
+// ---------------------------------------------------------------------------
+
+func TestCorruptFileHandling(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	// Create a valid session first so the directory exists.
+	validSess := makeSession("valid1", "/tmp/corrupt", "m")
+	if err := store.Create(ctx, validSess); err != nil {
+		t.Fatalf("Create valid: %v", err)
+	}
+
+	// Manually write a corrupt file into the same cwd directory.
+	dir := store.SessionsDirForTest("/tmp/corrupt")
+	corruptPath := dir + "/corrupt-session.jsonl"
+	if err := os.WriteFile(corruptPath, []byte("not-json\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile corrupt: %v", err)
+	}
+
+	// List should skip the corrupt file and return the valid one.
+	list, err := store.List(ctx, "/tmp/corrupt")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("list count: got %d, want 1 (corrupt file should be skipped)", len(list))
+	}
+	if list[0].ID != "valid1" {
+		t.Errorf("item ID: got %q, want valid1", list[0].ID)
+	}
+}
+
+func TestEmptyFileHandling(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	// Create a valid session so the directory exists.
+	validSess := makeSession("valid2", "/tmp/empty-file", "m")
+	if err := store.Create(ctx, validSess); err != nil {
+		t.Fatalf("Create valid: %v", err)
+	}
+
+	// Manually write an empty file into the same cwd directory.
+	dir := store.SessionsDirForTest("/tmp/empty-file")
+	emptyPath := dir + "/empty-session.jsonl"
+	if err := os.WriteFile(emptyPath, []byte{}, 0o644); err != nil {
+		t.Fatalf("WriteFile empty: %v", err)
+	}
+
+	// List should skip the empty file gracefully.
+	list, err := store.List(ctx, "/tmp/empty-file")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("list count: got %d, want 1 (empty file should be skipped)", len(list))
+	}
+}
+
+func TestGetCorruptFile(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	// Write a corrupt file and try to Get it — should return an error, not panic.
+	validSess := makeSession("corrupt-get", "/tmp/corrupt-get", "m")
+	if err := store.Create(ctx, validSess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	dir := store.SessionsDirForTest("/tmp/corrupt-get")
+	// Overwrite the valid file with corrupt content.
+	if err := os.WriteFile(dir+"/corrupt-get.jsonl", []byte("bad json\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	_, err := store.Get(ctx, "corrupt-get")
+	if err == nil {
+		t.Fatal("expected error for corrupt file, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Delete
+// ---------------------------------------------------------------------------
+
+func TestDelete(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	sess := makeSession("del1", "/tmp/del", "claude-3")
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := store.Delete(ctx, "del1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	_, err := store.Get(ctx, "del1")
+	if err == nil {
+		t.Fatal("expected error after Delete, got nil")
+	}
+}
+
+func TestDeleteNotFound(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	if err := store.Delete(ctx, "ghost"); err == nil {
+		t.Fatal("expected error deleting nonexistent session, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Large session (>100 events)
+// ---------------------------------------------------------------------------
+
+func TestLargeSession(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	sess := makeSession("large1", "/tmp/large", "claude-3")
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	const total = 200
+	events := make([]sessions.Event, total)
+	for i := range events {
+		events[i] = makeEvent("message", fmt.Sprintf("payload-%d", i))
+	}
+
+	start := time.Now()
+	if err := store.AppendEvents(ctx, "large1", events); err != nil {
+		t.Fatalf("AppendEvents: %v", err)
+	}
+	appendDur := time.Since(start)
+
+	start = time.Now()
+	loaded, err := store.LoadEvents(ctx, "large1")
+	if err != nil {
+		t.Fatalf("LoadEvents: %v", err)
+	}
+	loadDur := time.Since(start)
+
+	if len(loaded) != total {
+		t.Fatalf("event count: got %d, want %d", len(loaded), total)
+	}
+
+	// Performance smoke-test: both operations should finish well under 1 second
+	// for 200 small events on any reasonable machine.
+	if appendDur > 2*time.Second {
+		t.Errorf("AppendEvents took too long: %v", appendDur)
+	}
+	if loadDur > 2*time.Second {
+		t.Errorf("LoadEvents took too long: %v", loadDur)
+	}
+	t.Logf("AppendEvents(%d events): %v, LoadEvents: %v", total, appendDur, loadDur)
+}

--- a/experimental/adk-go/runtime/sessions/jsonl_test.go
+++ b/experimental/adk-go/runtime/sessions/jsonl_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
@@ -178,6 +179,70 @@ func TestLoadEventsEmpty(t *testing.T) {
 	}
 }
 
+// TestLoadEventsCorruptLine verifies that a truncated/corrupt event line does
+// not prevent LoadEvents from returning the valid events around it (D2).
+func TestLoadEventsCorruptLine(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	sess := makeSession("corrupt-evts", "/tmp/corrupt-evts", "claude-3")
+	if err := store.Create(ctx, sess); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// Write two good events, then manually splice a corrupt line in the middle,
+	// then a third good event at the end — simulating a crash mid-flush.
+	goodBefore := []sessions.Event{
+		makeEvent("message", "before-corrupt"),
+	}
+	if err := store.AppendEvents(ctx, "corrupt-evts", goodBefore); err != nil {
+		t.Fatalf("AppendEvents (before): %v", err)
+	}
+
+	// Manually append a corrupt (truncated) line directly to the file.
+	dir := store.SessionsDirForTest("/tmp/corrupt-evts")
+	filePath := filepath.Join(dir, "corrupt-evts.jsonl")
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		t.Fatalf("OpenFile: %v", err)
+	}
+	if _, err := f.Write([]byte("{\"type\":\"truncated\",\"data\":\n")); err != nil {
+		f.Close()
+		t.Fatalf("Write corrupt line: %v", err)
+	}
+	f.Close()
+
+	goodAfter := []sessions.Event{
+		makeEvent("message", "after-corrupt"),
+	}
+	if err := store.AppendEvents(ctx, "corrupt-evts", goodAfter); err != nil {
+		t.Fatalf("AppendEvents (after): %v", err)
+	}
+
+	// LoadEvents must succeed and return the 2 valid events, skipping the bad line.
+	loaded, err := store.LoadEvents(ctx, "corrupt-evts")
+	if err != nil {
+		t.Fatalf("LoadEvents returned error on corrupt line (should skip): %v", err)
+	}
+	if len(loaded) != 2 {
+		t.Fatalf("event count: got %d, want 2 (1 before + 1 after corrupt)", len(loaded))
+	}
+	if loaded[0].Type != "message" || loaded[1].Type != "message" {
+		t.Errorf("unexpected event types: %q, %q", loaded[0].Type, loaded[1].Type)
+	}
+}
+
+// TestCreateEmptyCWD verifies that Create rejects an empty CWD (D5).
+func TestCreateEmptyCWD(t *testing.T) {
+	ctx := context.Background()
+	store := newStore(t)
+
+	sess := makeSession("no-cwd", "", "claude-3")
+	if err := store.Create(ctx, sess); err == nil {
+		t.Fatal("expected error for empty CWD, got nil")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // List sessions with cwd encoding
 // ---------------------------------------------------------------------------
@@ -188,15 +253,21 @@ func TestListSessions(t *testing.T) {
 
 	cwd := "/Users/alice/my project/с unicode"
 	sess1 := makeSession("s1", cwd, "claude-3")
-	sess1.Updated = time.Now().UTC().Add(-time.Hour)
 	sess2 := makeSession("s2", cwd, "gpt-4")
-	sess2.Updated = time.Now().UTC()
 
 	if err := store.Create(ctx, sess1); err != nil {
 		t.Fatalf("Create s1: %v", err)
 	}
 	if err := store.Create(ctx, sess2); err != nil {
 		t.Fatalf("Create s2: %v", err)
+	}
+
+	// Force sess1's file mtime to be 1 hour in the past so List sorts
+	// sess2 first regardless of filesystem mtime granularity.
+	dir := store.SessionsDirForTest(cwd)
+	past := time.Now().UTC().Add(-time.Hour)
+	if err := os.Chtimes(filepath.Join(dir, "s1.jsonl"), past, past); err != nil {
+		t.Fatalf("Chtimes: %v", err)
 	}
 
 	list, err := store.List(ctx, cwd)
@@ -435,7 +506,7 @@ func TestLargeSession(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 
-	const total = 200
+	const total = 1000
 	events := make([]sessions.Event, total)
 	for i := range events {
 		events[i] = makeEvent("message", fmt.Sprintf("payload-%d", i))
@@ -458,12 +529,12 @@ func TestLargeSession(t *testing.T) {
 		t.Fatalf("event count: got %d, want %d", len(loaded), total)
 	}
 
-	// Performance smoke-test: both operations should finish well under 1 second
-	// for 200 small events on any reasonable machine.
-	if appendDur > 2*time.Second {
+	// Performance smoke-test: both operations should finish well under 5 seconds
+	// for 1000 small events on any reasonable machine.
+	if appendDur > 5*time.Second {
 		t.Errorf("AppendEvents took too long: %v", appendDur)
 	}
-	if loadDur > 2*time.Second {
+	if loadDur > 5*time.Second {
 		t.Errorf("LoadEvents took too long: %v", loadDur)
 	}
 	t.Logf("AppendEvents(%d events): %v, LoadEvents: %v", total, appendDur, loadDur)

--- a/experimental/adk-go/runtime/sessions/store.go
+++ b/experimental/adk-go/runtime/sessions/store.go
@@ -1,0 +1,59 @@
+// Package sessions provides session persistence for the Go runner.
+package sessions
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// Session holds metadata for a single coding session.
+type Session struct {
+	ID      string    `json:"id"`
+	CWD     string    `json:"cwd"`
+	Model   string    `json:"model"`
+	Created time.Time `json:"created"`
+	Updated time.Time `json:"updated"`
+}
+
+// SessionMeta is identical to Session and is used when listing sessions
+// (only the first line of each JSONL file is read, so events are not loaded).
+type SessionMeta struct {
+	ID      string    `json:"id"`
+	CWD     string    `json:"cwd"`
+	Model   string    `json:"model"`
+	Created time.Time `json:"created"`
+	Updated time.Time `json:"updated"`
+}
+
+// Event represents a single recorded event in a session.
+type Event struct {
+	Type      string          `json:"type"`      // message, tool_use, tool_result, system, etc.
+	Timestamp time.Time       `json:"timestamp"`
+	Data      json.RawMessage `json:"data"`
+}
+
+// SessionStore defines the persistence interface for sessions.
+type SessionStore interface {
+	// Create writes a new session to the store. Returns an error if a session
+	// with the same ID already exists.
+	Create(ctx context.Context, session *Session) error
+
+	// Get retrieves session metadata by ID.
+	Get(ctx context.Context, id string) (*Session, error)
+
+	// List returns metadata for all sessions whose CWD matches the given cwd,
+	// sorted by Updated descending (most-recently updated first).
+	// Returns an empty slice (not an error) when no sessions exist for that cwd.
+	List(ctx context.Context, cwd string) ([]*SessionMeta, error)
+
+	// AppendEvents appends the given events to an existing session's JSONL file.
+	AppendEvents(ctx context.Context, id string, events []Event) error
+
+	// LoadEvents reads all events recorded for the session (all lines after the
+	// first metadata line).
+	LoadEvents(ctx context.Context, id string) ([]Event, error)
+
+	// Delete removes the session file entirely.
+	Delete(ctx context.Context, id string) error
+}

--- a/experimental/adk-go/runtime/sessions/store.go
+++ b/experimental/adk-go/runtime/sessions/store.go
@@ -16,15 +16,9 @@ type Session struct {
 	Updated time.Time `json:"updated"`
 }
 
-// SessionMeta is identical to Session and is used when listing sessions
-// (only the first line of each JSONL file is read, so events are not loaded).
-type SessionMeta struct {
-	ID      string    `json:"id"`
-	CWD     string    `json:"cwd"`
-	Model   string    `json:"model"`
-	Created time.Time `json:"created"`
-	Updated time.Time `json:"updated"`
-}
+// SessionMeta is an alias for Session. List returns []*SessionMeta; callers
+// may treat it identically to *Session.
+type SessionMeta = Session
 
 // Event represents a single recorded event in a session.
 type Event struct {


### PR DESCRIPTION
Night Shift dish 007 — implements SessionStore interface with JSONL file backend

## What

Adds `experimental/adk-go/runtime/sessions` — a new Go module providing append-only JSONL session persistence for the Go runner.

## Files

- `sessions/store.go` — `SessionStore` interface, `Session`, `SessionMeta`, and `Event` types
- `sessions/jsonl.go` — `JSONLStore` implementation: file-per-session JSONL format, mutex-protected concurrent access
- `sessions/export_test.go` — test-only export of internal helper
- `sessions/jsonl_test.go` — 16 tests covering all required scenarios

## Design

- **File layout:** `<baseDir>/sessions/<url-encoded-cwd>/<session-id>.jsonl`
- **Line 1:** Session metadata JSON; **Line 2+:** Event JSON (one per line, append-only)
- **CWD encoding:** `url.PathEscape` — safe, reversible, human-readable for common paths
- **Concurrency:** single `sync.RWMutex` (write ops exclusive, reads shared)
- **Graceful degradation:** corrupt/empty files are skipped in `List`, not panicked on

## Tests (16, all passing with -race)

- Create + Get round-trip
- Duplicate Create returns error
- Get nonexistent returns error
- AppendEvents + LoadEvents
- Multiple append batches accumulate correctly
- LoadEvents on fresh session returns empty slice
- List sorted by Updated desc
- List returns empty slice for nonexistent cwd
- List scoped by cwd (sessions in other cwds not leaked)
- Concurrent append safety (10 goroutines × 20 events = 200 total, verified)
- Corrupt file skipped in List
- Empty file skipped in List
- Get on corrupt file returns error (no panic)
- Delete removes file
- Delete nonexistent returns error
- Large session (200 events) — append + load each < 2s