### PR TITLE
feat(ui): rewind conversation from the web UI (/rewind, TUI fork parity)

### DIFF
--- a/packages/cli/src/extensions/remote-commands.ts
+++ b/packages/cli/src/extensions/remote-commands.ts
@@ -13,6 +13,8 @@ export type RemoteExecRequest =
     | { type: "exec"; id: string; command: "compact"; customInstructions?: string }
     | { type: "exec"; id: string; command: "set_session_name"; name: string }
     | { type: "exec"; id: string; command: "get_last_assistant_text" }
+    | { type: "exec"; id: string; command: "get_fork_messages" }
+    | { type: "exec"; id: string; command: "fork"; entryId: string }
     | { type: "exec"; id: string; command: "list_resume_sessions"; limit?: number; cursor?: string }
     | { type: "exec"; id: string; command: "resume_session"; query?: string; sessionPath?: string }
     | { type: "exec"; id: string; command: "export_html"; outputPath?: string }

--- a/packages/cli/src/extensions/remote-exec-fork.test.ts
+++ b/packages/cli/src/extensions/remote-exec-fork.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "bun:test";
+import { handleExecFromWeb, type ExecHandlerCallbacks } from "./remote-exec-handler.js";
+import type { RemoteExecRequest } from "./remote-commands.js";
+
+const callbacks: ExecHandlerCallbacks = {
+    setModelFromWeb: async () => {},
+    markSessionNameBroadcasted: () => {},
+};
+
+function buildRctx(overrides: Record<string, unknown> = {}) {
+    const sent: any[] = [];
+    const forwarded: any[] = [];
+    const rctx: any = {
+        pi: {},
+        latestCtx: {
+            sessionManager: {
+                getEntries: () => [
+                    { type: "message", id: "u1", message: { role: "user", content: "first question" } },
+                    {
+                        type: "message",
+                        id: "a1",
+                        message: { role: "assistant", content: [{ type: "text", text: "answer" }] },
+                    },
+                    {
+                        type: "message",
+                        id: "u2",
+                        message: { role: "user", content: [{ type: "text", text: "second question" }] },
+                    },
+                    // Image-only user message has no text — excluded from fork list
+                    { type: "message", id: "u3", message: { role: "user", content: [{ type: "image", data: "…" }] } },
+                ],
+            },
+        },
+        sendToWeb: (msg: unknown) => sent.push(msg),
+        forwardEvent: (evt: unknown) => forwarded.push(evt),
+        emitSessionActive: () => forwarded.push({ type: "session_active" }),
+        buildHeartbeat: () => ({ type: "heartbeat" }),
+        ...overrides,
+    };
+    return { rctx, sent, forwarded };
+}
+
+describe("exec get_fork_messages", () => {
+    test("lists user messages with text", async () => {
+        const { rctx, sent } = buildRctx();
+        const req: RemoteExecRequest = { type: "exec", id: "1", command: "get_fork_messages" };
+
+        await handleExecFromWeb(req, rctx, callbacks);
+
+        expect(sent).toHaveLength(1);
+        expect(sent[0].ok).toBe(true);
+        expect(sent[0].result.messages).toEqual([
+            { entryId: "u1", text: "first question" },
+            { entryId: "u2", text: "second question" },
+        ]);
+    });
+
+    test("errors without an active session", async () => {
+        const { rctx, sent } = buildRctx({ latestCtx: null });
+
+        await handleExecFromWeb({ type: "exec", id: "1", command: "get_fork_messages" }, rctx, callbacks);
+
+        expect(sent[0].ok).toBe(false);
+        expect(sent[0].error).toContain("No active session");
+    });
+});
+
+describe("exec fork", () => {
+    test("forks via pi.fork and pushes a fresh snapshot", async () => {
+        const forkCalls: string[] = [];
+        const { rctx, sent, forwarded } = buildRctx({
+            pi: {
+                fork: async (entryId: string) => {
+                    forkCalls.push(entryId);
+                    return { cancelled: false, selectedText: "second question" };
+                },
+            },
+        });
+
+        await handleExecFromWeb({ type: "exec", id: "1", command: "fork", entryId: "u2" }, rctx, callbacks);
+
+        expect(forkCalls).toEqual(["u2"]);
+        expect(sent[0].ok).toBe(true);
+        expect(sent[0].result.text).toBe("second question");
+        expect(forwarded.map((e: any) => e.type)).toEqual(["session_active", "heartbeat"]);
+    });
+
+    test("reports cancellation as an error", async () => {
+        const { rctx, sent, forwarded } = buildRctx({
+            pi: { fork: async () => ({ cancelled: true }) },
+        });
+
+        await handleExecFromWeb({ type: "exec", id: "1", command: "fork", entryId: "u2" }, rctx, callbacks);
+
+        expect(sent[0].ok).toBe(false);
+        expect(sent[0].error).toContain("cancelled");
+        expect(forwarded).toHaveLength(0);
+    });
+
+    test("errors when pi.fork is unavailable or entryId missing", async () => {
+        const { rctx, sent } = buildRctx();
+        await handleExecFromWeb({ type: "exec", id: "1", command: "fork", entryId: "u2" }, rctx, callbacks);
+        expect(sent[0].ok).toBe(false);
+        expect(sent[0].error).toContain("not available");
+
+        const { rctx: rctx2, sent: sent2 } = buildRctx({ pi: { fork: async () => ({ cancelled: false }) } });
+        await handleExecFromWeb({ type: "exec", id: "2", command: "fork", entryId: "  " } as any, rctx2, callbacks);
+        expect(sent2[0].ok).toBe(false);
+        expect(sent2[0].error).toContain("entryId");
+    });
+});

--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -15,6 +15,7 @@ import type { RemoteExecRequest, RemoteExecResponse } from "./remote-commands.js
 import type { RelayContext, RelayModelInfo } from "./remote-types.js";
 import { emitThinkingLevelChanged, emitCompactStarted, emitCompactEnded, emitRetryStateChanged, emitPluginTrustResolved } from "./remote-meta-events.js";
 import { listSessionsCached } from "../runner/session-list-cache.js";
