### PR TITLE
fix(mcp): use Claude Code's mcp__server__tool naming to stay in the subscription lane

### DIFF
--- a/packages/cli/scripts/probe-overage.ts
+++ b/packages/cli/scripts/probe-overage.ts
@@ -1,16 +1,23 @@
 /**
  * Programmatic isolation of the claude-subscription "out of extra usage /
- * org_level_disabled" failure. Fires a small matrix of /v1/messages requests
- * with the SAME Claude Code OAuth token, varying one axis at a time, and reports
- * HTTP status + the `anthropic-ratelimit-unified-overage-disabled-reason` header.
+ * org_level_disabled" / 429 failure. Fires a small matrix of /v1/messages
+ * requests with the SAME Claude Code OAuth token, varying ONE axis at a time
+ * (tool count/shape vs system-prompt size), and reports HTTP status plus all
+ * `anthropic-ratelimit-*` headers.
+ *
+ * Model + thinking are held constant at the known-good config (fable-5,
+ * adaptive) so any status/header delta is attributable to the varied axis.
  *
  * Run: cd packages/cli && bun scripts/probe-overage.ts
  *
- * Uses tiny max_tokens and spaces requests to limit quota use / avoid 429s.
+ * Caveat: overage-disable/429 discrimination is clearest when the plan is
+ * near its quota window limit; far from the limit everything may return 200 —
+ * the ratelimit headers are still worth comparing in that case.
  */
 
 import { AuthStorage } from "@earendil-works/pi-coding-agent";
 import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 
@@ -21,30 +28,113 @@ const FALLBACK_BETA = ",server-side-fallback-2026-06-01";
 
 function fp(t: string): string { return `…${t.slice(-6)}(len=${t.length})`; }
 
