### PR TITLE
docs: add slash commands reference and plan mode guide

### DIFF
--- a/packages/docs/src/content/docs/web-ui/plan-mode.mdx
+++ b/packages/docs/src/content/docs/web-ui/plan-mode.mdx
@@ -1,0 +1,138 @@
+---
+title: Plan Mode
+description: Explore the codebase safely and review plans before the agent makes changes. Plan mode blocks all write operations until you approve.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Plan mode is a two-phase agent workflow: **exploration** (read-only) followed by **review** (approve, edit, or reject a plan). When plan mode is active, the agent is blocked from writing files, editing files, running destructive bash commands, and spawning sessions — enforced at the OS sandbox level when a sandbox is active, and at the tool level otherwise.
+
+Use plan mode when you want the agent to **think before it acts** — explore an unfamiliar codebase, plan multi-step changes, or gate the agent before it modifies anything.
+
+<Aside type="tip">
+For the full technical details on how plan mode works (tool blocking, bash restrictions, sandbox enforcement), see the [Plan Mode](/features/plan-mode/) feature doc. This page covers how to use plan mode from the PizzaPi web UI.
+</Aside>
+
+## Activating plan mode
+
+There are two ways to turn plan mode on from the web UI:
+
+| Method | How |
+|--------|-----|
+| **Slash command** | Type `/plan` in the chat input — toggles plan mode on or off |
+| **Agent-initiated** | The agent calls the `toggle_plan_mode` tool directly |
+
+When plan mode activates, a notification appears in the conversation confirming that read-only exploration is enabled. The session toolbar also shows a **"Plan Mode"** status indicator so you can see at a glance that writes are blocked.
+
+Type `/plan` again to manually exit plan mode and restore full tool access.
+
+<Aside type="note">
+The agent can also call the `plan_mode` tool to submit a plan for review, which is separate from toggling plan mode on/off. See [The plan review flow](#the-plan-review-flow) below.
+</Aside>
+
+## The plan review flow
+
+When the agent finishes exploring and is ready to make changes, it calls the `plan_mode` tool to submit a structured plan. The web UI replaces the chat input with an interactive **plan review panel**:
+
+1. **The agent explores** — reads files, searches code, runs read-only commands.
+2. **The agent submits a plan** — a plan review panel appears in the composer area with a title, optional description, and numbered steps.
+3. **You review the plan** — expand steps to read descriptions, then choose an action.
+4. **The agent executes** — once approved, plan mode exits automatically and the agent proceeds with full write access.
+
+### Plan review panel
+
+The panel shows:
+
+- A **title** and optional **description** summarizing the plan
+- **Numbered steps** — each step has a title and an optional description with more detail
+- Steps auto-collapse when there are more than 5 (click the step count to expand)
+
+The panel scrolls internally and is capped at 50% viewport height (60% on desktop) so it never blocks the full screen.
+
+### Action buttons
+
+Four buttons at the bottom of the panel control what happens next:
+
+| Button | Effect |
+|--------|--------|
+| **Clear Context & Begin** | Approves the plan **and** strips accumulated context — the agent starts fresh with only the approved plan. Useful when the exploration phase filled up the context window. |
+| **Begin** | Approves the plan and keeps the existing conversation context intact. |
+| **Suggest Edit** | Reveals an inline text input — type your feedback and press <kbd>Enter</kbd> or click **Send** to return the plan to the agent for revision. |
+| **Cancel** | Rejects the plan entirely. The agent is told not to proceed. |
+
+<Aside type="tip">
+**Clear Context & Begin** is especially useful for long exploration sessions. Let the agent spend its context window on thorough analysis, then start execution with a clean slate focused on the approved plan.
+</Aside>
+
+After approval, plan mode exits automatically and the agent begins executing with full tool access. If the agent calls `plan_mode` again during execution, a new plan review panel appears.
+
+### Suggesting edits
+
+When you click **Suggest Edit**, an inline text input appears at the bottom of the panel:
+
+- Type your feedback (e.g., *"Step 2 should also update the test fixtures"*) and press <kbd>Enter</kbd> or click **Send**
+- Press <kbd>Escape</kbd> to dismiss the edit input without sending
+- The agent receives your feedback and should resubmit an updated plan
+
+## Parent-child plan reviews
+
+When a parent agent spawns a child session via `spawn_session`, the child can also present plans for review. Instead of waiting for a human, the child fires a `plan_review` **trigger** to the parent session.
+
+The parent sees a trigger message in its conversation showing the child's plan title, steps, and a trigger ID. The parent can then:
+
+- **Approve** — `respond_to_trigger(triggerId, "approve")` — the child proceeds
+- **Reject** — `respond_to_trigger(triggerId, "cancel")` — the child stops
+- **Request edits** — `respond_to_trigger(triggerId, "Your feedback", { action: "edit" })` — the child revises
+- **Escalate** — `escalate_trigger(triggerId)` — passes the decision to you (the human viewer)
+
+<Aside type="caution">
+Plan review triggers have a **5-minute timeout**. If the parent doesn't respond within 5 minutes, the child treats it as a cancellation.
+</Aside>
+
+For more on inter-agent communication and triggers, see [Subagents](/customization/subagents/).
+
+## Plan cards in the conversation
+
+After you respond to a plan, it remains in the conversation as a **styled card** — not just a text message. Cards show:
+
+- The plan **title** and **numbered steps**
+- A **status pill** indicating what happened: *Begin*, *Clear Context & Begin*, *Edit Suggested*, or *Cancelled*
+- If you suggested an edit, your feedback is shown below the steps
+
+Pending (unresolved) plans are visually distinct — they display a waiting indicator while the plan review panel is active in the composer area. Once resolved, the card updates with the final action.
+
+Plan cards are stored in the session history and survive page reloads.
+
+## Write-blocking enforcement
+
+Plan mode blocks writes through two layers:
+
+| Layer | How it works |
+|-------|-------------|
+| **OS sandbox overlay** | When a [sandbox](/security/sandbox/) is active, plan mode activates an OS-level read-only filesystem overlay. Even if a command bypasses the tool-level checks, the OS blocks the write. |
+| **Tool-level blocking** | Write and edit tools are disabled. Bash commands go through a destructive-command detector that blocks `rm`, `mv`, `npm install`, `git commit`, output redirection (`>` / `>>`), and more. |
+
+If no sandbox is active, plan mode falls back to tool-level and regex-based command blocking — but it cannot enforce at the OS level. The session toolbar always shows plan mode status when active, regardless of sandbox state.
+
+<Aside type="caution">
+Without a sandbox, tool-level blocking is the only defense. A determined command could potentially bypass regex checks. For full enforcement, run the agent with the sandbox enabled.
+</Aside>
+
+## Best practices
+
+**Use plan mode when:**
+- You're exploring a new or unfamiliar codebase
+- The task touches many files and you want to verify the approach before changes begin
+- The change is risky or hard to reverse (database migrations, config changes, refactors)
+- You're using a multi-agent setup and want parent approval before child agents make changes
+
+**Skip plan mode when:**
+- The task is simple and well-defined (fix a typo, add a log line)
+- You've already described the exact changes you want
+- Speed matters more than review — you can always undo with git
+
+**Tips:**
+- Review each step in the plan — the agent won't deviate without asking
+- Combine with **Clear Context & Begin** when the exploration phase has bloated the context window
+- You can toggle plan mode off manually with `/plan` at any time, even before the agent submits a plan
+- If the agent calls `plan_mode` again mid-execution, treat it as a checkpoint — review the new plan before continuing

--- a/packages/docs/src/content/docs/web-ui/slash-commands.mdx
+++ b/packages/docs/src/content/docs/web-ui/slash-commands.mdx
@@ -1,0 +1,99 @@
+---
+title: Slash Commands
+description: Quick-access keyboard commands for session control, model selection, MCP management, and more — all from the browser chat input.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Slash commands give you quick access to session control, model switching, MCP management, and other actions directly from the chat input. Type `/` and a command picker pops up — no mouse or toolbar hunting required.
+
+## Triggering the picker
+
+Type **`/`** in the chat input to open the slash command picker popover. The picker shows a scrollable list of available commands, grouped by type.
+
+- **Filter in real time** — keep typing after the `/` to narrow the list. For example, `/re` filters to `/resume`.
+- **Keyboard navigation** — press <kbd>↑</kbd> / <kbd>↓</kbd> to move through suggestions, then <kbd>Enter</kbd> to execute the highlighted command.
+- **Mouse** — click any command in the list to execute it.
+- **Dismiss** — press <kbd>Escape</kbd> or click outside the picker to close it without running anything.
+
+## Core commands
+
+The following commands are always available in the chat input:
+
+| Command | Description |
+|---------|-------------|
+| `/new` | Start a new conversation. If there are active linked child sessions, a confirmation dialog appears first. |
+| `/resume [query]` | Resume a previous session. Without a query, resumes the most recent session. With a query, opens a fuzzy-search picker matching against session names, IDs, paths, and first messages. |
+| `/plan` | Toggle plan mode on/off. In plan mode, the agent can only read files and run safe commands — useful for exploring the codebase before making changes. |
+| `/model` or `/cycle_model` | Open the model selector to switch to a different AI model mid-session. |
+| `/effort` or `/cycle_effort` | Cycle through reasoning effort levels (extended thinking). |
+| `/compact [instructions]` | Compact the context window. Optionally provides custom instructions for what to preserve. Shows a spinner while compacting. |
+| `/name <name>` | Set the session display name shown in the sidebar. |
+| `/copy` | Copy the last assistant message to clipboard. |
+| `/stop` | Abort the currently running agent generation. |
+| `/restart` | Restart the underlying CLI process — useful if the agent is stuck or needs a fresh start. |
+| `/sandbox` | Show current sandbox status (mode, platform, recent violations) if a runner is connected. |
+| `/skills` | Display available skills loaded on the runner. |
+| `/plugins` | List all loaded plugins with their commands, hooks, skills, agents, rules, and MCP integrations. |
+| `/agents [name]` | Spawn a new session as a named agent. Without a name, opens a picker showing available agents from the runner. With a name, dispatches immediately. |
+| `/mcp [status\|reload\|disable <name>\|enable <name>]` | MCP server management. See [MCP sub-commands](#mcp-sub-commands) below. |
+
+<Aside type="tip">
+You can also trigger context compaction by clicking the **context donut** in the session toolbar — it opens a confirmation dialog with the same effect as `/compact`. See [Web UI Overview](/web-ui/overview/#context-window-donut) for details.
+</Aside>
+
+### MCP sub-commands
+
+The `/mcp` command supports four sub-commands:
+
+| Sub-command | Description |
+|-------------|-------------|
+| `/mcp status` | Show all connected MCP servers and their current status. |
+| `/mcp reload` | Reconnect all MCP servers. |
+| `/mcp disable <name>` | Disable a specific MCP server by name. |
+| `/mcp enable <name>` | Enable a previously disabled MCP server by name. |
+
+## Sub-command mode
+
+For commands that accept sub-commands (like `/mcp`), typing the command name followed by a space enters **sub-command mode**. The picker filters to show only the sub-commands for that parent command.
+
+For example, typing `/mcp ` (note the space) narrows the picker to `status`, `reload`, `disable <server-name>`, and `enable <server-name>`.
+
+This also applies to plugin-provided extension commands and skill commands — any command that defines its own sub-command structure.
+
+## Pickers that stay open
+
+Some commands keep the picker open after you execute them because they're inherently interactive:
+
+- **`/resume`** — the session picker stays open so you can browse and select a session.
+- **`/agents`** — the agent picker stays open for selection.
+- **Any command with sub-commands** — the picker stays open in sub-command mode.
+
+You can continue filtering and selecting without re-triggering the picker. Press <kbd>Escape</kbd> when you're done to close it.
+
+## Dynamic commands
+
+Beyond the core commands, three categories of commands are loaded dynamically from the connected runner:
+
+### Skill commands
+
+One command per available skill. Skill commands are dispatched to the CLI for execution. For example, if you have a `typescript` skill configured, you'll see a `/typescript` command in the picker.
+
+### Plugin/extension commands
+
+Commands registered by Claude Code plugins. These may define their own sub-commands and appear in the picker alongside core commands. Plugin commands are grouped separately in the picker for easy identification.
+
+### Prompt template commands
+
+Commands for prompt templates defined in `~/.pizzapi/prompts/`. Each template file becomes a slash command you can invoke to inject that prompt into the conversation.
+
+<Aside type="note">
+All dynamic commands appear in the picker alongside core commands and support the same real-time filtering. They are only available when a runner is connected.
+</Aside>
+
+## Notes & limitations
+
+- **Chat input only** — slash commands work in the browser chat input, not in the [Web Terminal](/web-ui/terminal/).
+- **Runner required for full functionality** — commands like `/plugins`, `/skills`, `/sandbox`, and `/agents` require a connected runner. If no runner is available, they show an appropriate message indicating the runner is disconnected.
+- **Dynamic commands depend on runner state** — skill, plugin, and prompt template commands are loaded from the runner at session start. Changes to your configuration (adding a new skill, enabling a plugin) won't appear until the session reconnects or the runner refreshes.
+- **`/stop` vs `/restart`** — `/stop` aborts the current generation but keeps the CLI process alive. `/restart` kills and restarts the CLI process entirely. Use `/stop` for a stuck generation; use `/restart` only when the process itself is unresponsive.


### PR DESCRIPTION
## Summary

Adds two new documentation pages and completes the [Documentation Coverage epic](https://github.com/pizzaface/PizzaPi/issues) (34 ideas → 94% resolved):

### New Pages
- **Slash Commands** (`web-ui/slash-commands.mdx`) — full reference for all 15 slash commands in the web UI chat input, including sub-command mode, dynamic commands (skills/plugins/prompts), and keyboard navigation
- **Plan Mode** (`web-ui/plan-mode.mdx`) — user guide covering activation, the plan review flow (approve/edit/cancel), parent-child plan reviews, write-blocking enforcement, and best practices

### Existing Coverage Verified
The remaining 30+ documentation gaps were already covered in existing pages:
- **web-ui/overview.mdx** — 13 features (PWA, panels, donut, pizza, search cards, @mentions, etc.)
- **features/** — tunnels, multi-agent, webhooks
- **customization/** — tool search, prompt templates, plugin rules, runner services/triggers
- **reference/** — full API reference, protocol, environment variables
- **start-here/** — installation inventory, data migration
- **security/** — workspace roots, sandbox config

Builds clean (42 pages, 0 errors).