### PR TITLE
feat(subagent): add model parameter with system prompt encouragement

### DIFF
--- a/packages/cli/src/config/system-prompt.test.ts
+++ b/packages/cli/src/config/system-prompt.test.ts
@@ -137,6 +137,13 @@ describe("buildSystemPrompt", () => {
         expect(result).toContain("AskUserQuestion");
         expect(result).not.toContain("{{>");
     });
+
+    test("contains subagent model recommendation", () => {
+        const result = buildSystemPrompt();
+        expect(result).toContain("subagent-model-selection");
+        expect(result).toContain("Always set a `model` on subagent calls");
+        expect(result).toContain("claude-haiku-4-5");
+    });
 });
 
 describe("rewriteForClaudeCodeProvider", () => {

--- a/packages/cli/src/config/system-prompt.test.ts
+++ b/packages/cli/src/config/system-prompt.test.ts
@@ -141,8 +141,8 @@ describe("buildSystemPrompt", () => {
     test("contains subagent model recommendation", () => {
         const result = buildSystemPrompt();
         expect(result).toContain("subagent-model-selection");
-        expect(result).toContain("Always set a `model` on subagent calls");
-        expect(result).toContain("claude-haiku-4-5");
+        expect(result).toContain("automatically selects the most cost-effective");
+        expect(result).toContain("model: { provider, id }");
     });
 });
 

--- a/packages/cli/src/config/templates/system-prompt.hbs
+++ b/packages/cli/src/config/templates/system-prompt.hbs
@@ -18,6 +18,17 @@ Use the `spawn_session` tool to spawn long-running agent sessions (e.g., tasks t
 Use the `subagent` tool to delegate tasks to specialized agents with isolated context. A built-in `task` agent is always available for general-purpose work — use `subagent(agent: "task", task: "...")` to delegate any task without needing an agents folder. Additional agents are defined as markdown files in `~/.pizzapi/agents/` or `~/.claude/agents/` (user scope) and `.pizzapi/agents/` or `.claude/agents/` (project scope). Modes: single (`agent` + `task`), parallel (`tasks` array), chain (`chain` array with `\{{previous}}` placeholder). Set `agentScope: "both"` to include project-local agents.
 
 <important>Prefer `subagent` over `spawn_session` for delegating work. `subagent` is simpler, manages context isolation automatically, and returns results inline. Use `spawn_session` only when you need a long-running background session with independent lifecycle, or when you want to interact with the child session asynchronously via triggers. For most tasks — code changes, research, reviews, refactoring — `subagent` is the right choice.</important>
+
+<recommendation name="subagent-model-selection">
+**Always set a `model` on subagent calls.** Subagents often don't need the most capable (and expensive) model. Use `model: { provider: "anthropic", id: "claude-haiku-4-5" }` for:
+- Code review, research, and read-only analysis tasks
+- Parallel subagent work (reviews, searches, formatting)
+- Any task that doesn't require complex reasoning
+
+Reserve the default model (no model override) for tasks that explicitly need the parent's full capability. When in doubt, use haiku — it's faster and cheaper.
+
+You can also set model per-task in parallel/chain mode (`tasks: [{ agent: "reviewer", task: "...", model: { provider: "anthropic", id: "claude-haiku-4-5" } }]`), or set model at the top level to apply to all tasks in the call.
+</recommendation>
 </section>
 
 <section name="plan-mode">

--- a/packages/cli/src/config/templates/system-prompt.hbs
+++ b/packages/cli/src/config/templates/system-prompt.hbs
@@ -20,14 +20,9 @@ Use the `subagent` tool to delegate tasks to specialized agents with isolated co
 <important>Prefer `subagent` over `spawn_session` for delegating work. `subagent` is simpler, manages context isolation automatically, and returns results inline. Use `spawn_session` only when you need a long-running background session with independent lifecycle, or when you want to interact with the child session asynchronously via triggers. For most tasks — code changes, research, reviews, refactoring — `subagent` is the right choice.</important>
 
 <recommendation name="subagent-model-selection">
-**Always set a `model` on subagent calls.** Subagents often don't need the most capable (and expensive) model. Use `model: { provider: "anthropic", id: "claude-haiku-4-5" }` for:
-- Code review, research, and read-only analysis tasks
-- Parallel subagent work (reviews, searches, formatting)
-- Any task that doesn't require complex reasoning
+When calling `subagent`, the tool automatically selects the most cost-effective available model when no `model` is specified. You can override this by setting `model: { provider, id }` explicitly — either at the top level (applies to all tasks) or per-task in parallel/chain mode.
 
-Reserve the default model (no model override) for tasks that explicitly need the parent's full capability. When in doubt, use haiku — it's faster and cheaper.
-
-You can also set model per-task in parallel/chain mode (`tasks: [{ agent: "reviewer", task: "...", model: { provider: "anthropic", id: "claude-haiku-4-5" } }]`), or set model at the top level to apply to all tasks in the call.
+Use an explicit model when the task specifically requires a more capable model. Otherwise, let the auto-selection handle it.
 </recommendation>
 </section>
 

--- a/packages/cli/src/extensions/subagent.test.ts
+++ b/packages/cli/src/extensions/subagent.test.ts
@@ -12,6 +12,7 @@ import {
     summarizeResultForStreaming,
     summarizeResultsForStreaming,
     parseModelString,
+    selectLightweightModel,
 } from "./subagent.js";
 import { _setGlobalConfigDir, loadConfig, loadGlobalConfig } from "../config.js";
 
@@ -381,5 +382,57 @@ describe("parseModelString", () => {
 
     test("trims whitespace", () => {
         expect(parseModelString("  haiku  ")).toEqual({ provider: "anthropic", id: "claude-haiku-4-5" });
+    });
+});
+
+describe("selectLightweightModel", () => {
+    const makeRegistry = (models: Array<{ provider: string; id: string; cost: { input: number; output: number; cacheRead: number; cacheWrite: number } }>) => ({
+        find: (provider: string, modelId: string) => models.find(m => m.provider === provider && m.id === modelId) as any,
+        getAvailable: () => models as any[],
+    });
+
+    test("selects the cheapest model by output cost", () => {
+        const registry = makeRegistry([
+            { provider: "anthropic", id: "claude-opus-4-5", cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 18.75 } },
+            { provider: "anthropic", id: "claude-sonnet-4", cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 } },
+            { provider: "anthropic", id: "claude-haiku-4-5", cost: { input: 0.8, output: 4, cacheRead: 0.08, cacheWrite: 1 } },
+        ]);
+        const selected = selectLightweightModel(registry);
+        expect(selected).toBeDefined();
+        expect(selected!.id).toBe("claude-haiku-4-5");
+    });
+
+    test("returns undefined when no models are available", () => {
+        const registry = makeRegistry([]);
+        expect(selectLightweightModel(registry)).toBeUndefined();
+    });
+
+    test("returns the only model if just one is available", () => {
+        const registry = makeRegistry([
+            { provider: "google", id: "gemini-2.5-pro", cost: { input: 1.25, output: 10, cacheRead: 0, cacheWrite: 0 } },
+        ]);
+        const selected = selectLightweightModel(registry);
+        expect(selected).toBeDefined();
+        expect(selected!.id).toBe("gemini-2.5-pro");
+    });
+
+    test("selects across providers when multiple are available", () => {
+        const registry = makeRegistry([
+            { provider: "anthropic", id: "claude-opus-4-5", cost: { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 } },
+            { provider: "google", id: "gemini-2.5-flash", cost: { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 } },
+            { provider: "anthropic", id: "claude-haiku-4-5", cost: { input: 0.8, output: 4, cacheRead: 0, cacheWrite: 0 } },
+        ]);
+        const selected = selectLightweightModel(registry);
+        expect(selected!.id).toBe("gemini-2.5-flash");
+    });
+
+    test("does not mutate the registry's model array", () => {
+        const models = [
+            { provider: "anthropic", id: "opus", cost: { input: 15, output: 75, cacheRead: 0, cacheWrite: 0 } },
+            { provider: "anthropic", id: "haiku", cost: { input: 0.8, output: 4, cacheRead: 0, cacheWrite: 0 } },
+        ];
+        const registry = makeRegistry(models);
+        selectLightweightModel(registry);
+        expect(models[0].id).toBe("opus"); // not reordered
     });
 });

--- a/packages/cli/src/extensions/subagent.test.ts
+++ b/packages/cli/src/extensions/subagent.test.ts
@@ -11,6 +11,7 @@ import {
     shouldSpillParallelOutput,
     summarizeResultForStreaming,
     summarizeResultsForStreaming,
+    parseModelString,
 } from "./subagent.js";
 import { _setGlobalConfigDir, loadConfig, loadGlobalConfig } from "../config.js";
 
@@ -341,5 +342,44 @@ describe("subagent config", () => {
         const mergedConfig = loadConfig(projectDir);
         expect(mergedConfig.subagent?.maxParallelTasks).toBe(100); // project wins in merged
         _setGlobalConfigDir(null);
+    });
+});
+
+describe("parseModelString", () => {
+    test("resolves 'haiku' alias", () => {
+        expect(parseModelString("haiku")).toEqual({ provider: "anthropic", id: "claude-haiku-4-5" });
+    });
+
+    test("resolves 'sonnet' alias", () => {
+        expect(parseModelString("sonnet")).toEqual({ provider: "anthropic", id: "claude-sonnet-4-20250514" });
+    });
+
+    test("resolves 'opus' alias", () => {
+        expect(parseModelString("opus")).toEqual({ provider: "anthropic", id: "claude-opus-4-5" });
+    });
+
+    test("resolves aliases case-insensitively", () => {
+        expect(parseModelString("Haiku")).toEqual({ provider: "anthropic", id: "claude-haiku-4-5" });
+        expect(parseModelString("SONNET")).toEqual({ provider: "anthropic", id: "claude-sonnet-4-20250514" });
+    });
+
+    test("resolves 'provider/id' format", () => {
+        expect(parseModelString("google/gemini-2.5-pro")).toEqual({ provider: "google", id: "gemini-2.5-pro" });
+    });
+
+    test("resolves bare model ID (assumes anthropic)", () => {
+        expect(parseModelString("claude-haiku-4-5")).toEqual({ provider: "anthropic", id: "claude-haiku-4-5" });
+    });
+
+    test("returns undefined for 'inherit'", () => {
+        expect(parseModelString("inherit")).toBeUndefined();
+    });
+
+    test("returns undefined for empty string", () => {
+        expect(parseModelString("")).toBeUndefined();
+    });
+
+    test("trims whitespace", () => {
+        expect(parseModelString("  haiku  ")).toEqual({ provider: "anthropic", id: "claude-haiku-4-5" });
     });
 });

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -116,6 +116,33 @@ export function parseModelString(model: string): ModelOverride | undefined {
     return { provider: "anthropic", id: trimmed };
 }
 
