### PR TITLE
Per-provider overrides, AGENTS.md/system-prompt toggles, provider request diagnostics

### DIFF
--- a/packages/cli/scripts/diff-pi-pizza.ts
+++ b/packages/cli/scripts/diff-pi-pizza.ts
@@ -1,0 +1,303 @@
+/**
+ * A/B diff of the real Anthropic /v1/messages wire request: vanilla `pi` vs
+ * `pizza`, both routed through the minimalcc-pi claude-subscription provider.
+ *
+ * Run: cd packages/cli && bun scripts/diff-pi-pizza.ts [options]
+ *
+ * Options:
+ *   --live          actually send the requests (default: abort after capture,
+ *                   so no subscription tokens are spent)
+ *   --model <id>    force the same model on both legs (e.g. claude-opus-4-6)
+ *   --prompt <txt>  prompt to send (default "hi")
+ *   --safe          pizza leg skips MCP/plugins/hooks (isolates pizza's own
+ *                   prompt/tool additions from third-party ones)
+ *   --no-mcp        pizza leg skips MCP tools
+ *   --no-plugins    pizza leg skips Claude Code plugins
+ *   --no-hooks      pizza leg skips hooks
+ *   --no-agents     pizza leg omits AGENTS.md automatic context
+ *
+ * pi leg:    spawns the real `pi` binary with scripts/wire-tap.ts via -e
+ * pizza leg: builds the session exactly like src/index.ts (same config,
+ *            extension factories, skills, plugins, system prompt) in-process
+ *            and sends the same prompt
+ *
+ * The captures include the fetch-time call stack, which proves which module
+ * actually built the request (minimalcc-pi's native transport vs pi-ai's
+ * built-in anthropic provider).
+ */
+
+import {
+    createAgentSessionFromServices,
+    createAgentSessionServices,
+    SessionManager,
+} from "@earendil-works/pi-coding-agent";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    applyProviderSettingsEnv,
+    defaultAgentDir,
+    expandHome,
+    loadConfig,
+    maybeBuildSystemPrompt,
+} from "../src/config.js";
+import { getPluginSkillPaths } from "../src/extensions/claude-plugins.js";
+import { buildPizzaPiExtensionFactories } from "../src/extensions/factories.js";
+import { buildPromptTemplatePaths, buildSkillPaths, createAgentsFilesOverride } from "../src/skills.js";
+import { installWireTap } from "./wire-tap.js";
+
+// ── args ────────────────────────────────────────────────────────────────────
+const argv = process.argv.slice(2);
+const live = argv.includes("--live");
+const safe = argv.includes("--safe");
+const noMcp = safe || argv.includes("--no-mcp");
+const noPlugins = safe || argv.includes("--no-plugins");
+const noHooks = safe || argv.includes("--no-hooks");
+const noAgents = argv.includes("--no-agents");
+// A bare model id (e.g. claude-fable-5) can match the built-in `anthropic`
+// provider on both legs — always resolve against claude-subscription unless
+// the caller explicitly qualifies the provider.
+const rawModelArg = argv.includes("--model") ? argv[argv.indexOf("--model") + 1] : undefined;
+const [modelProvider, modelArg] = rawModelArg?.includes("/")
+    ? [rawModelArg.split("/")[0]!, rawModelArg.split("/")[1]]
+    : ["claude-subscription", rawModelArg];
+const promptText = argv.includes("--prompt") ? argv[argv.indexOf("--prompt") + 1]! : "hi";
+
+const captureDir = join(tmpdir(), `wire-diff-${Date.now()}`);
+mkdirSync(captureDir, { recursive: true });
+const piOut = join(captureDir, "pi.jsonl");
+const pizzaOut = join(captureDir, "pizza.jsonl");
+// pi loads -e extension files in a separate module realm whose globalThis is
+// not the one the provider reads, so the tap must be preloaded via NODE_OPTIONS.
+const preloadPath = join(import.meta.dirname, "wire-tap-preload.mjs");
+
+type Capture = {
+    label: string;
+    runtime: { execPath: string; argv: string[]; bun: string | null; node: string };
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    bodyBytes: number | null;
+    body: Record<string, any>;
+    stack: string[];
+};
+
+type ResponseCapture = {
+    label: string;
+    url: string;
+    status: number;
+    statusText: string;
+};
+
+// ── leg 1: vanilla pi (real binary, tap injected via -e) ────────────────────
+console.log(`captures → ${captureDir}`);
+console.log(`\n[1/2] running vanilla pi (${live ? "LIVE" : "abort-after-capture"})...`);
+{
+    const args = ["-a", "-p"];
+    if (modelArg) args.push("--model", `${modelProvider}/${modelArg}`);
+    args.push(promptText);
+    const res = spawnSync("pi", args, {
+        env: {
+            ...process.env,
+            NODE_OPTIONS: `${process.env.NODE_OPTIONS ?? ""} --import ${preloadPath}`.trim(),
+            WIRE_CAPTURE_OUT: piOut,
+            WIRE_CAPTURE_ABORT: live ? "0" : "1",
+        },
+        encoding: "utf-8",
+        timeout: 180_000,
+    });
+    if (!existsSync(piOut)) {
+        console.error("pi leg produced no capture. stdout/stderr:");
+        console.error(res.stdout?.slice(-2000));
+        console.error(res.stderr?.slice(-2000));
+        process.exit(1);
+    }
+}
+
+// ── leg 2: pizza (in-process, mirrors src/index.ts construction) ────────────
+console.log(`[2/2] running pizza session in-process (${safe ? "safe mode" : "custom mode"})...`);
+process.env.WIRE_CAPTURE_OUT = pizzaOut;
+process.env.WIRE_CAPTURE_ABORT = live ? "0" : "1";
+process.env.PIZZAPI_RELAY_URL = "off";
+installWireTap("pizza");
+
+const cwd = process.cwd();
+const config = loadConfig(cwd);
+const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
+applyProviderSettingsEnv(config);
+
+const extensionFactories = buildPizzaPiExtensionFactories({
+    cwd,
+    hooks: noHooks ? undefined : config.hooks,
+    skipMcp: noMcp,
+    skipPlugins: noPlugins,
+    skipRelay: true,
+}).filter((factory: any) => factory.displayName !== "provider-request-log");
+const agentsFilesOverride = createAgentsFilesOverride(cwd, {
+    sendAgentsMd: noAgents ? false : config.sendAgentsMd !== false,
+});
+const services = await createAgentSessionServices({
+    cwd,
+    agentDir,
+    resourceLoaderOptions: {
+        extensionFactories: extensionFactories as any,
+        additionalSkillPaths: [
+            ...buildSkillPaths(cwd, config.skills),
+            ...(noPlugins ? [] : getPluginSkillPaths(cwd)),
+        ],
+        additionalPromptTemplatePaths: buildPromptTemplatePaths(cwd),
+        ...(config.systemPrompt !== undefined && { systemPromptOverride: () => config.systemPrompt }),
+        appendSystemPrompt: [maybeBuildSystemPrompt(config, { cwd }), config.appendSystemPrompt].filter(Boolean) as string[],
+        ...(agentsFilesOverride && { agentsFilesOverride }),
+    },
+});
+const sessionManager = SessionManager.create(cwd, join(captureDir, "sessions"));
+const modelOverride = modelArg
+    ? services.modelRegistry.find(modelProvider, modelArg)
+    : undefined;
+if (modelArg && !modelOverride) {
+    console.error(`--model ${modelProvider}/${modelArg}: not found in pizza's model registry`);
+    process.exit(1);
+}
+const { session } = await createAgentSessionFromServices({
+    services,
+    sessionManager,
+    ...(modelOverride && { model: modelOverride as any }),
+});
+console.log(`  pizza session model: ${session.model?.provider}/${session.model?.id}`);
+console.log(`  pizza effective system prompt: ${session.systemPrompt.length} chars`);
+console.log(`  pizza tools: ${session.getAllTools().length}`);
+try {
+    await session.prompt(promptText);
+} catch {
+    // aborted request surfaces as an error turn — expected in capture mode
+}
+
+// ── diff ────────────────────────────────────────────────────────────────────
+function readCapture(file: string, name: string): Capture {
+    const line = existsSync(file)
+        ? readFileSync(file, "utf-8").split("\n").find((l) => l.includes('"url"'))
+        : undefined;
+    if (!line) {
+        console.error(`${name} leg produced no request capture (${file})`);
+        process.exit(1);
+    }
+    return JSON.parse(line) as Capture;
+}
+const pi = readCapture(piOut, "pi");
+const pizza = readCapture(pizzaOut, "pizza");
+
+function readResponseCapture(file: string): ResponseCapture | undefined {
+    if (!existsSync(file)) return undefined;
+    const line = readFileSync(file, "utf-8")
+        .split("\n")
+        .find((l) => l.includes('"marker":"fetch-response"'));
+    return line ? JSON.parse(line) as ResponseCapture : undefined;
+}
+const piResponse = readResponseCapture(piOut);
+const pizzaResponse = readResponseCapture(pizzaOut);
+
+const sha8 = (s: string) => createHash("sha256").update(s).digest("hex").slice(0, 8);
+const head = (s: string, n = 70) => s.replace(/\s+/g, " ").slice(0, n);
+const pad = (s: string, n: number) => s.padEnd(n);
+
+function section(title: string): void {
+    console.log(`\n━━ ${title} ${"━".repeat(Math.max(0, 66 - title.length))}`);
+}
+
+function row(key: string, a: unknown, b: unknown): void {
+    const as = a === undefined ? "—" : JSON.stringify(a);
+    const bs = b === undefined ? "—" : JSON.stringify(b);
+    const mark = as === bs ? "  " : "≠ ";
+    console.log(`${mark}${pad(key, 34)} pi: ${as}`);
+    if (as !== bs) console.log(`  ${pad("", 34)} pz: ${bs}`);
+}
+
+section("runtime");
+row("execPath", pi.runtime.execPath, pizza.runtime.execPath);
+row("engine", pi.runtime.bun ? `bun ${pi.runtime.bun}` : `node ${pi.runtime.node}`,
+    pizza.runtime.bun ? `bun ${pizza.runtime.bun}` : `node ${pizza.runtime.node}`);
+
+section("request sender (fetch call stack, top frames)");
+console.log("pi:");
+for (const f of pi.stack.slice(0, 5)) console.log(`    ${f}`);
+console.log("pizza:");
+for (const f of pizza.stack.slice(0, 5)) console.log(`    ${f}`);
+
+section("url / method / response");
+row("url", pi.url, pizza.url);
+row("method", pi.method, pizza.method);
+row("response status", piResponse?.status, pizzaResponse?.status);
+row("response statusText", piResponse?.statusText, pizzaResponse?.statusText);
+
+section("headers");
+for (const k of [...new Set([...Object.keys(pi.headers), ...Object.keys(pizza.headers)])].sort()) {
+    row(k, pi.headers[k], pizza.headers[k]);
+}
+
+section("body: scalar fields");
+const skip = new Set(["system", "messages", "tools"]);
+for (const k of [...new Set([...Object.keys(pi.body), ...Object.keys(pizza.body)])].sort()) {
+    if (!skip.has(k)) row(k, pi.body[k], pizza.body[k]);
+}
+
+section("body: system blocks");
+type Block = { text?: string; cache_control?: unknown };
+const sysBlocks = (b: Record<string, any>): Block[] =>
+    typeof b.system === "string" ? [{ text: b.system }] : (b.system ?? []);
+const piSys = sysBlocks(pi.body);
+const pzSys = sysBlocks(pizza.body);
+const totalChars = (blocks: Block[]) => blocks.reduce((n, b) => n + (b.text?.length ?? 0), 0);
+console.log(`  pi: ${piSys.length} block(s), ${totalChars(piSys)} chars | pizza: ${pzSys.length} block(s), ${totalChars(pzSys)} chars`);
+const pzShas = new Set(pzSys.map((b) => sha8(b.text ?? "")));
+const piShas = new Set(piSys.map((b) => sha8(b.text ?? "")));
+for (const [who, blocks, otherShas] of [["pi", piSys, pzShas], ["pizza", pzSys, piShas]] as const) {
+    blocks.forEach((b, i) => {
+        const h = sha8(b.text ?? "");
+        const match = otherShas.has(h) ? "= both " : `only ${who}`;
+        console.log(`  [${who} #${i}] ${match} sha:${h} ${String(b.text?.length ?? 0).padStart(6)}ch${b.cache_control ? " (cached)" : ""}  "${head(b.text ?? "")}"`);
+    });
+}
+
+section("body: tools");
+type ToolDef = { name?: string; input_schema?: unknown };
+const piTools: ToolDef[] = pi.body.tools ?? [];
+const pzTools: ToolDef[] = pizza.body.tools ?? [];
+const toolBytes = (tools: ToolDef[]) => Buffer.byteLength(JSON.stringify(tools));
+console.log(`  pi: ${piTools.length} tools (${toolBytes(piTools)} bytes) | pizza: ${pzTools.length} tools (${toolBytes(pzTools)} bytes)`);
+const piNames = new Set(piTools.map((t) => t.name));
+const pzNames = new Set(pzTools.map((t) => t.name));
+const onlyPi = [...piNames].filter((n) => !pzNames.has(n));
+const onlyPz = [...pzNames].filter((n) => !piNames.has(n));
+if (onlyPi.length) console.log(`  only pi:    ${onlyPi.join(", ")}`);
+if (onlyPz.length) console.log(`  only pizza: ${onlyPz.join(", ")}`);
+for (const n of [...piNames].filter((x) => pzNames.has(x))) {
+    const a = JSON.stringify(piTools.find((t) => t.name === n));
+    const b = JSON.stringify(pzTools.find((t) => t.name === n));
+    if (a !== b) console.log(`  shared tool '${n}' differs: pi ${a.length}B vs pizza ${b.length}B`);
+}
+
+section("body: messages");
+const roles = (b: Record<string, any>) => (b.messages ?? []).map((m: any) => m.role).join(",");
+row("count", (pi.body.messages ?? []).length, (pizza.body.messages ?? []).length);
+row("roles", roles(pi.body), roles(pizza.body));
+
+section("totals");
+row("body bytes", pi.bodyBytes, pizza.bodyBytes);
+row("~input tokens (bytes/4)", Math.round((pi.bodyBytes ?? 0) / 4), Math.round((pizza.bodyBytes ?? 0) / 4));
+
+section("agent settings (defaults each CLI reads)");
+try {
+    const piSettings = JSON.parse(readFileSync(join(homedir(), ".pi/agent/settings.json"), "utf-8"));
+    const pzSettings = JSON.parse(readFileSync(join(homedir(), ".pizzapi/settings.json"), "utf-8"));
+    for (const k of [...new Set([...Object.keys(piSettings), ...Object.keys(pzSettings)])].sort()) {
+        row(k, piSettings[k], pzSettings[k]);
+    }
+} catch (err) {
+    console.log(`  (could not read settings: ${err instanceof Error ? err.message : String(err)})`);
+}
+
+console.log(`\nraw captures: ${piOut}\n              ${pizzaOut}`);
+process.exit(0);

