### PR TITLE
fix(terminal): mobile terminal functionality — socket routing, PTY env (no TERM), Android IME backspace

### DIFF
--- a/packages/cli/src/runner/terminal-worker.ts
+++ b/packages/cli/src/runner/terminal-worker.ts
@@ -48,23 +48,38 @@ function send(msg: Record<string, unknown>): void {
 
 // ── Spawn PTY ──────────────────────────────────────────────────────────────────
 
+// @zenyr/bun-pty's FFI (bun_pty_spawn) accepts no environment: the `env` and
+// `name` options are silently ignored and the PTY child starts with a minimal
+// env — critically, NO TERM. Without TERM, zsh/bash load no termcap and line
+// editing degrades: Backspace erases in the line buffer but repaints as a bare
+// space, so deleted characters stay visible on screen. Arrow keys, vim, less
+// are similarly broken. Smuggle the vars in via /usr/bin/env on the command
+// line instead (POSIX only — PowerShell/cmd don't use TERM).
+const ptyEnvPairs = [
+    "TERM=xterm-256color",
+    "COLORTERM=truecolor",
+    `LANG=${process.env.LANG || "en_US.UTF-8"}`,
+    // Lets `pizza web` detect it's running inside a relay terminal.
+    `TERMINAL_WORKER_ID=${terminalId}`,
+    // Use Bun's built-in shell for `bun run` scripts instead of
+    // /bin/bash, which fails with EBADF in PTY environments.
+    // See: https://github.com/oven-sh/bun/issues/21447
+    `BUN_OPTIONS=${[process.env.BUN_OPTIONS, "--shell=bun"].filter(Boolean).join(" ")}`,
+];
+
 let ptyProcess: ReturnType<typeof spawnPty>;
 try {
-    ptyProcess = spawnPty(shell, getShellArgs(shell), {
-        name: "xterm-256color",
-        cols,
-        rows,
-        cwd,
-        env: {
-            ...process.env,
-            TERM: "xterm-256color",
-            COLORTERM: "truecolor",
-            // Use Bun's built-in shell for `bun run` scripts instead of
-            // /bin/bash, which fails with EBADF in PTY environments.
-            // See: https://github.com/oven-sh/bun/issues/21447
-            BUN_OPTIONS: [process.env.BUN_OPTIONS, "--shell=bun"].filter(Boolean).join(" "),
+    const useEnvWrapper = process.platform !== "win32";
+    ptyProcess = spawnPty(
+        useEnvWrapper ? "/usr/bin/env" : shell,
+        useEnvWrapper ? [...ptyEnvPairs, shell, ...getShellArgs(shell)] : getShellArgs(shell),
+        {
+            name: "xterm-256color",
+            cols,
+            rows,
+            cwd,
         },
-    });
+    );
 } catch (err) {
     send({ type: "error", message: err instanceof Error ? err.message : String(err) });
     process.exit(1);

--- a/packages/cli/src/web.ts
+++ b/packages/cli/src/web.ts
@@ -1192,6 +1192,18 @@ export async function runWeb(args: string[]): Promise<void> {
         uiDistHash: prebuildResult.distHash,
     });
 
+    // ponytail: TERMINAL_WORKER_ID is inherited from a PizzaPi relay-terminal PTY.
+    // Restarting the web stack from such a terminal kills the very relay the
+    // terminal is connected through: the socket drops, the relay loses the
+    // terminal mapping, and the PTY is orphaned on the runner. Warn so the
+    // disconnect reads as expected instead of "the terminal is broken".
+    if (process.env.TERMINAL_WORKER_ID) {
+        log.warn("⚠️  This terminal runs through the PizzaPi relay you are about to restart.");
+        log.warn("   The restart will finish in the background (Docker), but this terminal");
+        log.warn("   will disconnect and cannot be reattached — open a new terminal after.");
+        log.warn("");
+    }
+
     log.info(`Starting PizzaPi web on port ${config.port}...`);
     log.info(`  Repo:    ${repoPath}`);
     log.info(`  Config:  ${CONFIG_PATH}`);

--- a/packages/ui/src/components/WebTerminal.tsx
+++ b/packages/ui/src/components/WebTerminal.tsx
@@ -7,6 +7,7 @@ import "@xterm/xterm/css/xterm.css";
 import { io, type Socket } from "socket.io-client";
 import type { TerminalServerToClientEvents, TerminalClientToServerEvents } from "@pizzapi/protocol";
 import { SOCKET_PROTOCOL_VERSION } from "@pizzapi/protocol";
+import { getSocketIOBase, getSocketIOAuth } from "@/lib/relay";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { TerminalIcon, X, Maximize2, Minimize2 } from "lucide-react";
@@ -146,13 +147,16 @@ export function WebTerminal({ terminalId, onClose, className }: WebTerminalProps
     const retryTimer1 = setTimeout(doFit, 50);
     const retryTimer2 = setTimeout(doFit, 200);
 
-    // Connect to relay terminal via Socket.IO
-    const socket: Socket<TerminalServerToClientEvents, TerminalClientToServerEvents> = io("/terminal", {
-      auth: {
+    // Connect to relay terminal via Socket.IO. On the bundled Capacitor app
+    // the webview origin is local, so we must target the configured relay
+    // base and authenticate with the stored API key (same as useRunnersFeed).
+    const base = getSocketIOBase();
+    const socket: Socket<TerminalServerToClientEvents, TerminalClientToServerEvents> = io(base ? `${base}/terminal` : "/terminal", {
+      auth: getSocketIOAuth({
         terminalId,
         protocolVersion: SOCKET_PROTOCOL_VERSION,
         clientVersion: UI_VERSION,
-      },
+      }),
       withCredentials: true,
     });
     wsRef.current = socket;
@@ -239,6 +243,36 @@ export function WebTerminal({ terminalId, onClose, className }: WebTerminalProps
       }
     });
 
+    // Android soft keyboards (Gboard) deliver Backspace as an IME input
+    // event (inputType "deleteContentBackward") instead of a real keydown.
+    // xterm.js only handles "insertText" input events, so Backspace silently
+    // does nothing on Android. Translate delete inputs to control bytes here.
+    // Skip while the IME has an active composition — the user is editing the
+    // underlined word locally and nothing has reached the PTY yet.
+    let imeComposing = false;
+    const onCompositionStart = () => { imeComposing = true; };
+    const onCompositionEnd = () => { imeComposing = false; };
+    const onBeforeInput = (e: Event) => {
+      const ev = e as InputEvent;
+      if (imeComposing || ev.isComposing) return;
+      const data =
+        ev.inputType === "deleteContentBackward" ? "\x7f" :
+        ev.inputType === "deleteContentForward" ? "\x1b[3~" :
+        null;
+      if (data) {
+        ev.preventDefault();
+        ev.stopImmediatePropagation();
+        if (socket.connected) {
+          socket.emit("terminal_input", { terminalId, data: utf8ToBase64(data) });
+        }
+      }
+    };
+    const textarea = term.textarea;
+    textarea?.addEventListener("compositionstart", onCompositionStart);
+    textarea?.addEventListener("compositionend", onCompositionEnd);
+    // Capture phase so we run before xterm's own input handling.
+    textarea?.addEventListener("beforeinput", onBeforeInput, true);
+
     // Handle resize
     const resizeObserver = new ResizeObserver(() => {
       requestAnimationFrame(() => {
@@ -260,6 +294,9 @@ export function WebTerminal({ terminalId, onClose, className }: WebTerminalProps
     return () => {
       clearTimeout(retryTimer1);
       clearTimeout(retryTimer2);
+      textarea?.removeEventListener("compositionstart", onCompositionStart);
+      textarea?.removeEventListener("compositionend", onCompositionEnd);
+      textarea?.removeEventListener("beforeinput", onBeforeInput, true);
       inputDisposable.dispose();
       resizeObserver.disconnect();
       socket.disconnect();

--- a/packages/ui/src/lib/use-pizzapi-session.ts
+++ b/packages/ui/src/lib/use-pizzapi-session.ts
@@ -94,12 +94,20 @@ export function usePizzaPiSession(): PizzaPiSession {
         };
     }, [isMobileBundled, apiKey, cookieSession?.user?.id]);
 
+    // Memoize: a fresh object every render makes App.tsx's [session]-keyed
+    // effects re-fire in a render loop (each effect's state update triggers a
+    // re-render → new session identity → effects again → fetch flood).
+    const syntheticSession = React.useMemo(
+        () => (apiKeySession ? createSyntheticSession(apiKeySession.user.id, apiKeySession.user.name) : null),
+        [apiKeySession],
+    );
+
     if (cookieSession?.user?.id) {
         return { data: cookieSession, isPending: cookiePending };
     }
 
-    if (apiKeySession) {
-        return { data: createSyntheticSession(apiKeySession.user.id, apiKeySession.user.name), isPending: false };
+    if (syntheticSession) {
+        return { data: syntheticSession, isPending: false };
     }
 
     return { data: null, isPending: cookiePending || apiKeyPending };


### PR DESCRIPTION
## Summary

Debugged live on a physical Android device (Capacitor app → Tailscale relay → Mac runner). Terminal functionality on mobile was broken by four independent bugs stacked on top of each other:

### 1. Terminal socket never reached the relay (`WebTerminal.tsx`)
The `/terminal` Socket.IO connection used a relative `io("/terminal")` with cookie-only auth. Inside the Capacitor webview the origin is local (`https://localhost`), so the socket resolved to the app bundle instead of the relay and could never connect. Now uses `getSocketIOBase()` + `getSocketIOAuth()` like every other socket (`/runners`, `/hub`, `/viewer`).

### 2. Render loop flooding the relay (`use-pizzapi-session.ts`)
On the API-key (mobile) auth path, `createSyntheticSession()` returned a fresh object every render. `App.tsx` keys effects on `[session]`, so each render re-fired `fetchHiddenModels` + `checkVersionCompatibility`, whose state updates triggered the next render — an infinite loop hammering the relay with **~25 req/s** of `/health` and `/api/settings/hidden-models`, starving Socket.IO polling (`xhr poll error` spam). Fixed with `useMemo`.

### 3. PTY spawned with no TERM (`terminal-worker.ts`) — the big one
`@zenyr/bun-pty`'s `bun_pty_spawn` FFI signature is `(cmdline, cwd, cols, rows)` — **it accepts no environment**. The `env` and `name` options are silently ignored, so every runner terminal PTY started with no `TERM` at all. Consequences:

- zsh loaded no termcap → ZLE degraded: Backspace erased in the line buffer but echoed a bare `" "` instead of `\b \b`, so deleted characters stayed visible on screen ("backspace does nothing")
- arrow keys / history / `vim` / `less` rendering broken
- the `BUN_OPTIONS=--shell=bun` workaround never actually reached shells

Verified byte-for-byte: Python stdlib `pty` produced `\x08\x08x \x08` for the same input where bun-pty terminals produced `0x20`. Fixed by smuggling `TERM`/`COLORTERM`/`LANG`/`BUN_OPTIONS`/`TERMINAL_WORKER_ID` through `/usr/bin/env` on the spawn command line (POSIX only; PowerShell doesn't use TERM).

### 4. Android IME backspace dropped (`WebTerminal.tsx`)
Gboard delivers Backspace as `beforeinput` `inputType: deleteContentBackward` (keydown is `keyCode 229`). xterm.js 6.0.0 only handles `insertText` input events, so IME backspace was silently discarded. Captured the real event stream from the device to confirm both IME-style and real-keydown backspaces occur. Added a `beforeinput` translator → `\x7f` (and `deleteContentForward` → `\x1b[3~`), guarded against active composition.

### Bonus: `pizza web` self-restart warning (`web.ts`)
Running `pizza web --build` inside a relay terminal restarts the relay the terminal rides on — the socket drops, the relay loses the terminal mapping, and the PTY is orphaned on the runner (reproduced; confirmed zombie worker). The restart itself completes fine in the background, but it read as "the terminal broke". `pizza web` now warns when `TERMINAL_WORKER_ID` is present (which reaches shells thanks to fix 3).

## Testing

- Full E2E from the physical phone via CDP: terminal create → socket connect with API key → PTY spawn → `echo` round-trip ✅
- Relay-terminal byte-level test: DEL now produces proper `\b\bx \b` erase sequence ✅
- Verified fetch flood gone from device logs after session memoization ✅
- `bun test` UI suite: 1084 pass / 0 fail; `tsc --noEmit` clean on ui + cli ✅

## Follow-ups (not in this PR)

- File upstream issue on `@zenyr/bun-pty` (env/name options silently ignored)
- Consider reaping orphaned terminal workers on runner reconnect
