### PR TITLE
fix: implement real newSession/switchSession in headless worker

### DIFF
--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -328,11 +328,141 @@ async function main(): Promise<void> {
     await session.bindExtensions({
         commandContextActions: {
             waitForIdle: () => session.agent.waitForIdle(),
-            // Headless runner sessions don't switch/fork — return cancelled for all
-            newSession: async () => ({ cancelled: true }),
+
+            newSession: async () => {
+                const extensionRunner = session.extensionRunner;
+                const previousSessionFile = session.sessionFile;
+
+                // Let extensions cancel the switch (e.g. unsaved work)
+                if (extensionRunner?.hasHandlers("session_before_switch")) {
+                    const result = await extensionRunner.emit({
+                        type: "session_before_switch",
+                        reason: "new",
+                    });
+                    if ((result as any)?.cancel) {
+                        return { cancelled: true };
+                    }
+                }
+
+                // Stop any running agent turn
+                await session.abort();
+
+                // Reset agent transcript, queues, and runtime flags
+                session.agent.reset();
+
+                // Create a fresh session file
+                session.sessionManager.newSession();
+                session.agent.sessionId = session.sessionManager.getSessionId();
+
+                // Clear AgentSession's private tracking queues so stale steering/
+                // follow-up messages from the old conversation don't leak through.
+                (session as any)._steeringMessages = [];
+                (session as any)._followUpMessages = [];
+                (session as any)._pendingNextTurnMessages = [];
+                (session as any)._lastAssistantMessage = undefined;
+                (session as any)._overflowRecoveryAttempted = false;
+
+                // Persist the current thinking level in the new session header
+                session.sessionManager.appendThinkingLevelChange(session.thinkingLevel);
+
+                // Notify extensions — the remote extension's session_switch handler
+                // cancels pending triggers, delinks children, and pushes the new
+                // (empty) conversation to the web UI via session_active.
+                // NOTE: "session_switch" was removed from the upstream type union in
+                // 0.66.1, but PizzaPi's remote extension still registers a runtime
+                // handler for it. The cast is safe — emit() dispatches by string key.
+                if (extensionRunner) {
+                    await extensionRunner.emit({
+                        type: "session_switch" as any,
+                        reason: "new",
+                        previousSessionFile,
+                    });
+                }
+
+                logInfo("new session created (in-place)");
+                return { cancelled: false };
+            },
+
+            switchSession: async (sessionPath: string) => {
+                const extensionRunner = session.extensionRunner;
+                const previousSessionFile = session.sessionFile;
+
+                // Let extensions cancel
+                if (extensionRunner?.hasHandlers("session_before_switch")) {
+                    const result = await extensionRunner.emit({
+                        type: "session_before_switch",
+                        reason: "resume",
+                        targetSessionFile: sessionPath,
+                    });
+                    if ((result as any)?.cancel) {
+                        return { cancelled: true };
+                    }
+                }
+
+                await session.abort();
+
+                // Clear AgentSession queues
+                (session as any)._steeringMessages = [];
+                (session as any)._followUpMessages = [];
+                (session as any)._pendingNextTurnMessages = [];
+                (session as any)._lastAssistantMessage = undefined;
+                (session as any)._overflowRecoveryAttempted = false;
+
+                // Load the target session file into the existing SessionManager
+                session.sessionManager.setSessionFile(sessionPath);
+                session.agent.sessionId = session.sessionManager.getSessionId();
+
+                // Rebuild messages from the target session
+                const sessionContext = session.sessionManager.buildSessionContext();
+
+                // Notify extensions before we replace messages — the remote
+                // extension's session_switch handler emits session_active which
+                // reads from the (now updated) sessionManager.
+                // NOTE: see newSession comment for why this uses `as any`.
+                if (extensionRunner) {
+                    await extensionRunner.emit({
+                        type: "session_switch" as any,
+                        reason: "resume",
+                        previousSessionFile,
+                    });
+                }
+
+                // Restore the conversation transcript
+                session.agent.state.messages = sessionContext.messages;
+
+                // Restore model if the session had one saved
+                if (sessionContext.model) {
+                    const modelRegistry = (session as any)._modelRegistry;
+                    if (modelRegistry) {
+                        try {
+                            const available = await modelRegistry.getAvailable();
+                            const match = available.find(
+                                (m: any) =>
+                                    m.provider === sessionContext.model!.provider &&
+                                    m.id === sessionContext.model!.modelId,
+                            );
+                            if (match) {
+                                await session.setModel(match);
+                            }
+                        } catch {
+                            // Model restore is best-effort
+                        }
+                    }
+                }
+
+                // Restore thinking level if saved
+                if (sessionContext.thinkingLevel) {
+                    session.setThinkingLevel(sessionContext.thinkingLevel as any);
+                }
+
+                logInfo(`switched to session ${sessionPath}`);
+                return { cancelled: false };
+            },
+
+            // Fork and tree navigation are not supported in headless mode
             fork: async () => ({ cancelled: true }),
             navigateTree: async () => ({ cancelled: true }),
-            switchSession: async () => ({ cancelled: true }),
+
             reload: async () => {
                 await session.reload();
             },


### PR DESCRIPTION
## Problem

Clicking **New Session** in the web UI shows the error "New session was cancelled". Same for **Resume** ("Resume was cancelled").

## Root Cause

In `packages/cli/src/runner/worker.ts`, the `commandContextActions` for `newSession` and `switchSession` were hardcoded stubs that **always** returned `{ cancelled: true }`:

```ts
// Headless runner sessions don't switch/fork — return cancelled for all
newSession: async () => ({ cancelled: true }),
switchSession: async () => ({ cancelled: true }),
```

Call chain when the web UI clicks **New Session**:

1. Web UI → `new_session` remote command
2. `remote-exec-handler.ts` calls `pi.newSession()`
3. Patched `createExtensionAPI` delegates to `runtime.newSession()`
4. Patched `bindCommandContext` routes to `newSessionHandler`
5. `newSessionHandler` = the stub → `{ cancelled: true }`
6. Exec handler replies with error **"New session was cancelled"**

The comment in the worker ("Headless runner sessions don't switch/fork") was outdated — the web UI absolutely needs this capability.

## Fix

Replace both stubs with real implementations that mirror what `AgentSession.newSession()`/`switchSession()` did before they were moved to `AgentSessionRuntime` in upstream 0.66.1. The worker doesn't use `AgentSessionRuntime`, so the logic is implemented inline.

### `newSession`

- Emits `session_before_switch` (extensions can cancel)
- `session.abort()` → stops in-flight agent turn
- `session.agent.reset()` → clears transcript/queues/runtime flags
- `sessionManager.newSession()` → fresh session file
- Updates `agent.sessionId`
- Clears `AgentSession` private queues (`_steeringMessages`, `_followUpMessages`, `_pendingNextTurnMessages`, `_lastAssistantMessage`, `_overflowRecoveryAttempted`) to prevent state leaks between sessions
- Records thinking level in the new session header
- Emits `session_switch` with reason `"new"` — the remote extension's handler cancels pending triggers, delinks children, and pushes the empty conversation to the web UI via `session_active`

### `switchSession`

- Emits `session_before_switch` with `reason: "resume"`
- Aborts agent, clears private queues
- `sessionManager.setSessionFile(path)` loads target session entries
- Rebuilds messages via `sessionManager.buildSessionContext()`
- Emits `session_switch` with reason `"resume"`
- Replaces `agent.state.messages` with rebuilt transcript
- Restores model (best-effort lookup in `modelRegistry`) and thinking level

### Preserved

- `fork` and `navigateTree` remain stubbed — not needed in headless mode
- The relay connection and extension instances are **preserved** (operations are in-place, no dispose/recreate), so the relay session ID stays stable

## Notes

- The `"session_switch"` event was removed from the upstream type union in 0.66.1, but PizzaPi's remote extension in `lifecycle-handlers.ts` still registers a runtime handler for it. The cast to `any` on the event type is safe — `emit()` dispatches by string key.
- The exec handler's existing `rctx.emitSessionActive()` call after `replyOk()` becomes redundant (the `session_switch` handler already emits it), but re-emitting is harmless.

## Verification

- `bun run typecheck` ✓
- `bun run build` ✓
- `bun run test` — 941 pass, 0 fail