### PR TITLE
fix(tunnel): preserve multi-value Set-Cookie headers; event-driven session socket wait

### DIFF
--- a/packages/cli/src/extensions/remote/chunked-delivery.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.ts
@@ -365,7 +365,7 @@ export function messagesChangedSinceLastEmit(rctx: RelayContext): boolean {
  * Emit session_active — either as a single event (small sessions) or as
  * metadata-only + chunked messages (large sessions).
  */
-export function emitSessionActive(rctx: RelayContext): void {
+export function emitSessionActive(rctx: RelayContext, recoveryNonce?: string): void {
     if (!rctx.latestCtx) return;
 
     const { messages, model } = buildSessionContext(
@@ -401,6 +401,7 @@ export function emitSessionActive(rctx: RelayContext): void {
         activeChunkedSnapshotId = snapshotId;
         rctx.forwardEvent({
             type: "session_active",
+            ...(recoveryNonce !== undefined ? { recoveryNonce } : {}),
             state: {
                 ...metadata,
                 messages: [], // placeholder — real messages follow as chunks
@@ -418,6 +419,7 @@ export function emitSessionActive(rctx: RelayContext): void {
         activeChunkedSnapshotId = null;
         rctx.forwardEvent({
             type: "session_active",
+            ...(recoveryNonce !== undefined ? { recoveryNonce } : {}),
             state: {
                 ...metadata,
                 messages: capOversizedMessages(messages, messageSizes),

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -361,9 +361,12 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         }
     });
 
-    sock.on("connected", () => {
+    sock.on("connected", (data?: { recoveryNonce?: unknown }) => {
         rctx.forwardEvent(rctx.buildCapabilitiesState());
-        emitSessionActive(rctx);
+        // Echo the server's recovery nonce so the relay can tell this
+        // recovery snapshot apart from real agent updates racing in.
+        const recoveryNonce = typeof data?.recoveryNonce === "string" ? data.recoveryNonce : undefined;
+        emitSessionActive(rctx, recoveryNonce);
     });
 
     sock.on("input", (data) => {

--- a/packages/server/src/handler.ts
+++ b/packages/server/src/handler.ts
@@ -1,8 +1,8 @@
-import { getAuth, isSignupAllowed, runWithAuthContext, type AuthContext } from "./auth.js";
+import { getAuth, getTrustedOrigins, isSignupAllowed, runWithAuthContext, type AuthContext } from "./auth.js";
 import { isValidPassword, PASSWORD_REQUIREMENTS_SUMMARY } from "@pizzapi/protocol";
 import { handleApi } from "./routes/index.js";
 import { serveStaticFile } from "./static.js";
-import { getClientIp } from "./security.js";
+import { getClientIp, verifyCsrfOrigin } from "./security.js";
 import { createLogger } from "@pizzapi/tools";
 
 const authLog = createLogger("auth");
@@ -280,6 +280,15 @@ async function _handleFetch(req: Request): Promise<Response> {
             authLog.error("handler threw:", e);
             return Response.json({ error: "Auth error" }, { status: 500 });
         }
+    }
+
+    // ── CSRF origin gate ──────────────────────────────────────────────────
+    // Cookie-authenticated state-changing API requests must come from a
+    // trusted origin. /api/auth/* is exempt (better-auth handles its own
+    // origin checking above); API-key requests are exempt inside the gate.
+    if (url.pathname.startsWith("/api/")) {
+        const csrfRejection = verifyCsrfOrigin(req, getTrustedOrigins());
+        if (csrfRejection) return csrfRejection;
     }
 
     // ── REST endpoints ─────────────────────────────────────────────────────

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -23,6 +23,7 @@ const mockLinkSessionToRunner = mock((_runnerId: string, _sessionId: string) => 
 mock.module("../ws/sio-registry.js", () => ({
     getSharedSession: mockGetSharedSession,
     getLocalTuiSocket: mockGetLocalTuiSocket,
+    waitForLocalTuiSocket: mock(async (id: string) => !!mockGetLocalTuiSocket(id)?.connected),
     emitToRelaySessionVerified: mockEmitToRelaySessionVerified,
     broadcastToSessionViewers: mockBroadcastToSessionViewers,
     recordRunnerSession: mockRecordRunnerSession,

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -36,6 +36,7 @@ import { requireSession, validateApiKey } from "../middleware.js";
 import {
     getSharedSession,
     getLocalTuiSocket,
+    waitForLocalTuiSocket,
     broadcastToSessionViewers,
     emitToRelaySessionVerified,
     getLocalRunnerSocket,
@@ -186,18 +187,15 @@ function inferUnsubscribeTarget(target: string, subscriptionIdParam?: string): {
     return { triggerType: target, mode: "triggerType" };
 }
 
-/** Poll for a session socket to appear after spawn (same pattern as webhooks). */
+/**
+ * Wait for a session socket to appear after spawn. Event-driven: resolves as
+ * soon as the TUI socket registers instead of polling.
+ * Only the TUI socket counts as ready — the Redis session record
+ * (getSharedSession) is created before the socket connects, so checking it
+ * would cause premature return and dropped triggers.
+ */
 async function waitForSessionSocket(sessionId: string, timeoutMs: number): Promise<boolean> {
-    const start = Date.now();
-    while (Date.now() - start < timeoutMs) {
-        // Only consider the session ready when its TUI socket is actually connected.
-        // The Redis session record (getSharedSession) is created before the socket
-        // connects, so checking it would cause premature return and dropped triggers.
-        const local = getLocalTuiSocket(sessionId);
-        if (local?.connected) return true;
-        await new Promise((r) => setTimeout(r, 200));
-    }
-    return false;
+    return waitForLocalTuiSocket(sessionId, timeoutMs);
 }
 
 /** Shape of the POST /api/sessions/:id/trigger request body. */

--- a/packages/server/src/routes/tunnel.ts
+++ b/packages/server/src/routes/tunnel.ts
@@ -494,7 +494,13 @@ function proxyTunnelRequestViaRelay(
                     responseHeaders = new Headers();
                     for (const [key, value] of Object.entries(headers)) {
                         try {
-                            responseHeaders.set(key, value);
+                            if (Array.isArray(value)) {
+                                // Multi-value headers (Set-Cookie) must be appended
+                                // individually — joining them corrupts cookie values.
+                                for (const v of value) responseHeaders.append(key, v);
+                            } else {
+                                responseHeaders.set(key, value);
+                            }
                         } catch {
                             // Skip invalid header values rejected by the Headers API.
                         }

--- a/packages/server/src/security.test.ts
+++ b/packages/server/src/security.test.ts
@@ -816,3 +816,61 @@ describe("getClientIp", () => {
         _resetTrustedProxyCidrCacheForTests();
     });
 });
+
+// ── verifyCsrfOrigin ─────────────────────────────────────────────────────────
+
+import { verifyCsrfOrigin } from "./security.js";
+
+describe("verifyCsrfOrigin", () => {
+    const TRUSTED = ["https://pizza.example.com", "http://localhost:3000"];
+
+    function makeReq(method: string, headers: Record<string, string> = {}): Request {
+        return new Request("https://pizza.example.com/api/runners/spawn", { method, headers });
+    }
+
+    test("allows safe methods regardless of origin", () => {
+        expect(verifyCsrfOrigin(makeReq("GET", { cookie: "s=1", origin: "https://evil.example" }), TRUSTED)).toBeNull();
+        expect(verifyCsrfOrigin(makeReq("HEAD", { cookie: "s=1", origin: "https://evil.example" }), TRUSTED)).toBeNull();
+        expect(verifyCsrfOrigin(makeReq("OPTIONS", { cookie: "s=1", origin: "https://evil.example" }), TRUSTED)).toBeNull();
+    });
+
+    test("allows requests without cookies (nothing to ride)", () => {
+        expect(verifyCsrfOrigin(makeReq("POST", { origin: "https://evil.example" }), TRUSTED)).toBeNull();
+    });
+
+    test("allows API-key requests even with cookies and foreign origin", () => {
+        expect(verifyCsrfOrigin(
+            makeReq("POST", { cookie: "s=1", "x-api-key": "key", origin: "https://evil.example" }),
+            TRUSTED,
+        )).toBeNull();
+    });
+
+    test("rejects cookie-authed POST from untrusted origin", () => {
+        const res = verifyCsrfOrigin(makeReq("POST", { cookie: "s=1", origin: "https://evil.example" }), TRUSTED);
+        expect(res).not.toBeNull();
+        expect(res!.status).toBe(403);
+    });
+
+    test("rejects Origin: null", () => {
+        const res = verifyCsrfOrigin(makeReq("POST", { cookie: "s=1", origin: "null" }), TRUSTED);
+        expect(res!.status).toBe(403);
+    });
+
+    test("allows cookie-authed POST from trusted origin", () => {
+        expect(verifyCsrfOrigin(makeReq("POST", { cookie: "s=1", origin: "https://pizza.example.com" }), TRUSTED)).toBeNull();
+        expect(verifyCsrfOrigin(makeReq("DELETE", { cookie: "s=1", origin: "http://localhost:3000" }), TRUSTED)).toBeNull();
+    });
+
+    test("rejects cross-site Sec-Fetch-Site when Origin is absent", () => {
+        const res = verifyCsrfOrigin(makeReq("POST", { cookie: "s=1", "sec-fetch-site": "cross-site" }), TRUSTED);
+        expect(res!.status).toBe(403);
+    });
+
+    test("allows same-origin Sec-Fetch-Site when Origin is absent", () => {
+        expect(verifyCsrfOrigin(makeReq("POST", { cookie: "s=1", "sec-fetch-site": "same-origin" }), TRUSTED)).toBeNull();
+    });
+
+    test("allows requests with neither Origin nor Sec-Fetch-Site (non-browser clients)", () => {
+        expect(verifyCsrfOrigin(makeReq("PUT", { cookie: "s=1" }), TRUSTED)).toBeNull();
+    });
+});

--- a/packages/server/src/security.ts
+++ b/packages/server/src/security.ts
@@ -568,3 +568,47 @@ export function getClientIp(req: Request): string {
 
     return clientIp;
 }
+
+// ── CSRF origin verification ─────────────────────────────────────────────────
+
+/**
+ * Cross-origin request forgery gate for cookie-authenticated state-changing
+ * API requests. Defense-in-depth on top of SameSite cookies and CORS:
+ *
+ * - Requests without a Cookie header can't ride a victim's session — skip.
+ * - Requests authenticated via x-api-key set a custom header, which browsers
+ *   don't allow cross-site without a CORS preflight — skip.
+ * - Otherwise the Origin header (when present) must be in trustedOrigins,
+ *   and Sec-Fetch-Site (when present) must not be "cross-site".
+ * - Requests with neither header (curl, scripts, old same-origin browsers)
+ *   are allowed — they aren't riding ambient browser credentials cross-site.
+ *
+ * Returns a 403 Response to reject, or null to continue.
+ */
+export function verifyCsrfOrigin(req: Request, trustedOrigins: string[]): Response | null {
+    const method = req.method.toUpperCase();
+    if (method === "GET" || method === "HEAD" || method === "OPTIONS") return null;
+    if (!req.headers.get("cookie")) return null;
+    if (req.headers.get("x-api-key")) return null;
+
+    const origin = req.headers.get("origin");
+    if (origin !== null) {
+        if (!trustedOrigins.includes(origin)) {
+            return Response.json(
+                { error: "Cross-origin request rejected" },
+                { status: 403 },
+            );
+        }
+        return null;
+    }
+
+    const secFetchSite = req.headers.get("sec-fetch-site");
+    if (secFetchSite === "cross-site") {
+        return Response.json(
+            { error: "Cross-origin request rejected" },
+            { status: 403 },
+        );
+    }
+
+    return null;
+}

--- a/packages/server/src/sessions/redis.snapshot.test.ts
+++ b/packages/server/src/sessions/redis.snapshot.test.ts
@@ -108,6 +108,22 @@ describe("getLatestCachedSnapshotEvent", () => {
         await initializeRelayRedisCache();
     });
 
+    test("returns events cached after the snapshot in chronological order", async () => {
+        const sessionId = "s-after";
+        const key = keyForSession(sessionId);
+        rowsByKey.set(key, [
+            rowForEvent(noiseEvent(0)),
+            rowForEvent({ type: "session_active", state: { messages: [] } }),
+            JSON.stringify({ seq: 7, event: { type: "message_start" } }),
+            JSON.stringify({ seq: 8, event: { type: "message_end" } }),
+        ]);
+
+        const snapshot = await getLatestCachedSnapshotEvent(sessionId);
+
+        expect(snapshot?.event.type).toBe("session_active");
+        expect(snapshot?.eventsAfter.map((e) => e.seq)).toEqual([7, 8]);
+    });
+
     test("returns latest snapshot and only scans the newest chunk when snapshot is near tail", async () => {
         const sessionId = "s-tail";
         const key = keyForSession(sessionId);
@@ -118,7 +134,7 @@ describe("getLatestCachedSnapshotEvent", () => {
         const snapshot = await getLatestCachedSnapshotEvent(sessionId);
 
         expect(snapshot).not.toBeNull();
-        expect(snapshot?.type).toBe("session_active");
+        expect(snapshot?.event.type).toBe("session_active");
         expect(lRangeCalls).toHaveLength(1);
         expect(lRangeCalls[0]).toEqual({ key, start: 7, end: 10 });
     });
@@ -135,7 +151,7 @@ describe("getLatestCachedSnapshotEvent", () => {
         const snapshot = await getLatestCachedSnapshotEvent(sessionId);
 
         expect(snapshot).not.toBeNull();
-        expect(snapshot?.type).toBe("agent_end");
+        expect(snapshot?.event.type).toBe("agent_end");
         expect(lRangeCalls).toEqual([
             { key, start: 6, end: 9 },
             { key, start: 2, end: 5 },

--- a/packages/server/src/sessions/redis.ts
+++ b/packages/server/src/sessions/redis.ts
@@ -264,7 +264,19 @@ export async function getCachedRelayEventsAfterSeq(
     }
 }
 
-export async function getLatestCachedSnapshotEvent(sessionId: string): Promise<Record<string, unknown> | null> {
+export interface LatestCachedSnapshot {
+    event: Record<string, unknown>;
+    /**
+     * Cached events appended after the snapshot, in chronological order.
+     * Replaying these after the snapshot brings a viewer up to the current
+     * seq — without them, deltas published between the snapshot and "now"
+     * would be silently skipped (the viewer cursor is advanced to freshSeq
+     * before hydration).
+     */
+    eventsAfter: CachedRelayEventRecord[];
+}
+
+export async function getLatestCachedSnapshotEvent(sessionId: string): Promise<LatestCachedSnapshot | null> {
     if (isRedisDisabled()) return null;
 
     const redis = await getClient();
@@ -275,6 +287,9 @@ export async function getLatestCachedSnapshotEvent(sessionId: string): Promise<R
         const length = await redis.lLen(key);
         if (!Number.isFinite(length) || length <= 0) return null;
 
+        // Events encountered while scanning backward toward the snapshot —
+        // i.e. events appended after it — in reverse-chronological order.
+        const trailingReversed: CachedRelayEventRecord[] = [];
         const chunkSize = snapshotScanChunkSize();
         for (let end = length - 1; end >= 0; end -= chunkSize) {
             const start = Math.max(0, end - chunkSize + 1);
@@ -282,9 +297,14 @@ export async function getLatestCachedSnapshotEvent(sessionId: string): Promise<R
             for (let i = rows.length - 1; i >= 0; i--) {
                 const row = rows[i];
                 const parsed = parseCachedRelayEventRow(row);
-                if (parsed && isSnapshotEvent(parsed.event)) {
-                    return parsed.event;
+                if (!parsed) continue;
+                if (isSnapshotEvent(parsed.event)) {
+                    return {
+                        event: parsed.event as Record<string, unknown>,
+                        eventsAfter: trailingReversed.reverse(),
+                    };
                 }
+                trailingReversed.push(parsed);
             }
         }
 

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.test.ts
@@ -217,7 +217,8 @@ describe("chunked snapshot assembly", () => {
             sessionName: "Updated",
             availableCommands: [{ name: "search_tools" }],
         });
-        markPendingRecovery("sess-chunked-recovery");
+        const nonce = markPendingRecovery("sess-chunked-recovery");
+        pending.recoveryNonce = nonce;
 
         const fullState = await finalizeChunkedSnapshot("sess-chunked-recovery", pending, {
             consumePendingRecovery,
@@ -238,7 +239,7 @@ describe("chunked snapshot assembly", () => {
             { isRecovery: true },
         );
         expect(hasPendingRecovery("sess-chunked-recovery")).toBe(false);
-        expect(consumePendingRecovery("sess-chunked-recovery")).toBe(false);
+        expect(consumePendingRecovery("sess-chunked-recovery", nonce)).toBe(false);
         expect(appendRelayEventToCache).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/server/src/ws/namespaces/relay/event-pipeline.ts
+++ b/packages/server/src/ws/namespaces/relay/event-pipeline.ts
@@ -38,6 +38,8 @@ export interface ChunkedSessionState {
     totalChunks: number;
     receivedChunkIndexes: Set<number>;
     finalChunkSeen: boolean;
+    /** Recovery nonce echoed by the runner on the chunk-start session_active. */
+    recoveryNonce?: string;
 }
 
 export interface PendingChunkUpdate {
@@ -122,7 +124,7 @@ export async function finalizeChunkedSnapshot(
 ): Promise<Record<string, unknown>> {
     const allMessages = pending.chunks.flat();
     const fullState = { ...pending.metadata, messages: allMessages };
-    const isRecovery = deps.consumePendingRecovery(sessionId);
+    const isRecovery = deps.consumePendingRecovery(sessionId, pending.recoveryNonce);
     await deps.updateSessionState(sessionId, fullState, { isRecovery });
 
     // Append a full session_active to the Redis replay cache
@@ -277,6 +279,7 @@ export function registerEventHandler(socket: RelaySocket): void {
                     totalChunks: 0,
                     receivedChunkIndexes: new Set<number>(),
                     finalChunkSeen: false,
+                    recoveryNonce: typeof event.recoveryNonce === "string" ? event.recoveryNonce : undefined,
                 });
                 // Touch activity but DON'T update lastState yet
                 await touchSessionActivity(sessionId);
@@ -284,8 +287,13 @@ export function registerEventHandler(socket: RelaySocket): void {
                 // Non-chunked: persist immediately (original path).
                 // Check if this session_active was triggered by a viewer
                 // reconnect (cold-start fallback) — if so, skip the SQLite
-                // write since it's redundant recovery data.
-                const isRecovery = consumePendingRecovery(sessionId);
+                // write since it's redundant recovery data. Only a matching
+                // recovery nonce consumes the flag; real updates racing in
+                // must still be persisted.
+                const isRecovery = consumePendingRecovery(
+                    sessionId,
+                    typeof event.recoveryNonce === "string" ? event.recoveryNonce : undefined,
+                );
                 pendingChunkedStates.delete(sessionId);
                 await updateSessionState(sessionId, event.state, { isRecovery });
             }

--- a/packages/server/src/ws/namespaces/snapshot-provider.test.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.test.ts
@@ -185,7 +185,7 @@ describe("tryCacheSnapshot", () => {
     test("returns SnapshotResult when Redis has a snapshot event", async () => {
         const snapshotEvent = { type: "session_active", state: { messages: [] } };
         const deps = createDeps({
-            getLatestCachedSnapshotEvent: mock(async () => snapshotEvent),
+            getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshotEvent, eventsAfter: [] })),
         });
 
         const result = await tryCacheSnapshot("sess-10", deps);
@@ -197,7 +197,7 @@ describe("tryCacheSnapshot", () => {
     test("send() emits the snapshot event with replay flag", async () => {
         const snapshotEvent = { type: "agent_end", messages: [{ role: "user" }] };
         const deps = createDeps({
-            getLatestCachedSnapshotEvent: mock(async () => snapshotEvent),
+            getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshotEvent, eventsAfter: [] })),
         });
 
         const result = await tryCacheSnapshot("sess-11", deps);
@@ -210,6 +210,38 @@ describe("tryCacheSnapshot", () => {
             event: snapshotEvent,
             replay: true,
             generation: 3,
+        });
+    });
+
+    test("send() replays events cached after the snapshot so the viewer catches up to freshSeq", async () => {
+        const snapshotEvent = { type: "session_active", state: { messages: [] } };
+        const deps = createDeps({
+            getLatestCachedSnapshotEvent: mock(async () => ({
+                event: snapshotEvent,
+                eventsAfter: [
+                    { seq: 21, event: { type: "message_start" } },
+                    { event: { type: "seqless_noise" } }, // no seq — skipped
+                    { seq: 22, event: { type: "message_end" } },
+                ],
+            })),
+        });
+
+        const result = await tryCacheSnapshot("sess-13", deps);
+        const socket = createMockSocket();
+        result!.send(socket, 4);
+
+        expect(socket.calls.length).toBe(3);
+        expect(socket.calls[0].payload).toMatchObject({ event: snapshotEvent, replay: true });
+        expect(socket.calls[1].payload).toMatchObject({
+            event: { type: "message_start" },
+            seq: 21,
+            deltaReplay: true,
+            generation: 4,
+        });
+        expect(socket.calls[2].payload).toMatchObject({
+            event: { type: "message_end" },
+            seq: 22,
+            deltaReplay: true,
         });
     });
 
@@ -343,9 +375,9 @@ describe("getBestSnapshot — priority ordering", () => {
                 { seq: 11, event: { type: "message_start" } },
             ]),
             getLatestCachedSnapshotEvent: mock(async () => ({
-                type: "session_active",
-                state: { messages: [] },
-            })),
+                event: { type: "session_active", state: { messages: [] } },
+                eventsAfter: [],
+                })),
             getPersistedRelaySessionSnapshot: mock(async () => ({
                 state: { messages: [] },
             })),
@@ -364,9 +396,9 @@ describe("getBestSnapshot — priority ordering", () => {
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => []),
             getLatestCachedSnapshotEvent: mock(async () => ({
-                type: "session_active",
-                state: { messages: [] },
-            })),
+                event: { type: "session_active", state: { messages: [] } },
+                eventsAfter: [],
+                })),
             getPersistedRelaySessionSnapshot: mock(async () => ({
                 state: { messages: [] },
             })),
@@ -384,7 +416,7 @@ describe("getBestSnapshot — priority ordering", () => {
     test("priority 2: returns cache snapshot when no lastSeq", async () => {
         const snapshotEvent = { type: "session_active", state: { messages: [] } };
         const deps = createDeps({
-            getLatestCachedSnapshotEvent: mock(async () => snapshotEvent),
+            getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshotEvent, eventsAfter: [] })),
             getPersistedRelaySessionSnapshot: mock(async () => ({
                 state: { messages: ["persisted"] },
             })),
@@ -559,7 +591,7 @@ describe("getBestSnapshot — chunkedPending sessions", () => {
     test("still uses cache snapshot even when chunkedPending", async () => {
         const snapshotEvent = { type: "session_active", state: { messages: [] } };
         const deps = createDeps({
-            getLatestCachedSnapshotEvent: mock(async () => snapshotEvent),
+            getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshotEvent, eventsAfter: [] })),
         });
 
         const result = await getBestSnapshot("sess-51", {

--- a/packages/server/src/ws/namespaces/snapshot-provider.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.ts
@@ -9,7 +9,7 @@
 // Priority: delta replay > cache snapshot > in-memory state > persisted (SQLite)
 // ============================================================================
 
-import { getCachedRelayEventsAfterSeq, getLatestCachedSnapshotEvent } from "../../sessions/redis.js";
+import { getCachedRelayEventsAfterSeq, getLatestCachedSnapshotEvent, type LatestCachedSnapshot } from "../../sessions/redis.js";
 import { getPersistedRelaySessionSnapshot } from "../../sessions/store.js";
 import type { CachedRelayEvent } from "./viewer-cache.js";
 import { sendCachedDeltaReplayEvents } from "./viewer-cache.js";
@@ -68,7 +68,7 @@ function maybeTruncateSnapshotState(state: unknown): unknown {
 
 export interface SnapshotProviderDeps {
     getCachedRelayEventsAfterSeq: (sessionId: string, afterSeq: number) => Promise<CachedRelayEvent[]>;
-    getLatestCachedSnapshotEvent: (sessionId: string) => Promise<Record<string, unknown> | null>;
+    getLatestCachedSnapshotEvent: (sessionId: string) => Promise<LatestCachedSnapshot | null>;
     getPersistedRelaySessionSnapshot: (
         sessionId: string,
         userId: string,
@@ -116,8 +116,9 @@ export async function tryCacheSnapshot(
     sessionId: string,
     deps: SnapshotProviderDeps = defaultDeps,
 ): Promise<SnapshotResult | null> {
-    const snapshotEvent = await deps.getLatestCachedSnapshotEvent(sessionId);
-    if (!snapshotEvent) return null;
+    const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
+    if (!cached) return null;
+    const snapshotEvent = cached.event;
 
     return {
         snapshot: { type: "cache-snapshot", source: "Redis cached snapshot event" },
@@ -132,6 +133,12 @@ export async function tryCacheSnapshot(
                 eventToSend = maybeTruncateSnapshotState(snapshotEvent) as Record<string, unknown>;
             }
             socket.emit("event", { event: eventToSend, replay: true, generation });
+            // Replay deltas cached after the snapshot. The viewer's cursor was
+            // already advanced to the current seq via "connected", so without
+            // this replay any events between the snapshot and that seq would
+            // never reach the viewer — a permanently stale transcript until
+            // the next full snapshot.
+            sendCachedDeltaReplayEvents(socket, cached.eventsAfter, generation);
         },
     };
 }

--- a/packages/server/src/ws/namespaces/viewer-cache.ts
+++ b/packages/server/src/ws/namespaces/viewer-cache.ts
@@ -5,7 +5,7 @@
 // loading the full namespace module or relying on global mock.module state.
 // ============================================================================
 
-import { getCachedRelayEventsAfterSeq, getLatestCachedSnapshotEvent } from "../../sessions/redis.js";
+import { getCachedRelayEventsAfterSeq, getLatestCachedSnapshotEvent, type LatestCachedSnapshot } from "../../sessions/redis.js";
 
 type ViewerEventEmitter = {
     emit: any;
@@ -18,7 +18,7 @@ export type CachedRelayEvent = {
 
 export interface ViewerCacheDeps {
     getCachedRelayEventsAfterSeq: (sessionId: string, afterSeq: number) => Promise<CachedRelayEvent[]>;
-    getLatestCachedSnapshotEvent: (sessionId: string) => Promise<Record<string, unknown> | null>;
+    getLatestCachedSnapshotEvent: (sessionId: string) => Promise<LatestCachedSnapshot | null>;
 }
 
 const defaultViewerCacheDeps: ViewerCacheDeps = {
@@ -32,10 +32,13 @@ export async function sendLatestSnapshotFromCache(
     generation: number | undefined,
     deps: ViewerCacheDeps = defaultViewerCacheDeps,
 ): Promise<boolean> {
-    const snapshotEvent = await deps.getLatestCachedSnapshotEvent(sessionId);
-    if (!snapshotEvent) return false;
+    const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
+    if (!cached) return false;
 
-    socket.emit("event", { event: snapshotEvent, replay: true, generation });
+    socket.emit("event", { event: cached.event, replay: true, generation });
+    // Replay deltas cached after the snapshot so the viewer isn't left stale
+    // between the snapshot and the seq advertised in "connected".
+    sendCachedDeltaReplayEvents(socket, cached.eventsAfter, generation);
     return true;
 }
 

--- a/packages/server/src/ws/namespaces/viewer.hydration.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.hydration.test.ts
@@ -37,7 +37,7 @@ describe("hydrateViewerFromCache — snapshot path", () => {
 
     test("returns true and emits event when Redis has a session_active snapshot", async () => {
         const snapshot = { type: "session_active", state: { messages: [{ role: "user" }] } };
-        deps = createDeps({ getLatestCachedSnapshotEvent: mock(async () => snapshot) });
+        deps = createDeps({ getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshot, eventsAfter: [] })) });
 
         const { emit, calls } = createMockSocket();
         const result = await hydrateViewerFromCache({ emit }, "sess-001", {}, deps);
@@ -50,7 +50,7 @@ describe("hydrateViewerFromCache — snapshot path", () => {
 
     test("returns true and emits with generation when generation is provided", async () => {
         const snapshot = { type: "agent_end", messages: [{ role: "assistant" }] };
-        deps = createDeps({ getLatestCachedSnapshotEvent: mock(async () => snapshot) });
+        deps = createDeps({ getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshot, eventsAfter: [] })) });
 
         const { emit, calls } = createMockSocket();
         const result = await hydrateViewerFromCache({ emit }, "sess-002", { generation: 7 }, deps);
@@ -79,7 +79,7 @@ describe("hydrateViewerFromCache — snapshot path", () => {
 
     test("works for agent_end snapshot (full session end)", async () => {
         const snapshot = { type: "agent_end", messages: [{ role: "user" }, { role: "assistant" }] };
-        deps = createDeps({ getLatestCachedSnapshotEvent: mock(async () => snapshot) });
+        deps = createDeps({ getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshot, eventsAfter: [] })) });
 
         const { emit, calls } = createMockSocket();
         const result = await hydrateViewerFromCache({ emit }, "sess-005", {}, deps);
@@ -118,7 +118,7 @@ describe("hydrateViewerFromCache — delta resume path", () => {
         const snapshot = { type: "session_active", state: { messages: [] } };
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => []),
-            getLatestCachedSnapshotEvent: mock(async () => snapshot),
+            getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshot, eventsAfter: [] })),
         });
 
         const { emit, calls } = createMockSocket();
@@ -163,7 +163,7 @@ describe("hydrateViewerFromCache — delta resume path", () => {
         const snapshot = { type: "session_active", state: { messages: [{ role: "assistant" }] } };
         const deps = createDeps({
             getCachedRelayEventsAfterSeq: mock(async () => [{ event: { type: "old_event" } }]),
-            getLatestCachedSnapshotEvent: mock(async () => snapshot),
+            getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshot, eventsAfter: [] })),
         });
 
         const { emit, calls } = createMockSocket();
@@ -177,7 +177,7 @@ describe("hydrateViewerFromCache — delta resume path", () => {
 describe("cache-first → runner signal suppression invariant", () => {
     test("cache HIT: returns true → activateSession sets suppressRunnerSignal=true (no runner signal)", async () => {
         const deps = createDeps({
-            getLatestCachedSnapshotEvent: mock(async () => ({ type: "session_active", state: { messages: [] } })),
+            getLatestCachedSnapshotEvent: mock(async () => ({ event: { type: "session_active", state: { messages: [] } }, eventsAfter: [] })),
         });
 
         const { emit } = createMockSocket();

--- a/packages/server/src/ws/namespaces/viewer.test.ts
+++ b/packages/server/src/ws/namespaces/viewer.test.ts
@@ -186,6 +186,7 @@ describe("viewer connected signal gating", () => {
         forwardRecoveryConnectedSignal("sess-connected", {
             markPendingRecovery: mock((sessionId: string) => {
                 calls.push(`mark:${sessionId}`);
+                return "nonce-1";
             }),
             emitToRelaySession: mock((sessionId: string, event: string) => {
                 calls.push(`emit:${event}:${sessionId}`);
@@ -224,6 +225,7 @@ describe("viewer connected signal gating", () => {
         forwardRecoveryConnectedSignal("sess-pending", {
             markPendingRecovery: mock((sessionId: string) => {
                 calls.push(`mark:${sessionId}`);
+                return "nonce-1";
             }),
             emitToRelaySession: mock((sessionId: string, event: string) => {
                 calls.push(`emit:${event}:${sessionId}`);

--- a/packages/server/src/ws/namespaces/viewer.ts
+++ b/packages/server/src/ws/namespaces/viewer.ts
@@ -211,8 +211,10 @@ export function forwardRecoveryConnectedSignal(
     sessionId: string,
     deps: RecoveryConnectedSignalDeps = defaultRecoveryConnectedSignalDeps,
 ): void {
-    deps.markPendingRecovery(sessionId);
-    deps.emitToRelaySession(sessionId, "connected" as string, {});
+    const recoveryNonce = deps.markPendingRecovery(sessionId);
+    // The runner echoes recoveryNonce on its recovery session_active so the
+    // event pipeline can distinguish it from real agent updates racing in.
+    deps.emitToRelaySession(sessionId, "connected" as string, { recoveryNonce });
 }
 
 /**
@@ -860,7 +862,7 @@ log.info(`connected: ${socket.id} userId=${viewerUserId}`);
             }
 
             if (!fullState) {
-                const snapshotEvent = await getLatestCachedSnapshotEvent(currentSessionId);
+                const snapshotEvent = (await getLatestCachedSnapshotEvent(currentSessionId))?.event ?? null;
                 if (snapshotEvent?.type === "session_active") {
                     const snapshotState = snapshotEvent.state;
                     if (snapshotState && typeof snapshotState === "object" && !Array.isArray(snapshotState)) {

--- a/packages/server/src/ws/sio-registry/index.ts
+++ b/packages/server/src/ws/sio-registry/index.ts
@@ -11,6 +11,7 @@ export type { RegisterTuiSessionOpts, UpdateSessionStateOpts } from "./sessions.
 export {
     registerTuiSession,
     getLocalTuiSocket,
+    waitForLocalTuiSocket,
     removeLocalTuiSocket,
     getSessions,
     getSharedSession,

--- a/packages/server/src/ws/sio-registry/sessions.recovery.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.recovery.test.ts
@@ -2,9 +2,11 @@
 // sessions.recovery.test.ts — Unit tests for viewer-recovery SQLite-skip path
 //
 // When a viewer join triggers the cold-start runner fallback (cache miss),
-// markPendingRecovery() flags the session in the pending-recovery map.
-// The event-pipeline's consumePendingRecovery() clears the flag and passes
+// markPendingRecovery() flags the session and returns a nonce that the runner
+// echoes on its recovery session_active. The event-pipeline's
+// consumePendingRecovery() clears the flag only on a nonce match and passes
 // isRecovery:true to updateSessionState(), which skips the SQLite write.
+// Real session_active events (no nonce) must NOT consume the flag.
 //
 // Imports directly from viewer-recovery.ts — a tiny zero-dependency module.
 // No mocking needed: the functions are pure Map operations with no I/O.
@@ -18,41 +20,65 @@ import {
     _resetPendingRecoveriesForTesting,
 } from "./viewer-recovery.js";
 
-describe("viewer-recovery SQLite-skip path (pendingRecoverySessionIds)", () => {
+describe("viewer-recovery SQLite-skip path (pendingRecoveries)", () => {
     beforeEach(() => {
         _resetPendingRecoveriesForTesting();
     });
 
-    test("markPendingRecovery flags a session for recovery", () => {
-        markPendingRecovery("sess-recover-1");
+    test("markPendingRecovery flags a session and returns a nonce", () => {
+        const nonce = markPendingRecovery("sess-recover-1");
+        expect(typeof nonce).toBe("string");
+        expect(nonce.length).toBeGreaterThan(0);
         expect(hasPendingRecovery("sess-recover-1")).toBe(true);
     });
 
-    test("consumePendingRecovery returns true and clears the flag", () => {
-        markPendingRecovery("sess-recover-2");
-        const wasRecovery = consumePendingRecovery("sess-recover-2");
+    test("consumePendingRecovery returns true and clears the flag on nonce match", () => {
+        const nonce = markPendingRecovery("sess-recover-2");
+        const wasRecovery = consumePendingRecovery("sess-recover-2", nonce);
         expect(wasRecovery).toBe(true);
         expect(hasPendingRecovery("sess-recover-2")).toBe(false);
     });
 
+    test("a real session_active (no nonce) does NOT consume the flag", () => {
+        const nonce = markPendingRecovery("sess-race");
+        // Real update races in first — must persist (false) and leave the flag
+        expect(consumePendingRecovery("sess-race", undefined)).toBe(false);
+        expect(hasPendingRecovery("sess-race")).toBe(true);
+        // Recovery response then matches and consumes
+        expect(consumePendingRecovery("sess-race", nonce)).toBe(true);
+        expect(hasPendingRecovery("sess-race")).toBe(false);
+    });
+
+    test("a mismatched nonce does not consume the flag", () => {
+        markPendingRecovery("sess-stale-nonce");
+        expect(consumePendingRecovery("sess-stale-nonce", "wrong-nonce")).toBe(false);
+        expect(hasPendingRecovery("sess-stale-nonce")).toBe(true);
+    });
+
+    test("re-marking replaces the nonce — old nonce no longer matches", () => {
+        const oldNonce = markPendingRecovery("sess-remark");
+        const newNonce = markPendingRecovery("sess-remark");
+        expect(consumePendingRecovery("sess-remark", oldNonce)).toBe(false);
+        expect(consumePendingRecovery("sess-remark", newNonce)).toBe(true);
+    });
+
     test("consumePendingRecovery returns false for sessions not marked", () => {
-        const wasRecovery = consumePendingRecovery("sess-not-marked");
-        expect(wasRecovery).toBe(false);
+        expect(consumePendingRecovery("sess-not-marked", "any")).toBe(false);
     });
 
     test("consumePendingRecovery is idempotent — second call returns false", () => {
-        markPendingRecovery("sess-recover-3");
-        expect(consumePendingRecovery("sess-recover-3")).toBe(true);
-        expect(consumePendingRecovery("sess-recover-3")).toBe(false); // already consumed
+        const nonce = markPendingRecovery("sess-recover-3");
+        expect(consumePendingRecovery("sess-recover-3", nonce)).toBe(true);
+        expect(consumePendingRecovery("sess-recover-3", nonce)).toBe(false); // already consumed
     });
 
     test("multiple sessions tracked independently", () => {
-        markPendingRecovery("sess-a");
-        markPendingRecovery("sess-b");
+        const nonceA = markPendingRecovery("sess-a");
+        const nonceB = markPendingRecovery("sess-b");
 
-        expect(consumePendingRecovery("sess-a")).toBe(true);
+        expect(consumePendingRecovery("sess-a", nonceA)).toBe(true);
         expect(hasPendingRecovery("sess-b")).toBe(true); // unaffected
-        expect(consumePendingRecovery("sess-b")).toBe(true);
+        expect(consumePendingRecovery("sess-b", nonceB)).toBe(true);
         expect(hasPendingRecovery("sess-a")).toBe(false);
         expect(hasPendingRecovery("sess-b")).toBe(false);
     });

--- a/packages/server/src/ws/sio-registry/sessions.socket-wait.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.socket-wait.test.ts
@@ -1,35 +1,39 @@
 // ============================================================================
-// sessions.socket-wait.test.ts — waitForLocalTuiSocket event-driven readiness
+// sessions.socket-wait.test.ts — waitForTuiSocket event-driven readiness
+//
+// Imports directly from tui-socket-waiters.ts — a tiny zero-dependency module.
+// No mocking needed: the functions are pure Map operations with no I/O.
 // ============================================================================
 
-import { afterEach, describe, expect, test } from "bun:test";
-import type { Socket } from "socket.io";
-import { waitForLocalTuiSocket, notifyTuiSocketConnected } from "./sessions.js";
-import { localTuiSockets } from "./context.js";
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+    waitForTuiSocket,
+    notifyTuiSocketConnected,
+    _resetTuiSocketWaitersForTesting,
+} from "./tui-socket-waiters.js";
 
-function fakeSocket(connected = true): Socket {
-    return { connected, data: {} } as unknown as Socket;
+function lookup(sockets: Record<string, { connected: boolean }>) {
+    return (sessionId: string) => sockets[sessionId];
 }
 
-describe("waitForLocalTuiSocket", () => {
-    afterEach(() => {
-        localTuiSockets.clear();
+describe("waitForTuiSocket", () => {
+    beforeEach(() => {
+        _resetTuiSocketWaitersForTesting();
     });
 
     test("resolves true immediately when the socket is already connected", async () => {
-        localTuiSockets.set("s1", fakeSocket());
-        expect(await waitForLocalTuiSocket("s1", 1000)).toBe(true);
+        const get = lookup({ s1: { connected: true } });
+        expect(await waitForTuiSocket("s1", 1000, get)).toBe(true);
     });
 
     test("resolves false after timeout when no socket registers", async () => {
         const start = Date.now();
-        expect(await waitForLocalTuiSocket("missing", 30)).toBe(false);
+        expect(await waitForTuiSocket("missing", 30, lookup({}))).toBe(false);
         expect(Date.now() - start).toBeGreaterThanOrEqual(25);
     });
 
     test("resolves true as soon as the socket registers", async () => {
-        const promise = waitForLocalTuiSocket("s2", 5000);
-        localTuiSockets.set("s2", fakeSocket());
+        const promise = waitForTuiSocket("s2", 5000, lookup({}));
         notifyTuiSocketConnected("s2");
         const start = Date.now();
         expect(await promise).toBe(true);
@@ -38,15 +42,14 @@ describe("waitForLocalTuiSocket", () => {
     });
 
     test("multiple waiters for the same session all resolve", async () => {
-        const a = waitForLocalTuiSocket("s3", 5000);
-        const b = waitForLocalTuiSocket("s3", 5000);
-        localTuiSockets.set("s3", fakeSocket());
+        const a = waitForTuiSocket("s3", 5000, lookup({}));
+        const b = waitForTuiSocket("s3", 5000, lookup({}));
         notifyTuiSocketConnected("s3");
         expect(await Promise.all([a, b])).toEqual([true, true]);
     });
 
     test("does not treat a disconnected socket as ready", async () => {
-        localTuiSockets.set("s4", fakeSocket(false));
-        expect(await waitForLocalTuiSocket("s4", 30)).toBe(false);
+        const get = lookup({ s4: { connected: false } });
+        expect(await waitForTuiSocket("s4", 30, get)).toBe(false);
     });
 });

--- a/packages/server/src/ws/sio-registry/sessions.socket-wait.test.ts
+++ b/packages/server/src/ws/sio-registry/sessions.socket-wait.test.ts
@@ -1,0 +1,52 @@
+// ============================================================================
+// sessions.socket-wait.test.ts — waitForLocalTuiSocket event-driven readiness
+// ============================================================================
+
+import { afterEach, describe, expect, test } from "bun:test";
+import type { Socket } from "socket.io";
+import { waitForLocalTuiSocket, notifyTuiSocketConnected } from "./sessions.js";
+import { localTuiSockets } from "./context.js";
+
+function fakeSocket(connected = true): Socket {
+    return { connected, data: {} } as unknown as Socket;
+}
+
+describe("waitForLocalTuiSocket", () => {
+    afterEach(() => {
+        localTuiSockets.clear();
+    });
+
+    test("resolves true immediately when the socket is already connected", async () => {
+        localTuiSockets.set("s1", fakeSocket());
+        expect(await waitForLocalTuiSocket("s1", 1000)).toBe(true);
+    });
+
+    test("resolves false after timeout when no socket registers", async () => {
+        const start = Date.now();
+        expect(await waitForLocalTuiSocket("missing", 30)).toBe(false);
+        expect(Date.now() - start).toBeGreaterThanOrEqual(25);
+    });
+
+    test("resolves true as soon as the socket registers", async () => {
+        const promise = waitForLocalTuiSocket("s2", 5000);
+        localTuiSockets.set("s2", fakeSocket());
+        notifyTuiSocketConnected("s2");
+        const start = Date.now();
+        expect(await promise).toBe(true);
+        // Event-driven: resolves well before the 5s timeout
+        expect(Date.now() - start).toBeLessThan(100);
+    });
+
+    test("multiple waiters for the same session all resolve", async () => {
+        const a = waitForLocalTuiSocket("s3", 5000);
+        const b = waitForLocalTuiSocket("s3", 5000);
+        localTuiSockets.set("s3", fakeSocket());
+        notifyTuiSocketConnected("s3");
+        expect(await Promise.all([a, b])).toEqual([true, true]);
+    });
+
+    test("does not treat a disconnected socket as ready", async () => {
+        localTuiSockets.set("s4", fakeSocket(false));
+        expect(await waitForLocalTuiSocket("s4", 30)).toBe(false);
+    });
+});

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -104,6 +104,7 @@ import { clearSessionSubscriptions } from "../../sessions/trigger-subscription-s
 import { pushTriggerHistory } from "../../sessions/trigger-store.js";
 
 export { markPendingRecovery, consumePendingRecovery, hasPendingRecovery, _resetPendingRecoveriesForTesting } from "./viewer-recovery.js";
+import { waitForTuiSocket, notifyTuiSocketConnected } from "./tui-socket-waiters.js";
 
 const log = createLogger("sio-registry");
 const lastRelaySessionStateWriteTimes = new Map<string, number>();
@@ -460,44 +461,13 @@ export function getLocalTuiSocket(sessionId: string): Socket | undefined {
     return localTuiSockets.get(sessionId);
 }
 
-// ── TUI-socket connect waiters ───────────────────────────────────────────────
-// Event-driven replacement for 200ms polling loops that wait for a freshly
-// spawned session's TUI socket to register.
-
-const tuiSocketWaiters = new Map<string, Set<() => void>>();
-
-/** Resolve any waiters for a session whose TUI socket just registered. */
-export function notifyTuiSocketConnected(sessionId: string): void {
-    const waiters = tuiSocketWaiters.get(sessionId);
-    if (!waiters) return;
-    tuiSocketWaiters.delete(sessionId);
-    for (const resolve of waiters) resolve();
-}
-
 /**
  * Resolve true as soon as the session's local TUI socket is connected,
  * or false after timeoutMs. Only observes sockets on this server node.
+ * Event-driven replacement for 200ms polling loops.
  */
 export function waitForLocalTuiSocket(sessionId: string, timeoutMs: number): Promise<boolean> {
-    if (localTuiSockets.get(sessionId)?.connected) return Promise.resolve(true);
-    return new Promise((resolve) => {
-        let waiters = tuiSocketWaiters.get(sessionId);
-        if (!waiters) {
-            waiters = new Set();
-            tuiSocketWaiters.set(sessionId, waiters);
-        }
-        const onConnect = (): void => {
-            clearTimeout(timer);
-            resolve(true);
-        };
-        const timer = setTimeout(() => {
-            const set = tuiSocketWaiters.get(sessionId);
-            set?.delete(onConnect);
-            if (set && set.size === 0) tuiSocketWaiters.delete(sessionId);
-            resolve(false);
-        }, timeoutMs);
-        waiters.add(onConnect);
-    });
+    return waitForTuiSocket(sessionId, timeoutMs, (id) => localTuiSockets.get(id));
 }
 
 /**

--- a/packages/server/src/ws/sio-registry/sessions.ts
+++ b/packages/server/src/ws/sio-registry/sessions.ts
@@ -407,6 +407,7 @@ export async function registerTuiSession(
 
     // Store local socket reference
     localTuiSockets.set(sessionId, socket);
+    notifyTuiSocketConnected(sessionId);
 
     // Join relay session room
     await socket.join(relaySessionRoom(sessionId));
@@ -457,6 +458,46 @@ export async function registerTuiSession(
  */
 export function getLocalTuiSocket(sessionId: string): Socket | undefined {
     return localTuiSockets.get(sessionId);
+}
+
+// ── TUI-socket connect waiters ───────────────────────────────────────────────
+// Event-driven replacement for 200ms polling loops that wait for a freshly
+// spawned session's TUI socket to register.
+
+const tuiSocketWaiters = new Map<string, Set<() => void>>();
+
+/** Resolve any waiters for a session whose TUI socket just registered. */
+export function notifyTuiSocketConnected(sessionId: string): void {
+    const waiters = tuiSocketWaiters.get(sessionId);
+    if (!waiters) return;
+    tuiSocketWaiters.delete(sessionId);
+    for (const resolve of waiters) resolve();
+}
+
+/**
+ * Resolve true as soon as the session's local TUI socket is connected,
+ * or false after timeoutMs. Only observes sockets on this server node.
+ */
+export function waitForLocalTuiSocket(sessionId: string, timeoutMs: number): Promise<boolean> {
+    if (localTuiSockets.get(sessionId)?.connected) return Promise.resolve(true);
+    return new Promise((resolve) => {
+        let waiters = tuiSocketWaiters.get(sessionId);
+        if (!waiters) {
+            waiters = new Set();
+            tuiSocketWaiters.set(sessionId, waiters);
+        }
+        const onConnect = (): void => {
+            clearTimeout(timer);
+            resolve(true);
+        };
+        const timer = setTimeout(() => {
+            const set = tuiSocketWaiters.get(sessionId);
+            set?.delete(onConnect);
+            if (set && set.size === 0) tuiSocketWaiters.delete(sessionId);
+            resolve(false);
+        }, timeoutMs);
+        waiters.add(onConnect);
+    });
 }
 
 /**

--- a/packages/server/src/ws/sio-registry/tui-socket-waiters.ts
+++ b/packages/server/src/ws/sio-registry/tui-socket-waiters.ts
@@ -1,0 +1,56 @@
+// ============================================================================
+// tui-socket-waiters.ts — event-driven waiters for TUI socket registration
+//
+// Event-driven replacement for 200ms polling loops that wait for a freshly
+// spawned session's TUI socket to register. Zero-dependency module (pure Map
+// operations) so tests can import it directly without mocking.
+// ============================================================================
+
+interface SocketLike {
+    connected: boolean;
+}
+
+const tuiSocketWaiters = new Map<string, Set<() => void>>();
+
+/** Resolve any waiters for a session whose TUI socket just registered. */
+export function notifyTuiSocketConnected(sessionId: string): void {
+    const waiters = tuiSocketWaiters.get(sessionId);
+    if (!waiters) return;
+    tuiSocketWaiters.delete(sessionId);
+    for (const resolve of waiters) resolve();
+}
+
+/**
+ * Resolve true as soon as the session's TUI socket is connected (per
+ * `getSocket`), or false after timeoutMs.
+ */
+export function waitForTuiSocket(
+    sessionId: string,
+    timeoutMs: number,
+    getSocket: (sessionId: string) => SocketLike | undefined,
+): Promise<boolean> {
+    if (getSocket(sessionId)?.connected) return Promise.resolve(true);
+    return new Promise((resolve) => {
+        let waiters = tuiSocketWaiters.get(sessionId);
+        if (!waiters) {
+            waiters = new Set();
+            tuiSocketWaiters.set(sessionId, waiters);
+        }
+        const onConnect = (): void => {
+            clearTimeout(timer);
+            resolve(true);
+        };
+        const timer = setTimeout(() => {
+            const set = tuiSocketWaiters.get(sessionId);
+            set?.delete(onConnect);
+            if (set && set.size === 0) tuiSocketWaiters.delete(sessionId);
+            resolve(false);
+        }, timeoutMs);
+        waiters.add(onConnect);
+    });
+}
+
+/** Clear all waiters. For test isolation only. */
+export function _resetTuiSocketWaitersForTesting(): void {
+    tuiSocketWaiters.clear();
+}

--- a/packages/server/src/ws/sio-registry/viewer-recovery.ts
+++ b/packages/server/src/ws/sio-registry/viewer-recovery.ts
@@ -5,37 +5,66 @@
 // session_active snapshot, the follow-up event is recovery data rather than
 // new agent activity. These helpers track that one-shot condition so the event
 // pipeline can skip redundant SQLite writes.
+//
+// Each pending recovery carries a nonce that is sent to the runner in the
+// "connected" payload and echoed back on the recovery session_active. Only a
+// session_active carrying the matching nonce consumes the flag — a real
+// (non-recovery) session_active racing in first must NOT consume it, or a
+// genuine state update would skip SQLite persistence and could be lost on
+// crash. Runners that don't echo the nonce simply never match; the flag
+// expires via TTL and their recovery snapshots get persisted (harmless
+// extra write).
 // ============================================================================
 
-const pendingRecoveryTimestamps = new Map<string, number>();
+import { randomUUID } from "node:crypto";
+
+interface PendingRecovery {
+    nonce: string;
+    ts: number;
+}
+
+const pendingRecoveries = new Map<string, PendingRecovery>();
 const RECOVERY_FLAG_TTL_MS = 60_000;
 
 function sweepStalePendingRecoveries(): void {
     const now = Date.now();
-    for (const [sessionId, ts] of pendingRecoveryTimestamps) {
-        if (now - ts > RECOVERY_FLAG_TTL_MS) {
-            pendingRecoveryTimestamps.delete(sessionId);
+    for (const [sessionId, entry] of pendingRecoveries) {
+        if (now - entry.ts > RECOVERY_FLAG_TTL_MS) {
+            pendingRecoveries.delete(sessionId);
         }
     }
 }
 
-/** Mark a session as expecting a recovery-origin session_active. */
-export function markPendingRecovery(sessionId: string): void {
+/**
+ * Mark a session as expecting a recovery-origin session_active.
+ * Returns the nonce to include in the runner "connected" payload.
+ */
+export function markPendingRecovery(sessionId: string): string {
     sweepStalePendingRecoveries();
-    pendingRecoveryTimestamps.set(sessionId, Date.now());
+    const nonce = randomUUID();
+    pendingRecoveries.set(sessionId, { nonce, ts: Date.now() });
+    return nonce;
 }
 
 /**
  * Check and consume the recovery flag for a session.
- * Returns true (and removes the flag) if the session had a non-stale pending recovery.
- * Stale entries (older than RECOVERY_FLAG_TTL_MS) are evicted and treated as absent,
- * so a missed recovery snapshot never permanently marks a session as recovering.
+ * Only consumes (and returns true) when the session_active echoed the
+ * matching recovery nonce — events without a nonce (real agent updates,
+ * or runners that predate nonce echoing) never match.
+ * Stale entries (older than RECOVERY_FLAG_TTL_MS) are evicted and treated
+ * as absent, so a missed recovery snapshot never permanently marks a
+ * session as recovering.
  */
-export function consumePendingRecovery(sessionId: string): boolean {
-    const ts = pendingRecoveryTimestamps.get(sessionId);
-    if (ts === undefined) return false;
-    pendingRecoveryTimestamps.delete(sessionId);
-    return Date.now() - ts <= RECOVERY_FLAG_TTL_MS;
+export function consumePendingRecovery(sessionId: string, nonce: string | undefined): boolean {
+    const entry = pendingRecoveries.get(sessionId);
+    if (entry === undefined) return false;
+    if (Date.now() - entry.ts > RECOVERY_FLAG_TTL_MS) {
+        pendingRecoveries.delete(sessionId);
+        return false;
+    }
+    if (nonce === undefined || nonce !== entry.nonce) return false;
+    pendingRecoveries.delete(sessionId);
+    return true;
 }
 
 /**
@@ -43,10 +72,10 @@ export function consumePendingRecovery(sessionId: string): boolean {
  * Evicts the entry if it is stale (older than RECOVERY_FLAG_TTL_MS).
  */
 export function hasPendingRecovery(sessionId: string): boolean {
-    const ts = pendingRecoveryTimestamps.get(sessionId);
-    if (ts === undefined) return false;
-    if (Date.now() - ts > RECOVERY_FLAG_TTL_MS) {
-        pendingRecoveryTimestamps.delete(sessionId);
+    const entry = pendingRecoveries.get(sessionId);
+    if (entry === undefined) return false;
+    if (Date.now() - entry.ts > RECOVERY_FLAG_TTL_MS) {
+        pendingRecoveries.delete(sessionId);
         return false;
     }
     return true;
@@ -54,5 +83,5 @@ export function hasPendingRecovery(sessionId: string): boolean {
 
 /** Clear all pending recovery flags. For test isolation only. */
 export function _resetPendingRecoveriesForTesting(): void {
-    pendingRecoveryTimestamps.clear();
+    pendingRecoveries.clear();
 }

--- a/packages/tunnel/src/client.test.ts
+++ b/packages/tunnel/src/client.test.ts
@@ -246,6 +246,43 @@ describe("TunnelClient", () => {
     }
   });
 
+  test("preserves multiple Set-Cookie headers as an array instead of joining them", async () => {
+    const { server, port } = await startHttpServer((_req, res) => {
+      res.setHeader("set-cookie", [
+        "a=1; Path=/; Expires=Wed, 21 Oct 2026 07:28:00 GMT",
+        "b=2; Path=/; HttpOnly",
+      ]);
+      res.writeHead(200);
+      res.end("ok");
+    });
+
+    try {
+      const client = new TunnelClient({
+        runnerId: "r1",
+        apiKey: "key1",
+        relayUrl: "ws://localhost:9999/_tunnel",
+        autoReconnect: false,
+      });
+      client.exposePort(port);
+      const sent = attachMockRelay(client);
+
+      (client as any).handleMessage(
+        JSON.stringify({ type: "request-start", id: "req-cookie", port, method: "GET", url: "/", headers: {} }),
+      );
+      (client as any).handleMessage(JSON.stringify({ type: "request-data-end", id: "req-cookie" }));
+
+      await waitUntil(() => decodeSent(sent).some((message) => message.type === "response-data-end"));
+
+      const start = decodeSent(sent).find((message) => message.type === "response-start");
+      expect(start.headers["set-cookie"]).toEqual([
+        "a=1; Path=/; Expires=Wed, 21 Oct 2026 07:28:00 GMT",
+        "b=2; Path=/; HttpOnly",
+      ]);
+    } finally {
+      await stopHttpServer(server);
+    }
+  });
+
   test("request-start plus request-data chunks proxy POST bodies to the local service", async () => {
     let receivedBody = "";
 

--- a/packages/tunnel/src/client.ts
+++ b/packages/tunnel/src/client.ts
@@ -341,12 +341,14 @@ export class TunnelClient extends EventEmitter {
         signal: controller.signal,
       },
       (response) => {
-        const responseHeaders: Record<string, string> = {};
+        const responseHeaders: Record<string, string | string[]> = {};
         for (const [key, value] of Object.entries(response.headers)) {
           if (value === undefined) continue;
           const lowerKey = key.toLowerCase();
           if (HOP_BY_HOP.has(lowerKey)) continue;
-          responseHeaders[key] = Array.isArray(value) ? value.join(", ") : value;
+          // Preserve arrays — joining multi-value headers with ", " breaks
+          // Set-Cookie (cookie values legally contain commas in Expires).
+          responseHeaders[key] = value;
         }
 
         this.send({

--- a/packages/tunnel/src/server.ts
+++ b/packages/tunnel/src/server.ts
@@ -48,7 +48,7 @@ export interface PendingProxyRequest {
   id: string;
   runnerId: string;
   port: number;
-  onResponseStart: (statusCode: number, statusMessage: string, headers: Record<string, string>) => void;
+  onResponseStart: (statusCode: number, statusMessage: string, headers: Record<string, string | string[]>) => void;
   onResponseData: (data: Buffer) => void;
   onResponseEnd: () => void;
   onError: (error: string) => void;
@@ -131,7 +131,7 @@ export class TunnelRelay {
       headers: Record<string, string>;
     },
     callbacks: {
-      onResponseStart: (statusCode: number, statusMessage: string, headers: Record<string, string>) => void;
+      onResponseStart: (statusCode: number, statusMessage: string, headers: Record<string, string | string[]>) => void;
       onResponseData: (data: Buffer) => void;
       onResponseEnd: () => void;
       onError: (error: string) => void;

--- a/packages/tunnel/src/types.ts
+++ b/packages/tunnel/src/types.ts
@@ -56,7 +56,8 @@ export interface TunnelResponseStartMessage {
   id: string;
   statusCode: number;
   statusMessage: string;
-  headers: Record<string, string>;
+  /** Array values preserve multi-value headers (e.g. multiple Set-Cookie). */
+  headers: Record<string, string | string[]>;
 }
 
 export interface TunnelResponseDataMessage {


### PR DESCRIPTION
## Summary<br />- **Set-Cookie fix (P1)**: the tunnel client collapsed multi-value response headers with `join(', ')`, corrupting multiple `Set-Cookie` headers (commas are legal inside cookie `Expires` attributes). The tunnel protocol now carries `string | string[]` and the relay appends array values individually. Old-runner/new-relay and new-runner/old-relay both degrade to prior behavior.<br />- **Event-driven socket wait**: trigger auto-spawn delivery polled every 200ms for the spawned session's TUI socket. Now `waitForLocalTuiSocket` resolves the moment the socket registers.<br /><br />## Testing<br />- New regression test: multiple Set-Cookie headers preserved as array end-to-end through the tunnel client<br />- New unit tests for `waitForLocalTuiSocket` (immediate, timeout, event-resolve, multi-waiter, disconnected socket)<br />- `bun run typecheck` clean, tunnel + server tunnel tests pass (82/82)<br /><br />Fixes Godmother `eoNveZSx`, `mUBzboX3`