### PR TITLE
fix: apply settings default model for extension-registered providers

### DIFF
--- a/packages/cli/src/runner/apply-default-model.test.ts
+++ b/packages/cli/src/runner/apply-default-model.test.ts
@@ -1,0 +1,76 @@
+import { describe, test, expect } from "bun:test";
+import { applySettingsDefaultModel, type DefaultModelSession } from "./apply-default-model.js";
+
+function makeSession(overrides: Partial<{
+    current: { provider: string; id: string } | undefined;
+    defaultProvider: string | undefined;
+    defaultModel: string | undefined;
+    registryHas: boolean;
+    hasAuth: boolean;
+    messages: unknown[];
+}> = {}) {
+    const opts = {
+        current: { provider: "openai", id: "gpt-5.5" },
+        defaultProvider: "claude-subscription",
+        defaultModel: "claude-fable-5",
+        registryHas: true,
+        hasAuth: true,
+        messages: [],
+        ...overrides,
+    };
+    const setCalls: unknown[] = [];
+    const session: DefaultModelSession = {
+        model: opts.current,
+        settingsManager: {
+            getDefaultProvider: () => opts.defaultProvider,
+            getDefaultModel: () => opts.defaultModel,
+        },
+        modelRegistry: {
+            find: (p, m) => (opts.registryHas ? { provider: p, id: m } : undefined),
+            hasConfiguredAuth: () => opts.hasAuth,
+        },
+        agent: { state: { messages: opts.messages } },
+        setModel: async (m) => { setCalls.push(m); },
+    };
+    return { session, setCalls };
+}
+
+describe("applySettingsDefaultModel", () => {
+    test("switches to extension-registered default when it resolves post-load", async () => {
+        const { session, setCalls } = makeSession();
+        expect(await applySettingsDefaultModel(session)).toBe(true);
+        expect(setCalls).toEqual([{ provider: "claude-subscription", id: "claude-fable-5" }]);
+    });
+
+    test("no-op when current model already matches the default", async () => {
+        const { session, setCalls } = makeSession({
+            current: { provider: "claude-subscription", id: "claude-fable-5" },
+        });
+        expect(await applySettingsDefaultModel(session)).toBe(false);
+        expect(setCalls).toEqual([]);
+    });
+
+    test("no-op when no default is configured", async () => {
+        const { session, setCalls } = makeSession({ defaultProvider: undefined });
+        expect(await applySettingsDefaultModel(session)).toBe(false);
+        expect(setCalls).toEqual([]);
+    });
+
+    test("no-op when default still doesn't resolve in the registry", async () => {
+        const { session, setCalls } = makeSession({ registryHas: false });
+        expect(await applySettingsDefaultModel(session)).toBe(false);
+        expect(setCalls).toEqual([]);
+    });
+
+    test("no-op when default resolves but has no configured auth", async () => {
+        const { session, setCalls } = makeSession({ hasAuth: false });
+        expect(await applySettingsDefaultModel(session)).toBe(false);
+        expect(setCalls).toEqual([]);
+    });
+
+    test("no-op for sessions with restored messages (resume keeps its model)", async () => {
+        const { session, setCalls } = makeSession({ messages: [{ role: "user" }] });
+        expect(await applySettingsDefaultModel(session)).toBe(false);
+        expect(setCalls).toEqual([]);
+    });
+});

