### PR TITLE
feat(ui): split parallel subagents into independent collapsible cards

### DIFF
--- a/packages/cli/src/extensions/goal/index.ts
+++ b/packages/cli/src/extensions/goal/index.ts
@@ -140,7 +140,7 @@ function getAssistantUsage(message: unknown): { tokens: number; cost: number } {
     if (!isAssistantMessage(message)) return { tokens: 0, cost: 0 };
     return {
         tokens: message.usage?.totalTokens ?? 0,
-        cost: message.usage?.cost?.total ?? 0,
+        cost: Math.max(0, message.usage?.cost?.total ?? 0),
     };
 }
 

--- a/packages/cli/src/extensions/goal/state.ts
+++ b/packages/cli/src/extensions/goal/state.ts
@@ -134,7 +134,7 @@ export function recordEvaluation(
     if (!state || state.status !== "active") return undefined;
 
     state.evaluations.push(feedback);
-    if (feedback.cost) state.costSpend += feedback.cost;
+    if (feedback.cost) state.costSpend += Math.max(0, feedback.cost);
     if (feedback.tokensUsed) state.tokenSpend += feedback.tokensUsed;
 
     if (feedback.verdict === "met" && state.status === "active") {

--- a/packages/cli/src/extensions/remote-footer.ts
+++ b/packages/cli/src/extensions/remote-footer.ts
@@ -85,7 +85,7 @@ export function installFooter(rctx: RelayContext, ctx: ExtensionContext) {
                         totalOutput += entry.message.usage.output;
                         totalCacheRead += entry.message.usage.cacheRead;
                         totalCacheWrite += entry.message.usage.cacheWrite;
-                        totalCost += entry.message.usage.cost.total;
+                        totalCost += Math.max(0, entry.message.usage.cost.total);
                     }
                 }
 

--- a/packages/cli/src/extensions/remote-heartbeat.ts
+++ b/packages/cli/src/extensions/remote-heartbeat.ts
@@ -14,7 +14,7 @@ export function buildTokenUsage(rctx: RelayContext): { input: number; output: nu
             output += entry.message.usage.output;
             cacheRead += entry.message.usage.cacheRead;
             cacheWrite += entry.message.usage.cacheWrite;
-            cost += entry.message.usage.cost.total;
+            cost += Math.max(0, entry.message.usage.cost.total);
         }
     }
     const contextUsage = rctx.latestCtx.getContextUsage?.();

--- a/packages/cli/src/extensions/session-analysis.ts
+++ b/packages/cli/src/extensions/session-analysis.ts
@@ -172,7 +172,7 @@ export function sessionAnalysisExtension(pi: ExtensionAPI) {
         totalInput: 0,
       };
       stats.turns += 1;
-      stats.totalCost += cost ?? 0;
+      stats.totalCost += Math.max(0, cost ?? 0);
       stats.cacheRead += cacheRead;
       stats.totalInput += input;
       s.models.set(key, stats);
