### PR TITLE
fix(goal): steer goal messages, batch follow-ups, surface /goal in web UI

### DIFF
--- a/packages/cli/src/extensions/claude-plugins.ts
+++ b/packages/cli/src/extensions/claude-plugins.ts
@@ -127,6 +127,12 @@ function registerPluginCommand(
 
     pi.registerCommand(cmd.name, {
         description: cmd.frontmatter.description ?? `[${plugin.name}] ${cmd.name}`,
+        // Not part of pi's RegisteredCommand type, but preserved by
+        // getRegisteredCommands() spread — surfaces the plugin's
+        // `argument-hint` frontmatter in the web UI command popover.
+        ...(cmd.frontmatter["argument-hint"]
+            ? { argumentHint: cmd.frontmatter["argument-hint"] }
+            : {}),
         handler: async (args, ctx) => {
             let prompt = expandArguments(templateContent, args);
 

--- a/packages/cli/src/extensions/command-introspection.test.ts
+++ b/packages/cli/src/extensions/command-introspection.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import {
+    getCommandIntrospection,
+    setRegisteredCommandsProvider,
+} from "./command-introspection.js";
+
+describe("command-introspection", () => {
+    test("returns empty map when no provider is set", () => {
+        setRegisteredCommandsProvider(null as any);
+        expect(getCommandIntrospection().size).toBe(0);
+    });
+
+    test("snapshots sync completions and argument hints", () => {
+        setRegisteredCommandsProvider(() => [
+            {
+                name: "tool-search",
+                invocationName: "tool-search",
+                getArgumentCompletions: () => [
+                    { value: "status", label: "status" },
+                    { value: "reset", label: "reset", description: "Reset deferrals" },
+                ],
+            },
+            { name: "pr-review", argumentHint: "[pr-number]" },
+            { name: "plain" }, // no extras — omitted from the map
+        ]);
+
+        const map = getCommandIntrospection();
+        expect(map.get("tool-search")?.completions).toEqual([
+            { value: "status", label: "status", description: undefined },
+            { value: "reset", label: "reset", description: "Reset deferrals" },
+        ]);
+        expect(map.get("pr-review")?.argumentHint).toBe("[pr-number]");
+        expect(map.has("plain")).toBe(false);
+    });
+
+    test("filters malformed items and survives throwing providers", () => {
+        setRegisteredCommandsProvider(() => [
+            {
+                name: "messy",
+                getArgumentCompletions: () => [{ value: "ok" }, { nope: true }, null, "str"],
+            },
+            {
+                name: "boom",
+                getArgumentCompletions: () => {
+                    throw new Error("nope");
+                },
+            },
+        ]);
+
+        const map = getCommandIntrospection();
+        expect(map.get("messy")?.completions).toEqual([
+            { value: "ok", label: undefined, description: undefined },
+        ]);
+        expect(map.has("boom")).toBe(false);
+    });
+
+    test("async completions land in the cache for the next snapshot", async () => {
+        setRegisteredCommandsProvider(() => [
+            {
+                name: "slow",
+                getArgumentCompletions: () => Promise.resolve([{ value: "later", label: "later" }]),
+            },
+        ]);
+
+        // First snapshot: promise not yet resolved — no completions.
+        expect(getCommandIntrospection().has("slow")).toBe(false);
+        await Promise.resolve(); // let the .then() callback run
+        // Second snapshot: cached result is now available.
+        expect(getCommandIntrospection().get("slow")?.completions).toEqual([
+            { value: "later", label: "later", description: undefined },
+        ]);
+    });
+});

--- a/packages/cli/src/extensions/command-introspection.ts
+++ b/packages/cli/src/extensions/command-introspection.ts
@@ -1,0 +1,101 @@
+/**
+ * Command introspection bridge — exposes the extension runner's fully
+ * resolved commands (including `getArgumentCompletions` and `argumentHint`)
+ * to the remote extension, which only sees pi's `getCommands()` (names and
+ * descriptions, no completions).
+ *
+ * The worker registers a provider after creating the session; the relay
+ * context factory reads snapshots when building capabilities for the web UI.
+ * When no provider is set (e.g. TUI mode), callers gracefully get no extras.
+ */
+
+export interface CommandCompletionItem {
+    value: string;
+    label?: string;
+    description?: string;
+}
+
+export interface CommandIntrospection {
+    argumentHint?: string;
+    completions?: CommandCompletionItem[];
+}
+
+interface RegisteredCommandLike {
+    name: string;
+    invocationName?: string;
+    argumentHint?: string;
+    getArgumentCompletions?: (prefix: string) => unknown;
+}
+
+let provider: (() => RegisteredCommandLike[]) | null = null;
+
+// Async completion results land here for the NEXT capabilities push.
+const completionsCache = new Map<string, CommandCompletionItem[]>();
+
+export function setRegisteredCommandsProvider(fn: () => RegisteredCommandLike[]): void {
+    provider = fn;
+}
+
+/** Snapshot argumentHint + argument completions for every registered command. */
+export function getCommandIntrospection(): Map<string, CommandIntrospection> {
+    const out = new Map<string, CommandIntrospection>();
+    if (!provider) return out;
+
+    let commands: RegisteredCommandLike[];
+    try {
+        commands = provider() ?? [];
+    } catch {
+        return out;
+    }
+
+    for (const cmd of commands) {
+        const name = cmd.invocationName ?? cmd.name;
+        if (!name) continue;
+        const completions = snapshotCompletions(name, cmd);
+        const argumentHint = typeof cmd.argumentHint === "string" ? cmd.argumentHint : undefined;
+        if (completions?.length || argumentHint) {
+            out.set(name, { argumentHint, completions });
+        }
+    }
+    return out;
+}
+
+function snapshotCompletions(
+    name: string,
+    cmd: RegisteredCommandLike,
+): CommandCompletionItem[] | undefined {
+    if (typeof cmd.getArgumentCompletions !== "function") return undefined;
+    try {
+        // Empty prefix = "all options" (same call the TUI makes before typing).
+        const result = cmd.getArgumentCompletions("");
+        if (Array.isArray(result)) {
+            const items = normalizeItems(result);
+            completionsCache.set(name, items);
+            return items;
+        }
+        if (result && typeof (result as Promise<unknown>).then === "function") {
+            // ponytail: async completions resolve into the cache and show up on
+            // the next capabilities push instead of blocking this (sync) one.
+            (result as Promise<unknown>)
+                .then((items) => {
+                    if (Array.isArray(items)) completionsCache.set(name, normalizeItems(items));
+                })
+                .catch(() => {});
+        }
+    } catch {
+        // Completion providers must never break capability delivery.
+    }
+    return completionsCache.get(name);
+}
+
+function normalizeItems(items: unknown[]): CommandCompletionItem[] {
+    return items
+        .filter((i): i is Record<string, unknown> =>
+            i !== null && typeof i === "object" && typeof (i as Record<string, unknown>).value === "string")
+        .slice(0, 50)
+        .map((i) => ({
+            value: String(i.value),
+            label: typeof i.label === "string" ? i.label : undefined,
+            description: typeof i.description === "string" ? i.description : undefined,
+        }));
+}

--- a/packages/cli/src/extensions/goal/goal.test.ts
+++ b/packages/cli/src/extensions/goal/goal.test.ts
@@ -765,11 +765,12 @@ describe("goalExtension event wiring", () => {
 
         expect(getGoal("session-1")?.status).toBe("active");
         expect(getPendingGuidance("session-1")).toContain("pass");
-        // The goal loop keeps working: a not_met verdict triggers a follow-up turn.
+        // The goal loop keeps working: a not_met verdict triggers another turn,
+        // delivered as a steering message so it isn't stuck behind the queue.
         expect(userMessages.length).toBe(1);
         expect(userMessages[0]!.content).toContain("Goal not met");
         expect(userMessages[0]!.content).toContain("tests pass");
-        expect(userMessages[0]!.options?.deliverAs).toBe("followUp");
+        expect(userMessages[0]!.options?.deliverAs).toBe("steer");
     });
 
     test("turn_end goal met does not auto-continue", async () => {

--- a/packages/cli/src/extensions/goal/index.ts
+++ b/packages/cli/src/extensions/goal/index.ts
@@ -282,10 +282,11 @@ async function runGoalStopCheck(
         // Goal loop: a "not met" verdict starts another turn instead of
         // returning control to the user (parity with Claude Code /goal).
         // "uncertain" verdicts do NOT auto-continue, so a broken evaluator
-        // can't spin the session forever.
+        // can't spin the session forever. Delivered as "steer" so the goal
+        // notification is never stuck behind the follow-up queue.
         pi.sendUserMessage(
             `[Goal not met] ${lastEval.reason}\nContinue working toward the goal: ${state.condition.description}`,
-            { deliverAs: "followUp" },
+            { deliverAs: "steer" },
         );
     } else {
         clearPendingGuidance(sessionId);
@@ -308,7 +309,7 @@ export const goalExtension: ExtensionFactory = (pi) => {
                 // itself as the directive (parity with Claude Code /goal).
                 pi.sendUserMessage(
                     `Work toward this goal until it is met: ${result.state.condition.description}`,
-                    { deliverAs: "followUp" },
+                    { deliverAs: "steer" },
                 );
             }
         },

--- a/packages/cli/src/extensions/goal/index.ts
+++ b/packages/cli/src/extensions/goal/index.ts
@@ -296,6 +296,15 @@ async function runGoalStopCheck(
 export const goalExtension: ExtensionFactory = (pi) => {
     pi.registerCommand("goal", {
         description: "Set a success condition and optional budget for the session",
+        getArgumentCompletions: (prefix: string) => {
+            const options = [
+                { value: "status", label: "status", description: "Show the active goal and budget" },
+                { value: "clear", label: "clear", description: "Clear the active goal" },
+            ];
+            const p = prefix.trim().toLowerCase();
+            const filtered = p ? options.filter((o) => o.value.startsWith(p)) : options;
+            return filtered.length ? filtered : null;
+        },
         handler: async (args, ctx) => {
             const result = handleGoalCommand(args, ctx, pi);
             pi.sendMessage({

--- a/packages/cli/src/extensions/remote-types.ts
+++ b/packages/cli/src/extensions/remote-types.ts
@@ -229,7 +229,13 @@ export interface RelayContext {
     buildHeartbeat(): any;
     buildCapabilitiesState(): any;
     getConfiguredModels(): RelayModelInfo[];
-    getAvailableCommands(): Array<{ name: string; description?: string; source?: string }>;
+    getAvailableCommands(): Array<{
+        name: string;
+        description?: string;
+        source?: string;
+        argumentHint?: string;
+        completions?: Array<{ value: string; label?: string; description?: string }>;
+    }>;
     getCurrentSessionName(): string | null;
     getCurrentThinkingLevel(): string | null;
 

--- a/packages/cli/src/extensions/remote/relay-context-factory.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.ts
@@ -16,6 +16,7 @@ import { getCurrentTodoList } from "../update-todo.js";
 import { isDisabled, toWebSocketBaseUrl } from "./connection.js";
 import type { RelayContext, RelayModelInfo, TriggerResponse } from "../remote-types.js";
 import { getActiveGoalFromEntries, toMetaGoalStatus } from "../goal/state.js";
+import { getCommandIntrospection } from "../command-introspection.js";
 import type { RemoteExecResponse } from "../remote-commands.js";
 import type { ConversationTrigger } from "../triggers/types.js";
 import { isCancelTriggerAction } from "../remote-trigger-response.js";
@@ -160,13 +161,27 @@ export function createRelayContext(
             return buildHeartbeat(rctx);
         },
 
-        getAvailableCommands(): Array<{ name: string; description?: string; source?: string }> {
+        getAvailableCommands(): Array<{
+            name: string;
+            description?: string;
+            source?: string;
+            argumentHint?: string;
+            completions?: Array<{ value: string; label?: string; description?: string }>;
+        }> {
             if (!rctx.latestCtx) return [];
-            return ((pi as any).getCommands?.() ?? []).map((c: any) => ({
-                name: c.name,
-                description: c.description,
-                source: c.source,
-            }));
+            // Argument hints + completions come from the resolved command registry
+            // (worker-provided) so the web UI popover matches TUI autocomplete.
+            const introspection = getCommandIntrospection();
+            return ((pi as any).getCommands?.() ?? []).map((c: any) => {
+                const extra = introspection.get(c.name);
+                return {
+                    name: c.name,
+                    description: c.description,
+                    source: c.source,
+                    ...(extra?.argumentHint ? { argumentHint: extra.argumentHint } : {}),
+                    ...(extra?.completions?.length ? { completions: extra.completions } : {}),
+                };
+            });
         },
 
         buildCapabilitiesState() {

--- a/packages/cli/src/extensions/sandbox-events.ts
+++ b/packages/cli/src/extensions/sandbox-events.ts
@@ -46,6 +46,16 @@ export const sandboxEventsExtension: ExtensionFactory = (pi) => {
     // ── /sandbox slash command ─────────────────────────────────────────────
     pi.registerCommand?.("sandbox", {
         description: "Show sandbox status, violations, and config. Subcommands: status (default), violations, config",
+        getArgumentCompletions: (prefix: string) => {
+            const options = [
+                { value: "status", label: "status", description: "Show sandbox status (default)" },
+                { value: "violations", label: "violations", description: "List sandbox violations" },
+                { value: "config", label: "config", description: "Show sandbox configuration" },
+            ];
+            const p = prefix.trim().toLowerCase();
+            const filtered = p ? options.filter((o) => o.value.startsWith(p)) : options;
+            return filtered.length ? filtered : null;
+        },
         handler: async (_args: string, ctx: any) => {
             const subcommand = (_args ?? "").trim().split(/\s+/)[0] || "status";
 

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -393,6 +393,12 @@ async function main(): Promise<void> {
     });
     bootTimer.end("[boot] create-session");
 
+    // Deliver ALL queued follow-up messages at once when a turn ends, instead
+    // of pi's default one-at-a-time (which strands later follow-ups until the
+    // next turn ends). Set on the agent directly (not setFollowUpMode) so the
+    // user's global settings.json is left untouched.
+    session.agent.followUpMode = "all";
+
     // ── Inject context tracking entries ───────────────────────────────────
     // Emit non-context custom entries for each identifiable piece of context
     // (global rules, project rules, system prompt, user append prompt) so
@@ -563,6 +569,8 @@ async function main(): Promise<void> {
 
             reload: async () => {
                 await session.reload();
+                // reload() re-syncs queue modes from settings — re-apply.
+                session.agent.followUpMode = "all";
             },
         },
         shutdownHandler: () => {

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -4,6 +4,7 @@ import { join } from "node:path";
 import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "../config.js";
 import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "../skills.js";
 import { getPluginSkillPaths } from "../extensions/claude-plugins.js";
+import { setRegisteredCommandsProvider } from "../extensions/command-introspection.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 import { createBootTimer } from "./boot-timing.js";
 import { setLogComponent, setLogSessionId, logInfo, logWarn, logError, logAuth } from "./logger.js";
@@ -398,6 +399,12 @@ async function main(): Promise<void> {
     // next turn ends). Set on the agent directly (not setFollowUpMode) so the
     // user's global settings.json is left untouched.
     session.agent.followUpMode = "all";
+
+    // Expose resolved commands (argument hints + completions) so the remote
+    // extension can forward them to the web UI command popover (TUI parity).
+    setRegisteredCommandsProvider(
+        () => (session.extensionRunner as any)?.getRegisteredCommands?.() ?? [],
+    );
 
     // ── Inject context tracking entries ───────────────────────────────────
     // Emit non-context custom entries for each identifiable piece of context

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -230,7 +230,7 @@ export function SessionViewer({
       new Set([
         "new", "resume", "mcp", "plugins", "skills", "agents", "model",
         "cycle_model", "effort", "cycle_effort", "compact", "name", "copy",
-        "stop", "restart", "remote", "plan", "sandbox",
+        "stop", "restart", "remote", "plan", "sandbox", "goal",
       ]),
     [],
   );

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -1122,13 +1122,16 @@ export function SessionViewer({
                               <CommandItem key={cmd.name} value={cmd.name} onSelect={() => {
                                 setInput(`/${cmd.name} `);
                                 setCommandQuery("");
-                                setCommandOpen(false);
+                                setCommandOpen(keepPopoverOpenNames.has(cmd.name.toLowerCase()));
                                 requestAnimationFrame(() => document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]")?.focus());
                               }}>
                                 <div className="flex w-full items-center justify-between gap-2">
                                   <div className="flex items-center gap-1.5 min-w-0">
                                     <Puzzle className="size-3.5 shrink-0 text-primary/60" />
                                     <span className="font-mono text-sm truncate">/{cmd.name}</span>
+                                    {cmd.argumentHint && (
+                                      <span className="font-mono text-xs text-muted-foreground/70 truncate">{cmd.argumentHint}</span>
+                                    )}
                                   </div>
                                   {cmd.description && <span className="text-xs text-muted-foreground truncate max-w-[50%]">{cmd.description}</span>}
                                 </div>

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -167,7 +167,15 @@ export function useSlashCommands(
       { name: "stop", description: "Abort current generation" },
       { name: "restart", description: "Restart the CLI process" },
       { name: "plan", description: "Toggle plan mode (read-only exploration)" },
-      { name: "sandbox", description: "Show sandbox status" },
+      {
+        name: "sandbox",
+        description: "Show sandbox status",
+        subCommands: [
+          { name: "status", description: "Show sandbox status (default)" },
+          { name: "violations", description: "List sandbox violations" },
+          { name: "config", description: "Show sandbox configuration" },
+        ],
+      },
       {
         name: "goal",
         description: "Set a goal — /goal \"<condition>\" [--max-turns N] [--max-tokens N] [--max-cost N]",
@@ -189,13 +197,32 @@ export function useSlashCommands(
     return names;
   }, [supportedWebCommands, extensionCommands, skillCommands, promptCommands]);
 
-  const keepPopoverOpenNames = React.useMemo(() => {
-    const names = new Set(["resume", "agents"]);
+  // Sub-command lists per command: static web entries plus runner-provided
+  // argument completions on extension/plugin commands (TUI autocomplete parity).
+  const subCommandsByName = React.useMemo(() => {
+    const map = new Map<string, SupportedSubCommand[]>();
     for (const c of supportedWebCommands) {
-      if (c.subCommands && c.subCommands.length > 0) names.add(c.name.toLowerCase());
+      if (c.subCommands && c.subCommands.length > 0) map.set(c.name.toLowerCase(), c.subCommands);
     }
+    for (const c of extensionCommands) {
+      const key = c.name.toLowerCase();
+      if (!c.completions?.length || map.has(key)) continue;
+      map.set(
+        key,
+        c.completions.map((i) => ({
+          name: i.value,
+          description:
+            i.description ?? (i.label && i.label !== i.value ? i.label : ""),
+        })),
+      );
+    }
+    return map;
+  }, [supportedWebCommands, extensionCommands]);
+
+  const keepPopoverOpenNames = React.useMemo(() => {
+    const names = new Set(["resume", "agents", ...subCommandsByName.keys()]);
     return names;
-  }, [supportedWebCommands]);
+  }, [subCommandsByName]);
 
   // Reset all command picker state when the active session changes
   React.useEffect(() => {
@@ -278,22 +305,20 @@ export function useSlashCommands(
       return { active: false, parentCommand: "", subCommands: [], query: "", filtered: [] };
     const cmdName = match[1]!.toLowerCase();
     const argText = (match[2] ?? "").trim().toLowerCase();
-    const cmd = supportedWebCommands.find(
-      (c) => c.name.toLowerCase() === cmdName && c.subCommands && c.subCommands.length > 0,
-    );
-    if (!cmd?.subCommands)
+    const subCommands = subCommandsByName.get(cmdName);
+    if (!subCommands)
       return { active: false, parentCommand: "", subCommands: [], query: "", filtered: [] };
     const filtered = argText
-      ? cmd.subCommands.filter((sc) => sc.name.toLowerCase().includes(argText))
-      : cmd.subCommands;
+      ? subCommands.filter((sc) => sc.name.toLowerCase().includes(argText))
+      : subCommands;
     return {
       active: true,
-      parentCommand: cmd.name,
-      subCommands: cmd.subCommands,
+      parentCommand: match[1]!,
+      subCommands,
       query: argText,
       filtered,
     };
-  }, [trimmedInput, isResumeMode, isAgentMode, supportedWebCommands]);
+  }, [trimmedInput, isResumeMode, isAgentMode, subCommandsByName]);
 
   // Request resume sessions list when entering resume mode
   React.useEffect(() => {
@@ -488,7 +513,16 @@ export function useSlashCommands(
       }
 
       if (rawCommand === "sandbox") {
-        if (args.trim()) return false;
+        if (args.trim()) {
+          // Sub-commands (violations/config) are handled by the runner's
+          // sandbox extension — forward as raw input.
+          if (!onSendInput) return false;
+          void onSendInput({ text: trimmed, files: [] });
+          setInput("");
+          setCommandOpen(false);
+          setCommandQuery("");
+          return true;
+        }
         if (!runnerId) {
           setInput("");
           setCommandOpen(false);
@@ -601,9 +635,26 @@ export function useSlashCommands(
         return true;
       }
 
-      // /goal is executed by the runner's goal extension — forward the raw
-      // text as input so sub-command clicks (status/clear) actually dispatch.
-      if (rawCommand === "goal") {
+      // /remote manages the runner's relay connection — running it from the
+      // web UI (which is connected *through* that relay) would sever the
+      // session, so it is intentionally blocked here.
+      if (rawCommand === "remote") {
+        setInput("");
+        setCommandOpen(false);
+        setCommandQuery("");
+        onAppendSystemMessage?.(
+          "**/remote** manages the runner's relay connection and isn't available from the web UI.",
+        );
+        return true;
+      }
+
+      // Commands executed by runner extensions (/goal, /tool-search, plugin
+      // commands, …) — forward the raw text as input so sub-command clicks
+      // actually dispatch instead of being silently dropped.
+      const isExtensionCommand = extensionCommands.some(
+        (c) => c.name.toLowerCase() === rawCommand,
+      );
+      if (rawCommand === "goal" || isExtensionCommand) {
         if (!onSendInput) return false;
         void onSendInput({ text: trimmed, files: [] });
         setInput("");
@@ -737,6 +788,7 @@ export function useSlashCommands(
       runnerId,
       onAppendSystemMessage,
       skillCommands,
+      extensionCommands,
       sessionCwd,
       onShowModelSelector,
       isCompacting,

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -134,7 +134,7 @@ export function useSlashCommands(
       new Set([
         "new", "resume", "mcp", "plugins", "skills", "agents", "model",
         "cycle_model", "effort", "cycle_effort", "compact", "name", "copy",
-        "stop", "restart", "remote", "plan", "sandbox",
+        "stop", "restart", "remote", "plan", "sandbox", "goal",
       ]),
     [],
   );
@@ -168,6 +168,14 @@ export function useSlashCommands(
       { name: "restart", description: "Restart the CLI process" },
       { name: "plan", description: "Toggle plan mode (read-only exploration)" },
       { name: "sandbox", description: "Show sandbox status" },
+      {
+        name: "goal",
+        description: "Set a goal — /goal \"<condition>\" [--max-turns N] [--max-tokens N] [--max-cost N]",
+        subCommands: [
+          { name: "status", description: "Show the active goal and budget" },
+          { name: "clear", description: "Clear the active goal" },
+        ],
+      },
     ],
     [],
   );
@@ -587,6 +595,17 @@ export function useSlashCommands(
             }
           }
         }
+        setInput("");
+        setCommandOpen(false);
+        setCommandQuery("");
+        return true;
+      }
+
+      // /goal is executed by the runner's goal extension — forward the raw
+      // text as input so sub-command clicks (status/clear) actually dispatch.
+      if (rawCommand === "goal") {
+        if (!onSendInput) return false;
+        void onSendInput({ text: trimmed, files: [] });
         setInput("");
         setCommandOpen(false);
         setCommandQuery("");

--- a/packages/ui/src/components/session-viewer/viewer-types.ts
+++ b/packages/ui/src/components/session-viewer/viewer-types.ts
@@ -10,7 +10,15 @@ import type { MetaGoalStatus } from "@pizzapi/protocol";
 export type { RelayMessage, TodoItem, TokenUsage, QueuedMessage, ResumeSessionOption };
 
 /** A command entry (from availableCommands prop or derived lists). */
-export type CmdEntry = { name: string; description?: string; source?: string };
+export type CmdEntry = {
+  name: string;
+  description?: string;
+  source?: string;
+  /** TUI-style argument hint, e.g. "[pr-number]" (from plugin frontmatter). */
+  argumentHint?: string;
+  /** Snapshot of the command's argument completions (TUI autocomplete parity). */
+  completions?: Array<{ value: string; label?: string; description?: string }>;
+};
 
 export interface SessionViewerProps {
   sessionId: string | null;

--- a/packages/ui/src/lib/message-helpers.ts
+++ b/packages/ui/src/lib/message-helpers.ts
@@ -276,7 +276,13 @@ export function normalizeModelList(rawModels: unknown[]): ConfiguredModelInfo[] 
 /** Normalize a raw commands array from capabilities / session_active events. */
 export function normalizeCommandList(
   rawCommands: unknown[],
-): Array<{ name: string; description?: string; source?: string }> {
+): Array<{
+  name: string;
+  description?: string;
+  source?: string;
+  argumentHint?: string;
+  completions?: Array<{ value: string; label?: string; description?: string }>;
+}> {
   return rawCommands
     .filter(
       (c): c is Record<string, unknown> =>
@@ -288,6 +294,25 @@ export function normalizeCommandList(
       name: String(c.name),
       description: typeof c.description === "string" ? c.description : undefined,
       source: typeof c.source === "string" ? c.source : undefined,
+      argumentHint: typeof c.argumentHint === "string" ? c.argumentHint : undefined,
+      completions: normalizeCompletions(c.completions),
     }))
     .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function normalizeCompletions(
+  raw: unknown,
+): Array<{ value: string; label?: string; description?: string }> | undefined {
+  if (!Array.isArray(raw)) return undefined;
+  const items = raw
+    .filter(
+      (i): i is Record<string, unknown> =>
+        i !== null && typeof i === "object" && typeof (i as Record<string, unknown>).value === "string",
+    )
+    .map((i) => ({
+      value: String(i.value),
+      label: typeof i.label === "string" ? i.label : undefined,
+      description: typeof i.description === "string" ? i.description : undefined,
+    }));
+  return items.length ? items : undefined;
 }


### PR DESCRIPTION
## Summary

### Goal delivery
- **Batch follow-up delivery**: the runner worker sets `followUpMode = "all"` on the agent, so every queued follow-up is injected in one batch before the next assistant response instead of pi's default one-per-turn. Set directly on the agent (not `setFollowUpMode`) to leave the user's global `settings.json` untouched; re-applied after `session.reload()`, which re-syncs modes from settings.
- **`/goal` messages are steering messages**: both the kickoff and the not-met continuation now use `deliverAs: "steer"`, so the goal loop is never stuck behind other queued follow-ups — steering is drained immediately after `turn_end` in the agent loop.

### Web UI command parity (TUI-style autocomplete)
- **New command-introspection bridge** (`command-introspection.ts`): the worker exposes the extension runner's resolved commands — `argumentHint` and `getArgumentCompletions` — to the remote extension. `getAvailableCommands()` now ships a per-command completions snapshot to the web UI (async completion providers resolve into a cache for the next capabilities push).
- **Plugin commands** (claude-plugins) surface their `argument-hint` frontmatter in the web popover, same as TUI autocomplete.
- **`/goal` and `/sandbox`** register `getArgumentCompletions` (status/clear, status/violations/config) so both the TUI and web get argument popovers.
- **Generic sub-command popover**: any extension command with completions (`/tool-search`, plugin commands, …) now shows a `/mcp`-style sub-command list in the web popover, and sub-command clicks dispatch to the runner instead of being silently dropped.
- **`/sandbox violations|config`** forwards to the runner (previously returned false; sub-command clicks would have been dropped).
- **`/goal` is a first-class web command** with usage hint and status/clear sub-commands, deduped from the Plugin Commands group.
- **`/remote` is blocked on the web UI** with an explanatory message — running `/remote stop` from a viewer connected *through* that relay would sever the session.

## Testing

- `bun test packages/cli/src/extensions/goal/` — 78 pass
- `bun test packages/cli/src/extensions/command-introspection.test.ts` — 4 pass (new)
- claude-plugins / sandbox / tool-search / runner suites — 453 pass
- `tsc --noEmit` clean for `packages/cli` and `packages/ui`
- UI suites: same 4 pre-existing `@/` alias-resolution failures on clean main, no new failures