--- a/packages/cli/src/runner/apply-default-model.ts
+++ b/packages/cli/src/runner/apply-default-model.ts
@@ -1,0 +1,49 @@
+/**
+ * Re-apply the settings default model after extension providers registered.
+ *
+ * pi's createAgentSession resolves the initial model via findInitialModel
+ * BEFORE extension factories flush their pi.registerProvider() calls into the
+ * ModelRegistry (the flush happens later in the AgentSession constructor).
+ * So a settings.json default pointing at an extension-registered provider
+ * (e.g. minimalcc-pi's claude-subscription) never resolves and findInitialModel
+ * silently falls back to the first built-in provider default (openai/gpt-5.5).
+ *
+ * By the time createAgentSession returns, the registry is complete — so the
+ * worker calls this to re-resolve the default. Explicit spawn models
+ * (PIZZAPI_WORKER_INITIAL_MODEL_*) and resumed sessions set their own model
+ * later during bindExtensions session_start, so they still win over this.
+ */
+
+interface ModelRef {
+    provider: string;
+    id: string;
+}
+
+export interface DefaultModelSession {
+    model?: ModelRef;
+    settingsManager: {
+        getDefaultProvider(): string | undefined;
+        getDefaultModel(): string | undefined;
+    };
+    modelRegistry: {
+        find(provider: string, modelId: string): unknown;
+        hasConfiguredAuth(model: unknown): boolean;
+    };
+    agent: { state: { messages: unknown[] } };
+    setModel(model: unknown): Promise<void>;
+}
+
+/** Returns true when the session's model was switched to the settings default. */
+export async function applySettingsDefaultModel(session: DefaultModelSession): Promise<boolean> {
+    // A session with messages restored its own model — leave it alone.
+    if (session.agent.state.messages.length > 0) return false;
+    const provider = session.settingsManager.getDefaultProvider();
+    const modelId = session.settingsManager.getDefaultModel();
+    if (!provider || !modelId) return false;
+    const current = session.model;
+    if (current?.provider === provider && current?.id === modelId) return false;
+    const resolved = session.modelRegistry.find(provider, modelId);
+    if (!resolved || !session.modelRegistry.hasConfiguredAuth(resolved)) return false;
+    await session.setModel(resolved);
+    return true;
+}

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -7,6 +7,7 @@ import { getPluginSkillPaths } from "../extensions/claude-plugins.js";
 import { setRegisteredCommandsProvider } from "../extensions/command-introspection.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 import { createBootTimer } from "./boot-timing.js";
+import { applySettingsDefaultModel } from "./apply-default-model.js";
 import { setLogComponent, setLogSessionId, logInfo, logWarn, logError, logAuth } from "./logger.js";
 
 /**
@@ -393,6 +394,18 @@ async function main(): Promise<void> {
         resourceLoader: loader,
     });
     bootTimer.end("[boot] create-session");
+
+    // Re-resolve the settings default model now that extension-registered
+    // providers (e.g. minimalcc-pi's claude-subscription) are in the registry.
+    // Without this, a default pointing at such a provider silently falls back
+    // to a built-in provider default (openai/gpt-5.5). See apply-default-model.ts.
+    try {
+        if (await applySettingsDefaultModel(session as any)) {
+            logInfo(`applied settings default model ${session.model?.provider}/${session.model?.id} (provider registered by extension after initial resolution)`);
+        }
+    } catch (e) {
+        logWarn(`failed to apply settings default model: ${e instanceof Error ? e.message : String(e)}`);
+    }
 
     // Deliver ALL queued follow-up messages at once when a turn ends, instead
     // of pi's default one-at-a-time (which strands later follow-ups until the


### PR DESCRIPTION
## Problem

The Web UI **Default Model** setting (Runner Settings → Models) saves correctly to `~/.pizzapi/settings.json`, but new sessions ignored it when the default pointed at an extension-registered provider (e.g. minimalcc-pi's `claude-subscription`) — sessions started on `openai/gpt-5.5` instead.

## Root cause

pi's `createAgentSession` resolves the initial model via `findInitialModel` **before** extension factories flush their `pi.registerProvider()` calls into the ModelRegistry (the flush happens later in the AgentSession constructor via `_bindExtensionCore`). So `modelRegistry.find("claude-subscription", …)` failed at resolution time and `findInitialModel` fell back to the first built-in provider default: `openai/gpt-5.5`.

## Fix

`applySettingsDefaultModel()` — called in `worker.ts` right after `createAgentSession` returns, when the registry is complete. Re-resolves the settings default and switches to it. No-ops when:

- no default is configured
- the current model already matches
- the default still doesn't resolve or lacks configured auth
- the session restored messages (resume keeps its own model)

Explicit spawn models (`PIZZAPI_WORKER_INITIAL_MODEL_*`) and resumed sessions still win — they apply later during `bindExtensions` `session_start`.

## Testing

- 6 unit tests covering the switch + all no-op branches (`bun test` ✅)
- `tsc --noEmit` clean

Godmother: tb1tu097 (related: 9tG6kYuF made these providers visible in UI selectors; this makes them actually usable as defaults)