### PR TITLE
docs: add pi feature documentation (providers, sessions, packages)

### DIFF
--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -97,9 +97,12 @@ export default defineConfig({
                 {
                     label: "Features",
                     items: [
+                        { label: "Providers & Models", slug: "features/providers-and-models" },
+                        { label: "Sessions & Context", slug: "features/sessions" },
                         { label: "Slash Commands", slug: "features/slash-commands" },
                         { label: "Plan Mode", slug: "features/plan-mode" },
                         { label: "Multi-Agent Sessions", slug: "features/multi-agent" },
+                        { label: "Pi Packages", slug: "features/pi-packages" },
                         { label: "Webhooks", slug: "features/webhooks" },
                         { label: "Tunnel Tools", slug: "features/tunnels" },
                     ],

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -261,6 +261,47 @@ PIZZAPI_RELAY_URL=off pizzapi
 
 ---
 
+## Pi Agent Settings
+
+In addition to PizzaPi's own config, the underlying **pi agent** has its own settings file for model defaults, compaction, retry behavior, and UI preferences. These are separate from `~/.pizzapi/config.json`:
+
+| File | Scope |
+|------|-------|
+| `~/.pi/agent/settings.json` | Global pi settings |
+| `.pi/settings.json` | Project-local pi settings (overrides global) |
+
+Edit directly or use the `/settings` command inside a session.
+
+### Key Settings
+
+```json
+{
+  "defaultProvider": "anthropic",
+  "defaultModel": "claude-sonnet-4-20250514",
+  "defaultThinkingLevel": "medium",
+  "compaction": {
+    "enabled": true,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 20000
+  },
+  "retry": {
+    "enabled": true,
+    "maxRetries": 3,
+    "baseDelayMs": 2000,
+    "maxDelayMs": 60000
+  },
+  "enabledModels": ["claude-*", "gpt-4o"]
+}
+```
+
+See [Providers & Models](/PizzaPi/features/providers-and-models/) for model configuration and [Sessions & Context](/PizzaPi/features/sessions/) for compaction and session settings.
+
+<Aside type="note">
+  PizzaPi config (`~/.pizzapi/config.json`) controls the relay, MCP servers, hooks, and sandbox. Pi settings (`~/.pi/agent/settings.json`) control model defaults, compaction, retry, and session behavior. They are independent — don't mix them up.
+</Aside>
+
+---
+
 ## Merge Order
 
 When PizzaPi starts, config is resolved in this order (later entries win):

--- a/packages/docs/src/content/docs/features/pi-packages.mdx
+++ b/packages/docs/src/content/docs/features/pi-packages.mdx
@@ -1,0 +1,176 @@
+---
+title: Pi Packages
+description: Install, manage, and create community packages that add extensions, skills, prompt templates, and themes to PizzaPi.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+**Pi packages** bundle extensions, skills, prompt templates, and themes into installable packages shared via npm or git. PizzaPi inherits full support for pi's package system — install community packages to extend your agent's capabilities without writing code.
+
+<Aside type="caution">
+  Pi packages run with **full system access**. Extensions execute arbitrary code, and skills can instruct the model to perform any action. Always review source code before installing third-party packages.
+</Aside>
+
+---
+
+## Installing Packages
+
+Use `pi install` from the terminal (not from within a PizzaPi session):
+
+```bash
+# From npm
+pi install npm:@foo/pi-tools
+pi install npm:@foo/pi-tools@1.2.3      # pinned version
+
+# From git (multiple URL formats)
+pi install git:github.com/user/repo
+pi install git:github.com/user/repo@v1  # tag or commit
+pi install https://github.com/user/repo
+pi install ssh://git@github.com/user/repo
+
+# From local path
+pi install /path/to/package
+pi install ./relative/path
+```
+
+By default, packages install globally (`~/.pi/agent/settings.json`). Use `-l` for project-local installs (`.pi/settings.json`) — these can be shared with your team, and pi auto-installs missing packages on startup.
+
+### Try Without Installing
+
+Load a package for a single session without persisting it:
+
+```bash
+pi -e npm:@foo/bar
+pi -e git:github.com/user/repo
+```
+
+---
+
+## Managing Packages
+
+```bash
+pi list                    # Show installed packages
+pi update                  # Update all non-pinned packages
+pi remove npm:@foo/bar     # Remove a package
+pi config                  # Enable/disable specific resources
+```
+
+<Aside type="tip">
+  Packages with a pinned version (e.g., `npm:@foo/bar@1.2.3` or `git:...@v1`) are skipped by `pi update`. Remove the version pin to allow automatic updates.
+</Aside>
+
+---
+
+## Package Sources
+
+### npm Packages
+
+```
+npm:@scope/package
+npm:package@1.2.3
+```
+
+- Global installs use `npm install -g`
+- Project-local installs go under `.pi/npm/`
+- If you use a Node version manager, set `npmCommand` in settings:
+  ```json
+  { "npmCommand": ["mise", "exec", "node@20", "--", "npm"] }
+  ```
+
+### Git Repositories
+
+```
+git:github.com/user/repo@v1
+git:git@github.com:user/repo
+https://github.com/user/repo@v1
+ssh://git@github.com/user/repo
+```
+
+- Cloned to `~/.pi/agent/git/<host>/<path>` (global) or `.pi/git/<host>/<path>` (project)
+- Runs `npm install` after clone/pull if `package.json` exists
+- SSH URLs use your configured SSH keys automatically
+
+---
+
+## Package Filtering
+
+Control which resources load from a package using the object form in settings:
+
+```json
+{
+  "packages": [
+    "npm:simple-pkg",
+    {
+      "source": "npm:my-package",
+      "extensions": ["extensions/*.ts", "!extensions/legacy.ts"],
+      "skills": [],
+      "prompts": ["prompts/review.md"]
+    }
+  ]
+}
+```
+
+- Omit a key to load **all** of that type
+- Use `[]` to load **none** of that type
+- `!pattern` excludes matches
+
+Use `pi config` to interactively enable or disable resources from installed packages.
+
+---
+
+## Finding Packages
+
+- Browse the [Pi Package Gallery](https://shittycodingagent.ai/packages) — packages tagged with `pi-package` on npm
+- Search npm: [`npm search keywords:pi-package`](https://www.npmjs.com/search?q=keywords%3Api-package)
+- Check the [Pi Discord](https://discord.com/invite/3cU7Bz4UPx) community channel for recommendations
+
+---
+
+## Creating a Package
+
+To create your own package, add a `pi` manifest to `package.json`:
+
+```json
+{
+  "name": "my-pi-package",
+  "keywords": ["pi-package"],
+  "pi": {
+    "extensions": ["./extensions"],
+    "skills": ["./skills"],
+    "prompts": ["./prompts"],
+    "themes": ["./themes"]
+  }
+}
+```
+
+Without a `pi` manifest, pi auto-discovers resources from conventional directories: `extensions/`, `skills/`, `prompts/`, `themes/`.
+
+### Package Structure
+
+```
+my-pi-package/
+├── package.json           # With "pi" manifest
+├── extensions/            # TypeScript extension files
+│   └── my-extension.ts
+├── skills/                # Skill directories with SKILL.md
+│   └── my-skill/
+│       └── SKILL.md
+├── prompts/               # Prompt template .md files
+│   └── review.md
+└── themes/                # Theme .json files
+    └── my-theme.json
+```
+
+### Publishing
+
+Publish to npm with the `pi-package` keyword for gallery visibility:
+
+```bash
+npm publish
+```
+
+Or share via a git repository — users install with:
+
+```bash
+pi install git:github.com/you/my-pi-package
+```

--- a/packages/docs/src/content/docs/features/providers-and-models.mdx
+++ b/packages/docs/src/content/docs/features/providers-and-models.mdx
@@ -1,0 +1,301 @@
+---
+title: Providers & Models
+description: Configure AI providers, authenticate with subscriptions or API keys, add custom models, and switch models mid-session.
+---
+
+import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
+
+PizzaPi is built on the **pi** coding agent, which supports 20+ AI providers out of the box. You can authenticate with a paid subscription via OAuth, set API keys, or add custom providers like Ollama or LM Studio for local models.
+
+---
+
+## Supported Providers
+
+### Subscription Providers (OAuth)
+
+These providers use OAuth — authenticate with `/login` inside a session:
+
+| Provider | Subscription |
+|----------|-------------|
+| Anthropic | Claude Pro / Max |
+| OpenAI | ChatGPT Plus / Pro (Codex) |
+| GitHub Copilot | Copilot subscription |
+| Google Gemini CLI | Free with Google account |
+| Google Antigravity | Free with Google account |
+
+<Aside type="tip">
+  Google Gemini CLI and Antigravity are free with any Google account, subject to rate limits. For paid usage, set the `GOOGLE_CLOUD_PROJECT` environment variable.
+</Aside>
+
+### API Key Providers
+
+Set an environment variable or store the key in the auth file:
+
+| Provider | Environment Variable |
+|----------|---------------------|
+| Anthropic | `ANTHROPIC_API_KEY` |
+| OpenAI | `OPENAI_API_KEY` |
+| Google Gemini | `GEMINI_API_KEY` |
+| Azure OpenAI | `AZURE_OPENAI_API_KEY` |
+| Google Vertex AI | Uses Application Default Credentials |
+| Amazon Bedrock | `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` |
+| Mistral | `MISTRAL_API_KEY` |
+| Groq | `GROQ_API_KEY` |
+| Cerebras | `CEREBRAS_API_KEY` |
+| xAI | `XAI_API_KEY` |
+| OpenRouter | `OPENROUTER_API_KEY` |
+| Vercel AI Gateway | `AI_GATEWAY_API_KEY` |
+| Hugging Face | `HF_TOKEN` |
+| Kimi For Coding | `KIMI_API_KEY` |
+| MiniMax | `MINIMAX_API_KEY` |
+
+---
+
+## Authentication
+
+### Using `/login` (Subscriptions)
+
+Inside a PizzaPi session, type `/login` in the chat input. You'll be prompted to select a provider and complete the OAuth flow in your browser. Tokens are stored in `~/.pi/agent/auth.json` and auto-refresh when they expire.
+
+Use `/logout` to clear stored credentials.
+
+### Using API Keys
+
+Set the provider's environment variable before starting PizzaPi:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Or store it in the **auth file** at `~/.pi/agent/auth.json`:
+
+```json
+{
+  "anthropic": { "type": "api_key", "key": "sk-ant-..." },
+  "openai": { "type": "api_key", "key": "sk-..." }
+}
+```
+
+The auth file is created with `0600` permissions (user read/write only). Auth file credentials take priority over environment variables.
+
+### Key Resolution
+
+The `key` field in `auth.json` supports three formats:
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| Shell command | `"!security find-generic-password -ws 'anthropic'"` | Executes command, uses stdout |
+| Environment variable | `"MY_ANTHROPIC_KEY"` | Reads the named env var |
+| Literal value | `"sk-ant-..."` | Used directly |
+
+Shell commands are useful for pulling keys from password managers:
+
+```json
+{
+  "anthropic": { "type": "api_key", "key": "!op read 'op://vault/item/credential'" }
+}
+```
+
+### Credential Priority
+
+When multiple sources provide credentials for the same provider:
+
+1. CLI `--api-key` flag (highest priority)
+2. `auth.json` entry (API key or OAuth token)
+3. Environment variable
+4. Custom provider keys from `models.json`
+
+---
+
+## Switching Models
+
+### In the Web UI
+
+Use the `/model` command in the chat input to open the model selector. This shows all available models across your authenticated providers.
+
+You can also cycle through a subset of models using the `/cycle_model` command, or change reasoning effort with `/effort`.
+
+### Setting Defaults
+
+Set your preferred default model in `~/.pi/agent/settings.json`:
+
+```json
+{
+  "defaultProvider": "anthropic",
+  "defaultModel": "claude-sonnet-4-20250514",
+  "defaultThinkingLevel": "medium"
+}
+```
+
+### Scoped Model Cycling
+
+Limit which models appear when cycling:
+
+```json
+{
+  "enabledModels": ["claude-*", "gpt-4o", "gemini-2*"]
+}
+```
+
+---
+
+## Custom Models
+
+Add local or custom models (Ollama, vLLM, LM Studio, proxies) via `~/.pi/agent/models.json`. The file reloads each time you open `/model` — edit it mid-session without restarting.
+
+### Minimal Example (Ollama)
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://localhost:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "models": [
+        { "id": "llama3.1:8b" },
+        { "id": "qwen2.5-coder:7b" }
+      ]
+    }
+  }
+}
+```
+
+<Aside>
+  The `apiKey` is required by the schema but Ollama ignores it — any value works.
+</Aside>
+
+### Full Model Configuration
+
+```json
+{
+  "providers": {
+    "ollama": {
+      "baseUrl": "http://localhost:11434/v1",
+      "api": "openai-completions",
+      "apiKey": "ollama",
+      "models": [
+        {
+          "id": "llama3.1:8b",
+          "name": "Llama 3.1 8B (Local)",
+          "reasoning": false,
+          "input": ["text"],
+          "contextWindow": 128000,
+          "maxTokens": 32000,
+          "cost": { "input": 0, "output": 0, "cacheRead": 0, "cacheWrite": 0 }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Supported API Types
+
+| API | Use For |
+|-----|---------|
+| `openai-completions` | Most compatible — Ollama, vLLM, LM Studio, OpenRouter |
+| `openai-responses` | OpenAI Responses API |
+| `anthropic-messages` | Anthropic Messages API |
+| `google-generative-ai` | Google Generative AI |
+
+### Provider Configuration Fields
+
+| Field | Description |
+|-------|-------------|
+| `baseUrl` | API endpoint URL |
+| `api` | API type (see above) |
+| `apiKey` | API key (supports shell command, env var, or literal) |
+| `headers` | Custom headers (same resolution as apiKey) |
+| `authHeader` | Set `true` to add `Authorization: Bearer <apiKey>` |
+| `models` | Array of model definitions |
+| `modelOverrides` | Per-model overrides for built-in models |
+
+### Model Fields
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `id` | Yes | — | Model identifier passed to the API |
+| `name` | No | `id` | Human-readable label |
+| `api` | No | provider's | Override API type for this model |
+| `reasoning` | No | `false` | Supports extended thinking |
+| `input` | No | `["text"]` | Input types: `["text"]` or `["text", "image"]` |
+| `contextWindow` | No | `128000` | Context window (tokens) |
+| `maxTokens` | No | `16384` | Max output tokens |
+| `cost` | No | all zeros | Per-million-token costs |
+
+### OpenAI Compatibility
+
+For servers with partial OpenAI compatibility, use the `compat` field at the provider or model level:
+
+```json
+{
+  "providers": {
+    "local-llm": {
+      "baseUrl": "http://localhost:8080/v1",
+      "api": "openai-completions",
+      "compat": {
+        "supportsDeveloperRole": false,
+        "supportsReasoningEffort": false
+      },
+      "models": [{ "id": "my-model" }]
+    }
+  }
+}
+```
+
+This commonly applies to Ollama, vLLM, SGLang, and similar servers that don't understand the `developer` role or `reasoning_effort` parameter.
+
+---
+
+## Cloud Provider Setup
+
+### Azure OpenAI
+
+```bash
+export AZURE_OPENAI_API_KEY=...
+export AZURE_OPENAI_BASE_URL=https://your-resource.openai.azure.com
+# Optional
+export AZURE_OPENAI_API_VERSION=2024-02-01
+export AZURE_OPENAI_DEPLOYMENT_NAME_MAP=gpt-4=my-gpt4,gpt-4o=my-gpt4o
+```
+
+### Amazon Bedrock
+
+```bash
+# Option 1: AWS Profile
+export AWS_PROFILE=your-profile
+
+# Option 2: IAM Keys
+export AWS_ACCESS_KEY_ID=AKIA...
+export AWS_SECRET_ACCESS_KEY=...
+
+# Optional region (defaults to us-east-1)
+export AWS_REGION=us-west-2
+```
+
+### Google Vertex AI
+
+```bash
+gcloud auth application-default login
+export GOOGLE_CLOUD_PROJECT=your-project
+export GOOGLE_CLOUD_LOCATION=us-central1
+```
+
+---
+
+## Overriding Built-in Providers
+
+Route a built-in provider through a proxy without redefining its models:
+
+```json
+{
+  "providers": {
+    "anthropic": {
+      "baseUrl": "https://my-proxy.example.com/v1"
+    }
+  }
+}
+```
+
+All built-in Anthropic models remain available — only the endpoint changes.

--- a/packages/docs/src/content/docs/features/sessions.mdx
+++ b/packages/docs/src/content/docs/features/sessions.mdx
@@ -1,0 +1,218 @@
+---
+title: Sessions & Context
+description: Session management, branching, tree navigation, compaction, and context management in PizzaPi.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+PizzaPi sessions are powered by pi's session engine — a tree-structured conversation format that supports branching, forking, and automatic context compaction. This page covers how sessions work under the hood and the tools available for managing them.
+
+---
+
+## Session Basics
+
+### Starting and Resuming
+
+| Command | Description |
+|---------|-------------|
+| `/new` | Start a fresh session |
+| `/resume [query]` | Browse and resume a previous session — fuzzy-search by name, ID, or content |
+| `/name <name>` | Give the current session a display name |
+| `/session` | Show session info (path, tokens, cost) |
+
+Sessions auto-save as JSONL files under `~/.pi/agent/sessions/`, organized by working directory.
+
+### Session Storage
+
+Each session is a single `.jsonl` file with a tree structure. Every entry has an `id` and `parentId`, enabling in-place branching without creating new files. The file format preserves all history — even when you branch or compact, nothing is deleted.
+
+---
+
+## Branching with `/tree`
+
+The `/tree` command opens a tree-based navigator showing your full conversation history. Unlike linear chat, pi sessions form a tree — every time you go back and try a different approach, a new branch is created.
+
+### What You Can Do
+
+- **Navigate** to any point in the conversation
+- **Branch** from any message to try a different approach
+- **View branches** side by side to compare approaches
+- **Label** important messages as bookmarks
+
+### How It Works
+
+When you select a **user message** in the tree:
+1. The conversation pointer moves to the parent of that message
+2. The message text is placed in your editor for re-submission
+3. You can edit it and submit, creating a new branch
+
+When you select a **non-user message** (assistant response, compaction, etc.):
+1. The conversation continues from that point
+2. The editor stays empty
+
+### Branch Summarization
+
+When switching between branches, you'll be asked whether to **summarize** the branch you're leaving. This creates a compact summary that preserves context without keeping every message in the active context window. Options:
+
+- **No summary** — switch immediately
+- **Summarize** — generate a summary with the default prompt
+- **Summarize with custom prompt** — provide focus instructions for the summary
+
+<Aside type="tip">
+  Branch summaries are stored as separate entries in the session file. The full original messages are always preserved — summaries are additive, never destructive.
+</Aside>
+
+---
+
+## Forking with `/fork`
+
+While `/tree` branches within the same session file, `/fork` creates an **entirely new session** from any point in the current one.
+
+| Feature | `/tree` | `/fork` |
+|---------|---------|---------|
+| Result | New branch in same file | New session file |
+| History | Shared | Copied (independent) |
+| Summarization | Optional | Never |
+
+Use `/fork` when you want to explore a completely different direction without cluttering the original session's tree.
+
+---
+
+## Compaction
+
+Long conversations eventually fill the model's context window. **Compaction** summarizes older messages while keeping recent ones, freeing up context space.
+
+### Automatic Compaction
+
+Enabled by default. Triggers when:
+
+```
+contextTokens > contextWindow − reserveTokens
+```
+
+When triggered, pi:
+
+1. Walks backwards from the newest message, keeping recent messages (default: 20,000 tokens)
+2. Summarizes everything older into a structured summary
+3. Continues with the summary + recent messages
+
+<Aside>
+  Compaction is **lossy for the model's context** but **lossless for your session file**. The full history is always preserved — use `/tree` to revisit any earlier message.
+</Aside>
+
+### Manual Compaction
+
+Use `/compact` to trigger compaction manually, optionally with focus instructions:
+
+```
+/compact                           # Default summarization
+/compact focus on the auth module  # Guided summarization
+```
+
+This is useful when you want to steer what the summary emphasizes before the context runs out naturally.
+
+### Compaction Settings
+
+Configure in `~/.pi/agent/settings.json` (global) or `.pi/settings.json` (project):
+
+```json
+{
+  "compaction": {
+    "enabled": true,
+    "reserveTokens": 16384,
+    "keepRecentTokens": 20000
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `compaction.enabled` | `true` | Enable automatic compaction |
+| `compaction.reserveTokens` | `16384` | Tokens reserved for the model's response |
+| `compaction.keepRecentTokens` | `20000` | Recent tokens to keep (not summarized) |
+
+---
+
+## Session Settings
+
+Additional session-related settings:
+
+### Branch Summary
+
+```json
+{
+  "branchSummary": {
+    "reserveTokens": 16384,
+    "skipPrompt": false
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `branchSummary.reserveTokens` | `16384` | Tokens reserved for branch summarization |
+| `branchSummary.skipPrompt` | `false` | Skip the "Summarize branch?" prompt (defaults to no summary) |
+
+### Retry on Errors
+
+```json
+{
+  "retry": {
+    "enabled": true,
+    "maxRetries": 3,
+    "baseDelayMs": 2000,
+    "maxDelayMs": 60000
+  }
+}
+```
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `retry.enabled` | `true` | Auto-retry on transient errors |
+| `retry.maxRetries` | `3` | Maximum retry attempts |
+| `retry.baseDelayMs` | `2000` | Base delay (exponential backoff: 2s, 4s, 8s) |
+| `retry.maxDelayMs` | `60000` | Max delay before failing (prevents multi-hour waits) |
+
+### Custom Session Directory
+
+```json
+{
+  "sessionDir": "/path/to/sessions"
+}
+```
+
+Priority: `--session-dir` CLI flag → `sessionDir` in settings → default (`~/.pi/agent/sessions/`).
+
+---
+
+## Exporting and Sharing
+
+| Command | Description |
+|---------|-------------|
+| `/export [file]` | Export the current session to an HTML file |
+| `/share` | Upload as a private GitHub gist with a shareable HTML link |
+| `/copy` | Copy the last assistant message to your clipboard |
+
+---
+
+## Context Files
+
+pi automatically loads **context files** at startup to give the agent project-specific knowledge. These files are loaded from multiple locations and concatenated:
+
+| File | Location | Purpose |
+|------|----------|---------|
+| `AGENTS.md` or `CLAUDE.md` | `~/.pi/agent/`, parent directories, current directory | Project instructions, conventions, common commands |
+| `SYSTEM.md` | `.pi/SYSTEM.md` (project) or `~/.pi/agent/SYSTEM.md` (global) | Replace the default system prompt entirely |
+| `APPEND_SYSTEM.md` | Same locations | Append to the system prompt without replacing it |
+
+<Aside type="note">
+  PizzaPi uses `~/.pizzapi/` as its config directory, but pi's context file discovery still checks `~/.pi/agent/` and `.pi/` paths. Both conventions work — PizzaPi adds its own `AGENTS.md` at `~/.pizzapi/AGENTS.md` alongside the pi defaults.
+</Aside>
+
+### How Context Files Load
+
+1. Global `AGENTS.md` from `~/.pi/agent/` (or `~/.pizzapi/`)
+2. Walk up from the current working directory, loading each `AGENTS.md` or `CLAUDE.md` found
+3. Project-level `AGENTS.md` in the current directory
+
+All files are concatenated and included in the system prompt. This means you can have repository-wide instructions in the repo root and more specific instructions in subdirectories.

--- a/packages/docs/src/content/docs/features/slash-commands.mdx
+++ b/packages/docs/src/content/docs/features/slash-commands.mdx
@@ -48,6 +48,14 @@ If a sub-command requires an argument (like `/mcp disable`), selecting it fills 
 | `/resume [query]` | Resume a previous session. Opens a session picker showing recent sessions with name, date, and path. Type to fuzzy-search by session name, ID, path, or first message. |
 | `/stop` | Abort the current generation. |
 | `/restart` | Restart the underlying CLI process. |
+| `/session` | Show session info — file path, token usage, and cost. |
+
+### Session history
+
+| Command | Description |
+|---------|-------------|
+| `/tree` | Open tree-based session navigator. Browse all branches, jump to any point in the conversation, and optionally summarize the branch you're leaving. See [Sessions & Context](/PizzaPi/features/sessions/) for details. |
+| `/fork` | Fork the current session into a new session file. Opens a selector to choose a point — history is copied up to that point into a new, independent session. |
 
 <Aside type="tip">
   `/resume` keeps the picker open so you can browse and filter sessions interactively. Select a session with <kbd>Enter</kbd> or click/tap it.
@@ -66,8 +74,9 @@ If a sub-command requires an argument (like `/mcp disable`), selecting it fills 
 
 | Command | Description |
 |---------|-------------|
-| `/compact [instructions]` | Compact the conversation context. Optionally pass custom instructions to guide summarization, e.g. `/compact focus on the auth module`. |
+| `/compact [instructions]` | Compact the conversation context. Optionally pass custom instructions to guide summarization, e.g. `/compact focus on the auth module`. See [Sessions & Context](/PizzaPi/features/sessions/#compaction) for how compaction works. |
 | `/plan` | Toggle plan mode. In plan mode, the agent explores and plans without making changes (read-only). |
+| `/reload` | Reload keybindings, extensions, skills, prompt templates, and context files without restarting. |
 
 ### Session display
 
@@ -75,6 +84,15 @@ If a sub-command requires an argument (like `/mcp disable`), selecting it fills 
 |---------|-------------|
 | `/name <name>` | Set a display name for the current session, e.g. `/name auth-refactor`. |
 | `/copy` | Copy the last assistant message to your clipboard. |
+| `/export [file]` | Export the current session to an HTML file. |
+| `/share` | Upload as a private GitHub gist with a shareable HTML link. |
+
+### Authentication
+
+| Command | Description |
+|---------|-------------|
+| `/login` | Authenticate with a subscription provider (Claude Pro/Max, ChatGPT Plus/Pro, GitHub Copilot, Google Gemini). Opens an OAuth flow in your browser. See [Providers & Models](/PizzaPi/features/providers-and-models/) for details. |
+| `/logout` | Clear stored credentials for a provider. |
 
 ### Introspection
 
@@ -132,12 +150,19 @@ Prompt templates from your configuration appear in the **Prompts** group. Select
 ```
 /new                          # Start a fresh session
 /resume auth                  # Find and resume a session matching "auth"
+/tree                         # Browse session history tree
+/fork                         # Fork session into new file
 /compact focus on API routes  # Compact context with custom instructions
 /name deploy-fix              # Name the current session
+/login                        # Authenticate with a subscription provider
+/model                        # Switch to a different model
+/effort                       # Cycle to the next reasoning effort level
+/plan                         # Toggle read-only plan mode
+/export report.html           # Export session as HTML
+/share                        # Upload as private gist
+/copy                         # Copy last response to clipboard
 /mcp status                   # Check MCP server health
 /mcp disable filesystem       # Disable the "filesystem" MCP server
 /agents reviewer              # Start a session as the "reviewer" agent
-/effort                       # Cycle to the next reasoning effort level
-/plan                         # Toggle read-only plan mode
-/copy                         # Copy last response to clipboard
+/reload                       # Reload extensions, skills, prompts
 ```


### PR DESCRIPTION
## Summary
Adds comprehensive documentation pages for three core pi features that previously lacked dedicated docs.

## New Pages
- **Providers &amp; Models** (301 lines) — 20+ AI providers, OAuth, API keys, auth file formats, credential resolution
- **Sessions** (218 lines) — session basics, branching, forking, compaction
- **Pi Packages** (176 lines) — `pi install`, `pi list`, `pi update`, package sources, filtering

## Other Changes
- Astro config sidebar entries for all 3 new pages
- Cross-links from configuration docs
- Updated slash commands reference with missing commands

## Verification
- Docs build: 45 pages, no broken links, clean exit