### PR TITLE
Add Update & Reload button to version banner

### DIFF
--- a/packages/ui/src/components/VersionBanner.tsx
+++ b/packages/ui/src/components/VersionBanner.tsx
@@ -1,6 +1,22 @@
 import * as React from "react";
 import { X } from "lucide-react";
 
+/**
+ * Clear all Cache Storage entries and any active service worker,
+ * then do a hard reload so fresh assets are fetched from the network.
+ */
+async function clearCacheAndReload() {
+    if ("caches" in window) {
+        for (const name of await caches.keys()) await caches.delete(name);
+    }
+    if ("serviceWorker" in navigator) {
+        for (const reg of await navigator.serviceWorker.getRegistrations()) {
+            await reg.unregister();
+        }
+    }
+    location.reload();
+}
+
 export function VersionBanner({
     message,
     protocolCompatible,
@@ -16,6 +32,7 @@ export function VersionBanner({
 
     if (!message || dismissed) return null;
 
+    const isUpdate = message.toLowerCase().includes("newer") || message.toLowerCase().includes("deployed");
     const toneClasses = protocolCompatible
         ? "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20"
         : "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20";
@@ -25,17 +42,28 @@ export function VersionBanner({
             role="alert"
             className={`flex items-center justify-between gap-3 px-4 py-2 text-sm border-b ${toneClasses}`}
         >
-            <span>
+            <span className="flex items-center gap-2">
                 <span aria-hidden="true">⚠️</span> {message}
             </span>
-            <button
-                type="button"
-                aria-label="Dismiss"
-                onClick={() => setDismissed(true)}
-                className="shrink-0 rounded p-0.5 hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
-            >
-                <X className="size-4" />
-            </button>
+            <div className="flex items-center gap-1 shrink-0">
+                {isUpdate && (
+                    <button
+                        type="button"
+                        onClick={clearCacheAndReload}
+                        className="rounded px-2 py-1 font-medium hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+                    >
+                        Update &amp; Reload
+                    </button>
+                )}
+                <button
+                    type="button"
+                    aria-label="Dismiss"
+                    onClick={() => setDismissed(true)}
+                    className="rounded p-0.5 hover:bg-black/10 dark:hover:bg-white/10 transition-colors"
+                >
+                    <X className="size-4" />
+                </button>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary

When a new deploy is detected, the VersionBanner now offers an **"Update & Reload"** button that:

1. Clears all Cache Storage entries (Workbox precache + runtime caches)
2. Unregisters the active service worker
3. Hard reloads the page

This ensures fresh assets are fetched from the network instead of being served from stale Workbox cache.

## What changed

- `packages/ui/src/components/VersionBanner.tsx`
  - Added `clearCacheAndReload()` helper
  - Button appears only on update/deploy banners (not on protocol mismatch)
  - Layout uses flex for button + dismiss alignment

## Skipped

- Passing a `kind` field through `VersionNegotiationResult` — the `message` string is sufficient to distinguish the two cases today. Add it when a third banner type is introduced.