### PR TITLE
fix(queue): persist queued follow-ups across session switches; make web UI queue edits real

### DIFF
--- a/packages/cli/src/extensions/remote-commands.ts
+++ b/packages/cli/src/extensions/remote-commands.ts
@@ -24,6 +24,7 @@ export type RemoteExecRequest =
     | { type: "exec"; id: string; command: "plugin_trust_response"; promptId: string; trusted: boolean }
     | { type: "exec"; id: string; command: "mcp_toggle_server"; serverName: string; disabled: boolean }
     | { type: "exec"; id: string; command: "set_plan_mode"; enabled?: boolean }
+    | { type: "exec"; id: string; command: "set_queued_messages"; messages: string[] }
     | { type: "exec"; id: string; command: "sandbox_get_status" }
     | { type: "exec"; id: string; command: "sandbox_update_config"; config: any };
 

--- a/packages/cli/src/extensions/remote-exec-handler.test.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for the set_queued_messages exec command.
+ *
+ * Verifies web UI queue edits actually mutate pi's pending follow-up queue
+ * (previously they were cosmetic-only local UI state).
+ */
+import { describe, test, expect } from "bun:test";
+import { handleExecFromWeb, type ExecHandlerCallbacks } from "./remote-exec-handler.js";
+import type { RelayContext } from "./remote-types.js";
+
+const callbacks: ExecHandlerCallbacks = {
+    setModelFromWeb: async () => {},
+    markSessionNameBroadcasted: () => {},
+};
+
+function makeRctx(pi: unknown) {
+    const sent: unknown[] = [];
+    const forwarded: unknown[] = [];
+    const rctx = {
+        pi,
+        sendToWeb: (payload: unknown) => sent.push(payload),
+        forwardEvent: (event: unknown) => forwarded.push(event),
+        buildHeartbeat: () => ({ type: "heartbeat", queuedMessages: ["from-heartbeat"] }),
+    } as unknown as RelayContext;
+    return { rctx, sent, forwarded };
+}
+
+describe("set_queued_messages exec command", () => {
+    test("replaces pi's follow-up queue and broadcasts a heartbeat", async () => {
+        const replaced: string[][] = [];
+        const { rctx, sent, forwarded } = makeRctx({
+            replaceQueuedMessages: (messages: string[]) => replaced.push(messages),
+        });
+
+        await handleExecFromWeb(
+            { type: "exec", id: "1", command: "set_queued_messages", messages: ["edited text", "  ", "second"] } as any,
+            rctx,
+            callbacks,
+        );
+
+        // Blank entries are filtered; order preserved.
+        expect(replaced).toEqual([["edited text", "second"]]);
+        expect(sent).toEqual([
+            { type: "exec_result", id: "1", ok: true, command: "set_queued_messages", result: { queuedMessages: ["edited text", "second"] } },
+        ]);
+        expect(forwarded).toEqual([{ type: "heartbeat", queuedMessages: ["from-heartbeat"] }]);
+    });
+
+    test("empty array clears the queue", async () => {
+        const replaced: string[][] = [];
+        const { rctx, sent } = makeRctx({
+            replaceQueuedMessages: (messages: string[]) => replaced.push(messages),
+        });
+
+        await handleExecFromWeb(
+            { type: "exec", id: "2", command: "set_queued_messages", messages: [] } as any,
+            rctx,
+            callbacks,
+        );
+
+        expect(replaced).toEqual([[]]);
+        expect((sent[0] as any).ok).toBe(true);
+    });
+
+    test("missing messages replies with an error", async () => {
+        const { rctx, sent, forwarded } = makeRctx({
+            replaceQueuedMessages: () => { throw new Error("should not be called"); },
+        });
+
+        await handleExecFromWeb(
+            { type: "exec", id: "3", command: "set_queued_messages" } as any,
+            rctx,
+            callbacks,
+        );
+
+        expect((sent[0] as any).ok).toBe(false);
+        expect(forwarded).toEqual([]);
+    });
+
+    test("replace failure surfaces as an exec error", async () => {
+        const { rctx, sent, forwarded } = makeRctx({
+            replaceQueuedMessages: () => { throw new Error("stale ctx"); },
+        });
+
+        await handleExecFromWeb(
+            { type: "exec", id: "4", command: "set_queued_messages", messages: ["x"] } as any,
+            rctx,
+            callbacks,
+        );
+
+        expect((sent[0] as any).ok).toBe(false);
+        expect((sent[0] as any).error).toContain("stale ctx");
+        expect(forwarded).toEqual([]);
+    });
+});

--- a/packages/cli/src/extensions/remote-exec-handler.ts
+++ b/packages/cli/src/extensions/remote-exec-handler.ts
@@ -219,6 +219,25 @@ export async function handleExecFromWeb(
             return;
         }
 
