### PR TITLE
Fix trigger multiselect UI and docs

### DIFF
--- a/packages/cli/src/extensions/trigger-client.ts
+++ b/packages/cli/src/extensions/trigger-client.ts
@@ -27,6 +27,7 @@
 
 import { randomUUID } from "node:crypto";
 import { createLogger } from "@pizzapi/tools";
+import type { JsonValue } from "@pizzapi/protocol";
 import type { ServiceSigilDef } from "@pizzapi/protocol";
 import { getRelaySocket as getRelaySocketDefault } from "./remote.js";
 import { loadConfig } from "../config.js";
@@ -390,7 +391,7 @@ export async function subscribeTrigger(
     sessionId: string,
     triggerType: string,
     deps: Partial<TriggerClientDeps> = {},
-    params?: Record<string, string | number | boolean | Array<string | number | boolean>>,
+    params?: Record<string, JsonValue>,
     filters?: Array<{ field: string; value: string | number | boolean | Array<string | number | boolean>; op?: "eq" | "contains" }>,
     filterMode?: "and" | "or",
 ): Promise<SubscriptionResult> {
@@ -434,7 +435,7 @@ export async function updateTriggerSubscription(
         triggerType?: string;
     },
     updates: {
-        params?: Record<string, string | number | boolean | Array<string | number | boolean>>;
+        params?: Record<string, JsonValue>;
         filters?: Array<{ field: string; value: string | number | boolean | Array<string | number | boolean>; op?: "eq" | "contains" }>;
         filterMode?: "and" | "or";
     },

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -28,6 +28,16 @@ function preview(text: string, max = 50): string {
     return text.length > max ? text.slice(0, max) + "..." : text;
 }
 
+type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
+function isJsonValue(value: unknown): value is JsonValue {
+    if (value === null) return true;
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return true;
+    if (Array.isArray(value)) return value.every(isJsonValue);
+    if (typeof value === "object") return Object.values(value as Record<string, unknown>).every(isJsonValue);
+    return false;
+}
+
 /** Tracks triggers this session has received (as parent) for response routing. */
 export const receivedTriggers = new Map<string, { sourceSessionId: string; type: string; trackedAt: number }>();
 
@@ -666,22 +676,12 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                 return { content: [{ type: "text" as const, text: "Error: Could not determine session ID." }], details: null as any };
             }
 
-            // Coerce param values to primitives or arrays of primitives (multiselect)
-            let subParams: Record<string, string | number | boolean | Array<string | number | boolean>> | undefined;
+            // Coerce param values to JSON-safe values (including arrays/objects)
+            let subParams: Record<string, JsonValue> | undefined;
             if (params.params && typeof params.params === "object") {
                 subParams = {};
                 for (const [k, v] of Object.entries(params.params)) {
-                    if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
-                        subParams[k] = v;
-                    } else if (Array.isArray(v)) {
-                        const primitives = v.filter(
-                            (item): item is string | number | boolean =>
-                                typeof item === "string" || typeof item === "number" || typeof item === "boolean",
-                        );
-                        if (primitives.length > 0) subParams[k] = primitives;
-                    } else if (v !== undefined && v !== null) {
-                        subParams[k] = String(v);
-                    }
+                    if (isJsonValue(v)) subParams[k] = v;
                 }
                 if (Object.keys(subParams).length === 0) subParams = undefined;
             }
@@ -883,22 +883,12 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                 return { content: [{ type: "text" as const, text: "Error: Could not determine session ID." }], details: null as any };
             }
 
-            // Coerce param values to primitives
-            let subParams: Record<string, string | number | boolean | Array<string | number | boolean>> | undefined;
+            // Coerce param values to JSON-safe values (including arrays/objects)
+            let subParams: Record<string, JsonValue> | undefined;
             if (params.params && typeof params.params === "object") {
                 subParams = {};
                 for (const [k, v] of Object.entries(params.params)) {
-                    if (typeof v === "string" || typeof v === "number" || typeof v === "boolean") {
-                        subParams[k] = v;
-                    } else if (Array.isArray(v)) {
-                        const primitives = v.filter(
-                            (item): item is string | number | boolean =>
-                                typeof item === "string" || typeof item === "number" || typeof item === "boolean",
-                        );
-                        if (primitives.length > 0) subParams[k] = primitives;
-                    } else if (v !== undefined && v !== null) {
-                        subParams[k] = String(v);
-                    }
+                    if (isJsonValue(v)) subParams[k] = v;
                 }
                 if (Object.keys(subParams).length === 0) subParams = undefined;
             }

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -17,7 +17,7 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, extname, join, resolve } from "node:path";
 import type { ServiceHandler } from "./service-handler.js";
