### PR TITLE
fix(cli): surface extension-registered providers in Web UI model selectors

### DIFF
--- a/packages/cli/src/extensions/remote/relay-context-factory.test.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.test.ts
@@ -1,6 +1,10 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { createRelayContext } from "./relay-context-factory.js";
 import { createTriggerWaitManager } from "../trigger-wait-manager.js";
+import { readSessionModelsCache, resetSessionModelsCacheMemo } from "../../session-models-cache.js";
 
 function createSocketMock() {
     const listeners = new Map<string, Array<(data?: any) => void>>();
@@ -28,6 +32,41 @@ function createSocketMock() {
         },
     };
 }
+
+describe("getConfiguredModels session snapshot", () => {
+    let tempHome: string;
+    let originalHome: string | undefined;
+
+    beforeEach(() => {
+        originalHome = process.env.HOME;
+        tempHome = mkdtempSync(join(tmpdir(), "pizzapi-relay-models-"));
+        process.env.HOME = tempHome;
+        resetSessionModelsCacheMemo();
+    });
+
+    afterEach(() => {
+        process.env.HOME = originalHome;
+        rmSync(tempHome, { recursive: true, force: true });
+    });
+
+    test("writes the live model list (incl. extension-registered providers) to the cache", () => {
+        const rctx = createRelayContext({}, createTriggerWaitManager(), { lastBroadcastSessionName: null });
+        rctx.latestCtx = {
+            modelRegistry: {
+                getAvailable: () => [
+                    { provider: "claude-subscription", id: "claude-sonnet-5", name: "Claude Sonnet 5", reasoning: true, contextWindow: 200000 },
+                ],
+                hasConfiguredAuth: () => false,
+            },
+        } as any;
+
+        const models = rctx.getConfiguredModels();
+        expect(models).toHaveLength(1);
+        expect(readSessionModelsCache()).toEqual([
+            { provider: "claude-subscription", id: "claude-sonnet-5", name: "Claude Sonnet 5", reasoning: true, contextWindow: 200000 },
+        ]);
+    });
+});
 
 describe("createRelayContext child trigger delivery", () => {
     test("emitTriggerWithAck emits a child ask_user_question trigger and waits for relay ack", async () => {

--- a/packages/cli/src/extensions/remote/relay-context-factory.ts
+++ b/packages/cli/src/extensions/remote/relay-context-factory.ts
@@ -24,6 +24,7 @@ import type { TriggerWaitManager } from "../trigger-wait-manager.js";
 import { emitSessionActive } from "./chunked-delivery.js";
 import { emitSessionTriggerWithAck } from "./session-complete-delivery.js";
 import { fetchOllamaCloudModels, getCachedOllamaCloudModels } from "../../ollama-cloud-models.js";
+import { writeSessionModelsCache } from "../../session-models-cache.js";
 
 const RELAY_DEFAULT = "ws://localhost:7492";
 const RELAY_STATUS_KEY = "relay";
@@ -231,10 +232,15 @@ export function createRelayContext(
                 ...staticModels,
                 ...liveOllama.filter((m) => !seen.has(`${m.provider}:${m.id}`)),
             ];
-            return all.sort((a, b) => {
+            const sorted = all.sort((a, b) => {
                 if (a.provider !== b.provider) return a.provider.localeCompare(b.provider);
                 return a.id.localeCompare(b.id);
             });
+            // Snapshot the live model list (includes extension-registered providers,
+            // e.g. pi packages calling registerProvider) so the daemon's model
+            // listing — which only sees disk state — can surface them too.
+            writeSessionModelsCache(sorted);
+            return sorted;
         },
 
         getCurrentSessionName(): string | null {

--- a/packages/cli/src/models-command.ts
+++ b/packages/cli/src/models-command.ts
@@ -12,6 +12,7 @@ import { c } from "./cli-colors.js";
 import { defaultAgentDir, expandHome, loadConfig } from "./config.js";
 import { createLogger } from "@pizzapi/tools";
 import { fetchOllamaCloudModels, type OllamaCloudModel } from "./ollama-cloud-models.js";
+import { mergeModelLists, readSessionModelsCache } from "./session-models-cache.js";
 
 const log = createLogger("models");
 
@@ -54,15 +55,12 @@ export async function runModelsCommand(args: string[], cwd: string): Promise<num
         }
     }
 
-    // Deduplicate: static registry wins for any provider+id conflict.
-    const seen = new Set(staticEntries.map((m) => `${m.provider}:${m.id}`));
-    const allEntries = [
-        ...staticEntries,
-        ...ollamaEntries.filter((m) => !seen.has(`${m.provider}:${m.id}`)),
-    ].sort((a, b) => {
-        if (a.provider !== b.provider) return a.provider.localeCompare(b.provider);
-        return a.id.localeCompare(b.id);
-    });
+    // Deduplicate: static registry wins, then live Ollama, then the last live
+    // session's snapshot (extension-registered providers like claude-subscription).
+    const allEntries = mergeModelLists(
+        mergeModelLists(staticEntries, ollamaEntries),
+        readSessionModelsCache() ?? [],
+    );
 
     if (showJson) {
         log.info(JSON.stringify({ models: allEntries }, null, 2));

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -10,6 +10,7 @@ import { FileExplorerService } from "./services/file-explorer-service.js";
 import { GitService } from "./services/git-service.js";
 // Resolves @VARIABLE@ tokens used in service panel requires
 import { resolvePizzaPiVar } from "../config/io.js";
+import { mergeModelLists, readSessionModelsCache } from "../session-models-cache.js";
 import { TunnelService } from "./services/tunnel-service.js";
 import { TimeService, TIME_TRIGGER_DEFS, TIME_SIGIL_DEFS } from "./services/time-service.js";
 import { discoverServices } from "./service-loader.js";
@@ -446,7 +447,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             const agentDir = resolveConfiguredAgentDir(cwd);
             const authStorage = AuthStorage.create(join(agentDir, "auth.json"));
             const modelRegistry = ModelRegistry.create(authStorage, join(agentDir, "models.json"));
-            return modelRegistry
+            const diskModels = modelRegistry
                 .getAvailable()
                 .map((model: any) => ({
                     provider: model.provider,
@@ -454,11 +455,11 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     name: model.name,
                     reasoning: model.reasoning,
                     contextWindow: model.contextWindow,
-                }))
-                .sort((a: any, b: any) => {
-                    if (a.provider !== b.provider) return a.provider.localeCompare(b.provider);
-                    return a.id.localeCompare(b.id);
-                });
+                }));
+            // Extension-registered providers (pi packages calling registerProvider)
+            // only exist inside live sessions — merge the latest session snapshot so
+            // Web UI model selectors (Runner Settings, Fast Model) show them too.
+            return mergeModelLists(diskModels, readSessionModelsCache() ?? []);
         };
         const getContextWindowsForAnalysis = (cwd = process.cwd()): Map<string, number> => {
             const windows = new Map<string, number>();

--- a/packages/cli/src/session-models-cache.test.ts
+++ b/packages/cli/src/session-models-cache.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+    mergeModelLists,
+    readSessionModelsCache,
+    resetSessionModelsCacheMemo,
+    writeSessionModelsCache,
+    type SessionModelEntry,
+} from "./session-models-cache.js";
+
+const model = (provider: string, id: string, extra: Partial<SessionModelEntry> = {}): SessionModelEntry => ({
+    provider,
+    id,
+    name: id,
+    reasoning: false,
+    contextWindow: 100000,
+    ...extra,
+});
+
+let tempHome: string;
+let originalHome: string | undefined;
+
+beforeEach(() => {
+    originalHome = process.env.HOME;
+    tempHome = mkdtempSync(join(tmpdir(), "pizzapi-models-cache-"));
+    process.env.HOME = tempHome;
+    resetSessionModelsCacheMemo();
+});
+
+afterEach(() => {
+    process.env.HOME = originalHome;
+    rmSync(tempHome, { recursive: true, force: true });
+});
+
+describe("session models cache", () => {
+    test("write/read roundtrip", () => {
+        const models = [model("claude-subscription", "claude-sonnet-5"), model("openrouter", "gpt-6")];
+        writeSessionModelsCache(models);
+        expect(readSessionModelsCache()).toEqual(models);
+    });
+
+    test("returns null when cache file is missing", () => {
+        expect(readSessionModelsCache()).toBeNull();
+    });
+
+    test("returns null for corrupt or malformed cache", () => {
+        const dir = join(tempHome, ".pizzapi");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(join(dir, "session-models-cache.json"), "not json");
+        expect(readSessionModelsCache()).toBeNull();
+
+        writeFileSync(join(dir, "session-models-cache.json"), JSON.stringify({ models: "nope", fetchedAt: Date.now() }));
+        expect(readSessionModelsCache()).toBeNull();
+    });
+
+    test("returns null for stale cache", () => {
+        const dir = join(tempHome, ".pizzapi");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "session-models-cache.json"),
+            JSON.stringify({ models: [model("p", "m")], fetchedAt: Date.now() - 8 * 24 * 60 * 60 * 1000 }),
+        );
+        expect(readSessionModelsCache()).toBeNull();
+    });
+
+    test("filters invalid entries", () => {
+        const dir = join(tempHome, ".pizzapi");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "session-models-cache.json"),
+            JSON.stringify({ models: [model("p", "m"), { provider: "x" }], fetchedAt: Date.now() }),
+        );
+        expect(readSessionModelsCache()).toEqual([model("p", "m")]);
+    });
+
+    test("skips writes for empty and unchanged lists", () => {
+        writeSessionModelsCache([]);
+        expect(readSessionModelsCache()).toBeNull();
+
+        const models = [model("p", "m")];
+        writeSessionModelsCache(models);
+        const path = join(tempHome, ".pizzapi", "session-models-cache.json");
+        const first = readFileSync(path, "utf-8");
+        writeSessionModelsCache(models); // unchanged — should not rewrite
+        expect(readFileSync(path, "utf-8")).toBe(first);
+    });
+});
+
+describe("mergeModelLists", () => {
+    test("preferred wins conflicts, extras appended, sorted by provider then id", () => {
+        const preferred = [model("anthropic", "opus", { contextWindow: 200000 })];
+        const extra = [
+            model("anthropic", "opus", { contextWindow: 1 }),
+            model("claude-subscription", "sonnet"),
+            model("anthropic", "haiku"),
+        ];
+        const merged = mergeModelLists(preferred, extra);
+        expect(merged.map((m) => `${m.provider}:${m.id}`)).toEqual([
+            "anthropic:haiku",
+            "anthropic:opus",
+            "claude-subscription:sonnet",
+        ]);
+        expect(merged.find((m) => m.id === "opus")?.contextWindow).toBe(200000);
+    });
+
+    test("handles empty inputs", () => {
+        expect(mergeModelLists([], [])).toEqual([]);
+        expect(mergeModelLists([], [model("p", "m")])).toEqual([model("p", "m")]);
+        expect(mergeModelLists([model("p", "m")], [])).toEqual([model("p", "m")]);
+    });
+});

