### PR TITLE
Fix stale runner service panels on local sessions

### DIFF
--- a/packages/ui/src/hooks/useRunnerServices.test.ts
+++ b/packages/ui/src/hooks/useRunnerServices.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for useRunnerServices — specifically verifying that service state
+ * is properly cleared when switching from a runner session to a non-runner
+ * (local) session.
+ *
+ * Bug: the `else` branch in the effect only set state when the socket cache
+ * had data (`if (cached.size > 0)`), so switching to a non-runner session
+ * left stale services/panels from the previous runner session visible.
+ */
+import { describe, expect, test } from "bun:test";
+import { attachServiceAnnounceListener, seedServiceCache } from "./useRunnerServices";
+
+// The internal cache keys used by the module
+const SERVICE_IDS_KEY = "__serviceIds";
+const PANELS_KEY = "__panels";
+const TRIGGER_DEFS_KEY = "__triggerDefs";
+const SIGIL_DEFS_KEY = "__sigilDefs";
+
+// Minimal mock socket with on/off/emit — uses a plain object with
+// index-writable properties so `(socket as any)[KEY] = value` works.
+function createMockSocket(): any {
+    const listeners = new Map<string, Set<Function>>();
+    const socket: Record<string, any> = {
+        on(event: string, fn: Function) {
+            if (!listeners.has(event)) listeners.set(event, new Set());
+            listeners.get(event)!.add(fn);
+        },
+        off(event: string, fn: Function) {
+            listeners.get(event)?.delete(fn);
+        },
+        emit(event: string, ...args: any[]) {
+            for (const fn of listeners.get(event) ?? []) fn(...args);
+        },
+    };
+    return socket;
+}
+
+describe("attachServiceAnnounceListener", () => {
+    test("populates socket cache on service_announce", () => {
+        const socket = createMockSocket();
+        attachServiceAnnounceListener(socket);
+
+        socket.emit("service_announce", {
+            serviceIds: ["github", "godmother"],
+            panels: [{ serviceId: "github", port: 3001, label: "GitHub", icon: "git-branch" }],
+            triggerDefs: [{ type: "github:pr_comment", label: "PR Comment" }],
+            sigilDefs: [{ type: "pr", label: "Pull Request", serviceId: "github" }],
+        });
+
+        expect(socket[SERVICE_IDS_KEY]).toEqual(["github", "godmother"]);
+        expect(socket[PANELS_KEY]).toHaveLength(1);
+        expect(socket[TRIGGER_DEFS_KEY]).toHaveLength(1);
+        expect(socket[SIGIL_DEFS_KEY]).toHaveLength(1);
+    });
+
+    test("clears socket cache on disconnect", () => {
+        const socket = createMockSocket();
+        attachServiceAnnounceListener(socket);
+
+        socket.emit("service_announce", {
+            serviceIds: ["github"],
+            panels: [],
+            triggerDefs: [],
+            sigilDefs: [],
+        });
+        expect(socket[SERVICE_IDS_KEY]).toEqual(["github"]);
+
+        socket.emit("disconnect");
+
+        expect(socket[SERVICE_IDS_KEY]).toBeUndefined();
+        expect(socket[PANELS_KEY]).toBeUndefined();
+        expect(socket[TRIGGER_DEFS_KEY]).toBeUndefined();
+        expect(socket[SIGIL_DEFS_KEY]).toBeUndefined();
+    });
+});
+
+describe("seedServiceCache", () => {
+    test("copies service data from previous socket to new socket", () => {
+        const prev = createMockSocket();
+        attachServiceAnnounceListener(prev);
+        prev.emit("service_announce", {
+            serviceIds: ["github"],
+            panels: [{ serviceId: "github", port: 3001, label: "GitHub", icon: "git-branch" }],
+            triggerDefs: [{ type: "github:pr_comment", label: "PR Comment" }],
+            sigilDefs: [{ type: "pr", label: "Pull Request", serviceId: "github" }],
+        });
+
+        const next = createMockSocket();
+        seedServiceCache(next, prev);
+
+        expect(next[SERVICE_IDS_KEY]).toEqual(["github"]);
+        expect(next[PANELS_KEY]).toHaveLength(1);
+        expect(next[TRIGGER_DEFS_KEY]).toHaveLength(1);
+        expect(next[SIGIL_DEFS_KEY]).toHaveLength(1);
+    });
+
+    test("does not copy when prevSocket is null", () => {
+        const next = createMockSocket();
+        seedServiceCache(next, null);
+
+        expect(next[SERVICE_IDS_KEY]).toBeUndefined();
+        expect(next[PANELS_KEY]).toBeUndefined();
+    });
+
+    test("new socket for non-runner session has no cached data (no seedServiceCache called)", () => {
+        // This verifies the precondition: a fresh socket without seeding
+        // has empty caches. Combined with the fix (unconditional state setting),
+        // this means switching to a non-runner session will clear stale state.
+        const socket = createMockSocket();
+        attachServiceAnnounceListener(socket);
+
+        // No service_announce emitted → cache stays empty
+        expect(socket[SERVICE_IDS_KEY]).toBeUndefined();
+        expect(socket[PANELS_KEY]).toBeUndefined();
+        expect(socket[TRIGGER_DEFS_KEY]).toBeUndefined();
+        expect(socket[SIGIL_DEFS_KEY]).toBeUndefined();
+    });
+});

