### PR TITLE
Add first-party Ollama Cloud provider

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,9 +5,9 @@
     "": {
       "name": "pizzapi",
       "dependencies": {
-        "@mariozechner/pi-agent-core": "^0.67.5",
-        "@mariozechner/pi-ai": "^0.67.5",
-        "@mariozechner/pi-tui": "^0.67.5",
+        "@mariozechner/pi-agent-core": "^0.70.6",
+        "@mariozechner/pi-ai": "^0.70.6",
+        "@mariozechner/pi-tui": "^0.70.6",
         "motion": "^12.34.2",
         "pizzapi": ".",
       },
@@ -20,13 +20,13 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.5.2-dev.5",
+      "version": "0.5.2-dev.6",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
       },
       "dependencies": {
-        "@mariozechner/pi-coding-agent": "^0.67.5",
+        "@mariozechner/pi-coding-agent": "^0.70.6",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
@@ -61,8 +61,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@mariozechner/pi-agent-core": "^0.67.5",
-        "@mariozechner/pi-ai": "^0.67.5",
+        "@mariozechner/pi-agent-core": "^0.70.6",
+        "@mariozechner/pi-ai": "^0.70.6",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",
@@ -90,8 +90,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@mariozechner/pi-agent-core": "^0.67.5",
-        "@mariozechner/pi-ai": "^0.67.5",
+        "@mariozechner/pi-agent-core": "^0.70.6",
+        "@mariozechner/pi-ai": "^0.70.6",
       },
       "devDependencies": {
         "typescript": "^5.7.0",
@@ -170,9 +170,9 @@
     },
   },
   "patchedDependencies": {
-    "@mariozechner/pi-coding-agent@0.67.5": "patches/@mariozechner%2Fpi-coding-agent@0.67.5.patch",
-    "@mariozechner/pi-agent-core@0.67.5": "patches/@mariozechner%2Fpi-agent-core@0.67.5.patch",
-    "@mariozechner/pi-ai@0.67.5": "patches/@mariozechner%2Fpi-ai@0.67.5.patch",
+    "@mariozechner/pi-agent-core@0.70.6": "patches/@mariozechner%2Fpi-agent-core@0.70.6.patch",
+    "@mariozechner/pi-ai@0.70.6": "patches/@mariozechner%2Fpi-ai@0.70.6.patch",
+    "@mariozechner/pi-coding-agent@0.70.6": "patches/@mariozechner%2Fpi-coding-agent@0.70.6.patch",
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
@@ -689,7 +689,7 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.2", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.2", "@mariozechner/clipboard-darwin-universal": "0.3.2", "@mariozechner/clipboard-darwin-x64": "0.3.2", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2", "@mariozechner/clipboard-linux-arm64-musl": "0.3.2", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-musl": "0.3.2", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2", "@mariozechner/clipboard-win32-x64-msvc": "0.3.2" } }, "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA=="],
+    "@mariozechner/clipboard": ["@mariozechner/clipboard@0.3.5", "", { "optionalDependencies": { "@mariozechner/clipboard-darwin-arm64": "0.3.2", "@mariozechner/clipboard-darwin-universal": "0.3.2", "@mariozechner/clipboard-darwin-x64": "0.3.2", "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2", "@mariozechner/clipboard-linux-arm64-musl": "0.3.2", "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-gnu": "0.3.2", "@mariozechner/clipboard-linux-x64-musl": "0.3.2", "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2", "@mariozechner/clipboard-win32-x64-msvc": "0.3.2" } }, "sha512-D3F+UrU9CR7roJt0zDLp6Oc+4/KlLDIrN4frH+6V90SJNW2KKUec1oCQIPaaDjCqeOsQyX9dyqYbImIQIM45PA=="],
 
     "@mariozechner/clipboard-darwin-arm64": ["@mariozechner/clipboard-darwin-arm64@0.3.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw=="],
 
@@ -713,19 +713,19 @@
 
     "@mariozechner/jiti": ["@mariozechner/jiti@2.6.5", "", { "dependencies": { "std-env": "^3.10.0", "yoctocolors": "^2.1.2" }, "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw=="],
 
-    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.67.5", "", { "dependencies": { "@mariozechner/pi-ai": "^0.67.5" } }, "sha512-XZwAVYEja4YV3Or+Fb1fMvi/KphpaEvMcfGe1/lBNEOllDK3m6J/6MdqLJy85rettX3uKRuGjF3adDNju+LRow=="],
+    "@mariozechner/pi-agent-core": ["@mariozechner/pi-agent-core@0.70.6", "", { "dependencies": { "@mariozechner/pi-ai": "^0.70.6", "typebox": "^1.1.24" } }, "sha512-PovJZJqhY4ajgTJRUcLzfWKnlQuJHxHW3T030CafR9LYeLmOHi/HGS8DbCdRgSJNbnoIG+kl67/7++9DKZ2+sg=="],
 
-    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.67.5", "", { "dependencies": { "@anthropic-ai/sdk": "^0.90.0", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "1.14.1", "@sinclair/typebox": "^0.34.41", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-TgxI2seq+gIRy6oRQA/ogyj8c9vESMQEeICPKYe29hJCLkN/i7tgKnU9jIM+rcAJmtGaO4Iy0IL7wYV4g0qjsw=="],
+    "@mariozechner/pi-ai": ["@mariozechner/pi-ai@0.70.6", "", { "dependencies": { "@anthropic-ai/sdk": "^0.90.0", "@aws-sdk/client-bedrock-runtime": "^3.1030.0", "@google/genai": "^1.40.0", "@mistralai/mistralai": "^2.2.0", "chalk": "^5.6.2", "openai": "6.26.0", "partial-json": "^0.1.7", "proxy-agent": "^6.5.0", "typebox": "^1.1.24", "undici": "^7.19.1", "zod-to-json-schema": "^3.24.6" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-LVAadu0Y+hb7Bj7EDiLsx6AuGxHlxDq0euLzyqX698i9qt0BW6a+oQSUIZQz4rJwExF18OvyL7ygJ5781ojrIQ=="],
 
-    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.67.5", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.67.5", "@mariozechner/pi-ai": "^0.67.5", "@mariozechner/pi-tui": "^0.67.5", "@silvia-odwyer/photon-node": "^0.3.4", "ajv": "^8.17.1", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "undici": "^7.19.1", "uuid": "^11.1.0", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.2" }, "bin": { "pi": "dist/cli.js" } }, "sha512-U/kZ173IDmkwq7p8zKsrhb5fpxWUW53NTKXva6fyzwx3o/tGl3PzdnyxBfv7vHz15S7mgL/dpdiF/ANUV34JTw=="],
+    "@mariozechner/pi-coding-agent": ["@mariozechner/pi-coding-agent@0.70.6", "", { "dependencies": { "@mariozechner/jiti": "^2.6.2", "@mariozechner/pi-agent-core": "^0.70.6", "@mariozechner/pi-ai": "^0.70.6", "@mariozechner/pi-tui": "^0.70.6", "@silvia-odwyer/photon-node": "^0.3.4", "chalk": "^5.5.0", "cli-highlight": "^2.1.11", "diff": "^8.0.2", "extract-zip": "^2.0.1", "file-type": "^21.1.1", "glob": "^13.0.1", "hosted-git-info": "^9.0.2", "ignore": "^7.0.5", "marked": "^15.0.12", "minimatch": "^10.2.3", "proper-lockfile": "^4.1.2", "strip-ansi": "^7.1.0", "typebox": "^1.1.24", "undici": "^7.19.1", "uuid": "^14.0.0", "yaml": "^2.8.2" }, "optionalDependencies": { "@mariozechner/clipboard": "^0.3.3" }, "bin": { "pi": "dist/cli.js" } }, "sha512-S4hUZghBeHPqsL6+DNg/TbGLziSh5+/mEHPVlYq5y6ImirWXhISLdLCnyZUW83OblKWihmG7unhJXiHQTH82mQ=="],
 
-    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.67.5", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-e1dUhXDr2LUUkHmuVYxPubQnk3NYcZLNOinUVTYXCSTAEzgSq0vH5LMgf5/zHspi5AmncmJmc85Qf/VFmnpw7Q=="],
+    "@mariozechner/pi-tui": ["@mariozechner/pi-tui@0.70.6", "", { "dependencies": { "@types/mime-types": "^2.1.4", "chalk": "^5.5.0", "get-east-asian-width": "^1.3.0", "marked": "^15.0.12", "mime-types": "^3.0.1" }, "optionalDependencies": { "koffi": "^2.9.0" } }, "sha512-orBJEwMdpBC38AXfdVBKT5ZvqNTcKg6g3NdoF5a9aNQzDI/dOTu1UNYFYyEOTFRiTxSR1nw8eovbCcaSyekWfw=="],
 
     "@mdx-js/mdx": ["@mdx-js/mdx@3.1.1", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdx": "^2.0.0", "acorn": "^8.0.0", "collapse-white-space": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "markdown-extensions": "^2.0.0", "recma-build-jsx": "^1.0.0", "recma-jsx": "^1.0.0", "recma-stringify": "^1.0.0", "rehype-recma": "^1.0.0", "remark-mdx": "^3.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "source-map": "^0.7.0", "unified": "^11.0.0", "unist-util-position-from-estree": "^2.0.0", "unist-util-stringify-position": "^4.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" } }, "sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ=="],
 
     "@mermaid-js/parser": ["@mermaid-js/parser@1.0.0", "", { "dependencies": { "langium": "^4.0.0" } }, "sha512-vvK0Hi/VWndxoh03Mmz6wa1KDriSPjS2XMZL/1l19HFwygiObEEoEwSDxOqyLzzAI6J2PU3261JjTMTO7x+BPw=="],
 
-    "@mistralai/mistralai": ["@mistralai/mistralai@1.14.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.24.1" } }, "sha512-IiLmmZFCCTReQgPAT33r7KQ1nYo5JPdvGkrkZqA8qQ2qB1GHgs5LoP5K2ICyrjnpw2n8oSxMM/VP+liiKcGNlQ=="],
+    "@mistralai/mistralai": ["@mistralai/mistralai@2.2.1", "", { "dependencies": { "ws": "^8.18.0", "zod": "^3.25.0 || ^4.0.0", "zod-to-json-schema": "^3.25.0" } }, "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ=="],
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.27.1", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA=="],
 
