### PR TITLE
feat(usage): fall back to Claude Code's own OAuth token for Anthropic usage check

### DIFF
--- a/packages/cli/src/extensions/remote-provider-usage.ts
+++ b/packages/cli/src/extensions/remote-provider-usage.ts
@@ -9,6 +9,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { AuthStorage } from "@earendil-works/pi-coding-agent";
 import { loadConfig, defaultAgentDir, expandHome } from "../config.js";
+import { getAnthropicKeychainToken } from "../runner/usage-auth.js";
 import type { UsageWindow, ProviderUsageData } from "./remote-types.js";
 
 const DEFAULT_USAGE_CACHE_TTL = 5 * 60 * 1000; // 5 min
@@ -77,7 +78,10 @@ async function refreshFromRunnerCache(): Promise<void> {
 
 async function refreshAnthropicUsage(opts: { force?: boolean } = {}): Promise<void> {
     if (isCached("anthropic", opts)) return;
-    const token = getOAuthToken("anthropic");
+    // auth.json first, then Claude Code's own OAuth token (Keychain /
+    // ~/.claude/.credentials.json) for users who never ran /login inside
+    // pizzapi — read-only, never refreshed.
+    const token = getOAuthToken("anthropic") ?? getAnthropicKeychainToken();
     if (!token) return;
     try {
         const res = await fetch("https://api.anthropic.com/api/oauth/usage", {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -12,7 +12,7 @@ import {
 import { join } from "path";
 import { maybeBuildSystemPrompt, defaultAgentDir, expandHome, loadConfig, resolveSandboxConfig, validateSandboxOverride, applyProviderSettingsEnv } from "./config.js";
 import { isPackageCommand, runPackageCommand } from "./package-commands.js";
-import { getOAuthAccessToken } from "./runner/usage-auth.js";
+import { getOAuthAccessToken, getAnthropicKeychainToken } from "./runner/usage-auth.js";
 import { c, usageBar, colorPct, colorRemaining } from "./cli-colors.js";
 import { buildSkillPaths, buildPromptTemplatePaths, createAgentsFilesOverride } from "./skills.js";
 import { getPluginSkillPaths } from "./extensions/claude-plugins.js";
@@ -98,7 +98,10 @@ async function main() {
 
         // ── Anthropic ──────────────────────────────────────────────────────────
         if (showAnthropic) {
-            const accessToken = getOAuthAccessToken(authStorage.get("anthropic"));
+            // auth.json first, then fall back to Claude Code's own OAuth token
+            // (Keychain / ~/.claude/.credentials.json) for users who never ran
+            // /login inside pizzapi — read-only, never refreshed.
+            const accessToken = getOAuthAccessToken(authStorage.get("anthropic")) ?? getAnthropicKeychainToken();
             if (!accessToken) {
                 if (providerArg === "anthropic") {
                     log.error("No Anthropic credentials found. Log in with /login inside pizzapi.");

--- a/packages/cli/src/runner/runner-usage-cache.test.ts
+++ b/packages/cli/src/runner/runner-usage-cache.test.ts
@@ -59,6 +59,7 @@ describe("runner-usage-cache child", () => {
                 if (!raw || raw.type !== "oauth") return null;
                 return "token:" + raw.access;
             },
+            getAnthropicKeychainToken: () => null,
             parseGeminiQuotaCredential: () => null,
         }));
 

--- a/packages/cli/src/runner/runner-usage-cache.ts
+++ b/packages/cli/src/runner/runner-usage-cache.ts
@@ -3,7 +3,7 @@ import { homedir } from "node:os";
 import { join } from "node:path";
 import { AuthStorage } from "@earendil-works/pi-coding-agent";
 import { loadConfig, defaultAgentDir, expandHome } from "../config.js";
-import { getOAuthAccessToken, parseGeminiQuotaCredential } from "./usage-auth.js";
+import { getOAuthAccessToken, getAnthropicKeychainToken, parseGeminiQuotaCredential } from "./usage-auth.js";
 import { logInfo, logWarn } from "./logger.js";
 
 // ── Runner-wide usage cache (shared with worker processes via file) ───────────
@@ -90,6 +90,9 @@ async function fetchAnthropicUsageData(): Promise<ProviderUsageData | null> {
             token = getOAuthAccessToken(raw);
             if (token) break;
         }
+        // No anthropic entry in auth.json (never ran /login inside pizzapi) —
+        // fall back to Claude Code's own stored OAuth token, read-only.
+        if (!token) token = getAnthropicKeychainToken();
     } catch (err: any) {
         logWarn(`failed to get Anthropic credentials: ${err?.message ?? String(err)}`);
         return null;

--- a/packages/cli/src/runner/usage-auth.test.ts
+++ b/packages/cli/src/runner/usage-auth.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, mock, test } from "bun:test";
 import { getOAuthAccessToken, parseGeminiQuotaCredential } from "./usage-auth.js";
 
 describe("getOAuthAccessToken", () => {
@@ -13,6 +13,44 @@ describe("getOAuthAccessToken", () => {
     test("returns null for invalid payload", () => {
         expect(getOAuthAccessToken({})).toBeNull();
         expect(getOAuthAccessToken("token")).toBeNull();
+    });
+});
+
+describe("getAnthropicKeychainToken", () => {
+    afterEach(() => {
+        mock.restore();
+    });
+
+    test("returns the keychain access token when unexpired", async () => {
+        mock.module("./keychain-auth.js", () => ({
+            readBestExternalCredential: () => ({
+                credentials: { claudeAiOauth: { accessToken: "kc-token", refreshToken: "r", expiresAt: Date.now() + 60_000 } },
+                source: "keychain",
+                sourceLabel: "Claude Code-credentials",
+            }),
+        }));
+        const { getAnthropicKeychainToken } = await import("./usage-auth.js");
+        expect(getAnthropicKeychainToken()).toBe("kc-token");
+    });
+
+    test("returns null when the keychain token is expired (never refreshes)", async () => {
+        mock.module("./keychain-auth.js", () => ({
+            readBestExternalCredential: () => ({
+                credentials: { claudeAiOauth: { accessToken: "kc-token", refreshToken: "r", expiresAt: Date.now() - 1_000 } },
+                source: "keychain",
+                sourceLabel: "Claude Code-credentials",
+            }),
+        }));
+        const { getAnthropicKeychainToken } = await import("./usage-auth.js");
+        expect(getAnthropicKeychainToken()).toBeNull();
+    });
+
+    test("returns null when no external credential is found", async () => {
+        mock.module("./keychain-auth.js", () => ({
+            readBestExternalCredential: () => null,
+        }));
+        const { getAnthropicKeychainToken } = await import("./usage-auth.js");
+        expect(getAnthropicKeychainToken()).toBeNull();
     });
 });
 

--- a/packages/cli/src/runner/usage-auth.ts
+++ b/packages/cli/src/runner/usage-auth.ts
@@ -1,3 +1,5 @@
+import { readBestExternalCredential } from "./keychain-auth.js";
+
 export type RunnerAuthRecord = Record<string, unknown>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -18,6 +20,22 @@ export function getOAuthAccessToken(raw: unknown): string | null {
     const access = raw.access;
     if (typeof access === "string" && access.trim().length > 0) return access;
     return null;
+}
+
+/**
+ * Fallback Anthropic usage-check token: reads Claude Code's own OAuth token
+ * straight from the macOS Keychain / `~/.claude/.credentials.json` (same
+ * read-only lookup `readBestExternalCredential` already does) for users who
+ * only ever logged into Claude Code directly and have no `anthropic` entry
+ * in auth.json.
+ *
+ * Never refreshes or persists anything — an expired token is simply treated
+ * as absent so we can't accidentally rotate Claude Code's own credentials.
+ */
+export function getAnthropicKeychainToken(now = Date.now()): string | null {
+    const oauth = readBestExternalCredential()?.credentials.claudeAiOauth;
+    if (!oauth || oauth.expiresAt <= now) return null;
+    return oauth.accessToken;
 }
 
 /**


### PR DESCRIPTION
## What
The Anthropic usage check (`pizzapi usage`, runner background cache, web UI usage badge) already exists, but only reads `auth.json`. Users who never ran `/login` inside pizzapi — and only ever logged into Claude Code directly — get nothing, since there's no `anthropic` entry in `auth.json` to read.

`readBestExternalCredential()` (macOS Keychain / `~/.claude/.credentials.json`, freshest-pick, **read-only**) already existed in `keychain-auth.ts` for exactly this, but became dead code after commit 1a3cef71 removed its write-back callers (`syncKeychainToAuthStorage` / `syncKeychainToAuthJsonFile`) — those were removed because persisting a refreshed token back to `auth.json` caused Claude Code's own stored auth to go stale.

This re-adds just the **read** path, with the same "never expire/rotate it" guarantee: if the Keychain/`.credentials.json` token is expired, it's simply treated as absent rather than refreshed.

```ts
export function getAnthropicKeychainToken(now = Date.now()): string | null {
    const oauth = readBestExternalCredential()?.credentials.claudeAiOauth;
    if (!oauth || oauth.expiresAt <= now) return null;   // expired -> skip, never refresh
    return oauth.accessToken;
}
```

Wired as a fallback (`getOAuthAccessToken(...) ?? getAnthropicKeychainToken()`) in the three places that check Anthropic usage:
- `packages/cli/src/runner/runner-usage-cache.ts` — background cache feeding the web UI badge
- `packages/cli/src/index.ts` — `pizzapi usage` CLI command
- `packages/cli/src/extensions/remote-provider-usage.ts` — goal-context provider usage extension

## Testing
- `bun test src/runner/usage-auth.test.ts` — new coverage for `getAnthropicKeychainToken` (fresh token, expired token, no credential)
- `bun test src/runner/runner-usage-cache.test.ts src/runner/keychain-auth.test.ts` — unaffected, still green
- `bunx tsc --noEmit -p packages/cli` — clean

Godmother: yernnTE3 (branched from Qv3rQ2p7)
