### PR TITLE
fix: preserve trigger auto-close sessions waiting on linked children

### DIFF
--- a/packages/cli/src/extensions/remote/auto-close.test.ts
+++ b/packages/cli/src/extensions/remote/auto-close.test.ts
@@ -9,29 +9,8 @@
  * Since lifecycle-handlers.ts has heavy dependencies (pi event system,
  * relay context, etc.), we test the decision logic in isolation here.
  */
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
-
-// ── Decision logic extracted from lifecycle-handlers.ts ───────────────────
-// This mirrors the exact conditional in the agent_end handler.
-function shouldAutoClose(opts: {
-    autoCloseEnv: string | undefined;
-    exitReason: "completed" | "killed" | "error";
-    isChildSession: boolean;
-    hasPendingMessages: boolean;
-    activeSubscriptionCount?: number;
-}): boolean {
-    // Auto-close only applies to non-child sessions (trigger-spawned)
-    if (opts.isChildSession) return false;
-    // Only when explicitly enabled
-    if (opts.autoCloseEnv !== "true") return false;
-    // Only on successful completion
-    if (opts.exitReason !== "completed") return false;
-    // Only when there are no pending messages
-    if (opts.hasPendingMessages) return false;
-    // Skip if the session has active trigger subscriptions
-    if ((opts.activeSubscriptionCount ?? 0) > 0) return false;
-    return true;
-}
+import { describe, test, expect, afterEach } from "bun:test";
+import { shouldAutoClose } from "./auto-close.js";
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
@@ -52,6 +31,8 @@ describe("auto-close decision logic", () => {
             exitReason: "completed",
             isChildSession: false,
             hasPendingMessages: false,
+            activeSubscriptionCount: 0,
+            linkedChildCount: 0,
         })).toBe(true);
     });
 
@@ -61,6 +42,8 @@ describe("auto-close decision logic", () => {
             exitReason: "error",
             isChildSession: false,
             hasPendingMessages: false,
+            activeSubscriptionCount: 0,
+            linkedChildCount: 0,
         })).toBe(false);
     });
 
@@ -70,6 +53,8 @@ describe("auto-close decision logic", () => {
             exitReason: "killed",
             isChildSession: false,
             hasPendingMessages: false,
+            activeSubscriptionCount: 0,
+            linkedChildCount: 0,
         })).toBe(false);
     });
 
@@ -79,6 +64,8 @@ describe("auto-close decision logic", () => {
             exitReason: "completed",
             isChildSession: false,
             hasPendingMessages: false,
+            activeSubscriptionCount: 0,
+            linkedChildCount: 0,
         })).toBe(false);
     });
 
@@ -88,6 +75,8 @@ describe("auto-close decision logic", () => {
             exitReason: "completed",
             isChildSession: false,
             hasPendingMessages: false,
+            activeSubscriptionCount: 0,
+            linkedChildCount: 0,
         })).toBe(false);
     });
 
@@ -97,6 +86,8 @@ describe("auto-close decision logic", () => {
             exitReason: "completed",
             isChildSession: true,
             hasPendingMessages: false,
+            activeSubscriptionCount: 0,
+            linkedChildCount: 0,
         })).toBe(false);
     });
 
@@ -106,6 +97,8 @@ describe("auto-close decision logic", () => {
             exitReason: "completed",
             isChildSession: false,
             hasPendingMessages: true,
+            activeSubscriptionCount: 0,
+            linkedChildCount: 0,
         })).toBe(false);
     });
 
@@ -116,27 +109,53 @@ describe("auto-close decision logic", () => {
             isChildSession: false,
             hasPendingMessages: false,
             activeSubscriptionCount: 2,
+            linkedChildCount: 0,
         })).toBe(false);
     });
 
