### PR TITLE
fix: gate stale-connection watchdog on agentActive

### DIFF
--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -344,27 +344,31 @@ describe("pi-ai patch application — Anthropic web search", () => {
     });
 });
 
-describe("pi-ai patch application — Claude Code credentials fallback", () => {
-    test("anthropic.js (oauth): tryReadClaudeCodeCredentials function is present", async () => {
+describe("pi-ai patch application — Claude Code credentials fallback (Keychain-first)", () => {
+    test("anthropic.js (oauth): tryReadClaudeCodeCredentials with Keychain + file fallback", async () => {
         const source = await Bun.file(
             piAiPath("dist/utils/oauth/anthropic.js"),
         ).text();
 
         expect(source).toContain("PATCH(pizzapi): read Claude Code credentials as a refresh fallback");
-        expect(source).toContain("tryReadClaudeCodeCredentials");
+        expect(source).toContain("async function tryReadClaudeCodeCredentials");
+        // Keychain path (macOS preferred)
+        expect(source).toContain("security find-generic-password");
+        expect(source).toContain("Claude Code-credentials");
+        // File fallback path
         expect(source).toContain(".claude");
         expect(source).toContain(".credentials.json");
         expect(source).toContain("claudeAiOauth");
     });
 
-    test("anthropic.js (oauth): refreshToken tries Claude Code credentials first", async () => {
+    test("anthropic.js (oauth): refreshToken awaits Claude Code credentials first", async () => {
         const source = await Bun.file(
             piAiPath("dist/utils/oauth/anthropic.js"),
         ).text();
 
         expect(source).toContain("PATCH(pizzapi): try Claude Code credentials first");
-        // Verify the fallback calls tryReadClaudeCodeCredentials before refreshAnthropicToken
-        const ccCredsIndex = source.indexOf("tryReadClaudeCodeCredentials()");
+        // Verify the fallback awaits tryReadClaudeCodeCredentials before refreshAnthropicToken
+        const ccCredsIndex = source.indexOf("await tryReadClaudeCodeCredentials()");
         const refreshIndex = source.indexOf("refreshAnthropicToken(credentials.refresh)");
         expect(ccCredsIndex).toBeGreaterThan(-1);
         expect(refreshIndex).toBeGreaterThan(-1);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -325,7 +325,11 @@ export function App() {
   );
   const setAgentActive = React.useCallback(
     (v: React.SetStateAction<boolean>) =>
-      setSessionState((p: SessionState) => ({ ...p, agentActive: typeof v === "function" ? v(p.agentActive) : v })),
+      setSessionState((p: SessionState) => {
+        const next = typeof v === "function" ? v(p.agentActive) : v;
+        agentActiveRef.current = next;
+        return { ...p, agentActive: next };
+      }),
     []
   );
   const setEffortLevel = React.useCallback(
@@ -692,6 +696,7 @@ export function App() {
   // Tracked as state so HubSocketContext consumers re-render when the socket changes.
   const [hubSocket, setHubSocket] = React.useState<Socket<HubServerToClientEvents, HubClientToServerEvents> | null>(null);
   const activeSessionRef = React.useRef<string | null>(null);
+  const agentActiveRef = React.useRef(false);
   const viewerSwitchGenerationRef = React.useRef(0);
 
   const checkVersionCompatibility = React.useCallback(async () => {
@@ -2854,9 +2859,12 @@ export function App() {
 
       // Stale-connection watchdog: if the socket thinks it's connected but
       // no event has arrived for STALE_THRESHOLD_MS, force a reconnect.
+      // Only armed when the agent is active — idle sessions produce no events,
+      // so silence is expected and not a sign of a broken connection.
       staleCheckTimerRef.current = setInterval(() => {
         if (!activeSessionRef.current) return;
         if (!nextSocket.connected) return;
+        if (!agentActiveRef.current) return;
         const elapsed = Date.now() - lastViewerEventAtRef.current;
         if (elapsed > STALE_THRESHOLD_MS) {
           log.warn(`Stale connection detected (${Math.round(elapsed / 1000)}s since last event). Reconnecting…`);

--- a/patches/@mariozechner%2Fpi-ai@0.63.1.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.63.1.patch
@@ -1,6 +1,12 @@
-diff --git a/node_modules/@mariozechner/pi-ai/.bun-tag-308425d7494b03d6 b/.bun-tag-308425d7494b03d6
+diff --git a/node_modules/.bun/@mariozechner+pi-ai@0.63.1+36935d20367572cb/node_modules/@mariozechner/pi-ai/.bun-tag-120806c42c5c8a1b b/.bun-tag-120806c42c5c8a1b
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/.bun/@mariozechner+pi-ai@0.63.1+36935d20367572cb/node_modules/@mariozechner/pi-ai/.bun-tag-308425d7494b03d6 b/.bun-tag-308425d7494b03d6
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/dist/cli.js b/dist/cli.js
+old mode 100644
+new mode 100755
 diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
 index d4fc29b8c97264ae51b212bdf69b29f7e8001ad1..b24a943c5bb06f521c629bbe93c8ea2eb295b7c5 100644
 --- a/dist/providers/anthropic.js
@@ -130,32 +136,44 @@ index d4fc29b8c97264ae51b212bdf69b29f7e8001ad1..b24a943c5bb06f521c629bbe93c8ea2e
          return {
              name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
 diff --git a/dist/utils/oauth/anthropic.js b/dist/utils/oauth/anthropic.js
-index ba615d91cf0f91fe23c82c206e4397dd643f202f..50d8566b5c210063460d99165c88c16bde0b89d2 100644
+index ba615d91cf0f91fe23c82c206e4397dd643f202f..5189048fab951abb4c956c3cf0d7068a83d0b88f 100644
 --- a/dist/utils/oauth/anthropic.js
 +++ b/dist/utils/oauth/anthropic.js
-@@ -313,6 +313,32 @@ export async function refreshAnthropicToken(refreshToken) {
+@@ -313,6 +313,44 @@ export async function refreshAnthropicToken(refreshToken) {
          expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
      };
  }
 +// PATCH(pizzapi): read Claude Code credentials as a refresh fallback.
-+// If the user has Claude Code installed and authenticated, we can reuse
-+// its already-refreshed OAuth token instead of hitting the refresh endpoint,
-+// which avoids unnecessary round-trips and works even when the stored
-+// refresh_token has expired as long as Claude Code's session is still live.
-+function tryReadClaudeCodeCredentials() {
++// Prefer the macOS Keychain item first; if that isn't available, fall back to
++// `~/.claude/.credentials.json` for older installs.
++async function tryReadClaudeCodeCredentials() {
 +    try {
-+        const { readFileSync } = require("fs");
-+        const { join } = require("path");
-+        const { homedir } = require("os");
-+        const credPath = join(homedir(), ".claude", ".credentials.json");
-+        const creds = JSON.parse(readFileSync(credPath, "utf-8"));
-+        const cc = creds?.claudeAiOauth;
-+        if (cc && cc.accessToken && cc.expiresAt > Date.now() + 60000) {
-+            return {
-+                refresh: cc.refreshToken,
-+                access: cc.accessToken,
-+                expires: cc.expiresAt,
-+            };
++        if (process.platform === "darwin") {
++            const { execSync } = await import("node:child_process");
++            const raw = execSync(
++                `security find-generic-password -s ${JSON.stringify("Claude Code-credentials")} -w`,
++                { encoding: "utf-8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
++            ).trim();
++            if (raw) {
++                const cc = JSON.parse(raw)?.claudeAiOauth;
++                if (cc?.accessToken && cc?.refreshToken && cc.expiresAt > Date.now() + 60000) {
++                    return { refresh: cc.refreshToken, access: cc.accessToken, expires: cc.expiresAt };
++                }
++            }
++        }
++    }
++    catch {
++        // Missing entry, locked keychain, timeout, or invalid JSON — fall through.
++    }
++    try {
++        const [{ readFileSync }, { join }, { homedir }] = await Promise.all([
++            import("node:fs"),
++            import("node:path"),
++            import("node:os"),
++        ]);
++        const cc = JSON.parse(readFileSync(join(homedir(), ".claude", ".credentials.json"), "utf-8"))?.claudeAiOauth;
++        if (cc?.accessToken && cc?.refreshToken && cc.expiresAt > Date.now() + 60000) {
++            return { refresh: cc.refreshToken, access: cc.accessToken, expires: cc.expiresAt };
 +        }
 +    }
 +    catch {
@@ -166,12 +184,12 @@ index ba615d91cf0f91fe23c82c206e4397dd643f202f..50d8566b5c210063460d99165c88c16b
  export const anthropicOAuthProvider = {
      id: "anthropic",
      name: "Anthropic (Claude Pro/Max)",
-@@ -326,6 +352,11 @@ export const anthropicOAuthProvider = {
+@@ -326,6 +364,11 @@ export const anthropicOAuthProvider = {
          });
      },
      async refreshToken(credentials) {
 +        // PATCH(pizzapi): try Claude Code credentials first
-+        const ccCreds = tryReadClaudeCodeCredentials();
++        const ccCreds = await tryReadClaudeCodeCredentials();
 +        if (ccCreds) {
 +            return ccCreds;
 +        }

--- a/patches/README.md
+++ b/patches/README.md
@@ -39,12 +39,13 @@ on top.
 Same web search changes as 0.58.3 (see below), ported forward, plus one new
 patch:
 
-- **Claude Code credentials fallback:** When refreshing an expired Anthropic
-  OAuth token, the patch first checks `~/.claude/.credentials.json` for a
-  valid, pre-refreshed token from Claude Code. If found (and not expiring
-  within 60 seconds), it's returned directly — avoiding an API round-trip to
-  `platform.claude.com/v1/oauth/token`. Falls through to the normal refresh
-  flow if Claude Code isn't installed or its credentials are stale.
+- **Claude Code credentials fallback (Keychain-first):** When refreshing an
+  expired Anthropic OAuth token, the patch first reads the macOS Keychain
+  item `Claude Code-credentials` via `security find-generic-password`. If
+  the token is valid (and not expiring within 60 seconds), it's returned
+  directly — avoiding an API round-trip to `platform.claude.com/v1/oauth/token`.
+  If the Keychain entry is unavailable (non-macOS, locked keychain, missing
+  entry), the patch falls back to reading `~/.claude/.credentials.json`.
 
 **What it changes:**
 
@@ -54,7 +55,7 @@ patch:
 | `dist/providers/anthropic.js` — `buildParams()` | Inject `web_search_20250305` tool when `PIZZAPI_WEB_SEARCH` env var is set |
 | `dist/providers/anthropic.js` — stream handler | Handle `server_tool_use` and `web_search_tool_result` blocks |
 | `dist/providers/anthropic.js` — `convertMessages()` | Round-trip `_serverToolUse` and `_webSearchResult` blocks |
-| `dist/utils/oauth/anthropic.js` — `anthropicOAuthProvider.refreshToken()` | Try Claude Code credentials (`~/.claude/.credentials.json`) before API refresh |
+| `dist/utils/oauth/anthropic.js` — `anthropicOAuthProvider.refreshToken()` | Try Claude Code Keychain (`security find-generic-password`) first, then `~/.claude/.credentials.json`, before API refresh |
 
 ## @mariozechner/pi-coding-agent@0.58.3
 


### PR DESCRIPTION
## Problem

The viewer's stale-connection watchdog (`STALE_THRESHOLD_MS = 45s`) assumes "no events = broken connection." But for idle sessions (agent not running), silence is normal — no events flow through the `/viewer` socket.

This caused a reconnect loop:
1. Viewer connects → snapshot hydration for all watched sessions
2. Sessions are idle → no events for 45s
3. Watchdog fires → `disconnect()` + `connect()`
4. Full reconnection cycle with snapshot rehydration across all runners
5. Repeat every ~60s indefinitely

Each cycle involves multiple Redis round trips per session (service_announce lookups, snapshot provider fallback chain, meta room subscriptions), creating unnecessary server load and a visible UI hang.

## Fix

Gate the watchdog on `agentActiveRef` — only check for stale connections when the agent is actively running and events are expected. When idle, socket.io's built-in ping/pong (`pingInterval: 30s`, `pingTimeout: 60s`) already handles transport-level liveness detection.

## Changes

- Added `agentActiveRef` (kept in sync via `setAgentActive`)
- Added `if (!agentActiveRef.current) return` guard in the stale check interval