### PR TITLE
fix(tunnel): return 400 instead of 500 on malformed percent-encoded tunnel paths

### DIFF
--- a/packages/server/src/routes/tunnel.test.ts
+++ b/packages/server/src/routes/tunnel.test.ts
@@ -12,6 +12,20 @@ import {
     rewriteTunnelCss,
     proxyTunnelRequestViaRelay,
 } from "./tunnel";
+import { safeDecodePathComponent } from "./tunnel";
+
+describe("safeDecodePathComponent", () => {
+    test("decodes valid percent-encoding", () => {
+        expect(safeDecodePathComponent("session%20id")).toBe("session id");
+        expect(safeDecodePathComponent("plain")).toBe("plain");
+    });
+
+    test("returns empty string on malformed percent-encoding instead of throwing", () => {
+        expect(safeDecodePathComponent("%E0%A4%A")).toBe("");
+        expect(safeDecodePathComponent("%")).toBe("");
+        expect(safeDecodePathComponent("%ZZ")).toBe("");
+    });
+});
 
 describe("tunnel route URL rewriting", () => {
     test("getTunnelBasePath builds the session-scoped proxy prefix", () => {

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -29,6 +29,18 @@ const RUNNER_TUNNEL_PATH_RE = /^\/api\/tunnel\/runner\/([^/]+)\/(\d+)(\/.*)?$/;
 /** Pattern: /api/tunnel/:sessionId/:port/<rest> */
 const TUNNEL_PATH_RE = /^\/api\/tunnel\/([^/]+)\/(\d+)(\/.*)?$/;
 
+/**
+ * decodeURIComponent that returns "" on malformed percent-encoding instead of
+ * throwing URIError — callers already 400 on empty path components.
+ */
+export function safeDecodePathComponent(component: string): string {
+    try {
+        return decodeURIComponent(component);
+    } catch {
+        return "";
+    }
+}
+
 function getTunnelBasePath(sessionId: string, port: number): string {
     return `/api/tunnel/${encodeURIComponent(sessionId)}/${port}`;
 }
@@ -756,7 +768,7 @@ export const handleTunnelRoute: RouteHandler = async (req, url) => {
     if (identity instanceof Response) return identity;
 
     // ── Parse path segments ──────────────────────────────────────────────────
-    const sessionId = decodeURIComponent(match[1]);
+    const sessionId = safeDecodePathComponent(match[1]);
     const port = parseInt(match[2], 10);
     const proxyPath = match[3] ?? "/";
 
@@ -899,7 +911,7 @@ async function handleRunnerTunnel(req: Request, url: URL, match: RegExpMatchArra
     const identity = await requireSession(req);
     if (identity instanceof Response) return identity;
 
-    const runnerId = decodeURIComponent(match[1]);
+    const runnerId = safeDecodePathComponent(match[1]);
     const port = parseInt(match[2], 10);
     const proxyPath = match[3] ?? "/";
 


### PR DESCRIPTION
## Problem

`handleTunnelRoute` and `handleRunnerTunnel` in `packages/server/src/routes/tunnel.ts` call `decodeURIComponent()` on path segments without a guard. A malformed percent-encoded sessionId/runnerId (e.g. `/api/tunnel/%E0%A4%A/3000/`) throws an unhandled `URIError`, surfacing as a 500 instead of a 400.

`tunnel-ws.ts` already guards all of its decodes — the HTTP routes just never got the same treatment.

## Fix

Adds a small `safeDecodePathComponent()` helper that returns `""` on decode failure; both handlers already return 400 on empty path components. Unit tests included.

Godmother: 4ojODhqM