+        if (req.command === "set_queued_messages") {
+            // Replace the pending follow-up queue (web UI queue edit/remove/clear).
+            if (!Array.isArray(req.messages)) {
+                replyErr("Missing messages");
+                return;
+            }
+            const messages = req.messages.filter((m): m is string => typeof m === "string" && m.trim().length > 0);
+            try {
+                rctx.pi.replaceQueuedMessages(messages);
+            } catch (err) {
+                replyErr(`Failed to update queued messages: ${err instanceof Error ? err.message : String(err)}`);
+                return;
+            }
+            replyOk({ queuedMessages: messages });
+            // Broadcast the new queue state so all viewers converge immediately.
+            rctx.forwardEvent(rctx.buildHeartbeat());
+            return;
+        }
+
         if (req.command === "set_plan_mode") {
             const explicitEnabled = (req as any).enabled;
             if (typeof explicitEnabled === "boolean") {

--- a/packages/cli/src/extensions/remote-heartbeat.ts
+++ b/packages/cli/src/extensions/remote-heartbeat.ts
@@ -3,7 +3,7 @@
  */
 
 import type { RelayContext } from "./remote-types.js";
-import { emitSessionMetadataUpdate } from "./remote/chunked-delivery.js";
+import { emitSessionMetadataUpdate, readQueuedFollowUps } from "./remote/chunked-delivery.js";
 
 let tokenUsageCache: { key: string; value: ReturnType<typeof buildTokenUsage> } | null = null;
 
@@ -48,6 +48,7 @@ export function buildHeartbeat(rctx: RelayContext) {
         sessionName: rctx.getCurrentSessionName(),
         uptime: rctx.sessionStartedAt !== null ? Date.now() - rctx.sessionStartedAt : null,
         cwd: rctx.latestCtx?.cwd ?? null,
+        queuedMessages: readQueuedFollowUps(rctx),
     };
 }
 

--- a/packages/cli/src/extensions/remote/chunked-delivery.test.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.test.ts
@@ -13,6 +13,7 @@ import {
     emitSessionMetadataUpdate,
     emitSessionActive,
     buildLiveSessionAnalysis,
+    readQueuedFollowUps,
 } from "./chunked-delivery.js";
 import type { RelayContext } from "../remote-types.js";
 import { resetSessionAnalysis, sessionAnalysisExtension } from "../session-analysis.js";
@@ -196,6 +197,46 @@ describe("messagesChangedSinceLastEmit", () => {
 });
 
 // ── emitSessionMetadataUpdate ─────────────────────────────────────────────────
+
+describe("readQueuedFollowUps", () => {
+    test("returns [] when pi is unavailable", () => {
+        const ctx = makeContext();
+        expect(readQueuedFollowUps(ctx)).toEqual([]);
+    });
+
+    test("returns a copy of pi's follow-up queue", () => {
+        const ctx = makeContext();
+        const followUp = ["first", "second"];
+        (ctx as any).pi = { getQueuedMessages: () => ({ steering: ["s"], followUp }) };
+        const result = readQueuedFollowUps(ctx);
+        expect(result).toEqual(["first", "second"]);
+        expect(result).not.toBe(followUp);
+    });
+
+    test("returns [] when getQueuedMessages throws (stale extension ctx)", () => {
+        const ctx = makeContext();
+        (ctx as any).pi = { getQueuedMessages: () => { throw new Error("stale"); } };
+        expect(readQueuedFollowUps(ctx)).toEqual([]);
+    });
+
+    test("session_metadata_update and session_active include queuedMessages", () => {
+        const ctx = makeContext({ leafId: "leaf-queue" });
+        (ctx as any).pi = { getQueuedMessages: () => ({ steering: [], followUp: ["queued follow-up"] }) };
+
+        recordEmittedMessageState(ctx);
+        emitSessionMetadataUpdate(ctx);
+        const meta = ctx.emitted[0] as any;
+        expect(meta.type).toBe("session_metadata_update");
+        expect(meta.metadata.queuedMessages).toEqual(["queued follow-up"]);
+
+        const activeCtx = makeContext({ leafId: "leaf-queue-2" });
+        (activeCtx as any).pi = { getQueuedMessages: () => ({ steering: [], followUp: ["queued follow-up"] }) };
+        emitSessionActive(activeCtx);
+        const active = activeCtx.emitted[0] as any;
+        expect(active.type).toBe("session_active");
+        expect(active.state.queuedMessages).toEqual(["queued follow-up"]);
+    });
+});
 
 describe("emitSessionMetadataUpdate", () => {
     test("emits session_metadata_update when leafId has not changed", () => {

--- a/packages/cli/src/extensions/remote/chunked-delivery.ts
+++ b/packages/cli/src/extensions/remote/chunked-delivery.ts
@@ -26,6 +26,19 @@ import type { SessionAnalysis } from "../../session-analysis/types.js";
 
 const log = createLogger("remote");
 
+/**
+ * Read the pending follow-up queue from pi (authoritative source).
+ * Returns [] when the patched API is unavailable or the extension ctx is stale.
+ */
+export function readQueuedFollowUps(rctx: RelayContext): string[] {
+    try {
+        const queued = rctx.pi?.getQueuedMessages?.();
+        return Array.isArray(queued?.followUp) ? [...queued.followUp] : [];
+    } catch {
+        return [];
+    }
+}
+
 /** Estimated payload size (bytes) above which we chunk messages. */
 const CHUNK_THRESHOLD = 5 * 1024 * 1024; // 5 MB — safely below 10 MB server limit
 
@@ -388,6 +401,7 @@ export function emitSessionActive(rctx: RelayContext, recoveryNonce?: string): v
         todoList: getCurrentTodoList(),
         analysis: buildLiveSessionAnalysis(rctx),
         goal: resolveGoalMetadata(rctx),
+        queuedMessages: readQueuedFollowUps(rctx),
     };
 
     const messageSizes = computeMessageSizes(messages);
@@ -473,6 +487,7 @@ export function emitSessionMetadataUpdate(rctx: RelayContext): void {
             todoList: getCurrentTodoList(),
             analysis: buildLiveSessionAnalysis(rctx),
             goal: resolveGoalMetadata(rctx),
+            queuedMessages: readQueuedFollowUps(rctx),
         },
     });
 }

--- a/packages/cli/src/patches.test.ts
+++ b/packages/cli/src/patches.test.ts
@@ -73,6 +73,30 @@ describe("pi-coding-agent patch application", () => {
         expect(source).toContain("options?.expandPromptTemplates ?? false");
     });
 
+    test("agent-session.js: pending queues are exposed to extensions (getQueuedMessages/replaceQueuedMessages)", async () => {
+        const source = await Bun.file(
+            piCodingAgentPath("dist/core/agent-session.js"),
+        ).text();
+
+        expect(source).toContain("PATCH(pizzapi): expose the pending queues");
+        expect(source).toContain("getQueuedMessages: () => ({ steering: [...this._steeringMessages], followUp: [...this._followUpMessages] })");
+        expect(source).toContain("replaceQueuedMessages: (followUp) => {");
+    });
+
+    test("loader.js + runner.js: queue read/replace wired through ExtensionAPI", async () => {
+        const loader = await Bun.file(
+            piCodingAgentPath("dist/core/extensions/loader.js"),
+        ).text();
+        const runner = await Bun.file(
+            piCodingAgentPath("dist/core/extensions/runner.js"),
+        ).text();
+
+        expect(loader).toContain("getQueuedMessages()");
+        expect(loader).toContain("replaceQueuedMessages(followUp)");
+        expect(runner).toContain("this.runtime.getQueuedMessages = actions.getQueuedMessages");
+        expect(runner).toContain("this.runtime.replaceQueuedMessages = actions.replaceQueuedMessages");
+    });
+
     test("interactive-mode.js: version check call is removed from run()", async () => {
         const source = await Bun.file(
             piCodingAgentPath("dist/modes/interactive/interactive-mode.js"),

--- a/packages/server/src/ws/namespaces/snapshot-provider.test.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.test.ts
@@ -250,6 +250,22 @@ describe("tryCacheSnapshot", () => {
         const result = await tryCacheSnapshot("sess-12", deps);
         expect(result).toBeNull();
     });
+
+    test("overlays fresh queuedMessages from lastState onto a stale cached snapshot", async () => {
+        const snapshotEvent = { type: "session_active", state: { messages: [], queuedMessages: [] } };
+        const deps = createDeps({
+            getLatestCachedSnapshotEvent: mock(async () => ({ event: snapshotEvent, eventsAfter: [] })),
+        });
+
+        const lastState = JSON.stringify({ messages: [], queuedMessages: ["follow up 1", "follow up 2"] });
+        const result = await tryCacheSnapshot("sess-14", deps, lastState);
+        const socket = createMockSocket();
+        result!.send(socket, 1);
+
+        expect((socket.calls[0].payload.event as any).state.queuedMessages).toEqual(["follow up 1", "follow up 2"]);
+        // Original cached event is left untouched.
+        expect(snapshotEvent.state.queuedMessages).toEqual([]);
+    });
 });
 
 // ── tryMemoryState ───────────────────────────────────────────────────────────

--- a/packages/server/src/ws/namespaces/snapshot-provider.test.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.test.ts
@@ -262,7 +262,7 @@ describe("tryCacheSnapshot", () => {
         const socket = createMockSocket();
         result!.send(socket, 1);
 
-        expect((socket.calls[0].payload.event as any).state.queuedMessages).toEqual(["follow up 1", "follow up 2"]);
+        expect((socket.calls[0].payload as any).event.state.queuedMessages).toEqual(["follow up 1", "follow up 2"]);
         // Original cached event is left untouched.
         expect(snapshotEvent.state.queuedMessages).toEqual([]);
     });

--- a/packages/server/src/ws/namespaces/snapshot-provider.ts
+++ b/packages/server/src/ws/namespaces/snapshot-provider.ts
@@ -64,6 +64,17 @@ function maybeTruncateSnapshotState(state: unknown): unknown {
     return truncateSnapshotMessages(state as Record<string, unknown>);
 }
 
+/** Pull the fresh pending follow-up queue out of the durable lastState blob. */
+function extractLastStateQueue(lastState: string | null | undefined): string[] | null {
+    if (!lastState) return null;
+    try {
+        const parsed = JSON.parse(lastState);
+        const queue = parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>).queuedMessages : null;
+        if (Array.isArray(queue)) return queue.filter((m): m is string => typeof m === "string");
+    } catch { /* stale/corrupt lastState — leave the cached queue as-is */ }
+    return null;
+}
+
 // ── Dependency injection for testability ─────────────────────────────────────
 
 export interface SnapshotProviderDeps {
@@ -115,20 +126,27 @@ export async function tryDeltaReplay(
 export async function tryCacheSnapshot(
     sessionId: string,
     deps: SnapshotProviderDeps = defaultDeps,
+    lastState?: string | null,
 ): Promise<SnapshotResult | null> {
     const cached = await deps.getLatestCachedSnapshotEvent(sessionId);
     if (!cached) return null;
     const snapshotEvent = cached.event;
+    // The cached session_active predates later queue changes (session_metadata_update
+    // carries them but is intentionally not cached). lastState always holds the freshest
+    // reported queue, so overlay it — otherwise a stale empty queue clobbers the viewer's
+    // restored follow-ups on switch.
+    const freshQueue = extractLastStateQueue(lastState);
 
     return {
         snapshot: { type: "cache-snapshot", source: "Redis cached snapshot event" },
         send(socket, generation) {
             let eventToSend: Record<string, unknown> = snapshotEvent;
             if (snapshotEvent.type === "session_active") {
-                eventToSend = {
-                    ...snapshotEvent,
-                    state: maybeTruncateSnapshotState(snapshotEvent.state),
-                };
+                let state = maybeTruncateSnapshotState(snapshotEvent.state);
+                if (freshQueue && state && typeof state === "object" && !Array.isArray(state)) {
+                    state = { ...(state as Record<string, unknown>), queuedMessages: freshQueue };
+                }
+                eventToSend = { ...snapshotEvent, state };
             } else if (Array.isArray(snapshotEvent.messages)) {
                 eventToSend = maybeTruncateSnapshotState(snapshotEvent) as Record<string, unknown>;
             }
@@ -244,7 +262,7 @@ export async function getBestSnapshot(
 
     // ── Priority 2: Cache snapshot ───────────────────────────────────────
     try {
-        const cached = await tryCacheSnapshot(sessionId, deps);
+        const cached = await tryCacheSnapshot(sessionId, deps, lastState);
         if (cached) return cached;
     } catch {
         // Fall through

--- a/packages/server/src/ws/sio-registry/snapshot-state.ts
+++ b/packages/server/src/ws/sio-registry/snapshot-state.ts
@@ -44,6 +44,9 @@ export function buildSnapshotPatchFromMetadata(meta: Record<string, unknown>): R
     if (Array.isArray(meta.todoList)) {
         patch.todoList = meta.todoList;
     }
+    if (Array.isArray(meta.queuedMessages)) {
+        patch.queuedMessages = meta.queuedMessages;
+    }
     if (Object.prototype.hasOwnProperty.call(meta, "goal")) {
         patch.goal = meta.goal && typeof meta.goal === "object" ? meta.goal : null;
     }

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -123,6 +123,7 @@ import type { TodoItem, TokenUsage, ConfiguredModelInfo, ResumeSessionOption, Fo
 import type { MetaGoalStatus } from "@pizzapi/protocol";
 import { metaEventToStatePatch, type MetaStatePatch } from "@/lib/meta-state-apply";
 import { deriveSessionMetadataUpdatePatch } from "@/lib/session-metadata-update";
+import { reconcileMessageQueue } from "@/lib/message-queue";
 import { usePanelLayout } from "@/hooks/usePanelLayout";
 import { useTriggerCount } from "@/hooks/useTriggerCount";
 import { useButtonPosition, type ToolbarButtonId, type ButtonSlot } from "@/hooks/useButtonPosition";
@@ -742,6 +743,8 @@ export function App() {
   const staleCheckTimerRef = React.useRef<ReturnType<typeof setInterval> | null>(null);
   const STALE_THRESHOLD_MS = 45_000; // ~4.5 × 10s heartbeat interval
   const STALE_CHECK_INTERVAL_MS = 15_000;
+  // How long to ignore runner queue syncs after a local queue mutation.
+  const QUEUE_SYNC_SUPPRESS_MS = 5_000;
 
   // Snapshot guard: when connecting to a session, ignore streaming deltas
   // until the initial snapshot (session_active / agent_end / heartbeat) arrives.
@@ -965,6 +968,7 @@ export function App() {
       providerUsage: prev?.providerUsage ?? null,
       lastHeartbeatAt: prev?.lastHeartbeatAt ?? null,
       todoList: prev?.todoList ?? [],
+      messageQueue: prev?.messageQueue ?? [],
       analysis: prev?.analysis ?? null,
       pendingQuestion: prev?.pendingQuestion ?? null,
       pendingPlan: prev?.pendingPlan ?? null,
@@ -1296,14 +1300,35 @@ export function App() {
     if (!text) return;
 
     const trimmed = text.trim();
+    let nextQueue: QueuedMessage[] | null = null;
     setMessageQueue((prev) => {
       if (prev.length === 0) return prev;
       // Find the first queued message whose text matches and remove it
       const idx = prev.findIndex((qm) => qm.text.trim() === trimmed);
       if (idx === -1) return prev;
-      return [...prev.slice(0, idx), ...prev.slice(idx + 1)];
+      nextQueue = [...prev.slice(0, idx), ...prev.slice(idx + 1)];
+      return nextQueue;
     });
-  }, []);
+    if (nextQueue) patchSessionCache({ messageQueue: nextQueue });
+  }, [patchSessionCache]);
+
+  // Ignore runner queue syncs briefly after a local mutation / optimistic add
+  // so a stale in-flight heartbeat can't clobber state the runner hasn't
+  // applied yet. The next heartbeat after the window restores authority.
+  const queueSyncSuppressUntilRef = React.useRef(0);
+
+  /** Apply the authoritative pending follow-up queue reported by the runner. */
+  const applyQueuedMessagesSync = React.useCallback((texts: string[]) => {
+    if (Date.now() < queueSyncSuppressUntilRef.current) return;
+    let changed = false;
+    let nextQueue: QueuedMessage[] = [];
+    setMessageQueue((prev) => {
+      nextQueue = reconcileMessageQueue(prev, texts);
+      changed = nextQueue !== prev;
+      return nextQueue;
+    });
+    if (changed) patchSessionCache({ messageQueue: nextQueue });
+  }, [patchSessionCache]);
 
   const applyMcpReport = React.useCallback((mcpReport: {
     slow?: boolean;
@@ -1723,6 +1748,14 @@ export function App() {
         cachePatch.lastHeartbeatAt = hb.ts;
       }
 
+      // Sync the pending follow-up queue from the runner (authoritative).
+      // Skip liveness-only heartbeats — those replay the runner's last stored
+      // heartbeat on viewer switch and may carry stale queue state.
+      const hbQueue = (evt as { queuedMessages?: unknown }).queuedMessages;
+      if (!livenessOnly && Array.isArray(hbQueue)) {
+        applyQueuedMessagesSync(hbQueue.filter((m): m is string => typeof m === "string"));
+      }
+
       if (!livenessOnly && !metaSourceHubRef.current) {
         if (Object.prototype.hasOwnProperty.call(hb, "sessionName")) {
           const nextName = normalizeSessionName(hb.sessionName);
@@ -1814,6 +1847,10 @@ export function App() {
         const nextGoal = derived.goal ?? null;
         setGoal(nextGoal);
         cachePatch.goal = nextGoal;
+      }
+
+      if (Object.prototype.hasOwnProperty.call(derived, "queuedMessages")) {
+        applyQueuedMessagesSync(derived.queuedMessages ?? []);
       }
 
       if (Object.prototype.hasOwnProperty.call(meta, "analysis")) {
@@ -1945,9 +1982,16 @@ export function App() {
         pendingMcpReportRef.current = null;
       }
 
-      // Clear queued messages — the snapshot contains the full conversation
-      // including any follow-ups that were consumed by the agent.
-      setMessageQueue([]);
+      // Sync queued follow-ups from the snapshot — the runner reports its
+      // pending queue so messages queued before a session switch survive.
+      // Old runners don't send the field: clear, as before (consumed
+      // follow-ups are part of the conversation snapshot).
+      if (Array.isArray(state?.queuedMessages)) {
+        applyQueuedMessagesSync((state.queuedMessages as unknown[]).filter((m): m is string => typeof m === "string"));
+      } else {
+        setMessageQueue([]);
+        patchSessionCache({ messageQueue: [] });
+      }
 
       if (!metaViaHub) {
         // Extract thinkingLevel from session snapshot too
@@ -2108,8 +2152,10 @@ export function App() {
       setPendingPlan(null);
       setRetryState(null);
       setActiveToolCalls(new Map());
-      // Clear message queue — the agent processed any queued steer/followUp messages
+      // Clear message queue — the agent processed any queued steer/followUp
+      // messages. If any survived (e.g. abort), the next heartbeat re-syncs.
       setMessageQueue([]);
+      patchSessionCache({ messageQueue: [] });
       return;
     }
 
@@ -2460,6 +2506,7 @@ export function App() {
           messages: [],
           sessionName: null,
           agentActive: false,
+          messageQueue: [],
         });
         // Clear trigger history so the Triggers panel starts fresh
         const sid = activeSessionRef.current;
@@ -2908,6 +2955,7 @@ export function App() {
     getFallbackPromptKey,
     patchSessionCache,
     removeQueuedMessageByContent,
+    applyQueuedMessagesSync,
     activeModel,
   ]);
 
@@ -3202,6 +3250,10 @@ export function App() {
     setTokenUsage(cached?.tokenUsage ?? null);
     setLastHeartbeatAt(cached?.lastHeartbeatAt ?? null);
     setTodoList(cached?.todoList ?? []);
+    // Reset the queue-sync suppress window — it guards a mutation in the
+    // previous session and must not block this session's snapshot sync.
+    queueSyncSuppressUntilRef.current = 0;
+    setMessageQueue(cached?.messageQueue ?? []);
     setAnalysis(cached?.analysis ?? null);
     setGoal(cached?.goal ?? null);
 
@@ -3689,15 +3741,23 @@ export function App() {
           patchSessionCache({ messages: next });
           setViewerStatus("Steering message sent");
         } else {
-          setMessageQueue((prev) => [
-            ...prev,
-            {
-              id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
-              text: trimmed,
-              deliverAs,
-              timestamp: Date.now(),
-            },
-          ]);
+          // Suppress runner queue syncs briefly — a heartbeat built before
+          // the runner received this input would wipe the optimistic entry.
+          queueSyncSuppressUntilRef.current = Date.now() + QUEUE_SYNC_SUPPRESS_MS;
+          let nextQueue: QueuedMessage[] = [];
+          setMessageQueue((prev) => {
+            nextQueue = [
+              ...prev,
+              {
+                id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+                text: trimmed,
+                deliverAs,
+                timestamp: Date.now(),
+              },
+            ];
+            return nextQueue;
+          });
+          patchSessionCache({ messageQueue: nextQueue });
           setViewerStatus("Follow-up queued");
         }
       } else {
@@ -3942,17 +4002,35 @@ export function App() {
     return ok;
   }, [sendRemoteExec, usageRefreshing]);
 
+  /**
+   * Apply a local queue mutation and push the full replacement list to the
+   * runner (set_queued_messages) so pi's pending queue actually changes —
+   * without this, edits/removals were cosmetic and the runner still
+   * delivered the original messages.
+   */
+  const syncQueueToRunner = React.useCallback((next: QueuedMessage[]) => {
+    queueSyncSuppressUntilRef.current = Date.now() + QUEUE_SYNC_SUPPRESS_MS;
+    setMessageQueue(next);
+    patchSessionCache({ messageQueue: next });
+    sendRemoteExec({
+      type: "exec",
+      id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      command: "set_queued_messages",
+      messages: next.map((m) => m.text),
+    });
+  }, [patchSessionCache, sendRemoteExec]);
+
   const removeQueuedMessage = React.useCallback((id: string) => {
-    setMessageQueue((prev) => prev.filter((m) => m.id !== id));
-  }, []);
+    syncQueueToRunner(messageQueue.filter((m) => m.id !== id));
+  }, [messageQueue, syncQueueToRunner]);
 
   const editQueuedMessage = React.useCallback((id: string, newText: string) => {
-    setMessageQueue((prev) => prev.map((m) => m.id === id ? { ...m, text: newText } : m));
-  }, []);
+    syncQueueToRunner(messageQueue.map((m) => (m.id === id ? { ...m, text: newText } : m)));
+  }, [messageQueue, syncQueueToRunner]);
 
   const clearMessageQueue = React.useCallback(() => {
-    setMessageQueue([]);
-  }, []);
+    syncQueueToRunner([]);
+  }, [syncQueueToRunner]);
 
   const selectModel = React.useCallback((model: ConfiguredModelInfo) => {
     const socket = viewerWsRef.current;

--- a/packages/ui/src/components/SessionViewer.tsx
+++ b/packages/ui/src/components/SessionViewer.tsx
@@ -86,6 +86,7 @@ import type { SessionViewerProps as BaseSessionViewerProps, CmdEntry } from "@/c
 import { formatTokenCount } from "@/components/session-viewer/formatters";
 import { useMessageProcessor } from "@/components/session-viewer/message-processor";
 import { useDraftManagement } from "@/components/session-viewer/draft-management";
+import { queueRecallTarget } from "@/lib/message-queue";
 import { useSessionActionsSetup } from "@/components/session-viewer/session-actions";
 import { useAtMentionHandlers } from "@/components/session-viewer/at-mention-handlers";
 import { useSlashCommands } from "@/components/session-viewer/slash-commands";
@@ -214,6 +215,33 @@ export function SessionViewer({
   const sessionIdRef = React.useRef<string | null>(sessionId);
   const [editingQueuedId, setEditingQueuedId] = React.useState<string | null>(null);
   const [editingQueuedText, setEditingQueuedText] = React.useState("");
+
+  // Recall/browse queued follow-ups with Up/Down (shell-history style). Returns
+  // true when it handled the key so the caller can preventDefault.
+  const recallQueuedMessage = React.useCallback(
+    (currentId: string | null, dir: "up" | "down"): boolean => {
+      if (!messageQueue || messageQueue.length === 0) return false;
+      const targetId = queueRecallTarget(messageQueue, currentId, dir);
+      if (targetId === null) {
+        // Down past the newest hands focus back to the composer.
+        if (dir === "down" && currentId !== null) {
+          setEditingQueuedId(null);
+          setEditingQueuedText("");
+          requestAnimationFrame(() => {
+            document.querySelector<HTMLTextAreaElement>("[data-pp-prompt]")?.focus();
+          });
+          return true;
+        }
+        return false;
+      }
+      const target = messageQueue.find((m) => m.id === targetId);
+      if (!target) return false;
+      setEditingQueuedId(target.id);
+      setEditingQueuedText(target.text);
+      return true;
+    },
+    [messageQueue],
+  );
 
   // Keep sessionIdRef current for async callbacks
   React.useEffect(() => { sessionIdRef.current = sessionId; }, [sessionId]);
@@ -919,6 +947,11 @@ export function SessionViewer({
                                 } else if (e.key === "Escape") {
                                   setEditingQueuedId(null);
                                   setEditingQueuedText("");
+                                } else if (e.key === "ArrowUp" || e.key === "ArrowDown") {
+                                  // ponytail: arrows browse the queue rather than
+                                  // move within the box; queued follow-ups are
+                                  // short. Enter saves, Escape cancels.
+                                  if (recallQueuedMessage(qm.id, e.key === "ArrowUp" ? "up" : "down")) e.preventDefault();
                                 }
                               }}
                               autoFocus
@@ -1436,6 +1469,20 @@ export function SessionViewer({
                       if (event.key === "Enter" && event.altKey && agentActive) {
                         event.preventDefault();
                         setDeliveryMode((m) => m === "steer" ? "followUp" : "steer");
+                        return;
+                      }
+
+                      // Empty composer + ArrowUp recalls the last queued message
+                      // for editing (further Up/Down browse the queue). Gated on
+                      // an empty draft so text nav and popovers aren't hijacked.
+                      if (
+                        event.key === "ArrowUp" &&
+                        input === "" &&
+                        !commandOpen && !atMentionOpen && editingQueuedId === null &&
+                        !event.shiftKey && !event.altKey && !event.metaKey && !event.ctrlKey &&
+                        recallQueuedMessage(null, "up")
+                      ) {
+                        event.preventDefault();
                         return;
                       }
 

--- a/packages/ui/src/lib/message-queue.test.ts
+++ b/packages/ui/src/lib/message-queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { reconcileMessageQueue } from "./message-queue";
+import { queueRecallTarget, reconcileMessageQueue } from "./message-queue";
 import type { QueuedMessage } from "./types";
 
 const qm = (id: string, text: string): QueuedMessage => ({ id, text, deliverAs: "followUp", timestamp: 1 });
@@ -33,5 +33,38 @@ describe("reconcileMessageQueue", () => {
     const prev = [qm("a", "same"), qm("b", "same")];
     const next = reconcileMessageQueue(prev, ["same", "same"]);
     expect(next.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("queueRecallTarget", () => {
+  const queue = [qm("a", "one"), qm("b", "two"), qm("c", "three")];
+
+  test("Up from composer recalls the newest message", () => {
+    expect(queueRecallTarget(queue, null, "up")).toBe("c");
+  });
+
+  test("Down from composer does nothing", () => {
+    expect(queueRecallTarget(queue, null, "down")).toBeNull();
+  });
+
+  test("Up steps to the previous (older) message", () => {
+    expect(queueRecallTarget(queue, "c", "up")).toBe("b");
+    expect(queueRecallTarget(queue, "b", "up")).toBe("a");
+  });
+
+  test("Up at the oldest message stays put", () => {
+    expect(queueRecallTarget(queue, "a", "up")).toBeNull();
+  });
+
+  test("Down steps to the next (newer) message", () => {
+    expect(queueRecallTarget(queue, "a", "down")).toBe("b");
+  });
+
+  test("Down past the newest exits to the composer", () => {
+    expect(queueRecallTarget(queue, "c", "down")).toBeNull();
+  });
+
+  test("empty queue has no target", () => {
+    expect(queueRecallTarget([], null, "up")).toBeNull();
   });
 });

--- a/packages/ui/src/lib/message-queue.test.ts
+++ b/packages/ui/src/lib/message-queue.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { reconcileMessageQueue } from "./message-queue";
+import type { QueuedMessage } from "./types";
+
+const qm = (id: string, text: string): QueuedMessage => ({ id, text, deliverAs: "followUp", timestamp: 1 });
+
+describe("reconcileMessageQueue", () => {
+  test("returns same reference when nothing changed", () => {
+    const prev = [qm("a", "one"), qm("b", "two")];
+    expect(reconcileMessageQueue(prev, ["one", "two"])).toBe(prev);
+  });
+
+  test("preserves ids for matching texts and drops consumed entries", () => {
+    const prev = [qm("a", "one"), qm("b", "two"), qm("c", "three")];
+    const next = reconcileMessageQueue(prev, ["two", "three"]);
+    expect(next.map((m) => m.id)).toEqual(["b", "c"]);
+  });
+
+  test("adds entries for texts queued elsewhere (e.g. TUI)", () => {
+    const prev = [qm("a", "one")];
+    const next = reconcileMessageQueue(prev, ["one", "tui-queued"]);
+    expect(next[0].id).toBe("a");
+    expect(next[1].text).toBe("tui-queued");
+    expect(next[1].deliverAs).toBe("followUp");
+  });
+
+  test("empty runner queue clears local list", () => {
+    const prev = [qm("a", "one")];
+    expect(reconcileMessageQueue(prev, [])).toEqual([]);
+  });
+
+  test("duplicate texts map to distinct entries", () => {
+    const prev = [qm("a", "same"), qm("b", "same")];
+    const next = reconcileMessageQueue(prev, ["same", "same"]);
+    expect(next.map((m) => m.id)).toEqual(["a", "b"]);
+  });
+});

--- a/packages/ui/src/lib/message-queue.ts
+++ b/packages/ui/src/lib/message-queue.ts
@@ -1,0 +1,29 @@
+import type { QueuedMessage } from "./types";
+
+/**
+ * Reconcile the local queued-message list against the authoritative
+ * follow-up texts reported by the runner (heartbeat / session snapshot).
+ *
+ * - Reuses existing entry ids where texts match, so React keys and any
+ *   in-flight edit state stay stable across syncs.
+ * - Returns `prev` (same reference) when nothing changed, so callers can
+ *   skip re-renders and cache patches on every heartbeat.
+ */
+export function reconcileMessageQueue(prev: QueuedMessage[], followUpTexts: string[]): QueuedMessage[] {
+  const unchanged =
+    prev.length === followUpTexts.length &&
+    prev.every((qm, i) => qm.text === followUpTexts[i] && qm.deliverAs === "followUp");
+  if (unchanged) return prev;
+
+  const pool = [...prev];
+  return followUpTexts.map((text) => {
+    const idx = pool.findIndex((qm) => qm.text === text && qm.deliverAs === "followUp");
+    if (idx !== -1) return pool.splice(idx, 1)[0];
+    return {
+      id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      text,
+      deliverAs: "followUp" as const,
+      timestamp: Date.now(),
+    };
+  });
+}

--- a/packages/ui/src/lib/message-queue.ts
+++ b/packages/ui/src/lib/message-queue.ts
@@ -27,3 +27,24 @@ export function reconcileMessageQueue(prev: QueuedMessage[], followUpTexts: stri
     };
   });
 }
+
+/**
+ * Pick the queued-message id to recall when the user presses Up/Down to browse
+ * the queue (shell-history style).
+ *
+ * - `currentId === null` means focus is in the composer: Up recalls the newest
+ *   queued message, Down does nothing.
+ * - From a queued message: Up steps to the previous (older) one, Down to the
+ *   next (newer). Past the newest, Down returns `null` (exit back to composer);
+ *   at the oldest, Up returns `null` (stay put).
+ */
+export function queueRecallTarget(
+  queue: QueuedMessage[],
+  currentId: string | null,
+  dir: "up" | "down",
+): string | null {
+  if (queue.length === 0) return null;
+  const idx = currentId === null ? queue.length : queue.findIndex((m) => m.id === currentId);
+  const target = dir === "up" ? idx - 1 : idx + 1;
+  return target >= 0 && target < queue.length ? queue[target].id : null;
+}

--- a/packages/ui/src/lib/session-metadata-update.ts
+++ b/packages/ui/src/lib/session-metadata-update.ts
@@ -15,6 +15,8 @@ export interface SessionMetadataUpdatePatch {
   thinkingLevel?: string | null;
   todoList?: TodoItem[];
   goal?: MetaGoalStatus | null;
+  /** Pending follow-up texts reported by the runner (authoritative queue). */
+  queuedMessages?: string[];
 }
 
 export function deriveSessionMetadataUpdatePatch(input: {
@@ -60,6 +62,12 @@ export function deriveSessionMetadataUpdatePatch(input: {
 
   if (Array.isArray(metadata.todoList)) {
     patch.todoList = metadata.todoList as TodoItem[];
+  }
+
+  if (Array.isArray(metadata.queuedMessages)) {
+    patch.queuedMessages = (metadata.queuedMessages as unknown[]).filter(
+      (m): m is string => typeof m === "string",
+    );
   }
 
   if (Object.prototype.hasOwnProperty.call(metadata, "goal")) {

--- a/packages/ui/src/lib/types.ts
+++ b/packages/ui/src/lib/types.ts
@@ -75,6 +75,8 @@ export interface SessionUiCacheEntry {
   tokenUsage: TokenUsage | null;
   lastHeartbeatAt: number | null;
   todoList: TodoItem[];
+  /** Pending follow-up messages queued while the agent is busy. */
+  messageQueue: QueuedMessage[];
   pendingQuestion: { toolCallId: string; questions: Array<{ question: string; options: string[]; type?: QuestionType }>; display: QuestionDisplayMode } | null;
   pendingPlan: {
     toolCallId: string;

--- a/patches/@earendil-works%2Fpi-coding-agent@0.80.3.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.80.3.patch
@@ -1,6 +1,9 @@
 diff --git a/node_modules/@earendil-works/pi-coding-agent/.bun-tag-bc572afbfa496cd3 b/.bun-tag-bc572afbfa496cd3
 new file mode 100644
 index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
+diff --git a/node_modules/@earendil-works/pi-coding-agent/.bun-tag-d024f1ab98007b36 b/.bun-tag-d024f1ab98007b36
+new file mode 100644
+index 0000000000000000000000000000000000000000..e69de29bb2d1d6434b8b29ae775ad8c2e48c5391
 diff --git a/dist/config.js b/dist/config.js
 index 4600b23493be21d2316303d056ef135313dcef43..85bd9b0d26c0de32a7aabfd0e254fed05659f958 100644
 --- a/dist/config.js
@@ -36,7 +39,7 @@ index 4600b23493be21d2316303d056ef135313dcef43..85bd9b0d26c0de32a7aabfd0e254fed0
  /** Get path to user's custom themes directory */
  export function getCustomThemesDir() {
 diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
-index e223ce1f924fc70372dc2984faae427bf0019b98..fd4dc583f9efa18a56e3872d2a6772b0c282f061 100644
+index e223ce1f924fc70372dc2984faae427bf0019b98..88b24b216461116635ac8bb557e597346e1780ad 100644
 --- a/dist/core/agent-session.js
 +++ b/dist/core/agent-session.js
 @@ -1057,9 +1057,10 @@ export class AgentSession {
@@ -52,8 +55,26 @@ index e223ce1f924fc70372dc2984faae427bf0019b98..fd4dc583f9efa18a56e3872d2a6772b0
              streamingBehavior: options?.deliverAs,
              images,
              source: "extension",
+@@ -1809,6 +1810,17 @@ export class AgentSession {
+             },
+             getThinkingLevel: () => this.thinkingLevel,
+             setThinkingLevel: (level) => this.setThinkingLevel(level),
++            // PATCH(pizzapi): expose the pending queues so the remote extension can sync them to the web UI.
++            getQueuedMessages: () => ({ steering: [...this._steeringMessages], followUp: [...this._followUpMessages] }),
++            // PATCH(pizzapi): replace the pending follow-up queue (web UI queue edits/removals).
++            // ponytail: text-only — queued image attachments are dropped on replace; the queue mirrors only store text.
++            replaceQueuedMessages: (followUp) => {
++                const { steering } = this.clearQueue();
++                for (const text of steering)
++                    void this._queueSteer(text);
++                for (const text of followUp)
++                    void this._queueFollowUp(text);
++            },
+         }, {
+             getModel: () => this.model,
+             isIdle: () => !this.isStreaming,
 diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
-index 4b794828f33d7fad94fc0df69bc31959c94bf1c1..1a0ea062ac9a1f8e50aa384439126c84f3656214 100644
+index 4b794828f33d7fad94fc0df69bc31959c94bf1c1..941ef4a7e29ebe1e07baa2e4ce6941aeb5ace477 100644
 --- a/dist/core/extensions/loader.js
 +++ b/dist/core/extensions/loader.js
 @@ -137,6 +137,10 @@ export function createExtensionRuntime() {
@@ -67,7 +88,17 @@ index 4b794828f33d7fad94fc0df69bc31959c94bf1c1..1a0ea062ac9a1f8e50aa384439126c84
          getSessionName: notInitialized,
          setLabel: notInitialized,
          getActiveTools: notInitialized,
-@@ -236,6 +240,19 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
+@@ -148,6 +152,9 @@ export function createExtensionRuntime() {
+         setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
+         getThinkingLevel: notInitialized,
+         setThinkingLevel: notInitialized,
++        // PATCH(pizzapi): pending-queue read/replace for remote queue sync.
++        getQueuedMessages: notInitialized,
++        replaceQueuedMessages: notInitialized,
+         flagValues: new Map(),
+         pendingProviderRegistrations: [],
+         assertActive,
+@@ -236,6 +243,28 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
              runtime.assertActive();
              runtime.setSessionName(name);
          },
@@ -84,14 +115,33 @@ index 4b794828f33d7fad94fc0df69bc31959c94bf1c1..1a0ea062ac9a1f8e50aa384439126c84
 +            runtime.assertActive();
 +            return runtime.fork(entryId, options);
 +        },
++        // PATCH(pizzapi): pending-queue read/replace for remote queue sync (web UI queue edits).
++        getQueuedMessages() {
++            runtime.assertActive();
++            return runtime.getQueuedMessages();
++        },
++        replaceQueuedMessages(followUp) {
++            runtime.assertActive();
++            runtime.replaceQueuedMessages(followUp);
++        },
          getSessionName() {
              runtime.assertActive();
              return runtime.getSessionName();
 diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
-index 45d68a44d4fb1738509aae509ad7314150d87d74..a52dda99f0329a184eddcf1857a441f269002369 100644
+index 45d68a44d4fb1738509aae509ad7314150d87d74..361085e644c13e3b1977e1f573125bb4c8652736 100644
 --- a/dist/core/extensions/runner.js
 +++ b/dist/core/extensions/runner.js
-@@ -222,17 +222,24 @@ export class ExtensionRunner {
+@@ -169,6 +169,9 @@ export class ExtensionRunner {
+         this.runtime.setModel = actions.setModel;
+         this.runtime.getThinkingLevel = actions.getThinkingLevel;
+         this.runtime.setThinkingLevel = actions.setThinkingLevel;
++        // PATCH(pizzapi): expose pending-queue read/replace to extensions (remote queue sync).
++        this.runtime.getQueuedMessages = actions.getQueuedMessages;
++        this.runtime.replaceQueuedMessages = actions.replaceQueuedMessages;
+         // Context actions (required)
+         this.getModel = contextActions.getModel;
+         this.isIdleFn = contextActions.isIdle;
+@@ -222,17 +225,24 @@ export class ExtensionRunner {
          if (actions) {
              this.waitForIdleFn = actions.waitForIdle;
              this.newSessionHandler = actions.newSession;
@@ -117,10 +167,10 @@ index 45d68a44d4fb1738509aae509ad7314150d87d74..a52dda99f0329a184eddcf1857a441f2
      }
      setUIContext(uiContext, mode = "print") {
 diff --git a/dist/core/extensions/types.d.ts b/dist/core/extensions/types.d.ts
-index 828a90a283c5135b4e8f7d3845bed8e6d1aee653..5ddb445e7b11dfa46d035027fb55bafc5ff24046 100644
+index 828a90a283c5135b4e8f7d3845bed8e6d1aee653..18a33d22dcc7d7d5d311a4e206993cf146b36259 100644
 --- a/dist/core/extensions/types.d.ts
 +++ b/dist/core/extensions/types.d.ts
-@@ -881,11 +881,28 @@ export interface ExtensionAPI {
+@@ -881,11 +881,32 @@ export interface ExtensionAPI {
       */
      sendUserMessage(content: string | (TextContent | ImageContent)[], options?: {
          deliverAs?: "steer" | "followUp";
@@ -146,10 +196,14 @@ index 828a90a283c5135b4e8f7d3845bed8e6d1aee653..5ddb445e7b11dfa46d035027fb55bafc
 +        position?: "before" | "at";
 +        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
 +    }): Promise<{ cancelled: boolean; selectedText?: string; }>;
++    /** PATCH(pizzapi): read the pending steering/follow-up queues (remote queue sync). */
++    getQueuedMessages(): { steering: string[]; followUp: string[]; };
++    /** PATCH(pizzapi): replace the pending follow-up queue (web UI queue edits/removals). */
++    replaceQueuedMessages(followUp: string[]): void;
      /** Get the current session name, if set. */
      getSessionName(): string | undefined;
      /** Set or clear a label on an entry. Labels are user-defined markers for bookmarking/navigation. */
-@@ -1066,6 +1083,8 @@ export type SendMessageHandler = <T = unknown>(message: Pick<CustomMessage<T>, "
+@@ -1066,6 +1087,8 @@ export type SendMessageHandler = <T = unknown>(message: Pick<CustomMessage<T>, "
  }) => void;
  export type SendUserMessageHandler = (content: string | (TextContent | ImageContent)[], options?: {
      deliverAs?: "steer" | "followUp";
@@ -158,7 +212,7 @@ index 828a90a283c5135b4e8f7d3845bed8e6d1aee653..5ddb445e7b11dfa46d035027fb55bafc
  }) => void;
  export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
  export type SetSessionNameHandler = (name: string) => void;
-@@ -1117,6 +1136,9 @@ export interface ExtensionActions {
+@@ -1117,6 +1140,9 @@ export interface ExtensionActions {
      sendUserMessage: SendUserMessageHandler;
      appendEntry: AppendEntryHandler;
      setSessionName: SetSessionNameHandler;
@@ -168,6 +222,16 @@ index 828a90a283c5135b4e8f7d3845bed8e6d1aee653..5ddb445e7b11dfa46d035027fb55bafc
      getSessionName: GetSessionNameHandler;
      setLabel: SetLabelHandler;
      getActiveTools: GetActiveToolsHandler;
+@@ -1127,6 +1153,9 @@ export interface ExtensionActions {
+     setModel: SetModelHandler;
+     getThinkingLevel: GetThinkingLevelHandler;
+     setThinkingLevel: SetThinkingLevelHandler;
++    /** PATCH(pizzapi): pending-queue read/replace for remote queue sync. */
++    getQueuedMessages: () => { steering: string[]; followUp: string[]; };
++    replaceQueuedMessages: (followUp: string[]) => void;
+ }
+ /**
+  * Actions for ExtensionContext (ctx.* in event handlers).
 diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
 index 6ece8e7f75abf62bf82a48bf7c468d0a71a7c512..71d1a6fece63350921e9834c9396dd2cb529469d 100644
 --- a/dist/core/model-resolver.js


### PR DESCRIPTION
## Problem

1. **Queued follow-up messages vanished when switching sessions.** The web UI queue was optimistic local React state only — `openSession()` never restored it, and every `session_active` snapshot cleared it. The authoritative queue lives in pi on the runner but was never reported to viewers.
2. **Web UI queue edits were cosmetic.** Edit/remove/clear of queued messages only mutated local UI state — the runner still delivered the **original** text.

## Fix — make the runner's pi queue the single source of truth

- **pi patch** (`@earendil-works/pi-coding-agent@0.80.3`): expose `getQueuedMessages()` / `replaceQueuedMessages()` on the ExtensionAPI (bindCore action → runtime → loader surface). Replace is `clearQueue()` + re-enqueue, so pi's TUI pending display stays in sync too.
- **Runner:** report the pending follow-up queue in heartbeats, `session_active`, and `session_metadata_update`; add a `set_queued_messages` exec command — edit/remove/clear are all a full-list replace, confirmed with an immediate heartbeat broadcast.
- **Server:** merge `queuedMessages` metadata updates into the durable session snapshot so late/reconnecting viewers get fresh queue state.
- **UI:** cache `messageQueue` per session and restore it in `openSession`, reconcile against runner-reported state (stable ids so in-flight edits don't jump; no-op when unchanged), push queue mutations to the runner, and suppress runner syncs for 5s around local mutations so stale in-flight heartbeats can't clobber optimistic state.

Old runners that don't send the field keep the previous clear-on-snapshot behavior.

## Known ceilings (marked with `ponytail:` comments)

- Queued image attachments are dropped on queue replace — pi's queue mirror stores text only.
- Pending *steer* messages aren't synced into the queue panel; they already render optimistically in the conversation and deliver within seconds.

## Testing

- New tests: `reconcileMessageQueue` (ui), `readQueuedFollowUps` + snapshot/metadata inclusion (cli), `set_queued_messages` exec handler (cli), patch-presence assertions in `patches.test.ts`.
- Full suites green: cli 2213 ✓ / ui 1110 ✓ / server 1150 ✓, plus `tsc --build` across all packages.