### PR TITLE
feat(cli): Discord connector with generic message provider

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -20,7 +20,7 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.5.23",
+      "version": "0.5.4-dev.1",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
@@ -38,6 +38,9 @@
       "devDependencies": {
         "@types/bun": "^1.3.9",
         "typescript": "^5.7.0",
+      },
+      "optionalDependencies": {
+        "discord.js": "^14.18.0",
       },
     },
     "packages/docs": {
@@ -528,6 +531,18 @@
 
     "@ctrl/tinycolor": ["@ctrl/tinycolor@4.2.0", "", {}, "sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A=="],
 
+    "@discordjs/builders": ["@discordjs/builders@1.14.1", "", { "dependencies": { "@discordjs/formatters": "^0.6.2", "@discordjs/util": "^1.2.0", "@sapphire/shapeshift": "^4.0.0", "discord-api-types": "^0.38.40", "fast-deep-equal": "^3.1.3", "ts-mixer": "^6.0.4", "tslib": "^2.6.3" } }, "sha512-gSKkhXLqs96TCzk66VZuHHl8z2bQMJFGwrXC0f33ngK+FLNau4hU1PYny3DNJfNdSH+gVMzE85/d5FQ2BpcNwQ=="],
+
+    "@discordjs/collection": ["@discordjs/collection@1.5.3", "", {}, "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ=="],
+
+    "@discordjs/formatters": ["@discordjs/formatters@0.6.2", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ=="],
+
+    "@discordjs/rest": ["@discordjs/rest@2.6.1", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.2.0", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.5", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.40", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg=="],
+
+    "@discordjs/util": ["@discordjs/util@1.2.0", "", { "dependencies": { "discord-api-types": "^0.38.33" } }, "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg=="],
+
+    "@discordjs/ws": ["@discordjs/ws@1.2.3", "", { "dependencies": { "@discordjs/collection": "^2.1.0", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.0", "@sapphire/async-queue": "^1.5.2", "@types/ws": "^8.5.10", "@vladfrangu/async_event_emitter": "^2.2.4", "discord-api-types": "^0.38.1", "tslib": "^2.6.2", "ws": "^8.17.0" } }, "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw=="],
+
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.52.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w=="],
 
     "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.79.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.79.3", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-Ksvnu6CpQLYGbCSgnQEetzliI7yb+QkqtSlmmunJ69QluT45kd3DjQZRNHfRLk++Dd02Y8QvsRKMopSJCcWoWw=="],
@@ -1006,6 +1021,12 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.57.1", "", { "os": "win32", "cpu": "x64" }, "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA=="],
 
+    "@sapphire/async-queue": ["@sapphire/async-queue@1.5.5", "", {}, "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg=="],
+
+    "@sapphire/shapeshift": ["@sapphire/shapeshift@4.0.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "lodash": "^4.17.21" } }, "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg=="],
+
+    "@sapphire/snowflake": ["@sapphire/snowflake@3.5.3", "", {}, "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ=="],
+
     "@sec-ant/readable-stream": ["@sec-ant/readable-stream@0.4.1", "", {}, "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
@@ -1355,6 +1376,8 @@
     "@vite-pwa/assets-generator": ["@vite-pwa/assets-generator@1.0.2", "", { "dependencies": { "cac": "^6.7.14", "colorette": "^2.0.20", "consola": "^3.4.2", "sharp": "^0.33.5", "sharp-ico": "^0.1.5", "unconfig": "^7.3.1" }, "bin": { "pwa-assets-generator": "bin/pwa-assets-generator.mjs" } }, "sha512-MCbrb508JZHqe7bUibmZj/lyojdhLRnfkmyXnkrCM2zVrjTgL89U8UEfInpKTvPeTnxsw2hmyZxnhsdNR6yhwg=="],
 
     "@vitejs/plugin-react-swc": ["@vitejs/plugin-react-swc@4.3.0", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7", "@swc/core": "^1.15.11" }, "peerDependencies": { "vite": "^4 || ^5 || ^6 || ^7 || ^8" } }, "sha512-mOkXCII839dHyAt/gpoSlm28JIVDwhZ6tnG6wJxUy2bmOx7UaPjvOyIDf3SFv5s7Eo7HVaq6kRcu6YMEzt5Z7w=="],
+
+    "@vladfrangu/async_event_emitter": ["@vladfrangu/async_event_emitter@2.4.7", "", {}, "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
 
@@ -1761,6 +1784,10 @@
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "direction": ["direction@2.0.1", "", { "bin": { "direction": "cli.js" } }, "sha512-9S6m9Sukh1cZNknO1CWAr2QAWsbKLafQiyM5gZ7VgXHeuaoUwffKN4q6NC4A/Mf9iiPlOXQEKW/Mv/mh9/3YFA=="],
+
+    "discord-api-types": ["discord-api-types@0.38.48", "", {}, "sha512-WFUE/2o0lBlLeCQonQ+Pu2RqHAqbytBJ2RlXR91gzk05InSS6k9ShzzLYoymrA4c2oRgRKGE7/VqQJNNdGWSxQ=="],
+
+    "discord.js": ["discord.js@14.26.4", "", { "dependencies": { "@discordjs/builders": "^1.14.1", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.2", "@discordjs/rest": "^2.6.1", "@discordjs/util": "^1.2.0", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.40", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.13.0", "tslib": "^2.6.3", "undici": "6.24.1" } }, "sha512-4oBp8tc6Kf8IDBwAHhbsMaAqx1b5fob9SNasZT7V6yyyUydoO5i5fGuX7TmvRtR+q/WgKRnRViRoAWnG7fNyvA=="],
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
@@ -2350,6 +2377,8 @@
 
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
+    "lodash.snakecase": ["lodash.snakecase@4.1.1", "", {}, "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="],
+
     "lodash.sortby": ["lodash.sortby@4.7.0", "", {}, "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA=="],
 
     "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
@@ -2365,6 +2394,8 @@
     "lucide-react": ["lucide-react@0.575.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-VuXgKZrk0uiDlWjGGXmKV6MSk9Yy4l10qgVvzGn2AWBx1Ylt0iBexKOAoA6I7JO3m+M9oeovJd3yYENfkUbOeg=="],
 
     "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-bytes.js": ["magic-bytes.js@1.13.0", "", {}, "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -3134,6 +3165,8 @@
 
     "ts-dedent": ["ts-dedent@2.2.0", "", {}, "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ=="],
 
+    "ts-mixer": ["ts-mixer@6.0.4", "", {}, "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="],
+
     "ts-morph": ["ts-morph@26.0.0", "", { "dependencies": { "@ts-morph/common": "~0.27.0", "code-block-writer": "^13.0.3" } }, "sha512-ztMO++owQnz8c/gIENcM9XfCEzgoGphTv+nKpYNM1bgsdOVC/jRZuEBf6N+mLLDNg68Kl+GgUZfOySaRiG1/Ug=="],
 
     "tsconfck": ["tsconfck@3.1.6", "", { "peerDependencies": { "typescript": "^5.0.0" }, "optionalPeers": ["typescript"], "bin": { "tsconfck": "bin/tsconfck.js" } }, "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w=="],
@@ -3180,7 +3213,7 @@
 
     "uncrypto": ["uncrypto@0.1.3", "", {}, "sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q=="],
 
-    "undici": ["undici@8.3.0", "", {}, "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q=="],
+    "undici": ["undici@6.24.1", "", {}, "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA=="],
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
@@ -3484,6 +3517,12 @@
 
     "@better-auth/cli/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
 
+    "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/rest/@sapphire/snowflake": ["@sapphire/snowflake@3.5.5", "", {}, "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ=="],
+
+    "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
     "@dotenvx/dotenvx/commander": ["commander@11.1.0", "", {}, "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ=="],
 
     "@dotenvx/dotenvx/execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
@@ -3493,6 +3532,8 @@
     "@dotenvx/dotenvx/which": ["which@4.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg=="],
 
     "@earendil-works/pi-coding-agent/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@earendil-works/pi-coding-agent/undici": ["undici@8.3.0", "", {}, "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q=="],
 
     "@ecies/ciphers/@noble/ciphers": ["@noble/ciphers@1.3.0", "", {}, "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw=="],
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -28,6 +28,9 @@
     "build:binary:windows-x64": "bun build-binaries.ts --target windows-x64",
     "build:binaries": "bun build-binaries.ts"
   },
+  "optionalDependencies": {
+    "discord.js": "^14.18.0"
+  },
   "dependencies": {
     "@earendil-works/pi-coding-agent": "^0.79.3",
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/packages/cli/src/runner/services/message-provider/bridge-manifest.json
+++ b/packages/cli/src/runner/services/message-provider/bridge-manifest.json
@@ -1,0 +1,54 @@
+{
+  "id": "message-bridge",
+  "label": "Message Bridge",
+  "icon": "message-circle",
+  "panel": {
+    "dir": "./panel",
+    "requires": ["SESSION_ID"]
+  },
+  "triggers": [
+    {
+      "type": "message-bridge:inbound",
+      "label": "Inbound Message",
+      "description": "Fired when a message is received from an external platform (Discord, Slack, etc.)",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "providerId": { "type": "string" },
+          "channelId": { "type": "string" },
+          "channelName": { "type": "string" },
+          "author": { "type": "object" },
+          "content": { "type": "string" },
+          "isCommand": { "type": "boolean" },
+          "command": { "type": "object" },
+          "threadId": { "type": "string" },
+          "replyToId": { "type": "string" },
+          "messageId": { "type": "string" }
+        }
+      },
+      "params": [
+        {
+          "name": "providerId",
+          "label": "Provider",
+          "type": "string",
+          "enum": ["discord", "slack", "telegram"],
+          "description": "Only receive messages from this provider"
+        }
+      ]
+    },
+    {
+      "type": "message-bridge:send",
+      "label": "Send Message",
+      "description": "Fired when a message is successfully sent to an external platform",
+      "schema": {
+        "type": "object",
+        "properties": {
+          "providerId": { "type": "string" },
+          "channelId": { "type": "string" },
+          "content": { "type": "string" },
+          "messageId": { "type": "string" }
+        }
+      }
+    }
+  ]
+}

--- a/packages/cli/src/runner/services/message-provider/bridge-service.test.ts
+++ b/packages/cli/src/runner/services/message-provider/bridge-service.test.ts
@@ -1,0 +1,466 @@
+/**
+ * Tests for MessageBridgeService.
+ */
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Socket } from "socket.io-client";
+import type { TriggerSubscriptionEntry } from "@pizzapi/protocol";
+import { MessageBridgeService, type MessageBridgeConfig } from "./bridge-service.js";
+import type { Channel, InboundMessage, InboundMessageHandler, MessageProvider, OutboundMessage, ProviderConfig } from "./types.js";
+
+const originalFetch = globalThis.fetch;
+const originalHome = process.env.HOME;
+const originalRelayUrl = process.env.PIZZAPI_RELAY_URL;
+const originalApiKey = process.env.PIZZAPI_RUNNER_API_KEY;
+
+let service: MessageBridgeService | null = null;
+
+afterEach(async () => {
+    if (service) {
+        service.dispose();
+        await Promise.resolve();
+        service = null;
+    }
+
+    globalThis.fetch = originalFetch;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalRelayUrl === undefined) delete process.env.PIZZAPI_RELAY_URL;
+    else process.env.PIZZAPI_RELAY_URL = originalRelayUrl;
+    if (originalApiKey === undefined) delete process.env.PIZZAPI_RUNNER_API_KEY;
+    else process.env.PIZZAPI_RUNNER_API_KEY = originalApiKey;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+class MockProvider implements MessageProvider {
+    readonly id: string;
+    readonly label: string;
+    connected = false;
+    private readonly handlers = new Set<InboundMessageHandler>();
+
+    constructor(id: string, label: string) {
+        this.id = id;
+        this.label = label;
+    }
+
+    connect = mock((config: ProviderConfig) => {
+        this.connected = true;
+        return Promise.resolve();
+    });
+
+    disconnect = mock(() => {
+        this.connected = false;
+        return Promise.resolve();
+    });
+
+    isConnected(): boolean {
+        return this.connected;
+    }
+
+    send = mock((_channelId: string, _message: OutboundMessage) => Promise.resolve());
+
+    listChannels = mock(() =>
+        Promise.resolve<Channel[]>([
+            { id: "chan-1", name: "general", type: "text" },
+            { id: "chan-2", name: "dev", type: "text" },
+        ]),
+    );
+
+    onMessage(handler: InboundMessageHandler): void {
+        this.handlers.add(handler);
+    }
+
+    offMessage(handler: InboundMessageHandler): void {
+        this.handlers.delete(handler);
+    }
+
+    async emitMessage(message: InboundMessage): Promise<void> {
+        const promises: Promise<unknown>[] = [];
+        for (const handler of this.handlers) {
+            const result = handler(message);
+            if (result instanceof Promise) {
+                promises.push(result.catch(() => undefined));
+            }
+        }
+        await Promise.all(promises);
+    }
+}
+
+function createMockProvider(id: string, label: string): MockProvider {
+    return new MockProvider(id, label);
+}
+
+function fakeSocket(): Socket {
+    return {} as Socket;
+}
+
+function setupBroadcastEnv(): string {
+    const home = mkdtempSync(join(tmpdir(), "pizzapi-bridge-"));
+    mkdirSync(join(home, ".pizzapi"), { recursive: true });
+    writeFileSync(
+        join(home, ".pizzapi", "runner.json"),
+        JSON.stringify({ runnerId: "runner-test" }),
+        "utf-8",
+    );
+    process.env.HOME = home;
+    process.env.PIZZAPI_RELAY_URL = "http://relay.test";
+    process.env.PIZZAPI_RUNNER_API_KEY = "test-api-key";
+    return home;
+}
+
+function relayFetchMock(): {
+    fn: ReturnType<typeof mock<typeof fetch>>;
+    calls: Array<{ url: unknown; init?: RequestInit }>;
+} {
+    const calls: Array<{ url: unknown; init?: RequestInit }> = [];
+    const fn = mock(async (url: unknown, init?: RequestInit) => {
+        calls.push({ url, init });
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as unknown as ReturnType<typeof mock<typeof fetch>>;
+    return { fn, calls };
+}
+
+function mixedFetchMock(): {
+    fn: ReturnType<typeof mock<typeof fetch>>;
+    relayCalls: Array<{ url: unknown; init?: RequestInit }>;
+} {
+    const relayCalls: Array<{ url: unknown; init?: RequestInit }> = [];
+    const fn = mock(async (url: unknown, init?: RequestInit) => {
+        const urlString = String(url);
+        if (urlString.includes("/api/runners/") && urlString.includes("/trigger-broadcast")) {
+            relayCalls.push({ url, init });
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }
+        // Let real panel HTTP requests through.
+        return originalFetch(url as RequestInfo, init);
+    }) as unknown as ReturnType<typeof mock<typeof fetch>>;
+    return { fn, relayCalls };
+}
+
+function sampleInbound(overrides: Partial<InboundMessage> = {}): InboundMessage {
+    return {
+        id: "msg-1",
+        channelId: "chan-1",
+        channelName: "general",
+        author: { id: "u1", username: "user1", displayName: "User One" },
+        content: "hello",
+        timestamp: Date.now(),
+        isCommand: false,
+        raw: {},
+        ...overrides,
+    };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("MessageBridgeService", () => {
+    test("has expected id", () => {
+        service = new MessageBridgeService();
+        expect(service.id).toBe("message-bridge");
+    });
+
+    test("init() registers providers based on config", async () => {
+        const discord = createMockProvider("discord", "Discord");
+        const slack = createMockProvider("slack", "Slack");
+
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            discord: { token: "discord-token" },
+            slack: { token: "slack-token" },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: {
+                discord: () => discord,
+                slack: () => slack,
+            },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const providers = service.getRegistry().getProviders();
+        expect(providers.map((p) => p.id).sort()).toEqual(["discord", "slack"]);
+        expect(discord.connect).toHaveBeenCalled();
+        expect(slack.connect).toHaveBeenCalled();
+    });
+
+    test("providers that fail to connect are handled gracefully", async () => {
+        const good = createMockProvider("good", "Good Provider");
+        const bad = createMockProvider("bad", "Bad Provider");
+        bad.connect = mock(() => {
+            bad.connected = false;
+            return Promise.reject(new Error("login failed"));
+        });
+
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            good: { token: "good-token" },
+            bad: { token: "bad-token" },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: {
+                good: () => good,
+                bad: () => bad,
+            },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(good.connect).toHaveBeenCalled();
+        expect(bad.connect).toHaveBeenCalled();
+        expect(good.isConnected()).toBe(true);
+        expect(bad.isConnected()).toBe(false);
+    });
+
+    test("provider status reports correctly", () => {
+        const provider = createMockProvider("discord", "Discord");
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            discord: { token: "discord-token" },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: { discord: () => provider },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        provider.connected = true;
+        service.getRegistry().addChannelSession("discord", {
+            channelId: "chan-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only" },
+        });
+
+        const status = service.getRegistry().getStatus();
+        expect(status).toHaveLength(1);
+        expect(status[0]).toMatchObject({
+            id: "discord",
+            label: "Discord",
+            connected: true,
+            channelCount: 1,
+            sessionsMapped: 1,
+            messagesIn: 0,
+            messagesOut: 0,
+        });
+    });
+
+    test("inbound messages trigger broadcast via fetch", async () => {
+        setupBroadcastEnv();
+        const { fn, calls } = relayFetchMock();
+        globalThis.fetch = fn as unknown as typeof fetch;
+
+        const provider = createMockProvider("discord", "Discord");
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            discord: { token: "discord-token" },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: { discord: () => provider },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        await Promise.resolve();
+
+        const inbound = sampleInbound({ content: "!help" });
+        await provider.emitMessage(inbound);
+        await Promise.resolve();
+
+        expect(calls.length).toBeGreaterThanOrEqual(1);
+        const call = calls.find((c) =>
+            String(c.url).includes("/api/runners/runner-test/trigger-broadcast"),
+        );
+        expect(call).toBeDefined();
+        expect(call!.init?.method).toBe("POST");
+
+        const body = JSON.parse(call!.init?.body as string);
+        expect(body.type).toBe("message-bridge:inbound");
+        expect(body.source).toBe("message-bridge");
+        expect(body.payload.providerId).toBe("discord");
+        expect(body.payload.channelId).toBe("chan-1");
+        expect(body.payload.content).toBe("!help");
+        expect(body.payload.author.displayName).toBe("User One");
+        expect(body.deliverAs).toBe("followUp");
+        expect(body.summary).toContain("User One");
+    });
+
+    test("panel server responds to /api/status", async () => {
+        const provider = createMockProvider("discord", "Discord");
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            discord: { token: "discord-token" },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: { discord: () => provider },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        const port = service.getPanelPort();
+        expect(port).toBeGreaterThan(0);
+
+        const res = await fetch(`http://localhost:${port}/api/status`);
+        expect(res.status).toBe(200);
+        const data = (await res.json()) as Array<Record<string, unknown>>;
+        expect(data).toHaveLength(1);
+        expect(data[0].id).toBe("discord");
+    });
+
+    test("panel server responds to /api/send", async () => {
+        setupBroadcastEnv();
+        const { fn, relayCalls } = mixedFetchMock();
+        globalThis.fetch = fn as unknown as typeof fetch;
+
+        const provider = createMockProvider("discord", "Discord");
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            discord: { token: "discord-token" },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: { discord: () => provider },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        const port = service.getPanelPort()!;
+
+        const res = await fetch(`http://localhost:${port}/api/send`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ providerId: "discord", channelId: "chan-1", content: "hello" }),
+        });
+
+        expect(res.status).toBe(200);
+        const data = (await res.json()) as Record<string, unknown>;
+        expect(data.success).toBe(true);
+        expect(provider.send).toHaveBeenCalledWith("chan-1", { content: "hello" });
+
+        await Promise.resolve();
+        const relayCall = relayCalls.find((c) =>
+            String(c.url).includes("/api/runners/runner-test/trigger-broadcast"),
+        );
+        expect(relayCall).toBeDefined();
+        const body = JSON.parse(relayCall!.init?.body as string);
+        expect(body.type).toBe("message-bridge:send");
+        expect(body.payload.providerId).toBe("discord");
+        expect(body.payload.channelId).toBe("chan-1");
+        expect(body.payload.content).toBe("hello");
+    });
+
+    test("dispose() disconnects providers and stops server", async () => {
+        const provider = createMockProvider("discord", "Discord");
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            discord: { token: "discord-token" },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: { discord: () => provider },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        const port = service.getPanelPort()!;
+        await Promise.resolve();
+
+        service.dispose();
+        await Promise.resolve();
+
+        expect(provider.disconnect).toHaveBeenCalled();
+        expect(service.getPanelPort()).toBeUndefined();
+
+        // The server should no longer accept connections.
+        await expect(fetch(`http://localhost:${port}/api/status`)).rejects.toThrow();
+    });
+
+    test("config validation endpoint", async () => {
+        service = new MessageBridgeService({
+            config: { enabled: true },
+            factories: { discord: () => createMockProvider("discord", "Discord") },
+        });
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        const port = service.getPanelPort()!;
+
+        const valid = await fetch(`http://localhost:${port}/api/config/test`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ discord: { token: "valid-token" } }),
+        });
+        const validData = (await valid.json()) as Record<string, unknown>;
+        expect(valid.status).toBe(200);
+        expect(validData.valid).toBe(true);
+
+        const invalid = await fetch(`http://localhost:${port}/api/config/test`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ discord: {} }),
+        });
+        const invalidData = (await invalid.json()) as Record<string, unknown>;
+        expect(invalid.status).toBe(200);
+        expect(invalidData.valid).toBe(false);
+    });
+
+    test("reconcileSubscriptions tracks send sessions", () => {
+        service = new MessageBridgeService();
+
+        const snapshot: TriggerSubscriptionEntry[] = [
+            { sessionId: "s1", triggerType: "message-bridge:send", subscriptionId: "sub-1", runnerId: "runner-1" },
+            { sessionId: "s2", triggerType: "message-bridge:send", subscriptionId: "sub-2", runnerId: "runner-1" },
+            { sessionId: "s3", triggerType: "other:event", subscriptionId: "sub-3", runnerId: "runner-1" },
+        ];
+
+        const result = service.reconcileSubscriptions(snapshot, { mode: "snapshot" });
+        expect(result.applied).toBe(2);
+        expect(service.getSendSessions()).toContain("s1");
+        expect(service.getSendSessions()).toContain("s2");
+        expect(service.getSendSessions()).not.toContain("s3");
+
+        const deltaUnsub: TriggerSubscriptionEntry[] = [
+            { sessionId: "s1", triggerType: "message-bridge:send", subscriptionId: "sub-1", runnerId: "runner-1" },
+        ];
+        const unsubResult = service.reconcileSubscriptions(deltaUnsub, { mode: "delta", action: "unsubscribe" });
+        expect(unsubResult.applied).toBe(1);
+        expect(service.getSendSessions()).not.toContain("s1");
+        expect(service.getSendSessions()).toContain("s2");
+
+        const deltaSub: TriggerSubscriptionEntry[] = [
+            { sessionId: "s4", triggerType: "message-bridge:send", subscriptionId: "sub-4", runnerId: "runner-1" },
+        ];
+        const subResult = service.reconcileSubscriptions(deltaSub, { mode: "delta", action: "subscribe" });
+        expect(subResult.applied).toBe(1);
+        expect(service.getSendSessions()).toContain("s4");
+    });
+
+    test("announcePanel is called with panel port", () => {
+        const announcedPorts: number[] = [];
+        const provider = createMockProvider("discord", "Discord");
+
+        service = new MessageBridgeService({
+            config: { enabled: true, discord: { token: "discord-token" } },
+            factories: { discord: () => provider },
+        });
+
+        service.init(fakeSocket(), {
+            isShuttingDown: () => false,
+            announcePanel: (port) => announcedPorts.push(port),
+        });
+
+        const port = service.getPanelPort();
+        expect(port).toBeGreaterThan(0);
+        expect(announcedPorts).toEqual([port!]);
+    });
+});

--- a/packages/cli/src/runner/services/message-provider/bridge-service.ts
+++ b/packages/cli/src/runner/services/message-provider/bridge-service.ts
@@ -1,0 +1,448 @@
+/**
+ * MessageBridgeService — runner service that wires external message providers
+ * (Discord, Slack, Telegram, etc.) to PizzaPi's trigger system and relay.
+ *
+ * Responsibilities:
+ *   - Create provider instances from ~/.pizzapi/config.json.
+ *   - Forward routed inbound messages as `message-bridge:inbound` triggers.
+ *   - Track `message-bridge:send` subscriptions so send confirmations can be
+ *     broadcast back to listening sessions.
+ *   - Expose a small panel HTTP API for status, channel listing, sending, and
+ *     config validation.
+ */
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { Socket } from "socket.io-client";
+import type { ReconcileOptions, ServiceHandler, ServiceInitOptions } from "../../service-handler.js";
+import type { TriggerSubscriptionEntry } from "@pizzapi/protocol";
+import { DiscordProvider } from "./discord-provider.js";
+import { ProviderRegistry } from "./provider-registry.js";
+import type { InboundMessage, MessageProvider, OutboundMessage, ProviderConfig, ProviderStatus } from "./types.js";
+import { validateProviderConfig } from "./types.js";
+
+type BunServer = import("bun").Server<unknown>;
+
+// ── Config helpers ───────────────────────────────────────────────────────────
+
+export interface MessageBridgeConfig {
+    enabled?: boolean;
+    discord?: ProviderConfig;
+    slack?: ProviderConfig;
+    telegram?: ProviderConfig;
+    /** Additional provider-specific configs. */
+    [providerId: string]: unknown;
+}
+
+function readRunnerId(): string | null {
+    try {
+        const home = process.env.HOME || homedir();
+        const raw = JSON.parse(readFileSync(join(home, ".pizzapi", "runner.json"), "utf-8"));
+        return typeof raw?.runnerId === "string" ? raw.runnerId : null;
+    } catch {
+        return null;
+    }
+}
+
+function resolveRelayUrl(): string {
+    let raw = process.env.PIZZAPI_RELAY_URL?.trim();
+    if (!raw) {
+        try {
+            const home = process.env.HOME || homedir();
+            const cfg = JSON.parse(readFileSync(join(home, ".pizzapi", "config.json"), "utf-8"));
+            if (typeof cfg?.relayUrl === "string" && cfg.relayUrl !== "off") raw = cfg.relayUrl.trim();
+        } catch {
+            /* ignore */
+        }
+    }
+    raw = raw || "http://localhost:7492";
+    if (raw.startsWith("ws://")) return raw.replace(/^ws:/, "http:").replace(/\/$/, "");
+    if (raw.startsWith("wss://")) return raw.replace(/^wss:/, "https:").replace(/\/$/, "");
+    return raw.replace(/\/$/, "");
+}
+
+function getApiKey(): string | null {
+    return process.env.PIZZAPI_RUNNER_API_KEY ?? process.env.PIZZAPI_API_KEY ?? null;
+}
+
+function readBridgeConfig(): MessageBridgeConfig | undefined {
+    try {
+        const home = process.env.HOME || homedir();
+        const cfg = JSON.parse(readFileSync(join(home, ".pizzapi", "config.json"), "utf-8"));
+        const bridge = cfg?.providers?.["message-bridge"];
+        if (bridge && typeof bridge === "object") {
+            return bridge as MessageBridgeConfig;
+        }
+    } catch {
+        /* ignore */
+    }
+    return undefined;
+}
+
+// ── Provider factory ─────────────────────────────────────────────────────────
+
+export type ProviderFactory = () => MessageProvider;
+
+const DEFAULT_PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
+    discord: () => new DiscordProvider(),
+};
+
+// ── Service implementation ───────────────────────────────────────────────────
+
+export interface MessageBridgeServiceOptions {
+    /** Pre-loaded bridge config; falls back to ~/.pizzapi/config.json if omitted. */
+    config?: MessageBridgeConfig;
+    /** Provider factories keyed by provider id; defaults to Discord only. */
+    factories?: Record<string, ProviderFactory>;
+}
+
+export class MessageBridgeService implements ServiceHandler {
+    readonly id = "message-bridge";
+
+    #config: MessageBridgeConfig | undefined;
+    #factories: Record<string, ProviderFactory>;
+    #registry = new ProviderRegistry();
+    #server: BunServer | null = null;
+    #sendSessions = new Set<string>();
+    #initialized = false;
+
+    constructor(options: MessageBridgeServiceOptions = {}) {
+        this.#config = options.config;
+        this.#factories = { ...DEFAULT_PROVIDER_FACTORIES, ...(options.factories ?? {}) };
+    }
+
+    init(socket: Socket, { announcePanel }: ServiceInitOptions): void {
+        if (this.#initialized) return;
+        this.#initialized = true;
+
+        const bridgeConfig = this.#config ?? readBridgeConfig();
+        if (bridgeConfig?.enabled !== false) {
+            this.#registerProviders(bridgeConfig);
+        }
+
+        // Connect providers. Individual failures are recorded and do not stop others.
+        this.#registry.connectAll().catch((err) => {
+            this.#logError(`connectAll failed: ${err instanceof Error ? err.message : String(err)}`);
+        });
+
+        this.#server = Bun.serve({
+            port: 0,
+            fetch: (req) => this.#handlePanelRequest(req),
+        });
+
+        const port = this.#server.port;
+        if (announcePanel && port) {
+            announcePanel(port);
+        }
+    }
+
+    dispose(): void {
+        if (this.#server) {
+            this.#server.stop(true);
+            this.#server = null;
+        }
+
+        this.#registry.disconnectAll().catch((err) => {
+            this.#logError(`disconnectAll failed: ${err instanceof Error ? err.message : String(err)}`);
+        });
+
+        this.#sendSessions.clear();
+        this.#initialized = false;
+    }
+
+    reconcileSubscriptions(subscriptions: TriggerSubscriptionEntry[], options: ReconcileOptions = {}): { applied: number; errors?: string[] } {
+        const mode = options.mode ?? "snapshot";
+        const action = options.action ?? "subscribe";
+
+        const sendSubs = subscriptions.filter((s) => s.triggerType === "message-bridge:send");
+
+        if (mode === "snapshot") {
+            this.#sendSessions.clear();
+            for (const sub of sendSubs) {
+                this.#sendSessions.add(sub.sessionId);
+            }
+        } else {
+            for (const sub of sendSubs) {
+                if (action === "unsubscribe") {
+                    this.#sendSessions.delete(sub.sessionId);
+                } else {
+                    this.#sendSessions.add(sub.sessionId);
+                }
+            }
+        }
+
+        return { applied: sendSubs.length };
+    }
+
+    /** Direct access to the underlying registry (mostly for tests). */
+    getRegistry(): ProviderRegistry {
+        return this.#registry;
+    }
+
+    /** Current set of sessions subscribed to `message-bridge:send` (mostly for tests). */
+    getSendSessions(): ReadonlySet<string> {
+        return this.#sendSessions;
+    }
+
+    /** Current panel server port, or undefined if not started. */
+    getPanelPort(): number | undefined {
+        return this.#server?.port;
+    }
+
+    // ── Provider lifecycle ─────────────────────────────────────────────────
+
+    #registerProviders(bridgeConfig?: MessageBridgeConfig): void {
+        if (!bridgeConfig) return;
+
+        for (const [providerId, rawConfig] of Object.entries(bridgeConfig)) {
+            if (providerId === "enabled") continue;
+            if (!rawConfig || typeof rawConfig !== "object") {
+                this.#logWarn(`skipping provider "${providerId}": config is not an object`);
+                continue;
+            }
+
+            const factory = this.#factories[providerId];
+            if (!factory) {
+                this.#logWarn(`no factory registered for provider "${providerId}"`);
+                continue;
+            }
+
+            const validation = validateProviderConfig(rawConfig);
+            if (!validation.valid) {
+                this.#logWarn(
+                    `provider "${providerId}" config invalid: ${validation.errors.join(", ")}`,
+                );
+                continue;
+            }
+
+            try {
+                const provider = factory();
+                this.#registry.register(provider, rawConfig as ProviderConfig);
+                // Forward inbound messages as triggers to the relay.
+                provider.onMessage((inbound) => {
+                    void this.#broadcastInbound(provider.id, inbound);
+                });
+            } catch (err) {
+                this.#logError(
+                    `failed to register provider "${providerId}": ${err instanceof Error ? err.message : String(err)}`,
+                );
+            }
+        }
+    }
+
+    // ── Panel HTTP handlers ────────────────────────────────────────────────────
+
+    async #handlePanelRequest(req: Request): Promise<Response> {
+        const url = new URL(req.url);
+        const cors = this.#corsHeaders();
+
+        if (req.method === "OPTIONS") {
+            return new Response(null, {
+                status: 204,
+                headers: {
+                    ...cors,
+                    "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+                    "Access-Control-Allow-Headers": "*",
+                },
+            });
+        }
+
+        try {
+            if (url.pathname === "/api/status" && req.method === "GET") {
+                return Response.json(this.#registry.getStatus(), { headers: cors });
+            }
+
+            if (url.pathname.startsWith("/api/channels/") && req.method === "GET") {
+                const providerId = url.pathname.slice("/api/channels/".length);
+                return await this.#handleListChannels(providerId, cors);
+            }
+
+            if (url.pathname === "/api/send" && req.method === "POST") {
+                return await this.#handleSend(req, cors);
+            }
+
+            if (url.pathname === "/api/config/test" && req.method === "POST") {
+                return await this.#handleConfigTest(req, cors);
+            }
+
+            return Response.json({ error: "Not found" }, { status: 404, headers: cors });
+        } catch (err) {
+            return Response.json(
+                { error: err instanceof Error ? err.message : String(err) },
+                { status: 500, headers: cors },
+            );
+        }
+    }
+
+    async #handleListChannels(providerId: string, cors: Record<string, string>): Promise<Response> {
+        const provider = this.#registry.getProvider(providerId);
+        if (!provider) {
+            return Response.json({ error: "Provider not found" }, { status: 404, headers: cors });
+        }
+
+        try {
+            const channels = await provider.listChannels();
+            return Response.json(channels, { headers: cors });
+        } catch (err) {
+            return Response.json(
+                { error: err instanceof Error ? err.message : String(err) },
+                { status: 500, headers: cors },
+            );
+        }
+    }
+
+    async #handleSend(req: Request, cors: Record<string, string>): Promise<Response> {
+        let body: unknown;
+        try {
+            body = await req.json();
+        } catch {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400, headers: cors });
+        }
+
+        if (!body || typeof body !== "object") {
+            return Response.json({ error: "Body must be an object" }, { status: 400, headers: cors });
+        }
+
+        const { providerId, channelId, content, threadId, replyToId } = body as Record<string, unknown>;
+
+        if (typeof providerId !== "string" || typeof channelId !== "string" || typeof content !== "string") {
+            return Response.json(
+                { error: "providerId, channelId, and content are required strings" },
+                { status: 400, headers: cors },
+            );
+        }
+
+        const message: OutboundMessage = {
+            content,
+            threadId: typeof threadId === "string" ? threadId : undefined,
+            replyToId: typeof replyToId === "string" ? replyToId : undefined,
+        };
+        try {
+            await this.#registry.send(providerId, channelId, message);
+            void this.#broadcastSend(providerId, channelId, content);
+            return Response.json({ success: true }, { headers: cors });
+        } catch (err) {
+            return Response.json(
+                { error: err instanceof Error ? err.message : String(err) },
+                { status: 500, headers: cors },
+            );
+        }
+    }
+
+    async #handleConfigTest(req: Request, cors: Record<string, string>): Promise<Response> {
+        let body: unknown;
+        try {
+            body = await req.json();
+        } catch {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400, headers: cors });
+        }
+
+        if (!body || typeof body !== "object") {
+            return Response.json(
+                { valid: false, errors: ["Config must be an object"] },
+                { status: 400, headers: cors },
+            );
+        }
+
+        const results: Array<{ providerId: string; result: ReturnType<typeof validateProviderConfig> }> = [];
+        let hasProviderConfig = false;
+
+        for (const [providerId, rawConfig] of Object.entries(body as Record<string, unknown>)) {
+            if (providerId === "enabled") continue;
+            if (!rawConfig || typeof rawConfig !== "object") continue;
+            hasProviderConfig = true;
+            results.push({
+                providerId,
+                result: validateProviderConfig(rawConfig),
+            });
+        }
+
+        if (!hasProviderConfig) {
+            return Response.json(
+                { valid: false, errors: ["No provider config to validate"] },
+                { status: 400, headers: cors },
+            );
+        }
+
+        const allValid = results.every((r) => r.result.valid);
+        return Response.json(
+            { valid: allValid, results },
+            { headers: cors },
+        );
+    }
+
+    #corsHeaders(): Record<string, string> {
+        return { "Access-Control-Allow-Origin": "*" };
+    }
+
+    // ── Trigger broadcasting ─────────────────────────────────────────────────
+
+    async #broadcastInbound(providerId: string, inbound: InboundMessage): Promise<void> {
+        await this.#broadcastTrigger("message-bridge:inbound", {
+            providerId,
+            channelId: inbound.channelId,
+            channelName: inbound.channelName,
+            author: inbound.author,
+            content: inbound.content,
+            isCommand: inbound.isCommand,
+            command: inbound.command,
+            threadId: inbound.threadId,
+            replyToId: inbound.replyToId,
+            messageId: inbound.id,
+        }, { summary: `Message from ${inbound.author.displayName} in ${inbound.channelName}` });
+    }
+
+    async #broadcastSend(providerId: string, channelId: string, content: string): Promise<void> {
+        await this.#broadcastTrigger("message-bridge:send", {
+            providerId,
+            channelId,
+            content,
+            messageId: undefined,
+        });
+    }
+
+    async #broadcastTrigger(
+        type: string,
+        payload: Record<string, unknown>,
+        opts?: { deliverAs?: "steer" | "followUp"; summary?: string },
+    ): Promise<void> {
+        const runnerId = readRunnerId();
+        const apiKey = getApiKey();
+        if (!runnerId || !apiKey) {
+            this.#logWarn(`cannot broadcast ${type}: missing runnerId or apiKey`);
+            return;
+        }
+
+        try {
+            const res = await fetch(`${resolveRelayUrl()}/api/runners/${runnerId}/trigger-broadcast`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json", "x-api-key": apiKey },
+                body: JSON.stringify({
+                    type,
+                    payload,
+                    source: "message-bridge",
+                    deliverAs: opts?.deliverAs ?? "followUp",
+                    summary: opts?.summary,
+                }),
+            });
+
+            if (!res.ok) {
+                this.#logWarn(`trigger broadcast failed: ${res.status} ${res.statusText}`);
+            }
+        } catch (err) {
+            this.#logError(`trigger broadcast error: ${err instanceof Error ? err.message : String(err)}`);
+        }
+    }
+
+    // ── Logging helpers ──────────────────────────────────────────────────────
+
+    #logWarn(message: string): void {
+        // eslint-disable-next-line no-console
+        console.warn(`[message-bridge] ${message}`);
+    }
+
+    #logError(message: string): void {
+        // eslint-disable-next-line no-console
+        console.error(`[message-bridge] ${message}`);
+    }
+}

