### PR TITLE
Fix same-turn tool deferral loading

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ bun run clean
 - **Build order**: `tools` must be built before `server` or `cli`; `ui` can be built in parallel with `server`.
 - **TypeScript**: run `bun run typecheck` to check all packages at once.
 - **Patches**: Never edit files inside `node_modules` directly — changes go in `patches/` and are applied via `bun install`.
+- **Turn/lifecycle semantics matter**: When changing tools, prompts, models, or other agent capabilities at runtime, verify exactly *when* the change becomes visible to the next assistant response. Do not assume a setter like `setActiveTools()` is immediate inside the current loop — add an integration test that crosses the boundary you are changing.
 - **Redis** is required for the server. For local dev without Docker: `redis-server` or `docker compose up redis`.
 - **Do not repoint sandbox/test harnesses at an existing user or production Redis instance** (for example `redis://127.0.0.1:6379`) without explicit user permission. Sandboxes must use their own isolated Redis and must not assume the user's local Redis is safe to reuse.
 - **Database migrations**: run `bun run migrate` after schema changes. DB file is `packages/server/auth.db`.
@@ -108,7 +109,11 @@ bun run clean
 
 ## Upstream Patches
 
-PizzaPi patches two upstream pi packages via `patchedDependencies` in the root `package.json`. Patches live in `patches/` and are auto-applied on `bun install`. See `patches/README.md` for full details.
+PizzaPi patches three upstream pi packages via `patchedDependencies` in the root `package.json`. Patches live in `patches/` and are auto-applied on `bun install`. See `patches/README.md` for full details.
+
+### @mariozechner/pi-agent-core
+
+- **Dynamic tool refresh:** When a tool changes the active tool set mid-run (for example Tool Deferral loading a deferred tool), the next assistant response now sees the refreshed tools/system prompt instead of the stale turn-start snapshot.
 
 ### @mariozechner/pi-coding-agent
 
@@ -186,6 +191,7 @@ cd packages/cli && bun test src/patches.test.ts
 - **Run `bun run test` before committing.** Tests are part of the quality gates in session completion.
 - **Test pure logic first.** Validation, parsing, transforms, and utility functions should have thorough unit tests.
 - **Keep tests fast.** Avoid real network/Redis/DB calls in unit tests — mock or use in-memory alternatives.
+- **Test lifecycle boundaries explicitly.** If a bug depends on "next turn", "after tool call", startup sequencing, reloads, or streamed state, add a regression test that crosses that boundary. Snapshot/timing bugs are easy to miss with pure unit tests.
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.5.1-dev.2",
+      "version": "0.5.2-dev.5",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
@@ -171,6 +171,7 @@
   },
   "patchedDependencies": {
     "@mariozechner/pi-coding-agent@0.67.5": "patches/@mariozechner%2Fpi-coding-agent@0.67.5.patch",
+    "@mariozechner/pi-agent-core@0.67.5": "patches/@mariozechner%2Fpi-agent-core@0.67.5.patch",
     "@mariozechner/pi-ai@0.67.5": "patches/@mariozechner%2Fpi-ai@0.67.5.patch",
   },
   "packages": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   "version": "",
   "patchedDependencies": {
     "@mariozechner/pi-ai@0.67.5": "patches/@mariozechner%2Fpi-ai@0.67.5.patch",
-    "@mariozechner/pi-coding-agent@0.67.5": "patches/@mariozechner%2Fpi-coding-agent@0.67.5.patch"
+    "@mariozechner/pi-coding-agent@0.67.5": "patches/@mariozechner%2Fpi-coding-agent@0.67.5.patch",
+    "@mariozechner/pi-agent-core@0.67.5": "patches/@mariozechner%2Fpi-agent-core@0.67.5.patch"
   }
 }

--- a/packages/cli/src/extensions/mcp-extension.test.ts
+++ b/packages/cli/src/extensions/mcp-extension.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, test } from "bun:test";
+import { buildMcpStatusModel, decorateMcpSnapshotWithToolSearchState } from "./mcp-extension.js";
+
+describe("buildMcpStatusModel", () => {
+  test("classifies loaded, deferred, partial, and disabled MCP state", () => {
+    const model = buildMcpStatusModel({
+      effectiveServers: [
+        { name: "github", transport: "http", scope: "global", keyPath: "mcpServers.github", format: "mcpServers", sourcePath: "~/.pizzapi/config.json" },
+        { name: "linear", transport: "http", scope: "global", keyPath: "mcpServers.linear", format: "mcpServers", sourcePath: "~/.pizzapi/config.json" },
+        { name: "figma", transport: "http", scope: "global", keyPath: "mcpServers.figma", format: "mcpServers", sourcePath: "~/.pizzapi/config.json" },
+      ],
+      disabledServers: ["figma"],
+      serverTools: {
+        github: ["mcp_github_create_issue", "mcp_github_create_pr"],
+        linear: ["mcp_linear_search"],
+      },
+      toolSearch: {
+        active: true,
+        deferredTools: [
+          {
+            name: "mcp_github_create_pr",
+            description: "Create a PR",
+            parameterNames: ["title"],
+            charCount: 100,
+            serverName: "github",
+          },
+          {
+            name: "mcp_linear_search",
+            description: "Search Linear",
+            parameterNames: ["query"],
+            charCount: 100,
+            serverName: "linear",
+          },
+        ],
+        loadedOnDemandTools: [],
+      },
+    });
+
+    expect(model.counts).toEqual({
+      totalTools: 3,
+      loadedTools: 1,
+      deferredTools: 2,
+      loadedOnDemandTools: 0,
+      disabledServers: 1,
+    });
+
+    expect(model.serverStates).toHaveLength(3);
+    expect(model.serverStates).toContainEqual(
+      expect.objectContaining({ name: "figma", state: "disabled" }),
+    );
+    expect(model.serverStates).toContainEqual(
+      expect.objectContaining({ name: "github", state: "partial", loadedToolCount: 1, deferredToolCount: 1 }),
+    );
+    expect(model.serverStates).toContainEqual(
+      expect.objectContaining({ name: "linear", state: "deferred", loadedToolCount: 0, deferredToolCount: 1 }),
+    );
+
+    expect(model.toolStates).toEqual([
+      expect.objectContaining({ name: "mcp_github_create_issue", serverName: "github", state: "loaded" }),
+      expect.objectContaining({ name: "mcp_github_create_pr", serverName: "github", state: "deferred" }),
+      expect.objectContaining({ name: "mcp_linear_search", serverName: "linear", state: "deferred" }),
+    ]);
+  });
+
+  test("marks loaded-on-demand tools distinctly from always-loaded tools", () => {
+    const model = buildMcpStatusModel({
+      effectiveServers: [
+        { name: "github", transport: "http", scope: "global", keyPath: "mcpServers.github", format: "mcpServers", sourcePath: "~/.pizzapi/config.json" },
+      ],
+      disabledServers: [],
+      serverTools: {
+        github: ["mcp_github_create_issue", "mcp_github_create_pr"],
+      },
+      toolSearch: {
+        active: true,
+        deferredTools: [
+          {
+            name: "mcp_github_create_pr",
+            description: "Create a PR",
+            parameterNames: ["title"],
+            charCount: 100,
+            serverName: "github",
+          },
+        ],
+        loadedOnDemandTools: [
+          {
+            name: "mcp_github_create_issue",
+            description: "Create issue",
+            parameterNames: ["title"],
+            charCount: 100,
+            serverName: "github",
+          },
+        ],
+      },
+    });
+
+    expect(model.counts).toEqual({
+      totalTools: 2,
+      loadedTools: 0,
+      deferredTools: 1,
+      loadedOnDemandTools: 1,
+      disabledServers: 0,
+    });
+    expect(model.serverStates).toEqual([
+      expect.objectContaining({ name: "github", state: "partial", loadedToolCount: 0, deferredToolCount: 1, loadedOnDemandToolCount: 1 }),
+    ]);
+    expect(model.toolStates).toEqual([
+      expect.objectContaining({ name: "mcp_github_create_issue", state: "loaded_on_demand" }),
+      expect.objectContaining({ name: "mcp_github_create_pr", state: "deferred" }),
+    ]);
+  });
+
+  test("decorates cached snapshots with current tool-search state", () => {
+    const decorated = decorateMcpSnapshotWithToolSearchState({
+      toolCount: 2,
+      toolNames: ["mcp_github_create_issue", "mcp_github_create_pr"],
+      serverTools: {
+        github: ["mcp_github_create_issue", "mcp_github_create_pr"],
+      },
+      errors: [],
+      loadedAt: "2026-04-28T20:00:00.000Z",
+      config: {
+        global: { scope: "global", path: "~/.pizzapi/config.json", exists: true, hasMcpKey: false, hasMcpServersKey: true, preferredServers: [], compatibilityServers: [] },
+        project: { scope: "project", path: ".pizzapi/config.json", exists: false, hasMcpKey: false, hasMcpServersKey: false, preferredServers: [], compatibilityServers: [] },
+        effectivePreferredSource: "none",
+        effectiveCompatibilitySource: "global",
+        effectiveServers: [
+          { name: "github", transport: "http", scope: "global", keyPath: "mcpServers.github", format: "mcpServers", sourcePath: "~/.pizzapi/config.json" },
+        ],
+        disabledServers: [],
+      },
+      summary: "stale",
+      lines: ["stale"],
+      serverStates: [],
+      toolStates: [],
+      counts: {
+        totalTools: 0,
+        loadedTools: 0,
+        deferredTools: 0,
+        loadedOnDemandTools: 0,
+        disabledServers: 0,
+      },
+      serverTimings: [],
+      totalDurationMs: 0,
+    } as any, {
+      active: true,
+      deferredTools: [
+        {
+          name: "mcp_github_create_pr",
+          description: "Create a PR",
+          parameterNames: ["title"],
+          charCount: 100,
+          serverName: "github",
+        },
+      ],
+      loadedOnDemandTools: [
+        {
+          name: "mcp_github_create_issue",
+          description: "Create issue",
+          parameterNames: ["title"],
+          charCount: 100,
+          serverName: "github",
+        },
+      ],
+    });
+
+    expect(decorated.summary).toContain("1 loaded on-demand");
+    expect(decorated.summary).toContain("1 deferred");
+    expect(decorated.lines[0]).toContain("1 loaded on-demand");
+    expect(decorated.lines[0]).toContain("1 deferred");
+    expect(decorated.toolStates).toEqual([
+      expect.objectContaining({ name: "mcp_github_create_issue", state: "loaded_on_demand" }),
+      expect.objectContaining({ name: "mcp_github_create_pr", state: "deferred" }),
+    ]);
+  });
+});

