### PR TITLE
fix(git panel): update commit message popover when HEAD moves; make header responsive

### DIFF
--- a/packages/server/tests/harness/mock-runner.ts
+++ b/packages/server/tests/harness/mock-runner.ts
@@ -196,7 +196,8 @@ function defaultGitStatus(): MockGitStatus {
         changes: [
             // Porcelain v1 XY codes — the UI partitions staged/unstaged on the
             // 2-char status, so single-char codes render an empty Changes tab.
-            { status: " M", path: "src/index.ts" },
+            // "M " is a staged modification so the commit form is usable.
+            { status: "M ", path: "src/index.ts" },
             { status: "??", path: "notes.md" },
         ],
         ahead: 1,
@@ -269,6 +270,9 @@ export async function createMockRunner(
     let pluginsList: RunnerPlugin[] = opts?.plugins ?? defaultPlugins();
     const mockFiles: Map<string, MockFileEntry[]> = opts?.mockFiles ?? defaultMockFiles();
     let gitStatus: MockGitStatus = opts?.mockGitStatus ?? defaultGitStatus();
+    // Mutable HEAD state so the mock can simulate commits moving HEAD.
+    let headShortHash = "abc1234";
+    let headSubject = "Add harness scaffolding";
     let sandboxConfig: MockSandboxConfig = defaultSandboxConfig();
     sandboxConfig.platform = opts?.platform ?? "linux";
     let usageData: MockUsageData = defaultUsageData();
@@ -896,7 +900,7 @@ export async function createMockRunner(
                     },
                     currentBranch: gitStatus.branch,
                     branches: [
-                        { name: gitStatus.branch, shortHash: "abc1234", lastCommit: "2 hours ago", isCurrent: true, isRemote: false },
+                        { name: gitStatus.branch, shortHash: headShortHash, lastCommit: "2 hours ago", isCurrent: true, isRemote: false },
                         { name: "main", shortHash: "def5678", lastCommit: "1 day ago", isCurrent: false, isRemote: false },
                     ],
                     worktrees: [
@@ -904,7 +908,7 @@ export async function createMockRunner(
                             path: cwd,
                             displayPath: ".",
                             branch: gitStatus.branch,
-                            shortHash: "abc1234",
+                            shortHash: headShortHash,
                             isDetached: false,
                             isMain: true,
                             changeCount: gitStatus.changes.length,
@@ -934,12 +938,12 @@ export async function createMockRunner(
                     ok: true,
                     entries: [
                         {
-                            hash: "abc1234567890abcdef1234567890abcdef123456",
-                            shortHash: "abc1234",
+                            hash: `${headShortHash}${headShortHash.padEnd(40 - headShortHash.length, "0")}`,
+                            shortHash: headShortHash,
                             author: "Mock Author",
-                            authorDate: "2026-07-05T10:00:00Z",
-                            commitDate: "2026-07-05T10:00:00Z",
-                            subject: "Add harness scaffolding",
+                            authorDate: new Date().toISOString(),
+                            commitDate: new Date().toISOString(),
+                            subject: headSubject,
                             body: "",
                             refs: ["HEAD", gitStatus.branch],
                         },
@@ -969,7 +973,7 @@ export async function createMockRunner(
                             path: (payload.cwd as string) ?? "/mock",
                             displayPath: ".",
                             branch: gitStatus.branch,
-                            shortHash: "abc1234",
+                            shortHash: headShortHash,
                             isDetached: false,
                             isMain: true,
                             changeCount: gitStatus.changes.length,
@@ -985,7 +989,7 @@ export async function createMockRunner(
                     ok: true,
                     currentBranch: gitStatus.branch,
                     branches: [
-                        { name: gitStatus.branch, shortHash: "abc1234", lastCommit: "2 hours ago", isCurrent: true, isRemote: false },
+                        { name: gitStatus.branch, shortHash: headShortHash, lastCommit: "2 hours ago", isCurrent: true, isRemote: false },
                         { name: "main", shortHash: "def5678", lastCommit: "1 day ago", isCurrent: false, isRemote: false },
                     ],
                 });
@@ -1007,9 +1011,14 @@ export async function createMockRunner(
             case "git_unstage":
                 emitGit("git_unstage_result", { ok: true });
                 break;
-            case "git_commit":
-                emitGit("git_commit_result", { ok: true, summary: "[main abc1234] Mock commit" });
+            case "git_commit": {
+                const message = (payload.message as string) ?? "Mock commit";
+                // Simulate HEAD moving to a new commit.
+                headShortHash = Math.random().toString(16).slice(2, 9);
+                headSubject = message;
+                emitGit("git_commit_result", { ok: true, summary: `[${gitStatus.branch} ${headShortHash}] ${message}` });
                 break;
+            }
             case "git_push":
                 emitGit("git_push_result", { ok: true, output: "Everything up-to-date" });
                 break;

--- a/packages/ui/src/components/CombinedPanel.tsx
+++ b/packages/ui/src/components/CombinedPanel.tsx
@@ -271,7 +271,10 @@ export function CombinedPanel({
   const mountedTabs = tabs.filter((tab) => tab.id === activeTab?.id || tab.keepMountedWhenInactive);
 
   return (
-    <div className={cn("flex flex-col bg-background text-foreground", className)}>
+    // @container: panel content below keys responsive layout off the actual
+    // dock width, not the viewport — panels are resized independently of
+    // the browser window in the 9-zone dock layout.
+    <div className={cn("@container flex flex-col bg-background text-foreground", className)}>
       {/* Tab bar */}
       <div className="flex items-center border-b border-border bg-muted/50 shrink-0 min-h-[32px] overflow-hidden">
         <div className="flex items-center flex-1 min-w-0 overflow-x-auto gap-0.5 px-1 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">

--- a/packages/ui/src/components/TerminalManager.tsx
+++ b/packages/ui/src/components/TerminalManager.tsx
@@ -262,13 +262,13 @@ export function TerminalManager({
   return (
     <div className={cn("flex flex-col bg-background", className)}>
       {/* ── Persistent topbar ─────────────────────────────────────────────── */}
-      <div className="flex items-center border-b border-border bg-muted/50 shrink-0 min-h-[36px] md:min-h-[32px] overflow-hidden">
+      <div className="flex items-center border-b border-border bg-muted/50 shrink-0 min-h-[36px] @md:min-h-[32px] overflow-hidden">
         {/* Mobile: back button */}
         {onClose && (
           <Button
             variant="ghost"
             size="icon"
-            className="size-9 shrink-0 text-muted-foreground hover:text-foreground hover:bg-accent md:hidden rounded-none"
+            className="size-9 shrink-0 text-muted-foreground hover:text-foreground hover:bg-accent @md:hidden rounded-none"
             onClick={onClose}
             aria-label="Close terminal"
           >
@@ -323,7 +323,7 @@ export function TerminalManager({
         </div>
 
         {/* ── Right-side controls (desktop) ── */}
-        <div className="hidden md:flex items-center gap-px shrink-0 pr-1">
+        <div className="hidden @md:flex items-center gap-px shrink-0 pr-1">
           {/* Drag-to-reposition grip — hidden when embedded */}
           {!embedded && onDragStart && (
             <Tooltip>
@@ -392,7 +392,7 @@ export function TerminalManager({
         <Button
           variant="ghost"
           size="icon"
-          className="md:hidden size-9 shrink-0 text-muted-foreground hover:text-foreground hover:bg-accent rounded-none"
+          className="@md:hidden size-9 shrink-0 text-muted-foreground hover:text-foreground hover:bg-accent rounded-none"
           onClick={handleAddTerminal}
           disabled={spawning}
           aria-label="New terminal"

--- a/packages/ui/src/components/WebTerminal.tsx
+++ b/packages/ui/src/components/WebTerminal.tsx
@@ -353,7 +353,7 @@ export function WebTerminal({ terminalId, onClose, className }: WebTerminalProps
       )}
     >
       {/* Header bar — compact status + controls */}
-      <div className="flex items-center justify-between border-border border-b px-3 py-1 bg-muted/50 min-h-[36px] md:min-h-0">
+      <div className="flex items-center justify-between border-border border-b px-3 py-1 bg-muted/50 min-h-[36px] @md:min-h-0">
         <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
           <span className={cn("text-[10px]", statusColor)}>●</span>
           <span className={statusColor}>{statusLabel}</span>
@@ -364,7 +364,7 @@ export function WebTerminal({ terminalId, onClose, className }: WebTerminalProps
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-8 md:size-5 text-muted-foreground hover:text-foreground hover:bg-accent"
+                className="size-8 @md:size-5 text-muted-foreground hover:text-foreground hover:bg-accent"
                 onClick={() => setIsMaximized((v) => !v)}
                 aria-label={isMaximized ? "Restore terminal size" : "Maximize terminal"}
               >
@@ -380,7 +380,7 @@ export function WebTerminal({ terminalId, onClose, className }: WebTerminalProps
               <Button
                 variant="ghost"
                 size="icon"
-                className="size-8 md:size-5 text-muted-foreground hover:text-red-500 hover:bg-accent"
+                className="size-8 @md:size-5 text-muted-foreground hover:text-red-500 hover:bg-accent"
                 onClick={handleClose}
                 aria-label="Close terminal"
               >
@@ -401,7 +401,7 @@ export function WebTerminal({ terminalId, onClose, className }: WebTerminalProps
         style={{ minHeight: isMaximized ? undefined : "min(300px, calc(100dvh - 120px))" }}
       />
       {/* Mobile keyboard shortcut bar */}
-      <div className="md:hidden flex items-center gap-1.5 border-t border-border bg-muted/70 px-2 py-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
+      <div className="@md:hidden flex items-center gap-1.5 border-t border-border bg-muted/70 px-2 py-2 overflow-x-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
         {MOBILE_SHORTCUTS.map(({ label, data }) => (
           <button
             key={label}

--- a/packages/ui/src/components/git/GitBlameView.tsx
+++ b/packages/ui/src/components/git/GitBlameView.tsx
@@ -137,7 +137,7 @@ export function GitBlameView({ cwd, path, revision, className }: GitBlameViewPro
                                                 {isFirst && (
                                                     <td
                                                         rowSpan={group.count}
-                                                        className="align-top p-0 border-r border-border/50 bg-muted/20 w-28 sm:w-36 md:w-44"
+                                                        className="align-top p-0 border-r border-border/50 bg-muted/20 w-28 @sm:w-36 @md:w-44"
                                                     >
                                                         <button
                                                             type="button"
@@ -159,7 +159,7 @@ export function GitBlameView({ cwd, path, revision, className }: GitBlameViewPro
                                                         </button>
                                                     </td>
                                                 )}
-                                                <td className="w-10 sm:w-12 text-right text-muted-foreground/60 px-2 py-0.5 select-none align-top whitespace-nowrap">
+                                                <td className="w-10 @sm:w-12 text-right text-muted-foreground/60 px-2 py-0.5 select-none align-top whitespace-nowrap">
                                                     {lineNumber}
                                                 </td>
                                                 <td className="px-2 py-0.5 align-top">
@@ -305,10 +305,10 @@ function GitDiffCode({ diff }: { diff: string }) {
                         }
                         return (
                             <tr key={i} className={cn(rowClass, "border-b border-border/10 hover:bg-accent/5")}>
-                                <td className="w-10 sm:w-12 text-right px-2 py-0.5 select-none text-muted-foreground/50 align-top whitespace-nowrap">
+                                <td className="w-10 @sm:w-12 text-right px-2 py-0.5 select-none text-muted-foreground/50 align-top whitespace-nowrap">
                                     {line.oldLine ?? ""}
                                 </td>
-                                <td className="w-10 sm:w-12 text-right px-2 py-0.5 select-none text-muted-foreground/50 align-top whitespace-nowrap border-r border-border/30">
+                                <td className="w-10 @sm:w-12 text-right px-2 py-0.5 select-none text-muted-foreground/50 align-top whitespace-nowrap border-r border-border/30">
                                     {line.newLine ?? ""}
                                 </td>
                                 <td className="px-2 py-0.5 align-top">

--- a/packages/ui/src/components/git/GitCommitForm.tsx
+++ b/packages/ui/src/components/git/GitCommitForm.tsx
@@ -58,7 +58,7 @@ export function GitCommitForm({ hasStagedChanges, onCommit, isCommitting, disabl
                     "min-h-[36px]",
                 )}
             />
-            <div className="flex flex-col @sm:flex-row items-start @sm:items-center gap-2 @sm:justify-between">
+            <div className="flex flex-wrap items-center gap-2 justify-between">
                 <span className="text-[0.6rem] text-muted-foreground">
                     {hasStagedChanges
                         ? `${typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? "⌘" : "Ctrl+"}↵ to commit`
@@ -69,7 +69,7 @@ export function GitCommitForm({ hasStagedChanges, onCommit, isCommitting, disabl
                     onClick={handleCommit}
                     disabled={!canCommit}
                     className={cn(
-                        "inline-flex items-center justify-center gap-1.5 px-3 py-1 rounded text-xs font-medium transition-colors w-full @sm:w-auto min-h-9",
+                        "inline-flex items-center justify-center gap-1.5 px-3 py-1 rounded text-xs font-medium transition-colors min-h-9",
                         canCommit
                             ? "bg-primary text-primary-foreground hover:bg-primary/90"
                             : "bg-muted text-muted-foreground cursor-not-allowed",

--- a/packages/ui/src/components/git/GitCommitForm.tsx
+++ b/packages/ui/src/components/git/GitCommitForm.tsx
@@ -58,7 +58,7 @@ export function GitCommitForm({ hasStagedChanges, onCommit, isCommitting, disabl
                     "min-h-[36px]",
                 )}
             />
-            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 sm:justify-between">
+            <div className="flex flex-col @sm:flex-row items-start @sm:items-center gap-2 @sm:justify-between">
                 <span className="text-[0.6rem] text-muted-foreground">
                     {hasStagedChanges
                         ? `${typeof navigator !== "undefined" && /Mac|iPod|iPhone|iPad/.test(navigator.platform) ? "⌘" : "Ctrl+"}↵ to commit`
@@ -69,7 +69,7 @@ export function GitCommitForm({ hasStagedChanges, onCommit, isCommitting, disabl
                     onClick={handleCommit}
                     disabled={!canCommit}
                     className={cn(
-                        "inline-flex items-center justify-center gap-1.5 px-3 py-1 rounded text-xs font-medium transition-colors w-full sm:w-auto min-h-9",
+                        "inline-flex items-center justify-center gap-1.5 px-3 py-1 rounded text-xs font-medium transition-colors w-full @sm:w-auto min-h-9",
                         canCommit
                             ? "bg-primary text-primary-foreground hover:bg-primary/90"
                             : "bg-muted text-muted-foreground cursor-not-allowed",

--- a/packages/ui/src/components/git/GitDiffRevsView.tsx
+++ b/packages/ui/src/components/git/GitDiffRevsView.tsx
@@ -88,7 +88,7 @@ export function GitDiffRevsView({ cwd, path, className }: GitDiffRevsViewProps) 
 
     return (
         <div className={cn("flex flex-col h-full overflow-hidden", className)}>
-            <div className="flex flex-col @sm:flex-row items-start @sm:items-center gap-2 p-2 border-b border-border bg-muted/30 shrink-0">
+            <div className="flex flex-wrap items-center gap-2 p-2 border-b border-border bg-muted/30 shrink-0">
                 <RevPicker
                     label="Base"
                     value={base}
@@ -108,7 +108,7 @@ export function GitDiffRevsView({ cwd, path, className }: GitDiffRevsViewProps) 
                     size="sm"
                     disabled={!base || !head || base === head || loading}
                     onClick={handleDiff}
-                    className="w-full @sm:w-auto h-9"
+                    className="h-9"
                 >
                     <Diff className="size-3.5" />
                     <span className="ml-1.5">Diff</span>
@@ -153,7 +153,7 @@ function RevPicker({
     }, [options]);
 
     return (
-        <div className="flex items-center gap-2 w-full @sm:flex-1 min-w-0">
+        <div className="flex items-center gap-2 grow shrink basis-40 min-w-0">
             <span className="text-xs text-muted-foreground shrink-0 w-10">{label}</span>
             <Select value={value} onValueChange={onChange}>
                 <SelectTrigger className="w-full h-9 min-w-0">

--- a/packages/ui/src/components/git/GitDiffRevsView.tsx
+++ b/packages/ui/src/components/git/GitDiffRevsView.tsx
@@ -88,7 +88,7 @@ export function GitDiffRevsView({ cwd, path, className }: GitDiffRevsViewProps) 
 
     return (
         <div className={cn("flex flex-col h-full overflow-hidden", className)}>
-            <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 p-2 border-b border-border bg-muted/30 shrink-0">
+            <div className="flex flex-col @sm:flex-row items-start @sm:items-center gap-2 p-2 border-b border-border bg-muted/30 shrink-0">
                 <RevPicker
                     label="Base"
                     value={base}
@@ -108,7 +108,7 @@ export function GitDiffRevsView({ cwd, path, className }: GitDiffRevsViewProps) 
                     size="sm"
                     disabled={!base || !head || base === head || loading}
                     onClick={handleDiff}
-                    className="w-full sm:w-auto h-9"
+                    className="w-full @sm:w-auto h-9"
                 >
                     <Diff className="size-3.5" />
                     <span className="ml-1.5">Diff</span>
@@ -153,7 +153,7 @@ function RevPicker({
     }, [options]);
 
     return (
-        <div className="flex items-center gap-2 w-full sm:flex-1 min-w-0">
+        <div className="flex items-center gap-2 w-full @sm:flex-1 min-w-0">
             <span className="text-xs text-muted-foreground shrink-0 w-10">{label}</span>
             <Select value={value} onValueChange={onChange}>
                 <SelectTrigger className="w-full h-9 min-w-0">

--- a/packages/ui/src/components/git/GitHistoryView.tsx
+++ b/packages/ui/src/components/git/GitHistoryView.tsx
@@ -106,16 +106,16 @@ export function GitHistoryView({ cwd, path, className }: GitHistoryViewProps) {
     return (
         <div className={cn("flex flex-col h-full overflow-hidden", className)}>
             {selected.size === 2 && (
-                <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 p-2 border-b border-border bg-muted/30 shrink-0">
+                <div className="flex flex-col @sm:flex-row items-start @sm:items-center gap-2 p-2 border-b border-border bg-muted/30 shrink-0">
                     <span className="text-xs text-muted-foreground truncate flex-1 min-w-0">
                         Diff {short(Array.from(selected)[0])} ↔ {short(Array.from(selected)[1])}
                     </span>
-                    <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+                    <div className="flex flex-col @sm:flex-row gap-2 w-full @sm:w-auto">
                         <Button
                             size="sm"
                             disabled={loading}
                             onClick={viewSelectedDiff}
-                            className="w-full sm:w-auto h-9"
+                            className="w-full @sm:w-auto h-9"
                         >
                             <Diff className="size-3.5" />
                             <span className="ml-1.5">View diff</span>
@@ -124,7 +124,7 @@ export function GitHistoryView({ cwd, path, className }: GitHistoryViewProps) {
                             variant="outline"
                             size="sm"
                             onClick={() => setSelected(new Set())}
-                            className="w-full sm:w-auto h-9"
+                            className="w-full @sm:w-auto h-9"
                         >
                             Clear
                         </Button>
@@ -145,7 +145,7 @@ export function GitHistoryView({ cwd, path, className }: GitHistoryViewProps) {
                         {log.map((entry) => (
                             <div
                                 key={entry.hash}
-                                className="flex flex-col sm:flex-row sm:items-center gap-2 px-3 py-2 hover:bg-accent/30 transition-colors"
+                                className="flex flex-col @sm:flex-row @sm:items-center gap-2 px-3 py-2 hover:bg-accent/30 transition-colors"
                             >
                                 <div className="flex items-center gap-2 min-w-0 flex-1">
                                     <input
@@ -179,7 +179,7 @@ export function GitHistoryView({ cwd, path, className }: GitHistoryViewProps) {
                                     </button>
                                 </div>
                                 {entry.refs.length > 0 && (
-                                    <div className="flex flex-wrap gap-1 items-center shrink-0 pl-6 sm:pl-0">
+                                    <div className="flex flex-wrap gap-1 items-center shrink-0 pl-6 @sm:pl-0">
                                         {entry.refs.map((ref) => (
                                             <Badge key={ref} variant="secondary" className="text-[0.65rem]">
                                                 {ref}

--- a/packages/ui/src/components/git/GitPanel.test.tsx
+++ b/packages/ui/src/components/git/GitPanel.test.tsx
@@ -187,4 +187,61 @@ describe("GitPanel", () => {
         // reset for afterEach
         gitState.lastConflictType = null;
     });
+
+    test("re-fetches last-commit log when current branch shortHash changes", () => {
+        gitState.status.branch = "feature/test";
+        gitState.branches = [
+            { name: "feature/test", shortHash: "abc1234", lastCommit: "2 hours ago", isCurrent: true, isRemote: false },
+        ];
+        gitState.log = [];
+        const callsBefore = gitState.fetchLog.mock.calls.length;
+
+        const { rerender } = render(<GitPanel cwd="/repo" />);
+        expect(gitState.fetchLog.mock.calls.length).toBeGreaterThan(callsBefore);
+
+        const callsAfterInitial = gitState.fetchLog.mock.calls.length;
+
+        gitState.branches = [
+            { name: "feature/test", shortHash: "def5678", lastCommit: "1 hour ago", isCurrent: true, isRemote: false },
+        ];
+        rerender(<GitPanel cwd="/repo" />);
+        expect(gitState.fetchLog.mock.calls.length).toBe(callsAfterInitial + 1);
+    });
+
+    test("falls back to hash+date tooltip when log entry is stale relative to HEAD", () => {
+        gitState.status.branch = "feature/test";
+        gitState.branches = [
+            { name: "feature/test", shortHash: "newhash", lastCommit: "5 min ago", isCurrent: true, isRemote: false },
+        ];
+        gitState.log = [
+            {
+                hash: "oldhasholdhasholdhasholdhasholdhasholdhash",
+                shortHash: "oldhash",
+                author: "Dev",
+                authorDate: "2026-07-05T10:00:00Z",
+                commitDate: "2026-07-05T10:00:00Z",
+                subject: "Old subject",
+                body: "",
+                refs: ["HEAD", "feature/test"],
+            },
+        ];
+
+        const { rerender, getByText } = render(<GitPanel cwd="/repo" />);
+        expect(getByText("newhash · 5 min ago")).toBeTruthy();
+
+        gitState.log = [
+            {
+                hash: "newhashhashhashhashhashhashhashhashhashhas",
+                shortHash: "newhash",
+                author: "Dev",
+                authorDate: "2026-07-09T10:00:00Z",
+                commitDate: "2026-07-09T10:00:00Z",
+                subject: "New subject",
+                body: "",
+                refs: ["HEAD", "feature/test"],
+            },
+        ];
+        rerender(<GitPanel cwd="/repo" />);
+        expect(getByText("newhash New subject")).toBeTruthy();
+    });
 });

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -73,15 +73,22 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
     const [activeTab, setActiveTab] = useState<GitTab>("changes");
     const [pathFilter, setPathFilter] = useState("");
 
+    // Current branch info is used by the header hash chip and the commit
+    // message tooltip. Compute it early so the log fetch effect below can
+    // re-fire whenever HEAD moves (shortHash changes after commit/pull/etc).
+    const currentBranchInfo = git.branches.find((b) => b.isCurrent);
+
     // Fetch the last commit subject for the status row. Falls back to the
     // branch list's date text if log hasn't resolved yet.
     const branchNameForLog = git.status?.branch;
+    const currentShortHash = currentBranchInfo?.shortHash;
     useEffect(() => {
         if (!branchNameForLog) return;
-        // ponytail: one-entry log fetch, fire-and-forget; hook discards stale cwd results
+        // ponytail: one-entry log fetch; re-fire when HEAD shortHash changes
+        // so the tooltip shows the new commit message after a commit.
         git.fetchLog(undefined, 1).catch(() => {});
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [branchNameForLog]);
+    }, [branchNameForLog, currentShortHash]);
 
     // Toast-style feedback for operations
     const [toast, setToast] = useState<GitOperationFeedback | null>(null);
@@ -252,16 +259,19 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
     const showPush = git.status.ahead > 0 || !git.status.hasUpstream;
     const showPull = git.status.behind > 0 && git.status.hasUpstream;
 
-    const currentBranchInfo = git.branches.find((b) => b.isCurrent);
-    const lastCommitSubject = git.log[0]?.subject;
-    const lastCommitShortHash = lastCommitSubject
-        ? currentBranchInfo?.shortHash ?? git.log[0]?.shortHash
-        : currentBranchInfo?.shortHash;
-    const lastCommitTooltip = lastCommitSubject
-        ? `${currentBranchInfo?.shortHash ?? git.log[0]?.shortHash} ${lastCommitSubject}`
+    const headLogEntry = git.log[0];
+    // Only trust the log entry's subject while its shortHash matches the
+    // current branch head; otherwise show the hash + relative date fallback
+    // until the new log entry arrives.
+    const logMatchesHead = !!headLogEntry && currentBranchInfo?.shortHash === headLogEntry.shortHash;
+    const lastCommitShortHash = currentBranchInfo?.shortHash ?? headLogEntry?.shortHash;
+    const lastCommitTooltip = logMatchesHead
+        ? `${headLogEntry.shortHash} ${headLogEntry.subject}`
         : currentBranchInfo
-            ? `${currentBranchInfo.shortHash} ${currentBranchInfo.lastCommit}`
-            : undefined;
+            ? `${currentBranchInfo.shortHash} · ${currentBranchInfo.lastCommit}`
+            : headLogEntry
+                ? `${headLogEntry.shortHash} ${headLogEntry.subject}`
+                : undefined;
 
     return (
         <div className={cn("flex flex-col h-full overflow-hidden", className)}>
@@ -312,7 +322,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                             <Tooltip>
                                 <TooltipTrigger asChild>
                                     <span
-                                        className="hidden sm:inline-flex items-center gap-1 min-w-0 text-xs text-muted-foreground cursor-help"
+                                        className="inline-flex items-center gap-1 min-w-0 text-xs text-muted-foreground cursor-help"
                                     >
                                         <GitCommit className="size-3 shrink-0" />
                                         <span className="truncate">{lastCommitShortHash}</span>

--- a/packages/ui/src/components/git/GitPanel.tsx
+++ b/packages/ui/src/components/git/GitPanel.tsx
@@ -276,8 +276,8 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
     return (
         <div className={cn("flex flex-col h-full overflow-hidden", className)}>
             {/* Status / branch header */}
-            <div className="flex flex-col sm:flex-row sm:items-center gap-2 px-2 py-1.5 border-b border-border bg-muted/50 min-h-[40px] overflow-hidden">
-                <div className="flex items-center gap-1.5 min-w-0 w-full sm:w-auto sm:flex-1 overflow-hidden">
+            <div className="flex flex-col @sm:flex-row @sm:items-center gap-2 px-2 py-1.5 border-b border-border bg-muted/50 min-h-[40px] overflow-hidden">
+                <div className="flex items-center gap-1.5 min-w-0 w-full @sm:w-auto @sm:flex-1 overflow-hidden">
                     <GitBranchSelector
                         currentBranch={git.status.branch}
                         branches={git.branches}
@@ -298,7 +298,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                     )}
                 </div>
 
-                <div className="flex flex-wrap items-center justify-end gap-1.5 min-w-0 w-full sm:w-auto sm:shrink-0 sm:ml-auto">
+                <div className="flex flex-wrap items-center justify-end gap-1.5 min-w-0 w-full @sm:w-auto @sm:shrink-0 @sm:ml-auto">
                     {/* Ahead/behind badges */}
                     {git.status.ahead > 0 && (
                         <span
@@ -513,7 +513,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                 const isStashConflict = git.lastConflictType === "git_stash_result";
                 const isMergeConflict = git.lastConflictType === "git_merge_result";
                 return (
-                    <div className="flex flex-col sm:flex-row items-start sm:items-center gap-2 px-3 py-2 text-xs border-b bg-amber-500/10 border-amber-500/20 text-amber-600 dark:text-amber-400"
+                    <div className="flex flex-col @sm:flex-row items-start @sm:items-center gap-2 px-3 py-2 text-xs border-b bg-amber-500/10 border-amber-500/20 text-amber-600 dark:text-amber-400"
                     >
                         <div className="flex items-center gap-2 min-w-0 w-full">
                             <AlertCircle className="size-3 shrink-0" />
@@ -528,18 +528,18 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                                 type="button"
                                 onClick={() => git.mergeAbort()}
                                 disabled={git.operationInProgress !== null}
-                                className="inline-flex items-center justify-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500 dark:text-red-400 hover:bg-red-500/30 disabled:opacity-50 w-full sm:w-auto"
+                                className="inline-flex items-center justify-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500 dark:text-red-400 hover:bg-red-500/30 disabled:opacity-50 w-full @sm:w-auto"
                                 title="Abort the merge"
                             >
                                 <StopCircle className="size-3" /> Abort Merge
                             </button>
                         ) : isStashConflict ? null : (
-                            <div className="flex items-center gap-2 w-full sm:w-auto">
+                            <div className="flex items-center gap-2 w-full @sm:w-auto">
                                 <button
                                     type="button"
                                     onClick={() => git.rebaseContinue()}
                                     disabled={git.operationInProgress !== null}
-                                    className="inline-flex items-center justify-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-green-600/20 text-green-600 dark:text-green-400 hover:bg-green-600/30 disabled:opacity-50 flex-1 sm:flex-initial"
+                                    className="inline-flex items-center justify-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-green-600/20 text-green-600 dark:text-green-400 hover:bg-green-600/30 disabled:opacity-50 flex-1 @sm:flex-initial"
                                     title="Continue rebase after resolving conflicts"
                                 >
                                     <Play className="size-3" /> Continue
@@ -548,7 +548,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                                     type="button"
                                     onClick={() => git.rebaseAbort()}
                                     disabled={git.operationInProgress !== null}
-                                    className="inline-flex items-center justify-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500 dark:text-red-400 hover:bg-red-500/30 disabled:opacity-50 flex-1 sm:flex-initial"
+                                    className="inline-flex items-center justify-center gap-1 px-2 py-0.5 rounded text-xs font-medium bg-red-500/20 text-red-500 dark:text-red-400 hover:bg-red-500/30 disabled:opacity-50 flex-1 @sm:flex-initial"
                                     title="Abort the rebase"
                                 >
                                     <StopCircle className="size-3" /> Abort
@@ -567,7 +567,7 @@ export function GitPanel({ cwd, className }: GitPanelProps) {
                         type="button"
                         onClick={() => setActiveTab(t.id)}
                         className={cn(
-                            "px-2 py-1 text-[0.65rem] sm:px-2.5 sm:py-1.5 sm:text-xs font-medium whitespace-nowrap border-b-2 -mb-px transition-colors shrink-0",
+                            "px-2 py-1 text-[0.65rem] @sm:px-2.5 @sm:py-1.5 @sm:text-xs font-medium whitespace-nowrap border-b-2 -mb-px transition-colors shrink-0",
                             activeTab === t.id
                                 ? "border-primary text-foreground"
                                 : "border-transparent text-muted-foreground hover:text-foreground",

--- a/packages/ui/src/components/git/GitStagingArea.tsx
+++ b/packages/ui/src/components/git/GitStagingArea.tsx
@@ -90,15 +90,15 @@ export function GitStagingArea({
         <div className="py-1">
             {/* View mode toggle in staged header */}
             {staged.length > 0 && (
-                <div className="flex flex-col sm:flex-row sm:items-center gap-2 px-3 py-1.5">
-                    <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground sm:flex-1">
+                <div className="flex flex-col @sm:flex-row @sm:items-center gap-2 px-3 py-1.5">
+                    <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground @sm:flex-1">
                         Staged Changes ({staged.length})
                     </span>
                     <button
                         type="button"
                         onClick={onUnstageAll}
                         disabled={isBusy}
-                        className="text-[0.6rem] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 flex items-center justify-center gap-0.5 w-full sm:w-auto min-h-9"
+                        className="text-[0.6rem] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 flex items-center justify-center gap-0.5 w-full @sm:w-auto min-h-9"
                         title="Unstage all"
                     >
                         <ChevronDown className="size-3" /> Unstage All
@@ -149,15 +149,15 @@ export function GitStagingArea({
                     {/* Unstaged/untracked changes */}
                     {unstaged.length > 0 && (
                         <div>
-                            <div className="flex flex-col sm:flex-row sm:items-center gap-2 px-3 py-1.5">
-                                <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground sm:flex-1">
+                            <div className="flex flex-col @sm:flex-row @sm:items-center gap-2 px-3 py-1.5">
+                                <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground @sm:flex-1">
                                     Changes ({unstaged.length})
                                 </span>
                                 <button
                                     type="button"
                                     onClick={onStageAll}
                                     disabled={isBusy}
-                                    className="text-[0.6rem] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 flex items-center justify-center gap-0.5 w-full sm:w-auto min-h-9"
+                                    className="text-[0.6rem] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 flex items-center justify-center gap-0.5 w-full @sm:w-auto min-h-9"
                                     title="Stage all"
                                 >
                                     <ChevronUp className="size-3" /> Stage All

--- a/packages/ui/src/components/git/GitStagingArea.tsx
+++ b/packages/ui/src/components/git/GitStagingArea.tsx
@@ -90,15 +90,15 @@ export function GitStagingArea({
         <div className="py-1">
             {/* View mode toggle in staged header */}
             {staged.length > 0 && (
-                <div className="flex flex-col @sm:flex-row @sm:items-center gap-2 px-3 py-1.5">
-                    <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground @sm:flex-1">
+                <div className="flex flex-wrap items-center gap-2 px-3 py-1.5">
+                    <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground flex-1 min-w-[8rem]">
                         Staged Changes ({staged.length})
                     </span>
                     <button
                         type="button"
                         onClick={onUnstageAll}
                         disabled={isBusy}
-                        className="text-[0.6rem] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 flex items-center justify-center gap-0.5 w-full @sm:w-auto min-h-9"
+                        className="text-[0.6rem] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 flex items-center justify-center gap-0.5 min-h-9"
                         title="Unstage all"
                     >
                         <ChevronDown className="size-3" /> Unstage All
@@ -149,15 +149,15 @@ export function GitStagingArea({
                     {/* Unstaged/untracked changes */}
                     {unstaged.length > 0 && (
                         <div>
-                            <div className="flex flex-col @sm:flex-row @sm:items-center gap-2 px-3 py-1.5">
-                                <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground @sm:flex-1">
+                            <div className="flex flex-wrap items-center gap-2 px-3 py-1.5">
+                                <span className="text-[0.65rem] font-semibold uppercase tracking-wider text-muted-foreground flex-1 min-w-[8rem]">
                                     Changes ({unstaged.length})
                                 </span>
                                 <button
                                     type="button"
                                     onClick={onStageAll}
                                     disabled={isBusy}
-                                    className="text-[0.6rem] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 flex items-center justify-center gap-0.5 w-full @sm:w-auto min-h-9"
+                                    className="text-[0.6rem] text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 flex items-center justify-center gap-0.5 min-h-9"
                                     title="Stage all"
                                 >
                                     <ChevronUp className="size-3" /> Stage All

--- a/packages/ui/src/components/git/GitStashList.tsx
+++ b/packages/ui/src/components/git/GitStashList.tsx
@@ -145,7 +145,7 @@ export function GitStashList({ cwd, className }: GitStashListProps) {
                         {stashes.map((stash) => (
                             <div
                                 key={stash.index}
-                                className="flex flex-col @sm:flex-row @sm:items-center gap-2 px-3 py-2"
+                                className="flex flex-wrap items-center gap-2 px-3 py-2"
                             >
                                 <div className="flex items-center gap-2 min-w-0 flex-1">
                                     <span className="font-mono text-xs text-muted-foreground shrink-0">
@@ -153,17 +153,17 @@ export function GitStashList({ cwd, className }: GitStashListProps) {
                                     </span>
                                     <span className="truncate text-sm font-medium">{stash.message}</span>
                                 </div>
-                                <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0 min-w-0">
+                                <div className="flex items-center gap-3 text-xs text-muted-foreground shrink-0">
                                     <span className="font-mono shrink-0">{stash.shortHash}</span>
                                     <span className="truncate">{stash.date}</span>
                                 </div>
-                                <div className="flex flex-col @sm:flex-row gap-2 w-full @sm:w-auto">
+                                <div className="flex flex-wrap items-center gap-2 max-w-full">
                                     <Button
                                         variant="outline"
                                         size="sm"
                                         disabled={isBusy}
                                         onClick={() => handlePop(stash.index)}
-                                        className="w-full @sm:w-auto h-9"
+                                        className="h-9"
                                     >
                                         <RotateCcw className="size-3.5" />
                                         <span className="ml-1.5">Pop</span>
@@ -173,7 +173,7 @@ export function GitStashList({ cwd, className }: GitStashListProps) {
                                         size="sm"
                                         disabled={isBusy}
                                         onClick={() => handleApply(stash.index)}
-                                        className="w-full @sm:w-auto h-9"
+                                        className="h-9"
                                     >
                                         <CornerDownLeft className="size-3.5" />
                                         <span className="ml-1.5">Apply</span>
@@ -183,7 +183,7 @@ export function GitStashList({ cwd, className }: GitStashListProps) {
                                         size="sm"
                                         disabled={isBusy}
                                         onClick={() => handleDrop(stash.index)}
-                                        className="w-full @sm:w-auto h-9"
+                                        className="h-9"
                                     >
                                         <Trash2 className="size-3.5" />
                                         <span className="ml-1.5">Drop</span>

--- a/packages/ui/src/components/git/GitStashList.tsx
+++ b/packages/ui/src/components/git/GitStashList.tsx
@@ -104,7 +104,7 @@ export function GitStashList({ cwd, className }: GitStashListProps) {
 
             <form
                 onSubmit={handlePush}
-                className="flex flex-col sm:flex-row items-start sm:items-center gap-2 p-2 border-b border-border bg-muted/30"
+                className="flex flex-col @sm:flex-row items-start @sm:items-center gap-2 p-2 border-b border-border bg-muted/30"
             >
                 <Input
                     placeholder="Stash message (optional)"
@@ -127,7 +127,7 @@ export function GitStashList({ cwd, className }: GitStashListProps) {
                     type="submit"
                     disabled={isBusy}
                     size="sm"
-                    className="w-full sm:w-auto h-9"
+                    className="w-full @sm:w-auto h-9"
                 >
                     {isBusy ? <Spinner className="size-4" /> : <Archive className="size-4" />}
                     <span className="ml-1.5">Push</span>
@@ -145,7 +145,7 @@ export function GitStashList({ cwd, className }: GitStashListProps) {
                         {stashes.map((stash) => (
                             <div
                                 key={stash.index}
-                                className="flex flex-col sm:flex-row sm:items-center gap-2 px-3 py-2"
+                                className="flex flex-col @sm:flex-row @sm:items-center gap-2 px-3 py-2"
                             >
                                 <div className="flex items-center gap-2 min-w-0 flex-1">
                                     <span className="font-mono text-xs text-muted-foreground shrink-0">
@@ -157,13 +157,13 @@ export function GitStashList({ cwd, className }: GitStashListProps) {
                                     <span className="font-mono shrink-0">{stash.shortHash}</span>
                                     <span className="truncate">{stash.date}</span>
                                 </div>
-                                <div className="flex flex-col sm:flex-row gap-2 w-full sm:w-auto">
+                                <div className="flex flex-col @sm:flex-row gap-2 w-full @sm:w-auto">
                                     <Button
                                         variant="outline"
                                         size="sm"
                                         disabled={isBusy}
                                         onClick={() => handlePop(stash.index)}
-                                        className="w-full sm:w-auto h-9"
+                                        className="w-full @sm:w-auto h-9"
                                     >
                                         <RotateCcw className="size-3.5" />
                                         <span className="ml-1.5">Pop</span>
@@ -173,7 +173,7 @@ export function GitStashList({ cwd, className }: GitStashListProps) {
                                         size="sm"
                                         disabled={isBusy}
                                         onClick={() => handleApply(stash.index)}
-                                        className="w-full sm:w-auto h-9"
+                                        className="w-full @sm:w-auto h-9"
                                     >
                                         <CornerDownLeft className="size-3.5" />
                                         <span className="ml-1.5">Apply</span>
@@ -183,7 +183,7 @@ export function GitStashList({ cwd, className }: GitStashListProps) {
                                         size="sm"
                                         disabled={isBusy}
                                         onClick={() => handleDrop(stash.index)}
-                                        className="w-full sm:w-auto h-9"
+                                        className="w-full @sm:w-auto h-9"
                                     >
                                         <Trash2 className="size-3.5" />
                                         <span className="ml-1.5">Drop</span>

--- a/packages/ui/src/components/git/GitWorktreeList.tsx
+++ b/packages/ui/src/components/git/GitWorktreeList.tsx
@@ -170,7 +170,7 @@ function WorktreeRow({ worktree: wt, onRemove, isBusy }: { worktree: GitWorktree
     return (
         <div
             className={cn(
-                "grid grid-cols-1 md:grid-cols-[1fr_auto_auto] gap-2 px-3 py-2 md:py-1 mx-1 rounded text-xs",
+                "grid grid-cols-1 @md:grid-cols-[1fr_auto_auto] gap-2 px-3 py-2 @md:py-1 mx-1 rounded text-xs",
                 "hover:bg-muted/60 transition-colors group",
             )}
             title={wt.path}
@@ -199,7 +199,7 @@ function WorktreeRow({ worktree: wt, onRemove, isBusy }: { worktree: GitWorktree
             </div>
 
             {/* Badges: changes, ahead, behind */}
-            <div className="flex items-center gap-1.5 min-w-0 md:justify-end">
+            <div className="flex items-center gap-1.5 min-w-0 @md:justify-end">
                 {wt.changeCount > 0 && (
                     <span
                         className="inline-flex items-center gap-0.5 text-[0.6rem] text-amber-500 dark:text-amber-400"
@@ -234,7 +234,7 @@ function WorktreeRow({ worktree: wt, onRemove, isBusy }: { worktree: GitWorktree
 
             {/* Actions: remove */}
             {showActions && !wt.isMain && onRemove && (
-                <div className="flex items-center gap-1 min-w-0 md:justify-end opacity-100 transition-opacity md:opacity-0 md:group-hover:opacity-100">
+                <div className="flex items-center gap-1 min-w-0 @md:justify-end opacity-100 transition-opacity @md:opacity-0 @md:group-hover:opacity-100">
                     <button
                         type="button"
                         onClick={handleRemove}

--- a/packages/ui/src/components/session-viewer/SessionAnalyzerPanel.tsx
+++ b/packages/ui/src/components/session-viewer/SessionAnalyzerPanel.tsx
@@ -245,7 +245,7 @@ export function SessionAnalyzerBody({ analysis, runnerId, sessionId }: SessionAn
         <p className="text-xs text-muted-foreground py-1">Waiting for first response…</p>
       ) : (
         <>
-          <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="grid gap-2 @sm:grid-cols-2 @xl:grid-cols-4">
             <MetricCard
               label="Cache hit"
               value={formatPct(cacheHitRate)}


### PR DESCRIPTION
### What changed
- Fix stale commit-message tooltip by re-fetching the one-entry log whenever the current branch shortHash changes (after commit, pull, etc.).
- Guard the tooltip against stale log entries: fall back to "hash · relative date" until the log entry shortHash matches the current branch head.
- Show the last-commit hash chip at all widths instead of hiding it on narrow viewports.
- Enhance sandbox mock-runner so git_commit advances HEAD and updates branches/log/worktree data, enabling end-to-end verification.
- Add GitPanel unit tests for the re-fetch behavior and stale-log fallback.

### Verification
- bun run typecheck clean
- bun test in packages/ui: 1133 pass
- bun test tests/harness/mock-runner.test.ts tests/harness/sandbox.test.ts in packages/server: 20 pass
- Sandbox + Playwright: hovered hash chip (old subject), committed, hash chip and tooltip updated to new message; verified 375 px layout still shows the chip.