### PR TITLE
fix: allow cached Ollama Cloud model selection

### DIFF
--- a/packages/cli/src/__tests__/ollama-cloud-models.test.ts
+++ b/packages/cli/src/__tests__/ollama-cloud-models.test.ts
@@ -6,6 +6,7 @@ import {
     fetchOllamaCloudModels,
     extractContextLength,
     capabilitiesInclude,
+    getCachedOllamaCloudModels,
 } from "../ollama-cloud-models.js";
 
 const originalHome = process.env.HOME;
@@ -36,6 +37,17 @@ describe("ollama-cloud dynamic model discovery", () => {
     test("capabilitiesInclude is case-insensitive", () => {
         expect(capabilitiesInclude(["Thinking", "completion"], "thinking")).toBe(true);
         expect(capabilitiesInclude(["completion"], "thinking")).toBe(false);
+    });
+
+    test("invalid cached models are ignored", () => {
+        const dir = join(tempHome, ".pizzapi");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "ollama-cloud-models-cache.json"),
+            JSON.stringify({ models: [{ id: "broken" }], fetchedAt: Date.now() }),
+        );
+
+        expect(getCachedOllamaCloudModels()).toBeNull();
     });
 
     test("fetchOllamaCloudModels returns cached data when cache is fresh", async () => {

--- a/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
+++ b/packages/cli/src/extensions/remote/connection.startup-gate.test.ts
@@ -93,6 +93,7 @@ mock.module("../remote-meta-events.js", () => ({
     emitThinkingLevelChanged: mock(() => {}),
     emitAuthSourceChanged: mock(() => {}),
     emitModelChanged: mock(() => {}),
+    emitGoalUpdated: mock(() => {}),
 }));
 mock.module("../remote-auth-source.js", () => ({
     getAuthSource: mock(() => null),

--- a/packages/cli/src/extensions/remote/model-selection.test.ts
+++ b/packages/cli/src/extensions/remote/model-selection.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { setModelFromWeb } from "./model-selection.js";
+
+async function withTempHome(fn: () => Promise<void> | void) {
+    const previousHome = process.env.HOME;
+    const tempHome = mkdtempSync(join(tmpdir(), "model-selection-test-"));
+    process.env.HOME = tempHome;
+    try {
+        await fn();
+    } finally {
+        rmSync(tempHome, { recursive: true, force: true });
+        if (previousHome === undefined) delete process.env.HOME;
+        else process.env.HOME = previousHome;
+    }
+}
+
+function ollamaCloudModel(modelId: string) {
+    return {
+        id: modelId,
+        name: modelId,
+        provider: "ollama-cloud",
+        api: "openai-completions",
+        baseUrl: "https://ollama.com/v1",
+        reasoning: true,
+        input: ["text"],
+        contextWindow: 128000,
+        maxTokens: 32768,
+    };
+}
+
+function writeOllamaCloudCache(modelId: string, fetchedAt = Date.now()) {
+    const dir = join(process.env.HOME!, ".pizzapi");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+        join(dir, "ollama-cloud-models-cache.json"),
+        JSON.stringify({ fetchedAt, models: [ollamaCloudModel(modelId)] }),
+    );
+}
+
+function createRctx(modelFromRegistry?: any) {
+    const events: any[] = [];
+    const rctx: any = {
+        relaySessionId: "session-1",
+        goalState: null,
+        latestCtx: {
+            cwd: process.cwd(),
+            model: null,
+            modelRegistry: {
+                find: () => modelFromRegistry,
+                authStorage: { get: () => ({ type: "api_key" }) },
+            },
+            sessionManager: {
+                getEntries: () => [],
+                getLeafId: () => null,
+                getSessionName: () => null,
+                getSessionFile: () => undefined,
+            },
+        },
+        forwardEvent: (event: any) => events.push(event),
+        getCurrentThinkingLevel: () => null,
+        getCurrentSessionName: () => null,
+        getConfiguredModels: () => [],
+        getAvailableCommands: () => [],
+    };
+    return { rctx, events };
+}
+
+describe("setModelFromWeb", () => {
+    test("returns without side effects when there is no session context", async () => {
+        const events: any[] = [];
+        const pi = { setModel: async () => true };
+
+        await setModelFromWeb({ latestCtx: null, forwardEvent: (event: any) => events.push(event) } as any, pi, "x", "y");
+
+        expect(events).toEqual([]);
+    });
+
+    test("uses the static registry model when present", async () => {
+        const registryModel = ollamaCloudModel("glm-5.1");
+        const { rctx, events } = createRctx(registryModel);
+        let selected: any;
+        const pi = {
+            setModel: async (model: any) => {
+                selected = model;
+                return false;
+            },
+        };
+
+        await setModelFromWeb(rctx, pi, "ollama-cloud", "glm-5.1");
+
+        expect(selected).toBe(registryModel);
+        expect(events).toContainEqual({
+            type: "model_set_result",
+            ok: false,
+            provider: "ollama-cloud",
+            modelId: "glm-5.1",
+            message: "Model selected, but no valid credentials were found.",
+        });
+    });
+
+    test("forwards registry lookup errors", async () => {
+        const { rctx, events } = createRctx();
+        rctx.latestCtx.modelRegistry.find = () => {
+            throw new Error("registry broke");
+        };
+        const pi = { setModel: async () => true };
+
+        await setModelFromWeb(rctx, pi, "ollama-cloud", "glm-5.2");
+
+        expect(events).toContainEqual({
+            type: "model_set_result",
+            ok: false,
+            provider: "ollama-cloud",
+            modelId: "glm-5.2",
+            message: "registry broke",
+        });
+    });
+
+    test("can select cached Ollama Cloud models missing from the static registry", async () => {
+        await withTempHome(async () => {
+            writeOllamaCloudCache("glm-5.2");
+            const { rctx, events } = createRctx();
+            let selected: any;
+            const pi = {
+                setModel: async (model: any) => {
+                    selected = model;
+                    return false;
+                },
+            };
+
+            await setModelFromWeb(rctx, pi, "ollama-cloud", "glm-5.2");
+
+            expect(selected).toMatchObject({
+                provider: "ollama-cloud",
+                id: "glm-5.2",
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                compat: { supportsUsageInStreaming: true, maxTokensField: "max_tokens" },
+            });
+            expect(events).toContainEqual({
+                type: "model_set_result",
+                ok: false,
+                provider: "ollama-cloud",
+                modelId: "glm-5.2",
+                message: "Model selected, but no valid credentials were found.",
+            });
+        });
+    });
+
+    test("ignores stale cached Ollama Cloud models", async () => {
+        await withTempHome(async () => {
+            writeOllamaCloudCache("glm-5.2", Date.now() - 25 * 60 * 60 * 1000);
+            const { rctx, events } = createRctx();
+            const pi = { setModel: async () => true };
+
+            await setModelFromWeb(rctx, pi, "ollama-cloud", "glm-5.2");
+
+            expect(events).toContainEqual({
+                type: "model_set_result",
+                ok: false,
+                provider: "ollama-cloud",
+                modelId: "glm-5.2",
+                message: "Model is not configured for this session.",
+            });
+        });
+    });
+
+    test("emits model metadata after successful cached Ollama Cloud selection", async () => {
+        await withTempHome(async () => {
+            writeOllamaCloudCache("glm-5.2");
+            const { rctx, events } = createRctx();
+            const pi = {
+                setModel: async (model: any) => {
+                    rctx.latestCtx.model = model;
+                    return true;
+                },
+            };
+
+            await setModelFromWeb(rctx, pi, "ollama-cloud", "glm-5.2");
+
+            expect(events).toContainEqual({ type: "model_set_result", ok: true, provider: "ollama-cloud", modelId: "glm-5.2" });
+            expect(events).toContainEqual({
+                type: "model_changed",
+                model: { provider: "ollama-cloud", id: "glm-5.2", name: "glm-5.2", reasoning: true, contextWindow: 128000 },
+            });
+            expect(events).toContainEqual({ type: "auth_source_changed", source: "auth.json" });
+            expect(events.some((event) => event.type === "session_active")).toBe(true);
+        });
+    });
+
+    test("forwards cached model setModel errors", async () => {
+        await withTempHome(async () => {
+            writeOllamaCloudCache("glm-5.2");
+            const { rctx, events } = createRctx();
+            const pi = {
+                setModel: async () => {
+                    throw "bare string error";
+                },
+            };
+
+            await setModelFromWeb(rctx, pi, "ollama-cloud", "glm-5.2");
+
+            expect(events).toContainEqual({
+                type: "model_set_result",
+                ok: false,
+                provider: "ollama-cloud",
+                modelId: "glm-5.2",
+                message: "bare string error",
+            });
+        });
+    });
+
+    test("forwards setModel errors", async () => {
+        const { rctx, events } = createRctx(ollamaCloudModel("glm-5.1"));
+        const pi = {
+            setModel: async () => {
+                throw new Error("boom");
+            },
+        };
+
+        await setModelFromWeb(rctx, pi, "ollama-cloud", "glm-5.1");
+
+        expect(events).toContainEqual({
+            type: "model_set_result",
+            ok: false,
+            provider: "ollama-cloud",
+            modelId: "glm-5.1",
+            message: "boom",
+        });
+    });
+});

--- a/packages/cli/src/extensions/remote/model-selection.test.ts
+++ b/packages/cli/src/extensions/remote/model-selection.test.ts
@@ -185,7 +185,6 @@ describe("setModelFromWeb", () => {
                 type: "model_changed",
                 model: { provider: "ollama-cloud", id: "glm-5.2", name: "glm-5.2", reasoning: true, contextWindow: 128000 },
             });
-            expect(events).toContainEqual({ type: "auth_source_changed", source: "auth.json" });
             expect(events.some((event) => event.type === "session_active")).toBe(true);
         });
     });

