### PR TITLE
fix: Deduplicate repeated TUI startup log warnings

### DIFF
--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
@@ -886,6 +886,38 @@ describe("loadConfig transport field blocking", () => {
 
     const config = loadConfig(projectDir);
     expect(config.apiKey).toBe("real-global-key");
+  });
+
+  test("repeated config loads warn once per project issue", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ apiKey: "real-global-key" }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(
+      join(projectDir, ".pizzapi", "config.json"),
+      JSON.stringify({
+        apiKey: "project-key",
+        mcpServers: { playwright: { command: "npx" } },
+      }),
+    );
+
+    const originalWarn = console.warn;
+    const warn = mock((..._args: unknown[]) => undefined);
+    console.warn = warn as unknown as typeof console.warn;
+    try {
+      loadConfig(projectDir);
+      loadConfig(projectDir);
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    expect(warn).toHaveBeenCalledTimes(2);
+    const messages = warn.mock.calls.map((call) => String(call[2]));
+    expect(messages).toContain("Project config .pizzapi/config.json contains 'apiKey' — global config value will be used instead. Set it in ~/.pizzapi/config.json only.");
+    expect(messages).toContain('Project MCP servers found in .pizzapi/config.json. Set "allowProjectMcp": true in ~/.pizzapi/config.json or PIZZAPI_ALLOW_PROJECT_MCP=1 to suppress this warning.');
   });
 
   test("global relayUrl is preserved when project also sets relayUrl", () => {

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -13,6 +13,14 @@ import { mergeSandboxConfig } from "./sandbox.js";
 import { createLogger } from "@pizzapi/tools";
 
 const log = createLogger("hooks");
+const emittedLoadConfigWarnings = new Set<string>();
+
+function warnLoadConfigOnce(projectPath: string, code: string, message: string): void {
+    const key = `${projectPath}:${code}:${message}`;
+    if (emittedLoadConfigWarnings.has(key)) return;
+    emittedLoadConfigWarnings.add(key);
+    log.warn(message);
+}
 
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
@@ -130,7 +138,9 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     const projectHooksTrusted = isProjectHooksTrusted(global);
     const projectHooks = projectHooksTrusted ? project.hooks : undefined;
     if (project.hooks && !projectHooksTrusted) {
-        log.warn(
+        warnLoadConfigOnce(
+            projectPath,
+            "project-hooks-untrusted",
             "Project hooks found in .pizzapi/config.json but not trusted. " +
                 'Set "allowProjectHooks": true in ~/.pizzapi/config.json or ' +
                 "PIZZAPI_ALLOW_PROJECT_HOOKS=1 to enable.",
@@ -147,14 +157,18 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     // per-project relay configs are legitimate, but users should be aware.
     if ("apiKey" in project) {
         if (global.apiKey !== undefined) {
-            log.warn(
+            warnLoadConfigOnce(
+                projectPath,
+                "project-apiKey-global-wins",
                 "Project config .pizzapi/config.json contains 'apiKey' — " +
                     "global config value will be used instead. " +
                     "Set it in ~/.pizzapi/config.json only.",
             );
             config.apiKey = global.apiKey;
         } else {
-            log.warn(
+            warnLoadConfigOnce(
+                projectPath,
+                "project-apiKey-only",
                 "Project config .pizzapi/config.json contains 'apiKey' — " +
                     "consider moving this to ~/.pizzapi/config.json for better security.",
             );
@@ -168,14 +182,18 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
 
     if ("relayUrl" in project) {
         if (global.relayUrl !== undefined) {
-            log.warn(
+            warnLoadConfigOnce(
+                projectPath,
+                "project-relayUrl-global-wins",
                 "Project config .pizzapi/config.json contains 'relayUrl' — " +
                     "global config value will be used instead. " +
                     "Set it in ~/.pizzapi/config.json only.",
             );
             config.relayUrl = global.relayUrl;
         } else {
-            log.warn(
+            warnLoadConfigOnce(
+                projectPath,
+                "project-relayUrl-only",
                 "Project config .pizzapi/config.json contains 'relayUrl' — " +
                     "consider moving this to ~/.pizzapi/config.json for better security.",
             );
@@ -220,7 +238,9 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
     // P0 fix: warn-and-load by default. allowProjectMcp/PIZZAPI_ALLOW_PROJECT_MCP silences
     // the warning rather than being required to enable loading.
     if (hasProjectMcp && !projectMcpTrusted) {
-        log.warn(
+        warnLoadConfigOnce(
+            projectPath,
+            "project-mcp-untrusted",
             "Project MCP servers found in .pizzapi/config.json. " +
                 'Set "allowProjectMcp": true in ~/.pizzapi/config.json or ' +
                 "PIZZAPI_ALLOW_PROJECT_MCP=1 to suppress this warning.",

--- a/packages/cli/src/extensions/mcp-extension.test.ts
+++ b/packages/cli/src/extensions/mcp-extension.test.ts
@@ -1,5 +1,17 @@
 import { describe, expect, test } from "bun:test";
-import { buildMcpStatusModel, decorateMcpSnapshotWithToolSearchState, reconcileMcpActiveTools } from "./mcp-extension.js";
+import { buildMcpStatusModel, decorateMcpSnapshotWithToolSearchState, reconcileMcpActiveTools, shouldLogMcpEagerInitFailure } from "./mcp-extension.js";
+
+describe("shouldLogMcpEagerInitFailure", () => {
+  test("suppresses expected pre-runtime and abort eager init failures", () => {
+    expect(shouldLogMcpEagerInitFailure(new Error("Extension runtime not initialized. Action methods cannot be called during extension loading."))).toBe(false);
+    expect(shouldLogMcpEagerInitFailure(new Error("operation aborted"))).toBe(false);
+  });
+
+  test("keeps unexpected eager init failures visible", () => {
+    expect(shouldLogMcpEagerInitFailure(new Error("stdio handshake failed"))).toBe(true);
+    expect(shouldLogMcpEagerInitFailure("stdio handshake failed")).toBe(true);
+  });
+});
 
 describe("buildMcpStatusModel", () => {
   test("classifies loaded, deferred, partial, and disabled MCP state", () => {

--- a/packages/cli/src/extensions/mcp-extension.ts
+++ b/packages/cli/src/extensions/mcp-extension.ts
@@ -460,6 +460,13 @@ function buildMcpSummary(counts: McpStatusCounts): string {
   return parts.join(", ");
 }
 
+export function shouldLogMcpEagerInitFailure(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/aborted/i.test(msg)) return false;
+  if (/Extension runtime not initialized/i.test(msg)) return false;
+  return true;
+}
+
 export function reconcileMcpActiveTools(input: {
   currentActive: Iterable<string>;
   previousMcpToolNames: Iterable<string>;
@@ -879,7 +886,7 @@ export const mcpExtension: ExtensionFactory = async (pi: any) => {
       // Don't crash the factory — session_start will handle diagnostics.
       // Ignore expected aborts when session lifecycle changes.
       const msg = err instanceof Error ? err.message : String(err);
-      if (!/aborted/i.test(msg)) {
+      if (shouldLogMcpEagerInitFailure(err)) {
         log.warn(`pizzapi: MCP eager init failed, will retry in session_start: ${msg}`);
       }
       return null;

--- a/packages/cli/src/extensions/tool-search.lifecycle.test.ts
+++ b/packages/cli/src/extensions/tool-search.lifecycle.test.ts
@@ -270,7 +270,15 @@ describe("toolSearchExtension lifecycle sync", () => {
     const statusCommand = registeredCommands.get("tool-search");
     expect(statusCommand).toBeDefined();
 
-    expect(() => pi.events.emit("mcp:registry_updated", { server: "github" })).not.toThrow();
+    const originalLog = console.log;
+    const log = mock((..._args: unknown[]) => undefined);
+    console.log = log as unknown as typeof console.log;
+    try {
+      expect(() => pi.events.emit("mcp:registry_updated", { server: "github" })).not.toThrow();
+    } finally {
+      console.log = originalLog;
+    }
+    expect(log).not.toHaveBeenCalled();
 
     const skippedNotes: string[] = [];
     statusCommand.handler("status", { ui: { notify: (msg: string) => skippedNotes.push(msg) } });

--- a/packages/cli/src/extensions/tool-search.ts
+++ b/packages/cli/src/extensions/tool-search.ts
@@ -329,7 +329,8 @@ export const toolSearchExtension: ExtensionFactory = (pi: any) => {
       evaluateAndDeferImpl();
     } catch (err) {
       if (isExtensionRuntimeNotInitializedError(err)) {
-        log.info("Tool search: runtime not initialized yet; skipping MCP registry sync");
+        // MCP can publish registry updates before pi binds runtime action methods.
+        // This is expected during startup; session_start/next registry update resyncs.
         return;
       }
       throw err;

--- a/packages/cli/src/ollama-provider.test.ts
+++ b/packages/cli/src/ollama-provider.test.ts
@@ -14,18 +14,44 @@ function piCodingAgentPath(subpath: string): string {
 describe("Ollama built-in provider", () => {
   test("pi-ai exposes bundled Ollama Cloud models with cloud base URL", async () => {
     const { getModels } = await import("@mariozechner/pi-ai");
-    const models = (getModels as (provider: string) => Array<any>)("ollama-cloud");
+    const models = getModels("ollama-cloud");
+    const modelRecords = models as Array<any>;
 
-    expect(models.length).toBeGreaterThan(0);
+    expect(modelRecords.length).toBeGreaterThan(0);
     for (const id of ["glm-5.1", "gpt-oss:20b", "kimi-k2.6", "qwen3-coder-next", "deepseek-v4-pro"]) {
-      expect(models.some((m) => m.id === id)).toBe(true);
+      expect(modelRecords.some((m) => m.id === id)).toBe(true);
     }
 
-    const glm = models.find((m) => m.id === "glm-5.1");
+    const glm = modelRecords.find((m) => m.id === "glm-5.1");
     expect(glm).toBeDefined();
     expect(glm?.provider).toBe("ollama-cloud");
     expect(glm?.baseUrl).toBe("https://ollama.com/v1");
     expect(glm?.api).toBe("openai-completions");
+    expect(glm?.compat).toMatchObject({
+      supportsStore: false,
+      supportsDeveloperRole: false,
+      supportsReasoningEffort: false,
+      supportsUsageInStreaming: false,
+      supportsLongCacheRetention: false,
+      supportsStrictMode: false,
+      maxTokensField: "max_tokens",
+    });
+  });
+
+  test("pi-ai exposes Ollama Cloud models with scraped context windows", async () => {
+    const { getModels } = await import("@mariozechner/pi-ai");
+    const models = getModels("ollama-cloud");
+    const contextById = new Map((models as Array<any>).map((model) => [model.id, model.contextWindow]));
+
+    expect(contextById.get("deepseek-v4-pro")).toBe(1048576);
+    expect(contextById.get("deepseek-v4-flash")).toBe(1048576);
+    expect(contextById.get("nemotron-3-nano:30b")).toBe(1048576);
+    expect(contextById.get("rnj-1:8b")).toBe(32768);
+    expect(contextById.get("ministral-3:8b")).toBe(262144);
+    expect(contextById.get("minimax-m2.7")).toBe(204800);
+    expect(contextById.get("gemma3:12b")).toBe(32768);
+    expect(contextById.get("mistral-large-3:675b")).toBe(262144);
+    expect(contextById.get("devstral-small-2:24b")).toBe(262144);
   });
 
   test("pi-ai resolves OLLAMA_API_KEY from environment for ollama-cloud", async () => {
@@ -33,7 +59,7 @@ describe("Ollama built-in provider", () => {
     const prev = process.env.OLLAMA_API_KEY;
     process.env.OLLAMA_API_KEY = "test-ollama-key";
     try {
-      expect((getEnvApiKey as (provider: string) => string | undefined)("ollama-cloud")).toBe("test-ollama-key");
+      expect(getEnvApiKey("ollama-cloud")).toBe("test-ollama-key");
     } finally {
       if (prev === undefined) delete process.env.OLLAMA_API_KEY;
       else process.env.OLLAMA_API_KEY = prev;

--- a/packages/ui/src/components/ProviderIcon.test.tsx
+++ b/packages/ui/src/components/ProviderIcon.test.tsx
@@ -1,0 +1,55 @@
+import { afterAll, beforeAll, afterEach, describe, expect, mock, test } from "bun:test";
+import { cleanup, render } from "@testing-library/react";
+import { Window } from "happy-dom";
+import React from "react";
+
+mock.module("@/lib/utils", () => ({
+  cn: (...classes: Array<string | undefined | null | false>) => classes.filter(Boolean).join(" "),
+}));
+
+afterAll(() => mock.restore());
+
+const { ProviderIcon } = await import("./ProviderIcon");
+
+beforeAll(() => {
+  const win = new Window({ url: "http://localhost/" });
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  (globalThis as any).window = win;
+  (globalThis as any).document = win.document;
+  (globalThis as any).navigator = win.navigator;
+  (globalThis as any).HTMLElement = win.HTMLElement;
+  (globalThis as any).Element = win.Element;
+  (globalThis as any).Event = win.Event;
+  (globalThis as any).MouseEvent = win.MouseEvent;
+  (globalThis as any).MutationObserver = (win as any).MutationObserver;
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+});
+
+afterEach(() => cleanup());
+
+describe("ProviderIcon", () => {
+  test("renders Ollama provider with the Ollama SVG icon", () => {
+    const { container } = render(<ProviderIcon provider="ollama-cloud" className="size-4" />);
+
+    const icon = container.getElementsByTagName("svg").item(0);
+    expect(icon?.className).toContain("size-4");
+    expect(icon?.getAttribute("aria-hidden")).toBe("true");
+    expect(icon?.outerHTML).toContain("path");
+  });
+
+  test("falls back to generic robot icon for unknown providers", () => {
+    const { container } = render(<ProviderIcon provider="unknown-provider" />);
+
+    const icon = container.getElementsByTagName("svg").item(0);
+    expect(icon?.getAttribute("aria-hidden")).toBe("true");
+    expect(icon?.tagName.toLowerCase()).toBe("svg");
+  });
+
+  test("exposes an accessible image when an explicit title is provided", () => {
+    const { container } = render(<ProviderIcon provider="ollama-cloud" title="Ollama Cloud" />);
+
+    const icon = container.getElementsByTagName("svg").item(0);
+    expect(icon?.getAttribute("role")).toBe("img");
+    expect(icon?.getAttribute("aria-label")).toBe("Ollama Cloud");
+  });
+});

--- a/packages/ui/src/components/ProviderIcon.tsx
+++ b/packages/ui/src/components/ProviderIcon.tsx
@@ -1,8 +1,7 @@
-import * as React from "react";
 import { cn } from "@/lib/utils";
 
 import { RiClaudeFill, RiRobot2Fill } from "react-icons/ri";
-import { SiAmazon, SiGithub, SiGoogle, SiNvidia, SiOpenai } from "react-icons/si";
+import { SiAmazon, SiGithub, SiGoogle, SiNvidia, SiOllama, SiOpenai } from "react-icons/si";
 
 export interface ProviderIconProps {
   provider: string;
@@ -16,6 +15,7 @@ function pickIcon(provider: string) {
   // Common providers we support in PizzaPi
   if (p.includes("anthropic") || p.includes("claude")) return RiClaudeFill;
   if (p.includes("openai")) return SiOpenai;
+  if (p.includes("ollama")) return SiOllama;
   if (p.startsWith("google")) return SiGoogle;
   if (p.includes("github")) return SiGithub;
   if (p.includes("amazon") || p.includes("bedrock")) return SiAmazon;
@@ -25,12 +25,15 @@ function pickIcon(provider: string) {
 }
 
 export function ProviderIcon({ provider, className, title }: ProviderIconProps) {
-  const Icon = React.useMemo(() => pickIcon(provider), [provider]);
+  const Icon = pickIcon(provider);
+  const accessibilityProps = title
+    ? { title, "aria-label": title, role: "img" as const }
+    : { "aria-hidden": true as const };
+
   return (
     <Icon
       className={cn("shrink-0", className)}
-      title={title ?? provider}
-      aria-label={title ?? provider}
+      {...accessibilityProps}
     />
   );
 }

--- a/patches/@mariozechner%2Fpi-ai@0.70.6.patch
+++ b/patches/@mariozechner%2Fpi-ai@0.70.6.patch
@@ -186,6 +186,52 @@ diff --git a/dist/env-api-keys.js b/dist/env-api-keys.js
          "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
          zai: "ZAI_API_KEY",
          mistral: "MISTRAL_API_KEY",
+diff --git a/dist/types.d.ts b/dist/types.d.ts
+--- a/dist/types.d.ts
++++ b/dist/types.d.ts
+@@ -2,7 +2,7 @@
+ export type { AssistantMessageEventStream } from "./utils/event-stream.js";
+ export type KnownApi = "openai-completions" | "mistral-conversations" | "openai-responses" | "azure-openai-responses" | "openai-codex-responses" | "anthropic-messages" | "bedrock-converse-stream" | "google-generative-ai" | "google-gemini-cli" | "google-vertex";
+ export type Api = KnownApi | (string & {});
+-export type KnownProvider = "amazon-bedrock" | "anthropic" | "google" | "google-gemini-cli" | "google-antigravity" | "google-vertex" | "openai" | "azure-openai-responses" | "openai-codex" | "deepseek" | "github-copilot" | "xai" | "groq" | "cerebras" | "openrouter" | "vercel-ai-gateway" | "zai" | "mistral" | "minimax" | "minimax-cn" | "huggingface" | "fireworks" | "opencode" | "opencode-go" | "kimi-coding" | "cloudflare-workers-ai";
++export type KnownProvider = "amazon-bedrock" | "anthropic" | "google" | "google-gemini-cli" | "google-antigravity" | "google-vertex" | "openai" | "azure-openai-responses" | "openai-codex" | "deepseek" | "github-copilot" | "xai" | "groq" | "cerebras" | "openrouter" | "vercel-ai-gateway" | "zai" | "mistral" | "minimax" | "minimax-cn" | "huggingface" | "fireworks" | "opencode" | "opencode-go" | "kimi-coding" | "cloudflare-workers-ai" | "ollama-cloud";
+ export type Provider = KnownProvider | string;
+ export type ThinkingLevel = "minimal" | "low" | "medium" | "high" | "xhigh";
+ /** Token budgets for each thinking level (token-based providers only) */
+diff --git a/dist/models.generated.d.ts b/dist/models.generated.d.ts
+--- a/dist/models.generated.d.ts
++++ b/dist/models.generated.d.ts
+@@ -15836,4 +15836,30 @@
+         };
+     };
++    readonly "ollama-cloud": Record<string, {
++        id: string;
++        name: string;
++        api: "openai-completions";
++        provider: string;
++        baseUrl: string;
++        compat: {
++            supportsStore: false;
++            supportsDeveloperRole: false;
++            supportsReasoningEffort: false;
++            supportsUsageInStreaming: false;
++            supportsLongCacheRetention: false;
++            supportsStrictMode: false;
++            maxTokensField: "max_tokens";
++        };
++        reasoning: boolean;
++        input: ("image" | "text")[];
++        cost: {
++            input: number;
++            output: number;
++            cacheRead: number;
++            cacheWrite: number;
++        };
++        contextWindow: number;
++        maxTokens: number;
++    }>;
+ };
+ //# sourceMappingURL=models.generated.d.ts.map
 diff --git a/dist/models.generated.js b/dist/models.generated.js
 --- a/dist/models.generated.js
 +++ b/dist/models.generated.js
@@ -196,7 +242,7 @@ diff --git a/dist/models.generated.js b/dist/models.generated.js
 +// Ollama Cloud currently documents plan-based usage tiers rather than stable per-token rates.
 +// Keep cost metadata at zero until Ollama publishes machine-usable model pricing.
 +const OLLAMA_ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
-+const OLLAMA_COMPAT = { supportsDeveloperRole: false, supportsReasoningEffort: false, maxTokensField: "max_tokens" };
++const OLLAMA_COMPAT = { supportsStore: false, supportsDeveloperRole: false, supportsReasoningEffort: false, supportsUsageInStreaming: false, supportsLongCacheRetention: false, supportsStrictMode: false, maxTokensField: "max_tokens" };
 +function createOllamaModel(id, name, { reasoning = false, input = ["text"], contextWindow = 128000, maxTokens = 16384 } = {}) {
 +    return {
 +        id,
@@ -221,43 +267,43 @@ diff --git a/dist/models.generated.js b/dist/models.generated.js
      },
 +    "ollama-cloud": {
 +        "gpt-oss:120b": createOllamaModel("gpt-oss:120b", "GPT-OSS 120B", { reasoning: true, input: ["text"], contextWindow: 131072, maxTokens: 16384 }),
-+        "ministral-3:8b": createOllamaModel("ministral-3:8b", "Ministral 3 8B", { reasoning: false, input: ["text"], contextWindow: 128000, maxTokens: 16384 }),
-+        "ministral-3:14b": createOllamaModel("ministral-3:14b", "Ministral 3 14B", { reasoning: false, input: ["text"], contextWindow: 128000, maxTokens: 16384 }),
++        "ministral-3:8b": createOllamaModel("ministral-3:8b", "Ministral 3 8B", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 16384 }),
++        "ministral-3:14b": createOllamaModel("ministral-3:14b", "Ministral 3 14B", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 16384 }),
 +        "gemini-3-flash-preview": createOllamaModel("gemini-3-flash-preview", "Gemini 3 Flash Preview", { reasoning: true, input: ["text", "image"], contextWindow: 1048576, maxTokens: 65536 }),
 +        "qwen3.5:397b": createOllamaModel("qwen3.5:397b", "Qwen 3.5 397B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
 +        "glm-5.1": createOllamaModel("glm-5.1", "GLM 5.1", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 131072 }),
-+        "kimi-k2-thinking": createOllamaModel("kimi-k2-thinking", "Kimi K2 Thinking", { reasoning: true, input: ["text"], contextWindow: 256000, maxTokens: 32768 }),
++        "kimi-k2-thinking": createOllamaModel("kimi-k2-thinking", "Kimi K2 Thinking", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
 +        "qwen3-coder:480b": createOllamaModel("qwen3-coder:480b", "Qwen 3 Coder 480B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
 +        "gpt-oss:20b": createOllamaModel("gpt-oss:20b", "GPT-OSS 20B", { reasoning: true, input: ["text"], contextWindow: 131072, maxTokens: 16384 }),
-+        "minimax-m2.1": createOllamaModel("minimax-m2.1", "MiniMax M2.1", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
-+        "minimax-m2.7": createOllamaModel("minimax-m2.7", "MiniMax M2.7", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
-+        "kimi-k2:1t": createOllamaModel("kimi-k2:1t", "Kimi K2 1T", { reasoning: true, input: ["text"], contextWindow: 256000, maxTokens: 32768 }),
-+        "kimi-k2.6": createOllamaModel("kimi-k2.6", "Kimi K2.6", { reasoning: true, input: ["text"], contextWindow: 256000, maxTokens: 32768 }),
++        "minimax-m2.1": createOllamaModel("minimax-m2.1", "MiniMax M2.1", { reasoning: true, input: ["text"], contextWindow: 204800, maxTokens: 32768 }),
++        "minimax-m2.7": createOllamaModel("minimax-m2.7", "MiniMax M2.7", { reasoning: true, input: ["text"], contextWindow: 204800, maxTokens: 32768 }),
++        "kimi-k2:1t": createOllamaModel("kimi-k2:1t", "Kimi K2 1T", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++        "kimi-k2.6": createOllamaModel("kimi-k2.6", "Kimi K2.6", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
 +        "gemma4:31b": createOllamaModel("gemma4:31b", "Gemma 4 31B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
 +        "qwen3-vl:235b": createOllamaModel("qwen3-vl:235b", "Qwen 3 VL 235B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
-+        "mistral-large-3:675b": createOllamaModel("mistral-large-3:675b", "Mistral Large 3 675B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
-+        "gemma3:12b": createOllamaModel("gemma3:12b", "Gemma 3 12B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
-+        "kimi-k2.5": createOllamaModel("kimi-k2.5", "Kimi K2.5", { reasoning: true, input: ["text"], contextWindow: 256000, maxTokens: 32768 }),
-+        "deepseek-v3.2": createOllamaModel("deepseek-v3.2", "DeepSeek V3.2", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
-+        "deepseek-v3.1:671b": createOllamaModel("deepseek-v3.1:671b", "DeepSeek V3.1 671B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
-+        "ministral-3:3b": createOllamaModel("ministral-3:3b", "Ministral 3 3B", { reasoning: false, input: ["text"], contextWindow: 128000, maxTokens: 16384 }),
-+        "gemma3:4b": createOllamaModel("gemma3:4b", "Gemma 3 4B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++        "mistral-large-3:675b": createOllamaModel("mistral-large-3:675b", "Mistral Large 3 675B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++        "gemma3:12b": createOllamaModel("gemma3:12b", "Gemma 3 12B", { reasoning: false, input: ["text", "image"], contextWindow: 32768, maxTokens: 16384 }),
++        "kimi-k2.5": createOllamaModel("kimi-k2.5", "Kimi K2.5", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++        "deepseek-v3.2": createOllamaModel("deepseek-v3.2", "DeepSeek V3.2", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++        "deepseek-v3.1:671b": createOllamaModel("deepseek-v3.1:671b", "DeepSeek V3.1 671B", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++        "ministral-3:3b": createOllamaModel("ministral-3:3b", "Ministral 3 3B", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 16384 }),
++        "gemma3:4b": createOllamaModel("gemma3:4b", "Gemma 3 4B", { reasoning: false, input: ["text", "image"], contextWindow: 32768, maxTokens: 16384 }),
 +        "gemma3:27b": createOllamaModel("gemma3:27b", "Gemma 3 27B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
 +        "glm-4.6": createOllamaModel("glm-4.6", "GLM 4.6", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 65536 }),
-+        "deepseek-v4-flash": createOllamaModel("deepseek-v4-flash", "DeepSeek V4 Flash", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
-+        "minimax-m2.5": createOllamaModel("minimax-m2.5", "MiniMax M2.5", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "deepseek-v4-flash": createOllamaModel("deepseek-v4-flash", "DeepSeek V4 Flash", { reasoning: true, input: ["text"], contextWindow: 1048576, maxTokens: 32768 }),
++        "minimax-m2.5": createOllamaModel("minimax-m2.5", "MiniMax M2.5", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 32768 }),
 +        "glm-4.7": createOllamaModel("glm-4.7", "GLM 4.7", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 65536 }),
-+        "deepseek-v4-pro": createOllamaModel("deepseek-v4-pro", "DeepSeek V4 Pro", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
-+        "devstral-2:123b": createOllamaModel("devstral-2:123b", "Devstral 2 123B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
-+        "rnj-1:8b": createOllamaModel("rnj-1:8b", "RNJ 1 8B", { reasoning: false, input: ["text"], contextWindow: 128000, maxTokens: 16384 }),
-+        "nemotron-3-super": createOllamaModel("nemotron-3-super", "Nemotron 3 Super", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
-+        "cogito-2.1:671b": createOllamaModel("cogito-2.1:671b", "Cogito 2.1 671B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "deepseek-v4-pro": createOllamaModel("deepseek-v4-pro", "DeepSeek V4 Pro", { reasoning: true, input: ["text"], contextWindow: 1048576, maxTokens: 32768 }),
++        "devstral-2:123b": createOllamaModel("devstral-2:123b", "Devstral 2 123B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++        "rnj-1:8b": createOllamaModel("rnj-1:8b", "RNJ 1 8B", { reasoning: false, input: ["text"], contextWindow: 32768, maxTokens: 16384 }),
++        "nemotron-3-super": createOllamaModel("nemotron-3-super", "Nemotron 3 Super", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++        "cogito-2.1:671b": createOllamaModel("cogito-2.1:671b", "Cogito 2.1 671B", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
 +        "glm-5": createOllamaModel("glm-5", "GLM 5", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 131072 }),
 +        "qwen3-next:80b": createOllamaModel("qwen3-next:80b", "Qwen 3 Next 80B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
-+        "nemotron-3-nano:30b": createOllamaModel("nemotron-3-nano:30b", "Nemotron 3 Nano 30B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "nemotron-3-nano:30b": createOllamaModel("nemotron-3-nano:30b", "Nemotron 3 Nano 30B", { reasoning: true, input: ["text"], contextWindow: 1048576, maxTokens: 32768 }),
 +        "qwen3-vl:235b-instruct": createOllamaModel("qwen3-vl:235b-instruct", "Qwen 3 VL 235B Instruct", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
-+        "minimax-m2": createOllamaModel("minimax-m2", "MiniMax M2", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
-+        "devstral-small-2:24b": createOllamaModel("devstral-small-2:24b", "Devstral Small 2 24B", { reasoning: true, input: ["text"], contextWindow: 128000, maxTokens: 32768 }),
++        "minimax-m2": createOllamaModel("minimax-m2", "MiniMax M2", { reasoning: true, input: ["text"], contextWindow: 204800, maxTokens: 32768 }),
++        "devstral-small-2:24b": createOllamaModel("devstral-small-2:24b", "Devstral Small 2 24B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
 +        "qwen3-coder-next": createOllamaModel("qwen3-coder-next", "Qwen 3 Coder Next", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
 +    },
  };

--- a/patches/README.md
+++ b/patches/README.md
@@ -50,7 +50,7 @@ Same Anthropic web-search and Claude Code credential fallback changes as 0.67.5,
 | `dist/providers/anthropic.js` | Preserves PizzaPi's Anthropic web-search patch |
 | `dist/utils/oauth/anthropic.js` | Preserves Claude Code Keychain / credential-file fallback |
 | `dist/env-api-keys.js` | Recognizes `OLLAMA_API_KEY` for provider `ollama-cloud` |
-| `dist/models.generated.js` | Adds bundled `ollama-cloud` provider models targeting `https://ollama.com/v1` with OpenAI-compatible defaults |
+| `dist/models.generated.js` / `dist/models.generated.d.ts` / `dist/types.d.ts` | Adds typed bundled `ollama-cloud` provider models targeting `https://ollama.com/v1` with conservative OpenAI-compatible defaults and context windows scraped from Ollama's cloud model tables |
 
 ## @mariozechner/pi-coding-agent@0.66.1 (replaced by 0.67.5 patch)
 


### PR DESCRIPTION
## Summary
- Deduplicates repeated `loadConfig()` warnings so project `apiKey`, `relayUrl`, hooks, and MCP warnings appear only once per process
- Suppresses expected startup-time log noise (tool-search "runtime not initialized" and MCP eager init retry for pre-bind errors)
- Adds regression tests for repeated-warning dedup and suppressed expected messages

## Test Plan
- `bun run typecheck` — clean
- `bun run test` — 964 pass, 1 skip
- `bun run build` — clean