### PR TITLE
Fix popover arrow-key navigation

### DIFF
--- a/packages/ui/src/components/AtMentionPopover.test.tsx
+++ b/packages/ui/src/components/AtMentionPopover.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import React from "react";
+
+const win = new Window({ url: "http://localhost/" });
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(win as any).SyntaxError = SyntaxError;
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).KeyboardEvent = win.KeyboardEvent;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};
+(globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0);
+(globalThis as any).cancelAnimationFrame = (id: number) => clearTimeout(id);
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const mentionEntries = [
+  { name: "alpha.ts", path: "alpha.ts", isDirectory: false },
+  { name: "beta.ts", path: "beta.ts", isDirectory: false },
+];
+
+mock.module("@/hooks/useAtMentionFiles", () => ({
+  useAtMentionFiles: () => ({
+    entries: mentionEntries,
+    loading: false,
+    error: null,
+  }),
+}));
+
+mock.module("@/hooks/useAtMentionSearch", () => ({
+  useAtMentionSearch: () => ({ entries: [], loading: false, error: null }),
+}));
+
+const { AtMentionPopover } = await import("./AtMentionPopover");
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+  mock.restore();
+});
+
+describe("AtMentionPopover keyboard navigation", () => {
+  test("document ArrowDown moves between options and scrolls the highlighted option into view", async () => {
+    const scrollIntoView = mock(() => {});
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollIntoView as unknown as typeof HTMLElement.prototype.scrollIntoView;
+
+    try {
+      const highlighted: number[] = [];
+      const { container } = render(
+        <AtMentionPopover
+          open
+          runnerId="runner-1"
+          path=""
+          query=""
+          onSelectFile={() => {}}
+          onDrillInto={() => {}}
+          onClose={() => {}}
+          onHighlightedIndexChange={(index) => highlighted.push(index)}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(container.querySelectorAll("[role='option']").length).toBe(2);
+        expect(container.querySelector("[role='option'][aria-selected='true']")?.textContent).toContain("alpha.ts");
+      });
+
+      await act(async () => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }));
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector("[role='option'][aria-selected='true']")?.textContent).toContain("beta.ts");
+        expect(highlighted.at(-1)).toBe(1);
+        expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+      });
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+});

--- a/packages/ui/src/components/AtMentionPopover.tsx
+++ b/packages/ui/src/components/AtMentionPopover.tsx
@@ -258,7 +258,6 @@ export function AtMentionPopover({
     highlightedIndex: allItems.findIndex((item) => item.value === highlightedValue),
     setHighlightedIndex: updateHighlightedItemByIndex,
     popoverSelector: "[role='listbox'][aria-label='Mentions']",
-    ignoreTargetSelector: "[data-pp-prompt]",
   });
 
   // Keyboard navigation
