### PR TITLE
chore: bump @earendil-works/* 0.80.3 → 0.80.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,9 +12,9 @@
         "@capacitor/push-notifications": "^8.1.1",
         "@capawesome/capacitor-badge": "^8.0.2",
         "@capgo/capacitor-updater": "^8",
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
-        "@earendil-works/pi-tui": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.80.5",
+        "@earendil-works/pi-ai": "^0.80.5",
+        "@earendil-works/pi-tui": "^0.80.5",
         "motion": "^12.34.2",
         "pizzapi": ".",
       },
@@ -46,7 +46,7 @@
         "pizzapi": "src/index.ts",
       },
       "dependencies": {
-        "@earendil-works/pi-coding-agent": "^0.80.3",
+        "@earendil-works/pi-coding-agent": "^0.80.5",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
@@ -83,8 +83,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.80.5",
+        "@earendil-works/pi-ai": "^0.80.5",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",
@@ -112,8 +112,8 @@
       "version": "0.1.32",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.80.5",
+        "@earendil-works/pi-ai": "^0.80.5",
       },
       "devDependencies": {
         "typescript": "^5.7.0",
@@ -200,10 +200,10 @@
     },
   },
   "patchedDependencies": {
-    "@earendil-works/pi-coding-agent@0.80.3": "patches/@earendil-works%2Fpi-coding-agent@0.80.3.patch",
-    "@earendil-works/pi-agent-core@0.80.3": "patches/@earendil-works%2Fpi-agent-core@0.80.3.patch",
-    "@earendil-works/pi-ai@0.80.3": "patches/@earendil-works%2Fpi-ai@0.80.3.patch",
-    "@earendil-works/pi-tui@0.80.3": "patches/@earendil-works%2Fpi-tui@0.80.3.patch",
+    "@earendil-works/pi-coding-agent@0.80.5": "patches/@earendil-works%2Fpi-coding-agent@0.80.5.patch",
+    "@earendil-works/pi-agent-core@0.80.5": "patches/@earendil-works%2Fpi-agent-core@0.80.5.patch",
+    "@earendil-works/pi-ai@0.80.5": "patches/@earendil-works%2Fpi-ai@0.80.5.patch",
+    "@earendil-works/pi-tui@0.80.5": "patches/@earendil-works%2Fpi-tui@0.80.5.patch",
   },
   "packages": {
     "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.53", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.15", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-QT3FEoNARMRlk8JJVR7L98exiK9C8AGfrEJVbRxBT1yIXKs/N19o/+PsjTRVsARgDJNcy9JbJp1FspKucEat0Q=="],
@@ -584,13 +584,13 @@
 
     "@dotenvx/dotenvx": ["@dotenvx/dotenvx@1.52.0", "", { "dependencies": { "commander": "^11.1.0", "dotenv": "^17.2.1", "eciesjs": "^0.4.10", "execa": "^5.1.1", "fdir": "^6.2.0", "ignore": "^5.3.0", "object-treeify": "1.1.33", "picomatch": "^4.0.2", "which": "^4.0.0" }, "bin": { "dotenvx": "src/cli/dotenvx.js" } }, "sha512-CaQcc8JvtzQhUSm9877b6V4Tb7HCotkcyud9X2YwdqtQKwgljkMRwU96fVYKnzN3V0Hj74oP7Es+vZ0mS+Aa1w=="],
 
-    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.3", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.3", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-3qw0/GeRQBU/nlGjDe5Yb7ePKTmoxefx2YxyKMFAviFUMXpFexBG/hS7mBtwFahFvzrrTPPoRT6sFIDjwoDWPQ=="],
+    "@earendil-works/pi-agent-core": ["@earendil-works/pi-agent-core@0.80.5", "", { "dependencies": { "@earendil-works/pi-ai": "^0.80.5", "ignore": "7.0.5", "typebox": "1.1.38", "yaml": "2.9.0" } }, "sha512-413NZ5BEwSdL+BAtoBlk7hcA3UGvltcdAPtFoMZ1uqLZRNIoFU0WhNXGwv5Sp1SPBmMR6MAc3neoA+MdOlWJ2w=="],
 
-    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.3", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-jPZLMeGL5kkMSEAwAklfXTMHqZvfhsJtCCpKGIr5Duk7mc0n4skjB1dugk7y0z3z8ZHIUCmPAWHdyDqgUz5vdA=="],
+    "@earendil-works/pi-ai": ["@earendil-works/pi-ai@0.80.5", "", { "dependencies": { "@anthropic-ai/sdk": "0.91.1", "@aws-sdk/client-bedrock-runtime": "3.1048.0", "@google/genai": "1.52.0", "@mistralai/mistralai": "2.2.6", "@opentelemetry/api": "1.9.0", "@smithy/node-http-handler": "4.7.3", "http-proxy-agent": "7.0.2", "https-proxy-agent": "7.0.6", "openai": "6.26.0", "partial-json": "0.1.7", "typebox": "1.1.38" }, "bin": { "pi-ai": "dist/cli.js" } }, "sha512-+7UODYKu4o/X8sxTHG8HEV3+O+dOYKg5MeO3MJIFQ+wu65pIWDhjZGc759uWsRr79AhV7MSJEe4GWnFn4l68gw=="],
 
-    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.3", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.3", "@earendil-works/pi-ai": "^0.80.3", "@earendil-works/pi-tui": "^0.80.3", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-TIggw9gCXpA+Ph7OjdTA7ka2NPwTVuPmy39KDSyUzaKq8VvHfMGR7vtRz4JB7Um/RMRblmzhu4p9tUCk6MTgGA=="],
+    "@earendil-works/pi-coding-agent": ["@earendil-works/pi-coding-agent@0.80.5", "", { "dependencies": { "@earendil-works/pi-agent-core": "^0.80.5", "@earendil-works/pi-ai": "^0.80.5", "@earendil-works/pi-tui": "^0.80.5", "@silvia-odwyer/photon-node": "0.3.4", "chalk": "5.6.2", "cross-spawn": "7.0.6", "diff": "8.0.4", "glob": "13.0.6", "highlight.js": "10.7.3", "hosted-git-info": "9.0.3", "ignore": "7.0.5", "jiti": "2.7.0", "minimatch": "10.2.5", "proper-lockfile": "4.1.2", "semver": "7.8.0", "typebox": "1.1.38", "undici": "8.5.0", "yaml": "2.9.0" }, "optionalDependencies": { "@mariozechner/clipboard": "0.3.9" }, "bin": { "pi": "dist/cli.js" } }, "sha512-GPYFuHw1BN+3m5Gzw1HGH41WdFDzbplLauS0zYSf1ZOkgKFd6wtEAcjchB/vmz9YtTGbQOwECbsVj6GxZxungA=="],
 
-    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.3", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-2BJI6qwRQfnM0Q7seL1+SbacU/jRRjBnN7Hu3n9BjAn7/s5FaBNnvdD1qBQYRsFTHfjqMaDsjYqanPyqwXj99w=="],
+    "@earendil-works/pi-tui": ["@earendil-works/pi-tui@0.80.5", "", { "dependencies": { "get-east-asian-width": "1.6.0", "marked": "18.0.5" } }, "sha512-raxEUD2CvCDNJuOWEAI+xD7vmxCrGH0NYb31+GQDdL1q9WXn5+uNLgP1vkJfOsTvf9k5zU5sNFA06oBIcWSYtQ=="],
 
     "@ecies/ciphers": ["@ecies/ciphers@0.2.5", "", { "peerDependencies": { "@noble/ciphers": "^1.0.0" } }, "sha512-GalEZH4JgOMHYYcYmVqnFirFsjZHeoGMDt9IxEnM9F7GRUUyUksJ7Ou53L83WHJq3RWKD3AcBpo0iQh0oMpf8A=="],
 

--- a/package.json
+++ b/package.json
@@ -53,9 +53,9 @@
     "@capacitor/push-notifications": "^8.1.1",
     "@capawesome/capacitor-badge": "^8.0.2",
     "@capgo/capacitor-updater": "^8",
-    "@earendil-works/pi-agent-core": "^0.80.3",
-    "@earendil-works/pi-ai": "^0.80.3",
-    "@earendil-works/pi-tui": "^0.80.3",
+    "@earendil-works/pi-agent-core": "^0.80.5",
+    "@earendil-works/pi-ai": "^0.80.5",
+    "@earendil-works/pi-tui": "^0.80.5",
     "motion": "^12.34.2",
     "pizzapi": "."
   },
@@ -70,9 +70,9 @@
   },
   "version": "",
   "patchedDependencies": {
-    "@earendil-works/pi-agent-core@0.80.3": "patches/@earendil-works%2Fpi-agent-core@0.80.3.patch",
-    "@earendil-works/pi-tui@0.80.3": "patches/@earendil-works%2Fpi-tui@0.80.3.patch",
-    "@earendil-works/pi-ai@0.80.3": "patches/@earendil-works%2Fpi-ai@0.80.3.patch",
-    "@earendil-works/pi-coding-agent@0.80.3": "patches/@earendil-works%2Fpi-coding-agent@0.80.3.patch"
+    "@earendil-works/pi-agent-core@0.80.5": "patches/@earendil-works%2Fpi-agent-core@0.80.5.patch",
+    "@earendil-works/pi-tui@0.80.5": "patches/@earendil-works%2Fpi-tui@0.80.5.patch",
+    "@earendil-works/pi-ai@0.80.5": "patches/@earendil-works%2Fpi-ai@0.80.5.patch",
+    "@earendil-works/pi-coding-agent@0.80.5": "patches/@earendil-works%2Fpi-coding-agent@0.80.5.patch"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -29,7 +29,7 @@
     "build:binaries": "bun build-binaries.ts"
   },
   "dependencies": {
-    "@earendil-works/pi-coding-agent": "^0.80.3",
+    "@earendil-works/pi-coding-agent": "^0.80.5",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "@pizzapi/protocol": "workspace:*",
     "@pizzapi/tools": "workspace:*",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -14,8 +14,8 @@
     },
     "dependencies": {
         "@aws-sdk/client-s3": "^3.995.0",
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3",
+        "@earendil-works/pi-agent-core": "^0.80.5",
+        "@earendil-works/pi-ai": "^0.80.5",
         "@pizzapi/protocol": "workspace:*",
         "@pizzapi/tools": "workspace:*",
         "@pizzapi/tunnel": "workspace:*",

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -10,8 +10,8 @@
     },
     "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.41",
-        "@earendil-works/pi-agent-core": "^0.80.3",
-        "@earendil-works/pi-ai": "^0.80.3"
+        "@earendil-works/pi-agent-core": "^0.80.5",
+        "@earendil-works/pi-ai": "^0.80.5"
     },
     "devDependencies": {
         "typescript": "^5.7.0"

--- a/patches/@earendil-works%2Fpi-agent-core@0.80.5.patch
+++ b/patches/@earendil-works%2Fpi-agent-core@0.80.5.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/agent-loop.js b/dist/agent-loop.js
+index dcea976..a27a384 100644
+--- a/dist/agent-loop.js
++++ b/dist/agent-loop.js
+@@ -101,6 +101,9 @@ async function runLoop(initialContext, newMessages, initialConfig, signal, emit,
+                 }
+                 pendingMessages = [];
+             }
++            // PATCH(pizzapi): refresh dynamic tool/prompt state before each assistant response
++            currentContext.systemPrompt = currentContext.__getLatestSystemPrompt?.() ?? currentContext.systemPrompt;
++            currentContext.tools = currentContext.__getLatestTools?.() ?? currentContext.tools;
+             // Stream assistant response
+             const message = await streamAssistantResponse(currentContext, config, signal, emit, streamFn);
+             newMessages.push(message);
+diff --git a/dist/agent.js b/dist/agent.js
+index c98a07a..c2624ca 100644
+--- a/dist/agent.js
++++ b/dist/agent.js
+@@ -273,6 +273,9 @@ export class Agent {
+     createContextSnapshot() {
+         return {
+             systemPrompt: this._state.systemPrompt,
++            // PATCH(pizzapi): allow the agent loop to refresh dynamic tool/prompt state
++            __getLatestSystemPrompt: () => this._state.systemPrompt,
++            __getLatestTools: () => this._state.tools.slice(),
+             messages: this._state.messages.slice(),
+             tools: this._state.tools.slice(),
+         };

--- a/patches/@earendil-works%2Fpi-ai@0.80.5.patch
+++ b/patches/@earendil-works%2Fpi-ai@0.80.5.patch
@@ -1,0 +1,338 @@
+diff --git a/dist/api/anthropic-messages.js b/dist/api/anthropic-messages.js
+index 514e35f..9c4af7e 100644
+--- a/dist/api/anthropic-messages.js
++++ b/dist/api/anthropic-messages.js
+@@ -414,6 +414,29 @@ export const stream = (model, context, options) => {
+                         output.content.push(block);
+                         stream.push({ type: "toolcall_start", contentIndex: output.content.length - 1, partial: output });
+                     }
++                    // PATCH(pizzapi): handle server_tool_use (web search query)
++                    else if (event.content_block.type === "server_tool_use") {
++                        const block = {
++                            type: "text",
++                            text: "",
++                            partialJson: "",
++                            _serverToolUse: { id: event.content_block.id, name: event.content_block.name, input: event.content_block.input },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
++                    // PATCH(pizzapi): handle web_search_tool_result
++                    else if (event.content_block.type === "web_search_tool_result") {
++                        const block = {
++                            type: "text",
++                            text: "",
++                            _webSearchResult: { tool_use_id: event.content_block.tool_use_id, content: event.content_block.content },
++                            index: event.index,
++                        };
++                        output.content.push(block);
++                        stream.push({ type: "text_start", contentIndex: output.content.length - 1, partial: output });
++                    }
+                 }
+                 else if (event.type === "content_block_delta") {
+                     if (event.delta.type === "text_delta") {
+@@ -455,6 +478,10 @@ export const stream = (model, context, options) => {
+                                 partial: output,
+                             });
+                         }
++                        // PATCH(pizzapi): accumulate input_json_delta for server_tool_use blocks
++                        else if (block && block._serverToolUse && block.partialJson !== undefined) {
++                            block.partialJson += event.delta.partial_json;
++                        }
+                     }
+                     else if (event.delta.type === "signature_delta") {
+                         const index = blocks.findIndex((b) => b.index === event.index);
+@@ -471,6 +498,16 @@ export const stream = (model, context, options) => {
+                     if (block) {
+                         delete block.index;
+                         if (block.type === "text") {
++                            // PATCH(pizzapi): finalize server_tool_use input from accumulated JSON
++                            if (block._serverToolUse && block.partialJson) {
++                                try {
++                                    block._serverToolUse.input = JSON.parse(block.partialJson);
++                                }
++                                catch {
++                                    block._serverToolUse.input = parseStreamingJson(block.partialJson);
++                                }
++                            }
++                            delete block.partialJson;
+                             stream.push({
+                                 type: "text_end",
+                                 contentIndex: index,
+@@ -710,6 +747,22 @@ function buildParams(model, context, isOAuthToken, options) {
+     if (context.tools && context.tools.length > 0) {
+         params.tools = convertTools(context.tools, isOAuthToken, compat.supportsEagerToolInputStreaming, compat.supportsCacheControlOnTools ? cacheControl : undefined);
+     }
++    // PATCH(pizzapi): inject Anthropic web search tool when PIZZAPI_WEB_SEARCH is set
++    if (typeof process !== "undefined" && process.env.PIZZAPI_WEB_SEARCH && !["0", "false", "no", "off"].includes(process.env.PIZZAPI_WEB_SEARCH.toLowerCase())) {
++        if (!params.tools)
++            params.tools = [];
++        const webSearchTool = { type: "web_search_20250305", name: "web_search" };
++        const maxUses = parseInt(process.env.PIZZAPI_WEB_SEARCH_MAX_USES || "5", 10);
++        if (maxUses > 0)
++            webSearchTool.max_uses = maxUses;
++        if (process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS) {
++            webSearchTool.allowed_domains = process.env.PIZZAPI_WEB_SEARCH_ALLOWED_DOMAINS.split(",").map((d) => d.trim());
++        }
++        if (process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS) {
++            webSearchTool.blocked_domains = process.env.PIZZAPI_WEB_SEARCH_BLOCKED_DOMAINS.split(",").map((d) => d.trim());
++        }
++        params.tools.push(webSearchTool);
++    }
+     // Configure thinking mode: adaptive, budget-based, or explicitly disabled.
+     if (model.reasoning) {
+         if (options?.thinkingEnabled) {
+@@ -811,7 +864,23 @@ function convertMessages(messages, model, isOAuthToken, cacheControl, allowEmpty
+         else if (msg.role === "assistant") {
+             const blocks = [];
+             for (const block of msg.content) {
+-                if (block.type === "text") {
++                // PATCH(pizzapi): round-trip server tool use and web search results
++                if (block.type === "text" && block._serverToolUse) {
++                    blocks.push({
++                        type: "server_tool_use",
++                        id: block._serverToolUse.id,
++                        name: block._serverToolUse.name,
++                        input: block._serverToolUse.input,
++                    });
++                }
++                else if (block.type === "text" && block._webSearchResult) {
++                    blocks.push({
++                        type: "web_search_tool_result",
++                        tool_use_id: block._webSearchResult.tool_use_id,
++                        content: block._webSearchResult.content,
++                    });
++                }
++                else if (block.type === "text") {
+                     if (block.text.trim().length === 0)
+                         continue;
+                     blocks.push({
+@@ -931,6 +1000,10 @@ function convertTools(tools, isOAuthToken, supportsEagerToolInputStreaming, cach
+     if (!tools)
+         return [];
+     return tools.map((tool, index) => {
++        // PATCH(pizzapi): pass through server-side tools (e.g., web_search) as-is
++        if (tool.type && typeof tool.type === "string") {
++            return tool;
++        }
+         const schema = tool.parameters;
+         return {
+             name: isOAuthToken ? toClaudeCodeName(tool.name) : tool.name,
+diff --git a/dist/env-api-keys.js b/dist/env-api-keys.js
+index 2e96cfa..47cdddc 100644
+--- a/dist/env-api-keys.js
++++ b/dist/env-api-keys.js
+@@ -77,6 +77,7 @@ function getApiKeyEnvVars(provider) {
+         cerebras: "CEREBRAS_API_KEY",
+         xai: "XAI_API_KEY",
+         openrouter: "OPENROUTER_API_KEY",
++        "ollama-cloud": "OLLAMA_API_KEY",
+         "vercel-ai-gateway": "AI_GATEWAY_API_KEY",
+         zai: "ZAI_API_KEY",
+         "zai-coding-cn": "ZAI_CODING_CN_API_KEY",
+diff --git a/dist/models.generated.d.ts b/dist/models.generated.d.ts
+index 8a75ffa..09727a0 100644
+--- a/dist/models.generated.d.ts
++++ b/dist/models.generated.d.ts
+@@ -21661,5 +21661,32 @@ export declare const MODELS: {
+             maxTokens: number;
+         };
+     };
++    // PATCH(pizzapi): Ollama Cloud provider models
++    readonly "ollama-cloud": Record<string, {
++        id: string;
++        name: string;
++        api: "openai-completions";
++        provider: string;
++        baseUrl: string;
++        compat: {
++            supportsStore: false;
++            supportsDeveloperRole: false;
++            supportsReasoningEffort: false;
++            supportsUsageInStreaming: true;
++            supportsLongCacheRetention: false;
++            supportsStrictMode: false;
++            maxTokensField: "max_tokens";
++        };
++        reasoning: boolean;
++        input: ("image" | "text")[];
++        cost: {
++            input: number;
++            output: number;
++            cacheRead: number;
++            cacheWrite: number;
++        };
++        contextWindow: number;
++        maxTokens: number;
++    }>;
+ };
+ //# sourceMappingURL=models.generated.d.ts.map
+\ No newline at end of file
+diff --git a/dist/models.generated.js b/dist/models.generated.js
+index 59ee4c5..a103a47 100644
+--- a/dist/models.generated.js
++++ b/dist/models.generated.js
+@@ -35,6 +35,73 @@ import { XIAOMI_TOKEN_PLAN_CN_MODELS } from "./providers/xiaomi-token-plan-cn.mo
+ import { XIAOMI_TOKEN_PLAN_SGP_MODELS } from "./providers/xiaomi-token-plan-sgp.models.js";
+ import { ZAI_MODELS } from "./providers/zai.models.js";
+ import { ZAI_CODING_CN_MODELS } from "./providers/zai-coding-cn.models.js";
++// PATCH(pizzapi): Ollama Cloud provider models. Sourced from the OpenAI-compatible
++// Ollama Cloud list endpoint (https://ollama.com/v1/models) with context windows
++// and capabilities from https://ollama.com/api/show with the corresponding
++// :cloud/-cloud model name. Cost metadata is zero until Ollama publishes
++// machine-usable per-token pricing.
++const OLLAMA_BASE_URL = "https://ollama.com/v1";
++const OLLAMA_ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
++const OLLAMA_COMPAT = { supportsStore: false, supportsDeveloperRole: false, supportsReasoningEffort: false, supportsUsageInStreaming: true, supportsLongCacheRetention: false, supportsStrictMode: false, maxTokensField: "max_tokens" };
++function createOllamaModel(id, name, { reasoning = false, input = ["text"], contextWindow = 128000, maxTokens = 16384 } = {}) {
++    return {
++        id,
++        name,
++        api: "openai-completions",
++        provider: "ollama-cloud",
++        baseUrl: OLLAMA_BASE_URL,
++        compat: OLLAMA_COMPAT,
++        reasoning,
++        input,
++        cost: OLLAMA_ZERO_COST,
++        contextWindow,
++        maxTokens,
++    };
++}
++const OLLAMA_CLOUD_MODELS = {
++    "cogito-2.1:671b": createOllamaModel("cogito-2.1:671b", "Cogito 2.1 671B", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++    "deepseek-v3.1:671b": createOllamaModel("deepseek-v3.1:671b", "DeepSeek V3.1 671B", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++    "deepseek-v3.2": createOllamaModel("deepseek-v3.2", "DeepSeek V3.2", { reasoning: true, input: ["text"], contextWindow: 163840, maxTokens: 32768 }),
++    "deepseek-v4-flash": createOllamaModel("deepseek-v4-flash", "DeepSeek V4 Flash", { reasoning: true, input: ["text"], contextWindow: 1048576, maxTokens: 32768 }),
++    "deepseek-v4-pro": createOllamaModel("deepseek-v4-pro", "DeepSeek V4 Pro", { reasoning: true, input: ["text"], contextWindow: 524288, maxTokens: 32768 }),
++    "devstral-2:123b": createOllamaModel("devstral-2:123b", "Devstral 2 123B", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "devstral-small-2:24b": createOllamaModel("devstral-small-2:24b", "Devstral Small 2 24B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "gemini-3-flash-preview": createOllamaModel("gemini-3-flash-preview", "Gemini 3 Flash Preview", { reasoning: true, input: ["text", "image"], contextWindow: 1048576, maxTokens: 65536 }),
++    "gemma3:12b": createOllamaModel("gemma3:12b", "Gemma 3 12B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++    "gemma3:27b": createOllamaModel("gemma3:27b", "Gemma 3 27B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++    "gemma3:4b": createOllamaModel("gemma3:4b", "Gemma 3 4B", { reasoning: false, input: ["text", "image"], contextWindow: 131072, maxTokens: 16384 }),
++    "gemma4:31b": createOllamaModel("gemma4:31b", "Gemma 4 31B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "glm-4.6": createOllamaModel("glm-4.6", "GLM 4.6", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 65536 }),
++    "glm-4.7": createOllamaModel("glm-4.7", "GLM 4.7", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 65536 }),
++    "glm-5": createOllamaModel("glm-5", "GLM 5", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 131072 }),
++    "glm-5.1": createOllamaModel("glm-5.1", "GLM 5.1", { reasoning: true, input: ["text"], contextWindow: 202752, maxTokens: 131072 }),
++    "gpt-oss:120b": createOllamaModel("gpt-oss:120b", "GPT-OSS 120B", { reasoning: true, input: ["text"], contextWindow: 131072, maxTokens: 16384 }),
++    "gpt-oss:20b": createOllamaModel("gpt-oss:20b", "GPT-OSS 20B", { reasoning: true, input: ["text"], contextWindow: 131072, maxTokens: 16384 }),
++    "kimi-k2-thinking": createOllamaModel("kimi-k2-thinking", "Kimi K2 Thinking", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2.5": createOllamaModel("kimi-k2.5", "Kimi K2.5", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2.6": createOllamaModel("kimi-k2.6", "Kimi K2.6", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2.7-code": createOllamaModel("kimi-k2.7-code", "Kimi K2.7 Code", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "kimi-k2:1t": createOllamaModel("kimi-k2:1t", "Kimi K2 1T", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "minimax-m2": createOllamaModel("minimax-m2", "MiniMax M2", { reasoning: false, input: ["text"], contextWindow: 204800, maxTokens: 32768 }),
++    "minimax-m2.1": createOllamaModel("minimax-m2.1", "MiniMax M2.1", { reasoning: true, input: ["text"], contextWindow: 204800, maxTokens: 32768 }),
++    "minimax-m2.5": createOllamaModel("minimax-m2.5", "MiniMax M2.5", { reasoning: true, input: ["text"], contextWindow: 196608, maxTokens: 32768 }),
++    "minimax-m2.7": createOllamaModel("minimax-m2.7", "MiniMax M2.7", { reasoning: true, input: ["text"], contextWindow: 196608, maxTokens: 32768 }),
++    "minimax-m3": createOllamaModel("minimax-m3", "MiniMax M3", { reasoning: true, input: ["text", "image"], contextWindow: 524288, maxTokens: 32768 }),
++    "ministral-3:14b": createOllamaModel("ministral-3:14b", "Ministral 3 14B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "ministral-3:3b": createOllamaModel("ministral-3:3b", "Ministral 3 3B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "ministral-3:8b": createOllamaModel("ministral-3:8b", "Ministral 3 8B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 16384 }),
++    "mistral-large-3:675b": createOllamaModel("mistral-large-3:675b", "Mistral Large 3 675B", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "nemotron-3-nano:30b": createOllamaModel("nemotron-3-nano:30b", "Nemotron 3 Nano 30B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "nemotron-3-super": createOllamaModel("nemotron-3-super", "Nemotron 3 Super", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "nemotron-3-ultra": createOllamaModel("nemotron-3-ultra", "Nemotron 3 Ultra", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-coder-next": createOllamaModel("qwen3-coder-next", "Qwen 3 Coder Next", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-coder:480b": createOllamaModel("qwen3-coder:480b", "Qwen 3 Coder 480B", { reasoning: false, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-next:80b": createOllamaModel("qwen3-next:80b", "Qwen 3 Next 80B", { reasoning: true, input: ["text"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-vl:235b": createOllamaModel("qwen3-vl:235b", "Qwen 3 VL 235B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3-vl:235b-instruct": createOllamaModel("qwen3-vl:235b-instruct", "Qwen 3 VL 235B Instruct", { reasoning: false, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "qwen3.5:397b": createOllamaModel("qwen3.5:397b", "Qwen 3.5 397B", { reasoning: true, input: ["text", "image"], contextWindow: 262144, maxTokens: 32768 }),
++    "rnj-1:8b": createOllamaModel("rnj-1:8b", "RNJ 1 8B", { reasoning: false, input: ["text"], contextWindow: 32768, maxTokens: 16384 }),
++};
+ export const MODELS = {
+     "amazon-bedrock": AMAZON_BEDROCK_MODELS,
+     "ant-ling": ANT_LING_MODELS,
+@@ -62,6 +129,7 @@ export const MODELS = {
+     "opencode": OPENCODE_MODELS,
+     "opencode-go": OPENCODE_GO_MODELS,
+     "openrouter": OPENROUTER_MODELS,
++    "ollama-cloud": OLLAMA_CLOUD_MODELS,
+     "together": TOGETHER_MODELS,
+     "vercel-ai-gateway": VERCEL_AI_GATEWAY_MODELS,
+     "xai": XAI_MODELS,
+diff --git a/dist/types.d.ts b/dist/types.d.ts
+index bdbadd7..6f4c608 100644
+--- a/dist/types.d.ts
++++ b/dist/types.d.ts
+@@ -14,7 +14,7 @@ export type KnownApi = "openai-completions" | "mistral-conversations" | "openai-
+ export type Api = KnownApi | (string & {});
+ export type KnownImagesApi = "openrouter-images";
+ export type ImagesApi = KnownImagesApi | (string & {});
+-export type KnownProvider = "amazon-bedrock" | "ant-ling" | "anthropic" | "google" | "google-vertex" | "openai" | "azure-openai-responses" | "openai-codex" | "nvidia" | "deepseek" | "github-copilot" | "xai" | "groq" | "cerebras" | "openrouter" | "vercel-ai-gateway" | "zai" | "zai-coding-cn" | "mistral" | "minimax" | "minimax-cn" | "moonshotai" | "moonshotai-cn" | "huggingface" | "fireworks" | "together" | "opencode" | "opencode-go" | "kimi-coding" | "cloudflare-workers-ai" | "cloudflare-ai-gateway" | "xiaomi" | "xiaomi-token-plan-cn" | "xiaomi-token-plan-ams" | "xiaomi-token-plan-sgp";
++export type KnownProvider = "amazon-bedrock" | "ant-ling" | "anthropic" | "google" | "google-vertex" | "openai" | "azure-openai-responses" | "openai-codex" | "nvidia" | "deepseek" | "github-copilot" | "xai" | "groq" | "cerebras" | "openrouter" | "ollama-cloud" | "vercel-ai-gateway" | "zai" | "zai-coding-cn" | "mistral" | "minimax" | "minimax-cn" | "moonshotai" | "moonshotai-cn" | "huggingface" | "fireworks" | "together" | "opencode" | "opencode-go" | "kimi-coding" | "cloudflare-workers-ai" | "cloudflare-ai-gateway" | "xiaomi" | "xiaomi-token-plan-cn" | "xiaomi-token-plan-ams" | "xiaomi-token-plan-sgp";
+ export type ProviderId = KnownProvider | string;
+ export type KnownImagesProvider = "openrouter";
+ export type ImagesProviderId = KnownImagesProvider | string;
+diff --git a/dist/utils/oauth/anthropic.js b/dist/utils/oauth/anthropic.js
+index 6972a57..d2309f7 100644
+--- a/dist/utils/oauth/anthropic.js
++++ b/dist/utils/oauth/anthropic.js
+@@ -314,6 +314,37 @@ export async function refreshAnthropicToken(refreshToken) {
+         expires: Date.now() + data.expires_in * 1000 - 5 * 60 * 1000,
+     };
+ }
++// PATCH(pizzapi): read Claude Code credentials as a refresh fallback.
++async function tryReadClaudeCodeCredentials() {
++    try {
++        if (process.platform === "darwin") {
++            const { execSync } = await import("node:child_process");
++            const raw = execSync(`security find-generic-password -s ${JSON.stringify("Claude Code-credentials")} -w`, { encoding: "utf-8", timeout: 5000, stdio: ["pipe", "pipe", "pipe"] }).trim();
++            if (raw) {
++                const cc = JSON.parse(raw)?.claudeAiOauth;
++                if (cc?.accessToken && cc?.refreshToken && cc.expiresAt > Date.now() + 60000) {
++                    return { refresh: cc.refreshToken, access: cc.accessToken, expires: cc.expiresAt };
++                }
++            }
++        }
++    }
++    catch {
++    }
++    try {
++        const [{ readFileSync }, { join }, { homedir }] = await Promise.all([
++            import("node:fs"),
++            import("node:path"),
++            import("node:os"),
++        ]);
++        const cc = JSON.parse(readFileSync(join(homedir(), ".claude", ".credentials.json"), "utf-8"))?.claudeAiOauth;
++        if (cc?.accessToken && cc?.refreshToken && cc.expiresAt > Date.now() + 60000) {
++            return { refresh: cc.refreshToken, access: cc.accessToken, expires: cc.expiresAt };
++        }
++    }
++    catch {
++    }
++    return null;
++}
+ export const anthropicOAuth = {
+     name: "Anthropic (Claude Pro/Max)",
+     async login(callbacks) {
+@@ -358,6 +389,11 @@ export const anthropicOAuthProvider = {
+         });
+     },
+     async refreshToken(credentials) {
++        // PATCH(pizzapi): try Claude Code credentials first
++        const ccCreds = await tryReadClaudeCodeCredentials();
++        if (ccCreds) {
++            return ccCreds;
++        }
+         return refreshAnthropicToken(credentials.refresh);
+     },
+     getApiKey(credentials) {
+diff --git a/dist/utils/retry.js b/dist/utils/retry.js
+index b3c27c8..6ff384e 100644
+--- a/dist/utils/retry.js
++++ b/dist/utils/retry.js
+@@ -59,6 +59,9 @@ const RETRYABLE_PROVIDER_ERROR_PATTERN = buildProviderErrorPattern([
+     "ended without",
+     "stream ended before message_stop",
+     "http2 request did not get a response",
++    // PATCH(pizzapi): retry transient JSON parse failures from truncated provider streams.
++    "json.?parse.?error",
++    "unexpected.?end.?of.?json",
+     // Provider-requested retry delay cap failures should flow through the outer
+     // retry policy so callers can surface/abort the backoff (#1123).
+     "retry delay",

--- a/patches/@earendil-works%2Fpi-coding-agent@0.80.5.patch
+++ b/patches/@earendil-works%2Fpi-coding-agent@0.80.5.patch
@@ -1,0 +1,331 @@
+diff --git a/dist/config.js b/dist/config.js
+index 4600b23..85bd9b0 100644
+--- a/dist/config.js
++++ b/dist/config.js
+@@ -358,6 +358,10 @@ export function getExamplesPath() {
+ }
+ /** Get path to CHANGELOG.md */
+ export function getChangelogPath() {
++    // PATCH(pizzapi): allow PizzaPi to display its wrapper changelog.
++    if (process.env.PIZZAPI_CHANGELOG_PATH) {
++        return resolve(process.env.PIZZAPI_CHANGELOG_PATH);
++    }
+     return resolve(join(getPackageDir(), "CHANGELOG.md"));
+ }
+ /**
+@@ -391,7 +395,7 @@ const piConfigName = pkg.piConfig?.name;
+ export const PACKAGE_NAME = pkg.name || "@earendil-works/pi-coding-agent";
+ export const APP_NAME = piConfigName || "pi";
+ export const APP_TITLE = piConfigName ? APP_NAME : "π";
+-export const CONFIG_DIR_NAME = pkg.piConfig?.configDir || ".pi";
++export const CONFIG_DIR_NAME = ".pizzapi"; // PATCH(pizzapi): force PizzaPi's config namespace instead of upstream .pi.
+ export const VERSION = pkg.version || "0.0.0";
+ // e.g., PI_CODING_AGENT_DIR or TAU_CODING_AGENT_DIR
+ export const ENV_AGENT_DIR = `${APP_NAME.toUpperCase()}_CODING_AGENT_DIR`;
+@@ -414,7 +418,8 @@ export function getAgentDir() {
+     if (envDir) {
+         return expandTildePath(envDir);
+     }
+-    return join(homedir(), CONFIG_DIR_NAME, "agent");
++    // PATCH(pizzapi): flat directory structure, no nested agent/ segment.
++    return join(homedir(), CONFIG_DIR_NAME);
+ }
+ /** Get path to user's custom themes directory */
+ export function getCustomThemesDir() {
+diff --git a/dist/core/agent-session.js b/dist/core/agent-session.js
+index a208774..793a3d3 100644
+--- a/dist/core/agent-session.js
++++ b/dist/core/agent-session.js
+@@ -1104,9 +1104,10 @@ export class AgentSession {
+             if (images.length === 0)
+                 images = undefined;
+         }
+-        // Use prompt() with expandPromptTemplates: false to skip command handling and template expansion
++        // Use prompt() with expandPromptTemplates: false by default to skip command handling and template expansion.
++        // PATCH(pizzapi): allow callers to opt into command/template expansion (e.g. web UI input).
+         await this.prompt(text, {
+-            expandPromptTemplates: false,
++            expandPromptTemplates: options?.expandPromptTemplates ?? false,
+             streamingBehavior: options?.deliverAs,
+             images,
+             source: "extension",
+@@ -1866,6 +1867,17 @@ export class AgentSession {
+             },
+             getThinkingLevel: () => this.thinkingLevel,
+             setThinkingLevel: (level) => this.setThinkingLevel(level),
++            // PATCH(pizzapi): expose the pending queues so the remote extension can sync them to the web UI.
++            getQueuedMessages: () => ({ steering: [...this._steeringMessages], followUp: [...this._followUpMessages] }),
++            // PATCH(pizzapi): replace the pending follow-up queue (web UI queue edits/removals).
++            // ponytail: text-only — queued image attachments are dropped on replace; the queue mirrors only store text.
++            replaceQueuedMessages: (followUp) => {
++                const { steering } = this.clearQueue();
++                for (const text of steering)
++                    void this._queueSteer(text);
++                for (const text of followUp)
++                    void this._queueFollowUp(text);
++            },
+         }, {
+             getModel: () => this.model,
+             isIdle: () => this.isIdle,
+diff --git a/dist/core/extensions/loader.js b/dist/core/extensions/loader.js
+index 575a208..987fd0c 100644
+--- a/dist/core/extensions/loader.js
++++ b/dist/core/extensions/loader.js
+@@ -137,6 +137,10 @@ export function createExtensionRuntime() {
+         sendUserMessage: notInitialized,
+         appendEntry: notInitialized,
+         setSessionName: notInitialized,
++        // PATCH(pizzapi): expose session-control actions on ExtensionAPI, not only command contexts.
++        newSession: () => Promise.reject(new Error("Extension runtime not initialized")),
++        switchSession: () => Promise.reject(new Error("Extension runtime not initialized")),
++        fork: () => Promise.reject(new Error("Extension runtime not initialized")),
+         getSessionName: notInitialized,
+         setLabel: notInitialized,
+         getActiveTools: notInitialized,
+@@ -148,6 +152,9 @@ export function createExtensionRuntime() {
+         setModel: () => Promise.reject(new Error("Extension runtime not initialized")),
+         getThinkingLevel: notInitialized,
+         setThinkingLevel: notInitialized,
++        // PATCH(pizzapi): pending-queue read/replace for remote queue sync.
++        getQueuedMessages: notInitialized,
++        replaceQueuedMessages: notInitialized,
+         flagValues: new Map(),
+         pendingProviderRegistrations: [],
+         assertActive,
+@@ -241,6 +248,28 @@ function createExtensionAPI(extension, runtime, cwd, eventBus) {
+             runtime.assertActive();
+             runtime.setSessionName(name);
+         },
++        // PATCH(pizzapi): remote exec handlers need /new and /resume from lifecycle/event handlers.
++        newSession(options) {
++            runtime.assertActive();
++            return runtime.newSession(options);
++        },
++        switchSession(sessionPath, options) {
++            runtime.assertActive();
++            return runtime.switchSession(sessionPath, options);
++        },
++        fork(entryId, options) {
++            runtime.assertActive();
++            return runtime.fork(entryId, options);
++        },
++        // PATCH(pizzapi): pending-queue read/replace for remote queue sync (web UI queue edits).
++        getQueuedMessages() {
++            runtime.assertActive();
++            return runtime.getQueuedMessages();
++        },
++        replaceQueuedMessages(followUp) {
++            runtime.assertActive();
++            runtime.replaceQueuedMessages(followUp);
++        },
+         getSessionName() {
+             runtime.assertActive();
+             return runtime.getSessionName();
+diff --git a/dist/core/extensions/runner.js b/dist/core/extensions/runner.js
+index a8923cf..71b02b2 100644
+--- a/dist/core/extensions/runner.js
++++ b/dist/core/extensions/runner.js
+@@ -169,6 +169,9 @@ export class ExtensionRunner {
+         this.runtime.setModel = actions.setModel;
+         this.runtime.getThinkingLevel = actions.getThinkingLevel;
+         this.runtime.setThinkingLevel = actions.setThinkingLevel;
++        // PATCH(pizzapi): expose pending-queue read/replace to extensions (remote queue sync).
++        this.runtime.getQueuedMessages = actions.getQueuedMessages;
++        this.runtime.replaceQueuedMessages = actions.replaceQueuedMessages;
+         // Context actions (required)
+         this.getModel = contextActions.getModel;
+         this.isIdleFn = contextActions.isIdle;
+@@ -222,17 +225,24 @@ export class ExtensionRunner {
+         if (actions) {
+             this.waitForIdleFn = actions.waitForIdle;
+             this.newSessionHandler = actions.newSession;
++            // PATCH(pizzapi): make session controls available to ExtensionAPI callers.
++            this.runtime.newSession = (options) => this.newSessionHandler(options);
+             this.forkHandler = actions.fork;
++            this.runtime.fork = (entryId, options) => this.forkHandler(entryId, options);
+             this.navigateTreeHandler = actions.navigateTree;
+             this.switchSessionHandler = actions.switchSession;
++            this.runtime.switchSession = (sessionPath, options) => this.switchSessionHandler(sessionPath, options);
+             this.reloadHandler = actions.reload;
+             return;
+         }
+         this.waitForIdleFn = async () => { };
+         this.newSessionHandler = async () => ({ cancelled: false });
++        this.runtime.newSession = (options) => this.newSessionHandler(options);
+         this.forkHandler = async () => ({ cancelled: false });
++        this.runtime.fork = (entryId, options) => this.forkHandler(entryId, options);
+         this.navigateTreeHandler = async () => ({ cancelled: false });
+         this.switchSessionHandler = async () => ({ cancelled: false });
++        this.runtime.switchSession = (sessionPath, options) => this.switchSessionHandler(sessionPath, options);
+         this.reloadHandler = async () => { };
+     }
+     setUIContext(uiContext, mode = "print") {
+diff --git a/dist/core/extensions/types.d.ts b/dist/core/extensions/types.d.ts
+index 581fb2a..f3d2d2a 100644
+--- a/dist/core/extensions/types.d.ts
++++ b/dist/core/extensions/types.d.ts
+@@ -902,11 +902,32 @@ export interface ExtensionAPI {
+      */
+     sendUserMessage(content: string | (TextContent | ImageContent)[], options?: {
+         deliverAs?: "steer" | "followUp";
++        /** PATCH(pizzapi): opt into slash-command and template expansion (default false). */
++        expandPromptTemplates?: boolean;
+     }): void;
+     /** Append a custom entry to the session for state persistence (not sent to LLM). */
+     appendEntry<T = unknown>(customType: string, data?: T): void;
+     /** Set the session display name (shown in session selector). */
+     setSessionName(name: string): void;
++    /** Start a new session. Available to PizzaPi remote event handlers. */
++    newSession(options?: {
++        parentSession?: string;
++        setup?: (sessionManager: SessionManager) => Promise<void>;
++        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
++    }): Promise<{ cancelled: boolean; }>;
++    /** Switch to a different session file. Available to PizzaPi remote event handlers. */
++    switchSession(sessionPath: string, options?: {
++        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
++    }): Promise<{ cancelled: boolean; }>;
++    /** Fork from a specific entry, creating a new session file. Available to PizzaPi remote event handlers. */
++    fork(entryId: string, options?: {
++        position?: "before" | "at";
++        withSession?: (ctx: ReplacedSessionContext) => Promise<void>;
++    }): Promise<{ cancelled: boolean; selectedText?: string; }>;
++    /** PATCH(pizzapi): read the pending steering/follow-up queues (remote queue sync). */
++    getQueuedMessages(): { steering: string[]; followUp: string[]; };
++    /** PATCH(pizzapi): replace the pending follow-up queue (web UI queue edits/removals). */
++    replaceQueuedMessages(followUp: string[]): void;
+     /** Get the current session name, if set. */
+     getSessionName(): string | undefined;
+     /** Set or clear a label on an entry. Labels are user-defined markers for bookmarking/navigation. */
+@@ -1092,6 +1113,8 @@ export type SendMessageHandler = <T = unknown>(message: Pick<CustomMessage<T>, "
+ }) => void;
+ export type SendUserMessageHandler = (content: string | (TextContent | ImageContent)[], options?: {
+     deliverAs?: "steer" | "followUp";
++    /** PATCH(pizzapi): opt into slash-command and template expansion (default false). */
++    expandPromptTemplates?: boolean;
+ }) => void;
+ export type AppendEntryHandler = <T = unknown>(customType: string, data?: T) => void;
+ export type SetSessionNameHandler = (name: string) => void;
+@@ -1143,6 +1166,9 @@ export interface ExtensionActions {
+     sendUserMessage: SendUserMessageHandler;
+     appendEntry: AppendEntryHandler;
+     setSessionName: SetSessionNameHandler;
++    newSession: ExtensionCommandContextActions["newSession"];
++    switchSession: ExtensionCommandContextActions["switchSession"];
++    fork: ExtensionCommandContextActions["fork"];
+     getSessionName: GetSessionNameHandler;
+     setLabel: SetLabelHandler;
+     getActiveTools: GetActiveToolsHandler;
+@@ -1153,6 +1179,9 @@ export interface ExtensionActions {
+     setModel: SetModelHandler;
+     getThinkingLevel: GetThinkingLevelHandler;
+     setThinkingLevel: SetThinkingLevelHandler;
++    /** PATCH(pizzapi): pending-queue read/replace for remote queue sync. */
++    getQueuedMessages: () => { steering: string[]; followUp: string[]; };
++    replaceQueuedMessages: (followUp: string[]) => void;
+ }
+ /**
+  * Actions for ExtensionContext (ctx.* in event handlers).
+diff --git a/dist/core/model-resolver.js b/dist/core/model-resolver.js
+index a2b74cc..96c810c 100644
+--- a/dist/core/model-resolver.js
++++ b/dist/core/model-resolver.js
+@@ -20,6 +20,7 @@ export const defaultModelPerProvider = {
+     "google-vertex": "gemini-3.1-pro-preview",
+     "github-copilot": "gpt-5.4",
+     openrouter: "moonshotai/kimi-k2.6",
++    "ollama-cloud": "glm-5.1",
+     "vercel-ai-gateway": "zai/glm-5.1",
+     xai: "grok-4.20-0309-reasoning",
+     groq: "openai/gpt-oss-120b",
+diff --git a/dist/core/provider-display-names.js b/dist/core/provider-display-names.js
+index 28c807e..2f0f07e 100644
+--- a/dist/core/provider-display-names.js
++++ b/dist/core/provider-display-names.js
+@@ -23,6 +23,7 @@ export const BUILT_IN_PROVIDER_DISPLAY_NAMES = {
+     "opencode-go": "OpenCode Go",
+     openai: "OpenAI",
+     openrouter: "OpenRouter",
++    "ollama-cloud": "Ollama Cloud",
+     together: "Together AI",
+     "vercel-ai-gateway": "Vercel AI Gateway",
+     xai: "xAI",
+diff --git a/dist/index.d.ts b/dist/index.d.ts
+index c421274..0465adb 100644
+--- a/dist/index.d.ts
++++ b/dist/index.d.ts
+@@ -12,6 +12,7 @@ export { ModelRegistry } from "./core/model-registry.ts";
+ export { type ModelScopeDiagnostic, type ResolveCliModelResult, type ResolveModelScopeResult, resolveCliModel, resolveModelScopeWithDiagnostics, type ScopedModel, } from "./core/model-resolver.ts";
+ export type { PackageManager, PathMetadata, ProgressCallback, ProgressEvent, ResolvedPaths, ResolvedResource, } from "./core/package-manager.ts";
+ export { DefaultPackageManager } from "./core/package-manager.ts";
++export { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.ts";
+ export type { ResourceCollision, ResourceDiagnostic, ResourceLoader } from "./core/resource-loader.ts";
+ export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.ts";
+ export { AgentSessionRuntime, type AgentSessionRuntimeDiagnostic, type AgentSessionServices, type CreateAgentSessionFromServicesOptions, type CreateAgentSessionOptions, type CreateAgentSessionResult, type CreateAgentSessionRuntimeFactory, type CreateAgentSessionRuntimeResult, type CreateAgentSessionServicesOptions, createAgentSession, createAgentSessionFromServices, createAgentSessionRuntime, createAgentSessionServices, createBashTool, createCodingTools, createEditTool, createFindTool, createGrepTool, createLsTool, createReadOnlyTools, createReadTool, createWriteTool, type PromptTemplate, } from "./core/sdk.ts";
+diff --git a/dist/index.js b/dist/index.js
+index 2cb0269..4c33cf9 100644
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -13,6 +13,7 @@ export { convertToLlm } from "./core/messages.js";
+ export { ModelRegistry } from "./core/model-registry.js";
+ export { resolveCliModel, resolveModelScopeWithDiagnostics, } from "./core/model-resolver.js";
+ export { DefaultPackageManager } from "./core/package-manager.js";
++export { handleConfigCommand, handlePackageCommand } from "./package-manager-cli.js";
+ export { DefaultResourceLoader, loadProjectContextFiles } from "./core/resource-loader.js";
+ // SDK for programmatic usage
+ export { AgentSessionRuntime, 
+diff --git a/dist/modes/interactive/interactive-mode.js b/dist/modes/interactive/interactive-mode.js
+index 02455d6..374379f 100644
+--- a/dist/modes/interactive/interactive-mode.js
++++ b/dist/modes/interactive/interactive-mode.js
+@@ -34,7 +34,6 @@ import { getCwdRelativePath } from "../../utils/paths.js";
+ import { getPiUserAgent } from "../../utils/pi-user-agent.js";
+ import { killTrackedDetachedChildren } from "../../utils/shell.js";
+ import { ensureTool } from "../../utils/tools-manager.js";
+-import { checkForNewPiVersion } from "../../utils/version-check.js";
+ import { ArminComponent } from "./components/armin.js";
+ import { AssistantMessageComponent } from "./components/assistant-message.js";
+ import { BashExecutionComponent } from "./components/bash-execution.js";
+@@ -592,12 +591,6 @@ export class InteractiveMode {
+      */
+     async run() {
+         await this.init();
+-        // Start version check asynchronously
+-        checkForNewPiVersion(this.version).then((newRelease) => {
+-            if (newRelease) {
+-                this.showNewVersionNotification(newRelease);
+-            }
+-        });
+         // Start package update check asynchronously
+         this.checkForPackageUpdates().then((updates) => {
+             if (updates.length > 0) {
+@@ -3155,29 +3148,6 @@ export class InteractiveMode {
+         this.chatContainer.addChild(new Text(theme.fg("warning", `Warning: ${warningMessage}`), 1, 0));
+         this.ui.requestRender();
+     }
+-    showNewVersionNotification(release) {
+-        const action = theme.fg("accent", `${APP_NAME} update`);
+-        const updateInstruction = theme.fg("muted", `New version ${release.version} is available. Run `) + action;
+-        const changelogUrl = "https://pi.dev/changelog";
+-        const changelogLink = getCapabilities().hyperlinks
+-            ? hyperlink(theme.fg("accent", changelogUrl), changelogUrl)
+-            : theme.fg("accent", changelogUrl);
+-        const changelogLine = theme.fg("muted", "Changelog: ") + changelogLink;
+-        const note = release.note?.trim();
+-        this.chatContainer.addChild(new Spacer(1));
+-        this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+-        this.chatContainer.addChild(new Text(`${theme.bold(theme.fg("warning", "Update Available"))}\n${updateInstruction}`, 1, 0));
+-        if (note) {
+-            this.chatContainer.addChild(new Spacer(1));
+-            this.chatContainer.addChild(new Markdown(note, 1, 0, this.getMarkdownThemeWithSettings(), {
+-                color: (text) => theme.fg("muted", text),
+-            }));
+-            this.chatContainer.addChild(new Spacer(1));
+-        }
+-        this.chatContainer.addChild(new Text(changelogLine, 1, 0));
+-        this.chatContainer.addChild(new DynamicBorder((text) => theme.fg("warning", text)));
+-        this.ui.requestRender();
+-    }
+     showPackageUpdateNotification(packages) {
+         const action = theme.fg("accent", `${APP_NAME} update --extensions`);
+         const updateInstruction = theme.fg("muted", "Package updates are available. Run ") + action;

--- a/patches/@earendil-works%2Fpi-tui@0.80.5.patch
+++ b/patches/@earendil-works%2Fpi-tui@0.80.5.patch
@@ -1,0 +1,161 @@
+diff --git a/dist/terminal.js b/dist/terminal.js
+index 71db088..2cb9fe5 100644
+--- a/dist/terminal.js
++++ b/dist/terminal.js
+@@ -6,6 +6,100 @@ import { setKittyProtocolActive } from "./keys.js";
+ import { isNativeModifierPressed } from "./native-modifiers.js";
+ import { StdinBuffer } from "./stdin-buffer.js";
+ const cjsRequire = createRequire(import.meta.url);
++// PATCH(pizzapi): Windows console output lifecycle helpers
++function safeWindowsCall(fn) {
++    try {
++        return fn();
++    }
++    catch {
++        return undefined;
++    }
++}
++/**
++ * Create a Windows console lifecycle helper that enables VT output and UTF-8
++ * code pages on activation, and restores the original state on teardown.
++ */
++export function createWindowsConsoleLifecycle() {
++    let state = undefined;
++    return {
++        activate() {
++            if (process.platform !== "win32") {
++                return { stdoutMode: "unknown", stderrMode: "unknown", source: "pi-tui" };
++            }
++            const result = safeWindowsCall(() => {
++                const koffi = cjsRequire("koffi");
++                const k32 = koffi.load("kernel32.dll");
++                const GetStdHandle = k32.func("void* __stdcall GetStdHandle(int)");
++                const GetConsoleMode = k32.func("bool __stdcall GetConsoleMode(void*, _Out_ uint32_t*)");
++                const SetConsoleMode = k32.func("bool __stdcall SetConsoleMode(void*, uint32_t)");
++                const GetConsoleCP = k32.func("uint32_t __stdcall GetConsoleCP()");
++                const SetConsoleCP = k32.func("bool __stdcall SetConsoleCP(uint32_t)");
++                const GetConsoleOutputCP = k32.func("uint32_t __stdcall GetConsoleOutputCP()");
++                const SetConsoleOutputCP = k32.func("bool __stdcall SetConsoleOutputCP(uint32_t)");
++                const STD_OUTPUT_HANDLE = -11;
++                const STD_ERROR_HANDLE = -12;
++                const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
++                const handleModes = { stdout: undefined, stderr: undefined };
++                for (const { key, n } of [
++                    { key: "stdout", n: STD_OUTPUT_HANDLE },
++                    { key: "stderr", n: STD_ERROR_HANDLE },
++                ]) {
++                    const handle = GetStdHandle(n);
++                    const mode = new Uint32Array(1);
++                    if (GetConsoleMode(handle, mode)) {
++                        handleModes[key] = mode[0];
++                        SetConsoleMode(handle, mode[0] | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
++                    }
++                }
++                const inputCP = GetConsoleCP();
++                const outputCP = GetConsoleOutputCP();
++                SetConsoleCP(65001);
++                SetConsoleOutputCP(65001);
++                return { handleModes, inputCP, outputCP };
++            });
++            const stdoutOk = result?.handleModes?.stdout !== undefined;
++            const stderrOk = result?.handleModes?.stderr !== undefined;
++            const caps = {
++                stdoutMode: stdoutOk ? "unicode" : "ascii",
++                stderrMode: stderrOk ? "unicode" : "ascii",
++                source: "pi-tui",
++            };
++            state = result ?? undefined;
++            return caps;
++        },
++        restore() {
++            if (!state || process.platform !== "win32")
++                return;
++            safeWindowsCall(() => {
++                const koffi = cjsRequire("koffi");
++                const k32 = koffi.load("kernel32.dll");
++                const GetStdHandle = k32.func("void* __stdcall GetStdHandle(int)");
++                const SetConsoleMode = k32.func("bool __stdcall SetConsoleMode(void*, uint32_t)");
++                const SetConsoleCP = k32.func("bool __stdcall SetConsoleCP(uint32_t)");
++                const SetConsoleOutputCP = k32.func("bool __stdcall SetConsoleOutputCP(uint32_t)");
++                const STD_OUTPUT_HANDLE = -11;
++                const STD_ERROR_HANDLE = -12;
++                for (const { key, n } of [
++                    { key: "stdout", n: STD_OUTPUT_HANDLE },
++                    { key: "stderr", n: STD_ERROR_HANDLE },
++                ]) {
++                    const handle = GetStdHandle(n);
++                    const mode = state.handleModes[key];
++                    if (mode !== undefined) {
++                        SetConsoleMode(handle, mode);
++                    }
++                }
++                if (state.inputCP !== undefined) {
++                    SetConsoleCP(state.inputCP);
++                }
++                if (state.outputCP !== undefined) {
++                    SetConsoleOutputCP(state.outputCP);
++                }
++            });
++            state = undefined;
++        },
++    };
++}
+ const TERMINAL_PROGRESS_KEEPALIVE_MS = 1000;
+ const TERMINAL_PROGRESS_ACTIVE_SEQUENCE = "\x1b]9;4;3\x07";
+ const TERMINAL_PROGRESS_CLEAR_SEQUENCE = "\x1b]9;4;0;\x07";
+@@ -49,6 +143,7 @@ export class ProcessTerminal {
+     stdinBuffer;
+     stdinDataHandler;
+     progressInterval;
++    windowsConsoleLifecycle;
+     writeLogPath = (() => {
+         const env = process.env.PI_TUI_WRITE_LOG || "";
+         if (!env)
+@@ -95,10 +190,29 @@ export class ProcessTerminal {
+         // events that lose modifier information. Must run AFTER setRawMode(true)
+         // since that resets console mode flags.
+         this.enableWindowsVTInput();
++        // PATCH(pizzapi): Windows console output lifecycle
++        this.setupWindowsConsole();
+         // Query Kitty keyboard protocol and fall back to modifyOtherKeys when DA confirms no Kitty response.
+         // See: https://sw.kovidgoyal.net/kitty/keyboard-protocol/
+         this.queryAndEnableKittyProtocol();
+     }
++    /**
++     * On Windows, set up VT output and UTF-8 code page for Unicode rendering,
++     * and publish a capability signal for downstream renderers.
++     */
++    setupWindowsConsole() {
++        if (process.platform !== "win32")
++            return;
++        try {
++            this.windowsConsoleLifecycle = createWindowsConsoleLifecycle();
++            const result = this.windowsConsoleLifecycle.activate();
++            const globalObj = globalThis;
++            globalObj.__PI_WINDOWS_CONSOLE_CAPS__ = result;
++        }
++        catch {
++            // Best-effort: if console API setup fails, leave it alone
++        }
++    }
+     /**
+      * Set up StdinBuffer to split batched input into individual sequences.
+      * This ensures components receive single events, making matchesKey/isKeyRelease work correctly.
+@@ -350,6 +464,17 @@ export class ProcessTerminal {
+             process.stdout.removeListener("resize", this.resizeHandler);
+             this.resizeHandler = undefined;
+         }
++        // PATCH(pizzapi): restore Windows console state
++        if (this.windowsConsoleLifecycle) {
++            try {
++                this.windowsConsoleLifecycle.restore();
++            }
++            catch {
++                // Best-effort restore
++            }
++            this.windowsConsoleLifecycle = undefined;
++            delete globalThis.__PI_WINDOWS_CONSOLE_CAPS__;
++        }
+         // Pause stdin to prevent any buffered input (e.g., Ctrl+D) from being
+         // re-interpreted after raw mode is disabled. This fixes a race condition
+         // where Ctrl+D could close the parent shell over SSH.

--- a/patches/README.md
+++ b/patches/README.md
@@ -4,7 +4,7 @@ Patches in this directory are applied automatically by Bun via the
 `patchedDependencies` field in the root `package.json`. They are reapplied on
 every `bun install` — no postinstall script is needed.
 
-## @earendil-works/pi-agent-core@0.80.3
+## @earendil-works/pi-agent-core@0.80.5
 
 Adds one PizzaPi-specific runtime fix:
 
@@ -24,7 +24,7 @@ Adds one PizzaPi-specific runtime fix:
 
 **Tests:** `packages/cli/src/patches.test.ts` verifies the regression behavior with a live `Agent` instance.
 
-## @earendil-works/pi-coding-agent@0.80.3
+## @earendil-works/pi-coding-agent@0.80.5
 
 PizzaPi integration changes ported forward to the 0.80.x upstream layout.
 Upstream provides session-control actions for command contexts; PizzaPi also
@@ -46,7 +46,7 @@ below).
 | `dist/modes/interactive/interactive-mode.js` | Removes upstream version-notification UI (import, `run()` call, and `showNewVersionNotification()` method) |
 | `dist/index.js` / `dist/index.d.ts` | Re-exports `handlePackageCommand` and `handleConfigCommand` so the `pizza` CLI can inherit `install`/`remove`/`update`/`list`/`config` without a subpath import |
 
-## @earendil-works/pi-ai@0.80.3
+## @earendil-works/pi-ai@0.80.5
 
 Same Anthropic web-search and Claude Code credential fallback changes as 0.79.3,
 ported to the 0.80.x upstream layout (the Anthropic streaming implementation
@@ -103,7 +103,7 @@ Notable upstream changes in 0.66.1:
 | `dist/modes/interactive/interactive-mode.js` — section headers | Box-drawing themed headers, compact extension table |
 | `dist/modes/interactive/interactive-mode.js` — diagnostics | Uses themed section headers for skill/prompt/extension/theme issues |
 
-## @earendil-works/pi-tui@0.80.3
+## @earendil-works/pi-tui@0.80.5
 
 Adds Windows console output lifecycle management so Unicode glyphs render
 reliably on Windows terminals.
@@ -302,6 +302,16 @@ syntactic validity. Run with `bun test packages/cli/src/patches.test.ts`.
 this patch can be deleted.
 
 ## Previously patched (no longer needed)
+
+### @earendil-works/*@0.80.3 (replaced by 0.80.5 patches)
+
+The 0.80.3 patch files are retained in this directory for history but are no
+longer referenced by `patchedDependencies`. The 0.80.5 patches port the same
+intent forward; no patch hunk needed adjustment — the upstream changes between
+0.80.3 and 0.80.5 (truncated-tool-call handling in `agent-loop.js`, a new
+`cache-stats` module, config-selector refactor) do not overlap with any PizzaPi
+patch site. The stale `.bun-tag` marker files that `bun patch` had injected into
+the 0.80.3 `pi-coding-agent` patch were dropped in the 0.80.5 regeneration.
 
 ### @earendil-works/*@0.79.3 (replaced by 0.80.3 patches)
 


### PR DESCRIPTION
Bumps all four patched `@earendil-works/*` packages (`pi-agent-core`, `pi-ai`, `pi-coding-agent`, `pi-tui`) from 0.80.3 to 0.80.5 and ports the PizzaPi patches forward.

## What changed

- Bumped deps in root, `packages/cli`, `packages/server`, `packages/tools` `package.json`
- Regenerated all four patch files against the 0.80.5 dist
- Updated `patches/README.md` version headers + added a history note for the superseded 0.80.3 patches (retained on disk per existing convention)

## Patch port notes

No patch hunk needed adjustment — the upstream changes between 0.80.3 and 0.80.5 (truncated-tool-call handling in `agent-loop.js`, a new `cache-stats` module, config-selector refactor) do not overlap with any PizzaPi patch site. Also dropped the stale `.bun-tag` marker files that `bun patch` had injected into the 080.3 `pi-coding-agent` patch.

## Verification

- `bun install` clean; patches apply (PATCH markers confirmed in installed `node_modules`)
- `patches.test.ts`: 37/37 pass
- `typecheck`: clean
- `packages/cli` full suite: 2256/2256 pass