### PR TITLE
fix: Escape no longer kills child sessions or fires behind previews

### DIFF
--- a/packages/cli/src/extensions/remote/followup-grace.test.ts
+++ b/packages/cli/src/extensions/remote/followup-grace.test.ts
@@ -1,5 +1,13 @@
 import { beforeEach, describe, expect, mock, test } from "bun:test";
-import { createFollowUpGrace, type FollowUpGraceState } from "./followup-grace.js";
+import { createFollowUpGrace, isManualAbort, type FollowUpGraceState } from "./followup-grace.js";
+
+describe("isManualAbort", () => {
+    test("true only for an abort outside shutdown", () => {
+        expect(isManualAbort({ wasAborted: true, shuttingDown: false })).toBe(true);
+        expect(isManualAbort({ wasAborted: true, shuttingDown: true })).toBe(false);
+        expect(isManualAbort({ wasAborted: false, shuttingDown: false })).toBe(false);
+    });
+});
 
 const mockEmitSessionCompleteWithAck = mock(async (_opts: any) => ({ ok: true }));
 const mockLogger = {

--- a/packages/cli/src/extensions/remote/followup-grace.ts
+++ b/packages/cli/src/extensions/remote/followup-grace.ts
@@ -19,6 +19,17 @@ const FOLLOWUP_GRACE_MS = 10 * 60 * 1_000;
 const SESSION_COMPLETE_RETRY_MS = 3_000;
 const log = createLogger("remote");
 
+/**
+ * True when an agent_end on a child session came from a manual abort (Esc /
+ * abort exec) rather than a real shutdown. In that case session_complete must
+ * NOT be sent — the parent would ack "killed" and tear the session down — and
+ * no follow-up grace timer should start: the user took control and will steer
+ * or end the session themselves.
+ */
+export function isManualAbort(opts: { wasAborted: boolean; shuttingDown: boolean }): boolean {
+    return opts.wasAborted && !opts.shuttingDown;
+}
+
 export interface FollowUpGraceState {
     /** Set to true once session_complete has been emitted — prevents double-fire. */
     sessionCompleteFired: boolean;

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -52,6 +52,7 @@ import type { RelayContext } from "../remote-types.js";
 import type { TriggerWaitManager } from "../trigger-wait-manager.js";
 import type { DelinkManager } from "./delink-management.js";
 import type { CancellationManager } from "./trigger-cancellation.js";
+import { isManualAbort } from "./followup-grace.js";
 import type { FollowUpGraceManager } from "./followup-grace.js";
 
 const log = createLogger("remote");
@@ -407,7 +408,18 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
             }
 
             const exitReason = rctx.wasAborted ? "killed" : lastError ? "error" : "completed";
-            void followUpGrace.fireSessionComplete(summary, fullOutputPath, exitReason);
+            // Manual abort (Esc in the web UI / abort exec) on a child session:
+            // skip session_complete — the parent would ack "killed" and tear the
+            // session down, wiping it (and its transcript) from the web UI.
+            // Keep it alive for steering instead. session_shutdown still reports
+            // "killed" when the session is actually ending (end_session sets
+            // shuttingDown before shutdown()).
+            const manualAbort = isManualAbort(rctx);
+            if (rctx.isChildSession && manualAbort) {
+                log.info("pizzapi: turn aborted manually — keeping child session alive");
+            } else {
+                void followUpGrace.fireSessionComplete(summary, fullOutputPath, exitReason);
+            }
 
             // Fire session_error for terminal usage-limit errors (one-shot, only at agent_end).
             if (
@@ -428,7 +440,9 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
             }
 
             if (rctx.isChildSession) {
-                followUpGrace.startFollowUpGrace(ctx);
+                // No grace-period auto-shutdown after a manual abort — the user
+                // took control and will steer or end the session themselves.
+                if (!manualAbort) followUpGrace.startFollowUpGrace(ctx);
             } else if (process.env.PIZZAPI_WORKER_AUTO_CLOSE === "true" && exitReason === "completed") {
                 // Auto-close: trigger-spawned sessions with autoClose shut down
                 // immediately on successful completion — no follow-up grace.

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -48,6 +48,7 @@ import { PlanModePanel, type PlanModeAnswer } from "@/components/ai-elements/pla
 import { formatAnswersForAgent } from "@/lib/ask-user-questions";
 import { exportToMarkdown } from "@/lib/export-markdown";
 import { dismissNotificationsForSession } from "@/lib/push";
+import { isEscapeAbortBlocked } from "@/lib/escape-abort-guard";
 import {
   AlertTriangleIcon,
   BookOpen,
@@ -366,6 +367,8 @@ export function SessionViewer({
     const handleKeyDown = (e: KeyboardEvent) => {
       if (e.key !== "Escape") return;
       if (showEndSessionDialog || showIncompleteTriggerDialog || commandOpen || atMentionOpen) return;
+      // Never abort while a file/diff preview or a dialog is on screen.
+      if (isEscapeAbortBlocked()) return;
       e.preventDefault();
       onExec({ type: "exec", id: `${Date.now()}-${Math.random().toString(16).slice(2)}`, command: "abort" });
     };

--- a/packages/ui/src/components/file-explorer/FileExplorer.tsx
+++ b/packages/ui/src/components/file-explorer/FileExplorer.tsx
@@ -307,7 +307,7 @@ export function FileExplorer({ runnerId, cwd, className, onClose, position = "le
     const isMarkdown = isMarkdownFile(viewingFileName);
 
     return (
-      <div ref={previewContainerRef} tabIndex={-1} className={cn("flex flex-col bg-background text-foreground outline-none", className)}>
+      <div ref={previewContainerRef} tabIndex={-1} data-escape-abort-guard className={cn("flex flex-col bg-background text-foreground outline-none", className)}>
         {isImage ? (
           <ImageViewer
             runnerId={runnerId}

--- a/packages/ui/src/components/file-explorer/git-changes-view.tsx
+++ b/packages/ui/src/components/file-explorer/git-changes-view.tsx
@@ -155,7 +155,7 @@ export function GitChangesView({
 
   if (selectedDiff) {
     return (
-      <div ref={diffContainerRef} tabIndex={-1} className="flex flex-col h-full overflow-hidden outline-none">
+      <div ref={diffContainerRef} tabIndex={-1} data-escape-abort-guard className="flex flex-col h-full overflow-hidden outline-none">
         <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-muted/50">
           <button
             type="button"

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -231,7 +231,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
 
     if (selectedDiff) {
         return (
-            <div ref={diffContainerRef} tabIndex={-1} className={cn("flex flex-col h-full outline-none", className)}>
+            <div ref={diffContainerRef} tabIndex={-1} data-escape-abort-guard className={cn("flex flex-col h-full outline-none", className)}>
                 <GitDiffView
                     path={selectedDiff.path}
                     diff={selectedDiff.diff}

--- a/packages/ui/src/lib/escape-abort-guard.test.ts
+++ b/packages/ui/src/lib/escape-abort-guard.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { Window } from "happy-dom";
+import { isEscapeAbortBlocked, ESCAPE_ABORT_GUARD_ATTR } from "./escape-abort-guard";
+
+function doc(html: string): Document {
+  const win = new Window({ url: "http://localhost/" });
+  // happy-dom's selector parser references window.SyntaxError, which is
+  // undefined outside a registered global window (same shim as GitPanel.test).
+  (win as any).SyntaxError = SyntaxError;
+  win.document.body.innerHTML = html;
+  return win.document as unknown as Document;
+}
+
+describe("isEscapeAbortBlocked", () => {
+  test("false when nothing is open", () => {
+    expect(isEscapeAbortBlocked(doc("<div>chat</div>"))).toBe(false);
+  });
+
+  test("true when a visible preview surface is mounted", () => {
+    expect(isEscapeAbortBlocked(doc(`<div ${ESCAPE_ABORT_GUARD_ATTR}>preview</div>`))).toBe(true);
+  });
+
+  test("false when the preview is in a hidden CombinedPanel tab", () => {
+    expect(
+      isEscapeAbortBlocked(doc(`<div class="invisible"><div ${ESCAPE_ABORT_GUARD_ATTR}>preview</div></div>`)),
+    ).toBe(false);
+  });
+
+  test("true when a Radix dialog is open", () => {
+    expect(isEscapeAbortBlocked(doc('<div role="dialog" data-state="open">dialog</div>'))).toBe(true);
+  });
+
+  test("false when a dialog is closed", () => {
+    expect(isEscapeAbortBlocked(doc('<div role="dialog" data-state="closed">dialog</div>'))).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/escape-abort-guard.ts
+++ b/packages/ui/src/lib/escape-abort-guard.ts
@@ -1,0 +1,21 @@
+/**
+ * Guard for SessionViewer's Escape→abort shortcut.
+ *
+ * Full-panel preview surfaces (file preview, git diff view) mark their
+ * container with ESCAPE_ABORT_GUARD_ATTR. While one is visible, Escape must
+ * never reach the abort handler — even when keyboard focus has fallen back to
+ * <body>, which defeats the focus-based interception inside those components.
+ */
+export const ESCAPE_ABORT_GUARD_ATTR = "data-escape-abort-guard";
+
+/** True when Escape should NOT abort the agent turn. */
+export function isEscapeAbortBlocked(doc: Document = document): boolean {
+  // Radix dialogs (image lightbox, settings, …) own Escape globally.
+  if (doc.querySelector('[role="dialog"][data-state="open"]')) return true;
+  // A visible preview surface. Previews hidden in an inactive CombinedPanel
+  // tab have an ancestor with the `invisible` class — ignore those.
+  for (const el of doc.querySelectorAll(`[${ESCAPE_ABORT_GUARD_ATTR}]`)) {
+    if (!el.closest(".invisible")) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Problem

Hitting Escape in the web UI while viewing a **child session** made the whole session (and its transcript/history) disappear:

Escape → abort exec → agent_end with `exitReason: "killed"` → child fires `session_complete` to parent → parent acks → `cleanup_child_session` → `endSharedSession` → `session_removed` broadcast wipes it from the hub and force-disconnects viewers.

Escape also fired the abort while looking at file/diff previews whenever keyboard focus had fallen back to `<body>`, defeating the previews' focus-based interception.

## Fix

**CLI** (`lifecycle-handlers.ts`, `followup-grace.ts`)
- New `isManualAbort({ wasAborted, shuttingDown })` predicate.
- On `agent_end`, a manual abort on a child session skips `session_complete` **and** the 10-min follow-up grace shutdown — the session stays alive for steering.
- Real shutdowns (`end_session`, process exit) still report `"killed"` to the parent via `session_shutdown`, and `turn_start` resets the flag so later natural completions notify normally.

**Web UI** (`escape-abort-guard.ts`, `SessionViewer.tsx`)
- `isEscapeAbortBlocked()`: skip the Escape→abort shortcut when any Radix dialog is open (`[role="dialog"][data-state="open"]`) or a visible `data-escape-abort-guard` surface exists (ignoring ones hidden in an inactive CombinedPanel tab).
- Marked the three preview surfaces: FileExplorer file preview, git-changes diff view, GitPanel diff view.

## Tests

- `followup-grace.test.ts`: `isManualAbort` truth table.
- `escape-abort-guard.test.ts`: 5 DOM cases via happy-dom (open/closed dialog, visible/hidden preview, nothing open).
- `bun run typecheck` clean; `packages/cli` remote suite (296) and `packages/ui` git/file-explorer/lib suites (453) all pass.
