### PR TITLE
fix: sandbox DegradedBanner false positive + tunnel WS proxy fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "dev": "concurrently \"bun run dev:server\" \"bun run dev:ui --host\" --kill-others-on-exit",
     "dev:server": "cd packages/server && bun run dev",
     "dev:ui": "cd packages/ui && bun run dev",
+    "dev:redis": "bash scripts/start-redis.sh",
+    "dev:redis:stop": "bash scripts/stop-redis.sh",
     "dev:cli": "bun packages/cli/src/index.ts",
     "dev:runner": "bun packages/cli/src/index.ts runner",
     "test": "bun test --max-concurrency=1 packages/protocol/src packages/tunnel/src packages/server/src packages/server/tests/pi-compat.test.ts packages/server/tests/prune.test.ts packages/server/tests/touch.test.ts packages/server/tests/validation.test.ts packages/tools/src && bun test --max-concurrency=1 packages/server/tests/e2e/signup.test.ts && bun test --max-concurrency=1 packages/server/tests/harness && cd packages/cli && bun test src && cd ../ui && bun test src",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "dev:redis:stop": "bash scripts/stop-redis.sh",
     "dev:cli": "bun packages/cli/src/index.ts",
     "dev:runner": "bun packages/cli/src/index.ts runner",
-    "test": "bun test --max-concurrency=1 packages/protocol/src packages/tunnel/src packages/server/src packages/server/tests/pi-compat.test.ts packages/server/tests/prune.test.ts packages/server/tests/touch.test.ts packages/server/tests/validation.test.ts packages/tools/src && bun test --max-concurrency=1 packages/server/tests/e2e/signup.test.ts && bun test --max-concurrency=1 packages/server/tests/harness && cd packages/cli && bun test src && cd ../ui && bun test src",
+    "test": "bun test --max-concurrency=1 scripts/start-redis.test.ts packages/protocol/src packages/tunnel/src packages/server/src packages/server/tests/pi-compat.test.ts packages/server/tests/prune.test.ts packages/server/tests/touch.test.ts packages/server/tests/validation.test.ts packages/tools/src && bun test --max-concurrency=1 packages/server/tests/e2e/signup.test.ts && bun test --max-concurrency=1 packages/server/tests/harness && cd packages/cli && bun test src && cd ../ui && bun test src",
     "typecheck": "bun packages/cli/scripts/compile-prompt.ts && tsc --build && bun run --cwd packages/protocol typecheck:tests && bun run --cwd packages/server typecheck:tests",
     "migrate": "cd packages/server && bun run migrate",
     "clean": "bun -e \"['protocol','tunnel','tools','server','ui','cli','docs'].forEach(p=>{require('fs').rmSync('packages/'+p+'/dist',{recursive:true,force:true});require('fs').rmSync('packages/'+p+'/tsconfig.tsbuildinfo',{force:true})})\"",

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -150,7 +150,10 @@ export default defineConfig({
         https: tlsConfig,
         proxy: {
             "/health": `http://localhost:${API_PORT}`,
-            "/api": `http://localhost:${API_PORT}`,
+            "/api": {
+                target: `http://localhost:${API_PORT}`,
+                ws: true,
+            },
             "/socket.io": {
                 target: `http://localhost:${API_PORT}`,
                 ws: true,

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -5,7 +5,7 @@ import { VitePWA } from "vite-plugin-pwa";
 import path from "path";
 import fs from "fs";
 
-const API_PORT = process.env.PORT ?? "3001";
+const API_PORT = process.env.PORT ?? "7492";
 const buildTimestamp = new Date().toISOString();
 const uiPackageJson = JSON.parse(
     fs.readFileSync(path.resolve(__dirname, "./package.json"), "utf8"),
@@ -149,6 +149,7 @@ export default defineConfig({
         allowedHosts: extraAllowedHosts.length ? extraAllowedHosts : undefined,
         https: tlsConfig,
         proxy: {
+            "/health": `http://localhost:${API_PORT}`,
             "/api": `http://localhost:${API_PORT}`,
             "/socket.io": {
                 target: `http://localhost:${API_PORT}`,

--- a/scripts/start-redis.sh
+++ b/scripts/start-redis.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Start a Redis container for local PizzaPi development.
+#
+# Usage:
+#   ./scripts/start-redis.sh
+#
+# Starts redis:7-alpine on port 6379. If the container already exists but
+# is stopped, it restarts it.  If Redis is already running on 6379, this
+# is a no-op.
+#
+# The server (bun run dev) defaults to redis://localhost:6379, so no env
+# var configuration is needed.
+#
+# Stop with: ./scripts/stop-redis.sh
+
+set -euo pipefail
+
+CONTAINER_NAME="pizzapi-redis-dev"
+REDIS_PORT="6379"
+
+# ── Docker available? ─────────────────────────────────────────────────────────
+if ! command -v docker &>/dev/null; then
+    echo "❌ Docker is not installed or not in PATH."
+    echo "   Install Docker from https://docs.docker.com/get-docker/"
+    exit 1
+fi
+
+if ! docker info &>/dev/null; then
+    echo "❌ Docker is not running. Start Docker Desktop (or dockerd) and retry."
+    exit 1
+fi
+
+# ── Already running? ──────────────────────────────────────────────────────────
+if docker inspect "$CONTAINER_NAME" --format '{{.State.Status}}' 2>/dev/null | grep -q 'running'; then
+    echo "✅ Redis ($CONTAINER_NAME) is already running on port $REDIS_PORT."
+    echo "   URL: redis://localhost:$REDIS_PORT"
+    exit 0
+fi
+
+# ── Port already in use (non-Docker Redis)? ──────────────────────────────────
+if lsof -i ":$REDIS_PORT" -sTCP:LISTEN &>/dev/null; then
+    echo "⚠️  Port $REDIS_PORT is already in use by another process:"
+    lsof -i ":$REDIS_PORT" -sTCP:LISTEN
+    echo ""
+    echo "   Kill that process or change REDIS_PORT in this script."
+    exit 1
+fi
+
+# ── Container exists but stopped → restart ────────────────────────────────────
+if docker inspect "$CONTAINER_NAME" &>/dev/null; then
+    echo "🔄 Restarting existing Redis container ($CONTAINER_NAME)..."
+    docker start "$CONTAINER_NAME"
+else
+    echo "🚀 Starting Redis container ($CONTAINER_NAME) on port $REDIS_PORT..."
+    docker run -d \
+        --name "$CONTAINER_NAME" \
+        -p "$REDIS_PORT:6379" \
+        --restart unless-stopped \
+        redis:7-alpine \
+        redis-server --save "" --appendonly no
+fi
+
+# ── Wait for Redis to accept connections ──────────────────────────────────────
+echo -n "⏳ Waiting for Redis..."
+for i in $(seq 1 30); do
+    if docker exec "$CONTAINER_NAME" redis-cli ping 2>/dev/null | grep -q PONG; then
+        echo " ready!"
+        break
+    fi
+    sleep 0.5
+    echo -n "."
+done
+
+# Verify it actually responds
+if ! docker exec "$CONTAINER_NAME" redis-cli ping 2>/dev/null | grep -q PONG; then
+    echo ""
+    echo "❌ Redis failed to start within 15s. Check docker logs:"
+    echo "   docker logs $CONTAINER_NAME"
+    exit 1
+fi
+
+echo ""
+echo "✅ Redis is ready!"
+echo "   Container: $CONTAINER_NAME"
+echo "   URL:       redis://localhost:$REDIS_PORT"
+echo ""
+echo "   Stop with: ./scripts/stop-redis.sh"
+echo "   You can now run: bun run dev"

--- a/scripts/start-redis.sh
+++ b/scripts/start-redis.sh
@@ -37,13 +37,13 @@ if docker inspect "$CONTAINER_NAME" --format '{{.State.Status}}' 2>/dev/null | g
     exit 0
 fi
 
-# ── Port already in use (non-Docker Redis)? ──────────────────────────────────
+# ── Port already in use (reuse existing local Redis) ──────────────────────────
 if lsof -i ":$REDIS_PORT" -sTCP:LISTEN &>/dev/null; then
-    echo "⚠️  Port $REDIS_PORT is already in use by another process:"
+    echo "✅ Port $REDIS_PORT is already in use by an existing local service."
     lsof -i ":$REDIS_PORT" -sTCP:LISTEN
     echo ""
-    echo "   Kill that process or change REDIS_PORT in this script."
-    exit 1
+    echo "   Reusing redis://localhost:$REDIS_PORT"
+    exit 0
 fi
 
 # ── Container exists but stopped → restart ────────────────────────────────────

--- a/scripts/start-redis.test.ts
+++ b/scripts/start-redis.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const repoRoot = join(import.meta.dir, "..");
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeExecutable(path: string, content: string) {
+  writeFileSync(path, content);
+  chmodSync(path, 0o755);
+}
+
+describe("scripts/start-redis.sh", () => {
+  test("treats an existing listener on port 6379 as success", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "pizzapi-start-redis-"));
+    tempDirs.push(tempDir);
+
+    const fakeBin = join(tempDir, "bin");
+    mkdirSync(fakeBin, { recursive: true });
+
+    const dockerLog = join(tempDir, "docker.log");
+
+    makeExecutable(
+      join(fakeBin, "docker"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${dockerLog}"
+case "\${1:-}" in
+  info)
+    exit 0
+    ;;
+  inspect)
+    exit 1
+    ;;
+  *)
+    echo "unexpected docker command: $*" >&2
+    exit 99
+    ;;
+esac
+`,
+    );
+
+    makeExecutable(
+      join(fakeBin, "lsof"),
+      `#!/usr/bin/env bash
+set -euo pipefail
+echo 'redis-server 123 pizza 3u IPv4 0t0 TCP localhost:6379 (LISTEN)'
+`,
+    );
+
+    const result = Bun.spawnSync({
+      cmd: ["bash", "scripts/start-redis.sh"],
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        PATH: `${fakeBin}:${process.env.PATH ?? ""}`,
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr.toString()).toBe("");
+    expect(result.stdout.toString()).toContain(
+      "✅ Port 6379 is already in use by an existing local service.",
+    );
+    expect(result.stdout.toString()).toContain("Reusing redis://localhost:6379");
+
+    const dockerCommands = readFileSync(dockerLog, "utf8");
+    expect(dockerCommands).toContain("info");
+    expect(dockerCommands).toContain("inspect pizzapi-redis-dev --format {{.State.Status}}");
+    expect(dockerCommands).not.toContain(" run ");
+    expect(dockerCommands).not.toContain(" start ");
+    expect(dockerCommands).not.toContain(" exec ");
+  });
+});

--- a/scripts/stop-redis.sh
+++ b/scripts/stop-redis.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Stop the dev Redis container started by start-redis.sh.
+#
+# Usage:
+#   ./scripts/stop-redis.sh
+
+set -euo pipefail
+
+CONTAINER_NAME="pizzapi-redis-dev"
+
+if ! docker inspect "$CONTAINER_NAME" &>/dev/null; then
+    echo "📭 No Redis container ($CONTAINER_NAME) found. Nothing to stop."
+    exit 0
+fi
+
+STATUS=$(docker inspect "$CONTAINER_NAME" --format '{{.State.Status}}' 2>/dev/null)
+
+if [ "$STATUS" != "running" ]; then
+    echo "📭 Redis container ($CONTAINER_NAME) is not running (status: $STATUS)."
+    echo "   Remove with: docker rm $CONTAINER_NAME"
+    exit 0
+fi
+
+echo "🛑 Stopping Redis container ($CONTAINER_NAME)..."
+docker stop "$CONTAINER_NAME"
+echo "✅ Redis stopped."
+echo "   Remove completely with: docker rm $CONTAINER_NAME"


### PR DESCRIPTION
## What

Fixes three bugs in the Vite dev proxy that caused the sandbox to appear broken:

### 1. `/health` route not proxied → false positive DegradedBanner
The DegradedBanner component calls `fetch("/health")`, which hit the Vite dev server (returning HTML/404) instead of the API server. JSON parsing failed, and `fetchHealthDegraded` treated it as "degraded" — the banner showed even when the server was fine.

**Fix:** Added `"/health"` to the Vite proxy config.

### 2. Mismatched default ports
Server defaults to port `7492` (`packages/server/src/index.ts`), but the Vite proxy defaulted to `3001`. With no `PORT` env var, the proxy would target the wrong port.

**Fix:** Changed Vite `API_PORT` default from `3001` to `7492`.

### 3. Missing `ws: true` on `/api` proxy → broken tunnel WebSockets
The tunnel system (`tunnel-ws.ts`) proxies WebSocket connections at `/api/tunnel/*` from browser to runner. The Vite proxy's `/api` entry had no `ws: true`, so WebSocket upgrades to `/api/tunnel/*` would silently fail in local dev.

**Fix:** Added `ws: true` to the `/api` proxy entry (`/socket.io` already had it).

### 4. Dev Redis convenience scripts
Added `scripts/start-redis.sh`, `scripts/stop-redis.sh`, and `bun run dev:redis` / `bun run dev:redis:stop` to make local dev setup easier.

## Testing
- All 84 sandbox harness tests pass
- Typecheck clean across all packages
- Sandbox starts correctly with in-memory Redis