-    test("shuts down when session has zero subscriptions", () => {
+    test("does NOT shut down when session still has linked children", () => {
         expect(shouldAutoClose({
             autoCloseEnv: "true",
             exitReason: "completed",
             isChildSession: false,
             hasPendingMessages: false,
             activeSubscriptionCount: 0,
+            linkedChildCount: 1,
+        })).toBe(false);
+    });
+
+    test("shuts down when session has zero subscriptions and no linked children", () => {
+        expect(shouldAutoClose({
+            autoCloseEnv: "true",
+            exitReason: "completed",
+            isChildSession: false,
+            hasPendingMessages: false,
+            activeSubscriptionCount: 0,
+            linkedChildCount: 0,
         })).toBe(true);
     });
 
-    test("shuts down when subscription count is undefined (query failed)", () => {
-        // If we can't check subscriptions, proceed with auto-close
+    test("does NOT shut down when linked-child count is unknown", () => {
+        // Fail safe: if we can't prove there are no linked children, preserve the session.
+        expect(shouldAutoClose({
+            autoCloseEnv: "true",
+            exitReason: "completed",
+            isChildSession: false,
+            hasPendingMessages: false,
+            activeSubscriptionCount: 0,
+            linkedChildCount: null,
+        })).toBe(false);
+    });
+
+    test("does NOT shut down when subscription count is undefined (query failed)", () => {
+        // If we can't check subscriptions, preserve the session.
         expect(shouldAutoClose({
             autoCloseEnv: "true",
             exitReason: "completed",
             isChildSession: false,
             hasPendingMessages: false,
             activeSubscriptionCount: undefined,
-        })).toBe(true);
+            linkedChildCount: 0,
+        })).toBe(false);
     });
 });

--- a/packages/cli/src/extensions/remote/auto-close.ts
+++ b/packages/cli/src/extensions/remote/auto-close.ts
@@ -1,0 +1,20 @@
+export interface AutoCloseDecisionOptions {
+    autoCloseEnv: string | undefined;
+    exitReason: "completed" | "killed" | "error";
+    isChildSession: boolean;
+    hasPendingMessages: boolean;
+    activeSubscriptionCount?: number | null;
+    linkedChildCount?: number | null;
+}
+
+export function shouldAutoClose(opts: AutoCloseDecisionOptions): boolean {
+    if (opts.isChildSession) return false;
+    if (opts.autoCloseEnv !== "true") return false;
+    if (opts.exitReason !== "completed") return false;
+    if (opts.hasPendingMessages) return false;
+    if (opts.activeSubscriptionCount == null) return false;
+    if (opts.activeSubscriptionCount > 0) return false;
+    if (opts.linkedChildCount == null) return false;
+    if (opts.linkedChildCount > 0) return false;
+    return true;
+}

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -418,11 +418,19 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
                         return;
                     }
 
