### PR TITLE
fix(runner): resolve dynamic Ollama Cloud models across all model-resolution paths

### DIFF
--- a/packages/cli/src/__tests__/ollama-cloud-models.test.ts
+++ b/packages/cli/src/__tests__/ollama-cloud-models.test.ts
@@ -7,6 +7,7 @@ import {
     extractContextLength,
     capabilitiesInclude,
     getCachedOllamaCloudModels,
+    findCachedOllamaCloudModel,
 } from "../ollama-cloud-models.js";
 
 const originalHome = process.env.HOME;
@@ -74,6 +75,36 @@ describe("ollama-cloud dynamic model discovery", () => {
 
         const result = await fetchOllamaCloudModels();
         expect(result).toEqual(expected);
+    });
+
+    test("findCachedOllamaCloudModel resolves a cached id, ignores other providers", () => {
+        const dir = join(tempHome, ".pizzapi");
+        mkdirSync(dir, { recursive: true });
+        writeFileSync(
+            join(dir, "ollama-cloud-models-cache.json"),
+            JSON.stringify({
+                models: [
+                    {
+                        id: "glm-5.2",
+                        name: "glm-5.2",
+                        provider: "ollama-cloud",
+                        api: "openai-completions",
+                        baseUrl: "https://ollama.com/v1",
+                        reasoning: true,
+                        input: ["text"],
+                        contextWindow: 1000000,
+                        maxTokens: 32768,
+                    },
+                ],
+                fetchedAt: Date.now(),
+            }),
+        );
+
+        const model = findCachedOllamaCloudModel("ollama-cloud", "glm-5.2");
+        expect(model?.id).toBe("glm-5.2");
+        expect(model?.api).toBe("openai-completions");
+        expect(findCachedOllamaCloudModel("ollama-cloud", "nope")).toBeUndefined();
+        expect(findCachedOllamaCloudModel("anthropic", "glm-5.2")).toBeUndefined();
     });
 
     test("force refetches even when cache is fresh", async () => {

--- a/packages/cli/src/extensions/initial-prompt.ts
+++ b/packages/cli/src/extensions/initial-prompt.ts
@@ -2,6 +2,7 @@ import type { ExtensionFactory } from "@earendil-works/pi-coding-agent";
 import { createLogger } from "@pizzapi/tools";
 import { waitForRelayRegistration } from "./remote.js";
 import { waitForWorkerStartupComplete } from "./worker-startup-gate.js";
+import { findCachedOllamaCloudModel } from "../ollama-cloud-models.js";
 
 const log = createLogger("worker");
 
@@ -52,7 +53,12 @@ export const initialPromptExtension: ExtensionFactory = (pi) => {
 
         // Set the model first if requested.
         if (initialModelProvider && initialModelId) {
-            const model = ctx.modelRegistry.find(initialModelProvider, initialModelId);
+            // Ollama Cloud models are discovered dynamically and aren't in the
+            // static registry — fall back to the cached catalog so spawns pinned
+            // to e.g. ollama-cloud/glm-5.2 resolve instead of using the default.
+            const model =
+                ctx.modelRegistry.find(initialModelProvider, initialModelId) ??
+                findCachedOllamaCloudModel(initialModelProvider, initialModelId);
             if (model) {
                 try {
                     const ok = await pi.setModel(model);

--- a/packages/cli/src/extensions/remote/model-selection.ts
+++ b/packages/cli/src/extensions/remote/model-selection.ts
@@ -7,7 +7,7 @@
 import type { RelayContext } from "../remote-types.js";
 import { getAuthSource } from "../remote-auth-source.js";
 import { emitSessionActive } from "./chunked-delivery.js";
-import { getCachedOllamaCloudModels, toOllamaCloudRuntimeModel } from "../../ollama-cloud-models.js";
+import { findCachedOllamaCloudModel } from "../../ollama-cloud-models.js";
 
 /**
  * Handle a web-initiated model change request.
@@ -70,9 +70,3 @@ export async function setModelFromWeb(
     }
 }
 
-function findCachedOllamaCloudModel(provider: string, modelId: string) {
-    if (provider !== "ollama-cloud") return undefined;
-    const cached = getCachedOllamaCloudModels();
-    const model = cached?.find((m) => m.id === modelId);
-    return model ? toOllamaCloudRuntimeModel(model) : undefined;
-}

--- a/packages/cli/src/extensions/subagent/engine.ts
+++ b/packages/cli/src/extensions/subagent/engine.ts
@@ -15,6 +15,7 @@ import {
 import type { AgentConfig } from "../subagent-agents.js";
 import type { Model } from "@earendil-works/pi-ai";
 import { defaultAgentDir } from "../../config.js";
+import { findCachedOllamaCloudModel } from "../../ollama-cloud-models.js";
 import type { SingleResult, SubagentDetails, OnUpdateCallback } from "./types.js";
 import { getFinalOutput, summarizeResultForStreaming } from "./types.js";
 
@@ -261,8 +262,12 @@ export async function runSingleAgent(
         let resolvedModel: Model<any> | undefined;
         const modelSpec = modelOverride ?? (agent.model ? parseModelString(agent.model) : undefined);
         if (modelSpec && modelRegistry) {
-            // Explicit model specified — look it up
-            resolvedModel = modelRegistry.find(modelSpec.provider, modelSpec.id);
+            // Explicit model specified — look it up. Ollama Cloud models are
+            // discovered dynamically and aren't in the static registry, so fall
+            // back to the cached catalog before giving up.
+            resolvedModel =
+                modelRegistry.find(modelSpec.provider, modelSpec.id) ??
+                findCachedOllamaCloudModel(modelSpec.provider, modelSpec.id);
             if (!resolvedModel) {
                 currentResult.exitCode = 1;
                 currentResult.stderr = `Model not found: ${modelSpec.provider}/${modelSpec.id}. Use the \`models\` command to see available models.`;

--- a/packages/cli/src/ollama-cloud-models.ts
+++ b/packages/cli/src/ollama-cloud-models.ts
@@ -131,6 +131,22 @@ export function getCachedOllamaCloudModels(): OllamaCloudModel[] | null {
     return null;
 }
 
+/**
+ * Resolve a provider/id pair against the cached Ollama Cloud model list.
+ * Returns a ready-to-use runtime model, or undefined when the provider isn't
+ * ollama-cloud or the id isn't in the cache. Ollama Cloud models are discovered
+ * dynamically, so they never appear in the static ModelRegistry — callers use
+ * this as a fallback after registry.find() misses.
+ */
+export function findCachedOllamaCloudModel(
+    provider: string,
+    modelId: string,
+): Model<"openai-completions"> | undefined {
+    if (provider !== "ollama-cloud") return undefined;
+    const model = getCachedOllamaCloudModels()?.find((m) => m.id === modelId);
+    return model ? toOllamaCloudRuntimeModel(model) : undefined;
+}
+
 export function toOllamaCloudRuntimeModel(model: OllamaCloudModel): Model<"openai-completions"> {
     return {
         ...model,

--- a/packages/cli/src/runner/apply-default-model.test.ts
+++ b/packages/cli/src/runner/apply-default-model.test.ts
@@ -1,4 +1,7 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { applySettingsDefaultModel, type DefaultModelSession } from "./apply-default-model.js";
 
 function makeSession(overrides: Partial<{
@@ -60,6 +63,55 @@ describe("applySettingsDefaultModel", () => {
         const { session, setCalls } = makeSession({ registryHas: false });
         expect(await applySettingsDefaultModel(session)).toBe(false);
         expect(setCalls).toEqual([]);
+    });
+
+    describe("dynamic Ollama Cloud fallback", () => {
+        const originalHome = process.env.HOME;
+        let tempHome: string;
+
+        beforeEach(() => {
+            tempHome = mkdtempSync(join(tmpdir(), "apply-default-ollama-"));
+            process.env.HOME = tempHome;
+            const dir = join(tempHome, ".pizzapi");
+            mkdirSync(dir, { recursive: true });
+            writeFileSync(
+                join(dir, "ollama-cloud-models-cache.json"),
+                JSON.stringify({
+                    models: [
+                        {
+                            id: "glm-5.2",
+                            name: "glm-5.2",
+                            provider: "ollama-cloud",
+                            api: "openai-completions",
+                            baseUrl: "https://ollama.com/v1",
+                            reasoning: true,
+                            input: ["text"],
+                            contextWindow: 1000000,
+                            maxTokens: 32768,
+                        },
+                    ],
+                    fetchedAt: Date.now(),
+                }),
+            );
+        });
+
+        afterEach(() => {
+            process.env.HOME = originalHome;
+            try { rmSync(tempHome, { recursive: true, force: true }); } catch { /* ignore */ }
+        });
+
+        test("resolves an ollama-cloud default from the cache when registry misses", async () => {
+            const { session, setCalls } = makeSession({
+                defaultProvider: "ollama-cloud",
+                defaultModel: "glm-5.2",
+                registryHas: false,
+                hasAuth: true,
+            });
+            expect(await applySettingsDefaultModel(session)).toBe(true);
+            expect(setCalls).toHaveLength(1);
+            expect((setCalls[0] as any).id).toBe("glm-5.2");
+            expect((setCalls[0] as any).provider).toBe("ollama-cloud");
+        });
     });
 
     test("no-op when default resolves but has no configured auth", async () => {

--- a/packages/cli/src/runner/apply-default-model.ts
+++ b/packages/cli/src/runner/apply-default-model.ts
@@ -13,6 +13,7 @@
  * (PIZZAPI_WORKER_INITIAL_MODEL_*) and resumed sessions set their own model
  * later during bindExtensions session_start, so they still win over this.
  */
+import { findCachedOllamaCloudModel } from "../ollama-cloud-models.js";
 
 interface ModelRef {
     provider: string;
@@ -42,7 +43,12 @@ export async function applySettingsDefaultModel(session: DefaultModelSession): P
     if (!provider || !modelId) return false;
     const current = session.model;
     if (current?.provider === provider && current?.id === modelId) return false;
-    const resolved = session.modelRegistry.find(provider, modelId);
+    // Ollama Cloud models are discovered dynamically and aren't in the static
+    // registry — fall back to the cached catalog so a settings default pointing
+    // at e.g. ollama-cloud/glm-5.2 still gets applied.
+    const resolved =
+        session.modelRegistry.find(provider, modelId) ??
+        findCachedOllamaCloudModel(provider, modelId);
     if (!resolved || !session.modelRegistry.hasConfiguredAuth(resolved)) return false;
     await session.setModel(resolved);
     return true;

--- a/packages/cli/src/runner/worker.ts
+++ b/packages/cli/src/runner/worker.ts
@@ -9,6 +9,7 @@ import { initSandbox, cleanupSandbox, isSandboxActive } from "@pizzapi/tools";
 import { createBootTimer } from "./boot-timing.js";
 import { headlessFork } from "./worker-fork.js";
 import { applySettingsDefaultModel } from "./apply-default-model.js";
+import { findCachedOllamaCloudModel } from "../ollama-cloud-models.js";
 import { setLogComponent, setLogSessionId, logInfo, logWarn, logError, logAuth } from "./logger.js";
 
 /**
@@ -561,11 +562,19 @@ async function main(): Promise<void> {
                     if (modelRegistry) {
                         try {
                             const available = await modelRegistry.getAvailable();
-                            const match = available.find(
-                                (m: any) =>
-                                    m.provider === sessionContext.model!.provider &&
-                                    m.id === sessionContext.model!.modelId,
-                            );
+                            // Ollama Cloud models are discovered dynamically and
+                            // aren't in getAvailable() — fall back to the cached
+                            // catalog so a resumed ollama-cloud model is restored.
+                            const match =
+                                available.find(
+                                    (m: any) =>
+                                        m.provider === sessionContext.model!.provider &&
+                                        m.id === sessionContext.model!.modelId,
+                                ) ??
+                                findCachedOllamaCloudModel(
+                                    sessionContext.model!.provider,
+                                    sessionContext.model!.modelId,
+                                );
                             if (match) {
                                 await session.setModel(match);
                             }


### PR DESCRIPTION
Follow-up to #592.

## Context

#592 fixed the daemon's model *list*. But #592's squash merge only captured the first commit — the **subagent engine fix** (shared `findCachedOllamaCloudModel` helper) never made it to main. Meanwhile, several other code paths resolve models via `modelRegistry.find()` / `getAvailable()`, which **never contain dynamically-discovered Ollama Cloud models**. So selecting/spawning/resuming an ollama-cloud model (e.g. `glm-5.2`) silently failed or fell back to the default.

This PR closes all remaining gaps by falling back to the cached Ollama Cloud catalog after the registry misses.

## Paths fixed

| Path | Symptom before | File |
|------|----------------|------|
| **subagent tool** | `Model not found: ollama-cloud/glm-5.2` (re-landed from orphaned #592 commit) | `subagent/engine.ts` |
| **spawn_session explicit model** | logs "not found in registry — using default" | `initial-prompt.ts` |
| **settings default re-apply** | default silently not applied | `runner/apply-default-model.ts` |
| **session resume restore** | saved model silently not restored | `runner/worker.ts` |

Also extracts `findCachedOllamaCloudModel()` as a shared helper in `ollama-cloud-models.ts` and dedupes the web model-selection path.

## Tests
- `findCachedOllamaCloudModel` unit test + `force` refetch test (from re-landed commit).
- New: `applySettingsDefaultModel` resolves an ollama-cloud default from cache when the registry misses.
- `bun run typecheck` clean; cli suites pass.

Godmother: `3Fxz4a0C`