### PR TITLE
perf(server): parallelize N+1 sequential awaits in delink and trigger fan-out

### DIFF
--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -959,64 +959,69 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             ts,
         };
 
-        let delivered = 0;
-        for (const targetSessionId of subscriberIds) {
-            const targetSession = await getSharedSession(targetSessionId);
-            // Only deliver to sessions belonging to the same user (ownership check)
-            // and sessions that are actually connected.
-            if (!targetSession || targetSession.userId !== identity.userId) continue;
+        // Process all subscribers concurrently. Each subscriber's filtering,
+        // ownership check, and delivery are independent; the only shared result
+        // is the delivered count, which is summed from per-subscriber booleans.
+        const deliveredResults = await Promise.all(
+            subscriberIds.map(async (targetSessionId) => {
+                const targetSession = await getSharedSession(targetSessionId);
+                // Only deliver to sessions belonging to the same user (ownership check)
+                // and sessions that are actually connected.
+                if (!targetSession || targetSession.userId !== identity.userId) return false;
 
-            // Filter by subscription filters (based on output schema fields).
-            // New subscriptions always have a filterData result (even with filters=[]).
-            // Legacy subscriptions return undefined and fall back to param matching.
-            const filterData = normalizeFilterRecords(await getSubscriptionFilters(targetSessionId, body.type));
-            if (filterData) {
-                const matchedAny = filterData.length === 0 || filterData.some((record) => filterRecordMatchesPayload(body.payload, record));
-                if (!matchedAny) continue;
-            } else {
-                const subParams = await getSubscriptionParams(targetSessionId, body.type);
-                if (subParams) {
-                    const legacyFilters = legacyParamsToFilters(subParams);
-                    if (!payloadMatchesFilters(body.payload, legacyFilters, "and")) continue;
+                // Filter by subscription filters (based on output schema fields).
+                // New subscriptions always have a filterData result (even with filters=[]).
+                // Legacy subscriptions return undefined and fall back to param matching.
+                const filterData = normalizeFilterRecords(await getSubscriptionFilters(targetSessionId, body.type));
+                if (filterData) {
+                    const matchedAny = filterData.length === 0 || filterData.some((record) => filterRecordMatchesPayload(body.payload, record));
+                    if (!matchedAny) return false;
+                } else {
+                    const subParams = await getSubscriptionParams(targetSessionId, body.type);
+                    if (subParams) {
+                        const legacyFilters = legacyParamsToFilters(subParams);
+                        if (!payloadMatchesFilters(body.payload, legacyFilters, "and")) return false;
+                    }
                 }
-            }
 
-            const historyEntry = {
-                triggerId: `${triggerId}_${targetSessionId.slice(0, 8)}`,
-                type: body.type,
-                // Prefix with "external:" so deriveLinkedSessions() in the UI
-                // doesn't misclassify service sources as child sessions.
-                source: `external:${body.source ?? "service"}`,
-                summary: body.summary,
-                payload: body.payload,
-                deliverAs,
-                ts,
-                direction: "inbound" as const,
-            };
+                const historyEntry = {
+                    triggerId: `${triggerId}_${targetSessionId.slice(0, 8)}`,
+                    type: body.type,
+                    // Prefix with "external:" so deriveLinkedSessions() in the UI
+                    // doesn't misclassify service sources as child sessions.
+                    source: `external:${body.source ?? "service"}`,
+                    summary: body.summary,
+                    payload: body.payload,
+                    deliverAs,
+                    ts,
+                    direction: "inbound" as const,
+                };
 
-            // Write history only after confirmed delivery so the log reflects
-            // what the session actually received (not optimistically before delivery).
-            const localSocket = getLocalTuiSocket(targetSessionId);
-            if (localSocket?.connected) {
-                try {
-                    localSocket.emit("session_trigger", { trigger: { ...trigger, targetSessionId } });
+                // Write history only after confirmed delivery so the log reflects
+                // what the session actually received (not optimistically before delivery).
+                const localSocket = getLocalTuiSocket(targetSessionId);
+                if (localSocket?.connected) {
+                    try {
+                        localSocket.emit("session_trigger", { trigger: { ...trigger, targetSessionId } });
+                        void Promise.resolve(pushTriggerHistory(targetSessionId, historyEntry)).catch(() => {});
+                        broadcastToSessionViewers(targetSessionId, "trigger_delivered", { triggerId: historyEntry.triggerId });
+                        return true;
+                    } catch {
+                        // fall through to cross-node
+                    }
+                }
+                const crossNode = await emitToRelaySessionVerified(
+                    targetSessionId, "session_trigger", { trigger: { ...trigger, targetSessionId } },
+                );
+                if (crossNode) {
                     void Promise.resolve(pushTriggerHistory(targetSessionId, historyEntry)).catch(() => {});
                     broadcastToSessionViewers(targetSessionId, "trigger_delivered", { triggerId: historyEntry.triggerId });
-                    delivered++;
-                    continue;
-                } catch {
-                    // fall through to cross-node
+                    return true;
                 }
-            }
-            const crossNode = await emitToRelaySessionVerified(
-                targetSessionId, "session_trigger", { trigger: { ...trigger, targetSessionId } },
-            );
-            if (crossNode) {
-                void Promise.resolve(pushTriggerHistory(targetSessionId, historyEntry)).catch(() => {});
-                broadcastToSessionViewers(targetSessionId, "trigger_delivered", { triggerId: historyEntry.triggerId });
-                delivered++;
-            }
-        }
+                return false;
+            }),
+        );
+        const delivered = deliveredResults.reduce((sum, didDeliver) => sum + (didDeliver ? 1 : 0), 0);
 
         // ── Runner-level auto-spawn listeners ──────────────────────────
         let spawned = 0;

--- a/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
+++ b/packages/server/src/ws/namespaces/relay/child-lifecycle.ts
@@ -216,9 +216,21 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             // (this handles the case where a stale child reconnected and got a
             // fresh startedAt timestamp).
             if (epoch && childIds.length > 0) {
+                // Fetch all session hashes concurrently, then check delink markers
+                // only for the subset that started after the epoch.
+                const sessions = await Promise.all(childIds.map((childId) => getSession(childId)));
+                const markerCandidates = childIds.filter((_, i) => {
+                    const childSession = sessions[i];
+                    if (!childSession?.startedAt) return false;
+                    return new Date(childSession.startedAt).getTime() > epoch;
+                });
+                const markerResults = await Promise.all(markerCandidates.map((childId) => isChildDelinked(childId)));
+                const markerMap = new Map(markerCandidates.map((childId, i) => [childId, markerResults[i]]));
+
                 const filtered: string[] = [];
-                for (const childId of childIds) {
-                    const childSession = await getSession(childId);
+                for (let i = 0; i < childIds.length; i++) {
+                    const childId = childIds[i];
+                    const childSession = sessions[i];
                     if (!childSession?.startedAt) {
                         // No session data — conservative: include it
                         filtered.push(childId);
@@ -231,7 +243,7 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
                         // Child started after epoch, but check if it already has a delink marker.
                         // If it does, it's a stale child that reconnected and should be delinked
                         // regardless of its fresh startedAt timestamp.
-                        const hasDelinkMarker = await isChildDelinked(childId);
+                        const hasDelinkMarker = markerMap.get(childId)!;
                         if (hasDelinkMarker) {
                             filtered.push(childId);
                             log.info(`delink_children: including child ${childId} (startedAt > epoch but has delink marker)`);
@@ -249,12 +261,14 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             // already find the marker and refuse to re-link. If we cleared
             // first and wrote markers second, a reconnecting child could slip
             // through before its marker exists.
-            for (const childId of childIds) {
-                // Store the parent session ID in the marker so that
-                // addChildSession can scrub the child from this parent's
-                // pending-delink retry set when the child is re-linked elsewhere.
-                await markChildAsDelinked(childId, sessionId);
-            }
+            await Promise.all(
+                childIds.map((childId) => {
+                    // Store the parent session ID in the marker so that
+                    // addChildSession can scrub the child from this parent's
+                    // pending-delink retry set when the child is re-linked elsewhere.
+                    return markChildAsDelinked(childId, sessionId);
+                }),
+            );
             await addPendingParentDelinkChildren(sessionId, childIds);
 
             // Remove only the snapshotted children from the membership set.
@@ -279,16 +293,18 @@ export function registerChildLifecycleHandlers(socket: RelaySocket, io: SocketIO
             // event causes rctx.parentSessionId = null so reconnects won't re-link.
             // For offline children (who never received parent_delinked), the marker
             // we just wrote above prevents re-link.
-            for (const childId of childIds) {
-                const payload = { parentSessionId: sessionId };
-                const delivery = await emitToRelaySessionAwaitingAck(childId, "parent_delinked", payload);
-                if (delivery.hadListeners && !delivery.acked) {
-                    throw new Error(`parent_delinked delivery was not confirmed for child ${childId}`);
-                }
-                // Offline children are safe to clear from the retry set too:
-                // their delink marker will prevent re-linking on reconnect.
-                await removePendingParentDelinkChild(sessionId, childId);
-            }
+            await Promise.all(
+                childIds.map(async (childId) => {
+                    const payload = { parentSessionId: sessionId };
+                    const delivery = await emitToRelaySessionAwaitingAck(childId, "parent_delinked", payload);
+                    if (delivery.hadListeners && !delivery.acked) {
+                        throw new Error(`parent_delinked delivery was not confirmed for child ${childId}`);
+                    }
+                    // Offline children are safe to clear from the retry set too:
+                    // their delink marker will prevent re-linking on reconnect.
+                    await removePendingParentDelinkChild(sessionId, childId);
+                }),
+            );
 
             // Acknowledge that the delink completed only after every
             // connected child has confirmed parent_delinked delivery. The


### PR DESCRIPTION
Parallelizes independent per-child and per-subscriber awaits in server hot paths.

Changes:
- `packages/server/src/ws/namespaces/relay/child-lifecycle.ts`
  - Epoch filter: fetches all child session hashes concurrently, then checks `isChildDelinked` only for children whose `startedAt > epoch`. Preserves original `childIds` order, inclusion logic, and log lines.
  - Marker writes: writes all `markChildAsDelinked` markers concurrently, keeping the existing barrier that all markers complete before `addPendingParentDelinkChildren` / `removeChildren` run.
  - `parent_delinked` fan-out: runs per-child `emitToRelaySessionAwaitingAck` → ack check → `removePendingParentDelinkChild` sequences concurrently. Each child still throws the same unconfirmed-delivery error; `Promise.all` rejects as before.

- `packages/server/src/routes/triggers.ts`
  - Trigger broadcast fan-out: processes each subscriber inside an async function and awaits all via `Promise.all`. Each function returns whether it delivered; results are summed for `delivered`. All ownership checks, filter evaluation, fallback-to-cross-node delivery, and history/viewer side effects are preserved exactly.

No shared-state ordering constraints require sequential handling in the trigger fan-out: per-subscriber operations are independent (ownership read, filter read, local/cross-node emit, fire-and-forget history write, viewer broadcast).
