### PR TITLE
feat: @VARIABLE@ substitution for MCP servers, hooks, and runner services

### DIFF
--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { toggleMcpServer, loadConfig, _setGlobalConfigDir, resolveSandboxConfig, validateSandboxOverride, saveGlobalConfig, applyProviderSettingsEnv, isProjectMcpTrusted, type PizzaPiConfig } from "./config.js";
+import { toggleMcpServer, loadConfig, _setGlobalConfigDir, resolveSandboxConfig, validateSandboxOverride, saveGlobalConfig, applyProviderSettingsEnv, isProjectMcpTrusted, expandVars, expandVarsDeep, resolvePizzaPiVar, PIZZAPI_VARS_HELP, type PizzaPiConfig } from "./config.js";
 
 describe("toggleMcpServer", () => {
   let tempDir: string;
@@ -996,5 +996,155 @@ describe("loadConfig transport field blocking", () => {
     expect(config.mcpTimeout).toBe(9999);
     // Project apiKey loads with a warning (not stripped) when global has no apiKey
     expect(config.apiKey).toBe("project-key");
+  });
+});
+
+describe("expandVars", () => {
+  const originalEnv = { ...process.env };
+  const originalCwd = process.cwd;
+
+  beforeEach(() => {
+    process.env.PIZZAPI_SESSION_ID = "test-session-abc";
+    process.env.PIZZAPI_PROJECT_DIR = "/custom/project";
+    process.env.USER = "testuser";
+    process.env.USERNAME = "testuser-win";
+  });
+
+  afterEach(() => {
+    process.env.PIZZAPI_SESSION_ID = originalEnv.PIZZAPI_SESSION_ID;
+    process.env.PIZZAPI_PROJECT_DIR = originalEnv.PIZZAPI_PROJECT_DIR;
+    process.env.USER = originalEnv.USER;
+    process.env.USERNAME = originalEnv.USERNAME;
+  });
+
+  describe("resolvePizzaPiVar", () => {
+    test("resolves PWD", () => {
+      expect(resolvePizzaPiVar("PWD")).toBe(process.cwd());
+    });
+
+    test("resolves SESSION_ID from env", () => {
+      expect(resolvePizzaPiVar("SESSION_ID")).toBe("test-session-abc");
+    });
+
+    test("resolves SESSION_ID to empty when not set", () => {
+      delete process.env.PIZZAPI_SESSION_ID;
+      expect(resolvePizzaPiVar("SESSION_ID")).toBe("");
+    });
+
+    test("resolves HOME", () => {
+      expect(resolvePizzaPiVar("HOME")).toBe(require("os").homedir());
+    });
+
+    test("resolves USER from env", () => {
+      expect(resolvePizzaPiVar("USER")).toBe("testuser");
+    });
+
+    test("resolves USER to empty when not set", () => {
+      delete process.env.USER;
+      delete process.env.USERNAME;
+      expect(resolvePizzaPiVar("USER")).toBe("");
+    });
+
+    test("resolves PROJECT_DIR from env", () => {
+      expect(resolvePizzaPiVar("PROJECT_DIR")).toBe("/custom/project");
+    });
+
+    test("resolves PROJECT_DIR to cwd fallback when not set", () => {
+      delete process.env.PIZZAPI_PROJECT_DIR;
+      expect(resolvePizzaPiVar("PROJECT_DIR")).toBe(process.cwd());
+    });
+
+    test("returns empty string for unknown variable", () => {
+      expect(resolvePizzaPiVar("UNKNOWN")).toBe("");
+    });
+  });
+
+  describe("expandVars", () => {
+    test("replaces a single variable", () => {
+      const result = expandVars("@PWD@/some/path");
+      expect(result).toBe(`${process.cwd()}/some/path`);
+    });
+
+    test("replaces multiple variables in one string", () => {
+      const result = expandVars("session=@SESSION_ID@, pwd=@PWD@");
+      expect(result).toBe(`session=test-session-abc, pwd=${process.cwd()}`);
+    });
+
+    test("leaves unknown variables untouched", () => {
+      const result = expandVars("@UNKNOWN@/path");
+      expect(result).toBe("@UNKNOWN@/path");
+    });
+
+    test("returns input unchanged if no variables", () => {
+      const result = expandVars("just a plain string");
+      expect(result).toBe("just a plain string");
+    });
+
+    test("handles empty string", () => {
+      const result = expandVars("");
+      expect(result).toBe("");
+    });
+  });
+
+  describe("expandVarsDeep", () => {
+    test("expands a plain string", () => {
+      const result = expandVarsDeep("session: @SESSION_ID@");
+      expect(result).toBe("session: test-session-abc");
+    });
+
+    test("expands an array of strings", () => {
+      const result = expandVarsDeep(["@PWD@", "@SESSION_ID@", "untouched"]);
+      expect(result).toEqual([process.cwd(), "test-session-abc", "untouched"]);
+    });
+
+    test("expands an object's string values", () => {
+      const result = expandVarsDeep({
+        url: "@PWD@/api",
+        token: "bearer-@SESSION_ID@",
+        count: 42,
+        flag: true,
+      });
+      expect(result).toEqual({
+        url: `${process.cwd()}/api`,
+        token: "bearer-test-session-abc",
+        count: 42,
+        flag: true,
+      });
+    });
+
+    test("expands nested objects", () => {
+      const result = expandVarsDeep({
+        server: {
+          url: "@PWD@/mcp",
+          headers: { "X-Session": "@SESSION_ID@" },
+        },
+      });
+      expect(result).toEqual({
+        server: {
+          url: `${process.cwd()}/mcp`,
+          headers: { "X-Session": "test-session-abc" },
+        },
+      });
+    });
+
+    test("passes through non-string scalars unchanged", () => {
+      const result = expandVarsDeep(42);
+      expect(result).toBe(42);
+    });
+
+    test("passes through null unchanged", () => {
+      const result = expandVarsDeep(null);
+      expect(result).toBe(null);
+    });
+  });
+
+  describe("PIZZAPI_VARS_HELP", () => {
+    test("contains all variable names", () => {
+      expect(PIZZAPI_VARS_HELP).toContain("@PWD@");
+      expect(PIZZAPI_VARS_HELP).toContain("@SESSION_ID@");
+      expect(PIZZAPI_VARS_HELP).toContain("@HOME@");
+      expect(PIZZAPI_VARS_HELP).toContain("@USER@");
+      expect(PIZZAPI_VARS_HELP).toContain("@PROJECT_DIR@");
+    });
   });
 });

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -308,6 +308,68 @@ export function defaultAgentDir(): string {
     return join(homedir(), ".pizzapi");
 }
 