+                    // Re-check idleness after the async probes: a trigger,
+                    // user message, or new turn may have arrived while we were
+                    // awaiting subscription/child-count results.
+                    if (ctx.hasPendingMessages() || rctx.isAgentActive) {
+                        log.info("pizzapi: auto-close skipped — new work arrived during async checks");
+                        return;
+                    }
+
                     if (!shouldAutoClose({
                         autoCloseEnv: process.env.PIZZAPI_WORKER_AUTO_CLOSE,
                         exitReason,
                         isChildSession: rctx.isChildSession,
-                        hasPendingMessages: false,
+                        hasPendingMessages: ctx.hasPendingMessages(),
                         activeSubscriptionCount,
                         linkedChildCount,
                     })) {

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -45,6 +45,7 @@ import { registerAskUserTool } from "../remote-ask-user.js";
 import { registerPlanModeTool } from "../remote-plan-mode.js";
 import { isDisabled } from "./connection.js";
 import { emitSessionActive } from "./chunked-delivery.js";
+import { shouldAutoClose } from "./auto-close.js";
 import type { RelayContext } from "../remote-types.js";
 import type { TriggerWaitManager } from "../trigger-wait-manager.js";
 import type { DelinkManager } from "./delink-management.js";
@@ -52,6 +53,33 @@ import type { CancellationManager } from "./trigger-cancellation.js";
 import type { FollowUpGraceManager } from "./followup-grace.js";
 
 const log = createLogger("remote");
+const LINKED_CHILD_COUNT_TIMEOUT_MS = 2_000;
+
+async function getLinkedChildCount(rctx: RelayContext): Promise<number | null> {
+    if (!rctx.relay || !rctx.sioSocket?.connected) return null;
+
+    return await new Promise<number | null>((resolve) => {
+        let settled = false;
+        const finish = (count: number | null) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            resolve(count);
+        };
+        const timeout = setTimeout(() => finish(null), LINKED_CHILD_COUNT_TIMEOUT_MS);
+        rctx.sioSocket!.emit(
+            "get_linked_child_count",
+            { token: rctx.relay!.token },
+            (result?: { ok?: boolean; count?: number }) => {
+                if (!result?.ok || typeof result.count !== "number") {
+                    finish(null);
+                    return;
+                }
+                finish(result.count);
+            },
+        );
+    });
+}
 
 /** Shared mutable state fields accessed by the lifecycle handlers. */
 export interface LifecycleHandlerState {
@@ -370,21 +398,38 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
             } else if (process.env.PIZZAPI_WORKER_AUTO_CLOSE === "true" && exitReason === "completed") {
                 // Auto-close: trigger-spawned sessions with autoClose shut down
                 // immediately on successful completion — no follow-up grace.
-                // But skip if the session has active trigger subscriptions —
-                // it may be waiting for future events (e.g. github:pr_comment).
+                // But skip if the session still has active trigger subscriptions
+                // or linked child sessions that may session_complete later.
                 void (async () => {
-                    try {
-                        const sessionId = rctx.relaySessionId;
-                        if (sessionId) {
-                            const subs = await listTriggerSubscriptions(sessionId);
-                            if (subs.length > 0) {
-                                log.info(`pizzapi: auto-close skipped — session has ${subs.length} active trigger subscription(s)`);
-                                return;
-                            }
-                        }
-                    } catch {
-                        // If we can't check subscriptions, proceed with auto-close
+                    const sessionId = rctx.relaySessionId;
+                    const activeSubscriptionCount = sessionId
+                        ? await listTriggerSubscriptions(sessionId)
+                            .then((subs) => subs.length)
+                            .catch(() => null)
+                        : null;
+                    if (typeof activeSubscriptionCount === "number" && activeSubscriptionCount > 0) {
+                        log.info(`pizzapi: auto-close skipped — session has ${activeSubscriptionCount} active trigger subscription(s)`);
+                        return;
                     }
+
+                    const linkedChildCount = await getLinkedChildCount(rctx);
+                    if (typeof linkedChildCount === "number" && linkedChildCount > 0) {
+                        log.info(`pizzapi: auto-close skipped — session has ${linkedChildCount} linked child session(s)`);
+                        return;
+                    }
+
+                    if (!shouldAutoClose({
+                        autoCloseEnv: process.env.PIZZAPI_WORKER_AUTO_CLOSE,
+                        exitReason,
+                        isChildSession: rctx.isChildSession,
+                        hasPendingMessages: false,
+                        activeSubscriptionCount,
+                        linkedChildCount,
+                    })) {
+                        log.info("pizzapi: auto-close skipped — unable to prove session is fully idle");
+                        return;
+                    }
+
                     log.info("pizzapi: auto-close enabled and session completed successfully — shutting down");
                     ctx.shutdown();
                 })();

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -87,6 +87,11 @@ export interface RelayClientToServerEvents {
     childSessionId: string;
   }, ack?: (result: { ok: boolean; error?: string }) => void) => void;
 
+  /** Returns how many linked child sessions are still associated with this parent. */
+  get_linked_child_count: (data: {
+    token: string;
+  }, ack?: (result: { ok: boolean; count?: number; error?: string }) => void) => void;
+
   /** Parent requests delinking of all child sessions (e.g. on /new).
    *  The server clears child→parent links and notifies children their parent is gone. */
   delink_children: (data: {

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.test.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, mock, test } from "bun:test";
+import { countLinkedChildrenForParent } from "./child-lifecycle.js";
+
+describe("countLinkedChildrenForParent", () => {
+    test("returns the linked child count for a parent session", async () => {
+        const getChildSessions = mock(async (_parentSessionId: string) => ["child-1", "child-2", "child-3"]);
+
+        await expect(countLinkedChildrenForParent("parent-1", { getChildSessions })).resolves.toBe(3);
+        expect(getChildSessions).toHaveBeenCalledWith("parent-1");
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.test.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.test.ts
@@ -2,10 +2,73 @@ import { describe, expect, mock, test } from "bun:test";
 import { countLinkedChildrenForParent } from "./child-lifecycle.js";
 
 describe("countLinkedChildrenForParent", () => {
-    test("returns the linked child count for a parent session", async () => {
-        const getChildSessions = mock(async (_parentSessionId: string) => ["child-1", "child-2", "child-3"]);
+    test("returns count of live, linked children", async () => {
+        const getChildSessions = mock(async () => ["child-1", "child-2", "child-3"]);
+        const getSession = mock(async (id: string) => {
+            if (id === "child-1") return { parentSessionId: "parent-1" } as any;
+            if (id === "child-2") return { parentSessionId: "parent-1" } as any;
+            if (id === "child-3") return { parentSessionId: "parent-1" } as any;
+            return null;
+        });
 
-        await expect(countLinkedChildrenForParent("parent-1", { getChildSessions })).resolves.toBe(3);
+        const count = await countLinkedChildrenForParent("parent-1", { getChildSessions, getSession });
+        expect(count).toBe(3);
         expect(getChildSessions).toHaveBeenCalledWith("parent-1");
+    });
+
+    test("excludes children whose session hash is gone (ended)", async () => {
+        const getChildSessions = mock(async () => ["child-live", "child-dead"]);
+        const getSession = mock(async (id: string) => {
+            if (id === "child-live") return { parentSessionId: "parent-1" } as any;
+            return null; // child-dead has no session hash
+        });
+
+        const count = await countLinkedChildrenForParent("parent-1", { getChildSessions, getSession });
+        expect(count).toBe(1);
+    });
+
+    test("excludes children that point at a different parent", async () => {
+        const getChildSessions = mock(async () => ["child-mine", "child-stale"]);
+        const getSession = mock(async (id: string) => {
+            if (id === "child-mine") return { parentSessionId: "parent-1" } as any;
+            if (id === "child-stale") return { parentSessionId: "other-parent" } as any;
+            return null;
+        });
+
+        const count = await countLinkedChildrenForParent("parent-1", { getChildSessions, getSession });
+        expect(count).toBe(1);
+    });
+
+    test("counts children linked via linkedParentId", async () => {
+        const getChildSessions = mock(async () => ["child-1"]);
+        const getSession = mock(async () => ({
+            parentSessionId: null, // cleared during transient offline
+            linkedParentId: "parent-1",
+        }) as any);
+
+        const count = await countLinkedChildrenForParent("parent-1", { getChildSessions, getSession });
+        expect(count).toBe(1);
+    });
+
+    test("returns 0 when membership set is empty", async () => {
+        const getChildSessions = mock(async () => [] as string[]);
+        const getSession = mock(async () => null);
+
+        const count = await countLinkedChildrenForParent("parent-1", { getChildSessions, getSession });
+        expect(count).toBe(0);
+        // getSession should not be called at all when there are no children
+        expect(getSession).not.toHaveBeenCalled();
+    });
+
+    test("returns 0 when all children are stale (ended or re-linked)", async () => {
+        const getChildSessions = mock(async () => ["child-dead", "child-relinked"]);
+        const getSession = mock(async (id: string) => {
+            if (id === "child-dead") return null;
+            if (id === "child-relinked") return { parentSessionId: "different-parent" } as any;
+            return null;
+        });
+
+        const count = await countLinkedChildrenForParent("parent-1", { getChildSessions, getSession });
+        expect(count).toBe(0);
     });
 });

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
@@ -27,12 +27,40 @@ import { createLogger } from "@pizzapi/tools";
 
 const log = createLogger("sio/relay");
 
+/**
+ * Count only *live* linked children for a parent session.
+ *
+ * The Redis children set intentionally retains entries for disconnected or
+ * ended children (so delink_children can still reach them later).  For the
+ * auto-close decision we must not count those stale entries — only children
+ * whose session hash still exists AND still points at this parent.
+ */
 export async function countLinkedChildrenForParent(
     parentSessionId: string,
-    deps: { getChildSessions?: typeof getChildSessions } = {},
+    deps: {
+        getChildSessions?: typeof getChildSessions;
+        getSession?: typeof getSession;
+    } = {},
 ): Promise<number> {
-    const childIds = await (deps.getChildSessions ?? getChildSessions)(parentSessionId);
-    return childIds.length;
+    const _getChildSessions = deps.getChildSessions ?? getChildSessions;
+    const _getSession = deps.getSession ?? getSession;
+
+    const childIds = await _getChildSessions(parentSessionId);
+    if (childIds.length === 0) return 0;
+
+    // Check each child in parallel — only count those still alive and linked.
+    const checks = await Promise.all(
+        childIds.map(async (childId) => {
+            const session = await _getSession(childId);
+            if (!session) return false; // session hash gone — child already ended
+            // Child still linked if parentSessionId or linkedParentId points here.
+            return (
+                session.parentSessionId === parentSessionId ||
+                (session as any).linkedParentId === parentSessionId
+            );
+        }),
+    );
+    return checks.filter(Boolean).length;
 }
 
 export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIOServer): void {

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
@@ -27,7 +27,32 @@ import { createLogger } from "@pizzapi/tools";
 
 const log = createLogger("sio/relay");
 
+export async function countLinkedChildrenForParent(
+    parentSessionId: string,
+    deps: { getChildSessions?: typeof getChildSessions } = {},
+): Promise<number> {
+    const childIds = await (deps.getChildSessions ?? getChildSessions)(parentSessionId);
+    return childIds.length;
+}
+
 export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIOServer): void {
+    socket.on("get_linked_child_count", async (data, ack) => {
+        const sessionId = socket.data.sessionId;
+        if (!sessionId || data?.token !== socket.data.token) {
+            socket.emit("error", { message: "Invalid token" });
+            if (typeof ack === "function") ack({ ok: false, error: "Invalid token" });
+            return;
+        }
+
+        try {
+            const count = await countLinkedChildrenForParent(sessionId);
+            if (typeof ack === "function") ack({ ok: true, count });
+        } catch (err: any) {
+            log.error(`get_linked_child_count failed for parent=${sessionId}:`, err);
+            if (typeof ack === "function") ack({ ok: false, error: err?.message ?? "Internal error" });
+        }
+    });
+
     // ── cleanup_child_session — parent requests child teardown on ack ────
     socket.on("cleanup_child_session", async (data, ack) => {
         const sessionId = socket.data.sessionId;


### PR DESCRIPTION
## Summary
- prevent trigger auto-close sessions from shutting down while linked child sessions are still attached
- add a relay child-count query so the worker can prove there are no linked children before auto-closing
- cover the regression with auto-close and relay child-lifecycle tests

## Test Plan
- bun test packages/cli/src/extensions/remote/auto-close.test.ts packages/server/src/ws/namespaces/relay/child-lifecycle.test.ts
- bun run typecheck
