### PR TITLE
Bound CLI memory retention

### DIFF
--- a/packages/cli/src/extensions/session-message-bus.test.ts
+++ b/packages/cli/src/extensions/session-message-bus.test.ts
@@ -1,27 +1,21 @@
 import { describe, test, expect, beforeEach } from "bun:test";
-
-// The message bus is a singleton, so we need to re-import a fresh module for
-// each test. Instead, we test the exported singleton directly and accept that
-// state accumulates — tests are ordered to account for this, or we drain
-// between tests.
-
-// We can't easily reset the singleton, so we'll test the public API in a way
-// that doesn't depend on prior state by using unique session IDs per test.
-
 import { messageBus } from "./session-message-bus.js";
 
 function makeMsg(fromSessionId: string, message: string, ts?: string) {
     return { fromSessionId, message, ts: ts ?? new Date().toISOString() };
 }
 
-describe("SessionMessageBus.hasConsumedMessagesFrom", () => {
+describe("SessionMessageBus", () => {
+    beforeEach(() => {
+        messageBus.resetForTests();
+    });
+
     test("returns false for unknown session", () => {
         expect(messageBus.hasConsumedMessagesFrom("never-seen-session")).toBe(false);
     });
 
     test("returns true after waitForMessage resolves from queue", async () => {
         const sid = `queue-consume-${Date.now()}`;
-        // Queue a message first, then consume it
         messageBus.receive(makeMsg(sid, "hello"));
         const msg = await messageBus.waitForMessage(sid);
         expect(msg).not.toBeNull();
@@ -31,9 +25,7 @@ describe("SessionMessageBus.hasConsumedMessagesFrom", () => {
 
     test("returns true after waitForMessage resolves from waiter", async () => {
         const sid = `waiter-consume-${Date.now()}`;
-        // Start waiting before the message arrives
         const promise = messageBus.waitForMessage(sid);
-        // Deliver the message (resolves the waiter)
         messageBus.receive(makeMsg(sid, "world"));
         const msg = await promise;
         expect(msg).not.toBeNull();
@@ -65,7 +57,7 @@ describe("SessionMessageBus.hasConsumedMessagesFrom", () => {
         messageBus.receive(makeMsg(sid1, "a"));
         messageBus.receive(makeMsg(sid2, "b"));
         const drained = messageBus.drain();
-        expect(drained.length).toBeGreaterThanOrEqual(2);
+        expect(drained).toHaveLength(2);
         expect(messageBus.hasConsumedMessagesFrom(sid1)).toBe(true);
         expect(messageBus.hasConsumedMessagesFrom(sid2)).toBe(true);
     });
@@ -74,7 +66,40 @@ describe("SessionMessageBus.hasConsumedMessagesFrom", () => {
         const sid = `received-not-consumed-${Date.now()}`;
         messageBus.receive(makeMsg(sid, "pending"));
         expect(messageBus.hasConsumedMessagesFrom(sid)).toBe(false);
-        // Clean up
-        messageBus.drain(sid);
+    });
+
+    test("caps queued messages per sender to prevent unbounded growth", () => {
+        const sid = `queue-cap-${Date.now()}`;
+        for (let i = 0; i < 150; i++) {
+            messageBus.receive(makeMsg(sid, `msg-${i}`, `2026-01-01T00:00:${String(i).padStart(2, "0")}Z`));
+        }
+
+        expect(messageBus.pendingCount(sid)).toBe(100);
+
+        const drained = messageBus.drain(sid);
+        expect(drained).toHaveLength(100);
+        expect(drained[0]?.message).toBe("msg-50");
+        expect(drained[99]?.message).toBe("msg-149");
+    });
+
+    test("clears stale queued, waiter, and consumed state when the session id changes", async () => {
+        const consumedSid = `consumed-child-${Date.now()}`;
+        messageBus.receive(makeMsg(consumedSid, "before-switch"));
+        await messageBus.waitForMessage(consumedSid);
+        expect(messageBus.hasConsumedMessagesFrom(consumedSid)).toBe(true);
+
+        const queuedSid = `queued-child-${Date.now()}`;
+        messageBus.receive(makeMsg(queuedSid, "queued-before-switch"));
+        expect(messageBus.pendingCount(queuedSid)).toBe(1);
+
+        const waitingSid = `waiting-child-${Date.now()}`;
+        const waiter = messageBus.waitForMessage(waitingSid);
+
+        messageBus.setOwnSessionId("session-a");
+        messageBus.setOwnSessionId("session-b");
+
+        expect(await waiter).toBeNull();
+        expect(messageBus.hasConsumedMessagesFrom(consumedSid)).toBe(false);
+        expect(messageBus.pendingCount(queuedSid)).toBe(0);
     });
 });

--- a/packages/cli/src/extensions/session-message-bus.ts
+++ b/packages/cli/src/extensions/session-message-bus.ts
@@ -16,13 +16,16 @@ export interface SessionMessage {
     ts: string;
 }
 
-type MessageListener = (msg: SessionMessage) => void;
+type MessageListener = (msg: SessionMessage | null) => void;
 
 /** Callback used by the bus to actually send a message over the relay WebSocket. */
 type SendFn = (targetSessionId: string, message: string) => boolean;
 
-class SessionMessageBus {
-    /** Queued incoming messages, keyed by fromSessionId. "any" collects all. */
+const MAX_QUEUED_MESSAGES_PER_SESSION = 100;
+const MAX_TRACKED_CONSUMED_SESSIONS = 1000;
+
+export class SessionMessageBus {
+    /** Queued incoming messages, keyed by fromSessionId. */
     private queues = new Map<string, SessionMessage[]>();
     /** Listeners waiting for a message. */
     private waiters: Array<{
@@ -39,6 +42,28 @@ class SessionMessageBus {
      * triggers when the parent already processed the child's output via messages.
      */
     private consumedSessions = new Set<string>();
+    /** FIFO order for consumed session tracking so old entries can be evicted. */
+    private consumedSessionOrder: string[] = [];
+
+    private markConsumed(sessionId: string): void {
+        if (this.consumedSessions.has(sessionId)) return;
+        this.consumedSessions.add(sessionId);
+        this.consumedSessionOrder.push(sessionId);
+        while (this.consumedSessionOrder.length > MAX_TRACKED_CONSUMED_SESSIONS) {
+            const oldest = this.consumedSessionOrder.shift();
+            if (oldest) this.consumedSessions.delete(oldest);
+        }
+    }
+
+    private resetForNewSession(): void {
+        this.queues.clear();
+        for (const waiter of this.waiters) {
+            waiter.resolve(null);
+        }
+        this.waiters = [];
+        this.consumedSessions.clear();
+        this.consumedSessionOrder = [];
+    }
 
     /** Called by remote extension to wire up the send path. */
     setSendFn(fn: SendFn | null): void {
@@ -47,6 +72,9 @@ class SessionMessageBus {
 
     /** Called by remote extension after relay registration. */
     setOwnSessionId(id: string): void {
+        if (this.ownSessionId && this.ownSessionId !== id) {
+            this.resetForNewSession();
+        }
         this.ownSessionId = id;
     }
 
@@ -67,16 +95,20 @@ class SessionMessageBus {
             const waiter = this.waiters[i];
             if (waiter.fromSessionId === null || waiter.fromSessionId === msg.fromSessionId) {
                 this.waiters.splice(i, 1);
-                this.consumedSessions.add(msg.fromSessionId);
+                this.markConsumed(msg.fromSessionId);
                 waiter.resolve(msg);
                 return;
             }
         }
 
-        // No waiter matched — queue it.
+        // No waiter matched — queue it, but cap queue growth per sender.
         const key = msg.fromSessionId;
         if (!this.queues.has(key)) this.queues.set(key, []);
-        this.queues.get(key)!.push(msg);
+        const queue = this.queues.get(key)!;
+        if (queue.length >= MAX_QUEUED_MESSAGES_PER_SESSION) {
+            queue.shift();
+        }
+        queue.push(msg);
     }
 
     /**
@@ -92,7 +124,7 @@ class SessionMessageBus {
             const q = this.queues.get(fromSessionId);
             if (q && q.length > 0) {
                 const msg = q.shift()!;
-                this.consumedSessions.add(msg.fromSessionId);
+                this.markConsumed(msg.fromSessionId);
                 return Promise.resolve(msg);
             }
         } else {
@@ -108,7 +140,7 @@ class SessionMessageBus {
             }
             if (oldest) {
                 this.queues.get(oldest.key)!.shift();
-                this.consumedSessions.add(oldest.msg.fromSessionId);
+                this.markConsumed(oldest.msg.fromSessionId);
                 return Promise.resolve(oldest.msg);
             }
         }
@@ -135,13 +167,13 @@ class SessionMessageBus {
     drain(fromSessionId?: string): SessionMessage[] {
         if (fromSessionId) {
             const q = this.queues.get(fromSessionId) ?? [];
-            if (q.length > 0) this.consumedSessions.add(fromSessionId);
+            if (q.length > 0) this.markConsumed(fromSessionId);
             this.queues.delete(fromSessionId);
             return q;
         }
         const all: SessionMessage[] = [];
         for (const [key, q] of this.queues) {
-            if (q.length > 0) this.consumedSessions.add(key);
+            if (q.length > 0) this.markConsumed(key);
             all.push(...q);
         }
         this.queues.clear();
@@ -161,6 +193,13 @@ class SessionMessageBus {
         let count = 0;
         for (const [, q] of this.queues) count += q.length;
         return count;
+    }
+
+    /** Test helper: reset singleton state between tests. */
+    resetForTests(): void {
+        this.sendFn = null;
+        this.ownSessionId = null;
+        this.resetForNewSession();
     }
 }
 

--- a/packages/cli/src/runner/session-list-cache.test.ts
+++ b/packages/cli/src/runner/session-list-cache.test.ts
@@ -278,6 +278,43 @@ describe("session-list-cache", () => {
         expect(results[0].firstMessage).toBe("(no messages)");
         expect(results[0].messageCount).toBe(0);
     });
+
+    test("truncates cached allMessagesText for very large sessions", async () => {
+        const huge = "x".repeat(5000);
+        writeSessionFile(sessionDir, "huge-session.jsonl", {
+            id: "huge-session",
+            messages: Array.from({ length: 30 }, (_, idx) => ({
+                role: idx % 2 === 0 ? "user" : "assistant",
+                content: huge,
+            })),
+        });
+
+        const results = await listSessionsCached(sessionDir);
+        expect(results).toHaveLength(1);
+        expect(results[0].messageCount).toBe(30);
+        expect(results[0].allMessagesText.length).toBeLessThanOrEqual(8192);
+        expect(results[0].allMessagesText).toContain("x");
+    });
+
+    test("persists truncated allMessagesText to disk", async () => {
+        const huge = "y".repeat(5000);
+        writeSessionFile(sessionDir, "persist-huge.jsonl", {
+            id: "persist-huge",
+            messages: Array.from({ length: 30 }, (_, idx) => ({
+                role: idx % 2 === 0 ? "user" : "assistant",
+                content: huge,
+            })),
+        });
+
+        await listSessionsCached(sessionDir);
+        flushSessionListCache();
+
+        const cachePath = join(fakeHome, ".pizzapi", "session-list-cache.json");
+        const cacheData = JSON.parse(readFileSync(cachePath, "utf-8"));
+        const entry = Object.values(cacheData.entries).find((candidate: any) => candidate.id === "persist-huge") as any;
+        expect(entry).toBeDefined();
+        expect(entry.allMessagesText.length).toBeLessThanOrEqual(8192);
+    });
 });
 
 // Restore HOME after all tests complete

--- a/packages/cli/src/runner/session-list-cache.ts
+++ b/packages/cli/src/runner/session-list-cache.ts
@@ -28,6 +28,7 @@ import type { SessionInfo } from "@mariozechner/pi-coding-agent";
 // ── Cache file format ────────────────────────────────────────────────────────
 
 const CACHE_VERSION = 1;
+const MAX_CACHED_ALL_MESSAGES_TEXT_CHARS = 8192;
 
 interface CachedSessionEntry {
     mtimeMs: number;
@@ -239,6 +240,15 @@ function extractTextContent(msg: any): string {
     return "";
 }
 
+function appendWithLimit(current: string, text: string, limit: number): string {
+    if (!text || current.length >= limit) return current;
+    const separator = current.length > 0 ? " " : "";
+    const remaining = limit - current.length;
+    if (remaining <= separator.length) return current;
+    const allowedTextLength = remaining - separator.length;
+    return current + separator + text.slice(0, allowedTextLength);
+}
+
 async function parseSessionFile(filePath: string, stats: { mtime: Date }): Promise<SessionInfo | null> {
     try {
         const content = await readFile(filePath, "utf8");
@@ -258,7 +268,7 @@ async function parseSessionFile(filePath: string, stats: { mtime: Date }): Promi
 
         let messageCount = 0;
         let firstMessage = "";
-        const allMessages: string[] = [];
+        let allMessagesText = "";
         let name: string | undefined;
         let lastActivityTime: number | undefined;
 
@@ -288,7 +298,7 @@ async function parseSessionFile(filePath: string, stats: { mtime: Date }): Promi
 
             const textContent = extractTextContent(message);
             if (!textContent) continue;
-            allMessages.push(textContent);
+            allMessagesText = appendWithLimit(allMessagesText, textContent, MAX_CACHED_ALL_MESSAGES_TEXT_CHARS);
             if (!firstMessage && message!.role === "user") {
                 firstMessage = textContent;
             }
@@ -318,7 +328,7 @@ async function parseSessionFile(filePath: string, stats: { mtime: Date }): Promi
             modified,
             messageCount,
             firstMessage: firstMessage || "(no messages)",
-            allMessagesText: allMessages.join(" "),
+            allMessagesText,
         };
     } catch {
         return null;


### PR DESCRIPTION
## Summary
- cap per-session message bus queues and reset stale message-bus state when the parent session changes
- cap cached session transcript text in the resume cache so large sessions do not accumulate huge in-memory/disk entries
- add regression coverage for both retention paths

## Test Plan
- [x] bun test packages/cli/src/extensions/session-message-bus.test.ts packages/cli/src/runner/session-list-cache.test.ts
- [x] bun run typecheck