### PR TITLE
fix(runner): surface dynamic Ollama Cloud models in daemon model list

### DIFF
--- a/packages/cli/src/__tests__/ollama-cloud-models.test.ts
+++ b/packages/cli/src/__tests__/ollama-cloud-models.test.ts
@@ -75,4 +75,51 @@ describe("ollama-cloud dynamic model discovery", () => {
         const result = await fetchOllamaCloudModels();
         expect(result).toEqual(expected);
     });
+
+    test("force refetches even when cache is fresh", async () => {
+        const dir = join(tempHome, ".pizzapi");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "ollama-cloud-models-cache.json"),
+            JSON.stringify({
+                models: [
+                    {
+                        id: "stale-model",
+                        name: "stale-model",
+                        provider: "ollama-cloud",
+                        api: "openai-completions",
+                        baseUrl: "https://ollama.com/v1",
+                        reasoning: false,
+                        input: ["text"],
+                        contextWindow: 1234,
+                        maxTokens: 32768,
+                    },
+                ],
+                fetchedAt: Date.now(),
+            }),
+        );
+
+        let calls = 0;
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = (async (url: string | URL) => {
+            calls++;
+            const u = String(url);
+            if (u.includes("/v1/models")) {
+                return new Response(JSON.stringify({ data: [{ id: "new-model" }] }), { status: 200 });
+            }
+            return new Response(
+                JSON.stringify({ capabilities: ["thinking"], model_info: { "new.context_length": 4096 } }),
+                { status: 200 },
+            );
+        }) as typeof globalThis.fetch;
+
+        try {
+            const result = await fetchOllamaCloudModels({ force: true });
+            expect(calls).toBeGreaterThan(0);
+            expect(result.some((m) => m.id === "new-model")).toBe(true);
+            expect(result.some((m) => m.id === "stale-model")).toBe(false);
+        } finally {
+            globalThis.fetch = originalFetch;
+        }
+    });
 });

--- a/packages/cli/src/ollama-cloud-models.ts
+++ b/packages/cli/src/ollama-cloud-models.ts
@@ -147,10 +147,16 @@ export function toOllamaCloudRuntimeModel(model: OllamaCloudModel): Model<"opena
     };
 }
 
-export async function fetchOllamaCloudModels({ signal }: { signal?: AbortSignal } = {}): Promise<OllamaCloudModel[]> {
-    const cached = readCache();
-    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
-        return cached.models;
+export async function fetchOllamaCloudModels(
+    { signal, force }: { signal?: AbortSignal; force?: boolean } = {},
+): Promise<OllamaCloudModel[]> {
+    // force skips the freshness short-circuit so the runner's 12h refresh loop
+    // always re-fetches and rewrites the cache.
+    if (!force) {
+        const cached = readCache();
+        if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+            return cached.models;
+        }
     }
 
     const list = await fetchJson(OLLAMA_CLOUD_MODELS_URL, { signal });

--- a/packages/cli/src/runner/daemon.ts
+++ b/packages/cli/src/runner/daemon.ts
@@ -10,7 +10,8 @@ import { FileExplorerService } from "./services/file-explorer-service.js";
 import { GitService } from "./services/git-service.js";
 // Resolves @VARIABLE@ tokens used in service panel requires
 import { resolvePizzaPiVar } from "../config/io.js";
-import { mergeModelLists, readSessionModelsCache } from "../session-models-cache.js";
+import { mergeModelLists, readSessionModelsCache, type SessionModelEntry } from "../session-models-cache.js";
+import { getCachedOllamaCloudModels } from "../ollama-cloud-models.js";
 import { TunnelService } from "./services/tunnel-service.js";
 import { TimeService, TIME_TRIGGER_DEFS, TIME_SIGIL_DEFS } from "./services/time-service.js";
 import { discoverServices } from "./service-loader.js";
@@ -34,6 +35,7 @@ import { extractHookSummary } from "./hook-summary.js";
 import { sanitizeConfigForUI, restoreMaskedServerEntry, findRenamedServerMatch, MASK_SENTINEL, validateProviderOverridesSection, mergeProviderOverridesSection } from "./daemon-config-sanitize.js";
 import { defaultStatePath, acquireStateAndIdentity, releaseStateLock } from "./runner-state.js";
 import { startUsageRefreshLoop, stopUsageRefreshLoop } from "./runner-usage-cache.js";
+import { startOllamaModelsRefreshLoop, stopOllamaModelsRefreshLoop } from "./runner-ollama-models-cache.js";
 import { getWorkspaceRoots, isCwdAllowed } from "./workspace.js";
 import { type RunnerSession, spawnSession } from "./session-spawner.js";
 import { pruneSessionCloseMetadata, type SessionCloseMetadata } from "./session-close-metadata.js";
@@ -310,6 +312,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
     // Start fetching provider usage immediately so workers have cached data from
     // the moment they are spawned.  One daemon refresh covers all sessions on this node.
     startUsageRefreshLoop();
+    startOllamaModelsRefreshLoop();
 
     // Load global config so relayUrl and apiKey can be read from
     // ~/.pizzapi/config.json (important for LaunchAgent contexts where
@@ -456,10 +459,28 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
                     reasoning: model.reasoning,
                     contextWindow: model.contextWindow,
                 }));