+// ── Session info variable substitution ─────────────────────────────────────────
+
+const VARIABLE_RE = /@(PWD|SESSION_ID|HOME|USER|PROJECT_DIR)@/g;
+
+/**
+ * Available variable names and the values they resolve to.
+ * @internal
+ */
+export function resolvePizzaPiVar(name: string): string {
+    switch (name) {
+        case "PWD":
+            return process.cwd();
+        case "SESSION_ID":
+            return process.env.PIZZAPI_SESSION_ID ?? "";
+        case "HOME":
+            return homedir();
+        case "USER":
+            return process.env.USER ?? process.env.USERNAME ?? "";
+        case "PROJECT_DIR":
+            return process.env.PIZZAPI_PROJECT_DIR ?? process.cwd();
+        default:
+            return "";
+    }
+}
+
+/**
+ * Substitutes `@VARNAME@` tokens in a single string with their current values.
+ * Unknown variables are left as-is (not replaced).
+ */
+export function expandVars(value: string): string {
+    return value.replace(VARIABLE_RE, (_, name) => resolvePizzaPiVar(name));
+}
+
+/**
+ * Recursively expand `@VARNAME@` tokens in a config value.
+ * For objects, walks all string values. For arrays, walks all string elements.
+ * Scalars returned as-is.
+ */
+export function expandVarsDeep<T>(value: T): T {
+    if (typeof value === "string") {
+        return expandVars(value) as T;
+    }
+    if (Array.isArray(value)) {
+        return value.map((item) => expandVarsDeep(item)) as T;
+    }
+    if (value && typeof value === "object") {
+        const result: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+            result[k] = expandVarsDeep(v);
+        }
+        return result as T;
+    }
+    return value;
+}
+
+/**
+ * Human-readable list of available variables for error messages and docs.
+ * @internal
+ */
+export const PIZZAPI_VARS_HELP =
+    "Available variables: @PWD@, @SESSION_ID@, @HOME@, @USER@, @PROJECT_DIR@";
+
 // ── Changelog path ────────────────────────────────────────────────────────────
 
 /**

--- a/packages/cli/src/extensions/hooks/runner.ts
+++ b/packages/cli/src/extensions/hooks/runner.ts
@@ -2,6 +2,7 @@ import { execSync } from "child_process";
 import { existsSync } from "fs";
 import { join } from "path";
 import type { HookEntry } from "../../config.js";
+import { expandVars } from "../../config.js";
 import type { HookOutput, HookResult } from "./types.js";
 
 /**
@@ -115,7 +116,7 @@ export async function runHook(
     let timer: ReturnType<typeof setTimeout> | undefined;
 
     try {
-        const proc = spawnFn([shell, flag, entry.command], {
+        const proc = spawnFn([shell, flag, expandVars(entry.command)], {
             cwd,
             stdin: "pipe",
             stdout: "pipe",

--- a/packages/cli/src/extensions/mcp/registry.ts
+++ b/packages/cli/src/extensions/mcp/registry.ts
@@ -9,7 +9,7 @@
  *  - Registering MCP tools with the pi tool provider
  */
 