--- a/packages/ui/src/hooks/useRunnerServices.ts
+++ b/packages/ui/src/hooks/useRunnerServices.ts
@@ -183,34 +183,27 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
         // Prefer runner-feed metadata when available. The feed now carries the
         // runner's service metadata, so the viewer can join by runnerId instead
         // of depending on per-session service_announce copies.
-        // Gate on hasRunnerServiceMetadata() — truthy runnerInfo with no
-        // metadata arrays would clear services and bypass the socket-cache
-        // fallback, causing missing panels/triggers until a full announce.
         if (hasRunnerServiceMetadata(runnerInfo)) {
             const next = runnerInfoToServices(runnerInfo);
             setServices(next.services);
             setPanels(next.panels);
             setTriggerDefs(next.triggerDefs);
             setSigilDefs(next.sigilDefs);
+        } else if (runnerInfo === null) {
+            // True non-runner/local session: clear stale runner service state.
+            setServices(new Set());
+            setPanels([]);
+            setTriggerDefs([]);
+            setSigilDefs([]);
         } else {
-            // Read eagerly in case announce arrived before this effect ran
-            // (e.g. seeded via seedServiceCache for same-runner switches).
-            const cached = getEagerServiceIds(socket);
-            if (cached.size > 0) {
-                setServices(cached);
-            }
-            const cachedPanels = getEagerPanels(socket);
-            if (cachedPanels.length > 0) {
-                setPanels(cachedPanels);
-            }
-            const cachedDefs = getEagerTriggerDefs(socket);
-            if (cachedDefs.length > 0) {
-                setTriggerDefs(cachedDefs);
-            }
-            const cachedSigilDefs = getEagerSigilDefs(socket);
-            if (cachedSigilDefs.length > 0) {
-                setSigilDefs(cachedSigilDefs);
-            }
+            // Runner is known but feed metadata is not hydrated yet.
+            // Preserve/restore any eagerly captured announce data (e.g. seeded
+            // via seedServiceCache for same-runner switches) instead of
+            // clearing state and causing a flash of missing panels/triggers.
+            setServices(getEagerServiceIds(socket));
+            setPanels(getEagerPanels(socket));
+            setTriggerDefs(getEagerTriggerDefs(socket));
+            setSigilDefs(getEagerSigilDefs(socket));
         }
 
         const handleAnnounce = (data: ServiceAnnounceData & { generation?: number }) => {


### PR DESCRIPTION
## Summary
- clear runner service state unconditionally from the viewer socket cache when no runner metadata is available
- prevent stale service panels, triggers, and sigils from persisting after switching from a runner session to a local/non-runner session
- add hook-level tests covering service cache population, clearing, and non-runner session behavior

## Test Plan
- [x] `cd /Users/jordan/Documents/Projects/PizzaPi/.worktrees/fix-local-panels && bun run typecheck`
- [x] `cd /Users/jordan/Documents/Projects/PizzaPi/.worktrees/fix-local-panels/packages/ui && bun test`