--- a/packages/cli/scripts/probe-overage.ts
+++ b/packages/cli/scripts/probe-overage.ts
@@ -1,0 +1,114 @@
+/**
+ * Programmatic isolation of the claude-subscription "out of extra usage /
+ * org_level_disabled" failure. Fires a small matrix of /v1/messages requests
+ * with the SAME Claude Code OAuth token, varying one axis at a time, and reports
+ * HTTP status + the `anthropic-ratelimit-unified-overage-disabled-reason` header.
+ *
+ * Run: cd packages/cli && bun scripts/probe-overage.ts
+ *
+ * Uses tiny max_tokens and spaces requests to limit quota use / avoid 429s.
+ */
+
+import { AuthStorage } from "@earendil-works/pi-coding-agent";
+import { execSync } from "node:child_process";
+import { join } from "node:path";
+import { homedir } from "node:os";
+
+const IDENTITY = "You are Claude Code, Anthropic's official CLI for Claude.";
+const BASE_BETA = "oauth-2025-04-20,claude-code-20250219";
+const INTERLEAVED = ",interleaved-thinking-2025-05-14";
+const FALLBACK_BETA = ",server-side-fallback-2026-06-01";
+
+function fp(t: string): string { return `…${t.slice(-6)}(len=${t.length})`; }
+
+// Token the extension actually uses: Claude Code Keychain credential.
+function keychainToken(): string | null {
+    try {
+        const raw = execSync(`security find-generic-password -s ${JSON.stringify("Claude Code-credentials")} -w`, { encoding: "utf-8" }).trim();
+        return JSON.parse(raw)?.claudeAiOauth?.accessToken ?? null;
+    } catch { return null; }
+}
+
+const authToken = await AuthStorage.create(join(homedir(), ".pizzapi", "auth.json")).getApiKey("anthropic");
+const kcToken = keychainToken();
+console.log(`pizzapi auth.json token: ${authToken ? fp(authToken) : "(none)"}`);
+console.log(`keychain CC token:       ${kcToken ? fp(kcToken) : "(none)"}`);
+console.log(`same token? ${authToken === kcToken}\n`);
+const token = kcToken ?? authToken; // extension uses the Keychain token
+if (!token) { console.error("no anthropic token"); process.exit(1); }
+
+const bigSystem = "You are a coding assistant.\n".repeat(2300); // ~63k chars
+const smallSystem = "You are a coding assistant.";
+const manyTools = Array.from({ length: 58 }, (_, i) => ({
+    name: i < 4 ? ["read", "bash", "edit", "write"][i] : `tool_${i}`,
+    description: "x",
+    input_schema: { type: "object", properties: { a: { type: "string" } } },
+}));
+const fewTools = manyTools.slice(0, 4);
+
+type Case = {
+    label: string;
+    model: string;
+    system: string;
+    tools: unknown[];
+    beta: string;
+    thinking?: unknown;
+    output_config?: unknown;
+    fallbacks?: unknown;
+    max_tokens: number;
+};
+
+// A = working replica (raw pi / fable). B = failing replica (pizza / opus budget).
+// Then mutate B→A one axis at a time.
+const cases: Case[] = [
+    { label: "A  working replica: fable-5, small sys, 4 tools, adaptive (stream)",
+      model: "claude-fable-5", system: smallSystem, tools: fewTools, beta: BASE_BETA + FALLBACK_BETA,
+      thinking: { type: "adaptive", display: "summarized" }, output_config: { effort: "high" },
+      fallbacks: [{ model: "claude-opus-4-8" }], max_tokens: 128000 },
+
+    { label: "B  failing replica: opus-4-6, BIG sys, 58 tools, budget thinking (stream)",
+      model: "claude-opus-4-6", system: bigSystem, tools: manyTools, beta: BASE_BETA + INTERLEAVED,
+      thinking: { type: "enabled", budget_tokens: 20480 }, max_tokens: 128000 },
+];
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+for (const c of cases) {
+    const body: Record<string, unknown> = {
+        model: c.model,
+        max_tokens: c.max_tokens,
+        system: [{ type: "text", text: IDENTITY }, { type: "text", text: c.system }],
+        messages: [{ role: "user", content: "say hi in one word" }],
+        tools: c.tools,
+        stream: true,
+    };
+    if (c.thinking) body.thinking = c.thinking;
+    if (c.output_config) body.output_config = c.output_config;
+    if (c.fallbacks) body.fallbacks = c.fallbacks;
+
+    let status = 0, reason = "", errMsg = "";
+    for (let attempt = 0; attempt < 5; attempt++) {
+        const res = await fetch("https://api.anthropic.com/v1/messages", {
+            method: "POST",
+            headers: {
+                Authorization: `Bearer ${token}`,
+                "Content-Type": "application/json",
+                "anthropic-version": "2023-06-01",
+                "anthropic-beta": c.beta,
+            },
+            body: JSON.stringify(body),
+        });
+        status = res.status;
+        reason = res.headers.get("anthropic-ratelimit-unified-overage-disabled-reason") ?? "";
+        if (status === 429) { await sleep(12000); continue; }
+        // stream:true returns 200 then may error mid-stream — must read the body.
+        errMsg = await res.text();
+        break;
+    }
+    console.log(`\n===== ${c.label} =====`);
+    console.log(`HTTP ${status}  overage-header=${reason || "-"}`);
+    console.log(`--- full response body ---`);
+    console.log(errMsg);
+    console.log(`--- end ---`);
+    await sleep(6000);
+}

--- a/packages/cli/scripts/wire-tap-preload.mjs
+++ b/packages/cli/scripts/wire-tap-preload.mjs
@@ -1,0 +1,8 @@
+// Preload for the vanilla-pi leg of scripts/diff-pi-pizza.ts:
+//   NODE_OPTIONS="--import <this file>" pi -p "hi"
+// Installs the wire tap in the process's real main realm. pi loads -e
+// extension files in a separate module realm whose globalThis is not the one
+// the provider code reads, so an extension-based tap never sees the request.
+import { installWireTap } from "./wire-tap.ts";
+
+installWireTap("pi");

--- a/packages/cli/scripts/wire-tap.ts
+++ b/packages/cli/scripts/wire-tap.ts
@@ -1,0 +1,136 @@
+/**
+ * Wire tap for the Anthropic /v1/messages request, loadable in BOTH runtimes:
+ *   - vanilla pi:  pi -e packages/cli/scripts/wire-tap.ts -p "hi"
+ *   - pizza:       imported in-process by scripts/diff-pi-pizza.ts
+ *
+ * Must stay dependency-free so vanilla pi (which does not have this repo's
+ * node_modules) can load it as an extension file.
+ *
+ * Env:
+ *   WIRE_CAPTURE_OUT   — file to write the capture JSON to (required to capture)
+ *   WIRE_CAPTURE_ABORT — "1" to short-circuit the request with a synthetic 400
+ *                        after capturing, so no subscription tokens are spent
+ */
+
+import { appendFileSync } from "node:fs";
+
+let installed = false;
+
+function tokenFingerprint(v: string): string {
+    const tok = v.replace(/^Bearer\s+/i, "");
+    return `…${tok.slice(-6)}(len=${tok.length})`;
+}
+
+export function installWireTap(label: string): void {
+    if (installed) return;
+    installed = true;
+    const outFile = process.env.WIRE_CAPTURE_OUT;
+    if (!outFile) return;
+    appendFileSync(outFile, JSON.stringify({ label, installedAt: new Date().toISOString(), marker: "wire-tap-installed", pid: process.pid }) + "\n");
+    const abort = process.env.WIRE_CAPTURE_ABORT === "1";
+    let orig = globalThis.fetch;
+
+    const wrapped = (async (input: any, init?: any) => {
+        const url = typeof input === "string" ? input : (input?.url ?? String(input));
+        const isMessages = typeof url === "string"
+            && url.includes("api.anthropic.com")
+            && url.includes("/v1/messages");
+        if (process.env.WIRE_CAPTURE_ALL === "1") {
+            try { appendFileSync(outFile, JSON.stringify({ label, pid: process.pid, marker: "fetch-call", url: String(url).slice(0, 200) }) + "\n"); } catch {}
+        }
+        if (!isMessages) return orig(input, init);
+
+        try {
+            const headers = new Headers(init?.headers ?? (typeof input === "object" ? input.headers : undefined));
+            const hdr: Record<string, string> = {};
+            headers.forEach((v, k) => {
+                hdr[k] = k.toLowerCase() === "authorization" ? tokenFingerprint(v) : v;
+            });
+            const rawBody = init?.body ?? (typeof input === "object" ? input.body : undefined);
+            let body: unknown = null;
+            if (typeof rawBody === "string") {
+                try { body = JSON.parse(rawBody); } catch { body = { unparsed: rawBody.slice(0, 2000) }; }
+            }
+            // The stack proves WHICH module built this request (minimalcc-pi's
+            // native transport vs pi-ai's built-in anthropic provider).
+            const stack = (new Error().stack ?? "")
+                .split("\n")
+                .slice(2, 12)
+                .map((l) => l.trim());
+            const capture = {
+                label,
+                pid: process.pid,
+                capturedAt: new Date().toISOString(),
+                runtime: {
+                    execPath: process.execPath,
+                    argv: process.argv,
+                    bun: (process.versions as any).bun ?? null,
+                    node: process.versions.node,
+                },
+                url,
+                method: init?.method ?? (typeof input === "object" ? input.method : "GET"),
+                headers: hdr,
+                bodyBytes: typeof rawBody === "string" ? Buffer.byteLength(rawBody) : null,
+                body,
+                stack,
+            };
+            appendFileSync(outFile, JSON.stringify(capture) + "\n");
+        } catch {
+            // never break the request because of the tap
+        }
+
+        if (abort) {
+            return new Response(
+                JSON.stringify({ type: "error", error: { type: "wire_tap_abort", message: "captured by wire-tap.ts; request not sent" } }),
+                { status: 400, headers: { "content-type": "application/json" } },
+            );
+        }
+        const response = await orig(input, init);
+        if (isMessages) {
+            try {
+                let body: string | undefined;
+                if (!response.ok) {
+                    body = await response.clone().text().catch(() => undefined);
+                }
+                appendFileSync(outFile, JSON.stringify({
+                    label,
+                    pid: process.pid,
+                    marker: "fetch-response",
+                    url,
+                    status: response.status,
+                    statusText: response.statusText,
+                    ...(body ? { body: body.slice(0, 2000) } : {}),
+                }) + "\n");
+            } catch { /* ignore */ }
+        }
+        return response;
+    }) as typeof fetch;
+
+    // The host replaces globalThis.fetch after startup (observed with vanilla
+    // pi, ~right before the provider request). An accessor property survives
+    // plain reassignment race-free: writes swap the delegate, reads keep
+    // returning the wrap.
+    Object.defineProperty(globalThis, "fetch", {
+        configurable: true,
+        enumerable: true,
+        get: () => wrapped,
+        set: (fn) => {
+            try {
+                appendFileSync(outFile, JSON.stringify({
+                    label,
+                    pid: process.pid,
+                    marker: "fetch-replaced-rewrapping",
+                    at: new Date().toISOString(),
+                    replacementName: fn?.name ?? null,
+                    replacementSource: String(fn).slice(0, 200),
+                }) + "\n");
+            } catch { /* ignore */ }
+            orig = fn;
+        },
+    });
+}
+
+// pi extension entry point (pi -e wire-tap.ts)
+export default function wireTapExtension(_pi: unknown): void {
+    installWireTap("pi");
+}

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -7,6 +7,7 @@ import {
     type PizzaPiConfig,
     type HooksConfig,
     type HookEntry,
+    type ProviderOverrides,
     isPlainObject,
 } from "./types.js";
 import { mergeSandboxConfig } from "./sandbox.js";
@@ -310,7 +311,69 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
         delete config.disabledRunnerServices;
     }
 
-    return config;
+    return applyProviderOverrides(config);
+}
+
+// ── Per-provider overrides ──────────────────────────────────────────────────────────
+
+/**
+ * Resolve the model provider this session will start on.
+ *
+ * Order:
+ *   1. PIZZAPI_SESSION_PROVIDER — stable snapshot set by the worker at boot
+ *   2. PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER — spawn-time model override
+ *   3. `defaultProvider` in ~/.pizzapi/settings.json
+ *
+ * ponytail: provider is resolved once at session start — resumed sessions and
+ * mid-session /model switches keep boot-time config. Per-turn re-resolution
+ * would need dynamic tool/context reload; add if that ever matters.
+ */
+export function resolveSessionProvider(): string | undefined {
+    const envProvider =
+        process.env.PIZZAPI_SESSION_PROVIDER?.trim() ||
+        process.env.PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER?.trim();
+    if (envProvider) return envProvider;
+    try {
+        const settings = JSON.parse(
+            readFileSync(join(globalConfigDir(), "settings.json"), "utf-8"),
+        );
+        if (typeof settings.defaultProvider === "string" && settings.defaultProvider.trim()) {
+            return settings.defaultProvider.trim();
+        }
+    } catch {
+        // settings.json missing or malformed — no provider default
+    }
+    return undefined;
+}
+
+/**
+ * Apply `providerSettings.<provider>.overrides` on top of the merged config.
+ *
+ * Only the explicitly supported fields are copied (no blind spread — a
+ * project-supplied overrides object must not smuggle in trust-gated keys).
+ * `disabledMcpServers` is a union with the existing list, matching the
+ * global/project merge semantics.
+ */
+export function applyProviderOverrides(
+    config: PizzaPiConfig,
+    provider: string | undefined = resolveSessionProvider(),
+): PizzaPiConfig {
+    const raw = provider ? config.providerSettings?.[provider]?.overrides : undefined;
+    if (!raw || !isPlainObject(raw)) return config;
+    const o = raw as ProviderOverrides;
+    const merged = { ...config };
+    if (typeof o.systemPrompt === "string") merged.systemPrompt = o.systemPrompt;
+    if (typeof o.appendSystemPrompt === "string") merged.appendSystemPrompt = o.appendSystemPrompt;
+    if (typeof o.builtinSystemPrompt === "boolean") merged.builtinSystemPrompt = o.builtinSystemPrompt;
+    if (typeof o.sendAgentsMd === "boolean") merged.sendAgentsMd = o.sendAgentsMd;
+    if (Array.isArray(o.disabledMcpServers)) {
+        const union = [
+            ...(merged.disabledMcpServers ?? []),
+            ...o.disabledMcpServers.filter((s): s is string => typeof s === "string"),
+        ];
+        if (union.length > 0) merged.disabledMcpServers = [...new Set(union)];
+    }
+    return merged;
 }
 
 // ── Path utilities ────────────────────────────────────────────────────────────