-// Token the extension actually uses: Claude Code Keychain credential.
-function keychainToken(): string | null {
+// Token sources, in the same priority order the extension uses:
+// 1. ${CLAUDE_CONFIG_DIR:-~/.claude}/.credentials.json  2. macOS Keychain.
+function fileToken(): { token: string; expiresAt: number } | null {
+    try {
+        const dir = process.env.CLAUDE_CONFIG_DIR ?? join(homedir(), ".claude");
+        const raw = JSON.parse(readFileSync(join(dir, ".credentials.json"), "utf-8"))?.claudeAiOauth;
+        return raw?.accessToken ? { token: raw.accessToken, expiresAt: raw.expiresAt ?? 0 } : null;
+    } catch { return null; }
+}
+function keychainToken(): { token: string; expiresAt: number } | null {
     try {
         const raw = execSync(`security find-generic-password -s ${JSON.stringify("Claude Code-credentials")} -w`, { encoding: "utf-8" }).trim();
-        return JSON.parse(raw)?.claudeAiOauth?.accessToken ?? null;
+        const cc = JSON.parse(raw)?.claudeAiOauth;
+        return cc?.accessToken ? { token: cc.accessToken, expiresAt: cc.expiresAt ?? 0 } : null;
     } catch { return null; }
 }
 
 const authToken = await AuthStorage.create(join(homedir(), ".pizzapi", "auth.json")).getApiKey("anthropic");
-const kcToken = keychainToken();
-console.log(`pizzapi auth.json token: ${authToken ? fp(authToken) : "(none)"}`);
-console.log(`keychain CC token:       ${kcToken ? fp(kcToken) : "(none)"}`);
-console.log(`same token? ${authToken === kcToken}\n`);
-const token = kcToken ?? authToken; // extension uses the Keychain token
-if (!token) { console.error("no anthropic token"); process.exit(1); }
+const file = fileToken();
+const kc = keychainToken();
+const mins = (c: { expiresAt: number } | null) => c ? Math.round((c.expiresAt - Date.now()) / 60000) : null;
+console.log(`pizzapi auth.json token:  ${authToken ? fp(authToken) : "(none)"}`);
+console.log(`.credentials.json token:  ${file ? `${fp(file.token)} expires in ${mins(file)}min` : "(none)"}`);
+console.log(`keychain CC token:        ${kc ? `${fp(kc.token)} expires in ${mins(kc)}min` : "(none)"}`);
+const fresh = [file, kc].filter((c): c is NonNullable<typeof c> => !!c && c.expiresAt > Date.now() + 60000);
+const token = fresh[0]?.token ?? authToken;
+if (!token) { console.error("no unexpired anthropic token — log in with Claude Code first"); process.exit(1); }
+console.log(`using: ${fp(token)}\n`);
 
 const bigSystem = "You are a coding assistant.\n".repeat(2300); // ~63k chars
 const smallSystem = "You are a coding assistant.";
-const manyTools = Array.from({ length: 58 }, (_, i) => ({
-    name: i < 4 ? ["read", "bash", "edit", "write"][i] : `tool_${i}`,
-    description: "x",
-    input_schema: { type: "object", properties: { a: { type: "string" } } },
+
+// 26 builtin-shaped tools — mirrors what PizzaPi actually sends today (known
+// to work on the subscription lane).
+const BUILTIN_NAMES = [
+    "read", "bash", "edit", "write", "tell_child", "respond_to_trigger",
+    "fire_trigger", "escalate_trigger", "list_available_triggers",
+    "list_available_sigils", "subscribe_trigger", "unsubscribe_trigger",
+    "update_trigger_subscription", "AskUserQuestion", "plan_mode",
+    "create_tunnel", "list_tunnels", "close_tunnel", "web_search", "web_fetch",
+    "set_session_name", "update_todo", "spawn_session", "list_models",
+    "subagent", "toggle_plan_mode",
+];
+const builtinTools = BUILTIN_NAMES.map((name) => ({
+    name,
+    description: `Built-in tool: ${name}. Executes the ${name} operation in the current working directory and returns the result.`,
+    input_schema: {
+        type: "object",
+        properties: {
+            input: { type: "string", description: "Primary input for the operation" },
+            options: { type: "string", description: "Optional flags" },
+        },
+        required: ["input"],
+    },
 }));
-const fewTools = manyTools.slice(0, 4);
+
+// 32 MCP-shaped tools — realistic names/descriptions/schemas like the
+// godmother + jules servers would register.
+const MCP_VERBS = [
+    "capture_idea", "search_ideas", "list_ideas", "move_idea", "get_idea",
+    "branch_idea", "update_idea", "link_ideas", "related_ideas", "get_epic",
+    "update_epic", "list_epics", "create_epic", "delete_idea", "list_topics",
+    "tag_idea",
+];
+const mcpTools = [
+    ...MCP_VERBS.map((verb) => ({
+        name: `mcp_godmother_${verb}`,
+        description: `Godmother idea tracker: ${verb.replace(/_/g, " ")}. Operates on the semantic idea/task store with projects, topics, blocking dependencies, and vector search. Returns structured JSON describing the affected ideas and their statuses.`,
+        input_schema: {
+            type: "object",
+            properties: {
+                id: { type: "string", description: "Idea identifier (ULID)" },
+                query: { type: "string", description: "Semantic search query text" },
+                project: { type: "string", description: "Project name filter" },
+                status: { type: "string", enum: ["capture", "triage", "design", "plan", "execute", "completed", "review", "shipped"] },
+                topics: { type: "array", items: { type: "string" }, description: "Topic tags" },
+                summary: { type: "string", description: "One-line summary" },
+            },
+            required: [],
+        },
+    })),
+    ...MCP_VERBS.map((verb) => ({
+        name: `mcp_jules_${verb}`,
+        description: `Jules dispatch: ${verb.replace(/_/g, " ")}. Manages remote coding task sessions — creation, monitoring, activity feeds, and PR publication for asynchronous task execution.`,
+        input_schema: {
+            type: "object",
+            properties: {
+                session_id: { type: "string", description: "Jules session identifier" },
+                prompt: { type: "string", description: "Task prompt" },
+                repo: { type: "string", description: "owner/name of the target repository" },
+                branch: { type: "string", description: "Starting branch" },
+            },
+            required: [],
+        },
+    })),
+];
+
+const fewTools = builtinTools.slice(0, 4);
+const searchToolsTool = {
+    name: "search_tools",
+    description: "Search for available tools by keyword query. Some tools are deferred to save context space — use this to discover and load them. Returns matching tool names and descriptions; matched tools are automatically loaded.",
+    input_schema: {
+        type: "object",
+        properties: { query: { type: "string", description: "Search query — keywords describing the tool you need" } },
+        required: ["query"],
+    },
+};
 
 type Case = {
     label: string;
@@ -58,18 +148,100 @@ type Case = {
     max_tokens: number;
 };
 
-// A = working replica (raw pi / fable). B = failing replica (pizza / opus budget).
-// Then mutate B→A one axis at a time.
-const cases: Case[] = [
-    { label: "A  working replica: fable-5, small sys, 4 tools, adaptive (stream)",
-      model: "claude-fable-5", system: smallSystem, tools: fewTools, beta: BASE_BETA + FALLBACK_BETA,
-      thinking: { type: "adaptive", display: "summarized" }, output_config: { effort: "high" },
-      fallbacks: [{ model: "claude-opus-4-8" }], max_tokens: 128000 },
+// Known-good request shape (fable-5, adaptive thinking) held constant; only
+// the tools array and system size vary per case.
+const GOOD = {
+    model: "claude-fable-5",
+    beta: BASE_BETA + FALLBACK_BETA,
+    thinking: { type: "adaptive", display: "summarized" },
+    output_config: { effort: "high" },
+    fallbacks: [{ model: "claude-opus-4-8" }],
+    max_tokens: 128000,
+} as const;
 
-    { label: "B  failing replica: opus-4-6, BIG sys, 58 tools, budget thinking (stream)",
-      model: "claude-opus-4-6", system: bigSystem, tools: manyTools, beta: BASE_BETA + INTERLEAVED,
-      thinking: { type: "enabled", budget_tokens: 20480 }, max_tokens: 128000 },
+// Round 1 findings (2026-07-03): system size is NOT the trigger (63k-char
+// system + 4 tools → 200). The tools axis IS: 26 tools → 200, 32 tools → 400
+// "out of extra usage" (request classified out of the subscription bucket).
+const round1: Case[] = [
+    { ...GOOD, label: "A0 baseline: small sys, 4 tools",
+      system: smallSystem, tools: fewTools },
+
+    { ...GOOD, label: "T1 today's PizzaPi: small sys, 26 builtin tools",
+      system: smallSystem, tools: builtinTools },
+
+    { ...GOOD, label: "T2 deferred end-state: small sys, 26 builtin + search_tools + 5 MCP (32 tools)",
+      system: smallSystem, tools: [...builtinTools, searchToolsTool, ...mcpTools.slice(0, 5)] },
+
+    { ...GOOD, label: "T3 eager MCP: small sys, 26 builtin + 32 MCP tools (58 tools)",
+      system: smallSystem, tools: [...builtinTools, ...mcpTools] },
+
+    { ...GOOD, label: "S1 system axis: BIG sys (~63k chars), 4 tools",
+      system: bigSystem, tools: fewTools },
+
+    { ...GOOD, label: "B1 combined: BIG sys + 58 tools",
+      system: bigSystem, tools: [...builtinTools, ...mcpTools] },
 ];
+
+// Round 2: binary-search the tools axis — count vs bytes vs naming shape.
+const genericExtra = (n: number) => Array.from({ length: n }, (_, i) => ({
+    name: `extra_tool_${i + 1}`,
+    description: `Extra generic tool ${i + 1}. Performs an auxiliary operation and returns the result.`,
+    input_schema: {
+        type: "object",
+        properties: { input: { type: "string", description: "Primary input" } },
+        required: ["input"],
+    },
+}));
+const ccStyleMcp = mcpTools.slice(0, 5).map((t) => ({
+    ...t,
+    name: t.name.replace(/^mcp_godmother_/, "mcp__godmother__"),
+}));
+const fatBuiltinTools = builtinTools.map((t) => ({
+    ...t,
+    description: t.description + " " + "This tool participates in the PizzaPi agent harness and returns structured results suitable for downstream orchestration. ".repeat(2),
+}));
+
+const round2: Case[] = [
+    { ...GOOD, label: "R1 count 27: 26 builtin + 1 generic",
+      system: smallSystem, tools: [...builtinTools, ...genericExtra(1)] },
+
+    { ...GOOD, label: "R2 count 32: 26 builtin + 6 generic",
+      system: smallSystem, tools: [...builtinTools, ...genericExtra(6)] },
+
+    { ...GOOD, label: "R3 search_tools only: 26 builtin + search_tools (27)",
+      system: smallSystem, tools: [...builtinTools, searchToolsTool] },
+
+    { ...GOOD, label: "R4 mcp_ single-underscore: 26 builtin + 5 mcp_godmother_* (31)",
+      system: smallSystem, tools: [...builtinTools, ...mcpTools.slice(0, 5)] },
+
+    { ...GOOD, label: "R5 mcp__ CC-style: 26 builtin + 5 mcp__godmother__* (31)",
+      system: smallSystem, tools: [...builtinTools, ...ccStyleMcp] },
+
+    { ...GOOD, label: "R6 bytes axis: 26 builtin with fat descriptions (~14KB tools)",
+      system: smallSystem, tools: fatBuiltinTools },
+];
+
+// Round 2 findings (2026-07-03): count (R2: 32 generic → 200), bytes (R6:
+// 16KB tools → 200), and search_tools (R3 → 200) are all fine. The trigger is
+// naming: `mcp_x_y` single-underscore → 400 (R4); the SAME tools renamed to
+// Claude Code's canonical `mcp__x__y` → 200 (R5).
+
+// Round 3: confirm eager full-MCP exposure passes with CC-style naming.
+const ccStyleAll = mcpTools.map((t) => ({
+    ...t,
+    name: t.name.replace(/^mcp_(godmother|jules)_/, "mcp__$1__"),
+}));
+const round3: Case[] = [
+    { ...GOOD, label: "F1 eager CC-style: 26 builtin + 32 mcp__* (58 tools)",
+      system: smallSystem, tools: [...builtinTools, ...ccStyleAll] },
+
+    { ...GOOD, label: "F2 eager CC-style + BIG sys: 58 tools + 63k system",
+      system: bigSystem, tools: [...builtinTools, ...ccStyleAll] },
+];
+
+const cases: Case[] = process.argv.includes("--round1") ? round1
+    : process.argv.includes("--round2") ? round2
+    : round3;
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -86,8 +258,11 @@ for (const c of cases) {
     if (c.output_config) body.output_config = c.output_config;
     if (c.fallbacks) body.fallbacks = c.fallbacks;
 
-    let status = 0, reason = "", errMsg = "";
-    for (let attempt = 0; attempt < 5; attempt++) {
+    let status = 0, errMsg = "";
+    let rlHeaders: Record<string, string> = {};
+    let attempts = 0;
+    for (let attempt = 0; attempt < 3; attempt++) {
+        attempts = attempt + 1;
         const res = await fetch("https://api.anthropic.com/v1/messages", {
             method: "POST",
             headers: {
@@ -99,16 +274,30 @@ for (const c of cases) {
             body: JSON.stringify(body),
         });
         status = res.status;
-        reason = res.headers.get("anthropic-ratelimit-unified-overage-disabled-reason") ?? "";
-        if (status === 429) { await sleep(12000); continue; }
+        rlHeaders = {};
+        res.headers.forEach((v, k) => {
+            if (k.startsWith("anthropic-ratelimit")) rlHeaders[k] = v;
+        });
+        // A 429 on this case IS the signal — record it, retry to see if transient.
+        if (status === 429) { errMsg = await res.text(); await sleep(15000); continue; }
         // stream:true returns 200 then may error mid-stream — must read the body.
         errMsg = await res.text();
         break;
     }
+    const bodyBytes = Buffer.byteLength(JSON.stringify(body));
     console.log(`\n===== ${c.label} =====`);
-    console.log(`HTTP ${status}  overage-header=${reason || "-"}`);
-    console.log(`--- full response body ---`);
-    console.log(errMsg);
-    console.log(`--- end ---`);
+    console.log(`tools=${c.tools.length} sysChars=${c.system.length} bodyBytes=${bodyBytes} attempts=${attempts}`);
+    console.log(`HTTP ${status}`);
+    for (const [k, v] of Object.entries(rlHeaders).sort()) console.log(`  ${k}: ${v}`);
+    if (status !== 200) {
+        console.log(`--- response body ---`);
+        console.log(errMsg.slice(0, 2000));
+        console.log(`--- end ---`);
+    } else {
+        // don't dump the whole SSE stream — just confirm it completed vs errored.
+        const midStreamError = errMsg.includes('"type":"error"');
+        console.log(`stream: ${midStreamError ? "ERROR mid-stream" : "ok"} (${errMsg.length} bytes)`);
+        if (midStreamError) console.log(errMsg.slice(errMsg.indexOf('"type":"error"') - 100, errMsg.indexOf('"type":"error"') + 800));
+    }
     await sleep(6000);
 }

--- a/packages/cli/scripts/probe-overage.ts
+++ b/packages/cli/scripts/probe-overage.ts
@@ -49,13 +49,13 @@ const authToken = await AuthStorage.create(join(homedir(), ".pizzapi", "auth.jso
 const file = fileToken();
 const kc = keychainToken();
 const mins = (c: { expiresAt: number } | null) => c ? Math.round((c.expiresAt - Date.now()) / 60000) : null;
-console.log(`pizzapi auth.json token:  ${authToken ? fp(authToken) : "(none)"}`);
-console.log(`.credentials.json token:  ${file ? `${fp(file.token)} expires in ${mins(file)}min` : "(none)"}`);
-console.log(`keychain CC token:        ${kc ? `${fp(kc.token)} expires in ${mins(kc)}min` : "(none)"}`);
+console.log(`pizzapi auth.json token:  ${authToken ? "(present)" : "(none)"}`);
+console.log(`.credentials.json token:  ${file ? `(present) expires in ${mins(file)}min` : "(none)"}`);
+console.log(`keychain CC token:        ${kc ? `(present) expires in ${mins(kc)}min` : "(none)"}`);
 const fresh = [file, kc].filter((c): c is NonNullable<typeof c> => !!c && c.expiresAt > Date.now() + 60000);
 const token = fresh[0]?.token ?? authToken;
 if (!token) { console.error("no unexpired anthropic token — log in with Claude Code first"); process.exit(1); }
-console.log(`using: ${fp(token)}\n`);
+console.log("using: (token selected)\n");
 
 const bigSystem = "You are a coding assistant.\n".repeat(2300); // ~63k chars
 const smallSystem = "You are a coding assistant.";

--- a/packages/cli/src/extensions/mcp/tool-naming.test.ts
+++ b/packages/cli/src/extensions/mcp/tool-naming.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { allocateProviderSafeToolName } from "./tool-naming.js";
+
+describe("allocateProviderSafeToolName", () => {
+  test("uses Claude Code's mcp__<server>__<tool> double-underscore convention", () => {
+    // Anthropic's subscription-lane classifier rejects `mcp_x_y` (single
+    // underscore) names into the metered extra-usage lane. Only the CC-style
+    // `mcp__x__y` shape passes. Regression-guard the separator.
+    const name = allocateProviderSafeToolName("godmother", "capture_idea", new Set());
+    expect(name).toBe("mcp__godmother__capture_idea");
+  });
+
+  test("sanitizes and lowercases parts without breaking the __ separators", () => {
+    const name = allocateProviderSafeToolName("My Server!", "Do.Thing", new Set());
+    expect(name).toBe("mcp__my_server__do_thing");
+  });
+
+  test("deduplicates collisions with a hash suffix", () => {
+    const used = new Set<string>();
+    const first = allocateProviderSafeToolName("srv", "tool", used);
+    const second = allocateProviderSafeToolName("srv", "tool", used);
+    expect(first).toBe("mcp__srv__tool");
+    expect(second).not.toBe(first);
+    expect(second.startsWith("mcp__srv__tool_")).toBe(true);
+  });
+
+  test("clamps long names to 64 chars", () => {
+    const name = allocateProviderSafeToolName("server", "x".repeat(100), new Set());
+    expect(name.length).toBeLessThanOrEqual(64);
+    expect(name.startsWith("mcp__server__")).toBe(true);
+  });
+});

--- a/packages/cli/src/extensions/mcp/tool-naming.ts
+++ b/packages/cli/src/extensions/mcp/tool-naming.ts
@@ -47,7 +47,11 @@ function clampToolName(name: string, seed: string): string {
  * Generate a provider-safe, collision-free tool name for an MCP tool.
  *
  * The resulting name:
- *  - Uses the `mcp_<server>_<tool>` convention
+ *  - Uses Claude Code's `mcp__<server>__<tool>` convention. The double
+ *    underscore matters: Anthropic's subscription-lane classifier treats
+ *    `mcp_x_y` (single underscore) tool names as non-Claude-Code traffic and
+ *    rejects the request into the metered extra-usage lane (400 "out of
+ *    extra usage" / 429). Verified via scripts/probe-overage.ts (2026-07-03).
  *  - Is at most 64 characters
  *  - Is unique within `usedNames` (hash suffix added on collision)
  *
@@ -55,7 +59,7 @@ function clampToolName(name: string, seed: string): string {
  */
 export function allocateProviderSafeToolName(serverName: string, mcpToolName: string, usedNames: Set<string>): string {
   const source = `${serverName}:${mcpToolName}`;
-  const normalizedBase = `mcp_${sanitizeToolNamePart(serverName).toLowerCase()}_${sanitizeToolNamePart(mcpToolName).toLowerCase()}`;
+  const normalizedBase = `mcp__${sanitizeToolNamePart(serverName).toLowerCase()}__${sanitizeToolNamePart(mcpToolName).toLowerCase()}`;
 
   const preferred = clampToolName(normalizedBase, source);
   if (!usedNames.has(preferred)) {

--- a/packages/docs/src/content/docs/customization/agent-definitions.mdx
+++ b/packages/docs/src/content/docs/customization/agent-definitions.mdx
@@ -80,7 +80,7 @@ The `tools:` frontmatter limits what tools the agent can access:
 
 - Comma-separated tool names: `read,grep,find,ls`
 - **Omitting `tools:`** gives the agent access to ALL tools
-- MCP tools are referenced by their prefixed name (e.g. `mcp_tavily_tavily_search`)
+- MCP tools are referenced by their prefixed name (e.g. `mcp__tavily__tavily_search`)
 - Built-in tool names: `bash`, `read`, `write`, `edit`, `grep`, `find`, `ls`
 
 <Aside type="tip" title="Restrict tools for safety">

--- a/packages/docs/src/content/docs/customization/hooks.mdx
+++ b/packages/docs/src/content/docs/customization/hooks.mdx
@@ -205,7 +205,7 @@ Pi's internal tool names are mapped to display names for matching:
 | `find` | `Find` |
 | `ls` | `Ls` |
 
-MCP tool names are passed as-is (e.g., `mcp_tavily_tavily_search`). Matching is **case-insensitive** — both the internal name and display name are checked.
+MCP tool names are passed as-is (e.g., `mcp__tavily__tavily_search`). Matching is **case-insensitive** — both the internal name and display name are checked.
 
 <Aside type="tip">
   Regex groups inside parentheses are preserved during alternation splitting. The pattern `mcp__(github|filesystem)__.*` is treated as a single regex, not split on the `|` inside the group.


### PR DESCRIPTION
## Summary
- Anthropic's subscription-lane classifier rejects requests containing `mcp_x_y` (single-underscore) tool names into the metered extra-usage lane (`400 You're out of extra usage` / 429), with `overage-status: rejected`.
- Isolated with a 3-round live probe matrix (`scripts/probe-overage.ts`), same OAuth token / model / thinking across all cases:

| Varied axis | Result |
|---|---|
| 32–58 tools, arbitrary names | ✅ 200 |
| 63k-char system prompt | ✅ 200 |
| 16KB fat tool descriptions | ✅ 200 |
| 5 tools named `mcp_godmother_*` | ❌ 400 out-of-extra-usage |
| same 5 renamed `mcp__godmother__*` | ✅ 200 |
| 58 tools incl. 32 `mcp__*` + 63k system | ✅ 200 |

## Changes
- `tool-naming.ts`: generate `mcp__<server>__<tool>` (Claude Code's canonical double-underscore convention) + regression test
- `probe-overage.ts`: isolation matrix with recorded findings; prefer the fresher `.credentials.json` token over the expired Keychain entry (matches provider priority)
- docs: update prefixed-name examples

## Test plan
- [x] `bun test` (cli): 2188 pass
- [x] `bun run typecheck` clean
- [x] Live probe rounds 1–3 against the subscription lane