-import { type PizzaPiConfig } from "../../config.js";
+import { type PizzaPiConfig, expandVars, expandVarsDeep } from "../../config.js";
 import { PizzaPiOAuthProvider, type RelayContext } from "../mcp-oauth.js";
 import { createLogger, isSandboxActive, getResolvedConfig } from "@pizzapi/tools";
 import { createStdioMcpClient } from "./transport-stdio.js";
@@ -185,22 +185,26 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
       }
     } else if (s.transport === "http") {
       if (!isMcpDomainAllowed(s.url, s.name)) continue;
+      const url = expandVars(s.url);
+      const headers = s.headers ? expandVarsDeep(s.headers) as Record<string, string> : undefined;
       clients.push(
         createHttpMcpClient({
           name: s.name,
-          url: s.url,
-          headers: s.headers,
+          url,
+          headers,
         }),
       );
     } else if (s.transport === "streamable") {
       if (!isMcpDomainAllowed(s.url, s.name)) continue;
+      const url = expandVars(s.url);
+      const headers = s.headers ? expandVarsDeep(s.headers) as Record<string, string> : undefined;
       // Per-server clientId/clientSecret are a pair: if per-server clientId is set,
       // use its paired secret (even if undefined) — don't leak the global secret
       // to a server with a different client identity.
       const sClientId = s.oauthClientId ?? oauthClientId;
       const sClientSecret = s.oauthClientId !== undefined ? s.oauthClientSecret : oauthClientSecret;
       const provider = new PizzaPiOAuthProvider({
-        serverUrl: s.url,
+        serverUrl: url,
         serverName: s.name,
         clientName: s.oauthClientName || oauthClientName,
         clientId: sClientId,
@@ -247,8 +251,12 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
     if ("url" in def && typeof (def as any).url === "string") {
       const d = def as { url: string; transport?: string; type?: string; headers?: Record<string, string>; oauthClientName?: string; oauthClientId?: string; oauthClientSecret?: string; oauthCallbackPort?: number };
 
+      // Expand @VARNAME@ tokens in url and headers
+      const url = expandVars(d.url);
+      const headers = d.headers ? expandVarsDeep(d.headers) as Record<string, string> : undefined;
+
       // Domain gating for URL-based MCP servers
-      if (!isMcpDomainAllowed(d.url, name)) continue;
+      if (!isMcpDomainAllowed(url, name)) continue;
 
       // Determine transport mode:
       //  - "transport" field (our format): "streamable" → streamable, else plain HTTP
@@ -262,7 +270,7 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
         const dClientId = d.oauthClientId ?? oauthClientId;
         const dClientSecret = d.oauthClientId !== undefined ? d.oauthClientSecret : oauthClientSecret;
         const provider = new PizzaPiOAuthProvider({
-          serverUrl: d.url,
+          serverUrl: url,
           serverName: name,
           clientName: d.oauthClientName || oauthClientName,
           clientId: dClientId,
@@ -273,12 +281,12 @@ export async function createMcpClientsFromConfig(config: PizzaPiConfig & McpConf
         activeOAuthProviders.push(provider);
         clients.push(createStreamableMcpClient({
           name,
-          url: d.url,
-          headers: d.headers,
+          url,
+          headers,
           oauthProvider: provider,
         }));
       } else {
-        clients.push(createHttpMcpClient({ name, url: d.url, headers: d.headers }));
+        clients.push(createHttpMcpClient({ name, url, headers }));
       }
     }
   }

--- a/packages/cli/src/extensions/mcp/transport-stdio.ts
+++ b/packages/cli/src/extensions/mcp/transport-stdio.ts
@@ -6,7 +6,7 @@
  */
 
 import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
-import { expandHome } from "../../config.js";
+import { expandHome, expandVars, expandVarsDeep } from "../../config.js";
 import {
   MCP_PROTOCOL_VERSION,
   MCP_SUPPORTED_VERSIONS,
@@ -24,7 +24,12 @@ export async function createStdioMcpClient(opts: {
   env?: Record<string, string>;
   cwd?: string;
 }): Promise<McpClient> {
-  const mergedEnv = { ...process.env, ...(opts.env ?? {}) };
+  // Expand @VARNAME@ tokens in command, args, cwd, and env values
+  const command = expandVars(expandHome(opts.command));
+  const args = (opts.args ?? []).map((a) => expandVars(expandHome(a)));
+  const cwd = opts.cwd ? expandVars(expandHome(opts.cwd)) : undefined;
+  const env = opts.env ? expandVarsDeep({ ...opts.env }) as Record<string, string> : undefined;
+  const mergedEnv = { ...process.env, ...(env ?? {}) };
 
   // STDIO MCP servers are trusted local processes spawned from the user's
   // config — NOT agent-generated commands. We do NOT wrap them with the
@@ -34,9 +39,7 @@ export async function createStdioMcpClient(opts: {
   // Expand ~ in command, args, and cwd so paths resolve correctly even when
   // launched by macOS launchd (LaunchAgent/LaunchDaemon) where shell tilde
   // expansion doesn't occur.
-  const command = expandHome(opts.command);
-  const args = (opts.args ?? []).map(expandHome);
-  const cwd = opts.cwd ? expandHome(opts.cwd) : undefined;
+
 
   const child: ChildProcessWithoutNullStreams = spawn(command, args, {
     stdio: "pipe",

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -8,6 +8,8 @@ import { ServiceRegistry } from "./service-handler.js";
 import { TerminalService } from "./services/terminal-service.js";
 import { FileExplorerService } from "./services/file-explorer-service.js";
 import { GitService } from "./services/git-service.js";
+// Resolves @VARIABLE@ tokens used in service panel requires
+import { resolvePizzaPiVar } from "../config/io.js";
 import { TunnelService } from "./services/tunnel-service.js";
 import { TimeService, TIME_TRIGGER_DEFS, TIME_SIGIL_DEFS } from "./services/time-service.js";
 import { discoverServices } from "./service-loader.js";
@@ -61,6 +63,25 @@ import type { UsageRange } from "../usage/types.js";
 
 // Re-export migration from shared module — used on daemon startup
 import { migrateAgentDir } from "../migrations.js";
+
+/** Map variable name (e.g. "PROJECT_DIR") to camelCase query param key. */
+const VAR_TO_PARAM: Record<string, string> = {
+    PWD: "pwd",
+    SESSION_ID: "sessionId",
+    HOME: "home",
+    USER: "user",
+    PROJECT_DIR: "projectDir",
+};
+
+/** Resolve a requires[] array into a panelParams record for the UI. */
+function resolveRequires(requires: string[]): Record<string, string> {
+    const params: Record<string, string> = {};
+    for (const name of requires) {
+        const key = VAR_TO_PARAM[name];
+        if (key) params[key] = resolvePizzaPiVar(name);
+    }
+    return params;
+}
 
 /**
  * Read the `relayUrl` from ~/.pizzapi/config.json, returning undefined
@@ -332,6 +353,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
              * Defaults to true for plugin-provided services with a panel manifest.
              */
             hasPanel?: boolean;
+            /**
+             * Variable names the panel requires. The UI resolves these and appends
+             * them as query params to the iframe src.
+             */
+            requires?: string[];
         };
         const panelEntries = new Map<string, PanelEntry>();
 
@@ -356,8 +382,16 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         /** Emit service_announce with current service IDs, panel metadata, and trigger defs. */
         const emitServiceAnnounce = () => {
             const allServiceIds = registry.getAll().map((s) => s.id);
+            // Map panel entries to ServicePanelInfo, resolving requires → panelParams
             const panels = Array.from(panelEntries.values())
-                .filter((p): p is PanelEntry & { port: number } => p.port != null && p.hasPanel !== false);
+                .filter((p): p is PanelEntry & { port: number } => p.port != null && p.hasPanel !== false)
+                .map((p) => ({
+                    serviceId: p.serviceId,
+                    port: p.port,
+                    label: p.label,
+                    icon: p.icon,
+                    ...(p.requires ? { panelParams: resolveRequires(p.requires) } : {}),
+                }));
             // Collect all trigger defs and sigil defs across all services with manifests
             const allTriggerDefs: ServiceTriggerDef[] = [];
             const allSigilDefs: ServiceSigilDef[] = [];
@@ -409,6 +443,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                                 : {}),
                             ...(manifest.sigils && manifest.sigils.length > 0
                                 ? { sigils: manifest.sigils }
+                                : {}),
+                            ...(manifest.panel?.requires
+                                ? { requires: manifest.panel.requires }
                                 : {}),
                         });
                     }

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -18,6 +18,7 @@ import { homedir } from "node:os";
 import { basename, extname, join, resolve } from "node:path";
 import type { ServiceHandler } from "./service-handler.js";
 import type { JsonValue, ServiceTriggerDef, ServiceTriggerParamDef, ServiceSigilDef } from "@pizzapi/protocol";
+import { expandVars } from "../config/io.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -454,9 +455,9 @@ function parseServiceManifest(manifestPath: string): ServiceManifest {
         id: raw.id,
         label: raw.label,
         icon: typeof raw.icon === "string" ? raw.icon : "square",
-        entry: typeof raw.entry === "string" ? raw.entry : undefined,
+        entry: typeof raw.entry === "string" ? expandVars(raw.entry) : undefined,
         panel: raw.panel && typeof raw.panel === "object"
-            ? { dir: typeof raw.panel.dir === "string" ? raw.panel.dir : undefined }
+            ? { dir: typeof raw.panel.dir === "string" ? expandVars(raw.panel.dir) : undefined }
             : undefined,
         triggers: triggers.length > 0 ? triggers : undefined,
         sigils: sigils.length > 0 ? sigils : undefined,

--- a/packages/cli/src/runner/service-loader.ts
+++ b/packages/cli/src/runner/service-loader.ts
@@ -30,6 +30,8 @@ export interface ServiceManifest {
     entry?: string;
     panel?: {
         dir?: string;
+        /** Variable names the panel requires. UI resolves and passes as query params. */
+        requires?: string[];
     };
     /** Trigger types this service can emit. Declared in triggers.json or manifest.json. */
     triggers?: ServiceTriggerDef[];
@@ -436,6 +438,15 @@ function parseSigils(raw: unknown): ServiceSigilDef[] {
     return sigils;
 }
 
+/** Valid variable names for panel requires. */
+const VALID_REQUIRES = new Set(["PWD", "SESSION_ID", "HOME", "USER", "PROJECT_DIR"]);
+
+function parseRequires(raw: unknown): string[] | undefined {
+    if (!Array.isArray(raw)) return undefined;
+    const valid = raw.filter((v) => typeof v === "string" && VALID_REQUIRES.has(v)) as string[];
+    return valid.length > 0 ? [...new Set(valid)] : undefined;
+}
+
 function parseServiceManifest(manifestPath: string): ServiceManifest {
     const raw = JSON.parse(readFileSync(manifestPath, "utf-8"));
     if (!raw || typeof raw !== "object") {
@@ -457,7 +468,10 @@ function parseServiceManifest(manifestPath: string): ServiceManifest {
         icon: typeof raw.icon === "string" ? raw.icon : "square",
         entry: typeof raw.entry === "string" ? expandVars(raw.entry) : undefined,
         panel: raw.panel && typeof raw.panel === "object"
-            ? { dir: typeof raw.panel.dir === "string" ? expandVars(raw.panel.dir) : undefined }
+            ? {
+                dir: typeof raw.panel.dir === "string" ? expandVars(raw.panel.dir) : undefined,
+                requires: parseRequires(raw.panel.requires),
+            }
             : undefined,
         triggers: triggers.length > 0 ? triggers : undefined,
         sigils: sigils.length > 0 ? sigils : undefined,

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -80,6 +80,33 @@ Runner services are background processes on the runner daemon. They can:
 | `triggers` | No | `[]` | Array of trigger type definitions (see below). Can also live in `triggers.json`. |
 | `sigils` | No | `[]` | Array of sigil type definitions (see below). Can also live in `sigils.json`. |
 
+### Variable Substitution
+
+The `entry` and `panel.dir` fields support `@VARIABLE@` tokens that are expanded at load time. This lets services reference paths relative to the session, project, or home directory without hardcoding absolute paths.
+
+| Variable | Resolves to |
+|----------|-------------|
+| `@PWD@` | Current working directory |
+| `@SESSION_ID@` | Current session ID (`PIZZAPI_SESSION_ID` env var) |
+| `@HOME@` | User home directory (`$HOME`) |
+| `@USER@` | Current username (`$USER`) |
+| `@PROJECT_DIR@` | Project directory (`PIZZAPI_PROJECT_DIR` env var, falls back to cwd) |
+
+**Example — project-relative entry point:**
+
+```json
+{
+  "id": "project-watcher",
+  "label": "Project Watcher",
+  "entry": "@PROJECT_DIR@/scripts/watcher.ts",
+  "panel": {
+    "dir": "@HOME@/.pizzapi/services/project-watcher/panel"
+  }
+}
+```
+
+Unknown variables are left as-is (not replaced). These same variables are available across MCP server configs and hooks as well.
+
 ### Trigger Definitions
 
 Each entry in `triggers` declares a trigger type this service can emit:

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -34,7 +34,8 @@ Runner services are background processes on the runner daemon. They can:
   "icon": "activity",
   "entry": "./index.ts",
   "panel": {
-    "dir": "./panel"
+    "dir": "./panel",
+    "requires": ["PROJECT_DIR", "SESSION_ID"]
   },
   "triggers": [
     {
@@ -77,12 +78,15 @@ Runner services are background processes on the runner daemon. They can:
 | `icon` | No | `"square"` | [Lucide](https://lucide.dev/icons) icon name (kebab-case) |
 | `entry` | No | `./index.ts` | Service module path relative to folder |
 | `panel.dir` | No | `./panel` | Panel static files directory (omit if no panel) |
+| `panel.requires` | No | `[]` | Variable names the panel needs resolved as query params (e.g. `["PROJECT_DIR", "SESSION_ID"]`) |
 | `triggers` | No | `[]` | Array of trigger type definitions (see below). Can also live in `triggers.json`. |
 | `sigils` | No | `[]` | Array of sigil type definitions (see below). Can also live in `sigils.json`. |
 
 ### Variable Substitution
 
 The `entry` and `panel.dir` fields support `@VARIABLE@` tokens that are expanded at load time. This lets services reference paths relative to the session, project, or home directory without hardcoding absolute paths.
+
+Additionally, `panel.requires` declares which variables the panel needs at **runtime**. The daemon resolves these values and passes them as query parameters to the panel's iframe URL (e.g., `?projectDir=/path&sessionId=abc`). This is the recommended way to pass session context to panels — prefer it over `@VARIABLE@` in static file paths when the value changes per session.
 
 | Variable | Resolves to |
 |----------|-------------|

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -315,7 +315,15 @@ class MyService {
                 const url = new URL(req.url);
 
                 if (url.pathname.endsWith("/api/data")) {
-                    return Response.json({ hello: "world" }, {
+                    // Read panel context from query params (from panel.requires)
+                    const projectDir = url.searchParams.get("projectDir") || "unknown";
+                    const sessionId = url.searchParams.get("sessionId") || "unknown";
+
+                    return Response.json({
+                        hello: "world",
+                        projectDir,
+                        sessionId,
+                    }, {
                         headers: { "Access-Control-Allow-Origin": "*" },
                     });
                 }
@@ -417,6 +425,22 @@ The panel renders inside a 280px-tall iframe. Key constraints:
 - **Relative API URLs** — use `./api/data` (the tunnel proxy preserves the path)
 - **Polling** — use `setInterval` + `fetch` for live data (typically 3–5s)
 - **No external dependencies** — the iframe is sandboxed; CDN scripts may be blocked
+
+**Reading panel.requires query params** — if your manifest declares `panel.requires`, the UI appends them to the iframe URL as query params. Read them in the panel:
+
+```html
+<script>
+  // Values injected as query params from panel.requires
+  const params = new URLSearchParams(location.search);
+  const projectDir = params.get("projectDir"); // from requires: ["PROJECT_DIR"]
+  const sessionId = params.get("sessionId");   // from requires: ["SESSION_ID"]
+
+  // Pass them along to API calls so the backend also has context
+  fetch(`./api/state?${params.toString()}`)
+    .then(r => r.json())
+    .then(data => console.log(data));
+</script>
+```
 
 ## Services Without Panels
 

--- a/packages/protocol/src/shared.ts
+++ b/packages/protocol/src/shared.ts
@@ -136,6 +136,12 @@ export interface ServicePanelInfo {
   label: string;
   /** Lucide icon name (e.g. "activity", "cpu"). */
   icon: string;
+  /**
+   * Resolved key-value pairs for variables the panel requires.
+   * The daemon resolves variables declared in manifest panel.requires
+   * and passes the resolved values here. Keys are camelCase (e.g. "projectDir", "sessionId").
+   */
+  panelParams?: Record<string, string>;
 }
 
 // ── Service trigger types ─────────────────────────────────────────────────────

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -4256,7 +4256,7 @@ export function App() {
       const navParams = getServicePanelNavParams(serviceId);
       const content = staticDef
         ? <staticDef.component sessionId={effectiveSessionId} runnerId={activeSessionInfo?.runnerId ?? undefined} />
-        : <IframeServicePanel sessionId={effectiveSessionId} port={dynamicDef!.port} query={navParams?.query} fragment={navParams?.fragment} />;
+        : <IframeServicePanel sessionId={effectiveSessionId} port={dynamicDef!.port} query={navParams?.query} fragment={navParams?.fragment} panelParams={dynamicDef!.panelParams} cwd={activeSessionInfo?.cwd ?? undefined} />;
 
       tabs.push({
         id: serviceId,

--- a/packages/ui/src/components/RunnerServicesPanel.tsx
+++ b/packages/ui/src/components/RunnerServicesPanel.tsx
@@ -60,6 +60,7 @@ interface ServicePanel {
   port: number;
   label: string;
   icon: string;
+  panelParams?: Record<string, string>;
 }
 
 interface TriggerDef {

--- a/packages/ui/src/components/service-panels/IframeServicePanel.tsx
+++ b/packages/ui/src/components/service-panels/IframeServicePanel.tsx
@@ -25,12 +25,14 @@ export function IframeServicePanel({ sessionId, port, query, fragment, panelPara
     const src = useMemo(() => {
         let url = `/api/tunnel/${sessionId}/${port}/`;
         const params = new URLSearchParams();
-        // Panel requires params first
+        // Daemon-resolved panelParams first (HOME, USER, etc.)
         if (panelParams) {
             for (const [key, value] of Object.entries(panelParams)) {
                 params.set(key, value);
             }
         }
+        // Always include sessionId — UI has it, takes precedence over daemon-resolved
+        params.set("sessionId", sessionId);
         // Then existing query params from deep link (takes precedence)
         if (query) {
             const existing = new URLSearchParams(query);

--- a/packages/ui/src/components/service-panels/IframeServicePanel.tsx
+++ b/packages/ui/src/components/service-panels/IframeServicePanel.tsx
@@ -17,15 +17,32 @@ interface IframeServicePanelProps {
     query?: string;
     /** Hash fragment (without leading "#") forwarded from a deep link. */
     fragment?: string;
+    /** Resolved panelParams from service requires — appended as query params. */
+    panelParams?: Record<string, string>;
 }
 
-export function IframeServicePanel({ sessionId, port, query, fragment }: IframeServicePanelProps) {
+export function IframeServicePanel({ sessionId, port, query, fragment, panelParams }: IframeServicePanelProps) {
     const src = useMemo(() => {
         let url = `/api/tunnel/${sessionId}/${port}/`;
-        if (query) url += `?${query}`;
+        const params = new URLSearchParams();
+        // Panel requires params first
+        if (panelParams) {
+            for (const [key, value] of Object.entries(panelParams)) {
+                params.set(key, value);
+            }
+        }
+        // Then existing query params from deep link (takes precedence)
+        if (query) {
+            const existing = new URLSearchParams(query);
+            for (const [key, value] of existing) {
+                params.set(key, value);
+            }
+        }
+        const qs = params.toString();
+        if (qs) url += `?${qs}`;
         if (fragment) url += `#${fragment}`;
         return url;
-    }, [sessionId, port, query, fragment]);
+    }, [sessionId, port, query, fragment, panelParams]);
 
     return (
         <iframe

--- a/packages/ui/src/components/service-panels/IframeServicePanel.tsx
+++ b/packages/ui/src/components/service-panels/IframeServicePanel.tsx
@@ -19,9 +19,11 @@ interface IframeServicePanelProps {
     fragment?: string;
     /** Resolved panelParams from service requires — appended as query params. */
     panelParams?: Record<string, string>;
+    /** Session working directory — injected as projectDir query param. */
+    cwd?: string;
 }
 
-export function IframeServicePanel({ sessionId, port, query, fragment, panelParams }: IframeServicePanelProps) {
+export function IframeServicePanel({ sessionId, port, query, fragment, panelParams, cwd }: IframeServicePanelProps) {
     const src = useMemo(() => {
         let url = `/api/tunnel/${sessionId}/${port}/`;
         const params = new URLSearchParams();
@@ -31,8 +33,9 @@ export function IframeServicePanel({ sessionId, port, query, fragment, panelPara
                 params.set(key, value);
             }
         }
-        // Always include sessionId — UI has it, takes precedence over daemon-resolved
+        // Session-level vars from UI (takes precedence)
         params.set("sessionId", sessionId);
+        if (cwd) params.set("projectDir", cwd);
         // Then existing query params from deep link (takes precedence)
         if (query) {
             const existing = new URLSearchParams(query);
@@ -44,7 +47,7 @@ export function IframeServicePanel({ sessionId, port, query, fragment, panelPara
         if (qs) url += `?${qs}`;
         if (fragment) url += `#${fragment}`;
         return url;
-    }, [sessionId, port, query, fragment, panelParams]);
+    }, [sessionId, port, query, fragment, panelParams, cwd]);
 
     return (
         <iframe

--- a/packages/ui/src/components/service-panels/ServicePanels.tsx
+++ b/packages/ui/src/components/service-panels/ServicePanels.tsx
@@ -147,7 +147,7 @@ export function ServicePanelContainer({
                 {staticDef ? (
                     <staticDef.component sessionId={sessionId} runnerId={runnerId} />
                 ) : (
-                    <IframeServicePanel sessionId={sessionId} port={dynamicDef!.port} />
+                    <IframeServicePanel sessionId={sessionId} port={dynamicDef!.port} panelParams={dynamicDef!.panelParams} />
                 )}
             </div>
         </div>


### PR DESCRIPTION
## Summary

Adds `@VARIABLE@` token substitution across PizzaPi config surfaces using `@`-wrapping for cross-platform Windows compatibility.

### Variables

| Variable | Resolves to |
|----------|-------------|
| `@PWD@` | Current working directory |
| `@SESSION_ID@` | Current session ID (`PIZZAPI_SESSION_ID`) |
| `@HOME@` | User home directory |
| `@USER@` | Current username |
| `@PROJECT_DIR@` | Project directory (`PIZZAPI_PROJECT_DIR`, falls back to cwd) |

### Surfaces supported

| Surface | What's expanded |
|---------|----------------|
| **MCP stdio servers** | `command`, `args[]`, `cwd`, `env` values |
| **MCP HTTP/streamable servers** | `url`, `headers` values |
| **Hooks** | Hook `command` before execution |
| **Runner services** | Manifest `entry` and `panel.dir` |

### Example

Previously you'd hardcode absolute paths:
```json
{ "command": "/Users/jordan/Documents/Projects/PizzaPi/scripts/mcp.sh" }
```

Now you can use:
```json
{ "command": "@PROJECT_DIR@/scripts/mcp.sh" }
```

### Changes

- New `expandVars()` / `expandVarsDeep()` utility in `config/io.ts`
- Applied at each config consumption point (MCP, hooks, services)
- 21 new unit tests
- Updated `creating-runner-services` skill doc
- 981 tests passing, typecheck clean