--- a/packages/cli/src/session-models-cache.ts
+++ b/packages/cli/src/session-models-cache.ts
@@ -1,0 +1,95 @@
+/**
+ * Session models cache — bridges extension-registered providers to the daemon.
+ *
+ * Pi package extensions (e.g. minimalcc-pi's claude-subscription provider) register
+ * custom providers at session runtime via pi.registerProvider(). Those providers only
+ * exist inside a live session's ModelRegistry — the daemon builds its registry from
+ * disk (auth.json + models.json) and never sees them, so Web UI model selectors fed
+ * by /api/runners/:id/models (Runner Settings → Models / Fast Model) miss them.
+ *
+ * Fix: the remote extension snapshots the live session's model list to this cache;
+ * the daemon and `pizza models` merge it into their disk-registry list.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+// ponytail: 7-day TTL — stale entries only linger if a package is uninstalled and no
+// session starts afterward; every new session overwrites the snapshot.
+const CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+
+export interface SessionModelEntry {
+    provider: string;
+    id: string;
+    name: string;
+    reasoning: boolean;
+    contextWindow: number;
+}
+
+function cachePath(): string {
+    // Same convention as ollama-cloud-models cache: HOME env first so tests can redirect.
+    return join(process.env.HOME || homedir(), ".pizzapi", "session-models-cache.json");
+}
+
+function isEntry(value: unknown): value is SessionModelEntry {
+    if (typeof value !== "object" || value === null) return false;
+    const m = value as Record<string, unknown>;
+    return (
+        typeof m.provider === "string" &&
+        typeof m.id === "string" &&
+        typeof m.name === "string" &&
+        typeof m.reasoning === "boolean" &&
+        typeof m.contextWindow === "number"
+    );
+}
+
+/** Read the cached session model snapshot. Returns null if missing, corrupt, or stale. */
+export function readSessionModelsCache(): SessionModelEntry[] | null {
+    const path = cachePath();
+    if (!existsSync(path)) return null;
+    try {
+        const raw = JSON.parse(readFileSync(path, "utf-8"));
+        if (
+            typeof raw !== "object" || raw === null ||
+            !Array.isArray(raw.models) || typeof raw.fetchedAt !== "number"
+        ) return null;
+        if (Date.now() - raw.fetchedAt >= CACHE_TTL_MS) return null;
+        return raw.models.filter(isEntry);
+    } catch {
+        return null;
+    }
+}
+
+let lastWritten: string | null = null;
+
+/** Snapshot the live session's model list. No-ops when the list is unchanged. */
+export function writeSessionModelsCache(models: SessionModelEntry[]): void {
+    if (models.length === 0) return;
+    const serialized = JSON.stringify(models);
+    if (serialized === lastWritten) return;
+    try {
+        const dir = join(process.env.HOME || homedir(), ".pizzapi");
+        if (!existsSync(dir)) mkdirSync(dir, { recursive: true, mode: 0o700 });
+        writeFileSync(cachePath(), JSON.stringify({ models, fetchedAt: Date.now() }), { mode: 0o600 });
+        lastWritten = serialized;
+    } catch {
+        // Best-effort cache — never break the session over it.
+    }
+}
+
+/** Test hook: reset the write-dedupe memo. */
+export function resetSessionModelsCacheMemo(): void {
+    lastWritten = null;
+}
+
+/**
+ * Union two model lists keyed by provider:id. Entries in `preferred` win conflicts.
+ * Result is sorted by provider, then id.
+ */
+export function mergeModelLists<T extends SessionModelEntry>(preferred: T[], extra: T[]): T[] {
+    const seen = new Set(preferred.map((m) => `${m.provider}:${m.id}`));
+    return [...preferred, ...extra.filter((m) => !seen.has(`${m.provider}:${m.id}`))].sort((a, b) => {
+        if (a.provider !== b.provider) return a.provider.localeCompare(b.provider);
+        return a.id.localeCompare(b.id);
+    });
+}


### PR DESCRIPTION
Pi package extensions (e.g. minimalcc-pi's `claude-subscription`) register custom providers at session runtime via `pi.registerProvider()`. The daemon builds its ModelRegistry from disk and never loads extensions, so the Runner Settings model selectors (`/api/runners/:id/models` → Default Model, Fast Model) missed those providers entirely — including the user's active default provider.<br /><br /><b>Fix</b><br />- The remote extension now snapshots the live session's model list (which includes extension-registered providers) to `~/.pizzapi/session-models-cache.json` whenever it builds capabilities.<br />- The daemon's `listConfiguredModels` and `pizza models` merge that snapshot into the disk-registry list (disk wins conflicts, 7-day TTL, overwritten on every session).<br /><br /><b>Tests</b><br />- New `session-models-cache.test.ts`: roundtrip, staleness, corruption, invalid entries, write dedupe, merge precedence.<br />- `relay-context-factory.test.ts`: asserts `getConfiguredModels()` writes the snapshot.