### PR TITLE
fix(ui): suppress spurious 'update deployed' banner on mobile app

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -935,6 +935,7 @@ export function App() {
         uiVersion: UI_VERSION,
         clientSocketProtocol: SOCKET_PROTOCOL_VERSION,
         uiBuildTimestamp: BUILD_TIMESTAMP,
+        isMobileBundled,
       });
       setVersionBanner({
         message: negotiation.message,
@@ -943,7 +944,7 @@ export function App() {
     } catch {
       // Best effort only — do not surface transient fetch errors as hard failures.
     }
-  }, []);
+  }, [isMobileBundled]);
 
   // Cache last-known UI state per relay session so switching sessions feels instant.
   const sessionUiCacheRef = React.useRef<Map<string, SessionUiCacheEntry>>(new Map());

--- a/packages/ui/src/lib/version-negotiation.test.ts
+++ b/packages/ui/src/lib/version-negotiation.test.ts
@@ -139,6 +139,46 @@ describe("evaluateVersionNegotiation", () => {
         expect(result.message).toBeNull();
     });
 
+    test("suppresses the deployed-update banner on the bundled mobile app", () => {
+        const result = evaluateVersionNegotiation(
+            {
+                version: {
+                    server: "0.1.32",
+                    socketProtocol: 1,
+                    buildTimestamp: "2024-06-02T10:00:00.000Z",
+                },
+            },
+            {
+                uiVersion: "0.1.32",
+                clientSocketProtocol: 1,
+                uiBuildTimestamp: "2024-06-01T10:00:00.000Z",
+                isMobileBundled: true,
+            },
+        );
+
+        expect(result.updateAvailable).toBe(false);
+        expect(result.message).toBeNull();
+    });
+
+    test("still reports a real semver update on the bundled mobile app", () => {
+        const result = evaluateVersionNegotiation(
+            {
+                version: {
+                    server: "0.2.0",
+                    socketProtocol: 1,
+                },
+            },
+            {
+                uiVersion: "0.1.32",
+                clientSocketProtocol: 1,
+                isMobileBundled: true,
+            },
+        );
+
+        expect(result.updateAvailable).toBe(true);
+        expect(result.message).toContain("newer than this UI");
+    });
+
     test("exposes serverBuildTimestamp from payload", () => {
         const ts = "2024-06-02T10:00:00.000Z";
         const result = evaluateVersionNegotiation(

--- a/packages/ui/src/lib/version-negotiation.ts
+++ b/packages/ui/src/lib/version-negotiation.ts
@@ -16,6 +16,15 @@ export function evaluateVersionNegotiation(
         clientSocketProtocol: number;
         /** Build timestamp baked into this UI bundle at compile time. */
         uiBuildTimestamp?: string | null;
+        /**
+         * True when running inside the bundled Capacitor mobile app. The mobile
+         * bundle's build timestamp comes from a separate build pipeline than the
+         * relay server's web UI, so comparing them produces a permanent false
+         * positive ("update deployed") that "Refresh" can't fix anyway — the
+         * native shell doesn't pull fresh assets from the network. Skip that
+         * check on mobile; semver/protocol mismatches (real signals) still fire.
+         */
+        isMobileBundled?: boolean;
     },
 ): VersionNegotiationResult {
     const rawVersion =
@@ -50,6 +59,7 @@ export function evaluateVersionNegotiation(
     // this UI bundle, a new image was deployed after the user loaded the page.
     const buildTimestampMismatch =
         !semverNewer &&
+        !opts.isMobileBundled &&
         typeof serverBuildTimestamp === "string" &&
         serverBuildTimestamp !== null &&
         typeof opts.uiBuildTimestamp === "string" &&


### PR DESCRIPTION
## What

Suppress the near-permanent false-positive **"A newer version of PizzaPi has been deployed. Refresh to update."** banner on the bundled mobile (Capacitor) app.

## Why

The mobile app bundles its own UI build with its own build timestamp, produced by a **separate pipeline** than the relay server's web deploy. The `buildTimestampMismatch` check in `evaluateVersionNegotiation` compares the two, so it fires almost permanently on mobile — and **"Refresh" can't fix it** there anyway, because the native WebView loads bundled assets, not fresh network assets.

## Change

`evaluateVersionNegotiation` gains an `isMobileBundled` opt that skips **only** the build-timestamp check. Real signals still surface on mobile:
- server **semver** newer than the UI
- **socket protocol** mismatch

Wired from `App.tsx` via the existing `getMobileRuntimeConfig().isMobileBundled`.

## Tests

`packages/ui/src/lib/version-negotiation.test.ts` — added mobile-suppression + "real semver update still fires on mobile" cases. All 10 pass; UI typecheck clean.
