### PR TITLE
feat: Unified Provider Interface — lifecycle hooks + context injection API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ User-facing documentation lives in `packages/docs/` — a [Starlight](https://st
 | Skills | `customization/skills.mdx` |
 | Agent definitions | `customization/agent-definitions.mdx` |
 | Claude plugins | `customization/claude-plugins.mdx` |
+| Provider services | `customization/providers.mdx` |
 | Subagents | `customization/subagents.mdx` |
 | `pizza web`, Docker | `deployment/self-hosting.mdx` |
 | Tailscale HTTPS | `deployment/tailscale.mdx` |

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -74,6 +74,7 @@ export function mergeHooks(a?: HooksConfig, b?: HooksConfig): HooksConfig | unde
         "SessionBeforeCompact",
         "SessionBeforeTree",
         "ModelSelect",
+        "SessionStart",
     ];
     for (const key of entryKeys) {
         const combined = [

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -70,6 +70,7 @@ export function mergeHooks(a?: HooksConfig, b?: HooksConfig): HooksConfig | unde
         "SessionBeforeSwitch",
         "SessionBeforeFork",
         "SessionShutdown",
+        "TurnEnd",
         "SessionBeforeCompact",
         "SessionBeforeTree",
         "ModelSelect",

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -103,6 +103,13 @@ export interface HooksConfig {
      * Exit code is ignored.
      */
     ModelSelect?: HookEntry[];
+
+    /**
+     * Fires when a session starts (startup, reload, new, resume, fork).
+     * Receives JSON on stdin with event name, reason, session ID, and model info.
+     * Fire-and-forget — exit code is ignored.
+     */
+    SessionStart?: HookEntry[];
 }
 
 // ── Sandbox configuration ─────────────────────────────────────────────────────

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -289,6 +289,11 @@ export interface ToolSearchConfig {
     keepLoadedTools?: boolean;
 }
 
+export interface ProviderConfig {
+  enabled?: boolean;
+  [key: string]: unknown;
+}
+
 export interface PizzaPiConfig {
     /** Override the default system prompt */
     systemPrompt?: string;
@@ -465,4 +470,6 @@ export interface PizzaPiConfig {
      * Also supports per-server `deferLoading: true` in mcpServers entries.
      */
     toolSearch?: ToolSearchConfig;
+    /** Extension provider configurations, keyed by provider ID. */
+    providers?: Record<string, ProviderConfig>;
 }

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -327,6 +327,9 @@ export interface PizzaPiConfig {
      */
     allowProjectHooks?: boolean;
 
+    /** Allow loading providers from project-local .pizzapi/providers/ directories. Default: false. */
+    allowProjectProviders?: boolean;
+
     /**
      * Trust gate: allow project-local MCP server definitions (.pizzapi/config.json) to be loaded.
      * Must be set in the GLOBAL ~/.pizzapi/config.json (or via

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -78,6 +78,12 @@ export interface HooksConfig {
      */
     SessionShutdown?: HookEntry[];
 
+    /**
+     * Fires at the end of each agent turn.
+     * Fire-and-forget — exit code is ignored.
+     */
+    TurnEnd?: HookEntry[];
+
     // -- Second wave hooks --
 
     /**

--- a/packages/cli/src/extensions/claude-plugins.ts
+++ b/packages/cli/src/extensions/claude-plugins.ts
@@ -280,7 +280,13 @@ function registerHookGroup(
 
         case "session_start":
             pi.on("session_start", async (_event, ctx) => {
-                const stdinData = { session_id: "" };
+                const modelInfo = ctx.model
+                    ? { provider: ctx.model.provider, id: ctx.model.id, name: ctx.model.name }
+                    : undefined;
+                const stdinData: Record<string, unknown> = {
+                    session_id: "",
+                    model: modelInfo ?? null,
+                };
                 for (const hook of hooks) {
                     if (!hook.command) continue;
                     const result = await execHookCommand(hook.command, plugin.rootPath, stdinData, (hook.timeout ?? 10) * 1000);

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -7,6 +7,7 @@ import type { HooksConfig } from "../config.js";
 import { buildPizzaPiExtensionFactories } from "./factories.js";
 import { mcpExtension } from "./mcp-extension.js";
 import { remoteExtension } from "./remote.js";
+import { providerExtension } from "./providers/extension.js";
 import { restartExtension } from "./restart.js";
 
 import { setSessionNameExtension } from "./set-session-name.js";
@@ -39,6 +40,7 @@ const CORE_EXTENSIONS: ExtensionFactory[] = [
     sandboxEventsExtension,
     pizzapiTitleExtension,
     pizzapiHeaderExtension,
+    providerExtension,  // Always registered
 ];
 
 /**

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -19,6 +19,7 @@ import { pizzapiTitleExtension } from "./pizzapi-title.js";
 import { pizzapiHeaderExtension } from "./pizzapi-header.js";
 import { toolSearchExtension } from "./tool-search.js";
 import { ollamaWebToolsExtension } from "./ollama-web-tools.js";
+import { providerExtension } from "./providers/extension.js";
 
 export interface BuildExtensionFactoriesOptions {
     cwd: string;
@@ -74,6 +75,9 @@ export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesO
         named(pizzapiTitleExtension, "title"),
         named(pizzapiHeaderExtension, "header"),
     );
+
+    // Provider interface — context injection + lifecycle hooks
+    factories.push(named(providerExtension, "providers"));
 
     if (options.includeInitialPrompt) {
         factories.push(named(initialPromptExtension, "initial-prompt"));

--- a/packages/cli/src/extensions/hooks.test.ts
+++ b/packages/cli/src/extensions/hooks.test.ts
@@ -1551,6 +1551,14 @@ describe("mergeHooks — event hooks", () => {
         expect(result?.ModelSelect).toHaveLength(2);
     });
 
+    test("merges SessionStart hooks", () => {
+        const result = mergeHooks(
+            { SessionStart: [{ command: "init-env.sh" }] },
+            { SessionStart: [{ command: "log-startup.sh" }] },
+        );
+        expect(result?.SessionStart).toHaveLength(2);
+    });
+
     test("merges SessionBeforeCompact hooks", () => {
         const result = mergeHooks(
             { SessionBeforeCompact: [{ command: "check.sh" }] },
@@ -1830,5 +1838,34 @@ describe("event hook integration — second wave", () => {
             source: "set",
         });
         await runFireAndForgetHooks(hooks, payload, process.cwd(), "ModelSelect");
+    });
+
+    test("SessionStart runs as fire-and-forget with model info", async () => {
+        const hooks: HookEntry[] = [
+            // Even with exit 1, should not throw
+            { command: "exit 1" },
+        ];
+        const payload = JSON.stringify({
+            event: "SessionStart",
+            reason: "startup",
+            previous_session_file: null,
+            session_id: "test-session-1",
+            model: { provider: "anthropic", id: "claude-sonnet-4-20250514", name: "Claude 4 Sonnet" },
+        });
+        await runFireAndForgetHooks(hooks, payload, process.cwd(), "SessionStart");
+    });
+
+    test("SessionStart payload works with null model", async () => {
+        const hooks: HookEntry[] = [
+            { command: "exit 0" },
+        ];
+        const payload = JSON.stringify({
+            event: "SessionStart",
+            reason: "new",
+            previous_session_file: "/old/session.json",
+            session_id: "test-session-2",
+            model: null,
+        });
+        await runFireAndForgetHooks(hooks, payload, process.cwd(), "SessionStart");
     });
 });

--- a/packages/cli/src/extensions/hooks/extension.ts
+++ b/packages/cli/src/extensions/hooks/extension.ts
@@ -47,6 +47,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
     const hasSessionBeforeSwitchHooks = (hooksConfig.SessionBeforeSwitch?.length ?? 0) > 0;
     const hasSessionBeforeForkHooks = (hooksConfig.SessionBeforeFork?.length ?? 0) > 0;
     const hasSessionShutdownHooks = (hooksConfig.SessionShutdown?.length ?? 0) > 0;
+    const hasTurnEndHooks = (hooksConfig.TurnEnd?.length ?? 0) > 0;
     const hasSessionBeforeCompactHooks = (hooksConfig.SessionBeforeCompact?.length ?? 0) > 0;
     const hasSessionBeforeTreeHooks = (hooksConfig.SessionBeforeTree?.length ?? 0) > 0;
     const hasModelSelectHooks = (hooksConfig.ModelSelect?.length ?? 0) > 0;
@@ -405,7 +406,8 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
         if (hasSessionShutdownHooks) {
             pi.on("session_shutdown", async () => {
                 try {
-                    const payload = JSON.stringify({ event: "SessionShutdown" });
+                    const sessionFile = process.env.PIZZAPI_SESSION_FILE ?? undefined;
+                    const payload = JSON.stringify({ event: "SessionShutdown", session_file: sessionFile });
                     await runFireAndForgetHooks(
                         hooksConfig.SessionShutdown!,
                         payload,
@@ -415,6 +417,33 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
                     log.error(`SessionShutdown handler error: ${msg}`);
+                }
+            });
+        }
+
+        // ---------------------------------------------------------------
+        // Turn End — fire-and-forget observability
+        // ---------------------------------------------------------------
+
+        if (hasTurnEndHooks) {
+            pi.on("turn_end", async (event, ctx) => {
+                try {
+                    const payload = JSON.stringify({
+                        event: "TurnEnd",
+                        turn_index: event.turnIndex,
+                        stop_reason: event.message.role === "assistant" ? event.message.stopReason : undefined,
+                        session_id: (ctx as any)?.sessionId ?? process.env.PIZZAPI_SESSION_ID ?? process.env.SESSION_ID ?? "",
+                    });
+
+                    await runFireAndForgetHooks(
+                        hooksConfig.TurnEnd!,
+                        payload,
+                        cwd,
+                        "TurnEnd",
+                    );
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    log.error(`TurnEnd handler error: ${msg}`);
                 }
             });
         }

--- a/packages/cli/src/extensions/hooks/extension.ts
+++ b/packages/cli/src/extensions/hooks/extension.ts
@@ -51,6 +51,7 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
     const hasSessionBeforeCompactHooks = (hooksConfig.SessionBeforeCompact?.length ?? 0) > 0;
     const hasSessionBeforeTreeHooks = (hooksConfig.SessionBeforeTree?.length ?? 0) > 0;
     const hasModelSelectHooks = (hooksConfig.ModelSelect?.length ?? 0) > 0;
+    const hasSessionStartHooks = (hooksConfig.SessionStart?.length ?? 0) > 0;
 
     // Advisory context from PreToolUse hooks is stashed here per tool-call-id
     // and injected into the tool_result so the agent sees it in the same turn
@@ -535,6 +536,33 @@ export function createHooksExtension(hooksConfig: HooksConfig | undefined, cwd: 
                 } catch (err) {
                     const msg = err instanceof Error ? err.message : String(err);
                     log.error(`ModelSelect handler error: ${msg}`);
+                }
+            });
+        }
+
+        if (hasSessionStartHooks) {
+            pi.on("session_start", async (event, ctx) => {
+                try {
+                    const modelInfo = ctx.model
+                        ? { provider: ctx.model.provider, id: ctx.model.id, name: ctx.model.name }
+                        : undefined;
+                    const payload = JSON.stringify({
+                        event: "SessionStart",
+                        reason: event.reason,
+                        previous_session_file: event.previousSessionFile ?? null,
+                        session_id: process.env.PIZZAPI_SESSION_ID ?? process.env.SESSION_ID ?? "",
+                        model: modelInfo ?? null,
+                    });
+
+                    await runFireAndForgetHooks(
+                        hooksConfig.SessionStart!,
+                        payload,
+                        cwd,
+                        "SessionStart",
+                    );
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    log.error(`SessionStart handler error: ${msg}`);
                 }
             });
         }

--- a/packages/cli/src/extensions/providers/extension.test.ts
+++ b/packages/cli/src/extensions/providers/extension.test.ts
@@ -5,9 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 function writeProvider(homeDir: string, id: string): void {
-  const providerDir = join(homeDir, ".pizzapi", "providers", id);
-  mkdirSync(providerDir, { recursive: true });
-  writeFileSync(join(providerDir, "index.ts"), `
+  writeProviderSource(homeDir, id, `
     export default {
       id: "${id}",
       capabilities: ["lifecycle"],
@@ -21,6 +19,35 @@ function writeProvider(homeDir: string, id: string): void {
   `);
 }
 
+function writeProviderSource(homeDir: string, id: string, source: string): void {
+  const providerDir = join(homeDir, ".pizzapi", "providers", id);
+  mkdirSync(providerDir, { recursive: true });
+  writeFileSync(join(providerDir, "index.ts"), source);
+}
+
+function makeCtx(cwd: string) {
+  return {
+    cwd,
+    signal: new AbortController().signal,
+    sessionManager: { getSessionFile: () => "test-session.json" },
+  };
+}
+
+async function startProviderExtension(cwd: string) {
+  const handlers = new Map<string, (event: any, ctx: any) => unknown | Promise<unknown>>();
+  const mockPi = {
+    on(event: string, handler: (event: any, ctx: any) => unknown | Promise<unknown>) {
+      handlers.set(event, handler);
+    },
+    registerCommand: () => {},
+  } as unknown as ExtensionAPI;
+
+  const ext = await import("./extension");
+  await ext.default(mockPi);
+  await handlers.get("session_start")?.({ reason: "startup" }, makeCtx(cwd));
+  return handlers;
+}
+
 describe("provider extension", () => {
   let tmpHome: string;
   let origHome: string | undefined;
@@ -30,10 +57,12 @@ describe("provider extension", () => {
     origHome = process.env.HOME;
     process.env.HOME = tmpHome;
     (globalThis as any).__providerInitCalls = [];
+    (globalThis as any).__providerExtensionCalls = [];
   });
 
   afterEach(() => {
     delete (globalThis as any).__providerInitCalls;
+    delete (globalThis as any).__providerExtensionCalls;
     process.env.HOME = origHome;
     if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
   });
@@ -103,4 +132,124 @@ describe("provider extension", () => {
 
     await handlers.get("session_shutdown")?.({ reason: "quit" }, { cwd, signal: new AbortController().signal });
   });
+
+  test("excludes providers whose init failed from bridge hooks", async () => {
+    const cwd = join(tmpHome, "project");
+    mkdirSync(cwd, { recursive: true });
+    writeProviderSource(tmpHome, "bad-init", initTrackingProviderSource("bad-init", "BAD", { failInit: true }));
+    writeProviderSource(tmpHome, "good-init", initTrackingProviderSource("good-init", "GOOD"));
+
+    const handlers = await startProviderExtension(cwd);
+
+    const result = await handlers.get("before_agent_start")?.(
+      { prompt: "hello", images: [], systemPrompt: "line 1\nline 2\nline 3\nline 4" },
+      makeCtx(cwd),
+    ) as { systemPrompt?: string } | undefined;
+
+    expect(result?.systemPrompt).toContain("GOOD context");
+    expect(result?.systemPrompt).not.toContain("BAD context");
+    expect((globalThis as any).__providerExtensionCalls).toContain("good-init:start");
+    expect((globalThis as any).__providerExtensionCalls).not.toContain("bad-init:start");
+
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd));
+  });
+
+  test("inserts prepended provider context after the system prompt preamble with delimiters", async () => {
+    const cwd = join(tmpHome, "project");
+    mkdirSync(cwd, { recursive: true });
+    writeProviderSource(tmpHome, "placement", placementProviderSource());
+    const handlers = await startProviderExtension(cwd);
+
+    const basePrompt = Array.from({ length: 12 }, (_, i) => `line-${i + 1}`).join("\n");
+    const result = await handlers.get("before_agent_start")?.(
+      { prompt: "hello", images: [], systemPrompt: basePrompt },
+      makeCtx(cwd),
+    ) as { systemPrompt?: string } | undefined;
+
+    expect(result?.systemPrompt).toStartWith(
+      "line-1\nline-2\nline-3\n\n<!-- Provider Context -->\nPREPEND context\n<!-- End Provider Context -->\nline-4",
+    );
+    expect(result?.systemPrompt).toEndWith("\nAPPEND context\n");
+
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd));
+  });
+
+  test("resets provider dedupe state at each new prompt boundary", async () => {
+    const cwd = join(tmpHome, "project");
+    mkdirSync(cwd, { recursive: true });
+    writeProviderSource(tmpHome, "prompt-dedup", promptDedupProviderSource());
+    const handlers = await startProviderExtension(cwd);
+
+    const first = await handlers.get("before_agent_start")?.(
+      { prompt: "first", images: [], systemPrompt: "line 1\nline 2\nline 3\nline 4" },
+      makeCtx(cwd),
+    ) as { systemPrompt?: string } | undefined;
+    expect(first?.systemPrompt).toContain("Memory for first");
+
+    const second = await handlers.get("before_agent_start")?.(
+      { prompt: "second", images: [], systemPrompt: "line 1\nline 2\nline 3\nline 4" },
+      makeCtx(cwd),
+    ) as { systemPrompt?: string } | undefined;
+    expect(second?.systemPrompt).toContain("Memory for second");
+    expect(second?.systemPrompt).not.toContain("Memory for first");
+
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, makeCtx(cwd));
+  });
 });
+
+function initTrackingProviderSource(
+  id: string,
+  label: string,
+  options: { failInit?: boolean } = {},
+) {
+  return `
+export default {
+  id: ${JSON.stringify(id)},
+  capabilities: ["context", "lifecycle"],
+  init() {
+    const calls = globalThis.__providerExtensionCalls || [];
+    calls.push(${JSON.stringify(`${id}:init`)});
+    globalThis.__providerExtensionCalls = calls;
+    ${options.failInit ? "throw new Error(\"init failed\");" : ""}
+  },
+  dispose() {},
+  onBeforeAgentStart: async () => [
+    { text: ${JSON.stringify(`${label} context`)}, placement: "prepend", order: 50, summary: ${JSON.stringify(label)}, dedupeKey: ${JSON.stringify(label)} },
+  ],
+  onSessionStart: async () => {
+    const calls = globalThis.__providerExtensionCalls || [];
+    calls.push(${JSON.stringify(`${id}:start`)});
+    globalThis.__providerExtensionCalls = calls;
+  },
+};
+`;
+}
+
+function placementProviderSource() {
+  return `
+export default {
+  id: "placement",
+  capabilities: ["context"],
+  init() {},
+  dispose() {},
+  onBeforeAgentStart: async () => [
+    { text: "PREPEND context", placement: "prepend", order: 50, summary: "Prepend" },
+    { text: "APPEND context", placement: "append", order: 50, summary: "Append" },
+  ],
+};
+`;
+}
+
+function promptDedupProviderSource() {
+  return `
+export default {
+  id: "prompt-dedup",
+  capabilities: ["context"],
+  init() {},
+  dispose() {},
+  onBeforeAgentStart: async (event) => [
+    { text: "Memory for " + event.prompt, placement: "prepend", order: 50, summary: "Prompt memory", dedupeKey: "same-key" },
+  ],
+};
+`;
+}

--- a/packages/cli/src/extensions/providers/extension.test.ts
+++ b/packages/cli/src/extensions/providers/extension.test.ts
@@ -1,0 +1,25 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { describe, test, expect } from "bun:test";
+
+describe("provider extension", () => {
+  test("extension module exports a default function", async () => {
+    const mod = await import("./extension");
+    expect(typeof mod.default).toBe("function");
+  });
+
+  test("extension registers on session_start, before_agent_start, turn_end, session_shutdown", async () => {
+    const events: string[] = [];
+    const mockPi = {
+      on: (event: string) => { events.push(event); },
+      registerCommand: () => {},
+    } as unknown as ExtensionAPI;
+
+    const ext = await import("./extension");
+    await ext.default(mockPi);
+
+    expect(events).toContain("session_start");
+    expect(events).toContain("before_agent_start");
+    expect(events).toContain("turn_end");
+    expect(events).toContain("session_shutdown");
+  });
+});

--- a/packages/cli/src/extensions/providers/extension.test.ts
+++ b/packages/cli/src/extensions/providers/extension.test.ts
@@ -43,6 +43,11 @@ describe("provider extension", () => {
     expect(typeof mod.default).toBe("function");
   });
 
+  test("triggerSessionClose is exported", async () => {
+    const mod = await import("./extension");
+    expect(typeof mod.triggerSessionClose).toBe("function");
+  });
+
   test("extension registers on session_start, before_agent_start, turn_end, session_shutdown", async () => {
     const events: string[] = [];
     const mockPi = {

--- a/packages/cli/src/extensions/providers/extension.test.ts
+++ b/packages/cli/src/extensions/providers/extension.test.ts
@@ -1,7 +1,43 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function writeProvider(homeDir: string, id: string): void {
+  const providerDir = join(homeDir, ".pizzapi", "providers", id);
+  mkdirSync(providerDir, { recursive: true });
+  writeFileSync(join(providerDir, "index.ts"), `
+    export default {
+      id: "${id}",
+      capabilities: ["lifecycle"],
+      init(ctx) {
+        globalThis.__providerInitCalls = globalThis.__providerInitCalls || [];
+        globalThis.__providerInitCalls.push({ id: "${id}", config: ctx.config });
+      },
+      dispose() {},
+      onSessionStart: async () => {},
+    };
+  `);
+}
 
 describe("provider extension", () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "provider-extension-test-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+    (globalThis as any).__providerInitCalls = [];
+  });
+
+  afterEach(() => {
+    delete (globalThis as any).__providerInitCalls;
+    process.env.HOME = origHome;
+    if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+  });
+
   test("extension module exports a default function", async () => {
     const mod = await import("./extension");
     expect(typeof mod.default).toBe("function");
@@ -21,5 +57,45 @@ describe("provider extension", () => {
     expect(events).toContain("before_agent_start");
     expect(events).toContain("turn_end");
     expect(events).toContain("session_shutdown");
+  });
+
+  test("skips disabled providers and passes per-provider config", async () => {
+    const configDir = join(tmpHome, ".pizzapi");
+    const cwd = join(tmpHome, "project");
+    mkdirSync(configDir, { recursive: true });
+    mkdirSync(cwd, { recursive: true });
+    writeFileSync(join(configDir, "config.json"), JSON.stringify({
+      providers: {
+        "enabled-provider": { customValue: "from-config" },
+        "disabled-provider": { enabled: false, customValue: "skip-me" },
+      },
+    }));
+    writeProvider(tmpHome, "enabled-provider");
+    writeProvider(tmpHome, "disabled-provider");
+
+    const handlers = new Map<string, (event: any, ctx: any) => Promise<void>>();
+    const mockPi = {
+      on(event: string, handler: (event: any, ctx: any) => Promise<void>) {
+        handlers.set(event, handler);
+      },
+      registerCommand: () => {},
+    } as unknown as ExtensionAPI;
+
+    const ext = await import("./extension");
+    await ext.default(mockPi);
+    await handlers.get("session_start")?.(
+      { reason: "startup" },
+      {
+        cwd,
+        signal: new AbortController().signal,
+        sessionManager: { getSessionFile: () => "test-session.json" },
+      },
+    );
+
+    expect((globalThis as any).__providerInitCalls).toEqual([
+      { id: "enabled-provider", config: { customValue: "from-config" } },
+    ]);
+
+    await handlers.get("session_shutdown")?.({ reason: "quit" }, { cwd, signal: new AbortController().signal });
   });
 });

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -23,7 +23,7 @@ function makeProviderContext(
   };
 }
 
-export default async function (pi: ExtensionAPI) {
+export async function providerExtension(pi: ExtensionAPI) {
   // ── Session Start: discover and init providers ────────────────
   pi.on("session_start", async (event, ctx) => {
     const { discoverProviders } = await import("../../providers/loader");
@@ -149,3 +149,5 @@ export default async function (pi: ExtensionAPI) {
     currentTurnId = 0;
   });
 }
+
+export default providerExtension;

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -3,7 +3,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { ProviderBridge } from "../../providers/bridge";
-import type { ProviderContext } from "../../providers/types";
+import type { ProviderContext, SessionCloseResult } from "../../providers/types";
 
 let bridge: ProviderBridge | null = null;
 /** Provider instances tracked separately for disposal (bridge doesn't own lifecycle). */
@@ -38,6 +38,29 @@ function makeProviderContext(
     cwd: ctx.cwd,
     ...overrides,
   };
+}
+
+/**
+ * Called by the daemon when a session is being archived.
+ * Returns the close result if any provider handles it, or null.
+ */
+export async function triggerSessionClose(
+  sessionId: string,
+  sessionFile: string,
+  reason: "close" | "error" | "complete",
+  cwd: string,
+): Promise<SessionCloseResult | null> {
+  if (!bridge) return null;
+  return bridge.onSessionClose(
+    { reason, sessionFile },
+    {
+      signal: new AbortController().signal,
+      timeoutMs: 5000,
+      sessionId,
+      sessionFile,
+      cwd,
+    },
+  );
 }
 
 export async function providerExtension(pi: ExtensionAPI) {

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -1,4 +1,7 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 import { ProviderBridge } from "../../providers/bridge";
 import type { ProviderContext } from "../../providers/types";
 
@@ -9,6 +12,20 @@ let providerInstances: Array<{ id: string; dispose(): Promise<void> | void }> = 
 let currentPromptId: string | null = null;
 /** Turn counter within the current prompt. Reset on new prompt. */
 let currentTurnId = 0;
+
+export function loadProviderConfig(): Record<string, Record<string, unknown>> {
+  const configPath = join(process.env.HOME || homedir(), ".pizzapi", "config.json");
+  try {
+    if (existsSync(configPath)) {
+      const raw = JSON.parse(readFileSync(configPath, "utf-8"));
+      const providers = raw?.providers;
+      if (providers && typeof providers === "object" && !Array.isArray(providers)) {
+        return providers;
+      }
+    }
+  } catch {}
+  return {};
+}
 
 function makeProviderContext(
   ctx: { signal?: AbortSignal; cwd: string },
@@ -28,12 +45,25 @@ export async function providerExtension(pi: ExtensionAPI) {
   pi.on("session_start", async (event, ctx) => {
     const { discoverProviders } = await import("../../providers/loader");
 
-    const result = await discoverProviders({ cwd: ctx.cwd });
+    const result = await discoverProviders({
+      cwd: ctx.cwd,
+      allowProject: false, // TODO: wire from config.json allowProjectProviders
+    });
     for (const err of result.errors) {
       console.error(`[provider-extension] Load error: ${err.path} — ${err.error}`);
     }
 
-    if (result.providers.length === 0) {
+    const configs = loadProviderConfig();
+    const enabledProviders = result.providers.filter(({ provider }) => {
+      const cfg = configs[provider.id];
+      if (cfg?.enabled === false) {
+        console.log(`[provider-extension] Skipping disabled provider "${provider.id}"`);
+        return false;
+      }
+      return true;
+    });
+
+    if (enabledProviders.length === 0) {
       bridge = null;
       providerInstances = [];
       return;
@@ -41,11 +71,10 @@ export async function providerExtension(pi: ExtensionAPI) {
 
     const instances: Array<{ id: string; dispose(): Promise<void> | void }> = [];
 
-    for (const { provider } of result.providers) {
+    for (const { provider } of enabledProviders) {
       try {
-        // Config: load from daemon config.json providers key (wired via daemon later)
         await provider.init({
-          config: {},
+          config: configs[provider.id] ?? {},
           fireTrigger: async () => {},
           socket: null,
           publishMetadata: () => {},
@@ -58,7 +87,7 @@ export async function providerExtension(pi: ExtensionAPI) {
     }
 
     providerInstances = instances;
-    bridge = new ProviderBridge(result.providers.map((p) => p.provider));
+    bridge = new ProviderBridge(enabledProviders.map((p) => p.provider));
 
     // Reset prompt tracking
     currentPromptId = null;

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -70,7 +70,7 @@ export async function providerExtension(pi: ExtensionAPI) {
 
     const result = await discoverProviders({
       cwd: ctx.cwd,
-      allowProject: false, // TODO: wire from config.json allowProjectProviders
+      allowProject: ctx.config?.allowProjectProviders === true,
     });
     for (const err of result.errors) {
       console.error(`[provider-extension] Load error: ${err.path} — ${err.error}`);

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -110,7 +110,11 @@ export async function providerExtension(pi: ExtensionAPI) {
     }
 
     providerInstances = instances;
-    bridge = new ProviderBridge(enabledProviders.map((p) => p.provider));
+    const successfulProviders = instances.map((i) => i.id);
+    const bridgeProviders = enabledProviders
+      .map((p) => p.provider)
+      .filter((p) => successfulProviders.includes(p.id));
+    bridge = new ProviderBridge(bridgeProviders);
 
     // Reset prompt tracking
     currentPromptId = null;
@@ -130,6 +134,7 @@ export async function providerExtension(pi: ExtensionAPI) {
     // Start a new prompt boundary
     currentPromptId = `prompt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     currentTurnId = 0;
+    bridge.resetDedupeState();
 
     const result = await bridge.onBeforeAgentStart(
       { prompt: event.prompt, images: event.images as any, systemPrompt: event.systemPrompt },
@@ -138,17 +143,22 @@ export async function providerExtension(pi: ExtensionAPI) {
 
     if (result.prepend.length === 0 && result.append.length === 0) return;
 
-    // Inject prepended text after pi's preamble, appended text before user appendSystemPrompt.
-    // We split the system prompt at the first tool listing or guideline marker if present,
-    // otherwise we prepend/append to the full prompt.
     const prependBlock = result.prepend.length > 0
-      ? `\n${result.prepend.join("\n")}\n`
+      ? "\n<!-- Provider Context -->\n" + result.prepend.join("\n") + "\n<!-- End Provider Context -->\n"
       : "";
     const appendBlock = result.append.length > 0
       ? `\n${result.append.join("\n")}\n`
       : "";
 
-    return { systemPrompt: prependBlock + event.systemPrompt + appendBlock };
+    // Insert prepended text after the leading preamble. Pi's prompt structure is
+    // not formally parseable here, so use a conservative preamble window.
+    const lines = event.systemPrompt.split("\n");
+    const preambleEnd = Math.min(3, Math.floor(lines.length / 4));
+    const before = lines.slice(0, preambleEnd).join("\n");
+    const after = lines.slice(preambleEnd).join("\n");
+
+    const newPrompt = before + "\n" + prependBlock + after + appendBlock;
+    return { systemPrompt: newPrompt };
   });
 
   // ── Turn End: incremental indexing ────────────────────────────

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { ProviderBridge } from "../../providers/bridge";
 import type { ProviderContext, SessionCloseResult } from "../../providers/types";
+import { loadGlobalConfig } from "../../config/io";
 
 let bridge: ProviderBridge | null = null;
 /** Provider instances tracked separately for disposal (bridge doesn't own lifecycle). */
@@ -70,7 +71,7 @@ export async function providerExtension(pi: ExtensionAPI) {
 
     const result = await discoverProviders({
       cwd: ctx.cwd,
-      allowProject: ctx.config?.allowProjectProviders === true,
+      allowProject: loadGlobalConfig().allowProjectProviders === true,
     });
     for (const err of result.errors) {
       console.error(`[provider-extension] Load error: ${err.path} — ${err.error}`);

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -76,6 +76,17 @@ export async function providerExtension(pi: ExtensionAPI) {
       console.error(`[provider-extension] Load error: ${err.path} — ${err.error}`);
     }
 
+    // Dispose any providers from a prior session (defensive — session_shutdown
+    // normally handles this, but ensure cleanup if session_start fires twice).
+    for (const instance of providerInstances) {
+      try {
+        await instance.dispose();
+      } catch (err) {
+        console.error(`[provider-extension] Error disposing ${instance.id} on re-init:`, err);
+      }
+    }
+    providerInstances = [];
+
     const configs = loadProviderConfig();
     const enabledProviders = result.providers.filter(({ provider }) => {
       const cfg = configs[provider.id];

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -1,0 +1,151 @@
+import type { ExtensionAPI } from "@mariozechner/pi-coding-agent";
+import { ProviderBridge } from "../../providers/bridge";
+import type { ProviderContext } from "../../providers/types";
+
+let bridge: ProviderBridge | null = null;
+/** Provider instances tracked separately for disposal (bridge doesn't own lifecycle). */
+let providerInstances: Array<{ id: string; dispose(): Promise<void> | void }> = [];
+/** Current prompt boundary ID — generated once per user prompt. */
+let currentPromptId: string | null = null;
+/** Turn counter within the current prompt. Reset on new prompt. */
+let currentTurnId = 0;
+
+function makeProviderContext(
+  ctx: { signal?: AbortSignal; cwd: string },
+  overrides?: Partial<ProviderContext>,
+): ProviderContext {
+  return {
+    signal: ctx.signal ?? new AbortController().signal,
+    timeoutMs: 5000,
+    sessionId: "unknown",
+    cwd: ctx.cwd,
+    ...overrides,
+  };
+}
+
+export default async function (pi: ExtensionAPI) {
+  // ── Session Start: discover and init providers ────────────────
+  pi.on("session_start", async (event, ctx) => {
+    const { discoverProviders } = await import("../../providers/loader");
+
+    const result = await discoverProviders({ cwd: ctx.cwd });
+    for (const err of result.errors) {
+      console.error(`[provider-extension] Load error: ${err.path} — ${err.error}`);
+    }
+
+    if (result.providers.length === 0) {
+      bridge = null;
+      providerInstances = [];
+      return;
+    }
+
+    const instances: Array<{ id: string; dispose(): Promise<void> | void }> = [];
+
+    for (const { provider } of result.providers) {
+      try {
+        // Config: load from daemon config.json providers key (wired via daemon later)
+        await provider.init({
+          config: {},
+          fireTrigger: async () => {},
+          socket: null,
+          publishMetadata: () => {},
+        });
+        instances.push(provider);
+        console.log(`[provider-extension] Initialized provider "${provider.id}"`);
+      } catch (err) {
+        console.error(`[provider-extension] Failed to init "${provider.id}":`, err);
+      }
+    }
+
+    providerInstances = instances;
+    bridge = new ProviderBridge(result.providers.map((p) => p.provider));
+
+    // Reset prompt tracking
+    currentPromptId = null;
+    currentTurnId = 0;
+
+    // Notify lifecycle providers
+    await bridge.onSessionStart(
+      { reason: event.reason as "startup", previousSessionFile: event.previousSessionFile },
+      makeProviderContext(ctx, { sessionFile: ctx.sessionManager?.getSessionFile?.() ?? undefined }),
+    );
+  });
+
+  // ── Before Agent Start: inject context ────────────────────────
+  pi.on("before_agent_start", async (event, ctx) => {
+    if (!bridge) return;
+
+    // Start a new prompt boundary
+    currentPromptId = `prompt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    currentTurnId = 0;
+
+    const result = await bridge.onBeforeAgentStart(
+      { prompt: event.prompt, images: event.images as any, systemPrompt: event.systemPrompt },
+      makeProviderContext(ctx, { promptId: currentPromptId, turnId: 0, isFirstTurn: true }),
+    );
+
+    if (result.prepend.length === 0 && result.append.length === 0) return;
+
+    // Inject prepended text after pi's preamble, appended text before user appendSystemPrompt.
+    // We split the system prompt at the first tool listing or guideline marker if present,
+    // otherwise we prepend/append to the full prompt.
+    const prependBlock = result.prepend.length > 0
+      ? `\n${result.prepend.join("\n")}\n`
+      : "";
+    const appendBlock = result.append.length > 0
+      ? `\n${result.append.join("\n")}\n`
+      : "";
+
+    return { systemPrompt: prependBlock + event.systemPrompt + appendBlock };
+  });
+
+  // ── Turn End: incremental indexing ────────────────────────────
+  pi.on("turn_end", async (event, ctx) => {
+    if (!bridge) return;
+
+    currentTurnId++;
+
+    await bridge.onTurnEnd(
+      {
+        turnIndex: event.turnIndex,
+        message: {
+          role: "assistant",
+          content: typeof (event.message as any)?.content === "string"
+            ? (event.message as any).content
+            : JSON.stringify((event.message as any)?.content ?? ""),
+        },
+        toolResults: event.toolResults?.map((tr: any) => ({
+          name: tr.toolName ?? "unknown",
+          output: JSON.stringify(tr.content ?? tr.details ?? ""),
+          isError: tr.isError ?? false,
+        })),
+      },
+      makeProviderContext(ctx, { promptId: currentPromptId ?? undefined, turnId: currentTurnId }),
+    );
+  });
+
+  // ── Session Shutdown: dispose providers ───────────────────────
+  pi.on("session_shutdown", async (event, ctx) => {
+    if (bridge) {
+      // SessionClose is called separately by daemon before session_shutdown.
+      // Here we only notify shutdown and dispose.
+      await bridge.onSessionShutdown(
+        { reason: event.reason as "quit", targetSessionFile: event.targetSessionFile },
+        makeProviderContext(ctx),
+      );
+    }
+
+    for (const instance of providerInstances) {
+      try {
+        await instance.dispose();
+      } catch (err) {
+        console.error(`[provider-extension] Error disposing ${instance.id}:`, err);
+      }
+    }
+
+    bridge = null;
+    providerInstances = [];
+    currentPromptId = null;
+    currentTurnId = 0;
+  });
+}

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -121,8 +121,11 @@ export async function providerExtension(pi: ExtensionAPI) {
     currentTurnId = 0;
 
     // Notify lifecycle providers
+    const modelInfo = ctx.model
+      ? { provider: ctx.model.provider, id: ctx.model.id, name: ctx.model.name }
+      : undefined;
     await bridge.onSessionStart(
-      { reason: event.reason as "startup", previousSessionFile: event.previousSessionFile },
+      { reason: event.reason as "startup", previousSessionFile: event.previousSessionFile, model: modelInfo },
       makeProviderContext(ctx, { sessionFile: ctx.sessionManager?.getSessionFile?.() ?? undefined }),
     );
   });

--- a/packages/cli/src/extensions/providers/extension.ts
+++ b/packages/cli/src/extensions/providers/extension.ts
@@ -28,13 +28,13 @@ export function loadProviderConfig(): Record<string, Record<string, unknown>> {
 }
 
 function makeProviderContext(
-  ctx: { signal?: AbortSignal; cwd: string },
+  ctx: { signal?: AbortSignal; cwd: string; sessionId?: string },
   overrides?: Partial<ProviderContext>,
 ): ProviderContext {
   return {
     signal: ctx.signal ?? new AbortController().signal,
     timeoutMs: 5000,
-    sessionId: "unknown",
+    sessionId: ctx.sessionId ?? process.env.PIZZAPI_SESSION_ID ?? process.env.SESSION_ID ?? "unknown",
     cwd: ctx.cwd,
     ...overrides,
   };

--- a/packages/cli/src/extensions/remote/finalization-state.test.ts
+++ b/packages/cli/src/extensions/remote/finalization-state.test.ts
@@ -1,0 +1,209 @@
+import { describe, test, expect } from "bun:test";
+import {
+  applyFinalizationEvent,
+  type SessionFinalizationEntry,
+} from "./finalization-state.js";
+
+describe("applyFinalizationEvent", () => {
+  const now = 1_000_000;
+
+  test("none → closing", () => {
+    const result = applyFinalizationEvent(null, {
+      type: "closing",
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      updatedAt: now,
+    });
+    expect(result).toEqual({
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "closing",
+      updatedAt: now,
+    });
+  });
+
+  test("closing → finalizing", () => {
+    const current: SessionFinalizationEntry = {
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "closing",
+      updatedAt: now,
+      jobId: "job-1",
+    };
+    const result = applyFinalizationEvent(current, {
+      type: "finalizing",
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      updatedAt: now + 1,
+    });
+    expect(result).toEqual({
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "finalizing",
+      updatedAt: now + 1,
+      jobId: "job-1",
+    });
+  });
+
+  test("finalizing → ended on complete", () => {
+    const current: SessionFinalizationEntry = {
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "finalizing",
+      updatedAt: now,
+      jobId: "job-1",
+    };
+    const result = applyFinalizationEvent(current, {
+      type: "ended",
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      updatedAt: now + 2,
+    });
+    expect(result).toEqual({
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "ended",
+      updatedAt: now + 2,
+      jobId: "job-1",
+    });
+  });
+
+  test("finalizing → detached on timeout", () => {
+    const current: SessionFinalizationEntry = {
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "finalizing",
+      updatedAt: now,
+      jobId: "job-1",
+    };
+    const result = applyFinalizationEvent(current, {
+      type: "detached_finalization",
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      updatedAt: now + 3,
+    });
+    expect(result).toEqual({
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "detached_finalization",
+      updatedAt: now + 3,
+      jobId: "job-1",
+    });
+  });
+
+  test("detached → ended on service complete", () => {
+    const current: SessionFinalizationEntry = {
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "detached_finalization",
+      updatedAt: now,
+      jobId: "job-1",
+    };
+    const result = applyFinalizationEvent(current, {
+      type: "ended",
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      updatedAt: now + 4,
+    });
+    expect(result).toEqual({
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "ended",
+      updatedAt: now + 4,
+      jobId: "job-1",
+    });
+  });
+
+  test("detached → ended on service failed", () => {
+    const current: SessionFinalizationEntry = {
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "detached_finalization",
+      updatedAt: now,
+      jobId: "job-1",
+    };
+    const result = applyFinalizationEvent(current, {
+      type: "ended",
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      updatedAt: now + 5,
+    });
+    expect(result).toEqual({
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "ended",
+      updatedAt: now + 5,
+      jobId: "job-1",
+    });
+  });
+
+  test("returns null when service disconnects/cancels without persisting", () => {
+    const current: SessionFinalizationEntry = {
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "closing",
+      updatedAt: now,
+    };
+    const result = applyFinalizationEvent(current, {
+      type: "ended",
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      updatedAt: now + 6,
+    });
+    expect(result).toBeNull();
+  });
+
+  test("entries are keyed by serviceId + sessionId", () => {
+    const entry1 = applyFinalizationEvent(null, {
+      type: "closing",
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "first",
+      updatedAt: now,
+    });
+    const entry2 = applyFinalizationEvent(null, {
+      type: "closing",
+      serviceId: "svc-b",
+      sessionId: "sess-2",
+      label: "second",
+      updatedAt: now,
+    });
+
+    expect(entry1).not.toBeNull();
+    expect(entry2).not.toBeNull();
+    expect(entry1!.serviceId).toBe("svc-a");
+    expect(entry1!.sessionId).toBe("sess-1");
+    expect(entry2!.serviceId).toBe("svc-b");
+    expect(entry2!.sessionId).toBe("sess-2");
+  });
+
+  test("returns current unchanged for mismatched serviceId/sessionId", () => {
+    const current: SessionFinalizationEntry = {
+      serviceId: "svc-a",
+      sessionId: "sess-1",
+      label: "finalize me",
+      status: "closing",
+      updatedAt: now,
+    };
+    const result = applyFinalizationEvent(current, {
+      type: "finalizing",
+      serviceId: "svc-b",
+      sessionId: "sess-2",
+      updatedAt: now + 1,
+    });
+    expect(result).toBe(current);
+  });
+});

--- a/packages/cli/src/extensions/remote/finalization-state.ts
+++ b/packages/cli/src/extensions/remote/finalization-state.ts
@@ -1,0 +1,106 @@
+export type SessionFinalizationStatus =
+  | "closing"
+  | "finalizing"
+  | "detached_finalization"
+  | "ended";
+
+export interface SessionFinalizationEntry {
+  serviceId: string;
+  sessionId: string;
+  jobId?: string;
+  label: string;
+  status: SessionFinalizationStatus;
+  updatedAt: number;
+}
+
+export function applyFinalizationEvent(
+  current: SessionFinalizationEntry | null,
+  event: {
+    type: SessionFinalizationStatus;
+    serviceId: string;
+    sessionId: string;
+    jobId?: string;
+    label?: string;
+    updatedAt?: number;
+  },
+): SessionFinalizationEntry | null {
+  // Composite key mismatch — event does not belong to this entry.
+  if (
+    current !== null &&
+    (current.serviceId !== event.serviceId || current.sessionId !== event.sessionId)
+  ) {
+    return current;
+  }
+
+  // Starting a new finalization sequence.
+  if (current === null) {
+    if (event.type !== "closing") {
+      return null;
+    }
+    return {
+      serviceId: event.serviceId,
+      sessionId: event.sessionId,
+      jobId: event.jobId,
+      label: event.label ?? "",
+      status: "closing",
+      updatedAt: event.updatedAt ?? Date.now(),
+    };
+  }
+
+  // Terminal state — no further transitions.
+  if (current.status === "ended") {
+    return current;
+  }
+
+  const updatedAt = event.updatedAt ?? current.updatedAt;
+
+  switch (current.status) {
+    case "closing": {
+      if (event.type === "finalizing") {
+        return {
+          ...current,
+          status: "finalizing",
+          jobId: event.jobId ?? current.jobId,
+          updatedAt,
+        };
+      }
+      if (event.type === "ended") {
+        // Service disconnected or cancelled before persisting.
+        return null;
+      }
+      return current;
+    }
+
+    case "finalizing": {
+      if (event.type === "detached_finalization") {
+        return {
+          ...current,
+          status: "detached_finalization",
+          updatedAt,
+        };
+      }
+      if (event.type === "ended") {
+        return {
+          ...current,
+          status: "ended",
+          updatedAt,
+        };
+      }
+      return current;
+    }
+
+    case "detached_finalization": {
+      if (event.type === "ended") {
+        return {
+          ...current,
+          status: "ended",
+          updatedAt,
+        };
+      }
+      return current;
+    }
+
+    default:
+      return current;
+  }
+}

--- a/packages/cli/src/providers/bridge.test.ts
+++ b/packages/cli/src/providers/bridge.test.ts
@@ -2,14 +2,14 @@ import { describe, test, expect } from "bun:test";
 import { ProviderBridge } from "./bridge";
 import type { ExtensionProvider } from "./types";
 
-function makeProvider(overrides: Partial<ExtensionProvider> = {}): ExtensionProvider {
+function makeProvider(overrides: Record<string, any> = {}): ExtensionProvider {
   return {
     id: "test",
     capabilities: ["context", "lifecycle"] as const,
     init() {},
     dispose() {},
     ...overrides,
-  };
+  } as ExtensionProvider;
 }
 
 describe("ProviderBridge", () => {
@@ -148,9 +148,9 @@ describe("ProviderBridge", () => {
     const provider = makeProvider({
       id: "lifecycle",
       capabilities: ["lifecycle"] as const,
-      onTurnEnd: async (event) => { calls.push(`turn-${event.turnIndex}`); },
-      onSessionStart: async (event) => { calls.push(`start-${event.reason}`); },
-      onSessionShutdown: async (event) => { calls.push(`shutdown-${event.reason}`); },
+      onTurnEnd: async (event: { turnIndex: number }) => { calls.push(`turn-${event.turnIndex}`); },
+      onSessionStart: async (event: { reason: string }) => { calls.push(`start-${event.reason}`); },
+      onSessionShutdown: async (event: { reason: string }) => { calls.push(`shutdown-${event.reason}`); },
     });
 
     const bridge = new ProviderBridge([provider]);

--- a/packages/cli/src/providers/bridge.test.ts
+++ b/packages/cli/src/providers/bridge.test.ts
@@ -30,26 +30,38 @@ describe("ProviderBridge", () => {
     expect(result.summaries).toEqual(["A", "B"]);
   });
 
-  test("sorts by order ascending, then providerId (prepend: higher order closer to top)", async () => {
-    const a = makeProvider({
-      id: "alpha",
+  test("sorts by order and providerId within prepend and append groups", async () => {
+    const zeta = makeProvider({
+      id: "zeta",
       onBeforeAgentStart: async () => [
-        { text: "A-100", placement: "prepend", order: 100, summary: "A" },
+        { text: "zeta-100", placement: "prepend", order: 100, summary: "zeta prepend 100" },
+        { text: "zeta-10", placement: "append", order: 10, summary: "zeta append 10" },
+        { text: "zeta-25", placement: "append", order: 25, summary: "zeta append 25" },
       ],
     });
-    const b = makeProvider({
-      id: "beta",
+    const alpha = makeProvider({
+      id: "alpha",
       onBeforeAgentStart: async () => [
-        { text: "B-50", placement: "prepend", order: 50, summary: "B" },
+        { text: "alpha-100", placement: "prepend", order: 100, summary: "alpha prepend 100" },
+        { text: "alpha-50", placement: "prepend", order: 50, summary: "alpha prepend 50" },
+        { text: "alpha-10", placement: "append", order: 10, summary: "alpha append 10" },
       ],
     });
 
-    const bridge = new ProviderBridge([a, b]);
+    const bridge = new ProviderBridge([zeta, alpha]);
     const ctx = { signal: new AbortController().signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp", promptId: "p1", turnId: 0, isFirstTurn: true };
 
     const result = await bridge.onBeforeAgentStart({ prompt: "h", systemPrompt: "base" }, ctx);
-    // Sorted ascending by order: 50, 100 → prepended in order → higher order closer to top
-    expect(result.prepend).toEqual(["A-100", "B-50"]);
+    expect(result.prepend).toEqual(["alpha-100", "zeta-100", "alpha-50"]);
+    expect(result.append).toEqual(["alpha-10", "zeta-10", "zeta-25"]);
+    expect(result.summaries).toEqual([
+      "alpha prepend 100",
+      "zeta prepend 100",
+      "alpha prepend 50",
+      "alpha append 10",
+      "zeta append 10",
+      "zeta append 25",
+    ]);
   });
 
   test("deduplicates by providerId + dedupeKey across calls", async () => {
@@ -79,6 +91,32 @@ describe("ProviderBridge", () => {
     returnedKey = "key2";
     const r3 = await bridge.onBeforeAgentStart({ prompt: "c", systemPrompt: "base" }, ctx);
     expect(r3.prepend).toEqual(["Call 1", "Call 3"]);
+  });
+
+  test("resetDedupeState clears stored dedupe entries", async () => {
+    let callCount = 0;
+    const provider = makeProvider({
+      onBeforeAgentStart: async () => {
+        callCount++;
+        return [
+          { text: `Call ${callCount}`, placement: "prepend", order: 50, summary: "T", dedupeKey: "same" },
+        ];
+      },
+    });
+
+    const bridge = new ProviderBridge([provider]);
+    const ctx = { signal: new AbortController().signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp", promptId: "p1", turnId: 0, isFirstTurn: true };
+
+    const first = await bridge.onBeforeAgentStart({ prompt: "first", systemPrompt: "base" }, ctx);
+    expect(first.prepend).toEqual(["Call 1"]);
+
+    const deduped = await bridge.onBeforeAgentStart({ prompt: "same prompt", systemPrompt: "base" }, ctx);
+    expect(deduped.prepend).toEqual(["Call 1"]);
+
+    bridge.resetDedupeState();
+
+    const afterReset = await bridge.onBeforeAgentStart({ prompt: "new prompt", systemPrompt: "base" }, ctx);
+    expect(afterReset.prepend).toEqual(["Call 3"]);
   });
 
   test("isolates failing providers", async () => {

--- a/packages/cli/src/providers/bridge.test.ts
+++ b/packages/cli/src/providers/bridge.test.ts
@@ -1,0 +1,184 @@
+import { describe, test, expect } from "bun:test";
+import { ProviderBridge } from "./bridge";
+import type { ExtensionProvider } from "./types";
+
+function makeProvider(overrides: Partial<ExtensionProvider> = {}): ExtensionProvider {
+  return {
+    id: "test",
+    capabilities: ["context", "lifecycle"] as const,
+    init() {},
+    dispose() {},
+    ...overrides,
+  };
+}
+
+describe("ProviderBridge", () => {
+  test("collects and separates prepend/append contributions", async () => {
+    const provider = makeProvider({
+      onBeforeAgentStart: async () => [
+        { text: "A-prepend", placement: "prepend", order: 100, summary: "A" },
+        { text: "B-append", placement: "append", order: 50, summary: "B" },
+      ],
+    });
+
+    const bridge = new ProviderBridge([provider]);
+    const ctx = { signal: new AbortController().signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp", promptId: "p1", turnId: 0, isFirstTurn: true };
+
+    const result = await bridge.onBeforeAgentStart({ prompt: "hello", systemPrompt: "base" }, ctx);
+    expect(result.prepend).toEqual(["A-prepend"]);
+    expect(result.append).toEqual(["B-append"]);
+    expect(result.summaries).toEqual(["A", "B"]);
+  });
+
+  test("sorts by order ascending, then providerId (prepend: higher order closer to top)", async () => {
+    const a = makeProvider({
+      id: "alpha",
+      onBeforeAgentStart: async () => [
+        { text: "A-100", placement: "prepend", order: 100, summary: "A" },
+      ],
+    });
+    const b = makeProvider({
+      id: "beta",
+      onBeforeAgentStart: async () => [
+        { text: "B-50", placement: "prepend", order: 50, summary: "B" },
+      ],
+    });
+
+    const bridge = new ProviderBridge([a, b]);
+    const ctx = { signal: new AbortController().signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp", promptId: "p1", turnId: 0, isFirstTurn: true };
+
+    const result = await bridge.onBeforeAgentStart({ prompt: "h", systemPrompt: "base" }, ctx);
+    // Sorted ascending by order: 50, 100 → prepended in order → higher order closer to top
+    expect(result.prepend).toEqual(["A-100", "B-50"]);
+  });
+
+  test("deduplicates by providerId + dedupeKey across calls", async () => {
+    let callCount = 0;
+    let returnedKey = "key1";
+    const provider = makeProvider({
+      onBeforeAgentStart: async () => {
+        callCount++;
+        return [
+          { text: `Call ${callCount}`, placement: "prepend", order: 50, summary: "T", dedupeKey: returnedKey },
+        ];
+      },
+    });
+
+    const bridge = new ProviderBridge([provider]);
+    const ctx = { signal: new AbortController().signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp", promptId: "p1", turnId: 0, isFirstTurn: true };
+
+    // First call
+    const r1 = await bridge.onBeforeAgentStart({ prompt: "a", systemPrompt: "base" }, ctx);
+    expect(r1.prepend).toEqual(["Call 1"]);
+
+    // Same key — should retain first value (dedup)
+    const r2 = await bridge.onBeforeAgentStart({ prompt: "b", systemPrompt: "base" }, ctx);
+    expect(r2.prepend).toEqual(["Call 1"]);
+
+    // Different key — new value
+    returnedKey = "key2";
+    const r3 = await bridge.onBeforeAgentStart({ prompt: "c", systemPrompt: "base" }, ctx);
+    expect(r3.prepend).toEqual(["Call 1", "Call 3"]);
+  });
+
+  test("isolates failing providers", async () => {
+    const good = makeProvider({
+      id: "good",
+      onBeforeAgentStart: async () => [{ text: "Good", placement: "prepend", order: 50, summary: "G" }],
+    });
+    const bad = makeProvider({
+      id: "bad",
+      onBeforeAgentStart: async () => { throw new Error("boom"); },
+    });
+
+    const bridge = new ProviderBridge([good, bad]);
+    const ctx = { signal: new AbortController().signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp", promptId: "p1", turnId: 0, isFirstTurn: true };
+
+    const result = await bridge.onBeforeAgentStart({ prompt: "hello", systemPrompt: "base" }, ctx);
+    expect(result.prepend).toEqual(["Good"]);
+  });
+
+  test("disables provider after 3 consecutive errors", async () => {
+    const bad = makeProvider({
+      id: "bad",
+      onBeforeAgentStart: async () => { throw new Error("boom"); },
+    });
+
+    const bridge = new ProviderBridge([bad]);
+    const ctx = { signal: new AbortController().signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp", promptId: "p1", turnId: 0, isFirstTurn: true };
+
+    await bridge.onBeforeAgentStart({ prompt: "1", systemPrompt: "base" }, ctx);
+    await bridge.onBeforeAgentStart({ prompt: "2", systemPrompt: "base" }, ctx);
+    await bridge.onBeforeAgentStart({ prompt: "3", systemPrompt: "base" }, ctx);
+
+    expect(bridge.isDisabled("bad")).toBe(true);
+  });
+
+  test("resets error count on success", async () => {
+    let shouldFail = true;
+    const provider = makeProvider({
+      id: "flaky",
+      onBeforeAgentStart: async () => {
+        if (shouldFail) throw new Error("boom");
+        return [{ text: "OK", placement: "prepend", order: 50, summary: "OK" }];
+      },
+    });
+
+    const bridge = new ProviderBridge([provider]);
+    const ctx = { signal: new AbortController().signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp", promptId: "p1", turnId: 0, isFirstTurn: true };
+
+    // 2 fails, then 1 success, then 3 fails — should not disable until 3 consecutive
+    await bridge.onBeforeAgentStart({ prompt: "1", systemPrompt: "base" }, ctx);
+    await bridge.onBeforeAgentStart({ prompt: "2", systemPrompt: "base" }, ctx);
+    expect(bridge.isDisabled("flaky")).toBe(false);
+
+    shouldFail = false;
+    await bridge.onBeforeAgentStart({ prompt: "3", systemPrompt: "base" }, ctx);
+    expect(bridge.isDisabled("flaky")).toBe(false);
+
+    shouldFail = true;
+    await bridge.onBeforeAgentStart({ prompt: "4", systemPrompt: "base" }, ctx);
+    await bridge.onBeforeAgentStart({ prompt: "5", systemPrompt: "base" }, ctx);
+    await bridge.onBeforeAgentStart({ prompt: "6", systemPrompt: "base" }, ctx);
+    expect(bridge.isDisabled("flaky")).toBe(true);
+  });
+
+  test("calls lifecycle hooks", async () => {
+    const calls: string[] = [];
+    const provider = makeProvider({
+      id: "lifecycle",
+      capabilities: ["lifecycle"] as const,
+      onTurnEnd: async (event) => { calls.push(`turn-${event.turnIndex}`); },
+      onSessionStart: async (event) => { calls.push(`start-${event.reason}`); },
+      onSessionShutdown: async (event) => { calls.push(`shutdown-${event.reason}`); },
+    });
+
+    const bridge = new ProviderBridge([provider]);
+    const ctx = { signal: new AbortController().signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp" };
+
+    await bridge.onSessionStart({ reason: "startup" }, ctx);
+    await bridge.onTurnEnd({ turnIndex: 1, message: { role: "assistant", content: "ok" } }, { ...ctx, promptId: "p1", turnId: 1 });
+    await bridge.onSessionShutdown({ reason: "quit" }, ctx);
+
+    expect(calls).toEqual(["start-startup", "turn-1", "shutdown-quit"]);
+  });
+
+  test("onSessionClose returns first non-null result", async () => {
+    const a = makeProvider({
+      id: "alpha",
+      capabilities: ["lifecycle"] as const,
+      onSessionClose: async () => null,
+    });
+    const b = makeProvider({
+      id: "beta",
+      capabilities: ["lifecycle"] as const,
+      onSessionClose: async () => ({ label: "Flushing beta", jobRef: { id: "j1" } }),
+    });
+
+    const bridge = new ProviderBridge([a, b]);
+    const ctx = { signal: new AbortController().signal, timeoutMs: 5000, sessionId: "s1", cwd: "/tmp" };
+
+    const result = await bridge.onSessionClose({ reason: "close", sessionFile: "/tmp/s.jsonl" }, ctx);
+    expect(result).toEqual({ label: "Flushing beta", jobRef: { id: "j1" } });
+  });
+});

--- a/packages/cli/src/providers/bridge.ts
+++ b/packages/cli/src/providers/bridge.ts
@@ -54,7 +54,11 @@ export class ProviderBridge {
       if (!isContextProvider(provider)) continue;
 
       try {
-        const contributions = await provider.onBeforeAgentStart(event, ctx);
+        const contributions = await this.#withTimeout(
+          provider.onBeforeAgentStart(event, ctx),
+          ctx,
+          provider.id,
+        );
         if (!contributions || contributions.length === 0) continue;
 
         let dedupeMap = this.#dedupeState.get(provider.id);
@@ -152,7 +156,11 @@ export class ProviderBridge {
       if (!isLifecycleHook(provider)) continue;
       if (!provider.onSessionStart) continue;
       try {
-        await provider.onSessionStart(event, ctx);
+        await this.#withTimeout(
+          provider.onSessionStart(event, ctx),
+          ctx,
+          provider.id,
+        );
       } catch (err) {
         this.#recordError(provider.id, err);
       }
@@ -177,7 +185,11 @@ export class ProviderBridge {
       if (!isLifecycleHook(provider)) continue;
       if (!provider.onTurnEnd) continue;
       try {
-        await provider.onTurnEnd(event, ctx);
+        await this.#withTimeout(
+          provider.onTurnEnd(event, ctx),
+          ctx,
+          provider.id,
+        );
         this.#errorCounts.set(provider.id, 0);
       } catch (err) {
         this.#recordError(provider.id, err);
@@ -191,13 +203,54 @@ export class ProviderBridge {
       if (!isLifecycleHook(provider)) continue;
       if (!provider.onSessionClose) continue;
       try {
-        const result = await provider.onSessionClose(event, ctx);
+        const result = await this.#withTimeout(
+          provider.onSessionClose(event, ctx),
+          ctx,
+          provider.id,
+        );
         if (result) return result;
       } catch (err) {
         this.#recordError(provider.id, err);
       }
     }
     return null;
+  }
+
+  /**
+   * Wraps a provider hook promise with timeout and abort signal enforcement.
+   * If the abort signal fires, the promise is rejected with an AbortError.
+   * If the timeout elapses, the promise is rejected with a timeout error.
+   */
+  async #withTimeout<T>(
+    promise: Promise<T>,
+    ctx: ProviderContext,
+    providerId: string,
+  ): Promise<T> {
+    if (ctx.signal.aborted) {
+      throw new Error(`Provider "${providerId}" call aborted before execution`);
+    }
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        reject(new Error(`Provider "${providerId}" timed out after ${ctx.timeoutMs}ms`));
+      }, ctx.timeoutMs);
+    });
+
+    const abortPromise = new Promise<never>((_, reject) => {
+      const onAbort = () => {
+        ctx.signal.removeEventListener("abort", onAbort);
+        reject(new Error(`Provider "${providerId}" call aborted`));
+      };
+      ctx.signal.addEventListener("abort", onAbort, { once: true });
+    });
+
+    try {
+      const result = await Promise.race([promise, timeoutPromise, abortPromise]);
+      return result;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 
   #recordError(providerId: string, err: unknown): void {

--- a/packages/cli/src/providers/bridge.ts
+++ b/packages/cli/src/providers/bridge.ts
@@ -1,0 +1,195 @@
+import type {
+  ExtensionProvider, ContextProvider, LifecycleHook,
+  ContextContribution, ProviderContext, BeforeAgentStartEvent,
+  SessionStartEvent, SessionShutdownEvent, TurnEndEvent,
+  SessionCloseEvent, SessionCloseResult,
+} from "./types";
+import { isContextProvider, isLifecycleHook } from "./types";
+
+export interface BeforeAgentStartResult {
+  prepend: string[];
+  append: string[];
+  summaries: string[];
+  artifacts: ContextContribution["referencedArtifacts"];
+}
+
+interface CollectedContribution {
+  text: string;
+  placement: "prepend" | "append";
+  order: number;
+  summary: string;
+  artifacts?: ContextContribution["referencedArtifacts"];
+}
+
+const MAX_CONSECUTIVE_ERRORS = 3;
+
+export class ProviderBridge {
+  #providers: ExtensionProvider[];
+  #disabled = new Set<string>();
+  #errorCounts = new Map<string, number>();
+  /** Per-provider dedupe map. Key = dedupeKey, Value = collected contribution. */
+  #dedupeState = new Map<string, Map<string, CollectedContribution>>();
+
+  constructor(providers: ExtensionProvider[]) {
+    this.#providers = providers;
+  }
+
+  isDisabled(providerId: string): boolean {
+    return this.#disabled.has(providerId);
+  }
+
+  async onBeforeAgentStart(
+    event: BeforeAgentStartEvent,
+    ctx: ProviderContext,
+  ): Promise<BeforeAgentStartResult> {
+    const collected: CollectedContribution[] = [];
+
+    for (const provider of this.#providers) {
+      if (this.#disabled.has(provider.id)) continue;
+      if (!isContextProvider(provider)) continue;
+
+      try {
+        const contributions = await provider.onBeforeAgentStart(event, ctx);
+        if (!contributions || contributions.length === 0) continue;
+
+        let dedupeMap = this.#dedupeState.get(provider.id);
+        if (!dedupeMap) {
+          dedupeMap = new Map();
+          this.#dedupeState.set(provider.id, dedupeMap);
+        }
+
+        // Emit all previously stored deduped entries first (stable order)
+        for (const [, entry] of dedupeMap) {
+          collected.push(entry);
+        }
+
+        const emittedKeys = new Set<string>();
+
+        for (const c of contributions) {
+          if (c.dedupeKey) {
+            // If this key exists, skip (already emitted from stored entries above).
+            // If the key doesn't exist, store this contribution.
+            if (dedupeMap.has(c.dedupeKey)) {
+              emittedKeys.add(c.dedupeKey);
+            } else {
+              const entry: CollectedContribution = {
+                text: c.text,
+                placement: c.placement,
+                order: c.order ?? 100,
+                summary: c.summary,
+                artifacts: c.referencedArtifacts,
+              };
+              dedupeMap.set(c.dedupeKey, entry);
+              collected.push(entry);
+              emittedKeys.add(c.dedupeKey);
+            }
+          } else {
+            collected.push({
+              text: c.text,
+              placement: c.placement,
+              order: c.order ?? 100,
+              summary: c.summary,
+              artifacts: c.referencedArtifacts,
+            });
+          }
+        }
+
+        this.#errorCounts.set(provider.id, 0);
+      } catch (err) {
+        this.#recordError(provider.id, err);
+      }
+    }
+
+    // Sort by order within each group.
+    // Prepend: higher order closer to top (descending).
+    // Append: lower order closer to system prompt (ascending).
+    const prependColl = collected.filter((c) => c.placement === "prepend");
+    const appendColl = collected.filter((c) => c.placement === "append");
+    prependColl.sort((a, b) => b.order - a.order);
+    appendColl.sort((a, b) => a.order - b.order);
+
+    const prepend: string[] = [];
+    const append: string[] = [];
+    const summaries: string[] = [];
+    const artifacts: NonNullable<ContextContribution["referencedArtifacts"]> = [];
+
+    for (const c of prependColl) {
+      prepend.push(c.text);
+      summaries.push(c.summary);
+      if (c.artifacts) artifacts.push(...c.artifacts);
+    }
+    for (const c of appendColl) {
+      append.push(c.text);
+      summaries.push(c.summary);
+      if (c.artifacts) artifacts.push(...c.artifacts);
+    }
+
+    return { prepend, append, summaries, artifacts };
+  }
+
+  async onSessionStart(event: SessionStartEvent, ctx: ProviderContext): Promise<void> {
+    for (const provider of this.#providers) {
+      if (this.#disabled.has(provider.id)) continue;
+      if (!isLifecycleHook(provider)) continue;
+      if (!provider.onSessionStart) continue;
+      try {
+        await provider.onSessionStart(event, ctx);
+      } catch (err) {
+        this.#recordError(provider.id, err);
+      }
+    }
+  }
+
+  async onSessionShutdown(event: SessionShutdownEvent, ctx: ProviderContext): Promise<void> {
+    for (const provider of this.#providers) {
+      if (!isLifecycleHook(provider)) continue;
+      if (!provider.onSessionShutdown) continue;
+      try {
+        await provider.onSessionShutdown(event, ctx);
+      } catch {
+        // Silent — we're shutting down
+      }
+    }
+  }
+
+  async onTurnEnd(event: TurnEndEvent, ctx: ProviderContext): Promise<void> {
+    for (const provider of this.#providers) {
+      if (this.#disabled.has(provider.id)) continue;
+      if (!isLifecycleHook(provider)) continue;
+      if (!provider.onTurnEnd) continue;
+      try {
+        await provider.onTurnEnd(event, ctx);
+        this.#errorCounts.set(provider.id, 0);
+      } catch (err) {
+        this.#recordError(provider.id, err);
+      }
+    }
+  }
+
+  async onSessionClose(event: SessionCloseEvent, ctx: ProviderContext): Promise<SessionCloseResult | null> {
+    for (const provider of this.#providers) {
+      if (this.#disabled.has(provider.id)) continue;
+      if (!isLifecycleHook(provider)) continue;
+      if (!provider.onSessionClose) continue;
+      try {
+        const result = await provider.onSessionClose(event, ctx);
+        if (result) return result;
+      } catch (err) {
+        this.#recordError(provider.id, err);
+      }
+    }
+    return null;
+  }
+
+  #recordError(providerId: string, err: unknown): void {
+    const count = (this.#errorCounts.get(providerId) ?? 0) + 1;
+    this.#errorCounts.set(providerId, count);
+    if (count >= MAX_CONSECUTIVE_ERRORS) {
+      this.#disabled.add(providerId);
+      console.error(
+        `[ProviderBridge] Disabling provider "${providerId}" after ${count} consecutive errors:`,
+        err instanceof Error ? err.message : String(err),
+      );
+    }
+  }
+}

--- a/packages/cli/src/providers/bridge.ts
+++ b/packages/cli/src/providers/bridge.ts
@@ -14,6 +14,7 @@ export interface BeforeAgentStartResult {
 }
 
 interface CollectedContribution {
+  providerId: string;
   text: string;
   placement: "prepend" | "append";
   order: number;
@@ -36,6 +37,10 @@ export class ProviderBridge {
 
   isDisabled(providerId: string): boolean {
     return this.#disabled.has(providerId);
+  }
+
+  resetDedupeState(): void {
+    this.#dedupeState.clear();
   }
 
   async onBeforeAgentStart(
@@ -63,16 +68,13 @@ export class ProviderBridge {
           collected.push(entry);
         }
 
-        const emittedKeys = new Set<string>();
-
         for (const c of contributions) {
           if (c.dedupeKey) {
             // If this key exists, skip (already emitted from stored entries above).
             // If the key doesn't exist, store this contribution.
-            if (dedupeMap.has(c.dedupeKey)) {
-              emittedKeys.add(c.dedupeKey);
-            } else {
+            if (!dedupeMap.has(c.dedupeKey)) {
               const entry: CollectedContribution = {
+                providerId: provider.id,
                 text: c.text,
                 placement: c.placement,
                 order: c.order ?? 100,
@@ -81,10 +83,10 @@ export class ProviderBridge {
               };
               dedupeMap.set(c.dedupeKey, entry);
               collected.push(entry);
-              emittedKeys.add(c.dedupeKey);
             }
           } else {
             collected.push({
+              providerId: provider.id,
               text: c.text,
               placement: c.placement,
               order: c.order ?? 100,
@@ -100,13 +102,30 @@ export class ProviderBridge {
       }
     }
 
-    // Sort by order within each group.
-    // Prepend: higher order closer to top (descending).
-    // Append: lower order closer to system prompt (ascending).
-    const prependColl = collected.filter((c) => c.placement === "prepend");
+    collected.sort((a, b) => {
+      if (a.order !== b.order) return a.order - b.order;
+      return a.providerId.localeCompare(b.providerId);
+    });
+
+    // Prepend contributions are prepended in sorted order, which places higher
+    // order groups closer to the top while preserving providerId tie-breaks.
+    const prependColl: CollectedContribution[] = [];
+    let prependGroup: CollectedContribution[] = [];
+    let prependGroupOrder: number | undefined;
+    for (const contribution of collected) {
+      if (contribution.placement !== "prepend") continue;
+      if (prependGroupOrder === undefined || contribution.order === prependGroupOrder) {
+        prependGroup.push(contribution);
+        prependGroupOrder = contribution.order;
+        continue;
+      }
+      prependColl.unshift(...prependGroup);
+      prependGroup = [contribution];
+      prependGroupOrder = contribution.order;
+    }
+    if (prependGroup.length > 0) prependColl.unshift(...prependGroup);
+
     const appendColl = collected.filter((c) => c.placement === "append");
-    prependColl.sort((a, b) => b.order - a.order);
-    appendColl.sort((a, b) => a.order - b.order);
 
     const prepend: string[] = [];
     const append: string[] = [];

--- a/packages/cli/src/providers/e2e.test.ts
+++ b/packages/cli/src/providers/e2e.test.ts
@@ -80,12 +80,16 @@ describe("Provider Pipeline E2E", () => {
 
   // ── 2. Context Contributions & Sorting ───────────────────────
 
-  test("onBeforeAgentStart returns context contributions sorted correctly", async () => {
-    writeProvider("sort-test", sortingProviderSource());
+  test("onBeforeAgentStart returns context contributions sorted by order and providerId", async () => {
+    writeProvider("zeta-sort", sortingProviderSource("zeta-sort", "Z"));
+    writeProvider("alpha-sort", sortingProviderSource("alpha-sort", "A"));
 
     const { providers } = await discoverProviders();
     const bridge = new ProviderBridge(
-      providers.map((p) => p.provider),
+      providers
+        .slice()
+        .sort((a, b) => b.provider.id.localeCompare(a.provider.id))
+        .map((p) => p.provider),
     );
 
     const result = await bridge.onBeforeAgentStart(
@@ -93,23 +97,23 @@ describe("Provider Pipeline E2E", () => {
       ctx(),
     );
 
-    // Provider returns:
-    //   prepend order=50  → "A: prepend-order-50"
-    //   prepend order=100 → "B: prepend-order-100"
-    //   append  order=10  → "C: append-order-10"
-    //
-    // Sorted ascending:  C(10), A(50), B(100)
-    // prepend reversed:   B, A   (higher order closer to top)
-    // append kept:        C
     expect(result.prepend).toEqual([
-      "B: prepend-order-100",
+      "A: prepend-order-100",
+      "Z: prepend-order-100",
       "A: prepend-order-50",
+      "Z: prepend-order-50",
     ]);
-    expect(result.append).toEqual(["C: append-order-10"]);
+    expect(result.append).toEqual([
+      "A: append-order-10",
+      "Z: append-order-10",
+    ]);
     expect(result.summaries).toEqual([
-      "B: prepend order 100",
+      "A: prepend order 100",
+      "Z: prepend order 100",
       "A: prepend order 50",
-      "C: append order 10",
+      "Z: prepend order 50",
+      "A: append order 10",
+      "Z: append order 10",
     ]);
   });
 
@@ -339,6 +343,29 @@ describe("Provider Pipeline E2E", () => {
     expect(r2.prepend).toEqual(r1.prepend);
   });
 
+  test("dedup across prompts does not collide after resetDedupeState", async () => {
+    writeProvider("prompt-dedup-test", promptDependentDedupProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    const firstPrompt = await bridge.onBeforeAgentStart(
+      { prompt: "memory first", systemPrompt: "base" },
+      ctx({ promptId: "prompt-1" }),
+    );
+    expect(firstPrompt.prepend).toEqual(["Memory for memory first"]);
+
+    bridge.resetDedupeState();
+
+    const secondPrompt = await bridge.onBeforeAgentStart(
+      { prompt: "memory second", systemPrompt: "base" },
+      ctx({ promptId: "prompt-2" }),
+    );
+    expect(secondPrompt.prepend).toEqual(["Memory for memory second"]);
+  });
+
   // ── 6. Disabled provider test ────────────────────────────────
 
   test("disabled provider is skipped by bridge (verifies after 3 turn-end failures)", async () => {
@@ -428,17 +455,17 @@ export default {
 }
 
 /** Provider that returns contributions with explicit sort orders. */
-function sortingProviderSource() {
+function sortingProviderSource(providerId: string, label: string) {
   return `
 export default {
-  id: "sort-test",
+  id: ${JSON.stringify(providerId)},
   capabilities: ["context"],
   init() {},
   dispose() {},
   onBeforeAgentStart: async () => [
-    { text: "A: prepend-order-50",  placement: "prepend", order: 50,  summary: "A: prepend order 50" },
-    { text: "B: prepend-order-100", placement: "prepend", order: 100, summary: "B: prepend order 100" },
-    { text: "C: append-order-10",   placement: "append",  order: 10,  summary: "C: append order 10" },
+    { text: ${JSON.stringify(`${label}: prepend-order-50`)},  placement: "prepend", order: 50,  summary: ${JSON.stringify(`${label}: prepend order 50`)} },
+    { text: ${JSON.stringify(`${label}: prepend-order-100`)}, placement: "prepend", order: 100, summary: ${JSON.stringify(`${label}: prepend order 100`)} },
+    { text: ${JSON.stringify(`${label}: append-order-10`)},   placement: "append",  order: 10,  summary: ${JSON.stringify(`${label}: append order 10`)} },
   ],
 };
 `;
@@ -562,6 +589,26 @@ export default {
       return [
         { text: "Memory: use pnpm", placement: "prepend", order: 50, summary: "Pkg mgr", dedupeKey: "pkg" },
         { text: "Directive: write tests", placement: "append", order: 100, summary: "Testing", dedupeKey: "test" },
+      ];
+    }
+    return [];
+  },
+};
+`;
+}
+
+/** Provider for testing per-prompt dedup reset with a prompt-dependent value. */
+function promptDependentDedupProviderSource() {
+  return `
+export default {
+  id: "prompt-dedup-test",
+  capabilities: ["context"],
+  init() {},
+  dispose() {},
+  onBeforeAgentStart: async (event) => {
+    if (event.prompt.includes("memory")) {
+      return [
+        { text: "Memory for " + event.prompt, placement: "prepend", order: 50, summary: "Prompt memory", dedupeKey: "pkg" },
       ];
     }
     return [];

--- a/packages/cli/src/providers/e2e.test.ts
+++ b/packages/cli/src/providers/e2e.test.ts
@@ -253,13 +253,13 @@ describe("Provider Pipeline E2E", () => {
       { prompt: "1", systemPrompt: "base" },
       ctx(),
     );
-    expect(bridge.isDisabled("doomed")).toBe(false);
+    expect(bridge.isDisabled("bad-provider")).toBe(false);
 
     await bridge.onBeforeAgentStart(
       { prompt: "2", systemPrompt: "base" },
       ctx(),
     );
-    expect(bridge.isDisabled("doomed")).toBe(false);
+    expect(bridge.isDisabled("bad-provider")).toBe(false);
 
     await bridge.onBeforeAgentStart(
       { prompt: "3", systemPrompt: "base" },

--- a/packages/cli/src/providers/e2e.test.ts
+++ b/packages/cli/src/providers/e2e.test.ts
@@ -1,0 +1,571 @@
+/**
+ * E2E integration test for the provider pipeline.
+ *
+ * Validates the full lifecycle: discovery → loading → bridge → hooks → cleanup.
+ * Uses a temp directory to mimic ~/.pizzapi/providers/ with real file-based
+ * provider modules that are loaded via dynamic import.
+ */
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { discoverProviders, globalProvidersDir } from "./loader";
+import { ProviderBridge } from "./bridge";
+import type { ExtensionProvider } from "./types";
+
+// ── helpers ────────────────────────────────────────────────────
+
+/** Create a minimal AbortSignal for passing to provider contexts. */
+function signal() {
+  return new AbortController().signal;
+}
+
+/** Shared context factory matching what the extension constructs. */
+function ctx(overrides: Partial<import("./types").ProviderContext> = {}) {
+  return {
+    signal: signal(),
+    timeoutMs: 5000,
+    sessionId: "e2e-session",
+    sessionFile: "/tmp/e2e-session.jsonl",
+    cwd: "/tmp",
+    promptId: "prompt-1",
+    turnId: 0,
+    isFirstTurn: true,
+    ...overrides,
+  };
+}
+
+// ── test suite ─────────────────────────────────────────────────
+
+describe("Provider Pipeline E2E", () => {
+  let tmpHome: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "provider-e2e-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tmpHome;
+
+    // Reset global call tracker
+    (globalThis as any).__e2eCalls = [];
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    if (existsSync(tmpHome)) rmSync(tmpHome, { recursive: true, force: true });
+  });
+
+  // ── 1. Provider Discovery ────────────────────────────────────
+
+  test("discovers a valid provider and reports zero errors", async () => {
+    writeProvider("test-e2e", basicProviderSource());
+
+    const result = await discoverProviders();
+
+    expect(result.errors).toEqual([]);
+    expect(result.providers.length).toBe(1);
+    expect(result.providers[0].provider.id).toBe("test-e2e");
+    expect(result.providers[0].source.origin).toBe("global");
+  });
+
+  test("reports an error for an invalid provider module", async () => {
+    const providerDir = join(globalProvidersDir(), "bad-provider");
+    mkdirSync(providerDir, { recursive: true });
+    writeFileSync(join(providerDir, "index.ts"), `export default { notAProvider: true };`);
+
+    const result = await discoverProviders();
+    expect(result.providers).toEqual([]);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  // ── 2. Context Contributions & Sorting ───────────────────────
+
+  test("onBeforeAgentStart returns context contributions sorted correctly", async () => {
+    writeProvider("sort-test", sortingProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    const result = await bridge.onBeforeAgentStart(
+      { prompt: "hello world", systemPrompt: "base" },
+      ctx(),
+    );
+
+    // Provider returns:
+    //   prepend order=50  → "A: prepend-order-50"
+    //   prepend order=100 → "B: prepend-order-100"
+    //   append  order=10  → "C: append-order-10"
+    //
+    // Sorted ascending:  C(10), A(50), B(100)
+    // prepend reversed:   B, A   (higher order closer to top)
+    // append kept:        C
+    expect(result.prepend).toEqual([
+      "B: prepend-order-100",
+      "A: prepend-order-50",
+    ]);
+    expect(result.append).toEqual(["C: append-order-10"]);
+    expect(result.summaries).toEqual([
+      "B: prepend order 100",
+      "A: prepend order 50",
+      "C: append order 10",
+    ]);
+  });
+
+  test("onBeforeAgentStart with empty contributions returns empty arrays", async () => {
+    writeProvider("empty-test", emptyProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    const result = await bridge.onBeforeAgentStart(
+      { prompt: "no match", systemPrompt: "base" },
+      ctx(),
+    );
+
+    expect(result.prepend).toEqual([]);
+    expect(result.append).toEqual([]);
+    expect(result.summaries).toEqual([]);
+  });
+
+  // ── 3. Lifecycle Hooks ───────────────────────────────────────
+
+  test("onTurnEnd fires lifecycle hook with correct event data", async () => {
+    writeProvider("lifecycle-test", lifecycleProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    await bridge.onTurnEnd(
+      {
+        turnIndex: 3,
+        message: { role: "assistant" as const, content: "All done!" },
+        toolResults: [
+          { name: "read", output: "file content", isError: false },
+        ],
+      },
+      ctx({ turnId: 3, isFirstTurn: false }),
+    );
+
+    const calls: any[] = (globalThis as any).__e2eCalls;
+    const turnCall = calls.find((c: any) => c.type === "turnEnd");
+    expect(turnCall).toBeDefined();
+    expect(turnCall.turnIndex).toBe(3);
+  });
+
+  test("onSessionClose returns the first non-null result", async () => {
+    writeProvider("close-test", lifecycleProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    const result = await bridge.onSessionClose(
+      { reason: "close", sessionFile: "/tmp/e2e-session.jsonl" },
+      ctx(),
+    );
+
+    expect(result).toEqual({
+      label: "Finalizing e2e",
+      jobRef: { test: true },
+    });
+  });
+
+  test("onSessionClose returns null when no provider returns a result", async () => {
+    writeProvider("null-close-test", nullCloseProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    const result = await bridge.onSessionClose(
+      { reason: "close", sessionFile: "/tmp/e2e-session.jsonl" },
+      ctx(),
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test("onSessionStart and onSessionShutdown fire without errors", async () => {
+    writeProvider("lifecycle-test", lifecycleProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    await bridge.onSessionStart(
+      { reason: "startup" },
+      ctx({ promptId: undefined }),
+    );
+    await bridge.onSessionShutdown(
+      { reason: "quit" },
+      ctx({ promptId: undefined }),
+    );
+
+    // No errors thrown = pass
+  });
+
+  // ── 4. Error Isolation ───────────────────────────────────────
+
+  test("isolates a failing provider so other providers still contribute", async () => {
+    writeProvider("good-provider", basicProviderSource());
+    writeProvider("bad-provider", failingProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    const result = await bridge.onBeforeAgentStart(
+      { prompt: "hello", systemPrompt: "base" },
+      ctx(),
+    );
+
+    // The good provider's contributions should still appear
+    expect(result.prepend.length).toBeGreaterThan(0);
+    expect(result.summaries.some((s) => s.includes("Pkg mgr"))).toBe(true);
+  });
+
+  test("disables a provider after MAX_CONSECUTIVE_ERRORS (3) failures", async () => {
+    writeProvider("doomed", failingProviderSource());
+
+    const { providers } = await discoverProviders();
+    expect(providers.length).toBe(1);
+
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    // Fire 3 times — provider should fail each time
+    await bridge.onBeforeAgentStart(
+      { prompt: "1", systemPrompt: "base" },
+      ctx(),
+    );
+    expect(bridge.isDisabled("doomed")).toBe(false);
+
+    await bridge.onBeforeAgentStart(
+      { prompt: "2", systemPrompt: "base" },
+      ctx(),
+    );
+    expect(bridge.isDisabled("doomed")).toBe(false);
+
+    await bridge.onBeforeAgentStart(
+      { prompt: "3", systemPrompt: "base" },
+      ctx(),
+    );
+    // After 3 consecutive failures it should be disabled
+    expect(bridge.isDisabled("bad-provider")).toBe(true);
+  });
+
+  test("error count resets on a successful call", async () => {
+    writeProvider("flaky", flakyProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    // 2 failures (no-op prompts since provider only returns on "success")
+    await bridge.onBeforeAgentStart(
+      { prompt: "fail", systemPrompt: "base" },
+      ctx(),
+    );
+    await bridge.onBeforeAgentStart(
+      { prompt: "fail", systemPrompt: "base" },
+      ctx(),
+    );
+    expect(bridge.isDisabled("flaky")).toBe(false);
+
+    // 1 success resets error count
+    await bridge.onBeforeAgentStart(
+      { prompt: "success", systemPrompt: "base" },
+      ctx(),
+    );
+    expect(bridge.isDisabled("flaky")).toBe(false);
+
+    // 3 more failures — should now disable
+    await bridge.onBeforeAgentStart(
+      { prompt: "fail", systemPrompt: "base" },
+      ctx(),
+    );
+    await bridge.onBeforeAgentStart(
+      { prompt: "fail", systemPrompt: "base" },
+      ctx(),
+    );
+    await bridge.onBeforeAgentStart(
+      { prompt: "fail", systemPrompt: "base" },
+      ctx(),
+    );
+    expect(bridge.isDisabled("flaky")).toBe(true);
+  });
+
+  // ── 5. Deduplication ─────────────────────────────────────────
+
+  test("deduplicates onBeforeAgentStart contributions by dedupeKey across calls", async () => {
+    writeProvider("dedup-test", dedupProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    // First call — "memory" in prompt triggers contribution with dedupeKey "pkg"
+    const r1 = await bridge.onBeforeAgentStart(
+      { prompt: "search memory", systemPrompt: "base" },
+      ctx(),
+    );
+
+    expect(r1.summaries).toContain("Pkg mgr");
+    const prependLen1 = r1.prepend.length;
+
+    // Second call (same promptId, different turn) — same dedupeKey "pkg"
+    // The bridge already stored dedupeKey "pkg" → returns the already-collected value
+    const r2 = await bridge.onBeforeAgentStart(
+      { prompt: "search memory again", systemPrompt: "base" },
+      ctx({ turnId: 1, isFirstTurn: false }),
+    );
+
+    // prepend should have the same contributions (dedup prevented new ones)
+    expect(r2.prepend.length).toBe(prependLen1);
+    // The text should still be from the first call
+    expect(r2.prepend).toEqual(r1.prepend);
+  });
+
+  // ── 6. Disabled provider test ────────────────────────────────
+
+  test("disabled provider is skipped by bridge (verifies after 3 turn-end failures)", async () => {
+    writeProvider("will-disable", failingOnTurnEndProviderSource());
+
+    const { providers } = await discoverProviders();
+    const bridge = new ProviderBridge(
+      providers.map((p) => p.provider),
+    );
+
+    // 3 failures on onTurnEnd should disable "skip-me-2" (the failing provider's id)
+    await bridge.onTurnEnd(
+      { turnIndex: 0, message: { role: "assistant", content: "ok" } },
+      ctx(),
+    );
+    await bridge.onTurnEnd(
+      { turnIndex: 1, message: { role: "assistant", content: "ok" } },
+      ctx(),
+    );
+    await bridge.onTurnEnd(
+      { turnIndex: 2, message: { role: "assistant", content: "ok" } },
+      ctx(),
+    );
+
+    expect(bridge.isDisabled("skip-me-2")).toBe(true);
+  });
+});
+
+// ── Provider source factories ──────────────────────────────────
+
+/** Writes a provider index.ts under tmpHome/.pizzapi/providers/<id>/ */
+function writeProvider(id: string, source: string) {
+  const dir = join(globalProvidersDir(), id);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "index.ts"), source);
+}
+
+/** Standard provider with context + lifecycle capabilities. */
+function basicProviderSource() {
+  return `
+export default {
+  id: "test-e2e",
+  capabilities: ["context", "lifecycle"],
+  init() {},
+  dispose() {},
+  onBeforeAgentStart: async (event, ctx) => {
+    if (event.prompt.includes("memory") || event.prompt.includes("hello")) {
+      return [
+        {
+          text: "Memory: use pnpm",
+          placement: "prepend",
+          order: 50,
+          summary: "Pkg mgr",
+          dedupeKey: "pkg",
+        },
+        {
+          text: "Directive: write tests",
+          placement: "append",
+          order: 100,
+          summary: "Testing",
+          dedupeKey: "test",
+        },
+        {
+          text: "Tip: run typecheck",
+          placement: "prepend",
+          order: 75,
+          summary: "Typecheck tip",
+          dedupeKey: "tck",
+        },
+      ];
+    }
+    return [];
+  },
+  onTurnEnd: async (event, ctx) => {
+    const calls = globalThis.__e2eCalls || [];
+    calls.push({ type: "turnEnd", turnIndex: event.turnIndex });
+    globalThis.__e2eCalls = calls;
+  },
+  onSessionClose: async (event, ctx) => ({
+    label: "Finalizing e2e",
+    jobRef: { test: true },
+  }),
+  onSessionStart: async (event, ctx) => {},
+  onSessionShutdown: async (event, ctx) => {},
+};
+`;
+}
+
+/** Provider that returns contributions with explicit sort orders. */
+function sortingProviderSource() {
+  return `
+export default {
+  id: "sort-test",
+  capabilities: ["context"],
+  init() {},
+  dispose() {},
+  onBeforeAgentStart: async () => [
+    { text: "A: prepend-order-50",  placement: "prepend", order: 50,  summary: "A: prepend order 50" },
+    { text: "B: prepend-order-100", placement: "prepend", order: 100, summary: "B: prepend order 100" },
+    { text: "C: append-order-10",   placement: "append",  order: 10,  summary: "C: append order 10" },
+  ],
+};
+`;
+}
+
+/** Provider that returns no contributions. */
+function emptyProviderSource() {
+  return `
+export default {
+  id: "empty-test",
+  capabilities: ["context"],
+  init() {},
+  dispose() {},
+  onBeforeAgentStart: async () => [],
+};
+`;
+}
+
+/** Provider implementing all lifecycle hooks. */
+function lifecycleProviderSource() {
+  return `
+export default {
+  id: "lifecycle-test",
+  capabilities: ["lifecycle"],
+  init() {},
+  dispose() {},
+  onSessionStart: async (event, ctx) => {
+    const calls = globalThis.__e2eCalls || [];
+    calls.push({ type: "sessionStart", reason: event.reason });
+    globalThis.__e2eCalls = calls;
+  },
+  onSessionShutdown: async (event, ctx) => {
+    const calls = globalThis.__e2eCalls || [];
+    calls.push({ type: "sessionShutdown", reason: event.reason });
+    globalThis.__e2eCalls = calls;
+  },
+  onTurnEnd: async (event, ctx) => {
+    const calls = globalThis.__e2eCalls || [];
+    calls.push({ type: "turnEnd", turnIndex: event.turnIndex });
+    globalThis.__e2eCalls = calls;
+  },
+  onSessionClose: async (event, ctx) => ({
+    label: "Finalizing e2e",
+    jobRef: { test: true },
+  }),
+};
+`;
+}
+
+/** Provider whose onSessionClose returns null. */
+function nullCloseProviderSource() {
+  return `
+export default {
+  id: "null-close-test",
+  capabilities: ["lifecycle"],
+  init() {},
+  dispose() {},
+  onSessionClose: async () => null,
+};
+`;
+}
+
+/** Provider that always throws in onBeforeAgentStart. */
+function failingProviderSource() {
+  return `
+export default {
+  id: "bad-provider",
+  capabilities: ["context"],
+  init() {},
+  dispose() {},
+  onBeforeAgentStart: async () => {
+    throw new Error("simulated provider failure");
+  },
+};
+`;
+}
+
+/** Provider that throws on onTurnEnd (for testing disable via lifecycle errors). */
+function failingOnTurnEndProviderSource() {
+  return `
+export default {
+  id: "skip-me-2",
+  capabilities: ["lifecycle"],
+  init() {},
+  dispose() {},
+  onTurnEnd: async () => {
+    throw new Error("turn end failure");
+  },
+};
+`;
+}
+
+/** Flaky provider — fails unless prompt includes "success". */
+function flakyProviderSource() {
+  return `
+export default {
+  id: "flaky",
+  capabilities: ["context"],
+  init() {},
+  dispose() {},
+  onBeforeAgentStart: async (event) => {
+    if (event.prompt.includes("success")) {
+      return [{ text: "OK", placement: "prepend", order: 50, summary: "OK" }];
+    }
+    throw new Error("flaky failure");
+  },
+};
+`;
+}
+
+/** Provider for testing dedup — returns fixed dedupeKey. */
+function dedupProviderSource() {
+  return `
+export default {
+  id: "dedup-test",
+  capabilities: ["context"],
+  init() {},
+  dispose() {},
+  onBeforeAgentStart: async (event) => {
+    if (event.prompt.includes("memory")) {
+      return [
+        { text: "Memory: use pnpm", placement: "prepend", order: 50, summary: "Pkg mgr", dedupeKey: "pkg" },
+        { text: "Directive: write tests", placement: "append", order: 100, summary: "Testing", dedupeKey: "test" },
+      ];
+    }
+    return [];
+  },
+};
+`;
+}

--- a/packages/cli/src/providers/loader.test.ts
+++ b/packages/cli/src/providers/loader.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect, afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { discoverProviders, globalProvidersDir } from "./loader";
+import type { ExtensionProvider, ProviderInitContext } from "./types";
+
+describe("discoverProviders", () => {
+  let tmpDir: string;
+  let origHome: string | undefined;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "provider-loader-test-"));
+    origHome = process.env.HOME;
+    process.env.HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    process.env.HOME = origHome;
+    if (existsSync(tmpDir)) rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("returns empty when no providers directory exists", async () => {
+    const result = await discoverProviders();
+    expect(result.providers).toEqual([]);
+    expect(result.errors).toEqual([]);
+  });
+
+  test("discovers a single provider from global directory", async () => {
+    const providerDir = join(globalProvidersDir(), "test-provider");
+    mkdirSync(providerDir, { recursive: true });
+    writeFileSync(join(providerDir, "index.ts"), `
+      export default {
+        id: "test-provider",
+        capabilities: ["context"],
+        init() {},
+        dispose() {},
+        onBeforeAgentStart: async () => [],
+      };
+    `);
+
+    const result = await discoverProviders();
+    expect(result.errors).toEqual([]);
+    expect(result.providers.length).toBe(1);
+    expect(result.providers[0].provider.id).toBe("test-provider");
+  });
+
+  test("discovers from project-local directory", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "project-"));
+    const providerDir = join(projectDir, ".pizzapi", "providers", "local-provider");
+    mkdirSync(providerDir, { recursive: true });
+    writeFileSync(join(providerDir, "index.ts"), `
+      export default {
+        id: "local-provider",
+        capabilities: ["lifecycle"],
+        init() {},
+        dispose() {},
+        onSessionStart: async () => {},
+      };
+    `);
+
+    const result = await discoverProviders({ cwd: projectDir });
+    expect(result.providers.length).toBe(1);
+    expect(result.providers[0].provider.id).toBe("local-provider");
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test("reports error for invalid provider module", async () => {
+    const providerDir = join(globalProvidersDir(), "bad-provider");
+    mkdirSync(providerDir, { recursive: true });
+    writeFileSync(join(providerDir, "index.ts"), `
+      export default { notAProvider: true };
+    `);
+
+    const result = await discoverProviders();
+    expect(result.providers).toEqual([]);
+    expect(result.errors.length).toBeGreaterThan(0);
+  });
+
+  test("deduplicates by provider ID (global wins over project)", async () => {
+    const globalDir = join(globalProvidersDir(), "dup-provider");
+    mkdirSync(globalDir, { recursive: true });
+    writeFileSync(join(globalDir, "index.ts"), `
+      export default { id: "dup-provider", capabilities: ["context"], init() {}, dispose() {}, onBeforeAgentStart: async () => [] };
+    `);
+
+    const projectDir = mkdtempSync(join(tmpdir(), "project-dup-"));
+    const localDir = join(projectDir, ".pizzapi", "providers", "dup-provider");
+    mkdirSync(localDir, { recursive: true });
+    writeFileSync(join(localDir, "index.ts"), `
+      export default { id: "dup-provider", capabilities: ["lifecycle"], init() {}, dispose() {}, onSessionStart: async () => {} };
+    `);
+
+    const result = await discoverProviders({ cwd: projectDir });
+    expect(result.providers.length).toBe(1);
+    expect(result.providers[0].provider.capabilities).toContain("context");
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test("provider with only onSessionShutdown is accepted as lifecycle", async () => {
+    const providerDir = join(globalProvidersDir(), "shutdown-provider");
+    mkdirSync(providerDir, { recursive: true });
+    writeFileSync(join(providerDir, "index.ts"), `
+      export default {
+        id: "shutdown-provider",
+        capabilities: ["lifecycle"],
+        init() {},
+        dispose() {},
+        onSessionShutdown: async () => {},
+      };
+    `);
+
+    const result = await discoverProviders();
+    expect(result.providers.length).toBe(1);
+    expect(result.providers[0].provider.id).toBe("shutdown-provider");
+  });
+});

--- a/packages/cli/src/providers/loader.test.ts
+++ b/packages/cli/src/providers/loader.test.ts
@@ -59,9 +59,22 @@ describe("discoverProviders", () => {
       };
     `);
 
-    const result = await discoverProviders({ cwd: projectDir });
+    const result = await discoverProviders({ cwd: projectDir, allowProject: true });
     expect(result.providers.length).toBe(1);
     expect(result.providers[0].provider.id).toBe("local-provider");
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  test("skips project providers when allowProject is false", async () => {
+    const projectDir = mkdtempSync(join(tmpdir(), "project-skip-"));
+    const providerDir = join(projectDir, ".pizzapi", "providers", "skip-me");
+    mkdirSync(providerDir, { recursive: true });
+    writeFileSync(join(providerDir, "index.ts"), `
+      export default { id: "skip-me", capabilities: ["context"], init() {}, dispose() {}, onBeforeAgentStart: async () => [] };
+    `);
+
+    const result = await discoverProviders({ cwd: projectDir, allowProject: false });
+    expect(result.providers).toEqual([]);
     rmSync(projectDir, { recursive: true, force: true });
   });
 
@@ -91,7 +104,7 @@ describe("discoverProviders", () => {
       export default { id: "dup-provider", capabilities: ["lifecycle"], init() {}, dispose() {}, onSessionStart: async () => {} };
     `);
 
-    const result = await discoverProviders({ cwd: projectDir });
+    const result = await discoverProviders({ cwd: projectDir, allowProject: true });
     expect(result.providers.length).toBe(1);
     expect(result.providers[0].provider.capabilities).toContain("context");
     rmSync(projectDir, { recursive: true, force: true });

--- a/packages/cli/src/providers/loader.ts
+++ b/packages/cli/src/providers/loader.ts
@@ -1,0 +1,160 @@
+import { existsSync, readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionProvider } from "./types";
+
+export function globalProvidersDir(): string {
+  const home = process.env.HOME || homedir();
+  return join(home, ".pizzapi", "providers");
+}
+
+export function projectProvidersDir(cwd: string): string {
+  return join(cwd, ".pizzapi", "providers");
+}
+
+export interface ProviderPluginResult {
+  provider: ExtensionProvider;
+  source: ProviderSource;
+}
+
+export interface ProviderSource {
+  origin: "global" | "project";
+  path: string;
+}
+
+export interface ProviderLoadError {
+  path: string;
+  error: string;
+}
+
+export interface DiscoverProvidersResult {
+  providers: ProviderPluginResult[];
+  errors: ProviderLoadError[];
+}
+
+export interface DiscoverProvidersOptions {
+  cwd?: string;
+}
+
+function validateProvider(obj: unknown, sourcePath: string): ExtensionProvider | null {
+  if (!obj || typeof obj !== "object") return null;
+  const p = obj as Record<string, unknown>;
+
+  if (typeof p.id !== "string" || !p.id) return null;
+  if (!Array.isArray(p.capabilities)) return null;
+  if (typeof p.init !== "function" || typeof p.dispose !== "function") return null;
+
+  if (p.capabilities.includes("context") && typeof p.onBeforeAgentStart !== "function") return null;
+
+  if (p.capabilities.includes("lifecycle")) {
+    const hasMethod =
+      typeof p.onSessionStart === "function" ||
+      typeof p.onSessionShutdown === "function" ||
+      typeof p.onTurnEnd === "function" ||
+      typeof p.onSessionClose === "function";
+    if (!hasMethod) return null;
+  }
+
+  if (p.capabilities.includes("ui-panel")) {
+    const hasUI = p.panel !== undefined || p.sidebarWidgets !== undefined || p.sessionMetadataCards !== undefined;
+    if (!hasUI) return null;
+  }
+
+  if (p.capabilities.includes("metadata") && typeof p.getSessionMetadata !== "function") return null;
+
+  return p as unknown as ExtensionProvider;
+}
+
+async function loadProviderModule(filePath: string): Promise<ExtensionProvider | null> {
+  try {
+    const mod = await import(filePath);
+    const exported = mod.default ?? mod;
+
+    if (typeof exported === "function") {
+      try {
+        const instance = new exported();
+        return validateProvider(instance, filePath);
+      } catch {
+        try {
+          const result = await exported();
+          return validateProvider(result, filePath);
+        } catch {
+          return null;
+        }
+      }
+    }
+
+    return validateProvider(exported, filePath);
+  } catch {
+    return null;
+  }
+}
+
+async function scanProvidersDir(
+  dir: string,
+  origin: "global" | "project",
+): Promise<{ providers: ProviderPluginResult[]; errors: ProviderLoadError[] }> {
+  const providers: ProviderPluginResult[] = [];
+  const errors: ProviderLoadError[] = [];
+
+  if (!existsSync(dir)) return { providers, errors };
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (err) {
+    errors.push({ path: dir, error: `Failed to read: ${err}` });
+    return { providers, errors };
+  }
+
+  for (const entry of entries) {
+    if (entry.startsWith(".") || entry.startsWith("_")) continue;
+    const entryPath = join(dir, entry);
+    let stats;
+    try { stats = statSync(entryPath); } catch { continue; }
+
+    if (stats.isDirectory()) {
+      const indexPath = join(entryPath, "index.ts");
+      if (!existsSync(indexPath)) continue;
+
+      const provider = await loadProviderModule(indexPath);
+      if (provider) {
+        providers.push({ provider, source: { origin, path: entryPath } });
+      } else {
+        errors.push({ path: indexPath, error: "Module does not export a valid ExtensionProvider" });
+      }
+    }
+  }
+
+  return { providers, errors };
+}
+
+export async function discoverProviders(
+  options: DiscoverProvidersOptions = {},
+): Promise<DiscoverProvidersResult> {
+  const allProviders: ProviderPluginResult[] = [];
+  const allErrors: ProviderLoadError[] = [];
+  const seenIds = new Set<string>();
+
+  const globalResult = await scanProvidersDir(globalProvidersDir(), "global");
+  for (const p of globalResult.providers) {
+    seenIds.add(p.provider.id);
+    allProviders.push(p);
+  }
+  allErrors.push(...globalResult.errors);
+
+  if (options.cwd) {
+    const projectResult = await scanProvidersDir(projectProvidersDir(options.cwd), "project");
+    for (const p of projectResult.providers) {
+      if (seenIds.has(p.provider.id)) {
+        allErrors.push({ path: p.source.path, error: `Duplicate provider ID "${p.provider.id}" — skipped` });
+      } else {
+        seenIds.add(p.provider.id);
+        allProviders.push(p);
+      }
+    }
+    allErrors.push(...projectResult.errors);
+  }
+
+  return { providers: allProviders, errors: allErrors };
+}

--- a/packages/cli/src/providers/loader.ts
+++ b/packages/cli/src/providers/loader.ts
@@ -34,6 +34,8 @@ export interface DiscoverProvidersResult {
 
 export interface DiscoverProvidersOptions {
   cwd?: string;
+  /** Allow project-local providers. Default: false. */
+  allowProject?: boolean;
 }
 
 function validateProvider(obj: unknown, sourcePath: string): ExtensionProvider | null {
@@ -143,7 +145,7 @@ export async function discoverProviders(
   }
   allErrors.push(...globalResult.errors);
 
-  if (options.cwd) {
+  if (options.cwd && options.allowProject) {
     const projectResult = await scanProvidersDir(projectProvidersDir(options.cwd), "project");
     for (const p of projectResult.providers) {
       if (seenIds.has(p.provider.id)) {

--- a/packages/cli/src/providers/loader.ts
+++ b/packages/cli/src/providers/loader.ts
@@ -67,7 +67,7 @@ function validateProvider(obj: unknown, sourcePath: string): ExtensionProvider |
   return p as unknown as ExtensionProvider;
 }
 
-async function loadProviderModule(filePath: string): Promise<ExtensionProvider | null> {
+async function loadProviderModule(filePath: string): Promise<{ provider: ExtensionProvider | null; error?: string }> {
   try {
     const mod = await import(filePath);
     const exported = mod.default ?? mod;
@@ -75,20 +75,21 @@ async function loadProviderModule(filePath: string): Promise<ExtensionProvider |
     if (typeof exported === "function") {
       try {
         const instance = new exported();
-        return validateProvider(instance, filePath);
-      } catch {
+        return { provider: validateProvider(instance, filePath) };
+      } catch (err) {
+        const ctorErr = err instanceof Error ? err.message : String(err);
         try {
           const result = await exported();
-          return validateProvider(result, filePath);
-        } catch {
-          return null;
+          return { provider: validateProvider(result, filePath) };
+        } catch (err2) {
+          return { provider: null, error: `Constructor failed: ${ctorErr}; async factory also failed: ${err2 instanceof Error ? err2.message : String(err2)}` };
         }
       }
     }
 
-    return validateProvider(exported, filePath);
-  } catch {
-    return null;
+    return { provider: validateProvider(exported, filePath) };
+  } catch (err) {
+    return { provider: null, error: `Import failed: ${err instanceof Error ? err.message : String(err)}` };
   }
 }
 
@@ -119,11 +120,12 @@ async function scanProvidersDir(
       const indexPath = join(entryPath, "index.ts");
       if (!existsSync(indexPath)) continue;
 
-      const provider = await loadProviderModule(indexPath);
-      if (provider) {
-        providers.push({ provider, source: { origin, path: entryPath } });
+      const loaded = await loadProviderModule(indexPath);
+      if (loaded.provider) {
+        providers.push({ provider: loaded.provider, source: { origin, path: entryPath } });
       } else {
-        errors.push({ path: indexPath, error: "Module does not export a valid ExtensionProvider" });
+        const detail = loaded.error ? `: ${loaded.error}` : "";
+        errors.push({ path: indexPath, error: `Module does not export a valid ExtensionProvider${detail}` });
       }
     }
   }

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -1,0 +1,158 @@
+export const PROVIDER_CAPABILITIES = [
+  "context",
+  "lifecycle",
+  "ui-panel",
+  "metadata",
+] as const;
+export type ProviderCapability = (typeof PROVIDER_CAPABILITIES)[number];
+
+// ── Core Provider Contract ────────────────────────────────────
+
+export interface ExtensionProvider {
+  readonly id: string;
+  readonly label?: string;
+  readonly version?: string;
+  readonly capabilities: readonly ProviderCapability[];
+  init(ctx: ProviderInitContext): Promise<void> | void;
+  dispose(): Promise<void> | void;
+}
+
+export interface ProviderInitContext {
+  config: Record<string, unknown>;
+  fireTrigger(sessionId: string, type: string, payload: unknown): Promise<void>;
+  socket: unknown;
+  publishMetadata(sessionId: string, metadata: Record<string, unknown>): void;
+}
+
+export interface ProviderContext {
+  signal: AbortSignal;
+  timeoutMs: number;
+  sessionId: string;
+  sessionFile?: string;
+  cwd: string;
+  promptId?: string;
+  turnId?: number;
+  isFirstTurn?: boolean;
+}
+
+// ── Context Injection ─────────────────────────────────────────
+
+export interface ContextProvider {
+  onBeforeAgentStart(
+    event: BeforeAgentStartEvent,
+    ctx: ProviderContext,
+  ): Promise<ContextContribution[] | void>;
+}
+
+export interface BeforeAgentStartEvent {
+  prompt: string;
+  images?: Array<{ type: "image"; source: { type: "base64"; mediaType: string; data: string } }>;
+  systemPrompt: string;
+}
+
+export interface ContextContribution {
+  text: string;
+  placement: "prepend" | "append";
+  order?: number;
+  dedupeKey?: string;
+  summary: string;
+  referencedArtifacts?: Array<{ id: string; type: string; label: string }>;
+}
+
+// ── Lifecycle Hooks ───────────────────────────────────────────
+
+export interface LifecycleHook {
+  onSessionStart?(event: SessionStartEvent, ctx: ProviderContext): Promise<void>;
+  onSessionShutdown?(event: SessionShutdownEvent, ctx: ProviderContext): Promise<void>;
+  onTurnEnd?(event: TurnEndEvent, ctx: ProviderContext): Promise<void>;
+  onSessionClose?(event: SessionCloseEvent, ctx: ProviderContext): Promise<SessionCloseResult | null>;
+}
+
+export interface SessionStartEvent {
+  reason: "startup" | "reload" | "new" | "resume" | "fork";
+  previousSessionFile?: string;
+}
+
+export interface SessionShutdownEvent {
+  reason: "quit" | "reload" | "new" | "resume" | "fork";
+  targetSessionFile?: string;
+}
+
+export interface TurnEndEvent {
+  turnIndex: number;
+  message: { role: "assistant"; content: string };
+  toolResults?: Array<{ name: string; output: string; isError: boolean }>;
+}
+
+export interface SessionCloseEvent {
+  reason: "close" | "error" | "complete";
+  sessionFile: string;
+}
+
+export interface SessionCloseResult {
+  label: string;
+  jobRef: Record<string, unknown>;
+}
+
+// ── UI Extension ──────────────────────────────────────────────
+
+export interface UIPanelProvider {
+  panel?: PanelConfig;
+  sidebarWidgets?: SidebarWidgetDef[];
+  sessionMetadataCards?: MetadataCardDef[];
+}
+
+export interface PanelConfig {
+  dir: string;
+  requires?: string[];
+}
+
+export interface SidebarWidgetDef {
+  id: string;
+  label: string;
+  source: { type: "html"; dir: string } | { type: "api"; endpoint: string };
+}
+
+export interface MetadataCardDef {
+  id: string;
+  label: string;
+  source: { type: "html"; dir: string } | { type: "api"; endpoint: string };
+}
+
+// ── Session Metadata ──────────────────────────────────────────
+
+export interface MetadataProvider {
+  getSessionMetadata(sessionId: string, ctx: ProviderContext): Promise<Record<string, unknown>>;
+}
+
+// ── Type Guards ───────────────────────────────────────────────
+
+export function hasCapability<T extends ProviderCapability>(
+  provider: ExtensionProvider, capability: T,
+): boolean {
+  return (provider.capabilities as readonly string[]).includes(capability);
+}
+
+export function isContextProvider(p: ExtensionProvider): p is ExtensionProvider & ContextProvider {
+  return hasCapability(p, "context") && typeof (p as any).onBeforeAgentStart === "function";
+}
+
+export function isLifecycleHook(p: ExtensionProvider): p is ExtensionProvider & LifecycleHook {
+  if (!hasCapability(p, "lifecycle")) return false;
+  const lp = p as any;
+  return typeof lp.onSessionStart === "function"
+    || typeof lp.onSessionShutdown === "function"
+    || typeof lp.onTurnEnd === "function"
+    || typeof lp.onSessionClose === "function";
+}
+
+export function isUIPanelProvider(p: ExtensionProvider): p is ExtensionProvider & UIPanelProvider {
+  return hasCapability(p, "ui-panel")
+    && ((p as any).panel !== undefined
+      || (p as any).sidebarWidgets !== undefined
+      || (p as any).sessionMetadataCards !== undefined);
+}
+
+export function isMetadataProvider(p: ExtensionProvider): p is ExtensionProvider & MetadataProvider {
+  return hasCapability(p, "metadata") && typeof (p as any).getSessionMetadata === "function";
+}

--- a/packages/cli/src/providers/types.ts
+++ b/packages/cli/src/providers/types.ts
@@ -71,6 +71,8 @@ export interface LifecycleHook {
 export interface SessionStartEvent {
   reason: "startup" | "reload" | "new" | "resume" | "fork";
   previousSessionFile?: string;
+  /** The model active when the session started. May be undefined for very early startup. */
+  model?: { provider: string; id: string; name: string };
 }
 
 export interface SessionShutdownEvent {

--- a/packages/cli/src/runner/daemon-hooks.test.ts
+++ b/packages/cli/src/runner/daemon-hooks.test.ts
@@ -93,6 +93,16 @@ describe("extractHookSummary", () => {
         expect(result[0].scripts[0]).toBe("track-model.sh");
     });
 
+    test("extracts SessionStart hook entries", () => {
+        const hooks: HooksConfig = {
+            SessionStart: [{ command: "/hooks/on-start.sh" }],
+        };
+        const result = extractHookSummary(hooks);
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe("SessionStart");
+        expect(result[0].scripts[0]).toBe("on-start.sh");
+    });
+
     test("handles command with arguments — only basenames the first token", () => {
         const hooks: HooksConfig = {
             BeforeAgentStart: [{ command: "/path/to/inject-context.sh --verbose --output /tmp/log" }],

--- a/packages/cli/src/runner/daemon-hooks.test.ts
+++ b/packages/cli/src/runner/daemon-hooks.test.ts
@@ -126,4 +126,14 @@ describe("extractHookSummary", () => {
         const result = extractHookSummary(hooks);
         expect(result[0].scripts).toEqual(["hook-a.sh", "hook-b.sh"]);
     });
+
+    test("extracts TurnEnd hook entries", () => {
+        const hooks: HooksConfig = {
+            TurnEnd: [{ command: "/hooks/turn-end.sh" }],
+        };
+        const result = extractHookSummary(hooks);
+        expect(result).toHaveLength(1);
+        expect(result[0].type).toBe("TurnEnd");
+        expect(result[0].scripts).toContain("turn-end.sh");
+    });
 });

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -24,6 +24,7 @@ import { TunnelClient } from "@pizzapi/tunnel";
 import { loadGlobalConfig, defaultAgentDir, expandHome, loadConfig } from "../config.js";
 import { findSessionPathById } from "./session-list-cache.js";
 import { cleanupSessionAttachments, sweepOrphanedAttachments } from "../extensions/session-attachments.js";
+import { triggerSessionClose } from "../extensions/providers/extension.js";
 import { AuthStorage, ModelRegistry } from "@mariozechner/pi-coding-agent";
 import type { ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
@@ -309,6 +310,50 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             if (!gitService) return;
             const maybeGitService = gitService as GitService & { handleSessionEnded?: (id: string) => void };
             maybeGitService.handleSessionEnded?.(sessionId);
+        };
+        const sessionCloseMetadata = new Map<string, { cwd: string; sessionFile?: string }>();
+        const normalizeSessionCloseReason = (reason: unknown): "close" | "error" | "complete" => {
+            const text = typeof reason === "string" ? reason.toLowerCase() : "";
+            if (text.includes("error") || text.includes("crash") || text.includes("orphan")) return "error";
+            if (text.includes("complete")) return "complete";
+            return "close";
+        };
+        const resolveSessionFileForClose = async (sessionId: string, explicitSessionFile?: string): Promise<string> => {
+            if (explicitSessionFile) return explicitSessionFile;
+            const remembered = sessionCloseMetadata.get(sessionId)?.sessionFile;
+            if (remembered) return remembered;
+
+            try {
+                const sessionsRootDir = join(defaultAgentDir(), "agent", "sessions");
+                const found = await findSessionPathById(sessionsRootDir, sessionId);
+                if (found) return found;
+            } catch {
+                // Best-effort only — providers may still be able to use the relay session id.
+            }
+
+            return sessionId;
+        };
+        const notifyProviderSessionClose = async (
+            sessionId: string,
+            reason: unknown,
+            explicitSessionFile?: string,
+        ) => {
+            const metadata = sessionCloseMetadata.get(sessionId);
+            const cwd = metadata?.cwd ?? process.cwd();
+            const sessionFile = await resolveSessionFileForClose(sessionId, explicitSessionFile);
+            try {
+                const closeResult = await triggerSessionClose(
+                    sessionId,
+                    sessionFile,
+                    normalizeSessionCloseReason(reason),
+                    cwd,
+                );
+                if (closeResult) {
+                    logInfo(`[daemon] Provider close: ${closeResult.label}`);
+                }
+            } catch (err) {
+                logWarn(`[daemon] Provider close failed for ${sessionId}: ${err instanceof Error ? err.message : String(err)}`);
+            }
         };
         const tunnelService = new TunnelService();
         registry.register(tunnelService);
@@ -661,6 +706,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                             startedAt: Date.now(),
                             adopted: true,
                         });
+                        sessionCloseMetadata.set(sessionId, { cwd: typeof cwd === "string" && cwd ? cwd : process.cwd() });
                         adopted++;
                     }
                     if (adopted > 0) {
@@ -874,6 +920,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         : { hiddenModels: requestedHiddenModels, agent: resolvedAgent, parentSessionId: requestedParentSessionId, autoClose: requestedAutoClose === true }; // Always pass agent + hidden models + parent + autoClose on restart
                     isFirstSpawn = false;
                     spawnSession(sessionId, apiKey!, relayRaw, requestedCwd, runningSessions, restartingSessions, killedSessions, doSpawn, spawnOpts);
+                    sessionCloseMetadata.set(sessionId, {
+                        cwd: requestedCwd ?? process.cwd(),
+                        ...(resolvedResumePath ? { sessionFile: resolvedResumePath } : {}),
+                    });
                     socket.emit("session_ready", { sessionId });
                     // No need to re-emit service_announce here — the server
                     // persists the announce data in Redis and sends it to
@@ -888,7 +938,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             doSpawn();
         });
 
-        socket.on("kill_session", (data: any) => {
+        socket.on("kill_session", async (data: any) => {
             if (isShuttingDown) return;
             const { sessionId } = data;
             const entry = runningSessions.get(sessionId);
@@ -907,7 +957,10 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     socket.emit("disconnect_session", { sessionId });
                 }
                 runningSessions.delete(sessionId);
+                endedSessionIds.set(sessionId, Date.now());
+                await notifyProviderSessionClose(sessionId, "close");
                 cleanupGitSessionState(sessionId);
+                sessionCloseMetadata.delete(sessionId);
                 logInfo(`killed session ${sessionId}${entry.adopted ? " (adopted)" : ""}`);
                 socket.emit("session_killed", { sessionId });
                 // Clean up persisted attachments for this session
@@ -916,9 +969,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
         });
 
         // ── session_ended — relay notifies us a worker disconnected ───────
-        socket.on("session_ended", (data: any) => {
+        socket.on("session_ended", async (data: any) => {
             if (isShuttingDown) return;
-            const { sessionId, reason } = data;
+            const { sessionId, reason, sessionFile } = data;
 
             // If this session just did a restart-in-place (exit code 43), the relay fires
             // session_ended when the new worker's registerTuiSession tears down the OLD
@@ -939,6 +992,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             }
 
             const entry = runningSessions.get(sessionId);
+            let shouldNotifyProviderClose = false;
             if (entry) {
                 // If the child process is still alive AND this is a transient
                 // relay disconnect (not an expiry/orphan sweep), keep the entry
@@ -954,15 +1008,26 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                 runningSessions.delete(sessionId);
                 killedSessions.delete(sessionId);
                 endedSessionIds.set(sessionId, Date.now());
+                shouldNotifyProviderClose = true;
                 logInfo(`session ${sessionId} ended on relay${entry.adopted ? " (adopted)" : ""}${reason ? ` (${reason})` : ""}`);
             } else if (!endedSessionIds.has(sessionId)) {
                 // First duplicate — log once then suppress subsequent copies
                 endedSessionIds.set(sessionId, Date.now());
+                shouldNotifyProviderClose = true;
                 logInfo(`session_ended for unknown/already-removed session ${sessionId}`);
             }
             // else: duplicate session_ended for a session we already handled — silently ignore
 
+            if (shouldNotifyProviderClose) {
+                await notifyProviderSessionClose(
+                    sessionId,
+                    reason,
+                    typeof sessionFile === "string" ? sessionFile : undefined,
+                );
+            }
+
             cleanupGitSessionState(sessionId);
+            if (shouldNotifyProviderClose) sessionCloseMetadata.delete(sessionId);
 
             // Clean up persisted attachments.  For spawned sessions child.on("exit")
             // already ran cleanup, so this is a no-op (idempotent).  For adopted sessions

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -524,6 +524,19 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             },
         );
 
+        socket.io.on("reconnect_attempt", (attempt) => {
+            logInfo(`[relay] reconnect attempt ${attempt} to ${sioUrl}/runner`);
+        });
+        socket.io.on("reconnect_error", (err) => {
+            logWarn(`[relay] reconnect error: ${err instanceof Error ? err.message : String(err)}`);
+        });
+        socket.io.on("reconnect", (attempt) => {
+            logInfo(`[relay] reconnected after ${attempt} attempt(s)`);
+        });
+        socket.io.on("error", (err) => {
+            logWarn(`[relay] manager error: ${err instanceof Error ? err.message : String(err)}`);
+        });
+
         // Service init happens in runner_registered after plugin discovery completes.
 
         if (tunnelClient) {
@@ -622,9 +635,14 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             emitRegister();
         });
 
-        socket.on("disconnect", (reason) => {
+        socket.on("disconnect", (reason, details) => {
             if (isShuttingDown) return;
-            logInfo(`disconnected (${reason}). Socket.IO will reconnect automatically.`);
+            const engine = socket.io.engine;
+            const transportName = engine?.transport?.name ?? "unknown";
+            logInfo(
+                `disconnected (${reason}). Socket.IO will reconnect automatically. `
+                + `transport=${transportName} details=${JSON.stringify(details ?? {})}`,
+            );
         });
 
         // ── Registration confirmation ─────────────────────────────────────

--- a/packages/cli/src/runner/hook-summary.ts
+++ b/packages/cli/src/runner/hook-summary.ts
@@ -32,6 +32,7 @@ export function extractHookSummary(hooks?: HooksConfig): RunnerHook[] {
         "SessionBeforeSwitch",
         "SessionBeforeFork",
         "SessionShutdown",
+        "TurnEnd",
         "SessionBeforeCompact",
         "SessionBeforeTree",
         "ModelSelect",

--- a/packages/cli/src/runner/hook-summary.ts
+++ b/packages/cli/src/runner/hook-summary.ts
@@ -35,6 +35,7 @@ export function extractHookSummary(hooks?: HooksConfig): RunnerHook[] {
         "SessionBeforeCompact",
         "SessionBeforeTree",
         "ModelSelect",
+        "SessionStart",
     ] as const;
     for (const type of entryTypes) {
         const entries = (hooks[type] as { command: string }[] | undefined) ?? [];

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -321,6 +321,10 @@ async function main(): Promise<void> {
     // triggers / remote input cannot start the first turn until all startup
     // work (notably MCP initialization) has completed.
     armWorkerStartupGate();
+    // Make session file path available to hooks/extensions (e.g. pertinence retrospective)
+    if (session.sessionFile) {
+      process.env.PIZZAPI_SESSION_FILE = session.sessionFile;
+    }
     bootTimer.start("[boot] bind-extensions");
     try {
     await session.bindExtensions({

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -77,6 +77,8 @@ class MyProvider implements ExtensionProvider {
 
   async onSessionStart(event, ctx) {
     // event.reason — "startup" | "reload" | "new" | "resume" | "fork"
+    // event.model  — { provider, id, name } | undefined  (model active at session start)
+    // Use event.model to gate provider behavior on the current model
     // Rehydrate session state, load pending jobs
   }
 
@@ -179,6 +181,45 @@ Every hook method receives `ProviderContext`:
 ## Error Isolation
 
 PizzaPi catches provider errors and continues without the failing provider's contribution. After 3 consecutive errors, a provider is temporarily disabled for the remainder of the session. Errors are logged and surfaced in the provider's panel.
+
+## SessionStart Model Information
+
+`onSessionStart` now receives the active model in the event payload. This lets providers and hooks gate behavior on the model at session start — for example, adjusting context injection strategy per-model.
+
+```typescript
+async onSessionStart(event, ctx) {
+  // event.model — { provider: string; id: string; name: string } | undefined
+  // undefined only during very early startup before model resolution
+  console.log(`Session started with model: ${event.model?.id ?? 'unknown'}`);
+}
+```
+
+The same model information is also available to **native hooks** via the `SessionStart` hook:
+
+```json
+// ~/.pizzapi/config.json
+{
+  "hooks": {
+    "SessionStart": [{
+      "command": "echo $PIZZAPI_MODEL_ID > /tmp/session-model.txt"
+    }]
+  }
+}
+```
+
+Hook scripts receive JSON on stdin:
+
+```json
+{
+  "event": "SessionStart",
+  "reason": "startup",
+  "previous_session_file": null,
+  "session_id": "abc123",
+  "model": { "provider": "anthropic", "id": "claude-sonnet-4-20250514", "name": "Claude 4 Sonnet" }
+}
+```
+
+When no model is available yet, `model` is `null`. This is a fire-and-forget hook — exit codes are ignored.
 
 ---
 

--- a/packages/cli/src/skills/creating-runner-services/SKILL.md
+++ b/packages/cli/src/skills/creating-runner-services/SKILL.md
@@ -1,29 +1,190 @@
 ---
 name: creating-runner-services
-description: Use when building a new runner service — background processes with optional UI panels, custom triggers agents can subscribe to, or sigils that render inline references in the UI
+description: Use when building a new runner service — background processes with optional UI panels, custom triggers agents can subscribe to, sigils that render inline references in the UI, or lifecycle-aware context injection into agent turns
 ---
 
 # Creating Runner Services
 
-Runner services are background processes on the runner daemon. They can:
+Runner services are background processes on the runner daemon. Pick the right API for your needs:
 
-- **Expose a UI panel** — an iframe in the PizzaPi web interface (no React needed)
-- **Advertise custom triggers** — agents discover and subscribe to them at runtime
-- **Define sigils** — teach the UI how to render `[[type:id]]` inline references
-- **Fire triggers** — broadcast events to all subscribed agent sessions via the relay API
+| API | Directory | Use when |
+|-----|-----------|----------|
+| **ExtensionProvider** | `~/.pizzapi/providers/` | You need lifecycle hooks (session start/end, turn end), context injection into the LLM's system prompt, or session metadata attachment. Preferred for new services. |
+| **ServiceHandler** | `~/.pizzapi/services/` | You only need a panel, triggers, or sigils — no lifecycle awareness. Simpler, less boilerplate for panel-only services. |
+
+---
+
+# ExtensionProvider API (Recommended)
+
+The `ExtensionProvider` interface gives services direct access to:
+
+- **Context injection** — inject text into the LLM's system prompt before each turn
+- **Lifecycle hooks** — react to session_start, turn_end, session_shutdown, session_close
+- **UI extension** — sidebar widgets, metadata cards, and panels visible in the web UI
+- **Session metadata** — attach typed metadata to session records
 
 ## Folder Structure
 
 ```
-~/.pizzapi/services/<service-name>/
-  manifest.json       # Required — core identity (id, label, icon, entry, panel)
-  triggers.json       # Optional — trigger definitions (overrides manifest.triggers)
-  sigils.json         # Optional — sigil type definitions (overrides manifest.sigils)
-  index.ts            # ServiceHandler module (default export)
-  panel/              # Optional — only needed if the service has a UI panel
-    index.html        # Self-contained UI (HTML/CSS/JS)
-    ...               # Any additional static assets
+~/.pizzapi/providers/<provider-id>/
+  index.ts            # ExtensionProvider module (default export)
+  panel/              # Optional — static panel assets (HTML/CSS/JS)
 ```
+
+## ExtensionProvider Template
+
+```typescript
+import type { ExtensionProvider, ProviderInitContext, ProviderContext } from "@pizzapi/cli/providers/types";
+
+class MyProvider implements ExtensionProvider {
+  id = "my-provider";
+  capabilities = ["context", "lifecycle", "ui-panel", "metadata"] as const;
+
+  // ── Core Lifecycle ────────────────────────────────────────
+
+  init(ctx: ProviderInitContext) {
+    // ctx.config — per-provider config from config.json
+    // ctx.fireTrigger(sessionId, type, payload) — fire triggers
+    // ctx.publishMetadata(sessionId, metadata) — push metadata to UI
+    // ctx.socket — relay socket for custom protocols
+  }
+
+  dispose() {
+    // Cleanup
+  }
+
+  // ── Context Injection ─────────────────────────────────────
+
+  async onBeforeAgentStart(event, ctx) {
+    // Search your DB for relevant context based on event.prompt
+    return [
+      {
+        text: "Memory: use pnpm, not npm",
+        placement: "prepend",        // "prepend" | "append"
+        order: 50,                   // Lower = sorted first (default 100)
+        dedupeKey: "pkg-mgr",        // Same key + providerId = dedup
+        summary: "Package manager preference",
+        referencedArtifacts: [{
+          id: "mem-123",
+          type: "memory",
+          label: "Use pnpm"
+        }],
+      },
+    ];
+  }
+
+  // ── Lifecycle Hooks ───────────────────────────────────────
+
+  async onSessionStart(event, ctx) {
+    // event.reason — "startup" | "reload" | "new" | "resume" | "fork"
+    // Rehydrate session state, load pending jobs
+  }
+
+  async onTurnEnd(event, ctx) {
+    // event.turnIndex, event.message, event.toolResults
+    // Incremental indexing — scan messages for signals
+  }
+
+  async onSessionShutdown(event, ctx) {
+    // event.reason — "quit" | "reload" | "new" | "resume" | "fork"
+    // Flush pending writes
+  }
+
+  async onSessionClose(event, ctx) {
+    // event.reason — "close" | "error" | "complete"
+    // Best-effort final flush before archival
+    return { label: "Finalizing memory…", jobRef: { jobId: "123" } };
+  }
+
+  // ── UI Extension ──────────────────────────────────────────
+
+  get panel() {
+    return { dir: "./panel", requires: ["SESSION_ID", "PROJECT_DIR"] };
+  }
+
+  get sidebarWidgets() {
+    return [{
+      id: "my-timeline",
+      label: "Recent Activity",
+      source: { type: "html", dir: "./widgets/timeline" },
+    }];
+  }
+
+  get sessionMetadataCards() {
+    return [{
+      id: "my-stats",
+      label: "Provider Stats",
+      source: { type: "api", endpoint: "./api/stats" },
+    }];
+  }
+
+  // ── Session Metadata ──────────────────────────────────────
+
+  async getSessionMetadata(sessionId, ctx) {
+    return {
+      activeDirectives: 3,
+      recentMemories: ["Use pnpm", "Write tests first"],
+    };
+  }
+}
+
+export default MyProvider;
+```
+
+## Capability Interfaces
+
+A provider implements capability interfaces by duck-typing. PizzaPi discovers what a provider supports by checking its method signatures. Declare which capabilities you implement in the `capabilities` array:
+
+| Capability | Key methods/properties |
+|-----------|----------------------|
+| `"context"` | `onBeforeAgentStart(event, ctx)` → `ContextContribution[]` |
+| `"lifecycle"` | `onSessionStart`, `onTurnEnd`, `onSessionClose`, `onSessionShutdown` |
+| `"ui-panel"` | `panel`, `sidebarWidgets`, `sessionMetadataCards` |
+| `"metadata"` | `getSessionMetadata(sessionId, ctx)` → `Record<string, unknown>` |
+
+## Provider Configuration
+
+Providers can be configured in `~/.pizzapi/config.json`:
+
+```json
+{
+  "providers": {
+    "my-provider": {
+      "enabled": true,
+      "dbPath": "/custom/path/to/db.sqlite"
+    }
+  }
+}
+```
+
+The config object is passed to `ProviderInitContext.config` during `init()`. Set `"enabled": false` to disable a provider.
+
+**Trust gate:** Project-local providers (`.pizzapi/providers/`) are disabled by default. Set `"allowProjectProviders": true` in `config.json` to enable them for a specific project.
+
+## ProviderContext Fields
+
+Every hook method receives `ProviderContext`:
+
+| Field | Description |
+|-------|-------------|
+| `signal` | `AbortSignal` — respect this to cancel work |
+| `timeoutMs` | Timeout budget for this hook (default 5000ms) |
+| `sessionId` | Current session ID |
+| `sessionFile` | Path to session JSONL file |
+| `cwd` | Working directory |
+| `promptId` | Stable across all turns of one user prompt (turn-scoped only) |
+| `turnId` | Incrementing turn index within the current prompt |
+| `isFirstTurn` | `true` only for turn 0 |
+
+## Error Isolation
+
+PizzaPi catches provider errors and continues without the failing provider's contribution. After 3 consecutive errors, a provider is temporarily disabled for the remainder of the session. Errors are logged and surfaced in the provider's panel.
+
+---
+
+# ServiceHandler API (Legacy)
+
+Use the `ServiceHandler` interface for simple services that only need a panel, triggers, or sigils — no lifecycle awareness.
 
 ## manifest.json
 
@@ -458,6 +619,21 @@ A service doesn't need a panel. Omit `panel` from manifest.json and skip the `an
 ```
 
 ## How It Works
+
+### ExtensionProvider
+
+```
+1. Daemon discovers folder in ~/.pizzapi/providers/
+2. Reads index.ts → validates capabilities against declared methods
+3. Calls provider.init(config) → provider initializes its DB/state
+4. On session_start → bridge fires onSessionStart on all providers
+5. On before_agent_start → bridge collects ContextContribution[], sorts, dedupes, injects into system prompt
+6. On turn_end → bridge fires onTurnEnd for incremental indexing
+7. On session archival → daemon calls onSessionClose for final flush
+8. On session_shutdown → bridge fires onSessionShutdown, then calls provider.dispose()
+```
+
+### ServiceHandler
 
 ```
 1. Daemon discovers folder in ~/.pizzapi/services/

--- a/packages/docs/astro.config.mjs
+++ b/packages/docs/astro.config.mjs
@@ -119,6 +119,7 @@ export default defineConfig({
                         { label: "Agent Definitions", slug: "customization/agent-definitions" },
                         { label: "Claude Code Plugins", slug: "customization/claude-plugins" },
                         { label: "Runner Services", slug: "customization/runner-services" },
+                        { label: "Extension Providers", slug: "customization/providers" },
                         { label: "Subagents", slug: "customization/subagents" },
                     ],
                 },

--- a/packages/docs/src/content/docs/customization/providers.mdx
+++ b/packages/docs/src/content/docs/customization/providers.mdx
@@ -1,0 +1,541 @@
+---
+title: Extension Providers
+description: Build plugins that inject context, hook into session lifecycle events, and extend the PizzaPi web UI.
+---
+
+import { Aside, FileTree, Steps } from "@astrojs/starlight/components";
+
+Extension Providers are a plugin system for extending the coding agent at runtime. Unlike [AI model providers](/PizzaPi/features/providers-and-models/) (which configure model backends like Anthropic or Ollama), Extension Providers are lifecycle-aware plugins that run inside the agent process.
+
+A provider can:
+
+- **Inject context** into every agent turn — add notes, rules, or references to the system prompt
+- **Hook into session lifecycle** — react to session start, turn end, shutdown, and close events
+- **Add UI panels and widgets** — register sidebar widgets or metadata cards in the web interface
+- **Contribute session metadata** — provide structured data about the session
+
+Providers live in `~/.pizzapi/providers/<name>/index.ts` and are discovered automatically on session start.
+
+---
+
+## Quick Start
+
+<Steps>
+
+1. **Create the provider directory:**
+
+   ```bash
+   mkdir -p ~/.pizzapi/providers/my-provider
+   ```
+
+2. **Add `index.ts`** with an ExtensionProvider:
+
+   ```typescript
+   // ~/.pizzapi/providers/my-provider/index.ts
+   export default {
+     id: "my-provider",
+     capabilities: ["context", "lifecycle"],
+     
+     init() {
+       console.log("[my-provider] initialized");
+     },
+     dispose() {
+       console.log("[my-provider] disposed");
+     },
+
+     onBeforeAgentStart(event, ctx) {
+       // Injected into every agent turn
+       return [
+         {
+           text: "Important: always run tests before committing.",
+           placement: "prepend",
+           order: 50,
+           summary: "Testing reminder",
+           dedupeKey: "test-reminder",
+         },
+       ];
+     },
+
+     onTurnEnd(event, ctx) {
+       // Called after each assistant response
+       console.log(`Turn ${event.turnIndex} complete`);
+     },
+   };
+   ```
+
+3. **Restart the runner** — the provider is loaded on the next session start.
+
+</Steps>
+
+---
+
+## Folder Structure
+
+<FileTree>
+- ~/.pizzapi/providers/
+  - my-provider/
+    - index.ts — ExtensionProvider module (default export)
+  - another-provider/
+    - index.ts
+    - helpers.ts — imported by index.ts
+</FileTree>
+
+Directories starting with `.` or `_` are ignored.
+
+---
+
+## ExtensionProvider Interface
+
+Every provider module must export a default value matching the `ExtensionProvider` interface:
+
+```typescript
+interface ExtensionProvider {
+  id: string;
+  label?: string;
+  version?: string;
+  capabilities: ("context" | "lifecycle" | "ui-panel" | "metadata")[];
+  init(ctx: ProviderInitContext): Promise<void> | void;
+  dispose(): Promise<void> | void;
+}
+```
+
+### Module Formats
+
+The loader accepts three export patterns:
+
+**Object literal** (recommended):
+```typescript
+export default {
+  id: "my-provider",
+  capabilities: ["context"],
+  init() {},
+  dispose() {},
+  onBeforeAgentStart() { /* ... */ },
+};
+```
+
+**Class (instantiated with `new`)**:
+```typescript
+export default class MyProvider {
+  id = "my-provider";
+  capabilities = ["context"];
+  init() {}
+  dispose() {}
+  onBeforeAgentStart() { /* ... */ }
+}
+```
+
+**Factory function (called with `await`)**:
+```typescript
+export default async function createProvider() {
+  return {
+    id: "my-provider",
+    capabilities: ["context"],
+    init() {},
+    dispose() {},
+    onBeforeAgentStart() { /* ... */ },
+  };
+}
+```
+
+### `init()` and `dispose()`
+
+`init()` receives a `ProviderInitContext` with:
+
+```typescript
+interface ProviderInitContext {
+  config: Record<string, unknown>;     // Provider-specific config from config.json
+  fireTrigger(sessionId, type, payload): Promise<void>;
+  socket: unknown;                     // Socket.IO connection (if available)
+  publishMetadata(sessionId, metadata): void;
+}
+```
+
+The `config` object contains the provider's entry from `~/.pizzapi/config.json`:
+
+```json title="~/.pizzapi/config.json"
+{
+  "providers": {
+    "my-provider": {
+      "enabled": true,
+      "model": "claude-sonnet-4-20250514",
+      "customOption": "value"
+    }
+  }
+}
+```
+
+`dispose()` is called during session shutdown for cleanup (closing connections, releasing resources).
+
+---
+
+## Capabilities
+
+Providers declare what they do via the `capabilities` array. Each capability requires specific methods:
+
+### `"context"` — Context Injection
+
+Inject text into every turn's system prompt. Implement `onBeforeAgentStart`:
+
+```typescript
+async onBeforeAgentStart(
+  event: BeforeAgentStartEvent,
+  ctx: ProviderContext,
+): Promise<ContextContribution[] | void>;
+```
+
+Where:
+
+```typescript
+interface BeforeAgentStartEvent {
+  prompt: string;                   // The user's current prompt
+  images?: Array<{ type: "image"; source: { type: "base64"; mediaType: string; data: string } }>;
+  systemPrompt: string;            // The current system prompt
+}
+
+interface ContextContribution {
+  text: string;                    // The text to inject
+  placement: "prepend" | "append"; // Before or after the system prompt
+  order?: number;                  // Sort order (default: 100)
+  dedupeKey?: string;              // Deduplication key (see below)
+  summary: string;                 // Short description for logging
+  referencedArtifacts?: Array<{ id: string; type: string; label: string }>;
+}
+```
+
+**Sorting:** Contributions are sorted by `order` (ascending), then by provider ID alphabetically. Prepend items are grouped by order — higher-order groups are placed closer to the top of the prompt while preserving order within each group.
+
+**Deduplication:** When two contributions share the same `dedupeKey` within a single user prompt, the second is silently skipped. This prevents duplicate context when a provider fires `onBeforeAgentStart` multiple times per prompt (e.g., on retries). The dedupe state resets at the start of each new user prompt.
+
+### `"lifecycle"` — Session Lifecycle Hooks
+
+Hook into session lifecycle events. Any of these methods may be present:
+
+```typescript
+interface LifecycleHook {
+  onSessionStart?(event: SessionStartEvent, ctx: ProviderContext): Promise<void>;
+  onSessionShutdown?(event: SessionShutdownEvent, ctx: ProviderContext): Promise<void>;
+  onTurnEnd?(event: TurnEndEvent, ctx: ProviderContext): Promise<void>;
+  onSessionClose?(event: SessionCloseEvent, ctx: ProviderContext): Promise<SessionCloseResult | null>;
+}
+```
+
+**Lifecycle order:**
+
+```
+Session Start → [Turn 1: BeforeAgentStart → Turn 1: TurnEnd → Turn 2: ...] → Session Close → Session Shutdown
+```
+
+**`onSessionStart`** — Called when a session begins:
+```typescript
+interface SessionStartEvent {
+  reason: "startup" | "reload" | "new" | "resume" | "fork";
+  previousSessionFile?: string;     // Set when resuming/forking a previous session
+}
+```
+
+**`onSessionShutdown`** — Called during session teardown:
+```typescript
+interface SessionShutdownEvent {
+  reason: "quit" | "reload" | "new" | "resume" | "fork";
+  targetSessionFile?: string;       // Set when switching to a different session
+}
+```
+
+**`onTurnEnd`** — Called after each assistant response:
+```typescript
+interface TurnEndEvent {
+  turnIndex: number;
+  message: { role: "assistant"; content: string };
+  toolResults?: Array<{ name: string; output: string; isError: boolean }>;
+}
+```
+
+Use `onTurnEnd` for incremental indexing, saving context, or observability.
+
+**`onSessionClose`** — Called when a session is being archived:
+```typescript
+interface SessionCloseEvent {
+  reason: "close" | "error" | "complete";
+  sessionFile: string;
+}
+
+interface SessionCloseResult {
+  label: string;
+  jobRef: Record<string, unknown>;
+}
+```
+
+The first provider to return a non-null `SessionCloseResult` wins — other providers are not called. Return `null` to let the next provider handle it.
+
+### `"ui-panel"` — Web UI Extensions
+
+Add UI panels, sidebar widgets, or session metadata cards to the PizzaPi web interface:
+
+```typescript
+interface UIPanelProvider {
+  panel?: PanelConfig;              // Full panel in the UI
+  sidebarWidgets?: SidebarWidgetDef[];
+  sessionMetadataCards?: MetadataCardDef[];
+}
+
+interface PanelConfig {
+  dir: string;                      // Directory with HTML/CSS/JS
+  requires?: string[];              // Required capabilities
+}
+
+interface SidebarWidgetDef {
+  id: string;
+  label: string;
+  source: { type: "html"; dir: string } | { type: "api"; endpoint: string };
+}
+
+interface MetadataCardDef {
+  id: string;
+  label: string;
+  source: { type: "html"; dir: string } | { type: "api"; endpoint: string };
+}
+```
+
+### `"metadata"` — Session Metadata
+
+Contribute structured metadata for the session viewer:
+
+```typescript
+interface MetadataProvider {
+  getSessionMetadata(sessionId: string, ctx: ProviderContext): Promise<Record<string, unknown>>;
+}
+```
+
+---
+
+## Configuration
+
+Providers can be configured via `~/.pizzapi/config.json`:
+
+```json title="~/.pizzapi/config.json"
+{
+  "providers": {
+    "my-provider": {
+      "enabled": true,
+      "apiKey": "sk-...",
+      "model": "claude-sonnet-4-20250514",
+      "customSetting": "value"
+    }
+  }
+}
+```
+
+The `enabled` field can be set to `false` to skip a provider without removing its directory:
+
+```json
+{
+  "providers": {
+    "my-provider": {
+      "enabled": false
+    }
+  }
+}
+```
+
+The entire config object (excluding `enabled`) is passed to the provider's `init()` method as `ctx.config`.
+
+---
+
+## ProviderBridge Behavior
+
+The ProviderBridge orchestrates all active providers. Understanding its behavior helps you design reliable providers:
+
+### Error Isolation
+
+If a provider throws in `onBeforeAgentStart`, `onTurnEnd`, or `onSessionClose`:
+
+1. The error is caught and logged
+2. Other providers **still run** — one failing provider doesn't block others
+3. After **3 consecutive errors**, the provider is **auto-disabled** and won't be called again
+4. A successful call resets the error counter
+
+This means a buggy provider won't take down the entire session.
+
+### ProviderContext
+
+All lifecycle methods receive a `ProviderContext`:
+
+```typescript
+interface ProviderContext {
+  signal: AbortSignal;              // Abort signal for cancellation
+  timeoutMs: number;                // Recommended timeout (default: 5000)
+  sessionId: string;                // Current session ID
+  sessionFile?: string;             // Path to the session file
+  cwd: string;                      // Working directory
+  promptId?: string;                // Current prompt boundary (set during onBeforeAgentStart)
+  turnId?: number;                  // Current turn number within the prompt
+  isFirstTurn?: boolean;            // True if this is the first turn of the prompt
+}
+```
+
+### Deduplication Scope
+
+Deduplication is **per-prompt** — each user prompt gets a fresh dedupe state. This means:
+
+- Within a single user prompt, repeating `dedupeKey` values are skipped
+- Across different user prompts, dedupe keys are independent
+- The extension resets dedupe state at the start of each `before_agent_start` event
+
+---
+
+## Complete Example
+
+A provider that tracks file modifications and injects recent changes into each turn:
+
+```typescript
+// ~/.pizzapi/providers/git-context/index.ts
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { execSync } from "node:child_process";
+
+export default {
+  id: "git-context",
+  label: "Git Context Provider",
+  version: "1.0.0",
+  capabilities: ["context", "lifecycle"],
+
+  config: {},
+  gitDir: "",
+
+  init(ctx) {
+    this.config = ctx.config;
+    // Default to the session working directory
+    this.gitDir = ctx.config.gitDir ?? process.cwd();
+    console.log(`[git-context] Watching ${this.gitDir}`);
+  },
+
+  dispose() {
+    console.log("[git-context] disposed");
+  },
+
+  onSessionStart(event, ctx) {
+    if (event.reason === "resume" || event.reason === "fork") {
+      console.log(`[git-context] Resumed from ${event.previousSessionFile}`);
+    }
+  },
+
+  onBeforeAgentStart(event, ctx) {
+    try {
+      const root = execSync("git rev-parse --show-toplevel", {
+        cwd: this.gitDir,
+        encoding: "utf-8",
+        timeout: 3000,
+      }).trim();
+
+      const status = execSync("git status --short", {
+        cwd: root,
+        encoding: "utf-8",
+        timeout: 3000,
+      }).trim();
+
+      if (!status) return [];
+
+      const lines = status.split("\n").slice(0, 10);
+      const changes = lines.join("\n");
+
+      return [
+        {
+          text: `Current working tree changes:\n${changes}`,
+          placement: "prepend",
+          order: 40,
+          summary: `${lines.length} working tree changes`,
+          dedupeKey: `git-status-${ctx.promptId}`,
+        },
+      ];
+    } catch {
+      return [];
+    }
+  },
+
+  onTurnEnd(event, ctx) {
+    // Log assistant messages that mention files
+    if (event.message.content.includes("file") || event.message.content.includes("change")) {
+      console.log(`[git-context] Turn ${event.turnIndex}: file changes discussed`);
+    }
+  },
+
+  onSessionClose(event, ctx) {
+    // Record session closure for analytics
+    return {
+      label: "Git session recorded",
+      jobRef: { type: "git-session", sessionId: ctx.sessionId },
+    };
+  },
+};
+```
+
+---
+
+## Project-Local Providers
+
+Providers can also be placed in a project's `.pizzapi/providers/` directory:
+
+<FileTree>
+- .pizzapi/providers/
+  - project-tool/
+    - index.ts
+</FileTree>
+
+Project providers require explicit trust via `allowProjectProviders: true` in `~/.pizzapi/config.json`:
+
+```json title="~/.pizzapi/config.json"
+{
+  "allowProjectProviders": true
+}
+```
+
+When a project provider has the same `id` as a global provider, the project provider is **skipped** with a warning. Global providers always take priority.
+
+---
+
+## Validation Rules
+
+When a provider module is loaded, the system validates:
+
+- `id` must be a non-empty string
+- `capabilities` must be an array
+- `init()` and `dispose()` must be functions
+- If `capabilities` includes `"context"`, `onBeforeAgentStart` must be a function
+- If `capabilities` includes `"lifecycle"`, at least one lifecycle method must be present
+- If `capabilities` includes `"ui-panel"`, at least one UI property (`panel`, `sidebarWidgets`, or `sessionMetadataCards`) must be defined
+- If `capabilities` includes `"metadata"`, `getSessionMetadata` must be a function
+
+Invalid modules are reported as errors but don't prevent other providers from loading.
+
+---
+
+## Troubleshooting
+
+**Provider not loaded:**
+- Check that the directory is in `~/.pizzapi/providers/<name>/` and has an `index.ts` file
+- Verify the module exports a valid `ExtensionProvider` (default export)
+- Check for log messages starting with `[provider-extension]` on the runner
+- Ensure `enabled` is not set to `false` in `~/.pizzapi/config.json`
+
+**Context not appearing:**
+- Verify the `"context"` capability is declared
+- Check that `onBeforeAgentStart` returns a non-empty array
+- If using `dedupeKey`, ensure it's unique within the prompt — the same key is only emitted once
+
+**Provider disabled after errors:**
+- Check for `[ProviderBridge] Disabling provider` warnings in the runner logs
+- Fix the errors and restart the session
+- The 3-error threshold is reset by a single successful call
+
+**Project provider not loading:**
+- Ensure `allowProjectProviders: true` is set in `~/.pizzapi/config.json` (the global config, not the project one)
+- Check for duplicate ID warnings — another provider with the same `id` may already be loaded globally
+
+---
+
+## See Also
+
+- [Hooks](/PizzaPi/customization/hooks/) — shell-script lifecycle hooks (alternative to Extension Providers)
+- [Runner Services](/PizzaPi/customization/runner-services/) — background processes with UI panels and custom triggers
+- [ProviderBridge API](/PizzaPi/reference/architecture/) — how providers are orchestrated

--- a/packages/docs/src/content/docs/features/providers-and-models.mdx
+++ b/packages/docs/src/content/docs/features/providers-and-models.mdx
@@ -5,6 +5,13 @@ description: Configure AI providers, authenticate with subscriptions or API keys
 
 import { Aside, Steps, Tabs, TabItem } from "@astrojs/starlight/components";
 
+<Aside type="tip">
+  Looking for **Extension Providers** — the plugin system for injecting context,
+  hooking session lifecycle events, and adding UI panels? See
+  [Extension Providers](/PizzaPi/customization/providers/). This page covers
+  AI model backends (API keys, custom models, authentication) only.
+</Aside>
+
 PizzaPi is built on the **pi** coding agent, which supports 20+ AI providers out of the box. You can authenticate with a paid subscription via OAuth, set API keys, or add custom providers like Ollama or LM Studio for local models.
 
 ---

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -7,6 +7,7 @@ import { createLogger } from "@pizzapi/tools";
 
 const authLog = createLogger("auth");
 const apiLog = createLogger("api");
+const tunnelLog = createLogger("tunnel-relay");
 
 /** Default body size limit for API routes (1 MB). */
 export const MAX_BODY_SIZE = 1 * 1024 * 1024;
@@ -208,6 +209,15 @@ export async function handleFetch(req: Request, authContext: AuthContext): Promi
 
 async function _handleFetch(req: Request): Promise<Response> {
     const url = new URL(req.url);
+
+    if (url.pathname === "/_tunnel") {
+        tunnelLog.warn(
+            `/_tunnel reached HTTP handler without WebSocket upgrade method=${req.method} `
+            + `upgrade=${req.headers.get("upgrade") ?? "<none>"} connection=${req.headers.get("connection") ?? "<none>"} `
+            + `ua=${req.headers.get("user-agent") ?? "<none>"}`,
+        );
+        return new Response("Expected WebSocket upgrade", { status: 426 });
+    }
 
     // ── Body size guard ────────────────────────────────────────────────
     // Validates Content-Length when present (strict numeric parsing) and falls

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -179,7 +179,9 @@ async function sendFetchResponse(res: ServerResponse, response: Response): Promi
         }
     } finally {
         reader.releaseLock();
-        res.end();
+        if (!res.writableEnded && !res.destroyed) {
+            res.end();
+        }
     }
 }
 
@@ -199,6 +201,8 @@ const httpServer = createServer(async (req, res) => {
         await sendFetchResponse(res, fetchRes);
     } catch (e) {
         httpLog.error("Unhandled error:", e);
+        if (res.writableEnded || res.destroyed) return;
+
         if (!res.headersSent) {
             res.writeHead(500, {
                 "content-type": "application/json",
@@ -210,8 +214,14 @@ const httpServer = createServer(async (req, res) => {
                 "content-security-policy":
                     "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; connect-src 'self' ws: wss: blob:; font-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'",
             });
+            res.end(JSON.stringify({ error: "Internal server error" }));
+            return;
         }
-        res.end(JSON.stringify({ error: "Internal server error" }));
+
+        // If a streaming response failed after headers/body bytes were already
+        // sent, we cannot send a JSON 500 without corrupting the response or
+        // hitting ERR_STREAM_WRITE_AFTER_END. Close whatever remains instead.
+        res.end();
     }
 });
 

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -10,6 +10,7 @@
 import { getLatestNpmVersion } from "../version.js";
 import { serverHealth } from "../health.js";
 import { getServerRuntimeInfo } from "../runtime-version.js";
+import { createLogger } from "@pizzapi/tools";
 import { handleAuthRoute } from "./auth.js";
 import { handleRunnersRoute } from "./runners.js";
 import { handleSessionsRoute } from "./sessions.js";
@@ -22,6 +23,9 @@ import { handleTunnelRoute } from "./tunnel.js";
 import { handleTriggersRoute } from "./triggers.js";
 import { handleWebhooksRoute } from "./webhooks.js";
 import type { RouteHandler } from "./types.js";
+
+const healthLog = createLogger("health");
+let lastHealthSignature = "";
 
 /** All domain routers, tried in order. */
 const routers: RouteHandler[] = [
@@ -49,9 +53,17 @@ export async function handleApi(req: Request, url: URL): Promise<Response | unde
     if (url.pathname === "/health" || url.pathname === "/status" || url.pathname === "/api/status") {
         const { redis, socketio, startedAt } = serverHealth;
         const ok = redis && socketio;
+        const status = ok ? "ok" : "degraded";
+        const signature = `${status}:redis=${redis}:socketio=${socketio}`;
+        if (signature !== lastHealthSignature) {
+            lastHealthSignature = signature;
+            const message = `health status=${status} redis=${redis} socketio=${socketio} uptime=${Math.floor((Date.now() - startedAt) / 1000)}s`;
+            if (ok) healthLog.info(message);
+            else healthLog.warn(message);
+        }
         const { serverVersion, socketProtocolVersion, buildTimestamp } = await getServerRuntimeInfo();
         return Response.json({
-            status: ok ? "ok" : "degraded",
+            status,
             redis,
             socketio,
             uptime: Math.floor((Date.now() - startedAt) / 1000),

--- a/packages/server/src/routes/tunnel.test.ts
+++ b/packages/server/src/routes/tunnel.test.ts
@@ -10,6 +10,7 @@ import {
     shouldRewriteTunnelCss,
     rewriteTunnelJsModule,
     rewriteTunnelCss,
+    proxyTunnelRequestViaRelay,
 } from "./tunnel";
 
 describe("tunnel route URL rewriting", () => {
@@ -628,6 +629,52 @@ import bar from "../lib/bar.js";`;
         const js = `import React from '/node_modules/.vite/deps/react.js';`;
         const rewritten = rewriteTunnelJsModule(js, "s-1", 3000);
         expect(rewritten).toContain("from '/api/tunnel/s-1/3000/node_modules/.vite/deps/react.js'");
+    });
+});
+
+describe("tunnel route streaming proxy", () => {
+    test("closes an already-started streaming response cleanly when relay reports a late error", async () => {
+        let callbacks: {
+            onResponseStart: (statusCode: number, statusMessage: string, headers: Record<string, string>) => void;
+            onResponseData: (data: Buffer) => void;
+            onResponseEnd: () => void;
+            onError: (error: string) => void;
+        } | undefined;
+
+        const relay = {
+            proxyHttpRequest: (_runnerId: string, _request: unknown, cb: NonNullable<typeof callbacks>) => {
+                callbacks = cb;
+                return { cancel() {} };
+            },
+            sendRequestDataEnd() {},
+        };
+
+        const responsePromise = proxyTunnelRequestViaRelay(
+            new Request("http://localhost/api/tunnel/s-1/3000/data"),
+            relay as never,
+            "runner-1",
+            "request-1",
+            "/api/tunnel/s-1/3000",
+            3000,
+            "/data",
+            "/data",
+            {},
+        );
+
+        callbacks!.onResponseStart(200, "OK", { "content-type": "text/plain" });
+        const response = await responsePromise;
+        expect(response.status).toBe(200);
+        expect(response.body).toBeTruthy();
+
+        const reader = response.body!.getReader();
+        callbacks!.onResponseData(Buffer.from("hello"));
+        const first = await reader.read();
+        expect(first.done).toBe(false);
+        expect(Buffer.from(first.value!).toString("utf8")).toBe("hello");
+
+        callbacks!.onError("Tunnel request timed out");
+        await expect(reader.read()).resolves.toEqual({ done: true, value: undefined });
+        reader.releaseLock();
     });
 });
 

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -432,8 +432,20 @@ function proxyTunnelRequestViaRelay(
         let statusCode = 502;
         let responseHeaders = new Headers();
         let streamController: ReadableStreamDefaultController<Uint8Array> | null = null;
+        let streamClosed = false;
         let shouldBuffer = false;
         const bodyChunks: Buffer[] = [];
+
+        const closeStream = (): void => {
+            if (streamClosed) return;
+            streamClosed = true;
+            try {
+                streamController?.close();
+            } catch {
+                // The client may already have disconnected or the stream may
+                // have been closed by a racing response-end/error callback.
+            }
+        };
 
         const resolveOnce = (response: Response): void => {
             if (resolved) return;
@@ -472,6 +484,7 @@ function proxyTunnelRequestViaRelay(
                             streamController = controller;
                         },
                         cancel() {
+                            streamClosed = true;
                             cancel();
                         },
                     });
@@ -487,9 +500,14 @@ function proxyTunnelRequestViaRelay(
                         return;
                     }
 
-                    streamController?.enqueue(
-                        new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
-                    );
+                    if (streamClosed) return;
+                    try {
+                        streamController?.enqueue(
+                            new Uint8Array(chunk.buffer, chunk.byteOffset, chunk.byteLength),
+                        );
+                    } catch {
+                        streamClosed = true;
+                    }
                 },
                 onResponseEnd: () => {
                     if (shouldBuffer) {
@@ -512,7 +530,7 @@ function proxyTunnelRequestViaRelay(
                         return;
                     }
 
-                    streamController?.close();
+                    closeStream();
                 },
                 onError: (error) => {
                     if (!responseStarted || shouldBuffer) {
@@ -520,7 +538,12 @@ function proxyTunnelRequestViaRelay(
                         return;
                     }
 
-                    streamController?.error(new Error(error));
+                    // Once a streaming HTTP response has started, we can no
+                    // longer change the status code. Do not error the fetch
+                    // stream: Bun surfaces that as an unhandled server write
+                    // after the response may already be ended. Close the body
+                    // instead so the connection terminates cleanly.
+                    closeStream();
                 },
             },
         );
@@ -539,7 +562,7 @@ function proxyTunnelRequestViaRelay(
                 return;
             }
 
-            streamController?.error(new Error(message));
+            closeStream();
         });
     });
 }
@@ -764,4 +787,5 @@ export {
     shouldRewriteTunnelCss,
     rewriteTunnelJsModule,
     rewriteTunnelCss,
+    proxyTunnelRequestViaRelay,
 };

--- a/packages/server/src/tunnel-relay.ts
+++ b/packages/server/src/tunnel-relay.ts
@@ -2,7 +2,10 @@ import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { TunnelRelay } from "@pizzapi/tunnel";
 import { WebSocketServer, type WebSocket as NodeWebSocket, type RawData } from "ws";
+import { createLogger } from "@pizzapi/tools";
 import { bindAuthContext, getAuth, type AuthContext } from "./auth.js";
+
+const log = createLogger("tunnel-relay");
 
 let relay: TunnelRelay | null = null;
 let wss: WebSocketServer | null = null;
@@ -89,7 +92,16 @@ export function initTunnelRelay(context: AuthContext): TunnelRelay {
     });
 
     wss = new WebSocketServer({ noServer: true });
-    wss.on("connection", (ws) => {
+    wss.on("connection", (ws, req) => {
+        const openedAt = Date.now();
+        const remote = req.headers["x-forwarded-for"] ?? req.socket.remoteAddress ?? "unknown";
+        log.info(`/_tunnel WebSocket connected remote=${String(remote)} ua=${req.headers["user-agent"] ?? "<none>"}`);
+        ws.on("close", (code, reason) => {
+            log.info(`/_tunnel WebSocket closed code=${code} reason=${reason.toString() || "<none>"} uptimeMs=${Date.now() - openedAt}`);
+        });
+        ws.on("error", (err) => {
+            log.warn("/_tunnel WebSocket error:", err);
+        });
         relay!.handleConnection(adaptWs(ws) as unknown as WebSocket);
     });
 
@@ -103,7 +115,16 @@ export function handleTunnelRelayUpgrade(
 ): boolean {
     const pathname = (req.url ?? "/").split("?")[0];
     if (pathname !== "/_tunnel") return false;
-    if (!wss) return false;
+    if (!wss) {
+        log.warn("/_tunnel upgrade received before tunnel relay WebSocket server was initialized");
+        return false;
+    }
+
+    const remote = req.headers["x-forwarded-for"] ?? (socket as any).remoteAddress ?? "unknown";
+    log.info(`/_tunnel upgrade accepted remote=${String(remote)} headBytes=${head.length} ua=${req.headers["user-agent"] ?? "<none>"}`);
+    socket.once("error", (err) => {
+        log.warn("/_tunnel upgrade socket error:", err);
+    });
 
     wss.handleUpgrade(req, socket, head, (ws) => {
         wss!.emit("connection", ws, req);

--- a/packages/server/src/ws/namespaces/runner.ts
+++ b/packages/server/src/ws/namespaces/runner.ts
@@ -357,7 +357,10 @@ export function registerRunnerNamespace(io: SocketIOServer, context: AuthContext
 
     runner.on("connection", bindAuthContext(context, (socket) => {
         bindSocketHandlersToAuthContext(socket, context);
-        log.info(`connected: ${socket.id}`);
+        log.info(
+            `connected: ${socket.id} transport=${socket.conn.transport.name} `
+            + `remote=${socket.handshake.address} ua=${socket.handshake.headers["user-agent"] ?? "<none>"}`,
+        );
 
         // ── Periodic Redis TTL refresh ───────────────────────────────────────
         // The runner's Redis key has a 2-hour TTL. Without periodic refresh,
@@ -1119,13 +1122,17 @@ export function registerRunnerNamespace(io: SocketIOServer, context: AuthContext
         });
 
         // ── disconnect — clean up runner resources ───────────────────────────
-        socket.on("disconnect", async (reason) => {
-            log.info(`disconnected: ${socket.id} (${reason})`);
+        socket.on("disconnect", async (reason, details) => {
+            const runnerId = socket.data.runnerId;
+            const transport = socket.conn.transport.name;
+            log.info(
+                `disconnected: ${socket.id} runner=${runnerId ?? "<unregistered>"} (${reason}) `
+                + `transport=${transport} details=${JSON.stringify(details ?? {})}`,
+            );
             if (runnerTtlTimer) {
                 clearInterval(runnerTtlTimer);
                 runnerTtlTimer = null;
             }
-            const runnerId = socket.data.runnerId;
             if (runnerId) {
                 // During graceful shutdown (io.close()), Socket.IO disconnects
                 // all sockets with reason "server shutting down".  Skip

--- a/packages/tunnel/src/client.ts
+++ b/packages/tunnel/src/client.ts
@@ -91,6 +91,8 @@ export class TunnelClient extends EventEmitter {
   private consecutiveFailures = 0;
   /** Whether a "registered" message was received for the current connection. */
   private registeredThisConnection = false;
+  /** Wall-clock time when the current WebSocket attempt was created. */
+  private connectionStartedAt = 0;
 
   /** Active HTTP requests: requestId → { controller, req } */
   private activeRequests = new Map<string, { controller: AbortController; req: http.ClientRequest }>();
@@ -123,6 +125,7 @@ export class TunnelClient extends EventEmitter {
     }
 
     this.registeredThisConnection = false;
+    this.connectionStartedAt = Date.now();
     this.log.info("[tunnel-client] Connecting to", this.relayUrl);
     this.ws = new WebSocket(this.relayUrl);
 
@@ -135,8 +138,21 @@ export class TunnelClient extends EventEmitter {
       this.handleMessage(event.data as string | Buffer | ArrayBuffer | ArrayBufferView);
     });
 
-    this.ws.addEventListener("close", () => {
-      this.log.info("[tunnel-client] Disconnected");
+    this.ws.addEventListener("close", (event: CloseEvent) => {
+      const uptimeMs = this.connectionStartedAt > 0 ? Date.now() - this.connectionStartedAt : undefined;
+      this.log.info(
+        "[tunnel-client] Disconnected",
+        JSON.stringify({
+          code: event.code,
+          reason: event.reason || undefined,
+          wasClean: event.wasClean,
+          registered: this.registeredThisConnection,
+          consecutiveFailures: this.consecutiveFailures,
+          uptimeMs,
+          activeRequests: this.activeRequests.size,
+          activeWs: this.activeWs.size,
+        }),
+      );
       this.cleanup();
       this.ws = null;
 
@@ -175,7 +191,16 @@ export class TunnelClient extends EventEmitter {
         ?? (event as any)?.error
         ?? (event as any)?.type
         ?? "unknown error";
-      this.log.error("[tunnel-client] WebSocket error:", msg);
+      this.log.error(
+        "[tunnel-client] WebSocket error:",
+        msg,
+        JSON.stringify({
+          relayUrl: this.relayUrl,
+          readyState: this.ws?.readyState,
+          registered: this.registeredThisConnection,
+          consecutiveFailures: this.consecutiveFailures,
+        }),
+      );
     });
   }
 

--- a/packages/tunnel/src/server.test.ts
+++ b/packages/tunnel/src/server.test.ts
@@ -193,6 +193,90 @@ describe("TunnelRelay HTTP proxy callbacks", () => {
     expect(body.toString("binary")).toBe("hello");
   });
 
+  test("times out when the runner never starts a response", async () => {
+    const relay = new TunnelRelay({ apiKeys: ["key1"] });
+    const mockWs = createMockWebSocket();
+
+    relay.handleConnection(mockWs.ws);
+    mockWs.emit("message", {
+      data: JSON.stringify({ type: "register", runnerId: "r1", apiKey: "key1" }),
+    });
+    await waitForMicrotask();
+
+    const errors: string[] = [];
+    relay.proxyHttpRequest(
+      "r1",
+      { id: "req-timeout", port: 3000, method: "GET", url: "/events", headers: {} },
+      {
+        onResponseStart() {},
+        onResponseData() {},
+        onResponseEnd() {},
+        onError(error) {
+          errors.push(error);
+        },
+      },
+      5,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    expect(errors).toEqual(["Tunnel request timed out"]);
+    expect(JSON.parse(mockWs.sent.at(-1)!)).toMatchObject({ type: "request-end", id: "req-timeout" });
+  });
+
+  test("does not time out long-lived streams after response headers arrive", async () => {
+    const relay = new TunnelRelay({ apiKeys: ["key1"] });
+    const mockWs = createMockWebSocket();
+
+    relay.handleConnection(mockWs.ws);
+    mockWs.emit("message", {
+      data: JSON.stringify({ type: "register", runnerId: "r1", apiKey: "key1" }),
+    });
+    await waitForMicrotask();
+
+    const events: string[] = [];
+    relay.proxyHttpRequest(
+      "r1",
+      { id: "req-stream", port: 3000, method: "GET", url: "/events", headers: {} },
+      {
+        onResponseStart() {
+          events.push("start");
+        },
+        onResponseData() {
+          events.push("data");
+        },
+        onResponseEnd() {
+          events.push("end");
+        },
+        onError(error) {
+          events.push(`error:${error}`);
+        },
+      },
+      5,
+    );
+
+    mockWs.emit("message", {
+      data: JSON.stringify({
+        type: "response-start",
+        id: "req-stream",
+        statusCode: 200,
+        statusMessage: "OK",
+        headers: { "content-type": "text/event-stream" },
+      }),
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    mockWs.emit("message", {
+      data: JSON.stringify({ type: "response-data", id: "req-stream", data: "event: ping\\n\\n" }),
+    });
+    mockWs.emit("message", {
+      data: JSON.stringify({ type: "response-data-end", id: "req-stream" }),
+    });
+    await waitForMicrotask();
+
+    expect(events).toEqual(["start", "data", "end"]);
+  });
+
   test("disconnect only fails requests for the matching runner", async () => {
     const relay = new TunnelRelay({ apiKeys: ["key1"] });
     const runnerA = createMockWebSocket();

--- a/packages/tunnel/src/server.ts
+++ b/packages/tunnel/src/server.ts
@@ -355,6 +355,10 @@ export class TunnelRelay {
   private handleResponseStart(msg: TunnelResponseStartMessage): void {
     const pending = this.pendingRequests.get(msg.id);
     if (!pending) return;
+    // The timeout only protects the initial response handshake. Once headers
+    // have arrived, the response may legitimately be long-lived (SSE, logs,
+    // streaming dev servers), so do not abort it solely because it stays open.
+    clearTimeout(pending.timer);
     pending.onResponseStart(msg.statusCode, msg.statusMessage, msg.headers);
   }
 

--- a/packages/ui/src/components/ui/error-boundary.render.test.tsx
+++ b/packages/ui/src/components/ui/error-boundary.render.test.tsx
@@ -33,7 +33,15 @@ mock.module("@pizzapi/tools", () => ({
 
 // Restore all module mocks after this file so they don't bleed into other
 // test files running in the same Bun worker process.
-afterAll(() => mock.restore());
+afterAll(() => {
+	mock.restore();
+	// Restore clipboard mock
+	Object.defineProperty(globalThis, "navigator", {
+		value: undefined,
+		writable: true,
+		configurable: true,
+	});
+});
 
 // Dynamically imported after mock.module so the alias is already intercepted.
 const { ErrorBoundary } = await import("./error-boundary");
@@ -54,6 +62,18 @@ beforeAll(() => {
 	(globalThis as any).Event = win.Event;
 	(globalThis as any).MouseEvent = win.MouseEvent;
 	(globalThis as any).MutationObserver = (win as any).MutationObserver;
+
+	// Mock clipboard API — not available in happy-dom
+	Object.defineProperty(globalThis, "navigator", {
+		value: {
+			...win.navigator,
+			clipboard: {
+				writeText: mock(async (_text: string) => {}),
+			},
+		},
+		writable: true,
+		configurable: true,
+	});
 	/* eslint-enable @typescript-eslint/no-explicit-any */
 });
 
@@ -196,7 +216,8 @@ describe("ErrorBoundary render: retry button resets the boundary", () => {
 		const buttons = container.getElementsByTagName("button");
 		expect(buttons.length).toBeGreaterThan(0);
 
-		const retryBtn = buttons[0];
+		// buttons[0] is copy, buttons[1] is retry
+		const retryBtn = buttons[1];
 		expect(retryBtn.getAttribute("aria-label")).toBe("Retry");
 
 		// Allow the recovery to succeed
@@ -226,12 +247,16 @@ describe("ErrorBoundary render: retry button resets the boundary", () => {
 
 		expect(container.innerHTML).toContain("Something went wrong");
 
-		// There should be at least two buttons: Retry and Reload
+		// There should be three buttons: Copy Details, Retry, and Reload
 		const buttons = container.getElementsByTagName("button");
-		expect(buttons.length).toBeGreaterThanOrEqual(2);
+		expect(buttons.length).toBeGreaterThanOrEqual(3);
 
-		// First button should be "Retry"
-		const retryBtn = buttons[0];
+		// First button should be "Copy Details"
+		const copyBtn = buttons[0];
+		expect(copyBtn.textContent).toContain("Copy Details");
+
+		// Second button should be "Retry"
+		const retryBtn = buttons[1];
 		expect(retryBtn.textContent).toContain("Retry");
 
 		shouldThrow = false;
@@ -360,5 +385,68 @@ describe("ErrorBoundary render: level-specific fallback markup", () => {
 		// Default level is 'section'
 		const { container } = renderCrashed("boom");
 		expect(container.innerHTML).toContain("Something went wrong");
+	});
+});
+
+// ── 7. Copy error details button ─────────────────────────────────────────
+
+describe("ErrorBoundary render: copy error details button", () => {
+	test("widget level has a copy button with icon", () => {
+		const { container } = renderCrashed("boom", { level: "widget" });
+		// Widget level has 3 buttons: copy, retry (both aria-label only)
+		const buttons = container.getElementsByTagName("button");
+		expect(buttons.length).toBe(2);
+		expect(buttons[0].getAttribute("aria-label")).toContain("Copy error details");
+		expect(buttons[1].getAttribute("aria-label")).toBe("Retry");
+	});
+
+	test("section level has a Copy Details button", () => {
+		const { container } = renderCrashed("boom", { level: "section" });
+		expect(container.innerHTML).toContain("Copy Details");
+	});
+
+	test("root level has a Copy Details button", () => {
+		const { container } = renderCrashed("boom", { level: "root" });
+		expect(container.innerHTML).toContain("Copy Details");
+	});
+
+	test("clicking Copy Details writes error info to clipboard", async () => {
+		const writeTextMock = mock(async (_text: string) => {});
+		Object.defineProperty(globalThis, "navigator", {
+			value: {
+				clipboard: { writeText: writeTextMock },
+			},
+			writable: true,
+			configurable: true,
+		});
+
+		const { container } = renderCrashed("Test crash message", { level: "section" });
+
+		const buttons = container.getElementsByTagName("button");
+		const copyBtn = buttons[0];
+		expect(copyBtn.textContent).toContain("Copy Details");
+
+		await act(async () => {
+			fireEvent.click(copyBtn);
+		});
+
+		expect(writeTextMock).toHaveBeenCalledTimes(1);
+		const clipboardText = writeTextMock.mock.calls[0][0];
+		expect(clipboardText).toContain("Test crash message");
+	});
+
+	test("copy button shows 'Copied!' after click and reverts", async () => {
+		const { container } = renderCrashed("boom", { level: "section" });
+
+		const buttons = container.getElementsByTagName("button");
+		const copyBtn = buttons[0];
+		expect(copyBtn.textContent).toContain("Copy Details");
+
+		await act(async () => {
+			fireEvent.click(copyBtn);
+		});
+
+		// After click, button should show "Copied!"
+		expect(copyBtn.textContent).toContain("Copied!");
 	});
 });

--- a/packages/ui/src/components/ui/error-boundary.test.ts
+++ b/packages/ui/src/components/ui/error-boundary.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import type React from "react";
 
 /**
  * Tests for the ErrorBoundary React class component.
@@ -20,6 +21,7 @@ import { describe, expect, test } from "bun:test";
 interface ErrorBoundaryState {
   hasError: boolean;
   error: Error | null;
+  errorInfo: React.ErrorInfo | null;
 }
 
 interface ErrorBoundaryProps {
@@ -68,7 +70,7 @@ function shouldAutoReset(
  * Returns the next state after the user clicks "Retry".
  */
 function resetErrorBoundary(): ErrorBoundaryState {
-  return { hasError: false, error: null };
+  return { hasError: false, error: null, errorInfo: null };
 }
 
 // ── 1. getDerivedStateFromError ────────────────────────────────────────────────
@@ -108,12 +110,12 @@ describe("ErrorBoundary: retry reset (resetErrorBoundary)", () => {
 
   test("is idempotent — same result whether or not boundary was crashed", () => {
     // Crashed state → reset
-    const crashed: ErrorBoundaryState = { hasError: true, error: new Error("x") };
+    const crashed: ErrorBoundaryState = { hasError: true, error: new Error("x"), errorInfo: null };
     const afterReset = resetErrorBoundary();
     expect(afterReset.hasError).toBe(false);
 
     // Already-reset state → still reset
-    const clean: ErrorBoundaryState = { hasError: false, error: null };
+    const clean: ErrorBoundaryState = { hasError: false, error: null, errorInfo: null };
     const afterNoOp = resetErrorBoundary();
     expect(afterNoOp).toEqual(clean);
 
@@ -121,9 +123,9 @@ describe("ErrorBoundary: retry reset (resetErrorBoundary)", () => {
     void crashed;
   });
 
-  test("returned state has exactly the two expected fields", () => {
+  test("returned state has exactly the three expected fields", () => {
     const state = resetErrorBoundary();
-    expect(Object.keys(state).sort()).toEqual(["error", "hasError"]);
+    expect(Object.keys(state).sort()).toEqual(["error", "errorInfo", "hasError"]);
   });
 });
 
@@ -204,19 +206,19 @@ describe("ErrorBoundary resetKeys comparison logic", () => {
 
 describe("ErrorBoundary: auto-reset state machine (componentDidUpdate)", () => {
   test("does NOT reset when boundary has not tripped (hasError:false)", () => {
-    const state: ErrorBoundaryState = { hasError: false, error: null };
+    const state: ErrorBoundaryState = { hasError: false, error: null, errorInfo: null };
     // Even if resetKeys change, there is nothing to reset
     expect(shouldAutoReset(state, { resetKeys: ["a"] }, { resetKeys: ["b"] })).toBe(false);
   });
 
   test("does NOT reset when no resetKeys prop is provided", () => {
-    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash") };
+    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash"), errorInfo: null };
     expect(shouldAutoReset(state, {}, {})).toBe(false);
     expect(shouldAutoReset(state, { resetKeys: ["a"] }, {})).toBe(false);
   });
 
   test("does NOT reset when resetKeys are unchanged", () => {
-    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash") };
+    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash"), errorInfo: null };
     expect(shouldAutoReset(
       state,
       { resetKeys: ["session-1"] },
@@ -225,7 +227,7 @@ describe("ErrorBoundary: auto-reset state machine (componentDidUpdate)", () => {
   });
 
   test("DOES reset when resetKey changes (session switch clears sticky crash)", () => {
-    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash") };
+    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash"), errorInfo: null };
     expect(shouldAutoReset(
       state,
       { resetKeys: ["session-1"] },
@@ -234,7 +236,7 @@ describe("ErrorBoundary: auto-reset state machine (componentDidUpdate)", () => {
   });
 
   test("DOES reset when resetKey changes from non-null to null (session closed)", () => {
-    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash") };
+    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash"), errorInfo: null };
     expect(shouldAutoReset(
       state,
       { resetKeys: ["session-1"] },
@@ -243,7 +245,7 @@ describe("ErrorBoundary: auto-reset state machine (componentDidUpdate)", () => {
   });
 
   test("DOES reset when prevProps had no resetKeys but next does (first mount recovery)", () => {
-    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash") };
+    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash"), errorInfo: null };
     expect(shouldAutoReset(
       state,
       { resetKeys: undefined },
@@ -252,7 +254,7 @@ describe("ErrorBoundary: auto-reset state machine (componentDidUpdate)", () => {
   });
 
   test("DOES reset when second key in multi-key array changes", () => {
-    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash") };
+    const state: ErrorBoundaryState = { hasError: true, error: new Error("crash"), errorInfo: null };
     expect(shouldAutoReset(
       state,
       { resetKeys: ["session-1", "runner-a"] },
@@ -260,9 +262,9 @@ describe("ErrorBoundary: auto-reset state machine (componentDidUpdate)", () => {
     )).toBe(true);
   });
 
-  test("state after auto-reset is hasError:false error:null", () => {
+  test("state after auto-reset is hasError:false error:null errorInfo:null", () => {
     // Verify the reset state used by componentDidUpdate is the same as resetErrorBoundary
-    const afterAutoReset = { hasError: false, error: null };
+    const afterAutoReset = { hasError: false, error: null, errorInfo: null };
     const afterManualReset = resetErrorBoundary();
     expect(afterAutoReset).toEqual(afterManualReset);
   });
@@ -273,7 +275,7 @@ describe("ErrorBoundary: auto-reset state machine (componentDidUpdate)", () => {
 describe("ErrorBoundary: full state lifecycle", () => {
   test("idle → crashed → reset via retry button", () => {
     // Start idle
-    let state: ErrorBoundaryState = { hasError: false, error: null };
+    let state: ErrorBoundaryState = { hasError: false, error: null, errorInfo: null };
     expect(state.hasError).toBe(false);
 
     // A child crashes
@@ -286,10 +288,11 @@ describe("ErrorBoundary: full state lifecycle", () => {
     state = resetErrorBoundary();
     expect(state.hasError).toBe(false);
     expect(state.error).toBeNull();
+    expect(state.errorInfo).toBeNull();
   });
 
   test("idle → crashed → reset via session switch (resetKeys)", () => {
-    let state: ErrorBoundaryState = { hasError: false, error: null };
+    let state: ErrorBoundaryState = { hasError: false, error: null, errorInfo: null };
 
     // A child crashes
     state = getDerivedStateFromError(new Error("crash"));
@@ -308,6 +311,7 @@ describe("ErrorBoundary: full state lifecycle", () => {
     }
     expect(state.hasError).toBe(false);
     expect(state.error).toBeNull();
+    expect(state.errorInfo).toBeNull();
   });
 
   test("multiple crashes and resets are independent", () => {

--- a/packages/ui/src/components/ui/error-boundary.tsx
+++ b/packages/ui/src/components/ui/error-boundary.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { AlertCircle, RefreshCw } from "lucide-react";
+import { AlertCircle, Check, Copy, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { createLogger } from "@pizzapi/tools";
 
@@ -24,6 +24,7 @@ export interface ErrorBoundaryProps {
 interface ErrorBoundaryState {
   hasError: boolean;
   error: Error | null;
+  errorInfo: React.ErrorInfo | null;
 }
 
 /**
@@ -35,17 +36,21 @@ interface ErrorBoundaryState {
  * - `"widget"` — compact inline fallback for individual cards/tools
  */
 export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  private copied = false;
+  private copyTimer: ReturnType<typeof setTimeout> | null = null;
+
   constructor(props: ErrorBoundaryProps) {
     super(props);
-    this.state = { hasError: false, error: null };
+    this.state = { hasError: false, error: null, errorInfo: null };
   }
 
-  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+  static getDerivedStateFromError(error: Error): Partial<ErrorBoundaryState> {
     return { hasError: true, error };
   }
 
-  componentDidCatch(error: Error, info: React.ErrorInfo): void {
-    log.error("Caught render error:", error, info.componentStack);
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    log.error("Caught render error:", error, errorInfo.componentStack);
+    this.setState({ errorInfo });
   }
 
   componentDidUpdate(prevProps: ErrorBoundaryProps): void {
@@ -57,14 +62,38 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
       const changed = prevKeys.length !== nextKeys.length ||
         nextKeys.some((key, i) => !Object.is(key, prevKeys[i]));
       if (changed) {
-        this.setState({ hasError: false, error: null });
+        this.setState({ hasError: false, error: null, errorInfo: null });
       }
     }
   }
 
   /** Reset error state so children can be re-rendered without a full page reload. */
   resetErrorBoundary = (): void => {
-    this.setState({ hasError: false, error: null });
+    this.setState({ hasError: false, error: null, errorInfo: null });
+  };
+
+  /** Copy full error details (message, stack trace, component stack) to clipboard. */
+  copyErrorDetails = (): void => {
+    const { error, errorInfo } = this.state;
+    const details = [
+      error?.message && `Message: ${error.message}`,
+      error?.stack && `Stack:\n${error.stack}`,
+      errorInfo?.componentStack && `Component Stack:\n${errorInfo.componentStack}`,
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+
+    navigator.clipboard.writeText(details || "No error details available");
+
+    this.copied = true;
+    this.forceUpdate();
+
+    if (this.copyTimer) clearTimeout(this.copyTimer);
+    this.copyTimer = setTimeout(() => {
+      this.copied = false;
+      this.forceUpdate();
+      this.copyTimer = null;
+    }, 2000);
   };
 
   render(): React.ReactNode {
@@ -92,6 +121,18 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
           <span className="flex-1 min-w-0 truncate">
             {isDev && error?.message ? error.message : "Render error"}
           </span>
+          <button
+            type="button"
+            onClick={() => this.copyErrorDetails()}
+            className="shrink-0 rounded p-0.5 hover:bg-destructive/20 transition-colors"
+            aria-label={this.copied ? "Copied" : "Copy error details"}
+          >
+            {this.copied ? (
+              <Check className="size-3" />
+            ) : (
+              <Copy className="size-3" />
+            )}
+          </button>
           <button
             type="button"
             onClick={this.resetErrorBoundary}
@@ -138,6 +179,22 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
           </div>
 
           <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => this.copyErrorDetails()}
+              className={cn(
+                "inline-flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium",
+                "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+                "transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
+              )}
+            >
+              {this.copied ? (
+                <Check className="size-4" />
+              ) : (
+                <Copy className="size-4" />
+              )}
+              {this.copied ? "Copied!" : "Copy Details"}
+            </button>
             <button
               type="button"
               onClick={this.resetErrorBoundary}

--- a/packages/ui/src/hooks/useBrowserNotifications.test.ts
+++ b/packages/ui/src/hooks/useBrowserNotifications.test.ts
@@ -1,13 +1,12 @@
 import { describe, test, expect } from "bun:test";
+import * as browserNotifications from "../lib/browser-notifications";
 
 /**
- * Unit tests for the pure logic used by useBrowserNotifications.
+ * Unit tests for the logic used by useBrowserNotifications.
  *
  * Since Bun's test runner does not provide a DOM environment, we test
- * the helper functions and logical invariants rather than the React hook.
- * The helper `getSessionLabel` is re-used here since it's not exported
- * from the hook module (it's a file-local function), but the logic is
- * tested to match the source exactly.
+ * the helper functions and logical invariants rather than the React hook
+ * itself.
  */
 
 // ── Extracted from useBrowserNotifications.ts ───────────────────────────────
@@ -122,5 +121,42 @@ describe("useBrowserNotifications logic", () => {
     expect(notified.size).toBe(1);
     expect(notified.has("s1")).toBe(true);
     expect(notified.has("s2")).toBe(false);
+  });
+
+  test("shows browser input notifications through the service worker registration", async () => {
+    const calls: Array<{ title: string; options: any }> = [];
+    const registration = {
+      showNotification: async (title: string, options: any) => {
+        calls.push({ title, options });
+      },
+    };
+
+    await browserNotifications.showBrowserInputNotification(
+      registration,
+      "session-123",
+      "My Cool Session",
+    );
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0].title).toBe("Input needed");
+    expect(calls[0].options.tag).toBe("pizzapi-browser-input-session-123");
+    expect(calls[0].options.body).toBe(
+      'Agent in "My Cool Session" is waiting for your input.',
+    );
+    expect(calls[0].options.data).toEqual({
+      sessionId: "session-123",
+      type: "browser_input",
+    });
+  });
+
+  test("extracts session id from service worker open-session messages", () => {
+    expect(
+      browserNotifications.getOpenSessionMessageSessionId({
+        type: "open-session",
+        sessionId: "session-123",
+      }),
+    ).toBe("session-123");
+    expect(browserNotifications.getOpenSessionMessageSessionId({ type: "other" })).toBeNull();
+    expect(browserNotifications.getOpenSessionMessageSessionId(null)).toBeNull();
   });
 });

--- a/packages/ui/src/hooks/useBrowserNotifications.ts
+++ b/packages/ui/src/hooks/useBrowserNotifications.ts
@@ -1,5 +1,5 @@
 /**
- * useBrowserNotifications — fires in-browser Notification API alerts
+ * useBrowserNotifications — fires service-worker-backed browser notifications
  * and flashes the document title when an agent session is awaiting input
  * and the page is not visible/focused.
  *
@@ -10,6 +10,11 @@
  */
 import { useEffect, useRef, useCallback } from "react";
 import { getNotificationPermission } from "@/lib/push";
+import {
+  closeBrowserInputNotification,
+  getOpenSessionMessageSessionId,
+  showBrowserInputNotification,
+} from "@/lib/browser-notifications";
 
 /** How often to alternate the document title when input is needed (ms). */
 const TITLE_FLASH_INTERVAL_MS = 1500;
@@ -45,9 +50,10 @@ export interface BrowserNotificationOptions {
  *
  * Notifications are only shown when:
  * 1. The browser supports notifications (Notification API present)
- * 2. Permission has already been granted (we reuse the push permission — no
+ * 2. A service worker is available to display them
+ * 3. Permission has already been granted (we reuse the push permission — no
  *    extra prompt)
- * 3. The document is hidden OR the awaiting session is not the active one
+ * 4. The document is hidden OR the awaiting session is not the active one
  *
  * Each session gets at most one notification (tracked by a "notified" set).
  * When the session stops awaiting, the notification is auto-closed.
@@ -58,63 +64,96 @@ export function useBrowserNotifications({
   sessionNames,
 }: BrowserNotificationOptions): void {
   // Track which sessions we've already notified about to avoid spam.
-  const notifiedRef = useRef<Map<string, Notification>>(new Map());
+  const notifiedRef = useRef<Set<string>>(new Set());
+  const sessionsAwaitingInputRef = useRef<Set<string>>(sessionsAwaitingInput);
   const originalTitleRef = useRef<string>(document.title);
   const flashIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const hasPermission = useCallback((): boolean => {
     if (!("Notification" in window)) return false;
+    if (!("serviceWorker" in navigator)) return false;
     return getNotificationPermission() === "granted";
   }, []);
+
+  useEffect(() => {
+    sessionsAwaitingInputRef.current = sessionsAwaitingInput;
+  }, [sessionsAwaitingInput]);
 
   // Clean up notifications for sessions that are no longer awaiting.
   useEffect(() => {
     const notified = notifiedRef.current;
-    for (const [sessionId, notification] of notified) {
+    for (const sessionId of Array.from(notified)) {
       if (!sessionsAwaitingInput.has(sessionId)) {
-        notification.close();
         notified.delete(sessionId);
+        void closeBrowserInputNotification(sessionId);
       }
     }
   }, [sessionsAwaitingInput]);
 
-  // Fire notifications for newly awaiting sessions.
+  // When the service worker reports that a session was opened, clear the
+  // matching notification record so a future await can notify again.
+  useEffect(() => {
+    if (!("serviceWorker" in navigator)) return;
+
+    const handleMessage = (event: MessageEvent) => {
+      const sessionId = getOpenSessionMessageSessionId(event.data);
+      if (!sessionId || !notifiedRef.current.has(sessionId)) return;
+      notifiedRef.current.delete(sessionId);
+      void closeBrowserInputNotification(sessionId);
+    };
+
+    navigator.serviceWorker.addEventListener("message", handleMessage);
+    return () => navigator.serviceWorker.removeEventListener("message", handleMessage);
+  }, []);
+
   useEffect(() => {
     if (!hasPermission()) return;
 
-    const notified = notifiedRef.current;
-    const isHidden = document.hidden;
+    let cancelled = false;
 
-    for (const sessionId of sessionsAwaitingInput) {
-      // Already notified for this session.
-      if (notified.has(sessionId)) continue;
+    void (async () => {
+      try {
+        const registration = await navigator.serviceWorker.ready;
+        if (cancelled) return;
 
-      // If the tab is visible AND focused AND the user is viewing this session,
-      // no need to notify — they can see the input prompt directly.
-      // We check both document.hidden and document.hasFocus() because:
-      // - document.hidden is false when the tab is visible but the user alt-tabbed
-      // - document.hasFocus() catches the alt-tab case
-      if (!isHidden && document.hasFocus() && sessionId === activeSessionId) continue;
+        const notified = notifiedRef.current;
+        const isHidden = document.hidden;
 
-      const label = getSessionLabel(sessionId, sessionNames);
-      const notification = new Notification("Input needed", {
-        body: `Agent in "${label}" is waiting for your input.`,
-        icon: "/pwa-192x192.png",
-        tag: `pizzapi-browser-input-${sessionId}`,
-      } as NotificationOptions);
+        for (const sessionId of sessionsAwaitingInput) {
+          // Already notified for this session.
+          if (notified.has(sessionId)) continue;
 
-      // Clicking the notification focuses this tab.
-      notification.onclick = () => {
-        window.focus();
-        // Dispatch a custom event so the app can navigate to the session.
-        window.dispatchEvent(
-          new CustomEvent("pp-navigate-session", { detail: { sessionId } }),
-        );
-        notification.close();
-      };
+          // If the tab is visible AND focused AND the user is viewing this session,
+          // no need to notify — they can see the input prompt directly.
+          // We check both document.hidden and document.hasFocus() because:
+          // - document.hidden is false when the tab is visible but the user alt-tabbed
+          // - document.hasFocus() catches the alt-tab case
+          if (!isHidden && document.hasFocus() && sessionId === activeSessionId) continue;
 
-      notified.set(sessionId, notification);
-    }
+          const label = getSessionLabel(sessionId, sessionNames);
+          notified.add(sessionId);
+
+          try {
+            await showBrowserInputNotification(registration, sessionId, label);
+            if (!sessionsAwaitingInputRef.current.has(sessionId)) {
+              notified.delete(sessionId);
+              void closeBrowserInputNotification(sessionId);
+            }
+          } catch (error) {
+            notified.delete(sessionId);
+            console.error("Failed to show browser notification:", error);
+          }
+
+          if (cancelled) return;
+        }
+      } catch (error) {
+        console.error("Failed to prepare browser notifications:", error);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [sessionsAwaitingInput, activeSessionId, sessionNames, hasPermission]);
 
   // Flash the document title when any session is awaiting input and the tab is hidden.
@@ -168,11 +207,8 @@ export function useBrowserNotifications({
         }
         // Close notification for the active session (user is now looking at it).
         if (activeSessionId) {
-          const n = notifiedRef.current.get(activeSessionId);
-          if (n) {
-            n.close();
-            notifiedRef.current.delete(activeSessionId);
-          }
+          notifiedRef.current.delete(activeSessionId);
+          void closeBrowserInputNotification(activeSessionId);
         }
       }
     };
@@ -184,8 +220,8 @@ export function useBrowserNotifications({
   // Cleanup all notifications on unmount.
   useEffect(() => {
     return () => {
-      for (const [, n] of notifiedRef.current) {
-        n.close();
+      for (const sessionId of notifiedRef.current) {
+        void closeBrowserInputNotification(sessionId);
       }
       notifiedRef.current.clear();
       if (flashIntervalRef.current !== null) {

--- a/packages/ui/src/lib/browser-notifications.ts
+++ b/packages/ui/src/lib/browser-notifications.ts
@@ -1,0 +1,46 @@
+export const BROWSER_INPUT_NOTIFICATION_TAG_PREFIX = "pizzapi-browser-input-";
+
+export function getBrowserInputNotificationTag(sessionId: string): string {
+  return `${BROWSER_INPUT_NOTIFICATION_TAG_PREFIX}${sessionId}`;
+}
+
+export function getOpenSessionMessageSessionId(messageData: unknown): string | null {
+  if (!messageData || typeof messageData !== "object") return null;
+
+  const data = messageData as { type?: unknown; sessionId?: unknown };
+  if (data.type !== "open-session" || typeof data.sessionId !== "string") return null;
+
+  return data.sessionId;
+}
+
+export async function showBrowserInputNotification(
+  registration: Pick<ServiceWorkerRegistration, "showNotification">,
+  sessionId: string,
+  sessionLabel: string,
+): Promise<void> {
+  await registration.showNotification("Input needed", {
+    body: `Agent in "${sessionLabel}" is waiting for your input.`,
+    icon: "/pwa-192x192.png",
+    tag: getBrowserInputNotificationTag(sessionId),
+    data: {
+      sessionId,
+      type: "browser_input",
+    },
+  });
+}
+
+export async function closeBrowserInputNotification(sessionId: string): Promise<void> {
+  if (typeof navigator === "undefined" || !("serviceWorker" in navigator)) return;
+
+  try {
+    const registration = await navigator.serviceWorker.ready;
+    const notifications = await registration.getNotifications({
+      tag: getBrowserInputNotificationTag(sessionId),
+    });
+    for (const notification of notifications) {
+      notification.close();
+    }
+  } catch {
+    // Silently ignore — browser notifications are best-effort.
+  }
+}


### PR DESCRIPTION
## Summary

This PR currently collects the unified provider-interface work plus follow-up hardening that landed while stabilizing the branch.

### Main provider API work
- Adds `ExtensionProvider` types, capability guards, and config schema for provider services.
- Adds provider discovery/loading from user and project provider directories with trust-gated project providers and per-provider enable/disable config.
- Adds `ProviderBridge` aggregation with deterministic ordering, per-prompt dedupe, error isolation, and provider disable-on-repeat-failure behavior.
- Wires a provider Pi extension into the daemon extension chain so providers can react to session/turn lifecycle events and inject context into prompts.
- Documents the Extension Providers API in the docs site and updates runner-service skill guidance.

### Follow-up hardening included on the branch
- Adds session finalization reducer coverage for safer streamed/session-close state handling.
- Wires session-close finalization into daemon archival paths.
- Hardens hook/browser notification behavior.
- Fixes tunnel streaming/rollback paths and related server/tunnel tests.
- Adds UI error-boundary and browser-notification coverage.

## Key design decisions

- Provider capabilities are duck-typed so providers can implement only the surfaces they need.
- Context contributions are sorted by `order` and `providerId` for deterministic prompt placement.
- `dedupeKey` deduplication is scoped per prompt and resets on prompt boundaries.
- Provider failures are isolated: repeated failures disable that provider for the rest of the session instead of breaking the whole run.
- Project-local providers require an explicit trust gate and default off.

## Verification

Fresh local verification on this branch:

- `bun run typecheck` — passed
- `bun run test` — 988 pass, 1 skip, 0 fail
- `bun run build` — passed
- `git diff --check origin/main...HEAD` — passed
- Branch sync: `git pull --rebase` and `git push` both reported up-to-date

## Notes

- Existing ServiceHandler services continue to work; the provider API is additive.
- Pertinence is expected to be the first external consumer of this API.