### PR TITLE
fix: harden session_complete delivery

### DIFF
--- a/packages/cli/src/extensions/remote-ask-user.ts
+++ b/packages/cli/src/extensions/remote-ask-user.ts
@@ -455,7 +455,21 @@ export function registerAskUserTool(rctx: RelayContext) {
                     ts: new Date().toISOString(),
                 };
 
-                rctx.emitTrigger(trigger as any);
+                const deliveryResult = await rctx.emitTriggerWithAck(trigger as any);
+                if (!deliveryResult.ok) {
+                    const responseText = `Trigger delivery failed: ${deliveryResult.error ?? "unknown error"}`;
+                    return {
+                        content: [{ type: "text", text: responseText }],
+                        details: {
+                            questions,
+                            display,
+                            answers: null,
+                            answer: null,
+                            source: "parent_trigger" as any,
+                            cancelled: true,
+                        } satisfies AskUserQuestionDetails,
+                    };
+                }
 
                 const triggerResult = await rctx.waitForTriggerResponse(triggerId, trigger.timeoutMs, signal);
 

--- a/packages/cli/src/extensions/remote-plan-mode.ts
+++ b/packages/cli/src/extensions/remote-plan-mode.ts
@@ -453,7 +453,19 @@ export function registerPlanModeTool(rctx: RelayContext) {
                     ts: new Date().toISOString(),
                 };
 
-                rctx.emitTrigger(trigger as any);
+                const deliveryResult = await rctx.emitTriggerWithAck(trigger as any);
+                if (!deliveryResult.ok) {
+                    return {
+                        content: [{ type: "text", text: `Plan cancelled: Trigger delivery failed: ${deliveryResult.error ?? "unknown error"}` }],
+                        details: {
+                            title,
+                            description,
+                            steps,
+                            action: "cancel" as PlanModeAction,
+                            editSuggestion: null,
+                        } satisfies PlanModeDetails,
+                    };
+                }
 
                 const triggerResult = await rctx.waitForTriggerResponse(triggerId, trigger.timeoutMs, signal);
 

--- a/packages/cli/src/extensions/remote-session-complete.test.ts
+++ b/packages/cli/src/extensions/remote-session-complete.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "bun:test";
+import { sendSessionCompleteFollowUp } from "./remote/session-complete-followup.js";
 
-function simulateViewerSessionCompleteFollowUp(opts: { deliveryFails: boolean }) {
+async function simulateViewerSessionCompleteFollowUp(opts: { deliveryFails: boolean; disconnects?: boolean }) {
     const receivedTriggers = new Map<string, { sourceSessionId: string; type: string }>();
     receivedTriggers.set("trigger-1", { sourceSessionId: "child-1", type: "session_complete" });
 
     const listeners = new Map<string, Array<(data: any) => void>>();
     const socket = {
+        connected: true,
         on(event: string, handler: (data: any) => void) {
             const handlers = listeners.get(event) ?? [];
             handlers.push(handler);
@@ -20,30 +22,27 @@ function simulateViewerSessionCompleteFollowUp(opts: { deliveryFails: boolean })
                     handler({ targetSessionId: data.targetSessionId, error: "Target session not found or not connected" });
                 }
             }
+            if (event === "session_message" && opts.disconnects) {
+                socket.connected = false;
+                for (const handler of listeners.get("disconnect") ?? []) {
+                    handler(undefined);
+                }
+            }
         },
     };
 
     const pending = receivedTriggers.get("trigger-1");
     if (!pending) throw new Error("missing pending trigger");
 