@@ -308,7 +307,15 @@ export function AtMentionPopover({
       role="listbox"
       aria-label="Mentions"
     >
-      <Command className="w-full" shouldFilter={false}>
+      <Command
+        className="w-full"
+        shouldFilter={false}
+        value={highlightedValue}
+        onValueChange={(value) => {
+          const index = allItems.findIndex((item) => item.value === value);
+          if (index !== -1) updateHighlightedItemByIndex(index);
+        }}
+      >
         {/* Breadcrumb header */}
         <div className="flex items-center gap-2 px-3 py-2 border-b border-border/50 text-xs">
           {!isAtRoot && !isSearchMode && (

--- a/packages/ui/src/components/AtMentionPopover.tsx
+++ b/packages/ui/src/components/AtMentionPopover.tsx
@@ -11,6 +11,7 @@ import { useAtMentionFiles, type Entry } from "@/hooks/useAtMentionFiles";
 import { useAtMentionSearch } from "@/hooks/useAtMentionSearch";
 import { Bot, ChevronLeft, File, Folder, Search, X } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useDocumentPopoverKeyboardNavigation } from "@/components/session-viewer/popover-keyboard";
 
 // ── Icons ─────────────────────────────────────────────────────────────────────
 
@@ -211,6 +212,18 @@ export function AtMentionPopover({
   // Track the currently highlighted value for keyboard navigation
   const [highlightedValue, setHighlightedValue] = React.useState<string>("");
 
+  const updateHighlightedItemByIndex = React.useCallback(
+    (newIndex: number) => {
+      const newItem = allItems[newIndex];
+      if (!newItem) return;
+      setHighlightedValue(newItem.value);
+      onHighlightedIndexChange?.(newIndex);
+      onHighlightedEntryChange?.(newItem.kind === "file" ? newItem.entry : null);
+      onHighlightedAgentChange?.(newItem.kind === "agent" ? newItem.agent.name : null);
+    },
+    [allItems, onHighlightedIndexChange, onHighlightedEntryChange, onHighlightedAgentChange],
+  );
+
   // Reset highlighted index when items change
   React.useEffect(() => {
     if (allItems.length > 0) {
@@ -239,6 +252,15 @@ export function AtMentionPopover({
     });
   }, [highlightedValue]);
 
+  useDocumentPopoverKeyboardNavigation({
+    open,
+    totalItems: allItems.length,
+    highlightedIndex: allItems.findIndex((item) => item.value === highlightedValue),
+    setHighlightedIndex: updateHighlightedItemByIndex,
+    popoverSelector: "[role='listbox'][aria-label='Mentions']",
+    ignoreTargetSelector: "[data-pp-prompt]",
+  });
+
   // Keyboard navigation
   const handleKeyDown = React.useCallback(
     (e: React.KeyboardEvent) => {
@@ -260,23 +282,16 @@ export function AtMentionPopover({
           onDrillInto(newPath);
         }
       } else if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+        e.preventDefault();
+        e.stopPropagation();
         const currentIndex = allItems.findIndex(i => i.value === highlightedValue);
-        let newIndex: number;
-        if (e.key === "ArrowDown") {
-          newIndex = currentIndex < allItems.length - 1 ? currentIndex + 1 : 0;
-        } else {
-          newIndex = currentIndex > 0 ? currentIndex - 1 : allItems.length - 1;
-        }
-        const newItem = allItems[newIndex];
-        if (newItem) {
-          setHighlightedValue(newItem.value);
-          onHighlightedIndexChange?.(newIndex);
-          onHighlightedEntryChange?.(newItem.kind === "file" ? newItem.entry : null);
-          onHighlightedAgentChange?.(newItem.kind === "agent" ? newItem.agent.name : null);
-        }
+        const newIndex = e.key === "ArrowDown"
+          ? (currentIndex < allItems.length - 1 ? currentIndex + 1 : 0)
+          : (currentIndex > 0 ? currentIndex - 1 : allItems.length - 1);
+        updateHighlightedItemByIndex(newIndex);
       }
     },
-    [onClose, query, path, handleBack, allItems, highlightedValue, onDrillInto, onHighlightedIndexChange, onHighlightedEntryChange]
+    [onClose, query, path, handleBack, allItems, highlightedValue, onDrillInto, updateHighlightedItemByIndex]
   );
 
   if (!open) return null;

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -1319,15 +1319,6 @@ export function SessionViewer({
                         return;
                       }
 
-                      if (atMentionOpen && (event.key === "ArrowDown" || event.key === "ArrowUp")) {
-                        event.preventDefault();
-                        const popoverEl = document.querySelector<HTMLElement>("[role='listbox'][aria-label='Mentions']");
-                        if (popoverEl) {
-                          popoverEl.dispatchEvent(new KeyboardEvent("keydown", { key: event.key, bubbles: true, cancelable: true }));
-                        }
-                        return;
-                      }
-
                       if (atMentionOpen && event.key === "Enter" && !event.shiftKey) {
                         if (atMentionHighlightedAgent) {
                           event.preventDefault();

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -74,6 +74,7 @@ import { McpToggleContext } from "@/components/session-viewer/McpToggleContext";
 import { SessionActionsProvider } from "@/components/session-viewer/session-actions-context";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { type IncompleteTriggerItem } from "@/components/TriggersPanel";
+import { useDocumentPopoverKeyboardNavigation } from "@/components/session-viewer/popover-keyboard";
 import { resolveCommandPopoverState } from "@/components/session-viewer/utils";
 
 import { ContextDonut } from "@/components/session-viewer/rendering";
@@ -399,6 +400,34 @@ export function SessionViewer({
     skillSuggestions,
     commandHighlightedIndex,
   ]);
+
+  const commandOptionCount = React.useMemo(() => {
+    if (!commandOpen) return 0;
+    if (isResumeMode) return resumeCandidates.length;
+    if (isAgentMode) return agentCandidates.length;
+    if (subCommandMode.active) return subCommandMode.filtered.length;
+    return commandSuggestions.length + extensionSuggestions.length + promptSuggestions.length + skillSuggestions.length;
+  }, [
+    commandOpen,
+    isResumeMode,
+    resumeCandidates.length,
+    isAgentMode,
+    agentCandidates.length,
+    subCommandMode,
+    commandSuggestions.length,
+    extensionSuggestions.length,
+    promptSuggestions.length,
+    skillSuggestions.length,
+  ]);
+
+  useDocumentPopoverKeyboardNavigation({
+    open: commandOpen && !isTouchDevice,
+    totalItems: commandOptionCount,
+    highlightedIndex: commandHighlightedIndex,
+    setHighlightedIndex: setCommandHighlightedIndex,
+    popoverSelector: "[data-pp-command-popover]",
+    ignoreTargetSelector: "[data-pp-prompt]",
+  });
 
   const composerReady = canSubmitSessionInput(sessionId, viewerStatus, !!isCompacting);
 
@@ -929,7 +958,7 @@ export function SessionViewer({
 
             {/* Command picker */}
             {sessionId && commandOpen && (
-              <div className="mb-2 rounded-md border border-border bg-popover text-popover-foreground shadow-sm">
+              <div className="mb-2 rounded-md border border-border bg-popover text-popover-foreground shadow-sm" data-pp-command-popover="">
                 <Command
                   shouldFilter={false}
                   className="w-full"

--- a/packages/ui/src/components/session-viewer/popover-keyboard.test.tsx
+++ b/packages/ui/src/components/session-viewer/popover-keyboard.test.tsx
@@ -1,0 +1,82 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { Window } from "happy-dom";
+import { act, cleanup, render, waitFor } from "@testing-library/react";
+import React from "react";
+
+const win = new Window({ url: "http://localhost/" });
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(win as any).SyntaxError = SyntaxError;
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+(globalThis as any).SVGElement = win.SVGElement;
+(globalThis as any).KeyboardEvent = win.KeyboardEvent;
+(globalThis as any).MutationObserver = win.MutationObserver;
+(globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0);
+(globalThis as any).cancelAnimationFrame = (id: number) => clearTimeout(id);
+(globalThis as any).getComputedStyle = win.getComputedStyle.bind(win);
+/* eslint-enable @typescript-eslint/no-explicit-any */
+
+const { getNextPopoverIndex, useDocumentPopoverKeyboardNavigation } = await import("./popover-keyboard");
+
+afterEach(() => {
+  cleanup();
+  document.body.innerHTML = "";
+  mock.restore();
+});
+
+describe("popover keyboard navigation", () => {
+  test("getNextPopoverIndex wraps ArrowDown and ArrowUp through available options", () => {
+    expect(getNextPopoverIndex(0, 3, "ArrowDown")).toBe(1);
+    expect(getNextPopoverIndex(2, 3, "ArrowDown")).toBe(0);
+    expect(getNextPopoverIndex(0, 3, "ArrowUp")).toBe(2);
+    expect(getNextPopoverIndex(1, 3, "ArrowUp")).toBe(0);
+    expect(getNextPopoverIndex(0, 0, "ArrowDown")).toBeNull();
+    expect(getNextPopoverIndex(0, 3, "Enter")).toBeNull();
+  });
+
+  test("document ArrowDown moves to the next option and scrolls the highlighted option into view", async () => {
+    const scrollIntoView = mock(() => {});
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView;
+    HTMLElement.prototype.scrollIntoView = scrollIntoView as unknown as typeof HTMLElement.prototype.scrollIntoView;
+
+    function Harness() {
+      const [index, setIndex] = React.useState(0);
+      useDocumentPopoverKeyboardNavigation({
+        open: true,
+        totalItems: 3,
+        highlightedIndex: index,
+        setHighlightedIndex: setIndex,
+        popoverSelector: "[data-test-popover]",
+      });
+      return (
+        <div data-test-popover="">
+          {["one", "two", "three"].map((item, itemIndex) => (
+            <div key={item} data-option="" data-selected={itemIndex === index ? "true" : "false"}>
+              {item}
+            </div>
+          ))}
+        </div>
+      );
+    }
+
+    try {
+      const { container } = render(<Harness />);
+      expect(container.querySelector("[data-selected='true']")?.textContent).toBe("one");
+
+      await act(async () => {
+        document.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true, cancelable: true }));
+      });
+
+      await waitFor(() => {
+        expect(container.querySelector("[data-selected='true']")?.textContent).toBe("two");
+        expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+      });
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView;
+    }
+  });
+});

--- a/packages/ui/src/components/session-viewer/popover-keyboard.ts
+++ b/packages/ui/src/components/session-viewer/popover-keyboard.ts
@@ -1,0 +1,76 @@
+import * as React from "react";
+
+export type PopoverArrowKey = "ArrowDown" | "ArrowUp";
+
+export function getNextPopoverIndex(
+  currentIndex: number,
+  totalItems: number,
+  key: string,
+): number | null {
+  if (totalItems <= 0) return null;
+  if (key === "ArrowDown") {
+    return currentIndex >= 0 && currentIndex < totalItems - 1 ? currentIndex + 1 : 0;
+  }
+  if (key === "ArrowUp") {
+    return currentIndex > 0 ? currentIndex - 1 : totalItems - 1;
+  }
+  return null;
+}
+
+export interface DocumentPopoverKeyboardNavigationOptions {
+  open: boolean;
+  totalItems: number;
+  highlightedIndex: number;
+  setHighlightedIndex: (index: number) => void;
+  popoverSelector: string;
+  ignoreTargetSelector?: string;
+}
+
+function getSelectedPopoverOption(popover: ParentNode): HTMLElement | null {
+  return popover.querySelector<HTMLElement>(
+    "[data-selected='true'], [aria-selected='true'], [cmdk-item][data-selected='true']",
+  );
+}
+
+export function useDocumentPopoverKeyboardNavigation({
+  open,
+  totalItems,
+  highlightedIndex,
+  setHighlightedIndex,
+  popoverSelector,
+  ignoreTargetSelector,
+}: DocumentPopoverKeyboardNavigationOptions) {
+  React.useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      if (event.key !== "ArrowDown" && event.key !== "ArrowUp") return;
+
+      const target = event.target instanceof Element ? event.target : null;
+      if (target && ignoreTargetSelector && target.closest(ignoreTargetSelector)) return;
+
+      const nextIndex = getNextPopoverIndex(highlightedIndex, totalItems, event.key);
+      if (nextIndex === null) return;
+
+      event.preventDefault();
+      event.stopPropagation();
+      setHighlightedIndex(nextIndex);
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [open, totalItems, highlightedIndex, setHighlightedIndex, ignoreTargetSelector]);
+
+  React.useEffect(() => {
+    if (!open || highlightedIndex < 0) return;
+
+    const frame = requestAnimationFrame(() => {
+      const popover = document.querySelector(popoverSelector);
+      const selected = popover ? getSelectedPopoverOption(popover) : null;
+      selected?.scrollIntoView({ block: "nearest" });
+    });
+
+    return () => cancelAnimationFrame(frame);
+  }, [open, highlightedIndex, popoverSelector]);
+}


### PR DESCRIPTION
## Summary
- Add shared document-level arrow-key navigation for popovers
- Wire slash command and @ mention popovers to move highlighted options and scroll them into view
- Add regression tests for popover keyboard navigation

## Verification
- bun run typecheck
- cd packages/ui && bun test src
- cd packages/ui && bun run build
- bun run test