### PR TITLE
perf(server): fix RateLimiter key leak, batch Redis sync, tail-scan event cache

### DIFF
--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -66,6 +66,23 @@ describe("RateLimiter", () => {
         limiter.destroy();
     });
 
+    test("cleanup prunes knownKeys for expired entries", async () => {
+        const limiter = new RateLimiter(1, 50);
+        limiter.check("a");
+        limiter.check("b");
+
+        const knownKeys = (limiter as unknown as { knownKeys: Set<string> }).knownKeys;
+        expect(knownKeys.has("a")).toBe(true);
+        expect(knownKeys.has("b")).toBe(true);
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+        (limiter as unknown as { cleanup: () => void }).cleanup();
+
+        expect(knownKeys.has("a")).toBe(false);
+        expect(knownKeys.has("b")).toBe(false);
+        limiter.destroy();
+    });
+
     test("getRetryAfter returns seconds until window reset", () => {
         const limiter = new RateLimiter(1, 60_000); // 60s window
         const key = "retry-test-key";

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -85,14 +85,18 @@ export class RateLimiter {
     }
 
     private async syncFromRedis(): Promise<void> {
-        for (const key of this.knownKeys) {
-            const window = await getRateLimitWindow(key);
+        const keys = [...this.knownKeys];
+        const windows = await Promise.all(
+            keys.map(async (key) => ({ key, window: await getRateLimitWindow(key) })),
+        );
+        const now = Date.now();
+        for (const { key, window } of windows) {
             if (!window) continue;
             const record = this.hits.get(key);
             // Adopt the Redis window when it has a higher count or when our
             // local window has expired. This prevents long-running nodes from
             // falling behind the cluster-wide counter.
-            if (!record || Date.now() > record.resetTime || window.count > record.count) {
+            if (!record || now > record.resetTime || window.count > record.count) {
                 this.hits.set(key, window);
             }
         }
@@ -129,6 +133,7 @@ export class RateLimiter {
         for (const [key, record] of this.hits.entries()) {
             if (now > record.resetTime) {
                 this.hits.delete(key);
+                this.knownKeys.delete(key);
             }
         }
     }

--- a/packages/server/src/sessions/redis.ts
+++ b/packages/server/src/sessions/redis.ts
@@ -200,47 +200,64 @@ export async function getCachedRelayEventsAfterSeq(
     if (!redis) return [];
 
     try {
-        const rows = await redis.lRange(eventsKey(sessionId), 0, -1);
-        type SequencedRecord = CachedRelayEventRecord & { seq: number };
-        const events: SequencedRecord[] = [];
-        let sawLegacyRow = false;
+        const key = eventsKey(sessionId);
+        const length = await redis.lLen(key);
+        if (!Number.isFinite(length) || length <= 0) return [];
 
-        for (const row of rows) {
-            const parsed = parseCachedRelayEventRow(row);
-            if (!parsed) continue;
-            if (!isSequencedCachedRelayEvent(parsed)) {
-                sawLegacyRow = true;
-                continue;
+        type SequencedRecord = CachedRelayEventRecord & { seq: number };
+        const collected: SequencedRecord[] = [];
+        let sawLegacyRow = false;
+        const chunkSize = snapshotScanChunkSize();
+
+        // Events are rPush'd: newest at the tail. Scan backwards in chunks
+        // until we reach a sequenced event with seq <= afterSeq; everything
+        // older than that is irrelevant.
+        let stopped = false;
+        for (let end = length - 1; end >= 0; end -= chunkSize) {
+            const start = Math.max(0, end - chunkSize + 1);
+            const rows = await redis.lRange(key, start, end);
+            for (let i = rows.length - 1; i >= 0; i--) {
+                const parsed = parseCachedRelayEventRow(rows[i]);
+                if (!parsed) continue;
+                if (!isSequencedCachedRelayEvent(parsed)) {
+                    sawLegacyRow = true;
+                    continue;
+                }
+                if (parsed.seq <= afterSeq) {
+                    stopped = true;
+                    break;
+                }
+                collected.push(parsed);
             }
-            if (parsed.seq > afterSeq) {
-                events.push(parsed);
-            }
+            if (stopped) break;
         }
 
         if (afterSeq > 0 && sawLegacyRow) {
             return [];
         }
 
+        collected.reverse();
+
         // Verify contiguity: the first event must be afterSeq+1 and all
         // subsequent seqs must be consecutive.  If the cache was trimmed
         // (lTrim), earlier events may be missing — return empty so the
         // caller falls back to a full snapshot/resync instead of silently
         // skipping events.
-        if (events.length > 0) {
-            const first = events[0];
+        if (collected.length > 0) {
+            const first = collected[0];
             if (!first || first.seq !== afterSeq + 1) {
                 return [];
             }
-            for (let i = 1; i < events.length; i++) {
-                const curr = events[i];
-                const prev = events[i - 1];
+            for (let i = 1; i < collected.length; i++) {
+                const curr = collected[i];
+                const prev = collected[i - 1];
                 if (!curr || !prev || curr.seq !== prev.seq + 1) {
                     return [];
                 }
             }
         }
 
-        return events;
+        return collected;
     } catch (error) {
         logUnavailableOnce("Failed to read relay event cache from Redis", error);
         return [];


### PR DESCRIPTION
Fixes three server-side performance issues:\n\n1. **RateLimiter memory leak** —  was only ever growing; cleanup now deletes the key when its local window expires.\n2. **Sequential Redis sync** —  now fetches all windows concurrently with .\n3. **Full event-cache scan** —  now scans backwards from the tail in chunks, stopping at the first sequenced event with seq ≤ afterSeq, preserving legacy-row and contiguity semantics.\n\nVerified with `bun run typecheck` and `bun test --max-concurrency=1 packages/server/src` (991 pass, 0 fail).