-    const childId = pending.sourceSessionId;
-    let failed = false;
-    const onError = (err: { targetSessionId: string; error: string }) => {
-        if (err.targetSessionId === childId) {
-            failed = true;
-            socket.off("session_message_error", onError);
-        }
-    };
-
-    socket.on("session_message_error", onError);
-    socket.emit("session_message", {
-        targetSessionId: childId,
+    const result = await sendSessionCompleteFollowUp({
+        socket: socket as any,
+        token: "relay-token",
+        childSessionId: pending.sourceSessionId,
         message: "Please continue",
-        deliverAs: "input",
+        timeoutMs: 5,
     });
 
-    socket.off("session_message_error", onError);
-    if (!failed) {
+    if (result.ok) {
         receivedTriggers.delete("trigger-1");
     }
 
@@ -51,13 +50,18 @@ function simulateViewerSessionCompleteFollowUp(opts: { deliveryFails: boolean })
 }
 
 describe("remote escalated session_complete follow-up delivery", () => {
-    it("keeps the trigger pending when delivery fails", () => {
-        const receivedTriggers = simulateViewerSessionCompleteFollowUp({ deliveryFails: true });
+    it("keeps the trigger pending when delivery fails", async () => {
+        const receivedTriggers = await simulateViewerSessionCompleteFollowUp({ deliveryFails: true });
         expect(receivedTriggers.has("trigger-1")).toBe(true);
     });
 
-    it("clears the trigger when delivery succeeds", () => {
-        const receivedTriggers = simulateViewerSessionCompleteFollowUp({ deliveryFails: false });
+    it("clears the trigger when delivery succeeds", async () => {
+        const receivedTriggers = await simulateViewerSessionCompleteFollowUp({ deliveryFails: false });
         expect(receivedTriggers.has("trigger-1")).toBe(false);
+    });
+
+    it("keeps the trigger pending when the relay disconnects before delivery settles", async () => {
+        const receivedTriggers = await simulateViewerSessionCompleteFollowUp({ deliveryFails: false, disconnects: true });
+        expect(receivedTriggers.has("trigger-1")).toBe(true);
     });
 });

--- a/packages/cli/src/extensions/remote-types.ts
+++ b/packages/cli/src/extensions/remote-types.ts
@@ -201,6 +201,7 @@ export interface RelayContext {
     parentSessionId: string | null;
     isChildSession: boolean;
     relaySessionId: string;
+    supportsSessionTriggerAck: boolean;
 
     // Pending interaction state
     pendingAskUserQuestion: PendingAskUserQuestion | null;

--- a/packages/cli/src/extensions/remote-types.ts
+++ b/packages/cli/src/extensions/remote-types.ts
@@ -237,6 +237,7 @@ export interface RelayContext {
 
     // Trigger helpers (for child session trigger pattern)
     emitTrigger(trigger: ConversationTrigger): void;
+    emitTriggerWithAck(trigger: ConversationTrigger): Promise<{ ok: boolean; error?: string }>;
     waitForTriggerResponse(triggerId: string, timeoutMs: number, signal?: AbortSignal): Promise<TriggerResponse>;
 
     // Session name sync

--- a/packages/cli/src/extensions/remote/chunked-delivery.test.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.test.ts
@@ -102,6 +102,7 @@ function makeContext(opts: {
 
         // Triggers
         emitTrigger: () => {},
+        emitTriggerWithAck: async () => ({ ok: true }),
         waitForTriggerResponse: async () => ({ response: "" }),
 
         // Session name sync

--- a/packages/cli/src/extensions/remote/connection-handlers-factory.test.ts
+++ b/packages/cli/src/extensions/remote/connection-handlers-factory.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createConnectionHandlers } from "./connection-handlers-factory.js";
+
+describe("createConnectionHandlers flushDeferredDelinks", () => {
+    function makeDeps() {
+        const fireSessionComplete = mock(async () => ({ ok: true }));
+        const emitDelinkChildren = mock((_epoch: number) => {});
+        const emitDelinkOwnParent = mock(() => {});
+        const startPendingCancellationRetryLoop = mock(() => {});
+        const retryPendingTriggerCancellations = mock((_reason: string) => {});
+        const socket = { connected: true };
+        const state = {
+            pendingDelinkOwnParent: false,
+            serverClockOffset: 0,
+            staleChildIds: new Set<string>(),
+            stalePrimaryParentId: null,
+            pendingDelink: false,
+            pendingDelinkEpoch: null,
+            pendingCancellations: [],
+            sessionCompleteFired: false,
+            sessionCompleteTransportGeneration: 0,
+            pendingSessionCompleteDelivery: null as Promise<{ ok: boolean; error?: string }> | null,
+            pendingSessionCompleteSocket: null as any,
+            pendingSessionCompleteTransportGeneration: null as number | null,
+            sessionCompleteRetryTimer: null as ReturnType<typeof setTimeout> | null,
+            lastSessionCompletePayload: {
+                triggerId: "trigger-1",
+                summary: "Buffered summary",
+                fullOutputPath: "/tmp/out.md",
+                exitReason: "completed" as const,
+            },
+        };
+
+        const deps = {
+            pi: { sendUserMessage: () => {} },
+            rctx: {
+                isChildSession: true,
+                sioSocket: socket,
+                parentSessionId: "parent-1",
+            } as any,
+            state,
+            triggerWaits: {
+                cancelAll: () => 0,
+            } as any,
+            delinkManager: {
+                emitDelinkChildren,
+                emitDelinkOwnParent,
+                clearPendingDelinkRetryTimer: () => {},
+                clearPendingDelinkOwnParentRetryTimer: () => {},
+            } as any,
+            cancellationManager: {
+                startPendingCancellationRetryLoop,
+                retryPendingTriggerCancellations,
+                stopPendingCancellationRetryLoop: () => {},
+            } as any,
+            followUpGrace: {
+                clearFollowUpGrace: () => {},
+                shutdownFollowUpGraceImmediately: () => {},
+                startFollowUpGrace: () => {},
+                fireSessionComplete,
+            } as any,
+            setModelFromWeb: async () => {},
+        };
+
+        return { deps, fireSessionComplete, state, socket };
+    }
+
+    test("retries a buffered session_complete after reconnect", () => {
+        const { deps, fireSessionComplete } = makeDeps();
+        const { connectionHandlers } = createConnectionHandlers(deps as any);
+
+        connectionHandlers.flushDeferredDelinks();
+
+        expect(fireSessionComplete).toHaveBeenCalledTimes(1);
+        expect(fireSessionComplete).toHaveBeenCalledWith();
+    });
+
+    test("drops the stale in-flight delivery on disconnect so reconnect can resend immediately", () => {
+        const { deps, fireSessionComplete, state, socket } = makeDeps();
+        state.pendingSessionCompleteDelivery = new Promise(() => {});
+        state.pendingSessionCompleteSocket = socket as any;
+        state.pendingSessionCompleteTransportGeneration = 0;
+
+        const { connectionHandlers } = createConnectionHandlers(deps as any);
+        connectionHandlers.onDelinkDisconnect();
+        connectionHandlers.flushDeferredDelinks();
+
+        expect(state.sessionCompleteTransportGeneration).toBe(1);
+        expect(state.pendingSessionCompleteDelivery).toBeNull();
+        expect(fireSessionComplete).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/cli/src/extensions/remote/connection-handlers-factory.ts
+++ b/packages/cli/src/extensions/remote/connection-handlers-factory.ts
@@ -28,6 +28,18 @@ export interface ConnectionHandlerState {
     pendingDelink: boolean;
     pendingDelinkEpoch: number | null;
     pendingCancellations: Array<{ triggerId: string; childSessionId: string }>;
+    sessionCompleteFired: boolean;
+    sessionCompleteTransportGeneration: number;
+    pendingSessionCompleteDelivery: Promise<{ ok: boolean; error?: string }> | null;
+    pendingSessionCompleteSocket: RelayContext["sioSocket"] | null;
+    pendingSessionCompleteTransportGeneration: number | null;
+    sessionCompleteRetryTimer: ReturnType<typeof setTimeout> | null;
+    lastSessionCompletePayload: {
+        triggerId: string;
+        summary: string;
+        fullOutputPath?: string;
+        exitReason: "completed" | "killed" | "error";
+    } | null;
 }
 
 export interface ConnectionHandlersDeps {
@@ -116,12 +128,20 @@ export function createConnectionHandlers(deps: ConnectionHandlersDeps) {
                 cancellationManager.startPendingCancellationRetryLoop();
                 cancellationManager.retryPendingTriggerCancellations("registered");
             }
+            if (!state.sessionCompleteFired && state.lastSessionCompletePayload && rctx.isChildSession && rctx.sioSocket?.connected) {
+                void followUpGrace.fireSessionComplete();
+                log.info("pizzapi: retried buffered session_complete after reconnect");
+            }
         },
 
         onDelinkDisconnect: () => {
             cancellationManager.stopPendingCancellationRetryLoop();
             delinkManager.clearPendingDelinkRetryTimer();
             delinkManager.clearPendingDelinkOwnParentRetryTimer();
+            state.sessionCompleteTransportGeneration += 1;
+            state.pendingSessionCompleteDelivery = null;
+            state.pendingSessionCompleteSocket = null;
+            state.pendingSessionCompleteTransportGeneration = null;
         },
 
         onSocketTeardown: () => {

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -21,7 +21,7 @@ import { cancelPendingPlanMode, consumePendingPlanModeFromWeb } from "../remote-
 import { normalizeRemoteInputAttachments, buildUserMessageFromRemoteInput } from "../remote-input.js";
 import { handleExecFromWeb } from "../remote-exec-handler.js";
 import { renderTrigger, renderTriggerBatch } from "../triggers/registry.js";
-import { trackReceivedTrigger, receivedTriggers, sendTriggerResponseWithAck } from "../triggers/extension.js";
+import { trackReceivedTrigger, receivedTriggers, sendTriggerResponseWithAck, markTriggerHandled } from "../triggers/extension.js";
 import type { ConversationTrigger } from "../triggers/types.js";
 import type { RelayContext } from "../remote-types.js";
 import { emitSessionActive } from "./chunked-delivery.js";
@@ -29,6 +29,7 @@ import { resetRelayRegistrationGate, signalRelayRegistered } from "./registratio
 import { decideRegisteredParentState } from "../remote-registered-parent-state.js";
 import { waitForWorkerStartupComplete } from "../worker-startup-gate.js";
 import { resolveInputDeliverAs } from "./deliver-as-default.js";
+import { sendSessionCompleteFollowUp } from "./session-complete-followup.js";
 
 // ── Module-level singletons (safe: one relay extension per process) ───────────
 
@@ -291,6 +292,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         if (typeof data.serverTime === "number") {
             handlers.setServerClockOffset(data.serverTime - Date.now());
         }
+        rctx.supportsSessionTriggerAck = data.supportsSessionTriggerAck === true;
 
         messageBus.setOwnSessionId(rctx.relaySessionId);
         messageBus.setSendFn((targetSessionId: string, message: string) => {
@@ -450,7 +452,11 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         // completion — suppressing session_complete after any bus consumption
         // would cause the parent to miss the final completion signal. If a
         // parent doesn't want triggers, it should spawn with linked: false.
-        trackReceivedTrigger(trigger.triggerId, trigger.sourceSessionId, trigger.type);
+        const tracked = trackReceivedTrigger(trigger.triggerId, trigger.sourceSessionId, trigger.type);
+        if (!tracked) {
+            log.info(`dropping duplicate session_trigger (${trigger.type}) ${trigger.triggerId}`);
+            return;
+        }
         const rendered = renderTrigger(trigger);
         const deliverAs = trigger.deliverAs === "followUp" ? "followUp" as const : "steer" as const;
 
@@ -470,33 +476,23 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
             const action = data.action ?? "ack";
             if (action === "followUp") {
                 const childId = pending.sourceSessionId;
-                let failed = false;
-                const onError = (err: { targetSessionId: string; error: string }) => {
-                    if (err.targetSessionId === childId) {
-                        failed = true;
-                        rctx.sioSocket!.off("session_message_error" as any, onError);
-                    }
-                };
-                rctx.sioSocket.on("session_message_error" as any, onError);
-                rctx.sioSocket.emit("session_message", {
+                void sendSessionCompleteFollowUp({
+                    socket: rctx.sioSocket,
                     token: rctx.relay.token,
-                    targetSessionId: childId,
+                    childSessionId: childId,
                     message: data.response,
-                    deliverAs: "input",
-                });
-                setTimeout(() => {
-                    rctx.sioSocket?.off("session_message_error" as any, onError);
-                    if (!failed) {
-                        receivedTriggers.delete(data.triggerId);
+                }).then((result) => {
+                    if (result.ok) {
+                        markTriggerHandled(data.triggerId);
                     }
-                }, 3000);
+                });
             } else {
                 rctx.sioSocket.emit("cleanup_child_session", {
                     token: rctx.relay.token,
                     childSessionId: pending.sourceSessionId,
                 }, (result: { ok: boolean; error?: string }) => {
                     if (result?.ok) {
-                        receivedTriggers.delete(data.triggerId);
+                        markTriggerHandled(data.triggerId);
                     }
                 });
             }
@@ -510,7 +506,7 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
             targetSessionId: pending.sourceSessionId,
         }).then((result) => {
             if (result.ok) {
-                receivedTriggers.delete(data.triggerId);
+                markTriggerHandled(data.triggerId);
                 return;
             }
             log.info(`pizzapi: failed to deliver trigger response ${data.triggerId}: ${result.error ?? "unknown error"}`);

--- a/packages/cli/src/extensions/remote/followup-grace.test.ts
+++ b/packages/cli/src/extensions/remote/followup-grace.test.ts
@@ -1,0 +1,173 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const mockEmitSessionCompleteWithAck = mock(async (_opts: any) => ({ ok: true }));
+
+mock.module("./session-complete-delivery.js", () => ({
+    emitSessionCompleteWithAck: mockEmitSessionCompleteWithAck,
+}));
+
+mock.module("@pizzapi/tools", () => ({
+    createLogger: () => ({
+        info: () => {},
+        warn: () => {},
+        error: () => {},
+        debug: () => {},
+    }),
+}));
+
+import { createFollowUpGrace, type FollowUpGraceState } from "./followup-grace.js";
+
+afterAll(() => mock.restore());
+
+function makeState(): FollowUpGraceState {
+    return {
+        sessionCompleteFired: false,
+        followUpGraceTimer: null,
+        followUpGraceShutdown: null,
+        sessionCompleteGeneration: 0,
+        sessionCompleteTransportGeneration: 0,
+        sessionCompleteRetryTimer: null,
+        pendingSessionCompleteDelivery: null,
+        pendingSessionCompleteSocket: null,
+        pendingSessionCompleteTransportGeneration: null,
+        lastSessionCompletePayload: null,
+    };
+}
+
+function makeRelayContext() {
+    return {
+        isChildSession: true,
+        parentSessionId: "parent-1",
+        relay: { token: "relay-token", sessionId: "child-1" },
+        sioSocket: { connected: true },
+    } as any;
+}
+
+describe("createFollowUpGrace fireSessionComplete", () => {
+    beforeEach(() => {
+        mockEmitSessionCompleteWithAck.mockReset();
+    });
+
+    test("reuses the in-flight completion delivery promise instead of emitting twice", async () => {
+        let resolveDelivery: ((value: { ok: boolean; error?: string }) => void) | null = null;
+        mockEmitSessionCompleteWithAck.mockImplementation(
+            () => new Promise<{ ok: boolean; error?: string }>((resolve) => {
+                resolveDelivery = resolve;
+            }),
+        );
+
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState());
+        const first = followUpGrace.fireSessionComplete("Done", "/tmp/out.md", "completed");
+        const second = followUpGrace.fireSessionComplete(undefined, undefined, "completed");
+
+        expect(mockEmitSessionCompleteWithAck).toHaveBeenCalledTimes(1);
+        if (!resolveDelivery) throw new Error("missing deferred resolver");
+        const resolver = resolveDelivery as (value: { ok: boolean; error?: string }) => void;
+        resolver({ ok: true });
+        await expect(first).resolves.toEqual({ ok: true });
+        await expect(second).resolves.toEqual({ ok: true });
+    });
+
+    test("retries with the stored summary and fullOutputPath after an earlier failure", async () => {
+        mockEmitSessionCompleteWithAck
+            .mockImplementationOnce(async () => ({ ok: false, error: "Target session parent-1 is not connected" } as { ok: boolean; error?: string }))
+            .mockImplementationOnce(async () => ({ ok: true } as { ok: boolean; error?: string }));
+
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState());
+
+        const first = await followUpGrace.fireSessionComplete("Rich summary", "/tmp/out.md", "completed");
+        const second = await followUpGrace.fireSessionComplete(undefined, undefined, "completed");
+
+        expect(first).toEqual({ ok: false, error: "Target session parent-1 is not connected" });
+        expect(second).toEqual({ ok: true });
+        expect(mockEmitSessionCompleteWithAck).toHaveBeenCalledTimes(2);
+        expect(mockEmitSessionCompleteWithAck.mock.calls[1]?.[0]).toMatchObject({
+            summary: "Rich summary",
+            fullOutputPath: "/tmp/out.md",
+            exitReason: "completed",
+        });
+        expect(mockEmitSessionCompleteWithAck.mock.calls[1]?.[0]?.triggerId).toBe(
+            mockEmitSessionCompleteWithAck.mock.calls[0]?.[0]?.triggerId,
+        );
+    });
+
+    test("ignores a stale in-flight delivery that resolves after a new turn starts", async () => {
+        let resolveFirst: ((value: { ok: boolean; error?: string }) => void) | null = null;
+        mockEmitSessionCompleteWithAck.mockImplementationOnce(
+            () => new Promise<{ ok: boolean; error?: string }>((resolve) => {
+                resolveFirst = resolve;
+            }),
+        );
+        mockEmitSessionCompleteWithAck.mockImplementationOnce(async () => ({ ok: true }));
+
+        const state = makeState();
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), state);
+
+        const first = followUpGrace.fireSessionComplete("First turn", undefined, "completed");
+        expect(mockEmitSessionCompleteWithAck).toHaveBeenCalledTimes(1);
+
+        // Simulate turn_start/session_switch resetting completion state for a new turn.
+        state.sessionCompleteFired = false;
+        state.pendingSessionCompleteDelivery = null;
+        state.pendingSessionCompleteSocket = null;
+        state.pendingSessionCompleteTransportGeneration = null;
+        state.lastSessionCompletePayload = null;
+        state.sessionCompleteGeneration += 1;
+
+        if (!resolveFirst) throw new Error("missing first resolver");
+        const firstResolver = resolveFirst as (value: { ok: boolean; error?: string }) => void;
+        firstResolver({ ok: true });
+        await expect(first).resolves.toEqual({ ok: true });
+        expect(state.sessionCompleteFired).toBe(false);
+
+        const second = await followUpGrace.fireSessionComplete("Second turn", undefined, "completed");
+        expect(second).toEqual({ ok: true });
+        expect(mockEmitSessionCompleteWithAck).toHaveBeenCalledTimes(2);
+        expect(mockEmitSessionCompleteWithAck.mock.calls[1]?.[0]).toMatchObject({ summary: "Second turn" });
+    });
+
+    test("stores completion payload even when the first attempt cannot send due to a disconnected socket", async () => {
+        const disconnected = makeRelayContext();
+        disconnected.sioSocket = { connected: false };
+        const state = makeState();
+        const followUpGrace = createFollowUpGrace(disconnected, state);
+
+        const first = await followUpGrace.fireSessionComplete("Buffered summary", "/tmp/buffered.md", "completed");
+        expect(first).toEqual({ ok: false, error: "Child session is not connected to a linked parent" });
+
+        disconnected.sioSocket = { connected: true };
+        mockEmitSessionCompleteWithAck.mockResolvedValueOnce({ ok: true });
+
+        const second = await followUpGrace.fireSessionComplete(undefined, undefined, "completed");
+        expect(second).toEqual({ ok: true });
+        expect(mockEmitSessionCompleteWithAck).toHaveBeenCalledTimes(1);
+        expect(mockEmitSessionCompleteWithAck.mock.calls[0]?.[0]).toMatchObject({
+            summary: "Buffered summary",
+            fullOutputPath: "/tmp/buffered.md",
+            exitReason: "completed",
+        });
+    });
+
+    test("preserves the original error exitReason on a shutdown-style retry", async () => {
+        mockEmitSessionCompleteWithAck
+            .mockImplementationOnce(async () => ({ ok: false, error: "relay down" } as { ok: boolean; error?: string }))
+            .mockImplementationOnce(async () => ({ ok: true } as { ok: boolean; error?: string }));
+
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState());
+
+        const first = await followUpGrace.fireSessionComplete("Errored summary", "/tmp/error.md", "error");
+        const second = await followUpGrace.fireSessionComplete(undefined, undefined, "completed");
+
+        expect(first).toEqual({ ok: false, error: "relay down" });
+        expect(second).toEqual({ ok: true });
+        expect(mockEmitSessionCompleteWithAck).toHaveBeenCalledTimes(2);
+        expect(mockEmitSessionCompleteWithAck.mock.calls[1]?.[0]).toMatchObject({
+            summary: "Errored summary",
+            fullOutputPath: "/tmp/error.md",
+            exitReason: "error",
+        });
+        expect(mockEmitSessionCompleteWithAck.mock.calls[1]?.[0]?.triggerId).toBe(
+            mockEmitSessionCompleteWithAck.mock.calls[0]?.[0]?.triggerId,
+        );
+    });
+});

--- a/packages/cli/src/extensions/remote/followup-grace.ts
+++ b/packages/cli/src/extensions/remote/followup-grace.ts
@@ -13,8 +13,10 @@
 
 import { createLogger } from "@pizzapi/tools";
 import type { RelayContext } from "../remote-types.js";
+import { emitSessionCompleteWithAck } from "./session-complete-delivery.js";
 
 const FOLLOWUP_GRACE_MS = 10 * 60 * 1_000;
+const SESSION_COMPLETE_RETRY_MS = 3_000;
 const log = createLogger("remote");
 
 export interface FollowUpGraceState {
@@ -22,6 +24,20 @@ export interface FollowUpGraceState {
     sessionCompleteFired: boolean;
     followUpGraceTimer: ReturnType<typeof setTimeout> | null;
     followUpGraceShutdown: (() => void) | null;
+    /** Increments on each new turn/session so stale completion promises can be ignored. */
+    sessionCompleteGeneration: number;
+    /** Increments on relay disconnect so in-flight sends on the old transport are not reused after reconnect. */
+    sessionCompleteTransportGeneration: number;
+    sessionCompleteRetryTimer: ReturnType<typeof setTimeout> | null;
+    pendingSessionCompleteDelivery: Promise<{ ok: boolean; error?: string }> | null;
+    pendingSessionCompleteSocket: RelayContext["sioSocket"] | null;
+    pendingSessionCompleteTransportGeneration: number | null;
+    lastSessionCompletePayload: {
+        triggerId: string;
+        summary: string;
+        fullOutputPath?: string;
+        exitReason: "completed" | "killed" | "error";
+    } | null;
 }
 
 /**
@@ -35,6 +51,10 @@ export function createFollowUpGrace(rctx: RelayContext, state: FollowUpGraceStat
         if (state.followUpGraceTimer !== null) {
             clearTimeout(state.followUpGraceTimer);
             state.followUpGraceTimer = null;
+        }
+        if (state.sessionCompleteRetryTimer !== null) {
+            clearTimeout(state.sessionCompleteRetryTimer);
+            state.sessionCompleteRetryTimer = null;
         }
         state.followUpGraceShutdown = null;
     }
@@ -74,35 +94,102 @@ export function createFollowUpGrace(rctx: RelayContext, state: FollowUpGraceStat
 
     /**
      * Emit a session_complete trigger to the parent session.  Idempotent —
-     * subsequent calls after the first are silently ignored.
+     * subsequent calls after the first successful delivery are silently ignored.
      */
-    function fireSessionComplete(
+    async function fireSessionComplete(
         summary?: string,
         fullOutputPath?: string,
         exitReason?: "completed" | "killed" | "error",
-    ): void {
-        if (state.sessionCompleteFired) return;
-        if (!rctx.isChildSession || !rctx.parentSessionId || !rctx.relay || !rctx.sioSocket?.connected) return;
-        state.sessionCompleteFired = true;
-        rctx.sioSocket.emit("session_trigger" as any, {
+    ): Promise<{ ok: boolean; error?: string }> {
+        if (state.sessionCompleteFired) return { ok: true };
+
+        if (summary !== undefined || fullOutputPath !== undefined || state.lastSessionCompletePayload === null) {
+            state.lastSessionCompletePayload = {
+                triggerId: state.lastSessionCompletePayload?.triggerId ?? crypto.randomUUID(),
+                summary: summary ?? state.lastSessionCompletePayload?.summary ?? "Session completed",
+                fullOutputPath: fullOutputPath ?? state.lastSessionCompletePayload?.fullOutputPath,
+                exitReason: exitReason ?? state.lastSessionCompletePayload?.exitReason ?? "completed",
+            };
+        }
+
+        if (!rctx.isChildSession || !rctx.parentSessionId || !rctx.relay || !rctx.sioSocket?.connected) {
+            return { ok: false, error: "Child session is not connected to a linked parent" };
+        }
+
+        const payload = state.lastSessionCompletePayload ?? {
+            summary: "Session completed",
+            triggerId: crypto.randomUUID(),
+            fullOutputPath: undefined,
+            exitReason: exitReason ?? "completed",
+        };
+
+        if (
+            state.pendingSessionCompleteDelivery &&
+            state.pendingSessionCompleteSocket === rctx.sioSocket &&
+            state.pendingSessionCompleteTransportGeneration === state.sessionCompleteTransportGeneration
+        ) {
+            return await state.pendingSessionCompleteDelivery;
+        }
+
+        const generation = state.sessionCompleteGeneration;
+        const transportGeneration = state.sessionCompleteTransportGeneration;
+        const activeSocket = rctx.sioSocket;
+        const scheduleRetry = () => {
+            if (state.sessionCompleteRetryTimer !== null || state.sessionCompleteFired || !state.lastSessionCompletePayload) return;
+            state.sessionCompleteRetryTimer = setTimeout(() => {
+                state.sessionCompleteRetryTimer = null;
+                void fireSessionComplete();
+            }, SESSION_COMPLETE_RETRY_MS);
+            if (
+                state.sessionCompleteRetryTimer &&
+                typeof state.sessionCompleteRetryTimer === "object" &&
+                "unref" in state.sessionCompleteRetryTimer
+            ) {
+                (state.sessionCompleteRetryTimer as NodeJS.Timeout).unref();
+            }
+        };
+
+        const deliveryPromise = emitSessionCompleteWithAck({
+            socket: rctx.sioSocket,
             token: rctx.relay.token,
-            trigger: {
-                type: "session_complete",
-                sourceSessionId: rctx.relay.sessionId,
-                sourceSessionName: undefined,
-                targetSessionId: rctx.parentSessionId,
-                payload: {
-                    summary: summary ?? "Session completed",
-                    exitCode: exitReason === "killed" ? 130 : exitReason === "error" ? 1 : 0,
-                    exitReason: exitReason ?? "completed",
-                    ...(fullOutputPath ? { fullOutputPath } : {}),
-                },
-                deliverAs: "followUp" as const,
-                expectsResponse: true,
-                triggerId: crypto.randomUUID(),
-                ts: new Date().toISOString(),
-            },
+            sourceSessionId: rctx.relay.sessionId,
+            targetSessionId: rctx.parentSessionId,
+            triggerId: payload.triggerId,
+            summary: payload.summary,
+            fullOutputPath: payload.fullOutputPath,
+            exitReason: payload.exitReason,
+            assumeSuccessOnAckTimeout: !rctx.supportsSessionTriggerAck,
+        }).then((result) => {
+            if (state.sessionCompleteGeneration !== generation || state.sessionCompleteTransportGeneration !== transportGeneration) {
+                return result;
+            }
+            if (result.ok) {
+                state.sessionCompleteFired = true;
+                if (state.sessionCompleteRetryTimer !== null) {
+                    clearTimeout(state.sessionCompleteRetryTimer);
+                    state.sessionCompleteRetryTimer = null;
+                }
+            } else {
+                log.info(`pizzapi: session_complete delivery failed — ${result.error ?? "unknown error"}`);
+                scheduleRetry();
+            }
+            return result;
+        }).finally(() => {
+            if (
+                state.sessionCompleteGeneration === generation &&
+                state.sessionCompleteTransportGeneration === transportGeneration &&
+                state.pendingSessionCompleteDelivery === deliveryPromise
+            ) {
+                state.pendingSessionCompleteDelivery = null;
+                state.pendingSessionCompleteSocket = null;
+                state.pendingSessionCompleteTransportGeneration = null;
+            }
         });
+
+        state.pendingSessionCompleteDelivery = deliveryPromise;
+        state.pendingSessionCompleteSocket = activeSocket;
+        state.pendingSessionCompleteTransportGeneration = transportGeneration;
+        return await deliveryPromise;
     }
 
     return {

--- a/packages/cli/src/extensions/remote/index.ts
+++ b/packages/cli/src/extensions/remote/index.ts
@@ -112,6 +112,18 @@ export const remoteExtension: ExtensionFactory = (pi) => {
         sessionCompleteFired: false,
         followUpGraceTimer: null as ReturnType<typeof setTimeout> | null,
         followUpGraceShutdown: null as (() => void) | null,
+        sessionCompleteGeneration: 0,
+        sessionCompleteTransportGeneration: 0,
+        sessionCompleteRetryTimer: null as ReturnType<typeof setTimeout> | null,
+        pendingSessionCompleteDelivery: null as Promise<{ ok: boolean; error?: string }> | null,
+        pendingSessionCompleteSocket: null,
+        pendingSessionCompleteTransportGeneration: null as number | null,
+        lastSessionCompletePayload: null as {
+            triggerId: string;
+            summary: string;
+            fullOutputPath?: string;
+            exitReason: "completed" | "killed" | "error";
+        } | null,
         // Session name sync state
         sessionNameSyncTimer: null as ReturnType<typeof setInterval> | null,
         lastBroadcastSessionName: null as string | null,

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -93,6 +93,18 @@ export interface LifecycleHandlerState {
     pendingCancellations: Array<{ triggerId: string; childSessionId: string }>;
     // Grace (session_complete fired flag)
     sessionCompleteFired: boolean;
+    sessionCompleteGeneration: number;
+    sessionCompleteTransportGeneration: number;
+    sessionCompleteRetryTimer: ReturnType<typeof setTimeout> | null;
+    pendingSessionCompleteDelivery: Promise<{ ok: boolean; error?: string }> | null;
+    pendingSessionCompleteSocket: RelayContext["sioSocket"] | null;
+    pendingSessionCompleteTransportGeneration: number | null;
+    lastSessionCompletePayload: {
+        triggerId: string;
+        summary: string;
+        fullOutputPath?: string;
+        exitReason: "completed" | "killed" | "error";
+    } | null;
 }
 
 export interface LifecycleHandlersDeps {
@@ -273,6 +285,11 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
         }
 
         state.sessionCompleteFired = false;
+        state.sessionCompleteGeneration += 1;
+        state.pendingSessionCompleteDelivery = null;
+        state.pendingSessionCompleteSocket = null;
+        state.pendingSessionCompleteTransportGeneration = null;
+        state.lastSessionCompletePayload = null;
 
         installFooter(rctx, ctx);
         startSessionNameSync();
@@ -300,20 +317,25 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
 
     pi.on("turn_start", (event: any) => {
         state.sessionCompleteFired = false;
+        state.sessionCompleteGeneration += 1;
+        state.pendingSessionCompleteDelivery = null;
+        state.pendingSessionCompleteSocket = null;
+        state.pendingSessionCompleteTransportGeneration = null;
+        state.lastSessionCompletePayload = null;
         sessionErrorFired = false;
         rctx.wasAborted = false;
         followUpGrace.clearFollowUpGrace();
         rctx.forwardEvent(event);
     });
 
-    pi.on("session_shutdown", () => {
+    pi.on("session_shutdown", async () => {
         rctx.shuttingDown = true;
         followUpGrace.clearFollowUpGrace();
         stopHeartbeat();
         stopSessionNameSync();
         clearCtx();
         const shutdownExitReason = rctx.wasAborted ? "killed" : rctx.lastRetryableError ? "error" : "completed";
-        followUpGrace.fireSessionComplete(undefined, undefined, shutdownExitReason);
+        await followUpGrace.fireSessionComplete(undefined, undefined, shutdownExitReason);
         doDisconnect();
     });
 
@@ -373,7 +395,7 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
             }
 
             const exitReason = rctx.wasAborted ? "killed" : lastError ? "error" : "completed";
-            followUpGrace.fireSessionComplete(summary, fullOutputPath, exitReason);
+            void followUpGrace.fireSessionComplete(summary, fullOutputPath, exitReason);
 
             // Fire session_error for terminal usage-limit errors (one-shot, only at agent_end).
             if (

--- a/packages/cli/src/extensions/remote/relay-context-factory.test.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { createRelayContext } from "./relay-context-factory.js";
+import { createTriggerWaitManager } from "../trigger-wait-manager.js";
+
+function createSocketMock() {
+    const listeners = new Map<string, Array<(data?: any) => void>>();
+    const emitted: Array<{ event: string; data: any }> = [];
+
+    return {
+        connected: true,
+        emitted,
+        on(event: string, handler: (data?: any) => void) {
+            const handlers = listeners.get(event) ?? [];
+            handlers.push(handler);
+            listeners.set(event, handlers);
+        },
+        off(event: string, handler: (data?: any) => void) {
+            listeners.set(event, (listeners.get(event) ?? []).filter((fn) => fn !== handler));
+        },
+        emit(event: string, data: any, ack?: (result: { ok: boolean; error?: string }) => void) {
+            emitted.push({ event, data });
+            ack?.({ ok: true });
+        },
+        fire(event: string, data?: any) {
+            for (const handler of listeners.get(event) ?? []) {
+                handler(data);
+            }
+        },
+    };
+}
+
+describe("createRelayContext child trigger delivery", () => {
+    test("emitTriggerWithAck emits a child ask_user_question trigger and waits for relay ack", async () => {
+        const rctx = createRelayContext({}, createTriggerWaitManager(), { lastBroadcastSessionName: null });
+        const socket = createSocketMock();
+        rctx.relay = { sessionId: "child-1", token: "relay-token", shareUrl: "", seq: 0, ackedSeq: 0 };
+        rctx.sioSocket = socket as any;
+
+        const result = await rctx.emitTriggerWithAck({
+            type: "ask_user_question",
+            sourceSessionId: "child-1",
+            sourceSessionName: "Child",
+            targetSessionId: "parent-1",
+            payload: { question: "Continue?", options: ["Yes", "No"] },
+            deliverAs: "followUp",
+            expectsResponse: true,
+            triggerId: "trigger-1",
+            timeoutMs: 300_000,
+            ts: new Date().toISOString(),
+        });
+
+        expect(result).toEqual({ ok: true });
+        expect(socket.emitted).toHaveLength(1);
+        expect(socket.emitted[0]).toMatchObject({
+            event: "session_trigger",
+            data: {
+                token: "relay-token",
+                trigger: {
+                    type: "ask_user_question",
+                    targetSessionId: "parent-1",
+                    triggerId: "trigger-1",
+                },
+            },
+        });
+    });
+
+    test("waitForTriggerResponse ignores unrelated session_message_error events", async () => {
+        const rctx = createRelayContext({}, createTriggerWaitManager(), { lastBroadcastSessionName: null });
+        const socket = createSocketMock();
+        rctx.relay = { sessionId: "child-1", token: "relay-token", shareUrl: "", seq: 0, ackedSeq: 0 };
+        rctx.sioSocket = socket as any;
+        rctx.parentSessionId = "parent-1";
+
+        const responsePromise = rctx.waitForTriggerResponse("trigger-1", 100);
+        socket.fire("session_message_error", {
+            targetSessionId: "parent-1",
+            triggerId: "different-trigger",
+            error: "Unrelated delivery failure",
+        });
+        socket.fire("trigger_response", {
+            triggerId: "trigger-1",
+            response: "Approved",
+            action: "approve",
+        });
+
+        await expect(responsePromise).resolves.toEqual({
+            response: "Approved",
+            action: "approve",
+            cancelled: false,
+        });
+    });
+});

--- a/packages/cli/src/extensions/remote/relay-context-factory.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.ts
@@ -61,6 +61,7 @@ export function createRelayContext(
             process.env.PIZZAPI_SESSION_ID && process.env.PIZZAPI_SESSION_ID.trim().length > 0
                 ? process.env.PIZZAPI_SESSION_ID.trim()
                 : randomUUID(),
+        supportsSessionTriggerAck: false,
 
         pendingAskUserQuestion: null,
         pendingPlanMode: null,

--- a/packages/cli/src/extensions/remote/relay-context-factory.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.ts
@@ -20,6 +20,7 @@ import type { ConversationTrigger } from "../triggers/types.js";
 import { isCancelTriggerAction } from "../remote-trigger-response.js";
 import type { TriggerWaitManager } from "../trigger-wait-manager.js";
 import { emitSessionActive } from "./chunked-delivery.js";
+import { emitSessionTriggerWithAck } from "./session-complete-delivery.js";
 
 const RELAY_DEFAULT = "ws://localhost:7492";
 const RELAY_STATUS_KEY = "relay";
@@ -223,13 +224,24 @@ export function createRelayContext(
             });
         },
 
+        emitTriggerWithAck(trigger: ConversationTrigger) {
+            if (!rctx.relay || !rctx.sioSocket?.connected) {
+                return Promise.resolve({ ok: false, error: "Not connected to relay" });
+            }
+            return emitSessionTriggerWithAck({
+                socket: rctx.sioSocket,
+                token: rctx.relay.token,
+                trigger,
+                assumeSuccessOnAckTimeout: !rctx.supportsSessionTriggerAck,
+            });
+        },
+
         waitForTriggerResponse(
             triggerId: string,
             timeoutMs: number,
             signal?: AbortSignal,
         ): Promise<TriggerResponse> {
             return new Promise<TriggerResponse>((resolve) => {
-                const expectedParentSessionId = rctx.parentSessionId;
                 let settled = false;
                 let unregisterWait = () => {};
 
@@ -257,8 +269,8 @@ export function createRelayContext(
                     }
                 };
 
-                const errorHandler = (data: { targetSessionId: string; error: string }) => {
-                    if (expectedParentSessionId && data.targetSessionId === expectedParentSessionId) {
+                const errorHandler = (data: { targetSessionId: string; error: string; triggerId?: string }) => {
+                    if (data.triggerId === triggerId) {
                         finish({
                             response: `Trigger delivery failed: ${data.error}`,
                             cancelled: true,

--- a/packages/cli/src/extensions/remote/session-complete-delivery.test.ts
+++ b/packages/cli/src/extensions/remote/session-complete-delivery.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, test } from "bun:test";
+import { emitSessionCompleteWithAck } from "./session-complete-delivery.js";
+
+describe("emitSessionCompleteWithAck", () => {
+    test("emits session_complete and resolves when the relay acks delivery", async () => {
+        const calls: Array<{ event: string; data: any }> = [];
+        const socket = {
+            on() {},
+            off() {},
+            emit(event: string, data: any, ack?: (result: { ok: boolean; error?: string }) => void) {
+                calls.push({ event, data });
+                ack?.({ ok: true });
+            },
+        };
+
+        const result = await emitSessionCompleteWithAck({
+            socket: socket as any,
+            token: "relay-token",
+            sourceSessionId: "child-1",
+            targetSessionId: "parent-1",
+            triggerId: "trigger-1",
+            summary: "Done",
+            exitReason: "completed",
+        });
+
+        expect(result).toEqual({ ok: true });
+        expect(calls).toHaveLength(1);
+        expect(calls[0]?.event).toBe("session_trigger");
+        expect(calls[0]?.data).toMatchObject({
+            token: "relay-token",
+            trigger: {
+                type: "session_complete",
+                sourceSessionId: "child-1",
+                targetSessionId: "parent-1",
+                triggerId: "trigger-1",
+                deliverAs: "followUp",
+                expectsResponse: true,
+                payload: {
+                    summary: "Done",
+                    exitCode: 0,
+                    exitReason: "completed",
+                },
+            },
+        });
+        expect(typeof calls[0]?.data?.trigger?.ts).toBe("string");
+    });
+
+    test("surfaces relay rejection instead of silently succeeding", async () => {
+        const socket = {
+            on() {},
+            off() {},
+            emit(_event: string, _data: any, ack?: (result: { ok: boolean; error?: string }) => void) {
+                ack?.({ ok: false, error: "Target session parent-1 is not connected" });
+            },
+        };
+
+        const result = await emitSessionCompleteWithAck({
+            socket: socket as any,
+            token: "relay-token",
+            sourceSessionId: "child-1",
+            targetSessionId: "parent-1",
+            triggerId: "trigger-1",
+            summary: "Done",
+            exitReason: "completed",
+        });
+
+        expect(result).toEqual({ ok: false, error: "Target session parent-1 is not connected" });
+    });
+
+    test("treats missing ack as success for legacy relay servers when no error arrives", async () => {
+        const socket = {
+            on() {},
+            off() {},
+            emit(_event: string, _data: any, _ack?: (result: { ok: boolean; error?: string }) => void) {
+                // Legacy server: trigger is delivered but no ack callback is ever invoked.
+            },
+        };
+
+        const result = await emitSessionCompleteWithAck({
+            socket: socket as any,
+            token: "relay-token",
+            sourceSessionId: "child-1",
+            targetSessionId: "parent-1",
+            triggerId: "trigger-1",
+            summary: "Done",
+            exitReason: "completed",
+            timeoutMs: 5,
+            assumeSuccessOnAckTimeout: true,
+        });
+
+        expect(result).toEqual({ ok: true });
+    });
+
+    test("fails fast when the relay reports a delivery error for the same trigger", async () => {
+        const listeners = new Map<string, Array<(data: any) => void>>();
+        const socket = {
+            on(event: string, handler: (data: any) => void) {
+                const handlers = listeners.get(event) ?? [];
+                handlers.push(handler);
+                listeners.set(event, handlers);
+            },
+            off(event: string, handler: (data: any) => void) {
+                listeners.set(event, (listeners.get(event) ?? []).filter((fn) => fn !== handler));
+            },
+            emit(_event: string, data: any, _ack?: (result: { ok: boolean; error?: string }) => void) {
+                for (const handler of listeners.get("session_message_error") ?? []) {
+                    handler({
+                        targetSessionId: data.trigger.targetSessionId,
+                        triggerId: data.trigger.triggerId,
+                        error: "Sender is no longer a child of the target session",
+                    });
+                }
+            },
+        };
+
+        const result = await emitSessionCompleteWithAck({
+            socket: socket as any,
+            token: "relay-token",
+            sourceSessionId: "child-1",
+            targetSessionId: "parent-1",
+            triggerId: "trigger-1",
+            summary: "Done",
+            exitReason: "completed",
+            timeoutMs: 50,
+        });
+
+        expect(result).toEqual({ ok: false, error: "Sender is no longer a child of the target session" });
+    });
+
+    test("ignores unrelated session_message_error events for the same parent session", async () => {
+        const listeners = new Map<string, Array<(data: any) => void>>();
+        const socket = {
+            connected: true,
+            on(event: string, handler: (data: any) => void) {
+                const handlers = listeners.get(event) ?? [];
+                handlers.push(handler);
+                listeners.set(event, handlers);
+            },
+            off(event: string, handler: (data: any) => void) {
+                listeners.set(event, (listeners.get(event) ?? []).filter((fn) => fn !== handler));
+            },
+            emit(_event: string, data: any, _ack?: (result: { ok: boolean; error?: string }) => void) {
+                for (const handler of listeners.get("session_message_error") ?? []) {
+                    handler({
+                        targetSessionId: data.trigger.targetSessionId,
+                        triggerId: "different-trigger",
+                        error: "Unrelated trigger failed",
+                    });
+                }
+            },
+        };
+
+        const result = await emitSessionCompleteWithAck({
+            socket: socket as any,
+            token: "relay-token",
+            sourceSessionId: "child-1",
+            targetSessionId: "parent-1",
+            triggerId: "trigger-1",
+            summary: "Done",
+            exitReason: "completed",
+            timeoutMs: 5,
+            assumeSuccessOnAckTimeout: true,
+        });
+
+        expect(result).toEqual({ ok: true });
+    });
+
+    test("fails instead of assuming success when the socket disconnects before any ack arrives", async () => {
+        const listeners = new Map<string, Array<(data?: any) => void>>();
+        const socket = {
+            connected: true,
+            on(event: string, handler: (data?: any) => void) {
+                const handlers = listeners.get(event) ?? [];
+                handlers.push(handler);
+                listeners.set(event, handlers);
+            },
+            off(event: string, handler: (data?: any) => void) {
+                listeners.set(event, (listeners.get(event) ?? []).filter((fn) => fn !== handler));
+            },
+            emit(_event: string, _data: any, _ack?: (result: { ok: boolean; error?: string }) => void) {
+                socket.connected = false;
+                for (const handler of listeners.get("disconnect") ?? []) {
+                    handler();
+                }
+            },
+        };
+
+        const result = await emitSessionCompleteWithAck({
+            socket: socket as any,
+            token: "relay-token",
+            sourceSessionId: "child-1",
+            targetSessionId: "parent-1",
+            triggerId: "trigger-1",
+            summary: "Done",
+            exitReason: "completed",
+            timeoutMs: 5,
+        });
+
+        expect(result).toEqual({ ok: false, error: "Socket disconnected before relay ack" });
+    });
+
+    test("treats legacy delivery errors without triggerId as failures", async () => {
+        const listeners = new Map<string, Array<(data: any) => void>>();
+        const socket = {
+            on(event: string, handler: (data: any) => void) {
+                const handlers = listeners.get(event) ?? [];
+                handlers.push(handler);
+                listeners.set(event, handlers);
+            },
+            off(event: string, handler: (data: any) => void) {
+                listeners.set(event, (listeners.get(event) ?? []).filter((fn) => fn !== handler));
+            },
+            emit(_event: string, data: any, _ack?: (result: { ok: boolean; error?: string }) => void) {
+                for (const handler of listeners.get("session_message_error") ?? []) {
+                    handler({
+                        targetSessionId: data.trigger.targetSessionId,
+                        error: "Legacy relay reported delivery failure",
+                    });
+                }
+            },
+        };
+
+        const result = await emitSessionCompleteWithAck({
+            socket: socket as any,
+            token: "relay-token",
+            sourceSessionId: "child-1",
+            targetSessionId: "parent-1",
+            triggerId: "trigger-1",
+            summary: "Done",
+            exitReason: "completed",
+            timeoutMs: 5,
+            assumeSuccessOnAckTimeout: true,
+        });
+
+        expect(result).toEqual({ ok: false, error: "Legacy relay reported delivery failure" });
+    });
+});

--- a/packages/cli/src/extensions/remote/session-complete-delivery.ts
+++ b/packages/cli/src/extensions/remote/session-complete-delivery.ts
@@ -1,11 +1,20 @@
 import type { Socket } from "socket.io-client";
 import type { RelayClientToServerEvents, RelayServerToClientEvents } from "@pizzapi/protocol";
+import type { ConversationTrigger } from "../triggers/types.js";
 
 const DEFAULT_SESSION_COMPLETE_ACK_TIMEOUT_MS = 3_000;
 
 type RelayTriggerSocket = Pick<Socket<RelayServerToClientEvents, RelayClientToServerEvents>, "emit" | "on" | "off"> & {
     connected?: boolean;
 };
+
+export interface EmitSessionTriggerWithAckOptions {
+    socket: RelayTriggerSocket;
+    token: string;
+    trigger: ConversationTrigger;
+    timeoutMs?: number;
+    assumeSuccessOnAckTimeout?: boolean;
+}
 
 export interface EmitSessionCompleteWithAckOptions {
     socket: RelayTriggerSocket;
@@ -22,7 +31,7 @@ export interface EmitSessionCompleteWithAckOptions {
 
 function buildSessionCompleteTrigger(
     opts: EmitSessionCompleteWithAckOptions,
-): Parameters<RelayClientToServerEvents["session_trigger"]>[0]["trigger"] {
+): ConversationTrigger {
     return {
         type: "session_complete",
         sourceSessionId: opts.sourceSessionId,
@@ -41,18 +50,17 @@ function buildSessionCompleteTrigger(
     };
 }
 
-export async function emitSessionCompleteWithAck(
-    opts: EmitSessionCompleteWithAckOptions,
+export async function emitSessionTriggerWithAck(
+    opts: EmitSessionTriggerWithAckOptions,
 ): Promise<{ ok: boolean; error?: string }> {
     const timeoutMs = opts.timeoutMs ?? DEFAULT_SESSION_COMPLETE_ACK_TIMEOUT_MS;
 
     return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
-        const trigger = buildSessionCompleteTrigger(opts);
         let settled = false;
         let sawDisconnect = false;
         const errorHandler = (data: { targetSessionId: string; error: string; triggerId?: string }) => {
-            if (data?.targetSessionId !== opts.targetSessionId) return;
-            if (data.triggerId === trigger.triggerId) {
+            if (data?.targetSessionId !== opts.trigger.targetSessionId) return;
+            if (data.triggerId === opts.trigger.triggerId) {
                 finish({ ok: false, error: data.error });
                 return;
             }
@@ -73,11 +81,6 @@ export async function emitSessionCompleteWithAck(
         };
 
         const timeout = setTimeout(() => {
-            // Backward compatibility: older relay servers deliver session_trigger
-            // fire-and-forget and never invoke the ack callback. If no explicit
-            // delivery error arrived within the timeout window, treat the emit as
-            // successful — but only if the socket stayed connected throughout the
-            // wait. A disconnect means the relay may never have accepted the trigger.
             if (sawDisconnect || opts.socket.connected === false) {
                 finish({ ok: false, error: "Socket disconnected before relay ack" });
                 return;
@@ -95,7 +98,7 @@ export async function emitSessionCompleteWithAck(
         try {
             opts.socket.emit(
                 "session_trigger" as any,
-                { token: opts.token, trigger },
+                { token: opts.token, trigger: opts.trigger },
                 (result?: { ok: boolean; error?: string }) => {
                     finish(result ?? { ok: true });
                 },
@@ -103,5 +106,17 @@ export async function emitSessionCompleteWithAck(
         } catch (err) {
             finish({ ok: false, error: err instanceof Error ? err.message : String(err) });
         }
+    });
+}
+
+export async function emitSessionCompleteWithAck(
+    opts: EmitSessionCompleteWithAckOptions,
+): Promise<{ ok: boolean; error?: string }> {
+    return await emitSessionTriggerWithAck({
+        socket: opts.socket,
+        token: opts.token,
+        trigger: buildSessionCompleteTrigger(opts),
+        timeoutMs: opts.timeoutMs,
+        assumeSuccessOnAckTimeout: opts.assumeSuccessOnAckTimeout,
     });
 }

--- a/packages/cli/src/extensions/remote/session-complete-delivery.ts
+++ b/packages/cli/src/extensions/remote/session-complete-delivery.ts
@@ -1,0 +1,107 @@
+import type { Socket } from "socket.io-client";
+import type { RelayClientToServerEvents, RelayServerToClientEvents } from "@pizzapi/protocol";
+
+const DEFAULT_SESSION_COMPLETE_ACK_TIMEOUT_MS = 3_000;
+
+type RelayTriggerSocket = Pick<Socket<RelayServerToClientEvents, RelayClientToServerEvents>, "emit" | "on" | "off"> & {
+    connected?: boolean;
+};
+
+export interface EmitSessionCompleteWithAckOptions {
+    socket: RelayTriggerSocket;
+    token: string;
+    sourceSessionId: string;
+    targetSessionId: string;
+    triggerId: string;
+    summary: string;
+    exitReason: "completed" | "killed" | "error";
+    fullOutputPath?: string;
+    timeoutMs?: number;
+    assumeSuccessOnAckTimeout?: boolean;
+}
+
+function buildSessionCompleteTrigger(
+    opts: EmitSessionCompleteWithAckOptions,
+): Parameters<RelayClientToServerEvents["session_trigger"]>[0]["trigger"] {
+    return {
+        type: "session_complete",
+        sourceSessionId: opts.sourceSessionId,
+        sourceSessionName: undefined,
+        targetSessionId: opts.targetSessionId,
+        payload: {
+            summary: opts.summary,
+            exitCode: opts.exitReason === "killed" ? 130 : opts.exitReason === "error" ? 1 : 0,
+            exitReason: opts.exitReason,
+            ...(opts.fullOutputPath ? { fullOutputPath: opts.fullOutputPath } : {}),
+        },
+        deliverAs: "followUp",
+        expectsResponse: true,
+        triggerId: opts.triggerId,
+        ts: new Date().toISOString(),
+    };
+}
+
+export async function emitSessionCompleteWithAck(
+    opts: EmitSessionCompleteWithAckOptions,
+): Promise<{ ok: boolean; error?: string }> {
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_SESSION_COMPLETE_ACK_TIMEOUT_MS;
+
+    return await new Promise<{ ok: boolean; error?: string }>((resolve) => {
+        const trigger = buildSessionCompleteTrigger(opts);
+        let settled = false;
+        let sawDisconnect = false;
+        const errorHandler = (data: { targetSessionId: string; error: string; triggerId?: string }) => {
+            if (data?.targetSessionId !== opts.targetSessionId) return;
+            if (data.triggerId === trigger.triggerId) {
+                finish({ ok: false, error: data.error });
+                return;
+            }
+            if (opts.assumeSuccessOnAckTimeout === true && data.triggerId == null) {
+                finish({ ok: false, error: data.error });
+            }
+        };
+        const disconnectHandler = () => {
+            sawDisconnect = true;
+        };
+        const finish = (result: { ok: boolean; error?: string }) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            opts.socket.off?.("session_message_error", errorHandler);
+            opts.socket.off?.("disconnect", disconnectHandler);
+            resolve(result);
+        };
+
+        const timeout = setTimeout(() => {
+            // Backward compatibility: older relay servers deliver session_trigger
+            // fire-and-forget and never invoke the ack callback. If no explicit
+            // delivery error arrived within the timeout window, treat the emit as
+            // successful — but only if the socket stayed connected throughout the
+            // wait. A disconnect means the relay may never have accepted the trigger.
+            if (sawDisconnect || opts.socket.connected === false) {
+                finish({ ok: false, error: "Socket disconnected before relay ack" });
+                return;
+            }
+            if (opts.assumeSuccessOnAckTimeout === true) {
+                finish({ ok: true });
+                return;
+            }
+            finish({ ok: false, error: `Timed out waiting for relay ack after ${timeoutMs}ms` });
+        }, timeoutMs);
+
+        opts.socket.on?.("session_message_error", errorHandler);
+        opts.socket.on?.("disconnect", disconnectHandler);
+
+        try {
+            opts.socket.emit(
+                "session_trigger" as any,
+                { token: opts.token, trigger },
+                (result?: { ok: boolean; error?: string }) => {
+                    finish(result ?? { ok: true });
+                },
+            );
+        } catch (err) {
+            finish({ ok: false, error: err instanceof Error ? err.message : String(err) });
+        }
+    });
+}

--- a/packages/cli/src/extensions/remote/session-complete-followup.ts
+++ b/packages/cli/src/extensions/remote/session-complete-followup.ts
@@ -1,0 +1,54 @@
+type SessionCompleteFollowUpSocket = {
+    on: (...args: any[]) => void;
+    off: (...args: any[]) => void;
+    emit: (...args: any[]) => void;
+    connected?: boolean;
+};
+
+export async function sendSessionCompleteFollowUp(opts: {
+    socket: SessionCompleteFollowUpSocket;
+    token: string;
+    childSessionId: string;
+    message: string;
+    timeoutMs?: number;
+}): Promise<{ ok: boolean }> {
+    const timeoutMs = opts.timeoutMs ?? 3_000;
+
+    return await new Promise<{ ok: boolean }>((resolve) => {
+        let settled = false;
+        let sawDisconnect = false;
+        const finish = (result: { ok: boolean }) => {
+            if (settled) return;
+            settled = true;
+            clearTimeout(timeout);
+            opts.socket.off("session_message_error", onError);
+            opts.socket.off("disconnect", onDisconnect);
+            resolve(result);
+        };
+
+        const onError = (err: { targetSessionId: string; error: string }) => {
+            if (err.targetSessionId === opts.childSessionId) {
+                finish({ ok: false });
+            }
+        };
+        const onDisconnect = () => {
+            sawDisconnect = true;
+        };
+
+        const timeout = setTimeout(() => {
+            if (sawDisconnect || opts.socket.connected === false) {
+                finish({ ok: false });
+                return;
+            }
+            finish({ ok: true });
+        }, timeoutMs);
+        opts.socket.on("session_message_error", onError);
+        opts.socket.on("disconnect", onDisconnect);
+        opts.socket.emit("session_message", {
+            token: opts.token,
+            targetSessionId: opts.childSessionId,
+            message: opts.message,
+            deliverAs: "input",
+        });
+    });
+}

--- a/packages/cli/src/extensions/triggers/extension.ts
+++ b/packages/cli/src/extensions/triggers/extension.ts
@@ -41,6 +41,7 @@ function isJsonValue(value: unknown): value is JsonValue {
 
 /** Tracks triggers this session has received (as parent) for response routing. */
 export const receivedTriggers = new Map<string, { sourceSessionId: string; type: string; trackedAt: number }>();
+const handledTriggerTombstones = new Map<string, number>();
 
 const TRIGGER_TTL_MS = 10 * 60 * 1000; // 10 minutes
 const TRIGGER_RESPONSE_ACK_TIMEOUT_MS = 10_000;
@@ -134,14 +135,28 @@ export function clearAndCancelPendingTriggers(
     return { cancelled: count, sent, failed };
 }
 
-export function trackReceivedTrigger(triggerId: string, sourceSessionId: string, type: string): void {
-    if (receivedTriggers.has(triggerId)) return; // preserve original source on re-delivery
-    receivedTriggers.set(triggerId, { sourceSessionId, type, trackedAt: Date.now() });
-    // Prune stale entries to prevent unbounded growth
-    const now = Date.now();
+function pruneTriggerTracking(now: number): void {
     for (const [id, entry] of receivedTriggers) {
         if (now - entry.trackedAt > TRIGGER_TTL_MS) receivedTriggers.delete(id);
     }
+    for (const [id, handledAt] of handledTriggerTombstones) {
+        if (now - handledAt > TRIGGER_TTL_MS) handledTriggerTombstones.delete(id);
+    }
+}
+
+export function markTriggerHandled(triggerId: string): void {
+    const now = Date.now();
+    handledTriggerTombstones.set(triggerId, now);
+    receivedTriggers.delete(triggerId);
+    pruneTriggerTracking(now);
+}
+
+export function trackReceivedTrigger(triggerId: string, sourceSessionId: string, type: string): boolean {
+    const now = Date.now();
+    pruneTriggerTracking(now);
+    if (receivedTriggers.has(triggerId) || handledTriggerTombstones.has(triggerId)) return false;
+    receivedTriggers.set(triggerId, { sourceSessionId, type, trackedAt: now });
+    return true;
 }
 
 // ── Built-in sigils ──────────────────────────────────────────────────────────
@@ -318,7 +333,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                         });
                     });
                     if (result.ok) {
-                        receivedTriggers.delete(params.triggerId);
+                        markTriggerHandled(params.triggerId);
                     }
                     return { content: [{ type: "text" as const, text: result.text }], details: null as any };
                 }
@@ -342,7 +357,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                     // Don't delete the trigger — agent can retry
                     return { content: [{ type: "text" as const, text: `Failed to clean up child session ${pending.sourceSessionId}: ${cleanupResult.error ?? "unknown error"}` }], details: null as any };
                 }
-                receivedTriggers.delete(params.triggerId);
+                markTriggerHandled(params.triggerId);
                 return { content: [{ type: "text" as const, text: `Acknowledged session completion from ${pending.sourceSessionId}` }], details: null as any };
             }
 
@@ -361,7 +376,7 @@ export const triggersExtension: ExtensionFactory = (pi) => {
                     details: null as any,
                 };
             }
-            receivedTriggers.delete(params.triggerId);
+            markTriggerHandled(params.triggerId);
             return { content: [{ type: "text" as const, text: `Response sent for trigger ${params.triggerId}` }], details: null as any };
         },
         renderCall: (args: any, theme: any) => {

--- a/packages/protocol/src/relay.test.ts
+++ b/packages/protocol/src/relay.test.ts
@@ -158,6 +158,14 @@ describe("relay — RelayClientToServerEvents payloads", () => {
     expect(followUp.deliverAs).toBe("followUp");
   });
 
+  test("session_trigger supports an optional delivery ack callback", () => {
+    type Ack = Parameters<RelayClientToServerEvents["session_trigger"]>[1];
+    const ack: Ack = (result) => {
+      expect(result).toEqual({ ok: true });
+    };
+    ack?.({ ok: true });
+  });
+
   test("trigger_response carries token, triggerId, response, targetSessionId", () => {
     type Payload = Parameters<RelayClientToServerEvents["trigger_response"]>[0];
 
@@ -221,8 +229,10 @@ describe("relay — RelayServerToClientEvents payloads", () => {
     const withParent: Payload = {
       ...minimal,
       parentSessionId: "parent-sess",
+      supportsSessionTriggerAck: true,
     };
     expect(withParent.parentSessionId).toBe("parent-sess");
+    expect(withParent.supportsSessionTriggerAck).toBe(true);
   });
 
   test("registered parentSessionId can be null", () => {
@@ -303,14 +313,16 @@ describe("relay — RelayServerToClientEvents payloads", () => {
     expect(typeof p.ts).toBe("string");
   });
 
-  test("session_message_error carries targetSessionId and error", () => {
+  test("session_message_error carries targetSessionId, error, and optional triggerId", () => {
     type Payload = Parameters<RelayServerToClientEvents["session_message_error"]>[0];
     const p: Payload = {
       targetSessionId: "sess-gone",
       error: "Session not found",
+      triggerId: "trigger-1",
     };
     expect(typeof p.targetSessionId).toBe("string");
     expect(typeof p.error).toBe("string");
+    expect(p.triggerId).toBe("trigger-1");
   });
 
   test("session_trigger carries a full trigger payload", () => {

--- a/packages/protocol/src/relay.ts
+++ b/packages/protocol/src/relay.ts
@@ -69,7 +69,7 @@ export interface RelayClientToServerEvents {
       timeoutMs?: number;
       ts: string;
     };
-  }) => void;
+  }, ack?: (result: { ok: boolean; error?: string }) => void) => void;
 
   /** Parent sends a trigger response back to the child */
   trigger_response: (data: {
@@ -127,6 +127,8 @@ export interface RelayServerToClientEvents {
     parentSessionId?: string | null;
     /** Server wall-clock time (ms since epoch) for clock-offset calculation. */
     serverTime?: number;
+    /** True when the relay supports ack callbacks for session_trigger delivery. */
+    supportsSessionTriggerAck?: boolean;
     /**
      * True when parentSessionId is null because the parent explicitly delinked
      * this child (ran /new). Absent or false for transient parent-offline cases.
@@ -176,6 +178,7 @@ export interface RelayServerToClientEvents {
   session_message_error: (data: {
     targetSessionId: string;
     error: string;
+    triggerId?: string;
   }) => void;
 
   /** Delivers a trigger from a child to the target session */

--- a/packages/server/src/ws/namespaces/relay/messaging.test.ts
+++ b/packages/server/src/ws/namespaces/relay/messaging.test.ts
@@ -1,0 +1,139 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+const mockGetSharedSession = mock(async (_id: string) => null as any);
+const mockGetLocalTuiSocket = mock((_id: string) => undefined as any);
+const mockEmitToRelaySessionVerified = mock(async (_id: string, _event: string, _payload: any) => false);
+const mockBroadcastToSessionViewers = mock((_sessionId: string, _event: string, _payload: any) => {});
+const mockIsChildOfParent = mock(async (_parentId: string, _childId: string) => true);
+const mockIsPendingParentDelinkChild = mock(async (_targetId: string, _senderId: string) => false);
+const mockRefreshChildSessionsTTL = mock(async (_parentId: string) => {});
+const mockPushTriggerHistory = mock(async (_sessionId: string, _entry: any) => {});
+const mockRecordTriggerResponse = mock(async (_sessionId: string, _triggerId: string, _response: any) => {});
+
+mock.module("../../sio-registry.js", () => ({
+    getSharedSession: mockGetSharedSession,
+    getLocalTuiSocket: mockGetLocalTuiSocket,
+    emitToRelaySessionVerified: mockEmitToRelaySessionVerified,
+    broadcastToSessionViewers: mockBroadcastToSessionViewers,
+}));
+
+mock.module("../../sio-state/index.js", () => ({
+    isChildOfParent: mockIsChildOfParent,
+    isPendingParentDelinkChild: mockIsPendingParentDelinkChild,
+    refreshChildSessionsTTL: mockRefreshChildSessionsTTL,
+}));
+
+mock.module("../../../sessions/trigger-store.js", () => ({
+    pushTriggerHistory: mockPushTriggerHistory,
+    recordTriggerResponse: mockRecordTriggerResponse,
+}));
+
+import { registerMessagingHandlers } from "./messaging.js";
+
+afterAll(() => mock.restore());
+
+function createMockSocket(sessionId = "child-1") {
+    const handlers = new Map<string, Function>();
+    const emitted: Array<{ event: string; data: any }> = [];
+    return {
+        data: {
+            sessionId,
+            token: "relay-token",
+        },
+        on(event: string, handler: Function) {
+            handlers.set(event, handler);
+        },
+        emit(event: string, data: any) {
+            emitted.push({ event, data });
+        },
+        async fireEvent(event: string, data: any, ack?: (result: { ok: boolean; error?: string }) => void) {
+            return await handlers.get(event)?.(data, ack);
+        },
+        _emitted: emitted,
+        _handlers: handlers,
+    };
+}
+
+describe("registerMessagingHandlers session_trigger acking", () => {
+    beforeEach(() => {
+        mockGetSharedSession.mockReset();
+        mockGetLocalTuiSocket.mockReset();
+        mockEmitToRelaySessionVerified.mockReset();
+        mockBroadcastToSessionViewers.mockReset();
+        mockIsChildOfParent.mockReset();
+        mockIsPendingParentDelinkChild.mockReset();
+        mockRefreshChildSessionsTTL.mockReset();
+        mockPushTriggerHistory.mockReset();
+        mockRecordTriggerResponse.mockReset();
+
+        mockIsChildOfParent.mockResolvedValue(true);
+        mockIsPendingParentDelinkChild.mockResolvedValue(false);
+        mockRefreshChildSessionsTTL.mockResolvedValue(undefined);
+        mockPushTriggerHistory.mockResolvedValue(undefined);
+        mockRecordTriggerResponse.mockResolvedValue(undefined);
+    });
+
+    test("acks success after delivering a child trigger to the parent", async () => {
+        const socket = createMockSocket("child-1");
+        const parentSocketEmit = mock((_event: string, _data: any) => {});
+        mockGetSharedSession.mockImplementation(async (id: string) => {
+            if (id === "parent-1") return { userId: "u1" } as any;
+            if (id === "child-1") return { userId: "u1" } as any;
+            return null;
+        });
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: parentSocketEmit } as any);
+
+        registerMessagingHandlers(socket as any);
+        const ack = mock((_result: { ok: boolean; error?: string }) => {});
+
+        await socket.fireEvent("session_trigger", {
+            token: "relay-token",
+            trigger: {
+                type: "session_complete",
+                sourceSessionId: "child-1",
+                targetSessionId: "parent-1",
+                payload: { summary: "Done" },
+                deliverAs: "followUp",
+                expectsResponse: true,
+                triggerId: "trigger-1",
+                ts: new Date().toISOString(),
+            },
+        }, ack);
+
+        expect(parentSocketEmit).toHaveBeenCalledWith("session_trigger", {
+            trigger: expect.objectContaining({
+                type: "session_complete",
+                sourceSessionId: "child-1",
+                targetSessionId: "parent-1",
+            }),
+        });
+        expect(ack).toHaveBeenCalledWith({ ok: true });
+    });
+
+    test("acks failure when the parent session cannot be found", async () => {
+        const socket = createMockSocket("child-1");
+        mockGetSharedSession.mockImplementation(async (id: string) => {
+            if (id === "child-1") return { userId: "u1" } as any;
+            return null;
+        });
+
+        registerMessagingHandlers(socket as any);
+        const ack = mock((_result: { ok: boolean; error?: string }) => {});
+
+        await socket.fireEvent("session_trigger", {
+            token: "relay-token",
+            trigger: {
+                type: "session_complete",
+                sourceSessionId: "child-1",
+                targetSessionId: "parent-1",
+                payload: { summary: "Done" },
+                deliverAs: "followUp",
+                expectsResponse: true,
+                triggerId: "trigger-1",
+                ts: new Date().toISOString(),
+            },
+        }, ack);
+
+        expect(ack).toHaveBeenCalledWith({ ok: false, error: "Target session parent-1 is not connected" });
+    });
+});

--- a/packages/server/src/ws/namespaces/relay/messaging.ts
+++ b/packages/server/src/ws/namespaces/relay/messaging.ts
@@ -129,16 +129,18 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
     });
 
     // ── session_trigger — child-to-parent trigger routing ────────────────
-    socket.on("session_trigger", async (data) => {
+    socket.on("session_trigger", async (data, ack?: (result: { ok: boolean; error?: string }) => void) => {
         const sessionId = socket.data.sessionId;
         if (!sessionId || data?.token !== socket.data.token) {
             socket.emit("error", { message: "Invalid token" });
+            ack?.({ ok: false, error: "Invalid token" });
             return;
         }
 
         const trigger = data?.trigger;
         if (!trigger?.targetSessionId || !trigger?.triggerId) {
             socket.emit("error", { message: "session_trigger requires trigger with targetSessionId and triggerId" });
+            ack?.({ ok: false, error: "session_trigger requires trigger with targetSessionId and triggerId" });
             return;
         }
 
@@ -147,10 +149,13 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
         // Find the target session's relay socket and validate ownership
         const targetSession = await getSharedSession(targetSessionId);
         if (!targetSession) {
+            const error = `Target session ${targetSessionId} is not connected`;
             socket.emit("session_message_error", {
                 targetSessionId,
-                error: `Target session ${targetSessionId} is not connected`,
+                error,
+                triggerId: trigger.triggerId,
             });
+            ack?.({ ok: false, error });
             return;
         }
 
@@ -158,14 +163,18 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
         const senderSession = await getSharedSession(sessionId);
         if (!senderSession?.userId || senderSession.userId !== targetSession.userId) {
             socket.emit("error", { message: "Target session belongs to a different user" });
+            ack?.({ ok: false, error: "Target session belongs to a different user" });
             return;
         }
 
         if (targetSessionId !== sessionId && await isPendingParentDelinkChild(targetSessionId, sessionId)) {
+            const error = "Sender is currently being delinked from the target session";
             socket.emit("session_message_error", {
                 targetSessionId,
-                error: "Sender is currently being delinked from the target session",
+                error,
+                triggerId: trigger.triggerId,
             });
+            ack?.({ ok: false, error });
             return;
         }
 
@@ -177,10 +186,13 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
         if (targetSessionId !== sessionId) {
             const senderIsChild = await isChildOfParent(targetSessionId, sessionId);
             if (!senderIsChild) {
+                const error = "Sender is no longer a child of the target session (linked relationship is broken or stale)";
                 socket.emit("session_message_error", {
                     targetSessionId,
-                    error: "Sender is no longer a child of the target session (linked relationship is broken or stale)",
+                    error,
+                    triggerId: trigger.triggerId,
                 });
+                ack?.({ ok: false, error });
                 return;
             }
             await refreshChildSessionsTTL(targetSessionId);
@@ -203,20 +215,28 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
                 targetSocket.emit("session_trigger" as any, { trigger });
                 delivered = true;
             } catch {
+                const error = "Failed to deliver trigger to target session";
                 socket.emit("session_message_error", {
                     targetSessionId,
-                    error: "Failed to deliver trigger to target session",
+                    error,
+                    triggerId: trigger.triggerId,
                 });
+                ack?.({ ok: false, error });
+                return;
             }
         } else if (await emitToRelaySessionVerified(targetSessionId, "session_trigger", { trigger })) {
             delivered = true;
         } else {
             // Cross-node fallback: target TUI socket is on a different server node.
             // emitToRelaySessionVerified returns false when no relay recipient is present.
+            const error = `Target session ${targetSessionId} is not connected`;
             socket.emit("session_message_error", {
                 targetSessionId,
-                error: `Target session ${targetSessionId} is not connected`,
+                error,
+                triggerId: trigger.triggerId,
             });
+            ack?.({ ok: false, error });
+            return;
         }
 
         // Record in trigger history so the history API and linked-sessions
@@ -238,6 +258,7 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
                 triggerId: trigger.triggerId,
             });
         }
+        ack?.({ ok: true });
     });
 
     // ── trigger_response — parent-to-child response routing ────────────

--- a/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/session-lifecycle.ts
@@ -53,6 +53,7 @@ export function registerSessionLifecycleHandlers(socket: RelaySocket): void {
             // Server wall-clock time — lets the client compute
             // clock offset for accurate epoch-based delink filtering.
             serverTime: Date.now(),
+            supportsSessionTriggerAck: true,
             // Only include wasDelinked when it is true to keep the payload
             // minimal for non-child or non-delinked sessions.
             ...(wasDelinked ? { wasDelinked: true } : {}),


### PR DESCRIPTION
## Summary
- add acknowledged and retryable child `session_complete` delivery with reconnect buffering and stable trigger IDs
- keep legacy compatibility by distinguishing ack-capable relays from no-ack relays and correlating trigger delivery errors
- harden parent-side trigger handling/follow-up behavior with duplicate suppression and regression tests

## Test Plan
- `bun run typecheck`
- `cd packages/cli && bun test src/extensions/remote/session-complete-delivery.test.ts src/extensions/remote/followup-grace.test.ts src/extensions/remote/connection-handlers-factory.test.ts src/extensions/remote-session-complete.test.ts src/extensions/triggers/extension.test.ts`
- `bun test packages/server/src/ws/namespaces/relay/messaging.test.ts packages/server/src/ws/namespaces/relay-cleanup.test.ts packages/server/src/ws/namespaces/relay/child-lifecycle.test.ts`
- `bun test packages/protocol/src/relay.test.ts`
- `bun run build:protocol && bun run build:server && bun run build:cli`
