### PR TITLE
fix(ui): render live tool output during tool_execution_update streaming

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -128,6 +128,7 @@ import {
   normalizeModelList,
   normalizeCommandList,
   mergeChunkSnapshot,
+  buildStreamingPartialMessage,
 } from "@/lib/message-helpers";
 import { evictLruIfNeeded, touchSessionCache, MAX_SESSION_UI_CACHE_SIZE } from "@/lib/session-ui-cache";
 import { removeMessagesByStableKey, replaceMessageByStableKey } from "@/lib/mcp-auth-banners";
@@ -2371,22 +2372,17 @@ export function App() {
           // state (at most once per frame), so the grouping code merges it with
           // the pending-tool card and the UI renders live output.
           //
-          // For tools that send structured details (e.g., subagent), wrap content
-          // with the details so the card component can render the full structure.
-          const details = partial?.details;
-          const syntheticContent = details
-            ? { content, details }
-            : content;
-          pendingToolStreamRef.current.set(toolCallId, {
-            role: "toolResult",
+          // The shape (content/details as sibling fields, not wrapped) is
+          // produced by buildStreamingPartialMessage — see that helper for the
+          // rationale and the message-helpers regression tests.
+          pendingToolStreamRef.current.set(
             toolCallId,
-            toolName,
-            content: syntheticContent,
-            isError: false,
-            // Mark as a streaming partial so deduplication logic does not
-            // treat it as a terminal tool result (the tool is still in-flight).
-            isStreamingPartial: true,
-          });
+            buildStreamingPartialMessage({
+              toolCallId,
+              toolName,
+              partialResult: partial,
+            }),
+          );
           scheduleToolStreamFlush();
         }
       }

--- a/packages/ui/src/lib/message-helpers.test.ts
+++ b/packages/ui/src/lib/message-helpers.test.ts
@@ -9,7 +9,9 @@ import {
   normalizeModelList,
   normalizeCommandList,
   mergeChunkSnapshot,
+  buildStreamingPartialMessage,
 } from "./message-helpers";
