### PR TITLE
fix(goal): track and throttle /goal LLM evaluator API spend

### DIFF
--- a/packages/cli/src/config/types.ts
+++ b/packages/cli/src/config/types.ts
@@ -538,6 +538,12 @@ export interface PizzaPiConfig {
         evaluatorModel?: string;
         /** Maximum output tokens for the evaluator LLM call. Default: 512. */
         evaluatorMaxTokens?: number;
+        /**
+         * Default cadence (in turns) for the LLM evaluator across all goals
+         * that don't set `/goal --every`. 1 = every turn. Default: 3.
+         * Ignored by the keyword evaluator (free/local, always runs).
+         */
+        evaluateEveryNTurns?: number;
     };
 
     /** Extension provider configurations, keyed by provider ID. */

--- a/packages/cli/src/extensions/goal/evaluator.ts
+++ b/packages/cli/src/extensions/goal/evaluator.ts
@@ -24,6 +24,15 @@ import type {
 
 export const DEFAULT_EVALUATOR_MAX_TOKENS = 512;
 
+/**
+ * Default cadence (in turns) for the LLM evaluator when neither `/goal
+ * --every` nor `config.goal.evaluateEveryNTurns` is set. The judge call is a
+ * billed API request, so evaluating every turn is wasteful for multi-turn
+ * goals; every 3rd turn cuts that spend ~3x while still catching completion
+ * quickly (the first turn is always evaluated regardless of this rate).
+ */
+export const DEFAULT_EVALUATE_EVERY_N_TURNS = 3;
+
 function buildEvaluatorPrompt(state: GoalState, context: GoalEvaluationContext): string {
     const budgetParts: string[] = [];
     if (state.budget.maxTurns !== undefined) budgetParts.push(`turns ≤ ${state.budget.maxTurns}`);

--- a/packages/cli/src/extensions/goal/goal.integration.test.ts
+++ b/packages/cli/src/extensions/goal/goal.integration.test.ts
@@ -322,9 +322,13 @@ describe("/goal multi-turn integration", () => {
 
         goalExtension(pi);
 
-        // User sets a goal that uses the default LLM evaluator.
+        // User sets a goal that uses the default LLM evaluator. --every 1
+        // opts out of the default evaluator throttle (see goal.test.ts for
+        // dedicated throttling coverage) so this test can exercise the
+        // per-turn evaluate -> guidance -> re-evaluate flow across exactly
+        // the two turns below.
         const goalHandler = commands.get("goal")!;
-        await goalHandler('"services are green" --max-turns 5', ctx as ExtensionCommandContext);
+        await goalHandler('"services are green" --max-turns 5 --every 1', ctx as ExtensionCommandContext);
 
         expect(getGoal("goal-integration-session")?.condition.evaluator).toBe("llm");
         expect(messages.some((m) => m.content.includes("Goal set"))).toBe(true);

--- a/packages/cli/src/extensions/goal/goal.test.ts
+++ b/packages/cli/src/extensions/goal/goal.test.ts
@@ -142,6 +142,48 @@ describe("goal state", () => {
         expect(updated?.costSpend).toBe(0.001);
     });
 
+    test("recordEvaluation appends a goal_evaluator_usage entry when the LLM evaluator spends tokens/cost", () => {
+        resetSession("session-1");
+        makeGoal();
+        const entries: Array<{ customType: string; data: unknown }> = [];
+        const appendEntry = (customType: string, data: unknown) => entries.push({ customType, data });
+
+        recordEvaluation("session-1", {
+            turnIndex: 0,
+            verdict: "not_met",
+            reason: "still working",
+            tokensUsed: 42,
+            cost: 0.0007,
+            model: { provider: "anthropic", id: "claude-haiku" },
+            timestamp: Date.now(),
+        }, { appendEntry });
+
+        const usageEntries = entries.filter((e) => e.customType === "goal_evaluator_usage");
+        expect(usageEntries.length).toBe(1);
+        expect(usageEntries[0].data).toMatchObject({
+            provider: "anthropic",
+            model: "claude-haiku",
+            tokens: 42,
+            cost: 0.0007,
+        });
+    });
+
+    test("recordEvaluation skips the usage entry for the keyword evaluator (no cost/tokens)", () => {
+        resetSession("session-1");
+        makeGoal();
+        const entries: Array<{ customType: string; data: unknown }> = [];
+        const appendEntry = (customType: string, data: unknown) => entries.push({ customType, data });
+
+        recordEvaluation("session-1", {
+            turnIndex: 0,
+            verdict: "not_met",
+            reason: "no keyword match",
+            timestamp: Date.now(),
+        }, { appendEntry });
+
+        expect(entries.some((e) => e.customType === "goal_evaluator_usage")).toBe(false);
+    });
+
     test("keyword evaluator marks goal met", async () => {
         resetSession("session-1");
         makeGoal();

--- a/packages/cli/src/extensions/goal/goal.test.ts
+++ b/packages/cli/src/extensions/goal/goal.test.ts
@@ -105,6 +105,21 @@ describe("parseGoalArgs", () => {
     test("rejects keyword evaluator without keywords", () => {
         expect(() => parseGoalArgs("build passes --evaluator keyword")).toThrow("requires at least one --keyword");
     });
+
+    test("parses --every as the LLM evaluator cadence", () => {
+        const parsed = parseGoalArgs('"the tests pass" --every 5');
+        expect(parsed.condition.evaluateEveryNTurns).toBe(5);
+    });
+
+    test("rejects --every with a non-positive-integer value", () => {
+        expect(() => parseGoalArgs("the tests pass --every 0")).toThrow("positive integer");
+        expect(() => parseGoalArgs("the tests pass --every 1.5")).toThrow("positive integer");
+    });
+
+    test("leaves evaluateEveryNTurns undefined when --every is omitted", () => {
+        const parsed = parseGoalArgs("the tests pass");
+        expect(parsed.condition.evaluateEveryNTurns).toBeUndefined();
+    });
 });
 
 describe("goal state", () => {
@@ -886,6 +901,86 @@ describe("goalExtension event wiring", () => {
 
         expect(getPendingGuidance("session-1")).toContain("pass");
         expect(getPendingGuidance("session-1")).not.toContain("previous guidance");
+    });
+
+    test("throttles the LLM evaluator to every N turns while still looping and enforcing budgets", async () => {
+        resetSession("session-1");
+        const { pi, handlers, userMessages } = createFakePi();
+        const ctx = createFakeCtx();
+
+        goalExtension(pi);
+        setGoal(
+            "session-1",
+            { description: "the deploy succeeds", evaluator: "llm", evaluateEveryNTurns: 3 },
+            {},
+            pi,
+        );
+
+        const turnHandlers = handlers.get("turn_end") ?? [];
+        async function runTurn(text: string) {
+            for (const handler of turnHandlers) {
+                await handler({
+                    type: "turn_end",
+                    turnIndex: 1,
+                    message: makeAssistantMessage(text),
+                    toolResults: [],
+                } as TurnEndEvent, ctx);
+            }
+        }
+
+        // No configured evaluator model in the fake ctx, so every evaluation
+        // that does run resolves to "uncertain" (not "not_met") — this test
+        // only cares how many turns actually invoke the evaluator.
+        await runTurn("working on it"); // turn 1: always evaluated
+        expect(getGoal("session-1")?.evaluations.length).toBe(1);
+
+        await runTurn("still working"); // turn 2: throttled, skips evaluation
+        expect(getGoal("session-1")?.evaluations.length).toBe(1);
+        // The loop still continues even though the evaluator didn't run.
+        expect(userMessages.length).toBe(1);
+
+        await runTurn("still working"); // turn 3: 3 % 3 === 0, evaluates again
+        expect(getGoal("session-1")?.evaluations.length).toBe(2);
+
+        expect(getGoal("session-1")?.turnCount).toBe(3);
+        expect(getGoal("session-1")?.status).toBe("active");
+    });
+
+    test("throttled turns still stop the goal when a budget is exhausted", async () => {
+        resetSession("session-1");
+        const { pi, handlers, messages } = createFakePi();
+        const ctx = createFakeCtx();
+
+        goalExtension(pi);
+        setGoal(
+            "session-1",
+            { description: "the deploy succeeds", evaluator: "llm", evaluateEveryNTurns: 5 },
+            { maxTurns: 2 },
+            pi,
+        );
+
+        const turnHandlers = handlers.get("turn_end") ?? [];
+        for (const handler of turnHandlers) {
+            await handler({
+                type: "turn_end",
+                turnIndex: 1,
+                message: makeAssistantMessage("turn 1"),
+                toolResults: [],
+            } as TurnEndEvent, ctx);
+        }
+        // Turn 2 is throttled (rate 5) but still hits the maxTurns: 2 budget.
+        for (const handler of turnHandlers) {
+            await handler({
+                type: "turn_end",
+                turnIndex: 1,
+                message: makeAssistantMessage("turn 2"),
+                toolResults: [],
+            } as TurnEndEvent, ctx);
+        }
+
+        expect(getGoal("session-1")?.status).toBe("failed");
+        expect(getGoal("session-1")?.stopReason).toBe("max_turns");
+        expect(messages.some((m) => m.content.includes("budget reached"))).toBe(true);
     });
 
     test("before_agent_start injects pending guidance into system prompt without clearing it", async () => {

--- a/packages/cli/src/extensions/goal/index.ts
+++ b/packages/cli/src/extensions/goal/index.ts
@@ -52,6 +52,7 @@ import {
 import { parseGoalArgs } from "./parser.js";
 import {
     createLlmGoalEvaluator,
+    DEFAULT_EVALUATE_EVERY_N_TURNS,
     keywordGoalEvaluator,
     resolveEvaluatorModel,
 } from "./evaluator.js";
@@ -170,6 +171,42 @@ function buildEvaluationContext(
     };
 }
 
+/**
+ * How often (in turns) to invoke the LLM evaluator for this goal. The
+ * keyword evaluator is free/local and always runs every turn (rate 1).
+ * Resolution order: per-goal `--every` override, then
+ * `config.goal.evaluateEveryNTurns`, then the built-in default. Config load
+ * failures fall back to the default rather than surfacing an error here —
+ * evaluator-model resolution (below) is where config problems get reported.
+ */
+function resolveEvaluateRate(state: GoalState, ctx: ExtensionContext): number {
+    if (state.condition.evaluator === "keyword") return 1;
+    if (state.condition.evaluateEveryNTurns !== undefined) {
+        return Math.max(1, state.condition.evaluateEveryNTurns);
+    }
+    try {
+        const configured = loadConfig(ctx.cwd).goal?.evaluateEveryNTurns;
+        return configured !== undefined ? Math.max(1, configured) : DEFAULT_EVALUATE_EVERY_N_TURNS;
+    } catch {
+        return DEFAULT_EVALUATE_EVERY_N_TURNS;
+    }
+}
+
+function stopForBudget(
+    sessionId: string,
+    state: GoalState,
+    budgetReason: NonNullable<ReturnType<typeof checkBudget>>,
+    pi: Pick<ExtensionAPI, "appendEntry" | "sendMessage">,
+): void {
+    clearPendingGuidance(sessionId);
+    persist(state, pi);
+    pi.sendMessage({
+        customType: "goal_status",
+        content: `Goal budget reached: ${budgetReason}. The goal is now inactive; you may continue the session.`,
+        display: true,
+    });
+}
+
 async function runGoalStopCheck(
     event: TurnEndEvent,
     ctx: ExtensionContext,
@@ -180,7 +217,29 @@ async function runGoalStopCheck(
     if (!state || state.status !== "active") return;
 
     const usage = getAssistantUsage(event.message);
-    recordTurnSpend(sessionId, usage.tokens, usage.cost);
+    state = recordTurnSpend(sessionId, usage.tokens, usage.cost) ?? state;
+
+    // The LLM evaluator is a billed API call, so it's throttled to every
+    // `evaluateRate` turns instead of every turn. The first turn always
+    // evaluates so instantly-satisfied goals resolve right away; skipped
+    // turns still enforce budgets and keep the agent looping, they just
+    // don't spend a judge call.
+    const evaluateRate = resolveEvaluateRate(state, ctx);
+    if (state.turnCount > 1 && state.turnCount % evaluateRate !== 0) {
+        const budgetReason = checkBudget(state);
+        if (budgetReason) {
+            stopForBudget(sessionId, state, budgetReason, pi);
+            return;
+        }
+        const guidance = getPendingGuidance(sessionId);
+        pi.sendUserMessage(
+            guidance
+                ? `[Goal not met] ${guidance}\nContinue working toward the goal: ${state.condition.description}`
+                : `Work toward this goal until it is met: ${state.condition.description}`,
+            { deliverAs: "steer" },
+        );
+        return;
+    }
 
     const evalContext = buildEvaluationContext(state, event, ctx);
 
@@ -264,15 +323,9 @@ async function runGoalStopCheck(
     // budgeted turn reports "met" above instead of "budget reached".
     const budgetReason = checkBudget(state);
     if (budgetReason) {
-        clearPendingGuidance(sessionId);
-        persist(state, pi);
-        pi.sendMessage({
-            customType: "goal_status",
-            content: `Goal budget reached: ${budgetReason}. The goal is now inactive; you may continue the session.`,
-            display: true,
-        });
         // Do not shutdown the session; budget exhaustion only deactivates the
         // goal and lets the agent return control to the user naturally.
+        stopForBudget(sessionId, state, budgetReason, pi);
         return;
     }
 

--- a/packages/cli/src/extensions/goal/parser.ts
+++ b/packages/cli/src/extensions/goal/parser.ts
@@ -15,6 +15,7 @@ const KNOWN_FLAGS = new Set([
     "--max-cost",
     "--evaluator",
     "--keyword",
+    "--every",
 ]);
 
 function isFlag(token: string): boolean {
@@ -25,6 +26,14 @@ function parseNumber(value: string, label: string): number {
     const parsed = Number(value);
     if (!Number.isFinite(parsed) || parsed < 0) {
         throw new Error(`${label} must be a non-negative number, got "${value}"`);
+    }
+    return parsed;
+}
+
+function parsePositiveInt(value: string, label: string): number {
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < 1) {
+        throw new Error(`${label} must be a positive integer, got "${value}"`);
     }
     return parsed;
 }
@@ -76,6 +85,7 @@ export function parseGoalArgs(input: string): GoalCommandArgs {
     const budget: GoalBudget = {};
     const successKeywords: string[] = [];
     let evaluator: GoalEvaluatorKind = "llm";
+    let evaluateEveryNTurns: number | undefined;
     let conditionParts: string[] = [];
 
     let i = 0;
@@ -115,6 +125,12 @@ export function parseGoalArgs(input: string): GoalCommandArgs {
                 case "--keyword":
                     successKeywords.push(next);
                     break;
+                case "--every":
+                    // How often (in turns) to invoke the LLM evaluator. It's a
+                    // billed API call; --every N throttles it to cut cost.
+                    // No effect on the free/local keyword evaluator.
+                    evaluateEveryNTurns = parsePositiveInt(next, "--every");
+                    break;
             }
         } else {
             conditionParts.push(token);
@@ -138,6 +154,7 @@ export function parseGoalArgs(input: string): GoalCommandArgs {
         description: rawCondition,
         evaluator,
         successKeywords: successKeywords.length > 0 ? successKeywords : undefined,
+        evaluateEveryNTurns,
     };
 
     return { rawCondition, condition, budget, clear: false, statusOnly: false };

--- a/packages/cli/src/extensions/goal/state.ts
+++ b/packages/cli/src/extensions/goal/state.ts
@@ -19,6 +19,16 @@ import type {
 
 export const GOAL_STATE_CUSTOM_TYPE = "goal_state";
 
+/**
+ * Custom entry type for a single evaluator API call's cost/tokens. Written
+ * as a delta (not cumulative) so the usage scanner can sum it directly —
+ * unlike `goal_state`, which persists a running total and would double-count
+ * if summed across entries. The evaluator call is a real, separate API
+ * request (not part of the normal turn), so without this the /goal LLM
+ * evaluator's spend is invisible to the Usage dashboard.
+ */
+export const GOAL_EVALUATOR_USAGE_CUSTOM_TYPE = "goal_evaluator_usage";
+
 /** In-memory goal state keyed by session id. */
 const goalsBySessionId = new Map<string, GoalState>();
 
@@ -146,6 +156,16 @@ export function recordEvaluation(
     }
     if (feedback.cost) state.costSpend += Math.max(0, feedback.cost);
     if (feedback.tokensUsed) state.tokenSpend += feedback.tokensUsed;
+
+    if (feedback.cost || feedback.tokensUsed) {
+        pi.appendEntry(GOAL_EVALUATOR_USAGE_CUSTOM_TYPE, {
+            provider: feedback.model?.provider ?? "unknown",
+            model: feedback.model?.id ?? "unknown",
+            tokens: feedback.tokensUsed ?? 0,
+            cost: feedback.cost ?? 0,
+            timestamp: feedback.timestamp,
+        });
+    }
 
     if (feedback.verdict === "met" && state.status === "active") {
         markStopped(state, "goal_met");

--- a/packages/cli/src/extensions/goal/types.ts
+++ b/packages/cli/src/extensions/goal/types.ts
@@ -35,6 +35,14 @@ export interface GoalCondition {
      * assistant message or in tool results from the just-completed turn.
      */
     successKeywords?: string[];
+
+    /**
+     * How often (in turns) to invoke the LLM evaluator while the goal is
+     * active. 1 = every turn. Ignored by the keyword evaluator, which is
+     * free/local and always runs. Falls back to
+     * `config.goal.evaluateEveryNTurns`, then `DEFAULT_EVALUATE_EVERY_N_TURNS`.
+     */
+    evaluateEveryNTurns?: number;
 }
 
 /**

--- a/packages/cli/src/usage/scanner.test.ts
+++ b/packages/cli/src/usage/scanner.test.ts
@@ -184,6 +184,123 @@ describe("Scanner", () => {
     db.close();
   });
 
+  test("processFile includes /goal evaluator spend (goal_evaluator_usage custom entries) in usage totals", () => {
+    const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
+    const dbPath = join(tmpDir, "test.db");
+    const filePath = join(tmpDir, "session.jsonl");
+
+    const sessionHeader = {
+      type: "session",
+      version: 1,
+      id: "session-goal",
+      timestamp: "2026-03-23T12:00:00Z",
+      cwd: "/project/test",
+    } as const;
+
+    const usageMessage = {
+      type: "message",
+      id: "msg-001",
+      timestamp: "2026-03-23T12:05:00Z",
+      message: {
+        role: "assistant",
+        provider: "anthropic",
+        model: "claude-opus",
+        usage: {
+          input: 100,
+          output: 50,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 150,
+          cost: { total: 0.01, input: 0.006, output: 0.004, cacheRead: 0, cacheWrite: 0 },
+        },
+      },
+    };
+
+    // The /goal LLM evaluator makes a separate API call outside the normal
+    // turn pipeline; its spend is persisted as a goal_evaluator_usage custom
+    // entry (see extensions/goal/state.ts) rather than an assistant message.
+    const evaluatorUsage = {
+      type: "custom",
+      id: "entry-001",
+      customType: "goal_evaluator_usage",
+      timestamp: "2026-03-23T12:06:00Z",
+      data: {
+        provider: "anthropic",
+        model: "claude-haiku",
+        tokens: 60,
+        cost: 0.0002,
+        timestamp: new Date("2026-03-23T12:06:00Z").getTime(),
+      },
+    };
+
+    const content = `${JSON.stringify(sessionHeader)}\n${JSON.stringify(usageMessage)}\n${JSON.stringify(evaluatorUsage)}\n`;
+    writeFileSync(filePath, content);
+
+    const db = new Database(dbPath);
+    db.run("PRAGMA journal_mode=WAL");
+    db.run(`
+      CREATE TABLE usage_events (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        session_id TEXT NOT NULL,
+        project TEXT NOT NULL,
+        timestamp INTEGER NOT NULL,
+        provider TEXT NOT NULL,
+        model TEXT NOT NULL,
+        input_tokens INTEGER DEFAULT 0,
+        output_tokens INTEGER DEFAULT 0,
+        cache_read_tokens INTEGER DEFAULT 0,
+        cache_write_tokens INTEGER DEFAULT 0,
+        cost_usd REAL,
+        cost_input REAL,
+        cost_output REAL,
+        cost_cache_read REAL,
+        cost_cache_write REAL,
+        UNIQUE(session_id, timestamp, model)
+      )
+    `);
+    db.run(`
+      CREATE TABLE sessions (
+        id TEXT PRIMARY KEY,
+        project TEXT NOT NULL,
+        session_name TEXT,
+        started_at INTEGER NOT NULL,
+        ended_at INTEGER,
+        message_count INTEGER DEFAULT 0,
+        total_input INTEGER DEFAULT 0,
+        total_output INTEGER DEFAULT 0,
+        total_cache_read INTEGER DEFAULT 0,
+        total_cache_write INTEGER DEFAULT 0,
+        total_cost REAL,
+        primary_model TEXT,
+        primary_provider TEXT
+      )
+    `);
+    db.run(`
+      CREATE TABLE processing_state (
+        file_path TEXT PRIMARY KEY,
+        last_offset INTEGER DEFAULT 0,
+        last_modified INTEGER
+      )
+    `);
+
+    processFile(db, filePath, "session.jsonl", sessionHeader, content);
+
+    const events = db.query<any, []>("SELECT * FROM usage_events ORDER BY timestamp").all();
+    expect(events.length).toBe(2);
+    expect(events[1].model).toBe("claude-haiku");
+    expect(events[1].output_tokens).toBe(60);
+    expect(events[1].cost_usd).toBeCloseTo(0.0002, 6);
+
+    const sessions = db.query<any, []>("SELECT * FROM sessions").all();
+    expect(sessions.length).toBe(1);
+    // Evaluator spend must be folded into the session total, not silently
+    // dropped — this is the whole point of the fix.
+    expect(sessions[0].total_cost).toBeCloseTo(0.01 + 0.0002, 6);
+    expect(sessions[0].total_output).toBe(50 + 60);
+
+    db.close();
+  });
+
   test("processFile skips malformed JSON lines without crashing", () => {
     const tmpDir = mkdtempSync("/tmp/usage-scanner-test-");
     const dbPath = join(tmpDir, "test.db");

--- a/packages/cli/src/usage/scanner.ts
+++ b/packages/cli/src/usage/scanner.ts
@@ -6,6 +6,7 @@ import { homedir } from "node:os";
 import { createLogger } from "@pizzapi/tools";
 import type { SessionHeader, UsageMessage } from "./types.js";
 import { getSessionsDir } from "./schema.js";
+import { GOAL_EVALUATOR_USAGE_CUSTOM_TYPE } from "../extensions/goal/state.js";
 
 const log = createLogger("usage");
 
@@ -201,6 +202,32 @@ export function processFile(
 
         // Mark this line as successfully processed
         lastCompleteLineOffset += Buffer.byteLength(line, "utf-8") + 1; // +1 for newline
+      } else if (obj.type === "custom" && obj.customType === GOAL_EVALUATOR_USAGE_CUSTOM_TYPE) {
+        // /goal LLM evaluator calls are separate API requests outside the
+        // normal turn — surface their spend here so it isn't invisible to
+        // the Usage dashboard. Written as a per-call delta (see state.ts),
+        // so it's safe to add directly without cumulative double-counting.
+        const data = obj.data as { provider?: string; model?: string; tokens?: number; cost?: number; timestamp?: number };
+        const timestamp = data.timestamp ?? new Date(obj.timestamp).getTime();
+
+        modelUsage.set(data.model || "unknown", (modelUsage.get(data.model || "unknown") || 0) + 1);
+
+        events.push({
+          timestamp,
+          provider: data.provider || "unknown",
+          model: data.model || "unknown",
+          input_tokens: 0,
+          output_tokens: data.tokens || 0,
+          cache_read_tokens: 0,
+          cache_write_tokens: 0,
+          cost_usd: data.cost ?? null,
+          cost_input: null,
+          cost_output: data.cost ?? null,
+          cost_cache_read: null,
+          cost_cache_write: null,
+        });
+
+        lastCompleteLineOffset += Buffer.byteLength(line, "utf-8") + 1; // +1 for newline
       } else {
         // For other valid JSON types (like message without usage), still mark as processed
         lastCompleteLineOffset += Buffer.byteLength(line, "utf-8") + 1; // +1 for newline
@@ -241,8 +268,10 @@ export function processFile(
     }
   }
 
-  // For incremental scans, merge with existing data
-  if (existingSession && messageCount > 0) {
+  // For incremental scans, merge with existing data. Guard on events.length
+  // (not messageCount) — goal_evaluator_usage entries add events without
+  // being an assistant message, and would otherwise be dropped from history.
+  if (existingSession && events.length > 0) {
     totalInput += existingSession.total_input || 0;
     totalOutput += existingSession.total_output || 0;
     totalCacheRead += existingSession.total_cache_read || 0;

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -187,7 +187,7 @@ export function useSlashCommands(
       },
       {
         name: "goal",
-        description: "Set a goal — /goal \"<condition>\" [--max-turns N] [--max-tokens N] [--max-cost N]",
+        description: "Set a goal — /goal \"<condition>\" [--max-turns N] [--max-tokens N] [--max-cost N] [--every N]",
         subCommands: [
           { name: "status", description: "Show the active goal and budget" },
           { name: "clear", description: "Clear the active goal" },


### PR DESCRIPTION
## Part 1 — cost tracking (original)
The /goal LLM evaluator makes a real, separate model API call after every turn (`createLlmGoalEvaluator` → `completeSimple`) to judge whether the goal is met. That spend was only recorded into the cumulative `goal_state` custom entry (visible via `/goal status`), never as a `type: "message"` entry — so the Usage dashboard scanner silently dropped it.

- `state.ts`: `recordEvaluation` now also appends a `goal_evaluator_usage` custom entry (a per-call **delta**, not the cumulative total) whenever the evaluator reports cost/tokens.
- `scanner.ts`: parses `goal_evaluator_usage` entries into `usage_events` and rolls them into session totals.
- `scanner.ts`: fixed a latent incremental-scan bug — merging prior totals was gated on `messageCount > 0`; a scan with only `goal_evaluator_usage` entries (no new assistant message) would've overwritten history instead of adding to it. Now gated on `events.length > 0`.

## Part 2 — throttle the evaluator (follow-up)
Now that the spend is visible, the natural next question: is calling the judge model on *every single turn* necessary? It isn't — most turns aren't the one where a goal completes.

- New `/goal --every N` flag and `config.goal.evaluateEveryNTurns` default control how often (in turns) the LLM evaluator runs. Default: every 3 turns.
- The first turn always evaluates, so instantly-satisfied goals still resolve immediately.
- The keyword evaluator is free/local and is **never** throttled (rate is always 1 for it) — no behavior change there.
- Skipped (throttled) turns still enforce turn/token/cost budgets and keep the goal loop moving (a lightweight "keep working" steer message using the last known guidance), they just don't spend a judge call.
- Factored the budget-exhausted stop path into a shared `stopForBudget()` helper, reused by both the throttled-skip path and the normal evaluate path.
- Updated the `/goal` slash-command hint in the web UI to mention `--every`.

## Tests
- `goal.test.ts`: evaluator-usage-entry emission (cost/tokens vs. keyword no-op), `--every` parsing/validation, and a wiring test proving 3 turns only evaluate twice (turn 1 + turn 3) while still auto-continuing the loop, plus a throttled-turn budget-exhaustion test.
- `scanner.test.ts`: session totals correctly include evaluator spend.
- Existing `goal.integration.test.ts` LLM-loop test updated to pass `--every 1` since it specifically exercises per-turn evaluate → guidance → re-evaluate across exactly two turns.

`bunx tsc --noEmit` clean in both `packages/cli` and `packages/ui`. `bun test` green: 2211/2211 in `packages/cli`.

skipped: surfacing the resolved evaluate rate in `/goal status` output, add if users want to see the effective cadence without checking config. Also skipped smarter (non-fixed-N) throttling heuristics (e.g. skip evaluation on tool-call-only turns) — add if fixed-N proves too coarse in practice.