+            // Ollama Cloud models are discovered dynamically and are NOT in the
+            // static disk registry. Surface the cached list directly so newer
+            // models (e.g. glm-5.2) appear even when no live session has warmed
+            // the session snapshot yet. Gated on Ollama credentials so we don't
+            // advertise models the runner can't actually use.
+            let ollamaModels: SessionModelEntry[] = [];
+            if (authStorage.hasAuth("ollama-cloud") || process.env.OLLAMA_API_KEY) {
+                ollamaModels = (getCachedOllamaCloudModels() ?? []).map((model) => ({
+                    provider: model.provider,
+                    id: model.id,
+                    name: model.name,
+                    reasoning: model.reasoning,
+                    contextWindow: model.contextWindow,
+                }));
+            }
             // Extension-registered providers (pi packages calling registerProvider)
             // only exist inside live sessions — merge the latest session snapshot so
             // Web UI model selectors (Runner Settings, Fast Model) show them too.
-            return mergeModelLists(diskModels, readSessionModelsCache() ?? []);
+            return mergeModelLists(
+                mergeModelLists(diskModels, ollamaModels),
+                readSessionModelsCache() ?? [],
+            );
         };
         const getContextWindowsForAnalysis = (cwd = process.cwd()): Map<string, number> => {
             const windows = new Map<string, number>();
@@ -761,6 +782,7 @@ export async function runDaemon(_args: string[] = []): Promise<number> {
             void tunnelClient?.dispose();
             registry.disposeAll();
             stopUsageRefreshLoop();
+            stopOllamaModelsRefreshLoop();
             await closeUsage().catch((err) =>
                 logError("closeUsage failed during shutdown: " + (err instanceof Error ? err.message : String(err))),
             );

--- a/packages/cli/src/runner/runner-ollama-models-cache.ts
+++ b/packages/cli/src/runner/runner-ollama-models-cache.ts
@@ -1,0 +1,56 @@
+/**
+ * Runner-side Ollama Cloud model refresh loop.
+ *
+ * The daemon's model list surfaces Ollama Cloud models from the on-disk cache
+ * (see ollama-cloud-models.ts). That cache is normally warmed by live sessions,
+ * so a runner that hasn't started a session recently can serve a stale list and
+ * miss newer models (e.g. glm-5.2). This loop keeps the cache fresh on the
+ * runner itself, independent of session activity, refreshing every 12 hours.
+ */
+import { join } from "node:path";
+import { AuthStorage } from "@earendil-works/pi-coding-agent";
+import { loadConfig, defaultAgentDir, expandHome } from "../config.js";
+import { fetchOllamaCloudModels } from "../ollama-cloud-models.js";
+import { logInfo, logWarn } from "./logger.js";
+
+const OLLAMA_MODELS_REFRESH_INTERVAL = 12 * 60 * 60 * 1000;
+
+let _timer: ReturnType<typeof setInterval> | null = null;
+
+function hasOllamaCreds(): boolean {
+    if (process.env.OLLAMA_API_KEY) return true;
+    try {
+        const config = loadConfig(process.cwd());
+        const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
+        return AuthStorage.create(join(agentDir, "auth.json")).hasAuth("ollama-cloud");
+    } catch {
+        return false;
+    }
+}
+
+async function refresh(force: boolean): Promise<void> {
+    if (!hasOllamaCreds()) return;
+    try {
+        const models = await fetchOllamaCloudModels({ force });
+        logInfo(`ollama-cloud models refreshed (${models.length})`);
+    } catch (err: any) {
+        logWarn(`failed to refresh ollama-cloud models: ${err?.message ?? String(err)}`);
+    }
+}
+
+export function startOllamaModelsRefreshLoop(): void {
+    if (_timer !== null) return;
+    // Warm the cache on boot without forcing (respects the 24h TTL), then force
+    // a fresh fetch every 12h so the runner never serves a >12h-stale list.
+    void refresh(false);
+    _timer = setInterval(() => {
+        void refresh(true);
+    }, OLLAMA_MODELS_REFRESH_INTERVAL);
+}
+
+export function stopOllamaModelsRefreshLoop(): void {
+    if (_timer !== null) {
+        clearInterval(_timer);
+        _timer = null;
+    }
+}


### PR DESCRIPTION
## Problem

Selecting `ollama-cloud/glm-5.2` reported **"Model is not configured for this session"** even though glm-5.2 is live on Ollama (`/v1/models` + `/api/show` both return it, 1M ctx, thinking+tools) and present in the local `ollama-cloud-models-cache.json`.

**Root cause:** the daemon's `listConfiguredModels` merged only the static disk registry (pi-ai's built-in `OLLAMA_CLOUD_MODELS`, which lacks glm-5.2) with `readSessionModelsCache()`. Ollama Cloud models are discovered *dynamically* and only reach the runner's list once a live session warms the session snapshot. On a runner that hadn't started a session recently, newer models were invisible. (`pizza models` worked because it calls `fetchOllamaCloudModels()` directly; the daemon did not.)

## Fix

- **`listConfiguredModels` (daemon.ts):** include the on-disk Ollama Cloud cache directly via `getCachedOllamaCloudModels()`, gated on Ollama credentials (`hasAuth('ollama-cloud')` / `OLLAMA_API_KEY`) so we don't advertise unusable models.
- **12h refresh loop (`runner-ollama-models-cache.ts`):** the runner now refreshes the Ollama Cloud cache every 12 hours, independent of session activity. Adds a `force` option to `fetchOllamaCloudModels` that bypasses the 24h read TTL. Warms on boot (non-forced), force-refetches on the 12h interval. Started/stopped alongside the existing usage-refresh loop.

## Tests

- New: `force refetches even when cache is fresh` (mocked fetch, no real network — CI-safe).
- `bun run typecheck` clean; cli model/daemon test suites pass.

Godmother: `3Fxz4a0C`