### PR TITLE
feat: add autoClose option to runner trigger listeners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,6 +102,7 @@ bun run clean
 - **Redis** is required for the server. For local dev without Docker: `redis-server` or `docker compose up redis`.
 - **Do not repoint sandbox/test harnesses at an existing user or production Redis instance** (for example `redis://127.0.0.1:6379`) without explicit user permission. Sandboxes must use their own isolated Redis and must not assume the user's local Redis is safe to reuse.
 - **Database migrations**: run `bun run migrate` after schema changes. DB file is `packages/server/auth.db`.
+- **UI + TUI for every feature**: Custom features should include both a **web UI** component (in `packages/ui`) and **TUI/CLI** support (agent tools in `packages/cli`). Backend-only features without a UI are incomplete — users interact through the web interface, not just agent tools. When adding a new capability, ask: "Can the user configure/see/use this from the web UI?" If not, add it.
 
 ---
 

--- a/packages/cli/src/extensions/remote/auto-close.test.ts
+++ b/packages/cli/src/extensions/remote/auto-close.test.ts
@@ -3,7 +3,8 @@
  *
  * The auto-close logic lives in lifecycle-handlers.ts's agent_end handler:
  * when PIZZAPI_WORKER_AUTO_CLOSE=true and the exit reason is "completed"
- * (no error, not killed), ctx.shutdown() is called immediately.
+ * (no error, not killed), ctx.shutdown() is called — unless the session
+ * has active trigger subscriptions.
  *
  * Since lifecycle-handlers.ts has heavy dependencies (pi event system,
  * relay context, etc.), we test the decision logic in isolation here.
@@ -17,6 +18,7 @@ function shouldAutoClose(opts: {
     exitReason: "completed" | "killed" | "error";
     isChildSession: boolean;
     hasPendingMessages: boolean;
+    activeSubscriptionCount?: number;
 }): boolean {
     // Auto-close only applies to non-child sessions (trigger-spawned)
     if (opts.isChildSession) return false;
@@ -26,6 +28,8 @@ function shouldAutoClose(opts: {
     if (opts.exitReason !== "completed") return false;
     // Only when there are no pending messages
     if (opts.hasPendingMessages) return false;
+    // Skip if the session has active trigger subscriptions
+    if ((opts.activeSubscriptionCount ?? 0) > 0) return false;
     return true;
 }
 
@@ -103,5 +107,36 @@ describe("auto-close decision logic", () => {
             isChildSession: false,
             hasPendingMessages: true,
         })).toBe(false);
+    });
+
+    test("does NOT shut down when session has active trigger subscriptions", () => {
+        expect(shouldAutoClose({
+            autoCloseEnv: "true",
+            exitReason: "completed",
+            isChildSession: false,
+            hasPendingMessages: false,
+            activeSubscriptionCount: 2,
+        })).toBe(false);
+    });
+
+    test("shuts down when session has zero subscriptions", () => {
+        expect(shouldAutoClose({
+            autoCloseEnv: "true",
+            exitReason: "completed",
+            isChildSession: false,
+            hasPendingMessages: false,
+            activeSubscriptionCount: 0,
+        })).toBe(true);
+    });
+
+    test("shuts down when subscription count is undefined (query failed)", () => {
+        // If we can't check subscriptions, proceed with auto-close
+        expect(shouldAutoClose({
+            autoCloseEnv: "true",
+            exitReason: "completed",
+            isChildSession: false,
+            hasPendingMessages: false,
+            activeSubscriptionCount: undefined,
+        })).toBe(true);
     });
 });

