### PR TITLE
perf(ui): render hot-path fixes — structuredClone, memoized timestamps, scoped relative-time ticks, O(1) grouping dedup

### DIFF
--- a/packages/ui/src/components/HooksManager.tsx
+++ b/packages/ui/src/components/HooksManager.tsx
@@ -78,7 +78,7 @@ function isMatcherType(type: HookType): type is MatcherHookType {
 }
 
 function cloneHooks(hooks: Record<string, any>): Record<string, any> {
-    return JSON.parse(JSON.stringify(hooks ?? {}));
+    return structuredClone(hooks ?? {});
 }
 
 // ── Component ─────────────────────────────────────────────────────────────────

--- a/packages/ui/src/components/SessionSidebar.tsx
+++ b/packages/ui/src/components/SessionSidebar.tsx
@@ -806,14 +806,21 @@ export const SessionSidebar = React.memo(function SessionSidebar({
             runnerMap.get(key)!.sessions.push(s);
         }
 
+        // Pre-parse timestamps once so comparators don't re-parse on every
+        // comparison (O(log n) per sort) and every heartbeat memo recomputation.
+        const tsBySession = new Map<string, number>();
+        for (const s of liveSessions) {
+            tsBySession.set(s.sessionId, Date.parse(s.lastHeartbeatAt ?? s.startedAt));
+        }
+
         // Step 2: sort sessions within each runner — pinned first, then by most recently active/started.
         for (const entry of runnerMap.values()) {
             entry.sessions.sort((a, b) => {
                 const aPinned = pinnedSessionIds.has(a.sessionId) ? 1 : 0;
                 const bPinned = pinnedSessionIds.has(b.sessionId) ? 1 : 0;
                 if (bPinned !== aPinned) return bPinned - aPinned;
-                const aT = Date.parse(a.lastHeartbeatAt ?? a.startedAt);
-                const bT = Date.parse(b.lastHeartbeatAt ?? b.startedAt);
+                const aT = tsBySession.get(a.sessionId) ?? 0;
+                const bT = tsBySession.get(b.sessionId) ?? 0;
                 return (Number.isFinite(bT) ? bT : 0) - (Number.isFinite(aT) ? aT : 0);
             });
         }
@@ -852,7 +859,7 @@ export const SessionSidebar = React.memo(function SessionSidebar({
                 if (pinDiff !== 0) return pinDiff;
                 const latestTs = (grp: ProjectGroup) =>
                     Math.max(0, ...grp.sessions
-                        .map((s) => Date.parse(s.lastHeartbeatAt ?? s.startedAt))
+                        .map((s) => tsBySession.get(s.sessionId) ?? 0)
                         .filter(Number.isFinite));
                 return latestTs(b) - latestTs(a);
             });

--- a/packages/ui/src/components/TriggersPanel.tsx
+++ b/packages/ui/src/components/TriggersPanel.tsx
@@ -116,11 +116,10 @@ export interface LinkedSessionGroup {
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-function formatRelativeTime(isoTs: string): string {
-  const now = Date.now();
+function formatRelativeTime(isoTs: string, nowMs: number): string {
   const then = new Date(isoTs).getTime();
   if (isNaN(then)) return isoTs;
-  const diffMs = now - then;
+  const diffMs = nowMs - then;
   const diffSec = Math.floor(diffMs / 1000);
   if (diffSec < 5) return "just now";
   if (diffSec < 60) return `${diffSec}s ago`;
@@ -130,6 +129,18 @@ function formatRelativeTime(isoTs: string): string {
   if (diffHr < 24) return `${diffHr}h ago`;
   const diffDay = Math.floor(diffHr / 24);
   return `${diffDay}d ago`;
+}
+
+/** Renders a relative timestamp that ticks internally every 5s. */
+function RelativeTime({ isoTs }: { isoTs: string }) {
+  const [now, setNow] = React.useState(Date.now);
+
+  React.useEffect(() => {
+    const timer = setInterval(() => setNow(Date.now()), 5_000);
+    return () => clearInterval(timer);
+  }, []);
+
+  return <>{formatRelativeTime(isoTs, now)}</>;
 }
 
 /** Returns a lucide icon for the trigger source */
@@ -589,7 +600,7 @@ function EventRow({ entry }: { entry: TriggerHistoryEntry }) {
         )}
 
         <span className="text-[10px] text-muted-foreground/50 ml-auto shrink-0">
-          {formatRelativeTime(entry.ts)}
+          <RelativeTime isoTs={entry.ts} />
         </span>
 
         {entry.response && (
@@ -621,11 +632,9 @@ function EventRow({ entry }: { entry: TriggerHistoryEntry }) {
 interface LinkedSessionCardProps {
   group: LinkedSessionGroup;
   statusUpdates: Map<string, TriggerStatusUpdate>;
-  /** Force relative times to re-render */
-  tick: number;
 }
 
-function LinkedSessionCard({ group, statusUpdates, tick: _tick }: LinkedSessionCardProps) {
+function LinkedSessionCard({ group, statusUpdates }: LinkedSessionCardProps) {
   const [expanded, setExpanded] = React.useState(false);
   const status = deriveSessionStatus(group);
   const isPending = !!group.pendingTrigger;
@@ -733,7 +742,7 @@ function LinkedSessionCard({ group, statusUpdates, tick: _tick }: LinkedSessionC
                 {!["ask_user_question", "plan_review", "session_complete", "escalate"].includes(group.pendingTrigger!.type) && `Awaiting response to ${group.pendingTrigger!.type}`}
               </span>
               <span className="text-[10px] text-muted-foreground/60 ml-2">
-                {formatRelativeTime(group.pendingTrigger!.ts)}
+                <RelativeTime isoTs={group.pendingTrigger!.ts} />
               </span>
             </div>
           )}
@@ -755,7 +764,7 @@ function LinkedSessionCard({ group, statusUpdates, tick: _tick }: LinkedSessionC
                 Last: <span className="text-muted-foreground/80">{group.lastType}</span>
               </span>
               <span className="text-[10px] text-muted-foreground/40">
-                {formatRelativeTime(group.lastTs)}
+                <RelativeTime isoTs={group.lastTs} />
               </span>
             </div>
           )}
@@ -1729,7 +1738,7 @@ function OtherTriggerRow({ entry }: { entry: TriggerHistoryEntry }) {
             )}
           </div>
           <div className="flex items-center gap-2 mt-0.5">
-            <span className="text-[10px] text-muted-foreground/70">{formatRelativeTime(entry.ts)}</span>
+            <span className="text-[10px] text-muted-foreground/70"><RelativeTime isoTs={entry.ts} /></span>
             {entry.response && (
               <span className="text-[10px] text-emerald-500">
                 ✓ {entry.response.action ?? "responded"}
@@ -1803,10 +1812,9 @@ function OtherSourceGroup({ group }: OtherSourceGroupProps) {
 interface SourceAccordionProps {
   group: SourceGroup;
   statusUpdates: Map<string, TriggerStatusUpdate>;
-  tick: number;
 }
 
-function SourceAccordion({ group, statusUpdates, tick: _tick }: SourceAccordionProps) {
+function SourceAccordion({ group, statusUpdates }: SourceAccordionProps) {
   const [expanded, setExpanded] = React.useState(false);
   const isPending = !!group.pendingTrigger;
 
@@ -1881,7 +1889,7 @@ function SourceAccordion({ group, statusUpdates, tick: _tick }: SourceAccordionP
                 {!["ask_user_question", "plan_review", "session_complete", "escalate"].includes(group.pendingTrigger!.type) && `Awaiting response to ${group.pendingTrigger!.type}`}
               </span>
               <span className="text-[10px] text-muted-foreground/60 ml-2">
-                {formatRelativeTime(group.pendingTrigger!.ts)}
+                <RelativeTime isoTs={group.pendingTrigger!.ts} />
               </span>
             </div>
           )}
@@ -1903,7 +1911,7 @@ function SourceAccordion({ group, statusUpdates, tick: _tick }: SourceAccordionP
                 Last: <span className="text-muted-foreground/80">{group.events[0]?.type}</span>
               </span>
               <span className="text-[10px] text-muted-foreground/40">
-                {formatRelativeTime(group.lastTs)}
+                <RelativeTime isoTs={group.lastTs} />
               </span>
             </div>
           )}
@@ -1960,9 +1968,6 @@ export function TriggersPanel({ sessionId, triggerDefs = [], viewerSocket }: Tri
   // Ephemeral status updates keyed by triggerId
   const [statusUpdates, setStatusUpdates] = React.useState<Map<string, TriggerStatusUpdate>>(new Map());
 
-  // Tick counter for re-rendering relative times
-  const [tick, setTick] = React.useState(0);
-
   const fetchSubscriptions = React.useCallback(async () => {
     try {
       const res = await fetch(
@@ -2014,12 +2019,6 @@ export function TriggersPanel({ sessionId, triggerDefs = [], viewerSocket }: Tri
     const timer = setInterval(() => { void fetchTriggers(true); }, 10_000);
     return () => clearInterval(timer);
   }, [fetchTriggers]);
-
-  // Tick timer for relative time updates (every 5s)
-  React.useEffect(() => {
-    const timer = setInterval(() => { setTick((t) => t + 1); }, 5_000);
-    return () => clearInterval(timer);
-  }, []);
 
   // Instant refresh on trigger_delivered event
   React.useEffect(() => {
@@ -2179,7 +2178,6 @@ export function TriggersPanel({ sessionId, triggerDefs = [], viewerSocket }: Tri
                     key={group.source}
                     group={group}
                     statusUpdates={statusUpdates}
-                    tick={tick}
                   />
                 ))}
               </div>

--- a/packages/ui/src/components/session-viewer/grouping.ts
+++ b/packages/ui/src/components/session-viewer/grouping.ts
@@ -628,6 +628,8 @@ export function groupToolExecutionMessages(messages: RelayMessage[]): RelayMessa
   const pendingToolCalls: PendingToolCall[] = [];
 
   const grouped: RelayMessage[] = [];
+  const emittedKeys = new Set<string>();
+  const emittedAssistantBases = new Set<string>();
 
   for (const message of deduped) {
     if (message.role === "assistant" && Array.isArray(message.content)) {
@@ -655,11 +657,14 @@ export function groupToolExecutionMessages(messages: RelayMessage[]): RelayMessa
           }
         }
 
+        const partKey = `${message.key}:assistant:${assistantPartIndex++}`;
         grouped.push({
           ...message,
-          key: `${message.key}:assistant:${assistantPartIndex++}`,
+          key: partKey,
           content: buffer,
         });
+        emittedKeys.add(partKey);
+        emittedAssistantBases.add(message.key);
         buffer = [];
         pendingThinking = null;
       };
@@ -735,6 +740,7 @@ export function groupToolExecutionMessages(messages: RelayMessage[]): RelayMessa
               thinking: pendingText,
               thinkingDuration: pendingDuration,
             });
+            emittedKeys.add(itemKey);
           }
 
           pendingThinking = null; // Consumed
@@ -751,9 +757,10 @@ export function groupToolExecutionMessages(messages: RelayMessage[]): RelayMessa
       // no visible content blocks, make sure it still appears in the output so the
       // error banner renders.
       if (message.stopReason === "error" && message.errorMessage) {
-        const alreadyEmitted = grouped.some((g) => g.key === message.key || g.key.startsWith(`${message.key}:assistant:`));
+        const alreadyEmitted = emittedKeys.has(message.key) || emittedAssistantBases.has(message.key);
         if (!alreadyEmitted) {
           grouped.push(message);
+          emittedKeys.add(message.key);
         }
       }
       continue;
@@ -837,10 +844,12 @@ export function groupToolExecutionMessages(messages: RelayMessage[]): RelayMessa
         toolInput: resolvedArgs,
         toolCallId: resolvedToolCallId,
       });
+      emittedKeys.add(message.key);
       continue;
     }
 
     grouped.push(message);
+    emittedKeys.add(message.key);
   }
 
   // Deduplicate by key — snapshots may contain both a streaming partial and the


### PR DESCRIPTION
Four focused UI render-path optimizations:\n\n1. **HooksManager.tsx**: replace <code>JSON.parse(JSON.stringify(...))</code> with <code>structuredClone(...)</code>.\n2. **SessionSidebar.tsx**: pre-parse session timestamps into a single <code>Map&lt;string, number&gt;</code> inside the <code>liveGroups</code> memo so sort comparators do no redundant <code>Date.parse</code> work. Output unchanged.\n3. **TriggersPanel.tsx**: remove the global 5s tick that re-rendered the whole panel. Add a tiny <code>RelativeTime</code> component that owns its own 5s interval, and use it at the six relative-time call sites.\n4. **grouping.ts**: maintain <code>Set&lt;string&gt;</code> of emitted keys and assistant-part base keys so the error-message fallback dedup is O(1) instead of an O(n) scan per occurrence. Output unchanged — grouping tests still pass.\n\nVerified with \u0060bun run typecheck\u0060 and \u0060cd packages/ui && bun test src\u0060 (both exit 0).