+/** Narrow interface for the model registry — only what the engine needs. */
+export interface ModelRegistryLike {
+    find: (provider: string, modelId: string) => Model<any> | undefined;
+    getAvailable: () => Model<any>[];
+}
+
+/**
+ * Select the cheapest available model from the registry.
+ *
+ * When no model is explicitly specified (neither by the caller nor the agent
+ * frontmatter), subagents should use the most cost-effective model rather
+ * than inheriting the parent's (potentially expensive) default.
+ *
+ * Selection strategy:
+ *   1. Among available models, sort by output costascending.
+ *   2. Pick the cheapest model that has credentials configured.
+ *   3. If no available models, return undefined (fall back to default).
+ */
+export function selectLightweightModel(registry: ModelRegistryLike): Model<any> | undefined {
+    const available = registry.getAvailable();
+    if (available.length === 0) return undefined;
+
+    // Sort by output token cost ascending — cheapest first
+    const sorted = [...available].sort((a, b) => a.cost.output - b.cost.output);
+    return sorted[0];
+}
+
 export async function runSingleAgent(
     defaultCwd: string,
     agents: AgentConfig[],
@@ -127,7 +154,7 @@ export async function runSingleAgent(
     onUpdate: OnUpdateCallback | undefined,
     makeDetails: (results: SingleResult[]) => SubagentDetails,
     modelOverride?: ModelOverride,
-    modelRegistry?: { find: (provider: string, modelId: string) => Model<any> | undefined },
+    modelRegistry?: ModelRegistryLike,
 ): Promise<SingleResult> {
     const agent = agents.find((a) => a.name === agentName);
 
@@ -230,16 +257,22 @@ export async function runSingleAgent(
         });
         await loader.reload();
 
-        // Resolve model: tool parameter > agent frontmatter > default (unset)
+        // Resolve model: tool parameter > agent frontmatter > auto-select cheapest > inherit parent default
         let resolvedModel: Model<any> | undefined;
         const modelSpec = modelOverride ?? (agent.model ? parseModelString(agent.model) : undefined);
         if (modelSpec && modelRegistry) {
+            // Explicit model specified — look it up
             resolvedModel = modelRegistry.find(modelSpec.provider, modelSpec.id);
             if (!resolvedModel) {
                 currentResult.exitCode = 1;
                 currentResult.stderr = `Model not found: ${modelSpec.provider}/${modelSpec.id}. Use the \`models\` command to see available models.`;
                 return currentResult;
             }
+        } else if (modelRegistry) {
+            // No explicit model — auto-select the cheapest available model
+            resolvedModel = selectLightweightModel(modelRegistry);
+            // If no available models at all, resolvedModel stays undefined and
+            // createAgentSession will fall back to its own default selection.
         }
 
         const { session } = await createAgentSession({

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -13,6 +13,7 @@ import {
     createReadOnlyTools,
 } from "@mariozechner/pi-coding-agent";
 import type { AgentConfig } from "../subagent-agents.js";
+import type { Model } from "@mariozechner/pi-ai";
 import { defaultAgentDir } from "../../config.js";
 import type { SingleResult, SubagentDetails, OnUpdateCallback } from "./types.js";
 import { getFinalOutput, summarizeResultForStreaming } from "./types.js";
@@ -74,6 +75,47 @@ export async function mapWithConcurrencyLimit<TIn, TOut>(
 
 // ── Single-agent runner ────────────────────────────────────────────────
 
+export interface ModelOverride {
+    provider: string;
+    id: string;
+}
+
+// ── Model resolution helpers ───────────────────────────────────────────
+
+/** Common model shorthand aliases. */
+const MODEL_ALIASES: Record<string, { provider: string; id: string }> = {
+    haiku: { provider: "anthropic", id: "claude-haiku-4-5" },
+    sonnet: { provider: "anthropic", id: "claude-sonnet-4-20250514" },
+    opus: { provider: "anthropic", id: "claude-opus-4-5" },
+};
+
+/**
+ * Parse a model string from agent frontmatter into a {provider, id} pair.
+ *
+ * Accepts:
+ *   - Shorthand aliases: "haiku", "sonnet", "opus" → resolves to Anthropic model IDs
+ *   - Provider/id format: "anthropic/claude-haiku-4-5" → { provider: "anthropic", id: "claude-haiku-4-5" }
+ *   - Bare model ID (assumes Anthropic): "claude-haiku-4-5" → { provider: "anthropic", id: "claude-haiku-4-5" }
+ *   - "inherit" or empty string → undefined (use default)
+ */
+export function parseModelString(model: string): ModelOverride | undefined {
+    const trimmed = model.trim();
+    if (!trimmed || trimmed === "inherit") return undefined;
+
+    // Check alias map first
+    const alias = MODEL_ALIASES[trimmed.toLowerCase()];
+    if (alias) return alias;
+
+    // provider/id format
+    const slashIdx = trimmed.indexOf("/");
+    if (slashIdx > 0) {
+        return { provider: trimmed.slice(0, slashIdx), id: trimmed.slice(slashIdx + 1) };
+    }
+
+    // Bare model ID — assume anthropic
+    return { provider: "anthropic", id: trimmed };
+}
+
 export async function runSingleAgent(
     defaultCwd: string,
     agents: AgentConfig[],
@@ -84,6 +126,8 @@ export async function runSingleAgent(
     signal: AbortSignal | undefined,
     onUpdate: OnUpdateCallback | undefined,
     makeDetails: (results: SingleResult[]) => SubagentDetails,
+    modelOverride?: ModelOverride,
+    modelRegistry?: { find: (provider: string, modelId: string) => Model<any> | undefined },
 ): Promise<SingleResult> {
     const agent = agents.find((a) => a.name === agentName);
 
@@ -186,11 +230,24 @@ export async function runSingleAgent(
         });
         await loader.reload();
 
+        // Resolve model: tool parameter > agent frontmatter > default (unset)
+        let resolvedModel: Model<any> | undefined;
+        const modelSpec = modelOverride ?? (agent.model ? parseModelString(agent.model) : undefined);
+        if (modelSpec && modelRegistry) {
+            resolvedModel = modelRegistry.find(modelSpec.provider, modelSpec.id);
+            if (!resolvedModel) {
+                currentResult.exitCode = 1;
+                currentResult.stderr = `Model not found: ${modelSpec.provider}/${modelSpec.id}. Use the \`models\` command to see available models.`;
+                return currentResult;
+            }
+        }
+
         const { session } = await createAgentSession({
             cwd: sessionCwd,
             agentDir: defaultAgentDir(),
             tools,
             resourceLoader: loader,
+            ...(resolvedModel && { model: resolvedModel }),
         });
 
         // Subscribe to events to track messages and usage

--- a/packages/cli/src/extensions/subagent/index.ts
+++ b/packages/cli/src/extensions/subagent/index.ts
@@ -387,5 +387,5 @@ export const subagentExtension = (pi: ExtensionAPI) => {
 
 export * from "./types.js";
 export * from "./format.js";
-export { runSingleAgent, resolveTools, mapWithConcurrencyLimit, BUILTIN_TOOLS, parseModelString, type ModelOverride } from "./engine.js";
+export { runSingleAgent, resolveTools, mapWithConcurrencyLimit, BUILTIN_TOOLS, parseModelString, selectLightweightModel, type ModelOverride, type ModelRegistryLike } from "./engine.js";
 export { renderSubagentCall, renderSubagentResult } from "./render.js";

--- a/packages/cli/src/extensions/subagent/index.ts
+++ b/packages/cli/src/extensions/subagent/index.ts
@@ -40,10 +40,20 @@ import {
     type SubagentDetails,
     type SingleResult,
 } from "./types.js";
-import { runSingleAgent, mapWithConcurrencyLimit } from "./engine.js";
+import { runSingleAgent, mapWithConcurrencyLimit, type ModelOverride } from "./engine.js";
 import { renderSubagentCall, renderSubagentResult } from "./render.js";
 
 // ── Tool parameter schemas (JSON Schema) ───────────────────────────────
+
+const ModelSchema = {
+    type: "object",
+    description: "Model override for the subagent session. If omitted, uses the agent definition's model or falls back to the default model.",
+    properties: {
+        provider: { type: "string", description: "Model provider (e.g., 'anthropic', 'google', 'openai')" },
+        id: { type: "string", description: "Model ID (e.g., 'claude-haiku-4-5', 'gemini-2.5-pro')" },
+    },
+    required: ["provider", "id"],
+} as const;
 
 const TaskItemSchema = {
     type: "object",
@@ -51,6 +61,7 @@ const TaskItemSchema = {
         agent: { type: "string", description: "Name of the agent to invoke" },
         task: { type: "string", description: "Task to delegate to the agent" },
         cwd: { type: "string", description: "Working directory for the agent process" },
+        model: ModelSchema,
     },
     required: ["agent", "task"],
 } as const;
@@ -61,6 +72,7 @@ const ChainItemSchema = {
         agent: { type: "string", description: "Name of the agent to invoke" },
         task: { type: "string", description: "Task with optional {previous} placeholder for prior output" },
         cwd: { type: "string", description: "Working directory for the agent process" },
+        model: ModelSchema,
     },
     required: ["agent", "task"],
 } as const;
@@ -92,6 +104,7 @@ const SubagentParams = {
             default: true,
         },
         cwd: { type: "string", description: "Working directory for the agent process (single mode)" },
+        model: ModelSchema,
     },
 } as const;
 
@@ -106,6 +119,7 @@ export const subagentExtension = (pi: ExtensionAPI) => {
             "Modes: single (agent + task), parallel (tasks array), chain (sequential with {previous} placeholder).",
             'Default agent scope is "user" (from ~/.pizzapi/agents and ~/.claude/agents).',
             'To enable project-local agents in .pizzapi/agents or .claude/agents, set agentScope: "both" (or "project").',
+            "Set `model: { provider, id }` to override the model for the subagent session (recommended: use haiku for most tasks).",
             "Compatible with Claude Code agent definition files.",
         ].join(" "),
         parameters: SubagentParams as any,
@@ -120,11 +134,12 @@ export const subagentExtension = (pi: ExtensionAPI) => {
             const params = (rawParams ?? {}) as {
                 agent?: string;
                 task?: string;
-                tasks?: Array<{ agent: string; task: string; cwd?: string }>;
-                chain?: Array<{ agent: string; task: string; cwd?: string }>;
+                tasks?: Array<{ agent: string; task: string; cwd?: string; model?: { provider: string; id: string } }>;
+                chain?: Array<{ agent: string; task: string; cwd?: string; model?: { provider: string; id: string } }>;
                 agentScope?: AgentScope;
                 confirmProjectAgents?: boolean;
                 cwd?: string;
+                model?: { provider: string; id: string };
             };
             const agentScope: AgentScope = params.agentScope ?? "user";
             const pluginAgentDirs = getPluginAgentPaths(ctx.cwd);
@@ -223,6 +238,7 @@ export const subagentExtension = (pi: ExtensionAPI) => {
                     const result = await runSingleAgent(
                         ctx.cwd, agents, step.agent, taskWithContext,
                         step.cwd, i + 1, signal, chainUpdate, makeDetails("chain"),
+                        step.model ?? params.model, ctx.modelRegistry,
                     );
                     results.push(result);
 
@@ -286,6 +302,7 @@ export const subagentExtension = (pi: ExtensionAPI) => {
                             }
                         },
                         makeDetails("parallel"),
+                        t.model ?? params.model, ctx.modelRegistry,
                     );
                     allResults[index] = summarizeResultForStreaming(result);
                     emitParallelUpdate();
@@ -333,6 +350,7 @@ export const subagentExtension = (pi: ExtensionAPI) => {
                 const result = await runSingleAgent(
                     ctx.cwd, agents, params.agent, params.task,
                     params.cwd, undefined, signal, onUpdate, makeDetails("single"),
+                    params.model, ctx.modelRegistry,
                 );
                 if (isFailed(result)) {
                     const errorMsg = result.errorMessage || result.stderr || getFinalOutput(result.messages) || "(no output)";
@@ -369,5 +387,5 @@ export const subagentExtension = (pi: ExtensionAPI) => {
 
 export * from "./types.js";
 export * from "./format.js";
-export { runSingleAgent, resolveTools, mapWithConcurrencyLimit, BUILTIN_TOOLS } from "./engine.js";
+export { runSingleAgent, resolveTools, mapWithConcurrencyLimit, BUILTIN_TOOLS, parseModelString, type ModelOverride } from "./engine.js";
 export { renderSubagentCall, renderSubagentResult } from "./render.js";


### PR DESCRIPTION
## Problem

The `subagent` tool had no way to specify which model a subagent session should use. Agent definitions support a `model` frontmatter field, but it was **never passed** to `createAgentSession()`. The Night Shift plugin already instructs agents to pass `model: { provider, id }` to subagent calls — a feature that didnt exist yet.

## Changes

### Tool schema — `subagent/index.ts`
- Added `model: { provider, id }` parameter at the **top level** (applies to all tasks in the call)
- Added `model` to **per-task** items in `tasks[]` and `chain[]` arrays (overrides top-level)
- Per-task model takes precedence over top-level; either overrides the agent frontmatter model

### Model resolution — `subagent/engine.ts`
- Added `parseModelString()` with shorthand aliases:
  - `haiku` → `claude-haiku-4-5`
  - `sonnet` → `claude-sonnet-4-20250514`
  - `opus` → `claude-opus-4-5`
  - Also supports `provider/id` format and bare model IDs
- Extended `runSingleAgent()` with `modelOverride` and `modelRegistry` params
- Resolution order: **tool parameter → agent frontmatter → default**
- Model resolved via `modelRegistry.find()` and passed to `createAgentSession({ model })`
- Returns clear error if the specified model isnt found in the registry

### System prompt — `templates/system-prompt.hbs`
- Added `<recommendation name="subagent-model-selection">` section:
  - Encourages **always** setting a model on subagent calls
  - Recommends haiku for reviews, research, parallel work
  - Reserves the default model only for tasks that need full capability
  - Shows both top-level and per-task syntax

### Tests — 11 new
- 10 for `parseModelString` (aliases, provider/id, bare ID, inherit, empty, whitespace)
- 1 for system prompt containing the model recommendation

## Example Usage

```js
// Top-level model for single mode
subagent({ agent: "reviewer", task: "Review auth logic", model: { provider: "anthropic", id: "claude-haiku-4-5" } })

// Per-task model in parallel mode
subagent({ tasks: [
  { agent: "reviewer", task: "Review API", model: { provider: "anthropic", id: "claude-haiku-4-5" } },
  { agent: "task", task: "Fix the bug" }  // uses default model
]})

// Agent frontmatter model (resolved automatically)
---
name: critic
model: haiku
---
```