+import { extractTextFromToolContent, hasVisibleContent } from "@/components/session-viewer/utils";
 import type { RelayMessage } from "@/components/session-viewer/types";
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -535,5 +537,94 @@ describe("mergeChunkSnapshot", () => {
     // Storing finalMessages directly in the cache would silently drop them.
     expect(finalMessages.find((m) => m.key === "mcp_startup:1700000000000")).toBeUndefined();
     expect(finalMessages.find((m) => m.key === "trigger:abc123")).toBeUndefined();
+  });
+});
+
+describe("buildStreamingPartialMessage", () => {
+  // Regression test for live tool output (e.g. bash) appearing only at end of
+  // command instead of streaming as `tool_execution_update` events arrive.
+  //
+  // Symptom: Terminal pane in the BashToolCard showed only a blinking cursor
+  // until `tool_execution_end` landed, even though the WS frames were arriving
+  // every ~500ms.
+  //
+  // Root cause: the synthetic streaming-partial RelayMessage built from each
+  // `tool_execution_update` was wrapping `partialResult.content` and
+  // `partialResult.details` together inside the message's `content` field as
+  // `{ content, details }`. Because `extractTextFromToolContent` only unwraps
+  // an object's `.content` when it's a string (not an array), this returned
+  // null and the Terminal rendered an empty string.
+  //
+  // The shape produced here MUST match the final `message_end` shape:
+  // `content` and `details` as separate sibling fields on the RelayMessage.
+  test("places content and details as sibling fields, not wrapped inside content", () => {
+    const partialResult = {
+      content: [{ type: "text", text: "line 1\nline 2\nline 3" }],
+      details: { fullOutputPath: "/tmp/bash-out-abc.log" },
+    };
+
+    const msg = buildStreamingPartialMessage({
+      toolCallId: "toolu_01abc",
+      toolName: "bash",
+      partialResult,
+    });
+
+    expect(msg.role).toBe("toolResult");
+    expect(msg.toolCallId).toBe("toolu_01abc");
+    expect(msg.toolName).toBe("bash");
+    expect(msg.isStreamingPartial).toBe(true);
+    expect(msg.isError).toBe(false);
+
+    // Critical: content is the raw block array, NOT a wrapper object.
+    expect(Array.isArray(msg.content)).toBe(true);
+    expect(msg.content).toEqual(partialResult.content);
+
+    // details is a sibling field on the RelayMessage.
+    expect(msg.details).toEqual(partialResult.details);
+
+    // The text must be extractable by the same function the BashToolCard /
+    // Terminal use; otherwise the pane renders empty during streaming.
+    expect(extractTextFromToolContent(msg.content)).toBe("line 1\nline 2\nline 3");
+    expect(hasVisibleContent(msg.content)).toBe(true);
+  });
+
+  test("derives a stable key from toolCallId so subsequent partials upsert in place", () => {
+    const first = buildStreamingPartialMessage({
+      toolCallId: "toolu_01abc",
+      toolName: "bash",
+      partialResult: { content: [{ type: "text", text: "line 1\n" }], details: {} },
+    });
+    const second = buildStreamingPartialMessage({
+      toolCallId: "toolu_01abc",
+      toolName: "bash",
+      partialResult: { content: [{ type: "text", text: "line 1\nline 2\n" }], details: {} },
+    });
+
+    expect(first.key).toBe("tool-call:toolu_01abc");
+    expect(second.key).toBe(first.key);
+  });
+
+  test("handles a partialResult without details (no wrapper drift)", () => {
+    const msg = buildStreamingPartialMessage({
+      toolCallId: "tc1",
+      toolName: "bash",
+      partialResult: { content: [{ type: "text", text: "hello" }] },
+    });
+
+    expect(msg.content).toEqual([{ type: "text", text: "hello" }]);
+    expect(msg.details).toBeUndefined();
+    expect(extractTextFromToolContent(msg.content)).toBe("hello");
+  });
+
+  test("tolerates a non-object partialResult without throwing", () => {
+    const msg = buildStreamingPartialMessage({
+      toolCallId: "tc1",
+      toolName: "bash",
+      partialResult: undefined,
+    });
+
+    expect(msg.content).toBeUndefined();
+    expect(msg.details).toBeUndefined();
+    expect(msg.isStreamingPartial).toBe(true);
   });
 });

--- a/packages/ui/src/lib/message-helpers.ts
+++ b/packages/ui/src/lib/message-helpers.ts
@@ -161,6 +161,48 @@ export function mergeChunkSnapshot(
   return preserved.length > 0 ? [...snapshotMessages, ...preserved] : snapshotMessages;
 }
 
