### PR TITLE
fix(cli): use logError instead of undefined log in daemon shutdown

### DIFF
--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -707,7 +707,9 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             void tunnelClient?.dispose();
             registry.disposeAll();
             stopUsageRefreshLoop();
-            await closeUsage().catch((err) => log.error("closeUsage failed during shutdown:", err));
+            await closeUsage().catch((err) =>
+                logError("closeUsage failed during shutdown: " + (err instanceof Error ? err.message : String(err))),
+            );
             releaseStateLock(statePath);
             socket.disconnect();
             resolve(code);


### PR DESCRIPTION
## Problem

`tsc --build` on main fails:

```
packages/cli/src/runner/daemon.ts(710,47): error TS2304: Cannot find name 'log'.
```

Commit 53127be5 (#547) changed `closeUsage()` to async and added:

```ts
await closeUsage().catch((err) => log.error("closeUsage failed during shutdown:", err));
```

but `log` is not imported — only `logInfo`, `logWarn`, `logError` are.

## Fix

Use the existing `logError` helper with a formatted message.

Verified: `bun run typecheck` clean, `bun test packages/cli` 2131 pass.