### PR TITLE
feat(mobile): self-hosted OTA web-bundle updates (Capgo, manual mode) [spike]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ packages/cli/src/config/claude-code-provider.precompiled.ts
 01-landing.png
 .playwright-cli/
 .superpowers/
+
+# Published self-hosted mobile OTA bundles (generated)
+mobile-ota/

--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation project(':capacitor-local-notifications')
     implementation project(':capacitor-push-notifications')
     implementation project(':capawesome-capacitor-badge')
+    implementation project(':capgo-capacitor-updater')
 
 }
 

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -16,3 +16,6 @@ project(':capacitor-push-notifications').projectDir = new File('../node_modules/
 
 include ':capawesome-capacitor-badge'
 project(':capawesome-capacitor-badge').projectDir = new File('../node_modules/.bun/@capawesome+capacitor-badge@8.0.2+767ac80cbab8ae50/node_modules/@capawesome/capacitor-badge/android')
+
+include ':capgo-capacitor-updater'
+project(':capgo-capacitor-updater').projectDir = new File('../node_modules/.bun/@capgo+capacitor-updater@8.50.2+767ac80cbab8ae50/node_modules/@capgo/capacitor-updater/android')

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "@capacitor/local-notifications": "^8.2.0",
         "@capacitor/push-notifications": "^8.1.1",
         "@capawesome/capacitor-badge": "^8.0.2",
+        "@capgo/capacitor-updater": "^8",
         "@earendil-works/pi-agent-core": "^0.80.3",
         "@earendil-works/pi-ai": "^0.80.3",
         "@earendil-works/pi-tui": "^0.80.3",
@@ -39,7 +40,7 @@
     },
     "packages/cli": {
       "name": "@pizzapi/cli",
-      "version": "0.5.4-dev.3",
+      "version": "0.5.4",
       "bin": {
         "pizza": "src/index.ts",
         "pizzapi": "src/index.ts",
@@ -560,6 +561,8 @@
     "@capacitor/push-notifications": ["@capacitor/push-notifications@8.1.1", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-WqzjPKIbYbARMN+GC0XMAJcxJpUUzqgzS/Ny8RODLrro38pQhm3GXYwX2Mwd+LZlLY39rGImkCkrKyQSNfuikA=="],
 
     "@capawesome/capacitor-badge": ["@capawesome/capacitor-badge@8.0.2", "", { "peerDependencies": { "@capacitor/core": ">=8.0.0" } }, "sha512-4ZnRyFvViaokupdrOi3OkoBurH+23hnxni+PYq5C1ObNLYbhty/WK8BzMtndCv0S47XjGBLjQ9DJsYj3JDVxGQ=="],
+
+    "@capgo/capacitor-updater": ["@capgo/capacitor-updater@8.50.2", "", { "peerDependencies": { "@capacitor/core": "^8.0.0" } }, "sha512-bMsZFp17jg39hBqCioLrJfRyH4VDUS3vcvTJ55MlcdBAxEfj2rqkJZtBPVerO3Y8oJuoGM4x89ISdXJkPzmTfA=="],
 
     "@capsizecss/unpack": ["@capsizecss/unpack@4.0.0", "", { "dependencies": { "fontkitten": "^1.0.0" } }, "sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA=="],
 

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -20,8 +20,12 @@ const config: CapacitorConfig = {
         // chosen at runtime, so Capgo's build-time `updateUrl` isn't used.
         // `autoUpdate: false` stops the plugin from polling a config URL on its
         // own — our code drives download/set/reload against the paired server.
+        // `statsUrl: ""` disables Capgo's default telemetry
+        // (https://plugin.capgo.app/stats) so a self-hosted install never phones
+        // home on notifyAppReady()/update events.
         CapacitorUpdater: {
             autoUpdate: false,
+            statsUrl: "",
         },
     },
 };

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -15,6 +15,14 @@ const config: CapacitorConfig = {
         CapacitorHttp: {
             enabled: true,
         },
+        // Self-hosted OTA web-bundle updates. We run in MANUAL mode (see
+        // packages/ui/src/lib/mobile-ota.ts) because the relay server URL is
+        // chosen at runtime, so Capgo's build-time `updateUrl` isn't used.
+        // `autoUpdate: false` stops the plugin from polling a config URL on its
+        // own — our code drives download/set/reload against the paired server.
+        CapacitorUpdater: {
+            autoUpdate: false,
+        },
     },
 };
 

--- a/docs/mobile-ota.md
+++ b/docs/mobile-ota.md
@@ -23,11 +23,17 @@ app launch ──► fetch manifest ──► buildTimestamp newer? ──► Ca
 - **Integrity:** the native updater verifies the SHA-256 from the manifest
   before applying, and auto-rolls-back if the new bundle never calls
   `notifyAppReady()` (we call it on boot in `main.ts`).
+- **Plugin access:** the client reaches the updater through Capacitor's
+  `registerPlugin("CapacitorUpdater")` bridge (by name, like `PizzapiNtfy`) — it
+  does **not** import the `@capgo` JS wrapper, so the web build never resolves
+  the package and there's no bare-specifier `import()` for the WebView to fail
+  on. On native the proxy routes to the plugin `cap sync` installs.
 
 ## One-time native setup (run on a machine with the Android/iOS toolchain)
 
-The web build and unit tests do **not** need this — the plugin is imported
-dynamically and guarded to the native shell.
+The web build and unit tests do **not** need this — the client accesses the
+plugin via `registerPlugin` (by name) and guards every call to the native shell,
+so nothing imports the `@capgo` package until you add it here.
 
 ```bash
 bun add @capgo/capacitor-updater@^8    # matches @capacitor/core ^8

--- a/docs/mobile-ota.md
+++ b/docs/mobile-ota.md
@@ -7,8 +7,13 @@ no "install unknown apps" prompt (the signing key is never touched).
 
 ## How it works
 
+The OTA zip mirrors the Capacitor web root (`webDir: mobile`): the bootstrap
+shell `index.html` at the archive root, plus `app/` (built UI) and `vendor/`.
+Bundling only `app/` would drop the bootstrap/sign-out/re-pair flow after an
+update. `buildTimestamp` still comes from `app/build-info.json`.
+
 ```
-build:mobile ──► mobile/app/ ──► publish:mobile:ota ──► mobile-ota/{manifest.json, pizzapi-<ts>.zip}
+build:mobile ──► mobile/{index.html,app/,vendor/} ──► publish:mobile:ota ──► mobile-ota/{manifest.json, pizzapi-<ts>.zip}
                                                               │
 relay server (PIZZAPI_MOBILE_OTA_DIR) serves /api/mobile/ota/*
                                                               │

--- a/docs/mobile-ota.md
+++ b/docs/mobile-ota.md
@@ -41,7 +41,9 @@ pull it in. To package the native side, run a mobile build (which runs
 bun run build:mobile   # builds UI + copies to mobile/app + cap sync (installs the native plugin)
 ```
 
-`capacitor.config.ts` already sets `CapacitorUpdater: { autoUpdate: false }`.
+`capacitor.config.ts` already sets `CapacitorUpdater: { autoUpdate: false }`
+(manual mode) and `statsUrl: ""` (no telemetry to Capgo — self-hosted installs
+never phone home on `notifyAppReady()`/update events).
 
 ## Publishing an update
 

--- a/docs/mobile-ota.md
+++ b/docs/mobile-ota.md
@@ -1,0 +1,65 @@
+# Mobile OTA updates (self-hosted, manual mode)
+
+Ship **UI-only** changes to the installed mobile app without a store release or
+new APK. Native/plugin changes still need a new APK (rare). Updates are served
+by the **relay server the app already trusts** — no separate tunnel, no store,
+no "install unknown apps" prompt (the signing key is never touched).
+
+## How it works
+
+```
+build:mobile ──► mobile/app/ ──► publish:mobile:ota ──► mobile-ota/{manifest.json, pizzapi-<ts>.zip}
+                                                              │
+relay server (PIZZAPI_MOBILE_OTA_DIR) serves /api/mobile/ota/*
+                                                              │
+app launch ──► fetch manifest ──► buildTimestamp newer? ──► Capgo download+verify(sha256)+set+reload
+```
+
+- **Freshness key:** the bundle's `buildTimestamp` (same signal as the web
+  update banner). ISO-8601 sorts lexically, so "strictly newer" is a plain `>`.
+- **Manual mode:** the app's server URL is chosen at runtime, so Capgo's
+  build-time `autoUpdate.updateUrl` can't be used. `packages/ui/src/lib/mobile-ota.ts`
+  fetches the manifest and drives `download → set → reload` itself.
+- **Integrity:** the native updater verifies the SHA-256 from the manifest
+  before applying, and auto-rolls-back if the new bundle never calls
+  `notifyAppReady()` (we call it on boot in `main.ts`).
+
+## One-time native setup (run on a machine with the Android/iOS toolchain)
+
+The web build and unit tests do **not** need this — the plugin is imported
+dynamically and guarded to the native shell.
+
+```bash
+bun add @capgo/capacitor-updater@^8    # matches @capacitor/core ^8
+bun run build:mobile                   # builds UI + copies to mobile/app + cap sync
+```
+
+`capacitor.config.ts` already sets `CapacitorUpdater: { autoUpdate: false }`.
+
+## Publishing an update
+
+```bash
+bun run build:mobile                          # produce mobile/app/
+PIZZAPI_MOBILE_OTA_DIR=/srv/pizzapi-ota bun run publish:mobile:ota
+```
+
+Then run the relay server with the **same** dir:
+
+```bash
+PIZZAPI_MOBILE_OTA_DIR=/srv/pizzapi-ota <start server>
+```
+
+`GET /api/mobile/ota/manifest.json` should now return the manifest. On next
+launch, installed apps older than that `buildTimestamp` pull and apply it.
+
+When `PIZZAPI_MOBILE_OTA_DIR` is unset the feature is off (every OTA path 404s).
+
+## Notes / limits
+
+- The bundle is public (it's the same UI the server already serves) — no auth on
+  the endpoints; integrity comes from the checksum, not access control.
+- `publish:mobile:ota` uses the system `zip`. If a device ever rejects the
+  archive, swap that step for `@capgo/cli bundle zip` (their exact format).
+- Rollback/staged rollout/kill-switch are not implemented — add a
+  `minBuildTimestamp` gate in the manifest if you need to force-expire a bad
+  bundle.

--- a/docs/mobile-ota.md
+++ b/docs/mobile-ota.md
@@ -29,15 +29,16 @@ app launch ──► fetch manifest ──► buildTimestamp newer? ──► Ca
   the package and there's no bare-specifier `import()` for the WebView to fail
   on. On native the proxy routes to the plugin `cap sync` installs.
 
-## One-time native setup (run on a machine with the Android/iOS toolchain)
+## Native setup (run on a machine with the Android/iOS toolchain)
 
-The web build and unit tests do **not** need this — the client accesses the
-plugin via `registerPlugin` (by name) and guards every call to the native shell,
-so nothing imports the `@capgo` package until you add it here.
+`@capgo/capacitor-updater` is already a committed dependency, but the client
+never imports it — it reaches the plugin via `registerPlugin("CapacitorUpdater")`
+and guards every call to the native shell, so the web build/unit tests don't
+pull it in. To package the native side, run a mobile build (which runs
+`cap sync`, picking the plugin up from `package.json`):
 
 ```bash
-bun add @capgo/capacitor-updater@^8    # matches @capacitor/core ^8
-bun run build:mobile                   # builds UI + copies to mobile/app + cap sync
+bun run build:mobile   # builds UI + copies to mobile/app + cap sync (installs the native plugin)
 ```
 
 `capacitor.config.ts` already sets `CapacitorUpdater: { autoUpdate: false }`.
@@ -62,8 +63,13 @@ When `PIZZAPI_MOBILE_OTA_DIR` is unset the feature is off (every OTA path 404s).
 
 ## Notes / limits
 
+- **HTTPS-only.** OTA ships executable JS, so the client only applies a bundle
+  when the relay server URL is `https://` (`isSecureOtaOrigin`). The app allows
+  `http://` for LAN/loopback servers and `CapacitorHttp` bypasses mixed-content
+  blocking, so plain-http OTA would be MITM-exploitable — those servers update
+  via a new APK instead.
 - The bundle is public (it's the same UI the server already serves) — no auth on
-  the endpoints; integrity comes from the checksum, not access control.
+  the endpoints; integrity comes from the checksum + TLS, not access control.
 - `publish:mobile:ota` uses the system `zip`. If a device ever rejects the
   archive, swap that step for `@capgo/cli bundle zip` (their exact format).
 - Rollback/staged rollout/kill-switch are not implemented — add a

--- a/package.json
+++ b/package.json
@@ -46,12 +46,13 @@
     "postinstall": "bun scripts/link-workspaces.ts"
   },
   "dependencies": {
-    "@capacitor/core": "^8.4.1",
     "@aparajita/capacitor-secure-storage": "^8.0.0",
+    "@capacitor/core": "^8.4.1",
     "@capacitor/haptics": "^8.0.2",
     "@capacitor/local-notifications": "^8.2.0",
     "@capacitor/push-notifications": "^8.1.1",
     "@capawesome/capacitor-badge": "^8.0.2",
+    "@capgo/capacitor-updater": "^8",
     "@earendil-works/pi-agent-core": "^0.80.3",
     "@earendil-works/pi-ai": "^0.80.3",
     "@earendil-works/pi-tui": "^0.80.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build:mobile:android": "bun run build:protocol && bun run build:tools && VITE_MOBILE=1 VITE_BASE_URL=./ bun run build:ui && bun scripts/copy-mobile-ui.ts && bunx cap sync android && bun scripts/strip-synced-node-modules.ts && cd android && ./gradlew assembleDebug",
     "build:mobile:android:release": "bun run build:protocol && bun run build:tools && VITE_MOBILE=1 VITE_BASE_URL=./ bun run build:ui && bun scripts/copy-mobile-ui.ts && bunx cap sync android && bun scripts/strip-synced-node-modules.ts && cd android && ./gradlew assembleRelease bundleRelease && cd .. && bun scripts/verify-apk-signed.ts",
     "build:mobile:ios": "bun run build:protocol && bun run build:tools && VITE_MOBILE=1 VITE_BASE_URL=./ bun run build:ui && bun scripts/copy-mobile-ui.ts && bunx cap sync ios && bun scripts/strip-synced-node-modules.ts",
+    "publish:mobile:ota": "bun scripts/publish-mobile-ota.ts",
     "icons:generate": "bun run scripts/generate-mobile-icons.ts",
     "build:binaries": "cd packages/cli && bun run build:binaries",
     "build:npm": "bun packages/npm/build-npm.ts",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dev:redis:stop": "bash scripts/stop-redis.sh",
     "dev:cli": "bun packages/cli/src/index.ts",
     "dev:runner": "bun packages/cli/src/index.ts runner",
-    "test": "bun test --max-concurrency=1 scripts/start-redis.test.ts packages/protocol/src packages/tunnel/src packages/server/src packages/server/tests/pi-compat.test.ts packages/server/tests/prune.test.ts packages/server/tests/touch.test.ts packages/server/tests/validation.test.ts packages/tools/src && bun test --max-concurrency=1 packages/server/tests/e2e/signup.test.ts && bun test --max-concurrency=1 packages/server/tests/harness && cd packages/cli && bun test src && cd ../ui && bun test src && cd ../.. && bun test mobile",
+    "test": "bun test --max-concurrency=1 scripts/start-redis.test.ts packages/protocol/src packages/tunnel/src packages/server/src packages/server/tests/pi-compat.test.ts packages/server/tests/prune.test.ts packages/server/tests/touch.test.ts packages/server/tests/validation.test.ts packages/server/tests/mobile-ota.test.ts packages/tools/src && bun test --max-concurrency=1 packages/server/tests/e2e/signup.test.ts && bun test --max-concurrency=1 packages/server/tests/harness && cd packages/cli && bun test src && cd ../ui && bun test src && cd ../.. && bun test mobile",
     "typecheck": "bun packages/cli/scripts/compile-prompt.ts && tsc --build && bun run --cwd packages/protocol typecheck:tests && bun run --cwd packages/server typecheck:tests",
     "migrate": "cd packages/server && bun run migrate",
     "clean": "bun -e \"['protocol','tunnel','tools','server','ui','cli','docs'].forEach(p=>{require('fs').rmSync('packages/'+p+'/dist',{recursive:true,force:true});require('fs').rmSync('packages/'+p+'/tsconfig.tsbuildinfo',{force:true})})\"",

--- a/packages/server/src/routes/index.ts
+++ b/packages/server/src/routes/index.ts
@@ -15,6 +15,7 @@ import { requireSession } from "../middleware.js";
 import { handleAuthRoute } from "./auth.js";
 import { handleSetupClaimsRoute } from "./setup-claims.js";
 import { handleMobileLinksRoute } from "./mobile-links.js";
+import { handleMobileOtaRoute } from "./mobile-ota.js";
 import { handleRunnersRoute } from "./runners.js";
 import { handleSessionsRoute } from "./sessions.js";
 import { handleAttachmentsRoute } from "./attachments.js";
@@ -37,6 +38,7 @@ const routers: RouteHandler[] = [
     handleAuthRoute,
     handleSetupClaimsRoute, // QR-code setup claim lifecycle
     handleMobileLinksRoute, // Android app pairing lifecycle
+    handleMobileOtaRoute,   // Self-hosted OTA bundle for the mobile app (unauthenticated)
     handleTunnelRoute,     // Before runners — /api/tunnel/* is session-scoped, not runner-scoped
     handleRunnersRoute,
     handleRunnerSettingsRoute,

--- a/packages/server/src/routes/mobile-ota.ts
+++ b/packages/server/src/routes/mobile-ota.ts
@@ -1,0 +1,68 @@
+/**
+ * Mobile OTA router — serves the self-hosted Capacitor live-update bundle.
+ *
+ * The mobile app loads its UI from bundled assets baked into the APK. To ship
+ * UI-only changes without a new APK, the relay server (which the app already
+ * trusts) hosts the latest web bundle as a checksummed zip plus a small
+ * manifest. The mobile client (see packages/ui/src/lib/mobile-ota.ts) fetches
+ * the manifest, compares build timestamps, and — via @capgo/capacitor-updater
+ * in manual mode — downloads + verifies + swaps the bundle.
+ *
+ * Endpoints (unauthenticated by design — the bundle is the same public UI the
+ * server already serves; integrity is guaranteed by the SHA-256 the client
+ * passes to the native updater, not by access control):
+ *   GET /api/mobile/ota/manifest.json  → the manifest, or 404 when unpublished
+ *   GET /api/mobile/ota/<name>.zip      → a published bundle zip, or 404
+ *
+ * The published files live in PIZZAPI_MOBILE_OTA_DIR. When that env var is
+ * unset the feature is simply off (every path 404s).
+ *
+ * ponytail: static-file serve + traversal guard, no DB/state. Add auth/signing
+ * only if bundles ever contain non-public data (they don't today).
+ */
+
+import { existsSync } from "node:fs";
+import { resolve, sep } from "node:path";
+import type { RouteHandler } from "./types.js";
+
+const OTA_PREFIX = "/api/mobile/ota/";
+
+/** Resolve the configured OTA directory, or null when the feature is off. */
+function otaDir(): string | null {
+    const dir = process.env.PIZZAPI_MOBILE_OTA_DIR;
+    if (!dir) return null;
+    const resolved = resolve(dir);
+    return existsSync(resolved) ? resolved : null;
+}
+
+export const handleMobileOtaRoute: RouteHandler = async (req, url) => {
+    if (!url.pathname.startsWith(OTA_PREFIX)) return undefined;
+    if (req.method !== "GET") return undefined;
+
+    const dir = otaDir();
+    if (!dir) return new Response("OTA not configured", { status: 404 });
+
+    // Only ever serve the manifest or *.zip bundles — never anything else.
+    const name = url.pathname.slice(OTA_PREFIX.length);
+    const isManifest = name === "manifest.json";
+    const isBundle = /^[A-Za-z0-9._-]+\.zip$/.test(name);
+    if (!isManifest && !isBundle) return new Response("Not found", { status: 404 });
+
+    // Path-traversal guard: the resolved file must stay inside the OTA dir.
+    const filePath = resolve(dir, name);
+    const dirWithSep = dir.endsWith(sep) ? dir : dir + sep;
+    if (!filePath.startsWith(dirWithSep)) return new Response("Not found", { status: 404 });
+
+    const file = Bun.file(filePath);
+    if (!(await file.exists())) return new Response("Not found", { status: 404 });
+
+    return new Response(file, {
+        headers: {
+            "content-type": isManifest ? "application/json; charset=utf-8" : "application/zip",
+            // Manifest must never be cached (freshness check); bundles are
+            // content-addressed by name so they can cache forever.
+            "cache-control": isManifest ? "no-cache" : "public, max-age=31536000, immutable",
+            "x-content-type-options": "nosniff",
+        },
+    });
+};

--- a/packages/server/tests/mobile-ota.test.ts
+++ b/packages/server/tests/mobile-ota.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleMobileOtaRoute } from "../src/routes/mobile-ota.js";
+
+function get(path: string): Promise<Response | undefined> {
+    const url = new URL(`http://localhost${path}`);
+    return handleMobileOtaRoute(new Request(url, { method: "GET" }), url);
+}
+
+describe("handleMobileOtaRoute", () => {
+    let dir: string;
+    const prev = process.env.PIZZAPI_MOBILE_OTA_DIR;
+
+    beforeEach(() => {
+        dir = mkdtempSync(join(tmpdir(), "pp-ota-"));
+        writeFileSync(join(dir, "manifest.json"), JSON.stringify({ version: "t", checksum: "abc" }));
+        writeFileSync(join(dir, "pizzapi-t.zip"), "PK\u0003\u0004fake-zip");
+        process.env.PIZZAPI_MOBILE_OTA_DIR = dir;
+    });
+
+    afterEach(() => {
+        rmSync(dir, { recursive: true, force: true });
+        if (prev === undefined) delete process.env.PIZZAPI_MOBILE_OTA_DIR;
+        else process.env.PIZZAPI_MOBILE_OTA_DIR = prev;
+    });
+
+    it("ignores non-OTA paths", async () => {
+        expect(await get("/api/health")).toBeUndefined();
+    });
+
+    it("serves the manifest with no-cache", async () => {
+        const res = await get("/api/mobile/ota/manifest.json");
+        expect(res?.status).toBe(200);
+        expect(res?.headers.get("content-type")).toContain("application/json");
+        expect(res?.headers.get("cache-control")).toContain("no-cache");
+        expect(await res?.json()).toEqual({ version: "t", checksum: "abc" });
+    });
+
+    it("serves a bundle zip immutably", async () => {
+        const res = await get("/api/mobile/ota/pizzapi-t.zip");
+        expect(res?.status).toBe(200);
+        expect(res?.headers.get("content-type")).toBe("application/zip");
+        expect(res?.headers.get("cache-control")).toContain("immutable");
+    });
+
+    it("404s unknown bundles and non-zip names", async () => {
+        expect((await get("/api/mobile/ota/missing.zip"))?.status).toBe(404);
+        expect((await get("/api/mobile/ota/evil.sh"))?.status).toBe(404);
+    });
+
+    it("blocks path traversal", async () => {
+        expect((await get("/api/mobile/ota/..%2f..%2fetc%2fpasswd"))?.status).toBe(404);
+    });
+
+    it("404s the whole feature when unconfigured", async () => {
+        delete process.env.PIZZAPI_MOBILE_OTA_DIR;
+        expect((await get("/api/mobile/ota/manifest.json"))?.status).toBe(404);
+    });
+});