+/**
+ * Build a synthetic streaming-partial `RelayMessage` from a `tool_execution_update`
+ * event's `partialResult`. The shape produced here MUST match the shape of the
+ * final tool result delivered via `message_end` so the rendering pipeline
+ * (extractTextFromToolContent / hasVisibleContent / BashToolCard) handles it
+ * identically:
+ *
+ *   - `content`  — the raw content array/string from `partialResult.content`
+ *                  (NOT wrapped in `{ content, details }`)
+ *   - `details`  — the structured details object as a sibling field
+ *
+ * Bundling `{ content, details }` into the `content` field would hide the
+ * partial text from `extractTextFromToolContent` (which only unwraps an
+ * object's `.content` when it is a string, not an array), causing the Terminal
+ * pane in `BashToolCard` to render an empty pane until `tool_execution_end`
+ * delivers the final result — i.e. no live streaming output.
+ */
+export function buildStreamingPartialMessage(input: {
+  toolCallId: string;
+  toolName: string;
+  partialResult: unknown;
+}): RelayMessage {
+  const partial =
+    input.partialResult && typeof input.partialResult === "object"
+      ? (input.partialResult as Record<string, unknown>)
+      : null;
+  const content = partial ? partial.content : undefined;
+  const details = partial ? partial.details : undefined;
+  return {
+    key: `tool-call:${input.toolCallId}`,
+    role: "toolResult",
+    toolCallId: input.toolCallId,
+    toolName: input.toolName,
+    content,
+    details,
+    isError: false,
+    // Mark as a streaming partial so deduplication logic does not treat it as
+    // a terminal tool result (the tool is still in-flight).
+    isStreamingPartial: true,
+  };
+}
+
 export function normalizeMessages(rawMessages: unknown[], keyOffset = 0): RelayMessage[] {
   const all = rawMessages
     .map((m, i) => toRelayMessage(m, `snapshot-${keyOffset + i}`))


### PR DESCRIPTION
## Summary

Live output from streaming tools (e.g. `bash` commands that spawn long-running child processes) was not appearing in the Terminal pane of the tool card. The pane showed only a blinking cursor for the entire duration of the command, and the full output flushed all at once when the command finished.

`tool_execution_update` events were arriving over the WebSocket on time (verified end-to-end: `bash -> onUpdate -> agent_loop -> forwardEvent -> relay -> viewer`); the regression was purely on the rendering side.

## Repro

```bash
for i in $(seq 1 20); do echo "line $i"; sleep 0.5; done
```

In DevTools → Network → WS, ~20 `tool_execution_update` frames arrive every 500ms. The UI shows nothing in the bash card's Terminal output until the final `tool_execution_end` lands.

## Root cause

The `tool_execution_update` handler in `App.tsx` was constructing the synthetic streaming-partial `RelayMessage` like this:

```ts
const content = partial?.content;          // [{ type: "text", text: "..." }]
const details = partial?.details;          // { truncation, fullOutputPath, ... }
const syntheticContent = details
  ? { content, details }                   // ← wraps both into a single blob
  : content;
pendingToolStreamRef.current.set(toolCallId, {
  role: "toolResult",
  toolCallId,
  toolName,
  content: syntheticContent,               // ← stored in `content`
  ...
});
```

The bash tool ([`pi-coding-agent` `dist/core/tools/bash.js:236`](https://github.com/badlogic/pi-mono)) always emits `details` (truncation info / `fullOutputPath`), so `syntheticContent` was always the wrapper object — and the message's `content` field ended up as `{ content: [...], details: {...} }`.

`BashToolCard` (`tool-rendering.tsx:423`) renders the Terminal via:

```ts
const outputText = hasOutput ? extractTextFromToolContent(content) : null;
return <Terminal output={outputText ?? ""} ... />;
```

`extractTextFromToolContent` (`utils.ts:66`) handles strings and arrays of `{type,text}` blocks, but for a plain object it only unwraps `.content` when **`.content` is a string**:

```ts
if (content && typeof content === "object") {
  const obj = content as Record<string, unknown>;
  if (typeof obj.text === "string") return obj.text;
  if (typeof obj.content === "string") return obj.content;   // array → falls through
}
return null;
```

So the partial's text was never extractable, and the Terminal rendered an empty string until the *final* tool result arrived with the correct unwrapped shape via `message_end`.

## Fix

`RelayMessage` already carries `content` and `details` as **separate sibling fields** (`types.ts:24`):

```ts
export interface RelayMessage {
  ...
  content?: unknown;
  details?: unknown;
  ...
}
```

The existing grouping regression test (`grouping.test.ts:548`) also models streaming partials with `content` as the raw block array directly — i.e. the runtime was diverging from its own test contract.

This PR aligns the runtime with that contract by extracting a small pure helper, `buildStreamingPartialMessage`, that places `content` and `details` as siblings on the synthetic `RelayMessage` (matching the shape of the final `message_end`). `App.tsx` now calls the helper instead of building the message inline, which keeps the contract documented and lets us cover the bug in `message-helpers.test.ts`:

- `content`/`details` placed as siblings (not wrapped) so `extractTextFromToolContent` can pull text out of the partial
- `extractTextFromToolContent` returns the partial text and `hasVisibleContent` reports `true`
- Stable `tool-call:${toolCallId}` key so successive partials upsert in place across RAF flushes
- Graceful handling when `details` is absent or `partialResult` is not an object

## Testing

- `bun test packages/ui/src/lib/message-helpers.test.ts` — 66 pass (4 new)
- `bun test packages/ui` — 974 pass, 1 skip, 0 fail
- `cd packages/ui && bun run build` — clean Vite build
- Manual: live `for i in $(seq 1 20); do echo "line $i"; sleep 0.5; done` now streams into the Terminal pane line-by-line as frames arrive, instead of all-at-once at the end.
