### PR TITLE
fix: refresh session capabilities after slow MCP startup

### DIFF
--- a/packages/server/src/sessions/store.ts
+++ b/packages/server/src/sessions/store.ts
@@ -337,7 +337,7 @@ export async function updateRelaySessionRunner(
  */
 export async function updateRelaySessionName(
     sessionId: string,
-    sessionName: string,
+    sessionName: string | null,
 ): Promise<void> {
     await getKysely()
         .updateTable("relay_session")

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, spyOn, test } from "bun:test";
 import {
     applyChunkToPendingState,
+    applySnapshotPatchToPendingState,
     canFinalizeChunkedSnapshot,
     enqueueSessionEvent,
     finalizeChunkedSnapshot,
@@ -76,14 +77,16 @@ describe("chunked snapshot assembly", () => {
         const duplicateInsert = applyChunkToPendingState(pending, {
             chunkIndex: 0,
             chunkMessages: [{ id: "m1-duplicate" }],
-            totalChunks: 2,
-            isFinalChunk: false,
+            totalChunks: 99,
+            isFinalChunk: true,
         });
 
         expect(firstInsert).toBe(true);
         expect(duplicateInsert).toBe(false);
         expect(Array.from(pending.receivedChunkIndexes)).toEqual([0]);
         expect(pending.chunks[0]).toEqual([{ id: "m1" }]);
+        expect(pending.totalChunks).toBe(2);
+        expect(pending.finalChunkSeen).toBe(true);
         expect(canFinalizeChunkedSnapshot(pending)).toBe(false);
     });
 
@@ -185,10 +188,13 @@ describe("chunked snapshot assembly", () => {
         expect(assembled).toEqual(["c0", "c1", "c2"]);
     });
 
-    test("chunked finalization consumes and clears the recovery flag", async () => {
+    test("metadata patches update pending chunked snapshots before finalization", async () => {
         const pending: ChunkedSessionState = {
             snapshotId: "snap-recovery",
-            metadata: { sessionName: "Recovered" },
+            metadata: {
+                sessionName: "Recovered",
+                availableCommands: [],
+            },
             chunks: [[{ id: "m1" }], [{ id: "m2" }]],
             totalChunks: 2,
             receivedChunkIndexes: new Set<number>([0, 1]),
@@ -207,6 +213,10 @@ describe("chunked snapshot assembly", () => {
             appendRelayEventToCache: async () => {},
         }, "appendRelayEventToCache");
 
+        applySnapshotPatchToPendingState(pending, {
+            sessionName: "Updated",
+            availableCommands: [{ name: "search_tools" }],
+        });
         markPendingRecovery("sess-chunked-recovery");
 
         const fullState = await finalizeChunkedSnapshot("sess-chunked-recovery", pending, {
@@ -218,7 +228,8 @@ describe("chunked snapshot assembly", () => {
         });
 
         expect(fullState).toEqual({
-            sessionName: "Recovered",
+            sessionName: "Updated",
+            availableCommands: [{ name: "search_tools" }],
             messages: [{ id: "m1" }, { id: "m2" }],
         });
         expect(updateSessionState).toHaveBeenCalledWith(

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -5,6 +5,7 @@
 
 import {
     updateSessionState,
+    patchSessionSnapshotState,
     touchSessionActivity,
     updateSessionHeartbeat,
     getSharedSession,
@@ -15,6 +16,7 @@ import {
 import { appendRelayEventToCache } from "../../../sessions/redis.js";
 import { storeAndReplaceImagesInEvent, stripImagesFromPipelineEvent } from "../../strip-images.js";
 import { updateSessionMetaState, broadcastToSessionMeta, getSessionMetaState } from "../../sio-registry/meta.js";
+import { buildSnapshotPatchFromCapabilities, buildSnapshotPatchFromMetadata } from "../../sio-registry/snapshot-state.js";
 import { isMetaRelayEvent, metaEventToPatch, type MetaRelayEvent, type SessionMetaState } from "@pizzapi/protocol";
 import { updateSessionFields } from "../../sio-state/index.js";
 import { updateRelaySessionName } from "../../../sessions/store.js";
@@ -52,6 +54,13 @@ export function applyChunkToPendingState(
 ): boolean {
     const { chunkIndex, chunkMessages, totalChunks, isFinalChunk } = update;
 
+    if (pending.receivedChunkIndexes.has(chunkIndex)) {
+        if (isFinalChunk) {
+            pending.finalChunkSeen = true;
+        }
+        return false;
+    }
+
     if (Number.isInteger(totalChunks) && totalChunks > 0) {
         pending.totalChunks = totalChunks;
     }
@@ -60,13 +69,17 @@ export function applyChunkToPendingState(
         pending.finalChunkSeen = true;
     }
 
-    if (pending.receivedChunkIndexes.has(chunkIndex)) {
-        return false;
-    }
-
     pending.receivedChunkIndexes.add(chunkIndex);
     pending.chunks[chunkIndex] = chunkMessages;
     return true;
+}
+
+export function applySnapshotPatchToPendingState(
+    pending: ChunkedSessionState | null | undefined,
+    patch: Record<string, unknown>,
+): void {
+    if (!pending || Object.keys(patch).length === 0) return;
+    pending.metadata = { ...pending.metadata, ...patch };
 }
 
 export function hasAllChunkIndexes(pending: ChunkedSessionState): boolean {
@@ -284,9 +297,12 @@ export function registerEventHandler(socket: RelaySocket): void {
                 });
 
                 if (canFinalizeChunkedSnapshot(pending)) {
-                    // All chunks received — assemble and persist the full state
-                    pendingChunkedStates.delete(sessionId);
+                    // All chunks received — assemble and persist the full state.
+                    // Only clear the pending entry after finalization succeeds
+                    // so a transient failure can still be retried by later
+                    // chunk retransmits.
                     await finalizeChunkedSnapshot(sessionId, pending);
+                    pendingChunkedStates.delete(sessionId);
                 } else {
                     await touchSessionActivity(sessionId);
                 }
@@ -298,27 +314,23 @@ export function registerEventHandler(socket: RelaySocket): void {
             await updateSessionHeartbeat(sessionId, event);
         } else if (event.type === "session_metadata_update") {
             // Lightweight metadata-only heartbeat: touch activity but do NOT
-            // update lastState or append to the Redis event cache.  The full
-            // message history hasn't changed — viewers get the metadata delta
-            // via the broadcast below, and the existing lastState in Redis
-            // remains the authoritative snapshot for reconnecting viewers.
-            //
-            // We DO persist the metadata fields so reconnecting viewers get
-            // current values (model, sessionName, thinkingLevel, todoList)
-            // from the session hash rather than stale data from the last
-            // full session_active.
+            // append to the Redis event cache. The full message history hasn't
+            // changed, but we still merge reconnect-relevant metadata into the
+            // durable snapshot so late viewers don't stay stuck on a stale
+            // pre-MCP `session_active` until a manual session switch.
             await touchSessionActivity(sessionId);
             const meta = (event as any).metadata;
             if (meta && typeof meta === "object") {
                 const patch: Partial<SessionMetaState> = {};
+                let mergedModel: SessionMetaState["model"] | undefined;
                 if (meta.model && typeof meta.model === "object") {
                     // Merge with existing model to preserve fields (like contextWindow)
                     // that the lightweight metadata update may not include.
                     const existing = await getSessionMetaState(sessionId);
-                    const merged = existing?.model
+                    mergedModel = existing?.model
                         ? { ...existing.model, ...meta.model }
                         : meta.model;
-                    patch.model = merged;
+                    patch.model = mergedModel;
                 }
                 if (Object.prototype.hasOwnProperty.call(meta, "thinkingLevel")) {
                     patch.thinkingLevel = typeof meta.thinkingLevel === "string" ? meta.thinkingLevel : null;
@@ -327,14 +339,32 @@ export function registerEventHandler(socket: RelaySocket): void {
                 if (Object.keys(patch).length > 0) {
                     await updateSessionMetaState(sessionId, patch);
                 }
-                // sessionName lives in the session hash (not metaState).
-                if (Object.prototype.hasOwnProperty.call(meta, "sessionName") &&
-                    typeof meta.sessionName === "string" && meta.sessionName.trim()) {
-                    const trimmedName = meta.sessionName.trim();
-                    await updateSessionFields(sessionId, { sessionName: trimmedName });
-                    // Also persist to SQLite so historical session listings show names.
-                    void updateRelaySessionName(sessionId, trimmedName).catch(() => {});
+
+                const snapshotPatch = buildSnapshotPatchFromMetadata(meta as Record<string, unknown>);
+                if (mergedModel) {
+                    snapshotPatch.model = mergedModel;
                 }
+                if (Object.keys(snapshotPatch).length > 0) {
+                    applySnapshotPatchToPendingState(pendingChunkedStates.get(sessionId), snapshotPatch);
+                    await patchSessionSnapshotState(sessionId, snapshotPatch);
+                }
+
+                // sessionName lives in the session hash (not metaState).
+                if (Object.prototype.hasOwnProperty.call(meta, "sessionName")) {
+                    const normalizedSessionName = typeof meta.sessionName === "string" && meta.sessionName.trim()
+                        ? meta.sessionName.trim()
+                        : null;
+                    await updateSessionFields(sessionId, { sessionName: normalizedSessionName });
+                    // Also persist to SQLite so historical session listings show names.
+                    void updateRelaySessionName(sessionId, normalizedSessionName).catch(() => {});
+                }
+            }
+        } else if (event.type === "capabilities") {
+            await touchSessionActivity(sessionId);
+            const snapshotPatch = buildSnapshotPatchFromCapabilities(event as Record<string, unknown>);
+            if (Object.keys(snapshotPatch).length > 0) {
+                applySnapshotPatchToPendingState(pendingChunkedStates.get(sessionId), snapshotPatch);
+                await patchSessionSnapshotState(sessionId, snapshotPatch);
             }
         } else if (isMetaRelayEvent(event as { type?: unknown }) &&
                    // Old CLI emits mcp_startup_report in a flat format without
@@ -395,10 +425,7 @@ export function registerEventHandler(socket: RelaySocket): void {
             // Reconnecting viewers will get the full lastState snapshot instead.
             const isMetadataOnlyUpdate = event.type === "session_metadata_update";
             if (event.type === "session_messages_chunk" || isChunkedSessionActive || isMetadataOnlyUpdate) {
-                const viewerEvent = isMetadataOnlyUpdate && eventToPublish && typeof eventToPublish === "object"
-                    ? { ...(eventToPublish as Record<string, unknown>), _metaChannel: "hub" as const }
-                    : eventToPublish;
-                await broadcastSessionEventToViewers(sessionId, viewerEvent);
+                await broadcastSessionEventToViewers(sessionId, eventToPublish);
             } else {
                 // Publish to viewers via Redis cache + Socket.IO rooms
                 await publishSessionEvent(sessionId, eventToPublish);

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -16,6 +16,7 @@ export {
     getSharedSession,
     getSharedSessionSummary,
     updateSessionState,
+    patchSessionSnapshotState,
     getSessionState,
     touchSessionActivity,
     broadcastSessionEventToViewers,

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -48,6 +48,7 @@ import {
 import { appendRelayEventToCache } from "../../sessions/redis.js";
 import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "../strip-images.js";
 import { extractMetaFromHeartbeat } from "./meta.js";
+import { mergeSnapshotStatePatch } from "./snapshot-state.js";
 import { severStaleParentLink } from "../stale-parent-link.js";
 import type { SessionInfo } from "@pizzapi/protocol";
 import {
@@ -543,6 +544,42 @@ export async function updateSessionState(sessionId: string, state: unknown, opts
         );
     }
 
+}
+
+export async function patchSessionSnapshotState(
+    sessionId: string,
+    patch: Record<string, unknown>,
+): Promise<boolean> {
+    const session = await getSession(sessionId);
+    if (!session) return false;
+
+    const mergedState = mergeSnapshotStatePatch(session.lastState, patch);
+    if (!mergedState) return false;
+
+    const fields: Partial<RedisSessionData> = {
+        lastState: JSON.stringify(mergedState),
+    };
+
+    if (session.isEphemeral) {
+        fields.expiresAt = nextEphemeralExpiry();
+    }
+
+    await updateSessionFields(sessionId, fields);
+
+    const now = Date.now();
+    const stateMessages = Array.isArray(mergedState.messages) ? mergedState.messages : null;
+    const shouldPersistState =
+        stateMessages !== null && stateMessages.length > 0 ||
+        now - (lastRelaySessionStateWriteTimes.get(sessionId) ?? 0) >= SQLITE_STATE_WRITE_THROTTLE_MS;
+
+    if (shouldPersistState) {
+        lastRelaySessionStateWriteTimes.set(sessionId, now);
+        void recordRelaySessionState(sessionId, session.userId ?? null, mergedState).catch((error) => {
+            log.error("Failed to persist patched relay session state:", error);
+        });
+    }
+
+    return true;
 }
 
 /** Get session last state from Redis. */

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -48,7 +48,7 @@ import {
 import { appendRelayEventToCache } from "../../sessions/redis.js";
 import { storeAndReplaceImages, storeAndReplaceImagesInEvent } from "../strip-images.js";
 import { extractMetaFromHeartbeat } from "./meta.js";
-import { mergeSnapshotStatePatch } from "./snapshot-state.js";
+import { mergeSnapshotStatePatch, shouldPersistSnapshotPatch } from "./snapshot-state.js";
 import { severStaleParentLink } from "../stale-parent-link.js";
 import type { SessionInfo } from "@pizzapi/protocol";
 import {
@@ -567,10 +567,12 @@ export async function patchSessionSnapshotState(
     await updateSessionFields(sessionId, fields);
 
     const now = Date.now();
-    const stateMessages = Array.isArray(mergedState.messages) ? mergedState.messages : null;
-    const shouldPersistState =
-        stateMessages !== null && stateMessages.length > 0 ||
-        now - (lastRelaySessionStateWriteTimes.get(sessionId) ?? 0) >= SQLITE_STATE_WRITE_THROTTLE_MS;
+    const shouldPersistState = shouldPersistSnapshotPatch({
+        patch,
+        lastWriteAt: lastRelaySessionStateWriteTimes.get(sessionId) ?? 0,
+        now,
+        throttleMs: SQLITE_STATE_WRITE_THROTTLE_MS,
+    });
 
     if (shouldPersistState) {
         lastRelaySessionStateWriteTimes.set(sessionId, now);

--- a/packages/server/src/ws/sio-registry/snapshot-state.test.ts
+++ b/packages/server/src/ws/sio-registry/snapshot-state.test.ts
@@ -3,6 +3,7 @@ import {
     buildSnapshotPatchFromCapabilities,
     buildSnapshotPatchFromMetadata,
     mergeSnapshotStatePatch,
+    shouldPersistSnapshotPatch,
 } from "./snapshot-state.js";
 
 describe("buildSnapshotPatchFromMetadata", () => {
@@ -113,5 +114,34 @@ describe("mergeSnapshotStatePatch", () => {
     test("returns null when there is no existing snapshot state to patch", () => {
         expect(mergeSnapshotStatePatch(null, { availableCommands: [] })).toBeNull();
         expect(mergeSnapshotStatePatch("not json", { availableCommands: [] })).toBeNull();
+    });
+});
+
+describe("shouldPersistSnapshotPatch", () => {
+    test("throttles metadata-only patches even when the merged snapshot already has messages", () => {
+        expect(shouldPersistSnapshotPatch({
+            patch: { availableCommands: [{ name: "search_tools" }] },
+            lastWriteAt: 1_000,
+            now: 5_000,
+            throttleMs: 30_000,
+        })).toBe(false);
+    });
+
+    test("allows metadata-only patches through once the throttle window expires", () => {
+        expect(shouldPersistSnapshotPatch({
+            patch: { availableCommands: [{ name: "search_tools" }] },
+            lastWriteAt: 1_000,
+            now: 40_000,
+            throttleMs: 30_000,
+        })).toBe(true);
+    });
+
+    test("persists patches that explicitly update messages immediately", () => {
+        expect(shouldPersistSnapshotPatch({
+            patch: { messages: [{ role: "user", content: "hi" }] },
+            lastWriteAt: 39_000,
+            now: 40_000,
+            throttleMs: 30_000,
+        })).toBe(true);
     });
 });

--- a/packages/server/src/ws/sio-registry/snapshot-state.test.ts
+++ b/packages/server/src/ws/sio-registry/snapshot-state.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from "bun:test";
+import {
+    buildSnapshotPatchFromCapabilities,
+    buildSnapshotPatchFromMetadata,
+    mergeSnapshotStatePatch,
+} from "./snapshot-state.js";
+
+describe("buildSnapshotPatchFromMetadata", () => {
+    test("captures reconnect-relevant session metadata including models and commands", () => {
+        const patch = buildSnapshotPatchFromMetadata({
+            model: { provider: "anthropic", id: "claude-sonnet-4-5" },
+            sessionName: "  Session Name  ",
+            thinkingLevel: "high",
+            availableModels: [{ provider: "anthropic", id: "claude-sonnet-4-5" }],
+            availableCommands: [{ name: "search_tools", description: "search" }],
+            todoList: [{ id: 1, text: "todo", status: "pending" }],
+        });
+
+        expect(patch).toEqual({
+            model: { provider: "anthropic", id: "claude-sonnet-4-5" },
+            sessionName: "Session Name",
+            thinkingLevel: "high",
+            availableModels: [{ provider: "anthropic", id: "claude-sonnet-4-5" }],
+            availableCommands: [{ name: "search_tools", description: "search" }],
+            todoList: [{ id: 1, text: "todo", status: "pending" }],
+        });
+    });
+
+    test("preserves explicit clears for nullable fields", () => {
+        const patch = buildSnapshotPatchFromMetadata({
+            model: null,
+            sessionName: null,
+            thinkingLevel: null,
+            availableModels: [],
+            availableCommands: [],
+            todoList: [],
+        });
+
+        expect(patch).toEqual({
+            model: null,
+            sessionName: null,
+            thinkingLevel: null,
+            availableModels: [],
+            availableCommands: [],
+            todoList: [],
+        });
+    });
+});
+
+describe("buildSnapshotPatchFromCapabilities", () => {
+    test("maps capabilities payload into snapshot keys", () => {
+        expect(buildSnapshotPatchFromCapabilities({
+            models: [{ provider: "google", id: "gemini-2.5-pro" }],
+            commands: [{ name: "set_session_name" }],
+        })).toEqual({
+            availableModels: [{ provider: "google", id: "gemini-2.5-pro" }],
+            availableCommands: [{ name: "set_session_name" }],
+        });
+    });
+});
+
+describe("mergeSnapshotStatePatch", () => {
+    test("merges metadata without dropping transcript messages", () => {
+        const merged = mergeSnapshotStatePatch(
+            JSON.stringify({
+                messages: [{ role: "user", content: "hi" }],
+                sessionName: "Old",
+                availableCommands: [],
+            }),
+            {
+                sessionName: "New",
+                availableCommands: [{ name: "search_tools" }],
+            },
+        );
+
+        expect(merged).toEqual({
+            messages: [{ role: "user", content: "hi" }],
+            sessionName: "New",
+            availableCommands: [{ name: "search_tools" }],
+        });
+    });
+
+    test("preserves richer snapshot model fields when a later patch is partial", () => {
+        const merged = mergeSnapshotStatePatch(
+            JSON.stringify({
+                model: {
+                    provider: "anthropic",
+                    id: "claude-sonnet-4-5",
+                    name: "Claude Sonnet 4.5",
+                    reasoning: true,
+                    contextWindow: 200000,
+                },
+            }),
+            {
+                model: {
+                    provider: "anthropic",
+                    id: "claude-sonnet-4-5",
+                },
+            },
+        );
+
+        expect(merged).toEqual({
+            model: {
+                provider: "anthropic",
+                id: "claude-sonnet-4-5",
+                name: "Claude Sonnet 4.5",
+                reasoning: true,
+                contextWindow: 200000,
+            },
+        });
+    });
+
+    test("returns null when there is no existing snapshot state to patch", () => {
+        expect(mergeSnapshotStatePatch(null, { availableCommands: [] })).toBeNull();
+        expect(mergeSnapshotStatePatch("not json", { availableCommands: [] })).toBeNull();
+    });
+});

--- a/packages/server/src/ws/sio-registry/snapshot-state.ts
+++ b/packages/server/src/ws/sio-registry/snapshot-state.ts
@@ -1,0 +1,85 @@
+function normalizeSessionName(value: unknown): string | null {
+    if (typeof value !== "string") return null;
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : null;
+}
+
+function mergeModelPatch(
+    existing: unknown,
+    next: unknown,
+): unknown {
+    if (!next || typeof next !== "object" || Array.isArray(next)) return next;
+    if (!existing || typeof existing !== "object" || Array.isArray(existing)) return next;
+
+    const existingModel = existing as Record<string, unknown>;
+    const nextModel = next as Record<string, unknown>;
+    if (existingModel.provider !== nextModel.provider || existingModel.id !== nextModel.id) {
+        return next;
+    }
+
+    return {
+        ...existingModel,
+        ...Object.fromEntries(Object.entries(nextModel).filter(([, value]) => value !== undefined)),
+    };
+}
+
+export function buildSnapshotPatchFromMetadata(meta: Record<string, unknown>): Record<string, unknown> {
+    const patch: Record<string, unknown> = {};
+
+    if (Object.prototype.hasOwnProperty.call(meta, "model")) {
+        patch.model = meta.model && typeof meta.model === "object" ? meta.model : null;
+    }
+    if (Object.prototype.hasOwnProperty.call(meta, "sessionName")) {
+        patch.sessionName = normalizeSessionName(meta.sessionName);
+    }
+    if (Object.prototype.hasOwnProperty.call(meta, "thinkingLevel")) {
+        patch.thinkingLevel = typeof meta.thinkingLevel === "string" ? meta.thinkingLevel : null;
+    }
+    if (Array.isArray(meta.availableModels)) {
+        patch.availableModels = meta.availableModels;
+    }
+    if (Array.isArray(meta.availableCommands)) {
+        patch.availableCommands = meta.availableCommands;
+    }
+    if (Array.isArray(meta.todoList)) {
+        patch.todoList = meta.todoList;
+    }
+
+    return patch;
+}
+
+export function buildSnapshotPatchFromCapabilities(event: Record<string, unknown>): Record<string, unknown> {
+    const patch: Record<string, unknown> = {};
+    if (Array.isArray(event.models)) {
+        patch.availableModels = event.models;
+    }
+    if (Array.isArray(event.commands)) {
+        patch.availableCommands = event.commands;
+    }
+    return patch;
+}
+
+export function mergeSnapshotStatePatch(
+    rawLastState: string | null | undefined,
+    patch: Record<string, unknown>,
+): Record<string, unknown> | null {
+    if (!rawLastState) return null;
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(rawLastState);
+    } catch {
+        return null;
+    }
+
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return null;
+    }
+
+    const merged = { ...(parsed as Record<string, unknown>), ...patch };
+    if (Object.prototype.hasOwnProperty.call(patch, "model")) {
+        merged.model = mergeModelPatch((parsed as Record<string, unknown>).model, patch.model);
+    }
+
+    return merged;
+}

--- a/packages/server/src/ws/sio-registry/snapshot-state.ts
+++ b/packages/server/src/ws/sio-registry/snapshot-state.ts
@@ -59,6 +59,19 @@ export function buildSnapshotPatchFromCapabilities(event: Record<string, unknown
     return patch;
 }
 
+export function shouldPersistSnapshotPatch(input: {
+    patch: Record<string, unknown>;
+    lastWriteAt: number;
+    now: number;
+    throttleMs: number;
+}): boolean {
+    const { patch, lastWriteAt, now, throttleMs } = input;
+    if (Object.prototype.hasOwnProperty.call(patch, "messages")) {
+        return true;
+    }
+    return now - lastWriteAt >= throttleMs;
+}
+
 export function mergeSnapshotStatePatch(
     rawLastState: string | null | undefined,
     patch: Record<string, unknown>,

--- a/packages/ui/src/App.session-metadata-update.test.ts
+++ b/packages/ui/src/App.session-metadata-update.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+describe("App session metadata updates", () => {
+  test("reads the latest active model from a ref inside the relay event handler", () => {
+    const path = new URL("./App.tsx", import.meta.url);
+    const sourceText = readFileSync(path, "utf8");
+
+    expect(sourceText).toMatch(/const activeModelRef = React\.useRef<ConfiguredModelInfo \| null>\(activeModel\);/);
+    expect(sourceText).toMatch(/React\.useLayoutEffect\(\(\) => \{\s*activeModelRef\.current = activeModel;\s*\}, \[activeModel\]\);/s);
+    expect(sourceText).toMatch(/currentActiveModel:\s*activeModelRef\.current/);
+  });
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -129,6 +129,7 @@ import {
   mergeChunkSnapshot,
 } from "@/lib/message-helpers";
 import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
+import { removeMessagesByStableKey, replaceMessageByStableKey } from "@/lib/mcp-auth-banners";
 import {
   analyzeIncomingSeq,
   canFinalizeChunkHydration,
@@ -2242,16 +2243,11 @@ export function App() {
         // Store in ref so it survives wholesale setMessages replacements.
         // Upsert: replace existing message for this server (URL/state may
         // have changed on retry), or append if first time.
-        const idx = injectedMessagesRef.current.findIndex((m) => m.key === stableKey);
-        if (idx >= 0) {
-          injectedMessagesRef.current = injectedMessagesRef.current.map((m) => m.key === stableKey ? message : m);
-          setMessages((prev) => prev.map((m) => m.key === stableKey ? message : m));
-        } else {
-          injectedMessagesRef.current = [...injectedMessagesRef.current, message];
-          const next = [...messagesRef.current, message];
-          setMessages(next);
-          patchSessionCache({ messages: next });
-        }
+        const nextInjected = replaceMessageByStableKey(injectedMessagesRef.current, stableKey, message);
+        injectedMessagesRef.current = nextInjected;
+        const nextMessages = replaceMessageByStableKey(messagesRef.current, stableKey, message);
+        setMessages(nextMessages);
+        patchSessionCache({ messages: nextMessages });
       }
       return;
     }
@@ -2275,16 +2271,11 @@ export function App() {
           isError: false,
         };
         // Upsert: replace existing message (nonce/URL may change on retry)
-        const idx = injectedMessagesRef.current.findIndex((m) => m.key === stableKey);
-        if (idx >= 0) {
-          injectedMessagesRef.current = injectedMessagesRef.current.map((m) => m.key === stableKey ? message : m);
-          setMessages((prev) => prev.map((m) => m.key === stableKey ? message : m));
-        } else {
-          injectedMessagesRef.current = [...injectedMessagesRef.current, message];
-          const next = [...messagesRef.current, message];
-          setMessages(next);
-          patchSessionCache({ messages: next });
-        }
+        const nextInjected = replaceMessageByStableKey(injectedMessagesRef.current, stableKey, message);
+        injectedMessagesRef.current = nextInjected;
+        const nextMessages = replaceMessageByStableKey(messagesRef.current, stableKey, message);
+        setMessages(nextMessages);
+        patchSessionCache({ messages: nextMessages });
         // Add/update pending paste prompt (always update nonce/authUrl)
         setMcpOAuthPastes((prev) => [
           ...prev.filter((p) => p.serverName !== serverName),
@@ -2298,13 +2289,9 @@ export function App() {
       const serverName = typeof evt.serverName === "string" ? evt.serverName : "MCP server";
       const stableKey = `mcp_auth:${serverName}`;
       // Remove the auth banner for this server — auth succeeded
-      injectedMessagesRef.current = injectedMessagesRef.current.filter(
-        (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
-      );
+      injectedMessagesRef.current = removeMessagesByStableKey(injectedMessagesRef.current, stableKey);
       // Also remove from rendered messages
-      const filteredNext = messagesRef.current.filter(
-        (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
-      );
+      const filteredNext = removeMessagesByStableKey(messagesRef.current, stableKey);
       if (filteredNext.length !== messagesRef.current.length) {
         setMessages(filteredNext);
         patchSessionCache({ messages: filteredNext });
@@ -4835,23 +4822,18 @@ export function App() {
                         onMcpOAuthPasteDismiss={(serverName) => {
                           setMcpOAuthPastes((prev) => prev.filter((p) => p.serverName !== serverName));
                           const stableKey = `mcp_auth:${serverName}`;
-                          injectedMessagesRef.current = injectedMessagesRef.current.filter(
-                            (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
-                          );
-                          setMessages((prev) => {
-                            const next = prev.filter((m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`));
-                            return next.length !== prev.length ? next : prev;
-                          });
+                          injectedMessagesRef.current = removeMessagesByStableKey(injectedMessagesRef.current, stableKey);
+                          const next = removeMessagesByStableKey(messagesRef.current, stableKey);
+                          if (next.length !== messagesRef.current.length) {
+                            setMessages(next);
+                            patchSessionCache({ messages: next });
+                          }
                         }}
                         onMcpServerDisable={(serverName) => {
                           setMcpOAuthPastes((prev) => prev.filter((p) => p.serverName !== serverName));
                           const stableKey = `mcp_auth:${serverName}`;
-                          injectedMessagesRef.current = injectedMessagesRef.current.filter(
-                            (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
-                          );
-                          const disableNext = messagesRef.current.filter(
-                            (m) => m.key !== stableKey && !m.key.startsWith(`${stableKey}:`),
-                          );
+                          injectedMessagesRef.current = removeMessagesByStableKey(injectedMessagesRef.current, stableKey);
+                          const disableNext = removeMessagesByStableKey(messagesRef.current, stableKey);
                           if (disableNext.length !== messagesRef.current.length) {
                             setMessages(disableNext);
                             patchSessionCache({ messages: disableNext });

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -110,6 +110,7 @@ import {
 import { parsePendingQuestionDisplayMode, parsePendingQuestions, type QuestionDisplayMode, type QuestionType } from "@/lib/ask-user-questions";
 import type { TodoItem, TokenUsage, ConfiguredModelInfo, ResumeSessionOption, QueuedMessage, SessionUiCacheEntry } from "@/lib/types";
 import { metaEventToStatePatch, type MetaStatePatch } from "@/lib/meta-state-apply";
+import { deriveSessionMetadataUpdatePatch } from "@/lib/session-metadata-update";
 import { usePanelLayout } from "@/hooks/usePanelLayout";
 import { useTriggerCount } from "@/hooks/useTriggerCount";
 // Attention store: AttentionProvider is mounted in main.ts around <App/>
@@ -133,6 +134,7 @@ import {
   canFinalizeChunkHydration,
   mergeConnectedSeq,
   registerChunkIndex,
+  shouldAllowOutOfOrderSnapshotDuringHydration,
   shouldDeferEventForHydration,
 } from "@/lib/session-seq";
 import { createLogger } from "@pizzapi/tools";
@@ -1535,53 +1537,42 @@ export function App() {
 
     if (type === "session_metadata_update") {
       // Lightweight metadata-only heartbeat — messages haven't changed.
-      // Update metadata state without touching the messages array.
+      // These updates are delivered live on the viewer channel, so apply the
+      // full patch directly rather than treating hub meta as authoritative.
       const meta = (evt.metadata ?? {}) as Record<string, unknown>;
-      const metaChannelHub = evt._metaChannel === "hub";
-      if (metaChannelHub) {
-        metaSourceHubRef.current = true;
-      }
-      if (metaSourceHubRef.current || metaChannelHub) {
-        return;
-      }
+      const derived = deriveSessionMetadataUpdatePatch({
+        metadata: meta,
+        currentActiveModel: activeModel,
+      });
       const cachePatch: Partial<SessionUiCacheEntry> = {};
 
-      const metaModel = normalizeModel(meta.model);
-      if (metaModel) {
-        setActiveModel(metaModel);
-        cachePatch.activeModel = metaModel;
+      if (Object.prototype.hasOwnProperty.call(derived, "activeModel")) {
+        setActiveModel(derived.activeModel ?? null);
+        cachePatch.activeModel = derived.activeModel ?? null;
       }
 
-      const metaModels = Array.isArray(meta.availableModels)
-        ? normalizeModelList(meta.availableModels as unknown[])
-        : null;
-      if (metaModels) {
-        setAvailableModels(metaModels);
-        cachePatch.availableModels = metaModels;
+      if (Object.prototype.hasOwnProperty.call(derived, "availableModels")) {
+        setAvailableModels(derived.availableModels ?? []);
+        cachePatch.availableModels = derived.availableModels ?? [];
       }
 
-      const metaCommands = Array.isArray(meta.availableCommands)
-        ? normalizeCommandList(meta.availableCommands as unknown[])
-        : null;
-      if (metaCommands) {
-        setAvailableCommands(metaCommands);
-        cachePatch.availableCommands = metaCommands;
+      if (Object.prototype.hasOwnProperty.call(derived, "availableCommands")) {
+        setAvailableCommands(derived.availableCommands ?? []);
+        cachePatch.availableCommands = derived.availableCommands ?? [];
       }
 
-      if (Object.prototype.hasOwnProperty.call(meta, "sessionName")) {
-        const nextName = normalizeSessionName(meta.sessionName);
-        setSessionName(nextName);
-        cachePatch.sessionName = nextName;
+      if (Object.prototype.hasOwnProperty.call(derived, "sessionName")) {
+        setSessionName(derived.sessionName ?? null);
+        cachePatch.sessionName = derived.sessionName ?? null;
       }
 
-      if (Object.prototype.hasOwnProperty.call(meta, "thinkingLevel")) {
-        const level = typeof meta.thinkingLevel === "string" ? meta.thinkingLevel : null;
-        setEffortLevel(level);
-        cachePatch.effortLevel = level;
+      if (Object.prototype.hasOwnProperty.call(derived, "thinkingLevel")) {
+        setEffortLevel(derived.thinkingLevel ?? null);
+        cachePatch.effortLevel = derived.thinkingLevel ?? null;
       }
 
-      if (Array.isArray(meta.todoList)) {
-        const todos = meta.todoList as TodoItem[];
+      if (Object.prototype.hasOwnProperty.call(derived, "todoList")) {
+        const todos = derived.todoList ?? [];
         setTodoList(todos);
         cachePatch.todoList = todos;
       }
@@ -1629,10 +1620,11 @@ export function App() {
 
       // Extract commands from session_active state so cache-first hydration
       // (which only replays snapshot events) populates the command picker.
+      const hasStateCommands = !!state && Object.prototype.hasOwnProperty.call(state, "availableCommands");
       const stateCommands = Array.isArray(state?.availableCommands)
         ? normalizeCommandList(state.availableCommands as unknown[])
         : [];
-      if (stateCommands.length > 0) {
+      if (hasStateCommands) {
         setAvailableCommands(stateCommands);
       }
 
@@ -1712,7 +1704,7 @@ export function App() {
           activeModel: stateModel,
           ...(hasSessionName ? { sessionName: nextSessionName } : {}),
           availableModels: stateModels,
-          ...(stateCommands.length > 0 ? { availableCommands: stateCommands } : {}),
+          ...(hasStateCommands ? { availableCommands: stateCommands } : {}),
           effortLevel: thinkingLevel,
           todoList: stateTodos,
         });
@@ -1720,7 +1712,7 @@ export function App() {
         patchSessionCache({
           messages: normalizedMessages,
           availableModels: stateModels,
-          ...(stateCommands.length > 0 ? { availableCommands: stateCommands } : {}),
+          ...(hasStateCommands ? { availableCommands: stateCommands } : {}),
         });
       }
       return;
@@ -2620,6 +2612,7 @@ export function App() {
     getFallbackPromptKey,
     patchSessionCache,
     removeQueuedMessageByContent,
+    activeModel,
   ]);
 
   React.useEffect(() => {
@@ -3016,17 +3009,25 @@ export function App() {
           if (data.deltaReplay === true) {
             lastSeqRef.current = seq;
           } else {
-            const decision = analyzeIncomingSeq(lastSeqRef.current, seq);
-            if (!decision.accept) {
-              return;
+            const allowOutOfOrderHydrationSnapshot = shouldAllowOutOfOrderSnapshotDuringHydration(
+              eventType,
+              awaitingSnapshotRef.current,
+              lastSeqRef.current,
+              seq,
+            );
+            if (!allowOutOfOrderHydrationSnapshot) {
+              const decision = analyzeIncomingSeq(lastSeqRef.current, seq);
+              if (!decision.accept) {
+                return;
+              }
+              if (decision.gap && decision.expected !== null) {
+                log.warn(`Sequence gap: expected ${decision.expected}, got ${seq}. Requesting resync.`);
+                nextSocket.emit("resync", {
+                  lastSeq: lastSeqRef.current ?? undefined,
+                });
+              }
+              lastSeqRef.current = decision.nextSeq;
             }
-            if (decision.gap && decision.expected !== null) {
-              log.warn(`Sequence gap: expected ${decision.expected}, got ${seq}. Requesting resync.`);
-              nextSocket.emit("resync", {
-                lastSeq: lastSeqRef.current ?? undefined,
-              });
-            }
-            lastSeqRef.current = decision.nextSeq;
           }
         }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -395,6 +395,8 @@ export function App() {
   // which would otherwise be called speculatively in React concurrent mode.
   const messagesRef = React.useRef<RelayMessage[]>(messages);
   React.useLayoutEffect(() => { messagesRef.current = messages; }, [messages]);
+  const activeModelRef = React.useRef<ConfiguredModelInfo | null>(activeModel);
+  React.useLayoutEffect(() => { activeModelRef.current = activeModel; }, [activeModel]);
   const [relayStatus, setRelayStatus] = React.useState<DotState>("connecting");
   const [versionBanner, setVersionBanner] = React.useState<{ message: string | null; protocolCompatible: boolean }>({
     message: null,
@@ -1543,7 +1545,7 @@ export function App() {
       const meta = (evt.metadata ?? {}) as Record<string, unknown>;
       const derived = deriveSessionMetadataUpdatePatch({
         metadata: meta,
-        currentActiveModel: activeModel,
+        currentActiveModel: activeModelRef.current,
       });
       const cachePatch: Partial<SessionUiCacheEntry> = {};
 

--- a/packages/ui/src/lib/mcp-auth-banners.test.ts
+++ b/packages/ui/src/lib/mcp-auth-banners.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { removeMessagesByStableKey, replaceMessageByStableKey } from "./mcp-auth-banners";
+
+const baseMessages = [
+  { key: "m1", role: "user", content: "hi" },
+  { key: "mcp_auth:github", role: "system", content: "old" },
+  { key: "m2", role: "assistant", content: "hello" },
+];
+
+describe("replaceMessageByStableKey", () => {
+  test("replaces an existing auth banner in place", () => {
+    const next = replaceMessageByStableKey(baseMessages, "mcp_auth:github", {
+      key: "mcp_auth:github",
+      role: "system",
+      content: "new",
+    });
+
+    expect(next).toEqual([
+      { key: "m1", role: "user", content: "hi" },
+      { key: "mcp_auth:github", role: "system", content: "new" },
+      { key: "m2", role: "assistant", content: "hello" },
+    ]);
+  });
+
+  test("appends the auth banner when it does not exist yet", () => {
+    const next = replaceMessageByStableKey(baseMessages.filter((m) => m.key !== "mcp_auth:github"), "mcp_auth:github", {
+      key: "mcp_auth:github",
+      role: "system",
+      content: "new",
+    });
+
+    expect(next).toEqual([
+      { key: "m1", role: "user", content: "hi" },
+      { key: "m2", role: "assistant", content: "hello" },
+      { key: "mcp_auth:github", role: "system", content: "new" },
+    ]);
+  });
+});
+
+describe("removeMessagesByStableKey", () => {
+  test("removes exact and prefixed auth banner keys", () => {
+    const next = removeMessagesByStableKey([
+      ...baseMessages,
+      { key: "mcp_auth:github:retry", role: "system", content: "retry" },
+    ], "mcp_auth:github");
+
+    expect(next).toEqual([
+      { key: "m1", role: "user", content: "hi" },
+      { key: "m2", role: "assistant", content: "hello" },
+    ]);
+  });
+});

--- a/packages/ui/src/lib/mcp-auth-banners.ts
+++ b/packages/ui/src/lib/mcp-auth-banners.ts
@@ -1,0 +1,20 @@
+type MessageLike = { key?: string | null };
+
+export function replaceMessageByStableKey<T extends MessageLike>(
+  messages: T[],
+  stableKey: string,
+  message: T,
+): T[] {
+  const idx = messages.findIndex((m) => m.key === stableKey);
+  if (idx < 0) return [...messages, message];
+  return messages.map((m) => (m.key === stableKey ? message : m));
+}
+
+export function removeMessagesByStableKey<T extends MessageLike>(
+  messages: T[],
+  stableKey: string,
+): T[] {
+  return messages.filter(
+    (m) => m.key !== stableKey && !(typeof m.key === "string" && m.key.startsWith(`${stableKey}:`)),
+  );
+}

--- a/packages/ui/src/lib/session-metadata-update.test.ts
+++ b/packages/ui/src/lib/session-metadata-update.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { deriveSessionMetadataUpdatePatch } from "./session-metadata-update.js";
+
+describe("deriveSessionMetadataUpdatePatch", () => {
+  test("applies live metadata updates even when hub meta is authoritative", () => {
+    const patch = deriveSessionMetadataUpdatePatch({
+      metadata: {
+        model: { provider: "anthropic", id: "claude-sonnet-4-5" },
+        sessionName: "Live Session",
+        thinkingLevel: "high",
+        todoList: [{ id: 1, text: "live", status: "pending" }],
+        availableModels: [{ provider: "openai", id: "gpt-5" }],
+        availableCommands: [{ name: "search_tools", description: "Search" }],
+      },
+      hubAuthoritative: true,
+    });
+
+    expect(patch).toEqual({
+      activeModel: { provider: "anthropic", id: "claude-sonnet-4-5" },
+      sessionName: "Live Session",
+      thinkingLevel: "high",
+      todoList: [{ id: 1, text: "live", status: "pending" }],
+      availableModels: [{ provider: "openai", id: "gpt-5", name: undefined, reasoning: undefined, contextWindow: undefined }],
+      availableCommands: [{ name: "search_tools", description: "Search", source: undefined }],
+    });
+  });
+
+  test("applies the full metadata patch when hub meta is not authoritative", () => {
+    const patch = deriveSessionMetadataUpdatePatch({
+      metadata: {
+        model: { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+        sessionName: "  Session Name  ",
+        thinkingLevel: "medium",
+        todoList: [{ id: 1, text: "todo", status: "pending" }],
+        availableModels: [{ provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" }],
+        availableCommands: [{ name: "search_tools", description: "Search" }],
+      },
+      hubAuthoritative: false,
+    });
+
+    expect(patch).toEqual({
+      activeModel: { provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" },
+      sessionName: "Session Name",
+      thinkingLevel: "medium",
+      todoList: [{ id: 1, text: "todo", status: "pending" }],
+      availableModels: [{ provider: "anthropic", id: "claude-sonnet-4-5", name: "Claude Sonnet 4.5" }],
+      availableCommands: [{ name: "search_tools", description: "Search" }],
+    });
+  });
+
+  test("merges partial model metadata with the current active model", () => {
+    const patch = deriveSessionMetadataUpdatePatch({
+      metadata: {
+        model: { provider: "anthropic", id: "claude-sonnet-4-5" },
+      },
+      currentActiveModel: {
+        provider: "anthropic",
+        id: "claude-sonnet-4-5",
+        name: "Claude Sonnet 4.5",
+        reasoning: true,
+        contextWindow: 200000,
+      },
+    });
+
+    expect(patch.activeModel).toEqual({
+      provider: "anthropic",
+      id: "claude-sonnet-4-5",
+      name: "Claude Sonnet 4.5",
+      reasoning: true,
+      contextWindow: 200000,
+    });
+  });
+});

--- a/packages/ui/src/lib/session-metadata-update.ts
+++ b/packages/ui/src/lib/session-metadata-update.ts
@@ -1,0 +1,64 @@
+import type { TodoItem } from "@/lib/types";
+import {
+  normalizeCommandList,
+  normalizeModel,
+  normalizeModelList,
+  normalizeSessionName,
+} from "./message-helpers";
+
+export interface SessionMetadataUpdatePatch {
+  activeModel?: { provider: string; id: string; name?: string; reasoning?: boolean; contextWindow?: number } | null;
+  availableModels?: Array<{ provider: string; id: string; name?: string; reasoning?: boolean; contextWindow?: number }>;
+  availableCommands?: Array<{ name: string; description?: string; source?: string }>;
+  sessionName?: string | null;
+  thinkingLevel?: string | null;
+  todoList?: TodoItem[];
+}
+
+export function deriveSessionMetadataUpdatePatch(input: {
+  metadata: Record<string, unknown>;
+  hubAuthoritative?: boolean;
+  currentActiveModel?: SessionMetadataUpdatePatch["activeModel"];
+}): SessionMetadataUpdatePatch {
+  const { metadata, currentActiveModel } = input;
+  const patch: SessionMetadataUpdatePatch = {};
+
+  if (Object.prototype.hasOwnProperty.call(metadata, "availableModels") && Array.isArray(metadata.availableModels)) {
+    patch.availableModels = normalizeModelList(metadata.availableModels as unknown[]);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(metadata, "availableCommands") && Array.isArray(metadata.availableCommands)) {
+    patch.availableCommands = normalizeCommandList(metadata.availableCommands as unknown[]);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(metadata, "model")) {
+    const nextModel = normalizeModel(metadata.model);
+    if (
+      nextModel &&
+      currentActiveModel &&
+      currentActiveModel.provider === nextModel.provider &&
+      currentActiveModel.id === nextModel.id
+    ) {
+      patch.activeModel = {
+        ...currentActiveModel,
+        ...Object.fromEntries(Object.entries(nextModel).filter(([, value]) => value !== undefined)),
+      };
+    } else {
+      patch.activeModel = nextModel;
+    }
+  }
+
+  if (Object.prototype.hasOwnProperty.call(metadata, "sessionName")) {
+    patch.sessionName = normalizeSessionName(metadata.sessionName);
+  }
+
+  if (Object.prototype.hasOwnProperty.call(metadata, "thinkingLevel")) {
+    patch.thinkingLevel = typeof metadata.thinkingLevel === "string" ? metadata.thinkingLevel : null;
+  }
+
+  if (Array.isArray(metadata.todoList)) {
+    patch.todoList = metadata.todoList as TodoItem[];
+  }
+
+  return patch;
+}

--- a/packages/ui/src/lib/session-seq.test.ts
+++ b/packages/ui/src/lib/session-seq.test.ts
@@ -4,6 +4,7 @@ import {
   canFinalizeChunkHydration,
   mergeConnectedSeq,
   registerChunkIndex,
+  shouldAllowOutOfOrderSnapshotDuringHydration,
   shouldDeferEventForHydration,
 } from "./session-seq";
 
@@ -111,6 +112,20 @@ describe("chunk index tracking", () => {
     // Arrival order [2, 0, 1] must NOT be reflected in the final transcript
     expect(assembled[0]).toBe("msg-c0-a");
     expect(assembled[assembled.length - 1]).toBe("msg-c2-b");
+  });
+});
+
+describe("shouldAllowOutOfOrderSnapshotDuringHydration", () => {
+  test("allows an older snapshot seq after pre-snapshot metadata advanced the cursor", () => {
+    expect(shouldAllowOutOfOrderSnapshotDuringHydration("session_active", true, 11, 10)).toBe(true);
+    expect(shouldAllowOutOfOrderSnapshotDuringHydration("agent_end", true, 11, 10)).toBe(true);
+  });
+
+  test("rejects non-snapshot or non-hydration cases", () => {
+    expect(shouldAllowOutOfOrderSnapshotDuringHydration("heartbeat", true, 11, 10)).toBe(false);
+    expect(shouldAllowOutOfOrderSnapshotDuringHydration("session_active", false, 11, 10)).toBe(false);
+    expect(shouldAllowOutOfOrderSnapshotDuringHydration("session_active", true, null, 10)).toBe(false);
+    expect(shouldAllowOutOfOrderSnapshotDuringHydration("session_active", true, 10, 11)).toBe(false);
   });
 });
 

--- a/packages/ui/src/lib/session-seq.ts
+++ b/packages/ui/src/lib/session-seq.ts
@@ -38,6 +38,19 @@ export function shouldDeferEventForHydration(
   return false;
 }
 
+export function shouldAllowOutOfOrderSnapshotDuringHydration(
+  eventType: string,
+  awaitingSnapshot: boolean,
+  currentSeq: number | null,
+  incomingSeq: number,
+): boolean {
+  if (!awaitingSnapshot) return false;
+  if (eventType !== "session_active" && eventType !== "agent_end") return false;
+  if (currentSeq === null) return false;
+  if (!Number.isFinite(incomingSeq)) return false;
+  return incomingSeq < currentSeq;
+}
+
 export function registerChunkIndex(seenChunkIndexes: Set<number>, chunkIndex: number): boolean {
   if (seenChunkIndexes.has(chunkIndex)) {
     return false;


### PR DESCRIPTION
## Summary
- keep late MCP capability and metadata updates synced into durable session snapshots so reconnects do not require switching sessions away and back
- harden viewer hydration for chunked sessions, partial model updates, and out-of-order pre-snapshot metadata events
- keep MCP auth banners in the per-session UI cache so dismiss/replace flows stay consistent across session switches

## Test Plan
- bun test packages/server/src/ws/sio-registry/snapshot-state.test.ts packages/server/src/ws/namespaces/relay/event-pipeline.test.ts packages/server/src/ws/namespaces/relay-metadata.test.ts packages/ui/src/lib/session-metadata-update.test.ts packages/ui/src/lib/session-seq.test.ts packages/ui/src/lib/meta-state-apply.test.ts packages/ui/src/lib/mcp-auth-banners.test.ts
- bun run typecheck