### PR TITLE
fix: Use HEAD request instead of full blob download for attachment size

### DIFF
--- a/packages/ui/src/components/session-viewer/header-badge.tsx
+++ b/packages/ui/src/components/session-viewer/header-badge.tsx
@@ -84,10 +84,15 @@ export function ComposerAttachmentMeta({
       setSizeLabel("");
       return;
     }
-    fetch(url)
-      .then((res) => res.blob())
-      .then((blob) => {
-        if (!cancelled) setSizeLabel(formatFileSize(blob.size));
+    fetch(url, { method: "HEAD" })
+      .then((res) => {
+        const contentLength = res.headers.get("Content-Length");
+        if (contentLength != null) return parseInt(contentLength, 10);
+        // Fall back to full blob download if Content-Length is unavailable
+        return fetch(url).then((r) => r.blob()).then((b) => b.size);
+      })
+      .then((size) => {
+        if (!cancelled) setSizeLabel(formatFileSize(size));
       })
       .catch(() => {
         if (!cancelled) setSizeLabel("");


### PR DESCRIPTION
## Summary
`ComposerAttachmentMeta` was fetching the entire blob into memory just to display its file size. Switched to a HEAD request with Content-Length, falling back to blob download when Content-Length is unavailable.

## Change
- `packages/ui/src/components/session-viewer/header-badge.tsx`: `fetch(url)` → `fetch(url, { method: 'HEAD' })` with Content-Length header read + blob fallback

## Verification
- ✅ `bun run typecheck` clean
- ✅ `bun test packages/ui` — all passing