--- a/packages/cli/src/config/provider-overrides.test.ts
+++ b/packages/cli/src/config/provider-overrides.test.ts
@@ -1,0 +1,187 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+import {
+    loadConfig,
+    applyProviderOverrides,
+    resolveSessionProvider,
+    _setGlobalConfigDir,
+} from "./io.js";
+import type { PizzaPiConfig } from "./types.js";
+
+let tmpHome: string;
+let projectDir: string;
+const ENV_KEYS = ["PIZZAPI_SESSION_PROVIDER", "PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER"] as const;
+const savedEnv: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+    tmpHome = mkdtempSync(join(tmpdir(), "pizzapi-provider-overrides-"));
+    projectDir = join(tmpHome, "project");
+    mkdirSync(projectDir, { recursive: true });
+    _setGlobalConfigDir(tmpHome);
+    for (const k of ENV_KEYS) {
+        savedEnv[k] = process.env[k];
+        delete process.env[k];
+    }
+});
+
+afterEach(() => {
+    _setGlobalConfigDir(null);
+    rmSync(tmpHome, { recursive: true, force: true });
+    for (const k of ENV_KEYS) {
+        if (savedEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = savedEnv[k];
+    }
+});
+
+function writeGlobalConfig(config: Record<string, unknown>): void {
+    writeFileSync(join(tmpHome, "config.json"), JSON.stringify(config));
+}
+
+function writeSettings(settings: Record<string, unknown>): void {
+    writeFileSync(join(tmpHome, "settings.json"), JSON.stringify(settings));
+}
+
+// ── resolveSessionProvider ────────────────────────────────────────────────────
+
+describe("resolveSessionProvider", () => {
+    test("returns undefined when nothing is configured", () => {
+        expect(resolveSessionProvider()).toBeUndefined();
+    });
+
+    test("reads defaultProvider from settings.json", () => {
+        writeSettings({ defaultProvider: "claude-subscription" });
+        expect(resolveSessionProvider()).toBe("claude-subscription");
+    });
+
+    test("PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER beats settings.json", () => {
+        writeSettings({ defaultProvider: "anthropic" });
+        process.env.PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER = "openai";
+        expect(resolveSessionProvider()).toBe("openai");
+    });
+
+    test("PIZZAPI_SESSION_PROVIDER snapshot beats everything", () => {
+        writeSettings({ defaultProvider: "anthropic" });
+        process.env.PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER = "openai";
+        process.env.PIZZAPI_SESSION_PROVIDER = "google";
+        expect(resolveSessionProvider()).toBe("google");
+    });
+
+    test("ignores malformed settings.json", () => {
+        writeFileSync(join(tmpHome, "settings.json"), "{not json");
+        expect(resolveSessionProvider()).toBeUndefined();
+    });
+});
+
+// ── applyProviderOverrides ────────────────────────────────────────────────────
+
+describe("applyProviderOverrides", () => {
+    const base: PizzaPiConfig = {
+        appendSystemPrompt: "global append",
+        builtinSystemPrompt: true,
+        sendAgentsMd: true,
+        disabledMcpServers: ["already-off"],
+        providerSettings: {
+            anthropic: {
+                overrides: {
+                    builtinSystemPrompt: false,
+                    sendAgentsMd: false,
+                    appendSystemPrompt: "vanilla",
+                    disabledMcpServers: ["godmother", "already-off"],
+                },
+            },
+        },
+    };
+
+    test("no-op when provider is undefined", () => {
+        expect(applyProviderOverrides(base, undefined)).toBe(base);
+    });
+
+    test("no-op when provider has no overrides", () => {
+        expect(applyProviderOverrides(base, "openai")).toBe(base);
+    });
+
+    test("applies system prompt and AGENTS.md fields for matching provider", () => {
+        const merged = applyProviderOverrides(base, "anthropic");
+        expect(merged.builtinSystemPrompt).toBe(false);
+        expect(merged.sendAgentsMd).toBe(false);
+        expect(merged.appendSystemPrompt).toBe("vanilla");
+    });
+
+    test("unions disabledMcpServers with existing list", () => {
+        const merged = applyProviderOverrides(base, "anthropic");
+        expect(merged.disabledMcpServers!.sort()).toEqual(["already-off", "godmother"]);
+    });
+
+    test("supports full systemPrompt replacement", () => {
+        const config: PizzaPiConfig = {
+            providerSettings: { openai: { overrides: { systemPrompt: "You are a plain agent." } } },
+        };
+        expect(applyProviderOverrides(config, "openai").systemPrompt).toBe("You are a plain agent.");
+    });
+
+    test("ignores wrongly-typed override fields", () => {
+        const config = {
+            sendAgentsMd: true,
+            providerSettings: {
+                anthropic: { overrides: { sendAgentsMd: "nope", disabledMcpServers: [1, "ok"] } },
+            },
+        } as unknown as PizzaPiConfig;
+        const merged = applyProviderOverrides(config, "anthropic");
+        expect(merged.sendAgentsMd).toBe(true);
+        expect(merged.disabledMcpServers).toEqual(["ok"]);
+    });
+
+    test("does not mutate the input config", () => {
+        applyProviderOverrides(base, "anthropic");
+        expect(base.builtinSystemPrompt).toBe(true);
+        expect(base.disabledMcpServers).toEqual(["already-off"]);
+    });
+});
+
+// ── loadConfig integration ────────────────────────────────────────────────────
+
+describe("loadConfig provider overrides integration", () => {
+    test("applies overrides from settings.json defaultProvider", () => {
+        writeGlobalConfig({
+            sendAgentsMd: true,
+            providerSettings: {
+                "claude-subscription": {
+                    overrides: { builtinSystemPrompt: false, sendAgentsMd: false },
+                },
+            },
+        });
+        writeSettings({ defaultProvider: "claude-subscription" });
+
+        const config = loadConfig(projectDir);
+        expect(config.builtinSystemPrompt).toBe(false);
+        expect(config.sendAgentsMd).toBe(false);
+    });
+
+    test("no overrides applied for a different provider", () => {
+        writeGlobalConfig({
+            providerSettings: {
+                anthropic: { overrides: { sendAgentsMd: false } },
+            },
+        });
+        writeSettings({ defaultProvider: "openai" });
+
+        const config = loadConfig(projectDir);
+        expect(config.sendAgentsMd).toBeUndefined();
+    });
+
+    test("spawn-time provider env selects the override set", () => {
+        writeGlobalConfig({
+            providerSettings: {
+                anthropic: { overrides: { disabledMcpServers: ["playwright"] } },
+            },
+        });
+        writeSettings({ defaultProvider: "openai" });
+        process.env.PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER = "anthropic";
+
+        const config = loadConfig(projectDir);
+        expect(config.disabledMcpServers).toEqual(["playwright"]);
+    });
+});

--- a/packages/cli/src/config/system-prompt.test.ts
+++ b/packages/cli/src/config/system-prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from "bun:test";
-import { buildSystemPrompt, BUILTIN_SYSTEM_PROMPT } from "./system-prompt.js";
+import { buildSystemPrompt, maybeBuildSystemPrompt, BUILTIN_SYSTEM_PROMPT } from "./system-prompt.js";
 
 describe("buildSystemPrompt", () => {
     test("returns a non-empty string", () => {
@@ -143,6 +143,18 @@ describe("buildSystemPrompt", () => {
         expect(result).toContain("subagent-model-selection");
         expect(result).toContain("automatically selects the most cost-effective");
         expect(result).toContain("model: { provider, id }");
+    });
+});
+
+
+describe("maybeBuildSystemPrompt", () => {
+    test("returns the built-in prompt by default", () => {
+        expect(maybeBuildSystemPrompt({})).toContain('section name="sandbox"');
+        expect(maybeBuildSystemPrompt({ builtinSystemPrompt: true })).toContain('section name="sandbox"');
+    });
+
+    test("returns undefined when builtinSystemPrompt is false", () => {
+        expect(maybeBuildSystemPrompt({ builtinSystemPrompt: false })).toBeUndefined();
     });
 });
 

--- a/packages/cli/src/config/system-prompt.ts
+++ b/packages/cli/src/config/system-prompt.ts
@@ -62,6 +62,17 @@ export function buildSystemPrompt(ctx?: Partial<SystemPromptContext>): string {
 }
 
 /**
+ * Build the built-in system prompt unless the user disabled it via
+ * `builtinSystemPrompt: false` in ~/.pizzapi/config.json.
+ */
+export function maybeBuildSystemPrompt(
+    config: { builtinSystemPrompt?: boolean },
+    ctx?: Partial<SystemPromptContext>,
+): string | undefined {
+    return config.builtinSystemPrompt === false ? undefined : buildSystemPrompt(ctx);
+}
+
+/**
  * @deprecated Use `buildSystemPrompt()` for dynamic context support.
  * Kept for backward compatibility — evaluates with current date/time.
  */

--- a/packages/cli/src/config/templates/system-prompt.hbs
+++ b/packages/cli/src/config/templates/system-prompt.hbs
@@ -99,6 +99,7 @@ PizzaPi is built on top of pi but has its own configuration system. Understandin
 - `sandbox` — Sandbox mode and filesystem/network overrides.
 - `skills` — Additional skill paths beyond the defaults.
 - `appendSystemPrompt` — Extra system prompt text appended after the built-in prompt.
+- `sendAgentsMd` — Set to `false` to omit AGENTS.md files from automatic prompt context.
 - `allowProjectHooks` — Trust gate for project-local hooks (must be set in global config).
 - `trustedPlugins` — Trusted Claude Code plugin directories.
 </config>

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -314,6 +314,8 @@ export interface PizzaPiConfig {
     agentDir?: string;
     /** Prepend text to the system prompt without replacing it */
     appendSystemPrompt?: string;
+    /** Set to false to skip PizzaPi's built-in system prompt (vanilla pi prompt). Default: true */
+    builtinSystemPrompt?: boolean;
     /** API key for authenticating with the PizzaPi relay server */
     apiKey?: string;
     /** WebSocket URL of the PizzaPi relay server. Default: ws://localhost:7492. Set to "off" to disable relay entirely. */

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -263,12 +263,36 @@ export interface WebSearchConfig {
 }
 
 /**
+ * Per-provider config overrides, applied on top of the merged global+project
+ * config when a session's model provider matches the key.
+ *
+ * The provider is resolved once at session start (spawned model → env var,
+ * otherwise `defaultProvider` from ~/.pizzapi/settings.json). Mid-session
+ * model switches do NOT re-apply overrides — same "next session start"
+ * semantics as every other config change.
+ */
+export interface ProviderOverrides {
+    /** Replace the default system prompt for sessions on this provider. */
+    systemPrompt?: string;
+    /** Append to the system prompt for sessions on this provider. */
+    appendSystemPrompt?: string;
+    /** Set false to skip PizzaPi's built-in prompt additions on this provider. */
+    builtinSystemPrompt?: boolean;
+    /** Set false to omit AGENTS.md context on this provider. */
+    sendAgentsMd?: boolean;
+    /** Additional MCP server names to disable on this provider (union with global/project lists). */
+    disabledMcpServers?: string[];
+}
+
+/**
  * Provider-specific settings. Keys are provider names (e.g., "anthropic").
  */
 export interface ProviderSettings {
     [provider: string]: {
         /** Web search configuration. */
         webSearch?: WebSearchConfig;
+        /** Config overrides applied when a session starts on this provider. */
+        overrides?: ProviderOverrides;
     };
 }
 

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -376,6 +376,9 @@ export interface PizzaPiConfig {
      */
     disabledMcpServers?: string[];
 
+    /** PIZZAPI_* environment overrides applied to runner worker sessions. */
+    envOverrides?: Record<string, string>;
+
     /**
      * Timeout (in milliseconds) for each MCP server's tools/list call during
      * startup. Servers that don't respond within this window are skipped with

--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -316,6 +316,8 @@ export interface PizzaPiConfig {
     appendSystemPrompt?: string;
     /** Set to false to skip PizzaPi's built-in system prompt (vanilla pi prompt). Default: true */
     builtinSystemPrompt?: boolean;
+    /** Set to false to omit AGENTS.md files from automatic context loading. Default: true */
+    sendAgentsMd?: boolean;
     /** API key for authenticating with the PizzaPi relay server */
     apiKey?: string;
     /** WebSocket URL of the PizzaPi relay server. Default: ws://localhost:7492. Set to "off" to disable relay entirely. */

--- a/packages/cli/src/extensions/factories.test.ts
+++ b/packages/cli/src/extensions/factories.test.ts
@@ -25,8 +25,10 @@ import { pizzapiHeaderExtension } from "./pizzapi-header.js";
 import { toolSearchExtension } from "./tool-search.js";
 import { ollamaWebToolsExtension } from "./ollama-web-tools.js";
 import { sessionAnalysisExtension } from "./session-analysis.js";
+import { providerRequestLogExtension } from "./provider-request-log.js";
 
 const CORE_EXTENSIONS: ExtensionFactory[] = [
+    providerRequestLogExtension,
     triggersExtension,  // Must be before remoteExtension (shutdown ordering)
     remoteExtension,
     tunnelToolsExtension,

--- a/packages/cli/src/extensions/factories.ts
+++ b/packages/cli/src/extensions/factories.ts
@@ -22,6 +22,7 @@ import { toolSearchExtension } from "./tool-search.js";
 import { ollamaWebToolsExtension } from "./ollama-web-tools.js";
 import { providerExtension } from "./providers/extension.js";
 import { sessionAnalysisExtension } from "./session-analysis.js";
+import { providerRequestLogExtension } from "./provider-request-log.js";
 
 export interface BuildExtensionFactoriesOptions {
     cwd: string;
@@ -48,6 +49,10 @@ function named(factory: ExtensionFactory, displayName: string): ExtensionFactory
  */
 export function buildPizzaPiExtensionFactories(options: BuildExtensionFactoriesOptions): ExtensionFactory[] {
     const factories: ExtensionFactory[] = [];
+
+    // Diagnostic (off unless PIZZAPI_LOG_PROVIDER_REQUEST is set): log the
+    // resolved provider/api and request shape for each outbound turn.
+    factories.push(named(providerRequestLogExtension, "provider-request-log"));
 
     // triggersExtension provides tell_child, respond_to_trigger, escalate_trigger tools.
     // session_complete is fired from remoteExtension's shutdown handler (before disconnect).

--- a/packages/cli/src/extensions/provider-request-log.test.ts
+++ b/packages/cli/src/extensions/provider-request-log.test.ts
@@ -1,28 +1,49 @@
 import { describe, test, expect } from "bun:test";
 import { providerRequestLogExtension } from "./provider-request-log.js";
 
-// Minimal fake ExtensionAPI capturing handlers.
-function makeFakePi() {
-    const handlers: Record<string, Function> = {};
-    return {
-        pi: { on: (ev: string, h: Function) => { handlers[ev] = h; } } as any,
-        handlers,
-    };
-}
-
 describe("providerRequestLogExtension", () => {
-    test("registers a before_provider_request handler that never throws", () => {
-        const { pi, handlers } = makeFakePi();
-        providerRequestLogExtension(pi);
-        const handler = handlers["before_provider_request"];
-        expect(typeof handler).toBe("function");
-        // Handler must be defensive against odd payloads.
-        expect(() =>
-            handler(
-                { payload: { model: "m", system: [{ text: "a" }, { text: "bb" }], tools: [{ name: "Bash" }] } },
-                { model: { provider: "claude-subscription", id: "claude-sonnet-5", api: "claude-subscription-native" } },
-            ),
-        ).not.toThrow();
-        expect(() => handler({ payload: undefined }, {})).not.toThrow();
+    test("wraps global fetch and passes through non-anthropic calls unchanged", async () => {
+        const original = globalThis.fetch;
+        try {
+            let seen: any;
+            globalThis.fetch = (async (input: any, init?: any) => {
+                seen = { input, init };
+                return new Response("ok");
+            }) as unknown as typeof fetch;
+
+            providerRequestLogExtension({} as any);
+            // fetch should now be wrapped (different reference from our stub)
+            expect(globalThis.fetch).not.toBe(original);
+
+            const res = await globalThis.fetch("https://example.com/health", { method: "GET" });
+            expect(await res.text()).toBe("ok");
+            expect(seen.input).toBe("https://example.com/health");
+        } finally {
+            globalThis.fetch = original;
+        }
+    });
+
+    test("does not throw when logging an anthropic /v1/messages request", async () => {
+        const original = globalThis.fetch;
+        try {
+            globalThis.fetch = (async () => new Response("{}")) as unknown as typeof fetch;
+            providerRequestLogExtension({} as any);
+            const body = JSON.stringify({
+                model: "claude-fable-5",
+                max_tokens: 100,
+                system: [{ type: "text", text: "hi" }],
+                messages: [{ role: "user", content: "x" }],
+                tools: [{ name: "Bash" }],
+                thinking: { type: "adaptive" },
+            });
+            const res = await globalThis.fetch("https://api.anthropic.com/v1/messages", {
+                method: "POST",
+                headers: { Authorization: "Bearer sk-ant-oat01-SECRETSECRET", "anthropic-beta": "oauth-2025-04-20" },
+                body,
+            });
+            expect(res.status).toBe(200);
+        } finally {
+            globalThis.fetch = original;
+        }
     });
 });

--- a/packages/cli/src/extensions/provider-request-log.test.ts
+++ b/packages/cli/src/extensions/provider-request-log.test.ts
@@ -11,30 +11,18 @@ function makeFakePi() {
 }
 
 describe("providerRequestLogExtension", () => {
-    test("does not register when env flag is off", () => {
-        delete process.env.PIZZAPI_LOG_PROVIDER_REQUEST;
+    test("registers a before_provider_request handler that never throws", () => {
         const { pi, handlers } = makeFakePi();
         providerRequestLogExtension(pi);
-        expect(handlers["before_provider_request"]).toBeUndefined();
-    });
-
-    test("registers a before_provider_request handler when enabled and never throws", () => {
-        process.env.PIZZAPI_LOG_PROVIDER_REQUEST = "1";
-        try {
-            const { pi, handlers } = makeFakePi();
-            providerRequestLogExtension(pi);
-            const handler = handlers["before_provider_request"];
-            expect(typeof handler).toBe("function");
-            // Handler must be defensive against odd payloads.
-            expect(() =>
-                handler(
-                    { payload: { model: "m", system: [{ text: "a" }, { text: "bb" }], tools: [{ name: "Bash" }] } },
-                    { model: { provider: "claude-subscription", id: "claude-sonnet-5", api: "claude-subscription-native" } },
-                ),
-            ).not.toThrow();
-            expect(() => handler({ payload: undefined }, {})).not.toThrow();
-        } finally {
-            delete process.env.PIZZAPI_LOG_PROVIDER_REQUEST;
-        }
+        const handler = handlers["before_provider_request"];
+        expect(typeof handler).toBe("function");
+        // Handler must be defensive against odd payloads.
+        expect(() =>
+            handler(
+                { payload: { model: "m", system: [{ text: "a" }, { text: "bb" }], tools: [{ name: "Bash" }] } },
+                { model: { provider: "claude-subscription", id: "claude-sonnet-5", api: "claude-subscription-native" } },
+            ),
+        ).not.toThrow();
+        expect(() => handler({ payload: undefined }, {})).not.toThrow();
     });
 });

--- a/packages/cli/src/extensions/provider-request-log.test.ts
+++ b/packages/cli/src/extensions/provider-request-log.test.ts
@@ -1,0 +1,40 @@
+import { describe, test, expect } from "bun:test";
+import { providerRequestLogExtension } from "./provider-request-log.js";
+
+// Minimal fake ExtensionAPI capturing handlers.
+function makeFakePi() {
+    const handlers: Record<string, Function> = {};
+    return {
+        pi: { on: (ev: string, h: Function) => { handlers[ev] = h; } } as any,
+        handlers,
+    };
+}
+
+describe("providerRequestLogExtension", () => {
+    test("does not register when env flag is off", () => {
+        delete process.env.PIZZAPI_LOG_PROVIDER_REQUEST;
+        const { pi, handlers } = makeFakePi();
+        providerRequestLogExtension(pi);
+        expect(handlers["before_provider_request"]).toBeUndefined();
+    });
+
+    test("registers a before_provider_request handler when enabled and never throws", () => {
+        process.env.PIZZAPI_LOG_PROVIDER_REQUEST = "1";
+        try {
+            const { pi, handlers } = makeFakePi();
+            providerRequestLogExtension(pi);
+            const handler = handlers["before_provider_request"];
+            expect(typeof handler).toBe("function");
+            // Handler must be defensive against odd payloads.
+            expect(() =>
+                handler(
+                    { payload: { model: "m", system: [{ text: "a" }, { text: "bb" }], tools: [{ name: "Bash" }] } },
+                    { model: { provider: "claude-subscription", id: "claude-sonnet-5", api: "claude-subscription-native" } },
+                ),
+            ).not.toThrow();
+            expect(() => handler({ payload: undefined }, {})).not.toThrow();
+        } finally {
+            delete process.env.PIZZAPI_LOG_PROVIDER_REQUEST;
+        }
+    });
+});

--- a/packages/cli/src/extensions/provider-request-log.ts
+++ b/packages/cli/src/extensions/provider-request-log.ts
@@ -1,0 +1,68 @@
+/**
+ * Diagnostic: log which provider/api actually handles each outbound request,
+ * plus the shape of what PizzaPi puts on the wire (system-block sizes, tool
+ * names). Used to prove whether a turn routes through a custom provider's
+ * native path (e.g. `claude-subscription-native`) or falls back to a built-in
+ * API handler (e.g. `anthropic-messages`), and whether PizzaPi's system prompt
+ * diverges from what the provider expects.
+ *
+ * Enabled only when PIZZAPI_LOG_PROVIDER_REQUEST is set (off by default so it
+ * never adds log noise or per-request cost in normal operation).
+ */
+
+import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { logInfo } from "../runner/logger.js";
+
+function isEnabled(): boolean {
+    const v = process.env.PIZZAPI_LOG_PROVIDER_REQUEST;
+    return !!v && !["0", "false", "no", "off"].includes(v.toLowerCase());
+}
+
+function summarizeSystem(system: unknown): { blocks: number; chars: number; firstBlock: string } {
+    if (typeof system === "string") {
+        return { blocks: 1, chars: system.length, firstBlock: system.slice(0, 60) };
+    }
+    if (Array.isArray(system)) {
+        let chars = 0;
+        for (const b of system) {
+            const t = b && typeof b === "object" ? (b as { text?: unknown }).text : undefined;
+            if (typeof t === "string") chars += t.length;
+        }
+        const first = system[0] && typeof system[0] === "object" ? (system[0] as { text?: unknown }).text : undefined;
+        return { blocks: system.length, chars, firstBlock: typeof first === "string" ? first.slice(0, 60) : "" };
+    }
+    return { blocks: 0, chars: 0, firstBlock: "" };
+}
+
+export function providerRequestLogExtension(pi: ExtensionAPI): void {
+    if (!isEnabled()) return;
+
+    pi.on("before_provider_request", (event, ctx) => {
+        try {
+            const model = (ctx as { model?: { provider?: string; id?: string; api?: string } }).model;
+            const payload = event.payload as { model?: unknown; system?: unknown; tools?: unknown[] } | undefined;
+            const sys = summarizeSystem(payload?.system);
+            const tools = Array.isArray(payload?.tools) ? payload!.tools : [];
+            const toolNames = tools
+                .map((t) => (t && typeof t === "object" ? (t as { name?: unknown }).name : undefined))
+                .filter((n): n is string => typeof n === "string");
+
+            logInfo(
+                "[provider-request] " +
+                    JSON.stringify({
+                        provider: model?.provider,
+                        api: model?.api,
+                        modelId: model?.id,
+                        payloadModel: payload?.model,
+                        systemBlocks: sys.blocks,
+                        systemChars: sys.chars,
+                        systemFirstBlock: sys.firstBlock,
+                        toolCount: toolNames.length,
+                        toolNames: toolNames.slice(0, 40),
+                    }),
+            );
+        } catch {
+            // Diagnostic only — never disrupt the request.
+        }
+    });
+}

--- a/packages/cli/src/extensions/provider-request-log.ts
+++ b/packages/cli/src/extensions/provider-request-log.ts
@@ -1,61 +1,71 @@
 /**
- * Diagnostic: log which provider/api actually handles each outbound request,
- * plus the shape of what PizzaPi puts on the wire (system-block sizes, tool
- * names). Used to prove whether a turn routes through a custom provider's
- * native path (e.g. `claude-subscription-native`) or falls back to a built-in
- * API handler (e.g. `anthropic-messages`), and whether PizzaPi's system prompt
- * diverges from what the provider expects.
+ * Diagnostic: capture the ACTUAL outbound HTTP request to Anthropic's
+ * /v1/messages endpoint (headers + body), so we can compare byte-for-byte what
+ * PizzaPi sends vs what vanilla pi sends through the same claude-subscription
+ * extension. The `before_provider_request` event payload is NOT the real wire
+ * request (custom providers build their own via streamSimple), so we wrap
+ * global fetch instead.
  *
  * ponytail: temporarily always-on for debugging the claude-subscription
- * routing issue. Remove this extension (or re-gate it) once resolved.
+ * routing/billing issue. Remove this extension once resolved.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { logInfo } from "../runner/logger.js";
 
-function summarizeSystem(system: unknown): { blocks: number; chars: number; firstBlock: string } {
-    if (typeof system === "string") {
-        return { blocks: 1, chars: system.length, firstBlock: system.slice(0, 60) };
-    }
-    if (Array.isArray(system)) {
-        let chars = 0;
-        for (const b of system) {
-            const t = b && typeof b === "object" ? (b as { text?: unknown }).text : undefined;
-            if (typeof t === "string") chars += t.length;
-        }
-        const first = system[0] && typeof system[0] === "object" ? (system[0] as { text?: unknown }).text : undefined;
-        return { blocks: system.length, chars, firstBlock: typeof first === "string" ? first.slice(0, 60) : "" };
-    }
-    return { blocks: 0, chars: 0, firstBlock: "" };
+let fetchWrapped = false;
+
+/** Redact a bearer token to a short, non-reversible fingerprint. */
+function tokenFingerprint(auth: string | undefined): string {
+    if (!auth) return "(none)";
+    const tok = auth.replace(/^Bearer\s+/i, "");
+    // last 6 chars + length — enough to tell "same token?" without leaking it.
+    return `…${tok.slice(-6)}(len=${tok.length})`;
 }
 
-export function providerRequestLogExtension(pi: ExtensionAPI): void {
-    pi.on("before_provider_request", (event, ctx) => {
-        try {
-            const model = (ctx as { model?: { provider?: string; id?: string; api?: string } }).model;
-            const payload = event.payload as { model?: unknown; system?: unknown; tools?: unknown[] } | undefined;
-            const sys = summarizeSystem(payload?.system);
-            const tools = Array.isArray(payload?.tools) ? payload!.tools : [];
-            const toolNames = tools
-                .map((t) => (t && typeof t === "object" ? (t as { name?: unknown }).name : undefined))
-                .filter((n): n is string => typeof n === "string");
-
-            logInfo(
-                "[provider-request] " +
-                    JSON.stringify({
-                        provider: model?.provider,
-                        api: model?.api,
-                        modelId: model?.id,
-                        payloadModel: payload?.model,
-                        systemBlocks: sys.blocks,
-                        systemChars: sys.chars,
-                        systemFirstBlock: sys.firstBlock,
-                        toolCount: toolNames.length,
-                        toolNames: toolNames.slice(0, 40),
-                    }),
-            );
-        } catch {
-            // Diagnostic only — never disrupt the request.
+function summarizeBody(bodyText: string): Record<string, unknown> {
+    let body: any;
+    try { body = JSON.parse(bodyText); } catch { return { parseError: true, rawLen: bodyText.length }; }
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(body)) {
+        if (k === "system") {
+            const chars = Array.isArray(v)
+                ? v.reduce((n, b: any) => n + (typeof b?.text === "string" ? b.text.length : 0), 0)
+                : (typeof v === "string" ? v.length : 0);
+            out.systemBlocks = Array.isArray(v) ? v.length : 1;
+            out.systemChars = chars;
+        } else if (k === "messages") {
+            out.messageCount = Array.isArray(v) ? v.length : 0;
+        } else if (k === "tools") {
+            out.toolNames = Array.isArray(v) ? v.map((t: any) => t?.name).filter(Boolean) : [];
+        } else {
+            out[k] = v; // model, max_tokens, thinking, output_config, metadata, fallbacks, temperature, stream, …
         }
-    });
+    }
+    return out;
+}
+
+function wrapFetch(): void {
+    if (fetchWrapped) return;
+    fetchWrapped = true;
+    const orig = globalThis.fetch;
+    globalThis.fetch = (async (input: any, init?: any) => {
+        try {
+            const url = typeof input === "string" ? input : input?.url ?? String(input);
+            if (typeof url === "string" && url.includes("api.anthropic.com") && url.includes("/v1/messages")) {
+                const headers = new Headers(init?.headers ?? (typeof input === "object" ? input.headers : undefined));
+                const hdr: Record<string, string> = {};
+                headers.forEach((v, k) => { hdr[k] = k.toLowerCase() === "authorization" ? tokenFingerprint(v) : v; });
+                let bodyText = "";
+                const b = init?.body ?? (typeof input === "object" ? input.body : undefined);
+                if (typeof b === "string") bodyText = b;
+                logInfo("[anthropic-request] " + JSON.stringify({ url, headers: hdr, body: summarizeBody(bodyText) }));
+            }
+        } catch { /* never disrupt the request */ }
+        return orig(input, init);
+    }) as typeof fetch;
+}
+
+export function providerRequestLogExtension(_pi: ExtensionAPI): void {
+    wrapFetch();
 }

--- a/packages/cli/src/extensions/provider-request-log.ts
+++ b/packages/cli/src/extensions/provider-request-log.ts
@@ -6,17 +6,12 @@
  * API handler (e.g. `anthropic-messages`), and whether PizzaPi's system prompt
  * diverges from what the provider expects.
  *
- * Enabled only when PIZZAPI_LOG_PROVIDER_REQUEST is set (off by default so it
- * never adds log noise or per-request cost in normal operation).
+ * ponytail: temporarily always-on for debugging the claude-subscription
+ * routing issue. Remove this extension (or re-gate it) once resolved.
  */
 
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
 import { logInfo } from "../runner/logger.js";
-
-function isEnabled(): boolean {
-    const v = process.env.PIZZAPI_LOG_PROVIDER_REQUEST;
-    return !!v && !["0", "false", "no", "off"].includes(v.toLowerCase());
-}
 
 function summarizeSystem(system: unknown): { blocks: number; chars: number; firstBlock: string } {
     if (typeof system === "string") {
@@ -35,8 +30,6 @@ function summarizeSystem(system: unknown): { blocks: number; chars: number; firs
 }
 
 export function providerRequestLogExtension(pi: ExtensionAPI): void {
-    if (!isEnabled()) return;
-
     pi.on("before_provider_request", (event, ctx) => {
         try {
             const model = (ctx as { model?: { provider?: string; id?: string; api?: string } }).model;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -10,7 +10,7 @@ import {
     SessionManager,
 } from "@earendil-works/pi-coding-agent";
 import { join } from "path";
-import { buildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
+import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
 import { isPackageCommand, runPackageCommand } from "./package-commands.js";
 import { getOAuthAccessToken } from "./runner/usage-auth.js";
 import { c, usageBar, colorPct, colorRemaining } from "./cli-colors.js";
@@ -487,7 +487,7 @@ async function main() {
             : {}
         ),
         appendSystemPrompt: (() => {
-            const parts = [buildSystemPrompt({ cwd }), config.appendSystemPrompt].filter(Boolean) as string[];
+            const parts = [maybeBuildSystemPrompt(config, { cwd }), config.appendSystemPrompt].filter(Boolean) as string[];
             return parts;
         })(),
         ...(agentsFilesOverride && { agentsFilesOverride }),
@@ -510,7 +510,7 @@ async function main() {
                 ...(config.systemPrompt !== undefined && {
                     systemPromptOverride: () => config.systemPrompt,
                 }),
-                appendSystemPrompt: [buildSystemPrompt({ cwd: opts.cwd }), config.appendSystemPrompt].filter(Boolean) as string[],
+                appendSystemPrompt: [maybeBuildSystemPrompt(config, { cwd: opts.cwd }), config.appendSystemPrompt].filter(Boolean) as string[],
                 ...(agentsFilesOverride && { agentsFilesOverride }),
             },
         });

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -457,7 +457,9 @@ async function main() {
 
     // Build shared agentsFilesOverride (loads AGENTS.md + .agents/*.md from cwd,
     // deduplicating against what DefaultResourceLoader already discovers).
-    const agentsFilesOverride = createAgentsFilesOverride(cwd);
+    const agentsFilesOverride = createAgentsFilesOverride(cwd, {
+        sendAgentsMd: config.sendAgentsMd !== false,
+    });
 
     // Override relay URL if --no-relay was passed
     if (noRelay) {

--- a/packages/cli/src/runner/daemon-config-sanitize.test.ts
+++ b/packages/cli/src/runner/daemon-config-sanitize.test.ts
@@ -5,7 +5,105 @@ import {
     SENSITIVE_NAME_RE,
     MASK_SENTINEL,
     findRenamedServerMatch,
+    validateProviderOverridesSection,
+    mergeProviderOverridesSection,
 } from "./daemon-config-sanitize.js";
+
+// ── validateProviderOverridesSection ──────────────────────────────────────
+
+describe("validateProviderOverridesSection", () => {
+    test("accepts null/undefined and empty objects", () => {
+        expect(validateProviderOverridesSection(null)).toEqual([]);
+        expect(validateProviderOverridesSection(undefined)).toEqual([]);
+        expect(validateProviderOverridesSection({})).toEqual([]);
+    });
+
+    test("rejects non-object payloads", () => {
+        expect(validateProviderOverridesSection(["x"]).length).toBe(1);
+        expect(validateProviderOverridesSection("x").length).toBe(1);
+    });
+
+    test("accepts a valid override set", () => {
+        expect(
+            validateProviderOverridesSection({
+                anthropic: {
+                    builtinSystemPrompt: false,
+                    sendAgentsMd: false,
+                    appendSystemPrompt: "",
+                    disabledMcpServers: ["playwright"],
+                },
+            }),
+        ).toEqual([]);
+    });
+
+    test("reports each wrongly-typed field", () => {
+        const errors = validateProviderOverridesSection({
+            anthropic: {
+                builtinSystemPrompt: "no",
+                sendAgentsMd: 1,
+                appendSystemPrompt: 5,
+                disabledMcpServers: [1],
+            },
+            openai: "not-an-object",
+        });
+        expect(errors.length).toBe(5);
+    });
+});
+
+// ── mergeProviderOverridesSection ─────────────────────────────────────────
+
+describe("mergeProviderOverridesSection", () => {
+    test("adds overrides while preserving webSearch settings", () => {
+        const existing = {
+            anthropic: { webSearch: { enabled: true } },
+        };
+        const merged = mergeProviderOverridesSection(existing, {
+            anthropic: { sendAgentsMd: false },
+        });
+        expect(merged.anthropic).toEqual({
+            webSearch: { enabled: true },
+            overrides: { sendAgentsMd: false },
+        });
+    });
+
+    test("payload is authoritative — removed providers lose overrides", () => {
+        const existing = {
+            anthropic: { webSearch: { enabled: true }, overrides: { sendAgentsMd: false } },
+            openai: { overrides: { builtinSystemPrompt: false } },
+        };
+        const merged = mergeProviderOverridesSection(existing, {});
+        expect(merged.anthropic).toEqual({ webSearch: { enabled: true } });
+        expect(merged.openai).toBeUndefined();
+    });
+
+    test("drops unknown override keys", () => {
+        const merged = mergeProviderOverridesSection({}, {
+            anthropic: { sendAgentsMd: false, apiKey: "sneaky" },
+        });
+        expect((merged.anthropic as any).overrides).toEqual({ sendAgentsMd: false });
+    });
+
+    test("skips entries with no effective overrides", () => {
+        const merged = mergeProviderOverridesSection({}, {
+            anthropic: {},
+            openai: { disabledMcpServers: [] },
+        });
+        expect(merged).toEqual({});
+    });
+
+    test("keeps empty-string appendSystemPrompt as a real override", () => {
+        const merged = mergeProviderOverridesSection({}, {
+            anthropic: { appendSystemPrompt: "" },
+        });
+        expect((merged.anthropic as any).overrides).toEqual({ appendSystemPrompt: "" });
+    });
+
+    test("does not mutate the existing settings object", () => {
+        const existing = { anthropic: { overrides: { sendAgentsMd: false } } };
+        mergeProviderOverridesSection(existing, {});
+        expect(existing.anthropic.overrides).toEqual({ sendAgentsMd: false });
+    });
+});
 
 // ── SENSITIVE_NAME_RE ─────────────────────────────────────────────────────────
 

--- a/packages/cli/src/runner/daemon-config-sanitize.ts
+++ b/packages/cli/src/runner/daemon-config-sanitize.ts
@@ -161,6 +161,102 @@ export function restoreMaskedServerEntry(
 }
 
 
+// ── Provider overrides section ─────────────────────────────────────────────
+
+const OVERRIDE_KEYS = [
+    "systemPrompt",
+    "appendSystemPrompt",
+    "builtinSystemPrompt",
+    "sendAgentsMd",
+    "disabledMcpServers",
+] as const;
+
+/**
+ * Validate a `providerOverrides` settings payload — a map of
+ * provider name → ProviderOverrides. Returns a list of human-readable
+ * problems (empty = valid).
+ */
+export function validateProviderOverridesSection(value: unknown): string[] {
+    if (value == null) return [];
+    if (typeof value !== "object" || Array.isArray(value)) {
+        return ["providerOverrides must be a JSON object (Record<provider, overrides>)"];
+    }
+    const errors: string[] = [];
+    for (const [provider, entry] of Object.entries(value as Record<string, unknown>)) {
+        if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
+            errors.push(`"${provider}": must be an object`);
+            continue;
+        }
+        const e = entry as Record<string, unknown>;
+        if (e.systemPrompt !== undefined && typeof e.systemPrompt !== "string") {
+            errors.push(`"${provider}".systemPrompt must be a string`);
+        }
+        if (e.appendSystemPrompt !== undefined && typeof e.appendSystemPrompt !== "string") {
+            errors.push(`"${provider}".appendSystemPrompt must be a string`);
+        }
+        if (e.builtinSystemPrompt !== undefined && typeof e.builtinSystemPrompt !== "boolean") {
+            errors.push(`"${provider}".builtinSystemPrompt must be a boolean`);
+        }
+        if (e.sendAgentsMd !== undefined && typeof e.sendAgentsMd !== "boolean") {
+            errors.push(`"${provider}".sendAgentsMd must be a boolean`);
+        }
+        if (
+            e.disabledMcpServers !== undefined &&
+            (!Array.isArray(e.disabledMcpServers) ||
+                e.disabledMcpServers.some((s) => typeof s !== "string"))
+        ) {
+            errors.push(`"${provider}".disabledMcpServers must be an array of strings`);
+        }
+    }
+    return errors;
+}
+
+/**
+ * Merge a `providerOverrides` payload into existing `providerSettings`.
+ *
+ * The incoming map is authoritative for the `overrides` key: providers absent
+ * from the payload (or with no recognised override fields) lose their
+ * overrides. Other per-provider settings (e.g. `webSearch`) are preserved.
+ * Only recognised override keys are copied — unknown keys are dropped.
+ */
+export function mergeProviderOverridesSection(
+    existing: Record<string, unknown> | undefined,
+    incoming: Record<string, unknown>,
+): Record<string, unknown> {
+    const ps: Record<string, any> = { ...(existing ?? {}) };
+
+    // Drop all existing overrides — the payload replaces them wholesale.
+    for (const key of Object.keys(ps)) {
+        const entry = ps[key];
+        if (entry && typeof entry === "object" && "overrides" in entry) {
+            const { overrides: _dropped, ...rest } = entry;
+            if (Object.keys(rest).length > 0) ps[key] = rest;
+            else delete ps[key];
+        }
+    }
+
+    for (const [provider, value] of Object.entries(incoming)) {
+        if (!value || typeof value !== "object" || Array.isArray(value)) continue;
+        const overrides: Record<string, unknown> = {};
+        for (const k of OVERRIDE_KEYS) {
+            if ((value as Record<string, unknown>)[k] !== undefined) {
+                overrides[k] = (value as Record<string, unknown>)[k];
+            }
+        }
+        // Skip empty override objects and empty disable lists with nothing else set.
+        if (
+            Array.isArray(overrides.disabledMcpServers) &&
+            overrides.disabledMcpServers.length === 0
+        ) {
+            delete overrides.disabledMcpServers;
+        }
+        if (Object.keys(overrides).length === 0) continue;
+        ps[provider] = { ...(ps[provider] ?? {}), overrides };
+    }
+
+    return ps;
+}
+
 /**
  * Collect env/header keys that carry the mask sentinel on the given entry.
  */

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1916,6 +1916,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         const v = value as any;
                         const updates: Record<string, any> = {};
                         if (v?.appendSystemPrompt !== undefined) updates.appendSystemPrompt = v.appendSystemPrompt;
+                        if (v?.builtinSystemPrompt !== undefined) updates.builtinSystemPrompt = v.builtinSystemPrompt;
                         if (v?.skills !== undefined) updates.skills = v.skills;
                         saveGlobal(updates);
                     } else if (section === "envVars") {

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -1917,6 +1917,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         const updates: Record<string, any> = {};
                         if (v?.appendSystemPrompt !== undefined) updates.appendSystemPrompt = v.appendSystemPrompt;
                         if (v?.builtinSystemPrompt !== undefined) updates.builtinSystemPrompt = v.builtinSystemPrompt;
+                        if (v?.sendAgentsMd !== undefined) updates.sendAgentsMd = v.sendAgentsMd;
                         if (v?.skills !== undefined) updates.skills = v.skills;
                         saveGlobal(updates);
                     } else if (section === "envVars") {

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -30,7 +30,7 @@ import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import type { ServiceTriggerDef, ServiceSigilDef, TriggerSubscriptionEntry } from "@pizzapi/protocol";
 import { setLogComponent, logInfo, logWarn, logError } from "./logger.js";
 import { extractHookSummary } from "./hook-summary.js";
-import { sanitizeConfigForUI, restoreMaskedServerEntry, findRenamedServerMatch, MASK_SENTINEL } from "./daemon-config-sanitize.js";
+import { sanitizeConfigForUI, restoreMaskedServerEntry, findRenamedServerMatch, MASK_SENTINEL, validateProviderOverridesSection, mergeProviderOverridesSection } from "./daemon-config-sanitize.js";
 import { defaultStatePath, acquireStateAndIdentity, releaseStateLock } from "./runner-state.js";
 import { startUsageRefreshLoop, stopUsageRefreshLoop } from "./runner-usage-cache.js";
 import { getWorkspaceRoots, isCwdAllowed } from "./workspace.js";
@@ -1935,6 +1935,23 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                         }
                         const updates: Record<string, any> = { envOverrides: restoredOverrides };
                         saveGlobal(updates);
+                    } else if (section === "providerOverrides") {
+                        // Per-provider overrides (system prompt, AGENTS.md, MCP disable
+                        // list) go into providerSettings.<provider>.overrides.
+                        const validationErrors = validateProviderOverridesSection(value);
+                        if (validationErrors.length > 0) {
+                            socket.emit("file_result", {
+                                requestId,
+                                ok: false,
+                                message: `Invalid provider overrides:\n${validationErrors.join("\n")}`,
+                            });
+                            return;
+                        }
+                        const ps = mergeProviderOverridesSection(
+                            (existing as any).providerSettings,
+                            (value ?? {}) as Record<string, unknown>,
+                        );
+                        saveGlobal({ providerSettings: ps } as any);
                     } else if (section === "webSearch") {
                         // Web search config goes into providerSettings
                         const v = value as any;

--- a/packages/cli/src/runner/session-spawner.test.ts
+++ b/packages/cli/src/runner/session-spawner.test.ts
@@ -85,6 +85,17 @@ describe("session-spawner child", () => {
             isCwdAllowed,
         }));
 
+        mock.module("../config.js", () => ({
+            loadConfig: () => ({
+                envOverrides: {
+                    PIZZAPI_NO_MCP: "1",
+                    PIZZAPI_RELAY_URL: "ignored",
+                    ANTHROPIC_API_KEY: "ignored",
+                    NODE_OPTIONS: "ignored",
+                },
+            }),
+        }));
+
         const { spawnSession } = await import("./session-spawner.js");
         const tempCwd = mkdtempSync(join(tmpdir(), "session-spawner-child-"));
 
@@ -122,6 +133,7 @@ describe("session-spawner child", () => {
             expect(lastSpawnCall?.stdio).toEqual(["ignore", "inherit", "inherit", "ipc"]);
             expect(lastSpawnCall?.env).toMatchObject({
                 ANTHROPIC_API_KEY: "keep-me",
+                PIZZAPI_NO_MCP: "1",
                 PIZZAPI_RELAY_URL: "https://relay.example",
                 PIZZAPI_API_KEY: "api-key",
                 PIZZAPI_SESSION_ID: "sess-main",

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -116,6 +116,9 @@ export function spawnSession(
     const WORKER_ENV_DENYLIST = new Set([
         "PIZZAPI_RUNNER_TOKEN",
         "PIZZAPI_RUNNER_API_KEY",
+        // Per-session provider snapshot — each worker derives its own from
+        // PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER; never inherit the daemon's.
+        "PIZZAPI_SESSION_PROVIDER",
         "NODE_OPTIONS",
         "BUN_OPTIONS",           // Bun equivalent of NODE_OPTIONS — can inject code via --preload
         "LD_PRELOAD",

--- a/packages/cli/src/runner/session-spawner.ts
+++ b/packages/cli/src/runner/session-spawner.ts
@@ -5,6 +5,7 @@ import { cleanupSessionAttachments } from "../extensions/session-attachments.js"
 import { logInfo } from "./logger.js";
 import { runnerUsageCacheFilePath, trackSessionCwd, untrackSessionCwd } from "./runner-usage-cache.js";
 import { isCwdAllowed } from "./workspace.js";
+import { loadConfig } from "../config.js";
 
 export interface RunnerSession {
     sessionId: string;
@@ -129,8 +130,16 @@ export function spawnSession(
         }
     }
 
+    const envOverrides: Record<string, string> = {};
+    for (const [key, val] of Object.entries(loadConfig(effectiveCwd).envOverrides ?? {})) {
+        if (key.startsWith("PIZZAPI_") && !WORKER_ENV_DENYLIST.has(key) && typeof val === "string") {
+            envOverrides[key] = val;
+        }
+    }
+
     const env: Record<string, string> = {
         ...baseEnv,
+        ...envOverrides,
         // Use the daemon's resolved relay URL so workers always connect to the
         // same relay the daemon is using (not a potentially-changed config file).
         PIZZAPI_RELAY_URL: relayUrl,

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -1,7 +1,7 @@
 import { createAgentSession, DefaultResourceLoader, AuthStorage } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import { buildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "../config.js";
+import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "../config.js";
 import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "../skills.js";
 import { getPluginSkillPaths } from "../extensions/claude-plugins.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
@@ -179,7 +179,7 @@ function injectContextTrackingEntries(
     session: any,
     cwd: string,
     agentDir: string,
-    config: { appendSystemPrompt?: string },
+    config: { appendSystemPrompt?: string; builtinSystemPrompt?: boolean },
 ): void {
     const sm = session.sessionManager;
     if (!sm || typeof sm.appendCustomEntry !== "function") return;
@@ -213,10 +213,8 @@ function injectContextTrackingEntries(
 
     // ── Built-in system prompt ─────────────────────────────────────────────
     try {
-        appendContextTelemetry(
-            "context:builtin-prompt",
-            buildSystemPrompt({ cwd, isRunner: true }),
-        );
+        const builtin = maybeBuildSystemPrompt(config, { cwd, isRunner: true });
+        if (builtin) appendContextTelemetry("context:builtin-prompt", builtin);
     } catch { /* skip */ }
 
     // ── User append system prompt (from ~/.pizzapi/config.json) ───────────
@@ -334,7 +332,7 @@ async function main(): Promise<void> {
             : {}
         ),
         appendSystemPrompt: (() => {
-            const parts = [buildSystemPrompt({ cwd, isRunner: true }), config.appendSystemPrompt, agentSystemPrompt].filter(Boolean) as string[];
+            const parts = [maybeBuildSystemPrompt(config, { cwd, isRunner: true }), config.appendSystemPrompt, agentSystemPrompt].filter(Boolean) as string[];
             return parts;
         })(),
         ...(agentsFilesOverride && { agentsFilesOverride }),

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -258,6 +258,13 @@ async function main(): Promise<void> {
         process.exit(1);
     }
 
+    // Snapshot the session's provider before extensions clear the spawn-time
+    // model env vars — every later loadConfig() (MCP init, /mcp reload) must
+    // resolve per-provider overrides against the same provider.
+    if (process.env.PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER?.trim()) {
+        process.env.PIZZAPI_SESSION_PROVIDER = process.env.PIZZAPI_WORKER_INITIAL_MODEL_PROVIDER.trim();
+    }
+
     bootTimer.start("[boot] config");
     const config = loadConfig(cwd);
     const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -179,7 +179,7 @@ function injectContextTrackingEntries(
     session: any,
     cwd: string,
     agentDir: string,
-    config: { appendSystemPrompt?: string; builtinSystemPrompt?: boolean },
+    config: { appendSystemPrompt?: string; builtinSystemPrompt?: boolean; sendAgentsMd?: boolean },
 ): void {
     const sm = session.sessionManager;
     if (!sm || typeof sm.appendCustomEntry !== "function") return;
@@ -189,26 +189,28 @@ function injectContextTrackingEntries(
         sm.appendCustomEntry(customType, { content });
     };
 
-    // ── Global rules (from ~/.pizzapi/AGENTS.md) ──────────────────────────
-    const globalAgentsPath = join(agentDir, "AGENTS.md");
-    if (existsSync(globalAgentsPath)) {
-        try {
-            appendContextTelemetry(
-                "context:global-rules",
-                readFileSync(globalAgentsPath, "utf-8"),
-            );
-        } catch { /* skip unreadable */ }
-    }
+    if (config.sendAgentsMd !== false) {
+        // ── Global rules (from ~/.pizzapi/AGENTS.md) ──────────────────────────
+        const globalAgentsPath = join(agentDir, "AGENTS.md");
+        if (existsSync(globalAgentsPath)) {
+            try {
+                appendContextTelemetry(
+                    "context:global-rules",
+                    readFileSync(globalAgentsPath, "utf-8"),
+                );
+            } catch { /* skip unreadable */ }
+        }
 
-    // ── Project rules (from <cwd>/AGENTS.md) ──────────────────────────────
-    const projectAgentsPath = join(cwd, "AGENTS.md");
-    if (existsSync(projectAgentsPath)) {
-        try {
-            appendContextTelemetry(
-                "context:project-rules",
-                readFileSync(projectAgentsPath, "utf-8"),
-            );
-        } catch { /* skip unreadable */ }
+        // ── Project rules (from <cwd>/AGENTS.md) ──────────────────────────────
+        const projectAgentsPath = join(cwd, "AGENTS.md");
+        if (existsSync(projectAgentsPath)) {
+            try {
+                appendContextTelemetry(
+                    "context:project-rules",
+                    readFileSync(projectAgentsPath, "utf-8"),
+                );
+            } catch { /* skip unreadable */ }
+        }
     }
 
     // ── Built-in system prompt ─────────────────────────────────────────────
@@ -308,7 +310,9 @@ async function main(): Promise<void> {
 
     // Build shared agentsFilesOverride (loads AGENTS.md + .agents/*.md from cwd,
     // deduplicating against what DefaultResourceLoader already discovers).
-    const agentsFilesOverride = createAgentsFilesOverride(cwd);
+    const agentsFilesOverride = createAgentsFilesOverride(cwd, {
+        sendAgentsMd: config.sendAgentsMd !== false,
+    });
 
     bootTimer.start("[boot] resource-loader");
     const loader = new DefaultResourceLoader({

--- a/packages/cli/src/skills.test.ts
+++ b/packages/cli/src/skills.test.ts
@@ -564,6 +564,24 @@ describe("createAgentsFilesOverride", () => {
         expect(override).toBeNull();
     });
 
+    test("returns override when AGENTS.md sending is disabled", () => {
+        const override = createAgentsFilesOverride(dir, { sendAgentsMd: false });
+        expect(override).toBeInstanceOf(Function);
+    });
+
+    test("filters AGENTS.md files when sending is disabled", () => {
+        writeFileSync(join(dir, "AGENTS.md"), "# Agents", "utf-8");
+        const override = createAgentsFilesOverride(dir, { sendAgentsMd: false })!;
+        const base = {
+            agentsFiles: [
+                { path: "/home/user/.pizzapi/AGENTS.md", content: "# Global" },
+                { path: "/repo/CLAUDE.md", content: "# Claude" },
+            ],
+        };
+        const result = override(base);
+        expect(result.agentsFiles).toEqual([{ path: "/repo/CLAUDE.md", content: "# Claude" }]);
+    });
+
     test("returns override function when files exist", () => {
         writeFileSync(join(dir, "AGENTS.md"), "# Agents", "utf-8");
         const override = createAgentsFilesOverride(dir);

--- a/packages/cli/src/skills.ts
+++ b/packages/cli/src/skills.ts
@@ -7,7 +7,7 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { basename, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { expandHome } from "./config.js";
 
@@ -264,17 +264,32 @@ export function loadProjectAgentFiles(cwd: string): AgentFile[] {
  *
  * Returns null if there are no additional files to add.
  */
+export interface AgentsFilesOverrideOptions {
+    /** When false, do not send AGENTS.md context files automatically. */
+    sendAgentsMd?: boolean;
+}
+
+function isAgentsMdPath(path: string): boolean {
+    return basename(path).toLowerCase() === "agents.md";
+}
+
 export function createAgentsFilesOverride(
     cwd: string,
+    options: AgentsFilesOverrideOptions = {},
 ): ((base: { agentsFiles: AgentFile[] }) => { agentsFiles: AgentFile[] }) | null {
-    const additionalFiles = loadProjectAgentFiles(cwd);
-    if (additionalFiles.length === 0) return null;
+    const sendAgentsMd = options.sendAgentsMd !== false;
+    const additionalFiles = loadProjectAgentFiles(cwd)
+        .filter((file) => sendAgentsMd || !isAgentsMdPath(file.path));
+    if (additionalFiles.length === 0 && sendAgentsMd) return null;
 
     return (base) => {
-        const seenPaths = new Set(base.agentsFiles.map(f => f.path));
+        const baseFiles = sendAgentsMd
+            ? base.agentsFiles
+            : base.agentsFiles.filter((file) => !isAgentsMdPath(file.path));
+        const seenPaths = new Set(baseFiles.map(f => f.path));
         const deduped = additionalFiles.filter(f => !seenPaths.has(f.path));
         return {
-            agentsFiles: [...base.agentsFiles, ...deduped],
+            agentsFiles: [...baseFiles, ...deduped],
         };
     };
 }

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -114,6 +114,7 @@ You can also override any setting with **environment variables**.
 | `relayUrl` | `string` | `ws://localhost:7492` | WebSocket URL of the relay server. Set to `"off"` to disable relay entirely. |
 | `systemPrompt` | `string` | *(pi default)* | Fully replace the default system prompt |
 | `appendSystemPrompt` | `string` | — | Append to the default system prompt |
+| `builtinSystemPrompt` | `boolean` | `true` | Set to `false` to skip PizzaPi's built-in system prompt additions (subagents, plan mode, sigils, tunnels, PizzaPi config guidance) for a vanilla pi prompt |
 | `agentDir` | `string` | `~/.pizzapi` | Agent config directory (skills, extensions, etc.) |
 | `skills` | `string[]` | `[]` | Additional skill directories. Supports `~` expansion. |
 | `allowProjectHooks` | `boolean` | `false` | Trust gate: allow project-local hooks to run. **Global config only.** |

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -43,6 +43,10 @@ You can also override any setting with **environment variables**.
   // Append to the default system prompt without replacing it
   "appendSystemPrompt": "Always write tests for new code.",
 
+  // Send AGENTS.md files automatically as context. Set false to omit them
+  // unless the agent explicitly reads them with tools. Default: true.
+  "sendAgentsMd": true,
+
   // Override the agent config directory (skills, extensions, etc.)
   // Default: ~/.pizzapi
   "agentDir": "~/.pizzapi",
@@ -115,6 +119,7 @@ You can also override any setting with **environment variables**.
 | `systemPrompt` | `string` | *(pi default)* | Fully replace the default system prompt |
 | `appendSystemPrompt` | `string` | — | Append to the default system prompt |
 | `builtinSystemPrompt` | `boolean` | `true` | Set to `false` to skip PizzaPi's built-in system prompt additions (subagents, plan mode, sigils, tunnels, PizzaPi config guidance) for a vanilla pi prompt |
+| `sendAgentsMd` | `boolean` | `true` | Set to `false` to omit AGENTS.md files from automatic prompt context. The agent can still read them explicitly with tools. |
 | `agentDir` | `string` | `~/.pizzapi` | Agent config directory (skills, extensions, etc.) |
 | `skills` | `string[]` | `[]` | Additional skill directories. Supports `~` expansion. |
 | `allowProjectHooks` | `boolean` | `false` | Trust gate: allow project-local hooks to run. **Global config only.** |

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -205,7 +205,8 @@ For Ollama Cloud, enable web search under `providerSettings["ollama-cloud"].webS
 ## Per-Provider Overrides
 
 System prompt controls, AGENTS.md inclusion, and MCP server availability can be
-overridden per model provider via `providerSettings.<provider>.overrides`. The
+overridden per model provider via `providerSettings.<provider>.overrides` —
+editable in the web UI under **Runner → Settings → Provider Overrides**. The
 overrides apply when a session **starts** on that provider — either because it
 was spawned with an explicit model, or because it matches `defaultProvider` in
 `~/.pizzapi/settings.json`.

--- a/packages/docs/src/content/docs/customization/configuration.mdx
+++ b/packages/docs/src/content/docs/customization/configuration.mdx
@@ -139,7 +139,7 @@ You can also override any setting with **environment variables**.
 | `subagent.maxConcurrency` | `number` | `4` | Max concurrent agent sessions running simultaneously. **Global config only.** |
 | `goal.evaluatorModel` | `string` | cheapest available Haiku/mini | Model (`provider:modelId` or `modelId`) used by the `/goal` LLM evaluator. |
 | `goal.evaluatorMaxTokens` | `number` | `512` | Maximum output tokens for each `/goal` evaluator call. |
-| `providerSettings` | `object` | — | Provider-specific settings. See [Web Search](#web-search) below. |
+| `providerSettings` | `object` | — | Provider-specific settings. See [Web Search](#web-search) and [Per-Provider Overrides](#per-provider-overrides) below. |
 
 ---
 
@@ -201,6 +201,47 @@ For Ollama Cloud, enable web search under `providerSettings["ollama-cloud"].webS
 | `maxResults` | `number` | `5` | Default number of search results to request from Ollama (`1`–`10`). |
 | `maxContentChars` | `number` | `8000` | Truncate fetched page content to this many characters (`1`–`100000`). |
 | `maxLinks` | `number` | `100` | Truncate fetched page links to this many entries (`1`–`1000`). |
+
+## Per-Provider Overrides
+
+System prompt controls, AGENTS.md inclusion, and MCP server availability can be
+overridden per model provider via `providerSettings.<provider>.overrides`. The
+overrides apply when a session **starts** on that provider — either because it
+was spawned with an explicit model, or because it matches `defaultProvider` in
+`~/.pizzapi/settings.json`.
+
+```jsonc
+// ~/.pizzapi/config.json
+{
+  "providerSettings": {
+    "claude-subscription": {
+      "overrides": {
+        // Vanilla prompt for subscription sessions
+        "builtinSystemPrompt": false,
+        "sendAgentsMd": false,
+        "appendSystemPrompt": "",
+        // Disable heavyweight MCP servers on this provider
+        "disabledMcpServers": ["playwright"]
+      }
+    }
+  }
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `systemPrompt` | `string` | Fully replace the default system prompt for this provider. |
+| `appendSystemPrompt` | `string` | Replace the global `appendSystemPrompt` for this provider. |
+| `builtinSystemPrompt` | `boolean` | Override the global built-in prompt toggle. |
+| `sendAgentsMd` | `boolean` | Override automatic AGENTS.md context inclusion. |
+| `disabledMcpServers` | `string[]` | Additional MCP servers to disable (union with global/project lists). |
+
+:::note
+The provider is resolved once at session start. Switching models mid-session
+(or resuming a session saved on a different provider) does **not** re-apply
+overrides — the same “changes apply on next session start” semantics as all
+other config.
+:::
 
 ### Environment Variables
 

--- a/packages/docs/src/content/docs/reference/environment-variables.mdx
+++ b/packages/docs/src/content/docs/reference/environment-variables.mdx
@@ -93,7 +93,6 @@ These variables control which subsystems are loaded by runner-spawned worker ses
 | `PIZZAPI_NO_PLUGINS` | Set to `1` to skip Claude Code plugin loading. | — |
 | `PIZZAPI_NO_HOOKS` | Set to `1` to skip hook execution. | — |
 | `PIZZAPI_NO_RELAY` | Set to `1` to skip relay server connection. | — |
-| `PIZZAPI_LOG_PROVIDER_REQUEST` | Set to `1` to log the resolved provider/api, model id, system-block sizes, and tool names for each outbound request (diagnostic; helps confirm custom providers like `claude-subscription` route through their native path). | — |
 
 ---
 

--- a/packages/docs/src/content/docs/reference/environment-variables.mdx
+++ b/packages/docs/src/content/docs/reference/environment-variables.mdx
@@ -93,6 +93,7 @@ These variables control which subsystems are loaded by runner-spawned worker ses
 | `PIZZAPI_NO_PLUGINS` | Set to `1` to skip Claude Code plugin loading. | — |
 | `PIZZAPI_NO_HOOKS` | Set to `1` to skip hook execution. | — |
 | `PIZZAPI_NO_RELAY` | Set to `1` to skip relay server connection. | — |
+| `PIZZAPI_LOG_PROVIDER_REQUEST` | Set to `1` to log the resolved provider/api, model id, system-block sizes, and tool names for each outbound request (diagnostic; helps confirm custom providers like `claude-subscription` route through their native path). | — |
 
 ---
 

--- a/packages/server/src/routes/runner-settings.test.ts
+++ b/packages/server/src/routes/runner-settings.test.ts
@@ -41,6 +41,25 @@ describe("handleRunnerSettingsRoute", () => {
     mockSendRunnerCommand.mockReturnValue(Promise.resolve({ ok: true } as any));
   });
 
+  test("accepts providerOverrides as a valid settings section", async () => {
+    const payload = {
+      "claude-subscription": { builtinSystemPrompt: false, sendAgentsMd: false },
+    };
+
+    const [req, url] = makeReq("PUT", "/api/runners/runner-A/settings", {
+      section: "providerOverrides",
+      value: payload,
+    });
+    const res = await handleRunnerSettingsRoute(req, url);
+    expect(res).toBeTruthy();
+    expect(res!.status).toBe(200);
+    expect(mockSendRunnerCommand).toHaveBeenCalledWith("runner-A", {
+      type: "settings_update_section",
+      section: "providerOverrides",
+      value: payload,
+    });
+  });
+
   test("accepts toolSearch as a valid settings section", async () => {
     const payload = {
       enabled: true,

--- a/packages/server/src/routes/runner-settings.ts
+++ b/packages/server/src/routes/runner-settings.ts
@@ -21,6 +21,7 @@ const VALID_SECTIONS = new Set([
     "hooks",
     "sandbox",
     "webSearch",
+    "providerOverrides",
     "toolSearch",
     "security",
     "envVars",

--- a/packages/ui/src/components/runner-settings/EnvVarsSettings.tsx
+++ b/packages/ui/src/components/runner-settings/EnvVarsSettings.tsx
@@ -109,8 +109,7 @@ export default function EnvVarsSettings({ config, onSave, saving }: SectionProps
             <div className="flex items-start gap-2 rounded-md border border-border bg-muted/50 px-4 py-3 text-sm text-muted-foreground">
                 <Terminal className="mt-0.5 size-4 shrink-0" />
                 <span>
-                    Environment variable overrides are applied when the runner starts. Restart the runner for
-                    changes to take effect.
+                    Environment variable overrides are applied to new runner sessions.
                 </span>
             </div>
 

--- a/packages/ui/src/components/runner-settings/ProviderOverridesSettings.tsx
+++ b/packages/ui/src/components/runner-settings/ProviderOverridesSettings.tsx
@@ -1,0 +1,321 @@
+import { useState, useEffect, useMemo } from "react";
+import { Plus, Save, Trash2, Layers, Info } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from "@/components/ui/select";
+import type { SectionProps } from "./RunnerSettingsPanel";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/** Tri-state for boolean overrides: inherit the global value, or force on/off. */
+type TriState = "inherit" | "on" | "off";
+
+interface OverrideDraft {
+    builtinSystemPrompt: TriState;
+    sendAgentsMd: TriState;
+    /** Whether appendSystemPrompt is overridden (empty string is a valid override). */
+    appendOverride: boolean;
+    appendSystemPrompt: string;
+    /** Comma-separated MCP server names. */
+    disabledMcpServers: string;
+}
+
+const EMPTY_DRAFT: OverrideDraft = {
+    builtinSystemPrompt: "inherit",
+    sendAgentsMd: "inherit",
+    appendOverride: false,
+    appendSystemPrompt: "",
+    disabledMcpServers: "",
+};
+
+// ── Serialization ─────────────────────────────────────────────────────────────
+
+function toDraft(raw: Record<string, unknown>): OverrideDraft {
+    const tri = (v: unknown): TriState => (v === true ? "on" : v === false ? "off" : "inherit");
+    return {
+        builtinSystemPrompt: tri(raw.builtinSystemPrompt),
+        sendAgentsMd: tri(raw.sendAgentsMd),
+        appendOverride: typeof raw.appendSystemPrompt === "string",
+        appendSystemPrompt: typeof raw.appendSystemPrompt === "string" ? raw.appendSystemPrompt : "",
+        disabledMcpServers: Array.isArray(raw.disabledMcpServers)
+            ? (raw.disabledMcpServers as string[]).join(", ")
+            : "",
+    };
+}
+
+function fromDraft(draft: OverrideDraft): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    if (draft.builtinSystemPrompt !== "inherit") out.builtinSystemPrompt = draft.builtinSystemPrompt === "on";
+    if (draft.sendAgentsMd !== "inherit") out.sendAgentsMd = draft.sendAgentsMd === "on";
+    if (draft.appendOverride) out.appendSystemPrompt = draft.appendSystemPrompt;
+    const servers = draft.disabledMcpServers
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    if (servers.length > 0) out.disabledMcpServers = servers;
+    return out;
+}
+
+function initialDrafts(config: Record<string, any>): Record<string, OverrideDraft> {
+    const drafts: Record<string, OverrideDraft> = {};
+    const ps = config.providerSettings;
+    if (ps && typeof ps === "object") {
+        for (const [provider, entry] of Object.entries(ps as Record<string, any>)) {
+            if (entry && typeof entry === "object" && entry.overrides && typeof entry.overrides === "object") {
+                drafts[provider] = toDraft(entry.overrides);
+            }
+        }
+    }
+    return drafts;
+}
+
+// ── Tri-state select ──────────────────────────────────────────────────────────
+
+function TriStateSelect({
+    id,
+    value,
+    onChange,
+}: {
+    id: string;
+    value: TriState;
+    onChange: (v: TriState) => void;
+}) {
+    return (
+        <Select value={value} onValueChange={(v) => onChange(v as TriState)}>
+            <SelectTrigger id={id} className="w-32 h-8 text-xs">
+                <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+                <SelectItem value="inherit">Inherit</SelectItem>
+                <SelectItem value="on">On</SelectItem>
+                <SelectItem value="off">Off</SelectItem>
+            </SelectContent>
+        </Select>
+    );
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export default function ProviderOverridesSettings({ runnerId, config, onSave, saving }: SectionProps) {
+    const [drafts, setDrafts] = useState<Record<string, OverrideDraft>>(() => initialDrafts(config));
+    const [newProvider, setNewProvider] = useState("");
+    const [knownProviders, setKnownProviders] = useState<string[]>([]);
+
+    // Fetch configured providers for the datalist suggestions (best-effort).
+    useEffect(() => {
+        let cancelled = false;
+        (async () => {
+            try {
+                const res = await fetch(`/api/runners/${encodeURIComponent(runnerId)}/models`);
+                if (!res.ok) return;
+                const data = await res.json();
+                if (cancelled) return;
+                const providers = [...new Set((data.models ?? []).map((m: any) => m.provider))] as string[];
+                setKnownProviders(providers.sort());
+            } catch {
+                // Suggestions only — free-text entry still works.
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [runnerId]);
+
+    const suggestions = useMemo(
+        () => knownProviders.filter((p) => !(p in drafts)),
+        [knownProviders, drafts],
+    );
+
+    const updateDraft = (provider: string, patch: Partial<OverrideDraft>) => {
+        setDrafts((prev) => ({ ...prev, [provider]: { ...prev[provider], ...patch } }));
+    };
+
+    const addProvider = () => {
+        const name = newProvider.trim();
+        if (!name || name in drafts) return;
+        setDrafts((prev) => ({ ...prev, [name]: { ...EMPTY_DRAFT } }));
+        setNewProvider("");
+    };
+
+    const removeProvider = (provider: string) => {
+        setDrafts((prev) => {
+            const next = { ...prev };
+            delete next[provider];
+            return next;
+        });
+    };
+
+    const handleSave = () => {
+        const payload: Record<string, unknown> = {};
+        for (const [provider, draft] of Object.entries(drafts)) {
+            const overrides = fromDraft(draft);
+            if (Object.keys(overrides).length > 0) payload[provider] = overrides;
+        }
+        void onSave("providerOverrides", payload);
+    };
+
+    const providerNames = Object.keys(drafts).sort();
+
+    return (
+        <div className="flex flex-col gap-6">
+            <p className="text-xs text-muted-foreground leading-relaxed">
+                Override system prompt controls, AGENTS.md inclusion, and MCP server availability for
+                sessions that <span className="text-foreground">start</span> on a specific model provider.
+                Fields left on &ldquo;Inherit&rdquo; use this runner&rsquo;s global settings.
+            </p>
+
+            {/* ── Per-provider cards ───────────────────────────────── */}
+            {providerNames.map((provider) => {
+                const draft = drafts[provider];
+                return (
+                    <div
+                        key={provider}
+                        className="flex flex-col gap-4 rounded-md border border-border bg-muted/30 p-4"
+                    >
+                        <div className="flex items-center justify-between">
+                            <span className="flex items-center gap-2 text-sm font-medium font-mono">
+                                <Layers className="h-4 w-4 text-muted-foreground" />
+                                {provider}
+                            </span>
+                            <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => removeProvider(provider)}
+                                aria-label={`Remove overrides for ${provider}`}
+                            >
+                                <Trash2 className="h-3.5 w-3.5 text-muted-foreground hover:text-destructive" />
+                            </Button>
+                        </div>
+
+                        <div className="flex items-center justify-between">
+                            <Label htmlFor={`builtin-${provider}`} className="text-xs">
+                                Built-in System Prompt
+                            </Label>
+                            <TriStateSelect
+                                id={`builtin-${provider}`}
+                                value={draft.builtinSystemPrompt}
+                                onChange={(v) => updateDraft(provider, { builtinSystemPrompt: v })}
+                            />
+                        </div>
+
+                        <div className="flex items-center justify-between">
+                            <Label htmlFor={`agentsmd-${provider}`} className="text-xs">
+                                Send AGENTS.md Context
+                            </Label>
+                            <TriStateSelect
+                                id={`agentsmd-${provider}`}
+                                value={draft.sendAgentsMd}
+                                onChange={(v) => updateDraft(provider, { sendAgentsMd: v })}
+                            />
+                        </div>
+
+                        <div className="flex flex-col gap-2">
+                            <div className="flex items-center justify-between">
+                                <Label htmlFor={`append-toggle-${provider}`} className="text-xs">
+                                    Override Append System Prompt
+                                </Label>
+                                <Switch
+                                    id={`append-toggle-${provider}`}
+                                    checked={draft.appendOverride}
+                                    onCheckedChange={(v) => updateDraft(provider, { appendOverride: v })}
+                                />
+                            </div>
+                            {draft.appendOverride && (
+                                <Textarea
+                                    value={draft.appendSystemPrompt}
+                                    onChange={(e) => updateDraft(provider, { appendSystemPrompt: e.target.value })}
+                                    placeholder="Replaces the global append prompt for this provider. Leave empty to append nothing."
+                                    className="font-mono text-xs min-h-[80px] resize-y bg-muted/50 border-border"
+                                />
+                            )}
+                        </div>
+
+                        <div className="flex flex-col gap-2">
+                            <Label htmlFor={`mcp-${provider}`} className="text-xs">
+                                Disabled MCP Servers
+                            </Label>
+                            <Input
+                                id={`mcp-${provider}`}
+                                value={draft.disabledMcpServers}
+                                onChange={(e) => updateDraft(provider, { disabledMcpServers: e.target.value })}
+                                placeholder="server-one, server-two"
+                                className="font-mono text-xs h-8"
+                            />
+                            <p className="text-[10px] text-muted-foreground">
+                                Comma-separated. Disabled in addition to the global/project lists.
+                            </p>
+                        </div>
+                    </div>
+                );
+            })}
+
+            {/* ── Add provider ─────────────────────────────────────── */}
+            <div className="flex flex-col gap-2">
+                <Label htmlFor="new-provider" className="text-sm font-medium">
+                    Add Provider Override
+                </Label>
+                <div className="flex gap-2">
+                    <Input
+                        id="new-provider"
+                        list="provider-suggestions"
+                        value={newProvider}
+                        onChange={(e) => setNewProvider(e.target.value)}
+                        onKeyDown={(e) => {
+                            if (e.key === "Enter") {
+                                e.preventDefault();
+                                addProvider();
+                            }
+                        }}
+                        placeholder="e.g. anthropic, claude-subscription"
+                        className="font-mono text-sm flex-1 max-w-sm"
+                    />
+                    <datalist id="provider-suggestions">
+                        {suggestions.map((p) => (
+                            <option key={p} value={p} />
+                        ))}
+                    </datalist>
+                    <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={addProvider}
+                        disabled={!newProvider.trim() || newProvider.trim() in drafts}
+                    >
+                        <Plus className="h-4 w-4" />
+                    </Button>
+                </div>
+            </div>
+
+            {/* ── Notes ────────────────────────────────────────────── */}
+            <div className="flex flex-col gap-1.5 rounded-md bg-muted/40 border border-border px-3 py-2.5 text-xs text-muted-foreground">
+                <p className="flex items-start gap-1.5">
+                    <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                    The provider is resolved once at session start (spawned model, otherwise the default
+                    provider). Mid-session model switches do not re-apply overrides.
+                </p>
+                <p className="flex items-start gap-1.5">
+                    <Info className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                    Changes apply on next session start.
+                </p>
+            </div>
+
+            {/* ── Save ─────────────────────────────────────────────── */}
+            <div className="flex justify-end">
+                <Button onClick={handleSave} disabled={saving} size="sm">
+                    <Save className="h-4 w-4 mr-1.5" />
+                    {saving ? "Saving…" : "Save"}
+                </Button>
+            </div>
+        </div>
+    );
+}

--- a/packages/ui/src/components/runner-settings/RunnerSettingsPanel.tsx
+++ b/packages/ui/src/components/runner-settings/RunnerSettingsPanel.tsx
@@ -11,6 +11,7 @@ const WebSearchSettings = React.lazy(() => import("./WebSearchSettings"));
 const ToolSearchSettings = React.lazy(() => import("./ToolSearchSettings"));
 const EnvVarsSettings = React.lazy(() => import("./EnvVarsSettings"));
 const SystemPromptSettings = React.lazy(() => import("./SystemPromptSettings"));
+const ProviderOverridesSettings = React.lazy(() => import("./ProviderOverridesSettings"));
 const TuiPrefsSettings = React.lazy(() => import("./TuiPrefsSettings"));
 const FastModelSettings = React.lazy(() => import("./FastModelSettings"));
 const PackagesSettings = React.lazy(() => import("./PackagesSettings"));
@@ -23,6 +24,7 @@ export type SettingsSection =
     | "toolSearch"
     | "envVars"
     | "systemPrompt"
+    | "providerOverrides"
     | "tuiPreferences"
     | "goal"
     | "packages";
@@ -53,6 +55,7 @@ const SETTINGS_TABS: { key: SettingsSection; label: string }[] = [
     { key: "toolSearch", label: "Tool Search" },
     { key: "envVars", label: "Env Vars" },
     { key: "systemPrompt", label: "System Prompt" },
+    { key: "providerOverrides", label: "Provider Overrides" },
     { key: "tuiPreferences", label: "TUI Prefs" },
     { key: "packages", label: "Packages" },
 ];
@@ -169,6 +172,9 @@ export function RunnerSettingsPanel({ runnerId }: RunnerSettingsPanelProps) {
             break;
         case "systemPrompt":
             content = <SystemPromptSettings {...sectionProps} />;
+            break;
+        case "providerOverrides":
+            content = <ProviderOverridesSettings {...sectionProps} />;
             break;
         case "tuiPreferences":
             content = <TuiPrefsSettings {...sectionProps} />;

--- a/packages/ui/src/components/runner-settings/SystemPromptSettings.tsx
+++ b/packages/ui/src/components/runner-settings/SystemPromptSettings.tsx
@@ -15,6 +15,9 @@ export default function SystemPromptSettings({ config, onSave, saving }: Section
     const [builtinSystemPrompt, setBuiltinSystemPrompt] = useState<boolean>(
         (config.builtinSystemPrompt as boolean) ?? true,
     );
+    const [sendAgentsMd, setSendAgentsMd] = useState<boolean>(
+        (config.sendAgentsMd as boolean) ?? true,
+    );
     const [skills, setSkills] = useState<string[]>(
         Array.isArray(config.skills) ? (config.skills as string[]) : [],
     );
@@ -40,7 +43,7 @@ export default function SystemPromptSettings({ config, onSave, saving }: Section
     };
 
     const handleSave = () => {
-        void onSave("systemPrompt", { appendSystemPrompt, builtinSystemPrompt, skills });
+        void onSave("systemPrompt", { appendSystemPrompt, builtinSystemPrompt, sendAgentsMd, skills });
     };
 
     return (
@@ -61,6 +64,23 @@ export default function SystemPromptSettings({ config, onSave, saving }: Section
                 <p className="text-xs text-muted-foreground leading-relaxed">
                     PizzaPi&rsquo;s built-in prompt covers subagents, plan mode, sigils, tunnels, and
                     PizzaPi configuration. Turn off for a vanilla pi system prompt.
+                </p>
+            </div>
+
+            <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                    <Label htmlFor="send-agents-md" className="flex items-center gap-2 text-sm font-medium">
+                        <FileText className="h-4 w-4 text-muted-foreground" />
+                        Send AGENTS.md Context
+                    </Label>
+                    <Switch
+                        id="send-agents-md"
+                        checked={sendAgentsMd}
+                        onCheckedChange={setSendAgentsMd}
+                    />
+                </div>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                    Turn off to omit AGENTS.md files from automatic prompt context. The agent can still read them with tools.
                 </p>
             </div>
 

--- a/packages/ui/src/components/runner-settings/SystemPromptSettings.tsx
+++ b/packages/ui/src/components/runner-settings/SystemPromptSettings.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Plus, X, Save, FileText, Info, Shield } from "lucide-react";
+import { Plus, X, Save, FileText, Info } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -11,9 +11,6 @@ import type { SectionProps } from "./RunnerSettingsPanel";
 export default function SystemPromptSettings({ config, onSave, saving }: SectionProps) {
     const [appendSystemPrompt, setAppendSystemPrompt] = useState<string>(
         (config.appendSystemPrompt as string) ?? "",
-    );
-    const [claudeCodeProvider, setClaudeCodeProvider] = useState<boolean>(
-        (config.claudeCodeProvider as boolean) ?? false,
     );
     const [builtinSystemPrompt, setBuiltinSystemPrompt] = useState<boolean>(
         (config.builtinSystemPrompt as boolean) ?? true,
@@ -43,32 +40,11 @@ export default function SystemPromptSettings({ config, onSave, saving }: Section
     };
 
     const handleSave = () => {
-        void onSave("systemPrompt", { appendSystemPrompt, builtinSystemPrompt, skills, claudeCodeProvider });
+        void onSave("systemPrompt", { appendSystemPrompt, builtinSystemPrompt, skills });
     };
 
     return (
         <div className="flex flex-col gap-6">
-            {/* ── Claude Code Provider Mode ────────────────────────── */}
-            <div className="flex flex-col gap-2">
-                <div className="flex items-center justify-between">
-                    <Label htmlFor="claude-code-provider" className="flex items-center gap-2 text-sm font-medium">
-                        <Shield className="h-4 w-4 text-muted-foreground" />
-                        Claude Code Provider Mode
-                    </Label>
-                    <Switch
-                        id="claude-code-provider"
-                        checked={claudeCodeProvider}
-                        onCheckedChange={setClaudeCodeProvider}
-                    />
-                </div>
-                <p className="text-xs text-muted-foreground leading-relaxed">
-                    Rewrites the system prompt to use &ldquo;Claude Code&rdquo; branding instead of
-                    &ldquo;pi&rdquo; / &ldquo;PizzaPi&rdquo;. Useful for Anthropic Max subscriptions where
-                    server-side detection checks the system prompt content.
-                </p>
-            </div>
-
-            {/* ── Append System Prompt ──────────────────────────────── */}
             {/* ── Built-in System Prompt ───────────────────── */}
             <div className="flex flex-col gap-2">
                 <div className="flex items-center justify-between">

--- a/packages/ui/src/components/runner-settings/SystemPromptSettings.tsx
+++ b/packages/ui/src/components/runner-settings/SystemPromptSettings.tsx
@@ -15,6 +15,9 @@ export default function SystemPromptSettings({ config, onSave, saving }: Section
     const [claudeCodeProvider, setClaudeCodeProvider] = useState<boolean>(
         (config.claudeCodeProvider as boolean) ?? false,
     );
+    const [builtinSystemPrompt, setBuiltinSystemPrompt] = useState<boolean>(
+        (config.builtinSystemPrompt as boolean) ?? true,
+    );
     const [skills, setSkills] = useState<string[]>(
         Array.isArray(config.skills) ? (config.skills as string[]) : [],
     );
@@ -40,7 +43,7 @@ export default function SystemPromptSettings({ config, onSave, saving }: Section
     };
 
     const handleSave = () => {
-        void onSave("systemPrompt", { appendSystemPrompt, skills, claudeCodeProvider });
+        void onSave("systemPrompt", { appendSystemPrompt, builtinSystemPrompt, skills, claudeCodeProvider });
     };
 
     return (
@@ -66,6 +69,25 @@ export default function SystemPromptSettings({ config, onSave, saving }: Section
             </div>
 
             {/* ── Append System Prompt ──────────────────────────────── */}
+            {/* ── Built-in System Prompt ───────────────────── */}
+            <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                    <Label htmlFor="builtin-system-prompt" className="flex items-center gap-2 text-sm font-medium">
+                        <FileText className="h-4 w-4 text-muted-foreground" />
+                        Built-in System Prompt
+                    </Label>
+                    <Switch
+                        id="builtin-system-prompt"
+                        checked={builtinSystemPrompt}
+                        onCheckedChange={setBuiltinSystemPrompt}
+                    />
+                </div>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                    PizzaPi&rsquo;s built-in prompt covers subagents, plan mode, sigils, tunnels, and
+                    PizzaPi configuration. Turn off for a vanilla pi system prompt.
+                </p>
+            </div>
+
             <div className="flex flex-col gap-2">
                 <Label htmlFor="append-system-prompt" className="flex items-center gap-2 text-sm font-medium">
                     <FileText className="h-4 w-4 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- Add builtin system prompt toggle to disable PizzaPi's built-in prompt
- Add AGENTS.md context toggle
- Per-provider overrides for MCP, AGENTS.md, and system prompt config, with UI (Provider Overrides tab)
- Apply runner env overrides to workers
- Provider request diagnostics (PIZZAPI_LOG_PROVIDER_REQUEST) + diff script for debugging claude-subscription overage

## Test plan
- [ ] Manual verification in runner settings UI (Provider Overrides tab, AGENTS.md toggle, system prompt toggle)
- [ ] Verify worker env overrides applied correctly
