### PR TITLE
patch(pi-ai): Claude Code credentials fallback for OAuth refresh

### DIFF
--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -343,3 +343,48 @@ describe("pi-ai patch application — Anthropic web search", () => {
         expect(typeof mod.streamSimpleAnthropic).toBe("function");
     });
 });
+
+describe("pi-ai patch application — Claude Code credentials fallback", () => {
+    test("anthropic.js (oauth): tryReadClaudeCodeCredentials function is present", async () => {
+        const source = await Bun.file(
+            piAiPath("dist/utils/oauth/anthropic.js"),
+        ).text();
+
+        expect(source).toContain("PATCH(pizzapi): read Claude Code credentials as a refresh fallback");
+        expect(source).toContain("tryReadClaudeCodeCredentials");
+        expect(source).toContain(".claude");
+        expect(source).toContain(".credentials.json");
+        expect(source).toContain("claudeAiOauth");
+    });
+
+    test("anthropic.js (oauth): refreshToken tries Claude Code credentials first", async () => {
+        const source = await Bun.file(
+            piAiPath("dist/utils/oauth/anthropic.js"),
+        ).text();
+
+        expect(source).toContain("PATCH(pizzapi): try Claude Code credentials first");
+        // Verify the fallback calls tryReadClaudeCodeCredentials before refreshAnthropicToken
+        const ccCredsIndex = source.indexOf("tryReadClaudeCodeCredentials()");
+        const refreshIndex = source.indexOf("refreshAnthropicToken(credentials.refresh)");
+        expect(ccCredsIndex).toBeGreaterThan(-1);
+        expect(refreshIndex).toBeGreaterThan(-1);
+        expect(ccCredsIndex).toBeLessThan(refreshIndex);
+    });
+
+    test("anthropic.js (oauth): file is syntactically valid", async () => {
+        const mod = await import(piAiPath("dist/utils/oauth/anthropic.js"));
+        expect(typeof mod.anthropicOAuthProvider).toBe("object");
+        expect(typeof mod.anthropicOAuthProvider.refreshToken).toBe("function");
+        expect(typeof mod.loginAnthropic).toBe("function");
+        expect(typeof mod.refreshAnthropicToken).toBe("function");
+    });
+
+    test("anthropic.js (oauth): 60s safety margin on credential expiry", async () => {
+        const source = await Bun.file(
+            piAiPath("dist/utils/oauth/anthropic.js"),
+        ).text();
+
+        // Ensures we don't use credentials that expire within 60 seconds
+        expect(source).toContain("Date.now() + 60000");
+    });
+});

--- a/patches/@mariozechner%2Fpi-ai@0.63.1.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.63.1.patch
@@ -1,3 +1,6 @@
+diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-308425d7494b03d6 b/.bun-tag-308425d7494b03d6
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
 index d4fc29b8c97264ae51b212bdf69b29f7e8001ad1..b24a943c5bb06f521c629bbe93c8ea2eb295b7c5 100644
 --- a/dist/providers/anthropic.js
