### PR TITLE
Harden linked child orchestration

### DIFF
--- a/packages/cli/src/config/system-prompt.test.ts
+++ b/packages/cli/src/config/system-prompt.test.ts
@@ -103,6 +103,14 @@ describe("buildSystemPrompt", () => {
         expect(result).toContain("list_available_sigils");
     });
 
+    test("describes spawn_session as linked-only and does not teach message-bus opt-out", () => {
+        const result = buildSystemPrompt({ isRunner: true });
+        expect(result).toContain("Spawned sessions are automatically linked to you as children");
+        expect(result).not.toContain("linked: false");
+        expect(result).not.toContain("wait_for_message");
+        expect(result).not.toContain("send_message");
+    });
+
     test("describes id-based trigger CRUD for multi-subscription support", () => {
         const result = buildSystemPrompt({ isRunner: true });
         expect(result).toContain("subscriptionId");

--- a/packages/cli/src/config/templates/system-prompt.hbs
+++ b/packages/cli/src/config/templates/system-prompt.hbs
@@ -1,8 +1,6 @@
 {{#if isRunner}}
 <section name="spawning-sessions">
-Use the `spawn_session` tool to spawn long-running agent sessions (e.g., tasks that run in the background). Spawned sessions are automatically linked to you as children. Child session events (questions, plans, completion) are delivered as trigger messages in your conversation. No manual session ID plumbing needed — linking is automatic. Triggers arrive automatically as injected messages in your conversation — do NOT poll or wait for them. Do NOT stall your conversation with `sleep` loops or idle waits while a child is running. Simply stop responding — your session will automatically resume when the child's trigger arrives.
-
-<topic name="opting-out">Pass `linked: false` to `spawn_session` when you plan to communicate with the child via `send_message`/`wait_for_message` instead of triggers. This prevents redundant `session_complete` triggers from arriving after you've already consumed the child's output via messages.</topic>
+Use the `spawn_session` tool to spawn long-running agent sessions (e.g., tasks that run in the background). Spawned sessions are automatically linked to you as children — linked parent/child orchestration is the only supported spawn model. Child session events (questions, plans, completion) are delivered as trigger messages in your conversation. No manual session ID plumbing needed — linking is automatic. Triggers arrive automatically as injected messages in your conversation. Do NOT poll, busy-wait, or use shell `sleep` to wait for children. Simply stop responding — your session will automatically resume when the child's trigger arrives.
 
 <topic name="handling-child-triggers">
 - Trigger messages arrive with a `&lt;!-- trigger:ID --&gt;` metadata prefix in your conversation.
@@ -11,6 +9,7 @@ Use the `spawn_session` tool to spawn long-running agent sessions (e.g., tasks t
 - <important>`ack` terminates the child — use with care: `action: "ack"` on a `session_complete` trigger is NOT a passive acknowledgement. It emits a `cleanup_child_session` request to the relay, which sends SIGTERM to the child process and tears down its relay session. Only use `ack` when the child has truly finished all of its work and should be shut down. If the child's output indicates it is still working ("dispatching workers", "waiting for results", "running sub-tasks"), do NOT call `respond_to_trigger` yet — the child will continue and send another trigger when it is actually done. Calling `ack` on an intermediate `session_complete` trigger will prematurely kill the child.</important>
 - Use `escalate_trigger(triggerId)` to pass a trigger to the human viewer if you can't handle it.
 - Use `tell_child(sessionId, message)` to proactively send a message or instruction to a child session.
+- If a linked parent/child relationship is broken after reconnect, treat that as an orchestration failure — do not silently fall back to ad-hoc peer messaging.
 </topic>
 </section>
 {{/if}}

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -9,7 +9,6 @@ import { mcpExtension } from "./mcp-extension.js";
 import { remoteExtension } from "./remote.js";
 import { restartExtension } from "./restart.js";
 
-import { sessionMessagingExtension } from "./session-messaging.js";
 import { setSessionNameExtension } from "./set-session-name.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
@@ -33,7 +32,6 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     setSessionNameExtension,
     updateTodoExtension,
     spawnSessionExtension,
-    sessionMessagingExtension,
     subagentExtension,
     planModeToggleExtension,
     sandboxEventsExtension,

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -6,7 +6,6 @@ import { mcpExtension } from "./mcp-extension.js";
 import { remoteExtension } from "./remote.js";
 import { restartExtension } from "./restart.js";
 
-import { sessionMessagingExtension } from "./session-messaging.js";
 import { setSessionNameExtension } from "./set-session-name.js";
 import { spawnSessionExtension } from "./spawn-session.js";
 import { updateTodoExtension } from "./update-todo.js";
@@ -66,7 +65,6 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
         named(setSessionNameExtension, "session-name"),
         named(updateTodoExtension, "todo"),
         named(spawnSessionExtension, "spawn-session"),
-        named(sessionMessagingExtension, "messaging"),
         named(subagentExtension, "subagent"),
         named(planModeToggleExtension, "plan-mode"),
         named(sandboxEventsExtension, "sandbox"),

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -21,7 +21,7 @@ import { cancelPendingPlanMode, consumePendingPlanModeFromWeb } from "../remote-
 import { normalizeRemoteInputAttachments, buildUserMessageFromRemoteInput } from "../remote-input.js";
 import { handleExecFromWeb } from "../remote-exec-handler.js";
 import { renderTrigger, renderTriggerBatch } from "../triggers/registry.js";
-import { trackReceivedTrigger, receivedTriggers } from "../triggers/extension.js";
+import { trackReceivedTrigger, receivedTriggers, sendTriggerResponseWithAck } from "../triggers/extension.js";
 import type { ConversationTrigger } from "../triggers/types.js";
 import type { RelayContext } from "../remote-types.js";
 import { emitSessionActive } from "./chunked-delivery.js";
@@ -503,14 +503,22 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
             return;
         }
 
-        rctx.sioSocket.emit("trigger_response" as any, {
-            token: rctx.relay.token,
+        void sendTriggerResponseWithAck({ socket: rctx.sioSocket, token: rctx.relay.token }, {
             triggerId: data.triggerId,
             response: data.response,
-            ...(data.action ? { action: data.action } : {}),
+            action: data.action,
             targetSessionId: pending.sourceSessionId,
+        }).then((result) => {
+            if (result.ok) {
+                receivedTriggers.delete(data.triggerId);
+                return;
+            }
+            log.info(`pizzapi: failed to deliver trigger response ${data.triggerId}: ${result.error ?? "unknown error"}`);
+            rctx.latestCtx?.ui.notify(
+                `⚠ Failed to deliver trigger response ${data.triggerId}: ${result.error ?? "unknown error"}\n` +
+                "The linked parent/child relationship may be broken or stale. The trigger has been kept so it can be retried or escalated.",
+            );
         });
-        receivedTriggers.delete(data.triggerId);
     });
 
     sock.on("session_expired", (_data: any) => {

--- a/packages/cli/src/extensions/spawn-session.ts
+++ b/packages/cli/src/extensions/spawn-session.ts
@@ -61,10 +61,10 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
         name: "spawn_session",
         label: "Spawn Session",
         description:
-            "Spawn a new independent agent session on the runner. The new session runs in " +
-            "parallel and can be monitored through the PizzaPi web UI. Use this to delegate " +
-            "work to a separate agent session, optionally specifying a model and working directory. " +
-            "Returns the session ID and share URL of the spawned session.",
+            "Spawn a new independent linked child session on the runner. The new session runs in " +
+            "parallel and can be monitored through the PizzaPi web UI. Child questions, plans, errors, " +
+            "and completion flow back to the parent as triggers. Use this to delegate work to a separate " +
+            "agent session, optionally specifying a model and working directory. Returns the session ID and share URL of the spawned session.",
         parameters: {
             type: "object",
             properties: {
@@ -94,14 +94,6 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
                     description:
                         "Working directory for the new session. Defaults to the current session's working directory.",
                 },
-                linked: {
-                    type: "boolean",
-                    description:
-                        "Whether to auto-link the new session as a child (enables triggers like session_complete, " +
-                        "plan_review, ask_user_question). Defaults to true. Set to false when using send_message/" +
-                        "wait_for_message for communication instead of triggers — this avoids redundant session_complete " +
-                        "triggers arriving after you've already consumed the child's output via messages.",
-                },
                 runnerId: {
                     type: "string",
                     description:
@@ -116,7 +108,6 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
                 prompt: string;
                 model?: { provider: string; id: string };
                 cwd?: string;
-                linked?: boolean;
                 runnerId?: string;
             };
 
@@ -155,18 +146,18 @@ export const spawnSessionExtension: ExtensionFactory = (pi) => {
                 prompt,
             };
 
-            // Automatically link parent→child sessions for the trigger system
-            // unless the caller explicitly opted out with linked: false.
+            // Linked parent→child orchestration is mandatory.
             // Prefer the relay session ID (available for both runner-spawned and
             // standalone CLI sessions) over the env var, which is only set for
             // runner-spawned workers.
-            const linked = params.linked !== false; // default true
-            if (linked) {
-                const ownSessionId = getRelaySessionId();
-                if (ownSessionId) {
-                    body.parentSessionId = ownSessionId;
-                }
+            const ownSessionId = getRelaySessionId();
+            if (!ownSessionId) {
+                return ok(
+                    "Error: This session is not registered with the relay yet, so a linked child relationship cannot be established. Reconnect to the relay and retry.",
+                    { error: "No linked parent session available" },
+                );
             }
+            body.parentSessionId = ownSessionId;
 
             if (params.model) {
                 // Note: hidden-model enforcement is done server-side (runners.ts).

--- a/packages/cli/src/extensions/triggers/extension.test.ts
+++ b/packages/cli/src/extensions/triggers/extension.test.ts
@@ -7,26 +7,34 @@
 // ============================================================================
 
 import { describe, it, expect, beforeEach } from "bun:test";
-import { trackReceivedTrigger, receivedTriggers } from "./extension.js";
+import { trackReceivedTrigger, receivedTriggers, sendTriggerResponseWithAck } from "./extension.js";
 
 interface EmittedEvent {
     event: string;
     data: unknown;
 }
 
-function createMockSocket(opts?: { failSessionMessage?: boolean }) {
+function createMockSocket(opts?: { failSessionMessage?: boolean; failTriggerResponse?: boolean }) {
     const emitted: EmittedEvent[] = [];
     const listeners = new Map<string, ((...args: any[]) => void)[]>();
 
     return {
         emitted,
         socket: {
-            emit(event: string, data: any) {
+            emit(event: string, data: any, ack?: (result: { ok: boolean; error?: string }) => void) {
                 emitted.push({ event, data });
                 if (event === "session_message" && opts?.failSessionMessage) {
                     for (const handler of listeners.get("session_message_error") ?? []) {
                         handler({ targetSessionId: data.targetSessionId, error: "Target session not found or not connected" });
                     }
+                }
+                if (event === "trigger_response" && ack) {
+                    ack(opts?.failTriggerResponse
+                        ? { ok: false, error: "Sender is not the parent of the target session (linked relationship is broken or stale)" }
+                        : { ok: true });
+                }
+                if (event === "cleanup_child_session" && ack) {
+                    ack({ ok: true });
                 }
             },
             on(event: string, handler: (...args: any[]) => void) {
@@ -97,13 +105,15 @@ async function simulateRespondToTrigger(
         return { text: `Acknowledged session completion from ${pending.sourceSessionId}` };
     }
 
-    conn.socket.emit("trigger_response", {
-        token: conn.token,
+    const result = await sendTriggerResponseWithAck(conn as any, {
         triggerId: params.triggerId,
         response: params.response,
-        ...(params.action ? { action: params.action } : {}),
+        action: params.action,
         targetSessionId: pending.sourceSessionId,
     });
+    if (!result.ok) {
+        return { text: `Failed to deliver response for trigger ${params.triggerId}: ${result.error ?? "unknown error"}` };
+    }
     receivedTriggers.delete(params.triggerId);
     return { text: `Response sent for trigger ${params.triggerId}` };
 }
@@ -207,6 +217,19 @@ describe("respond_to_trigger handling for session_complete", () => {
             action: "approve",
             targetSessionId: "child-plan",
         });
+    });
+
+    it("non-session_complete preserves trigger when relay rejects delivery", async () => {
+        const conn = createMockSocket({ failTriggerResponse: true });
+        trackReceivedTrigger("trig_plan_fail", "child-plan", "plan_review");
+
+        const result = await simulateRespondToTrigger(
+            { triggerId: "trig_plan_fail", response: "Approved", action: "approve" },
+            conn,
+        );
+
+        expect(result?.text).toContain("Failed to deliver response for trigger trig_plan_fail");
+        expect(receivedTriggers.has("trig_plan_fail")).toBe(true);
     });
 
     it("expired triggers are rejected and removed", async () => {

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -43,6 +43,40 @@ function isJsonValue(value: unknown): value is JsonValue {
 export const receivedTriggers = new Map<string, { sourceSessionId: string; type: string; trackedAt: number }>();
 
 const TRIGGER_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const TRIGGER_RESPONSE_ACK_TIMEOUT_MS = 10_000;
+
+export async function sendTriggerResponseWithAck(
+    conn: { socket: { emit: (...args: any[]) => void }; token: string },
+    payload: {
+        triggerId: string;
+        response: string;
+        action?: string;
+        targetSessionId: string;
+    },
+): Promise<{ ok: boolean; error?: string }> {
+    return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+        let settled = false;
+        const finish = (result: { ok: boolean; error?: string }) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            resolve(result);
+        };
+        const timeout = setTimeout(() => {
+            finish({ ok: false, error: `Timed out waiting for relay ack after ${TRIGGER_RESPONSE_ACK_TIMEOUT_MS / 1000} seconds` });
+        }, TRIGGER_RESPONSE_ACK_TIMEOUT_MS);
+
+        conn.socket.emit("trigger_response" as any, {
+            token: conn.token,
+            triggerId: payload.triggerId,
+            response: payload.response,
+            ...(payload.action ? { action: payload.action } : {}),
+            targetSessionId: payload.targetSessionId,
+        }, (result?: { ok: boolean; error?: string }) => {
+            finish(result ?? { ok: true });
+        });
+    });
+}
 
 /** Register a received trigger for response routing. Called by remote.ts on trigger receipt.
  *  If the triggerId is already tracked (e.g. after escalation re-delivers the same trigger),
@@ -312,13 +346,21 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                 return { content: [{ type: "text" as const, text: `Acknowledged session completion from ${pending.sourceSessionId}` }], details: null as any };
             }
 
-            conn.socket.emit("trigger_response" as any, {
-                token: conn.token,
+            const result = await sendTriggerResponseWithAck(conn, {
                 triggerId: params.triggerId,
                 response: params.response,
-                ...(params.action ? { action: params.action } : {}),
+                action: params.action,
                 targetSessionId: pending.sourceSessionId,
             });
+            if (!result.ok) {
+                return {
+                    content: [{
+                        type: "text" as const,
+                        text: `Failed to deliver response for trigger ${params.triggerId}: ${result.error ?? "unknown error"}`,
+                    }],
+                    details: null as any,
+                };
+            }
             receivedTriggers.delete(params.triggerId);
             return { content: [{ type: "text" as const, text: `Response sent for trigger ${params.triggerId}` }], details: null as any };
         },

--- a/packages/docs/src/content/docs/customization/skills.mdx
+++ b/packages/docs/src/content/docs/customization/skills.mdx
@@ -128,8 +128,7 @@ PizzaPi ships with several built-in extensions that are always active:
 | **restart** | Allows the agent to restart itself within a session |
 | **set-session-name** | Gives the agent the `set_session_name` tool to title sessions in the UI |
 | **update-todo** | Gives the agent the `update_todo` tool to maintain a live task list in the UI |
-| **spawn-session** | Gives the agent the `spawn_session` tool to launch sub-sessions via the runner |
-| **session-messaging** | Gives the agent `send_message`, `wait_for_message`, and `check_messages` tools for inter-agent communication |
+| **spawn-session** | Gives the agent the `spawn_session` tool to launch linked child sessions via the runner |
 | **claude-plugins** | Discovers Claude Code plugins and loads their commands, hooks, and skills into the runtime |
 
 ---

--- a/packages/docs/src/content/docs/customization/subagents.mdx
+++ b/packages/docs/src/content/docs/customization/subagents.mdx
@@ -224,7 +224,7 @@ No additional configuration is needed — streaming works automatically when usi
 
 | Feature | `subagent` | `spawn_session` |
 |---------|-----------|----------------|
-| **Communication** | Tool call → result (synchronous) | `send_message` / `wait_for_message` |
+| **Communication** | Tool call → result (synchronous) | Triggers + `tell_child` |
 | **Context** | Isolated in-process session | Fully independent session |
 | **UI** | Inline in parent session | Separate session view |
 | **Overhead** | Near-zero (in-process SDK) | Higher (relay round-trip, new PTY) |

--- a/packages/docs/src/content/docs/features/multi-agent.mdx
+++ b/packages/docs/src/content/docs/features/multi-agent.mdx
@@ -3,9 +3,9 @@ title: Multi-Agent Sessions
 description: Spawn child sessions, communicate via triggers and messages, and orchestrate multi-agent workflows.
 ---
 
-import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+import { Aside, Steps } from "@astrojs/starlight/components";
 
-PizzaPi supports multiple agent sessions running in parallel, communicating through two complementary systems: **triggers** (automatic parent↔child events) and **messages** (explicit inter-session messaging). This guide covers all multi-agent communication primitives and when to use each.
+PizzaPi supports multiple agent sessions running in parallel through a single orchestration model: **linked parent/child sessions**. Linked children communicate upward through triggers, and parents communicate downward through `respond_to_trigger` and `tell_child`.
 
 ---
 
@@ -15,7 +15,7 @@ PizzaPi supports multiple agent sessions running in parallel, communicating thro
 ┌─────────────────────────────────────────────────────┐
 │  Parent Session                                     │
 │                                                     │
-│  spawn_session(prompt, linked: true)                │
+│  spawn_session(prompt)                              │
 │       │                                             │
 │       │ ◄── ask_user_question trigger ──┐           │
 │       │ ◄── plan_review trigger ────────┤           │
@@ -33,9 +33,7 @@ PizzaPi supports multiple agent sessions running in parallel, communicating thro
 └─────────────────────────────────────────────────────┘
 ```
 
-**Linked sessions** use triggers — structured events that arrive automatically in the parent's conversation. The parent responds with `respond_to_trigger`, `tell_child`, or `escalate_trigger`.
-
-**Unlinked sessions** use the message bus — explicit `send_message` / `wait_for_message` calls between any two sessions, regardless of parent-child relationship.
+Spawned sessions are always **linked**. Child events arrive automatically in the parent's conversation as triggers, and the parent responds with `respond_to_trigger`, `tell_child`, or `escalate_trigger`.
 
 ---
 
@@ -50,42 +48,25 @@ Spawn a new independent agent session on the runner. The new session runs in par
 | `prompt` | `string` | ✅ | — | Initial prompt for the new session. Must be self-contained — the child has no context from the parent. |
 | `model` | `{ provider, id }` | | Runner default | Model to use. Call `list_models` to discover available values. |
 | `cwd` | `string` | | Parent's cwd | Working directory for the new session. |
-| `linked` | `boolean` | | `true` | Whether to auto-link as a child session (enables trigger system). |
 | `runnerId` | `string` | | Current runner | Target runner ID. Usually not needed. |
 
 ### Return value
 
 On success, returns the session ID, runner ID, working directory, status (`Pending` or `Ready`), and a web UI share URL.
 
-### Linked vs. unlinked
+### Linked child sessions
 
-<Tabs>
-  <TabItem label="Linked (default)">
-    ```json
-    {
-      "prompt": "Refactor the auth module to use JWTs",
-      "model": { "provider": "anthropic", "id": "claude-sonnet-4-20250514" }
-    }
-    ```
+```json
+{
+  "prompt": "Refactor the auth module to use JWTs",
+  "model": { "provider": "anthropic", "id": "claude-sonnet-4-20250514" }
+}
+```
 
-    - `linked` defaults to `true`
-    - Parent's session ID is sent as `parentSessionId`
-    - Child events (questions, plans, completion, errors) arrive as triggers in the parent's conversation
-    - No manual polling needed — triggers are injected automatically
-  </TabItem>
-  <TabItem label="Unlinked">
-    ```json
-    {
-      "prompt": "Run the test suite and report results",
-      "linked": false
-    }
-    ```
-
-    - No trigger system — use `send_message` / `wait_for_message` for communication
-    - Avoids redundant `session_complete` triggers when you're already consuming output via messages
-    - Useful for peer-to-peer session communication patterns
-  </TabItem>
-</Tabs>
+- Parent's session ID is sent as `parentSessionId`
+- Child events (questions, plans, completion, errors) arrive as triggers in the parent's conversation
+- No manual polling needed — triggers are injected automatically
+- If the linked relationship cannot be restored after a reconnect, the harness surfaces that as an orchestration failure instead of silently degrading into peer messaging
 
 <Aside type="caution">
   **Don't stall while waiting for children.** Triggers arrive automatically as injected messages — do not use `sleep` loops or idle waits. Simply stop responding and your session will resume when the child's trigger arrives.
@@ -230,59 +211,13 @@ Proactively send a message to a linked child session. Unlike `respond_to_trigger
 
 ---
 
-## Manual messaging: `send_message`, `wait_for_message`, `check_messages`
+## Relationship durability
 
-For **unlinked sessions** or peer-to-peer communication, use the message bus. These tools work between any two sessions — no parent-child relationship required.
+Linked parent/child relationships are durable across transient relay outages:
 
-### `send_message`
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `sessionId` | `string` | ✅ | Target session ID |
-| `message` | `string` | ✅ | Message text |
-
-Sends a message to the target session's message queue. The recipient reads it with `wait_for_message` or `check_messages`.
-
-### `wait_for_message`
-
-| Parameter | Type | Required | Default | Description |
-|-----------|------|----------|---------|-------------|
-| `fromSessionId` | `string` | | Any session | Only accept messages from this sender |
-| `timeout` | `number` | | `120` | Max wait time in seconds |
-
-**Blocking.** Waits until a message arrives or the timeout expires. If a matching message is already queued, it resolves immediately.
-
-### `check_messages`
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `fromSessionId` | `string` | | Only check messages from this sender |
-
-**Non-blocking.** Drains all pending messages from the queue and returns them. Returns an empty list if no messages are waiting. Useful for polling between other work.
-
-### `get_session_id`
-
-Takes no parameters. Returns this session's own session ID — useful when you need to tell another agent your ID so they can send messages to you.
-
-### Example: two-session ping-pong
-
-```
-// Session A (spawner)
-spawn_session({ prompt: "...", linked: false })
-// → gets back sessionId: "child-xyz"
-
-send_message({ sessionId: "child-xyz", message: "Here's the data you need: ..." })
-response = wait_for_message({ fromSessionId: "child-xyz", timeout: 300 })
-```
-
-```
-// Session B (spawned with linked: false)
-myId = get_session_id()
-// wait for parent to send data
-data = wait_for_message({ timeout: 300 })
-// ... do work ...
-send_message({ sessionId: data.fromSessionId, message: "Results: ..." })
-```
+- The server preserves durable linkage metadata even when a reconnect temporarily clears `parentSessionId`
+- Trigger and follow-up routing falls back to durable linkage checks instead of treating the child as unrelated
+- If the harness cannot prove the relationship after reconnect, it surfaces an explicit broken-link/orchestration error instead of timing out silently
 
 ---
 
@@ -311,17 +246,17 @@ Fire a trigger into **any** session — not just children. This enables peer-to-
 
 ## Pattern comparison
 
-| | `subagent` tool | `spawn_session` (linked) | `spawn_session` (unlinked) + messages |
-|---|---|---|---|
-| **Communication** | Tool call → result (synchronous) | Triggers (automatic) | `send_message` / `wait_for_message` (manual) |
-| **Blocking** | Yes — parent waits for result | No — parent continues, triggers arrive async | Depends on `wait_for_message` usage |
-| **Context** | Isolated in-process session | Fully independent session + process | Fully independent session + process |
-| **UI** | Inline card in parent session | Separate session in web UI | Separate session in web UI |
-| **Overhead** | Near-zero (in-process SDK) | Higher (relay round-trip, new PTY) | Higher + manual coordination |
-| **Model selection** | Via agent definition `model` field | Via `model` parameter | Via `model` parameter |
-| **Best for** | Quick tasks: research, review, refactor | Long-running parallel work, background tasks | Peer-to-peer coordination, custom protocols |
-| **Agent definitions** | File-based (`~/.pizzapi/agents/`) | Prompt-based (inline) | Prompt-based (inline) |
-| **Modes** | Single, parallel, chain | One session per call | One session per call |
+| | `subagent` tool | `spawn_session` (linked child) |
+|---|---|---|
+| **Communication** | Tool call → result (synchronous) | Triggers + `tell_child` |
+| **Blocking** | Yes — parent waits for result | No — parent continues, triggers arrive async |
+| **Context** | Isolated in-process session | Fully independent session + process |
+| **UI** | Inline card in parent session | Separate session in web UI |
+| **Overhead** | Near-zero (in-process SDK) | Higher (relay round-trip, new PTY) |
+| **Model selection** | Via agent definition `model` field | Via `model` parameter |
+| **Best for** | Quick tasks: research, review, refactor | Long-running parallel work, background tasks |
+| **Agent definitions** | File-based (`~/.pizzapi/agents/`) | Prompt-based (inline) |
+| **Modes** | Single, parallel, chain | One session per call |
 
 <Aside type="tip">
   **Prefer `subagent` for most delegation.** It's simpler, manages context isolation automatically, and returns results inline. Use `spawn_session` only when you need independent lifecycle, background execution, or async trigger-based coordination. See the [Subagents guide](/PizzaPi/customization/subagents/) for full details.

--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -79,8 +79,8 @@ PizzaPi goes beyond basic terminal access to give you a full remote development 
   <Card title="🔔 Push Notifications" icon="approve-check">
     Get notified when sessions complete, agents need input, or errors occur — even when the browser tab is closed.
   </Card>
-  <Card title="💬 Inter-Agent Messaging" icon="comment">
-    Agents can communicate with each other via `send_message` and `wait_for_message`. Orchestrate complex multi-agent workflows from the UI.
+  <Card title="💬 Linked Child Orchestration" icon="comment">
+    Spawn linked child sessions that report back through triggers and can be steered with `respond_to_trigger` and `tell_child`.
   </Card>
   <Card title="🖥️ Multi-Runner Support" icon="list-format">
     Connect multiple dev machines (runners) to a single relay. Switch between them from the web UI and manage all your projects in one place.

--- a/packages/docs/src/content/docs/running/cli-reference.mdx
+++ b/packages/docs/src/content/docs/running/cli-reference.mdx
@@ -411,12 +411,8 @@ PizzaPi registers several tools that are available in every agent session:
 
 | Tool | Description |
 |------|-------------|
-| `spawn_session` | Spawn an independent agent session on the runner |
+| `spawn_session` | Spawn an independent linked child session on the runner |
 | `list_models` | List available models and providers |
-| `send_message` | Send a message to another agent session |
-| `wait_for_message` | Wait for a message from another session |
-| `check_messages` | Non-blocking check for pending messages |
-| `get_session_id` | Get this session's ID |
 | `set_session_name` | Set the session display name |
 | `update_todo` | Update the session's todo list |
 | `subagent` | Delegate tasks to specialized subagents with isolated context |

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -78,7 +78,7 @@ export interface RelayClientToServerEvents {
     response: string;
     action?: string;
     targetSessionId: string;
-  }) => void;
+  }, ack?: (result: { ok: boolean; error?: string }) => void) => void;
 
   /** Parent requests cleanup of a completed child session.
    *  The server validates the parent↔child relationship and tears down the child. */

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
@@ -110,8 +110,8 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
         const isParentOfChild = childSession.parentSessionId === sessionId
             || await isChildOfParent(sessionId, childSessionId);
         if (!isParentOfChild) {
-            socket.emit("error", { message: "Sender is not the parent of the target session" });
-            if (typeof ack === "function") ack({ ok: false, error: "Sender is not the parent of the target session" });
+            socket.emit("error", { message: "Sender is not the parent of the target session (linked relationship is broken or stale)" });
+            if (typeof ack === "function") ack({ ok: false, error: "Sender is not the parent of the target session (linked relationship is broken or stale)" });
             return;
         }
 

--- a/packages/server/src/ws/namespaces/relay/messaging.ts
+++ b/packages/server/src/ws/namespaces/relay/messaging.ts
@@ -61,7 +61,7 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
             if (!stillLinked) {
                 socket.emit("session_message_error", {
                     targetSessionId,
-                    error: "Sender is no longer a child of the target session",
+                    error: "Sender is no longer a child of the target session (linked relationship is broken or stale)",
                 });
                 return;
             }
@@ -80,7 +80,7 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
             if (!targetIsChild) {
                 socket.emit("session_message_error", {
                     targetSessionId,
-                    error: "Target session is not a child of the sender",
+                    error: "Target session is not a child of the sender (linked relationship is broken or stale)",
                 });
                 return;
             }
@@ -179,7 +179,7 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
             if (!senderIsChild) {
                 socket.emit("session_message_error", {
                     targetSessionId,
-                    error: "Sender is no longer a child of the target session",
+                    error: "Sender is no longer a child of the target session (linked relationship is broken or stale)",
                 });
                 return;
             }
@@ -298,8 +298,8 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
         const isParentOfTarget = targetSession.parentSessionId === socket.data.sessionId
             || await isChildOfParent(socket.data.sessionId, targetSessionId);
         if (!isParentOfTarget) {
-            socket.emit("error", { message: "Sender is not the parent of the target session" });
-            if (typeof ack === "function") ack({ ok: false, error: "Sender is not the parent of the target session" });
+            socket.emit("error", { message: "Sender is not the parent of the target session (linked relationship is broken or stale)" });
+            if (typeof ack === "function") ack({ ok: false, error: "Sender is not the parent of the target session (linked relationship is broken or stale)" });
             return;
         }
 

--- a/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.parent-miss-delink.test.ts
@@ -191,6 +191,7 @@ mock.module("./hub.js", () => ({
     broadcastToHub: async () => {},
 }));
 
+
 // Restore all module mocks after this file so they don't bleed into other
 // test files running in the same worker process.
 afterAll(() => mock.restore());

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -137,6 +137,7 @@ export async function registerTuiSession(
     // Socket.IO reconnects → repeat.
     let existing = await getSession(sessionId);
     const previousParentSessionId = existing?.parentSessionId ?? null;
+    const previousLinkedParentId = existing?.linkedParentId ?? existing?.parentSessionId ?? null;
     if (existing) {
         // Guard against cross-user session ID takeover: if the session is
         // already owned by a different user, do not evict them — instead fall
@@ -348,20 +349,24 @@ export async function registerTuiSession(
 
         // Push a synthetic trigger history entry so the parent's TriggersPanel
         // shows this child immediately (not only after the first real trigger).
-        const linkedTriggerId = `linked_${sessionId.replace(/-/g, "").slice(0, 16)}`;
-        void Promise.resolve(pushTriggerHistory(resolvedParentSessionId, {
-            triggerId: linkedTriggerId,
-            type: "session_linked",
-            source: sessionId,
-            summary: sessionName ?? undefined,
-            payload: {},
-            deliverAs: "followUp",
-            ts: new Date().toISOString(),
-            direction: "inbound",
-        })).catch(() => {});
-        broadcastToSessionViewers(resolvedParentSessionId, "trigger_delivered", {
-            triggerId: linkedTriggerId,
-        });
+        // Skip reconnects that preserved the same durable parent link — otherwise
+        // a flapping child session would spam duplicate session_linked entries.
+        if (previousLinkedParentId !== resolvedParentSessionId) {
+            const linkedTriggerId = `linked_${sessionId.replace(/-/g, "").slice(0, 16)}`;
+            void Promise.resolve(pushTriggerHistory(resolvedParentSessionId, {
+                triggerId: linkedTriggerId,
+                type: "session_linked",
+                source: sessionId,
+                summary: sessionName ?? undefined,
+                payload: {},
+                deliverAs: "followUp",
+                ts: new Date().toISOString(),
+                direction: "inbound",
+            })).catch(() => {});
+            broadcastToSessionViewers(resolvedParentSessionId, "trigger_delivered", {
+                triggerId: linkedTriggerId,
+            });
+        }
     }
 
     // Store local socket reference

--- a/packages/server/src/ws/sio-state-children.test.ts
+++ b/packages/server/src/ws/sio-state-children.test.ts
@@ -284,6 +284,22 @@ describe("child session helpers (sio-state)", () => {
         expect(ttlStore.get("pizzapi:sio:children:parent-rehydrate")).toBe(24 * 60 * 60);
     });
 
+    it("isChildOfParent falls back to linkedParentId when parentSessionId is null during transient offline", async () => {
+        store.set(
+            "__hash__:pizzapi:sio:session:child-linked-fallback",
+            JSON.stringify({
+                sessionId: "child-linked-fallback",
+                parentSessionId: "",
+                linkedParentId: "parent-linked",
+            }),
+        );
+
+        const result = await isChildOfParent("parent-linked", "child-linked-fallback");
+        expect(result).toBe(true);
+        expect(setStore.get("pizzapi:sio:children:parent-linked")?.has("child-linked-fallback")).toBe(true);
+        expect(ttlStore.get("pizzapi:sio:children:parent-linked")).toBe(24 * 60 * 60);
+    });
+
     it("isChildOfParent returns false via fallback when parentSessionId does not match", async () => {
         // The child's hash has a different parentSessionId (e.g. it was re-linked
         // to another parent). The fallback must not grant access.

--- a/packages/server/src/ws/sio-state.ts
+++ b/packages/server/src/ws/sio-state.ts
@@ -951,7 +951,9 @@ export async function isChildOfParent(parentSessionId: string, childSessionId: s
     // Fallback: the Redis children set may have expired without an explicit
     // delink.  Verify via the child's durable session hash.
     const childSession = await getSession(childSessionId);
-    if (childSession?.parentSessionId === parentSessionId) {
+    const stillLinked = childSession?.parentSessionId === parentSessionId
+        || childSession?.linkedParentId === parentSessionId;
+    if (stillLinked) {
         // Re-hydrate the children set and reset its TTL so future checks are
         // fast and the delink guard (clearAllChildren / clearParentSessionId)
         // still works correctly.

--- a/packages/server/src/ws/sio-state/child-sessions.ts
+++ b/packages/server/src/ws/sio-state/child-sessions.ts
@@ -84,7 +84,9 @@ export async function isChildOfParent(parentSessionId: string, childSessionId: s
     // Fallback: the Redis children set may have expired without an explicit
     // delink.  Verify via the child's durable session hash.
     const childSession = await getSession(childSessionId);
-    if (childSession?.parentSessionId === parentSessionId) {
+    const stillLinked = childSession?.parentSessionId === parentSessionId
+        || childSession?.linkedParentId === parentSessionId;
+    if (stillLinked) {
         // Re-hydrate the children set and reset its TTL so future checks are
         // fast and the delink guard (clearAllChildren / clearParentSessionId)
         // still works correctly.


### PR DESCRIPTION
## Summary
- remove the default manual session messaging path and make spawn_session always create linked child sessions
- harden linked parent/child recovery and broken-link surfacing across reconnects, relay routing, and trigger delivery
- update prompts, docs, and regression tests for the linked-only multi-agent model

## Test Plan
- [x] bun run typecheck
- [x] bun run test
- [x] cd packages/docs && bun run build