-import type { ServiceTriggerDef, ServiceTriggerParamDef, ServiceSigilDef } from "@pizzapi/protocol";
+import type { JsonValue, ServiceTriggerDef, ServiceTriggerParamDef, ServiceSigilDef } from "@pizzapi/protocol";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -60,6 +60,14 @@ export interface ServiceLoadError {
 export interface DiscoverServicesResult {
     services: ServicePluginResult[];
     errors: ServiceLoadError[];
+}
+
+function isJsonValue(value: unknown): value is JsonValue {
+    if (value === null) return true;
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return true;
+    if (Array.isArray(value)) return value.every(isJsonValue);
+    if (typeof value === "object") return Object.values(value as Record<string, unknown>).every(isJsonValue);
+    return false;
 }
 
 // ── Discovery directories ─────────────────────────────────────────────────────
@@ -359,8 +367,8 @@ function parseTriggers(raw: unknown): ServiceTriggerDef[] {
                 if (!p || typeof p !== "object") continue;
                 if (typeof p.name !== "string" || !p.name) continue;
                 if (typeof p.label !== "string" || !p.label) continue;
-                const pType = typeof p.type === "string" && ["string", "number", "boolean"].includes(p.type)
-                    ? p.type as "string" | "number" | "boolean"
+                const pType = typeof p.type === "string" && ["string", "number", "boolean", "json"].includes(p.type)
+                    ? p.type as "string" | "number" | "boolean" | "json"
                     : "string";
                 let enumVals: Array<string | number | boolean> | undefined;
                 if (Array.isArray(p.enum) && p.enum.length > 0) {
@@ -375,8 +383,8 @@ function parseTriggers(raw: unknown): ServiceTriggerDef[] {
                     type: pType,
                     description: typeof p.description === "string" ? p.description : undefined,
                     required: typeof p.required === "boolean" ? p.required : undefined,
-                    default: (typeof p.default === "string" || typeof p.default === "number" || typeof p.default === "boolean")
-                        ? p.default
+                    default: isJsonValue(p.default)
+                        ? p.default as JsonValue
                         : undefined,
                     ...(enumVals ? { enum: enumVals } : {}),
                     ...(enumVals && p.multiselect === true ? { multiselect: true } : {}),

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -102,12 +102,14 @@ Each entry in `params`:
 |-------|----------|-------------|
 | `name` | Yes | Parameter name — must match a key in the trigger payload |
 | `label` | Yes | Human-readable label for the UI |
-| `type` | No | Value type: `"string"` (default), `"number"`, or `"boolean"` |
+| `type` | No | Value type: `"string"` (default), `"number"`, `"boolean"`, or `"json"` |
 | `description` | No | Help text for the subscriber |
 | `required` | No | If `true`, subscriber must provide this param |
 | `default` | No | Default value if not provided |
 | `enum` | No | Array of allowed values — renders as a dropdown in the UI |
-| `multiselect` | No | If `true` (requires `enum`), subscriber can pick multiple values. Delivery matches if payload value is **in** the selected set (OR semantics). |
+| `multiselect` | No | If `true` (requires `enum`), subscriber can pick multiple values. Subscribers send an actual JSON array, the UI renders selected values as chips, and delivery matches if the payload value is **in** the selected set (OR semantics). |
++
++Use `type: "json"` when the subscription param should carry an arbitrary JSON value such as an object or array. The UI renders a JSON textarea for these params and forwards the parsed value to the service unchanged.
 
 **Example — scalar param with enum:**
 
@@ -126,6 +128,22 @@ An agent subscribes with: `subscribe_trigger(triggerType: "github:pr_comment_add
 
 Only events with `prNumber: 42` **and** `repo: "pizzapi"` in their payload are delivered.
 
+**Example — JSON param:**
+
+```json
+{
+  "type": "review:requested",
+  "label": "Review Requested",
+  "params": [
+    { "name": "config", "label": "Config", "type": "json", "description": "Arbitrary review routing config" }
+  ]
+}
+```
+
+An agent subscribes with: `subscribe_trigger(triggerType: "review:requested", params: { config: { reviewers: ["jordanpizza"], labels: ["bug"], dryRun: true } })`
+
+The service receives the parsed object exactly as provided.
+
 **Example — multiselect param:**
 
 ```json
@@ -142,7 +160,12 @@ An agent subscribes with: `subscribe_trigger(triggerType: "demo:message_sent", p
 
 Events with `channel: "alerts"` **or** `channel: "debug"` in their payload are delivered. Events with `channel: "general"` are not. Sessions subscribed without specifying `channel` receive all events.
 
-Array-valued payload fields also work with scalar subscription params: if the payload has `labels: ["bug", "urgent"]`, a subscriber with `labels: "bug"` receives the event.
+**Important contract:**
+- `multiselect` only works when `enum` is also declared
+- subscribers send a real JSON array, not a comma-separated string
+- matching is currently **subscriber array vs payload scalar** (`params.channel = ["alerts", "debug"]` matches payload `channel: "alerts"`)
+- array-valued payload fields also work with scalar subscription params: if the payload has `labels: ["bug", "urgent"]`, a subscriber with `labels: "bug"` receives the event
+- if you need arbitrary freeform lists (for example usernames not known ahead of time), `multiselect` is the wrong fit today unless you can declare those values in `enum`
 
 For substring filtering, name the param with a `Contains` suffix. For example, a trigger with `bodyContains` will match when the payload's `body` field includes the subscriber's text.
 

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -20,6 +20,7 @@ export type {
   ServiceTriggerDef,
   ServiceTriggerParamDef,
   ServiceSigilDef,
+  JsonValue,
   TriggerFilter,
   TriggerFilterMode,
   ServiceAnnounceData,

--- a/packages/protocol/src/runner.ts
+++ b/packages/protocol/src/runner.ts
@@ -2,7 +2,7 @@
 // /runner namespace — Runner daemon ↔ Server
 // ============================================================================
 
-import type { RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook, ServiceAnnounceData, ServiceEnvelope, SocketClientMetadata, TriggerFilter, TriggerFilterMode } from "./shared.js";
+import type { JsonValue, RunnerSkill, RunnerAgent, RunnerPlugin, RunnerHook, ServiceAnnounceData, ServiceEnvelope, SocketClientMetadata, TriggerFilter, TriggerFilterMode } from "./shared.js";
 
 // ---------------------------------------------------------------------------
 // Trigger subscription reconciliation types
@@ -18,7 +18,7 @@ export interface TriggerSubscriptionEntry {
   sessionId: string;
   triggerType: string;
   runnerId: string;
-  params?: Record<string, string | number | boolean | Array<string | number | boolean>>;
+  params?: Record<string, JsonValue>;
   filters?: TriggerFilter[];
   filterMode?: TriggerFilterMode;
 }

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -173,19 +173,21 @@ export interface ServiceTriggerDef {
  * Subscribers provide values for these when subscribing. These are forwarded
  * to the service for its own use — they do NOT filter trigger delivery.
  */
+export type JsonValue = null | boolean | number | string | JsonValue[] | { [key: string]: JsonValue };
+
 export interface ServiceTriggerParamDef {
   /** Parameter name — identifies this param to the service */
   name: string;
   /** Human-readable label for the UI */
   label: string;
   /** Value type */
-  type: "string" | "number" | "boolean";
+  type: "string" | "number" | "boolean" | "json";
   /** Optional description */
   description?: string;
   /** Whether the subscriber must provide this param */
   required?: boolean;
   /** Default value if not provided */
-  default?: string | number | boolean;
+  default?: JsonValue;
   /** Allowed values — renders as a dropdown in the UI */
   enum?: Array<string | number | boolean>;
   /**

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -719,6 +719,72 @@ describe("POST /api/sessions/:id/trigger-subscriptions", () => {
         expect(res!.status).toBe(400);
     });
 
+    test("accepts json params as objects", async () => {
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: "runner-A" } as any),
+        );
+        mockGetRunnerServices.mockReturnValue(Promise.resolve({
+            serviceIds: ["svc"],
+            triggerDefs: [{
+                type: "svc:event",
+                label: "Event",
+                params: [{ name: "config", label: "Config", type: "json" }],
+            }],
+        }));
+        mockSubscribeSessionToTrigger.mockReturnValue(Promise.resolve("sub-json"));
+
+        const [req, url] = makeReq("POST", "/api/sessions/sess-1/trigger-subscriptions", {
+            triggerType: "svc:event",
+            params: { config: { users: ["jordanpizza"], flags: { dryRun: true } } },
+        });
+        const res = await handleTriggersRoute(req, url);
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.params).toEqual({ config: { users: ["jordanpizza"], flags: { dryRun: true } } });
+        expect(mockSubscribeSessionToTrigger).toHaveBeenCalledWith(
+            "sess-1",
+            "runner-A",
+            "svc:event",
+            undefined,
+            { config: { users: ["jordanpizza"], flags: { dryRun: true } } },
+            undefined,
+            undefined,
+        );
+    });
+
+    test("accepts multiselect params as arrays", async () => {
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", sessionId: "sess-1", runnerId: "runner-A" } as any),
+        );
+        mockGetRunnerServices.mockReturnValue(Promise.resolve({
+            serviceIds: ["svc"],
+            triggerDefs: [{
+                type: "svc:event",
+                label: "Event",
+                params: [{ name: "channel", label: "Channel", type: "string", enum: ["alerts", "debug", "info"], multiselect: true }],
+            }],
+        }));
+        mockSubscribeSessionToTrigger.mockReturnValue(Promise.resolve("sub-multi"));
+
+        const [req, url] = makeReq("POST", "/api/sessions/sess-1/trigger-subscriptions", {
+            triggerType: "svc:event",
+            params: { channel: ["alerts", "debug"] },
+        });
+        const res = await handleTriggersRoute(req, url);
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.params).toEqual({ channel: ["alerts", "debug"] });
+        expect(mockSubscribeSessionToTrigger).toHaveBeenCalledWith(
+            "sess-1",
+            "runner-A",
+            "svc:event",
+            undefined,
+            { channel: ["alerts", "debug"] },
+            undefined,
+            undefined,
+        );
+    });
+
     test("returns 404 for wrong user", async () => {
         mockGetSharedSession.mockReturnValue(
             Promise.resolve({ userId: "user-2", sessionId: "sess-1" } as any),
@@ -1249,6 +1315,60 @@ describe("PUT /api/sessions/:id/trigger-subscriptions/:triggerType", () => {
         const res = await handleTriggersRoute(req, url);
         expect(res).toBeTruthy();
         expect(res!.status).toBe(404);
+    });
+
+    test("updates json params as objects", async () => {
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", runnerId: "runner-A" }),
+        );
+        mockGetRunnerServices.mockReturnValue(
+            Promise.resolve({ serviceIds: [], triggerDefs: [{ type: "svc:event", label: "Event", params: [{ name: "config", label: "Config", type: "json" }] }] }),
+        );
+        mockUpdateSessionSubscription.mockReturnValue(
+            Promise.resolve({ updated: true, runnerId: "runner-A" }),
+        );
+
+        const [req, url] = makeReq(
+            "PUT", "/api/sessions/session-1/trigger-subscriptions/svc:event",
+            { params: { config: { users: ["jordanpizza"], flags: { dryRun: true } } } },
+            { "x-api-key": "test-key" },
+        );
+        const res = await handleTriggersRoute(req, url);
+        const body = await res!.json();
+        expect(body.ok).toBe(true);
+        expect(body.params).toEqual({ config: { users: ["jordanpizza"], flags: { dryRun: true } } });
+        expect(mockUpdateSessionSubscription).toHaveBeenCalledWith(
+            "session-1",
+            "svc:event",
+            { params: { config: { users: ["jordanpizza"], flags: { dryRun: true } } }, filters: undefined, filterMode: undefined },
+        );
+    });
+
+    test("updates multiselect params as arrays", async () => {
+        mockGetSharedSession.mockReturnValue(
+            Promise.resolve({ userId: "user-1", runnerId: "runner-A" }),
+        );
+        mockGetRunnerServices.mockReturnValue(
+            Promise.resolve({ serviceIds: [], triggerDefs: [{ type: "svc:event", label: "Event", params: [{ name: "channel", label: "Channel", type: "string", enum: ["alerts", "debug"], multiselect: true }] }] }),
+        );
+        mockUpdateSessionSubscription.mockReturnValue(
+            Promise.resolve({ updated: true, runnerId: "runner-A" }),
+        );
+
+        const [req, url] = makeReq(
+            "PUT", "/api/sessions/session-1/trigger-subscriptions/svc:event",
+            { params: { channel: ["alerts", "debug"] } },
+            { "x-api-key": "test-key" },
+        );
+        const res = await handleTriggersRoute(req, url);
+        const body = await res!.json();
+        expect(body.ok).toBe(true);
+        expect(body.params).toEqual({ channel: ["alerts", "debug"] });
+        expect(mockUpdateSessionSubscription).toHaveBeenCalledWith(
+            "session-1",
+            "svc:event",
+            { params: { channel: ["alerts", "debug"] }, filters: undefined, filterMode: undefined },
+        );
     });
 
     test("updates filters and filterMode", async () => {

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -1489,6 +1489,8 @@ describe("POST /api/runners/:runnerId/trigger-broadcast — auto-spawn listeners
         mockGetSubscriptionFilters.mockReturnValue(Promise.resolve(undefined));
         mockGetRunnerListenerTypes.mockReset();
         mockGetRunnerTriggerListener.mockReset();
+        mockListRunnerTriggerListeners.mockReset();
+        mockListRunnerTriggerListeners.mockReturnValue(Promise.resolve([]));
         mockGetLocalRunnerSocket.mockReset();
         mockRecordRunnerSession.mockReset();
         mockRecordRunnerSession.mockReturnValue(Promise.resolve());
@@ -1503,11 +1505,11 @@ describe("POST /api/runners/:runnerId/trigger-broadcast — auto-spawn listeners
         const sessionEmitMock = mock(() => {});
 
         mockGetRunnerListenerTypes.mockReturnValue(Promise.resolve(["svc:event"]));
-        mockGetRunnerTriggerListener.mockReturnValue(Promise.resolve({
+        mockListRunnerTriggerListeners.mockReturnValue(Promise.resolve([{
             triggerType: "svc:event",
             prompt: "Focus on the failing tests first.",
             createdAt: "2026-03-29T00:00:00.000Z",
-        } as any));
+        }] as any));
         mockGetLocalRunnerSocket.mockReturnValue({ connected: true, emit: runnerEmitMock } as any);
         mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: sessionEmitMock } as any);
         mockGetSharedSession.mockReturnValue(Promise.resolve({ userId: "user-1", sessionId: "sess-1" } as any));
@@ -1543,7 +1545,7 @@ describe("POST /api/runners/:runnerId/trigger-broadcast — auto-spawn listeners
         const sessionEmitMock = mock(() => {});
 
         mockGetRunnerListenerTypes.mockReturnValue(Promise.resolve(["svc:event"]));
-        mockGetRunnerTriggerListener.mockReturnValue(Promise.resolve([
+        mockListRunnerTriggerListeners.mockReturnValue(Promise.resolve([
             {
                 listenerId: "listener-1",
                 triggerType: "svc:event",
@@ -1585,18 +1587,73 @@ describe("POST /api/runners/:runnerId/trigger-broadcast — auto-spawn listeners
         }));
     });
 
+    test("falls back to the full listener list when the newest listener does not match", async () => {
+        const runnerEmitMock = mock(() => {});
+        const sessionEmitMock = mock(() => {});
+
+        mockGetRunnerListenerTypes.mockReturnValue(Promise.resolve(["shortcut:story_commented"]));
+        mockGetRunnerTriggerListener.mockReturnValue(Promise.resolve({
+            listenerId: "listener-newest",
+            triggerType: "shortcut:story_commented",
+            prompt: "rewst prompt",
+            params: { author: "jordanpizza", textContains: "!pizza-rewst" },
+            createdAt: "2026-04-07T17:41:54.543Z",
+        } as any));
+        mockListRunnerTriggerListeners.mockReturnValue(Promise.resolve([
+            {
+                listenerId: "listener-newest",
+                triggerType: "shortcut:story_commented",
+                prompt: "rewst prompt",
+                params: { author: "jordanpizza", textContains: "!pizza-rewst" },
+                createdAt: "2026-04-07T17:41:54.543Z",
+            },
+            {
+                listenerId: "listener-rift",
+                triggerType: "shortcut:story_commented",
+                prompt: "rift prompt",
+                params: { author: "jordanpizza", textContains: "!pizza-rift" },
+                createdAt: "2026-04-07T17:41:37.737Z",
+            },
+        ] as any));
+        mockGetLocalRunnerSocket.mockReturnValue({ connected: true, emit: runnerEmitMock } as any);
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: sessionEmitMock } as any);
+        mockGetSharedSession.mockReturnValue(Promise.resolve({ userId: "user-1", sessionId: "sess-1" } as any));
+
+        const [req, url] = makeReq(
+            "POST", "/api/runners/runner-A/trigger-broadcast",
+            {
+                type: "shortcut:story_commented",
+                payload: { author: "jordanpizza", text: "please handle !pizza-rift" },
+                source: "shortcut",
+            },
+            { "x-api-key": "test-key" },
+        );
+        const res = await handleTriggersRoute(req, url);
+        expect(res?.status).toBe(200);
+
+        const body = await res!.json();
+        expect(body.spawned).toBe(1);
+        expect(runnerEmitMock).toHaveBeenCalledTimes(1);
+        expect(sessionEmitMock).toHaveBeenCalledTimes(1);
+        expect(sessionEmitMock).toHaveBeenCalledWith("session_trigger", expect.objectContaining({
+            trigger: expect.objectContaining({
+                payload: expect.objectContaining({ prompt: "rift prompt" }),
+            }),
+        }));
+    });
+
     test("passes autoClose flag to new_session when listener has autoClose: true", async () => {
         const runnerEmitMock = mock(() => {});
         const sessionEmitMock = mock(() => {});
 
         mockGetRunnerListenerTypes.mockReturnValue(Promise.resolve(["svc:event"]));
-        mockGetRunnerTriggerListener.mockReturnValue(Promise.resolve({
+        mockListRunnerTriggerListeners.mockReturnValue(Promise.resolve([{
             listenerId: "listener-ac",
             triggerType: "svc:event",
             prompt: "auto-close test",
             autoClose: true,
             createdAt: "2026-03-29T00:00:00.000Z",
-        } as any));
+        }] as any));
         mockGetLocalRunnerSocket.mockReturnValue({ connected: true, emit: runnerEmitMock } as any);
         mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: sessionEmitMock } as any);
         mockGetSharedSession.mockReturnValue(Promise.resolve({ userId: "user-1", sessionId: "sess-1" } as any));
@@ -1619,12 +1676,12 @@ describe("POST /api/runners/:runnerId/trigger-broadcast — auto-spawn listeners
         const sessionEmitMock = mock(() => {});
 
         mockGetRunnerListenerTypes.mockReturnValue(Promise.resolve(["svc:event"]));
-        mockGetRunnerTriggerListener.mockReturnValue(Promise.resolve({
+        mockListRunnerTriggerListeners.mockReturnValue(Promise.resolve([{
             listenerId: "listener-no-ac",
             triggerType: "svc:event",
             prompt: "no auto-close",
             createdAt: "2026-03-29T00:00:00.000Z",
-        } as any));
+        }] as any));
         mockGetLocalRunnerSocket.mockReturnValue({ connected: true, emit: runnerEmitMock } as any);
         mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: sessionEmitMock } as any);
         mockGetSharedSession.mockReturnValue(Promise.resolve({ userId: "user-1", sessionId: "sess-1" } as any));

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -91,6 +91,14 @@ interface ListenerLookupResult {
 
 const log = createLogger("triggers-api");
 
+function isJsonValue(value: unknown): value is null | string | number | boolean | unknown[] | Record<string, unknown> {
+    if (value === null) return true;
+    if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") return true;
+    if (Array.isArray(value)) return value.every(isJsonValue);
+    if (typeof value === "object") return Object.values(value as Record<string, unknown>).every(isJsonValue);
+    return false;
+}
+
 /**
  * Check whether a single filter condition matches a trigger payload field.
  */
@@ -526,6 +534,16 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                     continue;
                 }
 
+                // Generic JSON param: preserve object/array/scalar values as-is
+                if (def.type === "json") {
+                    if (!isJsonValue(raw)) {
+                        errors.push(`Param '${def.name}' must be valid JSON`);
+                    } else {
+                        validated[def.name] = raw as SubscriptionParams[string];
+                    }
+                    continue;
+                }
+
                 // Scalar: coerce to the declared type
                 if (def.type === "number") {
                     const num = Number(raw);
@@ -564,14 +582,8 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                 if (key in validated) continue;
                 if (paramDefs.some(d => d.name === key)) continue; // already processed
                 if (val === undefined || val === null) continue;
-                if (typeof val === "string" || typeof val === "number" || typeof val === "boolean") {
-                    validated[key] = val;
-                } else if (Array.isArray(val)) {
-                    const primitives = val.filter(
-                        (v: unknown): v is string | number | boolean =>
-                            typeof v === "string" || typeof v === "number" || typeof v === "boolean",
-                    );
-                    if (primitives.length > 0) validated[key] = primitives;
+                if (isJsonValue(val)) {
+                    validated[key] = val as SubscriptionParams[string];
                 }
             }
 
@@ -784,7 +796,10 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
                         else if (def.required) errors.push(`Param '${def.name}' requires at least one valid value`);
                         continue;
                     }
-                    if (def.type === "number") {
+                    if (def.type === "json") {
+                        if (!isJsonValue(raw)) errors.push(`Param '${def.name}' must be valid JSON`);
+                        else validated[def.name] = raw as SubscriptionParams[string];
+                    } else if (def.type === "number") {
                         const num = Number(raw);
                         // eslint-disable-next-line eqeqeq
                         if (isNaN(num)) errors.push(`Param '${def.name}' must be a number`);

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -67,7 +67,6 @@ import {
 } from "../sessions/trigger-subscription-store.js";
 import {
     getRunnerListenerTypes,
-    getRunnerTriggerListener,
     listRunnerTriggerListeners,
     updateRunnerTriggerListener,
 } from "../sessions/runner-trigger-listener-store.js";
@@ -77,16 +76,6 @@ interface SubscriptionFilterRecord {
     subscriptionId?: string;
     filters?: SubscriptionFilter[];
     filterMode?: SubscriptionFilterMode;
-}
-
-interface ListenerLookupResult {
-    listenerId?: string;
-    triggerType: string;
-    prompt?: string;
-    cwd?: string;
-    model?: { provider: string; id: string };
-    params?: Record<string, unknown>;
-    autoClose?: boolean;
 }
 
 const log = createLogger("triggers-api");
@@ -1033,15 +1022,12 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
         let spawned = 0;
         const listenerTypes = await getRunnerListenerTypes(runnerId);
         if (listenerTypes.includes(body.type)) {
-            const listenerLookup = await getRunnerTriggerListener(runnerId, body.type) as ListenerLookupResult | ListenerLookupResult[] | null;
-            const loadedListeners = Array.isArray(listenerLookup)
-                ? listenerLookup
-                : listenerLookup
-                    ? [listenerLookup]
-                    : [];
-            const listeners = loadedListeners.length > 0
-                ? loadedListeners
-                : (await listRunnerTriggerListeners(runnerId)).filter((listener) => listener.triggerType === body.type);
+            // Auto-spawn listeners support multiple rows for the same trigger type.
+            // Looking up by trigger type returns only the newest row, which can drop
+            // valid matches when older listeners have different params. Always load
+            // the full listener list for broadcast matching.
+            const listeners = (await listRunnerTriggerListeners(runnerId))
+                .filter((listener) => listener.triggerType === body.type);
             const matchingListeners = listeners.filter((listener) => {
                 if (listener.params && Object.keys(listener.params).length > 0) {
                     const listenerFilters = legacyParamsToFilters(listener.params);

--- a/packages/server/src/sessions/trigger-subscription-store.ts
+++ b/packages/server/src/sessions/trigger-subscription-store.ts
@@ -119,7 +119,7 @@ export async function nextTriggerSubRevision(): Promise<number> {
  * Subscription params — values the subscriber provided for the service to handle.
  * These are NOT used for server-side delivery filtering (use filters for that).
  */
-export type SubscriptionParamValue = string | number | boolean | Array<string | number | boolean>;
+export type SubscriptionParamValue = null | string | number | boolean | SubscriptionParamValue[] | { [key: string]: SubscriptionParamValue };
 export type SubscriptionParams = Record<string, SubscriptionParamValue>;
 
 /** A single filter condition on the trigger's output payload. */

--- a/packages/ui/src/components/RunnerTriggersPanel.test.tsx
+++ b/packages/ui/src/components/RunnerTriggersPanel.test.tsx
@@ -91,10 +91,8 @@ mock.module("@/lib/utils", () => ({
 mock.module("@/hooks/useRunnerModels", () => ({
   useRunnerModels: () => ({ models: [] }),
 }));
-
-mock.module("@/lib/path", () => ({
-  formatPathTail: (path: string) => path,
-}));
+const actualPathModule = await import("../lib/path");
+mock.module("@/lib/path", () => actualPathModule);
 
 afterAll(() => mock.restore());
 

--- a/packages/ui/src/components/RunnerTriggersPanel.test.tsx
+++ b/packages/ui/src/components/RunnerTriggersPanel.test.tsx
@@ -7,7 +7,9 @@ import { render, act, cleanup, fireEvent } from "@testing-library/react";
 import React from "react";
 
 const win = new Window({ url: "http://localhost/" });
+(win as any).SyntaxError = globalThis.SyntaxError;
 (globalThis as any).window = win;
+(globalThis as any).SyntaxError = globalThis.SyntaxError;
 (globalThis as any).document = win.document;
 (globalThis as any).navigator = win.navigator;
 (globalThis as any).HTMLElement = win.HTMLElement;
@@ -90,6 +92,9 @@ mock.module("@/hooks/useRunnerModels", () => ({
   useRunnerModels: () => ({ models: [] }),
 }));
 
+mock.module("@/lib/path", () => ({
+  formatPathTail: (path: string) => path,
+}));
 
 afterAll(() => mock.restore());
 
@@ -137,6 +142,110 @@ describe("RunnerTriggersPanel", () => {
     expect(Array.from(container.getElementsByTagName("button")).find((b) => b.getAttribute("aria-label") === "Edit listener listener-1 for svc:event")).toBeDefined();
     expect(Array.from(container.getElementsByTagName("button")).find((b) => b.getAttribute("aria-label") === "Delete listener listener-2 for svc:event")).toBeDefined();
     expect(Array.from(container.getElementsByTagName("button")).find((b) => b.getAttribute("aria-label") === "Add another listener for svc:event")).toBeDefined();
+  });
+
+  test("renders saved json listener params and shows a textarea editor for json params", async () => {
+    fetchState.response = {
+      ok: true,
+      body: {
+        triggerDefs: [{ type: "svc:event", label: "Service Event", params: [{ name: "config", label: "Config", type: "json" }] }],
+        listeners: [
+          { listenerId: "listener-json", triggerType: "svc:event", params: { config: { users: ["jordanpizza"], flags: { dryRun: true } } }, createdAt: "2026-04-03T00:00:00.000Z" },
+        ],
+      },
+    };
+
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<RunnerTriggersPanel runnerId="runner-1" />));
+    });
+
+    const accordionBtn = Array.from(container.getElementsByTagName("button")).find((b) => b.textContent?.includes("svc"));
+    await act(async () => {
+      fireEvent.click(accordionBtn!);
+    });
+
+    expect(container.textContent).toContain('config={"users":["jordanpizza"],"flags":{"dryRun":true}}');
+
+    const addBtn = Array.from(container.getElementsByTagName("button")).find((b) => b.getAttribute("aria-label") === "Add another listener for svc:event");
+    await act(async () => {
+      fireEvent.click(addBtn!);
+    });
+
+    const textareas = Array.from(container.getElementsByTagName("textarea"));
+    const textarea = textareas[textareas.length - 1];
+    expect(textarea).toBeDefined();
+  });
+
+  test("submits multiselect listener params as arrays and renders array values as separate chips", async () => {
+    let postBody: any = null;
+    fetchState.response = {
+      ok: true,
+      body: {
+        triggerDefs: [{
+          type: "svc:event",
+          label: "Service Event",
+          params: [{ name: "channel", label: "Channel", type: "string", enum: ["alerts", "debug", "info"], multiselect: true }],
+        }],
+        listeners: [
+          { listenerId: "listener-1", triggerType: "svc:event", params: { channel: ["alerts", "debug"] }, createdAt: "2026-04-03T00:00:00.000Z" },
+        ],
+      },
+    };
+
+    fetchSpy.mockImplementation((url: string, opts?: RequestInit) => {
+      if (url.includes("/api/runners/runner-1/trigger-listeners") && (opts?.method ?? "GET") === "POST") {
+        postBody = JSON.parse(String(opts?.body ?? "{}"));
+        return Promise.resolve({ ok: true, status: 200, json: async () => ({ ok: true, listenerId: "listener-new", triggerType: "svc:event" }) } as Response);
+      }
+      const { ok, status, body } = fetchState.response;
+      return Promise.resolve({
+        ok,
+        status: status ?? (ok ? 200 : 500),
+        json: async () => body,
+      } as Response);
+    });
+
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<RunnerTriggersPanel runnerId="runner-1" />));
+    });
+
+    const accordionBtn = Array.from(container.getElementsByTagName("button")).find((b) => b.textContent?.includes("svc"));
+    await act(async () => {
+      fireEvent.click(accordionBtn!);
+    });
+
+    const channelChipTexts = Array.from(container.getElementsByTagName("span"))
+      .map((el) => el.textContent)
+      .filter((text): text is string => !!text && text.startsWith("channel="));
+    expect(new Set(channelChipTexts)).toEqual(new Set(["channel=alerts", "channel=debug"]));
+
+    const addBtn = Array.from(container.getElementsByTagName("button")).find((b) => b.getAttribute("aria-label") === "Add another listener for svc:event");
+    await act(async () => {
+      fireEvent.click(addBtn!);
+    });
+
+    const checkboxes = Array.from(container.getElementsByTagName("input")).filter((input) => (input as HTMLInputElement).type === "checkbox") as HTMLInputElement[];
+    const alertsCheckbox = checkboxes.find((input) => input.parentElement?.textContent?.includes("alerts"));
+    const debugCheckbox = checkboxes.find((input) => input.parentElement?.textContent?.includes("debug"));
+    expect(alertsCheckbox).toBeDefined();
+    expect(debugCheckbox).toBeDefined();
+
+    await act(async () => {
+      fireEvent.click(alertsCheckbox!);
+      fireEvent.click(debugCheckbox!);
+    });
+
+    const submitBtn = Array.from(container.getElementsByTagName("button")).find((b) => b.textContent?.includes("Subscribe"));
+    await act(async () => {
+      fireEvent.click(submitBtn!);
+    });
+
+    expect(postBody).toMatchObject({
+      triggerType: "svc:event",
+      params: { channel: ["alerts", "debug"] },
+    });
   });
 
   test("keeps sibling listener actions available while one listener delete is pending", async () => {

--- a/packages/ui/src/components/RunnerTriggersPanel.tsx
+++ b/packages/ui/src/components/RunnerTriggersPanel.tsx
@@ -27,7 +27,7 @@ import { formatPathTail } from "@/lib/path";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import type { ServiceTriggerDef, ServiceTriggerParamDef } from "@pizzapi/protocol";
+import type { JsonValue, ServiceTriggerDef, ServiceTriggerParamDef } from "@pizzapi/protocol";
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
@@ -45,6 +45,31 @@ function truncateCompactId(id?: string, fallback?: string, maxLen = 18): string 
   if (!id) return fallback ?? "listener";
   if (id.length <= maxLen) return id;
   return id.slice(0, maxLen) + "…";
+}
+
+function formatParamValue(value: JsonValue): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+function renderParamValueBadges(
+  key: string,
+  value: JsonValue,
+  className: string,
+): React.ReactNode {
+  if (Array.isArray(value) && value.every((item) => typeof item === "string" || typeof item === "number" || typeof item === "boolean")) {
+    return value.map((item, index) => (
+      <Badge key={`${key}:${String(item)}:${index}`} variant="outline" className={className}>
+        {key}={String(item)}
+      </Badge>
+    ));
+  }
+
+  return (
+    <Badge key={key} variant="outline" className={className}>
+      {key}={formatParamValue(value)}
+    </Badge>
+  );
 }
 
 // ── Service Group ──────────────────────────────────────────────────────────
@@ -237,27 +262,38 @@ function ParamForm({
 
             {/* Multiselect: checkboxes */}
             {p.multiselect && p.enum ? (
-              <div className="flex-1 flex flex-wrap gap-x-3 gap-y-1">
-                {p.enum.map((opt) => {
-                  const optStr = String(opt);
-                  const checked = selectedArr.includes(optStr);
-                  return (
-                    <label key={optStr} className="flex items-center gap-1 cursor-pointer text-[11px] text-foreground/80">
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => {
-                          const next = checked
-                            ? selectedArr.filter(v => v !== optStr)
-                            : [...selectedArr, optStr];
-                          updateValue(p.name, next);
-                        }}
-                        className="accent-primary size-3"
-                      />
-                      {optStr}
-                    </label>
-                  );
-                })}
+              <div className="flex-1 space-y-1">
+                {selectedArr.length > 0 && (
+                  <div className="flex flex-wrap gap-1">
+                    {selectedArr.map((value, index) => (
+                      <Badge key={`${p.name}:${value}:${index}`} variant="outline" className="px-1 py-0 text-[10px] h-4 border-violet-500/30 text-violet-300/80 bg-violet-500/5">
+                        {value}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+                <div className="flex flex-wrap gap-x-3 gap-y-1">
+                  {p.enum.map((opt) => {
+                    const optStr = String(opt);
+                    const checked = selectedArr.includes(optStr);
+                    return (
+                      <label key={optStr} className="flex items-center gap-1 cursor-pointer text-[11px] text-foreground/80">
+                        <input
+                          type="checkbox"
+                          checked={checked}
+                          onChange={() => {
+                            const next = checked
+                              ? selectedArr.filter(v => v !== optStr)
+                              : [...selectedArr, optStr];
+                            updateValue(p.name, next);
+                          }}
+                          className="accent-primary size-3"
+                        />
+                        {optStr}
+                      </label>
+                    );
+                  })}
+                </div>
               </div>
 
             /* Enum single select: dropdown */
@@ -272,6 +308,16 @@ function ParamForm({
                   <option key={String(opt)} value={String(opt)}>{String(opt)}</option>
                 ))}
               </select>
+
+            /* JSON */
+            ) : p.type === "json" ? (
+              <textarea
+                rows={3}
+                placeholder={p.default !== undefined ? formatParamValue(p.default) : "{}"}
+                value={typeof currentVal === "string" ? currentVal : ""}
+                onChange={(e) => updateValue(p.name, e.target.value)}
+                className="flex-1 rounded border border-border bg-background px-2 py-1 text-[11px] font-mono focus:outline-none focus:ring-1 focus:ring-ring resize-y"
+              />
 
             /* Boolean */
             ) : p.type === "boolean" ? (
@@ -289,7 +335,7 @@ function ParamForm({
             ) : (
               <input
                 type={p.type === "number" ? "number" : "text"}
-                placeholder={p.default !== undefined ? String(p.default) : undefined}
+                placeholder={p.default !== undefined ? formatParamValue(p.default) : undefined}
                 value={typeof currentVal === "string" ? currentVal : ""}
                 onChange={(e) => updateValue(p.name, e.target.value)}
                 className="flex-1 rounded border border-border bg-background px-2 py-1 text-[11px] focus:outline-none focus:ring-1 focus:ring-ring"
@@ -445,9 +491,15 @@ function TriggerItem({
             if (listener.cwd) details.push(listener.cwd);
             if (listener.model) details.push(`${listener.model.provider}/${listener.model.id}`);
             if (listener.autoClose) details.push("auto-close");
+            const paramBadges = listener.params
+              ? Object.entries(listener.params).flatMap(([k, v]) => {
+                  const badges = renderParamValueBadges(k, v, "px-1 py-0 text-[9px] h-3.5 border-emerald-500/20 text-emerald-400/60");
+                  return Array.isArray(badges) ? badges : [badges];
+                })
+              : [];
             if (listener.params) {
               for (const [k, v] of Object.entries(listener.params)) {
-                details.push(`${k}=${Array.isArray(v) ? v.map(String).join(", ") : String(v)}`);
+                details.push(`${k}=${formatParamValue(v)}`);
               }
             }
             return (
@@ -460,9 +512,16 @@ function TriggerItem({
                       </p>
                     )}
                     {details.length > 0 && (
-                      <p className="text-[10px] font-mono text-muted-foreground/50 truncate">
-                        {details.join(" \u00B7 ")}
-                      </p>
+                      <div className="space-y-1">
+                        <p className="text-[10px] font-mono text-muted-foreground/50 truncate">
+                          {details.join(" \u00B7 ")}
+                        </p>
+                        {paramBadges.length > 0 && (
+                          <div className="flex items-center gap-1 flex-wrap">
+                            {paramBadges}
+                          </div>
+                        )}
+                      </div>
                     )}
                     {!listener.prompt && details.length === 0 && (
                       <p className="text-[10px] text-muted-foreground/40 italic">No config</p>
@@ -630,7 +689,7 @@ interface ListenerInfo {
   prompt?: string;
   cwd?: string;
   model?: { provider: string; id: string };
-  params?: Record<string, unknown>;
+  params?: Record<string, JsonValue>;
   autoClose?: boolean;
   createdAt: string;
 }
@@ -742,17 +801,19 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
 
     // Pre-populate param values from current listener
     const vals: Record<string, string | string[]> = {};
+    const paramDefsByName = new Map((def.params ?? []).map((param) => [param.name, param]));
     if (listener?.params) {
       for (const [k, v] of Object.entries(listener.params)) {
-        if (Array.isArray(v)) vals[k] = v.map(String);
-        else vals[k] = String(v);
+        const paramDef = paramDefsByName.get(k);
+        if (paramDef?.multiselect && Array.isArray(v)) vals[k] = v.map(String);
+        else vals[k] = formatParamValue(v);
       }
     }
     if (def.params) {
       for (const p of def.params) {
         if (vals[p.name] !== undefined) continue;
         if (p.multiselect) vals[p.name] = [];
-        else if (p.default !== undefined) vals[p.name] = String(p.default);
+        else if (p.default !== undefined) vals[p.name] = formatParamValue(p.default);
       }
     }
     setParamValues((prev) => ({ ...prev, [def.type]: vals }));
@@ -798,7 +859,7 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
       if (def.params) {
         for (const p of def.params) {
           if (p.multiselect) defaults[p.name] = [];
-          else if (p.default !== undefined) defaults[p.name] = String(p.default);
+          else if (p.default !== undefined) defaults[p.name] = formatParamValue(p.default);
         }
       }
       setParamValues((prev) => ({ ...prev, [def.type]: { ...defaults, ...prev[def.type] } }));
@@ -811,7 +872,7 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
 
   const handleParamSubmit = React.useCallback((def: ServiceTriggerDef) => {
     const vals = paramValues[def.type] ?? {};
-    const params: Record<string, unknown> = {};
+    const params: Record<string, JsonValue> = {};
     for (const p of (def.params ?? [])) {
       const raw = vals[p.name];
 
@@ -842,6 +903,13 @@ export function RunnerTriggersPanel({ runnerId, triggerDefs: propDefs }: RunnerT
         params[p.name] = num;
       } else if (p.type === "boolean") {
         params[p.name] = str === "true";
+      } else if (p.type === "json") {
+        try {
+          params[p.name] = JSON.parse(str) as JsonValue;
+        } catch {
+          setParamError(`'${p.label}' must be valid JSON`);
+          return;
+        }
       } else {
         params[p.name] = str;
       }

--- a/packages/ui/src/components/TriggersPanel.test.tsx
+++ b/packages/ui/src/components/TriggersPanel.test.tsx
@@ -18,8 +18,10 @@ import React from "react";
 
 // ── DOM globals ──────────────────────────────────────────────────────────────
 const win = new Window({ url: "http://localhost/" });
+(win as any).SyntaxError = globalThis.SyntaxError;
 /* eslint-disable @typescript-eslint/no-explicit-any */
 (globalThis as any).window = win;
+(globalThis as any).SyntaxError = globalThis.SyntaxError;
 (globalThis as any).document = win.document;
 (globalThis as any).navigator = win.navigator;
 (globalThis as any).HTMLElement = win.HTMLElement;
@@ -602,6 +604,120 @@ describe("TriggersPanel — trigger catalog", () => {
     expect(buttons.find((b) => b.getAttribute("aria-label") === "Edit subscription sub-1 for svc:event")).toBeDefined();
     expect(buttons.find((b) => b.getAttribute("aria-label") === "Delete subscription sub-2 for svc:event")).toBeDefined();
     expect(buttons.find((b) => b.getAttribute("aria-label") === "Add another subscription for svc:event")).toBeDefined();
+  });
+
+  test("renders saved json params and shows a textarea editor for json params", async () => {
+    fetchState.urlOverrides = {
+      "trigger-subscriptions": {
+        ok: true,
+        body: {
+          subscriptions: [
+            { subscriptionId: "sub-json", triggerType: "svc:event", runnerId: "runner-A", params: { config: { users: ["jordanpizza"], flags: { dryRun: true } } } },
+          ],
+        },
+      },
+    };
+
+    const triggerDefs = [{ type: "svc:event", label: "Service Event", params: [{ name: "config", label: "Config", type: "json" }] }];
+
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<TriggersPanel sessionId="sess-abc" triggerDefs={triggerDefs} />));
+    });
+
+    const accordionBtn = Array.from(container.getElementsByTagName("button")).find((b) => b.textContent?.includes("svc"));
+    await act(async () => { fireEvent.click(accordionBtn!); });
+
+    expect(container.textContent).toContain('config={"users":["jordanpizza"],"flags":{"dryRun":true}}');
+
+    const addBtn = Array.from(container.getElementsByTagName("button")).find((b) => b.getAttribute("aria-label") === "Add another subscription for svc:event");
+    await act(async () => { fireEvent.click(addBtn!); });
+
+    const textareas = Array.from(container.getElementsByTagName("textarea"));
+    const textarea = textareas[textareas.length - 1];
+    expect(textarea).toBeDefined();
+  });
+
+  test("submits multiselect params as arrays and renders array values as separate chips", async () => {
+    let postBody: any = null;
+    fetchState.urlOverrides = {
+      "trigger-subscriptions": {
+        ok: true,
+        body: {
+          subscriptions: [
+            { subscriptionId: "sub-1", triggerType: "svc:event", runnerId: "runner-A", params: { channel: ["alerts", "debug"] } },
+          ],
+        },
+      },
+    };
+
+    fetchSpy.mockImplementation((url: string, opts?: RequestInit) => {
+      if (url.includes("/api/sessions/sess-abc/trigger-subscriptions") && (opts?.method ?? "GET") === "POST") {
+        postBody = JSON.parse(String(opts?.body ?? "{}"));
+        return Promise.resolve({ ok: true, status: 200, json: async () => ({ ok: true, subscriptionId: "sub-new", triggerType: "svc:event", runnerId: "runner-A", params: postBody.params }) } as Response);
+      }
+      if (fetchState.urlOverrides) {
+        for (const [key, override] of Object.entries(fetchState.urlOverrides)) {
+          if (url.includes(key)) {
+            return Promise.resolve({
+              ok: override.ok,
+              status: override.status ?? (override.ok ? 200 : 500),
+              json: async () => override.body,
+            } as Response);
+          }
+        }
+      }
+      const { ok, status, body } = fetchState.response;
+      return Promise.resolve({
+        ok,
+        status: status ?? (ok ? 200 : 500),
+        json: async () => body,
+      } as Response);
+    });
+
+    const triggerDefs = [{
+      type: "svc:event",
+      label: "Service Event",
+      params: [{ name: "channel", label: "Channel", type: "string", enum: ["alerts", "debug", "info"], multiselect: true }],
+    }];
+
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<TriggersPanel sessionId="sess-abc" triggerDefs={triggerDefs} />));
+    });
+
+    const accordionBtn = Array.from(container.getElementsByTagName("button")).find((b) => b.textContent?.includes("svc"));
+    await act(async () => { fireEvent.click(accordionBtn!); });
+
+    const channelChipTexts = Array.from(container.getElementsByTagName("span"))
+      .map((el) => el.textContent)
+      .filter((text): text is string => !!text && text.startsWith("channel="));
+    expect(new Set(channelChipTexts)).toEqual(new Set(["channel=alerts", "channel=debug"]));
+
+    const addBtn = Array.from(container.getElementsByTagName("button")).find((b) => b.getAttribute("aria-label") === "Add another subscription for svc:event");
+    await act(async () => { fireEvent.click(addBtn!); });
+
+    const checkboxes = Array.from(container.getElementsByTagName("input")).filter((input) => (input as HTMLInputElement).type === "checkbox") as HTMLInputElement[];
+    const alertsCheckbox = checkboxes.find((input) => input.parentElement?.textContent?.includes("alerts"));
+    const debugCheckbox = checkboxes.find((input) => input.parentElement?.textContent?.includes("debug"));
+    expect(alertsCheckbox).toBeDefined();
+    expect(debugCheckbox).toBeDefined();
+
+    await act(async () => {
+      fireEvent.click(alertsCheckbox!);
+      fireEvent.click(debugCheckbox!);
+    });
+
+    expect(container.textContent).toContain("alerts");
+    expect(container.textContent).toContain("debug");
+
+    const submitBtn = Array.from(container.getElementsByTagName("button")).find((b) => b.textContent?.includes("Subscribe"));
+    await act(async () => { fireEvent.click(submitBtn!); });
+
+    expect(postBody).toMatchObject({
+      triggerType: "svc:event",
+      params: { channel: ["alerts", "debug"] },
+    });
   });
 
   test("keeps sibling subscription actions available while one unsubscribe is pending", async () => {

--- a/packages/ui/src/components/TriggersPanel.tsx
+++ b/packages/ui/src/components/TriggersPanel.tsx
@@ -46,7 +46,7 @@ import {
 } from "@/components/ui/dialog";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
-import type { ServiceTriggerDef, ServiceTriggerParamDef } from "@pizzapi/protocol";
+import type { JsonValue, ServiceTriggerDef, ServiceTriggerParamDef } from "@pizzapi/protocol";
 
 // ── Shared trigger utilities (re-exported for backward compat) ─────────────
 export type { TriggerHistoryEntry } from "../attention/trigger-utils";
@@ -60,7 +60,7 @@ export interface TriggerSubscription {
   subscriptionId?: string;
   triggerType: string;
   runnerId: string;
-  params?: Record<string, string | number | boolean | Array<string | number | boolean>>;
+  params?: Record<string, JsonValue>;
   filters?: Array<{ field: string; value: string | number | boolean | Array<string | number | boolean>; op?: "eq" | "contains" }>;
   filterMode?: "and" | "or";
 }
@@ -71,6 +71,31 @@ interface TriggerStatusUpdate {
   sourceSessionId: string;
   statusText: string;
   ts: string;
+}
+
+function formatParamValue(value: JsonValue): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+function renderParamValueBadges(
+  key: string,
+  value: JsonValue,
+  className: string,
+): React.ReactNode {
+  if (Array.isArray(value) && value.every((item) => typeof item === "string" || typeof item === "number" || typeof item === "boolean")) {
+    return value.map((item, index) => (
+      <Badge key={`${key}:${String(item)}:${index}`} variant="outline" className={className}>
+        {key}={String(item)}
+      </Badge>
+    ));
+  }
+
+  return (
+    <Badge key={key} variant="outline" className={className}>
+      {key}={formatParamValue(value)}
+    </Badge>
+  );
 }
 
 /** A linked child session derived from trigger history. */
@@ -919,17 +944,19 @@ function TriggerCatalogSection({ sessionId, triggerDefs, subscriptions, onSubscr
 
     // Pre-populate param values from current subscription
     const vals: Record<string, string | string[]> = {};
+    const paramDefsByName = new Map((def.params ?? []).map((param) => [param.name, param]));
     if (sub?.params) {
       for (const [k, v] of Object.entries(sub.params)) {
-        if (Array.isArray(v)) vals[k] = v.map(String);
-        else vals[k] = String(v);
+        const paramDef = paramDefsByName.get(k);
+        if (paramDef?.multiselect && Array.isArray(v)) vals[k] = v.map(String);
+        else vals[k] = formatParamValue(v);
       }
     }
     if (def.params) {
       for (const p of def.params) {
         if (vals[p.name] !== undefined) continue;
         if (p.multiselect) vals[p.name] = [];
-        else if (p.default !== undefined) vals[p.name] = String(p.default);
+        else if (p.default !== undefined) vals[p.name] = formatParamValue(p.default);
       }
     }
     setParamValues((prev) => ({ ...prev, [def.type]: vals }));
@@ -968,7 +995,7 @@ function TriggerCatalogSection({ sessionId, triggerDefs, subscriptions, onSubscr
           if (p.multiselect) {
             defaults[p.name] = defaults[p.name] ?? [];
           } else if (p.default !== undefined) {
-            defaults[p.name] = String(p.default);
+            defaults[p.name] = formatParamValue(p.default);
           }
         }
         setParamValues((prev) => ({ ...prev, [def.type]: { ...defaults, ...prev[def.type] } }));
@@ -980,7 +1007,7 @@ function TriggerCatalogSection({ sessionId, triggerDefs, subscriptions, onSubscr
 
   const handleParamSubmit = React.useCallback((def: ServiceTriggerDef) => {
     const vals = paramValues[def.type] ?? {};
-    const params: Record<string, unknown> = {};
+    const params: Record<string, JsonValue> = {};
     for (const p of (def.params ?? [])) {
       const raw = vals[p.name];
 
@@ -1019,6 +1046,13 @@ function TriggerCatalogSection({ sessionId, triggerDefs, subscriptions, onSubscr
         params[p.name] = num;
       } else if (p.type === "boolean") {
         params[p.name] = str === "true";
+      } else if (p.type === "json") {
+        try {
+          params[p.name] = JSON.parse(str) as JsonValue;
+        } catch {
+          setParamError(`'${p.label}' must be valid JSON`);
+          return;
+        }
       } else {
         params[p.name] = str;
       }
@@ -1272,9 +1306,13 @@ function ServiceCatalogAccordion({
                       const subKey = sub.subscriptionId ?? `${def.type}-${index}`;
                       const isPendingSub = pending.has(subKey) || isPendingToggle;
                       const details: string[] = [];
+                      const paramBadges: React.ReactNode[] = [];
                       if (sub.params && Object.keys(sub.params).length > 0) {
                         for (const [k, v] of Object.entries(sub.params)) {
-                          details.push(`${k}=${Array.isArray(v) ? v.map(String).join(", ") : String(v)}`);
+                          details.push(`${k}=${formatParamValue(v)}`);
+                          const badges = renderParamValueBadges(k, v, "px-1 py-0 text-[9px] h-3.5 border-emerald-500/20 text-emerald-400/60");
+                          if (Array.isArray(badges)) paramBadges.push(...badges);
+                          else paramBadges.push(badges);
                         }
                       }
                       if (sub.filters && sub.filters.length > 0) {
@@ -1287,9 +1325,16 @@ function ServiceCatalogAccordion({
                           <div className="flex items-center gap-2">
                             <div className="flex-1 min-w-0">
                               {details.length > 0 ? (
-                                <p className="text-[10px] font-mono text-muted-foreground/50 truncate">
-                                  {details.join(" \u00B7 ")}
-                                </p>
+                                <div className="space-y-1">
+                                  <p className="text-[10px] font-mono text-muted-foreground/50 truncate">
+                                    {details.join(" \u00B7 ")}
+                                  </p>
+                                  {paramBadges.length > 0 && (
+                                    <div className="flex items-center gap-1 flex-wrap">
+                                      {paramBadges}
+                                    </div>
+                                  )}
+                                </div>
                               ) : (
                                 <p className="text-[10px] text-muted-foreground/40 italic">No filters</p>
                               )}
@@ -1351,8 +1396,18 @@ function ServiceCatalogAccordion({
 
                           {/* Multiselect: checkboxes for each enum value */}
                           {p.multiselect && p.enum ? (
-                            <div className="flex-1 flex flex-wrap gap-x-2.5 gap-y-1">
-                              {p.enum.map((opt) => {
+                            <div className="flex-1 space-y-1">
+                              {selectedArr.length > 0 && (
+                                <div className="flex flex-wrap gap-1">
+                                  {selectedArr.map((value, index) => (
+                                    <Badge key={`${p.name}:${value}:${index}`} variant="outline" className="px-1 py-0 text-[9px] h-4 border-violet-500/30 text-violet-300/80 bg-violet-500/5">
+                                      {value}
+                                    </Badge>
+                                  ))}
+                                </div>
+                              )}
+                              <div className="flex flex-wrap gap-x-2.5 gap-y-1">
+                                {p.enum.map((opt) => {
                                 const optStr = String(opt);
                                 const checked = selectedArr.includes(optStr);
                                 return (
@@ -1372,7 +1427,8 @@ function ServiceCatalogAccordion({
                                     {optStr}
                                   </label>
                                 );
-                              })}
+                                })}
+                              </div>
                             </div>
 
                           /* Enum (single select): dropdown */
@@ -1390,6 +1446,19 @@ function ServiceCatalogAccordion({
                                 <option key={String(opt)} value={String(opt)}>{String(opt)}</option>
                               ))}
                             </select>
+
+                          /* JSON */
+                          ) : p.type === "json" ? (
+                            <textarea
+                              rows={3}
+                              placeholder={p.default !== undefined ? formatParamValue(p.default) : "{}"}
+                              value={typeof currentVal === "string" ? currentVal : ""}
+                              onChange={(e) => onParamValuesChange((prev) => ({
+                                ...prev,
+                                [def.type]: { ...prev[def.type], [p.name]: e.target.value },
+                              }))}
+                              className="flex-1 rounded border border-border bg-background px-1.5 py-1 text-[10px] font-mono focus:outline-none focus:ring-1 focus:ring-ring resize-y"
+                            />
 
                           /* Boolean */
                           ) : p.type === "boolean" ? (
@@ -1588,11 +1657,10 @@ function ActiveSubscriptionsSection({ subscriptions }: { subscriptions: TriggerS
             )}
             {sub.params && Object.keys(sub.params).length > 0 && (
               <div className="flex items-center gap-1 flex-wrap">
-                {Object.entries(sub.params).map(([k, v]) => (
-                  <Badge key={k} variant="outline" className="px-1 py-0 text-[9px] h-3.5 border-emerald-500/20 text-emerald-400/60">
-                    {k}={Array.isArray(v) ? v.map(String).join(", ") : String(v)}
-                  </Badge>
-                ))}
+                {Object.entries(sub.params).flatMap(([k, v]) => {
+                  const badges = renderParamValueBadges(k, v, "px-1 py-0 text-[9px] h-3.5 border-emerald-500/20 text-emerald-400/60");
+                  return Array.isArray(badges) ? badges : [badges];
+                })}
               </div>
             )}
             {sub.filters && sub.filters.length > 0 && (

--- a/packages/ui/src/hooks/useRunnerServices.test.ts
+++ b/packages/ui/src/hooks/useRunnerServices.test.ts
@@ -9,9 +9,8 @@
  */
 import { describe, expect, test, mock } from "bun:test";
 
-mock.module("@/lib/viewer-switch", () => ({
-    matchesViewerGeneration: () => true,
-}));
+const actualViewerSwitchModule = await import("../lib/viewer-switch");
+mock.module("@/lib/viewer-switch", () => actualViewerSwitchModule);
 
 const { attachServiceAnnounceListener, seedServiceCache } = await import("./useRunnerServices");
 

--- a/packages/ui/src/hooks/useRunnerServices.test.ts
+++ b/packages/ui/src/hooks/useRunnerServices.test.ts
@@ -7,8 +7,13 @@
  * had data (`if (cached.size > 0)`), so switching to a non-runner session
  * left stale services/panels from the previous runner session visible.
  */
-import { describe, expect, test } from "bun:test";
-import { attachServiceAnnounceListener, seedServiceCache } from "./useRunnerServices";
+import { describe, expect, test, mock } from "bun:test";
+
+mock.module("@/lib/viewer-switch", () => ({
+    matchesViewerGeneration: () => true,
+}));
+
+const { attachServiceAnnounceListener, seedServiceCache } = await import("./useRunnerServices");
 
 // The internal cache keys used by the module
 const SERVICE_IDS_KEY = "__serviceIds";

--- a/packages/ui/src/hooks/useRunnerServices.ts
+++ b/packages/ui/src/hooks/useRunnerServices.ts
@@ -197,9 +197,11 @@ export function useRunnerServices(socket: Socket | null, runnerInfo: RunnerInfo 
             setSigilDefs([]);
         } else {
             // Runner is known but feed metadata is not hydrated yet.
-            // Preserve/restore any eagerly captured announce data (e.g. seeded
-            // via seedServiceCache for same-runner switches) instead of
-            // clearing state and causing a flash of missing panels/triggers.
+            // Read any eagerly captured announce data (including values seeded
+            // via seedServiceCache for same-runner switches) and apply it
+            // unconditionally. When the cache is empty, this clears stale
+            // service state from the previous session instead of leaving old
+            // panels/triggers visible.
             setServices(getEagerServiceIds(socket));
             setPanels(getEagerPanels(socket));
             setTriggerDefs(getEagerTriggerDefs(socket));


### PR DESCRIPTION
## Summary
- render trigger multiselect selections as chips in subscription and runner listener UIs
- preserve and test array param submission for trigger subscribe/update flows
- document current enum-backed multiselect contract and note limitations for dynamic values
- include the existing useRunnerServices stale-cache clearing fix with coverage

## Testing
- bun test packages/ui/src/hooks/useRunnerServices.test.ts packages/ui/src/components/TriggersPanel.test.tsx packages/ui/src/components/RunnerTriggersPanel.test.tsx packages/server/src/routes/triggers.test.ts
- bun run typecheck