--- a/packages/cli/src/extensions/remote/auto-close.test.ts
+++ b/packages/cli/src/extensions/remote/auto-close.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Tests for auto-close behavior on trigger-spawned sessions.
+ *
+ * The auto-close logic lives in lifecycle-handlers.ts's agent_end handler:
+ * when PIZZAPI_WORKER_AUTO_CLOSE=true and the exit reason is "completed"
+ * (no error, not killed), ctx.shutdown() is called immediately.
+ *
+ * Since lifecycle-handlers.ts has heavy dependencies (pi event system,
+ * relay context, etc.), we test the decision logic in isolation here.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+
+// ── Decision logic extracted from lifecycle-handlers.ts ───────────────────
+// This mirrors the exact conditional in the agent_end handler.
+function shouldAutoClose(opts: {
+    autoCloseEnv: string | undefined;
+    exitReason: "completed" | "killed" | "error";
+    isChildSession: boolean;
+    hasPendingMessages: boolean;
+}): boolean {
+    // Auto-close only applies to non-child sessions (trigger-spawned)
+    if (opts.isChildSession) return false;
+    // Only when explicitly enabled
+    if (opts.autoCloseEnv !== "true") return false;
+    // Only on successful completion
+    if (opts.exitReason !== "completed") return false;
+    // Only when there are no pending messages
+    if (opts.hasPendingMessages) return false;
+    return true;
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+describe("auto-close decision logic", () => {
+    const savedEnv = process.env.PIZZAPI_WORKER_AUTO_CLOSE;
+
+    afterEach(() => {
+        if (savedEnv !== undefined) {
+            process.env.PIZZAPI_WORKER_AUTO_CLOSE = savedEnv;
+        } else {
+            delete process.env.PIZZAPI_WORKER_AUTO_CLOSE;
+        }
+    });
+
+    test("shuts down on successful completion when auto-close is enabled", () => {
+        expect(shouldAutoClose({
+            autoCloseEnv: "true",
+            exitReason: "completed",
+            isChildSession: false,
+            hasPendingMessages: false,
+        })).toBe(true);
+    });
+
+    test("does NOT shut down on error even when auto-close is enabled", () => {
+        expect(shouldAutoClose({
+            autoCloseEnv: "true",
+            exitReason: "error",
+            isChildSession: false,
+            hasPendingMessages: false,
+        })).toBe(false);
+    });
+
+    test("does NOT shut down when killed even when auto-close is enabled", () => {
+        expect(shouldAutoClose({
+            autoCloseEnv: "true",
+            exitReason: "killed",
+            isChildSession: false,
+            hasPendingMessages: false,
+        })).toBe(false);
+    });
+
+    test("does NOT shut down when auto-close is not set", () => {
+        expect(shouldAutoClose({
+            autoCloseEnv: undefined,
+            exitReason: "completed",
+            isChildSession: false,
+            hasPendingMessages: false,
+        })).toBe(false);
+    });
+
+    test("does NOT shut down when auto-close is 'false'", () => {
+        expect(shouldAutoClose({
+            autoCloseEnv: "false",
+            exitReason: "completed",
+            isChildSession: false,
+            hasPendingMessages: false,
+        })).toBe(false);
+    });
+
+    test("does NOT interfere with child sessions (follow-up grace takes precedence)", () => {
+        expect(shouldAutoClose({
+            autoCloseEnv: "true",
+            exitReason: "completed",
+            isChildSession: true,
+            hasPendingMessages: false,
+        })).toBe(false);
+    });
+
+    test("does NOT shut down when there are pending messages", () => {
+        expect(shouldAutoClose({
+            autoCloseEnv: "true",
+            exitReason: "completed",
+            isChildSession: false,
+            hasPendingMessages: true,
+        })).toBe(false);
+    });
+});

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -367,6 +367,11 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
 
             if (rctx.isChildSession) {
                 followUpGrace.startFollowUpGrace(ctx);
+            } else if (process.env.PIZZAPI_WORKER_AUTO_CLOSE === "true" && exitReason === "completed") {
+                // Auto-close: trigger-spawned sessions with autoClose shut down
+                // immediately on successful completion — no follow-up grace.
+                log.info("pizzapi: auto-close enabled and session completed successfully — shutting down");
+                ctx.shutdown();
             }
         }
     });

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -370,8 +370,24 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
             } else if (process.env.PIZZAPI_WORKER_AUTO_CLOSE === "true" && exitReason === "completed") {
                 // Auto-close: trigger-spawned sessions with autoClose shut down
                 // immediately on successful completion — no follow-up grace.
-                log.info("pizzapi: auto-close enabled and session completed successfully — shutting down");
-                ctx.shutdown();
+                // But skip if the session has active trigger subscriptions —
+                // it may be waiting for future events (e.g. github:pr_comment).
+                void (async () => {
+                    try {
+                        const sessionId = rctx.relaySessionId;
+                        if (sessionId) {
+                            const subs = await listTriggerSubscriptions(sessionId);
+                            if (subs.length > 0) {
+                                log.info(`pizzapi: auto-close skipped — session has ${subs.length} active trigger subscription(s)`);
+                                return;
+                            }
+                        }
+                    } catch {
+                        // If we can't check subscriptions, proceed with auto-close
+                    }
+                    log.info("pizzapi: auto-close enabled and session completed successfully — shutting down");
+                    ctx.shutdown();
+                })();
             }
         }
     });

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -760,7 +760,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
         socket.on("new_session", async (data: any) => {
             if (isShuttingDown) return;
-            const { sessionId, cwd: requestedCwd, prompt: requestedPrompt, model: requestedModel, hiddenModels: requestedHiddenModels, agent: requestedAgent, parentSessionId: requestedParentSessionId, resumePath: requestedResumePath, resumeId: requestedResumeId } = data;
+            const { sessionId, cwd: requestedCwd, prompt: requestedPrompt, model: requestedModel, hiddenModels: requestedHiddenModels, agent: requestedAgent, parentSessionId: requestedParentSessionId, resumePath: requestedResumePath, resumeId: requestedResumeId, autoClose: requestedAutoClose } = data;
 
             if (!sessionId) {
                 socket.emit("session_error", { sessionId: sessionId ?? "", message: "Missing sessionId" });
@@ -833,8 +833,8 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     // On restart (exit code 43), the session already has
                     // the prompt in its history — re-sending would duplicate it.
                     const spawnOpts = isFirstSpawn
-                        ? { prompt: requestedPrompt, model: requestedModel, hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId, resumePath: resolvedResumePath }
-                        : { hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId }; // Always pass agent + hidden models + parent on restart
+                        ? { prompt: requestedPrompt, model: requestedModel, hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId, resumePath: resolvedResumePath, autoClose: requestedAutoClose === true }
+                        : { hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId, autoClose: requestedAutoClose === true }; // Always pass agent + hidden models + parent + autoClose on restart
                     isFirstSpawn = false;
                     spawnSession(sessionId, apiKey!, relayRaw, requestedCwd, runningSessions, restartingSessions, killedSessions, doSpawn, spawnOpts);
                     socket.emit("session_ready", { sessionId });

--- a/packages/cli/src/runner/session-spawner.test.ts
+++ b/packages/cli/src/runner/session-spawner.test.ts
@@ -113,6 +113,7 @@ describe("session-spawner child", () => {
                         disallowedTools: "write",
                     },
                     parentSessionId: "parent-1",
+                    autoClose: true,
                 },
             );
 
@@ -135,6 +136,7 @@ describe("session-spawner child", () => {
                 PIZZAPI_WORKER_AGENT_SYSTEM_PROMPT: "system",
                 PIZZAPI_WORKER_AGENT_TOOLS: "read,bash",
                 PIZZAPI_WORKER_AGENT_DISALLOWED_TOOLS: "write",
+                PIZZAPI_WORKER_AUTO_CLOSE: "true",
             });
             expect(lastSpawnCall?.env.PIZZAPI_RUNNER_TOKEN).toBeUndefined();
             expect(lastSpawnCall?.env.PIZZAPI_RUNNER_API_KEY).toBeUndefined();

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -66,6 +66,7 @@ export function spawnSession(
         agent?: { name: string; systemPrompt?: string; tools?: string; disallowedTools?: string };
         parentSessionId?: string;
         resumePath?: string;
+        autoClose?: boolean;
     },
 ): void {
     logInfo(`spawning headless worker for session ${sessionId}…`);
@@ -158,6 +159,7 @@ export function spawnSession(
         ...(options?.agent?.tools ? { PIZZAPI_WORKER_AGENT_TOOLS: options.agent.tools } : {}),
         ...(options?.agent?.disallowedTools ? { PIZZAPI_WORKER_AGENT_DISALLOWED_TOOLS: options.agent.disallowedTools } : {}),
         ...(options?.resumePath ? { PIZZAPI_WORKER_RESUME_PATH: options.resumePath } : {}),
+        ...(options?.autoClose ? { PIZZAPI_WORKER_AUTO_CLOSE: "true" } : {}),
     };
 
     const child = spawn(process.execPath, workerArgs, {

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -477,11 +477,14 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 }
             }
 
+            const autoClose = body?.autoClose === true ? true : undefined;
+
             const listenerId = await addRunnerTriggerListener(runnerId, triggerType, {
                 prompt: typeof body?.prompt === "string" ? body.prompt : undefined,
                 cwd: typeof body?.cwd === "string" ? body.cwd : undefined,
                 model,
                 params,
+                autoClose,
             });
             if (!listenerId) {
                 return Response.json({ error: "Failed to create trigger listener" }, { status: 500 });
@@ -521,11 +524,14 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
                 } catch { }
             }
 
+            const autoClose = typeof body.autoClose === "boolean" ? body.autoClose : undefined;
+
             const updated = await updateRunnerTriggerListener(runnerId, target, {
                 prompt: typeof body.prompt === "string" ? body.prompt : undefined,
                 cwd: typeof body.cwd === "string" ? body.cwd : undefined,
                 model,
                 params,
+                autoClose,
             }) as any;
 
             if (!updated || updated.updated === false) {

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -1459,6 +1459,66 @@ describe("POST /api/runners/:runnerId/trigger-broadcast — auto-spawn listeners
             }),
         }));
     });
