### PR TITLE
Remove Beads sync from agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -262,7 +262,6 @@ Spawned sessions are **automatically linked** — child events (questions, plans
 4. **PUSH TO REMOTE** - This is MANDATORY:
    ```bash
    git pull --rebase
-   bd sync
    git push
    git status  # MUST show "up to date with origin"
    ```


### PR DESCRIPTION
## Summary
- remove the  step from agent-facing session-completion instructions
- verified no remaining Beads references in prompt/config instruction locations

## Verification
- 
- 

No code changed; full test suite not run.