### PR TITLE
fix: Remove dead listener_config_changed event emission

### DIFF
--- a/packages/server/src/routes/runners.test.ts
+++ b/packages/server/src/routes/runners.test.ts
@@ -156,8 +156,6 @@ describe("runner trigger listener routes", () => {
     });
 
     test("PUT updates one listener by id", async () => {
-        const runnerEmit = mock(() => {});
-        mockGetLocalRunnerSocket.mockReturnValue({ emit: runnerEmit } as any);
         mockUpdateRunnerTriggerListener.mockReturnValue(Promise.resolve({ updated: true, listenerId: "listener-123", triggerType: "svc:event" }));
 
         const [req, url] = makeReq("PUT", "/api/runners/runner-A/trigger-listeners/listener-123", {
@@ -169,10 +167,7 @@ describe("runner trigger listener routes", () => {
         expect(body.ok).toBe(true);
         expect(body.listenerId).toBe("listener-123");
         expect(body.triggerType).toBe("svc:event");
-        expect(runnerEmit).toHaveBeenCalledWith("listener_config_changed", expect.objectContaining({
-            listenerId: "listener-123",
-            triggerType: "svc:event",
-        }));
+
     });
 
     test("DELETE removes one listener by id", async () => {

--- a/packages/server/src/routes/runners.ts
+++ b/packages/server/src/routes/runners.ts
@@ -589,17 +589,7 @@ export const handleRunnersRoute: RouteHandler = async (req, url) => {
 
             const triggerType = updated.triggerType ?? target;
             const listenerId = updated.listenerId ?? (!target.includes(":") ? target : undefined);
-            const runnerSocket = getLocalRunnerSocket(runnerId);
-            if (runnerSocket) {
-                runnerSocket.emit("listener_config_changed" as any, {
-                    ...(listenerId ? { listenerId } : {}),
-                    triggerType,
-                    params: params ?? {},
-                    prompt: typeof body.prompt === "string" ? body.prompt : undefined,
-                    cwd: typeof body.cwd === "string" ? body.cwd : undefined,
-                    model,
-                });
-            }
+
             if (listenerId) {
                 await emitTriggerSubscriptionDelta(runnerId, {
                     action: "update",


### PR DESCRIPTION
## Summary
Removes dead code: the `listener_config_changed` Socket.IO event was emitted in runners.ts but nothing anywhere in the repo subscribed to it.

## Changes
- `packages/server/src/routes/runners.ts`: Removed emission block (11 lines)
- `packages/server/src/routes/runners.test.ts`: Removed associated mock + assertion (6 lines)

## Verification
- ✅ `bun run typecheck` clean
- ✅ `bun test packages/server/src/routes/runners.test.ts` — 9/9 pass