### PR TITLE
fix(ui): stop hidden dock tabs from relayouting on resize

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4107,6 +4107,7 @@ export function App() {
     icon: <TerminalIcon className="size-3.5" />,
     onClose: () => setShowTerminal(false),
     onDragStart: (e) => startPanelDragWith(e, handleTerminalPositionChange),
+    keepMountedWhenInactive: true,
     content: (
       <TerminalManager
         className="h-full"

--- a/packages/ui/src/components/CombinedPanel.test.tsx
+++ b/packages/ui/src/components/CombinedPanel.test.tsx
@@ -65,7 +65,7 @@ describe("CombinedPanel", () => {
     expect(closed).toBe(1);
   });
 
-  test("renders only the active tab content", () => {
+  test("renders only the active tab content by default", () => {
     const { container, rerender } = render(
       <CombinedPanel
         tabs={[
@@ -95,5 +95,64 @@ describe("CombinedPanel", () => {
 
     expect(container.textContent).not.toContain("Terminal content");
     expect(container.textContent).toContain("Files content");
+  });
+
+  test("can keep specific inactive tabs mounted", () => {
+    const { container, rerender } = render(
+      <CombinedPanel
+        tabs={[
+          {
+            id: "terminal",
+            label: "Terminal",
+            icon: <span>T</span>,
+            keepMountedWhenInactive: true,
+            content: <div>Terminal content</div>,
+          },
+          { id: "files", label: "Files", icon: <span>F</span>, content: <div>Files content</div> },
+          { id: "git", label: "Git", icon: <span>G</span>, content: <div>Git content</div> },
+        ]}
+        activeTabId="files"
+        onActiveTabChange={() => {}}
+        position="center-bottom"
+      />,
+    );
+
+    expect(container.textContent).toContain("Terminal content");
+    expect(container.textContent).toContain("Files content");
+    expect(container.textContent).not.toContain("Git content");
+
+    const layers = Array.from(container.getElementsByTagName("div")).filter((el) => {
+      const className = (el as HTMLElement).className ?? "";
+      return className.includes("absolute") && className.includes("inset-0");
+    }) as HTMLElement[];
+    const hiddenLayer = layers.find((el) => el.textContent?.includes("Terminal content"));
+    const activeLayer = layers.find((el) => el.textContent?.includes("Files content"));
+    expect(hiddenLayer?.className).toContain("hidden");
+    expect(hiddenLayer?.getAttribute("aria-hidden")).toBe("true");
+    expect(activeLayer?.className).not.toContain("hidden");
+    expect(activeLayer?.getAttribute("aria-hidden")).toBe("false");
+
+    rerender(
+      <CombinedPanel
+        tabs={[
+          {
+            id: "terminal",
+            label: "Terminal",
+            icon: <span>T</span>,
+            keepMountedWhenInactive: true,
+            content: <div>Terminal content</div>,
+          },
+          { id: "files", label: "Files", icon: <span>F</span>, content: <div>Files content</div> },
+          { id: "git", label: "Git", icon: <span>G</span>, content: <div>Git content</div> },
+        ]}
+        activeTabId="terminal"
+        onActiveTabChange={() => {}}
+        position="center-bottom"
+      />,
+    );
+
+    expect(container.textContent).toContain("Terminal content");
+    expect(container.textContent).not.toContain("Files content");
+    expect(container.textContent).not.toContain("Git content");
   });
 });

--- a/packages/ui/src/components/CombinedPanel.test.tsx
+++ b/packages/ui/src/components/CombinedPanel.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, describe, test, expect } from "bun:test";
+import { afterAll, afterEach, describe, test, expect, mock } from "bun:test";
 import { Window } from "happy-dom";
 import { render, fireEvent, cleanup } from "@testing-library/react";
 import React from "react";
@@ -18,7 +18,13 @@ const win = new Window({ url: "http://localhost/" });
 (globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
+mock.module("@/lib/utils", () => ({
+  cn: (...classes: (string | undefined | null | false)[]) => classes.filter(Boolean).join(" "),
+}));
+
 const { CombinedPanel } = await import("./CombinedPanel");
+
+afterAll(() => mock.restore());
 
 afterEach(() => {
   cleanup();
@@ -44,7 +50,7 @@ describe("CombinedPanel", () => {
         ]}
         activeTabId="tunnels"
         onActiveTabChange={() => {}}
-        position="right"
+        position="right-middle"
       />,
     );
 
@@ -57,5 +63,37 @@ describe("CombinedPanel", () => {
     fireEvent.click(closeButton!);
 
     expect(closed).toBe(1);
+  });
+
+  test("renders only the active tab content", () => {
+    const { container, rerender } = render(
+      <CombinedPanel
+        tabs={[
+          { id: "terminal", label: "Terminal", icon: <span>T</span>, content: <div>Terminal content</div> },
+          { id: "files", label: "Files", icon: <span>F</span>, content: <div>Files content</div> },
+        ]}
+        activeTabId="terminal"
+        onActiveTabChange={() => {}}
+        position="center-bottom"
+      />,
+    );
+
+    expect(container.textContent).toContain("Terminal content");
+    expect(container.textContent).not.toContain("Files content");
+
+    rerender(
+      <CombinedPanel
+        tabs={[
+          { id: "terminal", label: "Terminal", icon: <span>T</span>, content: <div>Terminal content</div> },
+          { id: "files", label: "Files", icon: <span>F</span>, content: <div>Files content</div> },
+        ]}
+        activeTabId="files"
+        onActiveTabChange={() => {}}
+        position="center-bottom"
+      />,
+    );
+
+    expect(container.textContent).not.toContain("Terminal content");
+    expect(container.textContent).toContain("Files content");
   });
 });

--- a/packages/ui/src/components/CombinedPanel.tsx
+++ b/packages/ui/src/components/CombinedPanel.tsx
@@ -229,6 +229,8 @@ export interface CombinedPanelTab {
   onClose?: () => void;
   /** When provided, dragging the tab triggers panel repositioning instead of tab switching */
   onDragStart?: (e: React.PointerEvent) => void;
+  /** Keep this tab mounted even while inactive (e.g. to preserve terminal connections). */
+  keepMountedWhenInactive?: boolean;
   content: React.ReactNode;
 }
 
@@ -265,6 +267,7 @@ export function CombinedPanel({
   } | null>(null);
 
   const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0] ?? null;
+  const mountedTabs = tabs.filter((tab) => tab.id === activeTab?.id || tab.keepMountedWhenInactive);
 
   return (
     <div className={cn("flex flex-col bg-background text-foreground", className)}>
@@ -362,14 +365,22 @@ export function CombinedPanel({
         </div>
       </div>
 
-      {/* Content — only the active panel stays mounted so hidden tabs do not
-          continue reacting to viewport/layout changes (e.g. DevTools resize). */}
+      {/* Content — inactive panels unmount by default so hidden tabs do not
+          continue reacting to viewport/layout changes (e.g. DevTools resize).
+          Specific tabs can opt into staying mounted while hidden. */}
       <div className="flex-1 min-h-0 relative">
-        {activeTab && (
-          <div key={activeTab.id} className="absolute inset-0">
-            {activeTab.content}
-          </div>
-        )}
+        {mountedTabs.map((tab) => {
+          const isActive = tab.id === activeTab?.id;
+          return (
+            <div
+              key={tab.id}
+              className={cn("absolute inset-0", !isActive && "hidden")}
+              aria-hidden={!isActive}
+            >
+              {tab.content}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/packages/ui/src/components/CombinedPanel.tsx
+++ b/packages/ui/src/components/CombinedPanel.tsx
@@ -264,7 +264,7 @@ export function CombinedPanel({
     activated: boolean;
   } | null>(null);
 
-  const activeTab = tabs.find((t) => t.id === activeTabId);
+  const activeTab = tabs.find((t) => t.id === activeTabId) ?? tabs[0] ?? null;
 
   return (
     <div className={cn("flex flex-col bg-background text-foreground", className)}>
@@ -362,19 +362,14 @@ export function CombinedPanel({
         </div>
       </div>
 
-      {/* Content — all panels stay mounted, only active one is visible */}
+      {/* Content — only the active panel stays mounted so hidden tabs do not
+          continue reacting to viewport/layout changes (e.g. DevTools resize). */}
       <div className="flex-1 min-h-0 relative">
-        {tabs.map((tab) => (
-          <div
-            key={tab.id}
-            className={cn(
-              "absolute inset-0",
-              activeTabId === tab.id ? "z-10 visible" : "z-0 invisible",
-            )}
-          >
-            {tab.content}
+        {activeTab && (
+          <div key={activeTab.id} className="absolute inset-0">
+            {activeTab.content}
           </div>
-        ))}
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- unmount inactive `CombinedPanel` tab content instead of keeping hidden panels mounted
- prevent hidden dock panels from reacting to browser DevTools viewport/layout changes
- add regression coverage that only the active tab content is present in the DOM

## Test Plan
- bun test packages/ui/src/components/DockedPanelGroup.test.tsx packages/ui/src/components/CombinedPanel.test.tsx
- bun test packages/ui
- bun run typecheck