--- a/packages/ui/src/lib/mobile-ota.test.ts
+++ b/packages/ui/src/lib/mobile-ota.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { shouldApplyOta } from "./mobile-ota";
+import { isSecureOtaOrigin, shouldApplyOta } from "./mobile-ota";
 
 const installed = "2026-07-09T10:00:00.000Z";
 const valid = {
@@ -34,5 +34,24 @@ describe("shouldApplyOta", () => {
 
     test("applies against an empty installed timestamp (fresh install / dev)", () => {
         expect(shouldApplyOta(valid, "")).toBe(true);
+    });
+});
+
+describe("isSecureOtaOrigin", () => {
+    test("allows https origins", () => {
+        expect(isSecureOtaOrigin("https://relay.example.com")).toBe(true);
+        expect(isSecureOtaOrigin("HTTPS://relay.example.com/")).toBe(true);
+        expect(isSecureOtaOrigin("  https://relay.example.com  ")).toBe(true);
+    });
+
+    test("rejects http (incl. LAN/loopback) and other schemes", () => {
+        expect(isSecureOtaOrigin("http://192.168.1.5:8080")).toBe(false);
+        expect(isSecureOtaOrigin("http://localhost:3000")).toBe(false);
+        expect(isSecureOtaOrigin("http://relay.local")).toBe(false);
+        expect(isSecureOtaOrigin("ftp://x")).toBe(false);
+        expect(isSecureOtaOrigin("")).toBe(false);
+        // Guard against sneaky prefixes that merely contain "https".
+        expect(isSecureOtaOrigin("httpshh://x")).toBe(false);
+        expect(isSecureOtaOrigin("http://x?https://y")).toBe(false);
     });
 });

--- a/packages/ui/src/lib/mobile-ota.test.ts
+++ b/packages/ui/src/lib/mobile-ota.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import { shouldApplyOta } from "./mobile-ota";
+
+const installed = "2026-07-09T10:00:00.000Z";
+const valid = {
+    buildTimestamp: "2026-07-09T12:00:00.000Z",
+    version: "2026-07-09T12:00:00.000Z",
+    url: "/api/mobile/ota/pizzapi-x.zip",
+    checksum: "abc123",
+};
+
+describe("shouldApplyOta", () => {
+    test("applies when the manifest is strictly newer", () => {
+        expect(shouldApplyOta(valid, installed)).toBe(true);
+    });
+
+    test("skips when same or older (ISO strings sort lexically)", () => {
+        expect(shouldApplyOta({ ...valid, buildTimestamp: installed }, installed)).toBe(false);
+        expect(shouldApplyOta({ ...valid, buildTimestamp: "2026-07-09T09:00:00.000Z" }, installed)).toBe(false);
+    });
+
+    test("rejects manifests missing url or checksum", () => {
+        expect(shouldApplyOta({ ...valid, url: "" }, installed)).toBe(false);
+        expect(shouldApplyOta({ ...valid, checksum: "" }, installed)).toBe(false);
+        const { checksum: _c, ...noChecksum } = valid;
+        expect(shouldApplyOta(noChecksum, installed)).toBe(false);
+    });
+
+    test("rejects non-object / junk payloads", () => {
+        expect(shouldApplyOta(null, installed)).toBe(false);
+        expect(shouldApplyOta("nope", installed)).toBe(false);
+        expect(shouldApplyOta({}, installed)).toBe(false);
+    });
+
+    test("applies against an empty installed timestamp (fresh install / dev)", () => {
+        expect(shouldApplyOta(valid, "")).toBe(true);
+    });
+});

--- a/packages/ui/src/lib/mobile-ota.ts
+++ b/packages/ui/src/lib/mobile-ota.ts
@@ -66,6 +66,18 @@ function nativeEnabled(): boolean {
     return getMobileRuntimeConfig().isMobileBundled && Capacitor.isNativePlatform();
 }
 
+/**
+ * OTA delivers executable JS, so it may only be pulled over an authenticated
+ * channel (TLS). The app allows `http://` for loopback/LAN servers, and
+ * `CapacitorHttp` routes fetch through native HTTP that bypasses mixed-content
+ * blocking — so over plain http a LAN attacker could swap the manifest + bundle
+ * + checksum and get arbitrary code applied. HTTPS-only closes that; http
+ * servers simply don't receive OTA (they can still update via a new APK).
+ */
+export function isSecureOtaOrigin(serverUrl: string): boolean {
+    return /^https:\/\//i.test(serverUrl.trim());
+}
+
 /** Minimal shape of the bits of @capgo/capacitor-updater we call. */
 interface CapgoUpdater {
     notifyAppReady(): Promise<unknown>;
@@ -122,6 +134,8 @@ export async function checkAndApplyOtaUpdate(
     const { serverUrl } = getMobileRuntimeConfig();
     if (!serverUrl) return false;
     const base = serverUrl.replace(/\/+$/, "");
+    // Never apply code fetched over an unauthenticated (http) channel.
+    if (!isSecureOtaOrigin(base)) return false;
 
     let manifest: unknown;
     try {

--- a/packages/ui/src/lib/mobile-ota.ts
+++ b/packages/ui/src/lib/mobile-ota.ts
@@ -14,13 +14,16 @@
  * `>` is a correct "strictly newer" test.
  *
  * Everything is a no-op outside the native Capacitor shell. The native plugin
- * is imported dynamically via a variable specifier so the web build never has
- * to resolve it (it's only installed for the mobile build + `cap sync`).
+ * is reached through Capacitor's `registerPlugin` bridge (by name — no bundled
+ * import of the @capgo JS wrapper), exactly like the PizzapiNtfy plugin. That
+ * means the web build never has to resolve the package, and on native the proxy
+ * routes to the plugin that `bun add @capgo/capacitor-updater` + `cap sync`
+ * install into the native project (see docs/mobile-ota.md).
  *
  * ponytail: no retry/scheduler/progress UI — one check on launch. Add a
  * progress bar + periodic re-check only if bundles get large or updates frequent.
  */
-import { Capacitor } from "@capacitor/core";
+import { Capacitor, registerPlugin } from "@capacitor/core";
 import { getMobileRuntimeConfig } from "./mobile-runtime.js";
 
 /** Build timestamp baked into THIS bundle (the currently-installed version). */
@@ -71,19 +74,27 @@ interface CapgoUpdater {
     reload(): Promise<unknown>;
 }
 
-/**
- * Load the native updater. Dynamic + variable specifier so the web build/tsc
- * never needs the package resolved; returns null if unavailable.
- */
-async function loadUpdater(): Promise<CapgoUpdater | null> {
-    try {
-        const spec = "@capgo/capacitor-updater";
-        const mod = (await import(/* @vite-ignore */ spec)) as { CapacitorUpdater?: CapgoUpdater };
-        return mod.CapacitorUpdater ?? null;
-    } catch {
-        return null;
+// Web no-op so the proxy never rejects on the PWA build (calls are guarded to
+// native anyway). On native, registerPlugin routes to the "CapacitorUpdater"
+// plugin that `cap sync` installs — no JS import of the @capgo wrapper needed.
+class CapacitorUpdaterWeb implements CapgoUpdater {
+    async notifyAppReady(): Promise<unknown> {
+        return {};
+    }
+    async download(): Promise<{ id: string }> {
+        return { id: "" };
+    }
+    async set(): Promise<unknown> {
+        return {};
+    }
+    async reload(): Promise<unknown> {
+        return {};
     }
 }
+
+const CapacitorUpdater = registerPlugin<CapgoUpdater>("CapacitorUpdater", {
+    web: async () => new CapacitorUpdaterWeb(),
+});
 
 /**
  * Tell the updater this bundle booted successfully, cancelling the automatic
@@ -92,9 +103,8 @@ async function loadUpdater(): Promise<CapgoUpdater | null> {
  */
 export async function notifyOtaReady(): Promise<void> {
     if (!nativeEnabled()) return;
-    const updater = await loadUpdater();
     try {
-        await updater?.notifyAppReady();
+        await CapacitorUpdater.notifyAppReady();
     } catch (err) {
         console.error("mobile-ota: notifyAppReady failed:", err);
     }
@@ -125,16 +135,14 @@ export async function checkAndApplyOtaUpdate(
     if (!shouldApplyOta(manifest, installedBuildTimestamp)) return false;
     const m = manifest as OtaManifest;
 
-    const updater = await loadUpdater();
-    if (!updater) return false;
     try {
-        const bundle = await updater.download({
+        const bundle = await CapacitorUpdater.download({
             url: m.url.startsWith("http") ? m.url : `${base}${m.url}`,
             version: m.version,
             checksum: m.checksum,
         });
-        await updater.set(bundle);
-        await updater.reload();
+        await CapacitorUpdater.set(bundle);
+        await CapacitorUpdater.reload();
         return true;
     } catch (err) {
         console.error("mobile-ota: update failed:", err);

--- a/packages/ui/src/lib/mobile-ota.ts
+++ b/packages/ui/src/lib/mobile-ota.ts
@@ -1,0 +1,143 @@
+/**
+ * Self-hosted OTA (over-the-air) web-bundle updates for the Capacitor app.
+ *
+ * The mobile app ships its UI baked into the APK. To deliver UI-only changes
+ * without a store release, the relay server hosts the latest bundle (see
+ * packages/server/src/routes/mobile-ota.ts). We run @capgo/capacitor-updater in
+ * **manual mode**: the app's server URL is chosen at runtime (bootstrap page),
+ * so Capgo's build-time `autoUpdate.updateUrl` can't be used — instead we fetch
+ * the manifest ourselves, decide freshness, and drive download → set → reload.
+ *
+ * Freshness reuses the existing build-timestamp signal (the same one behind the
+ * web "update available" banner): the manifest's `buildTimestamp` vs. the one
+ * baked into the running bundle. ISO-8601 strings sort lexically, so a plain
+ * `>` is a correct "strictly newer" test.
+ *
+ * Everything is a no-op outside the native Capacitor shell. The native plugin
+ * is imported dynamically via a variable specifier so the web build never has
+ * to resolve it (it's only installed for the mobile build + `cap sync`).
+ *
+ * ponytail: no retry/scheduler/progress UI — one check on launch. Add a
+ * progress bar + periodic re-check only if bundles get large or updates frequent.
+ */
+import { Capacitor } from "@capacitor/core";
+import { getMobileRuntimeConfig } from "./mobile-runtime.js";
+
+/** Build timestamp baked into THIS bundle (the currently-installed version). */
+declare const __PIZZAPI_BUILD_TIMESTAMP__: string;
+const INSTALLED_BUILD_TIMESTAMP =
+    typeof __PIZZAPI_BUILD_TIMESTAMP__ === "string" ? __PIZZAPI_BUILD_TIMESTAMP__ : "";
+
+export interface OtaManifest {
+    /** ISO-8601 build time of the published bundle — the freshness key. */
+    buildTimestamp: string;
+    /** Opaque version label handed to the native updater (we use the timestamp). */
+    version: string;
+    /** Bundle URL, relative to the server root, e.g. /api/mobile/ota/x.zip */
+    url: string;
+    /** SHA-256 hex of the zip; the native updater verifies it before applying. */
+    checksum: string;
+    /** Optional size in bytes (informational). */
+    bytes?: number;
+}
+
+/**
+ * Pure freshness decision: should the manifest replace the installed bundle?
+ * Exported for tests — no side effects, no native access.
+ */
+export function shouldApplyOta(manifest: unknown, installedBuildTimestamp: string): boolean {
+    if (!manifest || typeof manifest !== "object") return false;
+    const m = manifest as Partial<OtaManifest>;
+    return (
+        typeof m.buildTimestamp === "string" &&
+        typeof m.url === "string" &&
+        !!m.url &&
+        typeof m.checksum === "string" &&
+        !!m.checksum &&
+        m.buildTimestamp > installedBuildTimestamp
+    );
+}
+
+/** True only inside the bundled native shell — web/PWA is always a no-op. */
+function nativeEnabled(): boolean {
+    return getMobileRuntimeConfig().isMobileBundled && Capacitor.isNativePlatform();
+}
+
+/** Minimal shape of the bits of @capgo/capacitor-updater we call. */
+interface CapgoUpdater {
+    notifyAppReady(): Promise<unknown>;
+    download(opts: { url: string; version: string; checksum?: string }): Promise<{ id: string }>;
+    set(bundle: { id: string }): Promise<unknown>;
+    reload(): Promise<unknown>;
+}
+
+/**
+ * Load the native updater. Dynamic + variable specifier so the web build/tsc
+ * never needs the package resolved; returns null if unavailable.
+ */
+async function loadUpdater(): Promise<CapgoUpdater | null> {
+    try {
+        const spec = "@capgo/capacitor-updater";
+        const mod = (await import(/* @vite-ignore */ spec)) as { CapacitorUpdater?: CapgoUpdater };
+        return mod.CapacitorUpdater ?? null;
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Tell the updater this bundle booted successfully, cancelling the automatic
+ * rollback that would otherwise revert a freshly-applied OTA bundle. Call once
+ * on boot after the UI mounts. No-op on web.
+ */
+export async function notifyOtaReady(): Promise<void> {
+    if (!nativeEnabled()) return;
+    const updater = await loadUpdater();
+    try {
+        await updater?.notifyAppReady();
+    } catch (err) {
+        console.error("mobile-ota: notifyAppReady failed:", err);
+    }
+}
+
+/**
+ * Check the configured relay server for a newer bundle and, if found, download
+ * + verify + apply it (which reloads the WebView into the new bundle). Returns
+ * true when an update was applied. Best-effort and fully no-op on web.
+ */
+export async function checkAndApplyOtaUpdate(
+    installedBuildTimestamp: string = INSTALLED_BUILD_TIMESTAMP,
+): Promise<boolean> {
+    if (!nativeEnabled()) return false;
+    const { serverUrl } = getMobileRuntimeConfig();
+    if (!serverUrl) return false;
+    const base = serverUrl.replace(/\/+$/, "");
+
+    let manifest: unknown;
+    try {
+        const res = await fetch(`${base}/api/mobile/ota/manifest.json`, { cache: "no-store" });
+        if (!res.ok) return false;
+        manifest = await res.json();
+    } catch {
+        return false; // offline / not configured — nothing to do
+    }
+
+    if (!shouldApplyOta(manifest, installedBuildTimestamp)) return false;
+    const m = manifest as OtaManifest;
+
+    const updater = await loadUpdater();
+    if (!updater) return false;
+    try {
+        const bundle = await updater.download({
+            url: m.url.startsWith("http") ? m.url : `${base}${m.url}`,
+            version: m.version,
+            checksum: m.checksum,
+        });
+        await updater.set(bundle);
+        await updater.reload();
+        return true;
+    } catch (err) {
+        console.error("mobile-ota: update failed:", err);
+        return false;
+    }
+}

--- a/packages/ui/src/main.ts
+++ b/packages/ui/src/main.ts
@@ -1,5 +1,5 @@
 import { createRoot } from "react-dom/client";
-import { createElement } from "react";
+import { createElement, useEffect } from "react";
 import { App } from "./App.js";
 import { ErrorBoundary } from "./components/ui/error-boundary.js";
 import { AttentionProvider } from "./attention/index.js";
@@ -19,6 +19,22 @@ if (savedTheme === "dark" || (!savedTheme && window.matchMedia("(prefers-color-s
 // fragment) before installing the fetch patch / rendering. No-op on web.
 // Wrapped in an async boot function (not top-level await) so the build target
 // stays compatible with older browsers.
+// Fires the mobile OTA hooks, but only from a mount effect — i.e. AFTER React
+// has successfully committed. Rendered as a sibling of <App> inside the root
+// ErrorBoundary: if App throws during initial render, the boundary replaces the
+// whole subtree and this effect never runs, so we never tell Capgo the bundle
+// is healthy and it can auto-roll-back a broken OTA. All no-ops on web.
+function OtaReadyGate(): null {
+    useEffect(() => {
+        void (async () => {
+            // Mark this bundle healthy first, then look for a newer one.
+            await notifyOtaReady();
+            await checkAndApplyOtaUpdate();
+        })();
+    }, []);
+    return null;
+}
+
 async function boot(): Promise<void> {
     await initMobileRuntime();
 
@@ -33,14 +49,14 @@ async function boot(): Promise<void> {
     // inside App's own render method.
     createRoot(root).render(
         createElement(ErrorBoundary, { level: "root", children:
-            createElement(AttentionProvider, null, createElement(App)),
+            createElement(
+                AttentionProvider,
+                null,
+                createElement(App),
+                createElement(OtaReadyGate),
+            ),
         }),
     );
-
-    // Mobile OTA (no-op on web): confirm this bundle booted (cancels Capgo's
-    // auto-rollback), then check the relay for a newer bundle in the background.
-    void notifyOtaReady();
-    void checkAndApplyOtaUpdate();
 }
 
 // A silent boot failure used to leave a black screen (dark theme bg + no

--- a/packages/ui/src/main.ts
+++ b/packages/ui/src/main.ts
@@ -5,6 +5,7 @@ import { ErrorBoundary } from "./components/ui/error-boundary.js";
 import { AttentionProvider } from "./attention/index.js";
 import { installMobileFetchPatch } from "./lib/mobile-fetch.js";
 import { initMobileRuntime } from "./lib/mobile-runtime.js";
+import { notifyOtaReady, checkAndApplyOtaUpdate } from "./lib/mobile-ota.js";
 import "./style.css";
 
 // Apply dark mode before first render to avoid flash
@@ -35,6 +36,11 @@ async function boot(): Promise<void> {
             createElement(AttentionProvider, null, createElement(App)),
         }),
     );
+
+    // Mobile OTA (no-op on web): confirm this bundle booted (cancels Capgo's
+    // auto-rollback), then check the relay for a newer bundle in the background.
+    void notifyOtaReady();
+    void checkAndApplyOtaUpdate();
 }
 
 // A silent boot failure used to leave a black screen (dark theme bg + no

--- a/scripts/publish-mobile-ota.ts
+++ b/scripts/publish-mobile-ota.ts
@@ -2,11 +2,19 @@
 /**
  * Publish the built mobile UI as a self-hosted OTA bundle.
  *
- * Zips `mobile/app/` (with index.html at the archive root, as Capgo requires),
- * computes its SHA-256, and writes `<out>/manifest.json` + `<out>/pizzapi-*.zip`
- * where `<out>` is PIZZAPI_MOBILE_OTA_DIR (default: repo `mobile-ota/`). Start
- * the relay server with the same PIZZAPI_MOBILE_OTA_DIR and it serves these at
- * /api/mobile/ota/* for the mobile client to fetch, verify, and apply.
+ * Zips the Capacitor web root (`webDir: "mobile"`) so the OTA bundle mirrors
+ * exactly what the APK ships: `index.html` (the bootstrap/reconfiguration shell
+ * that redirects to `./app/index.html`) + `app/` (the built UI) + `vendor/`
+ * (jsqr for the QR scanner). Zipping only `app/` would drop the bootstrap shell,
+ * so after an OTA the app would boot straight into the UI and lose the
+ * server-setup / sign-out / re-pair flow. Dev files (package.json, tests,
+ * node_modules) are excluded. index.html sits at the archive root, as Capgo
+ * requires. buildTimestamp still comes from `app/build-info.json`.
+ *
+ * Writes `<out>/manifest.json` + `<out>/pizzapi-*.zip` where `<out>` is
+ * PIZZAPI_MOBILE_OTA_DIR (default: repo `mobile-ota/`). Start the relay server
+ * with the same PIZZAPI_MOBILE_OTA_DIR and it serves these at /api/mobile/ota/*
+ * for the mobile client to fetch, verify, and apply.
  *
  * Prereq: `bun run build:mobile` (produces mobile/app/). Requires the system
  * `zip` tool.
@@ -20,7 +28,8 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { join, resolve } from "node:path";
 
 const root = join(import.meta.dir, "..");
-const appDir = join(root, "mobile", "app");
+const webDir = join(root, "mobile");
+const appDir = join(webDir, "app");
 // Resolve to absolute: the zip step runs after `cd ${appDir}`, so a relative
 // outDir would otherwise be written under mobile/app and then not found.
 const outDir = resolve(process.env.PIZZAPI_MOBILE_OTA_DIR || join(root, "mobile-ota"));
@@ -46,9 +55,12 @@ mkdirSync(outDir, { recursive: true });
 const zipPath = join(outDir, zipName);
 rmSync(zipPath, { force: true });
 
-// Run from inside appDir so paths are relative → index.html sits at the zip
-// root. -X drops platform extras for a reproducible archive.
-await $`cd ${appDir} && zip -r -q -X ${zipPath} .`;
+// Zip the served webDir structure (index.html at root + app/ + vendor/) so the
+// bootstrap shell survives OTA. Explicit entries exclude dev files/node_modules.
+// -X drops platform extras for a reproducible archive.
+const entries = ["index.html", "app"];
+if (existsSync(join(webDir, "vendor"))) entries.push("vendor");
+await $`cd ${webDir} && zip -r -q -X ${zipPath} ${entries}`;
 
 const buf = readFileSync(zipPath);
 const checksum = createHash("sha256").update(buf).digest("hex");

--- a/scripts/publish-mobile-ota.ts
+++ b/scripts/publish-mobile-ota.ts
@@ -1,0 +1,75 @@
+#!/usr/bin/env bun
+/**
+ * Publish the built mobile UI as a self-hosted OTA bundle.
+ *
+ * Zips `mobile/app/` (with index.html at the archive root, as Capgo requires),
+ * computes its SHA-256, and writes `<out>/manifest.json` + `<out>/pizzapi-*.zip`
+ * where `<out>` is PIZZAPI_MOBILE_OTA_DIR (default: repo `mobile-ota/`). Start
+ * the relay server with the same PIZZAPI_MOBILE_OTA_DIR and it serves these at
+ * /api/mobile/ota/* for the mobile client to fetch, verify, and apply.
+ *
+ * Prereq: `bun run build:mobile` (produces mobile/app/). Requires the system
+ * `zip` tool.
+ *
+ * ponytail: system `zip` + node:crypto, no new deps. If a device ever rejects
+ * the archive, swap the zip step for `@capgo/cli bundle zip` (their format).
+ */
+import { $ } from "bun";
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const root = join(import.meta.dir, "..");
+const appDir = join(root, "mobile", "app");
+const outDir = process.env.PIZZAPI_MOBILE_OTA_DIR || join(root, "mobile-ota");
+
+if (!existsSync(join(appDir, "index.html"))) {
+    console.error(`No built mobile UI at ${appDir}.\nRun: bun run build:mobile`);
+    process.exit(1);
+}
+
+const info = JSON.parse(readFileSync(join(appDir, "build-info.json"), "utf8")) as {
+    buildTimestamp?: string;
+};
+const buildTimestamp = info.buildTimestamp;
+if (!buildTimestamp) {
+    console.error("mobile/app/build-info.json is missing buildTimestamp");
+    process.exit(1);
+}
+
+const slug = buildTimestamp.replace(/[:.]/g, "-");
+const zipName = `pizzapi-${slug}.zip`;
+
+mkdirSync(outDir, { recursive: true });
+const zipPath = join(outDir, zipName);
+rmSync(zipPath, { force: true });
+
+// Run from inside appDir so paths are relative → index.html sits at the zip
+// root. -X drops platform extras for a reproducible archive.
+await $`cd ${appDir} && zip -r -q -X ${zipPath} .`;
+
+const buf = readFileSync(zipPath);
+const checksum = createHash("sha256").update(buf).digest("hex");
+
+const manifest = {
+    buildTimestamp,
+    version: buildTimestamp,
+    url: `/api/mobile/ota/${zipName}`,
+    checksum,
+    bytes: buf.length,
+};
+writeFileSync(join(outDir, "manifest.json"), `${JSON.stringify(manifest, null, 2)}\n`);
+
+// Cheap self-check: a valid sha-256 is 64 hex chars and the zip is non-empty.
+if (checksum.length !== 64 || buf.length === 0) {
+    console.error("Publish produced an invalid bundle/checksum");
+    process.exit(1);
+}
+
+console.log(
+    `Published OTA bundle:\n` +
+        `  ${zipPath} (${buf.length} bytes)\n` +
+        `  sha256 ${checksum}\n` +
+        `  ${join(outDir, "manifest.json")}\n\n` +
+        `Serve it: start the server with PIZZAPI_MOBILE_OTA_DIR=${outDir}`,
+);

--- a/scripts/publish-mobile-ota.ts
+++ b/scripts/publish-mobile-ota.ts
@@ -17,11 +17,13 @@
 import { $ } from "bun";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 
 const root = join(import.meta.dir, "..");
 const appDir = join(root, "mobile", "app");
-const outDir = process.env.PIZZAPI_MOBILE_OTA_DIR || join(root, "mobile-ota");
+// Resolve to absolute: the zip step runs after `cd ${appDir}`, so a relative
+// outDir would otherwise be written under mobile/app and then not found.
+const outDir = resolve(process.env.PIZZAPI_MOBILE_OTA_DIR || join(root, "mobile-ota"));
 
 if (!existsSync(join(appDir, "index.html"))) {
     console.error(`No built mobile UI at ${appDir}.\nRun: bun run build:mobile`);


### PR DESCRIPTION
## What

Prototype (spike): **self-hosted OTA web-bundle updates** for the mobile app. Ship UI-only changes to an installed app without a new APK or store release, served by the **relay server the app already trusts** — no separate tunnel. Native/plugin changes still require an APK.

## Why not raw APK-over-tunnel

Deliberately rejected: needs `REQUEST_INSTALL_PACKAGES` + "install unknown apps" consent, must be signed with the same key, and serving installable binaries over an ad-hoc tunnel is a malware/MITM vector. OTA only ever replaces **web assets** — the signing key is untouched, no unknown-sources prompt.

## Design

`@capgo/capacitor-updater` in **manual mode**: the relay URL is chosen at runtime (bootstrap page), so Capgo's build-time `updateUrl` can't be used. The client fetches a manifest, compares **build timestamps** (same signal as the web update banner; ISO-8601 sorts lexically → `>` is "strictly newer"), then drives `download → verify(sha256) → set → reload`. The "Update & Reload" affordance hidden on mobile in #589 now has a real backend.

```
build:mobile → mobile/app/ → publish:mobile:ota → mobile-ota/{manifest.json, pizzapi-<ts>.zip}
relay serves /api/mobile/ota/*  →  app compares buildTimestamp  →  Capgo download+verify+set+reload
```

## Changes

- **server** `routes/mobile-ota.ts`: static serve of `manifest.json` + `*.zip`, path-traversal guarded, unauthenticated (public UI; integrity = checksum), feature-gated on `PIZZAPI_MOBILE_OTA_DIR`. +tests.
- **client** `lib/mobile-ota.ts`: pure `shouldApplyOta()` (tested) + guarded native `download/apply` via **dynamic import** so the web build never resolves the plugin. Boot hooks in `main.ts`.
- **publish** `scripts/publish-mobile-ota.ts`: zip + sha256 + manifest using system `zip` + `node:crypto` (no new deps). `package.json` `publish:mobile:ota`.
- `capacitor.config.ts`: `CapacitorUpdater.autoUpdate: false` (manual mode).
- `docs/mobile-ota.md`: RUNBOOK.

## Verification

Green here: server route (6 tests), client decision (5 tests), and the publish→serve loop (manifest + zip served, bytes/checksum match). UI + server typecheck clean.

**Needs a device (documented, not run here):** `bun add @capgo/capacitor-updater@^8`, `cap sync`, on-device download/apply. This PR does **not** add the native dependency — merging it is inert until that install runs.
