### PR TITLE
perf(server): use summary fetches instead of full session hashes on hot paths

### DIFF
--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -9,6 +9,7 @@ import {
     touchSessionActivity,
     updateSessionHeartbeat,
     getSharedSession,
+    getSharedSessionSummary,
     broadcastSessionEventToViewers,
     publishSessionEvent,
     consumePendingRecovery,
@@ -234,8 +235,15 @@ export function registerEventHandler(socket: RelaySocket): void {
         // consumers (state storage, Redis cache, viewer broadcast) see
         // already-stripped payloads. The _imagesStripped flag causes
         // storeAndReplaceImages / storeAndReplaceImagesInEvent to skip.
-        const session = await getSharedSession(sessionId);
-        const userId = session?.userId ?? "unknown";
+        // Only fetch the lightweight session summary for event types that
+        // actually carry images; all others skip the Redis round-trip.
+        const needsImageStrip =
+            event.type === "session_active" ||
+            event.type === "agent_end" ||
+            event.type === "session_messages_chunk";
+        const userId = needsImageStrip
+            ? (await getSharedSessionSummary(sessionId))?.userId ?? "unknown"
+            : "unknown";
         try {
             const stripped = await stripImagesFromPipelineEvent(event, sessionId, userId);
             if (stripped !== event) {

--- a/packages/server/src/ws/namespaces/relay/messaging.test.ts
+++ b/packages/server/src/ws/namespaces/relay/messaging.test.ts
@@ -12,6 +12,7 @@ const mockRecordTriggerResponse = mock(async (_sessionId: string, _triggerId: st
 
 mock.module("../../sio-registry.js", () => ({
     getSharedSession: mockGetSharedSession,
+    getSharedSessionSummary: mockGetSharedSession,
     getLocalTuiSocket: mockGetLocalTuiSocket,
     emitToRelaySessionVerified: mockEmitToRelaySessionVerified,
     broadcastToSessionViewers: mockBroadcastToSessionViewers,

--- a/packages/server/src/ws/namespaces/relay/messaging.ts
+++ b/packages/server/src/ws/namespaces/relay/messaging.ts
@@ -3,6 +3,7 @@
 
 import {
     getSharedSession,
+    getSharedSessionSummary,
     getLocalTuiSocket,
     emitToRelaySessionVerified,
     broadcastToSessionViewers,
@@ -31,8 +32,10 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
             return;
         }
 
-        const senderSession = await getSharedSession(sessionId);
-        const targetSession = await getSharedSession(targetSessionId);
+        const [senderSession, targetSession] = await Promise.all([
+            getSharedSessionSummary(sessionId),
+            getSharedSessionSummary(targetSessionId),
+        ]);
         if (!targetSession) {
             socket.emit("session_message_error", {
                 targetSessionId,
@@ -147,7 +150,10 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
         const targetSessionId = trigger.targetSessionId;
 
         // Find the target session's relay socket and validate ownership
-        const targetSession = await getSharedSession(targetSessionId);
+        const [senderSession, targetSession] = await Promise.all([
+            getSharedSessionSummary(sessionId),
+            getSharedSessionSummary(targetSessionId),
+        ]);
         if (!targetSession) {
             const error = `Target session ${targetSessionId} is not connected`;
             socket.emit("session_message_error", {
@@ -160,7 +166,6 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
         }
 
         // Validate that the target session belongs to the same user
-        const senderSession = await getSharedSession(sessionId);
         if (!senderSession?.userId || senderSession.userId !== targetSession.userId) {
             socket.emit("error", { message: "Target session belongs to a different user" });
             ack?.({ ok: false, error: "Target session belongs to a different user" });
@@ -284,8 +289,10 @@ export function registerMessagingHandlers(socket: RelaySocket): void {
         }
 
         // Validate that the target session belongs to the same user
-        const senderSession = await getSharedSession(socket.data.sessionId);
-        const targetSession = await getSharedSession(targetSessionId);
+        const [senderSession, targetSession] = await Promise.all([
+            getSharedSessionSummary(socket.data.sessionId),
+            getSharedSessionSummary(targetSessionId),
+        ]);
 
         // If the target session no longer exists (e.g. runner/server restarted
         // and the old child session was already cleaned up), treat the

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -733,7 +733,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             // If targetSessionId is explicitly provided, route to that child.
             // Validate ownership: the target session must belong to the same user.
             if (targetSessionId) {
-                const targetSession = await getSharedSession(targetSessionId);
+                const targetSession = await getSharedSessionSummary(targetSessionId);
                 if (!targetSession) {
                     // Target session no longer exists (child exited) — don't ack so the
                     // UI keeps retry controls visible, and emit trigger_error for feedback.
@@ -897,7 +897,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
 
         // ── Optional initial session bootstrap (backward compatibility) ─────
         if (initialSessionId) {
-            const initialSession = await getSharedSession(initialSessionId);
+            const initialSession = await getSharedSessionSummary(initialSessionId);
             if (!initialSession) {
                 // Session not live — try to replay a persisted snapshot for older
                 // clients that still bind the session in the handshake.

--- a/packages/server/src/ws/sio-registry/sessions.heartbeat.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.heartbeat.test.ts
@@ -15,7 +15,7 @@ const noopAsync = async () => {};
 mock.module("../sio-state/index.js", () => ({
     setSession: noopAsync,
     getSession: mockGetSession,
-    getSessionSummary: noopAsync,
+    getSessionSummary: mockGetSession,
     updateSessionFields: mockUpdateSessionFields,
     deleteSession: noopAsync,
     getAllSessionSummaries: noopAsync,

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -516,7 +516,7 @@ export interface UpdateSessionStateOpts {
 
 /** Update session state (lastState + sessionName detection). */
 export async function updateSessionState(sessionId: string, state: unknown, opts?: UpdateSessionStateOpts): Promise<void> {
-    const session = await getSession(sessionId);
+    const session = await getSessionSummary(sessionId);
     if (!session) return;
 
     // Extract inline base64 images from messages before storing in Redis.
@@ -697,7 +697,7 @@ export async function broadcastSessionEventToViewers(sessionId: string, event: u
  */
 export async function publishSessionEvent(sessionId: string, event: unknown): Promise<number> {
     const io = getIo();
-    const session = await getSession(sessionId);
+    const session = await getSessionSummary(sessionId);
 
     if (session?.isEphemeral) {
         await updateSessionFields(sessionId, { expiresAt: nextEphemeralExpiry() });
@@ -762,7 +762,7 @@ export async function updateSessionHeartbeat(
     sessionId: string,
     heartbeat: Record<string, unknown>,
 ): Promise<void> {
-    const session = await getSession(sessionId);
+    const session = await getSessionSummary(sessionId);
     if (!session) return;
 
     const prevHeartbeat = session.lastHeartbeat ? safeJsonParse(session.lastHeartbeat) : null;


### PR DESCRIPTION
Replace full `hGetAll` session reads with lightweight `hmGet` summary fetches where callers only need identity/liveness metadata, avoiding the potentially multi-MB `lastState` blob on hot paths.

## Changed call sites

### `packages/server/src/ws/sio-registry/sessions.ts`
- `publishSessionEvent`: only reads `isEphemeral` / `userId` → `getSessionSummary`
- `updateSessionHeartbeat`: only reads summary fields → `getSessionSummary`
- `updateSessionState`: only reads `userId` / `sessionName` / `isEphemeral` / `sessionId` → `getSessionSummary`

### `packages/server/src/ws/namespaces/relay/event-pipeline.ts`
- `registerEventHandler`: only fetches a session summary when the event type is one of `session_active`, `agent_end`, or `session_messages_chunk` — the only types `stripImagesFromPipelineEvent` acts on. Deltas, heartbeats, metadata updates, etc. now skip the Redis round-trip entirely.

### `packages/server/src/ws/namespaces/relay/messaging.ts`
- `session_message`, `session_trigger`, and `trigger_response`: parallelize the sender/target lookups with `Promise.all` and switch to `getSharedSessionSummary` (they only read `userId` / `parentSessionId`).

### `packages/server/src/ws/namespaces/viewer.ts`
- `trigger_response` target-session lookup: only reads `userId` → `getSharedSessionSummary`
- Initial handshake bootstrap: only checks existence + `userId` → `getSharedSessionSummary`

## Deliberately left as full fetches

These call sites read non-summary fields, so they keep `getSharedSession`:
- `activateSession` fresh-session fetch (`lastState`, `runnerId`, etc.)
- `resync` (`lastState`)
- `load_messages` (`lastState`)
- `input` / `model_set` / `exec` / `mcp_oauth_paste` / `service_message` (`collabMode`, and in service_message also `runnerId`)

## Verification
- `bun run typecheck` ✅
- `bun test --max-concurrency=1 packages/server/src` ✅ (990 pass, 0 fail)

Two test files were updated to mock `getSessionSummary` / `getSharedSessionSummary` alongside their full-fetch counterparts.