### PR TITLE
Fix terminal and runner memory leaks

### DIFF
--- a/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
+++ b/packages/server/src/ws/sio-registry/runners.broadcast.test.ts
@@ -139,7 +139,7 @@ function createFakeIo() {
     };
 }
 
-const { initSioRegistry, runnersUserRoom } = await import("./context.js");
+const { initSioRegistry, runnersUserRoom, runnerSecrets } = await import("./context.js");
 const { initStateRedis } = await import("../sio-state/index.js");
 const { registerRunner, removeRunner, updateRunnerSkills, updateRunnerAgents, updateRunnerPlugins, updateRunnerServices, getRunnerServices } =
     await import("./runners.js");
@@ -149,6 +149,7 @@ describe("runners broadcast", () => {
         store.clear();
         setStore.clear();
         emitCalls.length = 0;
+        runnerSecrets.clear();
         initSioRegistry(createFakeIo() as any);
         await initStateRedis(mockRedis as never);
     });
@@ -208,6 +209,32 @@ describe("runners broadcast", () => {
         );
         expect(removed).toBeDefined();
         expect((removed!.data as any).runnerId).toBe(runnerId);
+    });
+
+    it("removes persistent runner secrets when a runner is removed", async () => {
+        const socket = { join: mock(async () => {}), data: {} } as any;
+        const runnerId = "persistent-runner";
+        const runnerSecret = "super-secret";
+        const result = await registerRunner(socket, {
+            name: "runner-with-secret",
+            roots: [],
+            requestedRunnerId: runnerId,
+            runnerSecret,
+            skills: [],
+            agents: [],
+            plugins: [],
+            hooks: [],
+            version: null,
+            platform: null,
+            userId: "user-secret",
+            userName: "User Secret",
+        });
+        expect(result).toBe(runnerId);
+        expect(runnerSecrets.get(runnerId)).toBe(runnerSecret);
+
+        await removeRunner(runnerId);
+
+        expect(runnerSecrets.has(runnerId)).toBe(false);
     });
 
     it("broadcasts runner_updated after updateRunnerSkills", async () => {

--- a/packages/server/src/ws/sio-registry/runners.ts
+++ b/packages/server/src/ws/sio-registry/runners.ts
@@ -472,6 +472,7 @@ export async function removeRunner(runnerId: string): Promise<void> {
     // Read userId before deleting so we can target the correct user room
     const existing = await getRunnerState(runnerId);
     localRunnerSockets.delete(runnerId);
+    runnerSecrets.delete(runnerId);
     await deleteRunnerState(runnerId);
     if (existing) {
         void broadcastToRunnersNs(

--- a/packages/server/src/ws/sio-registry/terminals.test.ts
+++ b/packages/server/src/ws/sio-registry/terminals.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+import { localTerminalBuffers, localTerminalViewerSockets, localTerminalGcTimers } from "./context.js";
+import { sendToTerminalViewer } from "./terminals.js";
+
+describe("terminal buffering", () => {
+    beforeEach(() => {
+        localTerminalBuffers.clear();
+        localTerminalViewerSockets.clear();
+        for (const timer of localTerminalGcTimers.values()) {
+            clearTimeout(timer);
+        }
+        localTerminalGcTimers.clear();
+    });
+
+    it("caps buffered terminal messages when no viewer is attached", () => {
+        const terminalId = "term-buffer-cap";
+        localTerminalBuffers.set(terminalId, []);
+
+        for (let i = 0; i < 1500; i++) {
+            sendToTerminalViewer(terminalId, {
+                type: "terminal_data",
+                terminalId,
+                data: `chunk-${i}`,
+            });
+        }
+
+        const buffer = localTerminalBuffers.get(terminalId);
+        expect(buffer).toBeDefined();
+        expect(buffer!.length).toBe(1000);
+        expect((buffer![0] as { data: string }).data).toBe("chunk-500");
+        expect((buffer![999] as { data: string }).data).toBe("chunk-1499");
+    });
+});

--- a/packages/server/src/ws/sio-registry/terminals.ts
+++ b/packages/server/src/ws/sio-registry/terminals.ts
@@ -43,6 +43,12 @@ const TERMINAL_GC_DELAY_MS = 30_000;
 const TERMINAL_PENDING_TIMEOUT_MS = 60_000;
 
 /**
+ * Maximum number of terminal messages buffered while no viewer is attached.
+ * This is a ring buffer: once full, the oldest entries are dropped.
+ */
+const MAX_BUFFERED_TERMINAL_MESSAGES = 1000;
+
+/**
  * Register a terminal in Redis + set up local buffer and GC timer.
  */
 export async function registerTerminal(
@@ -189,9 +195,13 @@ export async function removeTerminal(terminalId: string): Promise<void> {
 export function sendToTerminalViewer(terminalId: string, msg: unknown): void {
     const viewers = localTerminalViewerSockets.get(terminalId);
     if (!viewers || viewers.size === 0) {
-        // Buffer for later replay
+        // Buffer for later replay, but cap growth so background/no-viewer
+        // terminals cannot retain unbounded output in server memory.
         const buffer = localTerminalBuffers.get(terminalId);
         if (buffer) {
+            if (buffer.length >= MAX_BUFFERED_TERMINAL_MESSAGES) {
+                buffer.shift();
+            }
             buffer.push(msg);
         } else {
             const type = msg && typeof msg === "object" ? (msg as Record<string, unknown>).type : "?";


### PR DESCRIPTION
## Summary
- cap buffered terminal output when no viewer is attached so server memory cannot grow without bound
- delete persistent runner secrets when a runner is removed
- add regression coverage for both leak paths

## Test Plan
- [x] bun test packages/server/src/ws/sio-registry/terminals.test.ts packages/server/src/ws/sio-registry/runners.broadcast.test.ts
- [x] bun run typecheck