### PR TITLE
perf(ui): lazy-load low-frequency panels to reduce initial bundle

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,7 +3,8 @@
   "version": "0.1.32",
   "type": "module",
   "scripts": {
-    "build": "vite build",
+    "build": "vite build && bun run bundle-budget",
+    "bundle-budget": "bun scripts/bundle-budget.ts",
     "dev": "vite",
     "preview": "vite preview"
   },

--- a/packages/ui/scripts/bundle-budget.ts
+++ b/packages/ui/scripts/bundle-budget.ts
@@ -1,0 +1,52 @@
+/**
+ * UI bundle budget check.
+ *
+ * Reads the main entry script from the built `dist/index.html` (so hashed
+ * filenames don't matter), gzips it, and fails if the compressed size exceeds
+ * the budget. No third-party dependencies — uses only Node/Bun stdlib.
+ */
+import fs from "fs";
+import path from "path";
+import { gzipSync } from "zlib";
+
+const DIST_DIR = path.resolve(import.meta.dir, "../dist");
+const INDEX_HTML = path.join(DIST_DIR, "index.html");
+const BUDGET_BYTES = 500 * 1024; // 500 KB gzip
+
+function formatBytes(bytes: number): string {
+    return `${(bytes / 1024).toFixed(2)} KB`;
+}
+
+function findMainScript(): string | null {
+    if (!fs.existsSync(INDEX_HTML)) {
+        console.error(`Missing ${INDEX_HTML}; run the UI build first.`);
+        return null;
+    }
+    const html = fs.readFileSync(INDEX_HTML, "utf8");
+    const match = html.match(/<script[^>]*\ssrc=["']([^"']+index-[^"']+\.js)["']/);
+    return match ? match[1] : null;
+}
+
+const mainScript = findMainScript();
+if (!mainScript) {
+    console.error("Could not find main index-*.js entry in dist/index.html");
+    process.exit(1);
+}
+
+const assetPath = path.join(DIST_DIR, mainScript.replace(/^\//, ""));
+if (!fs.existsSync(assetPath)) {
+    console.error(`Main script not found on disk: ${assetPath}`);
+    process.exit(1);
+}
+
+const raw = fs.readFileSync(assetPath);
+const gzipped = gzipSync(raw);
+const ok = gzipped.length <= BUDGET_BYTES;
+
+console.log(`Main entry: ${mainScript}`);
+console.log(`  minified: ${formatBytes(raw.length)}`);
+console.log(`  gzip:     ${formatBytes(gzipped.length)}`);
+console.log(`  budget:   ${formatBytes(BUDGET_BYTES)}`);
+console.log(`  status:   ${ok ? "✅ within budget" : "❌ exceeds budget"}`);
+
+process.exit(ok ? 0 : 1);

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import { Suspense } from "react";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { initAnimationSync } from "@/lib/synced-animation";
 import { SessionSidebar, type DotState, type HubSession } from "@/components/SessionSidebar";
@@ -6,15 +7,7 @@ import { SessionViewer, type RelayMessage } from "@/components/SessionViewer";
 import type { CommandResultData } from "@/components/session-viewer/rendering";
 import { detectInFlightTools } from "@/components/session-viewer/utils";
 import { DesktopHeader, MobileHeader } from "@/components/AppHeaders";
-import { UserPreferencesPanel } from "@/components/UserPreferencesPanel";
 import { AuthPage } from "@/components/AuthPage";
-import { ApiKeyManager } from "@/components/ApiKeyManager";
-import { RunnerTokenManager } from "@/components/RunnerTokenManager";
-import { DeviceSetupScanner } from "@/components/DeviceSetupScanner";
-import { MobileSetupQR } from "@/components/MobileSetupQR";
-import { RunnerManager } from "@/components/RunnerManager";
-import { NewSessionWizardDialog } from "@/components/NewSessionWizardDialog";
-import { HistoryCommandPalette } from "@/components/HistoryCommandPalette";
 import { authClient, type BetterAuthSession } from "@/lib/auth-client";
 import { usePizzaPiSession } from "@/lib/use-pizzapi-session";
 import { useRunnersFeed } from "@/lib/useRunnersFeed";
@@ -67,12 +60,8 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { X, TerminalIcon, FolderTree, GitBranch, EyeOff, Zap, BarChart3 } from "lucide-react";
-import { SessionAnalyzerBody } from "@/components/session-viewer/SessionAnalyzerPanel";
-import { TriggersPanel, type TriggerHistoryEntry } from "@/components/TriggersPanel";
+import type { TriggerHistoryEntry } from "@/components/TriggersPanel";
 import type { ProviderUsageMap } from "@/components/UsageIndicator";
-import { TerminalManager } from "@/components/TerminalManager";
-import { FileExplorer } from "@/components/FileExplorer";
-import { GitPanel } from "@/components/git";
 import { CombinedPanel, type CombinedPanelTab } from "@/components/CombinedPanel";
 import { DockedPanelGroup, TAB_BAR_HEIGHT } from "@/components/DockedPanelGroup";
 import type { PanelPosition } from "@/hooks/usePanelLayout";
@@ -105,11 +94,9 @@ import {
   ModelSelectorShortcut,
 } from "@/components/ai-elements/model-selector";
 import { HiddenModelsManager, loadHiddenModels, fetchHiddenModels, modelKey } from "@/components/HiddenModelsManager";
-import { ChangePasswordDialog } from "@/components/ChangePasswordDialog";
 import { DegradedBanner } from "@/components/DegradedBanner";
 import { RunnerWarningBanner } from "@/components/RunnerWarningBanner";
 import { VersionBanner } from "@/components/VersionBanner";
-import { ShortcutsDialog } from "@/components/ShortcutsDialog";
 import { ButtonRail, ButtonStrip } from "@/components/session-viewer/ButtonSidebar";
 import {
   beginInputAttempt,
@@ -156,6 +143,36 @@ import {
 } from "@/lib/session-seq";
 import { createLogger } from "@pizzapi/tools";
 import { isActiveViewerSessionPayload, matchesViewerGeneration } from "@/lib/viewer-switch";
+
+// Lazy-loaded low-frequency surfaces. Auth, session sidebar/viewer, banners,
+// and loading/error UI remain eager so critical paths stay fast.
+const LazyUserPreferencesPanel = React.lazy(() => import("@/components/UserPreferencesPanel").then((m) => ({ default: m.UserPreferencesPanel })));
+const LazyApiKeyManager = React.lazy(() => import("@/components/ApiKeyManager").then((m) => ({ default: m.ApiKeyManager })));
+const LazyRunnerTokenManager = React.lazy(() => import("@/components/RunnerTokenManager").then((m) => ({ default: m.RunnerTokenManager })));
+const LazyDeviceSetupScanner = React.lazy(() => import("@/components/DeviceSetupScanner").then((m) => ({ default: m.DeviceSetupScanner })));
+const LazyMobileSetupQR = React.lazy(() => import("@/components/MobileSetupQR").then((m) => ({ default: m.MobileSetupQR })));
+const LazyRunnerManager = React.lazy(() => import("@/components/RunnerManager").then((m) => ({ default: m.RunnerManager })));
+const LazyNewSessionWizardDialog = React.lazy(() => import("@/components/NewSessionWizardDialog").then((m) => ({ default: m.NewSessionWizardDialog })));
+const LazyHistoryCommandPalette = React.lazy(() => import("@/components/HistoryCommandPalette").then((m) => ({ default: m.HistoryCommandPalette })));
+const LazySessionAnalyzerBody = React.lazy(() => import("@/components/session-viewer/SessionAnalyzerPanel").then((m) => ({ default: m.SessionAnalyzerBody })));
+const LazyTriggersPanel = React.lazy(() => import("@/components/TriggersPanel").then((m) => ({ default: m.TriggersPanel })));
+const LazyTerminalManager = React.lazy(() => import("@/components/TerminalManager").then((m) => ({ default: m.TerminalManager })));
+const LazyFileExplorer = React.lazy(() => import("@/components/FileExplorer").then((m) => ({ default: m.FileExplorer })));
+const LazyGitPanel = React.lazy(() => import("@/components/git").then((m) => ({ default: m.GitPanel })));
+const LazyChangePasswordDialog = React.lazy(() => import("@/components/ChangePasswordDialog").then((m) => ({ default: m.ChangePasswordDialog })));
+const LazyShortcutsDialog = React.lazy(() => import("@/components/ShortcutsDialog").then((m) => ({ default: m.ShortcutsDialog })));
+
+/** Stable, accessible Suspense fallback for lazy panels. */
+function PanelFallback({ label }: { label?: string }) {
+  return (
+    <div className="flex h-full w-full min-h-[120px] items-center justify-center">
+      <div className="flex flex-col items-center gap-2 text-muted-foreground">
+        <Spinner className="size-5 text-primary/60" />
+        {label && <span className="text-xs">{label}</span>}
+      </div>
+    </div>
+  );
+}
 
 const log = createLogger("relay");
 
@@ -4651,25 +4668,27 @@ export function App() {
     onDragStart: (e) => startPanelDragWith(e, handleTerminalPositionChange),
     keepMountedWhenInactive: true,
     content: (
-      <TerminalManager
-        className="h-full"
-        embedded
-        sessionId={activeSessionId}
-        runnerId={activeSessionInfo?.runnerId ?? undefined}
-        defaultCwd={activeSessionInfo?.cwd || undefined}
-        runners={feedRunners.map(r => ({
-          runnerId: r.runnerId,
-          name: r.name,
-          roots: r.roots,
-          sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
-        }))}
-        runnersLoading={runnersStatus === "connecting"}
-        tabs={terminalTabs}
-        activeTabId={activeTerminalId}
-        onActiveTabChange={setActiveTerminalId}
-        onTabAdd={handleTerminalTabAdd}
-        onTabClose={handleTerminalTabClose}
-      />
+      <Suspense fallback={<PanelFallback label="Terminal" />}>
+        <LazyTerminalManager
+          className="h-full"
+          embedded
+          sessionId={activeSessionId}
+          runnerId={activeSessionInfo?.runnerId ?? undefined}
+          defaultCwd={activeSessionInfo?.cwd || undefined}
+          runners={feedRunners.map(r => ({
+            runnerId: r.runnerId,
+            name: r.name,
+            roots: r.roots,
+            sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length,
+          }))}
+          runnersLoading={runnersStatus === "connecting"}
+          tabs={terminalTabs}
+          activeTabId={activeTerminalId}
+          onActiveTabChange={setActiveTerminalId}
+          onTabAdd={handleTerminalTabAdd}
+          onTabClose={handleTerminalTabClose}
+        />
+      </Suspense>
     ),
   } : null, [showTerminal, activeSessionId, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, feedRunners, liveSessions, runnersStatus, terminalTabs, activeTerminalId, setActiveTerminalId, handleTerminalTabAdd, handleTerminalTabClose, startPanelDragWith, handleTerminalPositionChange]);
 
@@ -4680,11 +4699,13 @@ export function App() {
     onClose: () => setShowFileExplorer(false),
     onDragStart: (e) => startPanelDragWith(e, handleFilesPositionChange),
     content: (
-      <FileExplorer
-        runnerId={activeSessionInfo.runnerId}
-        cwd={activeSessionInfo.cwd}
-        className="h-full"
-      />
+      <Suspense fallback={<PanelFallback label="Files" />}>
+        <LazyFileExplorer
+          runnerId={activeSessionInfo.runnerId}
+          cwd={activeSessionInfo.cwd}
+          className="h-full"
+        />
+      </Suspense>
     ),
   } : null, [showFileExplorer, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, startPanelDragWith, handleFilesPositionChange]);
 
@@ -4695,9 +4716,11 @@ export function App() {
     onClose: () => setShowGit(false),
     onDragStart: (e) => startPanelDragWith(e, handleGitPositionChange),
     content: (
-      <GitPanel
-        cwd={activeSessionInfo.cwd}
-      />
+      <Suspense fallback={<PanelFallback label="Git" />}>
+        <LazyGitPanel
+          cwd={activeSessionInfo.cwd}
+        />
+      </Suspense>
     ),
   } : null, [showGit, activeSessionInfo?.runnerId, activeSessionInfo?.cwd, startPanelDragWith, handleGitPositionChange]);
 
@@ -4708,7 +4731,9 @@ export function App() {
     onClose: () => setShowTriggers(false),
     onDragStart: (e) => startPanelDragWith(e, handleTriggersPositionChange),
     content: (
-      <TriggersPanel sessionId={activeSessionId} triggerDefs={runnerTriggerDefs} viewerSocket={viewerSocket} />
+      <Suspense fallback={<PanelFallback label="Triggers" />}>
+        <LazyTriggersPanel sessionId={activeSessionId} triggerDefs={runnerTriggerDefs} viewerSocket={viewerSocket} />
+      </Suspense>
     ),
   } : null, [showTriggers, activeSessionId, runnerTriggerDefs, viewerSocket, startPanelDragWith, handleTriggersPositionChange, setShowTriggers]);
 