--- a/packages/cli/src/extensions/remote/model-selection.ts
+++ b/packages/cli/src/extensions/remote/model-selection.ts
@@ -8,6 +8,7 @@ import type { RelayContext } from "../remote-types.js";
 import { emitModelChanged, emitAuthSourceChanged } from "../remote-meta-events.js";
 import { getAuthSource } from "../remote-auth-source.js";
 import { emitSessionActive } from "./chunked-delivery.js";
+import { getCachedOllamaCloudModels, toOllamaCloudRuntimeModel } from "../../ollama-cloud-models.js";
 
 /**
  * Handle a web-initiated model change request.
@@ -22,19 +23,21 @@ export async function setModelFromWeb(
 ): Promise<void> {
     if (!rctx.latestCtx) return;
 
-    const model = rctx.latestCtx.modelRegistry.find(provider, modelId);
-    if (!model) {
-        rctx.forwardEvent({
-            type: "model_set_result",
-            ok: false,
-            provider,
-            modelId,
-            message: "Model is not configured for this session.",
-        });
-        return;
-    }
-
     try {
+        const model =
+            rctx.latestCtx.modelRegistry.find(provider, modelId) ??
+            findCachedOllamaCloudModel(provider, modelId);
+        if (!model) {
+            rctx.forwardEvent({
+                type: "model_set_result",
+                ok: false,
+                provider,
+                modelId,
+                message: "Model is not configured for this session.",
+            });
+            return;
+        }
+
         const ok = await (pi as any).setModel(model);
         rctx.forwardEvent({
             type: "model_set_result",
@@ -44,18 +47,13 @@ export async function setModelFromWeb(
             message: ok ? undefined : "Model selected, but no valid credentials were found.",
         });
         if (ok) {
-            emitModelChanged(
-                rctx,
-                rctx.latestCtx?.model
-                    ? {
-                          provider: rctx.latestCtx.model.provider,
-                          id: rctx.latestCtx.model.id,
-                          name: rctx.latestCtx.model.name,
-                          reasoning: rctx.latestCtx.model.reasoning,
-                          contextWindow: rctx.latestCtx.model.contextWindow,
-                      }
-                    : null,
-            );
+            emitModelChanged(rctx, {
+                provider: model.provider,
+                id: model.id,
+                name: model.name,
+                reasoning: model.reasoning,
+                contextWindow: model.contextWindow,
+            });
             emitAuthSourceChanged(rctx, getAuthSource(rctx.latestCtx));
             emitSessionActive(rctx);
         }
@@ -68,4 +66,11 @@ export async function setModelFromWeb(
             message: error instanceof Error ? error.message : String(error),
         });
     }
+}
+
+function findCachedOllamaCloudModel(provider: string, modelId: string) {
+    if (provider !== "ollama-cloud") return undefined;
+    const cached = getCachedOllamaCloudModels();
+    const model = cached?.find((m) => m.id === modelId);
+    return model ? toOllamaCloudRuntimeModel(model) : undefined;
 }

--- a/packages/cli/src/extensions/remote/model-selection.ts
+++ b/packages/cli/src/extensions/remote/model-selection.ts
@@ -5,7 +5,6 @@
  */
 
 import type { RelayContext } from "../remote-types.js";
