### PR TITLE
fix(ui): service panel icon focuses buried panel instead of closing it

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -90,7 +90,7 @@ import { PizzaPiNavProvider, type PizzaPiNavActions } from "@/components/sigils/
 import { ServicePanelButtons, useServicePanelState } from "@/components/service-panels/ServicePanels";
 import { SERVICE_PANELS } from "@/components/service-panels/registry";
 import { DynamicLucideIcon } from "@/components/service-panels/lucide-icon";
-import { resolveNewPanelPosition, resolveActiveTabIdFromIds } from "@/utils/servicePanelUtils";
+import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction } from "@/utils/servicePanelUtils";
 import { IframeServicePanel } from "@/components/service-panels/IframeServicePanel";
 import {
   ModelSelector,
@@ -4301,12 +4301,25 @@ export function App() {
     return () => { viewerSocket.off("service_message", handler); };
   }, [viewerSocket, activeServicePanels, toggleServicePanel]);
 
+  // Always-current ref to the computed panel groups (defined below) so the
+  // toggle handler can check zone contents without a dependency cycle.
+  const panelGroupsRef = React.useRef<Record<PanelPosition, CombinedPanelTab[]> | null>(null);
+
   const handleToggleServicePanel = React.useCallback((serviceId: string, query?: string, fragment?: string) => {
     // When called with nav params on an already-open panel, update params
     // and re-navigate rather than closing.
     const hasNavParams = !!(query || fragment);
     if (activeServicePanels.has(serviceId) && !hasNavParams) {
-      closeServicePanelById(serviceId);
+      // Only close when the panel is the tab actually shown in its dock zone.
+      // If another tab is on top of the same zone, bring this panel forward
+      // instead of closing it.
+      const zoneTabs = panelGroupsRef.current?.[getServicePanelPosition(serviceId)] ?? [];
+      const action = resolvePanelToggleAction(zoneTabs.map(t => t.id), combinedActiveTab, serviceId);
+      if (action === "close") {
+        closeServicePanelById(serviceId);
+      } else {
+        handleCombinedTabChange(serviceId);
+      }
     } else {
       if (!activeServicePanels.has(serviceId)) {
         // Resolve the correct position for the new panel using the shared pure
@@ -4481,6 +4494,7 @@ export function App() {
     for (const tab of servicePanelTabs) groups[getServicePanelPosition(tab.id)].push(tab);
     return groups;
   }, [terminalPanelTab, terminalPosition, filesPanelTab, filesPosition, gitPanelTab, gitPosition, triggersPanelTab, triggersPosition, analyzerPanelTab, analyzerPosition, servicePanelTabs, getServicePanelPosition]);
+  panelGroupsRef.current = panelGroups;
 
   // ── Derived column zone arrays ─────────────────────────────────────────────
   // Each side column orders its zones top→middle→bottom. Middle zone fills the

--- a/packages/ui/src/components/service-panels/ServicePanels.test.ts
+++ b/packages/ui/src/components/service-panels/ServicePanels.test.ts
@@ -22,7 +22,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { resolveNewPanelPosition, resolveActiveTabIdFromIds } from "../../utils/servicePanelUtils";
+import { resolveNewPanelPosition, resolveActiveTabIdFromIds, resolvePanelToggleAction } from "../../utils/servicePanelUtils";
 
 // ── Adding bug: new panel should join the current active group ────────────────
 
@@ -241,5 +241,23 @@ describe("resolveActiveTabIdFromIds — moving bug", () => {
         expect(
             resolveActiveTabIdFromIds(bottomGroupAfterMove, "godmother"),
         ).toBe("godmother");
+    });
+});
+
+// ── Toggle bug: icon click should focus a buried panel, not close it ──────────
+
+describe("resolvePanelToggleAction — toggle bug", () => {
+    test("closes when the panel is the shown tab in its zone", () => {
+        expect(resolvePanelToggleAction(["tunnel", "godmother"], "godmother", "godmother")).toBe("close");
+    });
+
+    test("focuses when another tab in the same zone is on top", () => {
+        expect(resolvePanelToggleAction(["tunnel", "godmother"], "tunnel", "godmother")).toBe("focus");
+    });
+
+    test("closes when the panel is shown via first-tab fallback (active tab in another zone)", () => {
+        // combinedActiveTab is "terminal" (a different zone) → zone shows tabs[0].
+        expect(resolvePanelToggleAction(["godmother", "tunnel"], "terminal", "godmother")).toBe("close");
+        expect(resolvePanelToggleAction(["tunnel", "godmother"], "terminal", "godmother")).toBe("focus");
     });
 });

--- a/packages/ui/src/utils/servicePanelUtils.ts
+++ b/packages/ui/src/utils/servicePanelUtils.ts
@@ -40,3 +40,17 @@ export function resolveActiveTabIdFromIds(tabIds: string[], combinedActiveTab: s
     if (tabIds.length === 0) return combinedActiveTab;
     return tabIds.includes(combinedActiveTab) ? combinedActiveTab : tabIds[0]!;
 }
+
+/**
+ * Decide what clicking an open panel's header icon should do.
+ *
+ * - Panel is the tab currently shown in its dock zone → "close" (toggle off).
+ * - Another tab is on top of the same zone → "focus" (bring the panel forward).
+ */
+export function resolvePanelToggleAction(
+    zoneTabIds: string[],
+    combinedActiveTab: string,
+    serviceId: string,
+): "close" | "focus" {
+    return resolveActiveTabIdFromIds(zoneTabIds, combinedActiveTab) === serviceId ? "close" : "focus";
+}


### PR DESCRIPTION
## Summary
- Clicking a service panel's header icon now only closes the panel when it's the tab actually **shown** in its dock zone
- If the panel is open but buried behind another tab in the same zone, the click brings it forward instead of closing it
- Extracted the decision into a pure helper `resolvePanelToggleAction` in `servicePanelUtils.ts` with regression tests

## Behavior
| State | Click result |
|-------|--------------|
| Panel closed | Opens (existing auto-placement unchanged) |
| Panel open, visible tab in its zone | Closes |
| Panel open, another tab on top in same zone | Focuses (brings forward) |

## Testing
- `bun test ServicePanels.test.ts` — 17 pass (3 new cases)
- `tsc --noEmit` clean