### PR TITLE
fix(docker): declare @capacitor deps in packages/ui so Docker UI build resolves them

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -131,6 +131,9 @@
       "version": "0.1.32",
       "dependencies": {
         "@aparajita/capacitor-secure-storage": "^8.0.0",
+        "@capacitor/core": "^8.4.1",
+        "@capacitor/local-notifications": "^8.2.0",
+        "@capawesome/capacitor-badge": "^8.0.2",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@radix-ui/react-collapsible": "^1.1.11",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,6 +9,9 @@
   },
   "dependencies": {
     "@aparajita/capacitor-secure-storage": "^8.0.0",
+    "@capacitor/core": "^8.4.1",
+    "@capacitor/local-notifications": "^8.2.0",
+    "@capawesome/capacitor-badge": "^8.0.2",
     "@pizzapi/protocol": "workspace:*",
     "@pizzapi/tools": "workspace:*",
     "@radix-ui/react-collapsible": "^1.1.11",


### PR DESCRIPTION
## Problem

Docker image build fails in the `build-ui` stage:

```
Rollup failed to resolve import ... If you do want to externalize this module
explicitly add it to build.rollupOptions.external
```

## Root cause

The UI imports `@capacitor/core`, `@capacitor/local-notifications`, and `@capawesome/capacitor-badge` (added in #545), but they were only declared in the **root** `package.json` dependencies. The Dockerfile generates a slimmed root `package.json` that keeps only `workspaces`, `patchedDependencies`, and a couple devDependencies — root `dependencies` are dropped. Locally the packages are hoisted from the root install, so the build passes; in Docker they were never installed and rollup couldn't resolve them.

## Fix

Declare the three packages where they are imported: `packages/ui/package.json` (same versions as root).

## Verification

- `docker build --target build-ui .` now succeeds (was the failing stage)
- Local Dockerfile-order build (protocol tsc → tools tsc → ui vite build) passes
- `bun test packages/ui` — 1084 pass, 0 fail