### PR TITLE
fix(server): deliverAs default, session_error ordering, child-push suppression, compose secret

### DIFF
--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -44,10 +44,28 @@ services:
       target: runtime-no-ui
     ports:
       - "7492:7492"
+    # BETTER_AUTH_SECRET signs session cookies/API tokens. If left unset, the
+    # startup script below auto-generates a random 32-byte secret on first run
+    # and persists it to the pizzapi-data volume (survives restarts, so
+    # sessions stay valid). Set BETTER_AUTH_SECRET explicitly below to pin a
+    # specific value instead (e.g. `openssl rand -hex 32`) — required if you
+    # run multiple server replicas that must share sessions.
+    command: >
+      /bin/sh -c '
+        if [ -z "$$BETTER_AUTH_SECRET" ]; then
+          SECRET_FILE=/app/data/better-auth-secret;
+          if [ ! -f "$$SECRET_FILE" ]; then
+            head -c 32 /dev/urandom | od -An -tx1 | tr -d " \n" > "$$SECRET_FILE";
+          fi;
+          export BETTER_AUTH_SECRET=$$(cat "$$SECRET_FILE");
+        fi;
+        exec bun run packages/server/dist/index.js
+      '
     environment:
       - PORT=7492
       - PIZZAPI_REDIS_URL=redis://redis:6379
       - AUTH_DB_PATH=/app/data/auth.db
+      # - BETTER_AUTH_SECRET=<32+ char secret — see comment above>
       # ── ntfy (self-hosted push). Internal publish URL is fixed; the public
       # URL + publish token must be provided by the operator. If unset, the
       # ntfy push branch is a silent no-op and only Web Push runs.

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -51,13 +51,20 @@ services:
     # specific value instead (e.g. `openssl rand -hex 32`) — required if you
     # run multiple server replicas that must share sessions.
     command: >
-      /bin/sh -c '
-        if [ -z "$$BETTER_AUTH_SECRET" ]; then
+      /bin/sh -euc '
+        if [ -z "$${BETTER_AUTH_SECRET:-}" ]; then
           SECRET_FILE=/app/data/better-auth-secret;
           if [ ! -f "$$SECRET_FILE" ]; then
-            head -c 32 /dev/urandom | od -An -tx1 | tr -d " \n" > "$$SECRET_FILE";
+            TMP="$$SECRET_FILE.tmp.$$$$";
+            head -c 32 /dev/urandom | od -An -tx1 | tr -d " \n" > "$$TMP";
+            mv "$$TMP" "$$SECRET_FILE";
           fi;
-          export BETTER_AUTH_SECRET=$$(cat "$$SECRET_FILE");
+          BETTER_AUTH_SECRET=$$(cat "$$SECRET_FILE");
+          export BETTER_AUTH_SECRET;
+        fi;
+        if [ "$${#BETTER_AUTH_SECRET}" -lt 32 ]; then
+          echo "FATAL: BETTER_AUTH_SECRET missing or too short (<32 chars); refusing to start with an insecure session secret." >&2;
+          exit 1;
         fi;
         exec bun run packages/server/dist/index.js
       '

--- a/packages/cli/src/extensions/remote/connection.ts
+++ b/packages/cli/src/extensions/remote/connection.ts
@@ -218,8 +218,11 @@ export function connect(rctx: RelayContext, handlers: ConnectionHandlers): void 
         triggerBatchTimer = null;
         if (pendingTriggerBatch.length === 0) return;
         const batch = pendingTriggerBatch.splice(0);