+import { extractUserMessageText } from "../runner/worker-fork.js";
 
 export interface ExecHandlerCallbacks {
     setModelFromWeb(provider: string, modelId: string): Promise<void>;
@@ -325,6 +326,54 @@ export async function handleExecFromWeb(
                             .join("")
                       : null;
             replyOk({ text });
+            return;
+        }
+
+        if (req.command === "get_fork_messages") {
+            if (!rctx.latestCtx) {
+                replyErr("No active session");
+                return;
+            }
+            // Mirrors pi's AgentSession.getUserMessagesForForking(): every user
+            // message in the session (including abandoned branches), append order.
+            const messages: Array<{ entryId: string; text: string }> = [];
+            for (const entry of rctx.latestCtx.sessionManager.getEntries()) {
+                if (entry.type !== "message") continue;
+                if ((entry as any).message?.role !== "user") continue;
+                const text = extractUserMessageText((entry as any).message.content);
+                if (text) messages.push({ entryId: entry.id, text });
+            }
+            replyOk({ messages });
+            return;
+        }
+
+        if (req.command === "fork") {
+            if (!rctx.latestCtx) {
+                replyErr("No active session");
+                return;
+            }
+            if (typeof (rctx.pi as any).fork !== "function") {
+                replyErr("fork is not available in this pi version");
+                return;
+            }
+            const entryId = typeof req.entryId === "string" ? req.entryId.trim() : "";
+            if (!entryId) {
+                replyErr("Missing entryId");
+                return;
+            }
+            try {
+                const result = await (rctx.pi as any).fork(entryId);
+                if (result?.cancelled) {
+                    replyErr("Fork was cancelled");
+                    return;
+                }
+                replyOk({ text: typeof result?.selectedText === "string" ? result.selectedText : null });
+            } catch (e) {
+                replyErr(e instanceof Error ? e.message : String(e));
+                return;
+            }
+            rctx.emitSessionActive();
+            rctx.forwardEvent(rctx.buildHeartbeat());
             return;
         }
 

--- a/packages/cli/src/runner/worker-fork.test.ts
+++ b/packages/cli/src/runner/worker-fork.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { SessionManager } from "@earendil-works/pi-coding-agent";
+import { extractUserMessageText, headlessFork, type ForkableSession } from "./worker-fork.js";
+
+function buildSession() {
+    const sm = SessionManager.inMemory("/tmp/fork-test");
+    const firstUserId = sm.appendMessage({ role: "user", content: "first question" } as any);
+    sm.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "first answer" }],
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+    } as any);
+    const secondUserId = sm.appendMessage({
+        role: "user",
+        content: [{ type: "text", text: "second question" }],
+    } as any);
+    sm.appendMessage({
+        role: "assistant",
+        content: [{ type: "text", text: "second answer" }],
+        usage: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0, cost: { total: 0 } },
+    } as any);
+
+    const emitted: any[] = [];
+    let aborted = false;
+    const session: ForkableSession = {
+        get sessionFile() {
+            return sm.getSessionFile() ?? undefined;
+        },
+        sessionManager: sm,
+        agent: { sessionId: sm.getSessionId(), state: { messages: sm.buildSessionContext().messages } },
+        extensionRunner: {
+            hasHandlers: () => true,
+            emit: async (event: unknown) => {
+                emitted.push(event);
+                return undefined;
+            },
+        },
+        abort: async () => {
+            aborted = true;
+        },
+    };
+    return { sm, session, firstUserId, secondUserId, emitted, wasAborted: () => aborted };
+}
+
+describe("headlessFork", () => {
+    test("forks before a user message, truncating the transcript and returning its text", async () => {
+        const { sm, session, secondUserId, emitted, wasAborted } = buildSession();
+        const originalSessionId = sm.getSessionId();
+
+        const result = await headlessFork(session, secondUserId);
+
+        expect(result.cancelled).toBe(false);
+        expect(result.selectedText).toBe("second question");
+        expect(wasAborted()).toBe(true);
+        // Transcript rewound to just the first exchange
+        const roles = (session.agent.state.messages as any[]).map((m) => m.role);
+        expect(roles).toEqual(["user", "assistant"]);
+        // New session identity
+        expect(sm.getSessionId()).not.toBe(originalSessionId);
+        expect(session.agent.sessionId).toBe(sm.getSessionId());
+        // Extensions notified with reason "fork"
+        const switchEvent = emitted.find((e) => e.type === "session_switch");
+        expect(switchEvent?.reason).toBe("fork");
+    });
+
+    test("forking at the first user message yields an empty session", async () => {
+        const { session, firstUserId } = buildSession();
+
+        const result = await headlessFork(session, firstUserId);
+
+        expect(result.cancelled).toBe(false);
+        expect(result.selectedText).toBe("first question");
+        expect(session.agent.state.messages).toEqual([]);
+    });
+
+    test("session_before_fork can cancel", async () => {
+        const { sm, session, secondUserId } = buildSession();
+        const originalSessionId = sm.getSessionId();
+        session.extensionRunner = {
+            hasHandlers: () => true,
+            emit: async () => ({ cancel: true }),
+        };
+
+        const result = await headlessFork(session, secondUserId);
+
+        expect(result.cancelled).toBe(true);
+        expect(sm.getSessionId()).toBe(originalSessionId);
+    });
+
+    test("rejects non-user entries and unknown ids", async () => {
+        const { sm, session } = buildSession();
+        const assistantEntry = sm
+            .getEntries()
+            .find((e: any) => e.type === "message" && e.message.role === "assistant") as any;
+
+        expect(headlessFork(session, assistantEntry.id)).rejects.toThrow("Invalid entry ID");
+        expect(headlessFork(session, "nonexistent")).rejects.toThrow("Invalid entry ID");
+    });
+
+    test("position 'at' keeps the entry (clone semantics)", async () => {
+        const { sm, session, secondUserId } = buildSession();
+
+        const result = await headlessFork(session, secondUserId, { position: "at" });
+
+        expect(result.cancelled).toBe(false);
+        const roles = (session.agent.state.messages as any[]).map((m) => m.role);
+        expect(roles).toEqual(["user", "assistant", "user"]);
+    });
+});
+
+describe("extractUserMessageText", () => {
+    test("handles strings, text blocks, and non-text content", () => {
+        expect(extractUserMessageText("plain")).toBe("plain");
+        expect(
+            extractUserMessageText([
+                { type: "text", text: "a" },
+                { type: "image", data: "..." },
+                { type: "text", text: "b" },
+            ]),
+        ).toBe("ab");
+        expect(extractUserMessageText(undefined)).toBe("");
+    });
+});

--- a/packages/cli/src/runner/worker-fork.ts
+++ b/packages/cli/src/runner/worker-fork.ts
@@ -1,0 +1,138 @@
+/**
+ * Headless fork ("rewind") support for the session worker.
+ *
+ * Mirrors pi's AgentSessionRuntime.fork() for headless mode: branch the
+ * session tree at (or just before) an entry, point the SessionManager at the
+ * new branched session file, and rebuild the agent transcript — without the
+ * interactive-mode runtime host that upstream fork depends on.
+ */
+
+/** Minimal slice of AgentSession that headlessFork needs. */
+export interface ForkableSession {
+    sessionFile: string | undefined;
+    sessionManager: {
+        getEntry(id: string): any;
+        newSession(options?: { parentSession?: string }): string | undefined;
+        createBranchedSession(leafId: string): string | undefined;
+        isPersisted(): boolean;
+        getSessionId(): string;
+        buildSessionContext(): { messages: unknown[] };
+    };
+    agent: { sessionId?: string | undefined; state: { messages: unknown[] } };
+    extensionRunner?: {
+        hasHandlers(type: string): boolean;
+        emit(event: unknown): Promise<unknown>;
+    } | null;
+    abort(): Promise<void>;
+}
+
+export function extractUserMessageText(content: unknown): string {
+    if (typeof content === "string") return content;
+    if (Array.isArray(content)) {
+        return content
+            .filter((c: any) => c && c.type === "text" && typeof c.text === "string")
+            .map((c: any) => c.text)
+            .join("");
+    }
+    return "";
+}
+
+/**
+ * Fork the session at `entryId`.
+ *
+ * position "before" (default): entryId must be a user message; the forked
+ * session contains everything up to (excluding) that message, and its text is
+ * returned so the caller can pre-fill an editor. position "at": the forked
+ * session includes the entry itself (pi's /clone behavior).
+ *
+ * @param onSessionReplaced Invoked right after the SessionManager points at
+ *        the forked session file, before extensions are notified — the worker
+ *        uses this to republish session metadata.
+ */
+export async function headlessFork(
+    session: ForkableSession,
+    entryId: string,
+    options?: { position?: "before" | "at" },
+    onSessionReplaced?: () => void,
+): Promise<{ cancelled: boolean; selectedText?: string }> {
+    const extensionRunner = session.extensionRunner;
+    const previousSessionFile = session.sessionFile;
+    const position = options?.position ?? "before";
+
+    const sm = session.sessionManager;
+    const entry = sm.getEntry(entryId);
+    if (!entry) {
+        throw new Error("Invalid entry ID for forking");
+    }
+
+    let targetLeafId: string | null;
+    let selectedText: string | undefined;
+    if (position === "at") {
+        targetLeafId = entry.id;
+    } else {
+        if (entry.type !== "message" || entry.message?.role !== "user") {
+            throw new Error("Invalid entry ID for forking");
+        }
+        targetLeafId = entry.parentId ?? null;
+        selectedText = extractUserMessageText(entry.message.content);
+    }
+
+    // Let extensions cancel (mirrors pi's session_before_fork)
+    if (extensionRunner?.hasHandlers("session_before_fork")) {
+        const result = await extensionRunner.emit({
+            type: "session_before_fork",
+            entryId,
+            position,
+        });
+        if ((result as any)?.cancel) {
+            return { cancelled: true };
+        }
+    }
+
+    // Stop any running agent turn
+    await session.abort();
+
+    // Clear AgentSession's private tracking queues so stale steering/
+    // follow-up messages from the pre-fork conversation don't leak through.
+    (session as any)._steeringMessages = [];
+    (session as any)._followUpMessages = [];
+    (session as any)._pendingNextTurnMessages = [];
+    (session as any)._lastAssistantMessage = undefined;
+    (session as any)._overflowRecoveryAttempted = false;
+
+    // Branch the session tree — createBranchedSession points the existing
+    // SessionManager at the new session file.
+    if (!targetLeafId) {
+        // Forking from the very first message → fresh empty session
+        sm.newSession({ parentSession: previousSessionFile });
+    } else {
+        const forkedPath = sm.createBranchedSession(targetLeafId);
+        // In-memory sessions return undefined on success — only persisted
+        // sessions are expected to yield a new session file path.
+        if (sm.isPersisted() && !forkedPath) {
+            throw new Error("Failed to create forked session");
+        }
+    }
+    session.agent.sessionId = sm.getSessionId();
+    onSessionReplaced?.();
+
+    // Rebuild the transcript from the forked session
+    const sessionContext = sm.buildSessionContext();
+
+    // Notify extensions before replacing messages — the remote extension's
+    // session_switch handler emits session_active from the (now forked)
+    // sessionManager. NOTE: "session_switch" was removed from the upstream
+    // type union in 0.66.1, but PizzaPi's remote extension still registers a
+    // runtime handler for it; emit() dispatches by string key.
+    if (extensionRunner) {
+        await extensionRunner.emit({
+            type: "session_switch",
+            reason: "fork",
+            previousSessionFile,
+        });
+    }
+
+    session.agent.state.messages = sessionContext.messages;
+
+    return { cancelled: false, selectedText };
+}

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -7,6 +7,7 @@ import { getPluginSkillPaths } from "../extensions/claude-plugins.js";
 import { setRegisteredCommandsProvider } from "../extensions/command-introspection.js";
 import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 import { createBootTimer } from "./boot-timing.js";
