### PR TITLE
fix: web_search returns readable text content for agents

### DIFF
--- a/packages/cli/src/extensions/ollama-web-tools.ts
+++ b/packages/cli/src/extensions/ollama-web-tools.ts
@@ -131,9 +131,17 @@ export function createOllamaWebTools(deps: OllamaWebToolDeps = {}): { webSearch:
             url: typeof r.url === "string" ? r.url : "",
           }))
           .filter((r: any) => r.url);
+
+        // Build readable text content so agents can see results inline
+        const textContent = webResults.length === 0
+          ? `No results found for "${query}".`
+          : webResults
+              .map((r: any, i: number) => `${i + 1}. **${r.title}**\n   ${r.url}`)
+              .join("\n\n");
+
         return {
           content: [
-            { type: "text" as const, text: "", _serverToolUse: { id: _toolCallId, name: "web_search", input: { query } } },
+            { type: "text" as const, text: textContent, _serverToolUse: { id: _toolCallId, name: "web_search", input: { query } } },
             { type: "text" as const, text: "", _webSearchResult: { tool_use_id: _toolCallId, content: webResults } },
           ],
           details: { type: "web_search", query, maxResults, resultCount: webResults.length },


### PR DESCRIPTION
## Problem

The `web_search` Ollama tool returned empty text content (`text: ""`) with search results only in the non-standard `_webSearchResult` property meant for UI rendering. This made search results invisible to agents — they saw empty tool output even though the Ollama Cloud API returned valid results (HTTP 200).

`web_fetch` worked correctly because it formats output as `JSON.stringify(output, null, 2)`.

## Fix

Format search results as numbered markdown text (`1. **Title**\n   URL`) in the first content block alongside the existing `_serverToolUse`/`_webSearchResult` fields.

## Before

```
content: [{ type: "text", text: "", _serverToolUse: {...} }]
→ agents see nothing
```

## After

```
content: [{ type: "text", text: "1. **Result Title**\n   https://...", _serverToolUse: {...} }]
→ agents see formatted results
```

## Verification

- `bun run typecheck` — clean
- `bun test packages/cli` — 1168 pass, 0 fail