@@ -4721,11 +4746,13 @@ export function App() {
       onClose: () => setShowAnalyzer(false),
       onDragStart: (e) => startPanelDragWith(e, handleAnalyzerPositionChange),
       content: (
-        <SessionAnalyzerBody
-          analysis={analysis}
-          runnerId={activeSessionInfo?.runnerId ?? null}
-          sessionId={activeSessionId}
-        />
+        <Suspense fallback={<PanelFallback label="Analysis" />}>
+          <LazySessionAnalyzerBody
+            analysis={analysis}
+            runnerId={activeSessionInfo?.runnerId ?? null}
+            sessionId={activeSessionId}
+          />
+        </Suspense>
       ),
     };
   }, [showAnalyzer, activeSessionId, activeSessionInfo?.runnerId, analysis, startPanelDragWith, handleAnalyzerPositionChange]);
@@ -5060,10 +5087,12 @@ export function App() {
         onHiddenModelsChange={setHiddenModels}
       />
 
-      <ChangePasswordDialog
-        open={changePasswordOpen}
-        onOpenChange={setChangePasswordOpen}
-      />
+      <Suspense fallback={<PanelFallback label="Password" />}>
+        <LazyChangePasswordDialog
+          open={changePasswordOpen}
+          onOpenChange={setChangePasswordOpen}
+        />
+      </Suspense>
 
       <div className="pp-shell flex flex-1 min-h-0 overflow-hidden relative">
         <div
@@ -5269,14 +5298,16 @@ export function App() {
               <div id="main-content" role="main" tabIndex={-1} className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden">
                   {showRunners ? (
                     <ErrorBoundary level="section" resetKeys={[activeSessionId]}>
-                      <RunnerManager
-                        runners={feedRunners}
-                        runnersStatus={runnersStatus}
-                        sessions={liveSessions}
-                        onOpenSession={(id) => { handleOpenSession(id); setShowRunners(false); }}
-                        selectedRunnerId={selectedRunnerId}
-                        onSelectRunner={setSelectedRunnerId}
-                      />
+                      <Suspense fallback={<PanelFallback label="Runners" />}>
+                        <LazyRunnerManager
+                          runners={feedRunners}
+                          runnersStatus={runnersStatus}
+                          sessions={liveSessions}
+                          onOpenSession={(id) => { handleOpenSession(id); setShowRunners(false); }}
+                          selectedRunnerId={selectedRunnerId}
+                          onSelectRunner={setSelectedRunnerId}
+                        />
+                      </Suspense>
                     </ErrorBoundary>
                   ) : (
                     <ErrorBoundary level="section" resetKeys={[activeSessionId]}>
@@ -5645,13 +5676,14 @@ export function App() {
             </div>
           )}
         </div>
-        <HistoryCommandPalette
-          open={historyOpen}
-          onOpenChange={setHistoryOpen}
-          sessions={resumeSessions}
-          loading={resumeSessionsLoading}
-          onRefresh={requestResumeSessions}
-          onResumeSession={async (sessionId) => {
+        <Suspense fallback={<PanelFallback label="History" />}>
+          <LazyHistoryCommandPalette
+            open={historyOpen}
+            onOpenChange={setHistoryOpen}
+            sessions={resumeSessions}
+            loading={resumeSessionsLoading}
+            onRefresh={requestResumeSessions}
+            onResumeSession={async (sessionId) => {
             const session = resumeSessions.find((s) => s.id === sessionId);
             if (!session) return;
 
@@ -5704,8 +5736,10 @@ export function App() {
           nextCursor={resumeSessionsNextCursor}
           onLoadMore={() => { if (resumeSessionsNextCursor) requestResumeSessions(resumeSessionsNextCursor); }}
         />
+      </Suspense>
 
-        <NewSessionWizardDialog
+        <Suspense fallback={<PanelFallback label="New session" />}>
+          <LazyNewSessionWizardDialog
           open={newSessionOpen}
           onOpenChange={(open) => { if (!spawningSession) setNewSessionOpen(open); }}
           runners={feedRunners.map((r) => ({ ...r, name: r.name ?? null, isOnline: true, sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length }))}
@@ -5714,13 +5748,16 @@ export function App() {
           initialCwd={spawnCwd}
           onSpawn={handleWizardSpawn}
         />
+      </Suspense>
 
         {showPreferences && (
-          <UserPreferencesPanel
-            onClose={() => setShowPreferences(false)}
-            onShowHiddenModels={() => setHiddenModelsOpen(true)}
-            hiddenModelCount={availableModels.filter(m => hiddenModels.has(modelKey(m.provider, m.id))).length}
-          />
+          <Suspense fallback={<PanelFallback label="Settings" />}>
+            <LazyUserPreferencesPanel
+              onClose={() => setShowPreferences(false)}
+              onShowHiddenModels={() => setHiddenModelsOpen(true)}
+              hiddenModelCount={availableModels.filter(m => hiddenModels.has(modelKey(m.provider, m.id))).length}
+            />
+          </Suspense>
         )}
 
         {showApiKeys && (
@@ -5748,24 +5785,30 @@ export function App() {
               </Tooltip>
             </div>
             <div className="flex-1 overflow-y-auto p-4">
-              <div className="flex flex-col gap-4">
-                <MobileSetupQR />
-                <ApiKeyManager refreshSignal={apiKeyVersion} onKeysChanged={() => setApiKeyVersion((v) => v + 1)} />
-                <RunnerTokenManager refreshSignal={apiKeyVersion} onKeysChanged={() => setApiKeyVersion((v) => v + 1)} />
-                <DeviceSetupScanner onClose={() => setShowApiKeys(false)} />
-              </div>
+              <Suspense fallback={<PanelFallback label="API keys" />}>
+                <div className="flex flex-col gap-4">
+                  <LazyMobileSetupQR />
+                  <LazyApiKeyManager refreshSignal={apiKeyVersion} onKeysChanged={() => setApiKeyVersion((v) => v + 1)} />
+                  <LazyRunnerTokenManager refreshSignal={apiKeyVersion} onKeysChanged={() => setApiKeyVersion((v) => v + 1)} />
+                  <LazyDeviceSetupScanner onClose={() => setShowApiKeys(false)} />
+                </div>
+              </Suspense>
             </div>
           </div>
         )}
 
-        <ShortcutsDialog open={showShortcutsHelp} onOpenChange={setShowShortcutsHelp} />
+        <Suspense fallback={<PanelFallback label="Shortcuts" />}>
+          <LazyShortcutsDialog open={showShortcutsHelp} onOpenChange={setShowShortcutsHelp} />
+        </Suspense>
 
         <Dialog open={setupClaimOpen} onOpenChange={setSetupClaimOpen}>
           <DialogContent className="max-w-md p-0 overflow-hidden">
-            <DeviceSetupScanner
-              initialToken={setupClaimToken ?? undefined}
-              onClose={() => setSetupClaimOpen(false)}
-            />
+            <Suspense fallback={<PanelFallback label="Device setup" />}>
+              <LazyDeviceSetupScanner
+                initialToken={setupClaimToken ?? undefined}
+                onClose={() => setSetupClaimOpen(false)}
+              />
+            </Suspense>
           </DialogContent>
         </Dialog>
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -119,6 +119,7 @@ import { exportToMarkdown } from "@/lib/export-markdown";
 import { useAttentionIngestion } from "@/hooks/useAttentionIngestion";
 import { useMobileSidebar } from "@/hooks/useMobileSidebar";
 import { useBrowserNotifications } from "@/hooks/useBrowserNotifications";
+import { useMountOnFirstOpen } from "@/hooks/useMountOnFirstOpen";
 import {
   toRelayMessage,
   deduplicateMessages,
@@ -509,6 +510,7 @@ export function App() {
   const [setupClaimToken, setSetupClaimToken] = React.useState<string | null>(null);
   const [showRunners, setShowRunners] = React.useState(false);
   const [historyOpen, setHistoryOpen] = React.useState(false);
+  const historyMounted = useMountOnFirstOpen(historyOpen);
   const [selectedRunnerId, setSelectedRunnerId] = React.useState<string | null>(null);
   const [runnersForSidebar, setRunnersForSidebar] = React.useState<Array<{
     runnerId: string;
@@ -682,6 +684,7 @@ export function App() {
   }, [draggingButton, buttonPositions, terminalColumnRef]);
 
   const [newSessionOpen, setNewSessionOpen] = React.useState(false);
+  const newSessionMounted = useMountOnFirstOpen(newSessionOpen);
   const [spawnRunnerId, setSpawnRunnerId] = React.useState<string | undefined>(undefined);
   const [spawnCwd, setSpawnCwd] = React.useState<string>("");
   const [spawnPreselectedRunnerId, setSpawnPreselectedRunnerId] = React.useState<string | null>(null);
@@ -715,6 +718,7 @@ export function App() {
   const [hiddenModels, setHiddenModels] = React.useState<Set<string>>(() => loadHiddenModels());
   const [hiddenModelsOpen, setHiddenModelsOpen] = React.useState(false);
   const [changePasswordOpen, setChangePasswordOpen] = React.useState(false);
+  const changePasswordMounted = useMountOnFirstOpen(changePasswordOpen);
 
   // Live session status from heartbeats (isCompacting and planModeEnabled are intentionally
   // NOT part of SessionState because they are not reset by clearSelection)
@@ -729,6 +733,7 @@ export function App() {
     return /Mac|iPhone|iPad/i.test(platform);
   }, []);
   const [showShortcutsHelp, setShowShortcutsHelp] = React.useState(false);
+  const shortcutsMounted = useMountOnFirstOpen(showShortcutsHelp);
 
   // Sequence tracking for gap detection
   const lastSeqRef = React.useRef<number | null>(null);
@@ -5087,12 +5092,14 @@ export function App() {
         onHiddenModelsChange={setHiddenModels}
       />
 
-      <Suspense fallback={<PanelFallback label="Password" />}>
-        <LazyChangePasswordDialog
-          open={changePasswordOpen}
-          onOpenChange={setChangePasswordOpen}
-        />
-      </Suspense>
+      {changePasswordMounted && (
+        <Suspense fallback={<PanelFallback label="Password" />}>
+          <LazyChangePasswordDialog
+            open={changePasswordOpen}
+            onOpenChange={setChangePasswordOpen}
+          />
+        </Suspense>
+      )}
 
       <div className="pp-shell flex flex-1 min-h-0 overflow-hidden relative">
         <div
@@ -5676,79 +5683,83 @@ export function App() {
             </div>
           )}
         </div>
-        <Suspense fallback={<PanelFallback label="History" />}>
-          <LazyHistoryCommandPalette
-            open={historyOpen}
-            onOpenChange={setHistoryOpen}
-            sessions={resumeSessions}
-            loading={resumeSessionsLoading}
-            onRefresh={requestResumeSessions}
-            onResumeSession={async (sessionId) => {
-            const session = resumeSessions.find((s) => s.id === sessionId);
-            if (!session) return;
+        {historyMounted && (
+          <Suspense fallback={<PanelFallback label="History" />}>
+            <LazyHistoryCommandPalette
+              open={historyOpen}
+              onOpenChange={setHistoryOpen}
+              sessions={resumeSessions}
+              loading={resumeSessionsLoading}
+              onRefresh={requestResumeSessions}
+              onResumeSession={async (sessionId) => {
+              const session = resumeSessions.find((s) => s.id === sessionId);
+              if (!session) return;
 
-            // Determine runnerId: prefer session-level (server-sourced), fall back to active session's runner
-            const runnerId = session.runnerId || activeSessionInfo?.runnerId;
-            if (!runnerId) {
-              setViewerStatus("No runner available for this session");
-              return;
-            }
-            setHistoryOpen(false);
-            setViewerStatus("Resuming session…");
-            try {
-              // Server-sourced sessions don't have the .jsonl path — send resumeId
-              // so the runner daemon resolves the path from the session ID.
-              const payload: any = {
-                runnerId,
-                ...(session.serverSourced
-                  ? { resumeId: session.id }
-                  : { resumePath: session.path }),
-                ...(session.cwd ? { cwd: session.cwd } : {}),
-              };
-              const res = await fetch("/api/runners/spawn", {
-                method: "POST",
-                credentials: "include",
-                headers: { "content-type": "application/json" },
-                body: JSON.stringify(payload),
-              });
-              const body = await res.json().catch(() => null) as { error?: string; sessionId?: string } | null;
-              if (!res.ok) {
-                setViewerStatus(body?.error ?? "Failed to resume session");
+              // Determine runnerId: prefer session-level (server-sourced), fall back to active session's runner
+              const runnerId = session.runnerId || activeSessionInfo?.runnerId;
+              if (!runnerId) {
+                setViewerStatus("No runner available for this session");
                 return;
               }
-              const newSessionId = typeof body?.sessionId === "string" ? body.sessionId : null;
-              if (!newSessionId) {
-                setViewerStatus("Resume failed: missing sessionId");
-                return;
+              setHistoryOpen(false);
+              setViewerStatus("Resuming session…");
+              try {
+                // Server-sourced sessions don't have the .jsonl path — send resumeId
+                // so the runner daemon resolves the path from the session ID.
+                const payload: any = {
+                  runnerId,
+                  ...(session.serverSourced
+                    ? { resumeId: session.id }
+                    : { resumePath: session.path }),
+                  ...(session.cwd ? { cwd: session.cwd } : {}),
+                };
+                const res = await fetch("/api/runners/spawn", {
+                  method: "POST",
+                  credentials: "include",
+                  headers: { "content-type": "application/json" },
+                  body: JSON.stringify(payload),
+                });
+                const body = await res.json().catch(() => null) as { error?: string; sessionId?: string } | null;
+                if (!res.ok) {
+                  setViewerStatus(body?.error ?? "Failed to resume session");
+                  return;
+                }
+                const newSessionId = typeof body?.sessionId === "string" ? body.sessionId : null;
+                if (!newSessionId) {
+                  setViewerStatus("Resume failed: missing sessionId");
+                  return;
+                }
+                const live = await waitForSessionToGoLive(newSessionId, 30_000);
+                if (!live) {
+                  setViewerStatus("Session is starting…");
+                  return;
+                }
+                handleOpenSession(newSessionId);
+                setViewerStatus("Connecting…");
+              } catch (err) {
+                setViewerStatus("Failed to resume session");
+                console.error("Resume session error:", err);
               }
-              const live = await waitForSessionToGoLive(newSessionId, 30_000);
-              if (!live) {
-                setViewerStatus("Session is starting…");
-                return;
-              }
-              handleOpenSession(newSessionId);
-              setViewerStatus("Connecting…");
-            } catch (err) {
-              setViewerStatus("Failed to resume session");
-              console.error("Resume session error:", err);
-            }
-          }}
-          nextCursor={resumeSessionsNextCursor}
-          onLoadMore={() => { if (resumeSessionsNextCursor) requestResumeSessions(resumeSessionsNextCursor); }}
-        />
-      </Suspense>
+            }}
+            nextCursor={resumeSessionsNextCursor}
+            onLoadMore={() => { if (resumeSessionsNextCursor) requestResumeSessions(resumeSessionsNextCursor); }}
+          />
+        </Suspense>
+      )}
 
-        <Suspense fallback={<PanelFallback label="New session" />}>
-          <LazyNewSessionWizardDialog
-          open={newSessionOpen}
-          onOpenChange={(open) => { if (!spawningSession) setNewSessionOpen(open); }}
-          runners={feedRunners.map((r) => ({ ...r, name: r.name ?? null, isOnline: true, sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length }))}
-          runnersLoading={runnersStatus === "connecting"}
-          preselectedRunnerId={spawnPreselectedRunnerId}
-          initialCwd={spawnCwd}
-          onSpawn={handleWizardSpawn}
-        />
-      </Suspense>
+        {newSessionMounted && (
+          <Suspense fallback={<PanelFallback label="New session" />}>
+            <LazyNewSessionWizardDialog
+            open={newSessionOpen}
+            onOpenChange={(open) => { if (!spawningSession) setNewSessionOpen(open); }}
+            runners={feedRunners.map((r) => ({ ...r, name: r.name ?? null, isOnline: true, sessionCount: liveSessions.filter(s => s.runnerId === r.runnerId).length }))}
+            runnersLoading={runnersStatus === "connecting"}
+            preselectedRunnerId={spawnPreselectedRunnerId}
+            initialCwd={spawnCwd}
+            onSpawn={handleWizardSpawn}
+          />
+        </Suspense>
+      )}
 
         {showPreferences && (
           <Suspense fallback={<PanelFallback label="Settings" />}>
@@ -5797,9 +5808,11 @@ export function App() {
           </div>
         )}
 
-        <Suspense fallback={<PanelFallback label="Shortcuts" />}>
-          <LazyShortcutsDialog open={showShortcutsHelp} onOpenChange={setShowShortcutsHelp} />
-        </Suspense>
+        {shortcutsMounted && (
+          <Suspense fallback={<PanelFallback label="Shortcuts" />}>
+            <LazyShortcutsDialog open={showShortcutsHelp} onOpenChange={setShowShortcutsHelp} />
+          </Suspense>
+        )}
 
         <Dialog open={setupClaimOpen} onOpenChange={setSetupClaimOpen}>
           <DialogContent className="max-w-md p-0 overflow-hidden">

--- a/packages/ui/src/hooks/useMountOnFirstOpen.test.ts
+++ b/packages/ui/src/hooks/useMountOnFirstOpen.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, afterAll } from "bun:test";
+import { Window } from "happy-dom";
+
+const win = new Window({ url: "http://localhost/" });
+(globalThis as unknown as Record<string, unknown>).window = win;
+(globalThis as unknown as Record<string, unknown>).document = win.document;
+(globalThis as unknown as Record<string, unknown>).navigator = win.navigator;
+(globalThis as unknown as Record<string, unknown>).localStorage = win.localStorage;
+(globalThis as unknown as Record<string, unknown>).HTMLElement = win.HTMLElement;
+(globalThis as unknown as Record<string, unknown>).Element = win.Element;
+(globalThis as unknown as Record<string, unknown>).Node = win.Node;
+(globalThis as unknown as Record<string, unknown>).MutationObserver = win.MutationObserver;
+(globalThis as unknown as Record<string, unknown>).getComputedStyle = win.getComputedStyle.bind(win);
+
+afterAll(() => {
+  (globalThis as unknown as Record<string, unknown>).window = undefined;
+  (globalThis as unknown as Record<string, unknown>).document = undefined;
+});
+
+const { renderHook, act } = await import("@testing-library/react");
+const { useMountOnFirstOpen } = await import("./useMountOnFirstOpen");
+
+describe("useMountOnFirstOpen", () => {
+    it("starts mounted when initially open", () => {
+        const { result } = renderHook(({ open }) => useMountOnFirstOpen(open), {
+            initialProps: { open: true },
+        });
+        expect(result.current).toBe(true);
+    });
+
+    it("stays unmounted while closed", () => {
+        const { result } = renderHook(({ open }) => useMountOnFirstOpen(open), {
+            initialProps: { open: false },
+        });
+        expect(result.current).toBe(false);
+    });
+
+    it("mounts on first open", () => {
+        const { result, rerender } = renderHook(({ open }) => useMountOnFirstOpen(open), {
+            initialProps: { open: false },
+        });
+        expect(result.current).toBe(false);
+
+        act(() => rerender({ open: true }));
+        expect(result.current).toBe(true);
+    });
+
+    it("stays mounted after closing", () => {
+        const { result, rerender } = renderHook(({ open }) => useMountOnFirstOpen(open), {
+            initialProps: { open: false },
+        });
+
+        act(() => rerender({ open: true }));
+        expect(result.current).toBe(true);
+
+        act(() => rerender({ open: false }));
+        expect(result.current).toBe(true);
+    });
+
+    it("remains mounted across repeated open/close cycles", () => {
+        const { result, rerender } = renderHook(({ open }) => useMountOnFirstOpen(open), {
+            initialProps: { open: false },
+        });
+
+        for (let i = 0; i < 3; i++) {
+            act(() => rerender({ open: true }));
+            expect(result.current).toBe(true);
+            act(() => rerender({ open: false }));
+            expect(result.current).toBe(true);
+        }
+    });
+});

--- a/packages/ui/src/hooks/useMountOnFirstOpen.ts
+++ b/packages/ui/src/hooks/useMountOnFirstOpen.ts
@@ -1,0 +1,17 @@
+import * as React from "react";
+
+/**
+ * Tracks whether a surface should be mounted. Returns `false` until the
+ * `open` prop first becomes `true`, then stays `true` afterward.
+ *
+ * This lets lazy-loaded dialogs/panels defer their React.lazy chunk request
+ * until first open while remaining mounted after close, so Radix focus
+ * restoration still runs its full lifecycle.
+ */
+export function useMountOnFirstOpen(open: boolean): boolean {
+  const [mounted, setMounted] = React.useState(open);
+  React.useEffect(() => {
+    if (open) setMounted(true);
+  }, [open]);
+  return mounted;
+}


### PR DESCRIPTION
## Goal
Materially reduce PizzaPi's initial web/mobile JavaScript without changing behavior.

## What changed
- Lazy-loaded low-frequency surfaces in `App.tsx` behind `React.lazy` + stable Suspense fallbacks:
  - Settings: `UserPreferencesPanel`
  - Managers: `RunnerManager`, `ApiKeyManager`, `RunnerTokenManager`, `DeviceSetupScanner`, `MobileSetupQR`
  - Session helpers: `NewSessionWizardDialog`, `HistoryCommandPalette`
  - Dockable panels: `TerminalManager`, `FileExplorer`, `GitPanel`, `TriggersPanel`, `SessionAnalyzerBody`
  - Dialogs: `ChangePasswordDialog`, `ShortcutsDialog`
- Kept the critical path eager: `AuthPage`, `SessionSidebar`, `SessionViewer`, headers, banners, loading/error UI.
- Added `packages/ui/scripts/bundle-budget.ts` (stdlib only) and wired it into `packages/ui/package.json` so the UI build fails if the main entry exceeds 500 KB gzip.

## Metrics
| Build | Main entry (minified) | Main entry (gzip) |
|---|---|---|
| Baseline | ~1,952 KB | ~552 KB |
| After | ~1,553 KB | ~454 KB |

## Verification
- `bun run typecheck` ✅
- `bun test` (all packages, UI + server + mobile) ✅
- `bun run build:ui` ✅ + bundle budget passes
- `VITE_MOBILE=1 VITE_BASE_URL=./ bun run build:ui` ✅ + bundle budget passes

Relates to godmother idea [[idea:41ZEXNZ4]]
