### PR TITLE
feat(ui): add Cancel button to question prompt

### DIFF
--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -929,6 +929,10 @@ export function SessionViewer({
                 questions={pendingQuestion.questions}
                 promptKey={pendingQuestion.toolCallId}
                 className="mb-2"
+                onCancel={onExec ? () => {
+                  onExec({ type: "exec", id: `${Date.now()}-${Math.random().toString(16).slice(2)}`, command: "abort" });
+                  onQuestionDismiss?.();
+                } : undefined}
                 onSubmit={(answers) => {
                   if (!onSendInput) return Promise.resolve(false);
                   setComposerError(null);

--- a/packages/ui/src/components/ai-elements/multiple-choice.tsx
+++ b/packages/ui/src/components/ai-elements/multiple-choice.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
-import { MessageCircleQuestion, PenLine, Send, Check, ArrowLeft, ArrowRight, GripVertical, ArrowUp, ArrowDown } from "lucide-react";
+import { MessageCircleQuestion, PenLine, Send, Check, ArrowLeft, ArrowRight, GripVertical, ArrowUp, ArrowDown, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import type { QuestionType } from "@/lib/ask-user-questions";
 
@@ -18,6 +18,8 @@ export interface MultipleChoiceQuestionsProps {
   /** Stable identity for this prompt (e.g. toolCallId). Used to reset selections on new prompt. */
   promptKey?: string;
   onSubmit: (answers: MultipleChoiceAnswers) => void | Promise<boolean | void>;
+  /** Cancel the prompt and abort the current turn (mobile has no Esc key). */
+  onCancel?: () => void;
   className?: string;
 }
 
@@ -40,6 +42,7 @@ export function MultipleChoiceQuestions({
   questions,
   promptKey,
   onSubmit,
+  onCancel,
   className,
 }: MultipleChoiceQuestionsProps) {
   // ── Radio state: selected option index per question ────────────────────────
@@ -536,6 +539,18 @@ export function MultipleChoiceQuestions({
           <MessageCircleQuestion className="size-3.5 text-violet-400" />
         </div>
         <span className="text-xs font-medium text-violet-300">Question {questions.length > 0 ? safeCurrentStep + 1 : 0} of {questions.length}</span>
+        {onCancel && (
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            aria-label="Cancel question"
+            className="ml-auto flex items-center gap-1 rounded-md px-2 py-1 text-xs text-violet-300/70 transition-colors hover:bg-violet-500/15 hover:text-violet-200"
+          >
+            <X className="size-3.5" />
+            Cancel
+          </button>
+        )}
       </div>
 
       <div className="shrink-0 px-3 pt-2.5">


### PR DESCRIPTION
## Summary
- Adds a **Cancel** button to the AskUserQuestion stepper header. On mobile there's no Esc key, so there was previously no way to end the current turn while a question prompt was active.
- Cancel sends the same `abort` exec as the existing Esc handler and dismisses the prompt.

## Changes
- `multiple-choice.tsx`: optional `onCancel` prop + header Cancel button (only rendered when provided).
- `SessionViewer.tsx`: wires `onCancel` to the abort exec + `onQuestionDismiss`.

## Testing
- `tsc --noEmit` clean in `packages/ui`
- `bun test` on multiple-choice tests passes