### PR TITLE
fix(cli): persist relayUrl, add config show, honest update --self

### DIFF
--- a/packages/cli/src/config-show.test.ts
+++ b/packages/cli/src/config-show.test.ts
@@ -2,8 +2,21 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { maskApiKey, runConfigShowCommand } from "./config-show.js";
+import { maskApiKey, maskUrlUserinfo, runConfigShowCommand } from "./config-show.js";
 import { _setGlobalConfigDir } from "./config.js";
+
+describe("maskUrlUserinfo", () => {
+    test("strips embedded user:pass credentials", () => {
+        expect(maskUrlUserinfo("ws://user:pass@relay.example.com:7492")).toBe("ws://relay.example.com:7492/");
+    });
+    test("leaves credential-free URLs unchanged", () => {
+        expect(maskUrlUserinfo("ws://localhost:7492")).toBe("ws://localhost:7492");
+    });
+    test("passes through non-URL and undefined values", () => {
+        expect(maskUrlUserinfo("off")).toBe("off");
+        expect(maskUrlUserinfo(undefined)).toBeUndefined();
+    });
+});
 
 describe("maskApiKey", () => {
     test("unset when no key", () => {

--- a/packages/cli/src/config-show.test.ts
+++ b/packages/cli/src/config-show.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { maskApiKey, maskUrlUserinfo, runConfigShowCommand } from "./config-show.js";
+import { deepRedactConfig, maskApiKey, maskUrlUserinfo, runConfigShowCommand } from "./config-show.js";
 import { _setGlobalConfigDir } from "./config.js";
 
 describe("maskUrlUserinfo", () => {
@@ -32,6 +32,44 @@ describe("maskApiKey", () => {
         const masked = maskApiKey(key);
         expect(masked).toBe("pk_l…wxyz");
         expect(masked).not.toContain(key.slice(8, -4));
+    });
+
+    test("does not throw on malformed non-string input", () => {
+        expect(maskApiKey(true)).toBe("set");
+        expect(maskApiKey({})).toBe("set");
+        expect(maskApiKey(12345678901234)).toBe("set");
+        expect(maskApiKey(null)).toBe("unset");
+    });
+});
+
+describe("deepRedactConfig", () => {
+    test("redacts nested secrets, env/header maps, and URL userinfo — not the harmless fields", () => {
+        const redacted = deepRedactConfig({
+            apiKey: "sk_live_abcdefghijklmnop",
+            relayUrl: "ws://user:pass@relay.example.com:7492",
+            oauthClientId: "public-client-id",
+            oauthClientSecret: "super-secret-value",
+            envOverrides: { OPENAI_API_KEY: "sk-leak-me", FOO: "bar" },
+            mcpServers: {
+                gh: { url: "https://tok:zzz@mcp.example.com", headers: { Authorization: "Bearer leak" }, command: "bunx" },
+            },
+        }) as Record<string, any>;
+
+        expect(redacted.apiKey).toBe("sk_l…mnop");
+        expect(redacted.relayUrl).toBe("ws://relay.example.com:7492/");
+        expect(redacted.oauthClientId).toBe("public-client-id");
+        expect(redacted.oauthClientSecret).toBe("«redacted»");
+        expect(redacted.envOverrides.OPENAI_API_KEY).toBe("«redacted»");
+        expect(redacted.envOverrides.FOO).toBe("«redacted»");
+        expect(redacted.mcpServers.gh.headers.Authorization).toBe("«redacted»");
+        expect(redacted.mcpServers.gh.url).toBe("https://mcp.example.com/");
+        expect(redacted.mcpServers.gh.command).toBe("bunx");
+
+        // the full serialized output leaks nothing sensitive
+        const dump = JSON.stringify(redacted);
+        for (const secret of ["super-secret-value", "sk-leak-me", "Bearer leak", "tok:zzz", "user:pass"]) {
+            expect(dump).not.toContain(secret);
+        }
     });
 });
 

--- a/packages/cli/src/config-show.test.ts
+++ b/packages/cli/src/config-show.test.ts
@@ -1,0 +1,106 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { maskApiKey, runConfigShowCommand } from "./config-show.js";
+import { _setGlobalConfigDir } from "./config.js";
+
+describe("maskApiKey", () => {
+    test("unset when no key", () => {
+        expect(maskApiKey(undefined)).toBe("unset");
+    });
+
+    test("set for short keys (avoids leaking short secrets)", () => {
+        expect(maskApiKey("abcd1234")).toBe("set");
+    });
+
+    test("shows first4…last4 for normal-length keys, never the full value", () => {
+        const key = "pk_live_abcdefghijklmnopqrstuvwxyz";
+        const masked = maskApiKey(key);
+        expect(masked).toBe("pk_l…wxyz");
+        expect(masked).not.toContain(key.slice(8, -4));
+    });
+});
+
+describe("runConfigShowCommand", () => {
+    let tmpDir: string;
+    let projectDir: string;
+    let globalDir: string;
+    let originalApiKeyEnv: string | undefined;
+    let originalRelayEnv: string | undefined;
+    let originalLog: typeof console.log;
+    let output: string[];
+
+    beforeEach(() => {
+        tmpDir = mkdtempSync(join(tmpdir(), "pizzapi-config-show-"));
+        globalDir = join(tmpDir, "global", ".pizzapi");
+        projectDir = join(tmpDir, "project");
+        mkdirSync(globalDir, { recursive: true });
+        mkdirSync(projectDir, { recursive: true });
+        _setGlobalConfigDir(globalDir);
+        originalApiKeyEnv = process.env.PIZZAPI_API_KEY;
+        originalRelayEnv = process.env.PIZZAPI_RELAY_URL;
+        delete process.env.PIZZAPI_API_KEY;
+        delete process.env.PIZZAPI_RELAY_URL;
+        output = [];
+        originalLog = console.log;
+        console.log = ((...args: unknown[]) => { output.push(args.join(" ")); }) as typeof console.log;
+    });
+
+    afterEach(() => {
+        console.log = originalLog;
+        _setGlobalConfigDir(null);
+        if (originalApiKeyEnv === undefined) delete process.env.PIZZAPI_API_KEY;
+        else process.env.PIZZAPI_API_KEY = originalApiKeyEnv;
+        if (originalRelayEnv === undefined) delete process.env.PIZZAPI_RELAY_URL;
+        else process.env.PIZZAPI_RELAY_URL = originalRelayEnv;
+        try { rmSync(tmpDir, { recursive: true, force: true }); } catch {}
+    });
+
+    test("returns 0 and never prints the full apiKey", () => {
+        writeFileSync(
+            join(globalDir, "config.json"),
+            JSON.stringify({ apiKey: "sk_super_secret_do_not_leak_1234", relayUrl: "ws://relay.example.com" }),
+        );
+
+        const code = runConfigShowCommand(projectDir);
+        expect(code).toBe(0);
+
+        const text = output.join("\n");
+        expect(text).not.toContain("sk_super_secret_do_not_leak_1234");
+        expect(text).toContain("ws://relay.example.com");
+        expect(text).toContain("sk_s…1234");
+    });
+
+    test("shows 'unset' apiKey and default relay URL when nothing is configured", () => {
+        writeFileSync(join(globalDir, "config.json"), JSON.stringify({}));
+
+        const code = runConfigShowCommand(projectDir);
+        expect(code).toBe(0);
+
+        const text = output.join("\n");
+        expect(text).toContain("unset");
+        expect(text).toContain("ws://localhost:7492");
+    });
+
+    test("reflects PIZZAPI_API_KEY / PIZZAPI_RELAY_URL env overrides in the effective values", () => {
+        writeFileSync(
+            join(globalDir, "config.json"),
+            JSON.stringify({ apiKey: "file-key-aaaaaaaa", relayUrl: "ws://file-relay.example.com" }),
+        );
+        process.env.PIZZAPI_API_KEY = "env-key-bbbbbbbbbbbb";
+        process.env.PIZZAPI_RELAY_URL = "ws://env-relay.example.com";
+
+        const code = runConfigShowCommand(projectDir);
+        expect(code).toBe(0);
+
+        // The top "effective" summary reflects the env override (what the CLI
+        // actually connects with); the raw config.json dump below still shows
+        // the on-disk value, which is expected — it's a separate section.
+        const summaryLine = output.find((line) => line.includes("relayUrl "));
+        expect(summaryLine).toContain("ws://env-relay.example.com");
+        expect(summaryLine).toContain("from PIZZAPI_RELAY_URL");
+        const text = output.join("\n");
+        expect(text).not.toContain("env-key-bbbbbbbbbbbb");
+    });
+});

--- a/packages/cli/src/config-show.ts
+++ b/packages/cli/src/config-show.ts
@@ -15,6 +15,23 @@ export function maskApiKey(key: string | undefined): string {
     return `${key.slice(0, 4)}…${key.slice(-4)}`;
 }
 
+/** Strip embedded userinfo (user:pass@) from a URL so credentials aren't printed. Non-URL strings pass through unchanged. */
+export function maskUrlUserinfo(url: string | undefined): string | undefined {
+    if (!url) return url;
+    try {
+        const u = new URL(url);
+        if (u.username || u.password) {
+            u.username = "";
+            u.password = "";
+            return u.toString();
+        }
+        return url;
+    } catch {
+        // Not a parseable URL (e.g. "off") — return as-is.
+        return url;
+    }
+}
+
 export function runConfigShowCommand(cwd: string = process.cwd()): number {
     const config = loadConfig(cwd);
     const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
@@ -28,11 +45,11 @@ export function runConfigShowCommand(cwd: string = process.cwd()): number {
     console.log(c.label("Effective PizzaPi config") + c.dim(`  (${cwd})`));
     console.log("");
     console.log(`  ${c.dim("apiKey")}      ${maskApiKey(effectiveApiKey)}${envApiKey ? c.dim("  (from PIZZAPI_API_KEY)") : ""}`);
-    console.log(`  ${c.dim("relayUrl")}    ${effectiveRelayUrl}${envRelayUrl ? c.dim("  (from PIZZAPI_RELAY_URL)") : ""}`);
+    console.log(`  ${c.dim("relayUrl")}    ${maskUrlUserinfo(effectiveRelayUrl)}${envRelayUrl ? c.dim("  (from PIZZAPI_RELAY_URL)") : ""}`);
     console.log(`  ${c.dim("agentDir")}    ${agentDir}`);
     console.log("");
 
-    const redacted = { ...config, apiKey: maskApiKey(config.apiKey) };
+    const redacted = { ...config, apiKey: maskApiKey(config.apiKey), relayUrl: maskUrlUserinfo(config.relayUrl) };
     console.log(c.dim("Resolved config.json (secrets redacted):"));
     console.log(JSON.stringify(redacted, null, 2));
     console.log("");

--- a/packages/cli/src/config-show.ts
+++ b/packages/cli/src/config-show.ts
@@ -1,0 +1,41 @@
+/**
+ * `pizza config show` — read-only, prints the resolved effective config
+ * (global ~/.pizzapi/config.json merged with project .pizzapi/config.json)
+ * with secrets redacted. Never writes anything.
+ */
+import { defaultAgentDir, expandHome, loadConfig } from "./config.js";
+import { c } from "./cli-colors.js";
+
+const RELAY_DEFAULT = "ws://localhost:7492";
+
+/** Redact an API key: "unset" if absent, "set" if too short to safely slice, else first4…last4. */
+export function maskApiKey(key: string | undefined): string {
+    if (!key) return "unset";
+    if (key.length <= 8) return "set";
+    return `${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+export function runConfigShowCommand(cwd: string = process.cwd()): number {
+    const config = loadConfig(cwd);
+    const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
+
+    const envApiKey = process.env.PIZZAPI_API_KEY;
+    const envRelayUrl = process.env.PIZZAPI_RELAY_URL;
+    const effectiveApiKey = envApiKey ?? config.apiKey;
+    const effectiveRelayUrl = envRelayUrl ?? config.relayUrl ?? RELAY_DEFAULT;
+
+    console.log("");
+    console.log(c.label("Effective PizzaPi config") + c.dim(`  (${cwd})`));
+    console.log("");
+    console.log(`  ${c.dim("apiKey")}      ${maskApiKey(effectiveApiKey)}${envApiKey ? c.dim("  (from PIZZAPI_API_KEY)") : ""}`);
+    console.log(`  ${c.dim("relayUrl")}    ${effectiveRelayUrl}${envRelayUrl ? c.dim("  (from PIZZAPI_RELAY_URL)") : ""}`);
+    console.log(`  ${c.dim("agentDir")}    ${agentDir}`);
+    console.log("");
+
+    const redacted = { ...config, apiKey: maskApiKey(config.apiKey) };
+    console.log(c.dim("Resolved config.json (secrets redacted):"));
+    console.log(JSON.stringify(redacted, null, 2));
+    console.log("");
+
+    return 0;
+}

--- a/packages/cli/src/config-show.ts
+++ b/packages/cli/src/config-show.ts
@@ -8,11 +8,47 @@ import { c } from "./cli-colors.js";
 
 const RELAY_DEFAULT = "ws://localhost:7492";
 
-/** Redact an API key: "unset" if absent, "set" if too short to safely slice, else first4…last4. */
-export function maskApiKey(key: string | undefined): string {
-    if (!key) return "unset";
+/** Redact an API key: "unset" if absent, "set" for non-strings or too-short values, else first4…last4. Accepts unknown because config JSON is loaded unvalidated. */
+export function maskApiKey(key: unknown): string {
+    if (key === undefined || key === null || key === "") return "unset";
+    if (typeof key !== "string") return "set";
     if (key.length <= 8) return "set";
     return `${key.slice(0, 4)}…${key.slice(-4)}`;
+}
+
+const REDACTED = "«redacted»";
+/** Key names whose value is a secret and must never be printed. */
+const SECRET_KEY_RE = /(secret|token|password|passwd|cookie|bearer|credential|private[_-]?key)/i;
+/** Key names that hold a map of arbitrary values (each of which may be a secret). */
+const OPAQUE_MAP_KEYS = new Set(["env", "envoverrides", "headers"]);
+
+/**
+ * Recursively redact a config object for display: masks apiKey-style fields,
+ * fully redacts secret-named keys and env/header maps, and strips embedded
+ * userinfo from every URL-shaped string. Never mutates the input.
+ */
+export function deepRedactConfig(value: unknown): unknown {
+    if (typeof value === "string") return maskUrlUserinfo(value) ?? value;
+    if (Array.isArray(value)) return value.map(deepRedactConfig);
+    if (value && typeof value === "object") {
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+            const lower = k.toLowerCase();
+            if (lower === "apikey" || lower.endsWith("apikey")) {
+                out[k] = v == null ? v : maskApiKey(v);
+            } else if (OPAQUE_MAP_KEYS.has(lower)) {
+                out[k] = v && typeof v === "object" && !Array.isArray(v)
+                    ? Object.fromEntries(Object.keys(v as object).map((ek) => [ek, REDACTED]))
+                    : (v == null ? v : REDACTED);
+            } else if (SECRET_KEY_RE.test(k)) {
+                out[k] = v == null ? v : REDACTED;
+            } else {
+                out[k] = deepRedactConfig(v);
+            }
+        }
+        return out;
+    }
+    return value;
 }
 
 /** Strip embedded userinfo (user:pass@) from a URL so credentials aren't printed. Non-URL strings pass through unchanged. */
@@ -49,7 +85,7 @@ export function runConfigShowCommand(cwd: string = process.cwd()): number {
     console.log(`  ${c.dim("agentDir")}    ${agentDir}`);
     console.log("");
 
-    const redacted = { ...config, apiKey: maskApiKey(config.apiKey), relayUrl: maskUrlUserinfo(config.relayUrl) };
+    const redacted = deepRedactConfig(config);
     console.log(c.dim("Resolved config.json (secrets redacted):"));
     console.log(JSON.stringify(redacted, null, 2));
     console.log("");

--- a/packages/cli/src/config.test.ts
+++ b/packages/cli/src/config.test.ts
@@ -1062,6 +1062,50 @@ describe("loadConfig transport field blocking", () => {
     // Project apiKey loads with a warning (not stripped) when global has no apiKey
     expect(config.apiKey).toBe("project-key");
   });
+
+  test("warns when apiKey is configured but relayUrl is 'off'", () => {
+    writeFileSync(
+      join(globalDir, "config.json"),
+      JSON.stringify({ apiKey: "real-key", relayUrl: "off" }),
+    );
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(join(projectDir, ".pizzapi", "config.json"), JSON.stringify({}));
+
+    const originalWarn = console.warn;
+    const warn = mock((..._args: unknown[]) => undefined);
+    console.warn = warn as unknown as typeof console.warn;
+    try {
+      const config = loadConfig(projectDir);
+      expect(config.relayUrl).toBe("off");
+      expect(config.apiKey).toBe("real-key");
+      const messages = warn.mock.calls.map((call) => String(call[2]));
+      expect(messages.some((m) => m.includes('"off"') && m.includes("apiKey is configured"))).toBe(true);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test("does not warn about disabled relay when no apiKey is configured", () => {
+    writeFileSync(join(globalDir, "config.json"), JSON.stringify({ relayUrl: "off" }));
+
+    const projectDir = join(tempDir, "project");
+    mkdirSync(join(projectDir, ".pizzapi"), { recursive: true });
+    writeFileSync(join(projectDir, ".pizzapi", "config.json"), JSON.stringify({}));
+
+    const originalWarn = console.warn;
+    const warn = mock((..._args: unknown[]) => undefined);
+    console.warn = warn as unknown as typeof console.warn;
+    try {
+      const config = loadConfig(projectDir);
+      expect(config.relayUrl).toBe("off");
+      const messages = warn.mock.calls.map((call) => String(call[2]));
+      expect(messages.some((m) => m.includes("apiKey is configured"))).toBe(false);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
 });
 
 describe("expandVars", () => {

--- a/packages/cli/src/config/io.ts
+++ b/packages/cli/src/config/io.ts
@@ -208,6 +208,19 @@ export function loadConfig(cwd: string = process.cwd()): PizzaPiConfig {
         delete config.relayUrl;
     }
 
+    // Footgun guard: an apiKey with no relay to send it to means the user thinks
+    // they've "configured a relay" (they have an API key!) but sessions will
+    // never appear in the web UI because relayUrl is explicitly disabled.
+    if (config.apiKey && typeof config.relayUrl === "string" && config.relayUrl.trim().toLowerCase() === "off") {
+        warnLoadConfigOnce(
+            projectPath,
+            "relay-off-with-apikey",
+            'Relay is disabled ("relayUrl": "off") even though an apiKey is configured — ' +
+                "sessions will not appear in the web UI. Update relayUrl in ~/.pizzapi/config.json " +
+                "(or re-run `pizzapi setup`) to re-enable the relay.",
+        );
+    }
+
     // Merge sandbox config securely — project cannot weaken global sandbox.
     // mergeSandboxConfig ensures: deny lists union, allow lists intersect,
     // mode/enabled cannot be relaxed by a project config.

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -311,6 +311,11 @@ async function main() {
         process.exit(code);
     }
 
+    if (args[0] === "config" && args[1] === "show") {
+        const { runConfigShowCommand } = await import("./config-show.js");
+        process.exit(runConfigShowCommand(cwd));
+    }
+
     if (isPackageCommand(args[0])) {
         const config = loadConfig(cwd);
         const agentDir = config.agentDir ? expandHome(config.agentDir) : defaultAgentDir();
@@ -344,6 +349,7 @@ async function main() {
         log.info(`  ${c.cmd("pizza update")} ${c.dim("[source|self]")}   Update installed pi packages`);
         log.info(`  ${c.cmd("pizza list")}                    List installed pi packages`);
         log.info(`  ${c.cmd("pizza config")}                  Enable/disable package resources`);
+        log.info(`  ${c.cmd("pizza config show")}             Print resolved effective config (secrets redacted)`);
         log.info("");
         log.info(c.label("Flags"));
         log.info(`  ${c.flag("--cwd")} ${c.dim("<path>")}         Set working directory`);

--- a/packages/cli/src/package-commands.test.ts
+++ b/packages/cli/src/package-commands.test.ts
@@ -62,18 +62,32 @@ describe("runPackageCommand", () => {
         expect(process.env.PI_CODING_AGENT_DIR).toBe(agentDir);
     });
 
-    test("update --self prints a note instead of invoking upstream self-update", async () => {
+    test("update --self is disabled: non-zero exit, no upstream self-update invoked", async () => {
         const agentDir = join(tmpDir, "agent");
         const cwd = join(tmpDir, "project");
-        const code = await runPackageCommand(["update", "--self"], cwd, agentDir);
-        expect(code).toBe(0);
+        const originalError = console.error;
+        const errors: unknown[][] = [];
+        console.error = ((...a: unknown[]) => { errors.push(a); }) as typeof console.error;
+        try {
+            const code = await runPackageCommand(["update", "--self"], cwd, agentDir);
+            expect(code).not.toBe(0);
+            expect(errors.join(" ")).toContain("self-update disabled");
+        } finally {
+            console.error = originalError;
+        }
     });
 
-    test("update pi is treated as a self-update request", async () => {
+    test("update pi is treated as a self-update request and is disabled", async () => {
         const agentDir = join(tmpDir, "agent");
         const cwd = join(tmpDir, "project");
-        const code = await runPackageCommand(["update", "pi"], cwd, agentDir);
-        expect(code).toBe(0);
+        const originalError = console.error;
+        console.error = (() => {}) as typeof console.error;
+        try {
+            const code = await runPackageCommand(["update", "pi"], cwd, agentDir);
+            expect(code).not.toBe(0);
+        } finally {
+            console.error = originalError;
+        }
     });
 
     test("update with no flags defaults to extensions-only (no self-update)", async () => {

--- a/packages/cli/src/package-commands.ts
+++ b/packages/cli/src/package-commands.ts
@@ -121,6 +121,10 @@ function printSelfUpdateNote(): void {
     console.log();
 }
 
+function printSelfUpdateDisabled(): void {
+    console.error(`self-update disabled — use ${c.cmd("npm install -g @pizzapi/pizza")} to update the PizzaPi wrapper itself.`);
+}
+
 /**
  * Parse update args to determine if self-update would be attempted.
  * Returns { includeSelf, argsForUpstream } where argsForUpstream is the
@@ -191,8 +195,8 @@ export async function runPackageCommand(args: string[], cwd: string, agentDir: s
         if (args[0] === "update") {
             const { includeSelf, argsForUpstream } = rewriteUpdateArgs(args);
             if (includeSelf) {
-                printSelfUpdateNote();
-                return 0;
+                printSelfUpdateDisabled();
+                return 1;
             }
             const wasRewritten = argsForUpstream !== args;
             try {

--- a/packages/cli/src/setup.test.ts
+++ b/packages/cli/src/setup.test.ts
@@ -70,6 +70,7 @@ describe("QR setup", () => {
 
             const config = JSON.parse(readFileSync(join(tmpDir, ".pizzapi", "config.json"), "utf-8"));
             expect(config.apiKey).toBe(apiKey);
+            expect(config.relayUrl).toBe("ws://localhost:7999");
             expect(process.env.PIZZAPI_API_KEY).toBe(apiKey);
             expect(process.env.PIZZAPI_RELAY_URL).toBe("ws://localhost:7999");
         } finally {
@@ -101,6 +102,21 @@ describe("QR setup", () => {
             expect(ok).toBe(false);
         } finally {
             globalThis.fetch = originalFetch;
+        }
+    });
+
+    // ponytail: runSetup()'s interactive wizard prompts via readline + raw-mode
+    // stdin, which isn't worth mocking end-to-end here. The QR-setup test above
+    // already exercises the identical saveGlobalConfig({ apiKey, relayUrl })
+    // save behavior; this is a cheap regression guard against reintroducing the
+    // exact audited bug (a save call that drops relayUrl) at either call site.
+    test("both saveGlobalConfig call sites in setup.ts persist relayUrl alongside apiKey", () => {
+        const source = readFileSync(join(import.meta.dir, "setup.ts"), "utf-8");
+        const calls = source.match(/saveGlobalConfig\(\{[^}]*\}\)/g) ?? [];
+        expect(calls.length).toBe(2);
+        for (const call of calls) {
+            expect(call).toContain("apiKey");
+            expect(call).toContain("relayUrl");
         }
     });
 });

--- a/packages/cli/src/setup.ts
+++ b/packages/cli/src/setup.ts
@@ -153,7 +153,7 @@ export async function runQrSetup(relayUrl: string, pollIntervalMs = 2000): Promi
             continue;
         }
         if (result.status === "approved" && result.apiKey) {
-            saveGlobalConfig({ apiKey: result.apiKey });
+            saveGlobalConfig({ apiKey: result.apiKey, relayUrl: wsRelayUrl });
             process.env.PIZZAPI_API_KEY = result.apiKey;
             process.env.PIZZAPI_RELAY_URL = wsRelayUrl;
 
@@ -266,8 +266,10 @@ export async function runSetup(opts: { force?: boolean; scan?: boolean } = {}): 
         // Derive ws:// URL for the relay config
         const wsRelayUrl = relayUrl.replace(/^http/, "ws");
 
-        // Save the server-issued API key
-        saveGlobalConfig({ apiKey: result.key });
+        // Save the server-issued API key alongside the relay it was issued for —
+        // otherwise a later run would fall back to the default relay while auth
+        // silently points at a different server.
+        saveGlobalConfig({ apiKey: result.key, relayUrl: wsRelayUrl });
         process.env.PIZZAPI_API_KEY = result.key;
         process.env.PIZZAPI_RELAY_URL = wsRelayUrl;
 


### PR DESCRIPTION
## CLI setup/config UX fixes

Fixes source-of-truth footguns behind several false docs claims. Scope: `packages/cli/**` only.

### Changes
1. **`runSetup()` / `runQrSetup()` now persist `relayUrl`** (previously saved only `apiKey`). Running `pizzapi setup` against a non-default relay no longer silently leaves the relay unconfigured.
2. **`loadConfig()` warns once** when `apiKey` is set but `relayUrl` resolves to `"off"`, naming the stale value and the file to fix.
3. **New `pizza config show`** — prints the resolved effective config with `apiKey` always masked (`first4…last4` / `unset`), never full. Wired ahead of the existing `config` package-command dispatch.
4. **`update --self` / `update self` / `update pi`** now print `self-update disabled — use npm …` to stderr and exit non-zero instead of silently exiting 0.

### Tests
New/updated: `config.test.ts`, `config-show.test.ts`, `setup.test.ts`, `package-commands.test.ts`.
`bun run typecheck` → exit 0. `bun test` (packages/cli) → 2247 pass, 0 fail.

Follow-up captured: `pizzapi runner install` launchd/systemd generator (deferred).