@@ -1026,8 +1026,6 @@
     "@shikijs/vscode-textmate": ["@shikijs/vscode-textmate@10.0.2", "", {}, "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg=="],
 
     "@silvia-odwyer/photon-node": ["@silvia-odwyer/photon-node@0.3.4", "", {}, "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA=="],
-
-    "@sinclair/typebox": ["@sinclair/typebox@0.34.48", "", {}, "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA=="],
 
     "@sindresorhus/merge-streams": ["@sindresorhus/merge-streams@4.0.0", "", {}, "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ=="],
 
@@ -3211,6 +3209,8 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
+    "typebox": ["typebox@1.1.34", "", {}, "sha512-V0fM5W5DTXlEMDxqtX1dQ25HR1RQ11DPUVrIup4sJi1yQtIyI30SHfxBy/HjXKL1CtUqc5or2igA/wa/v4hMKQ=="],
+
     "typed-array-buffer": ["typed-array-buffer@1.0.3", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "is-typed-array": "^1.1.14" } }, "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw=="],
 
     "typed-array-byte-length": ["typed-array-byte-length@1.0.3", "", { "dependencies": { "call-bind": "^1.0.8", "for-each": "^0.3.3", "gopd": "^1.2.0", "has-proto": "^1.2.0", "is-typed-array": "^1.1.14" } }, "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg=="],
@@ -3303,7 +3303,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
+    "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
 
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
@@ -3860,6 +3860,8 @@
     "make-dir/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "mermaid/marked": ["marked@16.4.2", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA=="],
+
+    "mermaid/uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "postinstall": "bun scripts/link-workspaces.ts"
   },
   "dependencies": {
-    "@mariozechner/pi-agent-core": "^0.67.5",
-    "@mariozechner/pi-ai": "^0.67.5",
-    "@mariozechner/pi-tui": "^0.67.5",
+    "@mariozechner/pi-agent-core": "^0.70.6",
+    "@mariozechner/pi-ai": "^0.70.6",
+    "@mariozechner/pi-tui": "^0.70.6",
     "motion": "^12.34.2",
     "pizzapi": "."
   },
@@ -51,8 +51,8 @@
   },
   "version": "",
   "patchedDependencies": {
-    "@mariozechner/pi-ai@0.67.5": "patches/@mariozechner%2Fpi-ai@0.67.5.patch",
-    "@mariozechner/pi-coding-agent@0.67.5": "patches/@mariozechner%2Fpi-coding-agent@0.67.5.patch",
-    "@mariozechner/pi-agent-core@0.67.5": "patches/@mariozechner%2Fpi-agent-core@0.67.5.patch"
+    "@mariozechner/pi-ai@0.70.6": "patches/@mariozechner%2Fpi-ai@0.70.6.patch",
+    "@mariozechner/pi-coding-agent@0.70.6": "patches/@mariozechner%2Fpi-coding-agent@0.70.6.patch",
+    "@mariozechner/pi-agent-core@0.70.6": "patches/@mariozechner%2Fpi-agent-core@0.70.6.patch"
   }
 }

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -6,6 +6,20 @@ ships with — this is how the TUI detects "what's new" on startup.
 
 ## [Unreleased]
 