--- a/packages/cli/src/extensions/mcp-extension.test.ts
+++ b/packages/cli/src/extensions/mcp-extension.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { buildMcpStatusModel, decorateMcpSnapshotWithToolSearchState } from "./mcp-extension.js";
+import { buildMcpStatusModel, decorateMcpSnapshotWithToolSearchState, reconcileMcpActiveTools } from "./mcp-extension.js";
 
 describe("buildMcpStatusModel", () => {
   test("classifies loaded, deferred, partial, and disabled MCP state", () => {
@@ -108,6 +108,19 @@ describe("buildMcpStatusModel", () => {
       expect.objectContaining({ name: "mcp_github_create_issue", state: "loaded_on_demand" }),
       expect.objectContaining({ name: "mcp_github_create_pr", state: "deferred" }),
     ]);
+  });
+
+  test("reconcileMcpActiveTools does not re-activate tools that are still deferred after reload", () => {
+    const result = reconcileMcpActiveTools({
+      currentActive: ["search_tools"],
+      previousMcpToolNames: ["mcp_github_create_issue"],
+      newMcpToolNames: ["mcp_github_create_issue", "mcp_github_create_pr"],
+      deferredToolNames: ["mcp_github_create_pr"],
+    });
+
+    expect(result).toContain("search_tools");
+    expect(result).toContain("mcp_github_create_issue");
+    expect(result).not.toContain("mcp_github_create_pr");
   });
 
   test("decorates cached snapshots with current tool-search state", () => {

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -14,6 +14,7 @@ import {
 import { setMcpBridge } from "./mcp-bridge.js";
 import type { RelayContext } from "./mcp-oauth.js";
 import { waitForRelayRegistration } from "./remote.js";
+import { getToolSearchBridge, type ToolSearchSnapshot } from "./tool-search-bridge.js";
 import { createLogger } from "@pizzapi/tools";
 
 const log = createLogger("mcp");
@@ -51,6 +52,41 @@ type McpConfigInspection = {
   disabledServers: string[];
 };
 
+export type McpToolRuntimeState = "loaded" | "deferred" | "loaded_on_demand";
+export type McpServerRuntimeState = "loaded" | "deferred" | "disabled" | "partial";
+
+export type McpToolStatus = {
+  name: string;
+  serverName: string;
+  state: McpToolRuntimeState;
+};
+
+export type McpServerStatus = {
+  name: string;
+  transport: string;
+  scope: string;
+  sourcePath: string;
+  state: McpServerRuntimeState;
+  totalToolCount: number;
+  loadedToolCount: number;
+  deferredToolCount: number;
+  loadedOnDemandToolCount: number;
+};
+
+export type McpStatusCounts = {
+  totalTools: number;
+  loadedTools: number;
+  deferredTools: number;
+  loadedOnDemandTools: number;
+  disabledServers: number;
+};
+
+export type McpStatusModel = {
+  serverStates: McpServerStatus[];
+  toolStates: McpToolStatus[];
+  counts: McpStatusCounts;
+};
+
 type McpSnapshot = {
   toolCount: number;
   toolNames: string[];
@@ -61,11 +97,144 @@ type McpSnapshot = {
   config: McpConfigInspection;
   summary: string;
   lines: string[];
+  serverStates: McpServerStatus[];
+  toolStates: McpToolStatus[];
+  counts: McpStatusCounts;
   /** Per-server init timing breakdown (available after first load). */
   serverTimings: McpServerInitResult[];
   /** Total wall-clock MCP initialization time (ms). */
   totalDurationMs: number;
 };
+
+export function buildMcpStatusModel(input: {
+  effectiveServers: EffectiveMcpServer[];
+  disabledServers: string[];
+  serverTools: Record<string, string[]>;
+  toolSearch?: ToolSearchSnapshot | null;
+}): McpStatusModel {
+  const disabledSet = new Set(input.disabledServers);
+  const deferredSet = new Set((input.toolSearch?.deferredTools ?? []).map((tool) => tool.name));
+  const loadedOnDemandSet = new Set((input.toolSearch?.loadedOnDemandTools ?? []).map((tool) => tool.name));
+
+  const toolStates: McpToolStatus[] = [];
+  const serverStates: McpServerStatus[] = [];
+  let loadedTools = 0;
+  let deferredTools = 0;
+  let loadedOnDemandTools = 0;
+
+  const seenServers = new Set<string>();
+  for (const server of input.effectiveServers) {
+    seenServers.add(server.name);
+    if (disabledSet.has(server.name)) {
+      serverStates.push({
+        name: server.name,
+        transport: server.transport,
+        scope: server.scope,
+        sourcePath: server.sourcePath,
+        state: "disabled",
+        totalToolCount: 0,
+        loadedToolCount: 0,
+        deferredToolCount: 0,
+        loadedOnDemandToolCount: 0,
+      });
+      continue;
+    }
+
+    const tools = input.serverTools[server.name] ?? [];
+    let serverLoaded = 0;
+    let serverDeferred = 0;
+    let serverLoadedOnDemand = 0;
+
+    for (const toolName of tools) {
+      let state: McpToolRuntimeState = "loaded";
+      if (loadedOnDemandSet.has(toolName)) {
+        state = "loaded_on_demand";
+        serverLoadedOnDemand++;
+        loadedOnDemandTools++;
+      } else if (deferredSet.has(toolName)) {
+        state = "deferred";
+        serverDeferred++;
+        deferredTools++;
+      } else {
+        serverLoaded++;
+        loadedTools++;
+      }
+      toolStates.push({ name: toolName, serverName: server.name, state });
+    }
+
+    const activeLoaded = serverLoaded + serverLoadedOnDemand;
+    const serverState: McpServerRuntimeState = tools.length === 0
+      ? "loaded"
+      : serverDeferred === tools.length
+        ? "deferred"
+        : activeLoaded === tools.length
+          ? "loaded"
+          : "partial";
+
+    serverStates.push({
+      name: server.name,
+      transport: server.transport,
+      scope: server.scope,
+      sourcePath: server.sourcePath,
+      state: serverState,
+      totalToolCount: tools.length,
+      loadedToolCount: serverLoaded,
+      deferredToolCount: serverDeferred,
+      loadedOnDemandToolCount: serverLoadedOnDemand,
+    });
+  }
+
+  for (const [serverName, tools] of Object.entries(input.serverTools)) {
+    if (seenServers.has(serverName) || disabledSet.has(serverName)) continue;
+    let serverLoaded = 0;
+    let serverDeferred = 0;
+    let serverLoadedOnDemand = 0;
+    for (const toolName of tools) {
+      let state: McpToolRuntimeState = "loaded";
+      if (loadedOnDemandSet.has(toolName)) {
+        state = "loaded_on_demand";
+        serverLoadedOnDemand++;
+        loadedOnDemandTools++;
+      } else if (deferredSet.has(toolName)) {
+        state = "deferred";
+        serverDeferred++;
+        deferredTools++;
+      } else {
+        serverLoaded++;
+        loadedTools++;
+      }
+      toolStates.push({ name: toolName, serverName, state });
+    }
+    const activeLoaded = serverLoaded + serverLoadedOnDemand;
+    serverStates.push({
+      name: serverName,
+      transport: "unknown",
+      scope: "unknown",
+      sourcePath: "",
+      state: serverDeferred === tools.length && tools.length > 0
+        ? "deferred"
+        : activeLoaded === tools.length
+          ? "loaded"
+          : "partial",
+      totalToolCount: tools.length,
+      loadedToolCount: serverLoaded,
+      deferredToolCount: serverDeferred,
+      loadedOnDemandToolCount: serverLoadedOnDemand,
+    });
+  }
+
+  return {
+    serverStates,
+    toolStates,
+    counts: {
+      totalTools: toolStates.length,
+      loadedTools,
+      deferredTools,
+      loadedOnDemandTools,
+      disabledServers: disabledSet.size,
+    },
+  };
+}
 
 type McpBridge = {
   status: () => McpSnapshot;
@@ -266,16 +435,75 @@ function formatFileState(file: McpConfigFileState): string {
   return `${file.scope}: ${file.path} (ok)`;
 }
 
+function formatToolState(state: McpToolRuntimeState): string {
+  switch (state) {
+    case "loaded_on_demand":
+      return "LOADED_ON_DEMAND";
+    case "deferred":
+      return "DEFERRED";
+    default:
+      return "LOADED";
+  }
+}
+
+function buildMcpSummary(counts: McpStatusCounts): string {
+  const parts = [`MCP tools: ${counts.loadedTools} loaded`];
+  if (counts.loadedOnDemandTools > 0) {
+    parts.push(`${counts.loadedOnDemandTools} loaded on-demand`);
+  }
+  if (counts.deferredTools > 0) {
+    parts.push(`${counts.deferredTools} deferred`);
+  }
+  if (counts.disabledServers > 0) {
+    parts.push(`${counts.disabledServers} disabled server${counts.disabledServers !== 1 ? "s" : ""}`);
+  }
+  return parts.join(", ");
+}
+
+export function decorateMcpSnapshotWithToolSearchState(
+  snapshot: McpSnapshot,
+  toolSearch?: ToolSearchSnapshot | null,
+): McpSnapshot {
+  const statusModel = buildMcpStatusModel({
+    effectiveServers: snapshot.config.effectiveServers,
+    disabledServers: snapshot.config.disabledServers,
+    serverTools: snapshot.serverTools,
+    toolSearch,
+  });
+  const next: McpSnapshot = {
+    ...snapshot,
+    summary: buildMcpSummary(statusModel.counts),
+    serverStates: statusModel.serverStates,
+    toolStates: statusModel.toolStates,
+    counts: statusModel.counts,
+    lines: [],
+  };
+  next.lines = buildStatusLines(next);
+  return next;
+}
+
 function buildStatusLines(snapshot: McpSnapshot): string[] {
   const lines: string[] = [];
-  lines.push(`MCP tools loaded: ${snapshot.toolCount}`);
+  lines.push(buildMcpSummary(snapshot.counts));
   lines.push(`Configured MCP server entries: ${snapshot.config.effectiveServers.length}`);
+  lines.push(`Known MCP tools: ${snapshot.counts.totalTools}`);
 
-  if (snapshot.toolNames.length > 0) {
+  if (snapshot.serverStates.length > 0) {
     lines.push("");
-    lines.push("Tools:");
-    for (const name of snapshot.toolNames.slice(0, 50)) lines.push(`- ${name}`);
-    if (snapshot.toolNames.length > 50) lines.push(`…and ${snapshot.toolNames.length - 50} more`);
+    lines.push("Server/tool state:");
+    for (const server of snapshot.serverStates) {
+      const counts = [];
+      if (server.totalToolCount > 0) {
+        if (server.loadedToolCount > 0) counts.push(`${server.loadedToolCount} loaded`);
+        if (server.loadedOnDemandToolCount > 0) counts.push(`${server.loadedOnDemandToolCount} on-demand`);
+        if (server.deferredToolCount > 0) counts.push(`${server.deferredToolCount} deferred`);
+      }
+      const detail = counts.length > 0 ? ` — ${counts.join(", ")}` : "";
+      lines.push(`- ${server.name} [${server.transport}] [${server.state.toUpperCase()}] from ${server.scope}${detail}`);
+      for (const tool of snapshot.toolStates.filter((entry) => entry.serverName === server.name)) {
+        lines.push(`  - ${tool.name} [${formatToolState(tool.state)}]`);
+      }
+    }
   }
 
   if (snapshot.errors.length > 0) {
@@ -294,15 +522,7 @@ function buildStatusLines(snapshot: McpSnapshot): string[] {
   lines.push(`- mcp.servers: ${snapshot.config.effectivePreferredSource}`);
   lines.push(`- mcpServers: ${snapshot.config.effectiveCompatibilitySource}`);
 
-  if (snapshot.config.effectiveServers.length > 0) {
-    lines.push("");
-    lines.push("Effective server entries:");
-    const disabledSet = new Set(snapshot.config.disabledServers);
-    for (const server of snapshot.config.effectiveServers) {
-      const disabledTag = disabledSet.has(server.name) ? " [DISABLED]" : "";
-      lines.push(`- ${server.name} [${server.transport}]${disabledTag} from ${server.scope} (${server.sourcePath} :: ${server.keyPath})`);
-    }
-  } else {
+  if (snapshot.config.effectiveServers.length === 0) {
     lines.push("");
     lines.push("No MCP server entries are currently configured.");
   }
@@ -385,8 +605,29 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
     errors: [],
     loadedAt: new Date(0).toISOString(),
     config: inspectMcpConfig(process.cwd()),
-    summary: "MCP tools loaded: 0",
-    lines: ["MCP tools loaded: 0"],
+    summary: buildMcpSummary({
+      totalTools: 0,
+      loadedTools: 0,
+      deferredTools: 0,
+      loadedOnDemandTools: 0,
+      disabledServers: 0,
+    }),
+    lines: [buildMcpSummary({
+      totalTools: 0,
+      loadedTools: 0,
+      deferredTools: 0,
+      loadedOnDemandTools: 0,
+      disabledServers: 0,
+    })],
+    serverStates: [],
+    toolStates: [],
+    counts: {
+      totalTools: 0,
+      loadedTools: 0,
+      deferredTools: 0,
+      loadedOnDemandTools: 0,
+      disabledServers: 0,
+    },
     serverTimings: [],
     totalDurationMs: 0,
   };
@@ -473,21 +714,27 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
 
     const loadedAt = new Date().toISOString();
 
-    const summary = `MCP tools loaded: ${res.toolCount}`;
-
-    lastSnapshot = {
+    lastSnapshot = decorateMcpSnapshotWithToolSearchState({
       toolCount: res.toolCount,
       toolNames: res.toolNames,
       serverTools: res.serverTools,
       errors: res.errors,
       loadedAt,
       config: inspection,
-      summary,
+      summary: "",
       lines: [],
+      serverStates: [],
+      toolStates: [],
+      counts: {
+        totalTools: 0,
+        loadedTools: 0,
+        deferredTools: 0,
+        loadedOnDemandTools: 0,
+        disabledServers: inspection.disabledServers.length,
+      },
       serverTimings: res.serverTimings,
       totalDurationMs: res.totalDurationMs,
-    };
-    lastSnapshot.lines = buildStatusLines(lastSnapshot);
+    }, getToolSearchBridge()?.status() ?? null);
 
     return lastSnapshot;
   }
@@ -525,7 +772,7 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
   let currentRelayContext: RelayContext | null = null;
 
   const bridge: McpBridge = {
-    status: () => lastSnapshot,
+    status: () => decorateMcpSnapshotWithToolSearchState(lastSnapshot, getToolSearchBridge()?.status() ?? null),
     async reload() {
       // Cancel any in-flight eager/background load so it can't finish after
       // this reload, tear down our freshly loaded clients, and restore stale
@@ -566,6 +813,27 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
     },
   };
   setMcpBridge(bridge);
+
+  pi.events?.on?.("mcp:registry_updated", (payload: any) => {
+    const server = typeof payload?.server === "string" ? payload.server : null;
+    const toolNames = Array.isArray(payload?.toolNames)
+      ? payload.toolNames.filter((name: unknown): name is string => typeof name === "string")
+      : null;
+    if (!server || !toolNames) return;
+
+    const mergedServerTools = { ...lastSnapshot.serverTools, [server]: toolNames };
+    const mergedToolNames = [...new Set(
+      Object.values(mergedServerTools)
+        .flat()
+        .filter((name): name is string => typeof name === "string"),
+    )];
+    lastSnapshot = decorateMcpSnapshotWithToolSearchState({
+      ...lastSnapshot,
+      toolCount: mergedToolNames.length,
+      toolNames: mergedToolNames,
+      serverTools: mergedServerTools,
+    }, getToolSearchBridge()?.status() ?? null);
+  });
 
   // Expose the callback-wait function so OAuth providers can use it
   // (relay context's waitForCallback delegates here).
@@ -797,7 +1065,7 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
         return;
       }
 
-      const snapshot = lastSnapshot;
+      const snapshot = bridge.status();
       ctx?.ui?.notify?.(snapshot.lines.join("\n"));
     },
   });

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -460,6 +460,31 @@ function buildMcpSummary(counts: McpStatusCounts): string {
   return parts.join(", ");
 }
 
+export function reconcileMcpActiveTools(input: {
+  currentActive: Iterable<string>;
+  previousMcpToolNames: Iterable<string>;
+  newMcpToolNames: Iterable<string>;
+  deferredToolNames?: Iterable<string>;
+}): string[] {
+  const currentActive = new Set(input.currentActive);
+  const previousMcpToolNames = new Set(input.previousMcpToolNames);
+  const newMcpToolNames = new Set(input.newMcpToolNames);
+  const deferredToolNames = new Set(input.deferredToolNames ?? []);
+
+  for (const old of previousMcpToolNames) {
+    if (!newMcpToolNames.has(old)) {
+      currentActive.delete(old);
+    }
+  }
+
+  for (const name of newMcpToolNames) {
+    if (deferredToolNames.has(name)) continue;
+    currentActive.add(name);
+  }
+
+  return [...currentActive];
+}
+
 export function decorateMcpSnapshotWithToolSearchState(
   snapshot: McpSnapshot,
   toolSearch?: ToolSearchSnapshot | null,
@@ -697,20 +722,14 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
     //
     // Fix: after all registerTool() calls, explicitly set active tools —
     // removing stale MCP tools and ensuring new/re-enabled ones are included.
-    const newMcpToolNames = new Set(res.toolNames);
-    const currentActive = new Set(pi.getActiveTools() as string[]);
-
-    // Remove tools from disabled/removed servers
-    for (const old of previousMcpToolNames) {
-      if (!newMcpToolNames.has(old)) {
-        currentActive.delete(old);
-      }
-    }
-    // Ensure all current MCP tools are active (handles re-enable after disable)
-    for (const name of newMcpToolNames) {
-      currentActive.add(name);
-    }
-    pi.setActiveTools([...currentActive]);
+    const toolSearchSnapshot = getToolSearchBridge()?.status() ?? null;
+    const nextActiveTools = reconcileMcpActiveTools({
+      currentActive: pi.getActiveTools() as string[],
+      previousMcpToolNames,
+      newMcpToolNames: res.toolNames,
+      deferredToolNames: toolSearchSnapshot?.deferredTools.map((tool) => tool.name) ?? [],
+    });
+    pi.setActiveTools(nextActiveTools);
 
     const loadedAt = new Date().toISOString();
 
@@ -734,7 +753,7 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
       },
       serverTimings: res.serverTimings,
       totalDurationMs: res.totalDurationMs,
-    }, getToolSearchBridge()?.status() ?? null);
+    }, toolSearchSnapshot);
 
     return lastSnapshot;
   }
@@ -793,6 +812,8 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
           provider.relayContext = currentRelayContext;
         }
       }
+      const report = buildStartupReport();
+      if (report) pi.events?.emit?.("mcp:startup_report", report);
       return snapshot;
     },
 
@@ -997,9 +1018,6 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
           // breaking web-based MCP OAuth for remote sessions.
           const snapshot = await bridge.reload();
           ctx?.ui?.notify?.(snapshot.lines.join("\n"));
-          // Emit report so web UI can update
-          const report = buildStartupReport();
-          if (report) pi.events?.emit?.("mcp:startup_report", report);
         } catch (err) {
           ctx?.ui?.notify?.(`MCP reload failed: ${err instanceof Error ? err.message : String(err)}`, "error");
         }
@@ -1024,8 +1042,6 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
             `✓ MCP server "${serverName}" disabled. ${snapshot.toolCount} tools loaded.\n` +
             `Use /mcp enable ${serverName} to re-enable.`,
           );
-          const report = buildStartupReport();
-          if (report) pi.events?.emit?.("mcp:startup_report", report);
         } catch (err) {
           ctx?.ui?.notify?.(`Config updated but MCP reload failed: ${err instanceof Error ? err.message : String(err)}`, "error");
         }
@@ -1057,8 +1073,6 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
           ctx?.ui?.notify?.(
             `✓ MCP server "${serverName}" enabled. ${snapshot.toolCount} tools loaded.`,
           );
-          const report = buildStartupReport();
-          if (report) pi.events?.emit?.("mcp:startup_report", report);
         } catch (err) {
           ctx?.ui?.notify?.(`Config updated but MCP reload failed: ${err instanceof Error ? err.message : String(err)}`, "error");
         }

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -580,6 +580,7 @@ export async function registerMcpTools(
           // resync against late or background MCP completion.
           pi.events?.emit?.("mcp:registry_updated", {
             server: client.name,
+            toolNames: serverToolList,
             toolCount: serverToolList.length,
             totalToolCount: toolCount,
           });

--- a/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
+++ b/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
@@ -65,21 +65,48 @@ mock.module("../session-message-bus.js", () => ({
         receive: mock(() => {}),
     },
 }));