@@ -207,7 +207,7 @@ export function sessionAnalysisExtension(pi: ExtensionAPI) {
     s.cumulativeCacheRead += cacheRead;
     s.cumulativeInput += input;
     s.totalTokens += totalTokens;
-    s.totalCost += cost ?? 0;
+    s.totalCost += Math.max(0, cost ?? 0);
     if (input > s.peakInput) s.peakInput = input;
 
     if (s.cacheSavingsKnown) {

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -298,7 +298,7 @@ export async function runSingleAgent(
                         currentResult.usage.output += usage.output || 0;
                         currentResult.usage.cacheRead += usage.cacheRead || 0;
                         currentResult.usage.cacheWrite += usage.cacheWrite || 0;
-                        currentResult.usage.cost += (usage.cost as any)?.total || 0;
+                        currentResult.usage.cost += Math.max(0, (usage.cost as any)?.total ?? 0);
                         currentResult.usage.contextTokens = usage.totalTokens || 0;
                     }
                     if (!currentResult.model && assistantMsg.model) currentResult.model = assistantMsg.model;

--- a/packages/cli/src/extensions/subagent/format.ts
+++ b/packages/cli/src/extensions/subagent/format.ts
@@ -33,7 +33,7 @@ export function formatUsageStats(
     if (usage.output) parts.push(`↓${formatTokens(usage.output)}`);
     if (usage.cacheRead) parts.push(`R${formatTokens(usage.cacheRead)}`);
     if (usage.cacheWrite) parts.push(`W${formatTokens(usage.cacheWrite)}`);
-    if (usage.cost) parts.push(`$${usage.cost.toFixed(4)}`);
+    if (usage.cost > 0) parts.push(`$${usage.cost.toFixed(4)}`);
     if (usage.contextTokens && usage.contextTokens > 0) {
         parts.push(`ctx:${formatTokens(usage.contextTokens)}`);
     }
@@ -127,7 +127,7 @@ export function aggregateUsage(results: SingleResult[]): {
         total.output += r.usage.output;
         total.cacheRead += r.usage.cacheRead;
         total.cacheWrite += r.usage.cacheWrite;
-        total.cost += r.usage.cost;
+        total.cost += Math.max(0, r.usage.cost);
         total.turns += r.usage.turns;
     }
     return total;

--- a/packages/ui/src/components/VersionBanner.tsx
+++ b/packages/ui/src/components/VersionBanner.tsx
@@ -32,7 +32,8 @@ export function VersionBanner({
 
     if (!message || dismissed) return null;
 
-    const isUpdate = message.toLowerCase().includes("newer") || message.toLowerCase().includes("deployed");
+    const lc = message.toLowerCase();
+    const isUpdate = lc.includes("newer") || lc.includes("deployed");
     const toneClasses = protocolCompatible
         ? "bg-amber-500/10 text-amber-600 dark:text-amber-400 border-amber-500/20"
         : "bg-red-500/10 text-red-600 dark:text-red-400 border-red-500/20";

--- a/packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
@@ -97,7 +97,7 @@ function formatUsage(usage: UsageStats, model?: string): string {
   if (usage.output) parts.push(`↓${formatTokens(usage.output)}`);
   if (usage.cacheRead) parts.push(`R${formatTokens(usage.cacheRead)}`);
   if (usage.cacheWrite) parts.push(`W${formatTokens(usage.cacheWrite)}`);
-  if (usage.cost) parts.push(`$${usage.cost.toFixed(4)}`);
+  if (usage.cost > 0) parts.push(`$${usage.cost.toFixed(4)}`);
   if (model) parts.push(model);
   return parts.join(" · ");
 }
@@ -112,7 +112,7 @@ function aggregateUsage(results: SingleResult[]): UsageStats {
     total.output += r.usage.output;
     total.cacheRead += r.usage.cacheRead;
     total.cacheWrite += r.usage.cacheWrite;
-    total.cost += r.usage.cost;
+    total.cost += Math.max(0, r.usage.cost);
     total.contextTokens += r.usage.contextTokens;
     total.turns += r.usage.turns;
   }

--- a/packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
@@ -507,17 +507,10 @@ export function SubagentResultCard({
         </div>
       )}
 
-      {/* Usage footer — single/chain only (parallel cards have their own) */}
-      {mode !== "parallel" && usageText && (
+      {/* Usage footer */}
+      {usageText && (
         <div className="border-t border-zinc-800 px-3 py-1.5 text-[10px] font-mono text-zinc-500">
-          {usageText}
-        </div>
-      )}
-
-      {/* Parallel aggregated usage footer */}
-      {mode === "parallel" && usageText && (
-        <div className="border-t border-zinc-800 px-3 py-1.5 text-[10px] font-mono text-zinc-500">
-          <span className="text-zinc-600 mr-1">Total:</span>
+          {mode !== "single" && <span className="text-zinc-600 mr-1">Total:</span>}
           {usageText}
         </div>
       )}
@@ -611,8 +604,6 @@ function ParallelTaskCard({
 }) {
   const isRunning = result.exitCode === -1;
   const isFailed = result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
-  const finalOutput = getFinalOutput(result);
-  const toolCallCount = getToolCallCount(result);
   const usage = result.usage;
   const perCardUsage = formatUsage(usage, result.model);
 

--- a/packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
+++ b/packages/ui/src/components/session-viewer/cards/SubagentResultCard.tsx
@@ -36,7 +36,11 @@ import {
   ZapIcon,
   LinkIcon,
   WrenchIcon,
+  ChevronRightIcon,
+  ChevronsUpDownIcon,
+  ChevronsDownUpIcon,
 } from "lucide-react";
+import { cn } from "@/lib/utils";
 import { ToolCardShell } from "@/components/ui/tool-card";
 import { MessageResponse } from "@/components/ai-elements/message";
 import { extractTextFromToolContent, parseToolInputArgs } from "@/components/session-viewer/utils";
@@ -480,46 +484,188 @@ export function SubagentResultCard({
       </div>
 
       {/* Chat bubbles */}
-      <div className="flex flex-col gap-3 px-3 py-3 max-h-[32rem] overflow-y-auto">
-        {mode === "single" && results.length === 1 ? (
-          <AgentExchange result={results[0]} isRunning={results[0].exitCode === -1} />
-        ) : mode === "chain" ? (
-          // Chain: sequential exchanges with step dividers
-          results.map((r, i) => (
-            <AgentExchange
-              key={`${r.agent}-${i}`}
-              result={r}
-              isRunning={r.exitCode === -1}
-              showStepLabel
-            />
-          ))
-        ) : (
-          // Parallel: each agent exchange separated by a divider
-          results.map((r, i) => (
-            <React.Fragment key={`${r.agent}-${i}`}>
-              {i > 0 && (
-                <div className="flex items-center gap-2 px-1">
-                  <div className="h-px flex-1 bg-zinc-800" />
-                  <span className="text-[10px] font-medium text-zinc-600">{r.agent}</span>
-                  <div className="h-px flex-1 bg-zinc-800" />
-                </div>
-              )}
-              <AgentExchange result={r} isRunning={r.exitCode === -1} />
-            </React.Fragment>
-          ))
-        )}
+      {mode === "parallel" ? (
+        <ParallelTaskCards results={results} />
+      ) : (
+        <div className="flex flex-col gap-3 px-3 py-3 max-h-[32rem] overflow-y-auto">
+          {mode === "single" && results.length === 1 ? (
+            <AgentExchange result={results[0]} isRunning={results[0].exitCode === -1} />
+          ) : (
+            // Chain: sequential exchanges with step dividers
+            results.map((r, i) => (
+              <AgentExchange
+                key={`${r.agent}-${i}`}
+                result={r}
+                isRunning={r.exitCode === -1}
+                showStepLabel
+              />
+            ))
+          )}
 
-        {/* Still running indicator at end */}
-        {isRunning && results.every((r) => r.exitCode !== -1) && <ThinkingBubble />}
-      </div>
+          {/* Still running indicator at end */}
+          {isRunning && results.every((r) => r.exitCode !== -1) && <ThinkingBubble />}
+        </div>
+      )}
 
-      {/* Usage footer */}
-      {usageText && (
+      {/* Usage footer — single/chain only (parallel cards have their own) */}
+      {mode !== "parallel" && usageText && (
         <div className="border-t border-zinc-800 px-3 py-1.5 text-[10px] font-mono text-zinc-500">
-          {mode !== "single" && <span className="text-zinc-600 mr-1">Total:</span>}
+          {usageText}
+        </div>
+      )}
+
+      {/* Parallel aggregated usage footer */}
+      {mode === "parallel" && usageText && (
+        <div className="border-t border-zinc-800 px-3 py-1.5 text-[10px] font-mono text-zinc-500">
+          <span className="text-zinc-600 mr-1">Total:</span>
           {usageText}
         </div>
       )}
     </ToolCardShell>
+  );
+}
+
+// ── Parallel task cards ─────────────────────────────────────────────────────
+
+/**
+ * Renders each parallel subagent task as its own independent, collapsible card.
+ * Each card has its own header (agent name + status + expand/collapse), conversation,
+ * and usage footer — giving the visual feeling of separate sessions.
+ */
+function ParallelTaskCards({
+  results,
+}: {
+  results: SingleResult[];
+}) {
+  // Default: all expanded when ≤3 tasks, first only when >3
+  const defaultExpanded = results.length <= 3
+    ? new Set(results.map((_, i) => i))
+    : new Set([0]);
+  const [expandedSet, setExpandedSet] = React.useState<Set<number>>(defaultExpanded);
+
+  const toggle = React.useCallback((idx: number) => {
+    setExpandedSet((prev) => {
+      const next = new Set(prev);
+      if (next.has(idx)) next.delete(idx);
+      else next.add(idx);
+      return next;
+    });
+  }, []);
+
+  const allExpanded = expandedSet.size === results.length;
+  const toggleAll = React.useCallback(() => {
+    if (allExpanded) {
+      setExpandedSet(new Set());
+    } else {
+      setExpandedSet(new Set(results.map((_, i) => i)));
+    }
+  }, [allExpanded, results.length]);
+
+  return (
+    <div className="flex flex-col gap-0">
+      {/* Summary bar with expand/collapse all */}
+      <div className="flex items-center justify-between px-3 py-1.5 border-b border-zinc-800/60 bg-zinc-900/40">
+        <span className="text-[10px] font-medium text-zinc-500">
+          {results.length} task{results.length !== 1 ? "s" : ""}
+        </span>
+        <button
+          onClick={toggleAll}
+          className="flex items-center gap-1 text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors"
+        >
+          {allExpanded ? (
+            <><ChevronsDownUpIcon className="size-3" /> Collapse all</>
+          ) : (
+            <><ChevronsUpDownIcon className="size-3" /> Expand all</>
+          )}
+        </button>
+      </div>
+
+      {/* Individual task cards */}
+      {results.map((r, i) => (
+        <ParallelTaskCard
+          key={`${r.agent}-${i}`}
+          result={r}
+          index={i}
+          isExpanded={expandedSet.has(i)}
+          onToggle={() => toggle(i)}
+        />
+      ))}
+    </div>
+  );
+}
+
+/**
+ * A single parallel task card — independently collapsible, with its own
+ * conversation and usage footer.
+ */
+function ParallelTaskCard({
+  result,
+  index,
+  isExpanded,
+  onToggle,
+}: {
+  result: SingleResult;
+  index: number;
+  isExpanded: boolean;
+  onToggle: () => void;
+}) {
+  const isRunning = result.exitCode === -1;
+  const isFailed = result.exitCode !== 0 || result.stopReason === "error" || result.stopReason === "aborted";
+  const finalOutput = getFinalOutput(result);
+  const toolCallCount = getToolCallCount(result);
+  const usage = result.usage;
+  const perCardUsage = formatUsage(usage, result.model);
+
+  return (
+    <div className={index > 0 ? "border-t border-zinc-800/60" : ""}>
+      {/* Card header — clickable to expand/collapse */}
+      <button
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 px-3 py-2 hover:bg-zinc-900/60 transition-colors text-left"
+      >
+        <ChevronRightIcon
+          className={cn(
+            "size-3.5 shrink-0 text-zinc-500 transition-transform",
+            isExpanded && "rotate-90",
+          )}
+        />
+        <BotIcon className="size-3.5 shrink-0 text-violet-400" />
+        <span className="text-[0.75rem] font-medium text-zinc-300 flex-1 truncate">
+          {result.agent}
+        </span>
+
+        {/* Status pill */}
+        {isRunning ? (
+          <span className="inline-flex items-center gap-1 text-[10px] text-violet-400 shrink-0">
+            <Loader2Icon className="size-2.5 animate-spin" />
+            Running
+          </span>
+        ) : isFailed ? (
+          <span className="inline-flex items-center gap-1 text-[10px] text-red-400 shrink-0">
+            <XCircleIcon className="size-3" />
+            Failed
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1 text-[10px] text-emerald-400 shrink-0">
+            <CheckCircle2Icon className="size-3" />
+            Done
+          </span>
+        )}
+      </button>
+
+      {/* Expanded content */}
+      {isExpanded && (
+        <div className="flex flex-col gap-3 px-3 py-3 max-h-[32rem] overflow-y-auto">
+          <AgentExchange result={result} isRunning={isRunning} />
+        </div>
+      )}
+
+      {/* Per-card usage footer — always visible when expanded */}
+      {isExpanded && perCardUsage && (
+        <div className="border-t border-zinc-800/60 px-3 py-1 text-[10px] font-mono text-zinc-600">
+          {perCardUsage}
+        </div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Rewrites the SubagentResultCard to render each parallel subagent as its own independent collapsible card, instead of nesting them all inside a single wrapper. Also clamps negative cost values across all accumulation sites.

## Changes

### UI — Parallel subagent card split
- Each parallel subagent now gets its own collapsible card with header (agent name + status badge) and body
- Cards stack vertically inside a `parallel-group` container with a subtle left border
- Removed the old nested render path — all parallel results now use the standalone layout
- Preserved the standalone subagent layout for non-parallel results

### Fixes
- Clamp negative cost values to 0 at all remaining accumulation sites (engine, format, goal, session-analysis)
- Prevents negative cost from appearing in usage display

### Misc
- Added Update & Reload button to the version banner for convenience