--- a/packages/cli/src/runner/services/message-provider/bridge-service.ts
+++ b/packages/cli/src/runner/services/message-provider/bridge-service.ts
@@ -17,8 +17,9 @@ import type { Socket } from "socket.io-client";
 import type { ReconcileOptions, ServiceHandler, ServiceInitOptions } from "../../service-handler.js";
 import type { TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import { DiscordProvider } from "./discord-provider.js";
+import { discordRoleAllowed } from "./discord-policy.js";
 import { ProviderRegistry } from "./provider-registry.js";
-import type { InboundMessage, MessageProvider, OutboundMessage, ProviderConfig, ProviderStatus } from "./types.js";
+import type { CanExecutePolicy, CanExecuteResult, InboundMessage, MessageProvider, OutboundMessage, ProviderConfig, ProviderStatus } from "./types.js";
 import { validateProviderConfig } from "./types.js";
 
 type BunServer = import("bun").Server<unknown>;
@@ -217,10 +218,27 @@ export class MessageBridgeService implements ServiceHandler {
 
             try {
                 const provider = factory();
-                this.#registry.register(provider, rawConfig as ProviderConfig);
+                const config = this.#ensureDefaultCanExecute(providerId, rawConfig as ProviderConfig);
+                this.#registry.register(provider, config);
                 // Forward inbound messages as triggers to the relay.
-                provider.onMessage((inbound) => {
-                    void this.#broadcastInbound(provider.id, inbound);
+                provider.onMessage(async (inbound) => {
+                    const policy = this.#resolveCanExecutePolicy(provider.id, inbound.channelId, config);
+                    if (policy) {
+                        let result: CanExecuteResult;
+                        try {
+                            result = await policy(inbound);
+                        } catch (err) {
+                            this.#logWarn(
+                                `[message-bridge] canExecute policy threw for ${inbound.author.username}: ${err instanceof Error ? err.message : String(err)}`,
+                            );
+                            return;
+                        }
+                        if (!result.allowed) {
+                            this.#logInfo(`Rejected message from ${inbound.author.username}: ${result.reason ?? "unauthorized"}`);
+                            return;
+                        }
+                    }
+                    await this.#broadcastInbound(provider.id, inbound);
                 });
             } catch (err) {
                 this.#logError(
@@ -228,6 +246,38 @@ export class MessageBridgeService implements ServiceHandler {
                 );
             }
         }
+    }
+
+    // ── Authorization helpers ────────────────────────────────────────────────
+
+    #ensureDefaultCanExecute(providerId: string, config: ProviderConfig): ProviderConfig {
+        if (providerId !== "discord") {
+            return config;
+        }
+
+        const discordOptions = config.options as
+            | { allowedRoles?: unknown; discord?: { allowedRoles?: unknown } }
+            | undefined;
+        const allowedRoles = discordOptions?.allowedRoles ?? discordOptions?.discord?.allowedRoles;
+
+        if (
+            Array.isArray(allowedRoles) &&
+            allowedRoles.every((role) => typeof role === "string") &&
+            !config.defaultCanExecute
+        ) {
+            config.defaultCanExecute = discordRoleAllowed(allowedRoles as string[]);
+        }
+
+        return config;
+    }
+
+    #resolveCanExecutePolicy(
+        providerId: string,
+        channelId: string,
+        providerConfig: ProviderConfig,
+    ): CanExecutePolicy | undefined {
+        const channelSession = this.#registry.getRouter(providerId).getSession(channelId);
+        return channelSession?.config?.canExecute ?? providerConfig.defaultCanExecute;
     }
 
     // ── Panel HTTP handlers ────────────────────────────────────────────────────