+## [0.70.6] - 2026-04-30
+
+### Upstream (pi 0.67.5 → 0.70.6)
+
+- Refreshed PizzaPi's upstream package set to `@mariozechner/pi-*` `0.70.6`
+- Re-ported PizzaPi's existing patches for config-dir flattening, extension session control, retryable JSON stream errors, Anthropic web search, and Claude Code credential fallback
+- Added built-in Ollama Cloud provider wiring to the patched upstream packages
+
+### PizzaPi
+
+- **First-party Ollama Cloud provider** — built-in `ollama-cloud` models now target `https://ollama.com/v1` and use `OLLAMA_API_KEY`
+- **Bundled Ollama model catalog** — PizzaPi ships a broad initial Ollama Cloud model list, including `glm-5.1`, `gpt-oss`, `kimi`, `qwen`, `deepseek`, `gemma`, and `devstral` families
+- **Docs refresh** — installation, getting started, environment-variable, and CLI reference docs now cover Ollama Cloud setup
+
 ## [0.63.1] - 2026-03-27
 
 ### Upstream (pi 0.58.3 → 0.63.1)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "build:binaries": "bun build-binaries.ts"
   },
   "dependencies": {
-    "@mariozechner/pi-coding-agent": "^0.67.5",
+    "@mariozechner/pi-coding-agent": "^0.70.6",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@pizzapi/protocol": "workspace:*",
     "@pizzapi/tools": "workspace:*",

--- a/packages/cli/src/extensions/set-session-name.ts
+++ b/packages/cli/src/extensions/set-session-name.ts
@@ -39,8 +39,9 @@ export const setSessionNameExtension: ExtensionFactory = (pi) => {
             required: ["name"],
         } as any,
         execute: async (_toolCallId, params) => {
-            if (!named && !pi.getSessionName()) {
-                pi.setSessionName(params.name.trim());
+            const parsed = params as { name?: string };
+            if (!named && !pi.getSessionName() && parsed.name?.trim()) {
+                pi.setSessionName(parsed.name.trim());
                 named = true;
             }
             return {

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -9,15 +9,8 @@ import type { AssistantMessage, Message } from "@mariozechner/pi-ai";
 import {
     createAgentSession,
     DefaultResourceLoader,
-    codingTools,
-    readOnlyTools,
-    bashTool,
-    readTool,
-    editTool,
-    writeTool,
-    grepTool,
-    findTool,
-    lsTool,
+    createCodingTools,
+    createReadOnlyTools,
 } from "@mariozechner/pi-coding-agent";
 import type { AgentConfig } from "../subagent-agents.js";
 import { defaultAgentDir } from "../../config.js";
@@ -26,26 +19,25 @@ import { getFinalOutput, summarizeResultForStreaming } from "./types.js";
 
 // ── Built-in tool registry ─────────────────────────────────────────────
 
-/** Map of all built-in tool names → tool objects. */
-export const BUILTIN_TOOLS: Record<string, (typeof codingTools)[number]> = {
-    bash: bashTool,
-    read: readTool,
-    edit: editTool,
-    write: writeTool,
-    grep: grepTool,
-    find: findTool,
-    ls: lsTool,
-};
+export const BUILTIN_TOOLS = {
+    bash: true,
+    read: true,
+    edit: true,
+    write: true,
+    grep: true,
+    find: true,
+    ls: true,
+} as const;
 
 /**
- * Resolve agent tool names to actual Tool objects from the built-in set.
+ * Resolve agent tool names to built-in tool names.
  * Returns null if any requested tool name is unknown (fail-closed).
  */
-export function resolveTools(toolNames: string[]): { tools: (typeof codingTools)[number][] } | { error: string } {
-    const resolved: (typeof codingTools)[number][] = [];
+export function resolveTools(toolNames: string[]): { tools: string[] } | { error: string } {
+    const resolved: string[] = [];
     const unknown: string[] = [];
     for (const name of toolNames) {
-        if (BUILTIN_TOOLS[name]) resolved.push(BUILTIN_TOOLS[name]);
+        if (name in BUILTIN_TOOLS) resolved.push(name);
         else unknown.push(name);
     }
     if (unknown.length > 0) {
@@ -157,10 +149,11 @@ export async function runSingleAgent(
         const isPlanMode = agent.permissionMode === "plan";
 
         // Build session options — resolve tools fail-closed
-        let tools: (typeof codingTools)[number][];
+        const sessionCwd = cwd ?? defaultCwd;
+        let tools: string[];
         if (isPlanMode) {
             // Plan mode: restrict to read-only tools regardless of agent config
-            tools = [...readOnlyTools];
+            tools = createReadOnlyTools(sessionCwd).map((tool) => tool.name);
         } else if (effectiveToolNames) {
             const resolved = resolveTools(effectiveToolNames);
             if ("error" in resolved) {
@@ -177,14 +170,14 @@ export async function runSingleAgent(
             }
             tools = resolved.tools;
         } else {
-            tools = [...codingTools];
+            tools = createCodingTools(sessionCwd).map((tool) => tool.name);
         }
-        const sessionCwd = cwd ?? defaultCwd;
 
         // Use a lightweight resource loader — no extensions, skills, themes, etc.
         // Just the system prompt from the agent definition.
         const loader = new DefaultResourceLoader({
             cwd: sessionCwd,
+            agentDir: defaultAgentDir(),
             noExtensions: true,
             noSkills: true,
             noPromptTemplates: true,

--- a/packages/cli/src/extensions/tool-search.lifecycle.test.ts
+++ b/packages/cli/src/extensions/tool-search.lifecycle.test.ts
@@ -56,11 +56,15 @@ describe("toolSearchExtension lifecycle sync", () => {
     mock.restore();
   });
 
-  function createHarness() {
+  function createHarness(options?: { runtimeReady?: boolean }) {
     const handlers = new Map<string, EventHandler[]>();
     const activeTools = new Set<string>(["mcp_github_create_issue", "search_tools"]);
     const registeredTools = new Map<string, any>();
     const registeredCommands = new Map<string, any>();
+    let runtimeReady = options?.runtimeReady ?? true;
+    const notInitialized = () => {
+      throw new Error("Extension runtime not initialized. Action methods cannot be called during extension loading.");
+    };
 
     const pi = {
       on: mock((event: string, handler: EventHandler) => {
@@ -86,22 +90,38 @@ describe("toolSearchExtension lifecycle sync", () => {
       registerCommand: mock((name: string, command: any) => {
         registeredCommands.set(name, command);
       }),
-      getAllTools: mock(() => ([
-        {
-          name: "mcp_github_create_issue",
-          description: "Create an issue in GitHub",
-          parameters: { type: "object", properties: { owner: { type: "string" }, repo: { type: "string" } } },
-          sourceInfo: undefined,
-        },
-      ])),
-      getActiveTools: mock(() => [...activeTools]),
+      getAllTools: mock(() => {
+        if (!runtimeReady) notInitialized();
+        return [
+          {
+            name: "mcp_github_create_issue",
+            description: "Create an issue in GitHub",
+            parameters: { type: "object", properties: { owner: { type: "string" }, repo: { type: "string" } } },
+            sourceInfo: undefined,
+          },
+        ];
+      }),
+      getActiveTools: mock(() => {
+        if (!runtimeReady) notInitialized();
+        return [...activeTools];
+      }),
       setActiveTools: mock((tools: string[]) => {
+        if (!runtimeReady) notInitialized();
         activeTools.clear();
         for (const tool of tools) activeTools.add(tool);
       }),
     };
 
-    return { pi, handlers, registeredTools, registeredCommands, activeTools };
+    return {
+      pi,
+      handlers,
+      registeredTools,
+      registeredCommands,
+      activeTools,
+      setRuntimeReady: (ready: boolean) => {
+        runtimeReady = ready;
+      },
+    };
   }
 
   async function loadExtension() {
@@ -238,6 +258,33 @@ describe("toolSearchExtension lifecycle sync", () => {
         }),
       ],
     });
+  });
+
+  test("ignores registry updates until runtime action methods are bound", async () => {
+    snapshot = { serverTools: { github: ["mcp_github_create_issue"] } };
+    const { toolSearchExtension } = await loadExtension();
+    const { pi, registeredCommands, activeTools, setRuntimeReady } = createHarness({ runtimeReady: false });
+
+    toolSearchExtension(pi as any);
+
+    const statusCommand = registeredCommands.get("tool-search");
+    expect(statusCommand).toBeDefined();
+
+    expect(() => pi.events.emit("mcp:registry_updated", { server: "github" })).not.toThrow();
+
+    const skippedNotes: string[] = [];
+    statusCommand.handler("status", { ui: { notify: (msg: string) => skippedNotes.push(msg) } });
+    expect(skippedNotes.at(-1)).toContain("Tool search: inactive");
+    expect(activeTools.has("mcp_github_create_issue")).toBe(true);
+
+    setRuntimeReady(true);
+    pi.events.emit("mcp:registry_updated", { server: "github" });
+
+    const refreshedNotes: string[] = [];
+    statusCommand.handler("status", { ui: { notify: (msg: string) => refreshedNotes.push(msg) } });
+    expect(refreshedNotes.at(-1)).toContain("Tool search: active");
+    expect(refreshedNotes.at(-1)).toContain("Deferred tools: 1");
+    expect(activeTools.has("mcp_github_create_issue")).toBe(false);
   });
 
   test("clears stale state when the MCP snapshot disappears", async () => {

--- a/packages/cli/src/extensions/tool-search.ts
+++ b/packages/cli/src/extensions/tool-search.ts
@@ -156,6 +156,10 @@ function getServerDeferConfig(config: PizzaPiConfig & McpConfig): Map<string, bo
 
 // ── Extension ───────────────────────────────────────────────────────────────
 
+function isExtensionRuntimeNotInitializedError(err: unknown): boolean {
+  return err instanceof Error && /Extension runtime not initialized/i.test(err.message);
+}
+
 export const toolSearchExtension: ExtensionFactory = (pi: any) => {
   const state: ToolSearchState = {
     deferredTools: new Map(),
@@ -187,11 +191,7 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
     }),
   });
 
-  /**
-   * Evaluate whether tool search should activate, and if so, which tools to defer.
-   * Called after MCP tools are loaded (on session_start, after MCP extension runs).
-   */
-  function evaluateAndDefer(): void {
+  function evaluateAndDeferImpl(): void {
     const config = loadConfig(process.cwd());
     const tsConfig = config.toolSearch;
 
@@ -316,6 +316,24 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
       `Tool search active: deferred ${state.deferredTools.size} tools ` +
       `(${totalMcpChars} chars, threshold ${threshold})`
     );
+  }
+
+  /**
+   * Evaluate whether tool search should activate, and if so, which tools to defer.
+   * MCP eager loading can emit `mcp:registry_updated` before Runner.bindCore()
+   * wires real action methods into the shared extension runtime, so we ignore
+   * those pre-bind events and wait for a later lifecycle event to resync.
+   */
+  function evaluateAndDefer(): void {
+    try {
+      evaluateAndDeferImpl();
+    } catch (err) {
+      if (isExtensionRuntimeNotInitializedError(err)) {
+        log.info("Tool search: runtime not initialized yet; skipping MCP registry sync");
+        return;
+      }
+      throw err;
+    }
   }
 
   // ── Register the search_tools tool ──────────────────────────────────────

--- a/packages/cli/src/ollama-provider.test.ts
+++ b/packages/cli/src/ollama-provider.test.ts
@@ -1,0 +1,87 @@
+import { describe, test, expect } from "bun:test";
+import { dirname, resolve, join } from "path";
+import { fileURLToPath } from "url";
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+
+function piCodingAgentPath(subpath: string): string {
+  const pkgMainUrl = import.meta.resolve("@mariozechner/pi-coding-agent");
+  const pkgMain = fileURLToPath(pkgMainUrl);
+  const pkgRoot = resolve(dirname(pkgMain), "..");
+  return resolve(pkgRoot, subpath);
+}
+
+describe("Ollama built-in provider", () => {
+  test("pi-ai exposes bundled Ollama Cloud models with cloud base URL", async () => {
+    const { getModels } = await import("@mariozechner/pi-ai");
+    const models = (getModels as (provider: string) => Array<any>)("ollama-cloud");
+
+    expect(models.length).toBeGreaterThan(0);
+    for (const id of ["glm-5.1", "gpt-oss:20b", "kimi-k2.6", "qwen3-coder-next", "deepseek-v4-pro"]) {
+      expect(models.some((m) => m.id === id)).toBe(true);
+    }
+
+    const glm = models.find((m) => m.id === "glm-5.1");
+    expect(glm).toBeDefined();
+    expect(glm?.provider).toBe("ollama-cloud");
+    expect(glm?.baseUrl).toBe("https://ollama.com/v1");
+    expect(glm?.api).toBe("openai-completions");
+  });
+
+  test("pi-ai resolves OLLAMA_API_KEY from environment for ollama-cloud", async () => {
+    const { getEnvApiKey } = await import("@mariozechner/pi-ai");
+    const prev = process.env.OLLAMA_API_KEY;
+    process.env.OLLAMA_API_KEY = "test-ollama-key";
+    try {
+      expect((getEnvApiKey as (provider: string) => string | undefined)("ollama-cloud")).toBe("test-ollama-key");
+    } finally {
+      if (prev === undefined) delete process.env.OLLAMA_API_KEY;
+      else process.env.OLLAMA_API_KEY = prev;
+    }
+  });
+
+  test("coding-agent treats Ollama Cloud as a built-in API-key login provider", async () => {
+    const { defaultModelPerProvider } = await import(piCodingAgentPath("dist/core/model-resolver.js"));
+    const { getApiKeyProviderDisplayName, isApiKeyLoginProvider } = await import(
+      piCodingAgentPath("dist/modes/interactive/interactive-mode.js")
+    );
+
+    expect(defaultModelPerProvider["ollama-cloud"]).toBe("glm-5.1");
+    expect(getApiKeyProviderDisplayName("ollama-cloud")).toBe("Ollama Cloud");
+    expect(isApiKeyLoginProvider("ollama-cloud", new Set())).toBe(true);
+  });
+
+  test("custom local ollama models remain separate from built-in cloud auth", async () => {
+    const { AuthStorage, ModelRegistry } = await import("@mariozechner/pi-coding-agent");
+
+    const dir = mkdtempSync(join(tmpdir(), "ollama-cloud-registry-"));
+    const modelsPath = join(dir, "models.json");
+    writeFileSync(
+      modelsPath,
+      JSON.stringify({
+        providers: {
+          ollama: {
+            baseUrl: "http://localhost:11434/v1",
+            api: "openai-completions",
+            apiKey: "ollama",
+            models: [{ id: "llama3.1:8b" }],
+          },
+        },
+      }),
+    );
+
+    const prev = process.env.OLLAMA_API_KEY;
+    process.env.OLLAMA_API_KEY = "test-ollama-key";
+    try {
+      const registry = ModelRegistry.create(AuthStorage.inMemory(), modelsPath);
+      const available = registry.getAvailable();
+
+      expect(available.some((m: any) => m.provider === "ollama-cloud" && m.id === "glm-5.1")).toBe(true);
+      expect(available.some((m: any) => m.provider === "ollama" && m.id === "llama3.1:8b")).toBe(true);
+      expect(registry.find("ollama", "llama3.1:8b")?.baseUrl).toBe("http://localhost:11434/v1");
+    } finally {
+      if (prev === undefined) delete process.env.OLLAMA_API_KEY;
+      else process.env.OLLAMA_API_KEY = prev;
+    }
+  });
+});

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -139,6 +139,18 @@ describe("pi-coding-agent patch application", () => {
         expect(source).not.toContain('return join(homedir(), CONFIG_DIR_NAME, "agent")');
         expect(source).toContain("PATCH(pizzapi): flat directory structure");
     });
+
+    test("config.js: getChangelogPath honors PIZZAPI_CHANGELOG_PATH", async () => {
+        const { getChangelogPath } = await import(piCodingAgentPath("dist/config.js"));
+        const prev = process.env.PIZZAPI_CHANGELOG_PATH;
+        process.env.PIZZAPI_CHANGELOG_PATH = "/tmp/pizzapi-changelog-test.md";
+        try {
+            expect(getChangelogPath()).toBe("/tmp/pizzapi-changelog-test.md");
+        } finally {
+            if (prev === undefined) delete process.env.PIZZAPI_CHANGELOG_PATH;
+            else process.env.PIZZAPI_CHANGELOG_PATH = prev;
+        }
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -167,6 +167,10 @@ You can also enable web search via environment variables (these take precedence 
   Web search works with both API key and OAuth authentication.
 </Aside>
 
+<Aside type="tip" title="Built-in Ollama Cloud auth uses an environment variable">
+  Ollama Cloud is available as a built-in provider via <code>OLLAMA_API_KEY</code>. Set it in the same environment as <code>pizzapi</code> or your runner daemon. This is provider auth, not a <code>providerSettings</code> entry.
+</Aside>
+
 ---
 
 ## Environment Variables

--- a/packages/docs/src/content/docs/reference/environment-variables.mdx
+++ b/packages/docs/src/content/docs/reference/environment-variables.mdx
@@ -69,6 +69,18 @@ These variables control Anthropic's server-side web search tool. They can also b
 | `PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS` | Comma-separated list of domains to restrict search results to. | — |
 | `PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS` | Comma-separated list of domains to exclude from search results. | — |
 
+### Provider Authentication Variables
+
+These variables are read by the underlying `pi` model providers. Set them in the same environment as `pizzapi` or the runner daemon.
+
+| Variable | Description | Default |
+|---|---|---|
+| `OLLAMA_API_KEY` | API key for the built-in Ollama Cloud provider (`https://ollama.com/v1`). Required to use Ollama Cloud models without entering the key manually through `/login`. | — |
+
+<Aside type="note">
+  If you run PizzaPi as a background runner service, export provider variables like <code>OLLAMA_API_KEY</code> in the service environment too — setting them only in your interactive shell is not enough for spawned worker sessions.
+</Aside>
+
 ### Worker Safe-Mode Variables
 
 These variables control which subsystems are loaded by runner-spawned worker sessions. They're equivalent to the CLI's `--no-*` flags. See [Safe Mode & Startup Performance](/PizzaPi/security/sandbox/) for details.

--- a/packages/docs/src/content/docs/running/cli-reference.mdx
+++ b/packages/docs/src/content/docs/running/cli-reference.mdx
@@ -337,6 +337,7 @@ provider   model                    notes
 anthropic  claude-opus-4-5          reasoning • 200,000 ctx • Claude Opus 4.5
 anthropic  claude-sonnet-4-20250514            200,000 ctx • Claude Sonnet 4
 google     gemini-2.5-pro           reasoning • 1,000,000 ctx • Gemini 2.5 Pro
+ollama-cloud  glm-5.1               reasoning • 202,752 ctx • GLM 5.1
 ```
 
 ---

--- a/packages/docs/src/content/docs/start-here/first-remote-session.mdx
+++ b/packages/docs/src/content/docs/start-here/first-remote-session.mdx
@@ -19,7 +19,7 @@ Before you start, make sure you have:
 
 - **PizzaPi CLI installed** — see [Installation](/PizzaPi/start-here/installation/)
 - **Docker and Docker Compose** — needed to run the relay server
-- **An AI provider API key** — Anthropic, OpenAI, Google, or a Claude Pro/Max subscription
+- **An AI provider API key** — Anthropic, OpenAI, Google, Ollama Cloud, or a Claude Pro/Max subscription
 
 ---
 

--- a/packages/docs/src/content/docs/start-here/getting-started.mdx
+++ b/packages/docs/src/content/docs/start-here/getting-started.mdx
@@ -25,12 +25,12 @@ You always need the CLI. The relay can be **hosted by someone else** (quickest) 
 Before you start, make sure you have:
 
 - **Node.js 18+** (or Bun) installed
-- **An AI provider API key** — PizzaPi uses the `pi` coding agent under the hood, which needs an API key from at least one provider (Anthropic, OpenAI, Google, etc.). Alternatively, a [Claude Pro/Max subscription](https://claude.ai) works via the Claude Code OAuth flow.
+- **An AI provider API key** — PizzaPi uses the `pi` coding agent under the hood, which needs an API key from at least one provider (Anthropic, OpenAI, Google, Ollama Cloud, etc.). Alternatively, a [Claude Pro/Max subscription](https://claude.ai) works via the Claude Code OAuth flow.
 - **A relay server URL** — either a hosted relay someone has shared with you, or you'll self-host one below.
 - **Docker + Docker Compose** — only if you self-host with `pizzapi web`
 
 <Aside type="note">
-  Don't have an API key yet? [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), and [Google AI Studio](https://aistudio.google.com/) all offer free-tier credits to get started.
+  Don't have an API key yet? [Anthropic](https://console.anthropic.com/), [OpenAI](https://platform.openai.com/), [Google AI Studio](https://aistudio.google.com/), and [Ollama Cloud](https://ollama.com/settings/keys) all offer starter tiers or credits to get started.
 </Aside>
 
 <Aside type="note">

--- a/packages/docs/src/content/docs/start-here/installation.mdx
+++ b/packages/docs/src/content/docs/start-here/installation.mdx
@@ -96,6 +96,19 @@ pizzapi models
 pizzapi usage
 ```
 
+### Quick start with Ollama Cloud
+
+PizzaPi now recognizes **Ollama Cloud** as a built-in API-key provider. Set `OLLAMA_API_KEY`, then open PizzaPi and select an Ollama Cloud model from `/model` (provider ID: `ollama-cloud`):
+
+```bash
+export OLLAMA_API_KEY=your_ollama_api_key
+pizzapi
+```
+
+The built-in provider targets the OpenAI-compatible Ollama Cloud endpoint at `https://ollama.com/v1`.
+
+If you already use local or self-hosted Ollama via `~/.pizzapi/models.json` under provider ID `ollama`, keep that config as-is — the built-in cloud provider is separate and shows up as `ollama-cloud`.
+
 ---
 
 ## Updating
@@ -116,7 +129,7 @@ PizzaPi stores all its data under `~/.pizzapi/`. Here's what each file is for:
 |------|-----------|---------|
 | `~/.pizzapi/config.json` | `pizzapi setup` / manual | CLI config: API key, relay URL, skills, hooks |
 | `~/.pizzapi/auth.json` | `/login` inside a session | AI provider credentials (OAuth tokens, API keys) |
-| `~/.pizzapi/models.json` | first session start | Cached model registry |
+| `~/.pizzapi/models.json` | manual / custom setup | Optional custom model + provider config (for local Ollama, proxies, vLLM, etc.). Built-in providers still work without this file. |
 | `~/.pizzapi/runner.json` | `pizzapi runner` (first start) | Runner identity, name, and PID tracking (auto-generated) |
 | `~/.pizzapi/usage-cache.json` | `pizzapi runner` | Shared provider quota cache (written by daemon, read by workers) |
 | `~/.pizzapi/logs/` | macOS LaunchAgent setup | Log files for runner stdout/stderr |
@@ -189,10 +202,11 @@ To log out of all AI providers and start fresh with `/login`:
 
 ```bash
 rm ~/.pizzapi/auth.json
-rm ~/.pizzapi/models.json
 ```
 
-Next time you start `pizzapi`, you'll see "No models available" and can run `/login` to re-authenticate.
+If you also use custom model/provider definitions in `~/.pizzapi/models.json` (for example local Ollama, LM Studio, or proxy endpoints), **do not delete that file** unless you intentionally want to remove those custom models too.
+
+Next time you start `pizzapi`, built-in providers will still be available via environment variables or `/login`, and any custom providers in `models.json` will remain intact.
 
 ### Reset runner identity
 

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,8 +14,8 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@mariozechner/pi-agent-core": "^0.67.5",
-        "@mariozechner/pi-ai": "^0.67.5",
+        "@mariozechner/pi-agent-core": "^0.70.6",
+        "@mariozechner/pi-ai": "^0.70.6",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,8 +10,8 @@
     },
     "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@mariozechner/pi-agent-core": "^0.67.5",
-        "@mariozechner/pi-ai": "^0.67.5"
+        "@mariozechner/pi-agent-core": "^0.70.6",
+        "@mariozechner/pi-ai": "^0.70.6"
     },
     "devDependencies": {
         "typescript": "^5.7.0"

--- a/patches/@mariozechner%2Fpi-agent-core@0.70.6.patch
+++ b/patches/@mariozechner%2Fpi-agent-core@0.70.6.patch
@@ -1,0 +1,26 @@
+diff --git a/dist/agent.js b/dist/agent.js
+--- a/dist/agent.js
++++ b/dist/agent.js
+@@ -269,6 +269,9 @@
+     createContextSnapshot() {
+         return {
+             systemPrompt: this._state.systemPrompt,
++            // PATCH(pizzapi): allow the agent loop to refresh dynamic tool/prompt state
++            __getLatestSystemPrompt: () => this._state.systemPrompt,
++            __getLatestTools: () => this._state.tools.slice(),
+             messages: this._state.messages.slice(),
+             tools: this._state.tools.slice(),
+         };
+diff --git a/dist/agent-loop.js b/dist/agent-loop.js
+--- a/dist/agent-loop.js
++++ b/dist/agent-loop.js
+@@ -99,6 +99,9 @@
+                 }
+                 pendingMessages = [];
+             }
++            // PATCH(pizzapi): refresh dynamic tool/prompt state before each assistant response
++            currentContext.systemPrompt = currentContext.__getLatestSystemPrompt?.() ?? currentContext.systemPrompt;
++            currentContext.tools = currentContext.__getLatestTools?.() ?? currentContext.tools;
+             // Stream assistant response
+             const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFn);
+             newMessages.push(message);

--- a/patches/@mariozechner%2Fpi-ai@0.70.6.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.70.6.patch
@@ -1,0 +1,265 @@
+diff --git a/dist/providers/anthropic.js b/dist/providers/anthropic.js
+--- a/dist/providers/anthropic.js
++++ b/dist/providers/anthropic.js
+@@ -373,7 +373,30 @@
+                         };
+                         output.content.push(block);
+                         stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
++                    }
++                    // PATCH(pizzapi): handle server_tool_use (web search query)
++                    else if (event.content_block.type === "server_tool_use") {
++                        const block = {
++                            type: "text",
++                            text: "",
++                            partialJson: "",
++                            _serverToolUse: { id: event.content_block.id, name: event.content_block.name, input: event.content_block.input },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
+                     }
++                    // PATCH(pizzapi): handle web_search_tool_result
++                    else if (event.content_block.type === "web_search_tool_result") {
++                        const block = {
++                            type: "text",
++                            text: "",
++                            _webSearchResult: { tool_use_id: event.content_block.tool_use_id, content: event.content_block.content },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
+                 }
+                 else if (event.type === "content_block_delta") {
+                     if (event.delta.type === "text_delta") {
+@@ -415,6 +438,10 @@
+                                 partial: output,
+                             });
+                         }
++                        // PATCH(pizzapi): accumulate input_json_delta for server_tool_use blocks
++                        else if (block && block._serverToolUse && block.partialJson !== undefined) {
++                            block.partialJson += event.delta.partial_json;
++                        }
+                     }
+                     else if (event.delta.type === "signature_delta") {
+                         const index = blocks.findIndex((b) => b.index === event.index);
+@@ -431,6 +458,16 @@
+                     if (block) {
+                         delete block.index;
+                         if (block.type === "text") {
++                            // PATCH(pizzapi): finalize server_tool_use input from accumulated JSON
++                            if (block._serverToolUse && block.partialJson) {
++                                try {
++                                    block._serverToolUse.input = JSON.parse(block.partialJson);
++                                }
++                                catch (e) {
++                                    block._serverToolUse.input = parseStreamingJson(block.partialJson);
++                                }
++                            }
++                            delete block.partialJson;
+                             stream.push({
+                                 type: "text_end",
+                                 contentIndex: index,
+@@ -680,6 +717,22 @@
+     if (context.tools && context.tools.length > 0) {
+         params.tools = convertTools(context.tools, isOAuthToken, getAnthropicCompat(model).supportsEagerToolInputStreaming, cacheControl);
+     }
++    // PATCH(pizzapi): inject Anthropic web search tool when PIZZAPI_WEB_SEARCH is set
++    if (typeof process !== "undefined" && process.env.PIZZAPI_WEB_SEARCH && !["0", "false", "no", "off"].includes(process.env.PIZZAPI_WEB_SEARCH.toLowerCase())) {
++        if (!params.tools)
++            params.tools = [];
++        const webSearchTool = { type: "web_search_20250305", name: "web_search" };
++        const maxUses = parseInt(process.env.PIZZAPI_WEB_SEARCH_MAX_USES || "5", 10);
++        if (maxUses > 0)
++            webSearchTool.max_uses = maxUses;
++        if (process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS) {
++            webSearchTool.allowed_domains = process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS.split(",").map((d) => d.trim());
++        }
++        if (process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS) {
++            webSearchTool.blocked_domains = process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS.split(",").map((d) => d.trim());
++        }
++        params.tools.push(webSearchTool);
++    }
+     // Configure thinking mode: adaptive (Opus 4.6+ and Sonnet 4.6),
+     // budget-based (older models), or explicitly disabled.
+     if (model.reasoning) {
+@@ -782,7 +835,23 @@
+         else if (msg.role === "assistant") {
+             const blocks = [];
+             for (const block of msg.content) {
+-                if (block.type === "text") {
++                // PATCH(pizzapi): round-trip server tool use and web search results
++                if (block.type === "text" && block._serverToolUse) {
++                    blocks.push({
++                        type: "server_tool_use",
++                        id: block._serverToolUse.id,
++                        name: block._serverToolUse.name,
++                        input: block._serverToolUse.input,
++                    });
++                }
++                else if (block.type === "text" && block._webSearchResult) {
++                    blocks.push({
++                        type: "web_search_tool_result",
++                        tool_use_id: block._webSearchResult.tool_use_id,
++                        content: block._webSearchResult.content,
++                    });
++                }
++                else if (block.type === "text") {
+                     if (block.text.trim().length === 0)
+                         continue;
+                     blocks.push({
+@@ -896,6 +965,10 @@
+     if (!tools)
+         return [];
+     return tools.map((tool, index) => {
++        // PATCH(pizzapi): pass through server-side tools (e.g., web_search) as-is
++        if (tool.type && typeof tool.type === "string") {
++            return tool;
++        }
+         const schema = tool.parameters;
+         return {
+             name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
+diff --git a/dist/utils/oauth/anthropic.js b/dist/utils/oauth/anthropic.js
+--- a/dist/utils/oauth/anthropic.js
++++ b/dist/utils/oauth/anthropic.js
+@@ -313,6 +313,40 @@
+         expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
+     };
+ }
++// PATCH(pizzapi): read Claude Code credentials as a refresh fallback.
++async function tryReadClaudeCodeCredentials() {
++    try {
++        if (process.platform === "darwin") {
++            const { execSync } = await import("node:child_process");
++            const raw = execSync(
++                `security find-generic-password -s ${JSON.stringify("Claude Code-credentials")} -w`,
++                { encoding: "utf-8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] },
++            ).trim();
++            if (raw) {
++                const cc = JSON.parse(raw)?.claudeAiOauth;
++                if (cc?.accessToken && cc?.refreshToken && cc.expiresAt > Date.now() + 60000) {
++                    return { refresh: cc.refreshToken, access: cc.accessToken, expires: cc.expiresAt };
++                }
++            }
++        }
++    }
++    catch {
++    }
++    try {
++        const [{ readFileSync }, { join }, { homedir }] = await Promise.all([
++            import("node:fs"),
++            import("node:path"),
++            import("node:os"),
++        ]);
++        const cc = JSON.parse(readFileSync(join(homedir(), ".claude", ".credentials.json"), "utf-8"))?.claudeAiOauth;
++        if (cc?.accessToken && cc?.refreshToken && cc.expiresAt > Date.now() + 60000) {
++            return { refresh: cc.refreshToken, access: cc.accessToken, expires: cc.expiresAt };
++        }
++    }
++    catch {
++    }
++    return null;
++}
+ export const anthropicOAuthProvider = {
+     id: "anthropic",
+     name: "Anthropic (Claude Pro/Max)",
+@@ -326,6 +360,11 @@
+         });
+     },
+     async refreshToken(credentials) {
++        // PATCH(pizzapi): try Claude Code credentials first
++        const ccCreds = await tryReadClaudeCodeCredentials();
++        if (ccCreds) {
++            return ccCreds;
++        }
+         return refreshAnthropicToken(credentials.refresh);
+     },
+     getApiKey(credentials) {
+diff --git a/dist/env-api-keys.js b/dist/env-api-keys.js
+--- a/dist/env-api-keys.js
++++ b/dist/env-api-keys.js
+@@ -94,6 +94,7 @@
+         cerebras: "CEREBRAS_API_KEY",
+         xai: "XAI_API_KEY",
+         openrouter: "OPENROUTER_API_KEY",
++        "ollama-cloud": "OLLAMA_API_KEY",
+         "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+         zai: "ZAI_API_KEY",
+         mistral: "MISTRAL_API_KEY",
+diff --git a/dist/models.generated.js b/dist/models.generated.js
+--- a/dist/models.generated.js
++++ b/dist/models.generated.js
+@@ -1,5 +1,25 @@
+ // This file is auto-generated by scripts/generate-models.ts
+ // Do not edit manually - run 'npm run generate-models' to update
++const OLLAMA_BASE_URL = "https://ollama.com/v1";
++// Ollama Cloud currently documents plan-based usage tiers rather than stable per-token rates.
++// Keep cost metadata at zero until Ollama publishes machine-usable model pricing.
++const OLLAMA_ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
++const OLLAMA_COMPAT = { supportsDeveloperRole: false, supportsReasoningEffort: false, maxTokensField: "max_tokens" };
++function createOllamaModel(id, name, { reasoning = false, input = ["text"], contextWindow = 128000, maxTokens = 16384 } = {}) {
++    return {
++        id,
++        name,
++        api: "openai-completions",
++        provider: "ollama-cloud",
++        baseUrl: OLLAMA_BASE_URL,
++        compat: OLLAMA_COMPAT,
++        reasoning,
++        input,
++        cost: OLLAMA_ZERO_COST,
++        contextWindow,
++        maxTokens,
++    };
++}
+ export const MODELS = {
+     "amazon-bedrock": {
+         "amazon.nova-2-lite-v1:0": {
+@@ -15585,5 +15605,46 @@
+             maxTokens: 131072,
+         },
+     },
++    "ollama-cloud": {
++        "gpt-oss:120b": createOllamaModel("gpt-oss:120b", "GPT-OSS 120B", { reasoning: true, input: ["text"], contextWindow: 131072, maxTokens: 16384 }),
++        "ministral-3:8b": createOllamaModel("ministral-3:8b", "Ministral 3 8B", { reasoning: false, input: ["text"], contextWindow: 128000, maxTokens: 16384 }),
++        "ministral-3:14b": createOllamaModel("ministral-3:14b", "Ministral 3 14B", { reasoning: false, input: ["text"], contextWindow: 128000, maxTokens: 16384 }),
++        "gemini-3-flash-preview": createOllamaModel("gemini-3-flash-preview", "Gemini 3 Flash Preview", { reasoning: true, input: ["text", "image"], contextWindow: 1048576, maxTokens: 65536 }),
++        "qwen3.5:397b": createOllamaModel("qwen3.5:397b", "Qwen 3.5 397B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++        "glm-5.1": createOllamaModel("glm-5.1", "GLM 5.1", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 131072 }),
++        "kimi-k2-thinking": createOllamaModel("kimi-k2-thinking", "Kimi K2 Thinking", { reasoning: true, input: ["text"], contextWindow: 256000, maxTokens: 32768 }),
++        "qwen3-coder:480b": createOllamaModel("qwen3-coder:480b", "Qwen 3 Coder 480B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++        "gpt-oss:20b": createOllamaModel("gpt-oss:20b", "GPT-OSS 20B", { reasoning: true, input: ["text"], contextWindow: 131072, maxTokens: 16384 }),
++        "minimax-m2.1": createOllamaModel("minimax-m2.1", "MiniMax M2.1", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "minimax-m2.7": createOllamaModel("minimax-m2.7", "MiniMax M2.7", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "kimi-k2:1t": createOllamaModel("kimi-k2:1t", "Kimi K2 1T", { reasoning: true, input: ["text"], contextWindow: 256000, maxTokens: 32768 }),
++        "kimi-k2.6": createOllamaModel("kimi-k2.6", "Kimi K2.6", { reasoning: true, input: ["text"], contextWindow: 256000, maxTokens: 32768 }),
++        "gemma4:31b": createOllamaModel("gemma4:31b", "Gemma 4 31B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++        "qwen3-vl:235b": createOllamaModel("qwen3-vl:235b", "Qwen 3 VL 235B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++        "mistral-large-3:675b": createOllamaModel("mistral-large-3:675b", "Mistral Large 3 675B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "gemma3:12b": createOllamaModel("gemma3:12b", "Gemma 3 12B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++        "kimi-k2.5": createOllamaModel("kimi-k2.5", "Kimi K2.5", { reasoning: true, input: ["text"], contextWindow: 256000, maxTokens: 32768 }),
++        "deepseek-v3.2": createOllamaModel("deepseek-v3.2", "DeepSeek V3.2", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "deepseek-v3.1:671b": createOllamaModel("deepseek-v3.1:671b", "DeepSeek V3.1 671B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "ministral-3:3b": createOllamaModel("ministral-3:3b", "Ministral 3 3B", { reasoning: false, input: ["text"], contextWindow: 128000, maxTokens: 16384 }),
++        "gemma3:4b": createOllamaModel("gemma3:4b", "Gemma 3 4B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++        "gemma3:27b": createOllamaModel("gemma3:27b", "Gemma 3 27B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++        "glm-4.6": createOllamaModel("glm-4.6", "GLM 4.6", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 65536 }),
++        "deepseek-v4-flash": createOllamaModel("deepseek-v4-flash", "DeepSeek V4 Flash", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "minimax-m2.5": createOllamaModel("minimax-m2.5", "MiniMax M2.5", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "glm-4.7": createOllamaModel("glm-4.7", "GLM 4.7", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 65536 }),
++        "deepseek-v4-pro": createOllamaModel("deepseek-v4-pro", "DeepSeek V4 Pro", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "devstral-2:123b": createOllamaModel("devstral-2:123b", "Devstral 2 123B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "rnj-1:8b": createOllamaModel("rnj-1:8b", "RNJ 1 8B", { reasoning: false, input: ["text"], contextWindow: 128000, maxTokens: 16384 }),
++        "nemotron-3-super": createOllamaModel("nemotron-3-super", "Nemotron 3 Super", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "cogito-2.1:671b": createOllamaModel("cogito-2.1:671b", "Cogito 2.1 671B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "glm-5": createOllamaModel("glm-5", "GLM 5", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 131072 }),
++        "qwen3-next:80b": createOllamaModel("qwen3-next:80b", "Qwen 3 Next 80B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++        "nemotron-3-nano:30b": createOllamaModel("nemotron-3-nano:30b", "Nemotron 3 Nano 30B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "qwen3-vl:235b-instruct": createOllamaModel("qwen3-vl:235b-instruct", "Qwen 3 VL 235B Instruct", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++        "minimax-m2": createOllamaModel("minimax-m2", "MiniMax M2", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "devstral-small-2:24b": createOllamaModel("devstral-small-2:24b", "Devstral Small 2 24B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "qwen3-coder-next": createOllamaModel("qwen3-coder-next", "Qwen 3 Coder Next", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    },
+ };
+ //# sourceMappingURL=models.generated.js.map
+\ No newline at end of file

--- a/patches/@mariozechner%2Fpi-coding-agent@0.70.6.patch
+++ b/patches/@mariozechner%2Fpi-coding-agent@0.70.6.patch
@@ -1,0 +1,197 @@
+diff --git a/dist/config.js b/dist/config.js
+--- a/dist/config.js
++++ b/dist/config.js
+@@ -243,6 +243,10 @@
+ }
+ /** Get path to CHANGELOG.md */
+ export function getChangelogPath() {
++    // PATCH(pizzapi): allow PizzaPi to redirect to its own changelog
++    if (process.env.PIZZAPI_CHANGELOG_PATH) {
++        return resolve(process.env.PIZZAPI_CHANGELOG_PATH);
++    }
+     return resolve(join(getPackageDir(), "CHANGELOG.md"));
+ }
+ /**
+@@ -268,7 +272,8 @@
+ export const PACKAGE_NAME = pkg.name || "@mariozechner/pi-coding-agent";
+ export const APP_NAME = piConfigName || "pi";
+ export const APP_TITLE = piConfigName ? APP_NAME : "π";
+-export const CONFIG_DIR_NAME = pkg.piConfig?.configDir || ".pi";
++// PATCH(pizzapi): override configDir
++export const CONFIG_DIR_NAME = ".pizzapi";
+ export const VERSION = pkg.version || "0.0.0";
+ // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
+ export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
+@@ -279,20 +284,20 @@
+     return `${baseUrl}#${gistId}`;
+ }
+ // =============================================================================
+-// User Config Paths (~/.pi/agent/*)
++// User Config Paths (~/.pizzapi/*)
+ // =============================================================================
+-/** Get the agent config directory (e.g., ~/.pi/agent/) */
++// PATCH(pizzapi): flat directory structure
++/** Get the agent config directory (e.g., ~/.pizzapi/) */
+ export function getAgentDir() {
+     const envDir = process.env[ENV_AGENT_DIR];
+     if (envDir) {
+-        // Expand tilde to home directory
+         if (envDir === "~")
+             return homedir();
+         if (envDir.startsWith("~/"))
+             return homedir() + envDir.slice(1);
+         return envDir;
+     }
+-    return join(homedir(), CONFIG_DIR_NAME, "agent");
++    return join(homedir(), CONFIG_DIR_NAME);
+ }
+ /** Get path to user's custom themes directory */
+ export function getCustomThemesDir() {
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -1927,7 +1927,8 @@
+             return false;
+         const err = message.errorMessage;
+         // Match: overloaded_error, provider returned error, rate limit, 429, 500, 502, 503, 504, service unavailable, network/connection errors (including connection lost), fetch failed, request ended without sending chunks, HTTP/2 closed before response, terminated, retry delay exceeded
+-        return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay/i.test(err);
++        // PATCH(pizzapi): add JSON parse errors to retryable patterns
++        return /overloaded|provider.?returned.?error|rate.?limit|too many requests|429|500|502|503|504|service.?unavailable|server.?error|internal.?error|network.?error|connection.?error|connection.?refused|connection.?lost|other side closed|fetch failed|upstream.?connect|reset before headers|socket hang up|ended without|http2 request did not get a response|timed? out|timeout|terminated|retry delay|json.?parse.?error|unexpected.?end.?of.?json/i.test(err);
+     }
+     /**
+      * Handle retryable errors with exponential backoff.
+diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
+--- a/dist/core/extensions/loader.js
++++ b/dist/core/extensions/loader.js
+@@ -119,6 +119,9 @@
+         setSessionName: notInitialized,
+         getSessionName: notInitialized,
+         setLabel: notInitialized,
++        // PATCH(pizzapi): session control for extensions
++        newSession: () => Promise.reject(new Error("Extension runtime not initialized")),
++        switchSession: () => Promise.reject(new Error("Extension runtime not initialized")),
+         getActiveTools: notInitialized,
+         getAllTools: notInitialized,
+         setActiveTools: notInitialized,
+@@ -215,6 +218,13 @@
+         setSessionName(name) {
+             runtime.assertActive();
+             runtime.setSessionName(name);
++        },
++        // PATCH(pizzapi): session control for extensions
++        newSession(options) {
++            return runtime.newSession(options);
++        },
++        switchSession(sessionPath) {
++            return runtime.switchSession(sessionPath);
+         },
+         getSessionName() {
+             runtime.assertActive();
+diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
+--- a/dist/core/extensions/runner.js
++++ b/dist/core/extensions/runner.js
+@@ -192,6 +192,9 @@
+             this.navigateTreeHandler = actions.navigateTree;
+             this.switchSessionHandler = actions.switchSession;
+             this.reloadHandler = actions.reload;
++            // PATCH(pizzapi): expose session control on runtime for extension access
++            this.runtime.newSession = (options) => this.newSessionHandler(options);
++            this.runtime.switchSession = (sessionPath) => this.switchSessionHandler(sessionPath);
+             return;
+         }
+         this.waitForIdleFn = async () => { };
+@@ -200,6 +203,9 @@
+         this.navigateTreeHandler = async () => ({ cancelled: false });
+         this.switchSessionHandler = async () => ({ cancelled: false });
+         this.reloadHandler = async () => { };
++        // PATCH(pizzapi): expose session control on runtime for extension access
++        this.runtime.newSession = (options) => this.newSessionHandler(options);
++        this.runtime.switchSession = (sessionPath) => this.switchSessionHandler(sessionPath);
+     }
+     setUIContext(uiContext) {
+         this.uiContext = uiContext ?? noOpUIContext;
+diff --git a/dist/core/resource-loader.js b/dist/core/resource-loader.js
+--- a/dist/core/resource-loader.js
++++ b/dist/core/resource-loader.js
+@@ -597,7 +597,9 @@
+         const extensions = [];
+         const errors = [];
+         for (const [index, factory] of this.extensionFactories.entries()) {
+-            const extensionPath = `<inline:${index + 1}>`;
++            // PATCH(pizzapi): use factory displayName/name instead of <inline:N>
++            const label = factory.displayName || factory.name || String(index + 1);
++            const extensionPath = `<inline:${label}>`;
+             try {
+                 const extension = await loadExtensionFromFactory(factory, this.cwd, this.eventBus, runtime, extensionPath);
+                 extensions.push(extension);
+diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
+--- a/dist/core/model-resolver.js
++++ b/dist/core/model-resolver.js
+@@ -20,6 +20,7 @@
+     "google-vertex": "gemini-3.1-pro-preview",
+     "github-copilot": "gpt-5.4",
+     openrouter: "moonshotai/kimi-k2.6",
++    "ollama-cloud": "glm-5.1",
+     "vercel-ai-gateway": "zai/glm-5.1",
+     xai: "grok-4.20-0309-reasoning",
+     groq: "openai/gpt-oss-120b",
+diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
+--- a/dist/modes/interactive/interactive-mode.js
++++ b/dist/modes/interactive/interactive-mode.js
+@@ -104,6 +104,7 @@
+     "opencode-go": "OpenCode Go",
+     openai: "OpenAI",
+     openrouter: "OpenRouter",
++    "ollama-cloud": "Ollama Cloud",
+     "vercel-ai-gateway": "Vercel AI Gateway",
+     xai: "xAI",
+     zai: "ZAI",
+@@ -504,12 +505,7 @@
+      */
+     async run() {
+         await this.init();
+-        // Start version check asynchronously
+-        checkForNewPiVersion(this.version).then((newVersion) => {
+-            if (newVersion) {
+-                this.showNewVersionNotification(newVersion);
+-            }
+-        });
++        // PATCH(pizzapi): version check removed
+         // Start package update check asynchronously
+         this.checkForPackageUpdates().then((updates) => {
+             if (updates.length > 0) {
+@@ -2873,17 +2869,6 @@
+     showWarning(warningMessage) {
+         this.chatContainer.addChild(new Spacer(1));
+         this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
+-        this.ui.requestRender();
+-    }
+-    showNewVersionNotification(newVersion) {
+-        const action = theme.fg("accent", `${APP_NAME} update`);
+-        const updateInstruction = theme.fg("muted", `New version ${newVersion} is available. Run `) + action;
+-        const changelogUrl = theme.fg("accent", "https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/CHANGELOG.md");
+-        const changelogLine = theme.fg("muted", "Changelog: ") + changelogUrl;
+-        this.chatContainer.addChild(new Spacer(1));
+-        this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+-        this.chatContainer.addChild(new Text(`${theme.bold(theme.fg("warning", "Update Available"))}\n${updateInstruction}\n${changelogLine}`, 1, 0));
+-        this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+         this.ui.requestRender();
+     }
+     showPackageUpdateNotification(packages) {
+@@ -3764,13 +3749,14 @@
+         await this.updateAvailableProviderCount();
+         this.footer.invalidate();
+         this.updateEditorBorderColor();
++        const actualAuthPath = this.session.modelRegistry.authStorage.storage?.authPath ?? getAuthPath();
+         if (selectedModel) {
+-            this.showStatus(`${actionLabel}. Selected ${selectedModel.id}. Credentials saved to ${getAuthPath()}`);
++            this.showStatus(`${actionLabel}. Selected ${selectedModel.id}. Credentials saved to ${actualAuthPath}`);
+             void this.maybeWarnAboutAnthropicSubscriptionAuth(selectedModel);
+             this.checkDaxnutsEasterEgg(selectedModel);
+         }
+         else {
+-            this.showStatus(`${actionLabel}. Credentials saved to ${getAuthPath()}`);
++            this.showStatus(`${actionLabel}. Credentials saved to ${actualAuthPath}`);
+             if (selectionError) {
+                 this.showError(selectionError);
+             }

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,7 +4,7 @@ Patches in this directory are applied automatically by Bun via the
 `patchedDependencies` field in the root `package.json`. They are reapplied on
 every `bun install` — no postinstall script is needed.
 
-## @mariozechner/pi-agent-core@0.67.5
+## @mariozechner/pi-agent-core@0.70.6
 
 Adds one PizzaPi-specific runtime fix:
 
@@ -24,14 +24,33 @@ Adds one PizzaPi-specific runtime fix:
 
 **Tests:** `packages/cli/src/patches.test.ts` verifies the regression behavior with a live `Agent` instance.
 
-## @mariozechner/pi-coding-agent@0.67.5
+## @mariozechner/pi-coding-agent@0.70.6
 
-Same changes as 0.66.1, ported forward. The upstream 0.67.x series changed
-`appendSystemPrompt` from `string` to `string[]` in `DefaultResourceLoaderOptions`.
+Same core PizzaPi integration changes as 0.67.5, ported forward to the 0.70.x upstream layout, plus one Ollama-first-party addition.
 
-## @mariozechner/pi-ai@0.67.5
+**What it changes:**
 
-Same changes as 0.66.1, ported forward. This version adds `claude-opus-4-7`.
+| File | Change |
+|------|--------|
+| `dist/config.js` | Hardcodes `".pizzapi"`, flattens `getAgentDir()`, and honors `PIZZAPI_CHANGELOG_PATH` |
+| `dist/core/agent-session.js` | Retries transient JSON parse stream failures |
+| `dist/core/extensions/loader.js` / `runner.js` | Exposes `newSession` / `switchSession` to extensions |
+| `dist/core/resource-loader.js` | Uses inline extension factory names for display |
+| `dist/core/model-resolver.js` | Adds built-in default model selection for `ollama-cloud` (`glm-5.1`) |
+| `dist/modes/interactive/interactive-mode.js` | Removes upstream version-notification UI, shows actual auth path, and exposes `ollama-cloud` in API-key login labels |
+
+## @mariozechner/pi-ai@0.70.6
+
+Same Anthropic web-search and Claude Code credential fallback changes as 0.67.5, ported forward, plus built-in **Ollama Cloud** provider support.
+
+**What it changes:**
+
+| File | Change |
+|------|--------|
+| `dist/providers/anthropic.js` | Preserves PizzaPi's Anthropic web-search patch |
+| `dist/utils/oauth/anthropic.js` | Preserves Claude Code Keychain / credential-file fallback |
+| `dist/env-api-keys.js` | Recognizes `OLLAMA_API_KEY` for provider `ollama-cloud` |
+| `dist/models.generated.js` | Adds bundled `ollama-cloud` provider models targeting `https://ollama.com/v1` with OpenAI-compatible defaults |
 
 ## @mariozechner/pi-coding-agent@0.66.1 (replaced by 0.67.5 patch)
 


### PR DESCRIPTION
## Summary
- upgrade the bundled `@mariozechner/pi-*` stack to `0.70.6` and refresh PizzaPi's maintained patch set
- add a built-in `ollama-cloud` provider backed by `https://ollama.com/v1` with `OLLAMA_API_KEY` auth and a bundled cloud model catalog
- preserve compatibility for existing custom/local `provider: "ollama"` configs by keeping the cloud provider under a separate ID
- update docs/changelog and add regression coverage for Ollama Cloud, changelog redirection, and custom/local Ollama separation

## Verification
- `bun run typecheck`
- `bun run build`
- `bun run build:docs`
- `bun test packages/server/tests/pi-compat.test.ts`
- `cd packages/cli && bun test src/patches.test.ts src/ollama-provider.test.ts`

## Notes
- `bun run test` was attempted but crashed inside Bun after many unrelated CLI test files with `panic(main thread): Segmentation fault at address 0x42`. The scoped checks above passed cleanly.