-import { emitModelChanged, emitAuthSourceChanged } from "../remote-meta-events.js";
 import { getAuthSource } from "../remote-auth-source.js";
 import { emitSessionActive } from "./chunked-delivery.js";
 import { getCachedOllamaCloudModels, toOllamaCloudRuntimeModel } from "../../ollama-cloud-models.js";
@@ -47,14 +46,17 @@ export async function setModelFromWeb(
             message: ok ? undefined : "Model selected, but no valid credentials were found.",
         });
         if (ok) {
-            emitModelChanged(rctx, {
-                provider: model.provider,
-                id: model.id,
-                name: model.name,
-                reasoning: model.reasoning,
-                contextWindow: model.contextWindow,
+            rctx.forwardEvent({
+                type: "model_changed",
+                model: {
+                    provider: model.provider,
+                    id: model.id,
+                    name: model.name,
+                    reasoning: model.reasoning,
+                    contextWindow: model.contextWindow,
+                },
             });
-            emitAuthSourceChanged(rctx, getAuthSource(rctx.latestCtx));
+            rctx.forwardEvent({ type: "auth_source_changed", source: getAuthSource(rctx.latestCtx) });
             emitSessionActive(rctx);
         }
     } catch (error) {

--- a/packages/cli/src/ollama-cloud-models.ts
+++ b/packages/cli/src/ollama-cloud-models.ts
@@ -9,6 +9,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import type { Model } from "@earendil-works/pi-ai";
 
 const OLLAMA_CLOUD_MODELS_URL = "https://ollama.com/v1/models";
 const OLLAMA_CLOUD_SHOW_URL = "https://ollama.com/api/show";
@@ -63,7 +64,9 @@ function readCache(): OllamaCloudCacheEntry | null {
             Array.isArray(raw.models) &&
             typeof raw.fetchedAt === "number"
         ) {
-            return raw as OllamaCloudCacheEntry;
+            const models = raw.models.filter(isOllamaCloudModel);
+            if (raw.models.length > 0 && models.length === 0) return null;
+            return { models, fetchedAt: raw.fetchedAt };
         }
     } catch {
         // ignore corrupt cache
@@ -75,6 +78,24 @@ function writeCache(entry: OllamaCloudCacheEntry): void {
     const dir = join(homeDir(), ".pizzapi");
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
     writeFileSync(cachePath(), JSON.stringify(entry, null, 2), { mode: 0o600 });
+}
+
+function isOllamaCloudModel(value: unknown): value is OllamaCloudModel {
+    if (typeof value !== "object" || value === null) return false;
+    const model = value as Record<string, unknown>;
+    return (
+        typeof model.id === "string" &&
+        typeof model.name === "string" &&
+        model.provider === "ollama-cloud" &&
+        model.api === "openai-completions" &&
+        typeof model.baseUrl === "string" &&
+        typeof model.reasoning === "boolean" &&
+        Array.isArray(model.input) &&
+        model.input.length > 0 &&
+        model.input.every((item) => item === "text" || item === "image") &&
+        typeof model.contextWindow === "number" &&
+        typeof model.maxTokens === "number"
+    );
 }
 
 async function fetchJson(url: string, options?: RequestInit): Promise<unknown> {
@@ -110,6 +131,22 @@ export function getCachedOllamaCloudModels(): OllamaCloudModel[] | null {
     return null;
 }
 
+export function toOllamaCloudRuntimeModel(model: OllamaCloudModel): Model<"openai-completions"> {
+    return {
+        ...model,
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        compat: {
+            supportsStore: false,
+            supportsDeveloperRole: false,
+            supportsReasoningEffort: false,
+            supportsUsageInStreaming: true,
+            supportsLongCacheRetention: false,
+            supportsStrictMode: false,
+            maxTokensField: "max_tokens",
+        },
+    };
+}
+
 export async function fetchOllamaCloudModels({ signal }: { signal?: AbortSignal } = {}): Promise<OllamaCloudModel[]> {
     const cached = readCache();
     if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
@@ -131,11 +168,8 @@ export async function fetchOllamaCloudModels({ signal }: { signal?: AbortSignal 
         }),
     );
 
-    // Filter out any entries we couldn't enrich (e.g. transient /api/show failures)
-    const valid = models.filter((m): m is OllamaCloudModel => m !== null);
-
-    writeCache({ models: valid, fetchedAt: Date.now() });
-    return valid;
+    writeCache({ models, fetchedAt: Date.now() });
+    return models;
 }
 
 async function fetchModelMetadata(
@@ -162,7 +196,7 @@ async function fetchModelMetadata(
     return null;
 }
 
-function buildModel(id: string, info: OllamaApiShowResponse | null): OllamaCloudModel | null {
+function buildModel(id: string, info: OllamaApiShowResponse | null): OllamaCloudModel {
     const caps = info?.capabilities ?? [];
     const contextWindow = extractContextLength(info?.model_info) ?? 128000;
     const reasoning = capabilitiesInclude(caps, "thinking");


### PR DESCRIPTION
## Summary
- Allow web model selection to fall back to cached dynamic Ollama Cloud models when the static registry lacks the selected ID
- Add runtime metadata for cached Ollama Cloud models before passing them to pi.setModel
- Harden Ollama Cloud cache validation and add regression tests

## Verification
- bun run typecheck
- bun run test
- bun run build