@@ -435,6 +485,11 @@ export class MessageBridgeService implements ServiceHandler {
     }
 
     // ── Logging helpers ──────────────────────────────────────────────────────
+
+    #logInfo(message: string): void {
+        // eslint-disable-next-line no-console
+        console.info(`[message-bridge] ${message}`);
+    }
 
     #logWarn(message: string): void {
         // eslint-disable-next-line no-console

--- a/packages/cli/src/runner/services/message-provider/canexecute.test.ts
+++ b/packages/cli/src/runner/services/message-provider/canexecute.test.ts
@@ -1,0 +1,418 @@
+/**
+ * Tests for the message-provider `canExecute` authorization gate.
+ */
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Socket } from "socket.io-client";
+import { MessageBridgeService, type MessageBridgeConfig } from "./bridge-service.js";
+import { ChannelRouter } from "./channel-router.js";
+import { discordRoleAllowed } from "./discord-policy.js";
+import type {
+    CanExecuteResult,
+    Channel,
+    InboundMessage,
+    InboundMessageHandler,
+    MessageProvider,
+    OutboundMessage,
+    ProviderConfig,
+} from "./types.js";
+
+const originalFetch = globalThis.fetch;
+const originalHome = process.env.HOME;
+const originalRelayUrl = process.env.PIZZAPI_RELAY_URL;
+const originalApiKey = process.env.PIZZAPI_RUNNER_API_KEY;
+
+let service: MessageBridgeService | null = null;
+
+afterEach(async () => {
+    if (service) {
+        service.dispose();
+        await Promise.resolve();
+        service = null;
+    }
+
+    globalThis.fetch = originalFetch;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalRelayUrl === undefined) delete process.env.PIZZAPI_RELAY_URL;
+    else process.env.PIZZAPI_RELAY_URL = originalRelayUrl;
+    if (originalApiKey === undefined) delete process.env.PIZZAPI_RUNNER_API_KEY;
+    else process.env.PIZZAPI_RUNNER_API_KEY = originalApiKey;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+class MockProvider implements MessageProvider {
+    readonly id: string;
+    readonly label: string;
+    connected = false;
+    private readonly handlers = new Set<InboundMessageHandler>();
+
+    constructor(id: string, label: string) {
+        this.id = id;
+        this.label = label;
+    }
+
+    connect = mock((config: ProviderConfig) => {
+        this.connected = true;
+        return Promise.resolve();
+    });
+
+    disconnect = mock(() => {
+        this.connected = false;
+        return Promise.resolve();
+    });
+
+    isConnected(): boolean {
+        return this.connected;
+    }
+
+    send = mock((_channelId: string, _message: OutboundMessage) => Promise.resolve());
+
+    listChannels = mock(() =>
+        Promise.resolve<Channel[]>([
+            { id: "chan-1", name: "general", type: "text" },
+        ]),
+    );
+
+    onMessage(handler: InboundMessageHandler): void {
+        this.handlers.add(handler);
+    }
+
+    offMessage(handler: InboundMessageHandler): void {
+        this.handlers.delete(handler);
+    }
+
+    async emitMessage(message: InboundMessage): Promise<void> {
+        const promises: Promise<unknown>[] = [];
+        for (const handler of this.handlers) {
+            const result = handler(message);
+            if (result instanceof Promise) {
+                promises.push(result.catch(() => undefined));
+            }
+        }
+        await Promise.all(promises);
+    }
+}
+
+function fakeSocket(): Socket {
+    return {} as Socket;
+}
+
+function setupBroadcastEnv(): string {
+    const home = mkdtempSync(join(tmpdir(), "pizzapi-bridge-"));
+    mkdirSync(join(home, ".pizzapi"), { recursive: true });
+    writeFileSync(
+        join(home, ".pizzapi", "runner.json"),
+        JSON.stringify({ runnerId: "runner-test" }),
+        "utf-8",
+    );
+    process.env.HOME = home;
+    process.env.PIZZAPI_RELAY_URL = "http://relay.test";
+    process.env.PIZZAPI_RUNNER_API_KEY = "test-api-key";
+    return home;
+}
+
+function relayFetchMock(): {
+    fn: ReturnType<typeof mock<typeof fetch>>;
+    calls: Array<{ url: unknown; init?: RequestInit }>;
+} {
+    const calls: Array<{ url: unknown; init?: RequestInit }> = [];
+    const fn = mock(async (url: unknown, init?: RequestInit) => {
+        const urlString = String(url);
+        if (urlString.includes("/api/runners/") && urlString.includes("/trigger-broadcast")) {
+            calls.push({ url, init });
+        }
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+    }) as unknown as ReturnType<typeof mock<typeof fetch>>;
+    return { fn, calls };
+}
+
+function sampleInbound(overrides: Partial<InboundMessage> = {}): InboundMessage {
+    return {
+        id: "msg-1",
+        channelId: "chan-1",
+        channelName: "general",
+        author: { id: "u1", username: "user1", displayName: "User One" },
+        content: "!status",
+        timestamp: Date.now(),
+        isCommand: true,
+        command: { name: "status", args: [], raw: "status" },
+        raw: {},
+        ...overrides,
+    };
+}
+
+function mockDiscordMessage(roles: Array<{ id: string; name: string }> = []): Record<string, unknown> {
+    const cache = new Map<string, { id: string; name: string }>();
+    for (const role of roles) {
+        cache.set(role.id, role);
+    }
+    return {
+        id: "msg-1",
+        channelId: "ch-1",
+        content: "!status",
+        author: { id: "user-1", username: "alice", displayName: "Alice" },
+        createdTimestamp: Date.now(),
+        thread: undefined,
+        reference: null,
+        member: {
+            roles: {
+                cache,
+            },
+        },
+        channel: { name: "dev-channel" },
+    };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("CanExecuteResult type", () => {
+    test("validates allowed and reason shape", () => {
+        const allowed: CanExecuteResult = { allowed: true };
+        expect(allowed.allowed).toBe(true);
+        expect(allowed.reason).toBeUndefined();
+
+        const denied: CanExecuteResult = { allowed: false, reason: "unauthorized" };
+        expect(denied.allowed).toBe(false);
+        expect(denied.reason).toBe("unauthorized");
+    });
+});
+
+describe("discordRoleAllowed policy", () => {
+    test("allows when member has a matching role name", () => {
+        const policy = discordRoleAllowed(["admin", "moderator"]);
+        const message = sampleInbound({ raw: mockDiscordMessage([{ id: "role-1", name: "admin" }]) });
+
+        expect(policy(message)).toEqual({ allowed: true });
+    });
+
+    test("allows when member has a matching role ID", () => {
+        const policy = discordRoleAllowed(["role-2"]);
+        const message = sampleInbound({ raw: mockDiscordMessage([{ id: "role-2", name: "devs" }]) });
+
+        expect(policy(message)).toEqual({ allowed: true });
+    });
+
+    test("denies when member lacks all required roles", () => {
+        const policy = discordRoleAllowed(["admin"]);
+        const message = sampleInbound({ raw: mockDiscordMessage([{ id: "role-3", name: "member" }]) });
+
+        const result = policy(message) as CanExecuteResult;
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain("user1 lacks required role");
+    });
+
+    test("denies DM or uncached member", () => {
+        const policy = discordRoleAllowed(["admin"]);
+        const message = sampleInbound({ raw: { ...mockDiscordMessage(), member: undefined } });
+
+        const result = policy(message) as CanExecuteResult;
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain("Guild member not available");
+    });
+
+    test("allows when allowedRoles is empty", () => {
+        const policy = discordRoleAllowed([]);
+        const dmMessage = sampleInbound({ raw: { ...mockDiscordMessage(), member: undefined } });
+
+        expect(policy(dmMessage)).toEqual({ allowed: true });
+    });
+
+    test("handles missing raw data gracefully", () => {
+        const policy = discordRoleAllowed(["admin"]);
+        const message = sampleInbound({ raw: undefined });
+
+        const result = policy(message) as CanExecuteResult;
+        expect(result.allowed).toBe(false);
+        expect(result.reason).toContain("Guild member not available");
+    });
+});
+
+describe("MessageBridgeService canExecute integration", () => {
+    test("message with matching role triggers broadcast", async () => {
+        setupBroadcastEnv();
+        const { fn, calls } = relayFetchMock();
+        globalThis.fetch = fn as unknown as typeof fetch;
+
+        const provider = new MockProvider("discord", "Discord");
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            discord: {
+                token: "discord-token",
+                options: { allowedRoles: ["admin"] },
+            },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: { discord: () => provider },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        await Promise.resolve();
+
+        const inbound = sampleInbound({
+            raw: mockDiscordMessage([{ id: "role-1", name: "admin" }]),
+        });
+        await provider.emitMessage(inbound);
+        await Promise.resolve();
+
+        const call = calls.find((c) =>
+            String(c.url).includes("/api/runners/runner-test/trigger-broadcast"),
+        );
+        expect(call).toBeDefined();
+    });
+
+    test("message without role is rejected and fetch is not called", async () => {
+        setupBroadcastEnv();
+        const { fn, calls } = relayFetchMock();
+        globalThis.fetch = fn as unknown as typeof fetch;
+
+        const provider = new MockProvider("discord", "Discord");
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            discord: {
+                token: "discord-token",
+                options: { allowedRoles: ["admin"] },
+            },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: { discord: () => provider },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        await Promise.resolve();
+
+        const inbound = sampleInbound({
+            raw: mockDiscordMessage([{ id: "role-3", name: "member" }]),
+        });
+        await provider.emitMessage(inbound);
+        await Promise.resolve();
+
+        const call = calls.find((c) =>
+            String(c.url).includes("/api/runners/runner-test/trigger-broadcast"),
+        );
+        expect(call).toBeUndefined();
+    });
+
+    test("no policy lets all messages pass through", async () => {
+        setupBroadcastEnv();
+        const { fn, calls } = relayFetchMock();
+        globalThis.fetch = fn as unknown as typeof fetch;
+
+        const provider = new MockProvider("discord", "Discord");
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            discord: { token: "discord-token" },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: { discord: () => provider },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        await Promise.resolve();
+
+        await provider.emitMessage(sampleInbound());
+        await Promise.resolve();
+
+        const call = calls.find((c) =>
+            String(c.url).includes("/api/runners/runner-test/trigger-broadcast"),
+        );
+        expect(call).toBeDefined();
+    });
+
+    test("per-channel canExecute overrides default policy", async () => {
+        setupBroadcastEnv();
+        const { fn, calls } = relayFetchMock();
+        globalThis.fetch = fn as unknown as typeof fetch;
+
+        const provider = new MockProvider("discord", "Discord");
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            discord: {
+                token: "discord-token",
+                defaultCanExecute: discordRoleAllowed(["admin"]),
+            },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: { discord: () => provider },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        await Promise.resolve();
+
+        // Map a channel with its own permissive policy.
+        service.getRegistry().addChannelSession("discord", {
+            channelId: "chan-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only", canExecute: () => ({ allowed: true }) },
+        });
+
+        const inbound = sampleInbound({
+            channelId: "chan-1",
+            raw: mockDiscordMessage([{ id: "role-3", name: "member" }]),
+        });
+        await provider.emitMessage(inbound);
+        await Promise.resolve();
+
+        const call = calls.find((c) =>
+            String(c.url).includes("/api/runners/runner-test/trigger-broadcast"),
+        );
+        expect(call).toBeDefined();
+    });
+});
+
+describe("ChannelRouter with canExecute", () => {
+    test("route respects an allowing policy", async () => {
+        const router = new ChannelRouter();
+        router.addSession({
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only", canExecute: () => ({ allowed: true }) },
+        });
+
+        const route = await router.route(sampleInbound({ channelId: "ch-1", content: "!go" }));
+        expect(route).toBeDefined();
+        expect(route!.shouldForward).toBe(true);
+    });
+
+    test("route respects a denying policy", async () => {
+        const router = new ChannelRouter();
+        router.addSession({
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only", canExecute: () => ({ allowed: false, reason: "nope" }) },
+        });
+
+        const route = await router.route(sampleInbound({ channelId: "ch-1", content: "!go" }));
+        expect(route).toBeDefined();
+        expect(route!.shouldForward).toBe(false);
+    });
+
+    test("policy errors do not crash routing", async () => {
+        const router = new ChannelRouter();
+        router.addSession({
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: {
+                mode: "commands-only",
+                canExecute: () => {
+                    throw new Error("policy boom");
+                },
+            },
+        });
+
+        const route = await router.route(sampleInbound({ channelId: "ch-1", content: "!go" }));
+        expect(route).toBeDefined();
+        expect(route!.shouldForward).toBe(false);
+    });
+});

--- a/packages/cli/src/runner/services/message-provider/canexecute.test.ts
+++ b/packages/cli/src/runner/services/message-provider/canexecute.test.ts
@@ -182,11 +182,13 @@ describe("CanExecuteResult type", () => {
 });
 
 describe("discordRoleAllowed policy", () => {
-    test("allows when member has a matching role name", () => {
+    test("does not match by role name — ID only", () => {
         const policy = discordRoleAllowed(["admin", "moderator"]);
         const message = sampleInbound({ raw: mockDiscordMessage([{ id: "role-1", name: "admin" }]) });
 
-        expect(policy(message)).toEqual({ allowed: true });
+        // Role name "admin" is not a role ID — should be denied
+        const result = policy(message) as CanExecuteResult;
+        expect(result.allowed).toBe(false);
     });
 
     test("allows when member has a matching role ID", () => {
@@ -202,7 +204,7 @@ describe("discordRoleAllowed policy", () => {
 
         const result = policy(message) as CanExecuteResult;
         expect(result.allowed).toBe(false);
-        expect(result.reason).toContain("user1 lacks required role");
+        expect(result.reason).toContain("lacks required role ID");
     });
 
     test("denies DM or uncached member", () => {
@@ -242,7 +244,7 @@ describe("MessageBridgeService canExecute integration", () => {
             enabled: true,
             discord: {
                 token: "discord-token",
-                options: { allowedRoles: ["admin"] },
+                options: { allowedRoles: ["role-1"] },
             },
         };
 
@@ -276,7 +278,7 @@ describe("MessageBridgeService canExecute integration", () => {
             enabled: true,
             discord: {
                 token: "discord-token",
-                options: { allowedRoles: ["admin"] },
+                options: { allowedRoles: ["role-1"] },
             },
         };
 

--- a/packages/cli/src/runner/services/message-provider/channel-router.ts
+++ b/packages/cli/src/runner/services/message-provider/channel-router.ts
@@ -1,0 +1,171 @@
+import type {
+    ChannelRouterConfig,
+    ChannelSession,
+    InboundMessage,
+    ParsedCommand,
+} from "./types.js";
+
+export interface RouteResult {
+    /** The mapped PizzaPi session ID. */
+    sessionId: string;
+    /** Router config that determined the route. */
+    config: ChannelRouterConfig;
+    /** Whether the message should be forwarded to the session. */
+    shouldForward: boolean;
+    /** The parsed (possibly truncated) message. */
+    message: InboundMessage;
+}
+
+const DEFAULT_PREFIX = "!";
+const DEFAULT_ROUTER: ChannelRouterConfig = { mode: "commands-only", commandPrefix: DEFAULT_PREFIX };
+
+/**
+ * Routes inbound platform messages to PizzaPi sessions.
+ *
+ * Responsibilities:
+ * - Maintains channelId → session mappings.
+ * - Parses command prefixes and extracts command names/args.
+ * - Applies per-channel router rules (mode, filters, truncation).
+ * - Decides whether a given message should be forwarded.
+ */
+export class ChannelRouter {
+    private readonly sessions = new Map<string, ChannelSession>();
+    private defaultRouter: ChannelRouterConfig = DEFAULT_ROUTER;
+
+    /**
+     * Register a channel-to-session mapping.
+     * Overwrites any existing mapping for the same channelId.
+     */
+    addSession(session: ChannelSession): void {
+        this.sessions.set(session.channelId, session);
+    }
+
+    /**
+     * Remove a channel-to-session mapping.
+     */
+    removeSession(channelId: string): void {
+        this.sessions.delete(channelId);
+    }
+
+    /**
+     * Replace the default router config used for mapped channels that do not
+     * carry their own config.
+     */
+    setDefaultRouter(config: ChannelRouterConfig): void {
+        this.defaultRouter = config;
+    }
+
+    /**
+     * Return all currently mapped sessions.
+     */
+    getSessions(): ChannelSession[] {
+        return Array.from(this.sessions.values());
+    }
+
+    /**
+     * Return channel sessions mapped to a specific PizzaPi session ID.
+     */
+    findChannelsBySessionId(sessionId: string): ChannelSession[] {
+        return this.getSessions().filter((session) => session.sessionId === sessionId);
+    }
+
+    /**
+     * Return the mapped session for a channel, if any.
+     */
+    getSession(channelId: string): ChannelSession | undefined {
+        return this.sessions.get(channelId);
+    }
+
+    /**
+     * Parse an inbound message: detect commands, truncate if needed, and return
+     * a new message object with derived fields populated.
+     */
+    parseMessage(
+        message: InboundMessage,
+        config: ChannelRouterConfig = this.defaultRouter,
+    ): InboundMessage {
+        const prefix = config.commandPrefix ?? DEFAULT_PREFIX;
+        const command = parseCommand(message.content, prefix);
+        const content = applyMaxLength(message.content, config.maxMessageLength);
+
+        return {
+            ...message,
+            content,
+            isCommand: command !== undefined,
+            command,
+        };
+    }
+
+    /**
+     * Route a message to a mapped session. Returns undefined when the channel is
+     * not mapped.
+     */
+    route(message: InboundMessage): RouteResult | undefined {
+        const session = this.sessions.get(message.channelId);
+        if (!session) {
+            return undefined;
+        }
+
+        const config = session.config ?? this.defaultRouter;
+        const parsed = this.parseMessage(message, config);
+        const shouldForward = this.shouldForward(parsed, config);
+
+        return {
+            sessionId: session.sessionId,
+            config,
+            shouldForward,
+            message: parsed,
+        };
+    }
+
+    /**
+     * Decide whether a parsed message should be forwarded, based on the router
+     * mode and filters.
+     */
+    private shouldForward(message: InboundMessage, config: ChannelRouterConfig): boolean {
+        switch (config.mode) {
+            case "all-messages":
+                return true;
+            case "commands-only":
+                return message.isCommand;
+            case "filtered":
+                return matchesFilter(message.content, config.filterPatterns);
+            default:
+                return false;
+        }
+    }
+}
+
+function parseCommand(content: string, prefix: string): ParsedCommand | undefined {
+    const trimmed = content.trim();
+    if (!trimmed.startsWith(prefix)) {
+        return undefined;
+    }
+
+    const raw = trimmed.slice(prefix.length).trim();
+    if (!raw) {
+        return undefined;
+    }
+
+    const parts = raw.split(/\s+/).filter(Boolean);
+    const [name, ...args] = parts;
+    if (!name) {
+        return undefined;
+    }
+
+    return { name, args, raw };
+}
+
+function applyMaxLength(content: string, maxLength?: number): string {
+    if (maxLength === undefined || maxLength <= 0 || content.length <= maxLength) {
+        return content;
+    }
+    return content.slice(0, maxLength);
+}
+
+function matchesFilter(content: string, patterns?: string[]): boolean {
+    if (!patterns || patterns.length === 0) {
+        return false;
+    }
+    return patterns.some((pattern) => content.includes(pattern));
+}

--- a/packages/cli/src/runner/services/message-provider/channel-router.ts
+++ b/packages/cli/src/runner/services/message-provider/channel-router.ts
@@ -1,4 +1,5 @@
 import type {
+    CanExecutePolicy,
     ChannelRouterConfig,
     ChannelSession,
     InboundMessage,
@@ -100,7 +101,7 @@ export class ChannelRouter {
      * Route a message to a mapped session. Returns undefined when the channel is
      * not mapped.
      */
-    route(message: InboundMessage): RouteResult | undefined {
+    async route(message: InboundMessage): Promise<RouteResult | undefined> {
         const session = this.sessions.get(message.channelId);
         if (!session) {
             return undefined;
@@ -108,7 +109,19 @@ export class ChannelRouter {
 
         const config = session.config ?? this.defaultRouter;
         const parsed = this.parseMessage(message, config);
-        const shouldForward = this.shouldForward(parsed, config);
+
+        let shouldForward = false;
+        try {
+            shouldForward = await this.shouldForward(parsed, config);
+        } catch (err) {
+            // A canExecute policy threw — drop the message rather than crash routing.
+            return {
+                sessionId: session.sessionId,
+                config,
+                shouldForward: false,
+                message: parsed,
+            };
+        }
 
         return {
             sessionId: session.sessionId,
@@ -120,9 +133,16 @@ export class ChannelRouter {
 
     /**
      * Decide whether a parsed message should be forwarded, based on the router
-     * mode and filters.
+     * mode, filters, and optional authorization policy.
      */
-    private shouldForward(message: InboundMessage, config: ChannelRouterConfig): boolean {
+    private async shouldForward(message: InboundMessage, config: ChannelRouterConfig): Promise<boolean> {
+        if (config.canExecute) {
+            const result = await config.canExecute(message);
+            if (!result.allowed) {
+                return false;
+            }
+        }
+
         switch (config.mode) {
             case "all-messages":
                 return true;

--- a/packages/cli/src/runner/services/message-provider/channel-router.ts
+++ b/packages/cli/src/runner/services/message-provider/channel-router.ts
@@ -148,6 +148,8 @@ export class ChannelRouter {
                 return true;
             case "commands-only":
                 return message.isCommand;
+            case "mentions":
+                return message.mentionedBot === true;
             case "filtered":
                 return matchesFilter(message.content, config.filterPatterns);
             default:

--- a/packages/cli/src/runner/services/message-provider/discord-policy.ts
+++ b/packages/cli/src/runner/services/message-provider/discord-policy.ts
@@ -1,0 +1,35 @@
+import type { CanExecutePolicy, CanExecuteResult, InboundMessage } from "./types.js";
+import type { Message, Role } from "discord.js";
+
+/**
+ * Create a CanExecutePolicy that checks Discord guild roles.
+ *
+ * The policy extracts roles from the raw discord.js Message object
+ * attached to InboundMessage.raw. If allowedRoles is empty or the
+ * message is not a guild message (DM), the policy allows by default.
+ *
+ * @param allowedRoles — Role names OR role IDs that grant access
+ */
+export function discordRoleAllowed(allowedRoles: string[]): CanExecutePolicy {
+    return (message: InboundMessage): CanExecuteResult => {
+        if (allowedRoles.length === 0) return { allowed: true };
+
+        const raw = message.raw as Message | undefined;
+        if (!raw || !raw.member) {
+            // DM or uncached member — deny by default when roles are required
+            return { allowed: false, reason: "Guild member not available (DM or uncached)" };
+        }
+
+        const memberRoles = raw.member.roles.cache;
+        const roleNames = Array.from(memberRoles.values()).map((r: Role) => r.name);
+        const roleIds = Array.from(memberRoles.values()).map((r: Role) => r.id);
+
+        const hasMatch = allowedRoles.some(allowed =>
+            roleNames.includes(allowed) || roleIds.includes(allowed)
+        );
+
+        return hasMatch
+            ? { allowed: true }
+            : { allowed: false, reason: `User ${message.author.username} lacks required role: ${allowedRoles.join(", ")}` };
+    };
+}

--- a/packages/cli/src/runner/services/message-provider/discord-policy.ts
+++ b/packages/cli/src/runner/services/message-provider/discord-policy.ts
@@ -2,13 +2,17 @@ import type { CanExecutePolicy, CanExecuteResult, InboundMessage } from "./types
 import type { Message, Role } from "discord.js";
 
 /**
- * Create a CanExecutePolicy that checks Discord guild roles.
+ * Create a CanExecutePolicy that checks Discord guild roles by ID.
  *
- * The policy extracts roles from the raw discord.js Message object
+ * The policy extracts role IDs from the raw discord.js Message object
  * attached to InboundMessage.raw. If allowedRoles is empty or the
  * message is not a guild message (DM), the policy allows by default.
  *
- * @param allowedRoles — Role names OR role IDs that grant access
+ * Role names are intentionally NOT matched — they are mutable, can be
+ * renamed or spoofed, and can differ across guilds. Role IDs are stable
+ * and canonical within a guild.
+ *
+ * @param allowedRoles — Role IDs that grant access
  */
 export function discordRoleAllowed(allowedRoles: string[]): CanExecutePolicy {
     return (message: InboundMessage): CanExecuteResult => {
@@ -21,15 +25,14 @@ export function discordRoleAllowed(allowedRoles: string[]): CanExecutePolicy {
         }
 
         const memberRoles = raw.member.roles.cache;
-        const roleNames = Array.from(memberRoles.values()).map((r: Role) => r.name);
         const roleIds = Array.from(memberRoles.values()).map((r: Role) => r.id);
 
         const hasMatch = allowedRoles.some(allowed =>
-            roleNames.includes(allowed) || roleIds.includes(allowed)
+            roleIds.includes(allowed)
         );
 
         return hasMatch
             ? { allowed: true }
-            : { allowed: false, reason: `User ${message.author.username} lacks required role: ${allowedRoles.join(", ")}` };
+            : { allowed: false, reason: `User ${message.author.username} lacks required role ID: ${allowedRoles.join(", ")}` };
     };
 }

--- a/packages/cli/src/runner/services/message-provider/discord-provider.test.ts
+++ b/packages/cli/src/runner/services/message-provider/discord-provider.test.ts
@@ -324,4 +324,69 @@ describe("DiscordProvider", () => {
         const inbound = provider._convertMessage(dmMessage);
         expect(inbound.channelName).toBe("DM");
     });
+
+    test("detects bot mention in message", async () => {
+        const client = createMockClient();
+        (client as unknown as Record<string, unknown>).user = { id: "bot-123" };
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+        client.emit("ready");
+
+        const mentioned = createMockMessage({ content: "<@bot-123> help me please" });
+        expect(provider._convertMessage(mentioned).mentionedBot).toBe(true);
+
+        const notMentioned = createMockMessage({ content: "hello world" });
+        expect(provider._convertMessage(notMentioned).mentionedBot).toBe(false);
+    });
+
+    test("detects bot mention with @! syntax", async () => {
+        const client = createMockClient();
+        (client as unknown as Record<string, unknown>).user = { id: "bot-456" };
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "t" });
+        client.emit("ready");
+
+        const msg = createMockMessage({ content: "<@!bot-456> do stuff" });
+        expect(provider._convertMessage(msg).mentionedBot).toBe(true);
+    });
+
+    test("parses content after mention into a command", async () => {
+        const client = createMockClient();
+        (client as unknown as Record<string, unknown>).user = { id: "bot-789" };
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "t" });
+        client.emit("ready");
+
+        const msg = createMockMessage({ content: "<@bot-789> status all" });
+        const inbound = provider._convertMessage(msg);
+        expect(inbound.mentionedBot).toBe(true);
+        expect(inbound.isCommand).toBe(true);
+        expect(inbound.command?.name).toBe("status");
+        expect(inbound.command?.args).toEqual(["all"]);
+    });
+
+    test("bare mention becomes ping command", async () => {
+        const client = createMockClient();
+        (client as unknown as Record<string, unknown>).user = { id: "bot-999" };
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "t" });
+        client.emit("ready");
+
+        const msg = createMockMessage({ content: "<@bot-999>" });
+        const inbound = provider._convertMessage(msg);
+        expect(inbound.mentionedBot).toBe(true);
+        expect(inbound.command?.name).toBe("ping");
+        expect(inbound.command?.args).toEqual([]);
+    });
+
+    test("does not detect mention if bot is not ready or no bot user", async () => {
+        const client = createMockClient();
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "t" });
+        // Do NOT emit ready — botUserId stays null
+
+        const msg = createMockMessage({ content: "<@some-id> hi" });
+        const inbound = provider._convertMessage(msg);
+        expect(inbound.mentionedBot).toBe(false);
+    });
 });

--- a/packages/cli/src/runner/services/message-provider/discord-provider.test.ts
+++ b/packages/cli/src/runner/services/message-provider/discord-provider.test.ts
@@ -1,0 +1,327 @@
+import { describe, test, expect, mock } from "bun:test";
+import { ChannelType, type Client, type Guild, type Message, type TextChannel } from "discord.js";
+import { DiscordProvider } from "./discord-provider.js";
+import type { InboundMessageHandler, OutboundMessage, ProviderConfig } from "./types.js";
+
+type MockClient = Client & { emit: (event: string, ...args: unknown[]) => void };
+type MockFn = ReturnType<typeof mock<(...args: unknown[]) => unknown>>;
+
+function createMockClient(): MockClient {
+    const events = new Map<string, Function[]>();
+    const client = {
+        login: mock(() => Promise.resolve()),
+        destroy: mock(() => {}),
+        removeAllListeners: mock(() => {
+            events.clear();
+        }),
+        once: mock((event: string, cb: Function) => {
+            events.set(event, [cb]);
+        }),
+        on: mock((event: string, cb: Function) => {
+            if (!events.has(event)) {
+                events.set(event, []);
+            }
+            events.get(event)!.push(cb);
+        }),
+        channels: {
+            fetch: mock((_id: string) => Promise.resolve(null)) as unknown as (
+                id: string,
+            ) => Promise<import("discord.js").Channel | null>,
+        },
+        guilds: {
+            cache: new Map(),
+        },
+        emit: (event: string, ...args: unknown[]) => {
+            for (const cb of events.get(event) ?? []) {
+                cb(...args);
+            }
+        },
+    } as unknown as MockClient;
+    return client;
+}
+
+function createMockMessage(overrides: Record<string, unknown> = {}): Message {
+    const channel = (overrides.channel as { name?: string } | undefined) ?? {
+        name: "general",
+        isTextBased: () => true,
+    };
+    return {
+        id: "msg-1",
+        channelId: "chan-1",
+        channel,
+        content: "hello world",
+        createdTimestamp: 1234567890,
+        author: {
+            id: "user-1",
+            username: "testuser",
+            displayName: "Test User",
+        },
+        reference: undefined,
+        thread: undefined,
+        ...overrides,
+    } as unknown as Message;
+}
+
+function createMockTextChannel(overrides: Record<string, unknown> = {}): TextChannel {
+    return {
+        id: "chan-1",
+        name: "general",
+        type: ChannelType.GuildText,
+        isTextBased: () => true,
+        send: mock(() => Promise.resolve({})),
+        ...overrides,
+    } as unknown as TextChannel;
+}
+
+function asHandler(mockFn: MockFn): InboundMessageHandler {
+    return mockFn as unknown as InboundMessageHandler;
+}
+
+describe("DiscordProvider", () => {
+    test("has expected id and label", () => {
+        const provider = new DiscordProvider();
+        expect(provider.id).toBe("discord");
+        expect(provider.label).toBe("Discord");
+    });
+
+    test("connect attaches listeners and login is called with token", async () => {
+        const client = createMockClient();
+        const provider = new DiscordProvider(client);
+
+        await provider.connect({ token: "bot-token" });
+
+        expect(client.login).toHaveBeenCalledWith("bot-token");
+        expect(provider.isConnected()).toBe(false);
+
+        client.emit("ready");
+        expect(provider.isConnected()).toBe(true);
+    });
+
+    test("disconnect destroys client and clears state", async () => {
+        const client = createMockClient();
+        const provider = new DiscordProvider(client);
+
+        await provider.connect({ token: "bot-token" });
+        client.emit("ready");
+        expect(provider.isConnected()).toBe(true);
+
+        await provider.disconnect();
+        expect(client.destroy).toHaveBeenCalled();
+        expect(client.removeAllListeners).toHaveBeenCalled();
+        expect(provider.isConnected()).toBe(false);
+    });
+
+    test("login failure is surfaced gracefully", async () => {
+        const client = createMockClient();
+        client.login = mock(() => Promise.reject(new Error("invalid token")));
+        const provider = new DiscordProvider(client);
+
+        await expect(provider.connect({ token: "bad-token" })).rejects.toThrow("invalid token");
+        expect(provider.isConnected()).toBe(false);
+    });
+
+    test("message conversion produces expected InboundMessage shape", async () => {
+        const client = createMockClient();
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+
+        const reference = { messageId: "reply-target" };
+        const thread = { id: "thread-1" };
+        const discordMessage = createMockMessage({
+            id: "msg-2",
+            channelId: "chan-2",
+            channel: { name: "dev" },
+            content: "plain text",
+            createdTimestamp: 42,
+            author: { id: "user-2", username: "u2", displayName: "Display Two" },
+            reference,
+            thread,
+        });
+
+        const inbound = provider._convertMessage(discordMessage);
+
+        expect(inbound.id).toBe("msg-2");
+        expect(inbound.channelId).toBe("chan-2");
+        expect(inbound.channelName).toBe("dev");
+        expect(inbound.author).toEqual({ id: "user-2", username: "u2", displayName: "Display Two" });
+        expect(inbound.content).toBe("plain text");
+        expect(inbound.timestamp).toBe(42);
+        expect(inbound.isCommand).toBe(false);
+        expect(inbound.command).toBeUndefined();
+        expect(inbound.replyToId).toBe("reply-target");
+        expect(inbound.threadId).toBe("thread-1");
+        expect(inbound.raw).toBe(discordMessage);
+    });
+
+    test("command detection with default prefix", async () => {
+        const client = createMockClient();
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+
+        const commandMsg = provider._convertMessage(createMockMessage({ content: "!run tests --watch" }));
+        expect(commandMsg.isCommand).toBe(true);
+        expect(commandMsg.command).toEqual({ name: "run", args: ["tests", "--watch"], raw: "run tests --watch" });
+
+        const normalMsg = provider._convertMessage(createMockMessage({ content: "hello" }));
+        expect(normalMsg.isCommand).toBe(false);
+        expect(normalMsg.command).toBeUndefined();
+    });
+
+    test("custom command prefix from default router", async () => {
+        const client = createMockClient();
+        const provider = new DiscordProvider(client);
+        const config: ProviderConfig = {
+            token: "bot-token",
+            defaultRouter: { mode: "commands-only", commandPrefix: "/" },
+        };
+        await provider.connect(config);
+
+        const commandMsg = provider._convertMessage(createMockMessage({ content: "/deploy prod" }));
+        expect(commandMsg.isCommand).toBe(true);
+        expect(commandMsg.command).toEqual({ name: "deploy", args: ["prod"], raw: "deploy prod" });
+
+        const ignoredMsg = provider._convertMessage(createMockMessage({ content: "!something" }));
+        expect(ignoredMsg.isCommand).toBe(false);
+    });
+
+    test("send routes to the fetched text channel", async () => {
+        const client = createMockClient();
+        const channel = createMockTextChannel({ id: "chan-1", name: "general" });
+        client.channels.fetch = mock(() => Promise.resolve(channel)) as unknown as typeof client.channels.fetch;
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+
+        const outbound: OutboundMessage = { content: "hello channel" };
+        await provider.send("chan-1", outbound);
+
+        expect(client.channels.fetch).toHaveBeenCalledWith("chan-1");
+        expect(channel.send).toHaveBeenCalledWith({ content: "hello channel" });
+    });
+
+    test("send with replyToId includes message reference", async () => {
+        const client = createMockClient();
+        const channel = createMockTextChannel({ id: "chan-1" });
+        client.channels.fetch = mock(() => Promise.resolve(channel)) as unknown as typeof client.channels.fetch;
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+
+        await provider.send("chan-1", { content: "replying", replyToId: "original-msg" });
+
+        expect(channel.send).toHaveBeenCalledWith({
+            content: "replying",
+            reply: { messageReference: "original-msg" },
+        });
+    });
+
+    test("send with threadId targets the thread", async () => {
+        const client = createMockClient();
+        const thread = createMockTextChannel({ id: "thread-1", name: "thread" });
+        client.channels.fetch = mock((id: string) => {
+            return id === "thread-1" ? Promise.resolve(thread) : Promise.resolve(null);
+        }) as unknown as typeof client.channels.fetch;
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+
+        await provider.send("chan-1", { content: "in thread", threadId: "thread-1" });
+
+        expect(client.channels.fetch).toHaveBeenCalledWith("thread-1");
+        expect(thread.send).toHaveBeenCalledWith({ content: "in thread" });
+    });
+
+    test("send throws when channel is not text-based", async () => {
+        const client = createMockClient();
+        const voiceChannel = { id: "voice-1", isTextBased: () => false };
+        client.channels.fetch = mock(() => Promise.resolve(voiceChannel)) as unknown as typeof client.channels.fetch;
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+
+        await expect(provider.send("voice-1", { content: "hello" })).rejects.toThrow("not text-based");
+    });
+
+    test("send throws when not connected", async () => {
+        const provider = new DiscordProvider();
+        await expect(provider.send("chan-1", { content: "hello" })).rejects.toThrow("not connected");
+    });
+
+    test("listChannels collects guild text channels", async () => {
+        const client = createMockClient();
+        const guild = {
+            channels: {
+                cache: new Map([
+                    ["text-1", { id: "text-1", name: "general", type: ChannelType.GuildText }],
+                    ["voice-1", { id: "voice-1", name: "voice", type: ChannelType.GuildVoice }],
+                    ["text-2", { id: "text-2", name: "dev", type: ChannelType.GuildText }],
+                ]),
+            },
+        };
+        client.guilds.cache.set("guild-1", guild as unknown as Guild);
+
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+
+        const channels = await provider.listChannels();
+        expect(channels).toHaveLength(2);
+        expect(channels).toContainEqual({ id: "text-1", name: "general", type: "text" });
+        expect(channels).toContainEqual({ id: "text-2", name: "dev", type: "text" });
+    });
+
+    test("onMessage registers handler and offMessage removes it", async () => {
+        const client = createMockClient();
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+
+        const handlerMock = mock(() => {});
+        const handler = asHandler(handlerMock);
+        provider.onMessage(handler);
+
+        client.emit("ready");
+        client.emit("messageCreate", createMockMessage({ content: "ping" }));
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(handlerMock).toHaveBeenCalled();
+
+        provider.offMessage(handler);
+        handlerMock.mockClear?.();
+        client.emit("messageCreate", createMockMessage({ content: "pong" }));
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(handlerMock).not.toHaveBeenCalled();
+    });
+
+    test("one throwing handler does not break other handlers", async () => {
+        const client = createMockClient();
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+
+        const goodHandlerMock = mock(() => {});
+        const badHandlerMock = mock(() => {
+            throw new Error("boom");
+        });
+
+        provider.onMessage(asHandler(badHandlerMock));
+        provider.onMessage(asHandler(goodHandlerMock));
+
+        client.emit("messageCreate", createMockMessage({ content: "test" }));
+        await Promise.resolve();
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(badHandlerMock).toHaveBeenCalled();
+        expect(goodHandlerMock).toHaveBeenCalled();
+    });
+
+    test("DM channel name falls back", async () => {
+        const client = createMockClient();
+        const provider = new DiscordProvider(client);
+        await provider.connect({ token: "bot-token" });
+
+        const dmMessage = createMockMessage({
+            channelId: "dm-1",
+            channel: {},
+            content: "hi",
+        });
+
+        const inbound = provider._convertMessage(dmMessage);
+        expect(inbound.channelName).toBe("DM");
+    });
+});

--- a/packages/cli/src/runner/services/message-provider/discord-provider.ts
+++ b/packages/cli/src/runner/services/message-provider/discord-provider.ts
@@ -34,6 +34,7 @@ export class DiscordProvider implements MessageProvider {
     private connected = false;
     private readonly handlers = new Set<InboundMessageHandler>();
     private readonly providedClient?: Client;
+    private botUserId: string | null = null;
 
     constructor(client?: Client) {
         this.providedClient = client;
@@ -55,6 +56,7 @@ export class DiscordProvider implements MessageProvider {
             });
 
         this.client.once("ready", () => {
+            this.botUserId = this.client?.user?.id ?? null;
             this.connected = true;
         });
 
@@ -136,7 +138,14 @@ export class DiscordProvider implements MessageProvider {
 
     private convertMessage(message: Message): InboundMessage {
         const prefix = this.config?.defaultRouter?.commandPrefix ?? DEFAULT_COMMAND_PREFIX;
-        const command = parseCommand(message.content, prefix);
+        const mentionedBot = this.botUserId !== null && isBotMention(message.content, this.botUserId);
+        // Strip mention prefix when in mentions mode so the rest is treated as payload
+        const contentForParsing = mentionedBot && this.botUserId
+            ? message.content.replace(new RegExp(`<@!?${escapeRegex(this.botUserId)}>`), "").trim()
+            : message.content;
+        const command = mentionedBot
+            ? parseMentionCommand(contentForParsing)
+            : parseCommand(message.content, prefix);
 
         return {
             id: message.id,
@@ -150,6 +159,7 @@ export class DiscordProvider implements MessageProvider {
             content: message.content,
             timestamp: message.createdTimestamp,
             isCommand: command !== undefined,
+            mentionedBot,
             command,
             raw: message,
             threadId: message.thread?.id,
@@ -209,4 +219,25 @@ function getChannelName(channel: { name?: string } | unknown): string {
         return (channel as { name: string }).name;
     }
     return "DM";
+}
+
+/** Detect a Discord bot mention in message content (<@BOTID> or <@!BOTID>). */
+function isBotMention(content: string, botUserId: string): boolean {
+    return new RegExp(`<@!?${escapeRegex(botUserId)}>`).test(content);
+}
+
+/** Parse text content after a mention has been stripped into a command. */
+function parseMentionCommand(content: string): ParsedCommand | undefined {
+    const trimmed = content.trim();
+    if (!trimmed) {
+        // Bare mention — forward as a "ping" command so the bridge can respond
+        return { name: "ping", args: [], raw: "" };
+    }
+    const parts = trimmed.split(/\s+/).filter(Boolean);
+    const [name, ...args] = parts;
+    return name ? { name, args, raw: trimmed } : undefined;
+}
+
+function escapeRegex(str: string): string {
+    return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/packages/cli/src/runner/services/message-provider/discord-provider.ts
+++ b/packages/cli/src/runner/services/message-provider/discord-provider.ts
@@ -48,6 +48,7 @@ export class DiscordProvider implements MessageProvider {
                 intents: [
                     GatewayIntentBits.Guilds,
                     GatewayIntentBits.GuildMessages,
+                    GatewayIntentBits.GuildMembers,
                     GatewayIntentBits.MessageContent,
                     GatewayIntentBits.GuildMessageReactions,
                 ],

--- a/packages/cli/src/runner/services/message-provider/discord-provider.ts
+++ b/packages/cli/src/runner/services/message-provider/discord-provider.ts
@@ -1,0 +1,211 @@
+import {
+    ChannelType,
+    Client,
+    GatewayIntentBits,
+    type Message,
+    type MessageCreateOptions,
+    type TextChannel,
+} from "discord.js";
+import type {
+    Channel,
+    InboundMessage,
+    InboundMessageHandler,
+    MessageProvider,
+    OutboundMessage,
+    ParsedCommand,
+    ProviderConfig,
+} from "./types.js";
+
+const DEFAULT_COMMAND_PREFIX = "!";
+
+/**
+ * Discord-backed implementation of the MessageProvider abstraction.
+ *
+ * Bridges discord.js events and channels to PizzaPi's generic inbound/outbound
+ * message model. Commands are detected using the default router's commandPrefix
+ * (default "!").
+ */
+export class DiscordProvider implements MessageProvider {
+    readonly id = "discord";
+    readonly label = "Discord";
+
+    private client: Client | null = null;
+    private config: ProviderConfig | null = null;
+    private connected = false;
+    private readonly handlers = new Set<InboundMessageHandler>();
+    private readonly providedClient?: Client;
+
+    constructor(client?: Client) {
+        this.providedClient = client;
+    }
+
+    async connect(config: ProviderConfig): Promise<void> {
+        this.config = config;
+
+        this.client =
+            this.providedClient ??
+            new Client({
+                intents: [
+                    GatewayIntentBits.Guilds,
+                    GatewayIntentBits.GuildMessages,
+                    GatewayIntentBits.MessageContent,
+                    GatewayIntentBits.GuildMessageReactions,
+                ],
+            });
+
+        this.client.once("ready", () => {
+            this.connected = true;
+        });
+
+        this.client.on("messageCreate", (message) => {
+            void this.handleMessageCreate(message);
+        });
+
+        try {
+            await this.client.login(config.token);
+        } catch (err) {
+            this.connected = false;
+            this.cleanupClient();
+            throw err;
+        }
+    }
+
+    async disconnect(): Promise<void> {
+        this.cleanupClient();
+        this.connected = false;
+        this.config = null;
+    }
+
+    isConnected(): boolean {
+        return this.connected;
+    }
+
+    async send(channelId: string, message: OutboundMessage): Promise<void> {
+        if (!this.client) {
+            throw new Error("DiscordProvider is not connected");
+        }
+
+        const targetId = message.threadId ?? channelId;
+        const channel = await this.client.channels.fetch(targetId);
+        if (!channel) {
+            throw new Error(`Channel ${targetId} not found`);
+        }
+
+        if (!channel.isTextBased()) {
+            throw new Error(`Channel ${targetId} is not text-based`);
+        }
+
+        const textChannel = channel as TextChannel;
+        const options: MessageCreateOptions = { content: message.content };
+        if (message.replyToId) {
+            options.reply = { messageReference: message.replyToId };
+        }
+
+        await textChannel.send(options);
+    }
+
+    async listChannels(): Promise<Channel[]> {
+        if (!this.client) {
+            return [];
+        }
+
+        const channels: Channel[] = [];
+        for (const guild of this.client.guilds.cache.values()) {
+            for (const ch of guild.channels.cache.values()) {
+                if (ch.type === ChannelType.GuildText) {
+                    channels.push({ id: ch.id, name: ch.name, type: "text" });
+                }
+            }
+        }
+        return channels;
+    }
+
+    onMessage(handler: InboundMessageHandler): void {
+        this.handlers.add(handler);
+    }
+
+    offMessage(handler: InboundMessageHandler): void {
+        this.handlers.delete(handler);
+    }
+
+    /** Internal test hook to exercise message conversion. */
+    _convertMessage(message: Message): InboundMessage {
+        return this.convertMessage(message);
+    }
+
+    private convertMessage(message: Message): InboundMessage {
+        const prefix = this.config?.defaultRouter?.commandPrefix ?? DEFAULT_COMMAND_PREFIX;
+        const command = parseCommand(message.content, prefix);
+
+        return {
+            id: message.id,
+            channelId: message.channelId,
+            channelName: getChannelName(message.channel),
+            author: {
+                id: message.author.id,
+                username: message.author.username,
+                displayName: message.author.displayName ?? message.author.username,
+            },
+            content: message.content,
+            timestamp: message.createdTimestamp,
+            isCommand: command !== undefined,
+            command,
+            raw: message,
+            threadId: message.thread?.id,
+            replyToId: message.reference?.messageId ?? undefined,
+        };
+    }
+
+    private async handleMessageCreate(discordMessage: Message): Promise<void> {
+        try {
+            const message = this.convertMessage(discordMessage);
+            for (const handler of this.handlers) {
+                try {
+                    const result = handler(message);
+                    if (result instanceof Promise) {
+                        await result.catch(() => undefined);
+                    }
+                } catch (err) {
+                    // Isolate handler errors so one bad handler cannot break the rest.
+                }
+            }
+        } catch (err) {
+            // Swallow conversion/dispatch errors to avoid crashing the client.
+        }
+    }
+
+    private cleanupClient(): void {
+        if (this.client) {
+            this.client.removeAllListeners();
+            void this.client.destroy();
+            this.client = null;
+        }
+    }
+}
+
+function parseCommand(content: string, prefix: string): ParsedCommand | undefined {
+    const trimmed = content.trim();
+    if (!trimmed.startsWith(prefix)) {
+        return undefined;
+    }
+
+    const raw = trimmed.slice(prefix.length).trim();
+    if (!raw) {
+        return undefined;
+    }
+
+    const parts = raw.split(/\s+/).filter(Boolean);
+    const [name, ...args] = parts;
+    if (!name) {
+        return undefined;
+    }
+
+    return { name, args, raw };
+}
+
+function getChannelName(channel: { name?: string } | unknown): string {
+    if (channel && typeof channel === "object" && "name" in channel && typeof (channel as { name?: unknown }).name === "string") {
+        return (channel as { name: string }).name;
+    }
+    return "DM";
+}

--- a/packages/cli/src/runner/services/message-provider/event-forwarder.ts
+++ b/packages/cli/src/runner/services/message-provider/event-forwarder.ts
@@ -1,0 +1,108 @@
+import type { OutboundMessage, SessionEventType } from "./types.js";
+import type { ProviderRegistry } from "./provider-registry.js";
+
+export interface SessionEvent {
+    /** Type of session event being forwarded. */
+    type: SessionEventType;
+    /** PizzaPi session ID the event relates to. */
+    sessionId: string;
+    /** Extra context used when rendering templates. */
+    payload?: Record<string, unknown>;
+}
+
+export type MessageTemplate = string;
+
+const DEFAULT_TEMPLATES: Record<SessionEventType, MessageTemplate> = {
+    "session.start": "Session {{sessionId}} started",
+    "session.complete": "Session {{sessionId}} completed",
+    "session.error": "Session {{sessionId}} errored: {{message}}",
+    "session.turn_end": "Session {{sessionId}} turn ended",
+    "build.success": "Build succeeded for session {{sessionId}}",
+    "build.failure": "Build failed for session {{sessionId}}: {{message}}",
+    "review.lgtm": "Review LGTM for session {{sessionId}}",
+    "review.failed": "Review failed for session {{sessionId}}: {{message}}",
+};
+
+/**
+ * Forwards PizzaPi session lifecycle events to message providers that have
+ * configured `forwardEvents`.
+ *
+ * Supports per-event-type message templates. Templates use simple {{key}}
+ * placeholders resolved from the event payload (with the sessionId always
+ * available).
+ */
+export class EventForwarder {
+    private readonly templates: Record<SessionEventType, MessageTemplate>;
+
+    constructor(
+        private readonly registry: ProviderRegistry,
+        templates?: Partial<Record<SessionEventType, MessageTemplate>>,
+    ) {
+        this.templates = { ...DEFAULT_TEMPLATES, ...templates };
+    }
+
+    /**
+     * Forward a session event to every connected provider that has subscribed
+     * to this event type, targeting only channels mapped to the event session.
+     */
+    async forward(event: SessionEvent): Promise<void> {
+        const content = renderTemplate(this.templates[event.type], event.sessionId, event.payload);
+        const message: OutboundMessage = { content };
+
+        const statuses = this.registry.getStatus();
+        const results = statuses
+            .filter((status) => status.connected)
+            .map(async (status) => {
+                const config = this.registry.getConfig(status.id);
+                if (!config || !config.forwardEvents || !config.forwardEvents.includes(event.type)) {
+                    return;
+                }
+
+                const channels = this.registry.getChannelsForSession(status.id, event.sessionId);
+                if (channels.length === 0) {
+                    return;
+                }
+
+                await Promise.all(
+                    channels.map((channel) =>
+                        this.registry.send(status.id, channel.channelId, message).catch((err) => {
+                            // Errors are recorded by ProviderRegistry.send.
+                            // Surface to console for debugging but do not fail
+                            // other providers/channels.
+                            if (err instanceof Error) {
+                                console.error(`[EventForwarder] ${status.id}/${channel.channelId}: ${err.message}`);
+                            }
+                        }),
+                    ),
+                );
+            });
+
+        await Promise.all(results);
+    }
+
+    /**
+     * Return a copy of the current template map.
+     */
+    getTemplates(): Record<SessionEventType, MessageTemplate> {
+        return { ...this.templates };
+    }
+
+    /**
+     * Update a single event template.
+     */
+    setTemplate(type: SessionEventType, template: MessageTemplate): void {
+        this.templates[type] = template;
+    }
+}
+
+function renderTemplate(
+    template: string,
+    sessionId: string,
+    payload?: Record<string, unknown>,
+): string {
+    const context: Record<string, unknown> = { sessionId, ...(payload ?? {}) };
+    return template.replace(/\{\{(\w+)\}\}/g, (_match, key: string) => {
+        const value = context[key];
+        return value === undefined || value === null ? "" : String(value);
+    });
+}

--- a/packages/cli/src/runner/services/message-provider/index.ts
+++ b/packages/cli/src/runner/services/message-provider/index.ts
@@ -2,3 +2,4 @@ export * from "./types.js";
 export * from "./channel-router.js";
 export * from "./provider-registry.js";
 export * from "./event-forwarder.js";
+export * from "./discord-provider.js";

--- a/packages/cli/src/runner/services/message-provider/index.ts
+++ b/packages/cli/src/runner/services/message-provider/index.ts
@@ -1,3 +1,4 @@
+export * from "./bridge-service.js";
 export * from "./types.js";
 export * from "./channel-router.js";
 export * from "./provider-registry.js";

--- a/packages/cli/src/runner/services/message-provider/index.ts
+++ b/packages/cli/src/runner/services/message-provider/index.ts
@@ -4,3 +4,4 @@ export * from "./channel-router.js";
 export * from "./provider-registry.js";
 export * from "./event-forwarder.js";
 export * from "./discord-provider.js";
+export * from "./discord-policy.js";

--- a/packages/cli/src/runner/services/message-provider/index.ts
+++ b/packages/cli/src/runner/services/message-provider/index.ts
@@ -1,0 +1,4 @@
+export * from "./types.js";
+export * from "./channel-router.js";
+export * from "./provider-registry.js";
+export * from "./event-forwarder.js";

--- a/packages/cli/src/runner/services/message-provider/integration.test.ts
+++ b/packages/cli/src/runner/services/message-provider/integration.test.ts
@@ -1,0 +1,452 @@
+/**
+ * Integration tests for the message-provider subsystem.
+ *
+ * These tests exercise the real classes together (with network mocked) to
+ * verify end-to-end routing, bridge wiring, config parsing, and manifest
+ * structure.
+ */
+import { describe, test, expect, mock, afterEach } from "bun:test";
+import { readFileSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Socket } from "socket.io-client";
+import type { TriggerSubscriptionEntry } from "@pizzapi/protocol";
+import { MessageBridgeService, type MessageBridgeConfig } from "./bridge-service.js";
+import { ChannelRouter } from "./channel-router.js";
+import { EventForwarder, type SessionEvent } from "./event-forwarder.js";
+import { ProviderRegistry } from "./provider-registry.js";
+import type { Channel, InboundMessage, InboundMessageHandler, MessageProvider, OutboundMessage, ProviderConfig, ProviderStatus } from "./types.js";
+
+const originalFetch = globalThis.fetch;
+const originalHome = process.env.HOME;
+const originalRelayUrl = process.env.PIZZAPI_RELAY_URL;
+const originalApiKey = process.env.PIZZAPI_RUNNER_API_KEY;
+
+let service: MessageBridgeService | null = null;
+
+afterEach(async () => {
+    if (service) {
+        service.dispose();
+        await Promise.resolve();
+        service = null;
+    }
+
+    globalThis.fetch = originalFetch;
+    if (originalHome === undefined) delete process.env.HOME;
+    else process.env.HOME = originalHome;
+    if (originalRelayUrl === undefined) delete process.env.PIZZAPI_RELAY_URL;
+    else process.env.PIZZAPI_RELAY_URL = originalRelayUrl;
+    if (originalApiKey === undefined) delete process.env.PIZZAPI_RUNNER_API_KEY;
+    else process.env.PIZZAPI_RUNNER_API_KEY = originalApiKey;
+});
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+class MockProvider implements MessageProvider {
+    readonly id: string;
+    readonly label: string;
+    connected = false;
+    private readonly handlers = new Set<InboundMessageHandler>();
+    private config: ProviderConfig | null = null;
+    private shouldFailConnect = false;
+    private shouldFailSend = false;
+
+    constructor(id: string, label: string, options?: { failConnect?: boolean; failSend?: boolean }) {
+        this.id = id;
+        this.label = label;
+        this.shouldFailConnect = options?.failConnect ?? false;
+        this.shouldFailSend = options?.failSend ?? false;
+    }
+
+    connect = mock((config: ProviderConfig) => {
+        this.config = config;
+        if (this.shouldFailConnect) {
+            return Promise.reject(new Error(`${this.id} connect failed`));
+        }
+        this.connected = true;
+        return Promise.resolve();
+    });
+
+    disconnect = mock(() => {
+        this.connected = false;
+        this.config = null;
+        return Promise.resolve();
+    });
+
+    isConnected(): boolean {
+        return this.connected;
+    }
+
+    send = mock((_channelId: string, _message: OutboundMessage) => {
+        if (this.shouldFailSend) {
+            return Promise.reject(new Error(`${this.id} send failed`));
+        }
+        return Promise.resolve();
+    });
+
+    listChannels = mock(() =>
+        Promise.resolve<Channel[]>([
+            { id: `${this.id}-chan-1`, name: "general", type: "text" },
+        ]),
+    );
+
+    onMessage(handler: InboundMessageHandler): void {
+        this.handlers.add(handler);
+    }
+
+    offMessage(handler: InboundMessageHandler): void {
+        this.handlers.delete(handler);
+    }
+
+    async emitMessage(message: InboundMessage): Promise<void> {
+        const promises: Promise<unknown>[] = [];
+        for (const handler of this.handlers) {
+            const result = handler(message);
+            if (result instanceof Promise) {
+                promises.push(result.catch(() => undefined));
+            }
+        }
+        await Promise.all(promises);
+    }
+
+    getConfig(): ProviderConfig | null {
+        return this.config;
+    }
+}
+
+function fakeSocket(): Socket {
+    return {} as Socket;
+}
+
+function setupBroadcastEnv(runnerId = "runner-test", apiKey = "test-api-key", relayUrl = "http://relay.test"): string {
+    const home = mkdtempSync(join(tmpdir(), "pizzapi-bridge-"));
+    mkdirSync(join(home, ".pizzapi"), { recursive: true });
+    writeFileSync(
+        join(home, ".pizzapi", "runner.json"),
+        JSON.stringify({ runnerId }),
+        "utf-8",
+    );
+    process.env.HOME = home;
+    process.env.PIZZAPI_RELAY_URL = relayUrl;
+    process.env.PIZZAPI_RUNNER_API_KEY = apiKey;
+    return home;
+}
+
+function relayFetchMock(): {
+    fn: ReturnType<typeof mock<typeof fetch>>;
+    calls: Array<{ url: unknown; init?: RequestInit }>;
+} {
+    const calls: Array<{ url: unknown; init?: RequestInit }> = [];
+    const fn = mock(async (url: unknown, init?: RequestInit) => {
+        const urlString = String(url);
+        if (urlString.includes("/api/runners/") && urlString.includes("/trigger-broadcast")) {
+            calls.push({ url, init });
+            return new Response(JSON.stringify({ ok: true }), { status: 200 });
+        }
+        // Let real panel HTTP requests through.
+        return originalFetch(url as RequestInfo, init);
+    }) as unknown as ReturnType<typeof mock<typeof fetch>>;
+    return { fn, calls };
+}
+
+function sampleInbound(overrides: Partial<InboundMessage> = {}): InboundMessage {
+    return {
+        id: "msg-1",
+        channelId: "chan-1",
+        channelName: "general",
+        author: { id: "u1", username: "user1", displayName: "User One" },
+        content: "!help",
+        timestamp: Date.now(),
+        isCommand: true,
+        command: { name: "help", args: [], raw: "help" },
+        raw: {},
+        ...overrides,
+    };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("Full message-provider integration", () => {
+    test("full message flow: inbound → router → outbound → event forwarder", async () => {
+        const provider = new MockProvider("mock", "Mock Provider");
+        const registry = new ProviderRegistry();
+        registry.register(provider, {
+            token: "token",
+            defaultRouter: { mode: "commands-only", commandPrefix: "!" },
+            forwardEvents: ["session.complete"],
+        });
+
+        registry.addChannelSession("mock", {
+            channelId: "chan-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only", commandPrefix: "!" },
+        });
+
+        const routedMessages: Array<{ message: InboundMessage; route: import("./channel-router.js").RouteResult }> = [];
+        registry.onRoutedMessage((message, route) => {
+            routedMessages.push({ message, route });
+        });
+
+        // Inbound command message is routed.
+        const inbound = sampleInbound({ channelId: "chan-1", content: "!hello world" });
+        await provider.emitMessage(inbound);
+
+        expect(routedMessages).toHaveLength(1);
+        expect(routedMessages[0].route.sessionId).toBe("sess-1");
+        expect(routedMessages[0].message.isCommand).toBe(true);
+        expect(routedMessages[0].message.command?.name).toBe("hello");
+        expect(routedMessages[0].message.command?.args).toEqual(["world"]);
+
+        // Outbound message reaches the provider.
+        await registry.send("mock", "chan-1", { content: "reply" });
+        expect(provider.send).toHaveBeenCalledWith("chan-1", { content: "reply" });
+
+        // Connect the provider so the event forwarder sees it as online.
+        await registry.connect("mock");
+
+        // Session event is forwarded to mapped channels.
+        const forwarder = new EventForwarder(registry);
+        await forwarder.forward({
+            type: "session.complete",
+            sessionId: "sess-1",
+            payload: { extra: "data" },
+        });
+
+        expect(provider.send).toHaveBeenCalledTimes(2);
+        const eventCall = provider.send.mock.calls[1];
+        expect(eventCall[0]).toBe("chan-1");
+        expect((eventCall[1] as OutboundMessage).content).toContain("sess-1 completed");
+
+        // Cleanup.
+        await registry.unregister("mock");
+    });
+
+    test("BridgeService with mock provider: init, inbound broadcast, dispose", async () => {
+        setupBroadcastEnv();
+        const { fn, calls } = relayFetchMock();
+        globalThis.fetch = fn as unknown as typeof fetch;
+
+        const provider = new MockProvider("mock", "Mock Provider");
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            mock: { token: "mock-token" },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: { mock: () => provider },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        await Promise.resolve();
+
+        // Provider is registered and connected.
+        const registered = service.getRegistry().getProvider("mock");
+        expect(registered).toBe(provider);
+        expect(provider.isConnected()).toBe(true);
+
+        // Inbound message triggers a broadcast.
+        const inbound = sampleInbound({ channelId: "chan-1", content: "!status" });
+        await provider.emitMessage(inbound);
+        await Promise.resolve();
+
+        const call = calls.find((c) => String(c.url).includes("/api/runners/runner-test/trigger-broadcast"));
+        expect(call).toBeDefined();
+        const body = JSON.parse(call!.init?.body as string);
+        expect(body.type).toBe("message-bridge:inbound");
+        expect(body.payload.providerId).toBe("mock");
+        expect(body.payload.content).toBe("!status");
+
+        // Dispose disconnects provider and stops server.
+        const port = service.getPanelPort();
+        expect(port).toBeGreaterThan(0);
+        service.dispose();
+        await Promise.resolve();
+
+        expect(provider.disconnect).toHaveBeenCalled();
+        expect(service.getPanelPort()).toBeUndefined();
+        await expect(fetch(`http://localhost:${port}/api/status`)).rejects.toThrow();
+    });
+
+    test("config parsing from object creates the right providers and validates bad configs", async () => {
+        const alpha = new MockProvider("alpha", "Alpha");
+        const beta = new MockProvider("beta", "Beta");
+
+        const config: MessageBridgeConfig = {
+            enabled: true,
+            alpha: { token: "alpha-token", defaultRouter: { mode: "all-messages" } },
+            beta: { token: "beta-token", defaultRouter: { mode: "commands-only" } },
+        };
+
+        service = new MessageBridgeService({
+            config,
+            factories: {
+                alpha: () => alpha,
+                beta: () => beta,
+            },
+        });
+
+        service.init(fakeSocket(), { isShuttingDown: () => false });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        const ids = service.getRegistry().getProviders().map((p) => p.id).sort();
+        expect(ids).toEqual(["alpha", "beta"]);
+        expect(alpha.isConnected()).toBe(true);
+        expect(beta.isConnected()).toBe(true);
+
+        // Bad config should not register a provider.
+        const badConfig: MessageBridgeConfig = {
+            enabled: true,
+            alpha: { token: "alpha-token" },
+            gamma: { token: "" } as ProviderConfig,
+        };
+
+        const badService = new MessageBridgeService({
+            config: badConfig,
+            factories: {
+                alpha: () => new MockProvider("alpha", "Alpha"),
+                gamma: () => new MockProvider("gamma", "Gamma"),
+            },
+        });
+        badService.init(fakeSocket(), { isShuttingDown: () => false });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(badService.getRegistry().getProviders().map((p) => p.id)).toEqual(["alpha"]);
+        badService.dispose();
+        await Promise.resolve();
+    });
+
+    test("multiple providers route and report status independently", async () => {
+        const alpha = new MockProvider("alpha", "Alpha");
+        const beta = new MockProvider("beta", "Beta");
+
+        const registry = new ProviderRegistry();
+        registry.register(alpha, { token: "a" });
+        registry.register(beta, { token: "b" });
+        registry.connectAll();
+        await Promise.resolve();
+
+        registry.addChannelSession("alpha", {
+            channelId: "alpha-chan",
+            sessionId: "sess-alpha",
+            config: { mode: "commands-only" },
+        });
+        registry.addChannelSession("beta", {
+            channelId: "beta-chan",
+            sessionId: "sess-beta",
+            config: { mode: "commands-only" },
+        });
+
+        await registry.send("alpha", "alpha-chan", { content: "to alpha" });
+        await registry.send("beta", "beta-chan", { content: "to beta" });
+
+        expect(alpha.send).toHaveBeenCalledWith("alpha-chan", { content: "to alpha" });
+        expect(beta.send).toHaveBeenCalledWith("beta-chan", { content: "to beta" });
+        expect(alpha.send).not.toHaveBeenCalledWith("beta-chan", expect.anything());
+        expect(beta.send).not.toHaveBeenCalledWith("alpha-chan", expect.anything());
+
+        const statuses = registry.getStatus();
+        expect(statuses).toHaveLength(2);
+        const byId = Object.fromEntries(statuses.map((s) => [s.id, s])) as Record<string, ProviderStatus>;
+        expect(byId.alpha.messagesOut).toBe(1);
+        expect(byId.beta.messagesOut).toBe(1);
+        expect(byId.alpha.sessionsMapped).toBe(1);
+        expect(byId.beta.sessionsMapped).toBe(1);
+
+        await registry.disconnectAll();
+    });
+
+    test("provider failure isolation: connect and send failures do not break other providers", async () => {
+        const good = new MockProvider("good", "Good Provider");
+        const badConnect = new MockProvider("bad-connect", "Bad Connect", { failConnect: true });
+        const badSend = new MockProvider("bad-send", "Bad Send", { failSend: true });
+
+        const registry = new ProviderRegistry();
+        registry.register(good, { token: "g" });
+        registry.register(badConnect, { token: "bc" });
+        registry.register(badSend, { token: "bs" });
+
+        await registry.connectAll();
+
+        expect(good.isConnected()).toBe(true);
+        expect(badConnect.isConnected()).toBe(false);
+        expect(badSend.isConnected()).toBe(true);
+
+        await expect(registry.send("good", "chan", { content: "ok" })).resolves.toBeUndefined();
+        await expect(registry.send("bad-send", "chan", { content: "fail" })).rejects.toThrow("bad-send send failed");
+
+        // Good provider remains usable after another provider's send failure.
+        await expect(registry.send("good", "chan", { content: "still ok" })).resolves.toBeUndefined();
+
+        const goodStatus = registry.getStatus().find((s) => s.id === "good");
+        expect(goodStatus?.messagesOut).toBe(2);
+
+        await registry.disconnectAll();
+    });
+});
+
+describe("Manifest and packaging verification", () => {
+    test("bridge-manifest.json is valid JSON with required fields", () => {
+        const raw = readFileSync(join(import.meta.dir, "bridge-manifest.json"), "utf-8");
+        const manifest = JSON.parse(raw) as Record<string, unknown>;
+
+        expect(typeof manifest.id).toBe("string");
+        expect(manifest.id).toBe("message-bridge");
+        expect(typeof manifest.label).toBe("string");
+        expect(manifest.label).toBe("Message Bridge");
+        expect(typeof manifest.icon).toBe("string");
+        expect(typeof manifest.panel).toBe("object");
+        expect(typeof (manifest.panel as Record<string, unknown>).dir).toBe("string");
+        expect(Array.isArray(manifest.triggers)).toBe(true);
+        expect(manifest.triggers).toHaveLength(2);
+
+        for (const trigger of manifest.triggers as Array<Record<string, unknown>>) {
+            expect(typeof trigger.type).toBe("string");
+            expect(typeof trigger.label).toBe("string");
+            expect(trigger.type).toMatch(/^message-bridge:[a-z-]+$/);
+            expect(typeof trigger.schema).toBe("object");
+        }
+    });
+
+    test("index.ts exports all required types and classes", async () => {
+        const exports = await import("./index.js");
+
+        expect(exports.MessageBridgeService).toBeFunction();
+        expect(exports.ProviderRegistry).toBeFunction();
+        expect(exports.ChannelRouter).toBeFunction();
+        expect(exports.EventForwarder).toBeFunction();
+        expect(exports.DiscordProvider).toBeFunction();
+
+        // Types are erased at runtime; ensure the module at least exports
+        // the concrete implementations that consumers need.
+        expect(Object.keys(exports).length).toBeGreaterThanOrEqual(6);
+    });
+
+    test("panel/index.html is well-formed HTML", () => {
+        const raw = readFileSync(join(import.meta.dir, "panel", "index.html"), "utf-8");
+
+        expect(raw.trim().toLowerCase().startsWith("<!doctype html>")).toBe(true);
+        expect(raw).toContain("<html");
+        expect(raw).toContain("</html>");
+        expect(raw).toContain("<head>");
+        expect(raw).toContain("</head>");
+        expect(raw).toContain("<body>");
+        expect(raw).toContain("</body>");
+        expect(raw).toContain('id="providers"');
+        expect(raw).toContain('id="config-form"');
+
+        // Opening and closing tags should be balanced at the top level.
+        const tagPattern = /<(\/?)(html|head|body|title|script|style|div|form|textarea|input|button|h1|h2|ul|li|span)[^>]*>/gi;
+        let depth = 0;
+        for (const match of raw.matchAll(tagPattern)) {
+            const closing = match[1] === "/";
+            const selfClosingTags = ["input"];
+            if (selfClosingTags.includes(match[2].toLowerCase())) continue;
+            depth += closing ? -1 : 1;
+            expect(depth).toBeGreaterThanOrEqual(0);
+        }
+    });
+});

--- a/packages/cli/src/runner/services/message-provider/panel/index.html
+++ b/packages/cli/src/runner/services/message-provider/panel/index.html
@@ -1,0 +1,311 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Message Bridge</title>
+  <style>
+    :root {
+      --bg: #0a0a0b;
+      --surface: #121214;
+      --text: #e4e4e7;
+      --muted: #a1a1aa;
+      --border: #27272a;
+      --accent: #22c55e;
+      --accent-dim: #ef4444;
+      --radius: 0.5rem;
+      --gap: 1rem;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.5;
+    }
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: var(--gap);
+    }
+    h1 {
+      margin: 0 0 var(--gap);
+      font-size: 1.25rem;
+      font-weight: 600;
+    }
+    .section {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: var(--gap);
+      margin-bottom: var(--gap);
+    }
+    .section h2 {
+      margin: 0 0 0.75rem;
+      font-size: 0.875rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: var(--muted);
+    }
+    .status-row {
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+      margin-bottom: 0.5rem;
+    }
+    .dot {
+      width: 0.625rem;
+      height: 0.625rem;
+      border-radius: 50%;
+      flex-shrink: 0;
+    }
+    .dot.connected { background: var(--accent); box-shadow: 0 0 0.375rem var(--accent); }
+    .dot.disconnected { background: var(--accent-dim); }
+    .provider-card {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 0.75rem;
+      margin-bottom: 0.75rem;
+    }
+    .provider-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+    }
+    .provider-title {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 600;
+    }
+    .metrics {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 0.5rem;
+      margin-top: 0.75rem;
+      font-size: 0.8125rem;
+      color: var(--muted);
+    }
+    .metric strong {
+      display: block;
+      color: var(--text);
+      font-size: 1rem;
+    }
+    .channels {
+      margin-top: 0.75rem;
+    }
+    .channels ul {
+      margin: 0.5rem 0 0;
+      padding-left: 1.25rem;
+      color: var(--muted);
+      font-size: 0.875rem;
+    }
+    .channels li {
+      margin-bottom: 0.25rem;
+    }
+    .empty {
+      color: var(--muted);
+      font-size: 0.875rem;
+    }
+    .error {
+      color: var(--accent-dim);
+      font-size: 0.875rem;
+    }
+    form {
+      display: flex;
+      flex-direction: column;
+      gap: 0.75rem;
+    }
+    textarea, input[type="text"] {
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      color: var(--text);
+      padding: 0.5rem 0.75rem;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.875rem;
+    }
+    textarea { min-height: 10rem; resize: vertical; }
+    input[type="text"]:focus, textarea:focus {
+      outline: none;
+      border-color: var(--accent);
+    }
+    button {
+      align-self: flex-start;
+      background: var(--accent);
+      color: #000;
+      border: none;
+      border-radius: var(--radius);
+      padding: 0.5rem 1rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    button:hover { filter: brightness(1.1); }
+    .result {
+      white-space: pre-wrap;
+      font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.8125rem;
+      color: var(--muted);
+      background: var(--bg);
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      padding: 0.75rem;
+      margin-top: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>Message Bridge</h1>
+
+    <div class="section">
+      <h2>Providers</h2>
+      <div id="providers">Loading…</div>
+    </div>
+
+    <div class="section">
+      <h2>Config Validator</h2>
+      <form id="config-form">
+        <textarea id="config-input" placeholder='Paste provider config JSON here, e.g. { "discord": { "token": "...", "defaultRouter": { "mode": "commands-only", "commandPrefix": "!" } } }'></textarea>
+        <button type="submit">Validate</button>
+      </form>
+      <div id="config-result" class="result" hidden></div>
+    </div>
+  </div>
+
+  <script>
+    const providersEl = document.getElementById('providers');
+    const configForm = document.getElementById('config-form');
+    const configInput = document.getElementById('config-input');
+    const configResult = document.getElementById('config-result');
+
+    function statusDot(connected) {
+      const span = document.createElement('span');
+      span.className = `dot ${connected ? 'connected' : 'disconnected'}`;
+      span.title = connected ? 'Connected' : 'Disconnected';
+      return span;
+    }
+
+    async function loadChannels(providerId) {
+      try {
+        const res = await fetch(`./api/channels/${encodeURIComponent(providerId)}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return await res.json();
+      } catch (err) {
+        return { error: err.message };
+      }
+    }
+
+    async function renderChannelList(providerId, container) {
+      const data = await loadChannels(providerId);
+      container.innerHTML = '';
+      if (data.error) {
+        container.innerHTML = `<div class="error">Channels unavailable: ${escapeHtml(data.error)}</div>`;
+        return;
+      }
+      if (!Array.isArray(data) || data.length === 0) {
+        container.innerHTML = '<div class="empty">No channels available</div>';
+        return;
+      }
+      const ul = document.createElement('ul');
+      for (const ch of data) {
+        const li = document.createElement('li');
+        li.textContent = `${ch.name || 'Unnamed'} (${ch.id})`;
+        ul.appendChild(li);
+      }
+      const label = document.createElement('div');
+      label.className = 'empty';
+      label.textContent = `Available channels (${data.length})`;
+      container.appendChild(label);
+      container.appendChild(ul);
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    async function renderProviders() {
+      try {
+        const res = await fetch('./api/status');
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const statuses = await res.json();
+        providersEl.innerHTML = '';
+        if (!Array.isArray(statuses) || statuses.length === 0) {
+          providersEl.innerHTML = '<div class="empty">No providers configured</div>';
+          return;
+        }
+        for (const p of statuses) {
+          const card = document.createElement('div');
+          card.className = 'provider-card';
+
+          const header = document.createElement('div');
+          header.className = 'provider-header';
+          const title = document.createElement('div');
+          title.className = 'provider-title';
+          title.appendChild(statusDot(p.connected));
+          title.appendChild(document.createTextNode(p.label || p.id));
+          header.appendChild(title);
+          const state = document.createElement('div');
+          state.className = 'empty';
+          state.textContent = p.connected ? 'Connected' : 'Disconnected';
+          header.appendChild(state);
+          card.appendChild(header);
+
+          const metrics = document.createElement('div');
+          metrics.className = 'metrics';
+          metrics.innerHTML = `
+            <div class="metric"><strong>${p.channelCount ?? 0}</strong>Channels</div>
+            <div class="metric"><strong>${p.sessionsMapped ?? 0}</strong>Sessions</div>
+            <div class="metric"><strong>${p.messagesIn ?? 0}</strong>In</div>
+            <div class="metric"><strong>${p.messagesOut ?? 0}</strong>Out</div>
+          `;
+          card.appendChild(metrics);
+
+          if (p.lastError) {
+            const err = document.createElement('div');
+            err.className = 'error';
+            err.textContent = `Last error: ${p.lastError}`;
+            card.appendChild(err);
+          }
+
+          const channels = document.createElement('div');
+          channels.className = 'channels';
+          channels.innerHTML = '<div class="empty">Loading channels…</div>';
+          card.appendChild(channels);
+          providersEl.appendChild(card);
+
+          void renderChannelList(p.id, channels);
+        }
+      } catch (err) {
+        providersEl.innerHTML = `<div class="error">Failed to load status: ${escapeHtml(err.message)}</div>`;
+      }
+    }
+
+    configForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      configResult.hidden = true;
+      try {
+        const body = JSON.parse(configInput.value);
+        const res = await fetch('./api/config/test', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+        const data = await res.json();
+        configResult.textContent = JSON.stringify(data, null, 2);
+        configResult.hidden = false;
+      } catch (err) {
+        configResult.textContent = `Error: ${err.message}`;
+        configResult.hidden = false;
+      }
+    });
+
+    renderProviders();
+    setInterval(renderProviders, 5000);
+  </script>
+</body>
+</html>

--- a/packages/cli/src/runner/services/message-provider/provider-registry.ts
+++ b/packages/cli/src/runner/services/message-provider/provider-registry.ts
@@ -288,7 +288,7 @@ export class ProviderRegistry {
     }
 
     private createProviderMessageHandler(providerId: string): InboundMessageHandler {
-        return (message: InboundMessage) => {
+        return async (message: InboundMessage) => {
             this.incrementMessagesIn(providerId);
 
             const config = this.providers.get(providerId)?.config;
@@ -301,7 +301,7 @@ export class ProviderRegistry {
                 return;
             }
 
-            const route = router.route(message);
+            const route = await router.route(message);
             if (!route || !route.shouldForward) {
                 return;
             }
@@ -328,9 +328,18 @@ export class ProviderRegistry {
 
     private rebuildRouter(id: string, config: ProviderConfig): void {
         const router = this.getRouter(id);
-        if (config.defaultRouter) {
-            router.setDefaultRouter(config.defaultRouter);
+
+        if (config.defaultRouter || config.defaultCanExecute) {
+            const defaultRouter: ChannelRouterConfig = {
+                mode: config.defaultRouter?.mode ?? "commands-only",
+                commandPrefix: config.defaultRouter?.commandPrefix,
+                filterPatterns: config.defaultRouter?.filterPatterns,
+                maxMessageLength: config.defaultRouter?.maxMessageLength,
+                canExecute: config.defaultRouter?.canExecute ?? config.defaultCanExecute,
+            };
+            router.setDefaultRouter(defaultRouter);
         }
+
         for (const session of router.getSessions()) {
             const channelConfig = config.channelRouters?.[session.channelId];
             if (channelConfig) {

--- a/packages/cli/src/runner/services/message-provider/provider-registry.ts
+++ b/packages/cli/src/runner/services/message-provider/provider-registry.ts
@@ -1,0 +1,367 @@
+import type {
+    ChannelRouterConfig,
+    ChannelSession,
+    InboundMessage,
+    InboundMessageHandler,
+    MessageProvider,
+    OutboundMessage,
+    ProviderConfig,
+    ProviderStatus,
+} from "./types.js";
+import { ChannelRouter, type RouteResult } from "./channel-router.js";
+
+interface ProviderEntry {
+    provider: MessageProvider;
+    config?: ProviderConfig;
+}
+
+interface ProviderMetrics {
+    messagesIn: number;
+    messagesOut: number;
+    lastError?: string;
+}
+
+export type RoutedInboundMessageHandler = (
+    message: InboundMessage,
+    route: RouteResult,
+) => void | Promise<void>;
+
+/**
+ * Manages the lifecycle, routing, and metrics of registered message providers.
+ *
+ * Each provider gets its own ChannelRouter instance so that per-provider
+ * channel mappings and router configs stay isolated.
+ */
+export class ProviderRegistry {
+    private readonly providers = new Map<string, ProviderEntry>();
+    private readonly metrics = new Map<string, ProviderMetrics>();
+    private readonly routers = new Map<string, ChannelRouter>();
+    private readonly providerMessageHandlers = new Map<string, InboundMessageHandler>();
+    private readonly routedHandlers: RoutedInboundMessageHandler[] = [];
+
+    /**
+     * Register a provider and its optional initial config.
+     * Throws if the provider id is already registered.
+     */
+    register(provider: MessageProvider, config?: ProviderConfig): void {
+        if (this.providers.has(provider.id)) {
+            throw new Error(`ProviderRegistry: duplicate provider id "${provider.id}"`);
+        }
+
+        this.providers.set(provider.id, { provider, config });
+        this.metrics.set(provider.id, { messagesIn: 0, messagesOut: 0 });
+        this.routers.set(provider.id, new ChannelRouter());
+
+        const handler = this.createProviderMessageHandler(provider.id);
+        this.providerMessageHandlers.set(provider.id, handler);
+        provider.onMessage(handler);
+    }
+
+    /**
+     * Unregister a provider, disconnecting it if connected and cleaning up
+     * listeners.
+     */
+    async unregister(id: string): Promise<void> {
+        const entry = this.providers.get(id);
+        if (!entry) {
+            return;
+        }
+
+        try {
+            if (entry.provider.isConnected()) {
+                await entry.provider.disconnect();
+            }
+        } catch (err) {
+            this.recordError(id, err);
+        }
+
+        const handler = this.providerMessageHandlers.get(id);
+        if (handler) {
+            entry.provider.offMessage(handler);
+        }
+
+        this.providers.delete(id);
+        this.metrics.delete(id);
+        this.routers.delete(id);
+        this.providerMessageHandlers.delete(id);
+    }
+
+    /**
+     * Update the stored config for a provider.
+     */
+    setConfig(id: string, config: ProviderConfig): void {
+        const entry = this.providers.get(id);
+        if (!entry) {
+            throw new Error(`ProviderRegistry: unknown provider "${id}"`);
+        }
+        entry.config = config;
+        this.rebuildRouter(id, config);
+    }
+
+    /**
+     * Return the stored config for a provider, if any.
+     */
+    getConfig(id: string): ProviderConfig | undefined {
+        return this.providers.get(id)?.config;
+    }
+
+    /**
+     * Look up a registered provider by id.
+     */
+    getProvider(id: string): MessageProvider | undefined {
+        return this.providers.get(id)?.provider;
+    }
+
+    /**
+     * Return all registered providers.
+     */
+    getProviders(): MessageProvider[] {
+        return Array.from(this.providers.values()).map((entry) => entry.provider);
+    }
+
+    /**
+     * Connect a single provider using its stored config.
+     */
+    async connect(id: string): Promise<void> {
+        const entry = this.providers.get(id);
+        if (!entry) {
+            throw new Error(`ProviderRegistry: unknown provider "${id}"`);
+        }
+        if (!entry.config) {
+            throw new Error(`ProviderRegistry: no config for provider "${id}"`);
+        }
+
+        try {
+            await entry.provider.connect(entry.config);
+        } catch (err) {
+            this.recordError(id, err);
+            throw err;
+        }
+    }
+
+    /**
+     * Connect all registered providers that have a stored config.
+     * Individual connection failures are recorded but do not stop others.
+     */
+    async connectAll(): Promise<void> {
+        for (const id of this.providers.keys()) {
+            const config = this.providers.get(id)?.config;
+            if (!config) {
+                continue;
+            }
+            try {
+                await this.connect(id);
+            } catch (err) {
+                // Error already recorded by connect(); continue with others.
+                if (err instanceof Error) {
+                    this.recordError(id, err);
+                }
+            }
+        }
+    }
+
+    /**
+     * Disconnect a single provider.
+     */
+    async disconnect(id: string): Promise<void> {
+        const entry = this.providers.get(id);
+        if (!entry) {
+            throw new Error(`ProviderRegistry: unknown provider "${id}"`);
+        }
+
+        try {
+            await entry.provider.disconnect();
+        } catch (err) {
+            this.recordError(id, err);
+            throw err;
+        }
+    }
+
+    /**
+     * Disconnect all registered providers.
+     * Individual disconnection failures are recorded but do not stop others.
+     */
+    async disconnectAll(): Promise<void> {
+        for (const id of this.providers.keys()) {
+            try {
+                await this.disconnect(id);
+            } catch (err) {
+                if (err instanceof Error) {
+                    this.recordError(id, err);
+                }
+            }
+        }
+    }
+
+    /**
+     * Send an outbound message through a provider and update metrics.
+     */
+    async send(providerId: string, channelId: string, message: OutboundMessage): Promise<void> {
+        const entry = this.providers.get(providerId);
+        if (!entry) {
+            throw new Error(`ProviderRegistry: unknown provider "${providerId}"`);
+        }
+
+        try {
+            await entry.provider.send(channelId, message);
+            this.incrementMessagesOut(providerId);
+        } catch (err) {
+            this.recordError(providerId, err);
+            throw err;
+        }
+    }
+
+    /**
+     * Add a channel-to-session mapping for a provider.
+     */
+    addChannelSession(providerId: string, session: ChannelSession): void {
+        const router = this.getRouter(providerId);
+        router.addSession(session);
+    }
+
+    /**
+     * Remove a channel-to-session mapping for a provider.
+     */
+    removeChannelSession(providerId: string, channelId: string): void {
+        const router = this.getRouter(providerId);
+        router.removeSession(channelId);
+    }
+
+    /**
+     * Return the router for a provider.
+     */
+    getRouter(providerId: string): ChannelRouter {
+        const router = this.routers.get(providerId);
+        if (!router) {
+            throw new Error(`ProviderRegistry: unknown provider "${providerId}"`);
+        }
+        return router;
+    }
+
+    /**
+     * Return all channel sessions mapped to a given PizzaPi session ID for a
+     * specific provider.
+     */
+    getChannelsForSession(providerId: string, sessionId: string): ChannelSession[] {
+        return this.getRouter(providerId).findChannelsBySessionId(sessionId);
+    }
+
+    /**
+     * Register a handler for routed inbound messages.
+     */
+    onRoutedMessage(handler: RoutedInboundMessageHandler): void {
+        if (!this.routedHandlers.includes(handler)) {
+            this.routedHandlers.push(handler);
+        }
+    }
+
+    /**
+     * Remove a routed inbound message handler.
+     */
+    offRoutedMessage(handler: RoutedInboundMessageHandler): void {
+        const index = this.routedHandlers.indexOf(handler);
+        if (index >= 0) {
+            this.routedHandlers.splice(index, 1);
+        }
+    }
+
+    /**
+     * Return status snapshots for all registered providers.
+     */
+    getStatus(): ProviderStatus[] {
+        return Array.from(this.providers.entries()).map(([id, entry]) => {
+            const metrics = this.metrics.get(id) ?? { messagesIn: 0, messagesOut: 0 };
+            const router = this.routers.get(id);
+            const sessionsMapped = router?.getSessions().length ?? 0;
+
+            return {
+                id,
+                label: entry.provider.label,
+                connected: entry.provider.isConnected(),
+                channelCount: entry.provider.isConnected() ? sessionsMapped : 0,
+                sessionsMapped,
+                messagesIn: metrics.messagesIn,
+                messagesOut: metrics.messagesOut,
+                lastError: metrics.lastError,
+            };
+        });
+    }
+
+    private createProviderMessageHandler(providerId: string): InboundMessageHandler {
+        return (message: InboundMessage) => {
+            this.incrementMessagesIn(providerId);
+
+            const config = this.providers.get(providerId)?.config;
+            if (!this.isChannelAllowed(message.channelId, config?.allowedChannels)) {
+                return;
+            }
+
+            const router = this.routers.get(providerId);
+            if (!router) {
+                return;
+            }
+
+            const route = router.route(message);
+            if (!route || !route.shouldForward) {
+                return;
+            }
+
+            for (const handler of this.routedHandlers) {
+                try {
+                    const result = handler(route.message, route);
+                    if (result instanceof Promise) {
+                        result.catch((err) => this.recordError(providerId, err));
+                    }
+                } catch (err) {
+                    this.recordError(providerId, err);
+                }
+            }
+        };
+    }
+
+    private isChannelAllowed(channelId: string, allowedChannels?: string[]): boolean {
+        if (!allowedChannels || allowedChannels.length === 0) {
+            return true;
+        }
+        return allowedChannels.includes(channelId);
+    }
+
+    private rebuildRouter(id: string, config: ProviderConfig): void {
+        const router = this.getRouter(id);
+        if (config.defaultRouter) {
+            router.setDefaultRouter(config.defaultRouter);
+        }
+        for (const session of router.getSessions()) {
+            const channelConfig = config.channelRouters?.[session.channelId];
+            if (channelConfig) {
+                router.addSession({ ...session, config: channelConfig });
+            }
+        }
+    }
+
+    private incrementMessagesIn(id: string): void {
+        const metrics = this.metrics.get(id);
+        if (metrics) {
+            metrics.messagesIn += 1;
+        }
+    }
+
+    private incrementMessagesOut(id: string): void {
+        const metrics = this.metrics.get(id);
+        if (metrics) {
+            metrics.messagesOut += 1;
+        }
+    }
+
+    private recordError(id: string, error: unknown): void {
+        const metrics = this.metrics.get(id);
+        if (!metrics) {
+            return;
+        }
+        if (error instanceof Error) {
+            metrics.lastError = error.message;
+        } else {
+            metrics.lastError = String(error);
+        }
+    }
+}

--- a/packages/cli/src/runner/services/message-provider/types.test.ts
+++ b/packages/cli/src/runner/services/message-provider/types.test.ts
@@ -64,10 +64,8 @@ class MockProvider implements MessageProvider {
         }
     }
 
-    emit(message: InboundMessage): void {
-        for (const handler of this.handlers) {
-            void handler(message);
-        }
+    async emit(message: InboundMessage): Promise<void> {
+        await Promise.all(this.handlers.map((handler) => handler(message)));
     }
 }
 
@@ -216,7 +214,7 @@ describe("ChannelRouter", () => {
         expect(parsed.content).toBe("a".repeat(10));
     });
 
-    test("routes to mapped session", () => {
+    test("routes to mapped session", async () => {
         const router = new ChannelRouter();
         const session: ChannelSession = {
             channelId: "ch-1",
@@ -225,28 +223,28 @@ describe("ChannelRouter", () => {
         };
         router.addSession(session);
 
-        const route = router.route(makeMessage({ content: "!status" }));
+        const route = await router.route(makeMessage({ content: "!status" }));
         expect(route).toBeDefined();
         expect(route!.sessionId).toBe("sess-1");
         expect(route!.shouldForward).toBe(true);
     });
 
-    test("does not route unmapped channels", () => {
+    test("does not route unmapped channels", async () => {
         const router = new ChannelRouter();
-        const route = router.route(makeMessage({ channelId: "unknown" }));
+        const route = await router.route(makeMessage({ channelId: "unknown" }));
         expect(route).toBeUndefined();
     });
 
-    test("all-messages mode forwards everything", () => {
+    test("all-messages mode forwards everything", async () => {
         const router = new ChannelRouter();
         router.addSession({ channelId: "ch-1", sessionId: "sess-1", config: { mode: "all-messages" } });
 
-        const route = router.route(makeMessage({ content: "hello" }));
+        const route = await router.route(makeMessage({ content: "hello" }));
         expect(route!.shouldForward).toBe(true);
         expect(route!.message.isCommand).toBe(false);
     });
 
-    test("filtered mode matches patterns", () => {
+    test("filtered mode matches patterns", async () => {
         const router = new ChannelRouter();
         router.addSession({
             channelId: "ch-1",
@@ -254,8 +252,8 @@ describe("ChannelRouter", () => {
             config: { mode: "filtered", filterPatterns: ["alert", "warn"] },
         });
 
-        expect(router.route(makeMessage({ content: "this is an alert" }))!.shouldForward).toBe(true);
-        expect(router.route(makeMessage({ content: "normal chat" }))!.shouldForward).toBe(false);
+        expect((await router.route(makeMessage({ content: "this is an alert" })))!.shouldForward).toBe(true);
+        expect((await router.route(makeMessage({ content: "normal chat" })))!.shouldForward).toBe(false);
     });
 
     test("finds channels by session id", () => {
@@ -268,11 +266,11 @@ describe("ChannelRouter", () => {
         expect(found.map((s) => s.channelId).sort()).toEqual(["ch-1", "ch-2"]);
     });
 
-    test("removeSession drops the mapping", () => {
+    test("removeSession drops the mapping", async () => {
         const router = new ChannelRouter();
         router.addSession({ channelId: "ch-1", sessionId: "sess-1", config: { mode: "commands-only" } });
         router.removeSession("ch-1");
-        expect(router.route(makeMessage())).toBeUndefined();
+        expect(await router.route(makeMessage())).toBeUndefined();
     });
 });
 
@@ -378,8 +376,8 @@ describe("ProviderRegistry", () => {
             received.push({ message, route });
         });
 
-        provider.emit(makeMessage({ content: "!status" }));
-        provider.emit(makeMessage({ content: "not a command" }));
+        await provider.emit(makeMessage({ content: "!status" }));
+        await provider.emit(makeMessage({ content: "not a command" }));
 
         expect(received).toHaveLength(1);
         expect(received[0].message.command?.name).toBe("status");
@@ -400,7 +398,7 @@ describe("ProviderRegistry", () => {
         expect(registry.getStatus()[0].messagesOut).toBe(1);
     });
 
-    test("allowedChannels filters inbound messages", () => {
+    test("allowedChannels filters inbound messages", async () => {
         const registry = new ProviderRegistry();
         const provider = new MockProvider("mock");
         registry.register(provider, {
@@ -416,8 +414,8 @@ describe("ProviderRegistry", () => {
             received.push(message);
         });
 
-        provider.emit(makeMessage({ channelId: "ch-1", content: "hello" }));
-        provider.emit(makeMessage({ channelId: "ch-2", content: "hello" }));
+        await provider.emit(makeMessage({ channelId: "ch-1", content: "hello" }));
+        await provider.emit(makeMessage({ channelId: "ch-2", content: "hello" }));
 
         expect(received).toHaveLength(1);
         expect(received[0].channelId).toBe("ch-1");

--- a/packages/cli/src/runner/services/message-provider/types.test.ts
+++ b/packages/cli/src/runner/services/message-provider/types.test.ts
@@ -78,6 +78,7 @@ function makeMessage(overrides: Partial<InboundMessage> = {}): InboundMessage {
         content: "hello",
         timestamp: Date.now(),
         isCommand: false,
+        mentionedBot: false,
         raw: {},
         ...overrides,
     };
@@ -130,6 +131,19 @@ describe("validateProviderConfig", () => {
         });
         expect(bad.valid).toBe(false);
         expect(bad.errors).toContain('channelRouters["c1"] is invalid');
+    });
+
+    test("accepts mentions mode in defaultRouter", () => {
+        const result = validateProviderConfig({ token: "abc", defaultRouter: { mode: "mentions" } });
+        expect(result.valid).toBe(true);
+    });
+
+    test("accepts mentions mode in channelRouters", () => {
+        const result = validateProviderConfig({
+            token: "abc",
+            channelRouters: { c1: { mode: "mentions" }, c2: { mode: "commands-only" } },
+        });
+        expect(result.valid).toBe(true);
     });
 
     test("validates defaultRouter", () => {
@@ -271,6 +285,25 @@ describe("ChannelRouter", () => {
         router.addSession({ channelId: "ch-1", sessionId: "sess-1", config: { mode: "commands-only" } });
         router.removeSession("ch-1");
         expect(await router.route(makeMessage())).toBeUndefined();
+    });
+
+    test("mentions mode forwards only when mentionedBot is true", async () => {
+        const router = new ChannelRouter();
+        router.addSession({ channelId: "ch-1", sessionId: "sess-1", config: { mode: "mentions" } });
+
+        const mentioned = await router.route(makeMessage({ mentionedBot: true, content: "<@123> help me" }));
+        expect(mentioned!.shouldForward).toBe(true);
+
+        const notMentioned = await router.route(makeMessage({ mentionedBot: false, content: "hello" }));
+        expect(notMentioned!.shouldForward).toBe(false);
+    });
+
+    test("mentions mode defaults false for undefined mentionedBot", async () => {
+        const router = new ChannelRouter();
+        router.addSession({ channelId: "ch-1", sessionId: "sess-1", config: { mode: "mentions" } });
+
+        const route = await router.route(makeMessage({ content: "hello" }));
+        expect(route!.shouldForward).toBe(false);
     });
 });
 

--- a/packages/cli/src/runner/services/message-provider/types.test.ts
+++ b/packages/cli/src/runner/services/message-provider/types.test.ts
@@ -1,0 +1,559 @@
+import { describe, test, expect } from "bun:test";
+import {
+    ChannelRouter,
+    ProviderRegistry,
+    EventForwarder,
+    validateProviderConfig,
+    isSessionEventType,
+    type Channel,
+    type ChannelRouterConfig,
+    type ChannelSession,
+    type InboundMessage,
+    type MessageProvider,
+    type OutboundMessage,
+    type ProviderConfig,
+    type SessionEvent,
+} from "./index.js";
+
+class MockProvider implements MessageProvider {
+    readonly id: string;
+    readonly label: string;
+    connected = false;
+    readonly handlers: Array<(message: InboundMessage) => void | Promise<void>> = [];
+    channels: Channel[] = [];
+    lastSent: { channelId: string; message: OutboundMessage } | undefined;
+    failNextConnect = false;
+
+    constructor(id: string, label = id) {
+        this.id = id;
+        this.label = label;
+    }
+
+    async connect(_config: ProviderConfig): Promise<void> {
+        if (this.failNextConnect) {
+            this.failNextConnect = false;
+            throw new Error("connect failed");
+        }
+        this.connected = true;
+    }
+
+    async disconnect(): Promise<void> {
+        this.connected = false;
+    }
+
+    isConnected(): boolean {
+        return this.connected;
+    }
+
+    async send(channelId: string, message: OutboundMessage): Promise<void> {
+        this.lastSent = { channelId, message };
+    }
+
+    async listChannels(): Promise<Channel[]> {
+        return this.channels;
+    }
+
+    onMessage(handler: (message: InboundMessage) => void | Promise<void>): void {
+        this.handlers.push(handler);
+    }
+
+    offMessage(handler: (message: InboundMessage) => void | Promise<void>): void {
+        const index = this.handlers.indexOf(handler);
+        if (index >= 0) {
+            this.handlers.splice(index, 1);
+        }
+    }
+
+    emit(message: InboundMessage): void {
+        for (const handler of this.handlers) {
+            void handler(message);
+        }
+    }
+}
+
+function makeMessage(overrides: Partial<InboundMessage> = {}): InboundMessage {
+    return {
+        id: "msg-1",
+        channelId: "ch-1",
+        channelName: "general",
+        author: { id: "u-1", username: "tester", displayName: "Tester" },
+        content: "hello",
+        timestamp: Date.now(),
+        isCommand: false,
+        raw: {},
+        ...overrides,
+    };
+}
+
+describe("validateProviderConfig", () => {
+    test("accepts a minimal valid config", () => {
+        const result = validateProviderConfig({ token: "abc" });
+        expect(result.valid).toBe(true);
+        expect(result.errors).toEqual([]);
+    });
+
+    test("rejects missing token", () => {
+        const result = validateProviderConfig({});
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("token must be a non-empty string");
+    });
+
+    test("rejects non-string token", () => {
+        const result = validateProviderConfig({ token: 123 });
+        expect(result.valid).toBe(false);
+        expect(result.errors).toContain("token must be a non-empty string");
+    });
+
+    test("validates allowedChannels", () => {
+        const good = validateProviderConfig({ token: "abc", allowedChannels: ["c1", "c2"] });
+        expect(good.valid).toBe(true);
+
+        const bad = validateProviderConfig({ token: "abc", allowedChannels: [1, 2] });
+        expect(bad.valid).toBe(false);
+        expect(bad.errors).toContain("allowedChannels must be an array of strings");
+    });
+
+    test("validates channelRouters", () => {
+        const good = validateProviderConfig({
+            token: "abc",
+            channelRouters: {
+                c1: { mode: "commands-only" },
+                c2: { mode: "all-messages" },
+                c3: { mode: "filtered", filterPatterns: ["alert"] },
+            },
+        });
+        expect(good.valid).toBe(true);
+
+        const bad = validateProviderConfig({
+            token: "abc",
+            channelRouters: {
+                c1: { mode: "invalid" } as unknown as ChannelRouterConfig,
+            },
+        });
+        expect(bad.valid).toBe(false);
+        expect(bad.errors).toContain('channelRouters["c1"] is invalid');
+    });
+
+    test("validates defaultRouter", () => {
+        const good = validateProviderConfig({ token: "abc", defaultRouter: { mode: "commands-only" } });
+        expect(good.valid).toBe(true);
+
+        const bad = validateProviderConfig({
+            token: "abc",
+            defaultRouter: { mode: "all-messages", commandPrefix: "" } as ChannelRouterConfig,
+        });
+        expect(bad.valid).toBe(false);
+        expect(bad.errors).toContain("defaultRouter is invalid");
+    });
+
+    test("validates forwardEvents", () => {
+        const good = validateProviderConfig({ token: "abc", forwardEvents: ["session.start", "build.success"] });
+        expect(good.valid).toBe(true);
+
+        const bad = validateProviderConfig({ token: "abc", forwardEvents: ["session.start", "nope"] });
+        expect(bad.valid).toBe(false);
+        expect(bad.errors).toContain("forwardEvents must be an array of valid SessionEventType values");
+    });
+
+    test("validates options", () => {
+        const good = validateProviderConfig({ token: "abc", options: { foo: "bar" } });
+        expect(good.valid).toBe(true);
+
+        const bad = validateProviderConfig({ token: "abc", options: "nope" });
+        expect(bad.valid).toBe(false);
+        expect(bad.errors).toContain("options must be an object");
+    });
+
+    test("isSessionEventType guards correctly", () => {
+        expect(isSessionEventType("session.start")).toBe(true);
+        expect(isSessionEventType("nope")).toBe(false);
+        expect(isSessionEventType(123)).toBe(false);
+    });
+});
+
+describe("ChannelRouter", () => {
+    test("parses command prefix and extracts name and args", () => {
+        const router = new ChannelRouter();
+        const message = makeMessage({ content: "!help arg1 arg2" });
+        const parsed = router.parseMessage(message, { mode: "commands-only" });
+
+        expect(parsed.isCommand).toBe(true);
+        expect(parsed.command).toEqual({ name: "help", args: ["arg1", "arg2"], raw: "help arg1 arg2" });
+    });
+
+    test("does not treat plain messages as commands", () => {
+        const router = new ChannelRouter();
+        const message = makeMessage({ content: "hello world" });
+        const parsed = router.parseMessage(message, { mode: "commands-only" });
+
+        expect(parsed.isCommand).toBe(false);
+        expect(parsed.command).toBeUndefined();
+    });
+
+    test("uses custom command prefix", () => {
+        const router = new ChannelRouter();
+        const message = makeMessage({ content: "/ping" });
+        const parsed = router.parseMessage(message, { mode: "commands-only", commandPrefix: "/" });
+
+        expect(parsed.isCommand).toBe(true);
+        expect(parsed.command?.name).toBe("ping");
+    });
+
+    test("ignores empty commands", () => {
+        const router = new ChannelRouter();
+        const message = makeMessage({ content: "!" });
+        const parsed = router.parseMessage(message, { mode: "commands-only" });
+
+        expect(parsed.isCommand).toBe(false);
+    });
+
+    test("truncates long messages", () => {
+        const router = new ChannelRouter();
+        const content = "a".repeat(100);
+        const message = makeMessage({ content });
+        const parsed = router.parseMessage(message, { mode: "all-messages", maxMessageLength: 10 });
+
+        expect(parsed.content).toBe("a".repeat(10));
+    });
+
+    test("routes to mapped session", () => {
+        const router = new ChannelRouter();
+        const session: ChannelSession = {
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only" },
+        };
+        router.addSession(session);
+
+        const route = router.route(makeMessage({ content: "!status" }));
+        expect(route).toBeDefined();
+        expect(route!.sessionId).toBe("sess-1");
+        expect(route!.shouldForward).toBe(true);
+    });
+
+    test("does not route unmapped channels", () => {
+        const router = new ChannelRouter();
+        const route = router.route(makeMessage({ channelId: "unknown" }));
+        expect(route).toBeUndefined();
+    });
+
+    test("all-messages mode forwards everything", () => {
+        const router = new ChannelRouter();
+        router.addSession({ channelId: "ch-1", sessionId: "sess-1", config: { mode: "all-messages" } });
+
+        const route = router.route(makeMessage({ content: "hello" }));
+        expect(route!.shouldForward).toBe(true);
+        expect(route!.message.isCommand).toBe(false);
+    });
+
+    test("filtered mode matches patterns", () => {
+        const router = new ChannelRouter();
+        router.addSession({
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "filtered", filterPatterns: ["alert", "warn"] },
+        });
+
+        expect(router.route(makeMessage({ content: "this is an alert" }))!.shouldForward).toBe(true);
+        expect(router.route(makeMessage({ content: "normal chat" }))!.shouldForward).toBe(false);
+    });
+
+    test("finds channels by session id", () => {
+        const router = new ChannelRouter();
+        router.addSession({ channelId: "ch-1", sessionId: "sess-a", config: { mode: "commands-only" } });
+        router.addSession({ channelId: "ch-2", sessionId: "sess-a", config: { mode: "commands-only" } });
+        router.addSession({ channelId: "ch-3", sessionId: "sess-b", config: { mode: "commands-only" } });
+
+        const found = router.findChannelsBySessionId("sess-a");
+        expect(found.map((s) => s.channelId).sort()).toEqual(["ch-1", "ch-2"]);
+    });
+
+    test("removeSession drops the mapping", () => {
+        const router = new ChannelRouter();
+        router.addSession({ channelId: "ch-1", sessionId: "sess-1", config: { mode: "commands-only" } });
+        router.removeSession("ch-1");
+        expect(router.route(makeMessage())).toBeUndefined();
+    });
+});
+
+describe("ProviderRegistry", () => {
+    test("register and get provider", () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, { token: "abc" });
+
+        expect(registry.getProvider("mock")).toBe(provider);
+        expect(registry.getConfig("mock")?.token).toBe("abc");
+    });
+
+    test("throws on duplicate provider id", () => {
+        const registry = new ProviderRegistry();
+        registry.register(new MockProvider("mock"), { token: "abc" });
+        expect(() => registry.register(new MockProvider("mock"), { token: "def" })).toThrow(
+            'ProviderRegistry: duplicate provider id "mock"',
+        );
+    });
+
+    test("connect and disconnect", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, { token: "abc" });
+
+        await registry.connect("mock");
+        expect(provider.isConnected()).toBe(true);
+
+        await registry.disconnect("mock");
+        expect(provider.isConnected()).toBe(false);
+    });
+
+    test("throws when connecting unknown provider", async () => {
+        const registry = new ProviderRegistry();
+        expect(registry.connect("missing")).rejects.toThrow('ProviderRegistry: unknown provider "missing"');
+    });
+
+    test("throws when connecting provider without config", async () => {
+        const registry = new ProviderRegistry();
+        registry.register(new MockProvider("mock"));
+        expect(registry.connect("mock")).rejects.toThrow('ProviderRegistry: no config for provider "mock"');
+    });
+
+    test("records lastError on connect failure", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        provider.failNextConnect = true;
+        registry.register(provider, { token: "abc" });
+
+        await expect(registry.connect("mock")).rejects.toThrow("connect failed");
+        const status = registry.getStatus()[0];
+        expect(status.lastError).toBe("connect failed");
+    });
+
+    test("unregister disconnects and removes provider", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, { token: "abc" });
+        await registry.connect("mock");
+
+        await registry.unregister("mock");
+        expect(registry.getProvider("mock")).toBeUndefined();
+        expect(provider.isConnected()).toBe(false);
+    });
+
+    test("status reflects connected state, metrics, and mapped sessions", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        provider.channels = [{ id: "ch-1", name: "general", type: "text" }];
+        registry.register(provider, { token: "abc" });
+        registry.addChannelSession("mock", {
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only" },
+        });
+
+        let status = registry.getStatus()[0];
+        expect(status.connected).toBe(false);
+        expect(status.sessionsMapped).toBe(1);
+
+        await registry.connect("mock");
+        status = registry.getStatus()[0];
+        expect(status.connected).toBe(true);
+        expect(status.channelCount).toBe(1);
+    });
+
+    test("inbound messages increment messagesIn and route to handlers", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, {
+            token: "abc",
+            channelRouters: { "ch-1": { mode: "commands-only" } },
+        });
+        registry.addChannelSession("mock", {
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only" },
+        });
+
+        const received: Array<{ message: InboundMessage; route: { sessionId: string } }> = [];
+        registry.onRoutedMessage((message, route) => {
+            received.push({ message, route });
+        });
+
+        provider.emit(makeMessage({ content: "!status" }));
+        provider.emit(makeMessage({ content: "not a command" }));
+
+        expect(received).toHaveLength(1);
+        expect(received[0].message.command?.name).toBe("status");
+        expect(received[0].route.sessionId).toBe("sess-1");
+
+        const status = registry.getStatus()[0];
+        expect(status.messagesIn).toBe(2);
+    });
+
+    test("send increments messagesOut", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, { token: "abc" });
+        await registry.connect("mock");
+
+        await registry.send("mock", "ch-1", { content: "hi" });
+        expect(provider.lastSent?.channelId).toBe("ch-1");
+        expect(registry.getStatus()[0].messagesOut).toBe(1);
+    });
+
+    test("allowedChannels filters inbound messages", () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, {
+            token: "abc",
+            allowedChannels: ["ch-1"],
+            channelRouters: { "ch-1": { mode: "all-messages" }, "ch-2": { mode: "all-messages" } },
+        });
+        registry.addChannelSession("mock", { channelId: "ch-1", sessionId: "s1", config: { mode: "all-messages" } });
+        registry.addChannelSession("mock", { channelId: "ch-2", sessionId: "s2", config: { mode: "all-messages" } });
+
+        const received: InboundMessage[] = [];
+        registry.onRoutedMessage((message) => {
+            received.push(message);
+        });
+
+        provider.emit(makeMessage({ channelId: "ch-1", content: "hello" }));
+        provider.emit(makeMessage({ channelId: "ch-2", content: "hello" }));
+
+        expect(received).toHaveLength(1);
+        expect(received[0].channelId).toBe("ch-1");
+    });
+
+    test("connectAll connects all configured providers", async () => {
+        const registry = new ProviderRegistry();
+        const a = new MockProvider("a");
+        const b = new MockProvider("b");
+        registry.register(a, { token: "a" });
+        registry.register(b); // no config
+
+        await registry.connectAll();
+        expect(a.isConnected()).toBe(true);
+        expect(b.isConnected()).toBe(false);
+    });
+});
+
+describe("EventForwarder", () => {
+    test("formats session events with default templates", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, { token: "abc", forwardEvents: ["session.start"] });
+        await registry.connect("mock");
+        registry.addChannelSession("mock", {
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only" },
+        });
+
+        const forwarder = new EventForwarder(registry);
+        await forwarder.forward({ type: "session.start", sessionId: "sess-1" });
+
+        expect(provider.lastSent?.channelId).toBe("ch-1");
+        expect(provider.lastSent?.message.content).toBe("Session sess-1 started");
+    });
+
+    test("renders custom templates and payload placeholders", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, {
+            token: "abc",
+            forwardEvents: ["build.failure"],
+        });
+        await registry.connect("mock");
+        registry.addChannelSession("mock", {
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only" },
+        });
+
+        const forwarder = new EventForwarder(registry, {
+            "build.failure": "🔥 {{sessionId}}: {{message}}",
+        });
+        await forwarder.forward({
+            type: "build.failure",
+            sessionId: "sess-1",
+            payload: { message: "tests failed" },
+        });
+
+        expect(provider.lastSent?.message.content).toBe("🔥 sess-1: tests failed");
+    });
+
+    test("does not forward to providers not subscribed to event", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, { token: "abc", forwardEvents: ["session.complete"] });
+        await registry.connect("mock");
+        registry.addChannelSession("mock", {
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only" },
+        });
+
+        const forwarder = new EventForwarder(registry);
+        await forwarder.forward({ type: "session.start", sessionId: "sess-1" });
+
+        expect(provider.lastSent).toBeUndefined();
+    });
+
+    test("does not forward to disconnected providers", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, { token: "abc", forwardEvents: ["session.start"] });
+        registry.addChannelSession("mock", {
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only" },
+        });
+        // intentionally not connected
+
+        const forwarder = new EventForwarder(registry);
+        await forwarder.forward({ type: "session.start", sessionId: "sess-1" });
+
+        expect(provider.lastSent).toBeUndefined();
+    });
+
+    test("does not forward when no channel is mapped to the session", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, { token: "abc", forwardEvents: ["session.start"] });
+        await registry.connect("mock");
+        // no channel mapping
+
+        const forwarder = new EventForwarder(registry);
+        await forwarder.forward({ type: "session.start", sessionId: "sess-1" });
+
+        expect(provider.lastSent).toBeUndefined();
+    });
+
+    test("forwards to multiple channels mapped to the same session", async () => {
+        const registry = new ProviderRegistry();
+        const provider = new MockProvider("mock");
+        registry.register(provider, { token: "abc", forwardEvents: ["session.start"] });
+        await registry.connect("mock");
+        registry.addChannelSession("mock", {
+            channelId: "ch-1",
+            sessionId: "sess-1",
+            config: { mode: "commands-only" },
+        });
+        registry.addChannelSession("mock", {
+            channelId: "ch-2",
+            sessionId: "sess-1",
+            config: { mode: "commands-only" },
+        });
+
+        const forwarder = new EventForwarder(registry);
+        await forwarder.forward({ type: "session.start", sessionId: "sess-1" });
+
+        expect(provider.lastSent?.channelId).toBe("ch-2");
+    });
+
+    test("setTemplate updates a single template", () => {
+        const registry = new ProviderRegistry();
+        const forwarder = new EventForwarder(registry);
+        forwarder.setTemplate("review.lgtm", "✅ {{sessionId}}");
+        expect(forwarder.getTemplates()["review.lgtm"]).toBe("✅ {{sessionId}}");
+    });
+});

--- a/packages/cli/src/runner/services/message-provider/types.ts
+++ b/packages/cli/src/runner/services/message-provider/types.ts
@@ -44,6 +44,8 @@ export interface InboundMessage {
     timestamp: number;
     /** Whether this message contains a command prefix */
     isCommand: boolean;
+    /** Whether this message is a bot mention (e.g. @PizzaBot) */
+    mentionedBot?: boolean;
     /** Parsed command (if isCommand) */
     command?: ParsedCommand;
     /** Raw provider-specific data */
@@ -93,8 +95,8 @@ export interface ChannelSession {
 export interface ChannelRouterConfig {
     /** Command prefix to recognize (default "!") */
     commandPrefix?: string;
-    /** Whether to forward all messages or only commands */
-    mode: "commands-only" | "all-messages" | "filtered";
+    /** Mode for deciding which messages to forward */
+    mode: "commands-only" | "all-messages" | "filtered" | "mentions";
     /** Patterns for filtered mode */
     filterPatterns?: string[];
     /** Maximum message length (truncate longer) */
@@ -224,7 +226,7 @@ function isValidChannelRouterConfig(config: unknown): config is ChannelRouterCon
     }
     const c = config as Partial<ChannelRouterConfig>;
 
-    const validModes: ChannelRouterConfig["mode"][] = ["commands-only", "all-messages", "filtered"];
+    const validModes: ChannelRouterConfig["mode"][] = ["commands-only", "all-messages", "filtered", "mentions"];
     if (!validModes.includes(c.mode as ChannelRouterConfig["mode"])) {
         return false;
     }

--- a/packages/cli/src/runner/services/message-provider/types.ts
+++ b/packages/cli/src/runner/services/message-provider/types.ts
@@ -1,0 +1,237 @@
+export interface MessageProvider {
+    /** Unique provider identifier (e.g., "discord", "slack") */
+    readonly id: string;
+
+    /** Human-readable display name */
+    readonly label: string;
+
+    /** Connect the provider and start receiving messages */
+    connect(config: ProviderConfig): Promise<void>;
+
+    /** Disconnect and clean up resources */
+    disconnect(): Promise<void>;
+
+    /** Whether the provider is currently connected */
+    isConnected(): boolean;
+
+    /** Send a message to a specific channel */
+    send(channelId: string, message: OutboundMessage): Promise<void>;
+
+    /** List available channels */
+    listChannels(): Promise<Channel[]>;
+
+    /** Register a handler for inbound messages */
+    onMessage(handler: InboundMessageHandler): void;
+
+    /** Remove the inbound message handler */
+    offMessage(handler: InboundMessageHandler): void;
+}
+
+export type InboundMessageHandler = (message: InboundMessage) => void | Promise<void>;
+
+export interface InboundMessage {
+    /** Unique message ID from the platform */
+    id: string;
+    /** Channel/conversation the message was sent in */
+    channelId: string;
+    /** Channel display name */
+    channelName: string;
+    /** User/author who sent the message */
+    author: MessageAuthor;
+    /** Message content (plain text) */
+    content: string;
+    /** Timestamp (Unix ms) */
+    timestamp: number;
+    /** Whether this message contains a command prefix */
+    isCommand: boolean;
+    /** Parsed command (if isCommand) */
+    command?: ParsedCommand;
+    /** Raw provider-specific data */
+    raw: unknown;
+    /** Thread/reply context (if in a thread) */
+    threadId?: string;
+    /** Reply-to message ID */
+    replyToId?: string;
+}
+
+export interface MessageAuthor {
+    id: string;
+    username: string;
+    displayName: string;
+}
+
+export interface ParsedCommand {
+    name: string;
+    args: string[];
+    raw: string;
+}
+
+export interface OutboundMessage {
+    /** Text content */
+    content: string;
+    /** Optional target thread to reply in */
+    threadId?: string;
+    /** Optional message to reply to */
+    replyToId?: string;
+}
+
+export interface Channel {
+    id: string;
+    name: string;
+    type: "text" | "voice" | "category" | "thread" | "dm";
+}
+
+export interface ChannelSession {
+    /** Platform channel ID */
+    channelId: string;
+    /** Mapped PizzaPi session ID */
+    sessionId: string;
+    /** Router config for this mapping */
+    config: ChannelRouterConfig;
+}
+
+export interface ChannelRouterConfig {
+    /** Command prefix to recognize (default "!") */
+    commandPrefix?: string;
+    /** Whether to forward all messages or only commands */
+    mode: "commands-only" | "all-messages" | "filtered";
+    /** Patterns for filtered mode */
+    filterPatterns?: string[];
+    /** Maximum message length (truncate longer) */
+    maxMessageLength?: number;
+}
+
+export interface ProviderConfig {
+    /** Platform-specific token/bot token */
+    token: string;
+    /** Allowed channel IDs (empty = all) */
+    allowedChannels?: string[];
+    /** Router config per channel (channelId → config) */
+    channelRouters?: Record<string, ChannelRouterConfig>;
+    /** Default router config for unmapped channels */
+    defaultRouter?: ChannelRouterConfig;
+    /** Events to forward from sessions to this channel */
+    forwardEvents?: SessionEventType[];
+    /** Platform-specific options */
+    options?: Record<string, unknown>;
+}
+
+export type SessionEventType =
+    | "session.start"
+    | "session.complete"
+    | "session.error"
+    | "session.turn_end"
+    | "build.success"
+    | "build.failure"
+    | "review.lgtm"
+    | "review.failed";
+
+export interface ProviderStatus {
+    id: string;
+    label: string;
+    connected: boolean;
+    channelCount: number;
+    sessionsMapped: number;
+    messagesIn: number;
+    messagesOut: number;
+    lastError?: string;
+}
+
+const SESSION_EVENT_TYPES: SessionEventType[] = [
+    "session.start",
+    "session.complete",
+    "session.error",
+    "session.turn_end",
+    "build.success",
+    "build.failure",
+    "review.lgtm",
+    "review.failed",
+];
+
+export function isSessionEventType(value: unknown): value is SessionEventType {
+    return typeof value === "string" && SESSION_EVENT_TYPES.includes(value as SessionEventType);
+}
+
+export interface ConfigValidationResult {
+    valid: boolean;
+    errors: string[];
+}
+
+/**
+ * Validate a ProviderConfig-shaped object.
+ *
+ * Returns a list of human-readable errors without throwing.
+ */
+export function validateProviderConfig(config: unknown): ConfigValidationResult {
+    const errors: string[] = [];
+
+    if (config === null || typeof config !== "object") {
+        return { valid: false, errors: ["ProviderConfig must be an object"] };
+    }
+
+    const c = config as Partial<ProviderConfig>;
+
+    if (typeof c.token !== "string" || c.token.length === 0) {
+        errors.push("token must be a non-empty string");
+    }
+
+    if (c.allowedChannels !== undefined) {
+        if (!Array.isArray(c.allowedChannels) || !c.allowedChannels.every((id) => typeof id === "string")) {
+            errors.push("allowedChannels must be an array of strings");
+        }
+    }
+
+    if (c.channelRouters !== undefined) {
+        if (typeof c.channelRouters !== "object" || c.channelRouters === null) {
+            errors.push("channelRouters must be an object");
+        } else {
+            for (const [channelId, router] of Object.entries(c.channelRouters)) {
+                if (!isValidChannelRouterConfig(router)) {
+                    errors.push(`channelRouters["${channelId}"] is invalid`);
+                }
+            }
+        }
+    }
+
+    if (c.defaultRouter !== undefined && !isValidChannelRouterConfig(c.defaultRouter)) {
+        errors.push("defaultRouter is invalid");
+    }
+
+    if (c.forwardEvents !== undefined) {
+        if (!Array.isArray(c.forwardEvents) || !c.forwardEvents.every(isSessionEventType)) {
+            errors.push("forwardEvents must be an array of valid SessionEventType values");
+        }
+    }
+
+    if (c.options !== undefined && (typeof c.options !== "object" || c.options === null)) {
+        errors.push("options must be an object");
+    }
+
+    return { valid: errors.length === 0, errors };
+}
+
+function isValidChannelRouterConfig(config: unknown): config is ChannelRouterConfig {
+    if (config === null || typeof config !== "object") {
+        return false;
+    }
+    const c = config as Partial<ChannelRouterConfig>;
+
+    const validModes: ChannelRouterConfig["mode"][] = ["commands-only", "all-messages", "filtered"];
+    if (!validModes.includes(c.mode as ChannelRouterConfig["mode"])) {
+        return false;
+    }
+
+    if (c.commandPrefix !== undefined && (typeof c.commandPrefix !== "string" || c.commandPrefix.length === 0)) {
+        return false;
+    }
+
+    if (c.filterPatterns !== undefined && (!Array.isArray(c.filterPatterns) || !c.filterPatterns.every((p) => typeof p === "string"))) {
+        return false;
+    }
+
+    if (c.maxMessageLength !== undefined && (typeof c.maxMessageLength !== "number" || c.maxMessageLength <= 0)) {
+        return false;
+    }
+
+    return true;
+}

--- a/packages/cli/src/runner/services/message-provider/types.ts
+++ b/packages/cli/src/runner/services/message-provider/types.ts
@@ -99,6 +99,8 @@ export interface ChannelRouterConfig {
     filterPatterns?: string[];
     /** Maximum message length (truncate longer) */
     maxMessageLength?: number;
+    /** Authorization policy for this channel */
+    canExecute?: CanExecutePolicy;
 }
 
 export interface ProviderConfig {
@@ -114,6 +116,8 @@ export interface ProviderConfig {
     forwardEvents?: SessionEventType[];
     /** Platform-specific options */
     options?: Record<string, unknown>;
+    /** Default authorization policy for all channels */
+    defaultCanExecute?: CanExecutePolicy;
 }
 
 export type SessionEventType =
@@ -207,6 +211,10 @@ export function validateProviderConfig(config: unknown): ConfigValidationResult 
         errors.push("options must be an object");
     }
 
+    if (c.defaultCanExecute !== undefined && typeof c.defaultCanExecute !== "function") {
+        errors.push("defaultCanExecute must be a function");
+    }
+
     return { valid: errors.length === 0, errors };
 }
 
@@ -233,5 +241,22 @@ function isValidChannelRouterConfig(config: unknown): config is ChannelRouterCon
         return false;
     }
 
+    if (c.canExecute !== undefined && typeof c.canExecute !== "function") {
+        return false;
+    }
+
     return true;
 }
+
+export interface CanExecuteResult {
+    /** Whether the message is authorized */
+    allowed: boolean;
+    /** Human-readable reason when denied */
+    reason?: string;
+}
+
+/**
+ * Authorization policy. Called before every inbound trigger fires.
+ * Receives the full InboundMessage including provider-specific `raw` data.
+ */
+export type CanExecutePolicy = (message: InboundMessage) => Promise<CanExecuteResult> | CanExecuteResult;


### PR DESCRIPTION
## Discord Connector: Generic External Message Provider

Adds a generic `MessageProvider` abstraction with a Discord bot as the first implementation, enabling two-way communication between Discord and PizzaPi sessions.

### What's included

**Generic abstraction** (`packages/cli/src/runner/services/message-provider/`)
- `MessageProvider` interface — connect, disconnect, send, onMessage, channel management
- `ProviderRegistry` — multi-provider lifecycle, metrics, routing
- `ChannelRouter` — channel→session mapping, command parsing, `mentions` mode
- `EventForwarder` — session events → platform messages
- `CanExecutePolicy` — authorization gate checked before every inbound trigger

**Discord implementation**
- `DiscordProvider` (discord.js) — bot token auth, message conversion, thread and mention support
- `discordRoleAllowed()` factory — role-**ID**-based authorization (role names not matched — IDs are stable & canonical)
- `MessageBridgeService` runner service — wires providers to relay triggers, panel API
- Web UI panel showing provider status, channels, and config validation

### Configuration

`~/.pizzapi/config.json`:
```json
{
  "providers": {
    "message-bridge": {
      "enabled": true,
      "discord": {
        "token": "YOUR_BOT_TOKEN",
        "allowedRoles": ["ROLE_ID_1", "ROLE_ID_2"],
        "allowedChannels": ["channel-id-1"],
        "defaultRouter": { "mode": "mentions" },
        "forwardEvents": ["session.start", "session.complete", "session.error"]
      }
    }
  }
}
```

Note: `allowedRoles` matches **role IDs only** — role display names are not matched (mutable, spoofable, non-canonical across guilds).

### Modes

- `commands-only` — messages starting with a prefix (default `!`)
- `mentions` — messages that `@mention` the bot (mention prefix stripped, remaining text parsed as command)
- `all-messages` — every message forwarded
- `filtered` — message content must match one of the provided patterns

### Quality gates
- `bun run typecheck` ✅
- `bun run build` ✅
- `bun test packages/cli/src/runner/services/message-provider/` ✅ (97 tests)
- `bun test packages/cli/src` ✅ (2085 tests)
- `bun run test` ✅