+import { headlessFork } from "./worker-fork.js";
 import { applySettingsDefaultModel } from "./apply-default-model.js";
 import { setLogComponent, setLogSessionId, logInfo, logWarn, logError, logAuth } from "./logger.js";
 
@@ -583,8 +584,17 @@ async function main(): Promise<void> {
                 return { cancelled: false };
             },
 
-            // Fork and tree navigation are not supported in headless mode
-            fork: async () => ({ cancelled: true }),
+            fork: async (entryId: string, options?: { position?: "before" | "at" }) => {
+                const result = await headlessFork(session, entryId, options, () => {
+                    publishSessionMetadata(session);
+                });
+                if (!result.cancelled) {
+                    logInfo(`forked session at entry ${entryId} → ${session.sessionManager.getSessionFile()}`);
+                }
+                return result;
+            },
+
+            // Tree navigation is not supported in headless mode
             navigateTree: async () => ({ cancelled: true }),
 
             reload: async () => {

--- a/packages/docs/src/content/docs/web-ui/slash-commands.mdx
+++ b/packages/docs/src/content/docs/web-ui/slash-commands.mdx
@@ -24,6 +24,7 @@ The following commands are always available in the chat input:
 |---------|-------------|
 | `/new` | Start a new conversation. If there are active linked child sessions, a confirmation dialog appears first. |
 | `/resume [query]` | Resume a previous session. Without a query, resumes the most recent session. With a query, opens a fuzzy-search picker matching against session names, IDs, paths, and first messages. |
+| `/rewind [query]` | Rewind the conversation to an earlier user message (same as the terminal UI's <kbd>Esc</kbd> <kbd>Esc</kbd> fork flow). Opens a picker of prior user messages; selecting one forks the session at that point and pre-fills the composer with the message so it can be edited and resent. `/fork` is an alias. |
 | `/plan` | Toggle plan mode on/off. In plan mode, the agent can only read files and run safe commands — useful for exploring the codebase before making changes. |
 | `/model` or `/cycle_model` | Open the model selector to switch to a different AI model mid-session. |
 | `/effort` or `/cycle_effort` | Cycle through reasoning effort levels (extended thinking). |
@@ -69,6 +70,7 @@ This also applies to plugin-provided extension commands and skill commands — a
 Some commands keep the picker open after you execute them because they're inherently interactive:
 
 - **`/resume`** — the session picker stays open so you can browse and select a session.
+- **`/rewind`** — the message picker stays open so you can choose where to rewind to.
 - **`/agents`** — the agent picker stays open for selection.
 - **Any command with sub-commands** — the picker stays open in sub-command mode.
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -119,7 +119,7 @@ import {
   type InputDedupeState,
 } from "@/lib/input-dedupe";
 import { parsePendingQuestionDisplayMode, parsePendingQuestions, type QuestionDisplayMode, type QuestionType } from "@/lib/ask-user-questions";
-import type { TodoItem, TokenUsage, ConfiguredModelInfo, ResumeSessionOption, QueuedMessage, SessionUiCacheEntry } from "@/lib/types";
+import type { TodoItem, TokenUsage, ConfiguredModelInfo, ResumeSessionOption, ForkMessageOption, QueuedMessage, SessionUiCacheEntry } from "@/lib/types";
 import type { MetaGoalStatus } from "@pizzapi/protocol";
 import { metaEventToStatePatch, type MetaStatePatch } from "@/lib/meta-state-apply";
 import { deriveSessionMetadataUpdatePatch } from "@/lib/session-metadata-update";
@@ -204,6 +204,8 @@ interface SessionState {
   resumeSessions: ResumeSessionOption[];
   resumeSessionsLoading: boolean;
   resumeSessionsNextCursor: string | null;
+  forkMessages: ForkMessageOption[];
+  forkMessagesLoading: boolean;
   goal: MetaGoalStatus | null;
 }
 
@@ -236,6 +238,8 @@ function createInitialSessionState(): SessionState {
     resumeSessions: [],
     resumeSessionsLoading: false,
     resumeSessionsNextCursor: null,
+    forkMessages: [],
+    forkMessagesLoading: false,
     goal: null,
   };
 }
@@ -291,6 +295,7 @@ export function App() {
     modelSelectorOpen, isChangingModel, agentActive, effortLevel, authSource,
     tokenUsage, providerUsage, usageRefreshing, lastHeartbeatAt,
     availableCommands, resumeSessions, resumeSessionsLoading, resumeSessionsNextCursor,
+    forkMessages, forkMessagesLoading,
     goal,
   } = sessionState;
 
@@ -439,6 +444,16 @@ export function App() {
   const setGoal = React.useCallback(
     (v: React.SetStateAction<MetaGoalStatus | null>) =>
       setSessionState((p: SessionState) => ({ ...p, goal: typeof v === "function" ? v(p.goal) : v })),
+    []
+  );
+  const setForkMessages = React.useCallback(
+    (v: React.SetStateAction<ForkMessageOption[]>) =>
+      setSessionState((p: SessionState) => ({ ...p, forkMessages: typeof v === "function" ? v(p.forkMessages) : v })),
+    []
+  );
+  const setForkMessagesLoading = React.useCallback(
+    (v: React.SetStateAction<boolean>) =>
+      setSessionState((p: SessionState) => ({ ...p, forkMessagesLoading: typeof v === "function" ? v(p.forkMessagesLoading) : v })),
     []
   );
   // Tracks whether the in-flight list_resume_sessions request is a "load more" (append) vs fresh load
@@ -2122,6 +2137,9 @@ export function App() {
         if (command === "list_resume_sessions") {
           setResumeSessionsLoading(false);
         }
+        if (command === "get_fork_messages") {
+          setForkMessagesLoading(false);
+        }
         if (command === "refresh_usage") {
           setUsageRefreshing(false);
         }
@@ -2191,6 +2209,31 @@ export function App() {
         if (!isAppend && normalized.length === 0) {
           setViewerStatus("No resumable sessions");
         }
+        return;
+      }
+
+      if (command === "get_fork_messages") {
+        const list: unknown[] = Array.isArray(result?.messages) ? (result.messages as unknown[]) : [];
+        const normalized: ForkMessageOption[] = [];
+        for (const item of list) {
+          if (!item || typeof item !== "object") continue;
+          const entry = item as Record<string, unknown>;
+          if (typeof entry.entryId !== "string" || typeof entry.text !== "string") continue;
+          normalized.push({ entryId: entry.entryId, text: entry.text });
+        }
+        setForkMessages(normalized);
+        setForkMessagesLoading(false);
+        if (normalized.length === 0) {
+          setViewerStatus("No messages to rewind to");
+        }
+        return;
+      }
+
+      if (command === "fork") {
+        // The runner emits a fresh session_active with the rewound transcript;
+        // stale fork candidates from the pre-fork session are cleared here.
+        setForkMessages([]);
+        setViewerStatus("Conversation rewound");
         return;
       }
 
@@ -3866,6 +3909,17 @@ export function App() {
     return ok;
   }, [sendRemoteExec, requestPersistedSessions]);
 
+  const requestForkMessages = React.useCallback(() => {
+    setForkMessagesLoading(true);
+    const ok = sendRemoteExec({
+      type: "exec",
+      id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      command: "get_fork_messages",
+    });
+    if (!ok) setForkMessagesLoading(false);
+    return ok;
+  }, [sendRemoteExec, setForkMessagesLoading]);
+
   const refreshUsage = React.useCallback(() => {
     if (usageRefreshing) return false;
     setUsageRefreshing(true);
@@ -5151,6 +5205,9 @@ export function App() {
                         resumeSessions={resumeSessions}
                         resumeSessionsLoading={resumeSessionsLoading}
                         onRequestResumeSessions={requestResumeSessions}
+                        forkMessages={forkMessages}
+                        forkMessagesLoading={forkMessagesLoading}
+                        onRequestForkMessages={requestForkMessages}
                         onSendInput={sendSessionInput}
                         onExec={sendRemoteExec}
                         onShowModelSelector={() => setModelSelectorOpen(true)}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -2140,6 +2140,13 @@ export function App() {
         if (command === "get_fork_messages") {
           setForkMessagesLoading(false);
         }
+        if (command === "fork") {
+          // A failed rewind leaves the transcript untouched — surface the error
+          // in the transcript itself, not just the easily-missed status line
+          // (e.g. "fork is not available in this pi version" from a runner
+          // that predates the rewind feature and needs a restart).
+          appendLocalSystemMessage(`**/rewind** failed: ${error}`);
+        }
         if (command === "refresh_usage") {
           setUsageRefreshing(false);
         }

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -123,6 +123,9 @@ export function SessionViewer({
   resumeSessions,
   resumeSessionsLoading,
   onRequestResumeSessions,
+  forkMessages,
+  forkMessagesLoading,
+  onRequestForkMessages,
   onSendInput,
   onExec,
   onShowModelSelector,
@@ -283,6 +286,8 @@ export function SessionViewer({
     onSendInput,
     resumeSessions,
     onRequestResumeSessions,
+    forkMessages,
+    onRequestForkMessages,
     runnerId,
     sessionCwd,
     onAppendSystemMessage,
@@ -313,7 +318,10 @@ export function SessionViewer({
     promptSuggestions,
     isResumeMode,
     isAgentMode,
+    isRewindMode,
     resumeCandidates,
+    rewindCandidates,
+    rewindToMessage,
     checkTriggersAndRun,
     requestNewSession,
     subCommandMode,
@@ -398,6 +406,7 @@ export function SessionViewer({
   const commandHighlightedValue = React.useMemo(() => {
     if (!commandOpen) return "";
     if (isResumeMode) return resumeCandidates[commandHighlightedIndex]?.path ?? "";
+    if (isRewindMode) return rewindCandidates[commandHighlightedIndex]?.entryId ?? "";
     if (isAgentMode) return agentCandidates[commandHighlightedIndex]?.name ?? "";
     if (subCommandMode.active)
       return subCommandMode.filtered[commandHighlightedIndex]?.name ?? "";
@@ -411,9 +420,11 @@ export function SessionViewer({
   }, [
     commandOpen,
     isResumeMode,
+    isRewindMode,
     isAgentMode,
     subCommandMode,
     resumeCandidates,
+    rewindCandidates,
     agentCandidates,
     commandSuggestions,
     extensionSuggestions,
@@ -425,6 +436,7 @@ export function SessionViewer({
   const commandOptionCount = React.useMemo(() => {
     if (!commandOpen) return 0;
     if (isResumeMode) return resumeCandidates.length;
+    if (isRewindMode) return rewindCandidates.length;
     if (isAgentMode) return agentCandidates.length;
     if (subCommandMode.active) return subCommandMode.filtered.length;
     return commandSuggestions.length + extensionSuggestions.length + promptSuggestions.length + skillSuggestions.length;
@@ -432,6 +444,8 @@ export function SessionViewer({
     commandOpen,
     isResumeMode,
     resumeCandidates.length,
+    isRewindMode,
+    rewindCandidates.length,
     isAgentMode,
     agentCandidates.length,
     subCommandMode,
@@ -1052,6 +1066,9 @@ export function SessionViewer({
                     if (isResumeMode) {
                       const idx = resumeCandidates.findIndex((s) => s.path.toLowerCase() === v.toLowerCase());
                       if (idx !== -1) setCommandHighlightedIndex(idx);
+                    } else if (isRewindMode) {
+                      const idx = rewindCandidates.findIndex((m) => m.entryId.toLowerCase() === v.toLowerCase());
+                      if (idx !== -1) setCommandHighlightedIndex(idx);
                     } else if (isAgentMode) {
                       const idx = agentCandidates.findIndex((a) => a.name.toLowerCase() === v.toLowerCase());
                       if (idx !== -1) setCommandHighlightedIndex(idx);
@@ -1067,7 +1084,7 @@ export function SessionViewer({
                 >
                   <div className="flex items-center justify-between px-3 py-1.5 border-b border-border/50">
                     <span className="text-xs text-muted-foreground font-medium">
-                      {isResumeMode ? "Resume session" : isAgentMode ? "Start as agent" : subCommandMode.active ? `/${subCommandMode.parentCommand}` : "Commands"}
+                      {isResumeMode ? "Resume session" : isRewindMode ? "Rewind conversation" : isAgentMode ? "Start as agent" : subCommandMode.active ? `/${subCommandMode.parentCommand}` : "Commands"}
                     </span>
                     <button type="button" onClick={() => { setCommandOpen(false); setCommandQuery(""); }} className="inline-flex items-center justify-center rounded-sm p-0.5 text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors" aria-label="Close command menu">
                       <X className="size-3.5" />
@@ -1096,6 +1113,22 @@ export function SessionViewer({
                                   <span className="text-[11px] text-muted-foreground shrink-0">{new Date(session.modified).toLocaleDateString()}</span>
                                 </div>
                                 <span className="text-[11px] text-muted-foreground truncate" title={session.path}>{formatPathTail(session.path, 2)}</span>
+                              </div>
+                            </CommandItem>
+                          ))}
+                        </CommandGroup>
+                      </>
+                    ) : isRewindMode ? (
+                      <>
+                        <CommandEmpty>{forkMessagesLoading ? "Loading messages…" : "No messages to rewind to"}</CommandEmpty>
+                        <CommandGroup heading="Rewind to message (forks the session)">
+                          {rewindCandidates.map((message, idx) => (
+                            <CommandItem key={message.entryId} value={message.entryId} onSelect={() => {
+                              rewindToMessage(message);
+                            }}>
+                              <div className="flex min-w-0 items-start gap-2">
+                                <span className="text-[11px] text-muted-foreground shrink-0 tabular-nums pt-0.5">#{rewindCandidates.length - idx}</span>
+                                <span className="text-sm line-clamp-2 break-words">{message.text}</span>
                               </div>
                             </CommandItem>
                           ))}
@@ -1463,11 +1496,13 @@ export function SessionViewer({
                           event.preventDefault();
                           const totalItems = isResumeMode
                             ? resumeCandidates.length
-                            : isAgentMode
-                              ? agentCandidates.length
-                              : subCommandMode.active
-                                ? subCommandMode.filtered.length
-                                : commandSuggestions.length + extensionSuggestions.length + promptSuggestions.length + skillSuggestions.length;
+                            : isRewindMode
+                              ? rewindCandidates.length
+                              : isAgentMode
+                                ? agentCandidates.length
+                                : subCommandMode.active
+                                  ? subCommandMode.filtered.length
+                                  : commandSuggestions.length + extensionSuggestions.length + promptSuggestions.length + skillSuggestions.length;
                           if (totalItems === 0) return;
                           setCommandHighlightedIndex((prev) => {
                             if (event.key === "ArrowDown") return prev < totalItems - 1 ? prev + 1 : 0;
@@ -1509,6 +1544,14 @@ export function SessionViewer({
                               setInput("");
                               setCommandQuery("");
                               setCommandOpen(false);
+                              setCommandHighlightedIndex(0);
+                              return;
+                            }
+                          } else if (isRewindMode) {
+                            const highlighted = rewindCandidates[commandHighlightedIndex];
+                            if (highlighted) {
+                              event.preventDefault();
+                              rewindToMessage(highlighted);
                               setCommandHighlightedIndex(0);
                               return;
                             }

--- a/packages/ui/src/components/session-viewer/slash-commands-rewind.test.tsx
+++ b/packages/ui/src/components/session-viewer/slash-commands-rewind.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for the /rewind (fork) slash-command mode in useSlashCommands.
+ */
+import { describe, expect, test, afterEach } from "bun:test";
+import { Window } from "happy-dom";
+
+// ── DOM globals ─────────────────────────────────────────────────────────────
+// Must be set BEFORE React or hook imports so module evaluation sees a browser
+// environment.
+const win = new Window({ url: "http://localhost/" });
+/* eslint-disable @typescript-eslint/no-explicit-any */
+(globalThis as any).window = win;
+(globalThis as any).document = win.document;
+(globalThis as any).navigator = win.navigator;
+(globalThis as any).HTMLElement = win.HTMLElement;
+(globalThis as any).Element = win.Element;
+(globalThis as any).Node = win.Node;
+// No-op rAF shim — rewindToMessage schedules a focus/cursor callback we don't
+// assert on. Deferring it (setTimeout) would fire after this file's DOM is
+// torn down and crash the next test file; invoking it synchronously trips a
+// happy-dom selector-parser incompatibility. Dropping it keeps tests hermetic.
+(globalThis as any).requestAnimationFrame = (() => 0) as any;
+
+const { renderHook, act, cleanup } = await import("@testing-library/react");
+const React = (await import("react")).default;
+const { useSlashCommands } = await import("./slash-commands");
+import type { SlashCommandDeps } from "./slash-commands";
+import type { ForkMessageOption } from "@/lib/types";
+
+afterEach(cleanup);
+
+function setup(options: {
+    input: string;
+    forkMessages?: ForkMessageOption[];
+    onExec?: (payload: unknown) => boolean | void;
+    onRequestForkMessages?: () => boolean | void;
+}) {
+    const setInputCalls: string[] = [];
+    const deps: SlashCommandDeps = {
+        sessionId: "sess-1",
+        sessionIdRef: { current: "sess-1" },
+        compactingRef: { current: false },
+        onExec: options.onExec,
+        forkMessages: options.forkMessages,
+        onRequestForkMessages: options.onRequestForkMessages,
+        skillCommands: [],
+        extensionCommands: [],
+        promptCommands: [],
+        onIncompleteTriggers: () => {},
+    };
+    const view = renderHook(
+        ({ input }: { input: string }) =>
+            useSlashCommands(input, (v) => setInputCalls.push(v), deps),
+        { initialProps: { input: options.input } },
+    );
+    return { view, setInputCalls };
+}
+
+const messages: ForkMessageOption[] = [
+    { entryId: "e1", text: "first question" },
+    { entryId: "e2", text: "second question" },
+    { entryId: "e3", text: "third about CSS" },
+];
+
+describe("rewind mode", () => {
+    test("activates for /rewind and /fork, not for other commands", () => {
+        expect(setup({ input: "/rewind" }).view.result.current.isRewindMode).toBe(true);
+        expect(setup({ input: "/fork " }).view.result.current.isRewindMode).toBe(true);
+        expect(setup({ input: "/resume" }).view.result.current.isRewindMode).toBe(false);
+        expect(setup({ input: "/rewindx" }).view.result.current.isRewindMode).toBe(false);
+    });
+
+    test("candidates are newest-first and filtered by query", () => {
+        const { view } = setup({ input: "/rewind", forkMessages: messages });
+        expect(view.result.current.rewindCandidates.map((m) => m.entryId)).toEqual(["e3", "e2", "e1"]);
+
+        view.rerender({ input: "/rewind css" });
+        expect(view.result.current.rewindCandidates.map((m) => m.entryId)).toEqual(["e3"]);
+    });
+
+    test("requests fork messages when the picker opens in rewind mode", () => {
+        let requests = 0;
+        const { view } = setup({
+            input: "/rewind",
+            onRequestForkMessages: () => {
+                requests += 1;
+            },
+        });
+        act(() => view.result.current.setCommandOpen(true));
+        expect(requests).toBe(1);
+    });
+
+    test("rewindToMessage dispatches fork exec and pre-fills the composer", () => {
+        const execs: any[] = [];
+        const { view, setInputCalls } = setup({
+            input: "/rewind",
+            forkMessages: messages,
+            onExec: (payload) => {
+                execs.push(payload);
+                return true;
+            },
+        });
+
+        act(() => view.result.current.rewindToMessage(messages[1]!));
+
+        expect(execs).toHaveLength(1);
+        expect(execs[0].command).toBe("fork");
+        expect(execs[0].entryId).toBe("e2");
+        expect(setInputCalls.at(-1)).toBe("second question");
+    });
+
+    test("executeSlashCommand with a bare /rewind keeps the picker open instead of forking", () => {
+        const execs: any[] = [];
+        const { view } = setup({
+            input: "/rewind",
+            forkMessages: messages,
+            onExec: (payload) => {
+                execs.push(payload);
+                return true;
+            },
+        });
+
+        let handled = false;
+        act(() => {
+            handled = view.result.current.executeSlashCommand("/rewind");
+        });
+
+        expect(handled).toBe(true);
+        expect(execs).toHaveLength(0);
+        expect(view.result.current.commandOpen).toBe(true);
+    });
+
+    test("executeSlashCommand with a query forks the newest matching message", () => {
+        const execs: any[] = [];
+        const { view } = setup({
+            input: "/rewind question",
+            forkMessages: messages,
+            onExec: (payload) => {
+                execs.push(payload);
+                return true;
+            },
+        });
+
+        act(() => {
+            view.result.current.executeSlashCommand("/rewind question");
+        });
+
+        // Newest match wins: e2 ("second question"), not e1
+        expect(execs).toHaveLength(1);
+        expect(execs[0].entryId).toBe("e2");
+    });
+});

--- a/packages/ui/src/components/session-viewer/slash-commands.ts
+++ b/packages/ui/src/components/session-viewer/slash-commands.ts
@@ -2,7 +2,7 @@ import * as React from "react";
 import type { CmdEntry } from "./viewer-types";
 import type { CommandResultData } from "./rendering";
 import type { SandboxViolationEntry } from "./cards/CommandResultCard";
-import type { ResumeSessionOption } from "@/lib/types";
+import type { ResumeSessionOption, ForkMessageOption } from "@/lib/types";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import {
   type IncompleteTriggerItem,
@@ -40,6 +40,8 @@ export interface SlashCommandDeps {
   ) => boolean | void | Promise<boolean | void>;
   resumeSessions?: ResumeSessionOption[];
   onRequestResumeSessions?: () => boolean | void;
+  forkMessages?: ForkMessageOption[];
+  onRequestForkMessages?: () => boolean | void;
   runnerId?: string;
   sessionCwd?: string;
   onAppendSystemMessage?: (content: string | CommandResultData) => void;
@@ -79,8 +81,12 @@ export interface SlashCommandState {
   promptSuggestions: CmdEntry[];
   isResumeMode: boolean;
   isAgentMode: boolean;
+  isRewindMode: boolean;
   resumeQuery: string;
   resumeCandidates: ResumeSessionOption[];
+  rewindCandidates: ForkMessageOption[];
+  /** Fork the session at the given user message and pre-fill the composer with its text. */
+  rewindToMessage: (message: ForkMessageOption) => void;
   /** Check for incomplete triggers, then run action (or invoke onIncompleteTriggers). */
   checkTriggersAndRun: (action: () => void) => Promise<void>;
   requestNewSession: () => void;
@@ -110,6 +116,8 @@ export function useSlashCommands(
     onSendInput,
     resumeSessions,
     onRequestResumeSessions,
+    forkMessages,
+    onRequestForkMessages,
     runnerId,
     sessionCwd,
     onAppendSystemMessage,
@@ -132,7 +140,7 @@ export function useSlashCommands(
   const webHandledCommands = React.useMemo(
     () =>
       new Set([
-        "new", "resume", "mcp", "plugins", "skills", "agents", "model",
+        "new", "resume", "rewind", "fork", "mcp", "plugins", "skills", "agents", "model",
         "cycle_model", "effort", "cycle_effort", "compact", "name", "copy",
         "stop", "restart", "remote", "plan", "sandbox", "goal",
       ]),
@@ -144,6 +152,7 @@ export function useSlashCommands(
     () => [
       { name: "new", description: "Start a new conversation" },
       { name: "resume", description: "Resume the previous session" },
+      { name: "rewind", description: "Rewind the conversation to a previous message" },
       {
         name: "mcp",
         description: "MCP server management",
@@ -220,7 +229,7 @@ export function useSlashCommands(
   }, [supportedWebCommands, extensionCommands]);
 
   const keepPopoverOpenNames = React.useMemo(() => {
-    const names = new Set(["resume", "agents", ...subCommandsByName.keys()]);
+    const names = new Set(["resume", "agents", "rewind", "fork", ...subCommandsByName.keys()]);
     return names;
   }, [subCommandsByName]);
 
@@ -275,6 +284,8 @@ export function useSlashCommands(
   const trimmedInput = input.trimStart();
   const isResumeMode = /^\/resume(?:\s|$)/i.test(trimmedInput);
   const isAgentMode = /^\/agents(?:\s|$)/i.test(trimmedInput);
+  // /fork is the TUI name for the same rewind flow (Esc-Esc selector)
+  const isRewindMode = /^\/(?:rewind|fork)(?:\s|$)/i.test(trimmedInput);
   const resumeQuery = isResumeMode
     ? trimmedInput.replace(/^\/resume\s*/i, "").trim().toLowerCase()
     : "";
@@ -296,9 +307,46 @@ export function useSlashCommands(
     });
   }, [resumeSessions, resumeQuery]);
 
+  const rewindQuery = isRewindMode
+    ? trimmedInput.replace(/^\/(?:rewind|fork)\s*/i, "").trim().toLowerCase()
+    : "";
+
+  // Newest first — rewinding to a recent message is the common case (TUI
+  // pre-selects the last user message for the same reason).
+  const rewindCandidates = React.useMemo(() => {
+    const list = [...(forkMessages ?? [])].reverse();
+    if (!rewindQuery) return list;
+    return list.filter((m) => m.text.toLowerCase().includes(rewindQuery));
+  }, [forkMessages, rewindQuery]);
+
+  const rewindToMessage = React.useCallback(
+    (message: ForkMessageOption) => {
+      setCommandOpen(false);
+      setCommandQuery("");
+      if (!onExec) {
+        setInput("");
+        return;
+      }
+      const dispatched = onExec({
+        type: "exec",
+        id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        command: "fork",
+        entryId: message.entryId,
+      });
+      // Pre-fill the composer with the rewound message so it can be edited
+      // and resent — mirrors the TUI fork flow.
+      setInput(dispatched === false ? "" : message.text);
+      requestAnimationFrame(() => {
+        const ta = document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]");
+        if (ta) { const len = ta.value.length; ta.setSelectionRange(len, len); ta.focus(); }
+      });
+    },
+    [onExec, setInput],
+  );
+
   // Sub-command mode (e.g. "/mcp " shows mcp sub-commands)
   const subCommandMode = React.useMemo<SubCommandMode>(() => {
-    if (isResumeMode || isAgentMode)
+    if (isResumeMode || isAgentMode || isRewindMode)
       return { active: false, parentCommand: "", subCommands: [], query: "", filtered: [] };
     const match = trimmedInput.match(/^\/(\S+)(?:\s(.*))?$/i);
     if (!match)
@@ -318,7 +366,7 @@ export function useSlashCommands(
       query: argText,
       filtered,
     };
-  }, [trimmedInput, isResumeMode, isAgentMode, subCommandsByName]);
+  }, [trimmedInput, isResumeMode, isAgentMode, isRewindMode, subCommandsByName]);
 
   // Request resume sessions list when entering resume mode
   React.useEffect(() => {
@@ -336,6 +384,19 @@ export function useSlashCommands(
   React.useEffect(() => {
     if (!commandOpen || !isResumeMode) resumeRequestedRef.current = null;
   }, [commandOpen, isResumeMode]);
+
+  // Request rewindable messages when entering rewind mode
+  const rewindRequestedRef = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    if (!sessionId || !commandOpen || !isRewindMode || !onRequestForkMessages) return;
+    if (rewindRequestedRef.current === sessionId) return;
+    rewindRequestedRef.current = sessionId;
+    onRequestForkMessages();
+  }, [sessionId, commandOpen, isRewindMode, onRequestForkMessages]);
+
+  React.useEffect(() => {
+    if (!commandOpen || !isRewindMode) rewindRequestedRef.current = null;
+  }, [commandOpen, isRewindMode]);
 
   /** Check for incomplete triggers, then run the action or invoke onIncompleteTriggers. */
   const checkTriggersAndRun = React.useCallback(
@@ -701,6 +762,22 @@ export function useSlashCommands(
         return true;
       }
 
+      if (rawCommand === "rewind" || rawCommand === "fork") {
+        // Rewinding requires an explicit selection from the picker — an exact
+        // query match is the only safe way to dispatch from raw text.
+        const query = args.trim().toLowerCase();
+        const match = query
+          ? [...(forkMessages ?? [])].reverse().find((m) => m.text.toLowerCase().includes(query))
+          : undefined;
+        if (match) {
+          rewindToMessage(match);
+        } else {
+          // Keep the picker open so the user can choose a message.
+          setCommandOpen(true);
+        }
+        return true;
+      }
+
       if (rawCommand === "model" || rawCommand === "cycle_model") {
         if (onShowModelSelector) {
           onShowModelSelector();
@@ -785,6 +862,8 @@ export function useSlashCommands(
       onExec,
       onSendInput,
       resumeSessions,
+      forkMessages,
+      rewindToMessage,
       runnerId,
       onAppendSystemMessage,
       skillCommands,
@@ -820,8 +899,11 @@ export function useSlashCommands(
     promptSuggestions,
     isResumeMode,
     isAgentMode,
+    isRewindMode,
     resumeQuery,
     resumeCandidates,
+    rewindCandidates,
+    rewindToMessage,
     checkTriggersAndRun,
     requestNewSession,
     resumeRequestedRef,

--- a/packages/ui/src/components/session-viewer/viewer-types.ts
+++ b/packages/ui/src/components/session-viewer/viewer-types.ts
@@ -1,5 +1,5 @@
 import type { RelayMessage } from "@/components/session-viewer/types";
-import type { TodoItem, TokenUsage, QueuedMessage, ResumeSessionOption } from "@/lib/types";
+import type { TodoItem, TokenUsage, QueuedMessage, ResumeSessionOption, ForkMessageOption } from "@/lib/types";
 import type { SessionAnalysis } from "@/components/session-inspector/types";
 import type { TriggerCounts } from "@/hooks/useTriggerCount";
 import type { QuestionDisplayMode } from "@/lib/ask-user-questions";
@@ -7,7 +7,7 @@ import type { CommandResultData } from "@/components/session-viewer/rendering";
 import type { PromptInputMessage } from "@/components/ai-elements/prompt-input";
 import type { MetaGoalStatus } from "@pizzapi/protocol";
 
-export type { RelayMessage, TodoItem, TokenUsage, QueuedMessage, ResumeSessionOption };
+export type { RelayMessage, TodoItem, TokenUsage, QueuedMessage, ResumeSessionOption, ForkMessageOption };
 
 /** A command entry (from availableCommands prop or derived lists). */
 export type CmdEntry = {
@@ -38,6 +38,10 @@ export interface SessionViewerProps {
   resumeSessions?: ResumeSessionOption[];
   resumeSessionsLoading?: boolean;
   onRequestResumeSessions?: () => boolean | void;
+  /** Prior user messages the conversation can be rewound (forked) to. */
+  forkMessages?: ForkMessageOption[];
+  forkMessagesLoading?: boolean;
+  onRequestForkMessages?: () => boolean | void;
   onSendInput?: (message: PromptInputMessage & { deliverAs?: "steer" | "followUp" } | string) => boolean | void | Promise<boolean | void>;
   onExec?: (payload: unknown) => boolean | void;
   onShowModelSelector?: () => void;

--- a/packages/ui/src/lib/remote-exec.ts
+++ b/packages/ui/src/lib/remote-exec.ts
@@ -13,6 +13,8 @@ export type RemoteExecCommand =
   | { command: "compact"; customInstructions?: string }
   | { command: "set_session_name"; name: string }
   | { command: "get_last_assistant_text" }
+  | { command: "get_fork_messages" }
+  | { command: "fork"; entryId: string }
   | { command: "list_resume_sessions"; limit?: number; cursor?: string }
   | { command: "resume_session"; query?: string; sessionPath?: string }
   | { command: "new_session" }

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -50,6 +50,12 @@ export interface ResumeSessionOption {
   serverSourced?: boolean;
 }
 
+/** A prior user message the conversation can be rewound (forked) to. */
+export interface ForkMessageOption {
+  entryId: string;
+  text: string;
+}
+
 export interface QueuedMessage {
   id: string;
   text: string;

--- a/patches/@earendil-works%2Fpi-coding-agent@0.80.3.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.80.3.patch
@@ -1,5 +1,8 @@
+diff --git a/node_modules/@earendil-works/pi-coding-agent/.bun-tag-bc572afbfa496cd3 b/.bun-tag-bc572afbfa496cd3
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/config.js b/dist/config.js
-index 4600b23..85bd9b0 100644
+index 4600b23493be21d2316303d056ef135313dcef43..85bd9b0d26c0de32a7aabfd0e254fed05659f958 100644
 --- a/dist/config.js
 +++ b/dist/config.js
 @@ -358,6 +358,10 @@ export function getExamplesPath() {
@@ -33,7 +36,7 @@ index 4600b23..85bd9b0 100644
  /** Get path to user's custom themes directory */
  export function getCustomThemesDir() {
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
-index e223ce1..fd4dc58 100644
+index e223ce1f924fc70372dc2984faae427bf0019b98..fd4dc583f9efa18a56e3872d2a6772b0c282f061 100644
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
 @@ -1057,9 +1057,10 @@ export class AgentSession {
@@ -50,20 +53,21 @@ index e223ce1..fd4dc58 100644
              images,
              source: "extension",
 diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
-index 4b79482..538a0ff 100644
+index 4b794828f33d7fad94fc0df69bc31959c94bf1c1..1a0ea062ac9a1f8e50aa384439126c84f3656214 100644
 --- a/dist/core/extensions/loader.js
 +++ b/dist/core/extensions/loader.js
-@@ -137,6 +137,9 @@ export function createExtensionRuntime() {
+@@ -137,6 +137,10 @@ export function createExtensionRuntime() {
          sendUserMessage: notInitialized,
          appendEntry: notInitialized,
          setSessionName: notInitialized,
 +        // PATCH(pizzapi): expose session-control actions on ExtensionAPI, not only command contexts.
 +        newSession: () => Promise.reject(new Error("Extension runtime not initialized")),
 +        switchSession: () => Promise.reject(new Error("Extension runtime not initialized")),
++        fork: () => Promise.reject(new Error("Extension runtime not initialized")),
          getSessionName: notInitialized,
          setLabel: notInitialized,
          getActiveTools: notInitialized,
-@@ -236,6 +239,15 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
+@@ -236,6 +240,19 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
              runtime.assertActive();
              runtime.setSessionName(name);
          },
@@ -76,20 +80,25 @@ index 4b79482..538a0ff 100644
 +            runtime.assertActive();
 +            return runtime.switchSession(sessionPath, options);
 +        },
++        fork(entryId, options) {
++            runtime.assertActive();
++            return runtime.fork(entryId, options);
++        },
          getSessionName() {
              runtime.assertActive();
              return runtime.getSessionName();
 diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
-index 45d68a4..38e27ca 100644
+index 45d68a44d4fb1738509aae509ad7314150d87d74..a52dda99f0329a184eddcf1857a441f269002369 100644
 --- a/dist/core/extensions/runner.js
 +++ b/dist/core/extensions/runner.js
-@@ -222,17 +222,22 @@ export class ExtensionRunner {
+@@ -222,17 +222,24 @@ export class ExtensionRunner {
          if (actions) {
              this.waitForIdleFn = actions.waitForIdle;
              this.newSessionHandler = actions.newSession;
 +            // PATCH(pizzapi): make session controls available to ExtensionAPI callers.
 +            this.runtime.newSession = (options) => this.newSessionHandler(options);
              this.forkHandler = actions.fork;
++            this.runtime.fork = (entryId, options) => this.forkHandler(entryId, options);
              this.navigateTreeHandler = actions.navigateTree;
              this.switchSessionHandler = actions.switchSession;
 +            this.runtime.switchSession = (sessionPath, options) => this.switchSessionHandler(sessionPath, options);
@@ -100,6 +109,7 @@ index 45d68a4..38e27ca 100644
          this.newSessionHandler = async () => ({ cancelled: false });
 +        this.runtime.newSession = (options) => this.newSessionHandler(options);
          this.forkHandler = async () => ({ cancelled: false });
++        this.runtime.fork = (entryId, options) => this.forkHandler(entryId, options);
          this.navigateTreeHandler = async () => ({ cancelled: false });
          this.switchSessionHandler = async () => ({ cancelled: false });
 +        this.runtime.switchSession = (sessionPath, options) => this.switchSessionHandler(sessionPath, options);
@@ -107,10 +117,10 @@ index 45d68a4..38e27ca 100644
      }
      setUIContext(uiContext, mode = "print") {
 diff --git a/dist/core/extensions/types.d.ts b/dist/core/extensions/types.d.ts
-index 828a90a..18282c3 100644
+index 828a90a283c5135b4e8f7d3845bed8e6d1aee653..5ddb445e7b11dfa46d035027fb55bafc5ff24046 100644
 --- a/dist/core/extensions/types.d.ts
 +++ b/dist/core/extensions/types.d.ts
-@@ -881,11 +881,23 @@ export interface ExtensionAPI {
+@@ -881,11 +881,28 @@ export interface ExtensionAPI {
       */
      sendUserMessage(content: string | (TextContent | ImageContent)[], options?: {
          deliverAs?: "steer" | "followUp";
@@ -131,10 +141,15 @@ index 828a90a..18282c3 100644
 +    switchSession(sessionPath: string, options?: {
 +        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
 +    }): Promise<{ cancelled: boolean; }>;
++    /** Fork from a specific entry, creating a new session file. Available to PizzaPi remote event handlers. */
++    fork(entryId: string, options?: {
++        position?: "before" | "at";
++        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
++    }): Promise<{ cancelled: boolean; selectedText?: string; }>;
      /** Get the current session name, if set. */
      getSessionName(): string | undefined;
      /** Set or clear a label on an entry. Labels are user-defined markers for bookmarking/navigation. */
-@@ -1066,6 +1078,8 @@ export type SendMessageHandler = <T = unknown>(message: Pick<CustomMessage<T>, "
+@@ -1066,6 +1083,8 @@ export type SendMessageHandler = <T = unknown>(message: Pick<CustomMessage<T>, "
  }) => void;
  export type SendUserMessageHandler = (content: string | (TextContent | ImageContent)[], options?: {
      deliverAs?: "steer" | "followUp";
@@ -143,17 +158,18 @@ index 828a90a..18282c3 100644
  }) => void;
  export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
  export type SetSessionNameHandler = (name: string) => void;
-@@ -1117,6 +1131,8 @@ export interface ExtensionActions {
+@@ -1117,6 +1136,9 @@ export interface ExtensionActions {
      sendUserMessage: SendUserMessageHandler;
      appendEntry: AppendEntryHandler;
      setSessionName: SetSessionNameHandler;
 +    newSession: ExtensionCommandContextActions["newSession"];
 +    switchSession: ExtensionCommandContextActions["switchSession"];
++    fork: ExtensionCommandContextActions["fork"];
      getSessionName: GetSessionNameHandler;
      setLabel: SetLabelHandler;
      getActiveTools: GetActiveToolsHandler;
 diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
-index 6ece8e7..71d1a6f 100644
+index 6ece8e7f75abf62bf82a48bf7c468d0a71a7c512..71d1a6fece63350921e9834c9396dd2cb529469d 100644
 --- a/dist/core/model-resolver.js
 +++ b/dist/core/model-resolver.js
 @@ -20,6 +20,7 @@ export const defaultModelPerProvider = {
@@ -165,7 +181,7 @@ index 6ece8e7..71d1a6f 100644
      xai: "grok-4.20-0309-reasoning",
      groq: "openai/gpt-oss-120b",
 diff --git a/dist/core/provider-display-names.js b/dist/core/provider-display-names.js
-index 28c807e..2f0f07e 100644
+index 28c807e8ca3e6375daf30e1b9ad491a428b9d429..2f0f07eff66c74099d379406f5e74c8783616cfa 100644
 --- a/dist/core/provider-display-names.js
 +++ b/dist/core/provider-display-names.js
 @@ -23,6 +23,7 @@ export const BUILT_IN_PROVIDER_DISPLAY_NAMES = {
@@ -177,7 +193,7 @@ index 28c807e..2f0f07e 100644
      "vercel-ai-gateway": "Vercel AI Gateway",
      xai: "xAI",
 diff --git a/dist/index.d.ts b/dist/index.d.ts
-index 0ff89a5..9c2e5a8 100644
+index 0ff89a530ee673c0fb10e63b684f53963cb4ffbe..9c2e5a8588542bbecc4f16e77f6d9971db1b375d 100644
 --- a/dist/index.d.ts
 +++ b/dist/index.d.ts
 @@ -11,6 +11,7 @@ export { convertToLlm } from "./core/messages.ts";
@@ -189,7 +205,7 @@ index 0ff89a5..9c2e5a8 100644
  export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.ts";
  export { AgentSessionRuntime, type AgentSessionRuntimeDiagnostic, type AgentSessionServices, type CreateAgentSessionFromServicesOptions, type CreateAgentSessionOptions, type CreateAgentSessionResult, type CreateAgentSessionRuntimeFactory, type CreateAgentSessionRuntimeResult, type CreateAgentSessionServicesOptions, createAgentSession, createAgentSessionFromServices, createAgentSessionRuntime, createAgentSessionServices, createBashTool, createCodingTools, createEditTool, createFindTool, createGrepTool, createLsTool, createReadOnlyTools, createReadTool, createWriteTool, type PromptTemplate, } from "./core/sdk.ts";
 diff --git a/dist/index.js b/dist/index.js
-index 6aaf484..e4896e4 100644
+index 6aaf4844cc6a9c2072e0c8dee652ced1e6ea8a22..e4896e463e3e0024d904fd9071ff247e0e892717 100644
 --- a/dist/index.js
 +++ b/dist/index.js
 @@ -12,6 +12,7 @@ export { createExtensionRuntime, defineTool, discoverAndLoadExtensions, Extensio
@@ -201,7 +217,7 @@ index 6aaf484..e4896e4 100644
  // SDK for programmatic usage
  export { AgentSessionRuntime, 
 diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
-index 5d65200..5572132 100644
+index 5d6520076da7b69d0ef7f481945f33ff2f507f23..557213259a17fd52869c21ffd779aecec35a012c 100644
 --- a/dist/modes/interactive/interactive-mode.js
 +++ b/dist/modes/interactive/interactive-mode.js
 @@ -33,7 +33,6 @@ import { getCwdRelativePath } from "../../utils/paths.js";

--- a/patches/README.md
+++ b/patches/README.md
@@ -39,8 +39,8 @@ below).
 |------|--------|
 | `dist/config.js` | Hardcodes `".pizzapi"`, flattens `getAgentDir()`, and honors `PIZZAPI_CHANGELOG_PATH` |
 | `dist/core/agent-session.js` | Extension `sendUserMessage` path accepts an `expandPromptTemplates` opt-in (default `false`) so web UI input can opt into slash-command/template expansion |
-| `dist/core/extensions/loader.js` / `dist/core/extensions/runner.js` | Exposes `newSession()` and `switchSession()` on the general extension API for remote exec handlers |
-| `dist/core/extensions/types.d.ts` | Types `newSession`/`switchSession` on `ExtensionAPI`, `expandPromptTemplates` on `sendUserMessage`/`SendUserMessageHandler`, and `newSession`/`switchSession` on `ExtensionActions` |
+| `dist/core/extensions/loader.js` / `dist/core/extensions/runner.js` | Exposes `newSession()`, `switchSession()`, and `fork()` on the general extension API for remote exec handlers |
+| `dist/core/extensions/types.d.ts` | Types `newSession`/`switchSession`/`fork` on `ExtensionAPI`, `expandPromptTemplates` on `sendUserMessage`/`SendUserMessageHandler`, and `newSession`/`switchSession`/`fork` on `ExtensionActions` |
 | `dist/core/model-resolver.js` | Adds built-in default model selection for `ollama-cloud` (`glm-5.1`) |
 | `dist/core/provider-display-names.js` | Exposes `Ollama Cloud` as a built-in provider display name |
 | `dist/modes/interactive/interactive-mode.js` | Removes upstream version-notification UI (import, `run()` call, and `showNewVersionNotification()` method) |


### PR DESCRIPTION
## Summary

Adds the terminal UI's Esc-Esc fork/rewind flow to the web UI — and the Capacitor Android app, which shares the same React UI, gets the interface for free.

- **Web UI / Android**: `/rewind` (alias `/fork`) turns the command popover into a picker of prior user messages (newest first, filterable). Selecting one forks the session at that point, rewinds the transcript, and pre-fills the composer with the message text for editing/resending — mirroring the TUI editor behavior. Fully touch-driven for mobile.
- **Runner exec**: new `get_fork_messages` (mirrors pi's `getUserMessagesForForking`) and `fork` commands; on success the runner emits a fresh `session_active` so the truncated transcript replaces the old one.
- **Headless worker**: implements real fork (previously stubbed `cancelled: true` / "not supported in headless mode") — branches the session tree in place via `createBranchedSession`, clears steering/follow-up queues, republishes session metadata, and emits `session_switch` with reason `fork`.
- **pi patch**: exposes `fork()` on `ExtensionAPI`, exactly mirroring the existing `newSession`/`switchSession` patch precedent (regenerated with `bun patch`; patches/README updated).
- **Docs**: web-ui slash-commands reference updated.
- **Server**: no changes — viewer `exec` is a generic passthrough.

## Test plan

- `packages/cli/src/runner/worker-fork.test.ts` — headless fork semantics against a real pi `SessionManager`: truncation, first-message fork → empty session, `session_before_fork` cancellation, invalid entries, `position: "at"` clone semantics.
- `packages/cli/src/extensions/remote-exec-fork.test.ts` — exec reply shapes for `get_fork_messages`/`fork`, cancellation, missing-`entryId`/unavailable-fork errors, snapshot+heartbeat emission.
- `packages/ui/src/components/session-viewer/slash-commands-rewind.test.tsx` — rewind-mode activation, newest-first + filtered candidates, fork dispatch + composer pre-fill, bare `/rewind` keeping the picker open.
- Full typecheck green; cli suite 2214 pass, ui suite 1110 pass.