### PR TITLE
fix(server): prevent path traversal in extracted image storage

### DIFF
--- a/packages/server/src/attachments/store.ts
+++ b/packages/server/src/attachments/store.ts
@@ -183,7 +183,9 @@ export async function storeExtractedImage(input: {
         ? base64Data.slice(base64Data.indexOf(",") + 1)
         : base64Data;
     const bytes = Buffer.from(rawB64, "base64");
-    const ext = mimeType.split("/").pop() ?? "png";
+    const VALID_IMAGE_EXTS = new Set(["png", "jpg", "jpeg", "gif", "webp", "svg", "avif", "ico"]);
+    const rawExt = mimeType.split("/").pop()?.split(";")[0]?.trim().toLowerCase() ?? "png";
+    const ext = VALID_IMAGE_EXTS.has(rawExt) ? rawExt : "bin";
     const filename = `extracted-${attachmentId}.${ext}`;
     const targetPath = path.join(uploadRoot, filename);
 


### PR DESCRIPTION
Sanitizes the file extension derived from the mimeType field against a strict allowlist before constructing the target file path in storeExtractedImage(). This prevents directory traversal attacks via maliciously crafted mimeTypes (e.g., 'image/png;../../.pizzapi/auth') that could otherwise cause path.join() to resolve outside the configured upload directory and allow arbitrary file writes.