-mock.module("../remote-provider-usage.js", () => ({ refreshAllUsage: mock(async () => {}) }));
-mock.module("../remote-heartbeat.js", () => ({ startHeartbeat: mock(() => {}), stopHeartbeat: mock(() => {}) }));
-mock.module("../remote-meta-events.js", () => ({
-    emitAuthSourceChanged: mock(() => {}),
-    emitThinkingLevelChanged: mock(() => {}),
-    emitMcpStartupReport: mock(() => {}),
+mock.module("../remote-provider-usage.js", () => ({
+    getOAuthToken: mock(() => null),
+    refreshAllUsage: mock(async () => {}),
+    buildProviderUsage: mock(() => ({})),
 }));
-mock.module("../remote-auth-source.js", () => ({ getAuthSource: mock(() => null) }));
+mock.module("../remote-heartbeat.js", () => ({
+    startHeartbeat: mock(() => {}),
+    stopHeartbeat: mock(() => {}),
+    buildHeartbeat: mock(() => ({ type: "heartbeat" })),
+    buildTokenUsage: mock(() => ({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, cost: 0, contextTokens: null })),
+}));
+mock.module("../remote-meta-events.js", () => ({
+    emitTodoUpdated: mock(() => {}),
+    emitQuestionPending: mock(() => {}),
+    emitQuestionCleared: mock(() => {}),
+    emitPlanPending: mock(() => {}),
+    emitPlanCleared: mock(() => {}),
+    emitPlanModeToggled: mock(() => {}),
+    emitCompactStarted: mock(() => {}),
+    emitCompactEnded: mock(() => {}),
+    emitRetryStateChanged: mock(() => {}),
+    emitPluginTrustRequired: mock(() => {}),
+    emitPluginTrustResolved: mock(() => {}),
+    emitMcpStartupReport: mock(() => {}),
+    emitTokenUsageUpdated: mock(() => {}),
+    emitThinkingLevelChanged: mock(() => {}),
+    emitAuthSourceChanged: mock(() => {}),
+    emitModelChanged: mock(() => {}),
+}));
+mock.module("../remote-auth-source.js", () => ({
+    getAuthSource: mock(() => null),
+    authSourceLabel: mock(() => ""),
+}));
 mock.module("../remote-ask-user.js", () => ({
     cancelPendingAskUserQuestion: mock(() => {}),
     consumePendingAskUserQuestionFromWeb: mock(() => false),
+    registerAskUserTool: mock(() => {}),
 }));
 mock.module("../remote-plan-mode.js", () => ({
     cancelPendingPlanMode: mock(() => {}),
     consumePendingPlanModeFromWeb: mock(() => false),
+    registerPlanModeTool: mock(() => {}),
 }));
 mock.module("../remote-input.js", () => ({
     normalizeRemoteInputAttachments: mock(() => []),
@@ -89,6 +116,7 @@ mock.module("../remote-exec-handler.js", () => ({ handleExecFromWeb: mock(async 
 mock.module("./registration-gate.js", () => ({
     resetRelayRegistrationGate: mock(() => {}),
     signalRelayRegistered: mock(() => {}),
+    waitForRelayRegistrationGated: mock(async () => {}),
 }));
 mock.module("../remote-registered-parent-state.js", () => ({
     decideRegisteredParentState: mock(() => ({ kind: "no_change" })),
@@ -101,15 +129,14 @@ const {
     _resetWorkerStartupGateForTesting,
 } = await import("../worker-startup-gate.js");
 
+// Restore the global module registry immediately after importing the system under test.
+// connection.js has already captured the mocked dependencies, but later test files
+// should still resolve the real config/heartbeat/etc modules.
+mock.restore();
+
 function sleep(ms: number) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
-
-// Restore top-level module mocks after this file so they do not leak into
-// later CLI test files that import the real config/mcp/heartbeat modules.
-afterAll(() => {
-    mock.restore();
-});
 
 describe("remote connection startup gate", () => {
     beforeEach(() => {

--- a/packages/cli/src/extensions/remote/followup-grace.test.ts
+++ b/packages/cli/src/extensions/remote/followup-grace.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 
 const mockEmitSessionCompleteWithAck = mock(async (_opts: any) => ({ ok: true }));
 
@@ -17,7 +17,10 @@ mock.module("@pizzapi/tools", () => ({
 
 import { createFollowUpGrace, type FollowUpGraceState } from "./followup-grace.js";
 
-afterAll(() => mock.restore());
+// Restore the global module registry immediately after importing the system under test.
+// followup-grace.js has already captured the mocked dependencies, but later test files
+// should still see the real session-complete-delivery/logger modules.
+mock.restore();
 
 function makeState(): FollowUpGraceState {
     return {

--- a/packages/cli/src/extensions/remote/followup-grace.test.ts
+++ b/packages/cli/src/extensions/remote/followup-grace.test.ts
@@ -1,26 +1,10 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-
-const mockEmitSessionCompleteWithAck = mock(async (_opts: any) => ({ ok: true }));
-
-mock.module("./session-complete-delivery.js", () => ({
-    emitSessionCompleteWithAck: mockEmitSessionCompleteWithAck,
-}));
-
-mock.module("@pizzapi/tools", () => ({
-    createLogger: () => ({
-        info: () => {},
-        warn: () => {},
-        error: () => {},
-        debug: () => {},
-    }),
-}));
-
 import { createFollowUpGrace, type FollowUpGraceState } from "./followup-grace.js";
 
-// Restore the global module registry immediately after importing the system under test.
-// followup-grace.js has already captured the mocked dependencies, but later test files
-// should still see the real session-complete-delivery/logger modules.
-mock.restore();
+const mockEmitSessionCompleteWithAck = mock(async (_opts: any) => ({ ok: true }));
+const mockLogger = {
+    info: mock((_message: string) => {}),
+};
 
 function makeState(): FollowUpGraceState {
     return {
@@ -49,6 +33,8 @@ function makeRelayContext() {
 describe("createFollowUpGrace fireSessionComplete", () => {
     beforeEach(() => {
         mockEmitSessionCompleteWithAck.mockReset();
+        mockEmitSessionCompleteWithAck.mockImplementation(async (_opts: any) => ({ ok: true }));
+        mockLogger.info.mockReset();
     });
 
     test("reuses the in-flight completion delivery promise instead of emitting twice", async () => {
@@ -59,7 +45,10 @@ describe("createFollowUpGrace fireSessionComplete", () => {
             }),
         );
 
-        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState());
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState(), {
+            emitSessionCompleteWithAck: mockEmitSessionCompleteWithAck,
+            logger: mockLogger,
+        });
         const first = followUpGrace.fireSessionComplete("Done", "/tmp/out.md", "completed");
         const second = followUpGrace.fireSessionComplete(undefined, undefined, "completed");
 
@@ -76,7 +65,10 @@ describe("createFollowUpGrace fireSessionComplete", () => {
             .mockImplementationOnce(async () => ({ ok: false, error: "Target session parent-1 is not connected" } as { ok: boolean; error?: string }))
             .mockImplementationOnce(async () => ({ ok: true } as { ok: boolean; error?: string }));
 
-        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState());
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState(), {
+            emitSessionCompleteWithAck: mockEmitSessionCompleteWithAck,
+            logger: mockLogger,
+        });
 
         const first = await followUpGrace.fireSessionComplete("Rich summary", "/tmp/out.md", "completed");
         const second = await followUpGrace.fireSessionComplete(undefined, undefined, "completed");
@@ -104,7 +96,10 @@ describe("createFollowUpGrace fireSessionComplete", () => {
         mockEmitSessionCompleteWithAck.mockImplementationOnce(async () => ({ ok: true }));
 
         const state = makeState();
-        const followUpGrace = createFollowUpGrace(makeRelayContext(), state);
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), state, {
+            emitSessionCompleteWithAck: mockEmitSessionCompleteWithAck,
+            logger: mockLogger,
+        });
 
         const first = followUpGrace.fireSessionComplete("First turn", undefined, "completed");
         expect(mockEmitSessionCompleteWithAck).toHaveBeenCalledTimes(1);
@@ -133,7 +128,10 @@ describe("createFollowUpGrace fireSessionComplete", () => {
         const disconnected = makeRelayContext();
         disconnected.sioSocket = { connected: false };
         const state = makeState();
-        const followUpGrace = createFollowUpGrace(disconnected, state);
+        const followUpGrace = createFollowUpGrace(disconnected, state, {
+            emitSessionCompleteWithAck: mockEmitSessionCompleteWithAck,
+            logger: mockLogger,
+        });
 
         const first = await followUpGrace.fireSessionComplete("Buffered summary", "/tmp/buffered.md", "completed");
         expect(first).toEqual({ ok: false, error: "Child session is not connected to a linked parent" });
@@ -156,7 +154,10 @@ describe("createFollowUpGrace fireSessionComplete", () => {
             .mockImplementationOnce(async () => ({ ok: false, error: "relay down" } as { ok: boolean; error?: string }))
             .mockImplementationOnce(async () => ({ ok: true } as { ok: boolean; error?: string }));
 
-        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState());
+        const followUpGrace = createFollowUpGrace(makeRelayContext(), makeState(), {
+            emitSessionCompleteWithAck: mockEmitSessionCompleteWithAck,
+            logger: mockLogger,
+        });
 
         const first = await followUpGrace.fireSessionComplete("Errored summary", "/tmp/error.md", "error");
         const second = await followUpGrace.fireSessionComplete(undefined, undefined, "completed");

--- a/packages/cli/src/extensions/remote/followup-grace.ts
+++ b/packages/cli/src/extensions/remote/followup-grace.ts
@@ -46,7 +46,17 @@ export interface FollowUpGraceState {
  * @param rctx  Relay context (for relay / sioSocket / isChildSession access).
  * @param state Mutable grace-period state.
  */
-export function createFollowUpGrace(rctx: RelayContext, state: FollowUpGraceState) {
+export function createFollowUpGrace(
+    rctx: RelayContext,
+    state: FollowUpGraceState,
+    deps?: {
+        emitSessionCompleteWithAck?: typeof emitSessionCompleteWithAck;
+        logger?: Pick<typeof log, "info">;
+    },
+) {
+    const emitSessionComplete = deps?.emitSessionCompleteWithAck ?? emitSessionCompleteWithAck;
+    const logger = deps?.logger ?? log;
+
     function clearFollowUpGrace(): void {
         if (state.followUpGraceTimer !== null) {
             clearTimeout(state.followUpGraceTimer);
@@ -64,7 +74,7 @@ export function createFollowUpGrace(rctx: RelayContext, state: FollowUpGraceStat
         if (state.followUpGraceShutdown) {
             const shutdown = state.followUpGraceShutdown;
             clearFollowUpGrace();
-            log.info("parent delinked while follow-up grace active — shutting down immediately");
+            logger.info("parent delinked while follow-up grace active — shutting down immediately");
             shutdown();
         }
     }
@@ -76,11 +86,11 @@ export function createFollowUpGrace(rctx: RelayContext, state: FollowUpGraceStat
     function startFollowUpGrace(ctx: { shutdown: () => void }): void {
         clearFollowUpGrace();
         state.followUpGraceShutdown = ctx.shutdown;
-        log.info(`pizzapi: waiting ${FOLLOWUP_GRACE_MS / 1_000}s for parent follow-up before shutting down`);
+        logger.info(`pizzapi: waiting ${FOLLOWUP_GRACE_MS / 1_000}s for parent follow-up before shutting down`);
         state.followUpGraceTimer = setTimeout(() => {
             state.followUpGraceTimer = null;
             state.followUpGraceShutdown = null;
-            log.info("pizzapi: follow-up grace period expired — shutting down");
+            logger.info("pizzapi: follow-up grace period expired — shutting down");
             ctx.shutdown();
         }, FOLLOWUP_GRACE_MS);
         if (
@@ -149,7 +159,7 @@ export function createFollowUpGrace(rctx: RelayContext, state: FollowUpGraceStat
             }
         };
 
-        const deliveryPromise = emitSessionCompleteWithAck({
+        const deliveryPromise = emitSessionComplete({
             socket: rctx.sioSocket,
             token: rctx.relay.token,
             sourceSessionId: rctx.relay.sessionId,
@@ -170,7 +180,7 @@ export function createFollowUpGrace(rctx: RelayContext, state: FollowUpGraceStat
                     state.sessionCompleteRetryTimer = null;
                 }
             } else {
-                log.info(`pizzapi: session_complete delivery failed — ${result.error ?? "unknown error"}`);
+                logger.info(`pizzapi: session_complete delivery failed — ${result.error ?? "unknown error"}`);
                 scheduleRetry();
             }
             return result;

--- a/packages/cli/src/extensions/tool-search-bridge.ts
+++ b/packages/cli/src/extensions/tool-search-bridge.ts
@@ -1,0 +1,27 @@
+export interface ToolSearchToolStatus {
+  name: string;
+  description: string;
+  parameterNames: string[];
+  charCount: number;
+  serverName?: string;
+}
+
+export interface ToolSearchSnapshot {
+  active: boolean;
+  deferredTools: ToolSearchToolStatus[];
+  loadedOnDemandTools: ToolSearchToolStatus[];
+}
+
+export interface ToolSearchBridge {
+  status: () => ToolSearchSnapshot;
+}
+
+let activeBridge: ToolSearchBridge | null = null;
+
+export function setToolSearchBridge(bridge: ToolSearchBridge | null) {
+  activeBridge = bridge;
+}
+
+export function getToolSearchBridge(): ToolSearchBridge | null {
+  return activeBridge;
+}

--- a/packages/cli/src/extensions/tool-search.lifecycle.test.ts
+++ b/packages/cli/src/extensions/tool-search.lifecycle.test.ts
@@ -1,25 +1,56 @@
 import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { _setGlobalConfigDir } from "../config.js";
+import { setMcpBridge } from "./mcp-bridge.js";
 
 type EventHandler = (event?: unknown, ctx?: unknown) => unknown;
 
 describe("toolSearchExtension lifecycle sync", () => {
   let snapshot: { serverTools?: Record<string, string[]> };
-  let config: Record<string, unknown>;
+  let tempRoot: string;
+  let globalConfigDir: string;
+  let projectDir: string;
+  let originalCwd: string;
 
   beforeEach(() => {
     snapshot = { serverTools: {} };
-    config = {
-      toolSearch: {
-        enabled: true,
-        tokenThreshold: 0,
-        maxResults: 5,
-        keepLoadedTools: true,
-      },
-      mcpServers: {},
-    };
+    originalCwd = process.cwd();
+    tempRoot = mkdtempSync(join(tmpdir(), "tool-search-lifecycle-"));
+    globalConfigDir = join(tempRoot, "global");
+    projectDir = join(tempRoot, "project");
+
+    mkdirSync(globalConfigDir, { recursive: true });
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(join(globalConfigDir, "config.json"), JSON.stringify({}), "utf-8");
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        toolSearch: {
+          enabled: true,
+          tokenThreshold: 0,
+          maxResults: 5,
+          keepLoadedTools: true,
+        },
+        mcpServers: {},
+      }),
+      "utf-8",
+    );
+
+    _setGlobalConfigDir(globalConfigDir);
+    process.chdir(projectDir);
+    setMcpBridge({
+      status: () => snapshot,
+      reload: async () => null,
+    });
   });
 
   afterEach(() => {
+    setMcpBridge(null);
+    _setGlobalConfigDir(null);
+    process.chdir(originalCwd);
+    rmSync(tempRoot, { recursive: true, force: true });
     mock.restore();
   });
 
@@ -72,21 +103,7 @@ describe("toolSearchExtension lifecycle sync", () => {
   }
 
   async function loadExtension() {
-    mock.module("../config.js", () => ({
-      loadConfig: mock(() => config),
-    }));
-    mock.module("./mcp-bridge.js", () => ({
-      getMcpBridge: mock(() => ({ status: () => snapshot })),
-    }));
-
-    const mod = await import("./tool-search.js");
-
-    // Restore immediately after import so the captured module graph keeps the
-    // mocked dependencies, but unrelated test files in the same worker resolve
-    // the real config/mcp-bridge modules.
-    mock.restore();
-
-    return mod;
+    return await import("./tool-search.js");
   }
 
   test("re-evaluates when MCP tools appear after startup", async () => {

--- a/packages/cli/src/extensions/tool-search.lifecycle.test.ts
+++ b/packages/cli/src/extensions/tool-search.lifecycle.test.ts
@@ -79,7 +79,14 @@ describe("toolSearchExtension lifecycle sync", () => {
       getMcpBridge: mock(() => ({ status: () => snapshot })),
     }));
 
-    return await import("./tool-search.js");
+    const mod = await import("./tool-search.js");
+
+    // Restore immediately after import so the captured module graph keeps the
+    // mocked dependencies, but unrelated test files in the same worker resolve
+    // the real config/mcp-bridge modules.
+    mock.restore();
+
+    return mod;
   }
 
   test("re-evaluates when MCP tools appear after startup", async () => {

--- a/packages/cli/src/extensions/tool-search.lifecycle.test.ts
+++ b/packages/cli/src/extensions/tool-search.lifecycle.test.ts
@@ -108,6 +108,80 @@ describe("toolSearchExtension lifecycle sync", () => {
     return await import("./tool-search.js");
   }
 
+  test("always-deferral still defers when total chars stay under the threshold", async () => {
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        toolSearch: {
+          enabled: true,
+          tokenThreshold: 999999,
+          maxResults: 5,
+          keepLoadedTools: true,
+        },
+        mcpServers: {
+          github: { deferLoading: true },
+        },
+      }),
+      "utf-8",
+    );
+
+    snapshot = { serverTools: { github: ["mcp_github_create_issue"] } };
+    const { toolSearchExtension } = await loadExtension();
+    const { pi, registeredCommands, activeTools } = createHarness();
+
+    toolSearchExtension(pi as any);
+
+    const sessionStart = pi.on.mock.calls.find(([event]) => event === "session_start")?.[1] as EventHandler | undefined;
+    expect(sessionStart).toBeDefined();
+    await sessionStart!(undefined, undefined);
+
+    const statusCommand = registeredCommands.get("tool-search");
+    const notes: string[] = [];
+    statusCommand.handler("status", { ui: { notify: (msg: string) => notes.push(msg) } });
+
+    expect(notes.at(-1)).toContain("Tool search: active");
+    expect(notes.at(-1)).toContain("Deferred tools: 1");
+    expect(activeTools.has("mcp_github_create_issue")).toBe(false);
+  });
+
+  test("always-deferral also works for preferred mcp.servers config under the threshold", async () => {
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        toolSearch: {
+          enabled: true,
+          tokenThreshold: 999999,
+          maxResults: 5,
+          keepLoadedTools: true,
+        },
+        mcp: {
+          servers: [
+            { name: "github", transport: "stdio", command: "noop", deferLoading: true },
+          ],
+        },
+      }),
+      "utf-8",
+    );
+
+    snapshot = { serverTools: { github: ["mcp_github_create_issue"] } };
+    const { toolSearchExtension } = await loadExtension();
+    const { pi, registeredCommands, activeTools } = createHarness();
+
+    toolSearchExtension(pi as any);
+
+    const sessionStart = pi.on.mock.calls.find(([event]) => event === "session_start")?.[1] as EventHandler | undefined;
+    expect(sessionStart).toBeDefined();
+    await sessionStart!(undefined, undefined);
+
+    const statusCommand = registeredCommands.get("tool-search");
+    const notes: string[] = [];
+    statusCommand.handler("status", { ui: { notify: (msg: string) => notes.push(msg) } });
+
+    expect(notes.at(-1)).toContain("Tool search: active");
+    expect(notes.at(-1)).toContain("Deferred tools: 1");
+    expect(activeTools.has("mcp_github_create_issue")).toBe(false);
+  });
+
   test("re-evaluates when MCP tools appear after startup", async () => {
     snapshot = { serverTools: {} };
     const { toolSearchExtension } = await loadExtension();
@@ -193,7 +267,7 @@ describe("toolSearchExtension lifecycle sync", () => {
     expect(clearedNotes.at(-1)).toContain("Tool search: inactive");
     expect(clearedNotes.at(-1)).toContain("Deferred tools: 0");
     expect(clearedNotes.at(-1)).toContain("Loaded on-demand: 0");
-    expect(activeTools.has("mcp_github_create_issue")).toBe(true);
+    expect(activeTools.has("mcp_github_create_issue")).toBe(false);
   });
 
   test("session shutdown clears loaded-on-demand state before the next session", async () => {

--- a/packages/cli/src/extensions/tool-search.lifecycle.test.ts
+++ b/packages/cli/src/extensions/tool-search.lifecycle.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _setGlobalConfigDir } from "../config.js";
 import { setMcpBridge } from "./mcp-bridge.js";
+import { getToolSearchBridge, setToolSearchBridge } from "./tool-search-bridge.js";
 
 type EventHandler = (event?: unknown, ctx?: unknown) => unknown;
 
@@ -48,6 +49,7 @@ describe("toolSearchExtension lifecycle sync", () => {
 
   afterEach(() => {
     setMcpBridge(null);
+    setToolSearchBridge(null);
     _setGlobalConfigDir(null);
     process.chdir(originalCwd);
     rmSync(tempRoot, { recursive: true, force: true });
@@ -135,16 +137,39 @@ describe("toolSearchExtension lifecycle sync", () => {
     expect(activeTools.has("search_tools")).toBe(true);
     expect(activeTools.has("mcp_github_create_issue")).toBe(false);
 
+    const bridge = getToolSearchBridge();
+    expect(bridge).toBeDefined();
+    expect(bridge?.status()).toMatchObject({
+      active: true,
+      deferredTools: [
+        expect.objectContaining({
+          name: "mcp_github_create_issue",
+          serverName: "github",
+        }),
+      ],
+      loadedOnDemandTools: [],
+    });
+
     const searchTool = registeredTools.get("search_tools");
     const result = await searchTool.execute("tool-call-1", { query: "github issue" }, undefined);
     const text = result.content?.[0]?.text ?? "";
     expect(text).toContain("mcp_github_create_issue");
+    expect(bridge?.status()).toMatchObject({
+      active: true,
+      deferredTools: [],
+      loadedOnDemandTools: [
+        expect.objectContaining({
+          name: "mcp_github_create_issue",
+          serverName: "github",
+        }),
+      ],
+    });
   });
 
   test("clears stale state when the MCP snapshot disappears", async () => {
     snapshot = { serverTools: { github: ["mcp_github_create_issue"] } };
     const { toolSearchExtension } = await loadExtension();
-    const { pi, registeredCommands } = createHarness();
+    const { pi, registeredCommands, activeTools } = createHarness();
 
     toolSearchExtension(pi as any);
 
@@ -168,5 +193,37 @@ describe("toolSearchExtension lifecycle sync", () => {
     expect(clearedNotes.at(-1)).toContain("Tool search: inactive");
     expect(clearedNotes.at(-1)).toContain("Deferred tools: 0");
     expect(clearedNotes.at(-1)).toContain("Loaded on-demand: 0");
+    expect(activeTools.has("mcp_github_create_issue")).toBe(true);
+  });
+
+  test("session shutdown clears loaded-on-demand state before the next session", async () => {
+    snapshot = { serverTools: { github: ["mcp_github_create_issue"] } };
+    const { toolSearchExtension } = await loadExtension();
+    const { pi, registeredTools, registeredCommands } = createHarness();
+
+    toolSearchExtension(pi as any);
+
+    const sessionStart = pi.on.mock.calls.find(([event]) => event === "session_start")?.[1] as EventHandler | undefined;
+    const sessionShutdown = pi.on.mock.calls.find(([event]) => event === "session_shutdown")?.[1] as EventHandler | undefined;
+    expect(sessionStart).toBeDefined();
+    expect(sessionShutdown).toBeDefined();
+
+    await sessionStart!(undefined, undefined);
+
+    const searchTool = registeredTools.get("search_tools");
+    await searchTool.execute("tool-call-1", { query: "github issue" }, undefined);
+
+    const activeNotes: string[] = [];
+    const statusCommand = registeredCommands.get("tool-search");
+    statusCommand.handler("status", { ui: { notify: (msg: string) => activeNotes.push(msg) } });
+    expect(activeNotes.at(-1)).toContain("Loaded on-demand: 1");
+
+    await sessionShutdown!(undefined, undefined);
+    await sessionStart!(undefined, undefined);
+
+    const nextSessionNotes: string[] = [];
+    statusCommand.handler("status", { ui: { notify: (msg: string) => nextSessionNotes.push(msg) } });
+    expect(nextSessionNotes.at(-1)).toContain("Deferred tools: 1");
+    expect(nextSessionNotes.at(-1)).toContain("Loaded on-demand: 0");
   });
 });

--- a/packages/cli/src/extensions/tool-search.ts
+++ b/packages/cli/src/extensions/tool-search.ts
@@ -213,7 +213,7 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
 
     if (!snapshot?.serverTools) {
       log.info("No MCP tools found, tool search not needed");
-      clearState({ restoreActiveTools: true });
+      clearState();
       return;
     }
 
@@ -267,7 +267,7 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
 
     if (toolsToDefer.length === 0) {
       log.info(`Tool search: no tools to defer (${totalMcpChars} chars, threshold ${threshold})`);
-      clearState({ restoreActiveTools: true });
+      clearState({ restoreActiveTools: mcpTools.length > 0 });
       return;
     }
 

--- a/packages/cli/src/extensions/tool-search.ts
+++ b/packages/cli/src/extensions/tool-search.ts
@@ -16,6 +16,7 @@ import type { ExtensionFactory } from "@mariozechner/pi-coding-agent";
 import { loadConfig, type PizzaPiConfig } from "../config.js";
 import { getMcpBridge } from "./mcp-bridge.js";
 import type { McpConfig } from "./mcp/registry.js";
+import { setToolSearchBridge } from "./tool-search-bridge.js";
 import { createLogger } from "@pizzapi/tools";
 
 const log = createLogger("tool-search");
@@ -42,7 +43,7 @@ type ToolSearchState = {
   /** Tools that have been deferred (removed from active set). */
   deferredTools: Map<string, ToolInfo>;
   /** Tools that have been loaded on-demand via search. */
-  loadedTools: Set<string>;
+  loadedTools: Map<string, ToolInfo>;
   /** Whether tool search is actively managing tools this session. */
   active: boolean;
 };
@@ -158,15 +159,33 @@ function getServerDeferConfig(config: PizzaPiConfig & McpConfig): Map<string, bo
 export const toolSearchExtension: ExtensionFactory = (pi: any) => {
   const state: ToolSearchState = {
     deferredTools: new Map(),
-    loadedTools: new Set(),
+    loadedTools: new Map(),
     active: false,
   };
 
-  function clearState(): void {
+  function restoreManagedTools(): void {
+    const currentActive = new Set(pi.getActiveTools() as string[]);
+    for (const name of state.deferredTools.keys()) currentActive.add(name);
+    for (const name of state.loadedTools.keys()) currentActive.add(name);
+    pi.setActiveTools([...currentActive]);
+  }
+
+  function clearState(options?: { restoreActiveTools?: boolean }): void {
+    if (options?.restoreActiveTools) {
+      restoreManagedTools();
+    }
     state.deferredTools.clear();
     state.loadedTools.clear();
     state.active = false;
   }
+
+  setToolSearchBridge({
+    status: () => ({
+      active: state.active,
+      deferredTools: [...state.deferredTools.values()],
+      loadedOnDemandTools: [...state.loadedTools.values()],
+    }),
+  });
 
   /**
    * Evaluate whether tool search should activate, and if so, which tools to defer.
@@ -177,7 +196,7 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
     const tsConfig = config.toolSearch;
 
     if (!tsConfig?.enabled) {
-      clearState();
+      clearState({ restoreActiveTools: true });
       return;
     }
 
@@ -194,7 +213,7 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
 
     if (!snapshot?.serverTools) {
       log.info("No MCP tools found, tool search not needed");
-      clearState();
+      clearState({ restoreActiveTools: true });
       return;
     }
 
@@ -248,11 +267,11 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
 
     if (toolsToDefer.length === 0) {
       log.info(`Tool search: no tools to defer (${totalMcpChars} chars, threshold ${threshold})`);
-      clearState();
+      clearState({ restoreActiveTools: true });
       return;
     }
 
-    const previousLoadedTools = new Set(state.loadedTools);
+    const previousLoadedTools = new Map(state.loadedTools);
 
     // Build deferred tool info map
     state.deferredTools.clear();
@@ -272,14 +291,20 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
     // Preserve any tools that were previously loaded on-demand and are still active.
     const currentActive = new Set(pi.getActiveTools() as string[]);
     state.loadedTools.clear();
-    for (const name of previousLoadedTools) {
+    for (const [name, info] of previousLoadedTools) {
       if (currentActive.has(name)) {
-        state.loadedTools.add(name);
+        state.loadedTools.set(name, info);
       }
+    }
+
+    const loadedOnDemandNames = new Set(state.loadedTools.keys());
+    for (const name of loadedOnDemandNames) {
+      state.deferredTools.delete(name);
     }
 
     // Deactivate deferred tools
     for (const name of toolsToDefer) {
+      if (loadedOnDemandNames.has(name)) continue;
       currentActive.delete(name);
     }
     // Ensure search_tools stays active
@@ -361,13 +386,9 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
         if (!currentActive.has(match.name)) {
           currentActive.add(match.name);
           newlyLoaded.push(match.name);
-          if (keepLoaded) {
-            state.loadedTools.add(match.name);
-          }
-          // Remove from deferred since they're now loaded
-          if (keepLoaded) {
-            state.deferredTools.delete(match.name);
-          }
+          state.loadedTools.set(match.name, match);
+          // Remove from deferred while loaded, even if keepLoadedTools=false.
+          state.deferredTools.delete(match.name);
         }
       }
 
@@ -441,8 +462,8 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
       if (state.loadedTools.size > 0) {
         lines.push("");
         lines.push("Loaded on-demand:");
-        for (const name of state.loadedTools) {
-          lines.push(`  - ${name}`);
+        for (const tool of state.loadedTools.values()) {
+          lines.push(`  - ${tool.name}`);
         }
       }
 
@@ -479,10 +500,16 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
 
     // Re-defer tools that were loaded on-demand
     const currentActive = new Set(pi.getActiveTools() as string[]);
-    for (const name of state.loadedTools) {
+    for (const [name, info] of state.loadedTools) {
       currentActive.delete(name);
+      state.deferredTools.set(name, info);
     }
     pi.setActiveTools([...currentActive]);
     state.loadedTools.clear();
+  });
+
+  pi.on?.("session_shutdown", async () => {
+    clearState();
+    setToolSearchBridge(null);
   });
 };

--- a/packages/cli/src/extensions/triggers/new-session-cleanup.test.ts
+++ b/packages/cli/src/extensions/triggers/new-session-cleanup.test.ts
@@ -8,9 +8,8 @@
 //   4. Calls onConfirmed when the server acks the cancel (at-least-once delivery)
 // ============================================================================
 
-import { afterAll, describe, it, expect, beforeEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, mock } from "bun:test";
 import * as actualRemote from "../remote.js";
-import { trackReceivedTrigger, receivedTriggers, clearAndCancelPendingTriggers } from "./extension.js";
 
 // ── Mock the relay socket used by clearAndCancelPendingTriggers ──────────────
 // The function calls getRelaySocket() from ../remote.js. We mock at the module
@@ -25,7 +24,7 @@ let mockSocket: {
 
 let mockToken = "test-token-123";
 
-// Mock getRelaySocket to return our mock
+// Mock getRelaySocket to return our mock.
 mock.module("../remote.js", () => ({
     ...actualRemote,
     getRelaySocket: () =>
@@ -35,9 +34,15 @@ mock.module("../remote.js", () => ({
     getRelaySessionId: () => "parent-session-1",
 }));
 
-// Restore all module mocks after this file so they don't bleed into other
-// test files running in the same worker process.
-afterAll(() => mock.restore());
+const {
+    trackReceivedTrigger,
+    receivedTriggers,
+    clearAndCancelPendingTriggers,
+} = await import("./extension.js");
+
+// extension.js has already captured the mocked remote helpers; restore the
+// global mock registry immediately so later test files resolve the real module.
+mock.restore();
 
 describe("clearAndCancelPendingTriggers", () => {
     beforeEach(() => {

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -34,6 +34,16 @@ function piAiPath(subpath: string): string {
     return resolve(pkgRoot, subpath);
 }
 
+/**
+ * Resolve a deep path inside @mariozechner/pi-agent-core.
+ */
+function piAgentCorePath(subpath: string): string {
+    const pkgMainUrl = import.meta.resolve("@mariozechner/pi-agent-core");
+    const pkgMain = fileURLToPath(pkgMainUrl);
+    const pkgRoot = resolve(dirname(pkgMain), "..");
+    return resolve(pkgRoot, subpath);
+}
+
 // ===========================================================================
 // pi-coding-agent patches
 // ===========================================================================
@@ -272,6 +282,143 @@ describe("pi-coding-agent API surface compatibility", () => {
     test("buildSessionContext is exported", async () => {
         const mod = await import("@mariozechner/pi-coding-agent");
         expect(typeof mod.buildSessionContext).toBe("function");
+    });
+});
+
+describe("pi-agent-core dynamic tool refresh", () => {
+    test("tools loaded during a tool call are visible to the very next assistant response", async () => {
+        const { Agent } = await import("@mariozechner/pi-agent-core");
+
+        const usage = {
+            input: 0,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 0,
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, total: 0 },
+        };
+        const model = {
+            id: "test-model",
+            name: "Test Model",
+            api: "test-api",
+            provider: "test-provider",
+            baseUrl: "http://localhost",
+            reasoning: false,
+            input: ["text"],
+            cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+            contextWindow: 128000,
+            maxTokens: 4096,
+        };
+
+        const seenToolSets: string[][] = [];
+        const responses = [
+            {
+                role: "assistant",
+                content: [{ type: "toolCall", id: "tc-search", name: "search_tools", arguments: { query: "load dynamic tool" } }],
+                api: model.api,
+                provider: model.provider,
+                model: model.id,
+                usage,
+                stopReason: "stop",
+                timestamp: Date.now(),
+            },
+            {
+                role: "assistant",
+                content: [{ type: "toolCall", id: "tc-dynamic", name: "dynamic_tool", arguments: {} }],
+                api: model.api,
+                provider: model.provider,
+                model: model.id,
+                usage,
+                stopReason: "stop",
+                timestamp: Date.now(),
+            },
+            {
+                role: "assistant",
+                content: [{ type: "text", text: "done" }],
+                api: model.api,
+                provider: model.provider,
+                model: model.id,
+                usage,
+                stopReason: "stop",
+                timestamp: Date.now(),
+            },
+        ];
+
+        const streamFn = async (_model: unknown, context: { tools?: Array<{ name: string }> }) => {
+            seenToolSets.push((context.tools ?? []).map((tool) => tool.name));
+            const message = responses.shift();
+            if (!message) throw new Error("No more responses queued");
+            return {
+                async *[Symbol.asyncIterator]() {
+                    yield { type: "done" } as const;
+                },
+                async result() {
+                    return message;
+                },
+            };
+        };
+
+        let agent: InstanceType<typeof Agent>;
+        const dynamicTool = {
+            name: "dynamic_tool",
+            label: "Dynamic Tool",
+            description: "Loaded on demand",
+            parameters: { type: "object", properties: {} },
+            async execute() {
+                return { content: [{ type: "text" as const, text: "dynamic ok" }], details: {} };
+            },
+        };
+        const searchTool = {
+            name: "search_tools",
+            label: "Search Tools",
+            description: "Loads the deferred tool",
+            parameters: {
+                type: "object",
+                properties: { query: { type: "string" } },
+                required: ["query"],
+            },
+            async execute() {
+                agent.state.tools = [searchTool, dynamicTool];
+                return { content: [{ type: "text" as const, text: "loaded dynamic_tool" }], details: {} };
+            },
+        };
+
+        agent = new Agent({
+            initialState: {
+                model: model as any,
+                systemPrompt: "test",
+                tools: [searchTool as any],
+            },
+            streamFn: streamFn as any,
+            toolExecution: "sequential",
+        });
+
+        await agent.prompt("go");
+
+        expect(seenToolSets).toHaveLength(3);
+        expect(seenToolSets[0]).toEqual(["search_tools"]);
+        expect(seenToolSets[1]).toContain("dynamic_tool");
+
+        const dynamicToolResult = agent.state.messages.find(
+            (message: any) => message.role === "toolResult" && message.toolName === "dynamic_tool",
+        ) as any;
+        expect(dynamicToolResult).toBeDefined();
+        expect(dynamicToolResult.isError).toBe(false);
+        expect(dynamicToolResult.content).toEqual([{ type: "text", text: "dynamic ok" }]);
+    });
+});
+
+describe("pi-agent-core patch application", () => {
+    test("agent.js + agent-loop.js include dynamic tool refresh patch markers", async () => {
+        const agentSource = await Bun.file(
+            piAgentCorePath("dist/agent.js"),
+        ).text();
+        const loopSource = await Bun.file(
+            piAgentCorePath("dist/agent-loop.js"),
+        ).text();
+
+        expect(agentSource).toContain("PATCH(pizzapi): allow the agent loop to refresh dynamic tool/prompt state");
+        expect(loopSource).toContain("PATCH(pizzapi): refresh dynamic tool/prompt state before each assistant response");
     });
 });
 

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1481,6 +1481,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         hooks: "hooks",
                         sandbox: "sandbox",
                         webSearch: "providerSettings",
+                        toolSearch: "toolSearch",
                         security: "_security",        // virtual — handled specially
                         envVars: "_envVars",          // virtual — handled specially
                         systemPrompt: "_systemPrompt", // virtual — handled specially
@@ -1525,6 +1526,51 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                             ps.anthropic = { ...ps.anthropic, webSearch: v.anthropic.webSearch };
                         }
                         saveGlobal({ providerSettings: ps } as any);
+                    } else if (section === "toolSearch") {
+                        if (value != null && (typeof value !== "object" || Array.isArray(value))) {
+                            socket.emit("file_result", {
+                                requestId,
+                                ok: false,
+                                message: "toolSearch must be a JSON object",
+                            });
+                            return;
+                        }
+
+                        const toolSearch = (value ?? {}) as Record<string, unknown>;
+                        const errors: string[] = [];
+                        const enabled = toolSearch.enabled;
+                        const tokenThreshold = toolSearch.tokenThreshold;
+                        const maxResults = toolSearch.maxResults;
+                        const keepLoadedTools = toolSearch.keepLoadedTools;
+
+                        if (enabled !== undefined && typeof enabled !== "boolean") {
+                            errors.push('"enabled" must be a boolean');
+                        }
+                        if (
+                            tokenThreshold !== undefined &&
+                            (typeof tokenThreshold !== "number" || !Number.isFinite(tokenThreshold) || tokenThreshold < 0)
+                        ) {
+                            errors.push('"tokenThreshold" must be a finite number >= 0');
+                        }
+                        if (
+                            maxResults !== undefined &&
+                            (typeof maxResults !== "number" || !Number.isFinite(maxResults) || maxResults < 1)
+                        ) {
+                            errors.push('"maxResults" must be a finite number >= 1');
+                        }
+                        if (keepLoadedTools !== undefined && typeof keepLoadedTools !== "boolean") {
+                            errors.push('"keepLoadedTools" must be a boolean');
+                        }
+                        if (errors.length > 0) {
+                            socket.emit("file_result", {
+                                requestId,
+                                ok: false,
+                                message: `Invalid Tool Search config:\n${errors.join("\n")}`,
+                            });
+                            return;
+                        }
+
+                        saveGlobal({ toolSearch: value as any });
                     } else if (section === "mcpServers") {
                         // Validate MCP server config before saving
                         if (value != null && (typeof value !== "object" || Array.isArray(value))) {
@@ -1627,7 +1673,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
 
                     // Reload and return the updated config — mask secrets before sending to browser
                     const updatedConfig = sanitizeConfigForUI(loadGlobal() as Record<string, unknown>);
-                    const isMcpSection = section === "mcpServers" || section === "mcp";
+                    const isMcpSection = section === "mcpServers" || section === "mcp" || section === "toolSearch";
                     const reloadHint = isMcpSection
                         ? "MCP server config saved. Active sessions can run /mcp reload to pick up changes."
                         : "Settings saved. Changes apply on next session start.";

--- a/packages/docs/src/content/docs/customization/tool-search.mdx
+++ b/packages/docs/src/content/docs/customization/tool-search.mdx
@@ -51,6 +51,15 @@ Enable Tool Search in `~/.pizzapi/config.json`:
 | `maxResults` | `number` | `5` | Maximum number of tools returned per `search_tools` call. |
 | `keepLoadedTools` | `boolean` | `true` | When `true`, discovered tools stay active for the rest of the session. When `false`, tools are deactivated after each agent turn — useful for very large tool sets where you want minimal context at all times. |
 
+## Web UI controls
+
+You can configure Tool Search from the PizzaPi web UI:
+
+- **Runner Settings → Tool Search** — edit the global `enabled`, `tokenThreshold`, `maxResults`, and `keepLoadedTools` settings.
+- **Runner → MCP Servers** — set each server's deferred-loading override to **Inherit**, **Always defer**, or **Never defer**.
+
+After saving either area, the UI also offers a **Reload MCP** button so active sessions can pick up the new Tool Search / MCP settings immediately without typing `/mcp reload` manually.
+
 ## Per-server `deferLoading` override
 
 You can force individual MCP servers to always defer (or never defer) their tools, regardless of whether the global threshold is exceeded:

--- a/packages/server/src/routes/runner-settings.test.ts
+++ b/packages/server/src/routes/runner-settings.test.ts
@@ -1,0 +1,114 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from "bun:test";
+
+afterAll(() => mock.restore());
+
+const mockRequireSession = mock((_req: Request) =>
+  Promise.resolve({ userId: "user-1", userName: "TestUser" } as any),
+);
+mock.module("../middleware.js", () => ({
+  requireSession: mockRequireSession,
+}));
+
+const mockGetRunnerData = mock((_runnerId: string) => Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
+mock.module("../ws/sio-registry.js", () => ({
+  getRunnerData: mockGetRunnerData,
+}));
+
+const mockSendRunnerCommand = mock((_runnerId: string, _command: Record<string, unknown>) => Promise.resolve({ ok: true } as any));
+mock.module("../ws/namespaces/runner.js", () => ({
+  sendRunnerCommand: mockSendRunnerCommand,
+}));
+
+const { handleRunnerSettingsRoute } = await import("./runner-settings.js");
+
+function makeReq(method: string, path: string, body?: object): [Request, URL] {
+  const url = new URL(`http://localhost${path}`);
+  const init: RequestInit = {
+    method,
+    headers: { "content-type": "application/json" },
+  };
+  if (body) init.body = JSON.stringify(body);
+  return [new Request(url.toString(), init), url];
+}
+
+describe("handleRunnerSettingsRoute", () => {
+  beforeEach(() => {
+    mockRequireSession.mockReset();
+    mockRequireSession.mockReturnValue(Promise.resolve({ userId: "user-1", userName: "TestUser" } as any));
+    mockGetRunnerData.mockReset();
+    mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
+    mockSendRunnerCommand.mockReset();
+    mockSendRunnerCommand.mockReturnValue(Promise.resolve({ ok: true } as any));
+  });
+
+  test("accepts toolSearch as a valid settings section", async () => {
+    const payload = {
+      enabled: true,
+      tokenThreshold: 12000,
+      maxResults: 8,
+      keepLoadedTools: false,
+    };
+
+    const [req, url] = makeReq("PUT", "/api/runners/runner-A/settings", {
+      section: "toolSearch",
+      value: payload,
+    });
+    const res = await handleRunnerSettingsRoute(req, url);
+    expect(res).toBeTruthy();
+    expect(res!.status).toBe(200);
+    expect(mockSendRunnerCommand).toHaveBeenCalledWith("runner-A", {
+      type: "settings_update_section",
+      section: "toolSearch",
+      value: payload,
+    });
+  });
+
+  test("also accepts the preferred mcp section", async () => {
+    const payload = { servers: [{ name: "github", url: "https://example.test/mcp", type: "http" }] };
+    const [req, url] = makeReq("PUT", "/api/runners/runner-A/settings", {
+      section: "mcp",
+      value: payload,
+    });
+    const res = await handleRunnerSettingsRoute(req, url);
+    expect(res!.status).toBe(200);
+    expect(mockSendRunnerCommand).toHaveBeenCalledWith("runner-A", {
+      type: "settings_update_section",
+      section: "mcp",
+      value: payload,
+    });
+  });
+
+  test("returns the daemon response body for toolSearch saves", async () => {
+    mockSendRunnerCommand.mockReturnValue(Promise.resolve({
+      ok: true,
+      saved: true,
+      message: "Tool Search settings saved.",
+      reloadHint: true,
+    } as any));
+
+    const [req, url] = makeReq("PUT", "/api/runners/runner-A/settings", {
+      section: "toolSearch",
+      value: { enabled: true },
+    });
+    const res = await handleRunnerSettingsRoute(req, url);
+    expect(res!.status).toBe(200);
+    const body = await res!.json();
+    expect(body).toEqual({
+      ok: true,
+      saved: true,
+      message: "Tool Search settings saved.",
+      reloadHint: true,
+    });
+  });
+
+  test("still rejects unknown sections", async () => {
+    const [req, url] = makeReq("PUT", "/api/runners/runner-A/settings", {
+      section: "notASection",
+      value: {},
+    });
+    const res = await handleRunnerSettingsRoute(req, url);
+    expect(res!.status).toBe(400);
+    const body = await res!.json();
+    expect(body.error).toContain('Invalid section "notASection"');
+  });
+});

--- a/packages/server/src/routes/runner-settings.ts
+++ b/packages/server/src/routes/runner-settings.ts
@@ -17,9 +17,11 @@ const SETTINGS_RE = /^\/api\/runners\/([^/]+)\/settings$/;
 const VALID_SECTIONS = new Set([
     "models",
     "mcpServers",
+    "mcp",
     "hooks",
     "sandbox",
     "webSearch",
+    "toolSearch",
     "security",
     "envVars",
     "systemPrompt",

--- a/packages/server/src/routes/runners.test.ts
+++ b/packages/server/src/routes/runners.test.ts
@@ -16,6 +16,8 @@ mock.module("../middleware.js", () => ({
 const mockGetRunnerData = mock((_runnerId: string) => Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
 const mockGetRunners = mock((_userId: string) => Promise.resolve([] as any[]));
 const mockGetLocalRunnerSocket = mock((_runnerId: string) => null as any);
+const mockGetLocalTuiSocket = mock((_sessionId: string) => undefined as any);
+const mockGetConnectedSessionsForRunner = mock((_runnerId: string) => Promise.resolve([] as Array<{ sessionId: string; cwd: string }>));
 const mockLinkSessionToRunner = mock((_runnerId: string, _sessionId: string) => Promise.resolve());
 const mockRecordRunnerSession = mock((_runnerId: string, _sessionId: string) => Promise.resolve());
 const mockRegisterTerminal = mock((_terminalId: string, _runnerId: string, _userId: string, _opts: any) => Promise.resolve());
@@ -23,6 +25,8 @@ mock.module("../ws/sio-registry.js", () => ({
     getRunnerData: mockGetRunnerData,
     getRunners: mockGetRunners,
     getLocalRunnerSocket: mockGetLocalRunnerSocket,
+    getLocalTuiSocket: mockGetLocalTuiSocket,
+    getConnectedSessionsForRunner: mockGetConnectedSessionsForRunner,
     linkSessionToRunner: mockLinkSessionToRunner,
     recordRunnerSession: mockRecordRunnerSession,
     registerTerminal: mockRegisterTerminal,
@@ -92,6 +96,9 @@ describe("runner trigger listener routes", () => {
         mockUpdateRunnerTriggerListener.mockReset();
         mockUpdateRunnerTriggerListener.mockReturnValue(Promise.resolve({ updated: false }));
         mockGetLocalRunnerSocket.mockReset();
+        mockGetLocalTuiSocket.mockReset();
+        mockGetConnectedSessionsForRunner.mockReset();
+        mockGetConnectedSessionsForRunner.mockReturnValue(Promise.resolve([]));
         mockEmitTriggerSubscriptionDelta.mockReset();
         mockEmitTriggerSubscriptionDelta.mockReturnValue(Promise.resolve());
     });
@@ -191,5 +198,77 @@ describe("runner trigger listener routes", () => {
         expect(body.ok).toBe(true);
         expect(body.triggerType).toBe("svc:event");
         expect(body.removed).toBe(2);
+    });
+});
+
+describe("runner MCP reload route", () => {
+    beforeEach(() => {
+        mockRequireSession.mockReset();
+        mockRequireSession.mockReturnValue(Promise.resolve({ userId: "user-1", userName: "TestUser" } as any));
+        mockGetRunnerData.mockReset();
+        mockGetRunnerData.mockReturnValue(Promise.resolve({ userId: "user-1", runnerId: "runner-A" } as any));
+        mockGetConnectedSessionsForRunner.mockReset();
+        mockGetLocalTuiSocket.mockReset();
+    });
+
+    test("POST reloads MCP for each connected runner session", async () => {
+        const emitA = mock(() => {});
+        const emitB = mock(() => {});
+        mockGetConnectedSessionsForRunner.mockReturnValue(Promise.resolve([
+            { sessionId: "sess-1", cwd: "/tmp/a" },
+            { sessionId: "sess-2", cwd: "/tmp/b" },
+        ]));
+        mockGetLocalTuiSocket.mockImplementation((sessionId: string) => {
+            if (sessionId === "sess-1") return { emit: emitA } as any;
+            if (sessionId === "sess-2") return { emit: emitB } as any;
+            return undefined;
+        });
+
+        const [req, url] = makeReq("POST", "/api/runners/runner-A/mcp/reload");
+        const res = await handleRunnersRoute(req, url);
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.ok).toBe(true);
+        expect(body.reloaded).toBe(2);
+        expect(body.failed).toBe(0);
+        expect(emitA).toHaveBeenCalledWith("exec", expect.objectContaining({ command: "mcp", action: "reload" }));
+        expect(emitB).toHaveBeenCalledWith("exec", expect.objectContaining({ command: "mcp", action: "reload" }));
+    });
+
+    test("POST reports sessions that could not be reloaded", async () => {
+        const emitA = mock(() => {});
+        mockGetConnectedSessionsForRunner.mockReturnValue(Promise.resolve([
+            { sessionId: "sess-1", cwd: "/tmp/a" },
+            { sessionId: "sess-2", cwd: "/tmp/b" },
+        ]));
+        mockGetLocalTuiSocket.mockImplementation((sessionId: string) => (
+            sessionId === "sess-1" ? { emit: emitA } as any : undefined
+        ));
+
+        const [req, url] = makeReq("POST", "/api/runners/runner-A/mcp/reload");
+        const res = await handleRunnersRoute(req, url);
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.reloaded).toBe(1);
+        expect(body.failed).toBe(1);
+        expect(body.sessionIds).toEqual(["sess-1"]);
+        expect(body.failedSessionIds).toEqual(["sess-2"]);
+    });
+
+    test("POST reports when all active sessions fail to reload", async () => {
+        mockGetConnectedSessionsForRunner.mockReturnValue(Promise.resolve([
+            { sessionId: "sess-1", cwd: "/tmp/a" },
+            { sessionId: "sess-2", cwd: "/tmp/b" },
+        ]));
+        mockGetLocalTuiSocket.mockReturnValue(undefined as any);
+
+        const [req, url] = makeReq("POST", "/api/runners/runner-A/mcp/reload");
+        const res = await handleRunnersRoute(req, url);
+        expect(res!.status).toBe(200);
+        const body = await res!.json();
+        expect(body.reloaded).toBe(0);
+        expect(body.failed).toBe(2);
+        expect(body.sessionIds).toEqual([]);
+        expect(body.failedSessionIds).toEqual(["sess-1", "sess-2"]);
     });
 });

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -10,6 +10,8 @@ import {
     getRunnerData,
     getRunners,
     getLocalRunnerSocket,
+    getLocalTuiSocket,
+    getConnectedSessionsForRunner,
     linkSessionToRunner,
     recordRunnerSession,
     registerTerminal,
@@ -53,6 +55,8 @@ function runnerListenerAsSubscription(runnerId: string, listener: {
         ...(listener.params ? { params: listener.params as Record<string, string | number | boolean | Array<string | number | boolean>> } : {}),
     };
 }
+
+const RUNNER_MCP_RELOAD_RE = /^\/api\/runners\/([^/]+)\/mcp\/reload$/;
 
 export const handleRunnersRoute: RouteHandler = async (req, url) => {
     // ── List runners ───────────────────────────────────────────────────
@@ -210,6 +214,51 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
         }
 
         return Response.json({ ok: true, runnerId, sessionId, pending: (ack as any).timeout === true });
+    }
+
+    // ── Reload MCP in active sessions for a runner ─────────────────────
+    {
+        const match = url.pathname.match(RUNNER_MCP_RELOAD_RE);
+        if (match && req.method === "POST") {
+            const identity = await requireSession(req);
+            if (identity instanceof Response) return identity;
+
+            const runnerId = decodeURIComponent(match[1]);
+            const runner = await getRunnerData(runnerId);
+            if (!runner) return Response.json({ error: "Runner not found" }, { status: 404 });
+            if (runner.userId !== identity.userId) return Response.json({ error: "Forbidden" }, { status: 403 });
+
+            const connectedSessions = await getConnectedSessionsForRunner(runnerId);
+            const reloadedSessionIds: string[] = [];
+            const failedSessionIds: string[] = [];
+
+            for (const { sessionId } of connectedSessions) {
+                const tuiSocket = getLocalTuiSocket(sessionId);
+                if (!tuiSocket) {
+                    failedSessionIds.push(sessionId);
+                    continue;
+                }
+                try {
+                    tuiSocket.emit("exec" as string, {
+                        type: "exec",
+                        id: crypto.randomUUID(),
+                        command: "mcp",
+                        action: "reload",
+                    });
+                    reloadedSessionIds.push(sessionId);
+                } catch {
+                    failedSessionIds.push(sessionId);
+                }
+            }
+
+            return Response.json({
+                ok: true,
+                reloaded: reloadedSessionIds.length,
+                failed: failedSessionIds.length,
+                sessionIds: reloadedSessionIds,
+                failedSessionIds,
+            });
+        }
     }
 
     // ── Restart runner ─────────────────────────────────────────────────

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1981,6 +1981,35 @@ export function App() {
         const disabledServersForMcp = Array.isArray(mcpConfig?.disabledServers)
           ? (mcpConfig.disabledServers as unknown[]).filter((s: unknown): s is string => typeof s === "string")
           : [];
+        const counts = result?.counts && typeof result.counts === "object"
+          ? result.counts as {
+            totalTools: number;
+            loadedTools: number;
+            deferredTools: number;
+            loadedOnDemandTools: number;
+            disabledServers: number;
+          }
+          : undefined;
+        const serverStates = Array.isArray(result?.serverStates)
+          ? result.serverStates as Array<{
+            name: string;
+            transport: string;
+            scope: string;
+            sourcePath?: string;
+            state: "loaded" | "deferred" | "disabled" | "partial";
+            totalToolCount: number;
+            loadedToolCount: number;
+            deferredToolCount: number;
+            loadedOnDemandToolCount: number;
+          }>
+          : undefined;
+        const toolStates = Array.isArray(result?.toolStates)
+          ? result.toolStates as Array<{
+            name: string;
+            serverName: string;
+            state: "loaded" | "deferred" | "loaded_on_demand";
+          }>
+          : undefined;
 
         appendLocalSystemMessage({
           kind: "mcp",
@@ -1992,6 +2021,9 @@ export function App() {
           errors,
           serverTools,
           disabledServers: disabledServersForMcp,
+          counts,
+          serverStates,
+          toolStates,
           loadedAt: typeof result?.loadedAt === "string" ? result.loadedAt : undefined,
         });
 
@@ -2019,6 +2051,35 @@ export function App() {
         const disabledServers = Array.isArray(toggleConfig?.disabledServers)
           ? (toggleConfig.disabledServers as unknown[]).filter((s: unknown): s is string => typeof s === "string")
           : [];
+        const counts = result?.counts && typeof result.counts === "object"
+          ? result.counts as {
+            totalTools: number;
+            loadedTools: number;
+            deferredTools: number;
+            loadedOnDemandTools: number;
+            disabledServers: number;
+          }
+          : undefined;
+        const serverStates = Array.isArray(result?.serverStates)
+          ? result.serverStates as Array<{
+            name: string;
+            transport: string;
+            scope: string;
+            sourcePath?: string;
+            state: "loaded" | "deferred" | "disabled" | "partial";
+            totalToolCount: number;
+            loadedToolCount: number;
+            deferredToolCount: number;
+            loadedOnDemandToolCount: number;
+          }>
+          : undefined;
+        const toolStates = Array.isArray(result?.toolStates)
+          ? result.toolStates as Array<{
+            name: string;
+            serverName: string;
+            state: "loaded" | "deferred" | "loaded_on_demand";
+          }>
+          : undefined;
         const toggledServer = typeof result?.toggledServer === "string" ? result.toggledServer : "";
         const disabled = result?.disabled === true;
 
@@ -2032,6 +2093,9 @@ export function App() {
           errors,
           serverTools,
           disabledServers,
+          counts,
+          serverStates,
+          toolStates,
           loadedAt: typeof result?.loadedAt === "string" ? result.loadedAt : undefined,
         });
 

--- a/packages/ui/src/components/McpServersManager.tsx
+++ b/packages/ui/src/components/McpServersManager.tsx
@@ -16,6 +16,7 @@ import {
     CheckCircle,
     Loader2,
     RotateCcw,
+    RefreshCw,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -25,6 +26,9 @@ import { Badge } from "@/components/ui/badge";
 import { ErrorAlert } from "@/components/ui/error-alert";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { applyDeferLoadingMode, deferLoadingValueToMode, type DeferLoadingMode } from "@/components/mcp-server-defer-loading";
+import { formatMcpReloadMessage } from "@/components/mcp-reload-status";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -37,9 +41,12 @@ interface McpServerEntry {
     command?: string;
     args?: string[];
     url?: string;
+    type?: string;
+    transport?: string;
     env?: Record<string, string>;
     cwd?: string;
     disabled?: boolean;
+    deferLoading?: boolean;
 }
 
 type ServersMap = Record<string, McpServerEntry>;
@@ -82,6 +89,9 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
     const [saving, setSaving] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [saveMessage, setSaveMessage] = useState<string | null>(null);
+    const [reloading, setReloading] = useState(false);
+    const [reloadMessage, setReloadMessage] = useState<string | null>(null);
+    const [hasPreferredFormatConfig, setHasPreferredFormatConfig] = useState(false);
 
     // Expand/delete state
     const [expandedServer, setExpandedServer] = useState<string | null>(null);
@@ -111,6 +121,8 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
             const raw = cfg.mcpServers;
             const parsed: ServersMap =
                 raw != null && typeof raw === "object" && !Array.isArray(raw) ? { ...raw } : {};
+            const preferredServers = Array.isArray(cfg.mcp?.servers) ? cfg.mcp.servers : [];
+            setHasPreferredFormatConfig(preferredServers.length > 0);
             setServers(parsed);
             setSavedServers(parsed);
         } catch (err) {
@@ -129,6 +141,7 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
     const handleSave = async () => {
         setSaving(true);
         setSaveMessage(null);
+        setReloadMessage(null);
         setError(null);
         try {
             const res = await fetch(`/api/runners/${encodeURIComponent(runnerId)}/settings`, {
@@ -142,7 +155,7 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
             }
             setSavedServers({ ...servers });
             setSaveMessage(
-                "MCP server config saved. Active sessions can run /mcp reload to pick up changes.",
+                "MCP server config saved. Reload MCP in active sessions to apply changes immediately.",
             );
         } catch (err) {
             setError(err instanceof Error ? err.message : String(err));
@@ -158,6 +171,13 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
 
     function updateServer(name: string, patch: Partial<McpServerEntry>) {
         setServers((prev) => ({ ...prev, [name]: { ...prev[name], ...patch } }));
+    }
+
+    function updateDeferLoading(name: string, mode: DeferLoadingMode) {
+        setServers((prev) => ({
+            ...prev,
+            [name]: applyDeferLoadingMode(prev[name] ?? {}, mode),
+        }));
     }
 
     function toggleDisabled(name: string) {
@@ -183,6 +203,7 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
             entry.args = parseArgs(newArgs);
         } else {
             entry.url = newUrl.trim();
+            entry.type = "http";
         }
         setServers((prev) => ({ ...prev, [name]: entry }));
         setNewName("");
@@ -191,6 +212,28 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
         setNewUrl("");
         setShowAdd(false);
         setExpandedServer(name);
+    }
+
+    async function reloadActiveSessions() {
+        setReloadMessage(null);
+        setError(null);
+        setReloading(true);
+        try {
+            const res = await fetch(`/api/runners/${encodeURIComponent(runnerId)}/mcp/reload`, {
+                method: "POST",
+                credentials: "include",
+            });
+            if (!res.ok) {
+                const body = await res.json().catch(() => ({}));
+                throw new Error(body.error ?? `HTTP ${res.status}`);
+            }
+            const body = await res.json() as { reloaded: number; failed: number };
+            setReloadMessage(formatMcpReloadMessage(body));
+        } catch (err) {
+            setError(err instanceof Error ? err.message : String(err));
+        } finally {
+            setReloading(false);
+        }
     }
 
     // ── Loading / error ───────────────────────────────────────────────────────
@@ -248,14 +291,21 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
                     size="sm"
                     className="gap-1.5"
                     onClick={() => setShowAdd(!showAdd)}
+                    disabled={hasPreferredFormatConfig}
                 >
                     <Plus className="h-3.5 w-3.5" />
                     Add Server
                 </Button>
             </div>
 
+            {hasPreferredFormatConfig && (
+                <div className="rounded-md border border-amber-500/30 bg-amber-500/5 px-4 py-3 text-sm text-amber-300">
+                    This runner is configured with the <code>mcp.servers[]</code> format. The web MCP editor currently supports only <code>mcpServers</code>, so editing is disabled here to avoid writing a conflicting config shape.
+                </div>
+            )}
+
             {/* Add new server form */}
-            {showAdd && (
+            {!hasPreferredFormatConfig && showAdd && (
                 <div className="rounded-md border border-border bg-card p-4 flex flex-col gap-3">
                     <p className="text-sm font-medium">New MCP Server</p>
 
@@ -361,7 +411,7 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
             )}
 
             {/* Server list */}
-            {serverNames.length === 0 && !showAdd && (
+            {!hasPreferredFormatConfig && serverNames.length === 0 && !showAdd && (
                 <div className="flex flex-col items-center justify-center py-10 gap-2 text-center">
                     <Server className="h-8 w-8 text-muted-foreground/40" />
                     <p className="text-sm text-muted-foreground">No MCP servers configured.</p>
@@ -371,7 +421,7 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
                 </div>
             )}
 
-            {serverNames.map((name) => {
+            {!hasPreferredFormatConfig && serverNames.map((name) => {
                 const server = servers[name];
                 const expanded = expandedServer === name;
                 const serverIsStdio = isStdio(server);
@@ -446,6 +496,27 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
                                             checked={!server.disabled}
                                             onCheckedChange={() => toggleDisabled(name)}
                                         />
+                                    </div>
+
+                                    {/* Deferred loading override */}
+                                    <div className="flex flex-col gap-1.5">
+                                        <Label className="text-xs">Deferred Loading</Label>
+                                        <Select
+                                            value={deferLoadingValueToMode(server.deferLoading)}
+                                            onValueChange={(value) => updateDeferLoading(name, value as DeferLoadingMode)}
+                                        >
+                                            <SelectTrigger className="w-full max-w-xs text-sm">
+                                                <SelectValue />
+                                            </SelectTrigger>
+                                            <SelectContent>
+                                                <SelectItem value="inherit">Inherit global behavior</SelectItem>
+                                                <SelectItem value="always">Always defer</SelectItem>
+                                                <SelectItem value="never">Never defer</SelectItem>
+                                            </SelectContent>
+                                        </Select>
+                                        <p className="text-xs text-muted-foreground">
+                                            Overrides Tool Search for this server only.
+                                        </p>
                                     </div>
 
                                     {serverIsStdio ? (
@@ -574,23 +645,37 @@ export function McpServersManager({ runnerId, bare }: McpServersManagerProps) {
             })}
 
             {/* Success message */}
-            {saveMessage && (
+            {!hasPreferredFormatConfig && saveMessage && (
                 <div className="flex items-start gap-2 rounded-md border border-green-500/30 bg-green-500/5 px-4 py-3 text-sm text-green-400">
                     <CheckCircle className="mt-0.5 size-4 shrink-0" />
                     <span>{saveMessage}</span>
                 </div>
             )}
 
+            {!hasPreferredFormatConfig && reloadMessage && (
+                <div className="rounded-md border border-blue-500/30 bg-blue-500/5 px-4 py-3 text-sm text-blue-300">
+                    {reloadMessage}
+                </div>
+            )}
+
             {/* Footer */}
-            <div className="flex items-center justify-between pt-2">
-                <p className="text-xs text-muted-foreground italic">
-                    Active sessions can run /mcp reload to pick up changes.
-                </p>
-                <Button onClick={handleSave} disabled={saving} size="sm" className="gap-1.5">
-                    <Save className="h-3.5 w-3.5" />
-                    {saving ? "Saving…" : "Save"}
-                </Button>
-            </div>
+            {!hasPreferredFormatConfig && (
+                <div className="flex items-center justify-between pt-2 gap-3">
+                    <p className="text-xs text-muted-foreground italic">
+                        Save updates config. Reload MCP applies changes to active sessions now.
+                    </p>
+                    <div className="flex items-center gap-2">
+                        <Button variant="outline" onClick={reloadActiveSessions} disabled={reloading} size="sm" className="gap-1.5">
+                            {reloading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+                            Reload MCP
+                        </Button>
+                        <Button onClick={handleSave} disabled={saving} size="sm" className="gap-1.5">
+                            <Save className="h-3.5 w-3.5" />
+                            {saving ? "Saving…" : "Save"}
+                        </Button>
+                    </div>
+                </div>
+            )}
         </div>
     );
 }

--- a/packages/ui/src/components/mcp-reload-status.test.ts
+++ b/packages/ui/src/components/mcp-reload-status.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { formatMcpReloadMessage } from "./mcp-reload-status";
+
+describe("formatMcpReloadMessage", () => {
+  test("reports when there are no active sessions", () => {
+    expect(formatMcpReloadMessage({ reloaded: 0, failed: 0 })).toBe(
+      "No active sessions were available to reload.",
+    );
+  });
+
+  test("reports when all active sessions fail to reload", () => {
+    expect(formatMcpReloadMessage({ reloaded: 0, failed: 2 })).toBe(
+      "Found 2 active sessions, but none could be reloaded.",
+    );
+  });
+
+  test("reports full success", () => {
+    expect(formatMcpReloadMessage({ reloaded: 1, failed: 0 })).toBe(
+      "Reloaded MCP in 1 active session.",
+    );
+  });
+
+  test("reports mixed success and failure", () => {
+    expect(formatMcpReloadMessage({ reloaded: 2, failed: 1 })).toBe(
+      "Reloaded MCP in 2 active sessions. 1 session could not be reloaded.",
+    );
+  });
+});

--- a/packages/ui/src/components/mcp-reload-status.ts
+++ b/packages/ui/src/components/mcp-reload-status.ts
@@ -1,0 +1,20 @@
+export interface McpReloadResult {
+  reloaded: number;
+  failed: number;
+}
+
+export function formatMcpReloadMessage(result: McpReloadResult): string {
+  const { reloaded, failed } = result;
+
+  if (reloaded === 0 && failed === 0) {
+    return "No active sessions were available to reload.";
+  }
+
+  if (reloaded === 0) {
+    return `Found ${failed} active session${failed === 1 ? "" : "s"}, but none could be reloaded.`;
+  }
+
+  const success = `Reloaded MCP in ${reloaded} active session${reloaded === 1 ? "" : "s"}.`;
+  if (failed === 0) return success;
+  return `${success} ${failed} session${failed === 1 ? "" : "s"} could not be reloaded.`;
+}

--- a/packages/ui/src/components/mcp-server-defer-loading.test.ts
+++ b/packages/ui/src/components/mcp-server-defer-loading.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { applyDeferLoadingMode, deferLoadingValueToMode } from "./mcp-server-defer-loading";
+
+describe("mcp server defer loading helpers", () => {
+  test("maps raw config values to UI modes", () => {
+    expect(deferLoadingValueToMode(undefined)).toBe("inherit");
+    expect(deferLoadingValueToMode(true)).toBe("always");
+    expect(deferLoadingValueToMode(false)).toBe("never");
+  });
+
+  test("inherit removes deferLoading while preserving other fields", () => {
+    const result = applyDeferLoadingMode(
+      { command: "npx", args: ["foo"], deferLoading: true, disabled: false },
+      "inherit",
+    );
+    expect(result).toEqual({ command: "npx", args: ["foo"], disabled: false });
+    expect("deferLoading" in result).toBe(false);
+  });
+
+  test("always writes deferLoading true", () => {
+    expect(applyDeferLoadingMode({ command: "npx" }, "always")).toEqual({
+      command: "npx",
+      deferLoading: true,
+    });
+  });
+
+  test("never writes deferLoading false", () => {
+    expect(applyDeferLoadingMode({ url: "http://localhost:3000/mcp" }, "never")).toEqual({
+      url: "http://localhost:3000/mcp",
+      deferLoading: false,
+    });
+  });
+});

--- a/packages/ui/src/components/mcp-server-defer-loading.ts
+++ b/packages/ui/src/components/mcp-server-defer-loading.ts
@@ -1,0 +1,21 @@
+export type DeferLoadingMode = "inherit" | "always" | "never";
+
+export function deferLoadingValueToMode(value: boolean | undefined): DeferLoadingMode {
+  if (value === true) return "always";
+  if (value === false) return "never";
+  return "inherit";
+}
+
+export function applyDeferLoadingMode<T extends object>(
+  entry: T,
+  mode: DeferLoadingMode,
+): T & { deferLoading?: boolean } {
+  if (mode === "inherit") {
+    const { deferLoading: _omit, ...rest } = entry as T & { deferLoading?: boolean };
+    return rest as T & { deferLoading?: boolean };
+  }
+  return {
+    ...entry,
+    deferLoading: mode === "always",
+  };
+}

--- a/packages/ui/src/components/runner-settings/RunnerSettingsPanel.tsx
+++ b/packages/ui/src/components/runner-settings/RunnerSettingsPanel.tsx
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 // Sub-tab components — lazy loaded
 const ModelsSettings = React.lazy(() => import("./ModelsSettings"));
 const WebSearchSettings = React.lazy(() => import("./WebSearchSettings"));
+const ToolSearchSettings = React.lazy(() => import("./ToolSearchSettings"));
 const EnvVarsSettings = React.lazy(() => import("./EnvVarsSettings"));
 const SystemPromptSettings = React.lazy(() => import("./SystemPromptSettings"));
 const TuiPrefsSettings = React.lazy(() => import("./TuiPrefsSettings"));
@@ -17,6 +18,7 @@ const TuiPrefsSettings = React.lazy(() => import("./TuiPrefsSettings"));
 export type SettingsSection =
     | "models"
     | "webSearch"
+    | "toolSearch"
     | "envVars"
     | "systemPrompt"
     | "tuiPreferences";
@@ -43,6 +45,7 @@ export interface SectionProps {
 const SETTINGS_TABS: { key: SettingsSection; label: string }[] = [
     { key: "models", label: "Models" },
     { key: "webSearch", label: "Web Search" },
+    { key: "toolSearch", label: "Tool Search" },
     { key: "envVars", label: "Env Vars" },
     { key: "systemPrompt", label: "System Prompt" },
     { key: "tuiPreferences", label: "TUI Prefs" },
@@ -148,6 +151,9 @@ export function RunnerSettingsPanel({ runnerId }: RunnerSettingsPanelProps) {
             break;
         case "webSearch":
             content = <WebSearchSettings {...sectionProps} />;
+            break;
+        case "toolSearch":
+            content = <ToolSearchSettings {...sectionProps} />;
             break;
         case "envVars":
             content = <EnvVarsSettings {...sectionProps} />;

--- a/packages/ui/src/components/runner-settings/ToolSearchSettings.tsx
+++ b/packages/ui/src/components/runner-settings/ToolSearchSettings.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useState } from "react";
+import { Info, Loader2, Save, Search, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { ErrorAlert } from "@/components/ui/error-alert";
+import type { SectionProps } from "./RunnerSettingsPanel";
+import { formatMcpReloadMessage, type McpReloadResult } from "@/components/mcp-reload-status";
+
+export default function ToolSearchSettings({ runnerId, config, onSave, saving }: SectionProps) {
+  const toolSearch = useMemo(() => {
+    const raw = config.toolSearch;
+    return raw && typeof raw === "object" && !Array.isArray(raw) ? raw as Record<string, unknown> : {};
+  }, [config.toolSearch]);
+
+  const [enabled, setEnabled] = useState<boolean>(toolSearch.enabled === true);
+  const [tokenThreshold, setTokenThreshold] = useState<number>(
+    typeof toolSearch.tokenThreshold === "number" ? Math.max(0, Math.floor(toolSearch.tokenThreshold)) : 10000,
+  );
+  const [maxResults, setMaxResults] = useState<number>(
+    typeof toolSearch.maxResults === "number" ? Math.max(1, Math.floor(toolSearch.maxResults)) : 5,
+  );
+  const [keepLoadedTools, setKeepLoadedTools] = useState<boolean>(toolSearch.keepLoadedTools !== false);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloading, setReloading] = useState(false);
+  const [reloadResult, setReloadResult] = useState<McpReloadResult | null>(null);
+
+  useEffect(() => {
+    setEnabled(toolSearch.enabled === true);
+    setTokenThreshold(
+      typeof toolSearch.tokenThreshold === "number" ? Math.max(0, Math.floor(toolSearch.tokenThreshold)) : 10000,
+    );
+    setMaxResults(
+      typeof toolSearch.maxResults === "number" ? Math.max(1, Math.floor(toolSearch.maxResults)) : 5,
+    );
+    setKeepLoadedTools(toolSearch.keepLoadedTools !== false);
+  }, [toolSearch]);
+
+  const isDirty =
+    enabled !== (toolSearch.enabled === true) ||
+    tokenThreshold !== (typeof toolSearch.tokenThreshold === "number" ? Math.max(0, Math.floor(toolSearch.tokenThreshold)) : 10000) ||
+    maxResults !== (typeof toolSearch.maxResults === "number" ? Math.max(1, Math.floor(toolSearch.maxResults)) : 5) ||
+    keepLoadedTools !== (toolSearch.keepLoadedTools !== false);
+
+  async function handleSave() {
+    setError(null);
+    setSuccessMessage(null);
+    setReloadResult(null);
+    try {
+      await onSave("toolSearch", {
+        enabled,
+        tokenThreshold,
+        maxResults,
+        keepLoadedTools,
+      });
+      setSuccessMessage("Tool Search settings saved. Reload MCP in active sessions to apply changes immediately.");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }
+
+  async function handleReloadActiveSessions() {
+    setReloading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/runners/${encodeURIComponent(runnerId)}/mcp/reload`, {
+        method: "POST",
+        credentials: "include",
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `HTTP ${res.status}`);
+      }
+      const body = await res.json() as McpReloadResult;
+      setReloadResult(body);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setReloading(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {error && <ErrorAlert>{error}</ErrorAlert>}
+
+      <div className="flex items-center gap-2">
+        <Search className="h-5 w-5 text-muted-foreground" />
+        <h3 className="text-sm font-medium">Tool Search</h3>
+      </div>
+
+      <div className="flex items-center justify-between rounded-md border border-border bg-card p-4">
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="tool-search-enabled" className="text-sm font-medium">
+            Enable Tool Search
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Defer MCP tools when they would take too much context, and expose them to the agent through <code>search_tools</code>.
+          </p>
+        </div>
+        <Switch id="tool-search-enabled" checked={enabled} onCheckedChange={setEnabled} />
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-2">
+        <div className="flex flex-col gap-2 rounded-md border border-border bg-card p-4">
+          <Label htmlFor="tool-search-threshold" className="text-sm font-medium">
+            Token Threshold (chars)
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            When total MCP tool definitions exceed this character count, unpinned tools are deferred.
+          </p>
+          <Input
+            id="tool-search-threshold"
+            type="number"
+            min={0}
+            step={1}
+            value={tokenThreshold}
+            onChange={(e) => {
+              const next = Number.parseInt(e.target.value, 10);
+              setTokenThreshold(Number.isFinite(next) ? Math.max(0, next) : 0);
+            }}
+            disabled={!enabled}
+            className="w-36"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2 rounded-md border border-border bg-card p-4">
+          <Label htmlFor="tool-search-max-results" className="text-sm font-medium">
+            Max Results
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            Maximum number of deferred MCP tools returned from a single <code>search_tools</code> call.
+          </p>
+          <Input
+            id="tool-search-max-results"
+            type="number"
+            min={1}
+            max={50}
+            step={1}
+            value={maxResults}
+            onChange={(e) => {
+              const next = Number.parseInt(e.target.value, 10);
+              setMaxResults(Number.isFinite(next) ? Math.max(1, Math.min(50, next)) : 1);
+            }}
+            disabled={!enabled}
+            className="w-28"
+          />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between rounded-md border border-border bg-card p-4">
+        <div className="flex flex-col gap-1">
+          <Label htmlFor="tool-search-keep-loaded" className="text-sm font-medium">
+            Keep Loaded Tools Active
+          </Label>
+          <p className="text-xs text-muted-foreground">
+            When enabled, tools discovered through <code>search_tools</code> stay loaded for the rest of the session.
+          </p>
+        </div>
+        <Switch
+          id="tool-search-keep-loaded"
+          checked={keepLoadedTools}
+          onCheckedChange={setKeepLoadedTools}
+          disabled={!enabled}
+        />
+      </div>
+
+      <div className="flex items-start gap-2 rounded-md border border-border bg-muted/50 px-4 py-3 text-sm text-muted-foreground">
+        <Info className="mt-0.5 size-4 shrink-0" />
+        <span>
+          Future sessions pick up these settings automatically. Use Reload MCP below to apply changes to active sessions now.
+        </span>
+      </div>
+
+      {successMessage && (
+        <div className="rounded-md border border-green-500/30 bg-green-500/5 px-4 py-3 text-sm text-green-400">
+          {successMessage}
+        </div>
+      )}
+
+      {reloadResult && (
+        <div className="rounded-md border border-blue-500/30 bg-blue-500/5 px-4 py-3 text-sm text-blue-300">
+          {formatMcpReloadMessage(reloadResult)}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between pt-2">
+        <div className="text-xs text-muted-foreground italic">
+          Save updates config. Reload MCP applies them to currently active sessions.
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleReloadActiveSessions}
+            disabled={reloading}
+            className="gap-1.5"
+          >
+            {reloading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <RefreshCw className="h-3.5 w-3.5" />}
+            Reload MCP
+          </Button>
+          <Button onClick={handleSave} disabled={saving || !isDirty} size="sm" className="gap-1.5">
+            {saving ? <Loader2 className="size-4 animate-spin" /> : <Save className="size-4" />}
+            Save
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/session-viewer/cards/CommandResultCard.test.tsx
+++ b/packages/ui/src/components/session-viewer/cards/CommandResultCard.test.tsx
@@ -1,0 +1,121 @@
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { cleanup, render } from "@testing-library/react";
+import React from "react";
+
+const win = new Window({ url: "http://localhost/" });
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+mock.module("@/components/ui/tool-card", () => ({
+  ToolCardShell: ({ children }: any) => <div>{children}</div>,
+  ToolCardHeader: ({ children }: any) => <div>{children}</div>,
+  ToolCardTitle: ({ children }: any) => <div>{children}</div>,
+  StatusPill: ({ children }: any) => <span>{children}</span>,
+}));
+mock.module("@/components/ui/badge", () => ({
+  Badge: ({ children }: any) => <span>{children}</span>,
+}));
+mock.module("@/components/session-viewer/McpToggleContext", () => ({
+  useMcpToggle: () => null,
+}));
+mock.module("@/lib/utils", () => ({
+  cn: (...classes: (string | undefined | null | false)[]) => classes.filter(Boolean).join(" "),
+}));
+
+const { CommandResultCard } = await import("./CommandResultCard");
+
+afterAll(() => mock.restore());
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+});
+
+describe("CommandResultCard MCP state rendering", () => {
+  test("renders loaded, deferred, loaded-on-demand, and disabled MCP state distinctly", () => {
+    const data: any = {
+      kind: "mcp",
+      action: "status",
+      toolCount: 3,
+      toolNames: ["mcp_github_create_issue", "mcp_github_create_pr", "mcp_linear_search"],
+      serverTools: {
+        github: ["mcp_github_create_issue", "mcp_github_create_pr"],
+        linear: ["mcp_linear_search"],
+      },
+      serverCount: 3,
+      servers: [
+        { name: "github", transport: "http", scope: "global", sourcePath: "~/.pizzapi/config.json" },
+        { name: "linear", transport: "http", scope: "global", sourcePath: "~/.pizzapi/config.json" },
+        { name: "figma", transport: "http", scope: "global", sourcePath: "~/.pizzapi/config.json" },
+      ],
+      errors: [],
+      disabledServers: ["figma"],
+      counts: {
+        totalTools: 3,
+        loadedTools: 0,
+        deferredTools: 1,
+        loadedOnDemandTools: 2,
+        disabledServers: 1,
+      },
+      serverStates: [
+        {
+          name: "github",
+          transport: "http",
+          scope: "global",
+          sourcePath: "~/.pizzapi/config.json",
+          state: "loaded",
+          totalToolCount: 2,
+          loadedToolCount: 2,
+          deferredToolCount: 0,
+          loadedOnDemandToolCount: 2,
+        },
+        {
+          name: "linear",
+          transport: "http",
+          scope: "global",
+          sourcePath: "~/.pizzapi/config.json",
+          state: "deferred",
+          totalToolCount: 1,
+          loadedToolCount: 0,
+          deferredToolCount: 1,
+          loadedOnDemandToolCount: 0,
+        },
+        {
+          name: "figma",
+          transport: "http",
+          scope: "global",
+          sourcePath: "~/.pizzapi/config.json",
+          state: "disabled",
+          totalToolCount: 0,
+          loadedToolCount: 0,
+          deferredToolCount: 0,
+          loadedOnDemandToolCount: 0,
+        },
+      ],
+      toolStates: [
+        { name: "mcp_github_create_issue", serverName: "github", state: "loaded_on_demand" },
+        { name: "mcp_github_create_pr", serverName: "github", state: "loaded_on_demand" },
+        { name: "mcp_linear_search", serverName: "linear", state: "deferred" },
+      ],
+    };
+
+    const { container } = render(<CommandResultCard data={data} />);
+    const text = container.textContent ?? "";
+
+    expect(text).toContain("loaded on-demand");
+    expect(text).toContain("deferred");
+    expect(text).toContain("disabled");
+    expect(text).toContain("mcp_github_create_issue");
+    expect(text).toContain("mcp_linear_search");
+  });
+});

--- a/packages/ui/src/components/session-viewer/cards/CommandResultCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/CommandResultCard.tsx
@@ -48,6 +48,32 @@ export interface McpError {
   error: string;
 }
 
+export interface McpToolStateEntry {
+  name: string;
+  serverName: string;
+  state: "loaded" | "deferred" | "loaded_on_demand";
+}
+
+export interface McpServerStateEntry {
+  name: string;
+  transport: string;
+  scope: string;
+  sourcePath?: string;
+  state: "loaded" | "deferred" | "disabled" | "partial";
+  totalToolCount: number;
+  loadedToolCount: number;
+  deferredToolCount: number;
+  loadedOnDemandToolCount: number;
+}
+
+export interface McpStatusCounts {
+  totalTools: number;
+  loadedTools: number;
+  deferredTools: number;
+  loadedOnDemandTools: number;
+  disabledServers: number;
+}
+
 export interface McpResultData {
   kind: "mcp";
   action: "status" | "reload";
@@ -61,6 +87,9 @@ export interface McpResultData {
   loadedAt?: string;
   /** Server names currently disabled via config */
   disabledServers?: string[];
+  counts?: McpStatusCounts;
+  serverStates?: McpServerStateEntry[];
+  toolStates?: McpToolStateEntry[];
 }
 
 // ── Plugins ───────────────────────────────────────────────────────────────────
@@ -122,19 +151,50 @@ export interface SandboxResultData {
 
 // ── Card Renderers ────────────────────────────────────────────────────────────
 
+function formatMcpStateLabel(state: "loaded" | "deferred" | "loaded_on_demand" | "disabled" | "partial") {
+  switch (state) {
+    case "loaded_on_demand":
+      return "loaded on-demand";
+    default:
+      return state;
+  }
+}
+
 /** Collapsible per-server tool group */
-function ServerToolGroup({ serverName, tools, transport, scope, defaultOpen, disabled, onToggle }: {
+function ServerToolGroup({
+  serverName,
+  tools,
+  transport,
+  scope,
+  defaultOpen,
+  state = "loaded",
+  loadedToolCount,
+  deferredToolCount,
+  loadedOnDemandToolCount,
+  onToggle,
+}: {
   serverName: string;
-  tools: string[];
+  tools: Array<{ name: string; state: "loaded" | "deferred" | "loaded_on_demand" }>;
   transport?: string;
   scope?: string;
   defaultOpen: boolean;
-  /** Whether this server is currently disabled */
-  disabled?: boolean;
+  state?: "loaded" | "deferred" | "disabled" | "partial";
+  loadedToolCount?: number;
+  deferredToolCount?: number;
+  loadedOnDemandToolCount?: number;
   /** Callback to toggle enabled/disabled state */
   onToggle?: (serverName: string, disabled: boolean) => void;
 }) {
+  const disabled = state === "disabled";
   const [open, setOpen] = React.useState(defaultOpen && !disabled);
+
+  const countBits: string[] = [];
+  if (!disabled) {
+    if (typeof loadedToolCount === "number" && loadedToolCount > 0) countBits.push(`${loadedToolCount} loaded`);
+    if (typeof loadedOnDemandToolCount === "number" && loadedOnDemandToolCount > 0) countBits.push(`${loadedOnDemandToolCount} loaded on-demand`);
+    if (typeof deferredToolCount === "number" && deferredToolCount > 0) countBits.push(`${deferredToolCount} deferred`);
+    if (countBits.length === 0) countBits.push(`${tools.length} tool${tools.length !== 1 ? "s" : ""}`);
+  }
 
   return (
     <div className={cn("border-b border-zinc-800/60 last:border-b-0", disabled && "opacity-50")}>
@@ -160,11 +220,14 @@ function ServerToolGroup({ serverName, tools, transport, scope, defaultOpen, dis
               {transport}
             </Badge>
           )}
+          <Badge variant="outline" className="h-3.5 px-1 text-[9px] font-mono border-zinc-700 text-zinc-400 capitalize">
+            {formatMcpStateLabel(state)}
+          </Badge>
           {disabled ? (
             <span className="text-[10px] text-zinc-600 tabular-nums ml-auto shrink-0">disabled</span>
           ) : (
             <span className="text-[10px] text-zinc-600 tabular-nums ml-auto shrink-0">
-              {tools.length} tool{tools.length !== 1 ? "s" : ""}
+              {countBits.join(" · ")}
               {scope && <span className="ml-1.5 text-zinc-600/70">{scope}</span>}
             </span>
           )}
@@ -186,9 +249,10 @@ function ServerToolGroup({ serverName, tools, transport, scope, defaultOpen, dis
       </div>
       {open && !disabled && tools.length > 0 && (
         <div className="px-4 pb-2.5 pt-0.5 flex flex-wrap gap-1">
-          {tools.map((name) => (
-            <span key={name} className="inline-block rounded bg-zinc-800/80 px-1.5 py-0.5 text-[10px] font-mono text-zinc-400">
-              {name}
+          {tools.map((tool) => (
+            <span key={tool.name} className="inline-flex items-center gap-1 rounded bg-zinc-800/80 px-1.5 py-0.5 text-[10px] font-mono text-zinc-400">
+              <span>{tool.name}</span>
+              <span className="text-zinc-500">{formatMcpStateLabel(tool.state)}</span>
             </span>
           ))}
         </div>
@@ -199,7 +263,6 @@ function ServerToolGroup({ serverName, tools, transport, scope, defaultOpen, dis
 
 function McpCard({ data }: { data: McpResultData }) {
   const hasErrors = data.errors.length > 0;
-  const hasServerTools = Object.keys(data.serverTools ?? {}).length > 0;
   const disabledSet = React.useMemo(() => new Set(data.disabledServers ?? []), [data.disabledServers]);
   const mcpToggle = useMcpToggle();
 
@@ -210,12 +273,84 @@ function McpCard({ data }: { data: McpResultData }) {
     return map;
   }, [data.servers]);
 
-  // Disabled servers that aren't already shown in serverTools (they were skipped)
-  const disabledOnlyServers = React.useMemo(() => {
-    return [...disabledSet].filter((name) => !data.serverTools[name]);
-  }, [disabledSet, data.serverTools]);
+  const toolStateMap = React.useMemo(() => {
+    const map = new Map<string, McpToolStateEntry[]>();
+    for (const tool of data.toolStates ?? []) {
+      const list = map.get(tool.serverName) ?? [];
+      list.push(tool);
+      map.set(tool.serverName, list);
+    }
+    return map;
+  }, [data.toolStates]);
 
-  const disabledCount = disabledSet.size;
+  const renderedServers = React.useMemo(() => {
+    const entries: Array<{
+      name: string;
+      transport?: string;
+      scope?: string;
+      state: "loaded" | "deferred" | "disabled" | "partial";
+      tools: Array<{ name: string; state: "loaded" | "deferred" | "loaded_on_demand" }>;
+      loadedToolCount?: number;
+      deferredToolCount?: number;
+      loadedOnDemandToolCount?: number;
+    }> = [];
+    const seen = new Set<string>();
+
+    for (const server of data.serverStates ?? []) {
+      seen.add(server.name);
+      entries.push({
+        name: server.name,
+        transport: server.transport,
+        scope: server.scope,
+        state: server.state,
+        tools: toolStateMap.get(server.name) ?? (data.serverTools[server.name] ?? []).map((name) => ({ name, state: "loaded" as const })),
+        loadedToolCount: server.loadedToolCount,
+        deferredToolCount: server.deferredToolCount,
+        loadedOnDemandToolCount: server.loadedOnDemandToolCount,
+      });
+    }
+
+    for (const server of data.servers) {
+      if (seen.has(server.name)) continue;
+      seen.add(server.name);
+      const toolNames = data.serverTools[server.name] ?? [];
+      const state = disabledSet.has(server.name) ? "disabled" as const : "loaded" as const;
+      entries.push({
+        name: server.name,
+        transport: server.transport,
+        scope: server.scope,
+        state,
+        tools: toolNames.map((name) => ({ name, state: "loaded" as const })),
+        loadedToolCount: state === "disabled" ? 0 : toolNames.length,
+        deferredToolCount: 0,
+        loadedOnDemandToolCount: 0,
+      });
+    }
+
+    for (const [serverName, toolNames] of Object.entries(data.serverTools)) {
+      if (seen.has(serverName)) continue;
+      entries.push({
+        name: serverName,
+        transport: serverConfigMap.get(serverName)?.transport,
+        scope: serverConfigMap.get(serverName)?.scope,
+        state: disabledSet.has(serverName) ? "disabled" as const : "loaded" as const,
+        tools: toolStateMap.get(serverName) ?? toolNames.map((name) => ({ name, state: "loaded" as const })),
+        loadedToolCount: disabledSet.has(serverName) ? 0 : toolNames.length,
+        deferredToolCount: 0,
+        loadedOnDemandToolCount: 0,
+      });
+    }
+
+    return entries;
+  }, [data.serverStates, data.servers, data.serverTools, disabledSet, toolStateMap, serverConfigMap]);
+
+  const counts = data.counts ?? {
+    totalTools: data.toolCount,
+    loadedTools: data.toolCount,
+    deferredTools: 0,
+    loadedOnDemandTools: 0,
+    disabledServers: disabledSet.size,
+  };
 
   return (
     <ToolCardShell>
@@ -235,13 +370,23 @@ function McpCard({ data }: { data: McpResultData }) {
               {data.errors.length} error{data.errors.length > 1 ? "s" : ""}
             </StatusPill>
           )}
-          {disabledCount > 0 && (
+          {counts.disabledServers > 0 && (
             <StatusPill variant="neutral">
-              {disabledCount} disabled
+              {counts.disabledServers} disabled
             </StatusPill>
           )}
-          <StatusPill variant={data.toolCount > 0 ? "success" : "neutral"}>
-            {data.toolCount} tool{data.toolCount !== 1 ? "s" : ""}
+          {counts.deferredTools > 0 && (
+            <StatusPill variant="neutral">
+              {counts.deferredTools} deferred
+            </StatusPill>
+          )}
+          {counts.loadedOnDemandTools > 0 && (
+            <StatusPill variant="neutral">
+              {counts.loadedOnDemandTools} loaded on-demand
+            </StatusPill>
+          )}
+          <StatusPill variant={counts.loadedTools > 0 || counts.loadedOnDemandTools > 0 ? "success" : "neutral"}>
+            {counts.totalTools} tool{counts.totalTools !== 1 ? "s" : ""}
           </StatusPill>
         </div>
       </ToolCardHeader>
@@ -264,49 +409,32 @@ function McpCard({ data }: { data: McpResultData }) {
         </div>
       )}
 
-      {/* Tools grouped by server (active servers) */}
-      {hasServerTools && (
-        Object.entries(data.serverTools).map(([serverName, tools]) => {
-          const config = serverConfigMap.get(serverName);
-          return (
-            <ServerToolGroup
-              key={serverName}
-              serverName={serverName}
-              tools={tools}
-              transport={config?.transport}
-              scope={config?.scope}
-              defaultOpen={Object.keys(data.serverTools).length <= 3}
-              disabled={disabledSet.has(serverName)}
-              onToggle={mcpToggle ?? undefined}
-            />
-          );
-        })
-      )}
-
-      {/* Disabled servers that weren't in serverTools (skipped during init) */}
-      {disabledOnlyServers.map((name) => {
-        const config = serverConfigMap.get(name);
-        return (
+      {/* Tools grouped by server */}
+      {renderedServers.length > 0 && (
+        renderedServers.map((server) => (
           <ServerToolGroup
-            key={name}
-            serverName={name}
-            tools={[]}
-            transport={config?.transport}
-            scope={config?.scope}
-            defaultOpen={false}
-            disabled={true}
+            key={server.name}
+            serverName={server.name}
+            tools={server.tools}
+            transport={server.transport}
+            scope={server.scope}
+            defaultOpen={renderedServers.length <= 3}
+            state={server.state}
+            loadedToolCount={server.loadedToolCount}
+            deferredToolCount={server.deferredToolCount}
+            loadedOnDemandToolCount={server.loadedOnDemandToolCount}
             onToggle={mcpToggle ?? undefined}
           />
-        );
-      })}
+        ))
+      )}
 
-      {/* Fallback: flat tool list if no serverTools grouping available (old CLI) */}
-      {!hasServerTools && data.toolNames.length > 0 && (
+      {/* Fallback: flat tool list if no server grouping available (old CLI) */}
+      {renderedServers.length === 0 && data.toolNames.length > 0 && (
         <FlatToolList toolNames={data.toolNames} />
       )}
 
       {/* No servers configured */}
-      {data.servers.length === 0 && data.toolCount === 0 && !hasErrors && disabledCount === 0 && (
+      {data.servers.length === 0 && counts.totalTools === 0 && !hasErrors && counts.disabledServers === 0 && (
         <div className="px-4 py-3 text-xs text-zinc-500 text-center">
           No MCP servers configured.
         </div>

--- a/patches/@mariozechner%2Fpi-agent-core@0.67.5.patch
+++ b/patches/@mariozechner%2Fpi-agent-core@0.67.5.patch
@@ -1,0 +1,24 @@
+--- a/dist/agent.js
++++ b/dist/agent.js
+@@ -269,6 +269,9 @@
+             systemPrompt: this._state.systemPrompt,
+             messages: this._state.messages.slice(),
+             tools: this._state.tools.slice(),
++            // PATCH(pizzapi): allow the agent loop to refresh dynamic tool/prompt state
++            __getLatestSystemPrompt: () => this._state.systemPrompt,
++            __getLatestTools: () => this._state.tools.slice(),
+         };
+     }
+     createLoopConfig(options = {}) {
+--- a/dist/agent-loop.js
++++ b/dist/agent-loop.js
+@@ -99,6 +99,9 @@
+                 }
+                 pendingMessages = [];
+             }
++            // PATCH(pizzapi): refresh dynamic tool/prompt state before each assistant response
++            currentContext.systemPrompt = currentContext.__getLatestSystemPrompt?.() ?? currentContext.systemPrompt;
++            currentContext.tools = currentContext.__getLatestTools?.() ?? currentContext.tools;
+             // Stream assistant response
+             const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFn);
+             newMessages.push(message);

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,6 +4,26 @@ Patches in this directory are applied automatically by Bun via the
 `patchedDependencies` field in the root `package.json`. They are reapplied on
 every `bun install` — no postinstall script is needed.
 
+## @mariozechner/pi-agent-core@0.67.5
+
+Adds one PizzaPi-specific runtime fix:
+
+- **Dynamic tool refresh between assistant responses:** when a tool changes the
+  active tool set mid-run (for example `search_tools` loading deferred tools),
+  the next assistant response now sees the refreshed tools and system prompt
+  instead of the stale turn-start snapshot. This fixes same-turn Tool Deferral
+  flows where the model successfully loads a tool and then immediately gets
+  `Unknown tool` / `tool isn't loaded` errors trying to call it.
+
+**What it changes:**
+
+| File | Change |
+|------|--------|
+| `dist/agent.js` — `createContextSnapshot()` | Exposes internal callbacks that return the latest tool set and system prompt |
+| `dist/agent-loop.js` — `runLoop()` | Refreshes `currentContext.tools` and `currentContext.systemPrompt` before each assistant response |
+
+**Tests:** `packages/cli/src/patches.test.ts` verifies the regression behavior with a live `Agent` instance.
+
 ## @mariozechner/pi-coding-agent@0.67.5
 
 Same changes as 0.66.1, ported forward. The upstream 0.67.x series changed


### PR DESCRIPTION
## Summary
- refresh the active tool set and system prompt between assistant responses so tools loaded by `search_tools` are available on the next model step in the same run
- add a regression test covering dynamic tool activation mid-run and register a new `@mariozechner/pi-agent-core` patch
- document the lifecycle/timing guardrail in `AGENTS.md` and patch docs to reduce future snapshot-timing regressions

## Test Plan
- [x] `cd packages/cli && bun test src/patches.test.ts src/extensions/tool-search.lifecycle.test.ts`
- [x] `cd packages/cli && bun run build`