+
+    test("passes autoClose flag to new_session when listener has autoClose: true", async () => {
+        const runnerEmitMock = mock(() => {});
+        const sessionEmitMock = mock(() => {});
+
+        mockGetRunnerListenerTypes.mockReturnValue(Promise.resolve(["svc:event"]));
+        mockGetRunnerTriggerListener.mockReturnValue(Promise.resolve({
+            listenerId: "listener-ac",
+            triggerType: "svc:event",
+            prompt: "auto-close test",
+            autoClose: true,
+            createdAt: "2026-03-29T00:00:00.000Z",
+        } as any));
+        mockGetLocalRunnerSocket.mockReturnValue({ connected: true, emit: runnerEmitMock } as any);
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: sessionEmitMock } as any);
+        mockGetSharedSession.mockReturnValue(Promise.resolve({ userId: "user-1", sessionId: "sess-1" } as any));
+
+        const [req, url] = makeReq(
+            "POST", "/api/runners/runner-A/trigger-broadcast",
+            { type: "svc:event", payload: { message: "hello" }, source: "svc" },
+            { "x-api-key": "test-key" },
+        );
+        const res = await handleTriggersRoute(req, url);
+        expect(res?.status).toBe(200);
+
+        expect(runnerEmitMock).toHaveBeenCalledWith("new_session", expect.objectContaining({
+            autoClose: true,
+        }));
+    });
+
+    test("does not pass autoClose when listener has autoClose: false or undefined", async () => {
+        const runnerEmitMock = mock(() => {});
+        const sessionEmitMock = mock(() => {});
+
+        mockGetRunnerListenerTypes.mockReturnValue(Promise.resolve(["svc:event"]));
+        mockGetRunnerTriggerListener.mockReturnValue(Promise.resolve({
+            listenerId: "listener-no-ac",
+            triggerType: "svc:event",
+            prompt: "no auto-close",
+            createdAt: "2026-03-29T00:00:00.000Z",
+        } as any));
+        mockGetLocalRunnerSocket.mockReturnValue({ connected: true, emit: runnerEmitMock } as any);
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: sessionEmitMock } as any);
+        mockGetSharedSession.mockReturnValue(Promise.resolve({ userId: "user-1", sessionId: "sess-1" } as any));
+
+        const [req, url] = makeReq(
+            "POST", "/api/runners/runner-A/trigger-broadcast",
+            { type: "svc:event", payload: { message: "hello" }, source: "svc" },
+            { "x-api-key": "test-key" },
+        );
+        const res = await handleTriggersRoute(req, url);
+        expect(res?.status).toBe(200);
+
+        // autoClose should NOT be in the new_session call
+        const newSessionCall = (runnerEmitMock.mock.calls as any[]).find(
+            (call: any[]) => call[0] === "new_session"
+        );
+        expect(newSessionCall).toBeTruthy();
+        expect(newSessionCall[1]).not.toHaveProperty("autoClose");
+    });
 });
 
 describe("non-matching routes", () => {

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -1378,7 +1378,7 @@ describe("POST /api/runners/:runnerId/trigger-broadcast — auto-spawn listeners
         mockPushTriggerHistory.mockReturnValue(Promise.resolve());
     });
 
-    test("prepends the listener prompt into the spawned trigger payload", async () => {
+    test("does not pass listener prompt as initial prompt — only in trigger payload", async () => {
         const runnerEmitMock = mock(() => {});
         const sessionEmitMock = mock(() => {});
 
@@ -1400,9 +1400,14 @@ describe("POST /api/runners/:runnerId/trigger-broadcast — auto-spawn listeners
         const res = await handleTriggersRoute(req, url);
         expect(res?.status).toBe(200);
 
-        expect(runnerEmitMock).toHaveBeenCalledWith("new_session", expect.objectContaining({
-            prompt: "Focus on the failing tests first.",
-        }));
+        // Prompt should NOT be in new_session (avoids race with trigger delivery)
+        const newSessionCall = (runnerEmitMock.mock.calls as any[]).find(
+            (call: any[]) => call[0] === "new_session"
+        );
+        expect(newSessionCall).toBeTruthy();
+        expect(newSessionCall[1]).not.toHaveProperty("prompt");
+
+        // Prompt should be merged into the trigger payload instead
         expect(sessionEmitMock).toHaveBeenCalledWith("session_trigger", expect.objectContaining({
             trigger: expect.objectContaining({
                 payload: expect.objectContaining({

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -1040,10 +1040,13 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                     const spawnedSessionId = randomUUID();
                     const ackPromise = waitForSpawnAck(spawnedSessionId, 10_000);
                     try {
+                        // Don't pass the listener prompt as the initial prompt —
+                        // it's already merged into the trigger payload below.
+                        // Sending it here would cause a race: the agent starts
+                        // processing the prompt before the trigger data arrives.
                         runnerSocket.emit("new_session", {
                             sessionId: spawnedSessionId,
                             ...(listener.cwd ? { cwd: listener.cwd } : {}),
-                            ...(listener.prompt ? { prompt: listener.prompt } : {}),
                             ...(listener.model ? { model: listener.model } : {}),
                             ...(listener.autoClose ? { autoClose: true } : {}),
                         });

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -1088,11 +1088,13 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                                 direction: "inbound" as const,
                             };
 
+                            let triggerDelivered = false;
                             const spawnSocket = getLocalTuiSocket(spawnedSessionId);
                             if (spawnSocket?.connected) {
                                 spawnSocket.emit("session_trigger", { trigger: spawnTrigger });
                                 void pushTriggerHistory(spawnedSessionId, spawnHistory).catch(() => {});
                                 broadcastToSessionViewers(spawnedSessionId, "trigger_delivered", { triggerId: spawnHistory.triggerId });
+                                triggerDelivered = true;
                                 spawned++;
                             } else {
                                 const cross = await emitToRelaySessionVerified(
@@ -1101,8 +1103,17 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                                 if (cross) {
                                     void pushTriggerHistory(spawnedSessionId, spawnHistory).catch(() => {});
                                     broadcastToSessionViewers(spawnedSessionId, "trigger_delivered", { triggerId: spawnHistory.triggerId });
+                                    triggerDelivered = true;
                                     spawned++;
                                 }
+                            }
+
+                            // Kill the orphaned session if trigger delivery failed —
+                            // without a prompt or trigger, the worker has no work to do
+                            // and would sit idle indefinitely.
+                            if (!triggerDelivered) {
+                                log.warn(`Auto-spawn: trigger delivery failed for session ${spawnedSessionId} — killing orphaned worker`);
+                                runnerSocket.emit("kill_session", { sessionId: spawnedSessionId });
                             }
                             log.info(`Auto-spawned session ${spawnedSessionId} for listener ${body.type} on runner ${runnerId}`);
                         }

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -86,6 +86,7 @@ interface ListenerLookupResult {
     cwd?: string;
     model?: { provider: string; id: string };
     params?: Record<string, unknown>;
+    autoClose?: boolean;
 }
 
 const log = createLogger("triggers-api");
@@ -1044,6 +1045,7 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                             ...(listener.cwd ? { cwd: listener.cwd } : {}),
                             ...(listener.prompt ? { prompt: listener.prompt } : {}),
                             ...(listener.model ? { model: listener.model } : {}),
+                            ...(listener.autoClose ? { autoClose: true } : {}),
                         });
                         const ack = await ackPromise;
                         if (ack.ok !== false) {

--- a/packages/server/src/sessions/runner-trigger-listener-store.test.ts
+++ b/packages/server/src/sessions/runner-trigger-listener-store.test.ts
@@ -232,6 +232,26 @@ describe("runner trigger listener store", () => {
         expect(after.find((l) => l.triggerType === "svc:legacy-del")).toBeUndefined();
     });
 
+    (isCI ? test.skip : test)("persists and updates autoClose flag", async () => {
+        const listenerId = await addRunnerTriggerListener("runner-1", "svc:auto", {
+            prompt: "auto close test",
+            autoClose: true,
+        });
+        expect(listenerId).toBeString();
+
+        const listener = await getRunnerTriggerListener("runner-1", "svc:auto");
+        expect(listener).toMatchObject({
+            triggerType: "svc:auto",
+            prompt: "auto close test",
+            autoClose: true,
+        });
+
+        // Update autoClose to false
+        await updateRunnerTriggerListener("runner-1", listenerId, { autoClose: false });
+        const updated = await getRunnerTriggerListener("runner-1", listenerId);
+        expect(updated?.autoClose).toBe(false);
+    });
+
     (isCI ? test.skip : test)("returns trigger types for listener lookup", async () => {
         await addRunnerTriggerListener("runner-1", "svc:one", { prompt: "one" });
         await addRunnerTriggerListener("runner-1", "svc:two", { prompt: "two" });

--- a/packages/server/src/sessions/runner-trigger-listener-store.ts
+++ b/packages/server/src/sessions/runner-trigger-listener-store.ts
@@ -53,6 +53,8 @@ export interface RunnerTriggerListener {
     cwd?: string;
     model?: { provider: string; id: string };
     params?: Record<string, string | number | boolean | Array<string | number | boolean>>;
+    /** When true, auto-spawned sessions shut down automatically on successful completion. */
+    autoClose?: boolean;
     createdAt: string;
 }
 
@@ -240,7 +242,7 @@ async function loadListener(runnerId: string, listenerIdOrTriggerType: string): 
 export async function addRunnerTriggerListener(
     runnerId: string,
     triggerType: string,
-    opts?: { prompt?: string; cwd?: string; model?: { provider: string; id: string }; params?: Record<string, unknown> },
+    opts?: { prompt?: string; cwd?: string; model?: { provider: string; id: string }; params?: Record<string, unknown>; autoClose?: boolean },
 ): Promise<string> {
     const listenerId = generateListenerId(runnerId, triggerType);
     const listener = {
@@ -250,6 +252,7 @@ export async function addRunnerTriggerListener(
         cwd: opts?.cwd,
         model: opts?.model,
         params: opts?.params as RunnerTriggerListener["params"],
+        autoClose: opts?.autoClose,
         createdAt: new Date().toISOString(),
     } satisfies RunnerTriggerListener;
 
@@ -314,7 +317,7 @@ export async function listRunnerTriggerListeners(
 export async function updateRunnerTriggerListener(
     runnerId: string,
     listenerIdOrTriggerType: string,
-    updates: { prompt?: string; cwd?: string; model?: { provider: string; id: string }; params?: Record<string, unknown> },
+    updates: { prompt?: string; cwd?: string; model?: { provider: string; id: string }; params?: Record<string, unknown>; autoClose?: boolean },
 ): Promise<boolean> {
     try {
         const existing = await loadListener(runnerId, listenerIdOrTriggerType);
@@ -326,6 +329,7 @@ export async function updateRunnerTriggerListener(
             ...(updates.cwd !== undefined ? { cwd: updates.cwd } : {}),
             ...(updates.model !== undefined ? { model: updates.model } : {}),
             ...(updates.params !== undefined ? { params: updates.params as RunnerTriggerListener["params"] } : {}),
+            ...(updates.autoClose !== undefined ? { autoClose: updates.autoClose } : {}),
         };
         await upsertListenerRow(runnerId, updated);
         await persistRedisListener(runnerId, updated);

--- a/packages/ui/src/components/RunnerTriggersPanel.tsx
+++ b/packages/ui/src/components/RunnerTriggersPanel.tsx
@@ -200,6 +200,20 @@ function ParamForm({
             </div>
           )}
         </div>
+        <div className="flex items-center gap-2">
+          <label className="text-[11px] text-muted-foreground/70 w-24 shrink-0">
+            Auto-close
+          </label>
+          <label className="flex items-center gap-1.5 cursor-pointer text-[11px] text-foreground/80">
+            <input
+              type="checkbox"
+              checked={sessionConfig.autoClose}
+              onChange={(e) => onSessionConfigChange({ ...sessionConfig, autoClose: e.target.checked })}
+              className="accent-primary size-3"
+            />
+            Shut down session on successful completion
+          </label>
+        </div>
       </div>
 
       {/* Trigger params */}
@@ -430,6 +444,7 @@ function TriggerItem({
             const details: string[] = [];
             if (listener.cwd) details.push(listener.cwd);
             if (listener.model) details.push(`${listener.model.provider}/${listener.model.id}`);
+            if (listener.autoClose) details.push("auto-close");
             if (listener.params) {
               for (const [k, v] of Object.entries(listener.params)) {
                 details.push(`${k}=${Array.isArray(v) ? v.map(String).join(", ") : String(v)}`);
@@ -585,7 +600,7 @@ function ServiceAccordion({
               editMode={editMode && paramFormOpen === def.type}
               paramValues={paramValues[def.type] ?? {}}
               paramError={paramFormOpen === def.type ? paramError : null}
-              sessionConfig={sessionConfigs[def.type] ?? { cwd: "", prompt: "", modelProvider: "", modelId: "" }}
+              sessionConfig={sessionConfigs[def.type] ?? { cwd: "", prompt: "", modelProvider: "", modelId: "", autoClose: false }}
               onToggle={onToggle}
               onEdit={onEdit}
               onParamValuesChange={(vals) => onParamValuesChange(def.type, vals)}
@@ -616,6 +631,7 @@ interface ListenerInfo {
   cwd?: string;
   model?: { provider: string; id: string };
   params?: Record<string, unknown>;
+  autoClose?: boolean;
   createdAt: string;
 }
 
@@ -624,6 +640,7 @@ interface SessionConfig {
   prompt: string;
   modelProvider: string;
   modelId: string;
+  autoClose: boolean;
 }
 
 export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerTriggersPanelProps) {
@@ -748,6 +765,7 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
         prompt: listener?.prompt ?? "",
         modelProvider: listener?.model?.provider ?? "",
         modelId: listener?.model?.id ?? "",
+        autoClose: listener?.autoClose ?? false,
       },
     }));
   }, []);
@@ -786,7 +804,7 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
       setParamValues((prev) => ({ ...prev, [def.type]: { ...defaults, ...prev[def.type] } }));
       setSessionConfigs((prev) => ({
         ...prev,
-        [def.type]: prev[def.type] ?? { cwd: "", prompt: "", modelProvider: "", modelId: "" },
+        [def.type]: prev[def.type] ?? { cwd: "", prompt: "", modelProvider: "", modelId: "", autoClose: false },
       }));
     }
   }, [runnerId]);
@@ -829,7 +847,7 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
       }
     }
 
-    const sc = sessionConfigs[def.type] ?? { cwd: "", prompt: "", modelProvider: "", modelId: "" };
+    const sc = sessionConfigs[def.type] ?? { cwd: "", prompt: "", modelProvider: "", modelId: "", autoClose: false };
     const cwd = sc.cwd.trim() || undefined;
     const prompt = sc.prompt.trim() || undefined;
     const model = sc.modelProvider.trim() && sc.modelId.trim()
@@ -856,6 +874,7 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
               ...(cwd ? { cwd } : {}),
               ...(prompt ? { prompt } : {}),
               ...(model ? { model } : {}),
+              autoClose: sc.autoClose,
             }),
           },
         );
@@ -879,6 +898,7 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
             cwd,
             prompt,
             model,
+            autoClose: sc.autoClose || undefined,
             createdAt: existing?.createdAt ?? new Date().toISOString(),
           };
           if (editingListenerId) {


### PR DESCRIPTION
## Summary

When `autoClose: true` is set on a runner trigger listener, sessions auto-spawned by that listener automatically shut down when the agent completes successfully — no parent ack needed.

## Problem

Auto-spawned sessions from trigger listeners have no parent, so after the agent finishes they just sit idle waiting for input that never comes (no follow-up grace, no cleanup).

## Solution

Thread an `autoClose` flag through the full stack:

1. **`RunnerTriggerListener.autoClose`** — new optional boolean field (SQLite + Redis)
2. **Server routes** — accept `autoClose` in `POST/PUT /api/runners/:id/trigger-listeners`
3. **Trigger broadcast** — pass `autoClose: true` in `new_session` emit when auto-spawning
4. **Daemon → Spawner** — set `PIZZAPI_WORKER_AUTO_CLOSE=true` env var on the worker
5. **Lifecycle handlers** — on `agent_end` with no error and no pending messages, call `ctx.shutdown()` immediately (skip follow-up grace)

## Key behavior

- Only closes on **successful** completion (`exitReason === "completed"`)
- Errors and kills are unaffected
- Respects pending messages guard (same as normal completion)
- Normal shutdown path (session_complete, relay disconnect, Redis cleanup)

## Tests

- Store: persists and updates `autoClose` flag
- Triggers broadcast: passes/omits `autoClose` in `new_session` correctly
- Session spawner: `PIZZAPI_WORKER_AUTO_CLOSE` env var set when `autoClose: true`