@@ -126,3 +129,52 @@ index d4fc29b8c97264ae51b212bdf69b29f7e8001ad1..b24a943c5bb06f521c629bbe93c8ea2e
          const jsonSchema = tool.parameters; // TypeBox already generates JSON Schema
          return {
              name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
+diff --git a/dist/utils/oauth/anthropic.js b/dist/utils/oauth/anthropic.js
+index ba615d91cf0f91fe23c82c206e4397dd643f202f..50d8566b5c210063460d99165c88c16bde0b89d2 100644
+--- a/dist/utils/oauth/anthropic.js
++++ b/dist/utils/oauth/anthropic.js
+@@ -313,6 +313,32 @@ export async function refreshAnthropicToken(refreshToken) {
+         expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
+     };
+ }
++// PATCH(pizzapi): read Claude Code credentials as a refresh fallback.
++// If the user has Claude Code installed and authenticated, we can reuse
++// its already-refreshed OAuth token instead of hitting the refresh endpoint,
++// which avoids unnecessary round-trips and works even when the stored
++// refresh_token has expired as long as Claude Code's session is still live.
++function tryReadClaudeCodeCredentials() {
++    try {
++        const { readFileSync } = require("fs");
++        const { join } = require("path");
++        const { homedir } = require("os");
++        const credPath = join(homedir(), ".claude", ".credentials.json");
++        const creds = JSON.parse(readFileSync(credPath, "utf-8"));
++        const cc = creds?.claudeAiOauth;
++        if (cc && cc.accessToken && cc.expiresAt > Date.now() + 60000) {
++            return {
++                refresh: cc.refreshToken,
++                access: cc.accessToken,
++                expires: cc.expiresAt,
++            };
++        }
++    }
++    catch {
++        // Claude Code not installed, credentials missing, or file unreadable — skip
++    }
++    return null;
++}
+ export const anthropicOAuthProvider = {
+     id: "anthropic",
+     name: "Anthropic (Claude Pro/Max)",
+@@ -326,6 +352,11 @@ export const anthropicOAuthProvider = {
+         });
+     },
+     async refreshToken(credentials) {
++        // PATCH(pizzapi): try Claude Code credentials first
++        const ccCreds = tryReadClaudeCodeCredentials();
++        if (ccCreds) {
++            return ccCreds;
++        }
+         return refreshAnthropicToken(credentials.refresh);
+     },
+     getApiKey(credentials) {

--- a/patches/README.md
+++ b/patches/README.md
@@ -36,8 +36,15 @@ on top.
 
 ## @mariozechner/pi-ai@0.63.1
 
-Same web search changes as 0.58.3 (see below), ported forward. No upstream
-changes affected our patch points in this release.
+Same web search changes as 0.58.3 (see below), ported forward, plus one new
+patch:
+
+- **Claude Code credentials fallback:** When refreshing an expired Anthropic
+  OAuth token, the patch first checks `~/.claude/.credentials.json` for a
+  valid, pre-refreshed token from Claude Code. If found (and not expiring
+  within 60 seconds), it's returned directly — avoiding an API round-trip to
+  `platform.claude.com/v1/oauth/token`. Falls through to the normal refresh
+  flow if Claude Code isn't installed or its credentials are stale.
 
 **What it changes:**
 
@@ -47,6 +54,7 @@ changes affected our patch points in this release.
 | `dist/providers/anthropic.js` — `buildParams()` | Inject `web_search_20250305` tool when `PIZZAPI_WEB_SEARCH` env var is set |
 | `dist/providers/anthropic.js` — stream handler | Handle `server_tool_use` and `web_search_tool_result` blocks |
 | `dist/providers/anthropic.js` — `convertMessages()` | Round-trip `_serverToolUse` and `_webSearchResult` blocks |
+| `dist/utils/oauth/anthropic.js` — `anthropicOAuthProvider.refreshToken()` | Try Claude Code credentials (`~/.claude/.credentials.json`) before API refresh |
 
 ## @mariozechner/pi-coding-agent@0.58.3
 


### PR DESCRIPTION
When refreshing an expired Anthropic OAuth token, check `~/.claude/.credentials.json` for a valid, pre-refreshed token from Claude Code before hitting the refresh endpoint.

**Why:** If the user has Claude Code installed and authenticated, PizzaPi can reuse its already-refreshed token — avoiding an API round-trip and working even when PizzaPi's own refresh token is rate-limited or failing.

**How it works:**
1. `tryReadClaudeCodeCredentials()` reads `claudeAiOauth` from `~/.claude/.credentials.json`
2. If the access token exists and won't expire within 60 seconds → return it directly
3. If anything fails (file missing, expired, parse error) → silently fall through to normal `refreshAnthropicToken()` API call

**Files:**
- `patches/@mariozechner%2Fpi-ai@0.63.1.patch` — new hunk in `dist/utils/oauth/anthropic.js`
- `patches/README.md` — documented the new patch
- `packages/cli/src/patches.test.ts` — 4 new tests