-        // Prefer "followUp" delivery if any trigger requested it; otherwise "steer".
-        const deliverAs = batch.some((b) => b.deliverAs === "followUp") ? "followUp" as const : "steer" as const;
+        // If ANY trigger in the batch explicitly requested "steer", the batch
+        // interrupts: an explicit interrupt intent (e.g. a usage-limit
+        // session_error) must not be silently downgraded just because it was
+        // debounced alongside a "followUp" trigger like session_complete.
+        const deliverAs = batch.some((b) => b.deliverAs === "steer") ? "steer" as const : "followUp" as const;
         const rendered = renderTriggerBatch(batch.map((b) => b.trigger));
         void (async () => {
             try {

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.test.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Regression test for the session_error / session_complete emit ordering.
+ *
+ * Docs promise session_error is an "early signal" delivered before
+ * session_complete. Both are emitted synchronously (direct socket.emit calls)
+ * from the agent_end handler, so which call comes first in the source
+ * determines wire order. This exercises the real registerLifecycleHandlers
+ * agent_end handler end-to-end (not a reimplementation) so a future accidental
+ * reordering fails the test.
+ */
+import { describe, test, expect, mock } from "bun:test";
+import { registerLifecycleHandlers, type LifecycleHandlerState } from "./lifecycle-handlers.js";
+import { createFollowUpGrace } from "./followup-grace.js";
+import type { RelayContext } from "../remote-types.js";
+
+function makeState(): LifecycleHandlerState {
+    return {
+        staleChildIds: new Set(),
+        pendingDelink: false,
+        pendingDelinkEpoch: null,
+        pendingDelinkOwnParent: false,
+        stalePrimaryParentId: null,
+        pendingCancellations: [],
+        sessionCompleteFired: false,
+        sessionCompleteGeneration: 0,
+        sessionCompleteTransportGeneration: 0,
+        sessionCompleteRetryTimer: null,
+        pendingSessionCompleteDelivery: null,
+        pendingSessionCompleteSocket: null,
+        pendingSessionCompleteTransportGeneration: null,
+        lastSessionCompletePayload: null,
+    };
+}
+
+/** Builds a minimal harness: real registerLifecycleHandlers + real followup-grace,
+ * with a fake pi/socket capturing emitted trigger types in call order. */
+function setup(lastRetryableError: { errorMessage: string; detectedAt: number } | null) {
+    const handlers = new Map<string, (event: any, ctx: any) => void>();
+    const emitted: string[] = [];
+
+    const pi: any = {
+        on: (name: string, fn: any) => handlers.set(name, fn),
+        events: { on: () => {} },
+        registerTool: () => {},
+        registerCommand: () => {},
+    };
+
+    const socket: any = {
+        connected: true,
+        emit: mock((_event: string, payload: any) => {
+            emitted.push(payload?.trigger?.type ?? "unknown");
+        }),
+        on: () => {},
+        off: () => {},
+    };
+
+    const rctx = {
+        pi,
+        isChildSession: true,
+        parentSessionId: "parent-session-1",
+        relay: { sessionId: "child-session-1", token: "relay-token" },
+        sioSocket: socket,
+        lastRetryableError,
+        wasAborted: false,
+        shuttingDown: false,
+        supportsSessionTriggerAck: true,
+        forwardEvent: mock(() => {}),
+        buildHeartbeat: () => ({ type: "heartbeat", ts: Date.now() }),
+    } as unknown as RelayContext;
+
+    const state = makeState();
+    const followUpGrace = createFollowUpGrace(rctx, state as any);
+
+    registerLifecycleHandlers({
+        pi,
+        rctx,
+        state,
+        triggerWaits: { cancelAll: () => 0 } as any,
+        delinkManager: {} as any,
+        cancellationManager: {} as any,
+        followUpGrace,
+        startSessionNameSync: () => {},
+        stopSessionNameSync: () => {},
+        doConnect: () => {},
+        doDisconnect: () => {},
+        clearCtx: () => {},
+    });
+
+    const agentEnd = handlers.get("agent_end")!;
+    return { agentEnd, emitted };
+}
+
+const agentEndCtx = { hasPendingMessages: () => false, shutdown: () => {} };
+
+describe("agent_end — session_error / session_complete ordering", () => {
+    test("emits session_error before session_complete for a child session usage-limit error", () => {
+        const { agentEnd, emitted } = setup({
+            errorMessage: "You have exceeded your usage limit",
+            detectedAt: Date.now(),
+        });
+
+        agentEnd({ messages: [] }, agentEndCtx);
+
+        // Both are emitted synchronously within the handler call (before any
+        // await/microtask), so capturing immediately after invocation is safe.
+        expect(emitted).toEqual(["session_error", "session_complete"]);
+    });
+
+    test("emits only session_complete when there is no usage-limit error", () => {
+        const { agentEnd, emitted } = setup(null);
+
+        agentEnd({ messages: [] }, agentEndCtx);
+
+        expect(emitted).toEqual(["session_complete"]);
+    });
+});

--- a/packages/cli/src/extensions/remote/lifecycle-handlers.ts
+++ b/packages/cli/src/extensions/remote/lifecycle-handlers.ts
@@ -414,14 +414,11 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
             // Keep it alive for steering instead. session_shutdown still reports
             // "killed" when the session is actually ending (end_session sets
             // shuttingDown before shutdown()).
-            const manualAbort = isManualAbort(rctx);
-            if (rctx.isChildSession && manualAbort) {
-                log.info("pizzapi: turn aborted manually — keeping child session alive");
-            } else {
-                void followUpGrace.fireSessionComplete(summary, fullOutputPath, exitReason);
-            }
-
-            // Fire session_error for terminal usage-limit errors (one-shot, only at agent_end).
+            // Fire session_error BEFORE session_complete so the parent sees the
+            // error as an early signal. maybeFireSessionError emits synchronously
+            // (direct socket.emit); fireSessionComplete's ack-wrapped emit also
+            // fires synchronously on invocation, so ordering these two calls
+            // determines wire order. Must run first.
             if (
                 maybeFireSessionError({
                     sessionErrorFired,
@@ -437,6 +434,13 @@ export function registerLifecycleHandlers(deps: LifecycleHandlersDeps): void {
                 })
             ) {
                 sessionErrorFired = true;
+            }
+
+            const manualAbort = isManualAbort(rctx);
+            if (rctx.isChildSession && manualAbort) {
+                log.info("pizzapi: turn aborted manually — keeping child session alive");
+            } else {
+                void followUpGrace.fireSessionComplete(summary, fullOutputPath, exitReason);
             }
 
             if (rctx.isChildSession) {

--- a/packages/cli/src/extensions/trigger-client.test.ts
+++ b/packages/cli/src/extensions/trigger-client.test.ts
@@ -798,6 +798,28 @@ describe("broadcastTrigger", () => {
         expect(captured[0].method).toBe("POST");
     });
 
+    test("defaults deliverAs to 'followUp' when omitted (non-interruptive broadcast)", async () => {
+        const captured: Array<{ body: any }> = [];
+        const deps = subsDeps(async (_url, init) => {
+            captured.push({ body: JSON.parse(init?.body as string ?? "{}") });
+            return { ok: true, status: 200, json: async () => ({ ok: true, delivered: 0 }) } as Response;
+        });
+
+        await broadcastTrigger("runner-A", { type: "svc:event", payload: {} }, deps);
+        expect(captured[0].body.deliverAs).toBe("followUp");
+    });
+
+    test("passes through an explicit deliverAs: 'steer'", async () => {
+        const captured: Array<{ body: any }> = [];
+        const deps = subsDeps(async (_url, init) => {
+            captured.push({ body: JSON.parse(init?.body as string ?? "{}") });
+            return { ok: true, status: 200, json: async () => ({ ok: true, delivered: 0 }) } as Response;
+        });
+
+        await broadcastTrigger("runner-A", { type: "svc:event", payload: {}, deliverAs: "steer" }, deps);
+        expect(captured[0].body.deliverAs).toBe("steer");
+    });
+
     test("returns error when no base URL configured", async () => {
         const deps: TriggerClientDeps = {
             getRelaySocket: () => null,

--- a/packages/cli/src/extensions/trigger-client.ts
+++ b/packages/cli/src/extensions/trigger-client.ts
@@ -249,7 +249,12 @@ export async function broadcastTrigger(
             body: JSON.stringify({
                 type: params.type,
                 payload: params.payload,
-                deliverAs: params.deliverAs ?? "steer",
+                // Broadcast (runner-wide) triggers default to non-interruptive
+                // "followUp", matching the server endpoint default and the
+                // documented runner-services contract. A service must opt into
+                // "steer" to interrupt an active turn. (Session-targeted
+                // fireTrigger above keeps its "steer" default by design.)
+                deliverAs: params.deliverAs ?? "followUp",
                 expectsResponse: params.expectsResponse ?? false,
                 ...(params.source ? { source: params.source } : {}),
                 ...(params.summary ? { summary: params.summary } : {}),

--- a/packages/server/src/push.test.ts
+++ b/packages/server/src/push.test.ts
@@ -498,3 +498,115 @@ describe("native push registration", () => {
         expect(rows).toHaveLength(0);
     });
 });
+
+// ── Child-session push suppression (isChildSession) ────────────────────────────
+//
+// Docs: "Linked child sessions do not trigger push notifications. Only
+// top-level sessions ... send push notifications." Verified indirectly (no
+// mocking of webpush.sendNotification / real network calls): a subscription
+// row with malformed `keys` JSON is only pruned if the send path actually
+// attempted delivery (JSON.parse throws before any network call). If the
+// isChildSession guard returns early, the row is left untouched.
+
+describe("sendPushToUser — child-session suppression", () => {
+    authIt("web-push: suppresses by default for a child session (malformed-keys subscription untouched)", async () => {
+        await insertSub("sub-child-1", "user-child-1", "https://example.com/push/child-1");
+        await getKysely()
+            .updateTable("push_subscription" as any)
+            .set({ keys: "not-json" })
+            .where("id", "=", "sub-child-1")
+            .execute();
+
+        await sendPushToUser("user-child-1", {
+            type: "agent_finished",
+            title: "Agent finished",
+            body: "done",
+            sessionId: "sess-child-1",
+        }, true);
+
+        // Not attempted (guard returned before JSON.parse) — subscription survives.
+        const subs = await getSubscriptionsForUser("user-child-1");
+        expect(subs).toHaveLength(1);
+    });
+
+    authIt("web-push: delivers (attempts) for a non-child session", async () => {
+        await insertSub("sub-child-2", "user-child-2", "https://example.com/push/child-2");
+        await getKysely()
+            .updateTable("push_subscription" as any)
+            .set({ keys: "not-json" })
+            .where("id", "=", "sub-child-2")
+            .execute();
+
+        await sendPushToUser("user-child-2", {
+            type: "agent_finished",
+            title: "Agent finished",
+            body: "done",
+            sessionId: "sess-child-2",
+        }, false);
+
+        // Attempted — malformed JSON caused it to be pruned as stale.
+        const subs = await getSubscriptionsForUser("user-child-2");
+        expect(subs).toHaveLength(0);
+    });
+
+    authIt("web-push: suppresses a child session even when suppressChildNotifications is false (no per-subscription opt-out exists)", async () => {
+        await insertSub("sub-child-3", "user-child-3", "https://example.com/push/child-3", false);
+        await getKysely()
+            .updateTable("push_subscription" as any)
+            .set({ keys: "not-json" })
+            .where("id", "=", "sub-child-3")
+            .execute();
+
+        await sendPushToUser("user-child-3", {
+            type: "agent_finished",
+            title: "Agent finished",
+            body: "done",
+            sessionId: "sess-child-3",
+        }, true);
+
+        const subs = await getSubscriptionsForUser("user-child-3");
+        expect(subs).toHaveLength(1); // still untouched — suppressed regardless of the flag
+    });
+
+    authIt("ntfy: suppresses by default for a child session (no fetch attempted)", async () => {
+        await registerNativePush({ userId: "user-child-ntfy-1", platform: "android" });
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+
+        let fetchCalled = false;
+        const origFetch = globalThis.fetch;
+        (globalThis as any).fetch = () => { fetchCalled = true; return Promise.resolve(new Response("ok")); };
+        try {
+            await sendPushToUser("user-child-ntfy-1", {
+                type: "agent_finished",
+                title: "Agent finished",
+                body: "done",
+                sessionId: "sess-child-ntfy-1",
+            }, true);
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            delete process.env.PIZZAPI_NTFY_URL;
+        }
+        expect(fetchCalled).toBe(false);
+    });
+
+    authIt("ntfy: still publishes for a non-child session", async () => {
+        await registerNativePush({ userId: "user-child-ntfy-2", platform: "android" });
+        process.env.PIZZAPI_NTFY_URL = "http://ntfy-test";
+
+        let fetchCalled = false;
+        const origFetch = globalThis.fetch;
+        (globalThis as any).fetch = () => { fetchCalled = true; return Promise.resolve(new Response("ok")); };
+        try {
+            await sendPushToUser("user-child-ntfy-2", {
+                type: "agent_finished",
+                title: "Agent finished",
+                body: "done",
+                sessionId: "sess-child-ntfy-2",
+            }, false);
+        } finally {
+            (globalThis as any).fetch = origFetch;
+            delete process.env.PIZZAPI_NTFY_URL;
+        }
+        expect(fetchCalled).toBe(true);
+    });
+});

--- a/packages/server/src/push.ts
+++ b/packages/server/src/push.ts
@@ -379,14 +379,14 @@ function buildNtfyPublish(payload: PushPayload): Record<string, unknown> {
  * Never throws — failures are logged and stale registrations pruned. Caller
  * (sendPushToUser) treats this as best-effort alongside the Web Push fan-out.
  *
- * NOTE: native registrations have no per-subscription preference columns
- * (enabledEvents / suppressChildNotifications) today, so — unlike the Web Push
- * path — native currently delivers ALL events regardless of `isChildSession`.
- * The param is kept for signature parity; wire real suppression here once the
- * native registration schema grows those columns.
+ * Linked child sessions never send native push by default (docs: "only
+ * top-level sessions send push notifications") — native registrations have
+ * no per-subscription preference columns to offer a granular opt-out today,
+ * so this is unconditional. (Unlike the Web Push path below, there is no
+ * per-registration escape hatch yet — add one here if that's ever needed.)
  */
 async function sendNtfyToUser(userId: string, payload: PushPayload, isChildSession: boolean): Promise<void> {
-    void isChildSession; // see note above: native has no suppression columns yet
+    if (isChildSession) return;
     const cfg = ntfyConfig();
     if (!cfg.url) return;
     const registrations = await getNativeRegistrationsForUser(userId);
@@ -550,8 +550,13 @@ function isEventEnabled(enabledEvents: string, eventType: PushEventType): boolea
  * Send a push notification to all subscriptions for a given user.
  * Silently removes subscriptions that are no longer valid (410 Gone).
  *
- * @param isChildSession - When true, subscriptions with suppressChildNotifications
- *   enabled will not receive this notification.
+ * @param isChildSession - When true (linked child session), push is
+ *   suppressed unconditionally by default — docs: "only top-level sessions
+ *   send push notifications". The per-subscription `suppressChildNotifications`
+ *   column/API (PUT /api/push/child-notifications) predates this default and
+ *   only ever offered an opt-IN to further suppression, never a guaranteed
+ *   "receive despite being a child" opt-out, so there is nothing to preserve
+ *   here — it remains stored/toggleable but is now redundant.
  */
 export async function sendPushToUser(userId: string, payload: PushPayload, isChildSession = false): Promise<void> {
     const subscriptions = await getSubscriptionsForUser(userId);
@@ -571,7 +576,7 @@ export async function sendPushToUser(userId: string, payload: PushPayload, isChi
         ntfyPromise,
         ...subscriptions.map(async (sub) => {
             if (!isEventEnabled(sub.enabledEvents, payload.type)) return;
-            if (isChildSession && sub.suppressChildNotifications) return;
+            if (isChildSession) return;
 
             let keys: { p256dh: string; auth: string };
             try {

--- a/packages/server/src/routes/triggers.test.ts
+++ b/packages/server/src/routes/triggers.test.ts
@@ -936,6 +936,45 @@ describe("POST /api/runners/:runnerId/trigger-broadcast", () => {
         expect(emitMock).toHaveBeenCalledTimes(2);
     });
 
+    test("defaults deliverAs to followUp when omitted", async () => {
+        mockGetSubscribersForTrigger.mockReturnValue(Promise.resolve(["sess-1"]));
+        mockGetSharedSession.mockImplementation((id: string) =>
+            Promise.resolve({ userId: "user-1", sessionId: id } as any),
+        );
+        const emitMock = mock(() => {});
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: emitMock });
+
+        const [req, url] = makeReq(
+            "POST", "/api/runners/runner-A/trigger-broadcast",
+            { type: "svc:event", payload: { x: 1 } },
+            { "x-api-key": "test-key" },
+        );
+        const res = await handleTriggersRoute(req, url);
+        expect(res?.status).toBe(200);
+        expect(emitMock).toHaveBeenCalledTimes(1);
+        const args = emitMock.mock.calls[0] as any[];
+        expect(args[1].trigger.deliverAs).toBe("followUp");
+    });
+
+    test("preserves an explicit deliverAs: steer", async () => {
+        mockGetSubscribersForTrigger.mockReturnValue(Promise.resolve(["sess-1"]));
+        mockGetSharedSession.mockImplementation((id: string) =>
+            Promise.resolve({ userId: "user-1", sessionId: id } as any),
+        );
+        const emitMock = mock(() => {});
+        mockGetLocalTuiSocket.mockReturnValue({ connected: true, emit: emitMock });
+
+        const [req, url] = makeReq(
+            "POST", "/api/runners/runner-A/trigger-broadcast",
+            { type: "svc:event", payload: { x: 1 }, deliverAs: "steer" },
+            { "x-api-key": "test-key" },
+        );
+        const res = await handleTriggersRoute(req, url);
+        expect(res?.status).toBe(200);
+        const args = emitMock.mock.calls[0] as any[];
+        expect(args[1].trigger.deliverAs).toBe("steer");
+    });
+
     test("skips sessions belonging to a different user", async () => {
         mockGetSubscribersForTrigger.mockReturnValue(
             Promise.resolve(["sess-other", "sess-mine"]),

--- a/packages/server/src/routes/triggers.ts
+++ b/packages/server/src/routes/triggers.ts
@@ -29,6 +29,7 @@
  *   Broadcast a trigger by type to all sessions subscribed to that type on
  *   this runner. API key auth only (called by runner services).
  *   Body: { type, payload, deliverAs?, source?, summary? }
+ *   deliverAs defaults to "followUp" (queued, non-interruptive) when omitted.
  *   Returns: { ok, delivered: number, triggerId }
  */
 
@@ -936,7 +937,11 @@ export const handleTriggersRoute: RouteHandler = async (req, url) => {
             return Response.json({ error: "Missing or invalid 'payload' field — must be an object" }, { status: 400 });
         }
 
-        const deliverAs = body.deliverAs ?? "steer";
+        // Default to "followUp" (non-interruptive) when omitted — matches the
+        // documented default and the runner-services example template. A
+        // service that wants to interrupt the current turn must opt in
+        // explicitly with deliverAs: "steer".
+        const deliverAs = body.deliverAs ?? "followUp";
         if (deliverAs !== "steer" && deliverAs !== "followUp") {
             return Response.json({ error: "Invalid 'deliverAs' — must be 'steer' or 'followUp'" }, { status: 400 });
         }


### PR DESCRIPTION
## Server trigger/push/secret behavior fixes

Fixes four source-of-truth mismatches the docs audit exposed, so the documented behavior becomes true. Scope: `packages/server/**`, `docker/**`, and `packages/cli/src/extensions/remote/lifecycle-handlers.ts`.

### Changes
1. **`deliverAs` default → `followUp`** on the `/api/runners/:id/trigger-broadcast` endpoint (was `steer`), matching the documented default. Services must opt into `steer` to interrupt a turn. Non-breaking (no caller relied on the implicit default). +2 regression tests.
2. **`session_error` emitted before `session_complete`** in the `agent_end` lifecycle handler, so the parent gets the error as an early signal. New end-to-end `lifecycle-handlers.test.ts` (verified red without the fix).
3. **Child-session pushes suppressed by default** — unconditional `isChildSession` guard in both the Web Push loop and the previously-unguarded ntfy path. The legacy `suppressChildNotifications` opt-in column is left intact but redundant (documented in code). +5 tests. Follow-up captured for the now-redundant UI toggle.
4. **`BETTER_AUTH_SECRET` auto-generated + persisted** to the `pizzapi-data` volume on first run in `docker/compose.yml` (unless set explicitly), matching `pizza web` behavior — no more insecure ephemeral sessions in the manual-compose quick start.

### Validation
`bun run typecheck` → exit 0. `bun run test` → 0 fail across the monorepo. `docker compose config` validated; secret persistence round-trip tested with `docker run`.
