### PR TITLE
fix(goal): auto-continue the loop when the goal is not met

### DIFF
--- a/packages/cli/src/extensions/goal/evaluator.ts
+++ b/packages/cli/src/extensions/goal/evaluator.ts
@@ -91,23 +91,36 @@ export function parseLlmVerdict(raw: string): { verdict: GoalVerdict; reason: st
 
     const firstLine = text.split("\n")[0] ?? text;
 
-    const yes = /\byes\b/i.test(firstLine) || /\bmet\b/i.test(firstLine);
-    const no = /\bno\b/i.test(firstLine) || /\bnot_met\b/i.test(firstLine) || /\bnot met\b/i.test(firstLine);
-
-    if (no) return { verdict: "not_met", reason: extractReason(text) };
-    if (yes) return { verdict: "met", reason: extractReason(text) };
+    if (isNegative(firstLine)) return { verdict: "not_met", reason: extractReason(text) };
+    if (isPositive(firstLine)) return { verdict: "met", reason: extractReason(text) };
 
     // Fallback: scan the whole response for a clear yes/no.
-    const fullNo = /\bno\b/i.test(lower) || /\bnot_met\b/i.test(lower) || /\bnot met\b/i.test(lower);
-    const fullYes = /\byes\b/i.test(lower) || /\bmet\b/i.test(lower);
-
-    if (fullNo) return { verdict: "not_met", reason: extractReason(text) };
-    if (fullYes) return { verdict: "met", reason: extractReason(text) };
+    if (isNegative(lower)) return { verdict: "not_met", reason: extractReason(text) };
+    if (isPositive(lower)) return { verdict: "met", reason: extractReason(text) };
 
     return {
         verdict: "uncertain",
         reason: `Could not parse a yes/no decision. Model said: ${text.slice(0, 200)}`,
     };
+}
+
+/**
+ * Free-text negative detection. Catches "no", "not_met", and negated forms of
+ * "met" such as "not met", "not been met", "not yet met", "hasn't been met" —
+ * these must be checked before any positive \bmet\b match to avoid parsing
+ * "the goal has not been met" as met.
+ */
+function isNegative(text: string): boolean {
+    return (
+        /\bno\b/i.test(text) ||
+        /\bnot_met\b/i.test(text) ||
+        /\b(?:not|never)\b[\s\S]{0,30}?\bmet\b/i.test(text) ||
+        /n't\b[\s\S]{0,30}?\bmet\b/i.test(text)
+    );
+}
+
+function isPositive(text: string): boolean {
+    return /\byes\b/i.test(text) || /\bmet\b/i.test(text);
 }
 
 function extractReason(text: string): string {

--- a/packages/cli/src/extensions/goal/goal.integration.test.ts
+++ b/packages/cli/src/extensions/goal/goal.integration.test.ts
@@ -65,6 +65,7 @@ interface FakePi {
     pi: ExtensionAPI;
     handlers: Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>;
     messages: Array<{ customType: string; content: string; display: boolean }>;
+    userMessages: Array<{ content: string; options?: { deliverAs?: string } }>;
     entries: Array<{ customType: string; data: unknown }>;
     events: Map<string, unknown[]>;
     commands: Map<string, (args: string, ctx: ExtensionCommandContext) => unknown>;
@@ -73,6 +74,7 @@ interface FakePi {
 function createFakePi(): FakePi {
     const handlers = new Map<string, Array<(event: unknown, ctx: ExtensionContext) => unknown>>();
     const messages: Array<{ customType: string; content: string; display: boolean }> = [];
+    const userMessages: Array<{ content: string; options?: { deliverAs?: string } }> = [];
     const entries: Array<{ customType: string; data: unknown }> = [];
     const events = new Map<string, unknown[]>();
     const commands = new Map<string, (args: string, ctx: ExtensionCommandContext) => unknown>();
@@ -85,6 +87,9 @@ function createFakePi(): FakePi {
         },
         sendMessage: (msg: { customType: string; content: string; display: boolean }) => {
             messages.push(msg);
+        },
+        sendUserMessage: (content: string, options?: { deliverAs?: string }) => {
+            userMessages.push({ content, options });
         },
         appendEntry: (customType: string, data?: unknown) => {
             entries.push({ customType, data });
@@ -101,7 +106,7 @@ function createFakePi(): FakePi {
         },
     } as unknown as ExtensionAPI;
 
-    return { pi, handlers, messages, entries, events, commands };
+    return { pi, handlers, messages, userMessages, entries, events, commands };
 }
 
 function createFakeCtx(overrides: {

--- a/packages/cli/src/extensions/goal/goal.test.ts
+++ b/packages/cli/src/extensions/goal/goal.test.ts
@@ -363,6 +363,15 @@ describe("parseLlmVerdict", () => {
     test("returns uncertain for ambiguous responses", () => {
         expect(parseLlmVerdict("maybe later").verdict).toBe("uncertain");
     });
+
+    test.each([
+        ["The goal has not been met yet"],
+        ["The goal has not yet been met"],
+        ["The condition hasn't been met"],
+        ["The goal was never met"],
+    ])("parses negated free-text %p as not_met", (input) => {
+        expect(parseLlmVerdict(input).verdict).toBe("not_met");
+    });
 });
 
 describe("resolveEvaluatorModel", () => {
@@ -582,12 +591,14 @@ function createFakePi(): {
     pi: ExtensionAPI;
     handlers: Map<string, ((event: unknown, ctx: ExtensionContext) => unknown)[]>;
     messages: Array<{ customType: string; content: string; display: boolean }>;
+    userMessages: Array<{ content: string; options?: { deliverAs?: string } }>;
     entries: Array<{ customType: string; data: unknown }>;
     events: Map<string, unknown[]>;
     commands: Map<string, (args: string, ctx: ExtensionCommandContext) => unknown>;
 } {
     const handlers = new Map<string, ((event: unknown, ctx: ExtensionContext) => unknown)[]>();
     const messages: Array<{ customType: string; content: string; display: boolean }> = [];
+    const userMessages: Array<{ content: string; options?: { deliverAs?: string } }> = [];
     const entries: Array<{ customType: string; data: unknown }> = [];
     const events = new Map<string, unknown[]>();
     const commands = new Map<string, (args: string, ctx: ExtensionCommandContext) => unknown>();
@@ -600,6 +611,9 @@ function createFakePi(): {
         },
         sendMessage: (msg: { customType: string; content: string; display: boolean }) => {
             messages.push(msg);
+        },
+        sendUserMessage: (content: string, options?: { deliverAs?: string }) => {
+            userMessages.push({ content, options });
         },
         appendEntry: (customType: string, data?: unknown) => {
             entries.push({ customType, data });
@@ -616,7 +630,7 @@ function createFakePi(): {
         },
     } as unknown as ExtensionAPI;
 
-    return { pi, handlers, messages, entries, events, commands };
+    return { pi, handlers, messages, userMessages, entries, events, commands };
 }
 
 function createFakeCtx(overrides: {
@@ -701,9 +715,9 @@ describe("goalExtension event wiring", () => {
         expect(messages.some((m) => m.content.includes("Goal met"))).toBe(true);
     });
 
-    test("turn_end keyword not met stores guidance for next turn", async () => {
+    test("turn_end keyword not met stores guidance and auto-continues the loop", async () => {
         resetSession("session-1");
-        const { pi, handlers } = createFakePi();
+        const { pi, handlers, userMessages } = createFakePi();
         const ctx = createFakeCtx();
 
         goalExtension(pi);
@@ -726,6 +740,56 @@ describe("goalExtension event wiring", () => {
 
         expect(getGoal("session-1")?.status).toBe("active");
         expect(getPendingGuidance("session-1")).toContain("pass");
+        // The goal loop keeps working: a not_met verdict triggers a follow-up turn.
+        expect(userMessages.length).toBe(1);
+        expect(userMessages[0]!.content).toContain("Goal not met");
+        expect(userMessages[0]!.content).toContain("tests pass");
+        expect(userMessages[0]!.options?.deliverAs).toBe("followUp");
+    });
+
+    test("turn_end goal met does not auto-continue", async () => {
+        resetSession("session-1");
+        const { pi, handlers, userMessages } = createFakePi();
+        const ctx = createFakeCtx();
+
+        goalExtension(pi);
+        setGoal(
+            "session-1",
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            {},
+            pi,
+        );
+
+        const turnHandlers = handlers.get("turn_end") ?? [];
+        for (const handler of turnHandlers) {
+            await handler({
+                type: "turn_end",
+                turnIndex: 1,
+                message: makeAssistantMessage("All tests pass"),
+                toolResults: [],
+            } as TurnEndEvent, ctx);
+        }
+
+        expect(getGoal("session-1")?.status).toBe("met");
+        expect(userMessages.length).toBe(0);
+    });
+
+    test("setting a goal kicks off a turn with the condition as directive", async () => {
+        resetSession("session-1");
+        const { pi, commands, userMessages } = createFakePi();
+        const ctx = createFakeCtx();
+
+        goalExtension(pi);
+        const goalHandler = commands.get("goal")!;
+        await goalHandler("tests pass --evaluator keyword --keyword pass", ctx as ExtensionCommandContext);
+
+        expect(userMessages.length).toBe(1);
+        expect(userMessages[0]!.content).toContain("tests pass");
+
+        // Status and clear do not kick off turns.
+        await goalHandler("status", ctx as ExtensionCommandContext);
+        await goalHandler("clear", ctx as ExtensionCommandContext);
+        expect(userMessages.length).toBe(1);
     });
 
     test("turn_end clears previous guidance after evaluation", async () => {
@@ -780,9 +844,9 @@ describe("goalExtension event wiring", () => {
         expect(getPendingGuidance("session-1")).toBe("add more tests");
     });
 
-    test("turn_end budget exhaustion warns but does not stop session", async () => {
+    test("turn_end budget exhaustion warns, stops the loop, and does not stop session", async () => {
         resetSession("session-1");
-        const { pi, handlers, messages } = createFakePi();
+        const { pi, handlers, messages, userMessages } = createFakePi();
         let shutdownCalled = false;
         const ctx = createFakeCtx({ shutdown: () => { shutdownCalled = true; } });
 
@@ -810,6 +874,8 @@ describe("goalExtension event wiring", () => {
         expect(getGoal("session-1")?.stopReason).toBe("max_turns");
         expect(shutdownCalled).toBe(false);
         expect(messages.some((m) => m.content.includes("budget reached"))).toBe(true);
+        // Turn 1 auto-continued (not met); turn 2 hit the budget — no continuation.
+        expect(userMessages.length).toBe(1);
     });
 
     test("broadcasts active goal status on set, update, and clear", async () => {

--- a/packages/cli/src/extensions/goal/goal.test.ts
+++ b/packages/cli/src/extensions/goal/goal.test.ts
@@ -90,12 +90,20 @@ describe("parseGoalArgs", () => {
         expect(parsed.statusOnly).toBe(false);
     });
 
-    test("rejects unknown flags", () => {
-        expect(() => parseGoalArgs("foo --unknown bar")).toThrow("Unknown flag: --unknown");
-    });
+
 
     test("rejects missing condition", () => {
         expect(() => parseGoalArgs("--max-turns 5")).toThrow("A goal condition is required");
+    });
+
+    test("treats unknown flags as condition text", () => {
+        const parsed = parseGoalArgs("fix the --dry-run handling");
+        expect(parsed.rawCondition).toBe("fix the --dry-run handling");
+        expect(parsed.budget).toEqual({});
+    });
+
+    test("rejects keyword evaluator without keywords", () => {
+        expect(() => parseGoalArgs("build passes --evaluator keyword")).toThrow("requires at least one --keyword");
     });
 });
 
@@ -106,6 +114,23 @@ describe("goal state", () => {
         expect(state.condition.description).toBe("the tests pass");
         expect(state.status).toBe("active");
         expect(getGoal("session-1")?.id).toBe(state.id);
+    });
+
+    test("recordEvaluation caps the persisted history", () => {
+        resetSession("session-1");
+        makeGoal();
+        for (let i = 0; i < 25; i++) {
+            recordEvaluation("session-1", {
+                turnIndex: i,
+                verdict: "not_met",
+                reason: `turn ${i}`,
+                timestamp: Date.now(),
+            }, { appendEntry: fakeAppendEntry });
+        }
+        const state = getGoal("session-1")!;
+        expect(state.evaluations.length).toBe(20);
+        expect(state.evaluations.at(-1)?.reason).toBe("turn 24");
+        expect(state.evaluations[0]?.reason).toBe("turn 5");
     });
 
     test("recordTurnSpend increments counters", () => {
@@ -842,6 +867,36 @@ describe("goalExtension event wiring", () => {
         expect(result?.systemPrompt).toContain("[Goal guidance]");
         expect(result?.systemPrompt).toContain("add more tests");
         expect(getPendingGuidance("session-1")).toBe("add more tests");
+    });
+
+    test("goal met on the final budgeted turn reports met, not budget reached", async () => {
+        resetSession("session-1");
+        const { pi, handlers, messages, userMessages } = createFakePi();
+        const ctx = createFakeCtx();
+
+        goalExtension(pi);
+        setGoal(
+            "session-1",
+            { description: "tests pass", evaluator: "keyword", successKeywords: ["pass"] },
+            { maxTurns: 1 },
+            pi,
+        );
+
+        const turnHandlers = handlers.get("turn_end") ?? [];
+        for (const handler of turnHandlers) {
+            await handler({
+                type: "turn_end",
+                turnIndex: 1,
+                message: makeAssistantMessage("All tests pass"),
+                toolResults: [],
+            } as TurnEndEvent, ctx);
+        }
+
+        expect(getGoal("session-1")?.status).toBe("met");
+        expect(getGoal("session-1")?.stopReason).toBe("goal_met");
+        expect(messages.some((m) => m.content.includes("Goal met"))).toBe(true);
+        expect(messages.some((m) => m.content.includes("budget reached"))).toBe(false);
+        expect(userMessages.length).toBe(0);
     });
 
     test("turn_end budget exhaustion warns, stops the loop, and does not stop session", async () => {

--- a/packages/cli/src/extensions/goal/index.ts
+++ b/packages/cli/src/extensions/goal/index.ts
@@ -6,9 +6,11 @@
  * - `pi.registerCommand("goal", …)` handles the slash command.
  * - `session_start` restores any persisted goal from custom entries.
  * - `turn_end` records turn spend, checks budgets, and runs the configured
- *   evaluator (keyword or LLM). When the goal is met or a budget is exhausted,
- *   it logs a status message and calls `ctx.shutdown()` to trigger the normal
- *   stop/session-shutdown hooks.
+ *   evaluator (keyword or LLM). A `not_met` verdict auto-continues the loop by
+ *   sending a follow-up user message, so the agent keeps working toward the
+ *   goal without the user prompting each turn. When the goal is met or a
+ *   budget is exhausted, it logs a status message and returns control to the
+ *   user.
  * - `before_agent_start` injects evaluator feedback as system-prompt guidance
  *   for the next turn when the goal has not yet been met.
  * - `session_shutdown` clears the in-memory entry for the session.
@@ -120,6 +122,7 @@ function handleGoalCommand(
             success: true,
             message: `Goal set: ${state.condition.description}`,
             state,
+            kickoff: true,
         };
     } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
@@ -169,7 +172,7 @@ function buildEvaluationContext(
 async function runGoalStopCheck(
     event: TurnEndEvent,
     ctx: ExtensionContext,
-    pi: Pick<ExtensionAPI, "appendEntry" | "sendMessage">,
+    pi: Pick<ExtensionAPI, "appendEntry" | "sendMessage" | "sendUserMessage">,
 ): Promise<void> {
     const sessionId = getSessionId(ctx);
     let state = getGoal(sessionId);
@@ -249,9 +252,17 @@ async function runGoalStopCheck(
     }
 
     const lastEval = state.evaluations.at(-1);
-    if (lastEval && lastEval.verdict === "not_met") {
+    if (lastEval && lastEval.verdict === "not_met" && state.status === "active") {
         clearPendingGuidance(sessionId);
         setPendingGuidance(sessionId, lastEval.reason);
+        // Goal loop: a "not met" verdict starts another turn instead of
+        // returning control to the user (parity with Claude Code /goal).
+        // "uncertain" verdicts do NOT auto-continue, so a broken evaluator
+        // can't spin the session forever.
+        pi.sendUserMessage(
+            `[Goal not met] ${lastEval.reason}\nContinue working toward the goal: ${state.condition.description}`,
+            { deliverAs: "followUp" },
+        );
     } else {
         clearPendingGuidance(sessionId);
     }
@@ -287,6 +298,14 @@ export const goalExtension: ExtensionFactory = (pi) => {
                 display: true,
             });
             broadcastGoalStatus(getSessionId(ctx), getGoal(getSessionId(ctx)), ctx, pi);
+            if (result.kickoff && result.state) {
+                // Setting a goal starts a turn immediately, with the condition
+                // itself as the directive (parity with Claude Code /goal).
+                pi.sendUserMessage(
+                    `Work toward this goal until it is met: ${result.state.condition.description}`,
+                    { deliverAs: "followUp" },
+                );
+            }
         },
     });
 

--- a/packages/cli/src/extensions/goal/index.ts
+++ b/packages/cli/src/extensions/goal/index.ts
@@ -34,6 +34,7 @@ import { loadConfig } from "../../config/io.js";
 import {
     checkBudget,
     clearGoal,
+    persist,
     clearPendingGuidance,
     formatGoalStatus,
     getActiveGoalFromEntries,
@@ -181,19 +182,6 @@ async function runGoalStopCheck(
     const usage = getAssistantUsage(event.message);
     recordTurnSpend(sessionId, usage.tokens, usage.cost);
 
-    const budgetReason = checkBudget(state);
-    if (budgetReason) {
-        clearPendingGuidance(sessionId);
-        pi.sendMessage({
-            customType: "goal_status",
-            content: `Goal budget reached: ${budgetReason}. The goal is now inactive; you may continue the session.`,
-            display: true,
-        });
-        // Do not shutdown the session; budget exhaustion only deactivates the
-        // goal and lets the agent return control to the user naturally.
-        return;
-    }
-
     const evalContext = buildEvaluationContext(state, event, ctx);
 
     let evaluator;
@@ -251,23 +239,8 @@ async function runGoalStopCheck(
         }, pi) ?? state;
     }
 
-    const lastEval = state.evaluations.at(-1);
-    if (lastEval && lastEval.verdict === "not_met" && state.status === "active") {
-        clearPendingGuidance(sessionId);
-        setPendingGuidance(sessionId, lastEval.reason);
-        // Goal loop: a "not met" verdict starts another turn instead of
-        // returning control to the user (parity with Claude Code /goal).
-        // "uncertain" verdicts do NOT auto-continue, so a broken evaluator
-        // can't spin the session forever.
-        pi.sendUserMessage(
-            `[Goal not met] ${lastEval.reason}\nContinue working toward the goal: ${state.condition.description}`,
-            { deliverAs: "followUp" },
-        );
-    } else {
-        clearPendingGuidance(sessionId);
-    }
-
     if (state.status !== "active") {
+        clearPendingGuidance(sessionId);
         if (state.stopReason === "goal_met") {
             pi.sendMessage({
                 customType: "goal_status",
@@ -281,9 +254,41 @@ async function runGoalStopCheck(
                 display: true,
             });
         }
-        // Never shutdown when the goal is met or a budget is exhausted. The
-        // agent should finish the current turn and return control to the user.
+        // Never shutdown when the goal is met. The agent finishes the current
+        // turn and returns control to the user.
         return;
+    }
+
+    // The goal is still unmet — enforce budgets before continuing the loop.
+    // Checking budgets AFTER evaluation means a goal met on the final
+    // budgeted turn reports "met" above instead of "budget reached".
+    const budgetReason = checkBudget(state);
+    if (budgetReason) {
+        clearPendingGuidance(sessionId);
+        persist(state, pi);
+        pi.sendMessage({
+            customType: "goal_status",
+            content: `Goal budget reached: ${budgetReason}. The goal is now inactive; you may continue the session.`,
+            display: true,
+        });
+        // Do not shutdown the session; budget exhaustion only deactivates the
+        // goal and lets the agent return control to the user naturally.
+        return;
+    }
+
+    const lastEval = state.evaluations.at(-1);
+    if (lastEval && lastEval.verdict === "not_met") {
+        setPendingGuidance(sessionId, lastEval.reason);
+        // Goal loop: a "not met" verdict starts another turn instead of
+        // returning control to the user (parity with Claude Code /goal).
+        // "uncertain" verdicts do NOT auto-continue, so a broken evaluator
+        // can't spin the session forever.
+        pi.sendUserMessage(
+            `[Goal not met] ${lastEval.reason}\nContinue working toward the goal: ${state.condition.description}`,
+            { deliverAs: "followUp" },
+        );
+    } else {
+        clearPendingGuidance(sessionId);
     }
 }
 

--- a/packages/cli/src/extensions/goal/parser.ts
+++ b/packages/cli/src/extensions/goal/parser.ts
@@ -84,7 +84,11 @@ export function parseGoalArgs(input: string): GoalCommandArgs {
 
         if (isFlag(token)) {
             if (!KNOWN_FLAGS.has(token)) {
-                throw new Error(`Unknown flag: ${token}`);
+                // Unknown "--flags" are condition text, not errors — conditions
+                // like "fix the --dry-run handling" must not throw.
+                conditionParts.push(token);
+                i += 1;
+                continue;
             }
             const next = tokens[i + 1];
             if (next === undefined || isFlag(next)) {
@@ -122,6 +126,12 @@ export function parseGoalArgs(input: string): GoalCommandArgs {
     const rawCondition = conditionParts.join(" ").trim();
     if (!rawCondition) {
         throw new Error("A goal condition is required. Example: /goal \"the tests pass\"");
+    }
+
+    // A keyword evaluator with no keywords can never be met — with the goal
+    // loop auto-continuing on not_met, that would run forever. Reject early.
+    if (evaluator === "keyword" && successKeywords.length === 0) {
+        throw new Error('--evaluator keyword requires at least one --keyword. Example: /goal "build passes" --evaluator keyword --keyword "build succeeded"');
     }
 
     const condition: GoalCondition = {

--- a/packages/cli/src/extensions/goal/state.ts
+++ b/packages/cli/src/extensions/goal/state.ts
@@ -28,6 +28,13 @@ const pendingGuidanceBySessionId = new Map<string, string>();
 /** Goals that have stopped are kept in memory for 24 hours, then pruned. */
 const STOPPED_GOAL_RETENTION_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Only the most recent evaluations are kept. The full state is persisted to
+ * the session file on every evaluation, so an unbounded history means O(n²)
+ * file growth on long-running goals. Nothing reads more than the latest entry.
+ */
+const MAX_EVALUATIONS = 20;
+
 function generateGoalId(): string {
     return `goal_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
 }
@@ -134,6 +141,9 @@ export function recordEvaluation(
     if (!state || state.status !== "active") return undefined;
 
     state.evaluations.push(feedback);
+    if (state.evaluations.length > MAX_EVALUATIONS) {
+        state.evaluations.splice(0, state.evaluations.length - MAX_EVALUATIONS);
+    }
     if (feedback.cost) state.costSpend += Math.max(0, feedback.cost);
     if (feedback.tokensUsed) state.tokenSpend += feedback.tokensUsed;
 

--- a/packages/cli/src/extensions/goal/types.ts
+++ b/packages/cli/src/extensions/goal/types.ts
@@ -180,4 +180,7 @@ export interface GoalCommandResult {
     success: boolean;
     message: string;
     state?: GoalState;
+
+    /** True when a new goal was just set and a kickoff turn should start. */
+    kickoff?: boolean;
 }


### PR DESCRIPTION
## Problem

`/goal` graded each turn but never continued the loop. On a `not_met` verdict it stored guidance for the next turn's system prompt and went idle — the agent only kept working if the user manually prompted again. As implemented, `/goal` was a per-turn grader with a status bar, not a goal loop.

Claude Code's `/goal` (which this mirrors): *"a 'no' tells Claude to keep working"* — the not-met verdict itself starts the next turn.

## Changes

**Commit 1 — the loop:**
- **Auto-continue on `not_met`**: `turn_end` now sends a follow-up user message (`pi.sendUserMessage`, `deliverAs: "followUp"`) carrying the evaluator's reason, so the agent keeps working toward the condition without user prompting. `uncertain` verdicts do **not** auto-continue — a broken/unauthenticated evaluator can't spin the session forever. Budgets still stop the loop.
- **Kickoff turn on set**: `/goal <condition>` starts a turn immediately with the condition as the directive (CC parity), instead of setting state and waiting.
- **Verdict parsing fix**: free-text like *"the goal has not been met yet"* parsed as **met** because bare `\bmet\b` was treated as yes before negation was considered — this would have closed goals prematurely. Negated forms (`not met`, `not been met`, `hasn't been met`, `never met`) are now checked first.

**Commit 2 — follow-ups:**
- **Budget check moved after evaluation**: a goal met on the final budgeted turn now reports "Goal met" instead of "budget reached". Budget stops are persisted so they survive resume.
- **Bounded persistence**: evaluations history capped at 20 entries. Full state is persisted on every evaluation, so unbounded history meant O(n²) session-file growth on long goals; nothing reads more than the latest entry.
- **Parser: unknown `--flags` are condition text**, not errors — `/goal fix the --dry-run handling` no longer throws (CC accepts arbitrary condition text).
- **Parser: `--evaluator keyword` with no `--keyword` is rejected** at parse time — it can never be met, and the auto-continuing loop would otherwise run forever.

## Tests

- `not_met` → continuation message sent with reason + condition, `deliverAs: followUp`
- `met` → no continuation; met on final budgeted turn → "Goal met", not "budget reached"
- budget exhaustion → loop stops (no continuation on the final turn)
- `/goal status` / `/goal clear` → no kickoff turn
- negated free-text verdicts parse as `not_met`
- evaluations history capped at 20
- unknown flags parse into the condition; keyword evaluator without keywords rejected

`bun test src/extensions/goal/`: 76 pass, 0 fail. `tsc --noEmit`: clean.
